### PR TITLE
feat: default interactive CLI startup to TUI

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -41,9 +41,9 @@ from loushang.coding.platform.output_guard import stdout_guard
 from loushang.coding.plugin import PluginManager
 from loushang.coding.plugin.lifecycle import is_remote_plugin_source
 from loushang.coding.policy import (
-    InteractiveApprovalResolver,
-    HeadlessApprovalResolver,
     ApprovalResolver,
+    HeadlessApprovalResolver,
+    InteractiveApprovalResolver,
     PackageSecurityPolicy,
     PolicyEngine,
 )
@@ -370,13 +370,14 @@ async def run_cli(
         if list_models_result is not None:
             return list_models_result
 
+        effective_tui = _effective_tui(args, stdin=stdin, stdout=stdout)
         with coding_observability_context(
             args=args,
             session=session,
             cwd=project_root,
-            mode=_observability_mode(args),
+            mode=_observability_mode(args, effective_tui=effective_tui),
         ):
-            if args.tui:
+            if effective_tui:
                 return await tui_runner(
                     runtime=runtime,
                     session=session,
@@ -615,8 +616,52 @@ def _workflow_output_mode(args: CliArgs) -> str:
     return "json" if args.mode == "json" else "text"
 
 
-def _observability_mode(args: CliArgs) -> str:
+def _effective_tui(args: CliArgs, *, stdin: TextIO, stdout: TextIO) -> bool:
     if args.tui:
+        return True
+    if args.no_tui:
+        return False
+    if not (_stream_is_tty(stdin) and _stream_is_tty(stdout)):
+        return False
+    if args.mode != "text":
+        return False
+    if args.prompt is not None or args.prompt_steps is not None:
+        return False
+    if args.messages or args.file_args or args.message_prompts:
+        return False
+    return not _has_command_style_operation(args)
+
+
+def _has_command_style_operation(args: CliArgs) -> bool:
+    return bool(
+        args.list_sessions
+        or args.list_models is not False
+        or args.list_commands
+        or args.list_diagnostics
+        or args.list_skills
+        or args.list_plugins
+        or args.list_packages
+        or args.export is not None
+        or args.diag_export
+        or args.command is not None
+        or args.enable_skills
+        or args.disable_skills
+        or args.add_plugin_sources
+        or args.remove_plugin_sources
+        or args.enable_plugins
+        or args.disable_plugins
+        or args.install_packages
+        or args.uninstall_packages
+        or args.materialize_packages
+        or args.update_packages
+        or args.remove_packages
+        or args.update_all_packages
+        or args.check_package_updates
+    )
+
+
+def _observability_mode(args: CliArgs, *, effective_tui: bool) -> str:
+    if effective_tui:
         return "tui"
     if args.prompt is not None:
         return "prompt"
@@ -1211,7 +1256,7 @@ def _detect_supported_image_mime_type(path: Path, payload: bytes) -> str | None:
 
 
 def _read_stdin_prompt(stdin: TextIO) -> str | None:
-    if _stdin_is_tty(stdin):
+    if _stream_is_tty(stdin):
         return None
     content = stdin.read()
     if not isinstance(content, str):
@@ -1220,8 +1265,8 @@ def _read_stdin_prompt(stdin: TextIO) -> str | None:
     return stripped or None
 
 
-def _stdin_is_tty(stdin: TextIO) -> bool:
-    isatty = getattr(stdin, "isatty", None)
+def _stream_is_tty(stream: TextIO) -> bool:
+    isatty = getattr(stream, "isatty", None)
     if not callable(isatty):
         return False
     try:

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -26,6 +26,7 @@ _BUILTIN_FLAG_NAMES = frozenset(
         "prompt",
         "prompt-steps",
         "tui",
+        "no-tui",
         "no-session",
         "session",
         "session-name",
@@ -122,6 +123,7 @@ class CliArgs:
     prompt: str | None
     prompt_steps: str | None
     tui: bool
+    no_tui: bool
     continue_: bool
     resume: bool | str
     no_session: bool
@@ -267,6 +269,7 @@ def parse_args(
         prompt=namespace.prompt,
         prompt_steps=namespace.prompt_steps,
         tui=namespace.tui,
+        no_tui=namespace.no_tui,
         continue_=namespace.continue_,
         resume=namespace.resume,
         no_session=namespace.no_session,
@@ -377,6 +380,7 @@ def _build_parser() -> ArgumentParser:
         help="Run a prompt workflow file against a coding session.",
     )
     parser.add_argument("--tui", action="store_true")
+    parser.add_argument("--no-tui", action="store_true")
     parser.add_argument("--no-session", action="store_true")
     parser.add_argument("--session")
     parser.add_argument("--session-name")

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -212,6 +212,11 @@ class FakeRunner:
         return self.exit_code
 
 
+class TtyStringIO(StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
 def _fake_services(
     session_dir: str | None = None,
     package_roots: tuple[str, ...] = (),
@@ -282,6 +287,14 @@ def test_parse_args_accepts_tui_flag() -> None:
     args = parse_args(["--tui"])
 
     assert args.tui is True
+
+
+def test_parse_args_accepts_no_tui_flag() -> None:
+    from loushang.coding.cli.args import parse_args
+
+    args = parse_args(["--no-tui"])
+
+    assert args.no_tui is True
 
 
 def test_parse_args_accepts_observability_flags() -> None:
@@ -3029,6 +3042,200 @@ def test_run_cli_dispatches_tui_mode(tmp_path) -> None:
     assert tui_runner.calls[0]["stdout"] is stdout
     assert tui_runner.calls[0]["stderr"] is stderr
     assert tui_runner.calls[0]["verbose"] is True
+
+
+def test_run_cli_defaults_to_tui_for_interactive_bare_startup(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    tui_runner = FakeRunner()
+    print_runner = FakeRunner()
+    stdout = TtyStringIO()
+    stderr = StringIO()
+
+    exit_code = asyncio.run(
+        run_cli(
+            [],
+            stdin=TtyStringIO(),
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            tui_runner=tui_runner,
+            print_runner=print_runner,
+        )
+    )
+
+    assert exit_code == 0
+    assert len(tui_runner.calls) == 1
+    assert tui_runner.calls[0]["runtime"] is runtime
+    assert tui_runner.calls[0]["session"] is runtime.get_current_session()
+    assert print_runner.calls == []
+    assert "prompt is required" not in stderr.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_restore"),
+    [
+        (["--resume", "abcd1234"], "abcd1234"),
+        (["--resume"], "/tmp/latest-session.jsonl"),
+        (["--continue"], "/tmp/latest-session.jsonl"),
+    ],
+)
+def test_run_cli_defaults_to_tui_for_interactive_resume_flows(tmp_path, argv, expected_restore) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    latest_session = SimpleNamespace(session_file=Path("/tmp/latest-session.jsonl"))
+    runtime = FakeRuntime(FakeSession("session-1"), records=[latest_session])
+    tui_runner = FakeRunner()
+    print_runner = FakeRunner()
+
+    exit_code = asyncio.run(
+        run_cli(
+            argv,
+            stdin=TtyStringIO(),
+            stdout=TtyStringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            tui_runner=tui_runner,
+            print_runner=print_runner,
+        )
+    )
+
+    assert exit_code == 0
+    assert runtime.restore_session_calls == [expected_restore]
+    assert len(tui_runner.calls) == 1
+    assert print_runner.calls == []
+
+
+def test_run_cli_no_tui_keeps_interactive_bare_startup_in_text_mode(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    stderr = StringIO()
+
+    exit_code = asyncio.run(
+        run_cli(
+            ["--no-tui"],
+            stdin=TtyStringIO(),
+            stdout=TtyStringIO(),
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: FakeRuntime(FakeSession("session-1")),
+            tui_runner=FakeRunner(),
+        )
+    )
+
+    assert exit_code == 2
+    assert "prompt is required" in stderr.getvalue()
+
+
+def test_run_cli_keeps_interactive_positional_prompt_out_of_default_tui(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    tui_runner = FakeRunner()
+    print_runner = FakeRunner()
+
+    exit_code = asyncio.run(
+        run_cli(
+            ["hello", "world"],
+            stdin=TtyStringIO(),
+            stdout=TtyStringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            tui_runner=tui_runner,
+            print_runner=print_runner,
+        )
+    )
+
+    assert exit_code == 0
+    assert tui_runner.calls == []
+    assert print_runner.calls[0]["user_input"] == "hello world"
+
+
+def test_run_cli_keeps_piped_stdin_out_of_default_tui(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    tui_runner = FakeRunner()
+    print_runner = FakeRunner()
+
+    exit_code = asyncio.run(
+        run_cli(
+            [],
+            stdin=StringIO("hello from pipe\n"),
+            stdout=TtyStringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            tui_runner=tui_runner,
+            print_runner=print_runner,
+        )
+    )
+
+    assert exit_code == 0
+    assert tui_runner.calls == []
+    assert print_runner.calls[0]["user_input"] == "hello from pipe"
+
+
+def test_run_cli_keeps_machine_readable_mode_out_of_default_tui(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    tui_runner = FakeRunner()
+    print_runner = FakeRunner()
+
+    exit_code = asyncio.run(
+        run_cli(
+            ["--mode", "json", "hello"],
+            stdin=TtyStringIO(),
+            stdout=TtyStringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            tui_runner=tui_runner,
+            print_runner=print_runner,
+        )
+    )
+
+    assert exit_code == 0
+    assert tui_runner.calls == []
+    assert print_runner.calls[0]["output_mode"] == "json"
+
+
+def test_run_cli_keeps_list_commands_out_of_default_tui(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    session = FakeSession("session-1")
+    session.set_commands([{"name": "review", "description": "Run review"}])
+    runtime = FakeRuntime(session)
+    tui_runner = FakeRunner()
+    stdout = TtyStringIO()
+
+    exit_code = asyncio.run(
+        run_cli(
+            ["--list-commands"],
+            stdin=TtyStringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            tui_runner=tui_runner,
+        )
+    )
+
+    assert exit_code == 0
+    assert tui_runner.calls == []
+    assert "review" in stdout.getvalue()
 
 
 def test_run_cli_configures_observability_for_tui_debug_trace(tmp_path) -> None:


### PR DESCRIPTION
  ## Summary

  - Default interactive `loushang` startup to the native TUI when no one-shot prompt, batch
  workflow, list command, or machine-readable mode is requested.
  - Default interactive `--resume` and `--continue` flows to the native TUI.
  - Add `--no-tui` as an explicit escape hatch for non-TUI text-mode startup.
  - Add CLI dispatch regressions for default TUI boundaries.

  ## Test Plan

  - `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q`
  - `uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli/__main__.py src/loushang/
  coding/cli/args.py tests/coding/test_cli.py`
  - `git diff --check`
  - Manual: `uv run loushang`
  - Manual: `uv run loushang --resume <session>`

  Refs #11
