### PR TITLE
Fix native TUI pending steer execution on interrupt

### DIFF
--- a/src/loushang/coding/ui/native_loop.py
+++ b/src/loushang/coding/ui/native_loop.py
@@ -136,6 +136,12 @@ async def run_native_coding_tui(
                         active_task = None
                         active_prompt_started_at = None
                         runtime.render_now()
+                        if handle_steer is not None:
+                            await _run_interrupt_pending_steer(
+                                app=app,
+                                handle_steer=handle_steer,
+                                runtime=runtime,
+                            )
                         continue
                     if result.prompt_text is not None:
                         active_prompt_started_at = app.state.active_started_at
@@ -397,6 +403,22 @@ async def _run_text_handler(
 ) -> int | None:
     result = await _call_text_handler(handler, text, images=images)
     return result if isinstance(result, int) else None
+
+
+async def _run_interrupt_pending_steer(
+    *,
+    app: NativeCodingTuiApp,
+    handle_steer: TextHandler,
+    runtime: TuiRuntime,
+) -> None:
+    if not app.state.pending_steers:
+        return
+    pending_steer = app.state.pending_steers.pop(0)
+    app.composer.clear()
+    try:
+        await _run_text_handler(handle_steer, pending_steer)
+    finally:
+        runtime.render_now()
 
 
 async def _call_text_handler(

--- a/src/loushang/coding/ui/native_loop.py
+++ b/src/loushang/coding/ui/native_loop.py
@@ -65,6 +65,7 @@ async def run_native_coding_tui(
     mode_factory = terminal_mode_factory or (lambda input_stream, output_stream: TerminalSession(stdin=input_stream, stdout=output_stream))
     active_task: asyncio.Task[int | None] | None = None
     active_prompt_started_at: float | None = None
+    queued_steers_while_running: list[str] = []
     render_wakeup = asyncio.Event()
     previous_render_requester = app.render_requester
     previous_terminal_diagnostics_provider = app.terminal_diagnostics_provider
@@ -92,6 +93,7 @@ async def run_native_coding_tui(
                     )
                     active_task = None
                     active_prompt_started_at = None
+                    queued_steers_while_running = []
                     runtime.render_now()
                     if exit_code is not None:
                         return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=exit_code)
@@ -132,6 +134,8 @@ async def run_native_coding_tui(
                         runtime.render_now()
                         return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=result.exit_code)
                     if result.abort_requested:
+                        queued_steers_before_abort = tuple(queued_steers_while_running)
+                        queued_steers_while_running = []
                         await _abort_active(app=app, active_task=active_task, on_abort=on_abort)
                         active_task = None
                         active_prompt_started_at = None
@@ -141,6 +145,7 @@ async def run_native_coding_tui(
                                 app=app,
                                 handle_steer=handle_steer,
                                 runtime=runtime,
+                                queued_steers_while_running=queued_steers_before_abort,
                             )
                         continue
                     if result.prompt_text is not None:
@@ -148,13 +153,17 @@ async def run_native_coding_tui(
                         active_task = asyncio.create_task(
                             _run_prompt_handler(handle_prompt, result.prompt_text, images=result.prompt_images)
                         )
+                        queued_steers_while_running = []
                     if result.local_text is not None and handle_local is not None:
                         exit_code = await _run_text_handler(handle_local, result.local_text)
                         if exit_code is not None:
                             runtime.render_now()
                             return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=exit_code)
                     if result.steer_text is not None and handle_steer is not None:
+                        was_running = active_task is not None
                         exit_code = await _run_text_handler(handle_steer, result.steer_text, images=result.steer_images)
+                        if was_running:
+                            queued_steers_while_running.append(result.steer_text)
                         if exit_code is not None:
                             runtime.render_now()
                             return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=exit_code)
@@ -410,15 +419,51 @@ async def _run_interrupt_pending_steer(
     app: NativeCodingTuiApp,
     handle_steer: TextHandler,
     runtime: TuiRuntime,
+    queued_steers_while_running: tuple[str, ...] = (),
 ) -> None:
-    if not app.state.pending_steers:
+    _remove_running_steers_from_pending_tail(
+        app.state.pending_steers,
+        queued_steers_while_running=queued_steers_while_running,
+    )
+    if app.state.pending_steers:
+        pending_steer = app.state.pending_steers.pop(0)
+    elif queued_steers_while_running:
+        pending_steer = queued_steers_while_running[0]
+    else:
         return
-    pending_steer = app.state.pending_steers.pop(0)
     app.composer.clear()
     try:
         await _run_text_handler(handle_steer, pending_steer)
     finally:
         runtime.render_now()
+
+
+def _remove_running_steers_from_pending_tail(
+    pending_steers: list[str],
+    *,
+    queued_steers_while_running: tuple[str, ...],
+) -> None:
+    if not pending_steers or not queued_steers_while_running:
+        return
+
+    pending_steers_len = len(pending_steers)
+    queue_len = len(queued_steers_while_running)
+    if pending_steers_len <= queue_len:
+        return
+
+    remove_count = 0
+    index = queue_len - 1
+    while remove_count < queue_len and remove_count < pending_steers_len:
+        if pending_steers[-1] == queued_steers_while_running[index]:
+            pending_steers.pop()
+            remove_count += 1
+            index -= 1
+            continue
+        break
+
+    # Keep the existing function intentionally conservative:
+    # only strip running submissions from the tail when we can preserve at least
+    # one non-running pending steer for immediate execution.
 
 
 async def _call_text_handler(

--- a/tests/coding/test_native_coding_tui_loop.py
+++ b/tests/coding/test_native_coding_tui_loop.py
@@ -528,6 +528,121 @@ def test_native_loop_executes_queued_steer_after_running_escape() -> None:
     assert steers == ["follow"]
 
 
+def test_native_loop_ignores_running_steer_duplicate_on_interrupt() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_loop import run_native_coding_tui
+
+    stdout = StringIO()
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5, 11.0]))
+    steers: list[str] = []
+
+    async def handle_prompt(_text: str) -> int | None:
+        await asyncio.Event().wait()
+        return None
+
+    async def handle_steer(text: str) -> int | None:
+        steers.append(text)
+        return None
+
+    result = asyncio.run(
+        run_native_coding_tui(
+            app=app,
+            stdin=StringIO("start\rfollow\x1b"),
+            stdout=stdout,
+            handle_prompt=handle_prompt,
+            handle_steer=handle_steer,
+            on_abort=lambda: None,
+            should_exit=lambda text: text in {"/quit", "/exit"},
+        )
+    )
+
+    assert result == 0
+    assert steers == ["follow"]
+
+
+def test_native_loop_abort_uses_preexisting_pending_steer_before_running_steer() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_loop import run_native_coding_tui
+
+    stdout = StringIO()
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5, 11.0]))
+    app.state.pending_steers.append("预先排队")
+    steers: list[str] = []
+
+    async def handle_prompt(_text: str) -> int | None:
+        await asyncio.Event().wait()
+        return None
+
+    async def handle_steer(text: str) -> int | None:
+        steers.append(text)
+        return None
+
+    result = asyncio.run(
+        run_native_coding_tui(
+            app=app,
+            stdin=StringIO("start\rfollow\x1b"),
+            stdout=stdout,
+            handle_prompt=handle_prompt,
+            handle_steer=handle_steer,
+            on_abort=lambda: None,
+            should_exit=lambda text: text in {"/quit", "/exit"},
+        )
+    )
+
+    assert result == 0
+    assert steers == ["follow", "预先排队"]
+    assert app.state.pending_steers == []
+
+
+def test_remove_running_steers_from_pending_tail_preserves_preexisting_queue() -> None:
+    from loushang.coding.ui.native_loop import _remove_running_steers_from_pending_tail
+
+    pending_steers = ["预先", "follow"]
+    _remove_running_steers_from_pending_tail(pending_steers, queued_steers_while_running=("follow",))
+
+    assert pending_steers == ["预先"]
+
+
+def test_remove_running_steers_from_pending_tail_keeps_running_only_queue() -> None:
+    from loushang.coding.ui.native_loop import _remove_running_steers_from_pending_tail
+
+    pending_steers = ["follow"]
+    _remove_running_steers_from_pending_tail(pending_steers, queued_steers_while_running=("follow",))
+
+    assert pending_steers == ["follow"]
+
+
+def test_run_interrupt_pending_steer_uses_running_steer_when_local_queue_empty() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_loop import _run_interrupt_pending_steer
+
+    class _Runtime:
+        def __init__(self) -> None:
+            self.rendered = False
+
+        def render_now(self) -> None:
+            self.rendered = True
+
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd")
+    runs: list[str] = []
+    runtime = _Runtime()
+
+    async def handle_steer(text: str) -> None:
+        runs.append(text)
+
+    asyncio.run(
+        _run_interrupt_pending_steer(
+            app=app,
+            handle_steer=handle_steer,
+            runtime=runtime,
+            queued_steers_while_running=("你好",),
+        )
+    )
+
+    assert runs == ["你好"]
+    assert runtime.rendered
+
+
 def test_native_loop_renders_streaming_updates_without_waiting_for_keyboard() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_loop import run_native_coding_tui

--- a/tests/coding/test_native_coding_tui_loop.py
+++ b/tests/coding/test_native_coding_tui_loop.py
@@ -495,6 +495,39 @@ def test_native_loop_dispatches_pending_steer_from_escape_when_idle() -> None:
     assert steers == ["你好"]
 
 
+def test_native_loop_executes_queued_steer_after_running_escape() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_loop import run_native_coding_tui
+
+    stdout = StringIO()
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5, 11.0]))
+    app.state.pending_steers.append("follow")
+    steers: list[str] = []
+
+    async def handle_prompt(_text: str) -> int | None:
+        await asyncio.Event().wait()
+        return None
+
+    async def handle_steer(text: str) -> int | None:
+        steers.append(text)
+        return None
+
+    result = asyncio.run(
+        run_native_coding_tui(
+            app=app,
+            stdin=StringIO("开始\r\x1b"),
+            stdout=stdout,
+            handle_prompt=handle_prompt,
+            handle_steer=handle_steer,
+            on_abort=lambda: None,
+            should_exit=lambda text: text in {"/quit", "/exit"},
+        )
+    )
+
+    assert result == 0
+    assert steers == ["follow"]
+
+
 def test_native_loop_renders_streaming_updates_without_waiting_for_keyboard() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_loop import run_native_coding_tui

--- a/tests/coding/test_native_coding_tui_loop.py
+++ b/tests/coding/test_native_coding_tui_loop.py
@@ -593,7 +593,6 @@ def test_native_loop_abort_uses_preexisting_pending_steer_before_running_steer()
     assert steers == ["follow", "预先排队"]
     assert app.state.pending_steers == []
 
-
 def test_remove_running_steers_from_pending_tail_preserves_preexisting_queue() -> None:
     from loushang.coding.ui.native_loop import _remove_running_steers_from_pending_tail
 
@@ -610,6 +609,17 @@ def test_remove_running_steers_from_pending_tail_keeps_running_only_queue() -> N
     _remove_running_steers_from_pending_tail(pending_steers, queued_steers_while_running=("follow",))
 
     assert pending_steers == ["follow"]
+
+
+def test_remove_running_steers_from_pending_tail_removes_matching_suffix() -> None:
+    from loushang.coding.ui.native_loop import _remove_running_steers_from_pending_tail
+
+    pending_steers = ["pre", "follow", "hello"]
+    _remove_running_steers_from_pending_tail(
+        pending_steers, queued_steers_while_running=("follow", "hello")
+    )
+
+    assert pending_steers == ["pre"]
 
 
 def test_run_interrupt_pending_steer_uses_running_steer_when_local_queue_empty() -> None:


### PR DESCRIPTION
  ## Summary
  - Execute queued steer input when ESC interrupts a running native TUI turn.
  - Guard pending-steer selection against queue sync churn during interruption.
  - Avoid duplicate pending steer execution after interrupt recovery.

  ## Test Plan
  - `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_loop.py
  tests/coding/test_native_coding_tui_input.py tests/coding/
  test_native_coding_tui_terminal_playback.py tests/coding/test_native_coding_tui_perf_probe.py
  tests/coding/test_ui_controller.py tests/tui/test_render_loop.py tests/tui/test_input_routing.py
  -q`
  - Manual smoke: start a long-running TUI response, submit a queued steer while running, press ESC,
  verify only one queued steer is executed and the TUI returns to idle cleanly.

  Refs #5