### PR TITLE
Add native TUI terminal compatibility playback coverage

### DIFF
--- a/src/loushang/coding/ui/playback_runner.py
+++ b/src/loushang/coding/ui/playback_runner.py
@@ -14,9 +14,11 @@ from loushang.coding.ui.perf_probe import build_synthetic_long_transcript_record
 from loushang.coding.ui.playback import (
     NativeTuiInputPlaybackResult,
     NativeTuiInputScenario,
+    NativeTuiLoopPlayback,
     NativeTuiLoopScenario,
 )
 from loushang.tui import PlaybackFrameBudget, SelectionSurface, SelectItem
+from loushang.tui.input import BRACKETED_PASTE_END, BRACKETED_PASTE_START
 
 INTERACTION_FRAME_BUDGET = PlaybackFrameBudget(
     disallowed_operation_classes=("baseline_repaint", "recovery_repaint"),
@@ -421,6 +423,229 @@ def _run_long_transcript_input() -> NativeTuiInputPlaybackResult:
     return result
 
 
+def _run_bracketed_paste_large_marker() -> NativeTuiInputPlaybackResult:
+    pasted = "\n".join(f"line {index}" for index in range(10))
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .render()
+        .key(f"{BRACKETED_PASTE_START}{pasted}{BRACKETED_PASTE_END}")
+        .run()
+    )
+    result.assert_composer_text(pasted)
+    result.assert_visible_contains("[paste #1 +10 lines]")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_resize_reflow_stable() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .render()
+        .type_text("resize keeps composer stable")
+        .resize(width=42, height=8)
+        .type_text(" after shrink")
+        .resize(width=100, height=14)
+        .type_text(" after grow")
+        .run()
+    )
+    result.assert_composer_text("resize keeps composer stable after shrink after grow")
+    result.assert_visible_contains("after grow")
+    assert any(step.diagnostics.operation_class == "resize_repaint" for step in result.steps)
+    result.assert_no_clear_scrollback()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_wide_char_input_cursor() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=32, height=10)
+        .render()
+        .type_chars("你好🙂 terminal")
+        .run()
+    )
+    result.assert_composer_text("你好🙂 terminal")
+    result.assert_visible_contains("你好🙂 terminal")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_keyboard_alt_enter_follow_up() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .with_running_prompt("active")
+        .render()
+        .type_text("follow-up through raw alt enter")
+        .key("\x1b\r")
+        .run()
+    )
+    assert result.app.state.pending_followups == ["follow-up through raw alt enter"]
+    result.assert_pending_steers()
+    result.assert_composer_text("")
+    result.assert_visible_contains("queued=1 steer=0")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_keyboard_shift_enter_newline() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .render()
+        .type_text("first line")
+        .key("\x1b[13;2u")
+        .type_text("second line")
+        .enter()
+        .run()
+    )
+    result.assert_prompt_texts("first line\nsecond line")
+    result.assert_composer_text("")
+    result.assert_visible_contains("› first line")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_mouse_select_active_surface() -> NativeTuiInputPlaybackResult:
+    surface = SelectionSurface(
+        [
+            SelectItem("First option", value="first"),
+            SelectItem("Second option", value="second"),
+            SelectItem("Third option", value="third"),
+        ],
+        max_visible=3,
+    )
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .with_active_surface(surface)
+        .render()
+        .key("\x1b[<0;1;2M")
+        .enter()
+        .run()
+    )
+    result.assert_surface_intents(("select", "second"))
+    result.assert_composer_text("")
+    result.assert_visible_contains("Second option")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_terminal_control_response_hidden() -> object:
+    playback = NativeTuiLoopPlayback(width=80, height=12)
+    contexts: list[_RecordingTerminalContext] = []
+    prompts: list[str] = []
+
+    async def handle_prompt(text: str) -> None:
+        prompts.append(text)
+        playback.app.begin_assistant()
+        playback.app.append_assistant_chunk("terminal control response was hidden")
+
+    def terminal_mode_factory(_stdin: object, _stdout: object) -> _RecordingTerminalContext:
+        context = _RecordingTerminalContext()
+        contexts.append(context)
+        return context
+
+    result = playback.run(
+        (0.00, "\x1b[?7u"),
+        (0.01, "\x1b[6;18;9t"),
+        (0.02, "hello"),
+        (0.02, "\r"),
+        (0.04, ""),
+        handle_prompt=handle_prompt,
+        terminal_mode_factory=terminal_mode_factory,
+    )
+    result.assert_exit_code(0)
+    assert prompts == ["hello"]
+    assert contexts
+    assert [(event.signal, event.text) for event in contexts[0].events] == [
+        ("kitty_protocol", "7"),
+        ("cell_size", "18;9"),
+    ]
+    assert "\x1b[?7u" not in result.output
+    assert "\x1b[6;18;9t" not in result.output
+    result.assert_text_not_contains("?7u")
+    result.assert_text_not_contains("18;9")
+    result.assert_text_contains("› hello")
+    result.assert_no_clear_screen()
+    return result
+
+
+def _run_apple_shift_enter_normalized() -> object:
+    playback = NativeTuiLoopPlayback(width=80, height=12)
+    contexts: list[_AppleShiftEnterTerminalContext] = []
+    prompts: list[str] = []
+
+    async def handle_prompt(text: str) -> None:
+        prompts.append(text)
+        playback.app.begin_assistant()
+        playback.app.append_assistant_chunk("apple shift enter inserted a newline")
+
+    def terminal_mode_factory(_stdin: object, _stdout: object) -> _AppleShiftEnterTerminalContext:
+        context = _AppleShiftEnterTerminalContext()
+        contexts.append(context)
+        return context
+
+    result = playback.run(
+        (0.00, "first"),
+        (0.01, "\r"),
+        (0.02, "second"),
+        (0.03, "\r"),
+        (0.05, ""),
+        handle_prompt=handle_prompt,
+        terminal_mode_factory=terminal_mode_factory,
+    )
+    result.assert_exit_code(0)
+    assert prompts == ["first\nsecond"]
+    assert contexts
+    assert contexts[0].return_key_count == 2
+    result.assert_text_contains("› first")
+    result.assert_text_contains("second")
+    result.assert_text_not_contains("[13;2u")
+    result.assert_no_clear_screen()
+    return result
+
+
+class _RecordingTerminalContext:
+    def __init__(self) -> None:
+        self.events: list[object] = []
+
+    def __enter__(self) -> _RecordingTerminalContext:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+    def consume_control_events(self, events: tuple[object, ...]) -> None:
+        self.events.extend(events)
+
+
+class _AppleShiftEnterTerminalContext:
+    def __init__(self) -> None:
+        self.return_key_count = 0
+
+    def __enter__(self) -> _AppleShiftEnterTerminalContext:
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+    def normalize_input_chunk(self, data: str) -> str:
+        if data != "\r":
+            return data
+        self.return_key_count += 1
+        if self.return_key_count == 1:
+            return "\x1b[13;2u"
+        return data
+
+
 DEFAULT_SUITE = NativePlaybackSuite(
     (
         NativePlaybackScenarioSpec(
@@ -477,6 +702,46 @@ DEFAULT_SUITE = NativePlaybackSuite(
             name="long-transcript-input",
             description="Echo input after a long transcript using bounded frame updates.",
             run=_run_long_transcript_input,
+        ),
+        NativePlaybackScenarioSpec(
+            name="bracketed-paste-large-marker",
+            description="Render a large bracketed paste as a stable composer marker.",
+            run=_run_bracketed_paste_large_marker,
+        ),
+        NativePlaybackScenarioSpec(
+            name="resize-reflow-stable",
+            description="Keep composer text and cursor stable across terminal resizes.",
+            run=_run_resize_reflow_stable,
+        ),
+        NativePlaybackScenarioSpec(
+            name="wide-char-input-cursor",
+            description="Keep CJK and emoji input cursor diagnostics aligned.",
+            run=_run_wide_char_input_cursor,
+        ),
+        NativePlaybackScenarioSpec(
+            name="keyboard-alt-enter-follow-up",
+            description="Route raw Alt+Enter to follow-up submission while running.",
+            run=_run_keyboard_alt_enter_follow_up,
+        ),
+        NativePlaybackScenarioSpec(
+            name="keyboard-shift-enter-newline",
+            description="Route raw Shift+Enter to composer newline before submission.",
+            run=_run_keyboard_shift_enter_newline,
+        ),
+        NativePlaybackScenarioSpec(
+            name="mouse-select-active-surface",
+            description="Route raw SGR mouse press events to an active selection surface.",
+            run=_run_mouse_select_active_surface,
+        ),
+        NativePlaybackScenarioSpec(
+            name="terminal-control-response-hidden",
+            description="Consume terminal control responses without echoing them as user input.",
+            run=_run_terminal_control_response_hidden,
+        ),
+        NativePlaybackScenarioSpec(
+            name="apple-shift-enter-normalized",
+            description="Normalize Apple Terminal Shift+Enter to a composer newline before submit.",
+            run=_run_apple_shift_enter_normalized,
         ),
     )
 )

--- a/src/loushang/tui/render_loop.py
+++ b/src/loushang/tui/render_loop.py
@@ -283,6 +283,14 @@ class RenderLoop:
                 delete_kitty_image_sequences=previous_kitty_delete_sequences,
             )
 
+        render_end = min(last_changed, len(current_lines) - 1)
+        hardware_cursor_row, hardware_cursor_column = _changed_range_hardware_cursor(
+            current_lines=current_lines,
+            previous_lines=previous_lines,
+            render_end=render_end,
+            declared_cursor=result.cursor,
+            size=size,
+        )
         return self._diagnostics(
             current_lines=current_lines,
             previous_lines=previous_lines,
@@ -300,10 +308,10 @@ class RenderLoop:
             ),
             changed_range=changed_range,
             viewport_top=differential_viewport_top,
-            render_end=min(last_changed, len(current_lines) - 1),
+            render_end=render_end,
             cursor=cursor,
-            hardware_cursor_row=result.cursor.row if result.cursor is not None else min(last_changed, len(current_lines) - 1),
-            hardware_cursor_column=cursor.column,
+            hardware_cursor_row=hardware_cursor_row,
+            hardware_cursor_column=hardware_cursor_column,
         )
 
     def _managed_viewport_repaint_diagnostics(
@@ -853,6 +861,24 @@ def _cursor_or_line_end(cursor: CursorDeclaration | None, lines: tuple[str, ...]
     row = max(0, len(lines) - 1)
     column = visible_width(lines[row]) if lines else 0
     return CursorDeclaration(row=row, column=column)
+
+
+def _changed_range_hardware_cursor(
+    *,
+    current_lines: tuple[str, ...],
+    previous_lines: tuple[str, ...],
+    render_end: int,
+    declared_cursor: CursorDeclaration | None,
+    size: TerminalSize,
+) -> tuple[int, int]:
+    if declared_cursor is not None:
+        return declared_cursor.row, declared_cursor.column
+    cleared_extra_lines = max(0, len(previous_lines) - len(current_lines))
+    if cleared_extra_lines:
+        return render_end + cleared_extra_lines, 0
+    if not current_lines:
+        return 0, 0
+    return render_end, min(visible_width(current_lines[render_end]), size.columns - 1)
 
 
 def _should_clear_scrollback(*, policy: ClearScrollbackPolicy, repaint_kind: str) -> bool:

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -26,6 +26,14 @@ def test_native_tui_playback_runner_lists_default_scenarios(capsys) -> None:
     assert "escape-pending-steer-fifo" in captured.out
     assert "escape-pending-steer-preserves-draft" in captured.out
     assert "running-follow-up-queued" in captured.out
+    assert "bracketed-paste-large-marker" in captured.out
+    assert "resize-reflow-stable" in captured.out
+    assert "wide-char-input-cursor" in captured.out
+    assert "keyboard-alt-enter-follow-up" in captured.out
+    assert "keyboard-shift-enter-newline" in captured.out
+    assert "terminal-control-response-hidden" in captured.out
+    assert "apple-shift-enter-normalized" in captured.out
+    assert "mouse-select-active-surface" in captured.out
 
 
 def test_native_tui_playback_runner_runs_named_scenario(capsys) -> None:

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -274,6 +274,22 @@ def test_changed_range_update_rewrites_only_visible_changed_rows() -> None:
     assert step.frame.screen_after.visible_lines[:3] == ("one", "TWO", "three")
 
 
+def test_changed_range_update_without_declared_cursor_reports_actual_hardware_cursor() -> None:
+    root = StaticRoot(("one", "two", "three"))
+    runtime = TuiRuntime(render_loop=RenderLoop(root), terminal=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)))
+    runtime.render_now()
+    root.lines = ("one", "TWO", "three")
+
+    step = runtime.render_now()
+
+    step.assert_operation_class("changed_range_update")
+    assert step.frame is not None
+    assert step.frame.screen_after.cursor_row == 1
+    assert step.frame.screen_after.cursor_column == 3
+    assert step.diagnostics.hardware_cursor_row == 1
+    assert step.diagnostics.hardware_cursor_column == 3
+
+
 def test_changed_range_update_uses_pi_style_relative_cursor_movement_inside_viewport() -> None:
     root = StaticRoot(("one", "two", "three", "four", "five"))
     runtime = TuiRuntime(render_loop=RenderLoop(root), terminal=FakeTerminalPort(size=TerminalSize(columns=20, rows=3)))

--- a/tests/tui/test_terminal_input.py
+++ b/tests/tui/test_terminal_input.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import termios
 from io import StringIO
 from typing import Any
 
@@ -9,6 +10,11 @@ from loushang.tui.input import (
     BRACKETED_PASTE_START,
     InputEvent,
     InputReader,
+)
+from loushang.tui.keyboard_protocol import (
+    KITTY_QUERY_SEQUENCE,
+    MODIFY_OTHER_KEYS_DISABLE_SEQUENCE,
+    MODIFY_OTHER_KEYS_ENABLE_SEQUENCE,
 )
 from loushang.tui.terminal_input import (
     TerminalInputMode,
@@ -25,6 +31,34 @@ def test_terminal_input_mode_does_not_write_modes_for_non_tty_streams() -> None:
         pass
 
     assert stdout.getvalue() == ""
+
+
+def test_terminal_input_mode_enables_and_restores_tty_modes(monkeypatch: Any) -> None:
+    stdin = _TtyInput()
+    stdout = StringIO()
+    original_attrs = [0, 0, 0, 0, 0, 0, [0] * 32]
+    tcsetattr_calls: list[tuple[int, int, list[Any]]] = []
+
+    monkeypatch.setattr("termios.tcgetattr", lambda fd: original_attrs)
+    monkeypatch.setattr(
+        "termios.tcsetattr",
+        lambda fd, when, attrs: tcsetattr_calls.append((fd, when, attrs)),
+    )
+    monkeypatch.setattr("tty.setcbreak", lambda fd: None)
+    monkeypatch.setattr("loushang.tui.terminal_input.drain_input", lambda *args, **kwargs: "")
+
+    with TerminalInputMode(stdin=stdin, stdout=stdout):
+        pass
+
+    output = stdout.getvalue()
+    assert "\x1b[?2004h" in output
+    assert "\x1b[?1004h" in output
+    assert KITTY_QUERY_SEQUENCE in output
+    assert MODIFY_OTHER_KEYS_ENABLE_SEQUENCE in output
+    assert "\x1b[?2004l" in output
+    assert "\x1b[?1004l" in output
+    assert MODIFY_OTHER_KEYS_DISABLE_SEQUENCE in output
+    assert tcsetattr_calls[-1] == (stdin.fileno(), termios.TCSADRAIN, original_attrs)
 
 
 def test_read_input_chunk_or_render_tick_reads_raw_stringio_escape_without_tail_joining() -> None:


### PR DESCRIPTION
## Summary
- Add runnable native TUI playback scenarios for terminal compatibility: bracketed paste, resize reflow, wide characters, raw keyboard protocols, terminal control responses, Apple Shift+Enter normalization, and mouse selection routing.
- Extend terminal input lifecycle coverage for tty mode setup/restore and keyboard protocol enable/disable behavior.
- Fix changed-range render diagnostics so hardware cursor coordinates match the actual terminal frame when no explicit cursor is declared.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_tui_playback_runner.py tests/coding/test_native_tui_playback_harness.py tests/tui/test_playback_harness.py tests/tui/test_terminal_input.py tests/tui/test_keyboard_protocol.py tests/tui/test_render_loop.py -q
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/playback_runner.py src/loushang/tui/render_loop.py tests/coding/test_native_tui_playback_runner.py tests/tui/test_terminal_input.py tests/tui/test_render_loop.py

Refs #19