### PR TITLE
test: add native TUI lifecycle playback scenarios

### DIFF
--- a/src/loushang/coding/ui/playback_runner.py
+++ b/src/loushang/coding/ui/playback_runner.py
@@ -227,6 +227,56 @@ def _run_active_surface() -> NativeTuiInputPlaybackResult:
     return result
 
 
+def _run_running_steer_queued() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .with_running_prompt("old")
+        .render()
+        .type_text("change")
+        .enter()
+        .run()
+    )
+    result.assert_steer_texts("change")
+    result.assert_pending_steers("change")
+    result.assert_composer_text("")
+    result.assert_visible_contains("Messages to be submitted after next tool call")
+    result.assert_visible_contains("change")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_running_escape_keeps_queued_steer() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .with_running_prompt("old")
+        .with_pending_steers("queued")
+        .render()
+        .escape()
+        .run()
+    )
+    result.assert_abort_requested()
+    result.assert_pending_steers("queued")
+    result.assert_visible_contains("Messages to be submitted after next tool call")
+    result.assert_visible_contains("queued")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_idle_escape_pops_pending_steer() -> NativeTuiInputPlaybackResult:
+    result = NativeTuiInputScenario(width=80, height=12).with_pending_steers("queued").render().escape().run()
+    result.assert_steer_texts("queued")
+    result.assert_pending_steers()
+    result.assert_visible_not_contains("Messages to be submitted after next tool call")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
 def _run_escape_pending_steer() -> object:
     scenario = NativeTuiLoopScenario()
     prompts: list[str] = []
@@ -271,6 +321,90 @@ def _run_escape_pending_steer() -> object:
     return result
 
 
+def _run_escape_pending_steer_fifo() -> object:
+    scenario = NativeTuiLoopScenario().with_pending_steers("prequeued")
+    prompts: list[str] = []
+    steers: list[str] = []
+
+    async def handle_prompt(text: str) -> None:
+        if text == "prequeued":
+            prompts.append(text)
+            return
+        scenario.app.begin_assistant()
+        scenario.app.append_assistant_chunk("working")
+        await _never()
+
+    async def handle_steer(text: str) -> None:
+        steers.append(text)
+
+    result = (
+        scenario.type_text("start")
+        .enter()
+        .wait(0.01)
+        .type_text("running steer")
+        .enter()
+        .wait(0.01)
+        .escape()
+        .wait(0.04)
+        .end_input()
+        .run(handle_prompt=handle_prompt, handle_steer=handle_steer)
+    )
+    result.assert_exit_code(0)
+    assert steers == ["running steer"]
+    assert prompts == ["prequeued"]
+    result.assert_pending_steers("running steer")
+    result.assert_no_clear_screen()
+    return result
+
+
+def _run_escape_pending_steer_preserves_draft() -> object:
+    scenario = NativeTuiLoopScenario().with_pending_steers("queued")
+    prompts: list[str] = []
+
+    async def handle_prompt(text: str) -> None:
+        if text == "queued":
+            prompts.append(text)
+            return
+        await _never()
+
+    result = (
+        scenario.type_text("start")
+        .enter()
+        .wait(0.01)
+        .type_text("draft")
+        .wait(0.01)
+        .escape()
+        .wait(0.04)
+        .end_input()
+        .run(handle_prompt=handle_prompt)
+    )
+    result.assert_exit_code(0)
+    assert prompts == ["queued"]
+    result.assert_composer_text("draft")
+    result.assert_pending_steers()
+    result.assert_no_clear_screen()
+    return result
+
+
+def _run_running_follow_up_queued() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .with_running_prompt("old")
+        .render()
+        .type_text("follow")
+        .key("\x1b\r")
+        .run()
+    )
+    assert result.app.state.pending_followups == ["follow"]
+    result.assert_pending_steers()
+    result.assert_composer_text("")
+    result.assert_visible_contains("queued=1 steer=0")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
 def _run_long_transcript_input() -> NativeTuiInputPlaybackResult:
     result = (
         NativeTuiInputScenario(width=100, height=18)
@@ -305,9 +439,39 @@ DEFAULT_SUITE = NativePlaybackSuite(
             run=_run_active_surface,
         ),
         NativePlaybackScenarioSpec(
+            name="running-steer-queued",
+            description="Queue a submitted steer while a prompt is running.",
+            run=_run_running_steer_queued,
+        ),
+        NativePlaybackScenarioSpec(
+            name="running-escape-keeps-queued-steer",
+            description="Abort a running prompt without dropping an existing queued steer.",
+            run=_run_running_escape_keeps_queued_steer,
+        ),
+        NativePlaybackScenarioSpec(
+            name="idle-escape-pops-pending-steer",
+            description="Pop and execute the first pending steer when ESC is pressed while idle.",
+            run=_run_idle_escape_pops_pending_steer,
+        ),
+        NativePlaybackScenarioSpec(
             name="escape-pending-steer",
             description="Exercise ESC with a queued steer through the native loop.",
             run=_run_escape_pending_steer,
+        ),
+        NativePlaybackScenarioSpec(
+            name="escape-pending-steer-fifo",
+            description="Preserve pending steer FIFO order when ESC interrupts a running prompt.",
+            run=_run_escape_pending_steer_fifo,
+        ),
+        NativePlaybackScenarioSpec(
+            name="escape-pending-steer-preserves-draft",
+            description="Run an interrupt pending steer without clearing an unsubmitted composer draft.",
+            run=_run_escape_pending_steer_preserves_draft,
+        ),
+        NativePlaybackScenarioSpec(
+            name="running-follow-up-queued",
+            description="Queue a follow-up while a prompt is running.",
+            run=_run_running_follow_up_queued,
         ),
         NativePlaybackScenarioSpec(
             name="long-transcript-input",

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -20,6 +20,12 @@ def test_native_tui_playback_runner_lists_default_scenarios(capsys) -> None:
     assert "completion-tab" in captured.out
     assert "long-transcript-input" in captured.out
     assert "escape-pending-steer" in captured.out
+    assert "running-steer-queued" in captured.out
+    assert "running-escape-keeps-queued-steer" in captured.out
+    assert "idle-escape-pops-pending-steer" in captured.out
+    assert "escape-pending-steer-fifo" in captured.out
+    assert "escape-pending-steer-preserves-draft" in captured.out
+    assert "running-follow-up-queued" in captured.out
 
 
 def test_native_tui_playback_runner_runs_named_scenario(capsys) -> None:
@@ -29,6 +35,15 @@ def test_native_tui_playback_runner_runs_named_scenario(capsys) -> None:
     assert exit_code == 0
     assert "PASS completion-tab" in captured.out
     assert "long-transcript-input" not in captured.out
+
+
+def test_native_tui_playback_runner_runs_lifecycle_scenario(capsys) -> None:
+    exit_code = run_playback_cli(["running-steer-queued"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS running-steer-queued" in captured.out
+    assert "PASS completion-tab" not in captured.out
 
 
 def test_native_tui_playback_runner_writes_artifacts(tmp_path, capsys) -> None:
@@ -50,8 +65,11 @@ def test_native_tui_playback_runner_writes_artifacts_for_all_default_scenarios(t
     assert exit_code == 0
     assert "PASS completion-tab" in captured.out
     assert "PASS escape-pending-steer" in captured.out
+    assert "PASS running-follow-up-queued" in captured.out
     assert (tmp_path / "completion-tab.jsonl").exists()
     assert (tmp_path / "escape-pending-steer-text.txt").exists()
+    assert (tmp_path / "running-steer-queued.jsonl").exists()
+    assert (tmp_path / "escape-pending-steer-fifo-text.txt").exists()
 
 
 def test_native_tui_playback_runner_reports_unknown_scenario(capsys) -> None:


### PR DESCRIPTION
 ## Summary

  - Add lifecycle-focused scenarios to the native TUI playback runner.
  - Cover queued steers, ESC behavior, pending steer FIFO, composer draft preservation, and running
  follow-up queueing.
  - Keep the change scoped to playback regression coverage without changing TUI runtime behavior.

  ## Test Plan

  - `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_tui_playback_runner.py
  tests/coding/test_native_tui_playback_harness.py tests/tui/test_playback_harness.py -q`
  - `uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/playback_runner.py tests/coding/
  test_native_tui_playback_runner.py`
  - `uv --cache-dir .uv-cache run python -m loushang.coding.ui.playback_runner --list`
  - `uv --cache-dir .uv-cache run python -m loushang.coding.ui.playback_runner running-steer-queued
  escape-pending-steer-fifo running-follow-up-queued`

  Refs #17