### PR TITLE
Add native TUI playback regression harness

### DIFF
--- a/docs/testing/native-tui-playback.md
+++ b/docs/testing/native-tui-playback.md
@@ -1,0 +1,24 @@
+# Native TUI Playback Regression Tests
+
+Use `tests/coding/native_tui_playback.py` when a native TUI change can affect terminal behavior, not just pure component rendering.
+
+Good candidates include:
+
+- composer input echo
+- Working timer frames
+- streaming updates
+- completion open and close
+- overlay and surface interactions
+- viewport or cursor positioning
+- long transcript resume behavior
+
+Prefer focused component tests for pure rendering functions. Use the playback harness when the test needs a `NativeCodingTuiApp`, `TuiRuntime`, and `FakeTerminalPort` together.
+
+Useful assertions:
+
+- `assert_no_clear(step)` for no `clear_screen` and no `clear_scrollback`
+- `assert_operation_class(step, "...")` for differential update expectations
+- `assert_visible_contains(text)` and `assert_visible_not_contains(text)` for visible terminal output
+- `assert_cursor_matches_diagnostics(step)` when cursor anchoring is part of the behavior
+
+Avoid broad snapshot-only tests. Prefer targeted assertions on terminal operations, diagnostics, visible text, and cursor/viewport invariants.

--- a/tests/coding/conftest.py
+++ b/tests/coding/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HELPER_DIR = Path(__file__).resolve().parent
+if str(_HELPER_DIR) not in sys.path:
+    sys.path.insert(0, str(_HELPER_DIR))

--- a/tests/coding/native_tui_playback.py
+++ b/tests/coding/native_tui_playback.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loushang.coding.ui.native_app import NativeCodingTuiApp
+from loushang.tui import (
+    FakeTerminalPort,
+    PlaybackStep,
+    RenderLoop,
+    TerminalOperation,
+    TerminalSize,
+    TuiRuntime,
+    strip_control_sequences,
+)
+
+
+@dataclass(slots=True)
+class NativeTuiScenario:
+    width: int = 80
+    height: int = 24
+    model_label: str = "kimi"
+    cwd: str = "/repo"
+    branch: str | None = "main"
+    session_label: str = "abcd"
+    now: float = 0.0
+    app: NativeCodingTuiApp = field(init=False)
+    port: FakeTerminalPort = field(init=False)
+    runtime: TuiRuntime = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.app = NativeCodingTuiApp(
+            model_label=self.model_label,
+            cwd=self.cwd,
+            branch=self.branch,
+            session_label=self.session_label,
+            now=lambda: self.now,
+        )
+        self.port = FakeTerminalPort(size=TerminalSize(columns=self.width, rows=self.height))
+        self.runtime = TuiRuntime(render_loop=RenderLoop(self.app), terminal=self.port)
+
+    def render(self) -> PlaybackStep:
+        return self.runtime.render_now()
+
+    def type_text(self, text: str) -> NativeTuiScenario:
+        self.app.composer.set_text(text)
+        return self
+
+    def advance_time(self, seconds: float) -> NativeTuiScenario:
+        self.now += seconds
+        return self
+
+    def visible_text(self) -> str:
+        return strip_control_sequences("\n".join(self.port.screen.visible_lines))
+
+    def assert_visible_contains(self, text: str) -> None:
+        assert text in self.visible_text()
+
+    def assert_visible_not_contains(self, text: str) -> None:
+        assert text not in self.visible_text()
+
+    def assert_operation_class(self, step: PlaybackStep, expected: str) -> None:
+        step.assert_operation_class(expected)
+
+    def assert_no_clear(self, step: PlaybackStep) -> None:
+        step.assert_no_clear_scrollback()
+        assert TerminalOperation.clear_screen() not in step.diagnostics.operations
+
+    def assert_cursor_matches_diagnostics(self, step: PlaybackStep) -> None:
+        assert step.frame is not None
+        assert step.frame.screen_after.cursor_row == step.diagnostics.hardware_cursor_row
+        assert step.frame.screen_after.cursor_column == step.diagnostics.hardware_cursor_column

--- a/tests/coding/test_native_coding_tui_terminal_playback.py
+++ b/tests/coding/test_native_coding_tui_terminal_playback.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from io import StringIO
 
+from native_tui_playback import NativeTuiScenario
+
 from loushang.coding.ui.native_app import NativeCodingTuiApp
 from loushang.coding.ui.native_input import NativeInputRouter
 from loushang.coding.ui.native_loop import _finish_tui_exit
@@ -332,15 +334,15 @@ def test_native_coding_tui_starts_below_existing_shell_output() -> None:
 
 
 def test_native_coding_tui_renders_pending_steer_and_followup_below_working_line() -> None:
-    app = _app()
-    runtime, port = _runtime(app, width=140, height=16)
+    scenario = NativeTuiScenario(width=140, height=16, now=3.0)
+    app = scenario.app
 
     app.start_prompt("current task", started_at=0.0)
     app.queue_steer("steer now")
     app.queue_followup("next prompt")
-    runtime.render_now()
+    scenario.render()
 
-    visible_lines = tuple(line.rstrip() for line in port.screen.visible_lines)
+    visible_lines = tuple(line.rstrip() for line in scenario.port.screen.visible_lines)
     working_index = next(index for index, line in enumerate(visible_lines) if "Working" in line)
     steer_index = visible_lines.index("• Messages to be submitted after next tool call (press esc to interrupt and send immediately)")
     followup_index = visible_lines.index("• Queued follow-up inputs")
@@ -353,49 +355,42 @@ def test_native_coding_tui_renders_pending_steer_and_followup_below_working_line
 
 
 def test_native_coding_tui_resumed_long_transcript_input_echo_uses_bounded_fake_terminal_update() -> None:
-    app = _app()
+    scenario = NativeTuiScenario(width=100, height=30, now=3.0)
+    app = scenario.app
     app.replace_transcript_window(
         build_synthetic_long_transcript_records(turns=180, tail_tool_output_lines=2400),
         reason="resume",
     )
     app.trim_active_transcript_window()
-    runtime, port = _runtime(app, width=100, height=30)
 
-    first = runtime.render_now()
-    app.composer.set_text("x")
-    step = runtime.render_now()
+    first = scenario.render()
+    step = scenario.type_text("x").render()
 
     assert len(first.diagnostics.current_logical_lines) <= 380
     assert len(step.diagnostics.current_logical_lines) <= 380
-    step.assert_operation_class("changed_range_update")
-    step.assert_no_clear_scrollback()
-    assert TerminalOperation.clear_screen() not in step.diagnostics.operations
-    assert step.frame is not None
-    assert any(line.rstrip() == "› x" for line in port.screen.visible_lines)
+    scenario.assert_operation_class(step, "changed_range_update")
+    scenario.assert_no_clear(step)
+    scenario.assert_visible_contains("› x")
 
 
 def test_native_coding_tui_resumed_long_transcript_working_timer_uses_bounded_fake_terminal_update() -> None:
-    app = _app()
-    app.now = lambda: 0.0
+    scenario = NativeTuiScenario(width=100, height=30, now=0.0)
+    app = scenario.app
     app.replace_transcript_window(
         build_synthetic_long_transcript_records(turns=180, tail_tool_output_lines=2400),
         reason="resume",
     )
     app.trim_active_transcript_window()
     app.begin_run(started_at=0.0)
-    runtime, port = _runtime(app, width=100, height=30)
 
-    first = runtime.render_now()
-    app.now = lambda: 0.2
-    step = runtime.render_now()
+    first = scenario.render()
+    step = scenario.advance_time(0.2).render()
 
     assert len(first.diagnostics.current_logical_lines) <= 380
     assert len(step.diagnostics.current_logical_lines) <= 380
-    step.assert_operation_class("changed_range_update")
-    step.assert_no_clear_scrollback()
-    assert TerminalOperation.clear_screen() not in step.diagnostics.operations
-    assert step.frame is not None
-    assert "Working 0.20s" in _visible_text(port)
+    scenario.assert_operation_class(step, "changed_range_update")
+    scenario.assert_no_clear(step)
+    scenario.assert_visible_contains("Working 0.20s")
 
 
 def _app() -> NativeCodingTuiApp:

--- a/tests/coding/test_native_tui_playback_harness.py
+++ b/tests/coding/test_native_tui_playback_harness.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from native_tui_playback import NativeTuiScenario
+
+
+def test_native_tui_scenario_renders_composer_input_without_screen_clear() -> None:
+    scenario = NativeTuiScenario(width=80, height=18)
+    scenario.render()
+
+    step = scenario.type_text("hello").render()
+
+    scenario.assert_operation_class(step, "changed_range_update")
+    scenario.assert_no_clear(step)
+    scenario.assert_visible_contains("› hello")
+    scenario.assert_cursor_matches_diagnostics(step)


### PR DESCRIPTION
## Summary
  - Add a reusable `NativeTuiScenario` helper for native TUI playback tests using
  `FakeTerminalPort`.
  - Convert representative native terminal playback regressions to use the helper.
  - Document when to use the native TUI playback harness and which terminal behaviors to assert.

  ## Test Plan
  - `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/
  test_native_coding_tui_terminal_playback.py tests/coding/test_native_tui_playback_harness.py
  tests/coding/test_native_coding_tui_mode.py tests/tui/test_render_loop.py -q`
  - `uv --cache-dir .uv-cache run ruff check tests/coding/
  test_native_coding_tui_terminal_playback.py tests/coding/test_native_tui_playback_harness.py
  tests/coding/native_tui_playback.py tests/coding/conftest.py`

  Refs #3