### PR TITLE
P1.5: method visibility CLI

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -64,6 +64,7 @@ from loushang.coding.workflow import (
     resolve_workflow_files,
     run_prompt_steps_workflow,
 )
+from loushang.method import MethodLoader
 from loushang.work import JsonlEventLogBackend
 
 _MISSING = object()
@@ -362,6 +363,10 @@ async def run_cli(
         if list_skills_result is not None:
             return list_skills_result
 
+        method_visibility_result = _run_method_visibility(args, project_root, stdout, stderr)
+        if method_visibility_result is not None:
+            return method_visibility_result
+
         list_plugins_result = _run_list_plugins(args, resolved_services, stdout, stderr)
         if list_plugins_result is not None:
             return list_plugins_result
@@ -584,6 +589,8 @@ def _stdout_guard_enabled(args: CliArgs) -> bool:
         or (args.list_commands and args.list_commands_format == "json")
         or (args.list_diagnostics and args.list_diagnostics_format == "json")
         or (args.list_skills and args.list_skills_format == "json")
+        or (args.list_methods and args.list_methods_format == "json")
+        or (args.show_method is not None and args.show_method_format == "json")
         or (args.list_plugins and args.list_plugins_format == "json")
         or (args.list_packages and args.list_packages_format == "json")
         or (args.export is not None and args.export_result_format == "json")
@@ -745,6 +752,8 @@ def _has_command_style_operation(args: CliArgs) -> bool:
         or args.list_commands
         or args.list_diagnostics
         or args.list_skills
+        or args.list_methods
+        or args.show_method is not None
         or args.list_plugins
         or args.list_packages
         or args.export is not None
@@ -813,6 +822,8 @@ def _runtime_args_for_bootstrap(args: CliArgs) -> CliArgs:
         args.list_commands
         or args.list_diagnostics
         or args.list_skills
+        or args.list_methods
+        or args.show_method is not None
         or args.list_plugins
         or args.list_packages
         or args.list_models is not False
@@ -1725,6 +1736,84 @@ def _normalize_skill_entry(skill: Any) -> dict[str, object] | None:
         "source_kind": _safe_getattr(skill, "source_kind", "") or "",
         "enabled": bool(_safe_getattr(skill, "enabled", True)),
     }
+
+
+def _run_method_visibility(
+    args: CliArgs,
+    project_root: Path,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> int | None:
+    if not args.list_methods and args.show_method is None:
+        return None
+
+    try:
+        methods = MethodLoader().discover_methods(project_root)
+    except Exception as error:
+        stderr.write(f"Error: {_format_cli_error(error)}\n")
+        return 1
+
+    if args.list_methods:
+        normalized = [_normalize_method_entry(method) for method in methods]
+        if args.list_methods_format == "json":
+            stdout.write(json.dumps(normalized, ensure_ascii=False) + "\n")
+            return 0
+        for method in normalized:
+            stdout.write(
+                f"{method['id']}\t{method['name']}\t{method['kind']}\t"
+                f"{method['element_type']}\t{method['path']}\n"
+            )
+        return 0
+
+    method = _find_method(methods, args.show_method or "")
+    if method is None:
+        stderr.write(f"Error: method not found: {args.show_method}\n")
+        return 1
+    payload = _normalize_method_entry(method)
+    payload["description"] = _safe_getattr(method, "description", "") or ""
+    payload["content"] = _safe_getattr(method, "content", "") or ""
+    if args.show_method_format == "json":
+        stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        return 0
+    stdout.write(_format_method_detail(payload))
+    return 0
+
+
+def _find_method(methods: list[Any], id_or_name: str) -> Any | None:
+    for method in methods:
+        if _safe_getattr(method, "id", None) == id_or_name or _safe_getattr(method, "name", None) == id_or_name:
+            return method
+    return None
+
+
+def _normalize_method_entry(method: Any) -> dict[str, object]:
+    return {
+        "id": _safe_getattr(method, "id", "") or "",
+        "name": _safe_getattr(method, "name", "") or "",
+        "kind": _safe_getattr(method, "kind", "") or "",
+        "element_type": _safe_getattr(method, "element_type", None),
+        "domain": _safe_getattr(method, "domain", None),
+        "meta_role": _safe_getattr(method, "meta_role", None),
+        "phase": _safe_getattr(method, "phase", None),
+        "path": _safe_getattr(method, "source_path", "") or "",
+    }
+
+
+def _format_method_detail(method: Mapping[str, object]) -> str:
+    lines = [
+        f"id: {method['id']}",
+        f"name: {method['name']}",
+        f"kind: {method['kind']}",
+    ]
+    for key in ("element_type", "domain", "meta_role", "phase", "path", "description"):
+        value = method.get(key)
+        if value:
+            lines.append(f"{key}: {value}")
+    lines.append("")
+    lines.append(str(method.get("content", "")))
+    if not lines[-1].endswith("\n"):
+        lines[-1] = f"{lines[-1]}\n"
+    return "\n".join(lines)
 
 
 def _run_list_plugins(

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -12,6 +12,8 @@ DiagnosticListFormat = Literal["tsv", "json"]
 ModelListFormat = Literal["text", "json"]
 SessionListFormat = Literal["tsv", "json"]
 SkillListFormat = Literal["tsv", "json"]
+MethodListFormat = Literal["tsv", "json"]
+MethodShowFormat = Literal["text", "json"]
 PluginListFormat = Literal["tsv", "json"]
 PackageListFormat = Literal["text", "tsv", "json"]
 ExportFormat = Literal["html", "jsonl"]
@@ -88,6 +90,10 @@ _BUILTIN_FLAG_NAMES = frozenset(
         "diag-output",
         "list-skills",
         "list-skills-format",
+        "list-methods",
+        "list-methods-format",
+        "show-method",
+        "show-method-format",
         "enable-skill",
         "disable-skill",
         "list-plugins",
@@ -164,6 +170,10 @@ class CliArgs:
     diag_output: str | None
     list_skills: bool
     list_skills_format: SkillListFormat
+    list_methods: bool
+    list_methods_format: MethodListFormat
+    show_method: str | None
+    show_method_format: MethodShowFormat
     enable_skills: tuple[str, ...]
     disable_skills: tuple[str, ...]
     list_plugins: bool
@@ -249,7 +259,9 @@ def parse_args(
         else:
             parser.add_argument(option, dest=dest, default=None)
 
-    raw_argv = _rewrite_observability_flags(_rewrite_package_subcommands(_rewrite_diag_subcommands(list(argv))))
+    raw_argv = _rewrite_observability_flags(
+        _rewrite_package_subcommands(_rewrite_diag_subcommands(_rewrite_method_subcommands(list(argv))))
+    )
     if allow_unknown:
         filtered_argv, unknown_flags = _extract_unknown_flags(
             raw_argv,
@@ -314,6 +326,10 @@ def parse_args(
         diag_output=namespace.diag_output,
         list_skills=namespace.list_skills,
         list_skills_format=namespace.list_skills_format,
+        list_methods=namespace.list_methods,
+        list_methods_format=namespace.list_methods_format,
+        show_method=namespace.show_method,
+        show_method_format=namespace.show_method_format,
         enable_skills=tuple(namespace.enable_skill),
         disable_skills=tuple(namespace.disable_skill),
         list_plugins=namespace.list_plugins,
@@ -479,6 +495,10 @@ def _build_parser() -> ArgumentParser:
     parser.add_argument("--diag-output")
     parser.add_argument("--list-skills", action="store_true")
     parser.add_argument("--list-skills-format", choices=("tsv", "json"), default="tsv")
+    parser.add_argument("--list-methods", action="store_true")
+    parser.add_argument("--list-methods-format", choices=("tsv", "json"), default="tsv")
+    parser.add_argument("--show-method")
+    parser.add_argument("--show-method-format", choices=("text", "json"), default="text")
     parser.add_argument("--enable-skill", action="append", default=[])
     parser.add_argument("--disable-skill", action="append", default=[])
     parser.add_argument("--list-plugins", action="store_true")
@@ -569,6 +589,32 @@ def _rewrite_package_subcommands(argv: list[str]) -> list[str]:
 
     flag = "--install-package" if command == "install" else "--uninstall-package"
     return [flag, source, "--package-scope", scope]
+
+
+def _rewrite_method_subcommands(argv: list[str]) -> list[str]:
+    method_index = _method_subcommand_index(argv)
+    if method_index is None:
+        return argv
+    if len(argv) <= method_index + 1:
+        return argv
+    prefix = argv[:method_index]
+    command = argv[method_index + 1]
+    suffix = argv[method_index + 2 :]
+    if command == "list":
+        return [*prefix, "--list-methods", *suffix]
+    if command == "show" and suffix:
+        return [*prefix, "--show-method", suffix[0], *suffix[1:]]
+    return argv
+
+
+def _method_subcommand_index(argv: list[str]) -> int | None:
+    if argv and argv[0] == "method":
+        return 0
+    if len(argv) >= 3 and argv[0] == "--cwd" and argv[2] == "method":
+        return 2
+    if len(argv) >= 2 and argv[0].startswith("--cwd=") and argv[1] == "method":
+        return 1
+    return None
 
 
 def _rewrite_diag_subcommands(argv: list[str]) -> list[str]:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -376,6 +376,34 @@ def test_parse_args_accepts_work_log_inspect_flags() -> None:
     assert args.work_log_inspect_format == "json"
 
 
+def test_parse_args_accepts_method_visibility_flags_and_subcommands() -> None:
+    from loushang.coding.cli.args import parse_args
+
+    args = parse_args(["--list-methods", "--list-methods-format", "json"])
+
+    assert args.list_methods is True
+    assert args.list_methods_format == "json"
+
+    show_args = parse_args(["method", "show", "method:task:review", "--show-method-format", "json"])
+
+    assert show_args.show_method == "method:task:review"
+    assert show_args.show_method_format == "json"
+
+    list_args = parse_args(["method", "list"])
+
+    assert list_args.list_methods is True
+
+    cwd_first_args = parse_args(["--cwd", "/tmp/project", "method", "list"])
+
+    assert cwd_first_args.cwd == "/tmp/project"
+    assert cwd_first_args.list_methods is True
+
+    message_args = parse_args(["fix", "method", "list"])
+
+    assert message_args.list_methods is False
+    assert message_args.messages == ("fix", "method", "list")
+
+
 def test_parse_args_accepts_observability_flags() -> None:
     from loushang.coding.cli.args import parse_args
 
@@ -4471,6 +4499,118 @@ def test_run_cli_lists_skills_as_json(tmp_path) -> None:
         }
     ]
     assert stderr.getvalue() == ""
+
+
+def test_run_cli_lists_methods_as_json(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    method_dir = tmp_path / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "domain: coding\n"
+        "meta_role: VALIDATOR\n"
+        "phase: VERIFY\n"
+        "---\n\n"
+        "Review the diff carefully.",
+        encoding="utf-8",
+    )
+    (tmp_path / "methods" / "METHOD.md").write_text("Future method manifest.", encoding="utf-8")
+    session = FakeSession("session-1")
+    runtime = FakeRuntime(session)
+    stdout = StringIO()
+    stderr = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["method", "list", "--list-methods-format", "json"],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert json.loads(stdout.getvalue()) == [
+        {
+            "id": "method:task:review",
+            "name": "review",
+            "kind": "method_resource",
+            "element_type": "task",
+            "domain": "coding",
+            "meta_role": "VALIDATOR",
+            "phase": "VERIFY",
+            "path": str(method_dir / "SKILL.md"),
+        }
+    ]
+    assert stderr.getvalue() == ""
+
+
+def test_run_cli_shows_method_as_text(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    skill_dir = tmp_path / "skills" / "debug"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: debug\ndescription: Debug failures.\ntype: task\n---\n\nDebug failures carefully.",
+        encoding="utf-8",
+    )
+    session = FakeSession("session-1")
+    runtime = FakeRuntime(session)
+    stdout = StringIO()
+    stderr = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["method", "show", "debug"],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    output = stdout.getvalue()
+    assert "id: skill:debug" in output
+    assert "kind: skill_backed" in output
+    assert "element_type: task" in output
+    assert "Debug failures carefully." in output
+    assert stderr.getvalue() == ""
+
+
+def test_run_cli_show_method_reports_missing_method(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    session = FakeSession("session-1")
+    runtime = FakeRuntime(session)
+    stderr = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["method", "show", "missing"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+        )
+        assert exit_code == 1
+
+    asyncio.run(scenario())
+
+    assert "Error: method not found: missing" in stderr.getvalue()
 
 
 def test_run_cli_lists_plugins_as_tsv(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Add method visibility flags and subcommand rewrites: `method list`, `method show <id-or-name>`, `--list-methods`, and `--show-method`.
- List project `skills/**/SKILL.md` and `methods/**/SKILL.md` through the existing `MethodLoader`.
- Keep this visibility-only: no prompt assembly, automatic method selection, or AgentSession behavior changes.

## Test Plan
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/method -q` -> 204 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli src/loushang/method tests/coding/test_cli.py tests/method` -> All checks passed
- Manual: `uv --cache-dir .uv-cache run loushang --cwd .tmp-method-demo method list`
- Manual: `uv --cache-dir .uv-cache run loushang --cwd .tmp-method-demo method show review`

Closes #38