### PR TITLE
Add JSON output to native TUI playback runner

### DIFF
--- a/src/loushang/coding/ui/playback_runner.py
+++ b/src/loushang/coding/ui/playback_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import inspect
+import json
 import sys
 import time
 from collections.abc import Callable, Sequence
@@ -158,10 +159,15 @@ def run_playback_cli(
         return 2
 
     for result in results:
+        if args.json:
+            continue
         status = "PASS" if result.ok else "FAIL"
         stdout.write(f"{status} {result.name} ({result.elapsed_ms:.1f}ms)\n")
         if result.error:
             stderr.write(f"{result.name}: {result.error}\n")
+    if args.json:
+        stdout.write(json.dumps(_json_summary(results), ensure_ascii=False))
+        stdout.write("\n")
     return 0 if all(result.ok for result in results) else 1
 
 
@@ -178,12 +184,29 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--list", action="store_true", help="List available scenarios.")
     parser.add_argument("--artifacts", help="Directory for manual inspection artifacts.")
     parser.add_argument("--include-frames", action="store_true", help="Include visible frames in JSONL artifacts.")
+    parser.add_argument("--json", action="store_true", help="Write a machine-readable JSON summary to stdout.")
     return parser
 
 
 def _write_scenario_list(suite: NativePlaybackSuite, stdout: TextIO) -> None:
     for scenario in suite.scenarios:
         stdout.write(f"{scenario.name}\t{scenario.description}\n")
+
+
+def _json_summary(results: Sequence[NativePlaybackScenarioResult]) -> dict[str, object]:
+    return {
+        "ok": all(result.ok for result in results),
+        "results": [
+            {
+                "name": result.name,
+                "ok": result.ok,
+                "elapsed_ms": result.elapsed_ms,
+                "artifacts": [str(path) for path in result.artifacts],
+                "error": result.error,
+            }
+            for result in results
+        ],
+    }
 
 
 def _run_completion_tab() -> NativeTuiInputPlaybackResult:

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -69,6 +69,32 @@ def test_native_tui_playback_runner_writes_artifacts(tmp_path, capsys) -> None:
     assert "visible_lines" in row
 
 
+def test_native_tui_playback_runner_writes_json_summary(tmp_path, capsys) -> None:
+    exit_code = run_playback_cli(["completion-tab", "--json", "--artifacts", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload == {
+        "ok": True,
+        "results": [
+            {
+                "name": "completion-tab",
+                "ok": True,
+                "error": None,
+                "artifacts": [
+                    str(tmp_path / "completion-tab.jsonl"),
+                    str(tmp_path / "completion-tab-screen.txt"),
+                ],
+                "elapsed_ms": payload["results"][0]["elapsed_ms"],
+            }
+        ],
+    }
+    assert payload["results"][0]["elapsed_ms"] >= 0
+    assert "PASS completion-tab" not in captured.out
+
+
 def test_native_tui_playback_runner_writes_artifacts_for_all_default_scenarios(tmp_path, capsys) -> None:
     exit_code = run_playback_cli(["--artifacts", str(tmp_path), "--include-frames"])
 
@@ -117,6 +143,41 @@ def test_native_tui_playback_runner_reports_failed_scenario(tmp_path, capsys) ->
     assert (tmp_path / "forced-failure-error.txt").read_text(encoding="utf-8") == "forced failure\n"
 
 
+def test_native_tui_playback_runner_writes_failed_json_summary(tmp_path, capsys) -> None:
+    def failing_run() -> None:
+        raise AssertionError("forced failure")
+
+    suite = NativePlaybackSuite(
+        (
+            NativePlaybackScenarioSpec(
+                name="forced-failure",
+                description="Fails for runner testing.",
+                run=failing_run,
+            ),
+        )
+    )
+
+    exit_code = run_playback_cli(
+        ["forced-failure", "--json", "--artifacts", str(tmp_path)],
+        suite=suite,
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 1
+    assert captured.err == ""
+    assert payload["ok"] is False
+    assert payload["results"] == [
+        {
+            "name": "forced-failure",
+            "ok": False,
+            "elapsed_ms": payload["results"][0]["elapsed_ms"],
+            "artifacts": [str(tmp_path / "forced-failure-error.txt")],
+            "error": "forced failure",
+        }
+    ]
+
+
 def test_native_tui_playback_runner_module_main_exits(monkeypatch) -> None:
     calls = []
 
@@ -148,3 +209,20 @@ def test_native_tui_playback_runner_main_uses_process_argv(monkeypatch, capsys) 
     captured = capsys.readouterr()
     assert "PASS completion-tab" in captured.out
     assert "long-transcript-input" not in captured.out
+
+
+def test_native_tui_playback_runner_main_can_emit_json(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(sys, "argv", ["playback-runner", "completion-tab", "--json"])
+
+    try:
+        playback_runner.main()
+    except SystemExit as error:
+        assert error.code == 0
+    else:
+        raise AssertionError("main should raise SystemExit")
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["ok"] is True
+    assert payload["results"][0]["name"] == "completion-tab"
+    assert "PASS completion-tab" not in captured.out


### PR DESCRIPTION
## Summary
- Add a `--json` flag to the native TUI playback runner for machine-readable result output.
- Include overall status and per-scenario name, pass/fail status, elapsed time, artifact paths, and error text.
- Cover successful, failed, and module-main JSON output paths while preserving existing human-readable output by default.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_tui_playback_runner.py -q
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/playback_runner.py tests/coding/test_native_tui_playback_runner.py
- uv --cache-dir .uv-cache run python -m loushang.coding.ui.playback_runner completion-tab --json

Fixes #22