### PR TITLE
fix: polish default TUI startup boundaries

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -229,6 +229,9 @@ async def run_cli(
         stdout.write(f"{_package_version()}\n")
         return 0
 
+    if bootstrap_args.tui and bootstrap_args.no_tui:
+        stderr.write("Error: --tui and --no-tui cannot be used together.\n")
+        return 2
     if bootstrap_args.fork and not (
         bootstrap_args.session or bootstrap_args.continue_ or bootstrap_args.resume
     ):

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -298,7 +298,7 @@ def _resume_command_for_session(session: Any) -> str | None:
     resume_ref = _resume_ref_for_session(session)
     if resume_ref is None:
         return None
-    return " ".join(shlex.quote(part) for part in ("loushang", "--tui", "--resume", resume_ref))
+    return " ".join(shlex.quote(part) for part in ("loushang", "--resume", resume_ref))
 
 
 def _resume_ref_for_session(session: Any) -> str | None:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -1113,6 +1113,27 @@ def test_run_cli_reports_parse_errors_to_provided_stderr(tmp_path) -> None:
     assert "invalid choice" in stderr.getvalue()
 
 
+def test_run_cli_rejects_conflicting_tui_flags(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    stderr = StringIO()
+
+    exit_code = asyncio.run(
+        run_cli(
+            ["--tui", "--no-tui"],
+            stdin=TtyStringIO(),
+            stdout=TtyStringIO(),
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: pytest.fail("runtime should not be built"),
+        )
+    )
+
+    assert exit_code == 2
+    assert "--tui and --no-tui cannot be used together" in stderr.getvalue()
+
+
 def test_main_uses_process_argv_when_argv_is_omitted(monkeypatch) -> None:
     from loushang.coding.cli.__main__ import main
 
@@ -1132,6 +1153,25 @@ def test_cli_package_lazily_exports_main_and_run_cli() -> None:
 
     assert cli.main
     assert cli.run_cli
+
+
+def test_loushang_tui_entrypoint_forces_tui(monkeypatch) -> None:
+    from loushang.coding.ui import cli as tui_cli
+
+    calls = []
+
+    async def fake_run_cli(argv):
+        calls.append(tuple(argv))
+        return 23
+
+    monkeypatch.setattr(sys, "argv", ["loushang-tui", "--resume", "abcd1234"])
+    monkeypatch.setattr(tui_cli, "run_cli", fake_run_cli)
+
+    with pytest.raises(SystemExit) as error:
+        tui_cli.main()
+
+    assert error.value.code == 23
+    assert calls == [("--tui", "--resume", "abcd1234")]
 
 
 def test_cli_main_handles_keyboard_interrupt(monkeypatch, capsys) -> None:

--- a/tests/coding/test_native_coding_tui_mode.py
+++ b/tests/coding/test_native_coding_tui_mode.py
@@ -194,7 +194,8 @@ def test_run_coding_tui_interactive_prints_resume_hint_on_clean_exit(monkeypatch
 
     assert exit_code == 0
     assert "Resume this session with:" in stdout.getvalue()
-    assert "loushang --tui --resume 254d6156" in stdout.getvalue()
+    assert "loushang --resume 254d6156" in stdout.getvalue()
+    assert "loushang --tui --resume" not in stdout.getvalue()
 
 
 def test_run_coding_tui_interactive_replays_resumed_session_history(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

  - Simplify clean-exit resume hints to `loushang --resume <session>` now that interactive resume
  defaults to TUI.
  - Reject conflicting `--tui --no-tui` startup flags before runtime dispatch.
  - Cover the dedicated `loushang-tui` entrypoint so it continues forcing TUI mode.

  ## Test Plan

  - `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/
  test_native_coding_tui_mode.py -q`
  - `uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli/__main__.py src/loushang/
  coding/ui/cli.py src/loushang/coding/ui/mode.py tests/coding/test_cli.py tests/coding/
  test_native_coding_tui_mode.py`
  - `git diff --check`

  Refs #13
