### PR TITLE
P1: method resource compatibility

### DIFF
--- a/docs/superpowers/plans/2026-06-02-method-p1-resource-compatibility.md
+++ b/docs/superpowers/plans/2026-06-02-method-p1-resource-compatibility.md
@@ -1,0 +1,102 @@
+# Method P1 Resource Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the P1 `loushang.method` package so existing skills and project method resources can be discovered, adapted, compiled, and projected without changing current CLI or `AgentSession` behavior.
+
+**Architecture:** Add a small independent `loushang.method` package. Keep `SkillDescriptor` knowledge isolated in `skill_adapter.py`, keep loader precedence in `loader.py`, and expose data-only objects from `types.py`.
+
+**Tech Stack:** Python dataclasses, existing `loushang.coding.loader.DefaultResourceLoader`, pytest, ruff.
+
+---
+
+### Task 1: Core Method Types
+
+**Files:**
+- Create: `src/loushang/method/__init__.py`
+- Create: `src/loushang/method/types.py`
+- Test: `tests/method/test_method_types.py`
+- Test: `tests/method/test_public_api.py`
+
+- [ ] Write failing tests for `MethodDescriptor`, `MethodContext`, `MethodPlan`, `MethodStep`, and `MethodProjection` defaults.
+- [ ] Verify tests fail because `loushang.method` does not exist.
+- [ ] Implement frozen dataclasses in `types.py` and public exports in `__init__.py`.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/method/test_method_types.py tests/method/test_public_api.py -q`.
+- [ ] Commit with `feat: add method p1 core types`.
+
+### Task 2: Skill Adapter
+
+**Files:**
+- Create: `src/loushang/method/skill_adapter.py`
+- Test: `tests/method/test_skill_adapter.py`
+
+- [ ] Write failing tests for `method_from_skill(...)`, including id normalization, metadata preservation, and taxonomy hint extraction from frontmatter.
+- [ ] Verify tests fail because `skill_adapter.py` does not exist.
+- [ ] Implement `method_from_skill(skill: SkillDescriptor) -> MethodDescriptor`.
+- [ ] Keep direct `SkillDescriptor` field access confined to `skill_adapter.py`.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/method/test_skill_adapter.py tests/method/test_method_types.py -q`.
+- [ ] Commit with `feat: adapt skills to methods`.
+
+### Task 3: Method Loader
+
+**Files:**
+- Create: `src/loushang/method/loader.py`
+- Test: `tests/method/test_method_loader.py`
+
+- [ ] Write failing tests for `discover_methods(...)`, `reload_methods(...)`, `list_methods()`, and `get_method(...)`.
+- [ ] Cover `skills/**/SKILL.md` discovery through `DefaultResourceLoader`.
+- [ ] Cover `methods/**/SKILL.md` discovery, `element_type` hints from frontmatter or path, and discovery-time de-duplication.
+- [ ] Verify tests fail because `MethodLoader` does not exist.
+- [ ] Implement loader cache semantics: `discover_methods` is stateless, `reload_methods` replaces snapshot, `list_methods` and `get_method` read snapshot.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/method/test_method_loader.py tests/method/test_skill_adapter.py -q`.
+- [ ] Commit with `feat: discover method resources`.
+
+### Task 4: Registry And Selector
+
+**Files:**
+- Create: `src/loushang/method/registry.py`
+- Create: `src/loushang/method/selector.py`
+- Test: `tests/method/test_method_registry.py`
+- Test: `tests/method/test_method_selector.py`
+
+- [ ] Write failing tests for registry list/get selected-state behavior and duplicate id rejection.
+- [ ] Write failing tests for exact id/name selector behavior.
+- [ ] Implement `MethodRegistry` and `MethodSelector`.
+- [ ] Run focused registry/selector tests.
+- [ ] Commit with `feat: add method registry and selector`.
+
+### Task 5: Compiler And Projection
+
+**Files:**
+- Create: `src/loushang/method/compiler.py`
+- Create: `src/loushang/method/projection.py`
+- Test: `tests/method/test_method_compiler.py`
+- Test: `tests/method/test_method_projection.py`
+
+- [ ] Write failing tests for single-turn compilation.
+- [ ] Write failing tests for deterministic projection guidance and optional role/temperature hint carrying.
+- [ ] Implement `MethodCompiler` and `MethodProjector`.
+- [ ] Run focused compiler/projection tests.
+- [ ] Commit with `feat: compile and project method guidance`.
+
+### Task 6: Optional Work Metadata Integration
+
+**Files:**
+- Modify: `src/loushang/work/coding.py`
+- Test: `tests/work/test_coding_work_shell.py`
+
+- [ ] Check current `WorkRun.method_id` usage and write a failing test for `CodingWorkShell.submit_coding_turn(..., method_id=...)`.
+- [ ] Implement metadata-only parameter plumbing.
+- [ ] Verify no prompt, method selection, or `AgentSession` behavior changes.
+- [ ] Run focused work tests.
+- [ ] Commit with `feat: record method id on coding work runs`.
+
+### Task 7: Regression
+
+**Files:**
+- Modify as needed: public exports and tests only.
+
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/method tests/coding/test_skill_loader.py tests/coding/test_cli.py tests/work -q`.
+- [ ] Run `uv --cache-dir .uv-cache run ruff check src/loushang/method tests/method`.
+- [ ] Fix issues without broadening P1 scope.
+- [ ] Commit any final fixes.

--- a/docs/superpowers/specs/2026-06-02-method-p1-resource-compatibility-design.md
+++ b/docs/superpowers/specs/2026-06-02-method-p1-resource-compatibility-design.md
@@ -76,6 +76,16 @@ P1 的处理原则：
 
 这意味着 `kind` 在 P1 仍然表示 method 的来源/消费分类，而不是最终方法论元素类型。方法论元素类型放在 `element_type` 这类可选 hint 中。
 
+### Future Resource Standards
+
+P1 should not close the door on richer standard files.
+
+- `SKILL.md` is the P1 compatibility and guidance primitive. Existing skills and experimental method resources can both use it.
+- `METHOD.md` can remain a future canonical method manifest. It is a good place to standardize composite methods that bind phases, activities, tasks, roles, guidance, work products, gates, and source-role relationships.
+- `SOUR.md` is a plausible future long-lived role/source descriptor if the project decides to standardize self-evolving roles. The idea is valuable, but the exact name and acronym should stay open until its semantics are crisp enough to document.
+
+P1 should ignore `METHOD.md` and `SOUR.md` for discovery. They are future standardization candidates, not P1 loader inputs.
+
 相关架构文档：
 
 - `docs/architecture/drafts/loushang-work-method-channel-harness-architecture.md`
@@ -176,6 +186,8 @@ Owns:
 
 This is the only P1 module that should know the details of `SkillDescriptor`.
 
+`loader.py` may call `method_from_skill(...)`, but it should not read `SkillDescriptor` fields directly. This keeps the coding-loader compatibility bridge isolated in the adapter.
+
 ### `loader.py`
 
 Owns:
@@ -185,6 +197,8 @@ Owns:
 - optional discovery from `methods/**/SKILL.md`
 
 P1 `MethodLoader` should be method-facing even if it delegates to `DefaultResourceLoader`.
+
+`MethodLoader` owns discovery-time precedence and should return a de-duplicated method list. `MethodRegistry` should still reject duplicate ids as a defensive invariant.
 
 ### `registry.py`
 
@@ -393,6 +407,13 @@ list_methods() -> list[MethodDescriptor]
 get_method(id_or_name: str) -> MethodDescriptor | None
 ```
 
+Cache semantics:
+
+- `discover_methods(...)` is stateless and returns a freshly discovered, de-duplicated list.
+- `reload_methods(...)` clears and replaces the loader's cached snapshot, then returns that new snapshot.
+- `list_methods()` and `get_method(...)` read the current cached snapshot.
+- P1 does not need incremental refresh.
+
 ### Work
 
 P1 does not need to modify `CodingWorkShell` immediately.
@@ -412,6 +433,8 @@ compile method -> project guidance -> caller prepends guidance to prompt
 The method package should not call `CodingWorkShell` directly.
 
 If `CodingWorkShell.submit_coding_turn(..., method_id=...)` is added in P1, it must only write `WorkRun.method_id` and related event metadata. It must not compile, project, select, or apply a method.
+
+`WorkRun.method_id` already exists in Work P0, so this task is parameter plumbing and event/log metadata only. It is not a Work data model change.
 
 ### AgentSession
 
@@ -505,7 +528,7 @@ Compile to single-turn plan and project stable guidance. Carry optional taxonomy
 
 If the implementation can stay small, allow `CodingWorkShell.submit_coding_turn(..., method_id=...)` to write `WorkRun.method_id`.
 
-This task is metadata-only. It must not apply prompt guidance or mutate `AgentSession`.
+This task is parameter plumbing and metadata-only because `WorkRun.method_id` already exists in Work P0. It must not apply prompt guidance or mutate `AgentSession`.
 
 ### Task 7: Public API And Regression
 
@@ -515,7 +538,8 @@ Add public API boundary tests and run focused regression.
 
 These are explicitly deferred unless implementation reveals a blocker:
 
-- Should `METHOD.md` ever exist, or should method resources continue to use `SKILL.md` with richer frontmatter?
+- Should `METHOD.md` become the canonical composite method manifest, while `SKILL.md` remains the reusable guidance primitive?
+- Should long-lived self-evolving role/source resources be standardized as `SOUR.md`, `ROLE.md`, or another file name?
 - When should taxonomy hints become mandatory validated fields rather than optional metadata?
 - Should selected method live in settings, session metadata, or work operation payload?
 - Should CLI expose `--method` before DomainApp exists?
@@ -528,4 +552,4 @@ P1 can ship without answering these globally.
 
 GitHub issue:
 
-- `#36 P1: method resource compatibility`
+- `#36 P1: method resource compatibility` - https://github.com/zhnt/loushang/issues/36

--- a/docs/superpowers/specs/2026-06-02-method-p1-resource-compatibility-design.md
+++ b/docs/superpowers/specs/2026-06-02-method-p1-resource-compatibility-design.md
@@ -1,0 +1,450 @@
+# Loushang Method P1 Resource Compatibility Design
+
+## Goal
+
+在 Work P0 已经合并的基础上，引入最小可运行的 `loushang.method` 资源层。
+
+P1 的目标不是实现完整方法论执行引擎，而是先让 Loushang 可以把现有 skill 生态看作一种 method 资源，并为后续 `methods/**/METHOD.md`、DomainApp、TaskFlow、多 agent 协作留下稳定边界。
+
+成功标准：
+
+- 现有 `skills/**/SKILL.md` 不迁移也能投影为 skill-backed method。
+- `MethodDescriptor`、`MethodLoader`、`MethodRegistry`、`MethodCompiler`、`MethodProjection` 有稳定 P1 公共 API。
+- method 可以编译成 single-turn `MethodPlan`。
+- method projection 可以生成 prompt guidance，但默认不改变现有 CLI / AgentSession 行为。
+- P1 public API 不暴露 TaskFlow、AgentLane、CollaborationBus、多步骤 workflow 等 P3/P4 概念。
+
+## Scope
+
+### In Scope
+
+- 新增独立包 `loushang.method`。
+- 定义 P1 `MethodDescriptor` schema。
+- 定义 `MethodLoader`，内部可以复用现有 coding resource discovery。
+- 定义 `MethodRegistry`，支持 list/get/select 的内存状态。
+- 定义 `SkillDescriptor -> MethodDescriptor(kind="skill_backed")` 适配规则。
+- 定义 single-turn `MethodPlan` 和 `MethodStep`。
+- 定义 `MethodCompiler`，P1 永远输出 single-turn plan。
+- 定义 `MethodProjector` / `MethodProjection`，把 plan 投影成 prompt guidance。
+- 增加 focused tests 和 public API tests。
+
+### Out Of Scope
+
+- 自动 method selection。
+- `--method` CLI 参数。
+- session 持久化 selected method。
+- 多步骤 TaskFlow。
+- `CodingDomainApp` 实现。
+- 多 agent 协作。
+- method marketplace / package lifecycle。
+- 迁移 `AgentSession` 内部职责。
+
+## Why This Comes Next
+
+Work P0 已经提供：
+
+- `WorkOperation`
+- `WorkRun`
+- `WorkEvent`
+- `EventLogBackend`
+- `CodingWorkShell`
+- JSONL work log
+- work log inspect CLI
+
+这让系统有了外部可观察的 work 生命周期。但目前 work 还不知道“该按什么方法执行”。如果直接进入 DomainApp 或多 agent，很容易把流程、领域、方法、队列混在一起。
+
+因此 P1 应先补上 method 资源兼容层，让 method 从 hardcoded prompt / skill usage 中独立出来。
+
+相关架构文档：
+
+- `docs/architecture/drafts/loushang-work-method-channel-harness-architecture.md`
+- `docs/architecture/drafts/loushang-runtime-architecture.md`
+- `docs/architecture/coding/core-data-objects/resource-descriptors.md`
+- `docs/architecture/coding/component-interfaces/method.md`
+
+## Approaches Considered
+
+### Approach 1: Put Method Under `loushang.coding.method`
+
+把 method 作为 coding 子模块实现。
+
+Pros:
+
+- 实现最快。
+- 可以直接依赖 `DefaultResourceLoader` 和 `SkillDescriptor`。
+
+Cons:
+
+- method 未来会跨 coding、research、cowork 等 domain。
+- 后续从 coding 迁出会产生迁移成本。
+- 容易让 method selection 和 coding prompt assembly 耦合。
+
+Rejected.
+
+### Approach 2: Independent `loushang.method`, Reusing Coding Resource Loader Internally
+
+新增独立包 `loushang.method`，P1 内部可以适配 `SkillDescriptor` 和 `DefaultResourceLoader`，但 method 公共 API 不放在 `loushang.coding` 下。
+
+Pros:
+
+- method 边界从第一天就是跨 domain 的。
+- P1 仍能复用现有 skill 生态，落地成本低。
+- 不要求修改 `ResourceBundle` 公共结构。
+- 可以渐进接入 work / domain app。
+
+Cons:
+
+- `loushang.method` P1 会临时依赖 coding loader 类型做兼容适配。
+- 需要明确该依赖是 compatibility bridge，不是长期 domain ownership。
+
+Recommended.
+
+### Approach 3: Extend `ResourceBundle` With `methods`
+
+直接给现有 resource loader 和 `ResourceBundle` 增加 `methods` 字段。
+
+Pros:
+
+- 资源发现入口统一。
+- 后续 extension / package 可能更容易看到 methods。
+
+Cons:
+
+- 太早扩大 loader 公共结构。
+- 会牵扯 extension discover hooks、package projection、session refresh、resource diagnostics。
+- P1 的核心其实是 method schema 和 skill compatibility，不是统一资源发现系统重构。
+
+Rejected for P1. This can be revisited after P1 API stabilizes.
+
+## Recommended Architecture
+
+P1 新增：
+
+```text
+src/loushang/method/
+  __init__.py
+  types.py
+  skill_adapter.py
+  loader.py
+  registry.py
+  compiler.py
+  projection.py
+```
+
+### `types.py`
+
+Owns:
+
+- `MethodDescriptor`
+- `MethodContext`
+- `MethodPlan`
+- `MethodStep`
+- `MethodProjection`
+
+This file should stay data-only. It must not import coding session, work shell, CLI, or resource loader implementation.
+
+### `skill_adapter.py`
+
+Owns:
+
+- `method_from_skill(skill: SkillDescriptor) -> MethodDescriptor`
+- skill-backed method id normalization
+- skill metadata preservation
+
+This is the only P1 module that should know the details of `SkillDescriptor`.
+
+### `loader.py`
+
+Owns:
+
+- `MethodLoader`
+- discovery from current resource loader
+- future placeholder for `methods/**/METHOD.md`
+
+P1 `MethodLoader` should be method-facing even if it delegates to `DefaultResourceLoader`.
+
+### `registry.py`
+
+Owns:
+
+- `MethodRegistry`
+- list/get/select semantics
+- selected method state in memory
+
+P1 registry does not persist selected method to session files.
+
+### `compiler.py`
+
+Owns:
+
+- `MethodCompiler`
+- `compile(descriptor, context) -> MethodPlan`
+
+P1 compiler always creates one step:
+
+```text
+MethodPlan(mode="single_turn")
+  MethodStep(id="main", executor="current_agent")
+```
+
+### `projection.py`
+
+Owns:
+
+- `MethodProjector`
+- `project(plan, step, context) -> MethodProjection`
+
+P1 projection turns method content into stable guidance. It does not mutate `AgentSession`, `WorkRun`, or prompt state directly.
+
+## Data Model
+
+### `MethodDescriptor`
+
+```python
+@dataclass(frozen=True)
+class MethodDescriptor:
+    id: str
+    name: str
+    description: str
+    kind: Literal["skill_backed", "method_resource"]
+    content: str
+    domain: str | None = None
+    source_path: str | None = None
+    version: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+```
+
+Required fields:
+
+- `id`
+- `name`
+- `description`
+- `kind`
+- `content`
+
+Compatibility rules:
+
+- Unknown `metadata` keys must be preserved.
+- P3 additions such as `steps`, `roles`, `gates`, and `artifacts` must be additive.
+- P1 must not require existing `SKILL.md` files to change.
+
+### Skill-Backed Method Mapping
+
+```text
+SkillDescriptor -> MethodDescriptor
+
+id          = "skill:<skill.name>"
+name        = skill.name
+description = skill.description or ""
+kind        = "skill_backed"
+content     = skill.content
+source_path = skill.source_path
+metadata    = skill source, frontmatter, activation, and compatibility hints where available
+```
+
+If a skill name already starts with `skill:`, the adapter should avoid double-prefixing.
+
+### `MethodContext`
+
+P1 context should be small:
+
+```python
+@dataclass(frozen=True)
+class MethodContext:
+    domain: str | None = None
+    task: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+```
+
+It is context for compiling/projecting a method, not a run state object.
+
+### `MethodPlan`
+
+```python
+@dataclass(frozen=True)
+class MethodPlan:
+    id: str
+    method_id: str
+    mode: Literal["single_turn"]
+    steps: tuple[MethodStep, ...]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+```
+
+### `MethodStep`
+
+```python
+@dataclass(frozen=True)
+class MethodStep:
+    id: str
+    title: str
+    executor: Literal["current_agent"]
+    projection: Mapping[str, object] = field(default_factory=dict)
+```
+
+P1 step is descriptive. It is not a TaskFlow step and does not own lifecycle events.
+
+### `MethodProjection`
+
+```python
+@dataclass(frozen=True)
+class MethodProjection:
+    method_id: str
+    step_id: str
+    system_guidance: str
+    user_guidance: str | None = None
+    allowed_skills: tuple[str, ...] = ()
+    suggested_tools: tuple[str, ...] = ()
+    expected_artifacts: tuple[str, ...] = ()
+    approval_gates: tuple[str, ...] = ()
+    metadata: Mapping[str, object] = field(default_factory=dict)
+```
+
+P1 `system_guidance` can be deterministic:
+
+```text
+Use the following method guidance when performing this turn:
+
+<method content>
+```
+
+## Relationship To Existing Components
+
+### Skill Loader
+
+P1 uses existing skills as source material, but it does not move skill discovery into method.
+
+`MethodLoader` can accept:
+
+```python
+resource_loader: DefaultResourceLoader | None
+package_roots: tuple[str, ...]
+```
+
+and expose:
+
+```python
+discover_methods(cwd: str | Path) -> list[MethodDescriptor]
+reload_methods(cwd: str | Path | None = None) -> list[MethodDescriptor]
+list_methods() -> list[MethodDescriptor]
+get_method(id_or_name: str) -> MethodDescriptor | None
+```
+
+### Work
+
+P1 does not need to modify `CodingWorkShell` immediately.
+
+The clean integration path is:
+
+1. P1 implements pure method APIs.
+2. A later small PR may allow work operations to carry `method_id`.
+3. DomainApp P2 will decide how to assemble projection into a domain prompt/tool/policy bundle.
+
+If P1 needs a smoke integration, it should be explicit and optional:
+
+```text
+compile method -> project guidance -> caller prepends guidance to prompt
+```
+
+The method package should not call `CodingWorkShell` directly.
+
+### AgentSession
+
+P1 does not mutate `AgentSession`.
+
+No selected method is persisted to session files. No prompt assembler default changes are allowed in P1.
+
+### CLI
+
+P1 should not add `--method`.
+
+CLI support can be a P1.5 or P2 follow-up after method APIs stabilize.
+
+## Error Handling
+
+P1 should keep errors simple and stable:
+
+- invalid descriptor id -> `ValueError`
+- duplicate method id in registry -> `ValueError`
+- missing selected method -> return `None`, not exception
+- loader discovery diagnostics should be preserved from resource loader where possible
+
+Avoid a large custom exception hierarchy in P1.
+
+## Testing Strategy
+
+### Unit Tests
+
+Add:
+
+```text
+tests/method/test_method_types.py
+tests/method/test_skill_adapter.py
+tests/method/test_method_loader.py
+tests/method/test_method_registry.py
+tests/method/test_method_compiler.py
+tests/method/test_method_projection.py
+tests/method/test_public_api.py
+```
+
+Coverage:
+
+- dataclass defaults
+- metadata is JSON-friendly and preserved
+- skill-backed id generation
+- loader discovers methods from skills
+- registry list/get/select
+- compiler returns single-turn plan
+- projector returns stable guidance
+- public API excludes P3/P4 concepts
+
+### Regression Tests
+
+Keep existing suites passing:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/method tests/coding/test_skill_loader.py tests/coding/test_cli.py tests/work -q
+uv --cache-dir .uv-cache run ruff check src/loushang/method tests/method
+```
+
+## Rollout Plan
+
+### Task 1: Core Method Types
+
+Create `loushang.method.types` and public exports.
+
+### Task 2: Skill Adapter
+
+Implement `SkillDescriptor -> MethodDescriptor`.
+
+### Task 3: Method Loader
+
+Wrap existing resource loader skill discovery into method discovery.
+
+### Task 4: Method Registry
+
+Add list/get/select behavior with duplicate id protection.
+
+### Task 5: Compiler And Projection
+
+Compile to single-turn plan and project stable guidance.
+
+### Task 6: Public API And Regression
+
+Add public API boundary tests and run focused regression.
+
+## Open Questions
+
+These are explicitly deferred unless implementation reveals a blocker:
+
+- Should `METHOD.md` use frontmatter identical to `SKILL.md`, or a separate schema?
+- Should selected method live in settings, session metadata, or work operation payload?
+- Should CLI expose `--method` before DomainApp exists?
+- Should method projection append to system prompt or user prompt by default?
+
+P1 can ship without answering these globally.
+
+## Tracking
+
+GitHub issue:
+
+- `#36 P1: method resource compatibility`

--- a/docs/superpowers/specs/2026-06-02-method-p1-resource-compatibility-design.md
+++ b/docs/superpowers/specs/2026-06-02-method-p1-resource-compatibility-design.md
@@ -4,12 +4,13 @@
 
 在 Work P0 已经合并的基础上，引入最小可运行的 `loushang.method` 资源层。
 
-P1 的目标不是实现完整方法论执行引擎，而是先让 Loushang 可以把现有 skill 生态看作一种 method 资源，并为后续 `methods/**/METHOD.md`、DomainApp、TaskFlow、多 agent 协作留下稳定边界。
+P1 的目标不是实现完整方法论执行引擎，而是先让 Loushang 可以把现有 skill 生态看作一种 method 资源，并为后续 `methods/**/SKILL.md`、DomainApp、TaskFlow、多 agent 协作留下稳定边界。
 
 成功标准：
 
 - 现有 `skills/**/SKILL.md` 不迁移也能投影为 skill-backed method。
-- `MethodDescriptor`、`MethodLoader`、`MethodRegistry`、`MethodCompiler`、`MethodProjection` 有稳定 P1 公共 API。
+- `skills/**/SKILL.md` 和 `methods/**/SKILL.md` 中已有的 `type`、`phase`、`meta_role`、`temperature` 等方法论提示可以被保留，但 P1 不强制解释。
+- `MethodDescriptor`、`MethodLoader`、`MethodRegistry`、`MethodSelector`、`MethodCompiler`、`MethodProjection` 有稳定 P1 公共 API。
 - method 可以编译成 single-turn `MethodPlan`。
 - method projection 可以生成 prompt guidance，但默认不改变现有 CLI / AgentSession 行为。
 - P1 public API 不暴露 TaskFlow、AgentLane、CollaborationBus、多步骤 workflow 等 P3/P4 概念。
@@ -21,8 +22,11 @@ P1 的目标不是实现完整方法论执行引擎，而是先让 Loushang 可�
 - 新增独立包 `loushang.method`。
 - 定义 P1 `MethodDescriptor` schema。
 - 定义 `MethodLoader`，内部可以复用现有 coding resource discovery。
-- 定义 `MethodRegistry`，支持 list/get/select 的内存状态。
+- 定义 `MethodRegistry`，支持 list/get 和 selected-state 的内存状态。
+- 定义极简 `MethodSelector`，只支持显式 id/name 精确匹配。
 - 定义 `SkillDescriptor -> MethodDescriptor(kind="skill_backed")` 适配规则。
+- 保留 `type` / `phase` / `meta_role` / `temperature` 等可选 taxonomy hints。
+- 支持 `methods/**/SKILL.md` 的 method resource discovery。
 - 定义 single-turn `MethodPlan` 和 `MethodStep`。
 - 定义 `MethodCompiler`，P1 永远输出 single-turn plan。
 - 定义 `MethodProjector` / `MethodProjection`，把 plan 投影成 prompt guidance。
@@ -36,6 +40,10 @@ P1 的目标不是实现完整方法论执行引擎，而是先让 Loushang 可�
 - 多步骤 TaskFlow。
 - `CodingDomainApp` 实现。
 - 多 agent 协作。
+- 冻结最终方法论 ontology。
+- 强制执行 phase/activity/task/role/guidance/workproduct 语义。
+- CONDUCTOR 调度。
+- SPEM 风格方法模型校验。
 - method marketplace / package lifecycle。
 - 迁移 `AgentSession` 内部职责。
 
@@ -54,6 +62,19 @@ Work P0 已经提供：
 这让系统有了外部可观察的 work 生命周期。但目前 work 还不知道“该按什么方法执行”。如果直接进入 DomainApp 或多 agent，很容易把流程、领域、方法、队列混在一起。
 
 因此 P1 应先补上 method 资源兼容层，让 method 从 hardcoded prompt / skill usage 中独立出来。
+
+## Experimental Methodology Alignment
+
+`docs/experimental/methodology/` 中的元方法、元角色、元阶段文档是高价值设计输入，但在 P1 不应被当作已经冻结的运行时契约。
+
+P1 的处理原则：
+
+- 吸收 taxonomy hints：`phase`、`activity`、`task`、`role`、`guidance`、`workproduct`、`meta_role`、`temperature` 等字段可以进入 descriptor / plan / projection。
+- 不冻结 ontology：P1 不把这些字段做成强枚举，也不要求所有 method 必须声明这些字段。
+- 保持向后兼容：现有 `skills/**/SKILL.md` 不需要修改；没有方法论字段时仍按 skill-backed method 工作。
+- 保持可演进：P3/P4 可以在不破坏 P1 API 的前提下，把这些 hints 提升为 TaskFlow、DomainApp policy 或 multi-agent role routing。
+
+这意味着 `kind` 在 P1 仍然表示 method 的来源/消费分类，而不是最终方法论元素类型。方法论元素类型放在 `element_type` 这类可选 hint 中。
 
 相关架构文档：
 
@@ -90,6 +111,7 @@ Pros:
 - method 边界从第一天就是跨 domain 的。
 - P1 仍能复用现有 skill 生态，落地成本低。
 - 不要求修改 `ResourceBundle` 公共结构。
+- 可以保留 experimental methodology 的 taxonomy hints，但不把它们变成强运行时依赖。
 - 可以渐进接入 work / domain app。
 
 Cons:
@@ -127,6 +149,7 @@ src/loushang/method/
   skill_adapter.py
   loader.py
   registry.py
+  selector.py
   compiler.py
   projection.py
 ```
@@ -159,7 +182,7 @@ Owns:
 
 - `MethodLoader`
 - discovery from current resource loader
-- future placeholder for `methods/**/METHOD.md`
+- optional discovery from `methods/**/SKILL.md`
 
 P1 `MethodLoader` should be method-facing even if it delegates to `DefaultResourceLoader`.
 
@@ -168,10 +191,19 @@ P1 `MethodLoader` should be method-facing even if it delegates to `DefaultResour
 Owns:
 
 - `MethodRegistry`
-- list/get/select semantics
+- list/get semantics
 - selected method state in memory
 
 P1 registry does not persist selected method to session files.
+
+### `selector.py`
+
+Owns:
+
+- `MethodSelector`
+- exact id/name matching against a registry or descriptor list
+
+P1 selector must not perform automatic, LLM-based, fuzzy, semantic, or task-classification selection.
 
 ### `compiler.py`
 
@@ -183,8 +215,8 @@ Owns:
 P1 compiler always creates one step:
 
 ```text
-MethodPlan(mode="single_turn")
-  MethodStep(id="main", executor="current_agent")
+MethodPlan(mode="single_turn", phase=None, activity=None, task=None)
+  MethodStep(id="main", executor="current_agent", role_variant=None)
 ```
 
 ### `projection.py`
@@ -206,9 +238,12 @@ class MethodDescriptor:
     id: str
     name: str
     description: str
-    kind: Literal["skill_backed", "method_resource"]
     content: str
+    kind: str  # P1 values: "skill_backed" | "method_resource"
+    element_type: str | None = None
     domain: str | None = None
+    meta_role: str | None = None
+    phase: str | None = None
     source_path: str | None = None
     version: str | None = None
     metadata: Mapping[str, object] = field(default_factory=dict)
@@ -219,12 +254,15 @@ Required fields:
 - `id`
 - `name`
 - `description`
-- `kind`
 - `content`
+- `kind`
 
 Compatibility rules:
 
 - Unknown `metadata` keys must be preserved.
+- `kind` is a source/compatibility classification. It is not the method ontology.
+- `element_type` preserves optional method taxonomy hints such as `phase`, `activity`, `task`, `role`, `guidance`, and `workproduct`.
+- `meta_role`, `phase`, `temperature`, `responsible`, and other methodology fields should be copied from frontmatter into explicit fields where P1 has them and into `metadata` otherwise.
 - P3 additions such as `steps`, `roles`, `gates`, and `artifacts` must be additive.
 - P1 must not require existing `SKILL.md` files to change.
 
@@ -237,12 +275,20 @@ id          = "skill:<skill.name>"
 name        = skill.name
 description = skill.description or ""
 kind        = "skill_backed"
+element_type = frontmatter.type, if present
+domain      = frontmatter.domain, if present
+meta_role   = frontmatter.meta_role or frontmatter.role, if present
+phase       = frontmatter.phase, if present
 content     = skill.content
 source_path = skill.source_path
 metadata    = skill source, frontmatter, activation, and compatibility hints where available
 ```
 
 If a skill name already starts with `skill:`, the adapter should avoid double-prefixing.
+
+For `skills/**/SKILL.md`, `kind` remains `"skill_backed"` even when frontmatter has `type: task` or `type: role`. The `type` value is copied to `element_type`.
+
+For `methods/**/SKILL.md`, `kind` should be `"method_resource"` and `element_type` should come from frontmatter `type` or, if absent, from the directory segment under `methods/`.
 
 ### `MethodContext`
 
@@ -265,8 +311,11 @@ It is context for compiling/projecting a method, not a run state object.
 class MethodPlan:
     id: str
     method_id: str
-    mode: Literal["single_turn"]
+    mode: str  # P1 value: "single_turn"
     steps: tuple[MethodStep, ...]
+    phase: str | None = None
+    activity: str | None = None
+    task: str | None = None
     metadata: Mapping[str, object] = field(default_factory=dict)
 ```
 
@@ -277,11 +326,14 @@ class MethodPlan:
 class MethodStep:
     id: str
     title: str
-    executor: Literal["current_agent"]
+    executor: str  # P1 value: "current_agent"
+    role_variant: str | None = None
     projection: Mapping[str, object] = field(default_factory=dict)
 ```
 
 P1 step is descriptive. It is not a TaskFlow step and does not own lifecycle events.
+
+`phase`, `activity`, `task`, `executor`, and `role_variant` exist so later method compilation can express `Phase > Activity > Task > Step` and meta-role routing without changing the P1 object shape. P1 should normally leave these hints unset except for `mode="single_turn"` and `executor="current_agent"`.
 
 ### `MethodProjection`
 
@@ -291,11 +343,14 @@ class MethodProjection:
     method_id: str
     step_id: str
     system_guidance: str
+    meta_role: str | None = None
+    role_variant: str | None = None
     user_guidance: str | None = None
     allowed_skills: tuple[str, ...] = ()
     suggested_tools: tuple[str, ...] = ()
     expected_artifacts: tuple[str, ...] = ()
     approval_gates: tuple[str, ...] = ()
+    temperature: float | None = None
     metadata: Mapping[str, object] = field(default_factory=dict)
 ```
 
@@ -307,11 +362,20 @@ Use the following method guidance when performing this turn:
 <method content>
 ```
 
+P1 projection may copy `meta_role`, `role_variant`, and `temperature` from descriptor/step hints when present. It must not interpret those values as scheduling or provider-routing policy yet.
+
 ## Relationship To Existing Components
 
-### Skill Loader
+### Skill And Method Resource Loader
 
-P1 uses existing skills as source material, but it does not move skill discovery into method.
+P1 uses existing skills as source material, but it does not move skill discovery ownership into method.
+
+Discovery rules:
+
+- `skills/**/SKILL.md` loads as `kind="skill_backed"`.
+- `methods/**/SKILL.md` loads as `kind="method_resource"`.
+- `methods/{phase|activity|task|role|guidance|workproduct}/{name}/SKILL.md` is an experimental-compatible layout, but P1 should treat the directory segment as a hint, not a mandatory ontology.
+- When ids collide, project-local method resources should override project-local skills, and project-local resources should override package resources.
 
 `MethodLoader` can accept:
 
@@ -336,7 +400,7 @@ P1 does not need to modify `CodingWorkShell` immediately.
 The clean integration path is:
 
 1. P1 implements pure method APIs.
-2. A later small PR may allow work operations to carry `method_id`.
+2. P1 may allow work operations to carry `method_id` as metadata-only run context.
 3. DomainApp P2 will decide how to assemble projection into a domain prompt/tool/policy bundle.
 
 If P1 needs a smoke integration, it should be explicit and optional:
@@ -346,6 +410,8 @@ compile method -> project guidance -> caller prepends guidance to prompt
 ```
 
 The method package should not call `CodingWorkShell` directly.
+
+If `CodingWorkShell.submit_coding_turn(..., method_id=...)` is added in P1, it must only write `WorkRun.method_id` and related event metadata. It must not compile, project, select, or apply a method.
 
 ### AgentSession
 
@@ -381,6 +447,7 @@ tests/method/test_method_types.py
 tests/method/test_skill_adapter.py
 tests/method/test_method_loader.py
 tests/method/test_method_registry.py
+tests/method/test_method_selector.py
 tests/method/test_method_compiler.py
 tests/method/test_method_projection.py
 tests/method/test_public_api.py
@@ -390,11 +457,15 @@ Coverage:
 
 - dataclass defaults
 - metadata is JSON-friendly and preserved
+- taxonomy hints are preserved without being required
 - skill-backed id generation
 - loader discovers methods from skills
-- registry list/get/select
+- loader discovers method resources from `methods/**/SKILL.md`
+- registry list/get and selected-state behavior
+- selector exact id/name matching
 - compiler returns single-turn plan
-- projector returns stable guidance
+- compiler leaves phase/activity/task unset unless hints are explicitly available
+- projector returns stable guidance and carries optional role/temperature hints
 - public API excludes P3/P4 concepts
 
 ### Regression Tests
@@ -416,19 +487,27 @@ Create `loushang.method.types` and public exports.
 
 Implement `SkillDescriptor -> MethodDescriptor`.
 
+Preserve frontmatter hints such as `type`, `domain`, `phase`, `meta_role`, `role`, and `temperature`.
+
 ### Task 3: Method Loader
 
-Wrap existing resource loader skill discovery into method discovery.
+Wrap existing resource loader skill discovery into method discovery and add `methods/**/SKILL.md` discovery.
 
-### Task 4: Method Registry
+### Task 4: Method Registry And Selector
 
-Add list/get/select behavior with duplicate id protection.
+Add list/get and selected-state behavior with duplicate id protection. Add exact id/name matching selector.
 
 ### Task 5: Compiler And Projection
 
-Compile to single-turn plan and project stable guidance.
+Compile to single-turn plan and project stable guidance. Carry optional taxonomy and role hints without turning them into scheduling behavior.
 
-### Task 6: Public API And Regression
+### Task 6: Optional Work Metadata Integration
+
+If the implementation can stay small, allow `CodingWorkShell.submit_coding_turn(..., method_id=...)` to write `WorkRun.method_id`.
+
+This task is metadata-only. It must not apply prompt guidance or mutate `AgentSession`.
+
+### Task 7: Public API And Regression
 
 Add public API boundary tests and run focused regression.
 
@@ -436,10 +515,12 @@ Add public API boundary tests and run focused regression.
 
 These are explicitly deferred unless implementation reveals a blocker:
 
-- Should `METHOD.md` use frontmatter identical to `SKILL.md`, or a separate schema?
+- Should `METHOD.md` ever exist, or should method resources continue to use `SKILL.md` with richer frontmatter?
+- When should taxonomy hints become mandatory validated fields rather than optional metadata?
 - Should selected method live in settings, session metadata, or work operation payload?
 - Should CLI expose `--method` before DomainApp exists?
 - Should method projection append to system prompt or user prompt by default?
+- Should heuristic or semantic method selection exist before DomainApp owns task classification?
 
 P1 can ship without answering these globally.
 

--- a/src/loushang/method/__init__.py
+++ b/src/loushang/method/__init__.py
@@ -1,3 +1,4 @@
+from loushang.method.loader import MethodLoader
 from loushang.method.skill_adapter import method_from_skill
 from loushang.method.types import (
     MethodContext,
@@ -8,6 +9,7 @@ from loushang.method.types import (
 )
 
 __all__ = [
+    "MethodLoader",
     "MethodContext",
     "MethodDescriptor",
     "MethodPlan",

--- a/src/loushang/method/__init__.py
+++ b/src/loushang/method/__init__.py
@@ -1,4 +1,6 @@
+from loushang.method.compiler import MethodCompiler
 from loushang.method.loader import MethodLoader
+from loushang.method.projection import MethodProjector
 from loushang.method.registry import MethodRegistry
 from loushang.method.selector import MethodSelector
 from loushang.method.skill_adapter import method_from_skill
@@ -12,6 +14,8 @@ from loushang.method.types import (
 
 __all__ = [
     "MethodLoader",
+    "MethodCompiler",
+    "MethodProjector",
     "MethodRegistry",
     "MethodSelector",
     "MethodContext",

--- a/src/loushang/method/__init__.py
+++ b/src/loushang/method/__init__.py
@@ -1,4 +1,6 @@
 from loushang.method.loader import MethodLoader
+from loushang.method.registry import MethodRegistry
+from loushang.method.selector import MethodSelector
 from loushang.method.skill_adapter import method_from_skill
 from loushang.method.types import (
     MethodContext,
@@ -10,6 +12,8 @@ from loushang.method.types import (
 
 __all__ = [
     "MethodLoader",
+    "MethodRegistry",
+    "MethodSelector",
     "MethodContext",
     "MethodDescriptor",
     "MethodPlan",

--- a/src/loushang/method/__init__.py
+++ b/src/loushang/method/__init__.py
@@ -1,0 +1,15 @@
+from loushang.method.types import (
+    MethodContext,
+    MethodDescriptor,
+    MethodPlan,
+    MethodProjection,
+    MethodStep,
+)
+
+__all__ = [
+    "MethodContext",
+    "MethodDescriptor",
+    "MethodPlan",
+    "MethodProjection",
+    "MethodStep",
+]

--- a/src/loushang/method/__init__.py
+++ b/src/loushang/method/__init__.py
@@ -1,3 +1,4 @@
+from loushang.method.skill_adapter import method_from_skill
 from loushang.method.types import (
     MethodContext,
     MethodDescriptor,
@@ -12,4 +13,5 @@ __all__ = [
     "MethodPlan",
     "MethodProjection",
     "MethodStep",
+    "method_from_skill",
 ]

--- a/src/loushang/method/compiler.py
+++ b/src/loushang/method/compiler.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Mapping as MappingABC
+
+from loushang.method.types import MethodContext, MethodDescriptor, MethodPlan, MethodStep
+
+
+class MethodCompiler:
+    def compile(self, descriptor: MethodDescriptor, context: MethodContext | None = None) -> MethodPlan:
+        _ = context
+        step = MethodStep(
+            id="main",
+            title=descriptor.name,
+            executor="current_agent",
+            projection={
+                "content": descriptor.content,
+                "meta_role": descriptor.meta_role,
+                "temperature": _temperature_hint(descriptor.metadata),
+            },
+        )
+        return MethodPlan(
+            id=f"plan:{descriptor.id}",
+            method_id=descriptor.id,
+            mode="single_turn",
+            steps=(step,),
+            phase=descriptor.phase,
+            metadata={
+                "method_kind": descriptor.kind,
+                "element_type": descriptor.element_type,
+            },
+        )
+
+
+def _temperature_hint(metadata: MappingABC[str, object]) -> float | None:
+    frontmatter = metadata.get("frontmatter")
+    if not isinstance(frontmatter, MappingABC):
+        return None
+    value = frontmatter.get("temperature")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+__all__ = ["MethodCompiler"]

--- a/src/loushang/method/compiler.py
+++ b/src/loushang/method/compiler.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from collections.abc import Mapping as MappingABC
 
-from loushang.method.types import MethodContext, MethodDescriptor, MethodPlan, MethodStep
+from loushang.method.types import (
+    MethodContext,
+    MethodDescriptor,
+    MethodPlan,
+    MethodStep,
+)
 
 
 class MethodCompiler:

--- a/src/loushang/method/loader.py
+++ b/src/loushang/method/loader.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from collections.abc import Mapping as MappingABC
+from pathlib import Path
+
+from loushang.coding.frontmatter import FrontmatterParseError, parse_frontmatter
+from loushang.coding.loader import DefaultResourceLoader
+from loushang.method.skill_adapter import method_from_skill
+from loushang.method.types import MethodDescriptor
+
+_METHOD_ELEMENT_TYPES = frozenset({"phase", "activity", "task", "role", "guidance", "workproduct"})
+
+
+class MethodLoader:
+    def __init__(
+        self,
+        resource_loader: DefaultResourceLoader | None = None,
+        package_roots: tuple[str | Path, ...] = (),
+    ) -> None:
+        self._package_roots = tuple(Path(root) for root in package_roots)
+        self._resource_loader = resource_loader or DefaultResourceLoader(package_roots=self._package_roots)
+        self._methods: tuple[MethodDescriptor, ...] = ()
+        self._cwd: Path | None = None
+
+    def discover_methods(self, cwd: str | Path) -> list[MethodDescriptor]:
+        root = Path(cwd)
+        skill_methods = [method_from_skill(skill) for skill in self._resource_loader.discover_resources(root).skills]
+        package_method_resources: list[MethodDescriptor] = []
+        for index, package_root in enumerate(self._package_roots):
+            package_method_resources.extend(
+                _discover_method_resources(
+                    package_root,
+                    source_kind="external_package",
+                    source_scope="package",
+                    source_root_order=index,
+                )
+            )
+        project_method_resources = _discover_method_resources(
+            root,
+            source_kind="project_local",
+            source_scope="project",
+            source_root_order=0,
+        )
+        return _deduplicate_by_name([*skill_methods, *package_method_resources, *project_method_resources])
+
+    def reload_methods(self, cwd: str | Path | None = None) -> list[MethodDescriptor]:
+        root = Path(cwd) if cwd is not None else self._cwd or Path.cwd()
+        methods = tuple(self.discover_methods(root))
+        self._methods = methods
+        self._cwd = root
+        return list(methods)
+
+    def list_methods(self) -> list[MethodDescriptor]:
+        return list(self._methods)
+
+    def get_method(self, id_or_name: str) -> MethodDescriptor | None:
+        for method in self._methods:
+            if method.id == id_or_name or method.name == id_or_name:
+                return method
+        return None
+
+
+def _discover_method_resources(
+    root: Path,
+    *,
+    source_kind: str,
+    source_scope: str,
+    source_root_order: int,
+) -> list[MethodDescriptor]:
+    methods_root = root / "methods"
+    if not methods_root.is_dir():
+        return []
+    descriptors: list[MethodDescriptor] = []
+    for skill_file in sorted(methods_root.rglob("SKILL.md")):
+        descriptor = _method_resource_from_file(
+            skill_file,
+            methods_root=methods_root,
+            source_kind=source_kind,
+            source_scope=source_scope,
+            source_root_order=source_root_order,
+        )
+        if descriptor is not None:
+            descriptors.append(descriptor)
+    return descriptors
+
+
+def _method_resource_from_file(
+    skill_file: Path,
+    *,
+    methods_root: Path,
+    source_kind: str,
+    source_scope: str,
+    source_root_order: int,
+) -> MethodDescriptor | None:
+    try:
+        content = skill_file.read_text(encoding="utf-8")
+        parsed = parse_frontmatter(content)
+    except (OSError, UnicodeError, FrontmatterParseError):
+        return None
+
+    frontmatter = parsed.frontmatter
+    relative_parts = skill_file.relative_to(methods_root).parts
+    path_element_type = relative_parts[0] if relative_parts and relative_parts[0] in _METHOD_ELEMENT_TYPES else None
+    element_type = _string_hint(frontmatter, "type") or path_element_type
+    name = _string_hint(frontmatter, "name") or skill_file.parent.name
+    metadata = {
+        "frontmatter": frontmatter,
+        "body": parsed.body,
+        "source_kind": source_kind,
+        "source_scope": source_scope,
+        "resource_type": "method",
+        "source_root": methods_root.as_posix(),
+        "source_root_order": source_root_order,
+        "relative_path": skill_file.relative_to(methods_root).as_posix(),
+    }
+    return MethodDescriptor(
+        id=_method_resource_id(name=name, element_type=element_type),
+        name=name,
+        description=_string_hint(frontmatter, "description") or "",
+        content=content,
+        kind="method_resource",
+        element_type=element_type,
+        domain=_string_hint(frontmatter, "domain"),
+        meta_role=_first_string_hint(frontmatter, ("meta_role", "meta-role", "role")),
+        phase=_string_hint(frontmatter, "phase"),
+        source_path=skill_file.as_posix(),
+        version=_string_hint(frontmatter, "version"),
+        metadata=metadata,
+    )
+
+
+def _method_resource_id(*, name: str, element_type: str | None) -> str:
+    if element_type:
+        return f"method:{element_type}:{name}"
+    return f"method:{name}"
+
+
+def _deduplicate_by_name(methods: Iterable[MethodDescriptor]) -> list[MethodDescriptor]:
+    by_name: dict[str, MethodDescriptor] = {}
+    for method in methods:
+        by_name[method.name] = method
+    return list(by_name.values())
+
+
+def _first_string_hint(frontmatter: MappingABC[str, object], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        if value := _string_hint(frontmatter, key):
+            return value
+    return None
+
+
+def _string_hint(frontmatter: MappingABC[str, object], key: str) -> str | None:
+    value = frontmatter.get(key)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+__all__ = ["MethodLoader"]

--- a/src/loushang/method/projection.py
+++ b/src/loushang/method/projection.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from loushang.method.types import MethodContext, MethodPlan, MethodProjection, MethodStep
+
+
+class MethodProjector:
+    def project(
+        self,
+        plan: MethodPlan,
+        step: MethodStep,
+        context: MethodContext | None = None,
+    ) -> MethodProjection:
+        _ = context
+        content = step.projection.get("content")
+        method_content = content if isinstance(content, str) else ""
+        return MethodProjection(
+            method_id=plan.method_id,
+            step_id=step.id,
+            system_guidance=f"Use the following method guidance when performing this turn:\n\n{method_content}",
+            meta_role=_string_projection_value(step, "meta_role"),
+            role_variant=step.role_variant,
+            temperature=_float_projection_value(step, "temperature"),
+            metadata={"source_projection": dict(step.projection)},
+        )
+
+
+def _string_projection_value(step: MethodStep, key: str) -> str | None:
+    value = step.projection.get(key)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _float_projection_value(step: MethodStep, key: str) -> float | None:
+    value = step.projection.get(key)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+__all__ = ["MethodProjector"]

--- a/src/loushang/method/projection.py
+++ b/src/loushang/method/projection.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from loushang.method.types import MethodContext, MethodPlan, MethodProjection, MethodStep
+from loushang.method.types import (
+    MethodContext,
+    MethodPlan,
+    MethodProjection,
+    MethodStep,
+)
 
 
 class MethodProjector:

--- a/src/loushang/method/registry.py
+++ b/src/loushang/method/registry.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from loushang.method.types import MethodDescriptor
+
+
+class MethodRegistry:
+    def __init__(self, methods: Iterable[MethodDescriptor] = ()) -> None:
+        self._methods: tuple[MethodDescriptor, ...] = ()
+        self._selected_method_id: str | None = None
+        self.replace_methods(methods)
+
+    def replace_methods(self, methods: Iterable[MethodDescriptor]) -> None:
+        method_tuple = tuple(methods)
+        seen: set[str] = set()
+        for method in method_tuple:
+            if method.id in seen:
+                raise ValueError(f"duplicate method id: {method.id}")
+            seen.add(method.id)
+        self._methods = method_tuple
+        if self._selected_method_id and self.get_method(self._selected_method_id) is None:
+            self._selected_method_id = None
+
+    def list_methods(self) -> list[MethodDescriptor]:
+        return list(self._methods)
+
+    def get_method(self, id_or_name: str) -> MethodDescriptor | None:
+        for method in self._methods:
+            if method.id == id_or_name or method.name == id_or_name:
+                return method
+        return None
+
+    def select_method(self, id_or_name: str) -> MethodDescriptor | None:
+        method = self.get_method(id_or_name)
+        self._selected_method_id = method.id if method is not None else None
+        return method
+
+    def get_selected_method(self) -> MethodDescriptor | None:
+        if self._selected_method_id is None:
+            return None
+        return self.get_method(self._selected_method_id)
+
+    def clear_selected_method(self) -> None:
+        self._selected_method_id = None
+
+
+__all__ = ["MethodRegistry"]

--- a/src/loushang/method/selector.py
+++ b/src/loushang/method/selector.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from loushang.method.registry import MethodRegistry
+from loushang.method.types import MethodDescriptor
+
+
+class MethodSelector:
+    def __init__(self, source: MethodRegistry | Iterable[MethodDescriptor]) -> None:
+        self._source = source
+
+    def select(self, id_or_name: str) -> MethodDescriptor | None:
+        if isinstance(self._source, MethodRegistry):
+            return self._source.get_method(id_or_name)
+        for method in self._source:
+            if method.id == id_or_name or method.name == id_or_name:
+                return method
+        return None
+
+
+__all__ = ["MethodSelector"]

--- a/src/loushang/method/skill_adapter.py
+++ b/src/loushang/method/skill_adapter.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections.abc import Mapping as MappingABC
+
+from loushang.coding.loader.types import SkillDescriptor
+from loushang.method.types import MethodDescriptor
+
+
+def method_from_skill(skill: SkillDescriptor) -> MethodDescriptor:
+    frontmatter = _frontmatter(skill.metadata)
+    metadata = {
+        **dict(skill.metadata),
+        "source_kind": skill.source_kind,
+        "source_scope": skill.source_scope,
+        "resource_type": skill.resource_type,
+        "skill_id": skill.id,
+        "skill_name": skill.name,
+    }
+    return MethodDescriptor(
+        id=_skill_method_id(skill.name),
+        name=skill.name,
+        description=skill.description or "",
+        content=skill.content or "",
+        kind="skill_backed",
+        element_type=_string_hint(frontmatter, "type"),
+        domain=_string_hint(frontmatter, "domain"),
+        meta_role=_first_string_hint(frontmatter, ("meta_role", "meta-role", "role")),
+        phase=_string_hint(frontmatter, "phase"),
+        source_path=skill.source_path.as_posix(),
+        version=_string_hint(frontmatter, "version"),
+        metadata=metadata,
+    )
+
+
+def _skill_method_id(skill_name: str) -> str:
+    if skill_name.startswith("skill:"):
+        return skill_name
+    return f"skill:{skill_name}"
+
+
+def _frontmatter(metadata: object) -> MappingABC[str, object]:
+    if isinstance(metadata, MappingABC):
+        frontmatter = metadata.get("frontmatter")
+        if isinstance(frontmatter, MappingABC):
+            return frontmatter
+    return {}
+
+
+def _first_string_hint(frontmatter: MappingABC[str, object], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        if value := _string_hint(frontmatter, key):
+            return value
+    return None
+
+
+def _string_hint(frontmatter: MappingABC[str, object], key: str) -> str | None:
+    value = frontmatter.get(key)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+__all__ = ["method_from_skill"]

--- a/src/loushang/method/types.py
+++ b/src/loushang/method/types.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Mapping
 
-
 _EMPTY_METADATA: Mapping[str, object] = MappingProxyType({})
 
 

--- a/src/loushang/method/types.py
+++ b/src/loushang/method/types.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Mapping
+
+
+_EMPTY_METADATA: Mapping[str, object] = MappingProxyType({})
+
+
+@dataclass(frozen=True)
+class MethodDescriptor:
+    id: str
+    name: str
+    description: str
+    content: str
+    kind: str
+    element_type: str | None = None
+    domain: str | None = None
+    meta_role: str | None = None
+    phase: str | None = None
+    source_path: str | None = None
+    version: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+
+
+@dataclass(frozen=True)
+class MethodContext:
+    domain: str | None = None
+    task: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+
+
+@dataclass(frozen=True)
+class MethodStep:
+    id: str
+    title: str
+    executor: str
+    role_variant: str | None = None
+    projection: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+
+
+@dataclass(frozen=True)
+class MethodPlan:
+    id: str
+    method_id: str
+    mode: str
+    steps: tuple[MethodStep, ...]
+    phase: str | None = None
+    activity: str | None = None
+    task: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+
+
+@dataclass(frozen=True)
+class MethodProjection:
+    method_id: str
+    step_id: str
+    system_guidance: str
+    meta_role: str | None = None
+    role_variant: str | None = None
+    user_guidance: str | None = None
+    allowed_skills: tuple[str, ...] = ()
+    suggested_tools: tuple[str, ...] = ()
+    expected_artifacts: tuple[str, ...] = ()
+    approval_gates: tuple[str, ...] = ()
+    temperature: float | None = None
+    metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+
+
+__all__ = [
+    "MethodContext",
+    "MethodDescriptor",
+    "MethodPlan",
+    "MethodProjection",
+    "MethodStep",
+]

--- a/src/loushang/work/coding.py
+++ b/src/loushang/work/coding.py
@@ -34,6 +34,7 @@ class CodingWorkShell:
         *,
         session_id: str,
         images: Sequence[object] | None = None,
+        method_id: str | None = None,
         operation_id: str | None = None,
         run_id: str | None = None,
     ) -> WorkRun:
@@ -45,7 +46,7 @@ class CodingWorkShell:
             kind="SubmitCodingTurn",
             session_id=session_id,
             domain="coding",
-            payload=_operation_payload(text=text, images=images),
+            payload=_operation_payload(text=text, images=images, method_id=method_id),
         )
         self._append_operation(operation, run_id=run_id, sequence=sequence)
 
@@ -55,6 +56,7 @@ class CodingWorkShell:
             session_id=session_id,
             domain="coding",
             status="running",
+            method_id=method_id,
         )
         sequence += 1
         self._append_event(
@@ -96,6 +98,7 @@ class CodingWorkShell:
                 session_id=session_id,
                 domain="coding",
                 status="failed",
+                method_id=method_id,
             )
             self._append_event(
                 _work_event(
@@ -117,6 +120,7 @@ class CodingWorkShell:
             session_id=session_id,
             domain="coding",
             status="completed",
+            method_id=method_id,
         )
         self._append_event(
             _work_event(
@@ -160,6 +164,9 @@ def _work_event(
     created_at: datetime,
     payload: Mapping[str, object],
 ) -> WorkEvent:
+    event_payload = dict(payload)
+    if run.method_id is not None:
+        event_payload["method_id"] = run.method_id
     return WorkEvent(
         event_id=f"{run.run_id}-event-{sequence}",
         kind=kind,
@@ -170,14 +177,16 @@ def _work_event(
         sequence=sequence,
         created_at=created_at,
         delivery_hint="immediate",
-        payload=payload,
+        payload=event_payload,
     )
 
 
-def _operation_payload(*, text: str, images: Sequence[object] | None) -> dict[str, object]:
+def _operation_payload(*, text: str, images: Sequence[object] | None, method_id: str | None) -> dict[str, object]:
     payload: dict[str, object] = {"text": text}
     if images is not None:
         payload["image_count"] = len(images)
+    if method_id is not None:
+        payload["method_id"] = method_id
     return payload
 
 

--- a/tests/method/test_method_compiler.py
+++ b/tests/method/test_method_compiler.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from loushang.method import MethodCompiler, MethodContext, MethodDescriptor
+
+
+def test_method_compiler_returns_single_turn_plan_with_main_step() -> None:
+    descriptor = MethodDescriptor(
+        id="method:task:review",
+        name="review",
+        description="Review changes.",
+        content="Review the diff carefully.",
+        kind="method_resource",
+        element_type="task",
+        meta_role="VALIDATOR",
+        phase="VERIFY",
+        metadata={"frontmatter": {"temperature": "0.2"}},
+    )
+
+    plan = MethodCompiler().compile(descriptor, MethodContext(domain="coding"))
+
+    assert plan.id == "plan:method:task:review"
+    assert plan.method_id == "method:task:review"
+    assert plan.mode == "single_turn"
+    assert plan.phase == "VERIFY"
+    assert plan.activity is None
+    assert plan.task is None
+    assert len(plan.steps) == 1
+    step = plan.steps[0]
+    assert step.id == "main"
+    assert step.title == "review"
+    assert step.executor == "current_agent"
+    assert step.role_variant is None
+    assert step.projection["content"] == "Review the diff carefully."
+    assert step.projection["meta_role"] == "VALIDATOR"
+    assert step.projection["temperature"] == 0.2
+
+
+def test_method_compiler_uses_none_for_missing_hints() -> None:
+    descriptor = MethodDescriptor(
+        id="skill:debug",
+        name="debug",
+        description="",
+        content="Debug failures.",
+        kind="skill_backed",
+    )
+
+    plan = MethodCompiler().compile(descriptor)
+
+    assert plan.phase is None
+    assert plan.steps[0].projection["meta_role"] is None
+    assert plan.steps[0].projection["temperature"] is None

--- a/tests/method/test_method_loader.py
+++ b/tests/method/test_method_loader.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from loushang.method import MethodLoader
+
+
+def test_method_loader_discovers_skill_backed_methods_without_mutating_cache(tmp_path) -> None:
+    project = tmp_path / "project"
+    skill_dir = project / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review code.\n"
+        "type: task\n"
+        "domain: coding\n"
+        "---\n\n"
+        "Review code changes.",
+        encoding="utf-8",
+    )
+    loader = MethodLoader()
+
+    methods = loader.discover_methods(project)
+
+    assert loader.list_methods() == []
+    assert [method.id for method in methods] == ["skill:review"]
+    method = methods[0]
+    assert method.kind == "skill_backed"
+    assert method.element_type == "task"
+    assert method.domain == "coding"
+
+
+def test_method_loader_reload_replaces_cached_snapshot(tmp_path) -> None:
+    project = tmp_path / "project"
+    skill_dir = project / "skills" / "debug"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("Debug failures.", encoding="utf-8")
+    loader = MethodLoader()
+
+    loaded = loader.reload_methods(project)
+
+    assert loader.list_methods() == loaded
+    assert loader.get_method("skill:debug") == loaded[0]
+    assert loader.get_method("debug") == loaded[0]
+
+    second_project = tmp_path / "second"
+    second_skill_dir = second_project / "skills" / "review"
+    second_skill_dir.mkdir(parents=True)
+    (second_skill_dir / "SKILL.md").write_text("Review code.", encoding="utf-8")
+
+    reloaded = loader.reload_methods(second_project)
+
+    assert [method.name for method in reloaded] == ["review"]
+    assert loader.get_method("debug") is None
+
+
+def test_method_loader_discovers_method_resources_and_ignores_future_manifests(tmp_path) -> None:
+    project = tmp_path / "project"
+    method_dir = project / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Method review.\n"
+        "type: task\n"
+        "domain: coding\n"
+        "meta_role: VALIDATOR\n"
+        "phase: VERIFY\n"
+        "version: 1\n"
+        "---\n\n"
+        "Use method review guidance.",
+        encoding="utf-8",
+    )
+    (project / "methods" / "METHOD.md").write_text("Future manifest.", encoding="utf-8")
+    (project / "methods" / "SOUR.md").write_text("Future source role.", encoding="utf-8")
+
+    methods = MethodLoader().discover_methods(project)
+
+    assert [method.id for method in methods] == ["method:task:review"]
+    method = methods[0]
+    assert method.name == "review"
+    assert method.kind == "method_resource"
+    assert method.element_type == "task"
+    assert method.domain == "coding"
+    assert method.meta_role == "VALIDATOR"
+    assert method.phase == "VERIFY"
+    assert method.version == "1"
+    assert method.metadata["body"] == "Use method review guidance."
+
+
+def test_method_loader_method_resource_overrides_skill_with_same_name(tmp_path) -> None:
+    project = tmp_path / "project"
+    skill_dir = project / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("Skill review.", encoding="utf-8")
+    method_dir = project / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\nname: review\n---\n\nMethod review.",
+        encoding="utf-8",
+    )
+
+    methods = MethodLoader().discover_methods(project)
+
+    assert [method.id for method in methods] == ["method:task:review"]
+    assert methods[0].kind == "method_resource"
+    assert methods[0].content == "---\nname: review\n---\n\nMethod review."

--- a/tests/method/test_method_projection.py
+++ b/tests/method/test_method_projection.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from loushang.method import MethodCompiler, MethodDescriptor, MethodProjector
+
+
+def test_method_projector_builds_stable_system_guidance() -> None:
+    descriptor = MethodDescriptor(
+        id="method:task:review",
+        name="review",
+        description="Review changes.",
+        content="Review the diff carefully.",
+        kind="method_resource",
+        meta_role="VALIDATOR",
+        metadata={"frontmatter": {"temperature": "0.2"}},
+    )
+    plan = MethodCompiler().compile(descriptor)
+    step = plan.steps[0]
+
+    projection = MethodProjector().project(plan, step)
+
+    assert projection.method_id == "method:task:review"
+    assert projection.step_id == "main"
+    assert projection.system_guidance == (
+        "Use the following method guidance when performing this turn:\n\n"
+        "Review the diff carefully."
+    )
+    assert projection.meta_role == "VALIDATOR"
+    assert projection.temperature == 0.2
+
+
+def test_method_projector_handles_empty_content() -> None:
+    descriptor = MethodDescriptor(id="skill:empty", name="empty", description="", content="", kind="skill_backed")
+    plan = MethodCompiler().compile(descriptor)
+
+    projection = MethodProjector().project(plan, plan.steps[0])
+
+    assert projection.system_guidance == "Use the following method guidance when performing this turn:\n\n"

--- a/tests/method/test_method_registry.py
+++ b/tests/method/test_method_registry.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from loushang.method import MethodDescriptor, MethodRegistry
+
+
+def _method(id: str, name: str | None = None) -> MethodDescriptor:
+    return MethodDescriptor(
+        id=id,
+        name=name or id,
+        description="",
+        content="Guidance.",
+        kind="method_resource",
+    )
+
+
+def test_method_registry_lists_and_gets_by_id_or_name() -> None:
+    review = _method("method:task:review", name="review")
+    registry = MethodRegistry([review])
+
+    assert registry.list_methods() == [review]
+    assert registry.get_method("method:task:review") == review
+    assert registry.get_method("review") == review
+    assert registry.get_method("missing") is None
+
+
+def test_method_registry_rejects_duplicate_ids() -> None:
+    with pytest.raises(ValueError, match="duplicate method id"):
+        MethodRegistry([_method("method:review", "review"), _method("method:review", "review-copy")])
+
+
+def test_method_registry_selected_state_is_in_memory() -> None:
+    review = _method("method:task:review", name="review")
+    registry = MethodRegistry([review])
+
+    assert registry.get_selected_method() is None
+    assert registry.select_method("review") == review
+    assert registry.get_selected_method() == review
+    assert registry.clear_selected_method() is None
+    assert registry.get_selected_method() is None
+
+
+def test_method_registry_missing_selection_returns_none() -> None:
+    registry = MethodRegistry()
+
+    assert registry.select_method("missing") is None
+    assert registry.get_selected_method() is None

--- a/tests/method/test_method_selector.py
+++ b/tests/method/test_method_selector.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from loushang.method import MethodDescriptor, MethodRegistry, MethodSelector
+
+
+def _method(id: str, name: str) -> MethodDescriptor:
+    return MethodDescriptor(id=id, name=name, description="", content="Guidance.", kind="method_resource")
+
+
+def test_method_selector_matches_exact_id_or_name_from_registry() -> None:
+    review = _method("method:task:review", "review")
+    selector = MethodSelector(MethodRegistry([review]))
+
+    assert selector.select("method:task:review") == review
+    assert selector.select("review") == review
+    assert selector.select("rev") is None
+
+
+def test_method_selector_matches_exact_id_or_name_from_descriptor_list() -> None:
+    review = _method("method:task:review", "review")
+    selector = MethodSelector([review])
+
+    assert selector.select("review") == review
+    assert selector.select("Review") is None

--- a/tests/method/test_method_types.py
+++ b/tests/method/test_method_types.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from loushang.method import MethodContext, MethodDescriptor, MethodPlan, MethodProjection, MethodStep
+
+
+def test_method_descriptor_defaults_and_taxonomy_hints() -> None:
+    descriptor = MethodDescriptor(
+        id="skill:code-review",
+        name="code-review",
+        description="Review code changes",
+        content="Review the diff carefully.",
+        kind="skill_backed",
+        element_type="task",
+        domain="coding",
+        meta_role="VALIDATOR",
+        phase="VERIFY",
+        source_path="skills/code-review/SKILL.md",
+        version="1",
+        metadata={"frontmatter": {"type": "task"}},
+    )
+
+    assert descriptor.id == "skill:code-review"
+    assert descriptor.kind == "skill_backed"
+    assert descriptor.element_type == "task"
+    assert descriptor.domain == "coding"
+    assert descriptor.meta_role == "VALIDATOR"
+    assert descriptor.phase == "VERIFY"
+    assert descriptor.metadata["frontmatter"] == {"type": "task"}
+
+    with pytest.raises(FrozenInstanceError):
+        descriptor.name = "changed"  # type: ignore[misc]
+
+
+def test_method_context_defaults_are_small() -> None:
+    context = MethodContext()
+
+    assert context.domain is None
+    assert context.task is None
+    assert context.metadata == {}
+
+
+def test_method_plan_and_step_support_single_turn_defaults() -> None:
+    step = MethodStep(id="main", title="Main", executor="current_agent")
+    plan = MethodPlan(id="plan:skill:review", method_id="skill:review", mode="single_turn", steps=(step,))
+
+    assert plan.steps == (step,)
+    assert plan.phase is None
+    assert plan.activity is None
+    assert plan.task is None
+    assert step.role_variant is None
+    assert step.projection == {}
+
+
+def test_method_projection_defaults_and_optional_role_hints() -> None:
+    projection = MethodProjection(
+        method_id="skill:review",
+        step_id="main",
+        system_guidance="Use this method.",
+        meta_role="VALIDATOR",
+        role_variant="reviewer",
+        temperature=0.2,
+    )
+
+    assert projection.system_guidance == "Use this method."
+    assert projection.meta_role == "VALIDATOR"
+    assert projection.role_variant == "reviewer"
+    assert projection.temperature == 0.2
+    assert projection.user_guidance is None
+    assert projection.allowed_skills == ()
+    assert projection.suggested_tools == ()
+    assert projection.expected_artifacts == ()
+    assert projection.approval_gates == ()
+    assert projection.metadata == {}

--- a/tests/method/test_method_types.py
+++ b/tests/method/test_method_types.py
@@ -4,7 +4,13 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from loushang.method import MethodContext, MethodDescriptor, MethodPlan, MethodProjection, MethodStep
+from loushang.method import (
+    MethodContext,
+    MethodDescriptor,
+    MethodPlan,
+    MethodProjection,
+    MethodStep,
+)
 
 
 def test_method_descriptor_defaults_and_taxonomy_hints() -> None:

--- a/tests/method/test_public_api.py
+++ b/tests/method/test_public_api.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import loushang.method as method
+
+
+def test_method_public_api_exports_p1_types_only() -> None:
+    expected = {
+        "MethodContext",
+        "MethodDescriptor",
+        "MethodPlan",
+        "MethodProjection",
+        "MethodStep",
+    }
+
+    for name in expected:
+        assert hasattr(method, name)
+
+    assert not hasattr(method, "TaskFlow")
+    assert not hasattr(method, "AgentLane")
+    assert not hasattr(method, "CollaborationBus")

--- a/tests/method/test_skill_adapter.py
+++ b/tests/method/test_skill_adapter.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loushang.coding.loader.types import SkillDescriptor
+from loushang.method import method_from_skill
+
+
+def test_method_from_skill_preserves_content_and_frontmatter_hints() -> None:
+    skill = SkillDescriptor(
+        name="code-review",
+        source_path=Path("skills/code-review/SKILL.md"),
+        content="Review code changes.",
+        description="Review code",
+        metadata={
+            "frontmatter": {
+                "type": "task",
+                "domain": "coding",
+                "meta_role": "VALIDATOR",
+                "phase": "VERIFY",
+                "temperature": 0.2,
+                "version": "1",
+            },
+            "body": "Review code changes.",
+        },
+    )
+
+    method = method_from_skill(skill)
+
+    assert method.id == "skill:code-review"
+    assert method.name == "code-review"
+    assert method.description == "Review code"
+    assert method.content == "Review code changes."
+    assert method.kind == "skill_backed"
+    assert method.element_type == "task"
+    assert method.domain == "coding"
+    assert method.meta_role == "VALIDATOR"
+    assert method.phase == "VERIFY"
+    assert method.version == "1"
+    assert method.source_path == "skills/code-review/SKILL.md"
+    assert method.metadata["frontmatter"] == skill.metadata["frontmatter"]
+    assert method.metadata["body"] == "Review code changes."
+    assert method.metadata["source_kind"] == "project_local"
+
+
+def test_method_from_skill_avoids_double_skill_prefix() -> None:
+    skill = SkillDescriptor(
+        name="skill:existing",
+        source_path=Path("skills/existing/SKILL.md"),
+        content="Existing content.",
+    )
+
+    method = method_from_skill(skill)
+
+    assert method.id == "skill:existing"
+    assert method.name == "skill:existing"
+
+
+def test_method_from_skill_accepts_missing_optional_skill_fields() -> None:
+    skill = SkillDescriptor(
+        name="minimal",
+        source_path=Path("skills/minimal/SKILL.md"),
+        content=None,
+        description=None,
+        metadata={"frontmatter": {"role": "DESIGNER"}},
+    )
+
+    method = method_from_skill(skill)
+
+    assert method.id == "skill:minimal"
+    assert method.description == ""
+    assert method.content == ""
+    assert method.meta_role == "DESIGNER"
+    assert method.element_type is None

--- a/tests/work/test_coding_work_shell.py
+++ b/tests/work/test_coding_work_shell.py
@@ -143,3 +143,34 @@ def test_coding_work_shell_jsonl_log_can_replay_persisted_turn(tmp_path) -> None
         assert replayed[4].payload["delivery_hint"] == "immediate"
 
     asyncio.run(scenario())
+
+
+def test_coding_work_shell_records_method_id_as_metadata_only() -> None:
+    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        session = FakePromptSession(events=[])
+        shell = CodingWorkShell(
+            session=session,
+            event_log=event_log,
+            clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        )
+
+        run = await shell.submit_coding_turn(
+            "fix this bug",
+            session_id="session-1",
+            operation_id="op-1",
+            run_id="run-1",
+            method_id="method:task:review",
+        )
+
+        assert session.prompts == ["fix this bug"]
+        assert run.method_id == "method:task:review"
+
+        entries = event_log.query(run_id="run-1")
+        assert entries[0].payload["payload"]["method_id"] == "method:task:review"
+        assert entries[1].payload["payload"]["method_id"] == "method:task:review"
+        assert entries[2].payload["payload"]["method_id"] == "method:task:review"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- Add the P1 `loushang.method` package with core types, skill adapter, method loader, registry, selector, compiler, and projector.
- Support `skills/**/SKILL.md` as skill-backed methods and `methods/**/SKILL.md` as method resources while preserving taxonomy hints.
- Record optional `method_id` on coding work runs as metadata only, without changing prompt or AgentSession behavior.

## Test Plan
- `uv --cache-dir .uv-cache run --extra dev pytest tests/method tests/coding/test_skill_loader.py tests/coding/test_cli.py tests/work -q` -> 220 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/method src/loushang/work/coding.py tests/method tests/work/test_coding_work_shell.py` -> All checks passed

Closes #36