### PR TITLE
Introduce coding command catalog for TUI command routing

### DIFF
--- a/src/loushang/coding/commands/catalog.py
+++ b/src/loushang/coding/commands/catalog.py
@@ -18,6 +18,23 @@ class CodingCommandCatalog:
     def __init__(self, *, session_commands: SessionCommandsProvider | None = None) -> None:
         self._session_commands = session_commands
 
+    def commands(self) -> tuple[CommandDef, ...]:
+        session_commands: list[CommandDef] = []
+        session_names: set[str] = set()
+        if self._session_commands is None:
+            return tuple(_LOCAL_COMMANDS_BY_NAME.values())
+        raw_commands = self._session_commands()
+        if isinstance(raw_commands, Iterable):
+            for raw_command in raw_commands:
+                command = _session_command_def(raw_command)
+                if command is not None and command.name not in session_names:
+                    session_commands.append(command)
+                    session_names.add(command.name)
+        local_commands = tuple(
+            command for name, command in _LOCAL_COMMANDS_BY_NAME.items() if name not in session_names
+        )
+        return (*session_commands, *local_commands)
+
     def effect_for_route(self, route: object, intent: object) -> CommandEffect | None:
         route_value = _route_value(route)
         command = _LOCAL_COMMANDS_BY_ROUTE_VALUE.get(route_value)
@@ -58,17 +75,10 @@ class CodingCommandCatalog:
         if not isinstance(raw_commands, Iterable):
             return None
         for raw_command in raw_commands:
-            command_name = _string_attr(raw_command, "invocation_name") or _string_attr(raw_command, "name")
-            if command_name is None or command_name.removeprefix("/") != normalized:
+            command = _session_command_def(raw_command)
+            if command is None or command.name.removeprefix("/") != normalized:
                 continue
-            return CommandDef(
-                id=f"coding.session.{normalized}",
-                name=normalized,
-                kind=CommandKind.SESSION,
-                description=_string_attr(raw_command, "description"),
-                source=_string_attr(raw_command, "source"),
-                argument_hint=_string_attr(raw_command, "argument_hint"),
-            )
+            return command
         return None
 
 
@@ -96,60 +106,84 @@ def _string_attr(value: Any, name: str) -> str | None:
     return raw if isinstance(raw, str) and raw else None
 
 
+def _session_command_def(raw_command: object) -> CommandDef | None:
+    name = _string_attr(raw_command, "invocation_name") or _string_attr(raw_command, "name")
+    if name is None:
+        return None
+    normalized = name.removeprefix("/")
+    return CommandDef(
+        id=f"coding.session.{normalized}",
+        name=normalized,
+        kind=CommandKind.SESSION,
+        description=_string_attr(raw_command, "description"),
+        source=_string_attr(raw_command, "source"),
+        argument_hint=_string_attr(raw_command, "argument_hint"),
+    )
+
+
 _LOCAL_COMMANDS_BY_ROUTE_VALUE: dict[str, CommandDef] = {
     "status": CommandDef(
         id="coding.ui.status",
         name="status",
         kind=CommandKind.LOCAL_UI,
         description="Show current status",
+        source="local",
     ),
     "model_select": CommandDef(
         id="coding.ui.model",
         name="model",
         kind=CommandKind.LOCAL_UI,
         description="Select model",
+        source="local",
     ),
     "models": CommandDef(
         id="coding.ui.models",
         name="models",
         kind=CommandKind.LOCAL_UI,
         description="Show available models",
+        source="local",
     ),
     "command_select": CommandDef(
         id="coding.ui.command",
         name="command",
         kind=CommandKind.LOCAL_UI,
         description="Select command",
+        source="local",
     ),
     "commands": CommandDef(
         id="coding.ui.commands",
         name="commands",
         kind=CommandKind.LOCAL_UI,
         description="Show commands",
+        source="local",
     ),
     "hotkeys": CommandDef(
         id="coding.ui.hotkeys",
         name="hotkeys",
         kind=CommandKind.LOCAL_UI,
         description="Show keyboard shortcuts",
+        source="local",
     ),
     "settings": CommandDef(
         id="coding.ui.settings",
         name="settings",
         kind=CommandKind.LOCAL_UI,
         description="Open settings",
+        source="local",
     ),
     "statusline": CommandDef(
         id="coding.ui.statusline",
         name="statusline",
         kind=CommandKind.LOCAL_UI,
         description="Configure status line visibility",
+        source="local",
     ),
     "terminal": CommandDef(
         id="coding.ui.terminal",
         name="terminal",
         kind=CommandKind.LOCAL_UI,
         description="Show terminal diagnostics",
+        source="local",
     ),
 }
 _LOCAL_COMMANDS_BY_NAME: dict[str, CommandDef] = {

--- a/src/loushang/coding/commands/catalog.py
+++ b/src/loushang/coding/commands/catalog.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from loushang.coding.commands.slash import split_slash_command
+from loushang.runtime.commands import (
+    CommandDef,
+    CommandEffect,
+    CommandEffectKind,
+    CommandKind,
+)
+
+SessionCommandsProvider = Callable[[], Iterable[object]]
+
+
+class CodingCommandCatalog:
+    def __init__(self, *, session_commands: SessionCommandsProvider | None = None) -> None:
+        self._session_commands = session_commands
+
+    def effect_for_route(self, route: object, intent: object) -> CommandEffect | None:
+        route_value = _route_value(route)
+        command = _LOCAL_COMMANDS_BY_ROUTE_VALUE.get(route_value)
+        if command is not None:
+            return CommandEffect(kind=CommandEffectKind.LOCAL_UI, command=command)
+        if route_value == "dispatch":
+            text = _string_attr(intent, "text")
+            if text is not None:
+                return self._session_effect_for_text(text)
+        return None
+
+    def lookup(self, text: str) -> CommandDef | None:
+        local_command = _local_command_for_text(text)
+        if local_command is not None:
+            return local_command
+        session_effect = self._session_effect_for_text(text)
+        if session_effect is None:
+            return None
+        return session_effect.command
+
+    def _session_effect_for_text(self, text: str) -> CommandEffect | None:
+        parsed = split_slash_command(text.strip())
+        if parsed is None or self._session_commands is None:
+            return None
+        invocation_name, args = parsed
+        command = self._session_command(invocation_name)
+        if command is None:
+            return None
+        return CommandEffect(
+            kind=CommandEffectKind.SESSION,
+            command=command,
+            payload={"invocation_name": invocation_name, "args": args},
+        )
+
+    def _session_command(self, invocation_name: str) -> CommandDef | None:
+        normalized = invocation_name.removeprefix("/")
+        raw_commands = self._session_commands()
+        if not isinstance(raw_commands, Iterable):
+            return None
+        for raw_command in raw_commands:
+            command_name = _string_attr(raw_command, "invocation_name") or _string_attr(raw_command, "name")
+            if command_name is None or command_name.removeprefix("/") != normalized:
+                continue
+            return CommandDef(
+                id=f"coding.session.{normalized}",
+                name=normalized,
+                kind=CommandKind.SESSION,
+                description=_string_attr(raw_command, "description"),
+                source=_string_attr(raw_command, "source"),
+                argument_hint=_string_attr(raw_command, "argument_hint"),
+            )
+        return None
+
+
+def _local_command_for_text(text: str) -> CommandDef | None:
+    parsed = split_slash_command(text.strip())
+    if parsed is None:
+        return None
+    invocation_name, _args = parsed
+    return _LOCAL_COMMANDS_BY_NAME.get(invocation_name.removeprefix("/"))
+
+
+def _route_value(route: object) -> str:
+    value = getattr(route, "value", route)
+    return value if isinstance(value, str) else str(value)
+
+
+def _string_attr(value: Any, name: str) -> str | None:
+    raw = getattr(value, name, None)
+    return raw if isinstance(raw, str) and raw else None
+
+
+_LOCAL_COMMANDS_BY_ROUTE_VALUE: dict[str, CommandDef] = {
+    "status": CommandDef(
+        id="coding.ui.status",
+        name="status",
+        kind=CommandKind.LOCAL_UI,
+        description="Show current status",
+    ),
+    "model_select": CommandDef(
+        id="coding.ui.model",
+        name="model",
+        kind=CommandKind.LOCAL_UI,
+        description="Select model",
+    ),
+    "models": CommandDef(
+        id="coding.ui.models",
+        name="models",
+        kind=CommandKind.LOCAL_UI,
+        description="Show available models",
+    ),
+    "command_select": CommandDef(
+        id="coding.ui.command",
+        name="command",
+        kind=CommandKind.LOCAL_UI,
+        description="Select command",
+    ),
+    "commands": CommandDef(
+        id="coding.ui.commands",
+        name="commands",
+        kind=CommandKind.LOCAL_UI,
+        description="Show commands",
+    ),
+    "hotkeys": CommandDef(
+        id="coding.ui.hotkeys",
+        name="hotkeys",
+        kind=CommandKind.LOCAL_UI,
+        description="Show keyboard shortcuts",
+    ),
+    "settings": CommandDef(
+        id="coding.ui.settings",
+        name="settings",
+        kind=CommandKind.LOCAL_UI,
+        description="Open settings",
+    ),
+    "statusline": CommandDef(
+        id="coding.ui.statusline",
+        name="statusline",
+        kind=CommandKind.LOCAL_UI,
+        description="Configure status line visibility",
+    ),
+}
+_LOCAL_COMMANDS_BY_NAME: dict[str, CommandDef] = {
+    command.name: command for command in _LOCAL_COMMANDS_BY_ROUTE_VALUE.values()
+}
+
+
+__all__ = ["CodingCommandCatalog", "SessionCommandsProvider"]

--- a/src/loushang/coding/commands/catalog.py
+++ b/src/loushang/coding/commands/catalog.py
@@ -76,8 +76,14 @@ def _local_command_for_text(text: str) -> CommandDef | None:
     parsed = split_slash_command(text.strip())
     if parsed is None:
         return None
-    invocation_name, _args = parsed
-    return _LOCAL_COMMANDS_BY_NAME.get(invocation_name.removeprefix("/"))
+    invocation_name, args = parsed
+    name = invocation_name.removeprefix("/")
+    command = _LOCAL_COMMANDS_BY_NAME.get(name)
+    if command is None:
+        return None
+    if args and name not in _LOCAL_COMMANDS_ACCEPT_ARGS:
+        return None
+    return command
 
 
 def _route_value(route: object) -> str:
@@ -139,10 +145,17 @@ _LOCAL_COMMANDS_BY_ROUTE_VALUE: dict[str, CommandDef] = {
         kind=CommandKind.LOCAL_UI,
         description="Configure status line visibility",
     ),
+    "terminal": CommandDef(
+        id="coding.ui.terminal",
+        name="terminal",
+        kind=CommandKind.LOCAL_UI,
+        description="Show terminal diagnostics",
+    ),
 }
 _LOCAL_COMMANDS_BY_NAME: dict[str, CommandDef] = {
     command.name: command for command in _LOCAL_COMMANDS_BY_ROUTE_VALUE.values()
 }
+_LOCAL_COMMANDS_ACCEPT_ARGS = frozenset({"command", "commands", "model", "models", "statusline"})
 
 
 __all__ = ["CodingCommandCatalog", "SessionCommandsProvider"]

--- a/src/loushang/coding/ui/app.py
+++ b/src/loushang/coding/ui/app.py
@@ -8,8 +8,8 @@ from typing import Any, Protocol, TextIO
 from loushang.coding.ui.abort import AbortHandler
 from loushang.coding.ui.command_list import (
     CommandPaletteChooser,
-    format_session_commands,
-    select_session_command,
+    format_coding_commands,
+    select_coding_command,
 )
 from loushang.coding.ui.controller import CodingUiController
 from loushang.coding.ui.debug_command import DebugCommandHandler
@@ -158,8 +158,8 @@ def build_coding_tui_app(
         status=status_provider.render,
         model_select=lambda query: select_available_model(session, query=query, choose=model_palette_chooser),
         models=lambda query: format_available_models(session, query=query),
-        command_select=lambda query: select_session_command(session, query=query, choose=command_palette_chooser),
-        commands=lambda query: format_session_commands(session, query=query),
+        command_select=lambda query: select_coding_command(session, query=query, choose=command_palette_chooser),
+        commands=lambda query: format_coding_commands(session, query=query),
         hotkeys=format_hotkeys,
         settings=status_provider.settings_text,
         settings_list=status_provider.settings_list,

--- a/src/loushang/coding/ui/command_list.py
+++ b/src/loushang/coding/ui/command_list.py
@@ -4,6 +4,7 @@ import inspect
 from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 
+from loushang.coding.commands.catalog import CodingCommandCatalog
 from loushang.tui import CommandPalette, CompletionItem, CompletionProvider
 
 CommandPaletteChooser = Callable[[CommandPalette], Awaitable[str | None] | str | None]
@@ -33,6 +34,15 @@ async def format_session_commands(session: Any, *, query: str = "") -> str:
     return "\n".join(["Commands:", *sorted(lines)])
 
 
+async def format_coding_commands(
+    session: Any,
+    *,
+    query: str = "",
+    command_catalog: CodingCommandCatalog | None = None,
+) -> str:
+    return _format_commands(_catalog_commands(session, command_catalog=command_catalog), query=query)
+
+
 async def session_command_completion_provider(session: Any) -> CompletionProvider:
     getter = getattr(session, "list_commands", None)
     if not callable(getter):
@@ -49,8 +59,26 @@ async def session_command_completion_provider(session: Any) -> CompletionProvide
     return CompletionProvider(tuple(items))
 
 
+async def coding_command_completion_provider(
+    session: Any,
+    *,
+    command_catalog: CodingCommandCatalog | None = None,
+) -> CompletionProvider:
+    return _completion_provider_from_commands(_catalog_commands(session, command_catalog=command_catalog))
+
+
 async def session_command_palette(session: Any, *, title: str = "Commands") -> CommandPalette:
     provider = await session_command_completion_provider(session)
+    return CommandPalette.from_completion_provider(provider, title=title)
+
+
+async def coding_command_palette(
+    session: Any,
+    *,
+    title: str = "Commands",
+    command_catalog: CodingCommandCatalog | None = None,
+) -> CommandPalette:
+    provider = await coding_command_completion_provider(session, command_catalog=command_catalog)
     return CommandPalette.from_completion_provider(provider, title=title)
 
 
@@ -85,6 +113,73 @@ async def select_session_command(
     return f"Command selected: {matches[0].value}"
 
 
+async def select_coding_command(
+    session: Any,
+    *,
+    query: str = "",
+    choose: CommandPaletteChooser | None = None,
+    command_catalog: CodingCommandCatalog | None = None,
+) -> str:
+    stripped_query = query.strip()
+    if not stripped_query:
+        if choose is not None:
+            selected = await _maybe_await(
+                choose(await coding_command_palette(session, title="Commands", command_catalog=command_catalog))
+            )
+            if selected is None:
+                return "Command selection cancelled."
+            return await select_coding_command(session, query=selected, command_catalog=command_catalog)
+        return await format_coding_commands(session, command_catalog=command_catalog)
+
+    provider = await coding_command_completion_provider(session, command_catalog=command_catalog)
+    matches = _matching_command_items(provider, stripped_query)
+    if not matches:
+        return f"No commands match: {stripped_query}"
+    if len(matches) != 1:
+        return "\n".join(
+            [
+                "Multiple commands match:",
+                *(f"  {item.value}" for item in matches),
+                "Use /command <full command> to select one.",
+            ]
+        )
+
+    return f"Command selected: {matches[0].value}"
+
+
+def _format_commands(raw_commands: Iterable[object], *, query: str = "") -> str:
+    lines = [_format_command(command) for command in raw_commands]
+    lines = [line for line in lines if line]
+    stripped_query = query.strip()
+    if stripped_query:
+        needle = stripped_query.lower()
+        lines = [line for line in lines if needle in line.lower()]
+
+    if not lines:
+        if stripped_query:
+            return f"No commands match: {stripped_query}"
+        return "No commands available."
+
+    return "\n".join(["Commands:", *sorted(lines)])
+
+
+def _completion_provider_from_commands(raw_commands: Iterable[object]) -> CompletionProvider:
+    items = sorted(
+        (
+            (item, _command_source_priority(command))
+            for command in raw_commands
+            if (item := _command_completion_item(command)) is not None
+        ),
+        key=lambda pair: (pair[1], pair[0].value),
+    )
+    return CompletionProvider(tuple(item for item, _priority in items))
+
+
+def _catalog_commands(session: Any, *, command_catalog: CodingCommandCatalog | None = None) -> tuple[object, ...]:
+    catalog = command_catalog or CodingCommandCatalog(session_commands=_session_commands_provider(session))
+    return catalog.commands()
+
+
 def _format_command(command: object) -> str:
     name = _string_attr(command, "invocation_name") or _string_attr(command, "name")
     if name is None:
@@ -110,6 +205,10 @@ def _command_completion_item(command: object) -> CompletionItem | None:
         description = f"{description} ({source})" if description else f"({source})"
     value = f"/{name}"
     return CompletionItem(value=value, label=_command_label(name, argument_hint), description=description)
+
+
+def _command_source_priority(command: object) -> int:
+    return 1 if _string_attr(command, "source") == "local" else 0
 
 
 def _command_label(name: str, argument_hint: str | None) -> str:
@@ -145,6 +244,13 @@ def _string_attr(value: object, name: str) -> str | None:
     return raw if isinstance(raw, str) and raw else None
 
 
+def _session_commands_provider(session: Any):
+    getter = getattr(session, "list_commands", None)
+    if not callable(getter):
+        return None
+    return getter
+
+
 async def _maybe_await(value: Any) -> Any:
     if inspect.isawaitable(value):
         return await value
@@ -153,7 +259,11 @@ async def _maybe_await(value: Any) -> Any:
 
 __all__ = [
     "CommandPaletteChooser",
+    "coding_command_completion_provider",
+    "coding_command_palette",
     "format_session_commands",
+    "format_coding_commands",
+    "select_coding_command",
     "select_session_command",
     "session_command_completion_provider",
     "session_command_palette",

--- a/src/loushang/coding/ui/completion.py
+++ b/src/loushang/coding/ui/completion.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from loushang.coding.ui.command_list import session_command_completion_provider
+from loushang.coding.ui.command_list import coding_command_completion_provider
 from loushang.coding.ui.model_list import available_model_completion_provider
 from loushang.tui import (
     CombinedCompletionProvider,
@@ -38,7 +38,7 @@ async def coding_inline_completion_provider(session: Any) -> Any:
 
 
 async def _slash_command_completion_provider(session: Any) -> SlashCommandCompletionProvider:
-    command_provider = await session_command_completion_provider(session)
+    command_provider = await coding_command_completion_provider(session)
     provider = await available_model_completion_provider(session)
     commands = [
         SlashCommand(

--- a/src/loushang/coding/ui/controller.py
+++ b/src/loushang/coding/ui/controller.py
@@ -27,6 +27,7 @@ class ControllerResult:
     handled: bool = True
     exit_code: int | None = None
     error_message: str | None = None
+    status_message: str | None = None
     traceback_text: str | None = None
 
 
@@ -41,8 +42,9 @@ class CodingUiController:
             return ControllerResult(handled=False)
         try:
             if isinstance(intent, PromptIntent):
-                if await self._dispatch_session_command(intent):
-                    return ControllerResult()
+                command_result = await self._dispatch_session_command(intent)
+                if command_result is not None:
+                    return command_result
                 await self._prompt(intent.text, images=intent.images)
                 return ControllerResult()
             if isinstance(intent, BashIntent):
@@ -136,24 +138,24 @@ class CodingUiController:
             raise RuntimeError("Session does not support prompts")
         await _call_text_method(method, text, images=images)
 
-    async def _dispatch_session_command(self, intent: PromptIntent) -> bool:
+    async def _dispatch_session_command(self, intent: PromptIntent) -> ControllerResult | None:
         if intent.images:
-            return False
+            return None
         executor = getattr(self.session, "execute_command_async", None)
         if not callable(executor):
-            return False
+            return None
         catalog = CodingCommandCatalog(session_commands=_session_commands_provider(self.session))
         effect = catalog.effect_for_route("dispatch", intent)
         if effect is None or effect.kind is not CommandEffectKind.SESSION:
-            return False
+            return None
         if effect.command.source not in {"builtin", "extension"}:
-            return False
+            return None
         invocation_name = effect.payload.get("invocation_name")
         args = effect.payload.get("args", "")
         if not isinstance(invocation_name, str) or not isinstance(args, str):
-            return False
-        await _maybe_await(executor(invocation_name, args))
-        return True
+            return None
+        execution = await _maybe_await(executor(invocation_name, args))
+        return _controller_result_from_command_execution(execution, invocation_name=invocation_name)
 
     async def _bash(self, command: str) -> None:
         method = getattr(self.session, "execute_bash", None)
@@ -216,6 +218,19 @@ def _session_commands_provider(session: Any):
     if not callable(getter):
         return None
     return getter
+
+
+def _controller_result_from_command_execution(execution: object, *, invocation_name: str) -> ControllerResult:
+    result = getattr(execution, "result", None)
+    if result is None and not hasattr(execution, "result"):
+        result = execution
+    if isinstance(result, dict):
+        message = result.get("message")
+        if isinstance(message, str) and message:
+            if result.get("status") == "error":
+                return ControllerResult(error_message=message)
+            return ControllerResult(status_message=message)
+    return ControllerResult(status_message=f"Command /{invocation_name} completed.")
 
 
 async def _maybe_await(value: Any) -> Any:

--- a/src/loushang/coding/ui/controller.py
+++ b/src/loushang/coding/ui/controller.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from loushang.ai.types import ImagePart
+from loushang.coding.commands.catalog import CodingCommandCatalog
 from loushang.coding.ui.intent import (
     AbortIntent,
     BashIntent,
@@ -16,6 +17,7 @@ from loushang.coding.ui.intent import (
     QuitIntent,
 )
 from loushang.observability import get_log
+from loushang.runtime.commands import CommandEffectKind
 
 log = get_log(__name__).bind(component="CodingUiController")
 
@@ -39,6 +41,8 @@ class CodingUiController:
             return ControllerResult(handled=False)
         try:
             if isinstance(intent, PromptIntent):
+                if await self._dispatch_session_command(intent):
+                    return ControllerResult()
                 await self._prompt(intent.text, images=intent.images)
                 return ControllerResult()
             if isinstance(intent, BashIntent):
@@ -132,6 +136,25 @@ class CodingUiController:
             raise RuntimeError("Session does not support prompts")
         await _call_text_method(method, text, images=images)
 
+    async def _dispatch_session_command(self, intent: PromptIntent) -> bool:
+        if intent.images:
+            return False
+        executor = getattr(self.session, "execute_command_async", None)
+        if not callable(executor):
+            return False
+        catalog = CodingCommandCatalog(session_commands=_session_commands_provider(self.session))
+        effect = catalog.effect_for_route("dispatch", intent)
+        if effect is None or effect.kind is not CommandEffectKind.SESSION:
+            return False
+        if effect.command.source not in {"builtin", "extension"}:
+            return False
+        invocation_name = effect.payload.get("invocation_name")
+        args = effect.payload.get("args", "")
+        if not isinstance(invocation_name, str) or not isinstance(args, str):
+            return False
+        await _maybe_await(executor(invocation_name, args))
+        return True
+
     async def _bash(self, command: str) -> None:
         method = getattr(self.session, "execute_bash", None)
         if not callable(method):
@@ -186,6 +209,13 @@ def _supports_keyword(method: Any, keyword: str) -> bool:
         return False
     parameters = signature.parameters.values()
     return any(parameter.kind is inspect.Parameter.VAR_KEYWORD or parameter.name == keyword for parameter in parameters)
+
+
+def _session_commands_provider(session: Any):
+    getter = getattr(session, "list_commands", None)
+    if not callable(getter):
+        return None
+    return getter
 
 
 async def _maybe_await(value: Any) -> Any:

--- a/src/loushang/coding/ui/handlers.py
+++ b/src/loushang/coding/ui/handlers.py
@@ -4,6 +4,7 @@ import inspect
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol
 
+from loushang.coding.commands.catalog import CodingCommandCatalog
 from loushang.coding.ui.intent import (
     CodingUiIntent,
     CommandSelectIntent,
@@ -19,6 +20,7 @@ from loushang.coding.ui.lifecycle import RunLifecycle
 from loushang.coding.ui.pending_queue import pending_queue_view, restore_queued_messages
 from loushang.coding.ui.prompt_dispatch import PromptDispatchOutcome
 from loushang.coding.ui.prompt_routing import PromptRoute, route_prompt_intent
+from loushang.runtime.commands import CommandEffect, CommandEffectKind
 from loushang.tui import InfoPanel, PendingQueueView, SettingsList
 
 
@@ -40,6 +42,10 @@ class PromptDispatchFn(Protocol):
 
 class PromptResultFn(Protocol):
     def __call__(self, outcome: Any, *, prompt_started: float) -> Awaitable[int | None]: ...
+
+
+class CommandCatalog(Protocol):
+    def effect_for_route(self, route: PromptRoute, intent: CodingUiIntent) -> CommandEffect | None: ...
 
 
 class ModelsFn(Protocol):
@@ -85,6 +91,7 @@ class CodingTuiHandlers:
         lifecycle: RunLifecycle,
         parse_prompt: Callable[[str], CodingUiIntent | None] = parse_prompt_intent,
         route_prompt: Callable[[CodingUiIntent, RunLifecycle], PromptRoute] = route_prompt_intent,
+        command_catalog: CommandCatalog | None = None,
         follow_up: FollowUpFn,
         steer: Callable[[str], Awaitable[int | None]],
         debug: Callable[[Any], Awaitable[int | None]],
@@ -115,6 +122,7 @@ class CodingTuiHandlers:
         self._lifecycle = lifecycle
         self._parse_prompt = parse_prompt
         self._route_prompt = route_prompt
+        self._command_catalog = command_catalog or CodingCommandCatalog(session_commands=_session_commands_provider(session))
         self._follow_up = follow_up
         self._steer = steer
         self._debug = debug
@@ -173,6 +181,17 @@ class CodingTuiHandlers:
             return await self._steer(text)
         if route is PromptRoute.DEBUG:
             return await self._debug(intent)
+        effect = self._command_catalog.effect_for_route(route, intent)
+        if effect is not None:
+            self._trace(
+                "prompt.command",
+                route=route.value,
+                command_id=effect.command.id,
+                command_name=effect.command.name,
+                effect=effect.kind.value,
+            )
+            if effect.kind is CommandEffectKind.LOCAL_UI and await self._handle_local_command_effect(effect, intent):
+                return None
         if route is PromptRoute.STATUS:
             await self._show_info("Status", self._status(), label="status:show", local=True)
             return None
@@ -212,6 +231,46 @@ class CodingTuiHandlers:
 
         outcome = await self._dispatch(intent)
         return await self._result(outcome, prompt_started=prompt_started)
+
+    async def _handle_local_command_effect(self, effect: CommandEffect, intent: CodingUiIntent) -> bool:
+        command_name = effect.command.name
+        if command_name == "status":
+            await self._show_info("Status", self._status(), label="status:show", local=True)
+            return True
+        if command_name == "model":
+            query = intent.query if isinstance(intent, ModelSelectIntent) else ""
+            text = await self._model_select(query)
+            await self._emit(lambda: self._render_info("Model", text), label="model:select")
+            return True
+        if command_name == "models":
+            query = intent.query if isinstance(intent, ModelsIntent) else ""
+            text = await self._models(query)
+            await self._show_info("Models", text, label="models:show", local=True)
+            return True
+        if command_name == "command":
+            query = intent.query if isinstance(intent, CommandSelectIntent) else ""
+            text = await self._command_select(query)
+            await self._emit(lambda: self._render_info("Command", text), label="command:select")
+            return True
+        if command_name == "commands":
+            query = intent.query if isinstance(intent, CommandsIntent) else ""
+            text = await self._commands(query)
+            await self._show_info("Commands", text, label="commands:show", local=True)
+            return True
+        if command_name == "hotkeys":
+            await self._show_info("Hotkeys", self._hotkeys(), label="hotkeys:show", local=True)
+            return True
+        if command_name == "settings":
+            if await self._show_settings_list():
+                return True
+            await self._emit(lambda: self._render_info("Settings", self._settings()), label="settings:show")
+            return True
+        if command_name == "statusline":
+            enabled = intent.enabled if isinstance(intent, StatuslineIntent) else None
+            message = self._statusline(enabled)
+            await self._emit(lambda: self._render_status(message), label="statusline:set")
+            return True
+        return False
 
     async def queue_follow_up(self, text: str, *, source: str) -> int | None:
         return await self._follow_up(text, source=source)
@@ -285,6 +344,15 @@ async def _empty_command_select(_query: str) -> str:
 
 def _empty_settings() -> str:
     return "No settings available."
+
+
+def _session_commands_provider(session: Any | None):
+    if session is None:
+        return None
+    getter = getattr(session, "list_commands", None)
+    if not callable(getter):
+        return None
+    return getter
 
 
 async def _resolve(value):

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -275,6 +275,9 @@ def _record_controller_result(
     if result.error_message:
         app.add_error(result.error_message)
         app.set_status(f"{status_label}: {result.error_message}")
+    elif result.status_message:
+        app.add_status(result.status_message)
+        app.set_status(result.status_message)
     if verbose and stderr is not None and result.traceback_text:
         stderr.write(result.traceback_text)
         stderr.flush()

--- a/src/loushang/coding/ui/native_app.py
+++ b/src/loushang/coding/ui/native_app.py
@@ -165,6 +165,10 @@ class NativeCodingTuiApp:
         self.state.add_error(summary, diagnostics)
         self._request_render("product")
 
+    def add_status(self, message: str) -> None:
+        self.state.add_status(message)
+        self._request_render("product")
+
     def replace_transcript_window(
         self,
         records: Iterable[DisplayRecord] | NativeTranscriptWindow,

--- a/src/loushang/coding/ui/native_state.py
+++ b/src/loushang/coding/ui/native_state.py
@@ -8,6 +8,8 @@ from loushang.tui.transcript import (
     DisplayRecord,
     ErrorRecord,
     StreamingTextBuffer,
+    ThinkingRecord,
+    ThinkingVisibility,
     ToolExecutionRecord,
     UserPromptRecord,
     WorkedDividerRecord,
@@ -169,6 +171,12 @@ class NativeCodingTuiState:
     def add_error(self, summary: str, diagnostics: str = "") -> None:
         if summary:
             self.records.append(ErrorRecord(summary, diagnostics))
+        self._pending_user_echo = None
+
+    def add_status(self, message: str) -> None:
+        stripped = message.strip()
+        if stripped:
+            self.records.append(ThinkingRecord(stripped, ThinkingVisibility.VISIBLE))
         self._pending_user_echo = None
 
     def consume_pending_user_echo(self, text: str) -> bool:

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
-from typing import Any, Awaitable, Literal
+from typing import Any, Awaitable, Literal, Protocol
 
+from loushang.coding.commands.catalog import CodingCommandCatalog
 from loushang.coding.ui.command_list import (
     format_session_commands,
     session_command_palette,
@@ -37,6 +38,7 @@ from loushang.coding.ui.model_list import (
 )
 from loushang.coding.ui.native_app import NativeCodingTuiApp
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+from loushang.runtime.commands import CommandDef, CommandKind
 from loushang.tui import (
     ApprovalSurface,
     CommandPalette,
@@ -62,6 +64,10 @@ NativeSurfacePresentation = Literal["bottom", "bottom-exclusive"]
 SurfaceEventKind = Literal["surface_submit", "surface_close"]
 SurfaceEventSource = Literal["model", "command", "settings", "dialog", "approval"]
 MODEL_SELECTOR_SELECTED_STYLE = {"color": 33, "bold": True}
+
+
+class NativeCommandCatalog(Protocol):
+    def lookup(self, text: str) -> CommandDef | None: ...
 
 
 @dataclass(slots=True)
@@ -309,6 +315,7 @@ class NativeSurfaceManager:
     status_provider: CodingTuiStatusProvider
     on_approval: Callable[[dict[str, Any]], Awaitable[None]] | None = None
     set_statusline_visible: Callable[[bool | None], str] | None = None
+    command_catalog: NativeCommandCatalog | None = None
     _handlers: dict[SurfaceEventSource, Callable[[Any], Awaitable[None]]] = field(init=False, repr=False)
     _active_overlay_view: NativeSurfaceView | None = None
     _active_overlay_handle: SurfaceHandle | None = None
@@ -321,42 +328,34 @@ class NativeSurfaceManager:
             "dialog": self._handle_dialog_submit,
             "approval": self._handle_approval_submit,
         }
+        if self.command_catalog is None:
+            self.command_catalog = CodingCommandCatalog(session_commands=_session_commands_provider(self.session))
 
     def is_local_command(self, text: str) -> bool:
-        return isinstance(
-            parse_prompt_intent(text),
-            (
-                CommandSelectIntent,
-                CommandsIntent,
-                HotkeysIntent,
-                ModelSelectIntent,
-                ModelsIntent,
-                SettingsIntent,
-                StatusIntent,
-                StatuslineIntent,
-                TerminalDiagnosticsIntent,
-            ),
-        )
+        return self._lookup_local_command(text) is not None
 
     async def handle_text(self, text: str) -> int | None:
+        command = self._lookup_local_command(text)
+        if command is None:
+            return None
         intent = parse_prompt_intent(text)
-        if isinstance(intent, ModelSelectIntent):
+        if command.name == "model" and isinstance(intent, ModelSelectIntent):
             await self._handle_model_intent(intent)
-        elif isinstance(intent, ModelsIntent):
+        elif command.name == "models" and isinstance(intent, ModelsIntent):
             self._open_info("Models", await format_available_models(self.session, query=intent.query))
-        elif isinstance(intent, CommandSelectIntent):
+        elif command.name == "command" and isinstance(intent, CommandSelectIntent):
             await self._handle_command_intent(intent)
-        elif isinstance(intent, CommandsIntent):
+        elif command.name == "commands" and isinstance(intent, CommandsIntent):
             self._open_info("Commands", await format_session_commands(self.session, query=intent.query))
-        elif isinstance(intent, StatusIntent):
+        elif command.name == "status" and isinstance(intent, StatusIntent):
             self._open_info("Status", self.status_provider.render())
-        elif isinstance(intent, TerminalDiagnosticsIntent):
+        elif command.name == "terminal" and isinstance(intent, TerminalDiagnosticsIntent):
             self._open_terminal_diagnostics()
-        elif isinstance(intent, HotkeysIntent):
+        elif command.name == "hotkeys" and isinstance(intent, HotkeysIntent):
             self._open_info("Hotkeys", format_hotkeys())
-        elif isinstance(intent, SettingsIntent):
+        elif command.name == "settings" and isinstance(intent, SettingsIntent):
             self._open_settings()
-        elif isinstance(intent, StatuslineIntent):
+        elif command.name == "statusline" and isinstance(intent, StatuslineIntent):
             setter = self.set_statusline_visible or self.status_provider.set_visible
             message = setter(intent.enabled)
             if intent.enabled is not None:
@@ -365,6 +364,14 @@ class NativeSurfaceManager:
                 self.app.set_statusline_visible(self.status_provider.is_visible())
             self.app.set_status(message)
         return None
+
+    def _lookup_local_command(self, text: str) -> CommandDef | None:
+        if self.command_catalog is None:
+            return None
+        command = self.command_catalog.lookup(text)
+        if command is None or command.kind is not CommandKind.LOCAL_UI:
+            return None
+        return command
 
     async def handle_surface_intent(self, intent: InputIntent) -> int | None:
         surface = self._current_surface()
@@ -653,6 +660,13 @@ def _selected_model_item_index(items: tuple[SelectItem, ...], selected_value: st
 def _recoverable_surface_error(error: Exception) -> str:
     message = str(error).strip() or error.__class__.__name__
     return f"Error: {message}"
+
+
+def _session_commands_provider(session: Any) -> Callable[[], Any] | None:
+    getter = getattr(session, "list_commands", None)
+    if not callable(getter):
+        return None
+    return getter
 
 
 __all__ = ["NativeSurfaceManager", "NativeSurfaceView"]

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -6,8 +6,8 @@ from typing import Any, Awaitable, Literal, Protocol
 
 from loushang.coding.commands.catalog import CodingCommandCatalog
 from loushang.coding.ui.command_list import (
-    format_session_commands,
-    session_command_palette,
+    coding_command_palette,
+    format_coding_commands,
 )
 from loushang.coding.ui.hotkeys import format_hotkeys
 from loushang.coding.ui.intent import (
@@ -68,6 +68,8 @@ MODEL_SELECTOR_SELECTED_STYLE = {"color": 33, "bold": True}
 
 class NativeCommandCatalog(Protocol):
     def lookup(self, text: str) -> CommandDef | None: ...
+
+    def commands(self) -> tuple[CommandDef, ...]: ...
 
 
 @dataclass(slots=True)
@@ -346,7 +348,14 @@ class NativeSurfaceManager:
         elif command.name == "command" and isinstance(intent, CommandSelectIntent):
             await self._handle_command_intent(intent)
         elif command.name == "commands" and isinstance(intent, CommandsIntent):
-            self._open_info("Commands", await format_session_commands(self.session, query=intent.query))
+            self._open_info(
+                "Commands",
+                await format_coding_commands(
+                    self.session,
+                    query=intent.query,
+                    command_catalog=self._list_command_catalog(),
+                ),
+            )
         elif command.name == "status" and isinstance(intent, StatusIntent):
             self._open_info("Status", self.status_provider.render())
         elif command.name == "terminal" and isinstance(intent, TerminalDiagnosticsIntent):
@@ -372,6 +381,9 @@ class NativeSurfaceManager:
         if command is None or command.kind is not CommandKind.LOCAL_UI:
             return None
         return command
+
+    def _list_command_catalog(self) -> CodingCommandCatalog | None:
+        return self.command_catalog if isinstance(self.command_catalog, CodingCommandCatalog) else None
 
     async def handle_surface_intent(self, intent: InputIntent) -> int | None:
         surface = self._current_surface()
@@ -481,7 +493,11 @@ class NativeSurfaceManager:
             self.app.composer.set_text(command + " ")
             self.app.set_status(f"Command selected: {command}")
             return
-        self._open_palette("Commands", await session_command_palette(self.session, title="Commands"), purpose="command")
+        self._open_palette(
+            "Commands",
+            await coding_command_palette(self.session, title="Commands", command_catalog=self._list_command_catalog()),
+            purpose="command",
+        )
 
     def _open_palette(self, title: str, palette: CommandPalette, *, purpose: Literal["model", "command"]) -> None:
         surface = CommandSurface(_palette_items(palette), max_visible=8)

--- a/src/loushang/coding/ui/prompt_result.py
+++ b/src/loushang/coding/ui/prompt_result.py
@@ -14,6 +14,7 @@ class Lifecycle(Protocol):
 
 
 class Renderer(Protocol):
+    def render_status(self, text: str) -> None: ...
     def render_error(self, text: str) -> None: ...
     def render_worked(self, elapsed_seconds: float) -> None: ...
 
@@ -69,6 +70,8 @@ class PromptResultHandler:
             if self._verbose and result.traceback_text:
                 self._stderr.write(result.traceback_text)
                 self._stderr.flush()
+        elif result.status_message:
+            await self._emit(lambda: self._renderer.render_status(result.status_message or ""), label="prompt:status")
         elif outcome.work_intent and result.exit_code is None:
             await self._emit(
                 lambda: self._renderer.render_worked(self._now() - outcome.started_at),

--- a/src/loushang/runtime/__init__.py
+++ b/src/loushang/runtime/__init__.py
@@ -1,0 +1,8 @@
+from loushang.runtime.commands import (
+    CommandDef,
+    CommandEffect,
+    CommandEffectKind,
+    CommandKind,
+)
+
+__all__ = ["CommandDef", "CommandEffect", "CommandEffectKind", "CommandKind"]

--- a/src/loushang/runtime/commands.py
+++ b/src/loushang/runtime/commands.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Mapping
+
+
+class CommandKind(Enum):
+    LOCAL_UI = "local_ui"
+    SESSION = "session"
+
+
+class CommandEffectKind(Enum):
+    LOCAL_UI = "local_ui"
+    SESSION = "session"
+
+
+@dataclass(frozen=True)
+class CommandDef:
+    id: str
+    name: str
+    kind: CommandKind
+    description: str | None = None
+    source: str | None = None
+    aliases: tuple[str, ...] = ()
+    argument_hint: str | None = None
+
+
+@dataclass(frozen=True)
+class CommandEffect:
+    kind: CommandEffectKind
+    command: CommandDef
+    payload: Mapping[str, object] = field(default_factory=dict)
+
+
+__all__ = ["CommandDef", "CommandEffect", "CommandEffectKind", "CommandKind"]

--- a/tests/coding/test_coding_command_catalog.py
+++ b/tests/coding/test_coding_command_catalog.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def test_coding_command_catalog_classifies_local_and_session_commands() -> None:
+    from loushang.coding.commands.catalog import CodingCommandCatalog
+    from loushang.coding.ui.intent import PromptIntent, StatusIntent
+    from loushang.coding.ui.prompt_routing import PromptRoute
+    from loushang.runtime.commands import CommandEffectKind, CommandKind
+
+    catalog = CodingCommandCatalog(
+        session_commands=lambda: [
+            SimpleNamespace(
+                name="name",
+                invocation_name="name",
+                description="Set session display name",
+                source="builtin",
+                argument_hint="<name>",
+            )
+        ]
+    )
+
+    status_effect = catalog.effect_for_route(PromptRoute.STATUS, StatusIntent())
+    assert status_effect is not None
+    assert status_effect.kind is CommandEffectKind.LOCAL_UI
+    assert status_effect.command.kind is CommandKind.LOCAL_UI
+    assert status_effect.command.id == "coding.ui.status"
+
+    name_effect = catalog.effect_for_route(PromptRoute.DISPATCH, PromptIntent("/name Project Alpha"))
+    assert name_effect is not None
+    assert name_effect.kind is CommandEffectKind.SESSION
+    assert name_effect.command.kind is CommandKind.SESSION
+    assert name_effect.command.name == "name"
+    assert name_effect.payload == {"invocation_name": "name", "args": "Project Alpha"}
+
+
+def test_coding_command_catalog_leaves_plain_prompts_and_queue_routes_unowned() -> None:
+    from loushang.coding.commands.catalog import CodingCommandCatalog
+    from loushang.coding.ui.intent import FollowUpIntent, PromptIntent
+    from loushang.coding.ui.prompt_routing import PromptRoute
+
+    catalog = CodingCommandCatalog(session_commands=lambda: [])
+
+    assert catalog.effect_for_route(PromptRoute.DISPATCH, PromptIntent("hello")) is None
+    assert catalog.effect_for_route(PromptRoute.STEER, PromptIntent("steer")) is None
+    assert catalog.effect_for_route(PromptRoute.FOLLOW_UP, FollowUpIntent("later")) is None

--- a/tests/coding/test_coding_command_catalog.py
+++ b/tests/coding/test_coding_command_catalog.py
@@ -45,3 +45,19 @@ def test_coding_command_catalog_leaves_plain_prompts_and_queue_routes_unowned() 
     assert catalog.effect_for_route(PromptRoute.DISPATCH, PromptIntent("hello")) is None
     assert catalog.effect_for_route(PromptRoute.STEER, PromptIntent("steer")) is None
     assert catalog.effect_for_route(PromptRoute.FOLLOW_UP, FollowUpIntent("later")) is None
+
+
+def test_coding_command_catalog_preserves_local_command_argument_rules() -> None:
+    from loushang.coding.commands.catalog import CodingCommandCatalog
+    from loushang.runtime.commands import CommandKind
+
+    catalog = CodingCommandCatalog(session_commands=lambda: [])
+
+    terminal = catalog.lookup("/terminal")
+    assert terminal is not None
+    assert terminal.kind is CommandKind.LOCAL_UI
+
+    assert catalog.lookup("/model kimi").name == "model"
+    assert catalog.lookup("/commands model").name == "commands"
+    assert catalog.lookup("/status extra") is None
+    assert catalog.lookup("/terminal extra") is None

--- a/tests/coding/test_coding_command_catalog.py
+++ b/tests/coding/test_coding_command_catalog.py
@@ -61,3 +61,25 @@ def test_coding_command_catalog_preserves_local_command_argument_rules() -> None
     assert catalog.lookup("/commands model").name == "commands"
     assert catalog.lookup("/status extra") is None
     assert catalog.lookup("/terminal extra") is None
+
+
+def test_coding_command_catalog_lists_local_and_session_commands_once() -> None:
+    from loushang.coding.commands.catalog import CodingCommandCatalog
+    from loushang.runtime.commands import CommandKind
+
+    catalog = CodingCommandCatalog(
+        session_commands=lambda: [
+            SimpleNamespace(name="status", description="Session status", source="builtin"),
+            SimpleNamespace(name="deploy", description="Deploy app", source="extension"),
+        ]
+    )
+
+    commands = catalog.commands()
+    by_name = {command.name: command for command in commands}
+
+    assert len([command for command in commands if command.name == "status"]) == 1
+    assert by_name["status"].kind is CommandKind.SESSION
+    assert by_name["status"].source == "builtin"
+    assert by_name["deploy"].kind is CommandKind.SESSION
+    assert by_name["deploy"].source == "extension"
+    assert by_name["settings"].kind is CommandKind.LOCAL_UI

--- a/tests/coding/test_native_coding_tui_loop.py
+++ b/tests/coding/test_native_coding_tui_loop.py
@@ -784,6 +784,27 @@ def test_native_loop_waits_for_abort_settle_before_running_popped_pending_steer(
     assert "Request cancelled" not in result.text
 
 
+def test_native_loop_dispatches_session_command_without_prompting_agent() -> None:
+    from loushang.coding.ui.controller import CodingUiController
+    from loushang.coding.ui.mode import _native_prompt_handler
+    from loushang.coding.ui.playback import NativeTuiLoopPlayback
+
+    playback = NativeTuiLoopPlayback()
+    session = _NameCommandSession()
+    controller = CodingUiController(session=session)
+
+    result = playback.run(
+        (0.0, "/name Project Alpha\r"),
+        handle_prompt=_native_prompt_handler(app=playback.app, controller=controller, stderr=StringIO(), verbose=False),
+    )
+
+    assert result.exit_code == 0
+    assert session.commands == [("name", "Project Alpha")]
+    assert session.prompt_calls == []
+    assert "Session name set: Project Alpha" in result.text
+    result.assert_no_clear_screen()
+
+
 def test_pop_interrupt_pending_steer_returns_none_when_queue_empty() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_loop import _pop_interrupt_pending_steer
@@ -941,6 +962,44 @@ class _AbortSettlingSession:
     async def wait_for_idle(self) -> None:
         self.wait_for_idle_calls += 1
         await self._idle.wait()
+
+
+class _NameCommandSession:
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, str]] = []
+        self.prompt_calls: list[str] = []
+
+    def list_commands(self) -> list[object]:
+        return [
+            SimpleNamespace(
+                name="name",
+                description="Set session display name",
+                source="builtin",
+                argument_hint="<name>",
+            )
+        ]
+
+    async def execute_command_async(self, invocation_name: str, args: str) -> object:
+        self.commands.append((invocation_name, args))
+        return SimpleNamespace(
+            invocation_name=invocation_name,
+            result={
+                "source": "builtin",
+                "command": invocation_name,
+                "status": "ok",
+                "message": f"Session name set: {args}",
+            },
+        )
+
+    async def prompt(
+        self,
+        text: str,
+        *,
+        streaming_behavior: str | None = None,
+        source: str | None = None,
+    ) -> None:
+        del streaming_behavior, source
+        self.prompt_calls.append(text)
 
 
 def _assert_exit_cleanup_clears_bottom_frame(raw_output: str) -> None:

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -274,6 +274,44 @@ def test_native_surface_manager_opens_terminal_diagnostics_surface() -> None:
     assert "cell_size: 9x18" in plain_lines
 
 
+def test_native_surface_manager_routes_local_commands_through_command_catalog() -> None:
+    from loushang.runtime.commands import CommandDef, CommandKind
+
+    class Catalog:
+        def __init__(self) -> None:
+            self.lookups: list[str] = []
+
+        def lookup(self, text: str) -> CommandDef | None:
+            self.lookups.append(text)
+            if text == "/status":
+                return CommandDef(
+                    id="coding.ui.status",
+                    name="status",
+                    kind=CommandKind.LOCAL_UI,
+                    description="Show current status",
+                )
+            return None
+
+    app = _app()
+    app.surface_host = SurfaceHost()
+    catalog = Catalog()
+    manager = NativeSurfaceManager(
+        app=app,
+        session=_Session(),
+        status_provider=_status_provider(app),
+        command_catalog=catalog,
+    )
+
+    assert manager.is_local_command("/status") is True
+    assert manager.is_local_command("/status extra") is False
+
+    asyncio.run(manager.handle_text("/status"))
+
+    view = _only_overlay_view(app)
+    assert view.title == "Status"
+    assert catalog.lookups == ["/status", "/status extra", "/status"]
+
+
 def test_native_surface_model_selector_filters_by_typed_search() -> None:
     session = _Session()
     app = _app()

--- a/tests/coding/test_ui_command_list.py
+++ b/tests/coding/test_ui_command_list.py
@@ -109,6 +109,28 @@ def test_session_command_completion_provider_uses_argument_hint_in_label() -> No
     )
 
 
+def test_format_coding_commands_includes_local_and_session_commands() -> None:
+    from loushang.coding.ui.command_list import format_coding_commands
+
+    text = asyncio.run(format_coding_commands(_Session(), query="terminal"))
+
+    assert text == "Commands:\n/terminal - Show terminal diagnostics (local)"
+
+
+def test_coding_command_completion_provider_includes_local_commands() -> None:
+    from loushang.coding.ui.command_list import coding_command_completion_provider
+    from loushang.tui import CompletionItem
+
+    provider = asyncio.run(coding_command_completion_provider(_Session()))
+
+    assert CompletionItem(
+        value="/settings",
+        label="/settings",
+        description="Open settings (local)",
+    ) in provider.items
+    assert len([item for item in provider.items if item.value == "/hotkeys"]) == 1
+
+
 def test_builtin_terminal_command_is_visible_in_command_completion_and_list() -> None:
     from loushang.coding.ui.command_list import (
         format_session_commands,

--- a/tests/coding/test_ui_completion.py
+++ b/tests/coding/test_ui_completion.py
@@ -56,6 +56,17 @@ def test_complete_coding_input_lists_matching_slash_commands() -> None:
     )
 
 
+def test_complete_coding_input_lists_local_commands_missing_from_session() -> None:
+    from loushang.coding.ui.completion import complete_coding_input
+    from loushang.tui import CompletionItem
+
+    completions = asyncio.run(complete_coding_input(_Session(), "/set"))
+
+    assert completions == (
+        CompletionItem(value="/settings", label="/settings", description="Open settings (local)"),
+    )
+
+
 def test_coding_input_completion_provider_matches_current_input_context() -> None:
     from loushang.coding.ui.completion import coding_input_completion_provider
     from loushang.tui import CompletionItem, CompletionProvider

--- a/tests/coding/test_ui_controller.py
+++ b/tests/coding/test_ui_controller.py
@@ -176,7 +176,15 @@ def test_controller_dispatches_catalog_session_command_without_prompting_agent()
 
         async def execute_command_async(self, invocation_name: str, args: str) -> object:
             self.commands.append((invocation_name, args))
-            return SimpleNamespace(invocation_name=invocation_name, result=None)
+            return SimpleNamespace(
+                invocation_name=invocation_name,
+                result={
+                    "source": "builtin",
+                    "command": invocation_name,
+                    "status": "ok",
+                    "message": "Session name set: Project Alpha",
+                },
+            )
 
     session = CommandSession()
     controller = CodingUiController(session=session)
@@ -184,6 +192,7 @@ def test_controller_dispatches_catalog_session_command_without_prompting_agent()
     result = asyncio.run(controller.dispatch(PromptIntent(text="/name Project Alpha")))
 
     assert result.error_message is None
+    assert result.status_message == "Session name set: Project Alpha"
     assert session.commands == [("name", "Project Alpha")]
     assert session.prompts == []
 

--- a/tests/coding/test_ui_controller.py
+++ b/tests/coding/test_ui_controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 
 class _Session:
@@ -152,6 +153,72 @@ def test_controller_dispatches_prompt_intent_to_session_prompt() -> None:
 
     assert result.error_message is None
     assert session.prompts == ["hello"]
+
+
+def test_controller_dispatches_catalog_session_command_without_prompting_agent() -> None:
+    from loushang.coding.ui.controller import CodingUiController
+    from loushang.coding.ui.intent import PromptIntent
+
+    class CommandSession(_Session):
+        def __init__(self) -> None:
+            super().__init__()
+            self.commands: list[tuple[str, str]] = []
+
+        def list_commands(self) -> list[object]:
+            return [
+                SimpleNamespace(
+                    name="name",
+                    description="Set session display name",
+                    source="builtin",
+                    argument_hint="<name>",
+                )
+            ]
+
+        async def execute_command_async(self, invocation_name: str, args: str) -> object:
+            self.commands.append((invocation_name, args))
+            return SimpleNamespace(invocation_name=invocation_name, result=None)
+
+    session = CommandSession()
+    controller = CodingUiController(session=session)
+
+    result = asyncio.run(controller.dispatch(PromptIntent(text="/name Project Alpha")))
+
+    assert result.error_message is None
+    assert session.commands == [("name", "Project Alpha")]
+    assert session.prompts == []
+
+
+def test_controller_leaves_prompt_resource_commands_on_prompt_path() -> None:
+    from loushang.coding.ui.controller import CodingUiController
+    from loushang.coding.ui.intent import PromptIntent
+
+    class PromptResourceSession(_Session):
+        def __init__(self) -> None:
+            super().__init__()
+            self.commands: list[tuple[str, str]] = []
+
+        def list_commands(self) -> list[object]:
+            return [
+                SimpleNamespace(
+                    name="review",
+                    description="Review pull request",
+                    source="prompt",
+                    argument_hint="<PR-URL>",
+                )
+            ]
+
+        async def execute_command_async(self, invocation_name: str, args: str) -> object:
+            self.commands.append((invocation_name, args))
+            return SimpleNamespace(invocation_name=invocation_name, result={"text": "expanded prompt"})
+
+    session = PromptResourceSession()
+    controller = CodingUiController(session=session)
+
+    result = asyncio.run(controller.dispatch(PromptIntent(text="/review https://example.test/pr/1")))
+
+    assert result.error_message is None
+    assert session.commands == []
+    assert session.prompts == ["/review https://example.test/pr/1"]
 
 
 def test_controller_dispatches_prompt_images_to_session_prompt() -> None:

--- a/tests/coding/test_ui_handlers.py
+++ b/tests/coding/test_ui_handlers.py
@@ -133,6 +133,67 @@ def test_coding_tui_handlers_renders_status_command() -> None:
     assert statuses == ["model=m cwd=/repo session=sid"]
 
 
+def test_coding_tui_handlers_routes_status_through_command_catalog() -> None:
+    from loushang.coding.ui.handlers import CodingTuiHandlers
+    from loushang.coding.ui.intent import StatusIntent
+    from loushang.coding.ui.prompt_routing import PromptRoute
+    from loushang.runtime.commands import (
+        CommandDef,
+        CommandEffect,
+        CommandEffectKind,
+        CommandKind,
+    )
+
+    emitted: list[str] = []
+    statuses: list[str] = []
+    catalog_calls: list[tuple[PromptRoute, object]] = []
+
+    class Catalog:
+        def effect_for_route(self, route: PromptRoute, intent: object) -> CommandEffect | None:
+            catalog_calls.append((route, intent))
+            return CommandEffect(
+                kind=CommandEffectKind.LOCAL_UI,
+                command=CommandDef(
+                    id="coding.ui.status",
+                    name="status",
+                    kind=CommandKind.LOCAL_UI,
+                    description="Show current status",
+                ),
+            )
+
+    async def emit(write, *, label: str):
+        emitted.append(label)
+        write()
+
+    intent = StatusIntent()
+    handlers = CodingTuiHandlers(
+        lifecycle=_Lifecycle(),
+        parse_prompt=lambda _text: intent,
+        route_prompt=lambda _intent, _lifecycle: PromptRoute.STATUS,
+        command_catalog=Catalog(),
+        follow_up=lambda _text, *, source: _async_none(),
+        steer=lambda _text: _async_none(),
+        debug=lambda _intent: _async_none(),
+        dispatch=lambda _intent: _async_none(),
+        result=lambda _outcome, *, prompt_started: _async_none(),
+        abort=lambda: _async_none(),
+        restore_queue=lambda _text: _async_none(),
+        emit=emit,
+        render_status=lambda text: statuses.append(text),
+        status=lambda: "model=m cwd=/repo session=sid",
+        now=lambda: 10.0,
+        session_running=lambda: False,
+        trace=lambda _name, **_data: None,
+    )
+
+    result = asyncio.run(handlers.handle_prompt("/status"))
+
+    assert result is None
+    assert emitted == ["status:show"]
+    assert statuses == ["model=m cwd=/repo session=sid"]
+    assert catalog_calls == [(PromptRoute.STATUS, intent)]
+
+
 def test_coding_tui_handlers_can_render_status_command_with_info_panel() -> None:
     from loushang.coding.ui.handlers import CodingTuiHandlers
     from loushang.coding.ui.intent import StatusIntent

--- a/tests/coding/test_ui_prompt_result.py
+++ b/tests/coding/test_ui_prompt_result.py
@@ -19,12 +19,16 @@ class _Renderer:
     def __init__(self) -> None:
         self.errors: list[str] = []
         self.worked: list[float] = []
+        self.statuses: list[str] = []
 
     def render_error(self, text: str) -> None:
         self.errors.append(text)
 
     def render_worked(self, elapsed_seconds: float) -> None:
         self.worked.append(elapsed_seconds)
+
+    def render_status(self, text: str) -> None:
+        self.statuses.append(text)
 
 
 async def _emit(write, *, label: str) -> None:
@@ -182,3 +186,41 @@ def test_prompt_result_renders_worked_for_successful_work_intent() -> None:
     assert exit_code is None
     assert emitted == ["prompt:worked"]
     assert renderer.worked == [2.5]
+
+
+def test_prompt_result_renders_controller_status_message_instead_of_worked() -> None:
+    from loushang.coding.ui.controller import ControllerResult
+    from loushang.coding.ui.prompt_dispatch import PromptDispatchOutcome
+    from loushang.coding.ui.prompt_result import PromptResultHandler
+
+    renderer = _Renderer()
+    emitted: list[str] = []
+    outcome = PromptDispatchOutcome(
+        result=ControllerResult(exit_code=None, status_message="Session name set: Project Alpha"),
+        run_id=2,
+        work_intent=True,
+        started_at=10.0,
+    )
+
+    async def emit(write, *, label: str) -> None:
+        emitted.append(label)
+        write()
+
+    handler = PromptResultHandler(
+        lifecycle=_Lifecycle(),
+        renderer=renderer,
+        emit=emit,
+        stderr=StringIO(),
+        verbose=False,
+        last_error_message=lambda: None,
+        session_error_message=lambda: None,
+        now=lambda: 12.5,
+        trace=lambda _name, **_data: None,
+    )
+
+    exit_code = asyncio.run(handler.handle(outcome, prompt_started=8.0))
+
+    assert exit_code is None
+    assert emitted == ["prompt:status"]
+    assert renderer.statuses == ["Session name set: Project Alpha"]
+    assert renderer.worked == []


### PR DESCRIPTION
## Summary
- Add neutral command definition/effect types and a coding command catalog for local UI and session command classification.
- Route plain/native TUI local commands, command listing, command selection, and slash completion through the catalog while preserving prompt/skill preflight behavior.
- Dispatch builtin/extension session commands from the TUI controller and render command status results in native playback.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_ui_controller.py tests/coding/test_ui_prompt_result.py tests/coding/test_native_coding_tui_loop.py tests/coding/test_native_coding_tui_playback.py tests/coding/test_session_command_controller.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k command -q
- uv --cache-dir .uv-cache run ruff check src/loushang/runtime src/loushang/coding/commands/catalog.py src/loushang/coding/ui/command_list.py src/loushang/coding/ui/completion.py src/loushang/coding/ui/app.py src/loushang/coding/ui/controller.py src/loushang/coding/ui/handlers.py src/loushang/coding/ui/native_surfaces.py src/loushang/coding/ui/native_state.py src/loushang/coding/ui/native_app.py src/loushang/coding/ui/mode.py src/loushang/coding/ui/prompt_result.py tests/coding/test_coding_command_catalog.py tests/coding/test_ui_command_list.py tests/coding/test_ui_completion.py tests/coding/test_ui_controller.py tests/coding/test_ui_prompt_result.py tests/coding/test_ui_handlers.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_loop.py