### PR TITLE
Submit pending steer as fresh TUI turn after interrupt

### DIFF
--- a/src/loushang/coding/ui/controller.py
+++ b/src/loushang/coding/ui/controller.py
@@ -123,6 +123,9 @@ class CodingUiController:
                 traceback_text=traceback.format_exc() if self.verbose else None,
             )
 
+    async def wait_for_idle(self) -> None:
+        await _call_if_available(self.session, "wait_for_idle")
+
     async def _prompt(self, text: str, images: tuple[ImagePart, ...] | list[ImagePart] | None = None) -> None:
         method = getattr(self.session, "prompt", None)
         if not callable(method):

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -259,6 +259,7 @@ def _native_text_handler(
 def _native_abort_handler(controller: CodingUiController):
     async def handle() -> None:
         await controller.dispatch(AbortIntent())
+        await controller.wait_for_idle()
 
     return handle
 

--- a/src/loushang/coding/ui/native_app.py
+++ b/src/loushang/coding/ui/native_app.py
@@ -112,6 +112,10 @@ class NativeCodingTuiApp:
         self.composer.add_history(text)
         self.composer.clear()
 
+    def start_pending_prompt(self, text: str, *, started_at: float | None = None) -> None:
+        self.state.start_prompt(text, started_at=self.now() if started_at is None else started_at)
+        self.composer.add_history(text)
+
     def begin_run(self, *, started_at: float | None = None) -> None:
         self.state.begin_run(started_at=self.now() if started_at is None else started_at)
 

--- a/src/loushang/coding/ui/native_input.py
+++ b/src/loushang/coding/ui/native_input.py
@@ -165,8 +165,6 @@ class NativeInputRouter:
             return NativeInputResult(abort_requested=True)
         if self.app.state.pending_steers:
             pending_steer = self.app.state.pending_steers.pop(0)
-            self.app.composer.clear()
-            self._clear_prompt_attachments()
             return NativeInputResult(steer_text=pending_steer)
         if self.app.composer.value:
             self.app.composer.clear()

--- a/src/loushang/coding/ui/native_loop.py
+++ b/src/loushang/coding/ui/native_loop.py
@@ -140,8 +140,9 @@ async def run_native_coding_tui(
                         active_task = None
                         active_prompt_started_at = None
                         runtime.render_now()
-                        if interrupt_pending_steer is not None and handle_steer is not None:
-                            active_task = asyncio.create_task(_run_text_handler(handle_steer, interrupt_pending_steer))
+                        if interrupt_pending_steer is not None:
+                            app.start_pending_prompt(interrupt_pending_steer)
+                            active_task = asyncio.create_task(_run_prompt_handler(handle_prompt, interrupt_pending_steer))
                             active_prompt_started_at = app.state.active_started_at
                             runtime.render_now()
                         continue
@@ -375,13 +376,15 @@ async def _abort_active(
     active_task: asyncio.Task[int | None] | None,
     on_abort: AbortHandler,
 ) -> None:
+    await _maybe_await(on_abort())
     if active_task is not None and not active_task.done():
         active_task.cancel()
         try:
             await active_task
         except asyncio.CancelledError:
             pass
-    await _maybe_await(on_abort())
+    elif active_task is not None:
+        await active_task
     app.state.abort(message="Conversation interrupted - tell the model what to do differently.", elapsed_seconds=app.elapsed_seconds())
 
 
@@ -415,7 +418,6 @@ def _pop_interrupt_pending_steer(app: NativeCodingTuiApp) -> str | None:
     if not app.state.pending_steers:
         return None
     pending_steer = app.state.pending_steers.pop(0)
-    app.composer.clear()
     return pending_steer
 
 

--- a/src/loushang/coding/ui/native_loop.py
+++ b/src/loushang/coding/ui/native_loop.py
@@ -134,19 +134,16 @@ async def run_native_coding_tui(
                         runtime.render_now()
                         return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=result.exit_code)
                     if result.abort_requested:
-                        queued_steers_before_abort = tuple(queued_steers_while_running)
                         queued_steers_while_running = []
+                        interrupt_pending_steer = _pop_interrupt_pending_steer(app)
                         await _abort_active(app=app, active_task=active_task, on_abort=on_abort)
                         active_task = None
                         active_prompt_started_at = None
                         runtime.render_now()
-                        if handle_steer is not None:
-                            await _run_interrupt_pending_steer(
-                                app=app,
-                                handle_steer=handle_steer,
-                                runtime=runtime,
-                                queued_steers_while_running=queued_steers_before_abort,
-                            )
+                        if interrupt_pending_steer is not None and handle_steer is not None:
+                            active_task = asyncio.create_task(_run_text_handler(handle_steer, interrupt_pending_steer))
+                            active_prompt_started_at = app.state.active_started_at
+                            runtime.render_now()
                         continue
                     if result.prompt_text is not None:
                         active_prompt_started_at = app.state.active_started_at
@@ -414,56 +411,12 @@ async def _run_text_handler(
     return result if isinstance(result, int) else None
 
 
-async def _run_interrupt_pending_steer(
-    *,
-    app: NativeCodingTuiApp,
-    handle_steer: TextHandler,
-    runtime: TuiRuntime,
-    queued_steers_while_running: tuple[str, ...] = (),
-) -> None:
-    _remove_running_steers_from_pending_tail(
-        app.state.pending_steers,
-        queued_steers_while_running=queued_steers_while_running,
-    )
-    if app.state.pending_steers:
-        pending_steer = app.state.pending_steers.pop(0)
-    elif queued_steers_while_running:
-        pending_steer = queued_steers_while_running[0]
-    else:
-        return
+def _pop_interrupt_pending_steer(app: NativeCodingTuiApp) -> str | None:
+    if not app.state.pending_steers:
+        return None
+    pending_steer = app.state.pending_steers.pop(0)
     app.composer.clear()
-    try:
-        await _run_text_handler(handle_steer, pending_steer)
-    finally:
-        runtime.render_now()
-
-
-def _remove_running_steers_from_pending_tail(
-    pending_steers: list[str],
-    *,
-    queued_steers_while_running: tuple[str, ...],
-) -> None:
-    if not pending_steers or not queued_steers_while_running:
-        return
-
-    pending_steers_len = len(pending_steers)
-    queue_len = len(queued_steers_while_running)
-    if pending_steers_len <= queue_len:
-        return
-
-    remove_count = 0
-    index = queue_len - 1
-    while remove_count < queue_len and remove_count < pending_steers_len:
-        if pending_steers[-1] == queued_steers_while_running[index]:
-            pending_steers.pop()
-            remove_count += 1
-            index -= 1
-            continue
-        break
-
-    # Keep the existing function intentionally conservative:
-    # only strip running submissions from the tail when we can preserve at least
-    # one non-running pending steer for immediate execution.
+    return pending_steer
 
 
 async def _call_text_handler(

--- a/tests/coding/native_tui_playback.py
+++ b/tests/coding/native_tui_playback.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import asyncio
+import os
+import threading
+import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from io import StringIO
 
 from loushang.coding.ui.native_app import NativeCodingTuiApp
+from loushang.coding.ui.native_loop import run_native_coding_tui
 from loushang.tui import (
     FakeTerminalPort,
     PlaybackStep,
@@ -12,6 +19,9 @@ from loushang.tui import (
     TuiRuntime,
     strip_control_sequences,
 )
+
+NativeTuiHandler = Callable[..., Awaitable[int | None] | int | None]
+NativeTuiAbortHandler = Callable[[], Awaitable[object] | object]
 
 
 @dataclass(slots=True)
@@ -69,3 +79,105 @@ class NativeTuiScenario:
         assert step.frame is not None
         assert step.frame.screen_after.cursor_row == step.diagnostics.hardware_cursor_row
         assert step.frame.screen_after.cursor_column == step.diagnostics.hardware_cursor_column
+
+
+@dataclass(frozen=True, slots=True)
+class NativeTuiLoopPlaybackResult:
+    exit_code: int
+    output: str
+    app: NativeCodingTuiApp
+
+    @property
+    def text(self) -> str:
+        return strip_control_sequences(self.output)
+
+
+@dataclass(slots=True)
+class NativeTuiLoopPlayback:
+    width: int = 80
+    height: int = 24
+    model_label: str = "kimi"
+    cwd: str = "/repo"
+    branch: str | None = "main"
+    session_label: str = "abcd"
+    now: float = 10.0
+    app: NativeCodingTuiApp = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.app = NativeCodingTuiApp(
+            model_label=self.model_label,
+            cwd=self.cwd,
+            branch=self.branch,
+            session_label=self.session_label,
+            now=lambda: self.now,
+        )
+
+    def run(
+        self,
+        *chunks: tuple[float, str],
+        handle_prompt: NativeTuiHandler | None = None,
+        handle_local: NativeTuiHandler | None = None,
+        handle_steer: NativeTuiHandler | None = None,
+        handle_followup: NativeTuiHandler | None = None,
+        on_abort: NativeTuiAbortHandler | None = None,
+        should_exit: Callable[[str], bool] | None = None,
+        is_local_command: Callable[[str], bool] | None = None,
+        terminal_mode_factory: Callable[..., object] | None = None,
+    ) -> NativeTuiLoopPlaybackResult:
+        stdout = StringIO()
+        stdin = _TimedTtyChunkInput(*chunks) if chunks else StringIO("")
+        exit_code = asyncio.run(
+            run_native_coding_tui(
+                app=self.app,
+                stdin=stdin,
+                stdout=stdout,
+                handle_prompt=handle_prompt or (lambda _text: None),
+                handle_local=handle_local,
+                handle_steer=handle_steer,
+                handle_followup=handle_followup,
+                terminal_mode_factory=terminal_mode_factory or (lambda _stdin, _stdout: _NoTerminalMode()),
+                on_abort=on_abort or (lambda: None),
+                should_exit=should_exit or (lambda text: text in {"/quit", "/exit"}),
+                is_local_command=is_local_command,
+            )
+        )
+        return NativeTuiLoopPlaybackResult(exit_code=exit_code, output=stdout.getvalue(), app=self.app)
+
+
+class _NoTerminalMode:
+    def __enter__(self) -> "_NoTerminalMode":
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+
+class _TimedTtyChunkInput:
+    def __init__(self, *chunks: tuple[float, str], block_seconds: float = 0.002) -> None:
+        self._start = time.perf_counter()
+        self._block_seconds = block_seconds
+        self._read_fd, write_fd = os.pipe()
+        self._closed = threading.Event()
+
+        def writer() -> None:
+            try:
+                for emit_at, chunk in chunks:
+                    while (remaining := emit_at - (time.perf_counter() - self._start)) > 0:
+                        time.sleep(min(self._block_seconds, remaining))
+                    if self._closed.is_set():
+                        break
+                    os.write(write_fd, chunk.encode())
+            finally:
+                os.close(write_fd)
+
+        self._writer = threading.Thread(target=writer, daemon=True)
+        self._writer.start()
+
+    def fileno(self) -> int:
+        return self._read_fd
+
+    def isatty(self) -> bool:
+        return True
+
+    def read(self, _size: int) -> str:
+        return ""

--- a/tests/coding/test_native_coding_tui_input.py
+++ b/tests/coding/test_native_coding_tui_input.py
@@ -65,7 +65,7 @@ def test_native_input_router_idle_interrupt_message_prefers_pending_steer() -> N
 
     assert result.steer_text == "你好"
     assert app.state.pending_steers == []
-    assert app.composer.value == ""
+    assert app.composer.value == "草稿"
 
 
 def test_native_input_router_running_alt_enter_queues_followup() -> None:

--- a/tests/coding/test_native_coding_tui_loop.py
+++ b/tests/coding/test_native_coding_tui_loop.py
@@ -436,8 +436,12 @@ def test_native_loop_dispatches_steer_and_followup_handlers() -> None:
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5]))
     steers: list[tuple[str, str]] = []
     followups: list[str] = []
+    prompts: list[str] = []
 
-    async def handle_prompt(_text: str) -> int | None:
+    async def handle_prompt(text: str) -> int | None:
+        if text != "start":
+            prompts.append(text)
+            return None
         app.begin_assistant()
         app.append_assistant_chunk("still running")
         await asyncio.Event().wait()
@@ -465,7 +469,8 @@ def test_native_loop_dispatches_steer_and_followup_handlers() -> None:
     )
 
     assert result == 0
-    assert steers == [("queue", "steer"), ("execute", "steer")]
+    assert steers == [("queue", "steer")]
+    assert prompts == ["steer"]
     assert followups == ["follow"]
 
 
@@ -476,6 +481,7 @@ def test_native_loop_dispatches_pending_steer_from_escape_when_idle() -> None:
     stdout = StringIO()
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 10.0)
     app.state.pending_steers.append("你好")
+    app.composer.set_text("draft")
     steers: list[str] = []
 
     async def handle_steer(text: str) -> int | None:
@@ -496,6 +502,7 @@ def test_native_loop_dispatches_pending_steer_from_escape_when_idle() -> None:
 
     assert result == 0
     assert steers == ["你好"]
+    assert app.composer.value == "draft"
 
 
 def test_native_loop_executes_queued_steer_after_running_escape() -> None:
@@ -505,14 +512,13 @@ def test_native_loop_executes_queued_steer_after_running_escape() -> None:
     stdout = StringIO()
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5, 11.0]))
     app.state.pending_steers.append("follow")
-    steers: list[str] = []
+    prompts: list[str] = []
 
-    async def handle_prompt(_text: str) -> int | None:
+    async def handle_prompt(text: str) -> int | None:
+        if text == "follow":
+            prompts.append(text)
+            return None
         await asyncio.Event().wait()
-        return None
-
-    async def handle_steer(text: str) -> int | None:
-        steers.append(text)
         return None
 
     result = asyncio.run(
@@ -521,14 +527,13 @@ def test_native_loop_executes_queued_steer_after_running_escape() -> None:
             stdin=StringIO("开始\r\x1b"),
             stdout=stdout,
             handle_prompt=handle_prompt,
-            handle_steer=handle_steer,
             on_abort=lambda: None,
             should_exit=lambda text: text in {"/quit", "/exit"},
         )
     )
 
     assert result == 0
-    assert steers == ["follow"]
+    assert prompts == ["follow"]
 
 
 def test_native_loop_executes_queued_steer_after_running_escape_with_delay() -> None:
@@ -544,17 +549,20 @@ def test_native_loop_executes_queued_steer_after_running_escape_with_delay() -> 
         now=_Clock([10.0, 10.5, 11.0]),
     )
     app.state.pending_steers.append("follow-up")
-    actions: list[tuple[str, str]] = []
+    prompts: list[str] = []
+    steers: list[str] = []
 
-    async def handle_prompt(_text: str) -> int | None:
+    async def handle_prompt(text: str) -> int | None:
+        if text == "follow-up":
+            prompts.append(text)
+            app.begin_assistant()
+            app.append_assistant_chunk(f"handled {text}")
+            return None
         await asyncio.Event().wait()
         return None
 
     async def handle_steer(text: str) -> int | None:
-        actions.append(("queue" if app.state.running else "execute", text))
-        if not app.state.running:
-            app.begin_assistant()
-            app.append_assistant_chunk(f"handled {text}")
+        steers.append(text)
         return None
 
     result = asyncio.run(
@@ -575,7 +583,8 @@ def test_native_loop_executes_queued_steer_after_running_escape_with_delay() -> 
     )
 
     assert result == 0
-    assert actions == [("queue", "follow"), ("execute", "follow-up")]
+    assert steers == ["follow"]
+    assert prompts == ["follow-up"]
 
 
 def test_native_loop_escape_runs_pending_steer_before_unsubmitted_composer_text() -> None:
@@ -591,14 +600,13 @@ def test_native_loop_escape_runs_pending_steer_before_unsubmitted_composer_text(
         now=_Clock([10.0, 10.5, 11.0]),
     )
     app.state.pending_steers.append("queued")
-    steers: list[str] = []
+    prompts: list[str] = []
 
-    async def handle_prompt(_text: str) -> int | None:
+    async def handle_prompt(text: str) -> int | None:
+        if text == "queued":
+            prompts.append(text)
+            return None
         await asyncio.Event().wait()
-        return None
-
-    async def handle_steer(text: str) -> int | None:
-        steers.append(text)
         return None
 
     result = asyncio.run(
@@ -611,7 +619,6 @@ def test_native_loop_escape_runs_pending_steer_before_unsubmitted_composer_text(
             ),
             stdout=stdout,
             handle_prompt=handle_prompt,
-            handle_steer=handle_steer,
             terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
             on_abort=lambda: None,
             should_exit=lambda text: text in {"/quit", "/exit"},
@@ -619,7 +626,8 @@ def test_native_loop_escape_runs_pending_steer_before_unsubmitted_composer_text(
     )
 
     assert result == 0
-    assert steers == ["queued"]
+    assert prompts == ["queued"]
+    assert app.composer.value == "draft"
 
 
 def test_native_loop_renders_pending_steer_stream_after_escape_interrupt() -> None:
@@ -636,16 +644,14 @@ def test_native_loop_renders_pending_steer_stream_after_escape_interrupt() -> No
     )
     app.state.pending_steers.append("queued")
 
-    async def handle_prompt(_text: str) -> int | None:
+    async def handle_prompt(text: str) -> int | None:
+        if text == "queued":
+            app.begin_assistant()
+            app.append_assistant_chunk("queued response")
+            await asyncio.sleep(0.03)
+            app.append_assistant_chunk(" done")
+            return None
         await asyncio.Event().wait()
-        return None
-
-    async def handle_steer(text: str) -> int | None:
-        assert text == "queued"
-        app.begin_assistant()
-        app.append_assistant_chunk("queued response")
-        await asyncio.sleep(0.03)
-        app.append_assistant_chunk(" done")
         return None
 
     result = asyncio.run(
@@ -654,7 +660,6 @@ def test_native_loop_renders_pending_steer_stream_after_escape_interrupt() -> No
             stdin=_TimedTtyChunkInput((0.0, "start\r"), (0.01, "\x1b"), (0.2, "")),
             stdout=stdout,
             handle_prompt=handle_prompt,
-            handle_steer=handle_steer,
             terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
             on_abort=lambda: None,
             should_exit=lambda text: text in {"/quit", "/exit"},
@@ -673,14 +678,18 @@ def test_native_loop_ignores_running_steer_duplicate_on_interrupt() -> None:
 
     stdout = StringIO()
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5, 11.0]))
-    actions: list[tuple[str, str]] = []
+    prompts: list[str] = []
+    steers: list[str] = []
 
-    async def handle_prompt(_text: str) -> int | None:
+    async def handle_prompt(text: str) -> int | None:
+        if text == "follow":
+            prompts.append(text)
+            return None
         await asyncio.Event().wait()
         return None
 
     async def handle_steer(text: str) -> int | None:
-        actions.append(("queue" if app.state.running else "execute", text))
+        steers.append(text)
         return None
 
     result = asyncio.run(
@@ -697,7 +706,8 @@ def test_native_loop_ignores_running_steer_duplicate_on_interrupt() -> None:
     )
 
     assert result == 0
-    assert actions == [("queue", "follow"), ("execute", "follow")]
+    assert steers == ["follow"]
+    assert prompts == ["follow"]
 
 
 def test_native_loop_abort_uses_first_pending_steer_before_running_steer() -> None:
@@ -707,14 +717,18 @@ def test_native_loop_abort_uses_first_pending_steer_before_running_steer() -> No
     stdout = StringIO()
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5, 11.0]))
     app.state.pending_steers.append("预先排队")
-    actions: list[tuple[str, str]] = []
+    prompts: list[str] = []
+    steers: list[str] = []
 
-    async def handle_prompt(_text: str) -> int | None:
+    async def handle_prompt(text: str) -> int | None:
+        if text == "预先排队":
+            prompts.append(text)
+            return None
         await asyncio.Event().wait()
         return None
 
     async def handle_steer(text: str) -> int | None:
-        actions.append(("queue" if app.state.running else "execute", text))
+        steers.append(text)
         return None
 
     result = asyncio.run(
@@ -731,8 +745,45 @@ def test_native_loop_abort_uses_first_pending_steer_before_running_steer() -> No
     )
 
     assert result == 0
-    assert actions == [("queue", "follow"), ("execute", "预先排队")]
+    assert steers == ["follow"]
+    assert prompts == ["预先排队"]
     assert app.state.pending_steers == ["follow"]
+
+
+def test_native_loop_waits_for_abort_settle_before_running_popped_pending_steer() -> None:
+    from native_tui_playback import NativeTuiLoopPlayback
+
+    from loushang.coding.ui.controller import CodingUiController
+    from loushang.coding.ui.mode import (
+        _native_abort_handler,
+        _native_prompt_handler,
+        _native_text_handler,
+    )
+
+    playback = NativeTuiLoopPlayback()
+    session = _AbortSettlingSession()
+    controller = CodingUiController(session=session)
+    fresh_prompt = "浪潮楼上平台介绍一下，只回答楼上平台，不要回答上一轮问题"
+
+    result = playback.run(
+        (0.0, "start\r"),
+        (0.01, f"{fresh_prompt}\r"),
+        (0.02, "\x1b"),
+        (0.12, ""),
+        handle_prompt=_native_prompt_handler(app=playback.app, controller=controller, stderr=StringIO(), verbose=False),
+        handle_steer=_native_text_handler(app=playback.app, dispatch=controller.steer, label="Steering failed"),
+        on_abort=_native_abort_handler(controller),
+    )
+
+    assert result.exit_code == 0
+    assert session.wait_for_idle_calls == 1
+    assert session.queued_while_streaming == [fresh_prompt]
+    assert session.prompt_calls == [
+        ("start", None, None),
+        (fresh_prompt, None, None),
+    ]
+    assert "Request cancelled" not in result.text
+
 
 def test_pop_interrupt_pending_steer_returns_none_when_queue_empty() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
@@ -846,6 +897,51 @@ class _ModelSurfaceSession:
 
     def get_available_model_details(self) -> list[object]:
         return []
+
+
+class _AbortSettlingSession:
+    def __init__(self) -> None:
+        self.is_streaming = False
+        self.prompt_calls: list[tuple[str, str | None, str | None]] = []
+        self.queued_while_streaming: list[str] = []
+        self.wait_for_idle_calls = 0
+        self._idle = asyncio.Event()
+        self._idle.set()
+
+    async def prompt(
+        self,
+        text: str,
+        *,
+        streaming_behavior: str | None = None,
+        source: str | None = None,
+    ) -> None:
+        if streaming_behavior == "steer" and self.is_streaming:
+            self.queued_while_streaming.append(text)
+            return
+        self.prompt_calls.append((text, streaming_behavior, source))
+        if text != "start":
+            return
+        self.is_streaming = True
+        self._idle.clear()
+        await self._idle.wait()
+
+    def abort(self) -> None:
+        async def settle() -> None:
+            await asyncio.sleep(0.03)
+            self.is_streaming = False
+            self._idle.set()
+
+        asyncio.create_task(settle())
+
+    def clear_queue(self) -> dict[str, list[str]]:
+        return {"steering": [], "follow_up": []}
+
+    def abort_bash(self) -> None:
+        return None
+
+    async def wait_for_idle(self) -> None:
+        self.wait_for_idle_calls += 1
+        await self._idle.wait()
 
 
 def _assert_exit_cleanup_clears_bottom_frame(raw_output: str) -> None:

--- a/tests/coding/test_native_coding_tui_loop.py
+++ b/tests/coding/test_native_coding_tui_loop.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import threading
 import time
 from io import StringIO
 from types import SimpleNamespace
@@ -326,11 +328,12 @@ def test_native_loop_escape_closes_model_surface_and_restores_prompt() -> None:
     result = asyncio.run(
         run_native_coding_tui(
             app=app,
-            stdin=_BlockingAfterScriptInput("/model\r\x1b"),
+            stdin=_TimedTtyChunkInput((0.0, "/model\r"), (0.01, "\x1b")),
             stdout=stdout,
             handle_prompt=lambda _text: None,
             handle_local=manager.handle_text,
             handle_surface_intent=manager.handle_surface_intent,
+            terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
             on_abort=lambda: None,
             should_exit=lambda text: text in {"/quit", "/exit"},
             is_local_command=manager.is_local_command,
@@ -431,7 +434,7 @@ def test_native_loop_dispatches_steer_and_followup_handlers() -> None:
 
     stdout = StringIO()
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5]))
-    steers: list[str] = []
+    steers: list[tuple[str, str]] = []
     followups: list[str] = []
 
     async def handle_prompt(_text: str) -> int | None:
@@ -441,7 +444,7 @@ def test_native_loop_dispatches_steer_and_followup_handlers() -> None:
         return None
 
     async def handle_steer(text: str) -> int | None:
-        steers.append(text)
+        steers.append(("queue" if app.state.running else "execute", text))
         return None
 
     async def handle_followup(text: str) -> int | None:
@@ -462,7 +465,7 @@ def test_native_loop_dispatches_steer_and_followup_handlers() -> None:
     )
 
     assert result == 0
-    assert steers == ["steer"]
+    assert steers == [("queue", "steer"), ("execute", "steer")]
     assert followups == ["follow"]
 
 
@@ -528,129 +531,227 @@ def test_native_loop_executes_queued_steer_after_running_escape() -> None:
     assert steers == ["follow"]
 
 
+def test_native_loop_executes_queued_steer_after_running_escape_with_delay() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_loop import run_native_coding_tui
+
+    stdout = StringIO()
+    app = NativeCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        now=_Clock([10.0, 10.5, 11.0]),
+    )
+    app.state.pending_steers.append("follow-up")
+    actions: list[tuple[str, str]] = []
+
+    async def handle_prompt(_text: str) -> int | None:
+        await asyncio.Event().wait()
+        return None
+
+    async def handle_steer(text: str) -> int | None:
+        actions.append(("queue" if app.state.running else "execute", text))
+        if not app.state.running:
+            app.begin_assistant()
+            app.append_assistant_chunk(f"handled {text}")
+        return None
+
+    result = asyncio.run(
+        run_native_coding_tui(
+            app=app,
+            stdin=_TimedTtyChunkInput(
+                (0.0, "start\r"),
+                (0.01, "follow\r"),
+                (0.02, "\x1b"),
+            ),
+            stdout=stdout,
+            handle_prompt=handle_prompt,
+            handle_steer=handle_steer,
+            terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
+            on_abort=lambda: None,
+            should_exit=lambda text: text in {"/quit", "/exit"},
+        )
+    )
+
+    assert result == 0
+    assert actions == [("queue", "follow"), ("execute", "follow-up")]
+
+
+def test_native_loop_escape_runs_pending_steer_before_unsubmitted_composer_text() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_loop import run_native_coding_tui
+
+    stdout = StringIO()
+    app = NativeCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        now=_Clock([10.0, 10.5, 11.0]),
+    )
+    app.state.pending_steers.append("queued")
+    steers: list[str] = []
+
+    async def handle_prompt(_text: str) -> int | None:
+        await asyncio.Event().wait()
+        return None
+
+    async def handle_steer(text: str) -> int | None:
+        steers.append(text)
+        return None
+
+    result = asyncio.run(
+        run_native_coding_tui(
+            app=app,
+            stdin=_TimedTtyChunkInput(
+                (0.0, "start\r"),
+                (0.01, "draft"),
+                (0.02, "\x1b"),
+            ),
+            stdout=stdout,
+            handle_prompt=handle_prompt,
+            handle_steer=handle_steer,
+            terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
+            on_abort=lambda: None,
+            should_exit=lambda text: text in {"/quit", "/exit"},
+        )
+    )
+
+    assert result == 0
+    assert steers == ["queued"]
+
+
+def test_native_loop_renders_pending_steer_stream_after_escape_interrupt() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_loop import run_native_coding_tui
+
+    stdout = StringIO()
+    app = NativeCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        now=_Clock([10.0, 10.5, 11.0, 11.2]),
+    )
+    app.state.pending_steers.append("queued")
+
+    async def handle_prompt(_text: str) -> int | None:
+        await asyncio.Event().wait()
+        return None
+
+    async def handle_steer(text: str) -> int | None:
+        assert text == "queued"
+        app.begin_assistant()
+        app.append_assistant_chunk("queued response")
+        await asyncio.sleep(0.03)
+        app.append_assistant_chunk(" done")
+        return None
+
+    result = asyncio.run(
+        run_native_coding_tui(
+            app=app,
+            stdin=_TimedTtyChunkInput((0.0, "start\r"), (0.01, "\x1b"), (0.2, "")),
+            stdout=stdout,
+            handle_prompt=handle_prompt,
+            handle_steer=handle_steer,
+            terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
+            on_abort=lambda: None,
+            should_exit=lambda text: text in {"/quit", "/exit"},
+        )
+    )
+
+    rendered = strip_control_sequences(stdout.getvalue())
+    assert result == 0
+    assert rendered.count("queued response") >= 2
+    assert "queued response done" in rendered
+
+
 def test_native_loop_ignores_running_steer_duplicate_on_interrupt() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_loop import run_native_coding_tui
 
     stdout = StringIO()
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5, 11.0]))
-    steers: list[str] = []
+    actions: list[tuple[str, str]] = []
 
     async def handle_prompt(_text: str) -> int | None:
         await asyncio.Event().wait()
         return None
 
     async def handle_steer(text: str) -> int | None:
-        steers.append(text)
+        actions.append(("queue" if app.state.running else "execute", text))
         return None
 
     result = asyncio.run(
         run_native_coding_tui(
             app=app,
-            stdin=StringIO("start\rfollow\x1b"),
+            stdin=_TimedTtyChunkInput((0.0, "start\r"), (0.01, "follow\r"), (0.02, "\x1b")),
             stdout=stdout,
             handle_prompt=handle_prompt,
             handle_steer=handle_steer,
+            terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
             on_abort=lambda: None,
             should_exit=lambda text: text in {"/quit", "/exit"},
         )
     )
 
     assert result == 0
-    assert steers == ["follow"]
+    assert actions == [("queue", "follow"), ("execute", "follow")]
 
 
-def test_native_loop_abort_uses_preexisting_pending_steer_before_running_steer() -> None:
+def test_native_loop_abort_uses_first_pending_steer_before_running_steer() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_loop import run_native_coding_tui
 
     stdout = StringIO()
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=_Clock([10.0, 10.5, 11.0]))
     app.state.pending_steers.append("预先排队")
-    steers: list[str] = []
+    actions: list[tuple[str, str]] = []
 
     async def handle_prompt(_text: str) -> int | None:
         await asyncio.Event().wait()
         return None
 
     async def handle_steer(text: str) -> int | None:
-        steers.append(text)
+        actions.append(("queue" if app.state.running else "execute", text))
         return None
 
     result = asyncio.run(
         run_native_coding_tui(
             app=app,
-            stdin=StringIO("start\rfollow\x1b"),
+            stdin=_TimedTtyChunkInput((0.0, "start\r"), (0.01, "follow\r"), (0.02, "\x1b")),
             stdout=stdout,
             handle_prompt=handle_prompt,
             handle_steer=handle_steer,
+            terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
             on_abort=lambda: None,
             should_exit=lambda text: text in {"/quit", "/exit"},
         )
     )
 
     assert result == 0
-    assert steers == ["follow", "预先排队"]
-    assert app.state.pending_steers == []
+    assert actions == [("queue", "follow"), ("execute", "预先排队")]
+    assert app.state.pending_steers == ["follow"]
 
-def test_remove_running_steers_from_pending_tail_preserves_preexisting_queue() -> None:
-    from loushang.coding.ui.native_loop import _remove_running_steers_from_pending_tail
-
-    pending_steers = ["预先", "follow"]
-    _remove_running_steers_from_pending_tail(pending_steers, queued_steers_while_running=("follow",))
-
-    assert pending_steers == ["预先"]
-
-
-def test_remove_running_steers_from_pending_tail_keeps_running_only_queue() -> None:
-    from loushang.coding.ui.native_loop import _remove_running_steers_from_pending_tail
-
-    pending_steers = ["follow"]
-    _remove_running_steers_from_pending_tail(pending_steers, queued_steers_while_running=("follow",))
-
-    assert pending_steers == ["follow"]
-
-
-def test_remove_running_steers_from_pending_tail_removes_matching_suffix() -> None:
-    from loushang.coding.ui.native_loop import _remove_running_steers_from_pending_tail
-
-    pending_steers = ["pre", "follow", "hello"]
-    _remove_running_steers_from_pending_tail(
-        pending_steers, queued_steers_while_running=("follow", "hello")
-    )
-
-    assert pending_steers == ["pre"]
-
-
-def test_run_interrupt_pending_steer_uses_running_steer_when_local_queue_empty() -> None:
+def test_pop_interrupt_pending_steer_returns_none_when_queue_empty() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
-    from loushang.coding.ui.native_loop import _run_interrupt_pending_steer
-
-    class _Runtime:
-        def __init__(self) -> None:
-            self.rendered = False
-
-        def render_now(self) -> None:
-            self.rendered = True
+    from loushang.coding.ui.native_loop import _pop_interrupt_pending_steer
 
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd")
-    runs: list[str] = []
-    runtime = _Runtime()
 
-    async def handle_steer(text: str) -> None:
-        runs.append(text)
+    assert _pop_interrupt_pending_steer(app) is None
 
-    asyncio.run(
-        _run_interrupt_pending_steer(
-            app=app,
-            handle_steer=handle_steer,
-            runtime=runtime,
-            queued_steers_while_running=("你好",),
-        )
-    )
 
-    assert runs == ["你好"]
-    assert runtime.rendered
+def test_pop_interrupt_pending_steer_uses_queue_fifo() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_loop import _pop_interrupt_pending_steer
+
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd")
+    app.state.pending_steers.extend(["预先排队", "follow"])
+
+    assert _pop_interrupt_pending_steer(app) == "预先排队"
+    assert app.state.pending_steers == ["follow"]
 
 
 def test_native_loop_renders_streaming_updates_without_waiting_for_keyboard() -> None:
@@ -658,7 +759,7 @@ def test_native_loop_renders_streaming_updates_without_waiting_for_keyboard() ->
     from loushang.coding.ui.native_loop import run_native_coding_tui
 
     stdout = StringIO()
-    stdin = _BlockingAfterScriptInput("go\r")
+    stdin = _TimedTtyChunkInput((0.0, "go\r"), (0.2, ""))
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd")
 
     async def handle_prompt(_text: str) -> int | None:
@@ -674,6 +775,7 @@ def test_native_loop_renders_streaming_updates_without_waiting_for_keyboard() ->
             stdin=stdin,
             stdout=stdout,
             handle_prompt=handle_prompt,
+            terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
             on_abort=lambda: None,
             should_exit=lambda text: text in {"/quit", "/exit"},
         )
@@ -690,7 +792,7 @@ def test_native_loop_wakes_stream_render_before_active_interval() -> None:
     from loushang.coding.ui.native_loop import run_native_coding_tui
 
     stdout = StringIO()
-    stdin = _BlockingAfterScriptInput("go\r")
+    stdin = _TimedTtyChunkInput((0.0, "go\r"), (0.1, ""))
     app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd")
 
     async def handle_prompt(_text: str) -> int | None:
@@ -706,6 +808,7 @@ def test_native_loop_wakes_stream_render_before_active_interval() -> None:
             stdin=stdin,
             stdout=stdout,
             handle_prompt=handle_prompt,
+            terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
             on_abort=lambda: None,
             should_exit=lambda text: text in {"/quit", "/exit"},
         )
@@ -769,3 +872,44 @@ class _BlockingAfterScriptInput:
 
     def isatty(self) -> bool:
         return False
+
+
+class _NoTerminalMode:
+    def __enter__(self) -> "_NoTerminalMode":
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+
+class _TimedTtyChunkInput:
+    def __init__(self, *chunks: tuple[float, str], block_seconds: float = 0.002) -> None:
+        self._start = time.perf_counter()
+        self._chunks = list(chunks)
+        self._block_seconds = block_seconds
+        self._read_fd, write_fd = os.pipe()
+        self._closed = threading.Event()
+
+        def writer() -> None:
+            try:
+                for emit_at, chunk in self._chunks:
+                    while (remaining := emit_at - (time.perf_counter() - self._start)) > 0:
+                        time.sleep(min(self._block_seconds, remaining))
+                    if self._closed.is_set():
+                        break
+                    os.write(write_fd, chunk.encode())
+            finally:
+                os.close(write_fd)
+
+        self._writer = threading.Thread(target=writer, daemon=True)
+        self._writer.start()
+
+    def fileno(self) -> int:
+        return self._read_fd
+
+    def isatty(self) -> bool:
+        return True
+
+    def read(self, _size: int) -> str:
+        # This stream is tty-like and read through the terminal reader path.
+        return ""

--- a/tests/coding/test_native_tui_playback_harness.py
+++ b/tests/coding/test_native_tui_playback_harness.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from native_tui_playback import NativeTuiScenario
+import asyncio
+
+from native_tui_playback import NativeTuiLoopPlayback, NativeTuiScenario
 
 
 def test_native_tui_scenario_renders_composer_input_without_screen_clear() -> None:
@@ -13,3 +15,39 @@ def test_native_tui_scenario_renders_composer_input_without_screen_clear() -> No
     scenario.assert_no_clear(step)
     scenario.assert_visible_contains("› hello")
     scenario.assert_cursor_matches_diagnostics(step)
+
+
+def test_native_tui_loop_playback_drives_running_steer_then_escape() -> None:
+    playback = NativeTuiLoopPlayback()
+    prompts: list[str] = []
+    steers: list[tuple[str, str]] = []
+
+    async def handle_prompt(text: str) -> None:
+        prompts.append(text)
+        if text == "change":
+            playback.app.begin_assistant()
+            playback.app.append_assistant_chunk("fresh change")
+            return
+        playback.app.begin_assistant()
+        playback.app.append_assistant_chunk("working")
+        await asyncio.Event().wait()
+
+    async def handle_steer(text: str) -> None:
+        steers.append(("queue" if playback.app.state.running else "execute", text))
+
+    result = playback.run(
+        (0.0, "go\r"),
+        (0.01, "change\r"),
+        (0.02, "\x1b"),
+        (0.06, ""),
+        handle_prompt=handle_prompt,
+        handle_steer=handle_steer,
+    )
+
+    assert result.exit_code == 0
+    assert prompts == ["go", "change"]
+    assert steers == [("queue", "change")]
+    assert "› go" in result.text
+    assert "› change" in result.text
+    assert "fresh change" in result.text
+    assert "Conversation interrupted" in result.text


### PR DESCRIPTION
## Summary
  - Submit pending steer input as a fresh native TUI turn after ESC interruption, instead of
  continuing the aborted turn.
  - Preserve composer draft text when ESC sends an existing pending steer.
  - Add native TUI loop playback coverage for running prompt, queued steer, ESC interrupt, idle
  settling, and fresh prompt execution.

  ## Test Plan
  - `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_loop.py
  tests/coding/test_native_tui_playback_harness.py tests/coding/test_native_coding_tui_playback.py
  tests/coding/test_native_coding_tui_input.py tests/coding/
  test_native_coding_tui_terminal_playback.py tests/coding/test_native_coding_tui_perf_probe.py
  tests/coding/test_ui_controller.py tests/tui/test_render_loop.py tests/tui/
  test_playback_harness.py tests/tui/test_input_routing.py -q`
  - `uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/native_app.py src/loushang/
  coding/ui/native_loop.py src/loushang/coding/ui/native_input.py src/loushang/coding/ui/
  controller.py src/loushang/coding/ui/mode.py tests/coding/test_native_coding_tui_loop.py tests/
  coding/test_native_coding_tui_input.py tests/coding/native_tui_playback.py tests/coding/
  test_native_tui_playback_harness.py`

  Refs #5
