### PR TITLE
Fix TUI long transcript input latency

### DIFF
--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -93,6 +93,14 @@ async def _run_native_interactive_tui(
     history_records = session_history_records(session, tool_definition_resolver=_tool_definition_resolver(session))
     if history_records:
         app.replace_transcript_window(history_records, reason="resume")
+        app.trim_active_transcript_window()
+        _trace(
+            "tui.resume_history",
+            record_count=len(history_records),
+            active_record_count=len(app.state.records),
+            evicted_record_count=app.state.evicted_prefix_record_count,
+            trimmed=app.state.evicted_prefix_record_count > 0,
+        )
     completion_provider = await _load_completion_provider(session)
     app.composer.set_completion_provider(completion_provider)
     controller = CodingUiController(runtime=runtime, session=session, verbose=verbose)

--- a/src/loushang/tui/runtime.py
+++ b/src/loushang/tui/runtime.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, cast
 
+from loushang.observability import get_log
 from loushang.tui.framework import ScreenRoot as OverlayScreenRoot
 from loushang.tui.framework import Surface, SurfaceHandle, SurfaceHost
 from loushang.tui.playback import PlaybackEvent, PlaybackStep
@@ -16,6 +17,8 @@ from loushang.tui.scheduler import (
     RenderScheduler,
 )
 from loushang.tui.terminal import TerminalPort
+
+_log = get_log(__name__).bind(component="TuiRuntime")
 
 
 @dataclass(slots=True)
@@ -29,10 +32,15 @@ class TuiRuntime:
     _overlay_host: SurfaceHost | None = field(default=None, init=False, repr=False)
 
     def render_now(self) -> PlaybackStep:
+        render_started = time.perf_counter()
         size = self.terminal.size()
         self._consume_screen_root_baseline_reset()
+        plan_started = time.perf_counter()
         diagnostics = self.render_loop.plan(size)
+        plan_ms = (time.perf_counter() - plan_started) * 1000
+        flush_started = time.perf_counter()
         frame = self.terminal.flush(diagnostics.operations)
+        flush_ms = (time.perf_counter() - flush_started) * 1000
         self.render_loop.commit(diagnostics, size=size)
         self._pending_render_due_ms = None
         rendered_at_ms = self.now_ms()
@@ -45,6 +53,22 @@ class TuiRuntime:
             frame=frame,
         )
         self._step_index += 1
+        changed_start, changed_end = diagnostics.changed_line_range or (None, None)
+        _log.debug_event(
+            "tui",
+            "render.frame",
+            operation_class=diagnostics.operation_class,
+            logical_line_count=len(diagnostics.current_logical_lines),
+            previous_line_count=len(diagnostics.previous_rendered_lines),
+            operation_count=len(diagnostics.operations),
+            changed_start=changed_start,
+            changed_end=changed_end,
+            viewport_top=diagnostics.viewport_top,
+            previous_viewport_top=diagnostics.previous_viewport_top,
+            plan_ms=round(plan_ms, 3),
+            flush_ms=round(flush_ms, 3),
+            total_ms=round((time.perf_counter() - render_started) * 1000, 3),
+        )
         return step
 
     def overlay_host(self) -> SurfaceHost:

--- a/tests/coding/test_native_coding_tui_mode.py
+++ b/tests/coding/test_native_coding_tui_mode.py
@@ -19,6 +19,9 @@ from loushang.coding.message import CompactionSummaryMessage
 from loushang.coding.message.entries import SessionContext
 from loushang.coding.types import ModelSelection
 from loushang.coding.ui.native_surfaces import NativeSurfaceManager
+from loushang.coding.ui.perf_probe import characterize_long_transcript_rendering
+from loushang.observability import configure_debug_logging, reset_observability
+from loushang.tui import RenderLoop, TerminalSize
 from loushang.tui.transcript import (
     AssistantMessageRecord,
     ContextCompactionRecord,
@@ -30,6 +33,20 @@ from loushang.tui.transcript import (
 class _TTYStringIO(StringIO):
     def isatty(self) -> bool:
         return True
+
+
+class _RecordingDebugSink:
+    def __init__(self) -> None:
+        self.events = []
+
+    def write_log(self, **_kwargs) -> None:
+        return None
+
+    def write_problem(self, _record) -> None:
+        return None
+
+    def write_debug_event(self, record) -> None:
+        self.events.append(record)
 
 
 class _Session:
@@ -239,6 +256,246 @@ def test_run_coding_tui_interactive_replays_resumed_session_history(monkeypatch)
     assert isinstance(records[3], ContextCompactionRecord)
     assert records[3].summary == "older context summary"
     assert records[3].tokens_before == 128
+
+
+def test_run_coding_tui_interactive_bounds_resumed_long_transcript_render_window(monkeypatch) -> None:
+    from loushang.coding.ui import mode
+
+    session = _Session()
+    usage = Usage(input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={})
+    for turn in range(24):
+        session.context_messages.append(
+            UserMessage(role="user", content=[TextPart(type="text", text=f"question {turn}")], timestamp=float(turn))
+        )
+        line_count = 900 if turn == 23 else 40
+        session.context_messages.append(
+            AssistantMessage(
+                role="assistant",
+                content=[TextPart(type="text", text="\n".join(f"answer {turn} line {line}" for line in range(line_count)))],
+                api="openai",
+                provider="moonshot",
+                model="kimi",
+                response_id=None,
+                usage=usage,
+                stop_reason="stop",
+                error_message=None,
+                timestamp=float(turn) + 0.5,
+            )
+        )
+    captured: dict[str, object] = {}
+
+    async def fake_native_loop(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(mode, "run_native_coding_tui", fake_native_loop)
+
+    exit_code = asyncio.run(
+        mode.run_coding_tui(
+            runtime=object(),
+            session=session,
+            stdin=_TTYStringIO(),
+            stdout=_TTYStringIO(),
+            stderr=StringIO(),
+        )
+    )
+
+    app = captured["app"]
+    render_loop = RenderLoop(screen_root=app)
+    first_metrics = characterize_long_transcript_rendering(
+        app,
+        width=100,
+        height=30,
+        render_loop=render_loop,
+        commit_plan=True,
+    )
+    input_metrics = characterize_long_transcript_rendering(
+        app,
+        width=100,
+        height=30,
+        composer_text="x",
+        render_loop=render_loop,
+        commit_plan=True,
+    )
+
+    assert exit_code == 0
+    assert getattr(app, "state").evicted_prefix_record_count > 0
+    assert first_metrics.render_loop_logical_line_count <= 380
+    assert input_metrics.render_loop_logical_line_count <= 380
+    assert input_metrics.render_loop_operation_class not in {
+        "baseline_repaint",
+        "managed_viewport_repaint",
+        "recovery_repaint",
+        "resize_repaint",
+    }
+
+
+def test_run_coding_tui_interactive_long_transcript_input_frame_does_not_clear_screen(monkeypatch) -> None:
+    from loushang.coding.ui import mode
+
+    session = _Session()
+    usage = Usage(input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={})
+    for turn in range(24):
+        session.context_messages.append(
+            UserMessage(role="user", content=[TextPart(type="text", text=f"question {turn}")], timestamp=float(turn))
+        )
+        session.context_messages.append(
+            AssistantMessage(
+                role="assistant",
+                content=[TextPart(type="text", text="\n".join(f"answer {turn} line {line}" for line in range(80)))],
+                api="openai",
+                provider="moonshot",
+                model="kimi",
+                response_id=None,
+                usage=usage,
+                stop_reason="stop",
+                error_message=None,
+                timestamp=float(turn) + 0.5,
+            )
+        )
+    captured: dict[str, object] = {}
+
+    async def fake_native_loop(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(mode, "run_native_coding_tui", fake_native_loop)
+
+    exit_code = asyncio.run(
+        mode.run_coding_tui(
+            runtime=object(),
+            session=session,
+            stdin=_TTYStringIO(),
+            stdout=_TTYStringIO(),
+            stderr=StringIO(),
+        )
+    )
+
+    app = captured["app"]
+    render_loop = RenderLoop(screen_root=app)
+    size = TerminalSize(columns=100, rows=30)
+    first = render_loop.plan(size)
+    render_loop.commit(first, size=size)
+    app.composer.set_text("x")
+    second = render_loop.plan(size)
+
+    assert exit_code == 0
+    assert second.operation_class == "changed_range_update"
+    assert {operation.kind for operation in second.operations}.isdisjoint({"clear_screen", "clear_scrollback"})
+
+
+def test_run_coding_tui_interactive_long_transcript_working_timer_frame_stays_bounded(monkeypatch) -> None:
+    from loushang.coding.ui import mode
+
+    session = _Session()
+    usage = Usage(input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={})
+    for turn in range(24):
+        session.context_messages.append(
+            UserMessage(role="user", content=[TextPart(type="text", text=f"question {turn}")], timestamp=float(turn))
+        )
+        session.context_messages.append(
+            AssistantMessage(
+                role="assistant",
+                content=[TextPart(type="text", text="\n".join(f"answer {turn} line {line}" for line in range(80)))],
+                api="openai",
+                provider="moonshot",
+                model="kimi",
+                response_id=None,
+                usage=usage,
+                stop_reason="stop",
+                error_message=None,
+                timestamp=float(turn) + 0.5,
+            )
+        )
+    captured: dict[str, object] = {}
+
+    async def fake_native_loop(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(mode, "run_native_coding_tui", fake_native_loop)
+
+    exit_code = asyncio.run(
+        mode.run_coding_tui(
+            runtime=object(),
+            session=session,
+            stdin=_TTYStringIO(),
+            stdout=_TTYStringIO(),
+            stderr=StringIO(),
+        )
+    )
+
+    app = captured["app"]
+    app.now = lambda: 10.0
+    app.begin_run(started_at=10.0)
+    render_loop = RenderLoop(screen_root=app)
+    size = TerminalSize(columns=100, rows=30)
+    first = render_loop.plan(size)
+    render_loop.commit(first, size=size)
+    app.now = lambda: 10.2
+    second = render_loop.plan(size)
+
+    assert exit_code == 0
+    assert len(second.current_logical_lines) <= 380
+    assert second.operation_class == "changed_range_update"
+    assert second.changed_line_range is not None
+    assert second.changed_line_range[0] >= len(second.current_logical_lines) - 8
+    assert {operation.kind for operation in second.operations}.isdisjoint({"clear_screen", "clear_scrollback"})
+
+
+def test_run_coding_tui_interactive_traces_resumed_transcript_window_trim(monkeypatch) -> None:
+    from loushang.coding.ui import mode
+
+    session = _Session()
+    usage = Usage(input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={})
+    for turn in range(24):
+        session.context_messages.append(
+            UserMessage(role="user", content=[TextPart(type="text", text=f"question {turn}")], timestamp=float(turn))
+        )
+        session.context_messages.append(
+            AssistantMessage(
+                role="assistant",
+                content=[TextPart(type="text", text="\n".join(f"answer {turn} line {line}" for line in range(80)))],
+                api="openai",
+                provider="moonshot",
+                model="kimi",
+                response_id=None,
+                usage=usage,
+                stop_reason="stop",
+                error_message=None,
+                timestamp=float(turn) + 0.5,
+            )
+        )
+    sink = _RecordingDebugSink()
+    captured: dict[str, object] = {}
+
+    async def fake_native_loop(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(mode, "run_native_coding_tui", fake_native_loop)
+    reset_observability()
+    configure_debug_logging(debug_sink=sink, debug_scopes=("tui",))
+    try:
+        exit_code = asyncio.run(
+            mode.run_coding_tui(
+                runtime=object(),
+                session=session,
+                stdin=_TTYStringIO(),
+                stdout=_TTYStringIO(),
+                stderr=StringIO(),
+            )
+        )
+    finally:
+        reset_observability()
+
+    event = next(event for event in sink.events if event.scope == "tui" and event.name == "tui.resume_history")
+    app = captured["app"]
+    assert exit_code == 0
+    assert event.data["record_count"] == 48
+    assert event.data["active_record_count"] == len(getattr(app, "state").records)
+    assert event.data["evicted_record_count"] == getattr(app, "state").evicted_prefix_record_count
+    assert event.data["trimmed"] is True
 
 
 def test_run_coding_tui_interactive_native_loop_dispatches_steer_and_followup(monkeypatch) -> None:

--- a/tests/coding/test_native_coding_tui_perf_probe.py
+++ b/tests/coding/test_native_coding_tui_perf_probe.py
@@ -40,3 +40,38 @@ def test_long_transcript_probe_shows_render_loop_plans_beyond_visible_height() -
     assert first_metrics.render_loop_logical_line_count > first_metrics.visible_render_line_count
     assert second_metrics.render_loop_logical_line_count == first_metrics.render_loop_logical_line_count
     assert second_metrics.render_loop_operation_class != "first_render"
+
+
+def test_long_transcript_probe_stays_bounded_after_active_window_trim() -> None:
+    records = build_synthetic_long_transcript_records(turns=180, tail_tool_output_lines=2400)
+    app = NativeCodingTuiApp(
+        model_label="fake-model",
+        cwd="/repo",
+        branch="main",
+        session_label="perf",
+    )
+    app.replace_transcript_window(records, reason="test")
+    app.trim_active_transcript_window()
+    render_loop = RenderLoop(screen_root=app)
+
+    first_metrics = characterize_long_transcript_rendering(
+        app,
+        width=100,
+        height=30,
+        render_loop=render_loop,
+        commit_plan=True,
+    )
+    second_metrics = characterize_long_transcript_rendering(
+        app,
+        width=100,
+        height=30,
+        composer_text="hello",
+        render_loop=render_loop,
+        commit_plan=True,
+    )
+
+    assert app.state.evicted_prefix_record_count > 0
+    assert first_metrics.render_loop_logical_line_count <= app.active_transcript_line_budget + 60
+    assert second_metrics.render_loop_logical_line_count <= app.active_transcript_line_budget + 60
+    assert second_metrics.render_loop_operation_class == "changed_range_update"
+    assert second_metrics.changed_line_range is not None

--- a/tests/coding/test_native_coding_tui_terminal_playback.py
+++ b/tests/coding/test_native_coding_tui_terminal_playback.py
@@ -5,6 +5,7 @@ from io import StringIO
 from loushang.coding.ui.native_app import NativeCodingTuiApp
 from loushang.coding.ui.native_input import NativeInputRouter
 from loushang.coding.ui.native_loop import _finish_tui_exit
+from loushang.coding.ui.perf_probe import build_synthetic_long_transcript_records
 from loushang.tui import (
     CompletionItem,
     CompletionProvider,
@@ -349,6 +350,52 @@ def test_native_coding_tui_renders_pending_steer_and_followup_below_working_line
     assert "  ↳ steer now" in visible_lines
     assert "  ↳ next prompt" in visible_lines
     assert "    alt + ↑ edit last queued message" in visible_lines
+
+
+def test_native_coding_tui_resumed_long_transcript_input_echo_uses_bounded_fake_terminal_update() -> None:
+    app = _app()
+    app.replace_transcript_window(
+        build_synthetic_long_transcript_records(turns=180, tail_tool_output_lines=2400),
+        reason="resume",
+    )
+    app.trim_active_transcript_window()
+    runtime, port = _runtime(app, width=100, height=30)
+
+    first = runtime.render_now()
+    app.composer.set_text("x")
+    step = runtime.render_now()
+
+    assert len(first.diagnostics.current_logical_lines) <= 380
+    assert len(step.diagnostics.current_logical_lines) <= 380
+    step.assert_operation_class("changed_range_update")
+    step.assert_no_clear_scrollback()
+    assert TerminalOperation.clear_screen() not in step.diagnostics.operations
+    assert step.frame is not None
+    assert any(line.rstrip() == "› x" for line in port.screen.visible_lines)
+
+
+def test_native_coding_tui_resumed_long_transcript_working_timer_uses_bounded_fake_terminal_update() -> None:
+    app = _app()
+    app.now = lambda: 0.0
+    app.replace_transcript_window(
+        build_synthetic_long_transcript_records(turns=180, tail_tool_output_lines=2400),
+        reason="resume",
+    )
+    app.trim_active_transcript_window()
+    app.begin_run(started_at=0.0)
+    runtime, port = _runtime(app, width=100, height=30)
+
+    first = runtime.render_now()
+    app.now = lambda: 0.2
+    step = runtime.render_now()
+
+    assert len(first.diagnostics.current_logical_lines) <= 380
+    assert len(step.diagnostics.current_logical_lines) <= 380
+    step.assert_operation_class("changed_range_update")
+    step.assert_no_clear_scrollback()
+    assert TerminalOperation.clear_screen() not in step.diagnostics.operations
+    assert step.frame is not None
+    assert "Working 0.20s" in _visible_text(port)
 
 
 def _app() -> NativeCodingTuiApp:

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from loushang.observability import configure_debug_logging, reset_observability
 from loushang.tui import (
     CURSOR_MARKER,
     FakeTerminalPort,
@@ -39,6 +40,20 @@ class TextRoot:
         return RenderResult.from_text(self.text, constraints=constraints)
 
 
+class RecordingDebugSink:
+    def __init__(self) -> None:
+        self.events = []
+
+    def write_log(self, **_kwargs) -> None:
+        return None
+
+    def write_problem(self, _record) -> None:
+        return None
+
+    def write_debug_event(self, record) -> None:
+        self.events.append(record)
+
+
 def test_first_render_flushes_full_logical_lines_without_clearing_scrollback() -> None:
     runtime = TuiRuntime(
         render_loop=RenderLoop(StaticRoot(("hello", "status"))),
@@ -54,6 +69,29 @@ def test_first_render_flushes_full_logical_lines_without_clearing_scrollback() -
     assert step.frame is not None
     assert step.frame.serialized_output == "\x1b[?2026hhello\r\nstatus\x1b[?2026l"
     assert step.frame.screen_after.visible_lines[:2] == ("hello", "status")
+
+
+def test_runtime_render_now_emits_tui_render_frame_diagnostics() -> None:
+    sink = RecordingDebugSink()
+    reset_observability()
+    configure_debug_logging(debug_sink=sink, debug_scopes=("tui",))
+    try:
+        runtime = TuiRuntime(
+            render_loop=RenderLoop(StaticRoot(("hello", "status"))),
+            terminal=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
+        )
+
+        runtime.render_now()
+    finally:
+        reset_observability()
+
+    event = next(event for event in sink.events if event.scope == "tui" and event.name == "render.frame")
+    assert event.data["operation_class"] == "first_render"
+    assert event.data["logical_line_count"] == 2
+    assert event.data["operation_count"] > 0
+    assert event.data["plan_ms"] >= 0
+    assert event.data["flush_ms"] >= 0
+    assert event.data["total_ms"] >= 0
 
 
 def test_fake_terminal_port_implements_terminal_port_boundary() -> None:


### PR DESCRIPTION
## Summary
  - Trim the native TUI active transcript window after resuming long histories while preserving full
  session history.
  - Add regression coverage for long transcript input echo and Working timer frames at mode, perf
  probe, and FakeTerminalPort layers.
  - Emit TUI render/resume diagnostics for render frame timings, operation class, logical line
  counts, and resume trimming.

  ## Test Plan
  - `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_mode.py
  tests/coding/test_native_coding_tui_perf_probe.py tests/coding/test_native_coding_tui_app.py
  tests/coding/test_native_coding_tui_terminal_playback.py tests/tui/test_render_loop.py -q`
  - `uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/mode.py src/loushang/tui/
  runtime.py tests/coding/test_native_coding_tui_mode.py tests/coding/
  test_native_coding_tui_terminal_playback.py tests/coding/test_native_coding_tui_perf_probe.py
  tests/tui/test_render_loop.py`

  Fixes #1

Refs #1