### PR TITLE
Add work P0 shell and event log

### DIFF
--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -35,7 +35,7 @@ Create frozen dataclasses and literal aliases. Do not add multi-agent public API
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_work_types.py -q`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 Commit message: `feat: add work p0 core types`
 
@@ -62,7 +62,7 @@ Create `EventLogEntry`, `EventPosition`, `EventLogBackend` protocol, and `InMemo
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_event_log.py -q`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 Commit message: `feat: add work event log backend`
 
@@ -89,7 +89,7 @@ Add pure functions that accept metadata plus `AgentEvent`/coding session event a
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_agent_event_projection.py -q`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 Commit message: `feat: project agent events to work events`
 
@@ -116,7 +116,7 @@ Keep it independent from concrete `AgentSession` construction. Accept a promptab
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_coding_work_shell.py -q`
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 Commit message: `feat: add coding work shell`
 
@@ -147,6 +147,6 @@ uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/agent/test_publ
 uv --cache-dir .uv-cache run ruff check src/loushang/work tests/work
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 Commit message: `test: cover work p0 public surface`

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -354,3 +354,48 @@ PY
 - [x] **Step 8: Commit**
 
 Commit message: `feat: add cli work log switch`
+
+### Task 9: CLI Work Log Inspect Command
+
+**Files:**
+- Modify: `src/loushang/coding/cli/args.py`
+- Modify: `src/loushang/coding/cli/__main__.py`
+- Test: `tests/coding/test_cli.py`
+
+- [x] **Step 1: Write failing CLI inspect tests**
+
+Cover `--work-log-inspect PATH` parsing, text summary output, JSON summary output, run filtering, and no runtime/session startup.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k work_log_inspect -q`
+
+Expected: parse failure or missing `work_log_inspect` attribute.
+
+- [x] **Step 3: Implement inspect arguments and read-only command**
+
+Add `CliArgs.work_log_inspect`, `CliArgs.work_log_run`, and `CliArgs.work_log_inspect_format`. Implement a read-only command that opens `JsonlEventLogBackend`, queries recent entries, and renders `sequence`, `kind`, `run_id`, `session_id`, and `delivery_hint` in text or JSON.
+
+- [x] **Step 4: Run focused suite**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k "work_log_inspect or work_log" -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/test_prompt_command.py tests/coding/test_print_mode.py tests/work -q
+uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli/args.py src/loushang/coding/cli/__main__.py tests/coding/test_cli.py
+```
+
+- [x] **Step 5: Manual verification**
+
+From the branch worktree:
+
+```bash
+uv --cache-dir .uv-cache run loushang --help | rg -- --work-log-inspect
+uv --cache-dir .uv-cache run loushang --work-log-inspect .loushang/work/events.jsonl
+uv --cache-dir .uv-cache run loushang --work-log-inspect .loushang/work/events.jsonl --work-log-inspect-format json
+```
+
+- [x] **Step 6: Commit**
+
+Commit message: `feat: add work log inspect command`

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -17,21 +17,21 @@
 - Create: `src/loushang/work/types.py`
 - Test: `tests/work/test_work_types.py`
 
-- [ ] **Step 1: Write failing tests for P0 dataclass defaults**
+- [x] **Step 1: Write failing tests for P0 dataclass defaults**
 
 Test `WorkOperation`, `WorkRun`, `WorkEvent`, and delivery hints with JSON-compatible payloads.
 
-- [ ] **Step 2: Run tests to verify RED**
+- [x] **Step 2: Run tests to verify RED**
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_work_types.py -q`
 
 Expected: import failure for `loushang.work`.
 
-- [ ] **Step 3: Implement minimal types**
+- [x] **Step 3: Implement minimal types**
 
 Create frozen dataclasses and literal aliases. Do not add multi-agent public APIs.
 
-- [ ] **Step 4: Run tests to verify GREEN**
+- [x] **Step 4: Run tests to verify GREEN**
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_work_types.py -q`
 

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -46,19 +46,19 @@ Commit message: `feat: add work p0 core types`
 - Modify: `src/loushang/work/__init__.py`
 - Test: `tests/work/test_event_log.py`
 
-- [ ] **Step 1: Write failing tests for append/query/subscribe**
+- [x] **Step 1: Write failing tests for append/query/subscribe**
 
 Cover append position ordering, query by run/session, and async subscribe receiving later entries.
 
-- [ ] **Step 2: Run tests to verify RED**
+- [x] **Step 2: Run tests to verify RED**
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_event_log.py -q`
 
-- [ ] **Step 3: Implement in-memory backend**
+- [x] **Step 3: Implement in-memory backend**
 
 Create `EventLogEntry`, `EventPosition`, `EventLogBackend` protocol, and `InMemoryEventLogBackend`.
 
-- [ ] **Step 4: Run tests to verify GREEN**
+- [x] **Step 4: Run tests to verify GREEN**
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_event_log.py -q`
 

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -73,19 +73,19 @@ Commit message: `feat: add work event log backend`
 - Modify: `src/loushang/work/__init__.py`
 - Test: `tests/work/test_agent_event_projection.py`
 
-- [ ] **Step 1: Write failing projection tests**
+- [x] **Step 1: Write failing projection tests**
 
 Cover `agent_start`, `agent_end`, `message_update`, `tool_execution_start`, `tool_execution_end`, and `queue_update`.
 
-- [ ] **Step 2: Run tests to verify RED**
+- [x] **Step 2: Run tests to verify RED**
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_agent_event_projection.py -q`
 
-- [ ] **Step 3: Implement projection helpers**
+- [x] **Step 3: Implement projection helpers**
 
 Add pure functions that accept metadata plus `AgentEvent`/coding session event and return one or more `WorkEvent` values.
 
-- [ ] **Step 4: Run tests to verify GREEN**
+- [x] **Step 4: Run tests to verify GREEN**
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_agent_event_projection.py -q`
 

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -126,19 +126,19 @@ Commit message: `feat: add coding work shell`
 - Modify: `src/loushang/work/__init__.py`
 - Create: `tests/work/test_public_api.py`
 
-- [ ] **Step 1: Write failing public API test**
+- [x] **Step 1: Write failing public API test**
 
 Assert the P0 public exports are available and do not include `AgentLane`, `TaskLedger`, or `CollaborationBus`.
 
-- [ ] **Step 2: Run test to verify RED**
+- [x] **Step 2: Run test to verify RED**
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_public_api.py -q`
 
-- [ ] **Step 3: Update exports**
+- [x] **Step 3: Update exports**
 
 Export only the P0 surface.
 
-- [ ] **Step 4: Run focused suite**
+- [x] **Step 4: Run focused suite**
 
 Run:
 

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -182,3 +182,100 @@ uv --cache-dir .uv-cache run ruff check src/loushang/work src/loushang/coding/mo
 - [x] **Step 5: Commit**
 
 Commit message: `feat: wire print mode to work shell`
+
+### Task 7: JSONL Event Log Persistence And Replay Smoke
+
+**Files:**
+- Modify: `src/loushang/work/event_log.py`
+- Modify: `src/loushang/work/__init__.py`
+- Test: `tests/work/test_event_log.py`
+- Test: `tests/work/test_coding_work_shell.py`
+
+- [x] **Step 1: Write failing JSONL backend tests**
+
+Cover append positions, query by run/session, `after` replay, reopening from disk, and subscribe replay/stream behavior.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_event_log.py -k jsonl -q`
+
+Expected: import failure for `JsonlEventLogBackend`.
+
+- [x] **Step 3: Implement minimal JSONL backend**
+
+Add `JsonlEventLogBackend` with one JSON object per line. Normalize payload values into JSON-safe data at append time. Keep `EventLogBackend` unchanged.
+
+- [x] **Step 4: Add work-shell replay smoke test**
+
+Use `CodingWorkShell` with `JsonlEventLogBackend`, run a fake coding turn, reopen the log, and assert the persisted WorkOperation/WorkEvent sequence is replayable.
+
+- [x] **Step 5: Run focused suite**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/coding/test_print_mode.py -q
+uv --cache-dir .uv-cache run ruff check src/loushang/work tests/work
+```
+
+- [x] **Step 6: Manual verification commands**
+
+From the branch worktree:
+
+```bash
+cd /home/dev/workspace/loushang/.worktrees/work-p0-28
+uv --cache-dir .uv-cache run loushang --help
+uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/coding/test_print_mode.py -q
+```
+
+No-provider smoke for the work log path:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev python - <<'PY'
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from loushang.work import CodingWorkShell, JsonlEventLogBackend
+
+class FakeSession:
+    def __init__(self):
+        self.listeners = []
+
+    def subscribe(self, listener):
+        self.listeners.append(listener)
+        return lambda: self.listeners.remove(listener)
+
+    async def prompt(self, text):
+        for listener in list(self.listeners):
+            result = listener({
+                "type": "message_update",
+                "message": {"role": "assistant"},
+                "assistant_message_event": {"type": "text_delta", "text": "ok"},
+            })
+            if result is not None:
+                await result
+
+async def main():
+    with TemporaryDirectory() as tmp:
+        path = Path(tmp) / "events.jsonl"
+        shell = CodingWorkShell(
+            session=FakeSession(),
+            event_log=JsonlEventLogBackend(path),
+            clock=lambda: datetime(2026, 6, 1, tzinfo=UTC),
+        )
+        run = await shell.submit_coding_turn("hello", session_id="manual", run_id="run-manual")
+        entries = JsonlEventLogBackend(path).query(run_id=run.run_id)
+        print(run.status)
+        print([entry.payload["kind"] for entry in entries])
+
+asyncio.run(main())
+PY
+```
+
+Expected output includes `completed` and the persisted event kinds.
+
+- [x] **Step 7: Commit**
+
+Commit message: `feat: add jsonl work event log`

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -1,0 +1,152 @@
+# Work P0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the P0 `loushang.work` shell around the existing coding fast path.
+
+**Architecture:** Add a small `loushang.work` package with stable dataclass models, an in-memory event log backend, and projection helpers from current `AgentEvent`/coding session events to `WorkEvent`. Keep `AgentSession` unchanged for P0; the work shell wraps and observes it rather than moving prompt/tool/session responsibilities.
+
+**Tech Stack:** Python 3.11+, dataclasses, `TypedDict`-style JSON-compatible payloads, pytest, existing `loushang.agent` and `loushang.coding.event` types.
+
+---
+
+### Task 1: Core Work Types
+
+**Files:**
+- Create: `src/loushang/work/__init__.py`
+- Create: `src/loushang/work/types.py`
+- Test: `tests/work/test_work_types.py`
+
+- [ ] **Step 1: Write failing tests for P0 dataclass defaults**
+
+Test `WorkOperation`, `WorkRun`, `WorkEvent`, and delivery hints with JSON-compatible payloads.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_work_types.py -q`
+
+Expected: import failure for `loushang.work`.
+
+- [ ] **Step 3: Implement minimal types**
+
+Create frozen dataclasses and literal aliases. Do not add multi-agent public APIs.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_work_types.py -q`
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat: add work p0 core types`
+
+### Task 2: EventLogBackend
+
+**Files:**
+- Create: `src/loushang/work/event_log.py`
+- Modify: `src/loushang/work/__init__.py`
+- Test: `tests/work/test_event_log.py`
+
+- [ ] **Step 1: Write failing tests for append/query/subscribe**
+
+Cover append position ordering, query by run/session, and async subscribe receiving later entries.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_event_log.py -q`
+
+- [ ] **Step 3: Implement in-memory backend**
+
+Create `EventLogEntry`, `EventPosition`, `EventLogBackend` protocol, and `InMemoryEventLogBackend`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_event_log.py -q`
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat: add work event log backend`
+
+### Task 3: AgentEvent To WorkEvent Projection
+
+**Files:**
+- Create: `src/loushang/work/projection.py`
+- Modify: `src/loushang/work/__init__.py`
+- Test: `tests/work/test_agent_event_projection.py`
+
+- [ ] **Step 1: Write failing projection tests**
+
+Cover `agent_start`, `agent_end`, `message_update`, `tool_execution_start`, `tool_execution_end`, and `queue_update`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_agent_event_projection.py -q`
+
+- [ ] **Step 3: Implement projection helpers**
+
+Add pure functions that accept metadata plus `AgentEvent`/coding session event and return one or more `WorkEvent` values.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_agent_event_projection.py -q`
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat: project agent events to work events`
+
+### Task 4: Coding Work Shell
+
+**Files:**
+- Create: `src/loushang/work/coding.py`
+- Modify: `src/loushang/work/__init__.py`
+- Test: `tests/work/test_coding_work_shell.py`
+
+- [ ] **Step 1: Write failing wrapper tests**
+
+Use a fake promptable session with `prompt()` and `subscribe()` to verify `SubmitCodingTurn` creates a `WorkRun`, appends operation/run/events, calls prompt once, and projects emitted events.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_coding_work_shell.py -q`
+
+- [ ] **Step 3: Implement minimal `CodingWorkShell`**
+
+Keep it independent from concrete `AgentSession` construction. Accept a promptable/subscribable session object and an `EventLogBackend`.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_coding_work_shell.py -q`
+
+- [ ] **Step 5: Commit**
+
+Commit message: `feat: add coding work shell`
+
+### Task 5: Public Surface And Focused Regression
+
+**Files:**
+- Modify: `src/loushang/work/__init__.py`
+- Create: `tests/work/test_public_api.py`
+
+- [ ] **Step 1: Write failing public API test**
+
+Assert the P0 public exports are available and do not include `AgentLane`, `TaskLedger`, or `CollaborationBus`.
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_public_api.py -q`
+
+- [ ] **Step 3: Update exports**
+
+Export only the P0 surface.
+
+- [ ] **Step 4: Run focused suite**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/agent/test_public_api.py tests/coding/test_session_events.py tests/coding/test_session_event_bus.py tests/coding/test_workflow_events.py -q
+uv --cache-dir .uv-cache run ruff check src/loushang/work tests/work
+```
+
+- [ ] **Step 5: Commit**
+
+Commit message: `test: cover work p0 public surface`

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -100,19 +100,19 @@ Commit message: `feat: project agent events to work events`
 - Modify: `src/loushang/work/__init__.py`
 - Test: `tests/work/test_coding_work_shell.py`
 
-- [ ] **Step 1: Write failing wrapper tests**
+- [x] **Step 1: Write failing wrapper tests**
 
 Use a fake promptable session with `prompt()` and `subscribe()` to verify `SubmitCodingTurn` creates a `WorkRun`, appends operation/run/events, calls prompt once, and projects emitted events.
 
-- [ ] **Step 2: Run tests to verify RED**
+- [x] **Step 2: Run tests to verify RED**
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_coding_work_shell.py -q`
 
-- [ ] **Step 3: Implement minimal `CodingWorkShell`**
+- [x] **Step 3: Implement minimal `CodingWorkShell`**
 
 Keep it independent from concrete `AgentSession` construction. Accept a promptable/subscribable session object and an `EventLogBackend`.
 
-- [ ] **Step 4: Run tests to verify GREEN**
+- [x] **Step 4: Run tests to verify GREEN**
 
 Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_coding_work_shell.py -q`
 

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -279,3 +279,78 @@ Expected output includes `completed` and the persisted event kinds.
 - [x] **Step 7: Commit**
 
 Commit message: `feat: add jsonl work event log`
+
+### Task 8: CLI Work Log Switch
+
+**Files:**
+- Modify: `src/loushang/coding/cli/args.py`
+- Modify: `src/loushang/coding/cli/__main__.py`
+- Modify: `src/loushang/coding/mode/base.py`
+- Modify: `src/loushang/coding/prompt_command.py`
+- Test: `tests/coding/test_cli.py`
+- Test: `tests/coding/test_print_mode.py`
+- Test: `tests/coding/test_prompt_command.py`
+
+- [x] **Step 1: Write failing CLI tests**
+
+Cover `--work-log PATH` parsing, prompt-command injection, print runner injection, default unified mode runner injection, and unsupported TUI/RPC/workflow paths.
+
+- [x] **Step 2: Run tests to verify RED**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k work_log -q`
+
+Expected: parse failure or missing `work_log` attribute.
+
+- [x] **Step 3: Implement CLI argument and backend wiring**
+
+Add `CliArgs.work_log`, parser support, builtin flag registration, and a helper that resolves relative paths under the project root into `JsonlEventLogBackend`.
+
+- [x] **Step 4: Pass work log through mode adapter**
+
+Add optional `work_event_log` plumbing through `run_mode()` / `create_mode_adapter()` into `PrintMode`.
+
+- [x] **Step 5: Add mode-level regression**
+
+Verify `run_mode(..., work_event_log=InMemoryEventLogBackend())` routes through `PrintMode` and records work events.
+
+- [x] **Step 6: Run focused suite**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k "work_log or default_path_uses_unified_mode_runner or mode_print_dispatches_print_adapter" -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_print_mode.py tests/work -q
+uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli src/loushang/coding/mode src/loushang/work tests/coding/test_cli.py tests/coding/test_print_mode.py tests/work
+```
+
+- [x] **Step 7: Manual verification**
+
+From the branch worktree:
+
+```bash
+cd /home/dev/workspace/loushang/.worktrees/work-p0-28
+uv --cache-dir .uv-cache run loushang --help | rg -- --work-log
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k work_log -q
+```
+
+With a configured provider/model, run:
+
+```bash
+uv --cache-dir .uv-cache run loushang --mode text --work-log .loushang/work/events.jsonl --prompt "hello"
+```
+
+Then inspect:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+from loushang.work import JsonlEventLogBackend
+
+entries = JsonlEventLogBackend(Path(".loushang/work/events.jsonl")).query(limit=20)
+print([entry.payload["kind"] for entry in entries])
+PY
+```
+
+- [x] **Step 8: Commit**
+
+Commit message: `feat: add cli work log switch`

--- a/docs/superpowers/plans/2026-06-01-work-p0.md
+++ b/docs/superpowers/plans/2026-06-01-work-p0.md
@@ -150,3 +150,35 @@ uv --cache-dir .uv-cache run ruff check src/loushang/work tests/work
 - [x] **Step 5: Commit**
 
 Commit message: `test: cover work p0 public surface`
+
+### Task 6: Optional Print Mode Work Logging
+
+**Files:**
+- Modify: `src/loushang/coding/mode/print_mode.py`
+- Modify: `src/loushang/work/coding.py`
+- Test: `tests/coding/test_print_mode.py`
+
+- [x] **Step 1: Write failing print-mode integration test**
+
+Verify `PrintMode` can optionally route prompts through `CodingWorkShell`, append `WorkEvent` entries to a caller-provided event log, preserve existing stdout behavior, and keep image arguments intact.
+
+- [x] **Step 2: Run test to verify RED**
+
+Run: `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_print_mode.py -k work_event_log -q`
+
+- [x] **Step 3: Implement optional work logging path**
+
+Add an optional event log parameter to print mode and route prompt execution through `CodingWorkShell` only when provided. Keep the default path unchanged.
+
+- [x] **Step 4: Run focused suite**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_print_mode.py tests/work -q
+uv --cache-dir .uv-cache run ruff check src/loushang/work src/loushang/coding/mode/print_mode.py tests/work tests/coding/test_print_mode.py
+```
+
+- [x] **Step 5: Commit**
+
+Commit message: `feat: wire print mode to work shell`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,7 @@ dependencies = [
   "markdown-it-py>=4.2,<5",
   "openai>=2.30.0",
   "pillow>=12.2.0",
-  "prompt-toolkit>=3,<4",
   "pygments>=2.19,<3",
-  "rich>=14,<15",
 ]
 
 [project.scripts]

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -67,6 +67,7 @@ from loushang.coding.workflow import (
 from loushang.work import JsonlEventLogBackend
 
 _MISSING = object()
+_WORK_LOG_INSPECT_LIMIT = 20
 
 
 @dataclass(frozen=True)
@@ -248,6 +249,9 @@ async def run_cli(
     if work_log_error is not None:
         stderr.write(f"Error: {work_log_error}.\n")
         return 2
+    work_log_inspect_result = _run_work_log_inspect(bootstrap_args, project_root, stdout, stderr)
+    if work_log_inspect_result is not None:
+        return work_log_inspect_result
 
     with _stdout_guard_context(bootstrap_args, stdout, stderr):
         resolved_services = services or build_default_services(project_root)
@@ -671,10 +675,67 @@ def _work_log_runtime_error(args: CliArgs, *, effective_tui: bool) -> str | None
 def _resolve_work_event_log(raw_path: str | None, project_root: Path) -> JsonlEventLogBackend | None:
     if raw_path is None:
         return None
+    return JsonlEventLogBackend(_resolve_work_log_path(raw_path, project_root))
+
+
+def _run_work_log_inspect(args: CliArgs, project_root: Path, stdout: TextIO, stderr: TextIO) -> int | None:
+    if args.work_log_inspect is None:
+        return None
+    try:
+        event_log = JsonlEventLogBackend(_resolve_work_log_path(args.work_log_inspect, project_root))
+        entries = event_log.query(run_id=args.work_log_run)[-_WORK_LOG_INSPECT_LIMIT:]
+    except Exception as error:
+        stderr.write(f"Error: {_format_cli_error(error)}\n")
+        return 1
+    if args.work_log_inspect_format == "json":
+        stdout.write(json.dumps([_work_log_entry_summary(entry) for entry in entries], ensure_ascii=False) + "\n")
+    else:
+        _write_work_log_text(entries, stdout)
+    return 0
+
+
+def _resolve_work_log_path(raw_path: str, project_root: Path) -> Path:
     path = Path(raw_path).expanduser()
     if not path.is_absolute():
         path = project_root / path
-    return JsonlEventLogBackend(path)
+    return path
+
+
+def _write_work_log_text(entries: list[Any], stdout: TextIO) -> None:
+    stdout.write("sequence\tkind\trun_id\tsession_id\tdelivery_hint\n")
+    for entry in entries:
+        stdout.write(
+            f"{entry.sequence}\t{_work_log_entry_kind(entry)}\t{entry.run_id}\t"
+            f"{entry.session_id}\t{_work_log_entry_delivery_hint(entry)}\n"
+        )
+
+
+def _work_log_entry_summary(entry: Any) -> dict[str, object]:
+    return {
+        "entry_id": entry.entry_id,
+        "entry_type": entry.entry_type,
+        "sequence": entry.sequence,
+        "kind": _work_log_entry_kind(entry),
+        "run_id": entry.run_id,
+        "session_id": entry.session_id,
+        "operation_id": entry.operation_id,
+        "event_id": entry.event_id,
+        "delivery_hint": _work_log_entry_delivery_hint(entry),
+    }
+
+
+def _work_log_entry_kind(entry: Any) -> str:
+    kind = entry.payload.get("kind")
+    if isinstance(kind, str) and kind:
+        return kind
+    return str(entry.entry_type)
+
+
+def _work_log_entry_delivery_hint(entry: Any) -> str:
+    delivery_hint = entry.payload.get("delivery_hint")
+    if isinstance(delivery_hint, str):
+        return delivery_hint
+    return ""
 
 
 def _has_command_style_operation(args: CliArgs) -> bool:
@@ -702,6 +763,7 @@ def _has_command_style_operation(args: CliArgs) -> bool:
         or args.remove_packages
         or args.update_all_packages
         or args.check_package_updates
+        or args.work_log_inspect is not None
     )
 
 

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -64,6 +64,7 @@ from loushang.coding.workflow import (
     resolve_workflow_files,
     run_prompt_steps_workflow,
 )
+from loushang.work import JsonlEventLogBackend
 
 _MISSING = object()
 
@@ -243,6 +244,10 @@ async def run_cli(
     if bootstrap_args.continue_ and bootstrap_args.resume:
         stderr.write("Error: --continue and --resume cannot be used together.\n")
         return 2
+    work_log_error = _work_log_static_error(bootstrap_args)
+    if work_log_error is not None:
+        stderr.write(f"Error: {work_log_error}.\n")
+        return 2
 
     with _stdout_guard_context(bootstrap_args, stdout, stderr):
         resolved_services = services or build_default_services(project_root)
@@ -374,6 +379,11 @@ async def run_cli(
             return list_models_result
 
         effective_tui = _effective_tui(args, stdin=stdin, stdout=stdout)
+        work_log_error = _work_log_runtime_error(args, effective_tui=effective_tui)
+        if work_log_error is not None:
+            stderr.write(f"Error: {work_log_error}.\n")
+            return 2
+        work_event_log = _resolve_work_event_log(args.work_log, project_root)
         with coding_observability_context(
             args=args,
             session=session,
@@ -448,6 +458,7 @@ async def run_cli(
                     images=print_input.images,
                     follow_up_messages=print_input.follow_up_messages,
                     verbose=args.verbose,
+                    work_event_log=work_event_log,
                 )
 
             output_mode = "text" if args.mode == "print" else args.mode
@@ -462,6 +473,7 @@ async def run_cli(
                     follow_up_messages=print_input.follow_up_messages,
                     output_mode=output_mode,
                     render_tool_events=args.render_tool_events,
+                    work_event_log=work_event_log,
                 )
 
             return await mode_runner(
@@ -477,6 +489,7 @@ async def run_cli(
                 stdin=stdin,
                 stdout=stdout,
                 stderr=stderr,
+                work_event_log=work_event_log,
             )
 
 
@@ -633,6 +646,35 @@ def _effective_tui(args: CliArgs, *, stdin: TextIO, stdout: TextIO) -> bool:
     if args.messages or args.file_args or args.message_prompts:
         return False
     return not _has_command_style_operation(args)
+
+
+def _work_log_static_error(args: CliArgs) -> str | None:
+    if args.work_log is None:
+        return None
+    if args.tui:
+        return "--work-log is not supported in TUI mode"
+    if args.mode == "rpc":
+        return "--work-log is not supported in RPC mode"
+    if args.prompt_steps is not None:
+        return "--work-log is not supported with --prompt-steps"
+    return None
+
+
+def _work_log_runtime_error(args: CliArgs, *, effective_tui: bool) -> str | None:
+    if args.work_log is None:
+        return None
+    if effective_tui:
+        return "--work-log is not supported in TUI mode"
+    return None
+
+
+def _resolve_work_event_log(raw_path: str | None, project_root: Path) -> JsonlEventLogBackend | None:
+    if raw_path is None:
+        return None
+    path = Path(raw_path).expanduser()
+    if not path.is_absolute():
+        path = project_root / path
+    return JsonlEventLogBackend(path)
 
 
 def _has_command_style_operation(args: CliArgs) -> bool:

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -17,6 +17,7 @@ PackageListFormat = Literal["text", "tsv", "json"]
 ExportFormat = Literal["html", "jsonl"]
 ExportResultFormat = Literal["text", "json"]
 CommandResultFormat = Literal["raw", "json"]
+WorkLogInspectFormat = Literal["text", "json"]
 ExtensionFlag: TypeAlias = RegisteredFlag | ResolvedFlag
 _BUILTIN_FLAG_NAMES = frozenset(
     {
@@ -111,6 +112,9 @@ _BUILTIN_FLAG_NAMES = frozenset(
         "command-result-format",
         "render-tool-events",
         "work-log",
+        "work-log-inspect",
+        "work-log-run",
+        "work-log-inspect-format",
         "message",
     }
 )
@@ -207,6 +211,9 @@ class CliArgs:
     export_result_format: ExportResultFormat
     render_tool_events: bool
     work_log: str | None
+    work_log_inspect: str | None
+    work_log_run: str | None
+    work_log_inspect_format: WorkLogInspectFormat
     messages: tuple[str, ...]
     file_args: tuple[str, ...]
     message_prompts: tuple[str, ...]
@@ -354,6 +361,9 @@ def parse_args(
         export_result_format=namespace.export_result_format,
         render_tool_events=namespace.render_tool_events,
         work_log=namespace.work_log,
+        work_log_inspect=namespace.work_log_inspect,
+        work_log_run=namespace.work_log_run,
+        work_log_inspect_format=namespace.work_log_inspect_format,
         messages=messages,
         file_args=file_args,
         message_prompts=tuple(namespace.message_prompts),
@@ -443,6 +453,13 @@ def _build_parser() -> ArgumentParser:
         "--work-log",
         help="Write WorkOperation/WorkEvent records for one-shot text/print/json prompts to a JSONL file.",
     )
+    parser.add_argument(
+        "--work-log-inspect",
+        metavar="PATH",
+        help="Inspect a work event JSONL log without starting a session.",
+    )
+    parser.add_argument("--work-log-run", help="Filter --work-log-inspect output to one run id.")
+    parser.add_argument("--work-log-inspect-format", choices=("text", "json"), default="text")
     parser.add_argument("--message", dest="message_prompts", action="append", default=[])
     parser.add_argument("--tool", dest="tool_flags", action="append", default=[])
     parser.add_argument("--tools", "-t", dest="tools", action="append", default=[])

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -110,6 +110,7 @@ _BUILTIN_FLAG_NAMES = frozenset(
         "command-args",
         "command-result-format",
         "render-tool-events",
+        "work-log",
         "message",
     }
 )
@@ -205,6 +206,7 @@ class CliArgs:
     export_format: ExportFormat
     export_result_format: ExportResultFormat
     render_tool_events: bool
+    work_log: str | None
     messages: tuple[str, ...]
     file_args: tuple[str, ...]
     message_prompts: tuple[str, ...]
@@ -351,6 +353,7 @@ def parse_args(
         export_format=namespace.export_format,
         export_result_format=namespace.export_result_format,
         render_tool_events=namespace.render_tool_events,
+        work_log=namespace.work_log,
         messages=messages,
         file_args=file_args,
         message_prompts=tuple(namespace.message_prompts),
@@ -435,6 +438,10 @@ def _build_parser() -> ArgumentParser:
         "--render-tool-events",
         action="store_true",
         help="Attach renderedToolCall/renderedToolResult payloads to JSON/RPC tool events.",
+    )
+    parser.add_argument(
+        "--work-log",
+        help="Write WorkOperation/WorkEvent records for one-shot text/print/json prompts to a JSONL file.",
     )
     parser.add_argument("--message", dest="message_prompts", action="append", default=[])
     parser.add_argument("--tool", dest="tool_flags", action="append", default=[])

--- a/src/loushang/coding/mode/base.py
+++ b/src/loushang/coding/mode/base.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, Protocol, Sequence, TextIO, TypedDict, cast, get_args
 
 from loushang.coding.event import JsonEventView
-
+from loushang.work import EventLogBackend
 
 ModeName = Literal["text", "print", "json", "rpc"]
 ModeActionType = Literal[
@@ -130,6 +130,7 @@ def create_mode_adapter(
     stdout: TextIO,
     stderr: TextIO | None = None,
     session: Any | None = None,
+    work_event_log: EventLogBackend | None = None,
 ) -> ModeAdapter:
     """Create the concrete adapter for a configured coding mode."""
 
@@ -160,6 +161,7 @@ def create_mode_adapter(
         event_view=config.event_view,
         event_select=config.event_select,
         render_tool_events=config.render_tool_events,
+        work_event_log=work_event_log,
     )
 
 
@@ -174,6 +176,7 @@ async def run_mode(
     user_input: str | None = None,
     images: list[object] | None = None,
     follow_up_messages: Sequence[str] = (),
+    work_event_log: EventLogBackend | None = None,
 ) -> int:
     adapter = create_mode_adapter(
         config,
@@ -182,6 +185,7 @@ async def run_mode(
         stdin=stdin,
         stdout=stdout,
         stderr=stderr,
+        work_event_log=work_event_log,
     )
     if config.mode == "rpc":
         return await adapter.start(user_input)

--- a/src/loushang/coding/mode/print_mode.py
+++ b/src/loushang/coding/mode/print_mode.py
@@ -6,8 +6,8 @@ import sys
 from typing import Any, Literal, Sequence, TextIO
 
 from loushang.coding.event import (
-    JsonEventView,
     SUPPORTED_JSON_EVENT_VIEWS,
+    JsonEventView,
     normalize_event_select,
     project_session_event,
     should_emit_projected_event,
@@ -15,6 +15,7 @@ from loushang.coding.event import (
 from loushang.coding.message.json_codec import serialize_session_header
 from loushang.coding.mode.base import ModeAdapter, ModeState
 from loushang.coding.tools import ToolDefinitionResolver, ToolRenderRuntime
+from loushang.work import CodingWorkShell, EventLogBackend
 
 
 class PrintMode(ModeAdapter):
@@ -29,6 +30,7 @@ class PrintMode(ModeAdapter):
         event_view: JsonEventView = "full",
         event_select: Sequence[str] | str | None = None,
         render_tool_events: bool = False,
+        work_event_log: EventLogBackend | None = None,
     ) -> None:
         if output_mode not in {"text", "json"}:
             raise ValueError(f"unsupported output mode: {output_mode}")
@@ -54,6 +56,7 @@ class PrintMode(ModeAdapter):
         self.event_view = event_view
         self.event_select = normalize_event_select(event_select)
         self.render_tool_events = render_tool_events
+        self.work_event_log = work_event_log
         self._tool_render_runtime: ToolRenderRuntime | None = None
         self._tool_definition_resolver: ToolDefinitionResolver | None = None
         self._disposed = False
@@ -124,10 +127,10 @@ class PrintMode(ModeAdapter):
                 header = self.session.session_manager.get_header()
                 self._write_json_line(serialize_session_header(header))
             unsubscribe = self.session.subscribe(self._handle_event)
-            await _prompt_session(self.session, user_input, images=images)
+            await self._prompt_session(user_input, images=images)
             await self.session.wait_for_idle()
             for message in follow_up_messages:
-                await _prompt_session(self.session, message)
+                await self._prompt_session(message)
                 await self.session.wait_for_idle()
             assistant_failure = _last_assistant_failure_message(self.session)
             if assistant_failure is not None:
@@ -232,6 +235,13 @@ class PrintMode(ModeAdapter):
             return json.dumps(args, ensure_ascii=False, sort_keys=True)
         except TypeError:
             return repr(args)
+
+    async def _prompt_session(self, user_input: str, *, images: list[object] | None = None) -> None:
+        if self.work_event_log is None:
+            await _prompt_session(self.session, user_input, images=images)
+            return
+        shell = CodingWorkShell(session=self.session, event_log=self.work_event_log)
+        await shell.submit_coding_turn(user_input, session_id=_work_session_id(self.session), images=images)
 
 
 def _serialize_print_mode_state(session: Any) -> ModeState:
@@ -367,6 +377,23 @@ def _safe_getattr(target: Any, name: str, default: object) -> object:
         return default
 
 
+def _work_session_id(session: Any) -> str:
+    session_id = _safe_getattr(session, "session_id", None)
+    if isinstance(session_id, str) and session_id:
+        return session_id
+    session_manager = getattr(session, "session_manager", None)
+    get_header = getattr(session_manager, "get_header", None)
+    if callable(get_header):
+        try:
+            header = get_header()
+        except Exception:
+            header = None
+        header_id = _safe_getattr(header, "id", None)
+        if isinstance(header_id, str) and header_id:
+            return header_id
+    return "session"
+
+
 async def run_print_mode(
     *,
     runtime: Any,
@@ -380,6 +407,7 @@ async def run_print_mode(
     event_view: JsonEventView = "full",
     event_select: Sequence[str] | str | None = None,
     render_tool_events: bool = False,
+    work_event_log: EventLogBackend | None = None,
 ) -> int:
     mode = PrintMode(
         runtime=runtime,
@@ -390,6 +418,7 @@ async def run_print_mode(
         event_view=event_view,
         event_select=event_select,
         render_tool_events=render_tool_events,
+        work_event_log=work_event_log,
     )
     return await mode.run_once(user_input, images=images, follow_up_messages=follow_up_messages)
 

--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -8,6 +8,7 @@ from typing import Any, Sequence, TextIO
 from loushang.coding.ui.events import CodingUiEventRenderer
 from loushang.coding.ui.model import ensure_usable_session_model
 from loushang.coding.ui.renderer import CodingUiRenderer
+from loushang.work import CodingWorkShell, EventLogBackend
 
 
 async def run_prompt_command(
@@ -20,6 +21,7 @@ async def run_prompt_command(
     images: list[object] | None = None,
     follow_up_messages: Sequence[str] = (),
     verbose: bool = False,
+    work_event_log: EventLogBackend | None = None,
 ) -> int:
     """Run one product prompt and render the stable coding transcript."""
 
@@ -39,6 +41,7 @@ async def run_prompt_command(
             event_renderer,
             prompt,
             images=images,
+            work_event_log=work_event_log,
         )
         if exit_code == 0:
             for message in follow_up_messages:
@@ -47,6 +50,7 @@ async def run_prompt_command(
                     renderer,
                     event_renderer,
                     message,
+                    work_event_log=work_event_log,
                 )
                 if exit_code != 0:
                     break
@@ -74,11 +78,12 @@ async def _run_turn(
     prompt: str,
     *,
     images: list[object] | None = None,
+    work_event_log: EventLogBackend | None = None,
 ) -> int:
     started_at = time.monotonic()
     previous_error = event_renderer.last_error_message
     renderer.render_user(prompt)
-    await _prompt_session(session, prompt, images=images)
+    await _run_prompt_session(session, prompt, images=images, work_event_log=work_event_log)
     await session.wait_for_idle()
     assistant_failure = _last_assistant_failure_message(session)
     if assistant_failure is None and event_renderer.last_error_message != previous_error:
@@ -87,6 +92,20 @@ async def _run_turn(
         return 1
     renderer.render_worked(time.monotonic() - started_at)
     return 0
+
+
+async def _run_prompt_session(
+    session: Any,
+    user_input: str,
+    *,
+    images: list[object] | None = None,
+    work_event_log: EventLogBackend | None = None,
+) -> None:
+    if work_event_log is None:
+        await _prompt_session(session, user_input, images=images)
+        return
+    shell = CodingWorkShell(session=session, event_log=work_event_log)
+    await shell.submit_coding_turn(user_input, session_id=_work_session_id(session), images=images)
 
 
 async def _prompt_session(session: Any, user_input: str, *, images: list[object] | None = None) -> None:
@@ -144,6 +163,23 @@ def _safe_getattr(target: Any, name: str, default: object) -> object:
         return getattr(target, name, default)
     except Exception:
         return default
+
+
+def _work_session_id(session: Any) -> str:
+    session_id = _safe_getattr(session, "session_id", None)
+    if isinstance(session_id, str) and session_id:
+        return session_id
+    session_manager = getattr(session, "session_manager", None)
+    get_header = getattr(session_manager, "get_header", None)
+    if callable(get_header):
+        try:
+            header = get_header()
+        except Exception:
+            header = None
+        header_id = _safe_getattr(header, "id", None)
+        if isinstance(header_id, str) and header_id:
+            return header_id
+    return "session"
 
 
 __all__ = ["run_prompt_command"]

--- a/src/loushang/coding/store/file_codec.py
+++ b/src/loushang/coding/store/file_codec.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
-import fcntl
 import json
 import os
 from pathlib import Path
@@ -28,6 +26,7 @@ from loushang.coding.message.json_codec import (
     serialize_content_part,
     serialize_session_header,
 )
+from loushang.coding.store.file_lock import session_file_lock
 
 
 class SessionFileError(ValueError):
@@ -153,7 +152,7 @@ def write_session_file(path: Path, header: SessionHeader, entries: list[SessionE
     lines = [json.dumps(_serialize_header(header))]
     lines.extend(json.dumps(_serialize_entry(entry)) for entry in entries)
     data = "\n".join(lines) + "\n"
-    with _session_file_lock(path, fcntl.LOCK_EX):
+    with session_file_lock(path, "exclusive"):
         path.parent.mkdir(parents=True, exist_ok=True)
         temp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
         with temp_path.open("w", encoding="utf-8") as handle:
@@ -165,7 +164,7 @@ def write_session_file(path: Path, header: SessionHeader, entries: list[SessionE
 
 def append_session_entry(path: Path, entry: SessionEntry) -> None:
     line = json.dumps(_serialize_entry(entry)) + "\n"
-    with _session_file_lock(path, fcntl.LOCK_EX):
+    with session_file_lock(path, "exclusive"):
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as handle:
             handle.write(line)
@@ -174,7 +173,7 @@ def append_session_entry(path: Path, entry: SessionEntry) -> None:
 
 
 def load_session_file(path: Path) -> tuple[SessionHeader, list[SessionEntry]]:
-    with _session_file_lock(path, fcntl.LOCK_SH):
+    with session_file_lock(path, "shared"):
         lines = [line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
     if not lines:
         raise SessionFileError("Session file is empty", path=path, code="empty_session_file")
@@ -210,14 +209,3 @@ def load_session_file(path: Path) -> tuple[SessionHeader, list[SessionEntry]]:
             continue
     return header, entries
 
-
-@contextmanager
-def _session_file_lock(path: Path, operation: int):
-    lock_path = path.with_name(f"{path.name}.lock")
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), operation)
-        try:
-            yield
-        finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)

--- a/src/loushang/coding/store/file_lock.py
+++ b/src/loushang/coding/store/file_lock.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Literal
+
+LockMode = Literal["exclusive", "shared"]
+
+
+@contextmanager
+def session_file_lock(path: Path, mode: LockMode) -> Iterator[None]:
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as handle:
+        _prepare_lock_byte(handle)
+        if _is_windows():
+            msvcrt = _load_msvcrt()
+            msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            return
+
+        fcntl = _load_fcntl()
+        operation = fcntl.LOCK_EX if mode == "exclusive" else fcntl.LOCK_SH
+        fcntl.flock(handle.fileno(), operation)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _prepare_lock_byte(handle) -> None:
+    handle.seek(0, os.SEEK_END)
+    if handle.tell() == 0:
+        handle.write(b"\0")
+        handle.flush()
+        os.fsync(handle.fileno())
+    handle.seek(0)
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _load_fcntl():
+    return importlib.import_module("fcntl")
+
+
+def _load_msvcrt():
+    return importlib.import_module("msvcrt")
+
+
+__all__ = ["LockMode", "session_file_lock"]

--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -4,6 +4,7 @@ from loushang.work.event_log import (
     EventLogEntry,
     EventPosition,
     InMemoryEventLogBackend,
+    JsonlEventLogBackend,
 )
 from loushang.work.projection import (
     WorkEventProjectionContext,
@@ -24,6 +25,7 @@ __all__ = [
     "EventLogEntry",
     "EventPosition",
     "InMemoryEventLogBackend",
+    "JsonlEventLogBackend",
     "WorkEventProjectionContext",
     "WorkEvent",
     "WorkOperation",

--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -1,3 +1,9 @@
+from loushang.work.event_log import (
+    EventLogBackend,
+    EventLogEntry,
+    EventPosition,
+    InMemoryEventLogBackend,
+)
 from loushang.work.types import (
     DeliveryHint,
     WorkEvent,
@@ -8,6 +14,10 @@ from loushang.work.types import (
 
 __all__ = [
     "DeliveryHint",
+    "EventLogBackend",
+    "EventLogEntry",
+    "EventPosition",
+    "InMemoryEventLogBackend",
     "WorkEvent",
     "WorkOperation",
     "WorkRun",

--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -1,3 +1,4 @@
+from loushang.work.coding import CodingWorkShell, PromptSession
 from loushang.work.event_log import (
     EventLogBackend,
     EventLogEntry,
@@ -17,11 +18,13 @@ from loushang.work.types import (
 )
 
 __all__ = [
+    "CodingWorkShell",
     "DeliveryHint",
     "EventLogBackend",
     "EventLogEntry",
     "EventPosition",
     "InMemoryEventLogBackend",
+    "PromptSession",
     "WorkEventProjectionContext",
     "WorkEvent",
     "WorkOperation",

--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -1,4 +1,4 @@
-from loushang.work.coding import CodingWorkShell, PromptSession
+from loushang.work.coding import CodingWorkShell
 from loushang.work.event_log import (
     EventLogBackend,
     EventLogEntry,
@@ -24,7 +24,6 @@ __all__ = [
     "EventLogEntry",
     "EventPosition",
     "InMemoryEventLogBackend",
-    "PromptSession",
     "WorkEventProjectionContext",
     "WorkEvent",
     "WorkOperation",

--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -1,0 +1,15 @@
+from loushang.work.types import (
+    DeliveryHint,
+    WorkEvent,
+    WorkOperation,
+    WorkRun,
+    WorkRunStatus,
+)
+
+__all__ = [
+    "DeliveryHint",
+    "WorkEvent",
+    "WorkOperation",
+    "WorkRun",
+    "WorkRunStatus",
+]

--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -4,6 +4,10 @@ from loushang.work.event_log import (
     EventPosition,
     InMemoryEventLogBackend,
 )
+from loushang.work.projection import (
+    WorkEventProjectionContext,
+    project_agent_event_to_work_events,
+)
 from loushang.work.types import (
     DeliveryHint,
     WorkEvent,
@@ -18,8 +22,10 @@ __all__ = [
     "EventLogEntry",
     "EventPosition",
     "InMemoryEventLogBackend",
+    "WorkEventProjectionContext",
     "WorkEvent",
     "WorkOperation",
     "WorkRun",
     "WorkRunStatus",
+    "project_agent_event_to_work_events",
 ]

--- a/src/loushang/work/coding.py
+++ b/src/loushang/work/coding.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Protocol
@@ -19,7 +19,7 @@ SessionEventListener = Callable[[Mapping[str, object]], Awaitable[None] | None]
 class PromptSession(Protocol):
     def subscribe(self, listener: SessionEventListener) -> Callable[[], None]: ...
 
-    def prompt(self, text: str) -> Awaitable[None]: ...
+    def prompt(self, text: str, *, images: Sequence[object] | None = None) -> Awaitable[None]: ...
 
 
 @dataclass
@@ -33,6 +33,7 @@ class CodingWorkShell:
         text: str,
         *,
         session_id: str,
+        images: Sequence[object] | None = None,
         operation_id: str | None = None,
         run_id: str | None = None,
     ) -> WorkRun:
@@ -44,7 +45,7 @@ class CodingWorkShell:
             kind="SubmitCodingTurn",
             session_id=session_id,
             domain="coding",
-            payload={"text": text},
+            payload=_operation_payload(text=text, images=images),
         )
         self._append_operation(operation, run_id=run_id, sequence=sequence)
 
@@ -83,7 +84,10 @@ class CodingWorkShell:
 
         unsubscribe = self.session.subscribe(listener)
         try:
-            await self.session.prompt(text)
+            if images is None:
+                await self.session.prompt(text)
+            else:
+                await self.session.prompt(text, images=images)
         except Exception:
             sequence += 1
             failed_run = WorkRun(
@@ -168,6 +172,13 @@ def _work_event(
         delivery_hint="immediate",
         payload=payload,
     )
+
+
+def _operation_payload(*, text: str, images: Sequence[object] | None) -> dict[str, object]:
+    payload: dict[str, object] = {"text": text}
+    if images is not None:
+        payload["image_count"] = len(images)
+    return payload
 
 
 def _event_log_entry_from_work_event(event: WorkEvent) -> EventLogEntry:

--- a/src/loushang/work/coding.py
+++ b/src/loushang/work/coding.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+from uuid import uuid4
+
+from loushang.work.event_log import EventLogBackend, EventLogEntry
+from loushang.work.projection import (
+    WorkEventProjectionContext,
+    project_agent_event_to_work_events,
+)
+from loushang.work.types import WorkEvent, WorkOperation, WorkRun
+
+SessionEventListener = Callable[[Mapping[str, object]], Awaitable[None] | None]
+
+
+class PromptSession(Protocol):
+    def subscribe(self, listener: SessionEventListener) -> Callable[[], None]: ...
+
+    def prompt(self, text: str) -> Awaitable[None]: ...
+
+
+@dataclass
+class CodingWorkShell:
+    session: PromptSession
+    event_log: EventLogBackend
+    clock: Callable[[], datetime] = lambda: datetime.now(UTC)
+
+    async def submit_coding_turn(
+        self,
+        text: str,
+        *,
+        session_id: str,
+        operation_id: str | None = None,
+        run_id: str | None = None,
+    ) -> WorkRun:
+        operation_id = operation_id or f"op-{uuid4().hex}"
+        run_id = run_id or f"run-{uuid4().hex}"
+        sequence = 0
+        operation = WorkOperation(
+            operation_id=operation_id,
+            kind="SubmitCodingTurn",
+            session_id=session_id,
+            domain="coding",
+            payload={"text": text},
+        )
+        self._append_operation(operation, run_id=run_id, sequence=sequence)
+
+        run = WorkRun(
+            run_id=run_id,
+            operation_id=operation_id,
+            session_id=session_id,
+            domain="coding",
+            status="running",
+        )
+        sequence += 1
+        self._append_event(
+            _work_event(
+                kind="WorkRunStarted",
+                run=run,
+                sequence=sequence,
+                created_at=self.clock(),
+                payload={"source_type": "work_shell"},
+            ),
+        )
+
+        async def listener(event: Mapping[str, object]) -> None:
+            nonlocal sequence
+            sequence += 1
+            context = WorkEventProjectionContext(
+                run_id=run_id,
+                session_id=session_id,
+                domain="coding",
+                operation_id=operation_id,
+                sequence=sequence,
+                created_at=self.clock(),
+                event_id_prefix=f"{run_id}-event",
+            )
+            for work_event in project_agent_event_to_work_events(event, context=context):
+                self._append_event(work_event)
+
+        unsubscribe = self.session.subscribe(listener)
+        try:
+            await self.session.prompt(text)
+        except Exception:
+            sequence += 1
+            failed_run = WorkRun(
+                run_id=run_id,
+                operation_id=operation_id,
+                session_id=session_id,
+                domain="coding",
+                status="failed",
+            )
+            self._append_event(
+                _work_event(
+                    kind="WorkRunFailed",
+                    run=failed_run,
+                    sequence=sequence,
+                    created_at=self.clock(),
+                    payload={"source_type": "work_shell"},
+                ),
+            )
+            raise
+        finally:
+            unsubscribe()
+
+        sequence += 1
+        completed_run = WorkRun(
+            run_id=run_id,
+            operation_id=operation_id,
+            session_id=session_id,
+            domain="coding",
+            status="completed",
+        )
+        self._append_event(
+            _work_event(
+                kind="WorkRunCompleted",
+                run=completed_run,
+                sequence=sequence,
+                created_at=self.clock(),
+                payload={"source_type": "work_shell"},
+            ),
+        )
+        return completed_run
+
+    def _append_operation(self, operation: WorkOperation, *, run_id: str, sequence: int) -> None:
+        self.event_log.append(
+            EventLogEntry(
+                entry_id=f"{run_id}-operation-{sequence}",
+                entry_type="operation",
+                operation_id=operation.operation_id,
+                event_id=None,
+                run_id=run_id,
+                session_id=operation.session_id or "",
+                sequence=sequence,
+                payload={
+                    "kind": operation.kind,
+                    "domain": operation.domain,
+                    "payload": dict(operation.payload),
+                },
+                created_at=self.clock(),
+            ),
+        )
+
+    def _append_event(self, event: WorkEvent) -> None:
+        self.event_log.append(_event_log_entry_from_work_event(event))
+
+
+def _work_event(
+    *,
+    kind: str,
+    run: WorkRun,
+    sequence: int,
+    created_at: datetime,
+    payload: Mapping[str, object],
+) -> WorkEvent:
+    return WorkEvent(
+        event_id=f"{run.run_id}-event-{sequence}",
+        kind=kind,
+        run_id=run.run_id,
+        session_id=run.session_id,
+        domain=run.domain,
+        operation_id=run.operation_id,
+        sequence=sequence,
+        created_at=created_at,
+        delivery_hint="immediate",
+        payload=payload,
+    )
+
+
+def _event_log_entry_from_work_event(event: WorkEvent) -> EventLogEntry:
+    return EventLogEntry(
+        entry_id=f"{event.run_id}-entry-{event.sequence}",
+        entry_type="event",
+        operation_id=event.operation_id,
+        event_id=event.event_id,
+        run_id=event.run_id,
+        session_id=event.session_id,
+        sequence=event.sequence,
+        payload={
+            "kind": event.kind,
+            "delivery_hint": event.delivery_hint,
+            "payload": dict(event.payload),
+            "source_event_ref": event.source_event_ref,
+        },
+        created_at=event.created_at,
+    )
+
+
+__all__ = ["CodingWorkShell", "PromptSession"]

--- a/src/loushang/work/event_log.py
+++ b/src/loushang/work/event_log.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
-from dataclasses import dataclass, field
+import json
+from collections.abc import AsyncIterator, Mapping
+from dataclasses import asdict, dataclass, field, is_dataclass
 from datetime import datetime
-from typing import Literal, Mapping, Protocol
+from pathlib import Path
+from typing import Literal, Protocol, cast
 
 
 @dataclass(frozen=True, order=True)
@@ -107,6 +109,78 @@ class InMemoryEventLogBackend:
         return stream()
 
 
+class JsonlEventLogBackend:
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._entries: list[tuple[EventPosition, EventLogEntry]] = []
+        self._subscribers: list[_Subscriber] = []
+        self._load()
+
+    def append(self, entry: EventLogEntry) -> EventPosition:
+        stored_entry = _normalize_entry(entry)
+        position = EventPosition(offset=len(self._entries) + 1)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8") as file:
+            file.write(json.dumps(_entry_to_json(stored_entry), ensure_ascii=False, sort_keys=True) + "\n")
+        self._entries.append((position, stored_entry))
+        for subscriber in list(self._subscribers):
+            if _matches(stored_entry, run_id=subscriber.run_id, session_id=subscriber.session_id):
+                subscriber.queue.put_nowait(stored_entry)
+        return position
+
+    def query(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+        limit: int | None = None,
+    ) -> list[EventLogEntry]:
+        selected: list[EventLogEntry] = []
+        for position, entry in self._entries:
+            if after is not None and position <= after:
+                continue
+            if not _matches(entry, run_id=run_id, session_id=session_id):
+                continue
+            selected.append(entry)
+            if limit is not None and len(selected) >= limit:
+                break
+        return selected
+
+    def subscribe(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+    ) -> AsyncIterator[EventLogEntry]:
+        async def stream() -> AsyncIterator[EventLogEntry]:
+            subscriber = _Subscriber(run_id=run_id, session_id=session_id)
+            self._subscribers.append(subscriber)
+            try:
+                for entry in self.query(run_id=run_id, session_id=session_id, after=after):
+                    yield entry
+                while True:
+                    yield await subscriber.queue.get()
+            finally:
+                if subscriber in self._subscribers:
+                    self._subscribers.remove(subscriber)
+
+        return stream()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        with self._path.open("r", encoding="utf-8") as file:
+            for line in file:
+                line = line.strip()
+                if not line:
+                    continue
+                entry = _entry_from_json(json.loads(line))
+                position = EventPosition(offset=len(self._entries) + 1)
+                self._entries.append((position, entry))
+
+
 def _matches(entry: EventLogEntry, *, run_id: str | None, session_id: str | None) -> bool:
     if run_id is not None and entry.run_id != run_id:
         return False
@@ -115,9 +189,66 @@ def _matches(entry: EventLogEntry, *, run_id: str | None, session_id: str | None
     return True
 
 
+def _normalize_entry(entry: EventLogEntry) -> EventLogEntry:
+    return EventLogEntry(
+        entry_id=entry.entry_id,
+        entry_type=entry.entry_type,
+        operation_id=entry.operation_id,
+        event_id=entry.event_id,
+        run_id=entry.run_id,
+        session_id=entry.session_id,
+        sequence=entry.sequence,
+        payload=cast(Mapping[str, object], _to_json_value(entry.payload)),
+        created_at=entry.created_at,
+    )
+
+
+def _entry_to_json(entry: EventLogEntry) -> dict[str, object]:
+    return {
+        "entry_id": entry.entry_id,
+        "entry_type": entry.entry_type,
+        "operation_id": entry.operation_id,
+        "event_id": entry.event_id,
+        "run_id": entry.run_id,
+        "session_id": entry.session_id,
+        "sequence": entry.sequence,
+        "payload": _to_json_value(entry.payload),
+        "created_at": entry.created_at.isoformat(),
+    }
+
+
+def _entry_from_json(data: Mapping[str, object]) -> EventLogEntry:
+    return EventLogEntry(
+        entry_id=str(data["entry_id"]),
+        entry_type=cast(Literal["operation", "event"], data["entry_type"]),
+        operation_id=str(data["operation_id"]),
+        event_id=cast(str | None, data["event_id"]),
+        run_id=str(data["run_id"]),
+        session_id=str(data["session_id"]),
+        sequence=int(cast(int, data["sequence"])),
+        payload=cast(Mapping[str, object], data["payload"]),
+        created_at=datetime.fromisoformat(str(data["created_at"])),
+    )
+
+
+def _to_json_value(value: object) -> object:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _to_json_value(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_to_json_value(item) for item in value]
+    if is_dataclass(value) and not isinstance(value, type):
+        return _to_json_value(asdict(value))
+    return repr(value)
+
+
 __all__ = [
     "EventLogBackend",
     "EventLogEntry",
     "EventPosition",
     "InMemoryEventLogBackend",
+    "JsonlEventLogBackend",
 ]

--- a/src/loushang/work/event_log.py
+++ b/src/loushang/work/event_log.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal, Mapping, Protocol
+
+
+@dataclass(frozen=True, order=True)
+class EventPosition:
+    offset: int
+
+
+@dataclass(frozen=True)
+class EventLogEntry:
+    entry_id: str
+    entry_type: Literal["operation", "event"]
+    operation_id: str
+    event_id: str | None
+    run_id: str
+    session_id: str
+    sequence: int
+    payload: Mapping[str, object]
+    created_at: datetime
+
+
+class EventLogBackend(Protocol):
+    def append(self, entry: EventLogEntry) -> EventPosition: ...
+
+    def query(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+        limit: int | None = None,
+    ) -> list[EventLogEntry]: ...
+
+    def subscribe(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+    ) -> AsyncIterator[EventLogEntry]: ...
+
+
+@dataclass
+class _Subscriber:
+    run_id: str | None
+    session_id: str | None
+    queue: asyncio.Queue[EventLogEntry] = field(default_factory=asyncio.Queue)
+
+
+class InMemoryEventLogBackend:
+    def __init__(self) -> None:
+        self._entries: list[tuple[EventPosition, EventLogEntry]] = []
+        self._subscribers: list[_Subscriber] = []
+
+    def append(self, entry: EventLogEntry) -> EventPosition:
+        position = EventPosition(offset=len(self._entries) + 1)
+        self._entries.append((position, entry))
+        for subscriber in list(self._subscribers):
+            if _matches(entry, run_id=subscriber.run_id, session_id=subscriber.session_id):
+                subscriber.queue.put_nowait(entry)
+        return position
+
+    def query(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+        limit: int | None = None,
+    ) -> list[EventLogEntry]:
+        selected: list[EventLogEntry] = []
+        for position, entry in self._entries:
+            if after is not None and position <= after:
+                continue
+            if not _matches(entry, run_id=run_id, session_id=session_id):
+                continue
+            selected.append(entry)
+            if limit is not None and len(selected) >= limit:
+                break
+        return selected
+
+    def subscribe(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+    ) -> AsyncIterator[EventLogEntry]:
+        async def stream() -> AsyncIterator[EventLogEntry]:
+            subscriber = _Subscriber(run_id=run_id, session_id=session_id)
+            self._subscribers.append(subscriber)
+            try:
+                for entry in self.query(run_id=run_id, session_id=session_id, after=after):
+                    yield entry
+                while True:
+                    yield await subscriber.queue.get()
+            finally:
+                if subscriber in self._subscribers:
+                    self._subscribers.remove(subscriber)
+
+        return stream()
+
+
+def _matches(entry: EventLogEntry, *, run_id: str | None, session_id: str | None) -> bool:
+    if run_id is not None and entry.run_id != run_id:
+        return False
+    if session_id is not None and entry.session_id != session_id:
+        return False
+    return True
+
+
+__all__ = [
+    "EventLogBackend",
+    "EventLogEntry",
+    "EventPosition",
+    "InMemoryEventLogBackend",
+]

--- a/src/loushang/work/projection.py
+++ b/src/loushang/work/projection.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+
+from loushang.work.types import DeliveryHint, WorkEvent
+
+
+@dataclass(frozen=True)
+class WorkEventProjectionContext:
+    run_id: str
+    session_id: str
+    domain: str
+    operation_id: str
+    sequence: int
+    created_at: datetime
+    event_id_prefix: str = "work-event"
+    source_event_ref: str | None = None
+
+
+def project_agent_event_to_work_events(
+    event: Mapping[str, object],
+    *,
+    context: WorkEventProjectionContext,
+) -> list[WorkEvent]:
+    source_type = event.get("type")
+    if not isinstance(source_type, str):
+        raise ValueError("Agent event must include a string type")
+
+    if source_type == "agent_start":
+        return [_event(context, kind="WorkRunStarted", delivery_hint="immediate", payload={"source_type": source_type})]
+    if source_type == "agent_end":
+        return [
+            _event(
+                context,
+                kind="WorkRunCompleted",
+                delivery_hint="immediate",
+                payload={
+                    "source_type": source_type,
+                    "messages": event.get("messages", []),
+                },
+            ),
+        ]
+    if source_type == "turn_start":
+        return [_event(context, kind="TaskStarted", delivery_hint="immediate", payload={"source_type": source_type})]
+    if source_type == "turn_end":
+        payload = _payload(event, "message", "tool_results")
+        return [_event(context, kind="TaskCompleted", delivery_hint="immediate", payload=payload)]
+    if source_type in {"message_start", "message_update", "message_end"}:
+        payload = _payload(event, "message", "assistant_message_event")
+        return [_event(context, kind="ContentDelta", delivery_hint="coalesce", payload=payload)]
+    if source_type == "tool_execution_start":
+        payload = _payload(event, "tool_call_id", "tool_name", "args")
+        return [_event(context, kind="ToolCallStarted", delivery_hint="coalesce", payload=payload)]
+    if source_type == "tool_execution_update":
+        payload = _payload(event, "tool_call_id", "tool_name", "args", "partial_result")
+        return [_event(context, kind="ToolCallProgress", delivery_hint="coalesce", payload=payload)]
+    if source_type == "tool_execution_end":
+        payload = _payload(event, "tool_call_id", "tool_name", "result", "is_error", "duration_ms")
+        delivery_hint: DeliveryHint = "immediate" if event.get("is_error") is True else "coalesce"
+        return [_event(context, kind="ToolCallCompleted", delivery_hint=delivery_hint, payload=payload)]
+    if source_type == "queue_update":
+        payload = _payload(event, "steering", "follow_up")
+        return [_event(context, kind="QueueUpdated", delivery_hint="coalesce", payload=payload)]
+    if source_type in {"auto_retry_start", "auto_retry_end"}:
+        return [
+            _event(
+                context,
+                kind="RetryDiagnostic",
+                delivery_hint="immediate" if event.get("success") is False else "coalesce",
+                payload=dict(event),
+            ),
+        ]
+    if source_type in {"compaction_start", "compaction_end", "package_progress"}:
+        return [_event(context, kind="MaintenanceProgress", delivery_hint="coalesce", payload=dict(event))]
+
+    return [_event(context, kind="WorkEvent", delivery_hint="coalesce", payload=dict(event))]
+
+
+def _event(
+    context: WorkEventProjectionContext,
+    *,
+    kind: str,
+    delivery_hint: DeliveryHint,
+    payload: Mapping[str, object],
+) -> WorkEvent:
+    return WorkEvent(
+        event_id=f"{context.event_id_prefix}-{context.sequence}",
+        kind=kind,
+        run_id=context.run_id,
+        session_id=context.session_id,
+        domain=context.domain,
+        operation_id=context.operation_id,
+        sequence=context.sequence,
+        created_at=context.created_at,
+        delivery_hint=delivery_hint,
+        payload=payload,
+        source_event_ref=context.source_event_ref,
+    )
+
+
+def _payload(event: Mapping[str, object], *keys: str) -> dict[str, object]:
+    payload: dict[str, object] = {"source_type": event["type"]}
+    for key in keys:
+        if key in event:
+            payload[key] = event[key]
+    return payload
+
+
+__all__ = [
+    "WorkEventProjectionContext",
+    "project_agent_event_to_work_events",
+]

--- a/src/loushang/work/types.py
+++ b/src/loushang/work/types.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Literal, Mapping, TypeAlias
-
+from typing import Literal, TypeAlias
 
 WorkRunStatus: TypeAlias = Literal[
     "accepted",

--- a/src/loushang/work/types.py
+++ b/src/loushang/work/types.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal, Mapping, TypeAlias
+
+
+WorkRunStatus: TypeAlias = Literal[
+    "accepted",
+    "running",
+    "cancelling",
+    "completed",
+    "failed",
+    "cancelled",
+]
+
+DeliveryHint: TypeAlias = Literal["immediate", "coalesce", "final_only"]
+
+
+@dataclass(frozen=True)
+class WorkOperation:
+    operation_id: str
+    kind: str
+    session_id: str | None
+    domain: str
+    payload: Mapping[str, object]
+    source: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WorkRun:
+    run_id: str
+    operation_id: str
+    session_id: str
+    domain: str
+    status: WorkRunStatus
+    method_id: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkEvent:
+    event_id: str
+    kind: str
+    run_id: str
+    session_id: str
+    domain: str
+    operation_id: str
+    sequence: int
+    created_at: datetime
+    delivery_hint: DeliveryHint
+    payload: Mapping[str, object]
+    source_event_ref: str | None = None
+
+
+__all__ = [
+    "DeliveryHint",
+    "WorkEvent",
+    "WorkOperation",
+    "WorkRun",
+    "WorkRunStatus",
+]

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import UTC, datetime
 from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
@@ -217,6 +218,26 @@ class TtyStringIO(StringIO):
         return True
 
 
+def _append_work_log_marker(event_log: object) -> Path:
+    from loushang.work import EventLogEntry
+
+    path = getattr(event_log, "_path")
+    event_log.append(
+        EventLogEntry(
+            entry_id="entry-1",
+            entry_type="event",
+            operation_id="op-1",
+            event_id="event-1",
+            run_id="run-1",
+            session_id="session-1",
+            sequence=1,
+            payload={"kind": "WorkRunStarted"},
+            created_at=datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        )
+    )
+    return path
+
+
 def _fake_services(
     session_dir: str | None = None,
     package_roots: tuple[str, ...] = (),
@@ -295,6 +316,15 @@ def test_parse_args_accepts_no_tui_flag() -> None:
     args = parse_args(["--no-tui"])
 
     assert args.no_tui is True
+
+
+def test_parse_args_accepts_work_log_flag() -> None:
+    from loushang.coding.cli.args import parse_args
+
+    args = parse_args(["--work-log", ".loushang/work/events.jsonl", "hello"])
+
+    assert args.work_log == ".loushang/work/events.jsonl"
+    assert args.messages == ("hello",)
 
 
 def test_parse_args_accepts_observability_flags() -> None:
@@ -2161,6 +2191,35 @@ def test_run_cli_dash_p_dispatches_prompt_command(tmp_path) -> None:
     assert print_runner.calls == []
 
 
+def test_run_cli_dash_p_passes_work_log_backend_to_prompt_command(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    prompt_runner = FakeRunner()
+    work_log_path = tmp_path / "prompt-work.jsonl"
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log", str(work_log_path), "-p", "hello"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            prompt_runner=prompt_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    event_log = prompt_runner.calls[0]["work_event_log"]
+    assert isinstance(event_log, JsonlEventLogBackend)
+    assert _append_work_log_marker(event_log) == work_log_path
+    assert work_log_path.exists()
+
+
 def test_run_cli_dash_ps_dispatches_prompt_steps_workflow(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
@@ -2398,6 +2457,35 @@ def test_run_cli_mode_print_dispatches_print_adapter(tmp_path) -> None:
     assert len(print_runner.calls) == 1
     assert print_runner.calls[0]["user_input"] == "hello"
     assert print_runner.calls[0]["output_mode"] == "text"
+
+
+def test_run_cli_mode_print_passes_work_log_backend_to_print_adapter(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    print_runner = FakeRunner()
+    work_log_path = tmp_path / "logs" / "work-events.jsonl"
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--mode", "print", "--work-log", "logs/work-events.jsonl", "hello"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            print_runner=print_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    event_log = print_runner.calls[0]["work_event_log"]
+    assert isinstance(event_log, JsonlEventLogBackend)
+    assert _append_work_log_marker(event_log) == work_log_path
+    assert work_log_path.exists()
 
 
 def test_run_cli_builds_initial_prompt_from_at_file_and_text(tmp_path) -> None:
@@ -3027,6 +3115,35 @@ def test_run_cli_default_path_uses_unified_mode_runner(tmp_path) -> None:
     assert mode_runner.calls[0]["user_input"] == "hello"
 
 
+def test_run_cli_default_path_passes_work_log_backend_to_unified_mode_runner(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    mode_runner = FakeRunner()
+    work_log_path = tmp_path / "events.jsonl"
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--mode", "json", "--work-log", str(work_log_path), "hello"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            mode_runner=mode_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    event_log = mode_runner.calls[0]["work_event_log"]
+    assert isinstance(event_log, JsonlEventLogBackend)
+    assert _append_work_log_marker(event_log) == work_log_path
+    assert work_log_path.exists()
+
+
 def test_run_cli_default_rpc_path_uses_unified_mode_runner(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
@@ -3052,6 +3169,41 @@ def test_run_cli_default_rpc_path_uses_unified_mode_runner(tmp_path) -> None:
     assert mode_runner.calls[0]["runtime"] is runtime
     assert mode_runner.calls[0]["session"] is runtime.get_current_session()
     assert mode_runner.calls[0]["user_input"] is None
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (["--tui", "--work-log", "events.jsonl"], "--work-log is not supported in TUI mode"),
+        (["--mode", "rpc", "--work-log", "events.jsonl"], "--work-log is not supported in RPC mode"),
+        (["--work-log", "events.jsonl", "--prompt-steps", "workflow.json"], "--work-log is not supported with --prompt-steps"),
+    ],
+)
+def test_run_cli_rejects_work_log_on_unsupported_paths(tmp_path, argv, message) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    stderr = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            argv,
+            stdin=TtyStringIO(""),
+            stdout=TtyStringIO(),
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            mode_runner=FakeRunner(),
+            prompt_runner=FakeRunner(),
+            rpc_runner=FakeRunner(),
+            tui_runner=FakeRunner(),
+        )
+        assert exit_code == 2
+
+    asyncio.run(scenario())
+
+    assert message in stderr.getvalue()
 
 
 def test_run_cli_dispatches_tui_mode(tmp_path) -> None:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -238,6 +238,36 @@ def _append_work_log_marker(event_log: object) -> Path:
     return path
 
 
+def _append_work_log_inspect_entry(
+    event_log: object,
+    *,
+    sequence: int,
+    kind: str,
+    run_id: str = "run-1",
+    session_id: str = "session-1",
+    entry_type: str = "event",
+    delivery_hint: str | None = None,
+) -> None:
+    from loushang.work import EventLogEntry
+
+    payload: dict[str, object] = {"kind": kind}
+    if delivery_hint is not None:
+        payload["delivery_hint"] = delivery_hint
+    event_log.append(
+        EventLogEntry(
+            entry_id=f"entry-{sequence}",
+            entry_type=entry_type,
+            operation_id=f"operation-{run_id}",
+            event_id=f"event-{sequence}" if entry_type == "event" else None,
+            run_id=run_id,
+            session_id=session_id,
+            sequence=sequence,
+            payload=payload,
+            created_at=datetime(2026, 6, 1, 10, 30, sequence, tzinfo=UTC),
+        )
+    )
+
+
 def _fake_services(
     session_dir: str | None = None,
     package_roots: tuple[str, ...] = (),
@@ -325,6 +355,25 @@ def test_parse_args_accepts_work_log_flag() -> None:
 
     assert args.work_log == ".loushang/work/events.jsonl"
     assert args.messages == ("hello",)
+
+
+def test_parse_args_accepts_work_log_inspect_flags() -> None:
+    from loushang.coding.cli.args import parse_args
+
+    args = parse_args(
+        [
+            "--work-log-inspect",
+            ".loushang/work/events.jsonl",
+            "--work-log-run",
+            "run-1",
+            "--work-log-inspect-format",
+            "json",
+        ]
+    )
+
+    assert args.work_log_inspect == ".loushang/work/events.jsonl"
+    assert args.work_log_run == "run-1"
+    assert args.work_log_inspect_format == "json"
 
 
 def test_parse_args_accepts_observability_flags() -> None:
@@ -3142,6 +3191,128 @@ def test_run_cli_default_path_passes_work_log_backend_to_unified_mode_runner(tmp
     assert isinstance(event_log, JsonlEventLogBackend)
     assert _append_work_log_marker(event_log) == work_log_path
     assert work_log_path.exists()
+
+
+def test_run_cli_work_log_inspect_outputs_text_without_runtime(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=1,
+        kind="SubmitCodingTurn",
+        entry_type="operation",
+    )
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=2,
+        kind="ContentDelta",
+        delivery_hint="coalesce",
+    )
+    stdout = StringIO()
+    stderr = StringIO()
+
+    def runtime_builder(**kwargs):
+        raise AssertionError("work log inspect should not build a runtime")
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path)],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=runtime_builder,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert stdout.getvalue().splitlines() == [
+        "sequence\tkind\trun_id\tsession_id\tdelivery_hint",
+        "1\tSubmitCodingTurn\trun-1\tsession-1\t",
+        "2\tContentDelta\trun-1\tsession-1\tcoalesce",
+    ]
+    assert stderr.getvalue() == ""
+
+
+def test_run_cli_work_log_inspect_outputs_json_without_runtime(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=3,
+        kind="TurnCompleted",
+        delivery_hint="immediate",
+    )
+    stdout = StringIO()
+
+    def runtime_builder(**kwargs):
+        raise AssertionError("work log inspect should not build a runtime")
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "json"],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=runtime_builder,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert json.loads(stdout.getvalue()) == [
+        {
+            "entry_id": "entry-3",
+            "entry_type": "event",
+            "sequence": 3,
+            "kind": "TurnCompleted",
+            "run_id": "run-1",
+            "session_id": "session-1",
+            "operation_id": "operation-run-1",
+            "event_id": "event-3",
+            "delivery_hint": "immediate",
+        }
+    ]
+
+
+def test_run_cli_work_log_inspect_filters_by_run(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(event_log, sequence=1, kind="ContentDelta", run_id="run-1")
+    _append_work_log_inspect_entry(event_log, sequence=2, kind="ApprovalRequested", run_id="run-2", delivery_hint="immediate")
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-run", "run-2"],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert stdout.getvalue().splitlines() == [
+        "sequence\tkind\trun_id\tsession_id\tdelivery_hint",
+        "2\tApprovalRequested\trun-2\tsession-1\timmediate",
+    ]
 
 
 def test_run_cli_default_rpc_path_uses_unified_mode_runner(tmp_path) -> None:

--- a/tests/coding/test_print_mode.py
+++ b/tests/coding/test_print_mode.py
@@ -719,6 +719,66 @@ def test_run_mode_routes_through_mode_adapter() -> None:
     asyncio.run(scenario())
 
 
+def test_run_mode_passes_work_event_log_to_print_adapter() -> None:
+    from loushang.coding.mode import ModeConfig, run_mode
+    from loushang.work import InMemoryEventLogBackend
+
+    class FakeRuntime:
+        pass
+
+    class FakeSession:
+        session_id = "session-1"
+
+        def __init__(self) -> None:
+            self.listeners = []
+
+        def subscribe(self, listener):
+            self.listeners.append(listener)
+
+            def unsubscribe() -> None:
+                self.listeners.remove(listener)
+
+            return unsubscribe
+
+        async def prompt(self, user_input: str, images=None) -> None:
+            del user_input, images
+            for listener in list(self.listeners):
+                result = listener(
+                    {
+                        "type": "message_update",
+                        "message": {"role": "assistant"},
+                        "assistant_message_event": {"type": "text_delta", "text": "done"},
+                    }
+                )
+                if result is not None:
+                    await result
+
+        async def wait_for_idle(self) -> None:
+            return None
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        exit_code = await run_mode(
+            ModeConfig(mode="text"),
+            runtime=FakeRuntime(),
+            session=FakeSession(),
+            user_input="hello",
+            stdin=StringIO(),
+            stdout=StringIO(),
+            work_event_log=event_log,
+        )
+
+        assert exit_code == 0
+        assert [entry.payload["kind"] for entry in event_log.query(session_id="session-1")] == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "ContentDelta",
+            "WorkRunCompleted",
+        ]
+
+    asyncio.run(scenario())
+
+
 def test_dispatch_mode_action_routes_to_adapter_contract() -> None:
     from loushang.coding.mode import ModeAction, dispatch_mode_action
 

--- a/tests/coding/test_print_mode.py
+++ b/tests/coding/test_print_mode.py
@@ -47,6 +47,92 @@ def test_print_mode_run_once_prompts_session_and_waits_for_idle() -> None:
     asyncio.run(scenario())
 
 
+def test_print_mode_work_event_log_records_coding_turn_and_preserves_prompt_behavior() -> None:
+    from loushang.ai.types import AssistantMessage, TextPart, Usage
+    from loushang.coding.mode import PrintMode
+    from loushang.work import InMemoryEventLogBackend
+
+    image = {"type": "image", "mime_type": "image/png", "data": "abc"}
+    usage = Usage(input=0, output=0, cache_read=0, cache_write=0, total_tokens=0, cost={})
+    assistant = AssistantMessage(
+        role="assistant",
+        content=[TextPart(type="text", text="done")],
+        api="anthropic-messages",
+        provider="faux",
+        model="faux-model",
+        response_id=None,
+        usage=usage,
+        stop_reason="stop",
+        error_message=None,
+        timestamp=0.0,
+    )
+
+    class FakeRuntime:
+        pass
+
+    class FakeSession:
+        session_id = "session-1"
+
+        def __init__(self) -> None:
+            self.prompt_calls: list[tuple[str, object]] = []
+            self.listeners = []
+
+        def subscribe(self, listener):
+            self.listeners.append(listener)
+
+            def unsubscribe() -> None:
+                self.listeners.remove(listener)
+
+            return unsubscribe
+
+        async def prompt(self, user_input: str, images=None) -> None:
+            self.prompt_calls.append((user_input, images))
+            for listener in list(self.listeners):
+                result = listener(
+                    {
+                        "type": "message_update",
+                        "message": {"role": "assistant"},
+                        "assistant_message_event": {"type": "text_delta", "text": "done"},
+                    }
+                )
+                if result is not None:
+                    await result
+                result = listener({"type": "message_end", "message": assistant})
+                if result is not None:
+                    await result
+
+        async def wait_for_idle(self) -> None:
+            return None
+
+    async def scenario() -> None:
+        stdout = StringIO()
+        event_log = InMemoryEventLogBackend()
+        session = FakeSession()
+        mode = PrintMode(
+            runtime=FakeRuntime(),
+            session=session,
+            stdout=stdout,
+            work_event_log=event_log,
+        )
+
+        exit_code = await mode.run_once("describe", images=[image])
+
+        assert exit_code == 0
+        assert stdout.getvalue() == "done\n"
+        assert session.prompt_calls == [("describe", [image])]
+        entries = event_log.query(session_id="session-1")
+        assert [entry.payload["kind"] for entry in entries] == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "ContentDelta",
+            "ContentDelta",
+            "WorkRunCompleted",
+        ]
+        assert entries[0].payload["payload"] == {"text": "describe", "image_count": 1}
+
+    asyncio.run(scenario())
+
+
 def test_print_mode_projects_assistant_text_and_tool_events() -> None:
     from loushang.ai.types import AssistantMessage, TextPart, Usage
     from loushang.coding.mode import PrintMode
@@ -1732,7 +1818,10 @@ def test_print_mode_json_streams_all_supported_session_events() -> None:
     from loushang.agent import AgentToolResult
     from loushang.ai.types import AssistantMessage, TextPart, ToolResultMessage, Usage
     from loushang.coding.message import SessionHeader
-    from loushang.coding.message.custom_messages import BranchSummaryMessage, CompactionSummaryMessage
+    from loushang.coding.message.custom_messages import (
+        BranchSummaryMessage,
+        CompactionSummaryMessage,
+    )
     from loushang.coding.mode import PrintMode
 
     usage = Usage(input=1, output=2, cache_read=3, cache_write=4, total_tokens=5, cost={})

--- a/tests/coding/test_prompt_command.py
+++ b/tests/coding/test_prompt_command.py
@@ -152,6 +152,68 @@ def test_prompt_command_selects_usable_model_before_prompt() -> None:
     asyncio.run(scenario())
 
 
+def test_prompt_command_work_event_log_records_prompt_turn() -> None:
+    from loushang.coding.prompt_command import run_prompt_command
+    from loushang.work import InMemoryEventLogBackend
+
+    class FakeRuntime:
+        pass
+
+    class FakeSession:
+        session_id = "session-1"
+
+        def __init__(self) -> None:
+            self.listeners = []
+
+        def get_model_selection(self):
+            return None
+
+        def subscribe(self, listener):
+            self.listeners.append(listener)
+
+            def unsubscribe() -> None:
+                self.listeners.remove(listener)
+
+            return unsubscribe
+
+        async def prompt(self, user_input: str, images=None) -> None:
+            del user_input, images
+            for listener in list(self.listeners):
+                result = listener(
+                    {
+                        "type": "message_update",
+                        "message": {"role": "assistant"},
+                        "assistant_message_event": {"type": "text_delta", "text": "done"},
+                    }
+                )
+                if result is not None:
+                    await result
+
+        async def wait_for_idle(self) -> None:
+            return None
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        exit_code = await run_prompt_command(
+            runtime=FakeRuntime(),
+            session=FakeSession(),
+            prompt="hello",
+            stdout=StringIO(),
+            stderr=StringIO(),
+            work_event_log=event_log,
+        )
+
+        assert exit_code == 0
+        assert [entry.payload["kind"] for entry in event_log.query(session_id="session-1")] == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "ContentDelta",
+            "WorkRunCompleted",
+        ]
+
+    asyncio.run(scenario())
+
+
 def test_prompt_command_does_not_render_worked_after_assistant_error() -> None:
     from loushang.coding.prompt_command import run_prompt_command
 

--- a/tests/coding/test_session_file_codec.py
+++ b/tests/coding/test_session_file_codec.py
@@ -1,11 +1,40 @@
 from __future__ import annotations
 
+import builtins
+import importlib
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from loushang.ai.types import AssistantMessage, TextPart, ToolResultMessage, Usage, UserMessage
+from loushang.ai.types import (
+    AssistantMessage,
+    TextPart,
+    ToolResultMessage,
+    Usage,
+    UserMessage,
+)
 from loushang.coding.message import CompactionEntry, SessionHeader, SessionMessageEntry
+
+
+def test_session_file_codec_import_does_not_require_fcntl(monkeypatch: pytest.MonkeyPatch) -> None:
+    sys.modules.pop("loushang.coding.store.file_codec", None)
+    store_package = sys.modules.get("loushang.coding.store")
+    if store_package is not None and hasattr(store_package, "file_codec"):
+        monkeypatch.delattr(store_package, "file_codec", raising=False)
+    original_import = builtins.__import__
+
+    def fake_import(name: str, *args: object, **kwargs: object):
+        if name == "fcntl":
+            raise ModuleNotFoundError("No module named 'fcntl'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module = importlib.import_module("loushang.coding.store.file_codec")
+
+    assert module.SessionFileError.__name__ == "SessionFileError"
 
 
 def test_write_then_load_jsonl_session_file(tmp_path: Path) -> None:
@@ -44,13 +73,21 @@ def test_session_file_codec_locks_reads_and_writes(tmp_path: Path, monkeypatch: 
     import fcntl
 
     import loushang.coding.store.file_codec as codec
+    import loushang.coding.store.file_lock as file_lock
 
     calls: list[int] = []
 
     def fake_flock(_fd: int, op: int) -> None:
         calls.append(op)
 
-    monkeypatch.setattr(codec.fcntl, "flock", fake_flock)
+    fake_fcntl = SimpleNamespace(
+        LOCK_EX=fcntl.LOCK_EX,
+        LOCK_SH=fcntl.LOCK_SH,
+        LOCK_UN=fcntl.LOCK_UN,
+        flock=fake_flock,
+    )
+    monkeypatch.setattr(file_lock, "_is_windows", lambda: False)
+    monkeypatch.setattr(file_lock, "_load_fcntl", lambda: fake_fcntl)
 
     header = SessionHeader(
         type="session",
@@ -80,6 +117,24 @@ def test_session_file_codec_locks_reads_and_writes(tmp_path: Path, monkeypatch: 
     assert fcntl.LOCK_EX in calls
     assert fcntl.LOCK_SH in calls
     assert calls.count(fcntl.LOCK_UN) == 3
+
+
+def test_session_file_lock_uses_msvcrt_on_windows(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import loushang.coding.store.file_lock as file_lock
+
+    calls: list[tuple[int, int]] = []
+    fake_msvcrt = SimpleNamespace(
+        LK_LOCK=10,
+        LK_UNLCK=11,
+        locking=lambda _fd, mode, nbytes: calls.append((mode, nbytes)),
+    )
+    monkeypatch.setattr(file_lock, "_is_windows", lambda: True)
+    monkeypatch.setattr(file_lock, "_load_msvcrt", lambda: fake_msvcrt)
+
+    with file_lock.session_file_lock(tmp_path / "session.jsonl", "shared"):
+        pass
+
+    assert calls == [(fake_msvcrt.LK_LOCK, 1), (fake_msvcrt.LK_UNLCK, 1)]
 
 
 def test_load_session_file_rejects_missing_header(tmp_path: Path) -> None:

--- a/tests/tui/test_import_boundaries.py
+++ b/tests/tui/test_import_boundaries.py
@@ -33,6 +33,15 @@ def test_pyproject_declares_markdown_it_py_as_direct_dependency() -> None:
     assert any(dependency.lower().startswith("markdown-it-py") for dependency in dependencies)
 
 
+def test_pyproject_does_not_declare_legacy_tui_dependencies() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = pyproject["project"]["dependencies"]
+    normalized_dependencies = tuple(dependency.lower() for dependency in dependencies)
+
+    assert not any(dependency.startswith("prompt-toolkit") for dependency in normalized_dependencies)
+    assert not any(dependency.startswith("rich") for dependency in normalized_dependencies)
+
+
 def _drop_modules_with_prefix(prefix: str) -> None:
     for module_name in tuple(sys.modules):
         if module_name == prefix or module_name.startswith(f"{prefix}."):

--- a/tests/work/test_agent_event_projection.py
+++ b/tests/work/test_agent_event_projection.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def _context(sequence: int = 1):
+    from loushang.work import WorkEventProjectionContext
+
+    return WorkEventProjectionContext(
+        run_id="run-1",
+        session_id="session-1",
+        domain="coding",
+        operation_id="op-1",
+        sequence=sequence,
+        created_at=datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        event_id_prefix="event",
+        source_event_ref="agent-event-1",
+    )
+
+
+def test_project_agent_start_and_end_events() -> None:
+    from loushang.work import project_agent_event_to_work_events
+
+    started = project_agent_event_to_work_events({"type": "agent_start"}, context=_context(1))
+    completed = project_agent_event_to_work_events({"type": "agent_end", "messages": []}, context=_context(2))
+
+    assert [event.kind for event in started] == ["WorkRunStarted"]
+    assert started[0].event_id == "event-1"
+    assert started[0].delivery_hint == "immediate"
+    assert started[0].payload == {"source_type": "agent_start"}
+    assert started[0].source_event_ref == "agent-event-1"
+
+    assert [event.kind for event in completed] == ["WorkRunCompleted"]
+    assert completed[0].event_id == "event-2"
+    assert completed[0].delivery_hint == "immediate"
+    assert completed[0].payload == {"source_type": "agent_end", "messages": []}
+
+
+def test_project_message_update_to_coalesced_content_delta() -> None:
+    from loushang.work import project_agent_event_to_work_events
+
+    events = project_agent_event_to_work_events(
+        {
+            "type": "message_update",
+            "message": {"role": "assistant"},
+            "assistant_message_event": {"type": "text_delta", "text": "hello"},
+        },
+        context=_context(3),
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.kind == "ContentDelta"
+    assert event.delivery_hint == "coalesce"
+    assert event.sequence == 3
+    assert event.payload == {
+        "source_type": "message_update",
+        "message": {"role": "assistant"},
+        "assistant_message_event": {"type": "text_delta", "text": "hello"},
+    }
+
+
+def test_project_tool_events_to_tool_call_work_events() -> None:
+    from loushang.work import project_agent_event_to_work_events
+
+    started = project_agent_event_to_work_events(
+        {
+            "type": "tool_execution_start",
+            "tool_call_id": "tool-1",
+            "tool_name": "bash",
+            "args": {"command": "pytest"},
+        },
+        context=_context(4),
+    )
+    completed = project_agent_event_to_work_events(
+        {
+            "type": "tool_execution_end",
+            "tool_call_id": "tool-1",
+            "tool_name": "bash",
+            "result": {"output": "failed"},
+            "is_error": True,
+            "duration_ms": 50,
+        },
+        context=_context(5),
+    )
+
+    assert started[0].kind == "ToolCallStarted"
+    assert started[0].delivery_hint == "coalesce"
+    assert started[0].payload["tool_call_id"] == "tool-1"
+    assert started[0].payload["tool_name"] == "bash"
+
+    assert completed[0].kind == "ToolCallCompleted"
+    assert completed[0].delivery_hint == "immediate"
+    assert completed[0].payload["is_error"] is True
+    assert completed[0].payload["duration_ms"] == 50
+
+
+def test_project_queue_update_to_coalesced_queue_metadata_event() -> None:
+    from loushang.work import project_agent_event_to_work_events
+
+    events = project_agent_event_to_work_events(
+        {"type": "queue_update", "steering": ["wait"], "follow_up": ["then test"]},
+        context=_context(6),
+    )
+
+    assert len(events) == 1
+    assert events[0].kind == "QueueUpdated"
+    assert events[0].delivery_hint == "coalesce"
+    assert events[0].payload == {
+        "source_type": "queue_update",
+        "steering": ["wait"],
+        "follow_up": ["then test"],
+    }

--- a/tests/work/test_coding_work_shell.py
+++ b/tests/work/test_coding_work_shell.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+
+
+class FakePromptSession:
+    def __init__(self, events: list[dict[str, object]]) -> None:
+        self.events = events
+        self.prompts: list[str] = []
+        self.listeners: list[Callable[[dict[str, object]], Awaitable[None] | None]] = []
+
+    def subscribe(self, listener: Callable[[dict[str, object]], Awaitable[None] | None]) -> Callable[[], None]:
+        self.listeners.append(listener)
+
+        def unsubscribe() -> None:
+            if listener in self.listeners:
+                self.listeners.remove(listener)
+
+        return unsubscribe
+
+    async def prompt(self, text: str) -> None:
+        self.prompts.append(text)
+        for event in self.events:
+            for listener in list(self.listeners):
+                result = listener(event)
+                if result is not None:
+                    await result
+
+
+def test_coding_work_shell_wraps_prompt_and_logs_operation_run_and_projected_events() -> None:
+    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        session = FakePromptSession(
+            events=[
+                {
+                    "type": "message_update",
+                    "message": {"role": "assistant"},
+                    "assistant_message_event": {"type": "text_delta", "text": "done"},
+                },
+                {
+                    "type": "tool_execution_end",
+                    "tool_call_id": "tool-1",
+                    "tool_name": "pytest",
+                    "result": {"output": "passed"},
+                    "is_error": False,
+                },
+            ],
+        )
+        shell = CodingWorkShell(
+            session=session,
+            event_log=event_log,
+            clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        )
+
+        run = await shell.submit_coding_turn(
+            "fix this bug",
+            session_id="session-1",
+            operation_id="op-1",
+            run_id="run-1",
+        )
+
+        assert session.prompts == ["fix this bug"]
+        assert run.status == "completed"
+        assert len(session.listeners) == 0
+
+        entries = event_log.query(run_id="run-1")
+        assert [entry.entry_type for entry in entries] == ["operation", "event", "event", "event", "event"]
+        assert entries[0].payload == {
+            "kind": "SubmitCodingTurn",
+            "domain": "coding",
+            "payload": {"text": "fix this bug"},
+        }
+        assert [entry.payload["kind"] for entry in entries[1:]] == [
+            "WorkRunStarted",
+            "ContentDelta",
+            "ToolCallCompleted",
+            "WorkRunCompleted",
+        ]
+        assert entries[2].payload["delivery_hint"] == "coalesce"
+        assert entries[3].payload["delivery_hint"] == "coalesce"
+        assert entries[4].payload["delivery_hint"] == "immediate"
+
+    asyncio.run(scenario())

--- a/tests/work/test_coding_work_shell.py
+++ b/tests/work/test_coding_work_shell.py
@@ -85,3 +85,61 @@ def test_coding_work_shell_wraps_prompt_and_logs_operation_run_and_projected_eve
         assert entries[4].payload["delivery_hint"] == "immediate"
 
     asyncio.run(scenario())
+
+
+def test_coding_work_shell_jsonl_log_can_replay_persisted_turn(tmp_path) -> None:
+    from loushang.ai.types import AssistantMessage, TextPart, Usage
+    from loushang.work import CodingWorkShell, JsonlEventLogBackend
+
+    usage = Usage(input=0, output=0, cache_read=0, cache_write=0, total_tokens=0, cost={})
+    assistant = AssistantMessage(
+        role="assistant",
+        content=[TextPart(type="text", text="done")],
+        api="anthropic-messages",
+        provider="faux",
+        model="faux-model",
+        response_id=None,
+        usage=usage,
+        stop_reason="stop",
+        error_message=None,
+        timestamp=0.0,
+    )
+
+    async def scenario() -> None:
+        log_path = tmp_path / "events.jsonl"
+        session = FakePromptSession(
+            events=[
+                {
+                    "type": "message_update",
+                    "message": {"role": "assistant"},
+                    "assistant_message_event": {"type": "text_delta", "text": "done"},
+                },
+                {"type": "message_end", "message": assistant},
+            ],
+        )
+        shell = CodingWorkShell(
+            session=session,
+            event_log=JsonlEventLogBackend(log_path),
+            clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        )
+
+        run = await shell.submit_coding_turn(
+            "persist this turn",
+            session_id="session-1",
+            operation_id="op-1",
+            run_id="run-1",
+        )
+
+        replayed = JsonlEventLogBackend(log_path).query(run_id=run.run_id)
+
+        assert [entry.payload["kind"] for entry in replayed] == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "ContentDelta",
+            "ContentDelta",
+            "WorkRunCompleted",
+        ]
+        assert replayed[3].payload["payload"]["message"]["role"] == "assistant"
+        assert replayed[4].payload["delivery_hint"] == "immediate"
+
+    asyncio.run(scenario())

--- a/tests/work/test_event_log.py
+++ b/tests/work/test_event_log.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+
+def _entry(
+    entry_id: str,
+    *,
+    entry_type: str = "event",
+    operation_id: str = "op-1",
+    event_id: str | None = "event-1",
+    run_id: str = "run-1",
+    session_id: str = "session-1",
+    sequence: int = 1,
+) -> object:
+    from loushang.work import EventLogEntry
+
+    return EventLogEntry(
+        entry_id=entry_id,
+        entry_type=entry_type,
+        operation_id=operation_id,
+        event_id=event_id,
+        run_id=run_id,
+        session_id=session_id,
+        sequence=sequence,
+        payload={"kind": "WorkRunStarted"},
+        created_at=datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+    )
+
+
+def test_in_memory_event_log_appends_and_queries_by_run_and_session() -> None:
+    from loushang.work import InMemoryEventLogBackend
+
+    backend = InMemoryEventLogBackend()
+    first = _entry("entry-1", run_id="run-1", session_id="session-1", sequence=1)
+    second = _entry("entry-2", run_id="run-2", session_id="session-1", sequence=1)
+    third = _entry("entry-3", run_id="run-1", session_id="session-2", sequence=2)
+
+    first_position = backend.append(first)
+    second_position = backend.append(second)
+    third_position = backend.append(third)
+
+    assert first_position.offset == 1
+    assert second_position.offset == 2
+    assert third_position.offset == 3
+    assert backend.query(run_id="run-1") == [first, third]
+    assert backend.query(session_id="session-1") == [first, second]
+    assert backend.query(run_id="run-1", session_id="session-2") == [third]
+    assert backend.query(run_id="run-1", after=first_position) == [third]
+    assert backend.query(limit=2) == [first, second]
+
+
+def test_in_memory_event_log_subscribe_replays_existing_then_streams_later_entries() -> None:
+    from loushang.work import InMemoryEventLogBackend
+
+    async def scenario() -> None:
+        backend = InMemoryEventLogBackend()
+        existing = _entry("entry-1", run_id="run-1", sequence=1)
+        ignored = _entry("entry-ignored", run_id="run-2", sequence=1)
+        later = _entry("entry-2", run_id="run-1", sequence=2)
+        backend.append(existing)
+
+        stream = backend.subscribe(run_id="run-1")
+        assert await asyncio.wait_for(anext(stream), timeout=0.1) == existing
+
+        next_entry = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0)
+        backend.append(ignored)
+        backend.append(later)
+
+        assert await asyncio.wait_for(next_entry, timeout=0.1) == later
+        await stream.aclose()
+
+    asyncio.run(scenario())

--- a/tests/work/test_event_log.py
+++ b/tests/work/test_event_log.py
@@ -13,6 +13,7 @@ def _entry(
     run_id: str = "run-1",
     session_id: str = "session-1",
     sequence: int = 1,
+    payload: dict[str, object] | None = None,
 ) -> object:
     from loushang.work import EventLogEntry
 
@@ -24,7 +25,7 @@ def _entry(
         run_id=run_id,
         session_id=session_id,
         sequence=sequence,
-        payload={"kind": "WorkRunStarted"},
+        payload=payload or {"kind": "WorkRunStarted"},
         created_at=datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
     )
 
@@ -56,6 +57,63 @@ def test_in_memory_event_log_subscribe_replays_existing_then_streams_later_entri
 
     async def scenario() -> None:
         backend = InMemoryEventLogBackend()
+        existing = _entry("entry-1", run_id="run-1", sequence=1)
+        ignored = _entry("entry-ignored", run_id="run-2", sequence=1)
+        later = _entry("entry-2", run_id="run-1", sequence=2)
+        backend.append(existing)
+
+        stream = backend.subscribe(run_id="run-1")
+        assert await asyncio.wait_for(anext(stream), timeout=0.1) == existing
+
+        next_entry = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0)
+        backend.append(ignored)
+        backend.append(later)
+
+        assert await asyncio.wait_for(next_entry, timeout=0.1) == later
+        await stream.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_jsonl_event_log_appends_queries_and_reopens(tmp_path) -> None:
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "work" / "events.jsonl"
+    backend = JsonlEventLogBackend(log_path)
+    first = _entry(
+        "entry-1",
+        run_id="run-1",
+        session_id="session-1",
+        sequence=1,
+        payload={"kind": "WorkRunStarted", "nested": {"at": datetime(2026, 6, 1, 10, 31, tzinfo=UTC)}},
+    )
+    second = _entry("entry-2", run_id="run-2", session_id="session-1", sequence=1)
+    third = _entry("entry-3", run_id="run-1", session_id="session-2", sequence=2)
+
+    first_position = backend.append(first)
+    backend.append(second)
+    backend.append(third)
+
+    assert first_position.offset == 1
+    assert log_path.read_text(encoding="utf-8").count("\n") == 3
+
+    reopened = JsonlEventLogBackend(log_path)
+    run_entries = reopened.query(run_id="run-1")
+    assert [entry.entry_id for entry in run_entries] == ["entry-1", "entry-3"]
+    assert run_entries[0].payload == {
+        "kind": "WorkRunStarted",
+        "nested": {"at": "2026-06-01T10:31:00+00:00"},
+    }
+    assert reopened.query(session_id="session-1") == [run_entries[0], second]
+    assert [entry.entry_id for entry in reopened.query(run_id="run-1", after=first_position)] == ["entry-3"]
+
+
+def test_jsonl_event_log_subscribe_replays_existing_then_streams_later_entries(tmp_path) -> None:
+    from loushang.work import JsonlEventLogBackend
+
+    async def scenario() -> None:
+        backend = JsonlEventLogBackend(tmp_path / "events.jsonl")
         existing = _entry("entry-1", run_id="run-1", sequence=1)
         ignored = _entry("entry-ignored", run_id="run-2", sequence=1)
         later = _entry("entry-2", run_id="run-1", sequence=2)

--- a/tests/work/test_public_api.py
+++ b/tests/work/test_public_api.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+
+def test_work_public_api_exposes_only_p0_surface() -> None:
+    import loushang.work as work
+
+    assert set(work.__all__) == {
+        "CodingWorkShell",
+        "DeliveryHint",
+        "EventLogBackend",
+        "EventLogEntry",
+        "EventPosition",
+        "InMemoryEventLogBackend",
+        "WorkEvent",
+        "WorkEventProjectionContext",
+        "WorkOperation",
+        "WorkRun",
+        "WorkRunStatus",
+        "project_agent_event_to_work_events",
+    }
+
+    assert not hasattr(work, "AgentLane")
+    assert not hasattr(work, "TaskLedger")
+    assert not hasattr(work, "CollaborationBus")
+    assert not hasattr(work, "PromptSession")

--- a/tests/work/test_public_api.py
+++ b/tests/work/test_public_api.py
@@ -11,6 +11,7 @@ def test_work_public_api_exposes_only_p0_surface() -> None:
         "EventLogEntry",
         "EventPosition",
         "InMemoryEventLogBackend",
+        "JsonlEventLogBackend",
         "WorkEvent",
         "WorkEventProjectionContext",
         "WorkOperation",

--- a/tests/work/test_work_types.py
+++ b/tests/work/test_work_types.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
+
+import pytest
+
+
+def test_work_operation_keeps_json_compatible_payload_and_source_defaults() -> None:
+    from loushang.work import WorkOperation
+
+    operation = WorkOperation(
+        operation_id="op-1",
+        kind="SubmitCodingTurn",
+        session_id=None,
+        domain="coding",
+        payload={"text": "fix this bug"},
+    )
+
+    assert operation.operation_id == "op-1"
+    assert operation.kind == "SubmitCodingTurn"
+    assert operation.session_id is None
+    assert operation.domain == "coding"
+    assert operation.payload == {"text": "fix this bug"}
+    assert operation.source == {}
+
+    with pytest.raises(FrozenInstanceError):
+        operation.domain = "research"  # type: ignore[misc]
+
+
+def test_work_run_tracks_p0_single_turn_metadata_without_multi_agent_surface() -> None:
+    from loushang.work import WorkRun
+
+    run = WorkRun(
+        run_id="run-1",
+        operation_id="op-1",
+        session_id="session-1",
+        domain="coding",
+        status="accepted",
+    )
+
+    assert run.run_id == "run-1"
+    assert run.operation_id == "op-1"
+    assert run.session_id == "session-1"
+    assert run.domain == "coding"
+    assert run.status == "accepted"
+    assert run.method_id is None
+    assert not hasattr(run, "agent_lane")
+    assert not hasattr(run, "task_ledger")
+    assert not hasattr(run, "collaboration_bus")
+
+
+def test_work_event_carries_delivery_hint_and_optional_source_event_ref() -> None:
+    from loushang.work import WorkEvent
+
+    created_at = datetime(2026, 6, 1, 10, 30, tzinfo=UTC)
+    event = WorkEvent(
+        event_id="event-1",
+        kind="ContentDelta",
+        run_id="run-1",
+        session_id="session-1",
+        domain="coding",
+        operation_id="op-1",
+        sequence=1,
+        created_at=created_at,
+        delivery_hint="coalesce",
+        payload={"text": "hello"},
+    )
+
+    assert event.event_id == "event-1"
+    assert event.kind == "ContentDelta"
+    assert event.run_id == "run-1"
+    assert event.session_id == "session-1"
+    assert event.domain == "coding"
+    assert event.operation_id == "op-1"
+    assert event.sequence == 1
+    assert event.created_at is created_at
+    assert event.delivery_hint == "coalesce"
+    assert event.payload == {"text": "hello"}
+    assert event.source_event_ref is None

--- a/uv.lock
+++ b/uv.lock
@@ -302,9 +302,7 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "openai" },
     { name = "pillow" },
-    { name = "prompt-toolkit" },
     { name = "pygments" },
-    { name = "rich" },
 ]
 
 [package.optional-dependencies]
@@ -322,10 +320,8 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15,<2" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "pillow", specifier = ">=12.2.0" },
-    { name = "prompt-toolkit", specifier = ">=3,<4" },
     { name = "pygments", specifier = ">=2.19,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
-    { name = "rich", specifier = ">=14,<15" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11,<1" },
 ]
 provides-extras = ["dev"]
@@ -544,18 +540,6 @@ wheels = [
 ]
 
 [[package]]
-name = "prompt-toolkit"
-version = "3.0.52"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
-]
-
-[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -693,19 +677,6 @@ wheels = [
 ]
 
 [[package]]
-name = "rich"
-version = "14.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.8"
 source = { registry = "https://pypi.org/simple" }
@@ -770,13 +741,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "wcwidth"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]


### PR DESCRIPTION
## Summary
- Add the P0 loushang.work surface: WorkOperation, WorkRun, WorkEvent, EventLogBackend, JSONL persistence, and AgentEvent projection.
- Wire one-shot coding prompt paths to optional work event logging and add work log inspect CLI output.
- Remove legacy direct TUI dependencies and make session file locks cross-platform for Windows startup.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/test_session_file_codec.py tests/tui/test_import_boundaries.py tests/work -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/test_prompt_command.py tests/coding/test_print_mode.py tests/work -q
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/store/file_codec.py src/loushang/coding/store/file_lock.py tests/coding/test_session_file_codec.py

Refs #28