### PR TITLE
feat: add coding domain app p2

### DIFF
--- a/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
+++ b/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
@@ -1,0 +1,81 @@
+# Coding DomainApp P2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the first `CodingDomainApp` slice so explicit `--method <id-or-name>` can guide one coding turn while preserving current behavior without `--method`.
+
+**Architecture:** Add a small `loushang.coding.domain` facade that consumes P1 method APIs and returns a prepared prompt plus `method_id`. Keep `AgentSession` unchanged; CLI applies the prepared prompt and threads `method_id` through prompt/print work logging only.
+
+**Tech Stack:** Python dataclasses, existing `loushang.method` APIs, existing coding CLI/prompt/print mode, pytest, ruff.
+
+---
+
+### Task 1: Coding Domain Types
+
+**Files:**
+- Create: `src/loushang/coding/domain/__init__.py`
+- Create: `src/loushang/coding/domain/types.py`
+- Test: `tests/coding/domain/test_coding_domain_app.py`
+
+- [ ] Write failing tests for `CodingDomainRequest` and `CodingDomainPreparedTurn` defaults.
+- [ ] Verify tests fail because `loushang.coding.domain` does not exist.
+- [ ] Implement frozen dataclasses and public exports.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q`.
+- [ ] Commit with `feat: add coding domain p2 types`.
+
+### Task 2: CodingDomainApp
+
+**Files:**
+- Create: `src/loushang/coding/domain/app.py`
+- Modify: `src/loushang/coding/domain/__init__.py`
+- Test: `tests/coding/domain/test_coding_domain_app.py`
+
+- [ ] Write failing tests for no-method unchanged prompt, explicit skill-backed method, explicit `methods/**/SKILL.md` method, missing method error, and empty guidance behavior.
+- [ ] Verify tests fail because `CodingDomainApp` does not exist.
+- [ ] Implement `DEFAULT_GUIDANCE_TEMPLATE`, `CodingDomainApp.prepare_turn(...)`, method lookup, compile/project, and prompt assembly.
+- [ ] Keep `prepare_turn(...)` synchronous.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py tests/method -q`.
+- [ ] Commit with `feat: prepare method-guided coding turns`.
+
+### Task 3: Prompt And Print Work Metadata Plumbing
+
+**Files:**
+- Modify: `src/loushang/coding/prompt_command.py`
+- Modify: `src/loushang/coding/mode/print_mode.py`
+- Modify: `src/loushang/coding/mode/base.py`
+- Test: `tests/coding/test_print_mode.py`
+- Test: `tests/coding/test_prompt_command.py`
+
+- [ ] Write failing tests showing `method_id` reaches `CodingWorkShell` when work logging is active in prompt and print paths.
+- [ ] Verify tests fail because prompt/print APIs do not accept `method_id`.
+- [ ] Add optional `method_id: str | None = None` to `run_prompt_command`, `_run_turn`, `_run_prompt_session`, `PrintMode`, `run_print_mode`, `create_mode_adapter`, and `run_mode`.
+- [ ] Pass `method_id` only to `CodingWorkShell.submit_coding_turn(...)`.
+- [ ] Run focused prompt/print tests.
+- [ ] Commit with `feat: thread method id through coding runners`.
+
+### Task 4: CLI `--method`
+
+**Files:**
+- Modify: `src/loushang/coding/cli/args.py`
+- Modify: `src/loushang/coding/cli/__main__.py`
+- Test: `tests/coding/test_cli.py`
+
+- [ ] Write failing parse tests for `--method`.
+- [ ] Write failing CLI tests for `--method review -p`, `--method review --mode print`, missing method, unsupported TUI/RPC, and unchanged no-method behavior.
+- [ ] Add `method: str | None` to `CliArgs` and parser.
+- [ ] Add runtime validation for unsupported TUI/RPC mode.
+- [ ] Use `CodingDomainApp.prepare_turn(...)` after resolving print input and before dispatching prompt/print/mode runners.
+- [ ] Pass `prepared_prompt` and `method_id` into prompt/print/mode runners.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/domain -q`.
+- [ ] Commit with `feat: add explicit method guided CLI turns`.
+
+### Task 5: Regression
+
+**Files:**
+- Modify as needed from previous tasks only.
+
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q`.
+- [ ] Run `uv --cache-dir .uv-cache run ruff check src/loushang/coding/domain src/loushang/coding/cli src/loushang/coding/mode src/loushang/coding/prompt_command.py tests/coding/domain tests/coding/test_cli.py`.
+- [ ] Manually verify `uv --cache-dir .uv-cache run loushang --cwd <demo> --method review -p "hello"` with a temporary `methods/task/review/SKILL.md`.
+- [ ] Remove temporary demo files.
+- [ ] Commit any final fixes.

--- a/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
+++ b/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
@@ -17,11 +17,11 @@
 - Create: `src/loushang/coding/domain/types.py`
 - Test: `tests/coding/domain/test_coding_domain_app.py`
 
-- [ ] Write failing tests for `CodingDomainRequest` and `CodingDomainPreparedTurn` defaults.
-- [ ] Verify tests fail because `loushang.coding.domain` does not exist.
-- [ ] Implement frozen dataclasses and public exports.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q`.
-- [ ] Commit with `feat: add coding domain p2 types`.
+- [x] Write failing tests for `CodingDomainRequest` and `CodingDomainPreparedTurn` defaults.
+- [x] Verify tests fail because `loushang.coding.domain` does not exist.
+- [x] Implement frozen dataclasses and public exports.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q`.
+- [x] Commit with `feat: add coding domain p2 types`.
 
 ### Task 2: CodingDomainApp
 

--- a/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
+++ b/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
@@ -46,12 +46,12 @@
 - Test: `tests/coding/test_print_mode.py`
 - Test: `tests/coding/test_prompt_command.py`
 
-- [ ] Write failing tests showing `method_id` reaches `CodingWorkShell` when work logging is active in prompt and print paths.
-- [ ] Verify tests fail because prompt/print APIs do not accept `method_id`.
-- [ ] Add optional `method_id: str | None = None` to `run_prompt_command`, `_run_turn`, `_run_prompt_session`, `PrintMode`, `run_print_mode`, `create_mode_adapter`, and `run_mode`.
-- [ ] Pass `method_id` only to `CodingWorkShell.submit_coding_turn(...)`.
-- [ ] Run focused prompt/print tests.
-- [ ] Commit with `feat: thread method id through coding runners`.
+- [x] Write failing tests showing `method_id` reaches `CodingWorkShell` when work logging is active in prompt and print paths.
+- [x] Verify tests fail because prompt/print APIs do not accept `method_id`.
+- [x] Add optional `method_id: str | None = None` to `run_prompt_command`, `_run_turn`, `_run_prompt_session`, `PrintMode`, `run_print_mode`, `create_mode_adapter`, and `run_mode`.
+- [x] Pass `method_id` only to `CodingWorkShell.submit_coding_turn(...)`.
+- [x] Run focused prompt/print tests.
+- [x] Commit with `feat: thread method id through coding runners`.
 
 ### Task 4: CLI `--method`
 

--- a/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
+++ b/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
@@ -60,14 +60,14 @@
 - Modify: `src/loushang/coding/cli/__main__.py`
 - Test: `tests/coding/test_cli.py`
 
-- [ ] Write failing parse tests for `--method`.
-- [ ] Write failing CLI tests for `--method review -p`, `--method review --mode print`, missing method, unsupported TUI/RPC, and unchanged no-method behavior.
-- [ ] Add `method: str | None` to `CliArgs` and parser.
-- [ ] Add runtime validation for unsupported TUI/RPC mode.
-- [ ] Use `CodingDomainApp.prepare_turn(...)` after resolving print input and before dispatching prompt/print/mode runners.
-- [ ] Pass `prepared_prompt` and `method_id` into prompt/print/mode runners.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/domain -q`.
-- [ ] Commit with `feat: add explicit method guided CLI turns`.
+- [x] Write failing parse tests for `--method`.
+- [x] Write failing CLI tests for `--method review -p`, `--method review --mode print`, missing method, unsupported TUI/RPC, and unchanged no-method behavior.
+- [x] Add `method: str | None` to `CliArgs` and parser.
+- [x] Add runtime validation for unsupported TUI/RPC mode.
+- [x] Use `CodingDomainApp.prepare_turn(...)` after resolving print input and before dispatching prompt/print/mode runners.
+- [x] Pass `prepared_prompt` and `method_id` into prompt/print/mode runners.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/domain -q`.
+- [x] Commit with `feat: add explicit method guided CLI turns`.
 
 ### Task 5: Regression
 

--- a/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
+++ b/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
@@ -30,12 +30,12 @@
 - Modify: `src/loushang/coding/domain/__init__.py`
 - Test: `tests/coding/domain/test_coding_domain_app.py`
 
-- [ ] Write failing tests for no-method unchanged prompt, explicit skill-backed method, explicit `methods/**/SKILL.md` method, missing method error, and empty guidance behavior.
-- [ ] Verify tests fail because `CodingDomainApp` does not exist.
-- [ ] Implement `DEFAULT_GUIDANCE_TEMPLATE`, `CodingDomainApp.prepare_turn(...)`, method lookup, compile/project, and prompt assembly.
-- [ ] Keep `prepare_turn(...)` synchronous.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py tests/method -q`.
-- [ ] Commit with `feat: prepare method-guided coding turns`.
+- [x] Write failing tests for no-method unchanged prompt, explicit skill-backed method, explicit `methods/**/SKILL.md` method, missing method error, and empty guidance behavior.
+- [x] Verify tests fail because `CodingDomainApp` does not exist.
+- [x] Implement `DEFAULT_GUIDANCE_TEMPLATE`, `CodingDomainApp.prepare_turn(...)`, method lookup, compile/project, and prompt assembly.
+- [x] Keep `prepare_turn(...)` synchronous.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py tests/method -q`.
+- [x] Commit with `feat: prepare method-guided coding turns`.
 
 ### Task 3: Prompt And Print Work Metadata Plumbing
 

--- a/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
+++ b/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
@@ -74,8 +74,10 @@
 **Files:**
 - Modify as needed from previous tasks only.
 
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q`.
-- [ ] Run `uv --cache-dir .uv-cache run ruff check src/loushang/coding/domain src/loushang/coding/cli src/loushang/coding/mode src/loushang/coding/prompt_command.py tests/coding/domain tests/coding/test_cli.py`.
-- [ ] Manually verify `uv --cache-dir .uv-cache run loushang --cwd <demo> --method review -p "hello"` with a temporary `methods/task/review/SKILL.md`.
-- [ ] Remove temporary demo files.
-- [ ] Commit any final fixes.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q`.
+- [x] Run ruff on touched files: `src/loushang/coding/domain`, `src/loushang/coding/cli`, `src/loushang/coding/mode/base.py`, `src/loushang/coding/mode/print_mode.py`, `src/loushang/coding/prompt_command.py`, and touched tests.
+- [x] Manually verify method-guided CLI dispatch with a temporary `methods/task/review/SKILL.md` and a fake prompt runner to avoid real provider calls.
+- [x] Remove temporary demo files.
+- [x] Commit any final fixes.
+
+Note: the broader planned `src/loushang/coding/mode` ruff target still reports pre-existing import-order findings in `mode/__init__.py` and `mode/rpc_mode.py`; P2 did not touch those files.

--- a/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
+++ b/docs/superpowers/plans/2026-06-02-coding-domain-app-p2.md
@@ -75,9 +75,9 @@
 - Modify as needed from previous tasks only.
 
 - [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q`.
-- [x] Run ruff on touched files: `src/loushang/coding/domain`, `src/loushang/coding/cli`, `src/loushang/coding/mode/base.py`, `src/loushang/coding/mode/print_mode.py`, `src/loushang/coding/prompt_command.py`, and touched tests.
+- [x] Run the broad planned ruff target: `src/loushang/coding/domain`, `src/loushang/coding/cli`, `src/loushang/coding/mode`, `src/loushang/coding/prompt_command.py`, `tests/coding/domain`, and `tests/coding/test_cli.py`.
 - [x] Manually verify method-guided CLI dispatch with a temporary `methods/task/review/SKILL.md` and a fake prompt runner to avoid real provider calls.
 - [x] Remove temporary demo files.
 - [x] Commit any final fixes.
 
-Note: the broader planned `src/loushang/coding/mode` ruff target still reports pre-existing import-order findings in `mode/__init__.py` and `mode/rpc_mode.py`; P2 did not touch those files.
+Note: the broader planned `src/loushang/coding/mode` ruff target initially exposed import-order findings in `mode/__init__.py` and `mode/rpc_mode.py`; those were fixed as a mechanical follow-up.

--- a/docs/superpowers/specs/2026-06-02-coding-domain-app-p2-design.md
+++ b/docs/superpowers/specs/2026-06-02-coding-domain-app-p2-design.md
@@ -1,0 +1,302 @@
+# Coding DomainApp P2 Minimal Method-Guided Turn Design
+
+## Goal
+
+P2 的目标是在 P1/P1.5 已经具备 method 资源、projection、visibility CLI 的基础上，实现第一版 `CodingDomainApp` 最小闭环。
+
+这个闭环只解决一件事：当用户显式指定 method 时，coding turn 可以由该 method 生成的 guidance 指导执行，并把 `method_id` 继续记录到 work metadata。
+
+成功标准：
+
+- 无 `--method` 时，现有 prompt / print / json / TUI 行为不变。
+- 有 `--method <id-or-name>` 时，CLI 可以解析并找到 method。
+- `MethodLoader -> MethodCompiler -> MethodProjector` 生成的 guidance 会被注入到本次 coding prompt。
+- `WorkRun.method_id` 和 work log payload 能记录显式 method id。
+- 缺失 method 时返回清晰错误，不启动 prompt run。
+- P2 public API 不暴露 TaskFlow、multi-agent、automatic method selection。
+
+## Scope
+
+### In Scope
+
+- 新增轻量 `loushang.coding.domain` 包。
+- 定义 `CodingDomainApp` 或等价 facade。
+- 定义 `CodingDomainRequest` / `CodingDomainPreparedTurn` 小数据对象。
+- 支持显式 method id/name 解析。
+- 使用 P1 method APIs 编译并投影 method guidance。
+- 将 guidance 作为 prompt prefix 注入一次 coding turn。
+- CLI 增加 `--method <id-or-name>`。
+- prompt / print / json 路径传递 `method_id` 到 `CodingWorkShell`。
+- focused tests 和 CLI regression。
+
+### Out Of Scope
+
+- 自动 method selection。
+- method 持久化为 session selected state。
+- TUI method picker。
+- TaskFlow / multi-step execution。
+- multi-agent collaboration。
+- METHOD.md / SOUR.md 标准实现。
+- 大规模重构 `AgentSession`。
+- 修改 P1 `loushang.method` schema。
+
+## Why This Comes Next
+
+P1/P1.5 已经完成：
+
+- `loushang.method` core types。
+- skill-backed method adapter。
+- `methods/**/SKILL.md` loader。
+- method registry / selector。
+- single-turn compiler / projector。
+- `method list/show` visibility CLI。
+- `WorkRun.method_id` metadata plumbing。
+
+现在缺的是 domain app 边界：谁负责把 method projection 应用到 coding turn。
+
+如果直接把 `MethodLoader` 和 projection 拼接逻辑写进 CLI 或 `AgentSession`，会重新制造耦合。P2 应该先把这层放到 `loushang.coding.domain`，让 CLI 只是调用者，让 `AgentSession` 继续保持现状。
+
+## Recommended Architecture
+
+新增：
+
+```text
+src/loushang/coding/domain/
+  __init__.py
+  app.py
+  types.py
+```
+
+### `types.py`
+
+Owns:
+
+- `CodingDomainRequest`
+- `CodingDomainPreparedTurn`
+
+Suggested shape:
+
+```python
+@dataclass(frozen=True)
+class CodingDomainRequest:
+    user_input: str
+    method: str | None = None
+    cwd: Path | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CodingDomainPreparedTurn:
+    user_input: str
+    method_id: str | None = None
+    method_guidance: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+```
+
+`CodingDomainPreparedTurn.user_input` is the final prompt text to send to the current session. P2 keeps this explicit so old session APIs do not need to change.
+
+### `app.py`
+
+Owns:
+
+- `CodingDomainApp`
+- method lookup
+- method compile/project
+- prompt guidance assembly
+
+Suggested shape:
+
+```python
+class CodingDomainApp:
+    def __init__(
+        self,
+        method_loader: MethodLoader | None = None,
+        method_compiler: MethodCompiler | None = None,
+        method_projector: MethodProjector | None = None,
+    ) -> None: ...
+
+    def prepare_turn(self, request: CodingDomainRequest) -> CodingDomainPreparedTurn: ...
+```
+
+The app is intentionally synchronous in P2 because method loading and projection are local file/resource operations.
+
+## Prompt Guidance Policy
+
+P2 should use a deterministic prefix:
+
+```text
+<method guidance>
+
+User request:
+
+<original user input>
+```
+
+Where `<method guidance>` is `MethodProjection.system_guidance`.
+
+This is not final prompt assembly architecture. It is a narrow compatibility path that lets current `AgentSession.prompt(...)` keep working while P2 validates the domain app boundary.
+
+Rules:
+
+- No method -> return original user input unchanged.
+- Explicit method -> prepend projected guidance.
+- Do not mutate session system prompt.
+- Do not mutate resource bundle.
+- Do not persist selected method.
+- Do not apply method to follow-up messages in P2 unless the current print/prompt path already treats them as separate turns.
+
+## CLI Integration
+
+Add:
+
+```text
+--method <id-or-name>
+```
+
+Behavior:
+
+- Only valid for prompt / text / print / json coding turns.
+- Not valid for TUI mode in P2.
+- Not valid for RPC mode in P2.
+- Not valid for `method list/show` visibility commands.
+- Missing method returns `Error: method not found: <id-or-name>` and exit code `1`.
+
+CLI flow:
+
+```text
+parse args
+resolve print input
+if --method:
+  CodingDomainApp.prepare_turn(user_input, method)
+  pass prepared.user_input to prompt/print/mode runner
+  pass prepared.method_id to work-shell capable paths
+else:
+  existing behavior
+```
+
+## Work Integration
+
+P1 already added `CodingWorkShell.submit_coding_turn(..., method_id=...)`.
+
+P2 should thread `method_id` through:
+
+- `run_prompt_command(...)`
+- `run_print_mode(...)`
+- `PrintMode`
+- CLI calls into prompt / print / json runners
+
+This remains metadata-only for Work. Work does not compile or apply methods.
+
+## Relationship To Existing Components
+
+### `loushang.method`
+
+P2 consumes `MethodLoader`, `MethodSelector`, `MethodCompiler`, and `MethodProjector`. It should not modify method schemas.
+
+### `AgentSession`
+
+P2 does not change `AgentSession`. It sends a prepared prompt string through existing `session.prompt(...)`.
+
+### CLI
+
+CLI parses `--method`, asks `CodingDomainApp` to prepare the turn, and routes the resulting text to existing runners.
+
+### Work
+
+Work receives `method_id` only when explicitly present. Work remains an observable execution layer, not a method runtime.
+
+## Error Handling
+
+- Missing method -> `ValueError("method not found: <id-or-name>")` or a small domain-specific exception.
+- Loader errors -> formatted CLI error.
+- Empty projected guidance -> still allowed if method content is empty, but tests should cover stable formatting.
+- `--method` with no prompt -> same prompt-required behavior unless the command is otherwise unsupported.
+
+Avoid a large custom exception hierarchy in P2.
+
+## Testing Strategy
+
+### Unit Tests
+
+Add:
+
+```text
+tests/coding/domain/test_coding_domain_app.py
+```
+
+Coverage:
+
+- no method returns original prompt unchanged。
+- explicit skill-backed method prepends guidance and returns `method_id`。
+- explicit `methods/**/SKILL.md` resource works。
+- missing method returns clear error。
+- `METHOD.md` / `SOUR.md` are still ignored by loader。
+
+### CLI Tests
+
+Extend `tests/coding/test_cli.py`:
+
+- `--method review -p "..."` passes prepared prompt to prompt runner。
+- `--method review --mode print "..."` passes prepared prompt to print runner。
+- `--method missing -p "..."` returns error before prompt runner。
+- no `--method` behavior remains unchanged。
+- `--method` in TUI/RPC mode returns unsupported error in P2。
+
+### Work Tests
+
+Extend focused work/prompt tests:
+
+- work log contains `method_id` when explicit method is used。
+- work log behavior unchanged without method。
+
+### Regression
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q
+uv --cache-dir .uv-cache run ruff check src/loushang/coding/domain src/loushang/coding/cli src/loushang/coding/mode src/loushang/coding/prompt_command.py tests/coding/domain tests/coding/test_cli.py
+```
+
+## Rollout Plan
+
+### Task 1: Coding Domain Types
+
+Create `loushang.coding.domain.types` and public exports.
+
+### Task 2: CodingDomainApp
+
+Implement method lookup, compile/project, and deterministic prompt guidance assembly.
+
+### Task 3: CLI `--method`
+
+Add parser field and validation. Keep `method list/show` unchanged.
+
+### Task 4: Prompt / Print Integration
+
+Thread prepared prompt and `method_id` through prompt and print/json paths.
+
+### Task 5: Work Metadata
+
+Pass explicit `method_id` into `CodingWorkShell` where work logging is active.
+
+### Task 6: Regression
+
+Run focused CLI, method, work, and domain tests.
+
+## Open Questions
+
+Deferred beyond P2:
+
+- Should TUI support explicit method in startup state?
+- Should selected method persist in session metadata?
+- Should method guidance be a dedicated prompt part instead of text prefix?
+- Should `MethodProjection.temperature` influence provider config?
+- Should future DomainApp choose methods automatically based on task?
+- Should method guidance apply to follow-up messages?
+
+## Tracking
+
+GitHub issue:
+
+- `#40 P2: CodingDomainApp minimal method-guided turn` - https://github.com/zhnt/loushang/issues/40

--- a/docs/superpowers/specs/2026-06-02-coding-domain-app-p2-design.md
+++ b/docs/superpowers/specs/2026-06-02-coding-domain-app-p2-design.md
@@ -87,13 +87,15 @@ class CodingDomainRequest:
 
 @dataclass(frozen=True)
 class CodingDomainPreparedTurn:
-    user_input: str
+    prepared_prompt: str
     method_id: str | None = None
     method_guidance: str | None = None
     metadata: Mapping[str, object] = field(default_factory=dict)
 ```
 
-`CodingDomainPreparedTurn.user_input` is the final prompt text to send to the current session. P2 keeps this explicit so old session APIs do not need to change.
+`CodingDomainPreparedTurn.prepared_prompt` is the final prompt text to send to the current session. P2 avoids the name `user_input` here because future versions may represent prompt parts rather than a single text string.
+
+The request object keeps `user_input` because it represents the original user request. The prepared object uses `prepared_prompt` because it represents domain-assembled execution input.
 
 ### `app.py`
 
@@ -110,6 +112,8 @@ Suggested shape:
 class CodingDomainApp:
     def __init__(
         self,
+        *,
+        cwd: Path | None = None,
         method_loader: MethodLoader | None = None,
         method_compiler: MethodCompiler | None = None,
         method_projector: MethodProjector | None = None,
@@ -120,9 +124,25 @@ class CodingDomainApp:
 
 The app is intentionally synchronous in P2 because method loading and projection are local file/resource operations.
 
+Default dependency behavior:
+
+- `cwd` defaults to `Path.cwd()` only if a request does not provide `cwd`.
+- `method_loader=None` creates a default `MethodLoader()`.
+- `method_compiler=None` creates a default `MethodCompiler()`.
+- `method_projector=None` creates a default `MethodProjector()`.
+- request `cwd` takes precedence over app `cwd`.
+
+P2 should not add `prepare_turn_async`. If method loading later becomes remote or provider-backed, the async boundary should be introduced with the component that actually needs it.
+
 ## Prompt Guidance Policy
 
-P2 should use a deterministic prefix:
+P2 should use a deterministic prefix exposed as a module constant:
+
+```python
+DEFAULT_GUIDANCE_TEMPLATE = "{guidance}\n\nUser request:\n\n{user_input}"
+```
+
+Rendered form:
 
 ```text
 <method guidance>
@@ -140,6 +160,7 @@ Rules:
 
 - No method -> return original user input unchanged.
 - Explicit method -> prepend projected guidance.
+- Empty guidance -> return original user input unchanged but still carry `method_id` metadata.
 - Do not mutate session system prompt.
 - Do not mutate resource bundle.
 - Do not persist selected method.
@@ -161,6 +182,8 @@ Behavior:
 - Not valid for `method list/show` visibility commands.
 - Missing method returns `Error: method not found: <id-or-name>` and exit code `1`.
 
+The unsupported TUI/RPC checks should happen at runtime after parsing, not through argparse mutually exclusive groups. Current CLI parsing uses intermixed args and subcommand rewrites; runtime validation is less invasive and matches existing option validation patterns.
+
 CLI flow:
 
 ```text
@@ -168,7 +191,7 @@ parse args
 resolve print input
 if --method:
   CodingDomainApp.prepare_turn(user_input, method)
-  pass prepared.user_input to prompt/print/mode runner
+  pass prepared.prepared_prompt to prompt/print/mode runner
   pass prepared.method_id to work-shell capable paths
 else:
   existing behavior
@@ -185,6 +208,8 @@ P2 should thread `method_id` through:
 - `PrintMode`
 - CLI calls into prompt / print / json runners
 
+`PrintMode` is currently a class in `loushang.coding.mode.print_mode`, not an enum. P2 can safely add a `method_id: str | None = None` field/constructor argument and use it only when calling `CodingWorkShell`.
+
 This remains metadata-only for Work. Work does not compile or apply methods.
 
 ## Relationship To Existing Components
@@ -193,13 +218,15 @@ This remains metadata-only for Work. Work does not compile or apply methods.
 
 P2 consumes `MethodLoader`, `MethodSelector`, `MethodCompiler`, and `MethodProjector`. It should not modify method schemas.
 
+These P1 components are already implemented and covered by `tests/method`. P2 depends on their current synchronous APIs.
+
 ### `AgentSession`
 
 P2 does not change `AgentSession`. It sends a prepared prompt string through existing `session.prompt(...)`.
 
 ### CLI
 
-CLI parses `--method`, asks `CodingDomainApp` to prepare the turn, and routes the resulting text to existing runners.
+CLI parses `--method`, asks `CodingDomainApp` to prepare the turn, and routes `prepared_prompt` to existing runners.
 
 ### Work
 
@@ -208,8 +235,9 @@ Work receives `method_id` only when explicitly present. Work remains an observab
 ## Error Handling
 
 - Missing method -> `ValueError("method not found: <id-or-name>")` or a small domain-specific exception.
+- `--method` in TUI/RPC mode -> explicit runtime validation error before prompt/session execution.
 - Loader errors -> formatted CLI error.
-- Empty projected guidance -> still allowed if method content is empty, but tests should cover stable formatting.
+- Empty projected guidance -> no prompt prefix is added, but `method_id` can still be recorded.
 - `--method` with no prompt -> same prompt-required behavior unless the command is otherwise unsupported.
 
 Avoid a large custom exception hierarchy in P2.

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -28,9 +28,9 @@ from loushang.coding.control.settings_store import (
     default_global_settings_path,
     default_project_settings_path,
 )
-from loushang.coding.domain import CodingDomainApp, CodingDomainRequest
 from loushang.coding.diag_export import export_diagnostics_bundle
 from loushang.coding.diagnostics import serialize_diagnostic
+from loushang.coding.domain import CodingDomainApp, CodingDomainRequest
 from loushang.coding.extensions.types import ResolvedFlag
 from loushang.coding.mode import ModeConfig, run_mode, run_print_mode, run_rpc_mode
 from loushang.coding.observability import (

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -28,6 +28,7 @@ from loushang.coding.control.settings_store import (
     default_global_settings_path,
     default_project_settings_path,
 )
+from loushang.coding.domain import CodingDomainApp, CodingDomainRequest
 from loushang.coding.diag_export import export_diagnostics_bundle
 from loushang.coding.diagnostics import serialize_diagnostic
 from loushang.coding.extensions.types import ResolvedFlag
@@ -250,6 +251,10 @@ async def run_cli(
     if work_log_error is not None:
         stderr.write(f"Error: {work_log_error}.\n")
         return 2
+    method_error = _method_static_error(bootstrap_args)
+    if method_error is not None:
+        stderr.write(f"Error: {method_error}.\n")
+        return 2
     work_log_inspect_result = _run_work_log_inspect(bootstrap_args, project_root, stdout, stderr)
     if work_log_inspect_result is not None:
         return work_log_inspect_result
@@ -392,6 +397,10 @@ async def run_cli(
         if work_log_error is not None:
             stderr.write(f"Error: {work_log_error}.\n")
             return 2
+        method_error = _method_runtime_error(args, effective_tui=effective_tui)
+        if method_error is not None:
+            stderr.write(f"Error: {method_error}.\n")
+            return 2
         work_event_log = _resolve_work_event_log(args.work_log, project_root)
         with coding_observability_context(
             args=args,
@@ -457,17 +466,30 @@ async def run_cli(
                 stderr.write("Error: prompt is required for prompt/text/print/json modes.\n")
                 return 2
 
+            try:
+                prepared_turn = CodingDomainApp(cwd=project_root).prepare_turn(
+                    CodingDomainRequest(
+                        user_input=print_input.user_input,
+                        cwd=project_root,
+                        method=args.method,
+                    )
+                )
+            except ValueError as error:
+                stderr.write(f"Error: {_format_cli_error(error)}\n")
+                return 1
+
             if args.prompt is not None:
                 return await prompt_runner(
                     runtime=runtime,
                     session=session,
-                    prompt=print_input.user_input,
+                    prompt=prepared_turn.prepared_prompt,
                     stdout=stdout,
                     stderr=stderr,
                     images=print_input.images,
                     follow_up_messages=print_input.follow_up_messages,
                     verbose=args.verbose,
                     work_event_log=work_event_log,
+                    method_id=prepared_turn.method_id,
                 )
 
             output_mode = "text" if args.mode == "print" else args.mode
@@ -475,7 +497,7 @@ async def run_cli(
                 return await print_runner(
                     runtime=runtime,
                     session=session,
-                    user_input=print_input.user_input,
+                    user_input=prepared_turn.prepared_prompt,
                     stdout=stdout,
                     stderr=stderr,
                     images=print_input.images,
@@ -483,6 +505,7 @@ async def run_cli(
                     output_mode=output_mode,
                     render_tool_events=args.render_tool_events,
                     work_event_log=work_event_log,
+                    method_id=prepared_turn.method_id,
                 )
 
             return await mode_runner(
@@ -492,13 +515,14 @@ async def run_cli(
                 ),
                 runtime=runtime,
                 session=session,
-                user_input=print_input.user_input,
+                user_input=prepared_turn.prepared_prompt,
                 images=print_input.images,
                 follow_up_messages=print_input.follow_up_messages,
                 stdin=stdin,
                 stdout=stdout,
                 stderr=stderr,
                 work_event_log=work_event_log,
+                method_id=prepared_turn.method_id,
             )
 
 
@@ -676,6 +700,26 @@ def _work_log_runtime_error(args: CliArgs, *, effective_tui: bool) -> str | None
         return None
     if effective_tui:
         return "--work-log is not supported in TUI mode"
+    return None
+
+
+def _method_static_error(args: CliArgs) -> str | None:
+    if args.method is None:
+        return None
+    if args.tui:
+        return "--method is not supported in TUI mode"
+    if args.mode == "rpc":
+        return "--method is not supported in RPC mode"
+    if args.prompt_steps is not None:
+        return "--method is not supported with --prompt-steps"
+    return None
+
+
+def _method_runtime_error(args: CliArgs, *, effective_tui: bool) -> str | None:
+    if args.method is None:
+        return None
+    if effective_tui:
+        return "--method is not supported in TUI mode"
     return None
 
 

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -26,6 +26,7 @@ _BUILTIN_FLAG_NAMES = frozenset(
         "help",
         "version",
         "mode",
+        "method",
         "prompt",
         "prompt-steps",
         "tui",
@@ -131,6 +132,7 @@ class CliArgs:
     help: bool
     version: bool
     mode: CliMode
+    method: str | None
     prompt: str | None
     prompt_steps: str | None
     tui: bool
@@ -287,6 +289,7 @@ def parse_args(
         help=namespace.help,
         version=namespace.version,
         mode=namespace.mode,
+        method=namespace.method,
         prompt=namespace.prompt,
         prompt_steps=namespace.prompt_steps,
         tui=namespace.tui,
@@ -398,6 +401,7 @@ def _build_parser() -> ArgumentParser:
     parser.add_argument("--help", "-h", action="store_true")
     parser.add_argument("--version", "-v", action="store_true")
     parser.add_argument("--mode", choices=("text", "print", "json", "rpc"), default="text")
+    parser.add_argument("--method", help="Guide one coding turn with a discovered method.")
     parser.add_argument(
         "--prompt",
         "-p",

--- a/src/loushang/coding/domain/__init__.py
+++ b/src/loushang/coding/domain/__init__.py
@@ -1,9 +1,15 @@
+from loushang.coding.domain.app import (
+    DEFAULT_GUIDANCE_TEMPLATE,
+    CodingDomainApp,
+)
 from loushang.coding.domain.types import (
     CodingDomainPreparedTurn,
     CodingDomainRequest,
 )
 
 __all__ = [
+    "CodingDomainApp",
     "CodingDomainPreparedTurn",
     "CodingDomainRequest",
+    "DEFAULT_GUIDANCE_TEMPLATE",
 ]

--- a/src/loushang/coding/domain/__init__.py
+++ b/src/loushang/coding/domain/__init__.py
@@ -1,0 +1,9 @@
+from loushang.coding.domain.types import (
+    CodingDomainPreparedTurn,
+    CodingDomainRequest,
+)
+
+__all__ = [
+    "CodingDomainPreparedTurn",
+    "CodingDomainRequest",
+]

--- a/src/loushang/coding/domain/app.py
+++ b/src/loushang/coding/domain/app.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loushang.coding.domain.types import CodingDomainPreparedTurn, CodingDomainRequest
+from loushang.method import (
+    MethodCompiler,
+    MethodContext,
+    MethodLoader,
+    MethodProjector,
+    MethodSelector,
+)
+from loushang.method.types import MethodDescriptor, MethodProjection
+
+DEFAULT_GUIDANCE_TEMPLATE = "{guidance}\n\nUser request:\n\n{user_input}"
+
+
+class CodingDomainApp:
+    def __init__(
+        self,
+        *,
+        cwd: Path | None = None,
+        method_loader: MethodLoader | None = None,
+        method_compiler: MethodCompiler | None = None,
+        method_projector: MethodProjector | None = None,
+    ) -> None:
+        self._cwd = cwd
+        self._method_loader = method_loader or MethodLoader()
+        self._method_compiler = method_compiler or MethodCompiler()
+        self._method_projector = method_projector or MethodProjector()
+
+    def prepare_turn(self, request: CodingDomainRequest) -> CodingDomainPreparedTurn:
+        method_name = request.method.strip() if request.method is not None else None
+        if not method_name:
+            return CodingDomainPreparedTurn(prepared_prompt=request.user_input)
+
+        cwd = request.cwd or self._cwd or Path.cwd()
+        methods = self._method_loader.discover_methods(cwd)
+        descriptor = MethodSelector(methods).select(method_name)
+        if descriptor is None:
+            raise ValueError(f"method not found: {method_name}")
+
+        context = MethodContext(domain="coding", metadata=request.metadata)
+        plan = self._method_compiler.compile(descriptor, context=context)
+        step = plan.steps[0]
+        projection = self._method_projector.project(plan, step, context=context)
+        if not _has_meaningful_guidance(descriptor, projection):
+            return CodingDomainPreparedTurn(
+                prepared_prompt=request.user_input,
+                method_id=descriptor.id,
+            )
+
+        guidance = projection.system_guidance
+        return CodingDomainPreparedTurn(
+            prepared_prompt=DEFAULT_GUIDANCE_TEMPLATE.format(
+                guidance=guidance,
+                user_input=request.user_input,
+            ),
+            method_id=projection.method_id,
+            method_guidance=guidance,
+            metadata={
+                "meta_role": projection.meta_role,
+                "role_variant": projection.role_variant,
+                "temperature": projection.temperature,
+            },
+        )
+
+
+def _has_meaningful_guidance(descriptor: MethodDescriptor, projection: MethodProjection) -> bool:
+    return bool(descriptor.content.strip() and projection.system_guidance.strip())
+
+
+__all__ = [
+    "CodingDomainApp",
+    "DEFAULT_GUIDANCE_TEMPLATE",
+]

--- a/src/loushang/coding/domain/types.py
+++ b/src/loushang/coding/domain/types.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import MappingProxyType
+
+_EMPTY_METADATA: Mapping[str, object] = MappingProxyType({})
+
+
+@dataclass(frozen=True)
+class CodingDomainRequest:
+    user_input: str
+    cwd: Path
+    method: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+
+
+@dataclass(frozen=True)
+class CodingDomainPreparedTurn:
+    prepared_prompt: str
+    method_id: str | None = None
+    method_guidance: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+
+
+__all__ = [
+    "CodingDomainPreparedTurn",
+    "CodingDomainRequest",
+]

--- a/src/loushang/coding/mode/__init__.py
+++ b/src/loushang/coding/mode/__init__.py
@@ -1,5 +1,3 @@
-from loushang.coding.mode.print_mode import PrintMode, run_print_mode
-from loushang.coding.mode.rpc_mode import RpcMode, run_rpc_mode
 from loushang.coding.mode.base import (
     ModeAction,
     ModeActionType,
@@ -12,6 +10,8 @@ from loushang.coding.mode.base import (
     normalize_mode_action,
     run_mode,
 )
+from loushang.coding.mode.print_mode import PrintMode, run_print_mode
+from loushang.coding.mode.rpc_mode import RpcMode, run_rpc_mode
 
 __all__ = [
     "ModeAction",

--- a/src/loushang/coding/mode/base.py
+++ b/src/loushang/coding/mode/base.py
@@ -131,6 +131,7 @@ def create_mode_adapter(
     stderr: TextIO | None = None,
     session: Any | None = None,
     work_event_log: EventLogBackend | None = None,
+    method_id: str | None = None,
 ) -> ModeAdapter:
     """Create the concrete adapter for a configured coding mode."""
 
@@ -162,6 +163,7 @@ def create_mode_adapter(
         event_select=config.event_select,
         render_tool_events=config.render_tool_events,
         work_event_log=work_event_log,
+        method_id=method_id,
     )
 
 
@@ -177,6 +179,7 @@ async def run_mode(
     images: list[object] | None = None,
     follow_up_messages: Sequence[str] = (),
     work_event_log: EventLogBackend | None = None,
+    method_id: str | None = None,
 ) -> int:
     adapter = create_mode_adapter(
         config,
@@ -186,6 +189,7 @@ async def run_mode(
         stdout=stdout,
         stderr=stderr,
         work_event_log=work_event_log,
+        method_id=method_id,
     )
     if config.mode == "rpc":
         return await adapter.start(user_input)

--- a/src/loushang/coding/mode/print_mode.py
+++ b/src/loushang/coding/mode/print_mode.py
@@ -31,6 +31,7 @@ class PrintMode(ModeAdapter):
         event_select: Sequence[str] | str | None = None,
         render_tool_events: bool = False,
         work_event_log: EventLogBackend | None = None,
+        method_id: str | None = None,
     ) -> None:
         if output_mode not in {"text", "json"}:
             raise ValueError(f"unsupported output mode: {output_mode}")
@@ -57,6 +58,7 @@ class PrintMode(ModeAdapter):
         self.event_select = normalize_event_select(event_select)
         self.render_tool_events = render_tool_events
         self.work_event_log = work_event_log
+        self.method_id = method_id
         self._tool_render_runtime: ToolRenderRuntime | None = None
         self._tool_definition_resolver: ToolDefinitionResolver | None = None
         self._disposed = False
@@ -241,7 +243,12 @@ class PrintMode(ModeAdapter):
             await _prompt_session(self.session, user_input, images=images)
             return
         shell = CodingWorkShell(session=self.session, event_log=self.work_event_log)
-        await shell.submit_coding_turn(user_input, session_id=_work_session_id(self.session), images=images)
+        await shell.submit_coding_turn(
+            user_input,
+            session_id=_work_session_id(self.session),
+            images=images,
+            method_id=self.method_id,
+        )
 
 
 def _serialize_print_mode_state(session: Any) -> ModeState:
@@ -408,6 +415,7 @@ async def run_print_mode(
     event_select: Sequence[str] | str | None = None,
     render_tool_events: bool = False,
     work_event_log: EventLogBackend | None = None,
+    method_id: str | None = None,
 ) -> int:
     mode = PrintMode(
         runtime=runtime,
@@ -419,6 +427,7 @@ async def run_print_mode(
         event_select=event_select,
         render_tool_events=render_tool_events,
         work_event_log=work_event_log,
+        method_id=method_id,
     )
     return await mode.run_once(user_input, images=images, follow_up_messages=follow_up_messages)
 

--- a/src/loushang/coding/mode/rpc_mode.py
+++ b/src/loushang/coding/mode/rpc_mode.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import asdict, is_dataclass
-import io
 import inspect
+import io
 import json
 import sys
 import uuid
 from collections.abc import Sequence
+from dataclasses import asdict, is_dataclass
 from pathlib import Path
 from typing import Any, NotRequired, Required, TextIO, TypedDict, cast
 
+from loushang.coding.commands import complete_slash_commands
 from loushang.coding.diagnostics import (
     DiagnosticsQuery,
     serialize_diagnostic,
@@ -18,19 +19,18 @@ from loushang.coding.diagnostics import (
     serialize_error_report,
 )
 from loushang.coding.event import (
-    JsonEventView,
     SUPPORTED_JSON_EVENT_VIEWS,
+    JsonEventView,
     normalize_event_select,
     project_session_event,
     shape_stream_event,
     should_emit_projected_event,
 )
-from loushang.coding.commands import complete_slash_commands
 from loushang.coding.message.json_codec import serialize_agent_message
-from loushang.coding.types import ModelSelection
-from loushang.coding.store import SessionQuery
 from loushang.coding.mode.base import ModeAdapter, ModeState
+from loushang.coding.store import SessionQuery
 from loushang.coding.tools import ToolDefinitionResolver, ToolRenderRuntime
+from loushang.coding.types import ModelSelection
 
 _THINKING_LEVEL_ORDER: tuple[str, ...] = ("off", "minimal", "low", "medium", "high", "xhigh")
 _MISSING = object()

--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -22,6 +22,7 @@ async def run_prompt_command(
     follow_up_messages: Sequence[str] = (),
     verbose: bool = False,
     work_event_log: EventLogBackend | None = None,
+    method_id: str | None = None,
 ) -> int:
     """Run one product prompt and render the stable coding transcript."""
 
@@ -42,6 +43,7 @@ async def run_prompt_command(
             prompt,
             images=images,
             work_event_log=work_event_log,
+            method_id=method_id,
         )
         if exit_code == 0:
             for message in follow_up_messages:
@@ -51,6 +53,7 @@ async def run_prompt_command(
                     event_renderer,
                     message,
                     work_event_log=work_event_log,
+                    method_id=method_id,
                 )
                 if exit_code != 0:
                     break
@@ -79,11 +82,12 @@ async def _run_turn(
     *,
     images: list[object] | None = None,
     work_event_log: EventLogBackend | None = None,
+    method_id: str | None = None,
 ) -> int:
     started_at = time.monotonic()
     previous_error = event_renderer.last_error_message
     renderer.render_user(prompt)
-    await _run_prompt_session(session, prompt, images=images, work_event_log=work_event_log)
+    await _run_prompt_session(session, prompt, images=images, work_event_log=work_event_log, method_id=method_id)
     await session.wait_for_idle()
     assistant_failure = _last_assistant_failure_message(session)
     if assistant_failure is None and event_renderer.last_error_message != previous_error:
@@ -100,12 +104,18 @@ async def _run_prompt_session(
     *,
     images: list[object] | None = None,
     work_event_log: EventLogBackend | None = None,
+    method_id: str | None = None,
 ) -> None:
     if work_event_log is None:
         await _prompt_session(session, user_input, images=images)
         return
     shell = CodingWorkShell(session=session, event_log=work_event_log)
-    await shell.submit_coding_turn(user_input, session_id=_work_session_id(session), images=images)
+    await shell.submit_coding_turn(
+        user_input,
+        session_id=_work_session_id(session),
+        images=images,
+        method_id=method_id,
+    )
 
 
 async def _prompt_session(session: Any, user_input: str, *, images: list[object] | None = None) -> None:

--- a/tests/coding/domain/test_coding_domain_app.py
+++ b/tests/coding/domain/test_coding_domain_app.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from loushang.coding.domain import CodingDomainPreparedTurn, CodingDomainRequest
+from loushang.coding.domain import (
+    DEFAULT_GUIDANCE_TEMPLATE,
+    CodingDomainApp,
+    CodingDomainPreparedTurn,
+    CodingDomainRequest,
+)
 
 
 def test_coding_domain_request_defaults() -> None:
@@ -32,3 +37,94 @@ def test_coding_domain_types_are_frozen() -> None:
 
     with pytest.raises(FrozenInstanceError):
         request.user_input = "changed"  # type: ignore[misc]
+
+
+def test_prepare_turn_without_method_keeps_prompt_unchanged(tmp_path: Path) -> None:
+    request = CodingDomainRequest(user_input="review this change", cwd=tmp_path)
+
+    prepared = CodingDomainApp().prepare_turn(request)
+
+    assert prepared.prepared_prompt == "review this change"
+    assert prepared.method_id is None
+    assert prepared.method_guidance is None
+
+
+def test_prepare_turn_with_skill_backed_method_adds_guidance(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "---\n\n"
+        "Review code carefully.",
+        encoding="utf-8",
+    )
+    request = CodingDomainRequest(
+        user_input="check src/app.py",
+        cwd=tmp_path,
+        method="review",
+    )
+
+    prepared = CodingDomainApp().prepare_turn(request)
+
+    assert prepared.method_id == "skill:review"
+    assert prepared.method_guidance is not None
+    assert "Review code carefully." in prepared.method_guidance
+    assert prepared.prepared_prompt == DEFAULT_GUIDANCE_TEMPLATE.format(
+        guidance=prepared.method_guidance,
+        user_input="check src/app.py",
+    )
+
+
+def test_prepare_turn_with_method_resource_adds_guidance(tmp_path: Path) -> None:
+    method_dir = tmp_path / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "meta_role: VALIDATOR\n"
+        "---\n\n"
+        "Use the review method.",
+        encoding="utf-8",
+    )
+    request = CodingDomainRequest(
+        user_input="check src/app.py",
+        cwd=tmp_path,
+        method="method:task:review",
+    )
+
+    prepared = CodingDomainApp().prepare_turn(request)
+
+    assert prepared.method_id == "method:task:review"
+    assert prepared.method_guidance is not None
+    assert "Use the review method." in prepared.method_guidance
+    assert prepared.metadata["meta_role"] == "VALIDATOR"
+    assert prepared.prepared_prompt.endswith("User request:\n\ncheck src/app.py")
+
+
+def test_prepare_turn_missing_method_raises_value_error(tmp_path: Path) -> None:
+    request = CodingDomainRequest(user_input="hello", cwd=tmp_path, method="missing")
+
+    with pytest.raises(ValueError, match="method not found: missing"):
+        CodingDomainApp().prepare_turn(request)
+
+
+def test_prepare_turn_empty_guidance_keeps_prompt_but_records_method(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skills" / "empty"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("", encoding="utf-8")
+    request = CodingDomainRequest(
+        user_input="hello",
+        cwd=tmp_path,
+        method="empty",
+    )
+
+    prepared = CodingDomainApp().prepare_turn(request)
+
+    assert prepared.method_id == "skill:empty"
+    assert prepared.method_guidance is None
+    assert prepared.prepared_prompt == "hello"

--- a/tests/coding/domain/test_coding_domain_app.py
+++ b/tests/coding/domain/test_coding_domain_app.py
@@ -1,0 +1,34 @@
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from loushang.coding.domain import CodingDomainPreparedTurn, CodingDomainRequest
+
+
+def test_coding_domain_request_defaults() -> None:
+    request = CodingDomainRequest(
+        user_input="review this change",
+        cwd=Path("/tmp/project"),
+    )
+
+    assert request.user_input == "review this change"
+    assert request.cwd == Path("/tmp/project")
+    assert request.method is None
+    assert request.metadata == {}
+
+
+def test_coding_domain_prepared_turn_defaults() -> None:
+    prepared = CodingDomainPreparedTurn(prepared_prompt="review this change")
+
+    assert prepared.prepared_prompt == "review this change"
+    assert prepared.method_id is None
+    assert prepared.method_guidance is None
+    assert prepared.metadata == {}
+
+
+def test_coding_domain_types_are_frozen() -> None:
+    request = CodingDomainRequest(user_input="hello", cwd=Path("/tmp/project"))
+
+    with pytest.raises(FrozenInstanceError):
+        request.user_input = "changed"  # type: ignore[misc]

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -284,6 +284,21 @@ def _fake_services(
     return SimpleNamespace(settings_manager=settings_manager, diagnostics_service=object())
 
 
+def _write_review_method(project_root: Path) -> None:
+    method_dir = project_root / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "meta_role: VALIDATOR\n"
+        "---\n\n"
+        "Use concise review guidance.",
+        encoding="utf-8",
+    )
+
+
 def test_parse_args_supports_modes_sessions_and_overrides() -> None:
     from loushang.coding.cli.args import parse_args
 
@@ -578,6 +593,7 @@ def test_parse_args_supports_prompt_alias_and_print_mode() -> None:
 
     short = parse_args(["-p", "hello"])
     long = parse_args(["--prompt", "hello"])
+    method = parse_args(["--method", "review", "-p", "hello"])
     print_mode = parse_args(["--mode", "print", "hello"])
     workflow = parse_args(["-ps", "scenarios/coding/bmi.workflow.yaml"])
 
@@ -585,6 +601,8 @@ def test_parse_args_supports_prompt_alias_and_print_mode() -> None:
     assert short.messages == ()
     assert long.prompt == "hello"
     assert long.messages == ()
+    assert method.method == "review"
+    assert method.prompt == "hello"
     assert print_mode.mode == "print"
     assert print_mode.messages == ("hello",)
     assert workflow.prompt_steps == "scenarios/coding/bmi.workflow.yaml"
@@ -2268,6 +2286,60 @@ def test_run_cli_dash_p_dispatches_prompt_command(tmp_path) -> None:
     assert print_runner.calls == []
 
 
+def test_run_cli_dash_p_with_method_prepares_prompt_and_method_id(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    _write_review_method(tmp_path)
+    runtime = FakeRuntime(FakeSession("session-1"))
+    prompt_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--method", "review", "-p", "check src/app.py"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            prompt_runner=prompt_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    call = prompt_runner.calls[0]
+    assert call["method_id"] == "method:task:review"
+    assert "Use concise review guidance." in call["prompt"]
+    assert call["prompt"].endswith("User request:\n\ncheck src/app.py")
+
+
+def test_run_cli_dash_p_with_missing_method_reports_error(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    stderr = StringIO()
+    prompt_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--method", "missing", "-p", "hello"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            prompt_runner=prompt_runner,
+        )
+        assert exit_code == 1
+
+    asyncio.run(scenario())
+
+    assert prompt_runner.calls == []
+    assert "method not found: missing" in stderr.getvalue()
+
+
 def test_run_cli_dash_p_passes_work_log_backend_to_prompt_command(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.work import JsonlEventLogBackend
@@ -2534,6 +2606,35 @@ def test_run_cli_mode_print_dispatches_print_adapter(tmp_path) -> None:
     assert len(print_runner.calls) == 1
     assert print_runner.calls[0]["user_input"] == "hello"
     assert print_runner.calls[0]["output_mode"] == "text"
+
+
+def test_run_cli_mode_print_with_method_prepares_prompt_and_method_id(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    _write_review_method(tmp_path)
+    runtime = FakeRuntime(FakeSession("session-1"))
+    print_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--method", "review", "--mode", "print", "check src/app.py"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            print_runner=print_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    call = print_runner.calls[0]
+    assert call["method_id"] == "method:task:review"
+    assert "Use concise review guidance." in call["user_input"]
+    assert call["user_input"].endswith("User request:\n\ncheck src/app.py")
+    assert call["output_mode"] == "text"
 
 
 def test_run_cli_mode_print_passes_work_log_backend_to_print_adapter(tmp_path) -> None:
@@ -3192,6 +3293,34 @@ def test_run_cli_default_path_uses_unified_mode_runner(tmp_path) -> None:
     assert mode_runner.calls[0]["user_input"] == "hello"
 
 
+def test_run_cli_default_path_with_method_prepares_prompt_and_method_id(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    _write_review_method(tmp_path)
+    runtime = FakeRuntime(FakeSession("session-1"))
+    mode_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--mode", "json", "--method", "review", "check src/app.py"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            mode_runner=mode_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    call = mode_runner.calls[0]
+    assert call["method_id"] == "method:task:review"
+    assert "Use concise review guidance." in call["user_input"]
+    assert call["user_input"].endswith("User request:\n\ncheck src/app.py")
+
+
 def test_run_cli_default_path_passes_work_log_backend_to_unified_mode_runner(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.work import JsonlEventLogBackend
@@ -3403,6 +3532,49 @@ def test_run_cli_rejects_work_log_on_unsupported_paths(tmp_path, argv, message) 
     asyncio.run(scenario())
 
     assert message in stderr.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("argv", "stdin", "stdout"),
+    [
+        (["--method", "review", "--mode", "rpc"], StringIO(""), StringIO()),
+        (["--method", "review", "--tui"], TtyStringIO(""), TtyStringIO()),
+    ],
+)
+def test_run_cli_rejects_method_on_unsupported_interactive_paths(tmp_path, argv, stdin, stdout) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    _write_review_method(tmp_path)
+    runtime = FakeRuntime(FakeSession("session-1"))
+    stderr = StringIO()
+    prompt_runner = FakeRunner()
+    mode_runner = FakeRunner()
+    rpc_runner = FakeRunner()
+    tui_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            argv,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            mode_runner=mode_runner,
+            prompt_runner=prompt_runner,
+            rpc_runner=rpc_runner,
+            tui_runner=tui_runner,
+        )
+        assert exit_code == 2
+
+    asyncio.run(scenario())
+
+    assert "--method is not supported" in stderr.getvalue()
+    assert prompt_runner.calls == []
+    assert mode_runner.calls == []
+    assert rpc_runner.calls == []
+    assert tui_runner.calls == []
 
 
 def test_run_cli_dispatches_tui_mode(tmp_path) -> None:

--- a/tests/coding/test_print_mode.py
+++ b/tests/coding/test_print_mode.py
@@ -113,6 +113,7 @@ def test_print_mode_work_event_log_records_coding_turn_and_preserves_prompt_beha
             session=session,
             stdout=stdout,
             work_event_log=event_log,
+            method_id="method:task:review",
         )
 
         exit_code = await mode.run_once("describe", images=[image])
@@ -128,7 +129,13 @@ def test_print_mode_work_event_log_records_coding_turn_and_preserves_prompt_beha
             "ContentDelta",
             "WorkRunCompleted",
         ]
-        assert entries[0].payload["payload"] == {"text": "describe", "image_count": 1}
+        assert entries[0].payload["payload"] == {
+            "text": "describe",
+            "image_count": 1,
+            "method_id": "method:task:review",
+        }
+        assert entries[1].payload["payload"]["method_id"] == "method:task:review"
+        assert entries[4].payload["payload"]["method_id"] == "method:task:review"
 
     asyncio.run(scenario())
 

--- a/tests/coding/test_prompt_command.py
+++ b/tests/coding/test_prompt_command.py
@@ -201,15 +201,20 @@ def test_prompt_command_work_event_log_records_prompt_turn() -> None:
             stdout=StringIO(),
             stderr=StringIO(),
             work_event_log=event_log,
+            method_id="method:task:review",
         )
 
         assert exit_code == 0
-        assert [entry.payload["kind"] for entry in event_log.query(session_id="session-1")] == [
+        entries = event_log.query(session_id="session-1")
+        assert [entry.payload["kind"] for entry in entries] == [
             "SubmitCodingTurn",
             "WorkRunStarted",
             "ContentDelta",
             "WorkRunCompleted",
         ]
+        assert entries[0].payload["payload"]["method_id"] == "method:task:review"
+        assert entries[1].payload["payload"]["method_id"] == "method:task:review"
+        assert entries[3].payload["payload"]["method_id"] == "method:task:review"
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary
- Add the P2 coding domain facade that prepares explicit method-guided coding turns.
- Thread method_id through prompt, print, and unified mode runners into Work events.
- Add CLI --method support for prompt/print/json one-shot turns, with TUI/RPC validation.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/domain src/loushang/coding/cli src/loushang/coding/mode/base.py src/loushang/coding/mode/print_mode.py src/loushang/coding/prompt_command.py tests/coding/domain tests/coding/test_cli.py tests/coding/test_print_mode.py tests/coding/test_prompt_command.py

Closes #40