### PR TITLE
feat: add method policy switch and observability

### DIFF
--- a/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
+++ b/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
@@ -51,18 +51,18 @@
 - Modify: `src/loushang/coding/cli/__main__.py`
 - Test: `tests/coding/test_cli.py`
 
-- [ ] Write failing parser test for `--no-method`.
-- [ ] Write failing CLI tests for:
+- [x] Write failing parser test for `--no-method`.
+- [x] Write failing CLI tests for:
   - `--no-method -p "hello"` dispatches original prompt and `method_id is None`.
   - `--method review --no-method -p "hello"` exits `2`.
   - existing `--method review -p "hello"` still applies method guidance.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/domain -q` and verify expected failures.
-- [ ] Add `no_method: bool` to `CliArgs`.
-- [ ] Add `--no-method` to parser and `_BUILTIN_FLAG_NAMES`.
-- [ ] Add static conflict validation for `args.method and args.no_method`.
-- [ ] Map CLI flags to `MethodPolicy.off()` or `MethodPolicy.explicit(args.method)` before calling `CodingDomainApp.prepare_turn(...)`.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/domain -q`.
-- [ ] Commit with `feat: add no-method cli switch`.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/domain -q` and verify expected failures.
+- [x] Add `no_method: bool` to `CliArgs`.
+- [x] Add `--no-method` to parser and `_BUILTIN_FLAG_NAMES`.
+- [x] Add static conflict validation for `args.method and args.no_method`.
+- [x] Map CLI flags to `MethodPolicy.off()` or `MethodPolicy.explicit(args.method)` before calling `CodingDomainApp.prepare_turn(...)`.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/domain -q`.
+- [x] Commit with `feat: add no-method cli switch`.
 
 ### Task 4: Work-Log Method Observability
 

--- a/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
+++ b/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
@@ -86,12 +86,12 @@
 - Modify: `src/loushang/coding/cli/__main__.py`
 - Test: `tests/coding/test_cli.py`
 
-- [ ] Write failing test asserting missing method error includes `Run 'loushang method list' to inspect available methods.`
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q` and verify expected failure.
-- [ ] Add a small formatter/helper for method lookup failures or special-case the `ValueError` from `CodingDomainApp`.
-- [ ] Keep exit code `1`.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q`.
-- [ ] Commit with `feat: add missing method cli hint`.
+- [x] Write failing test asserting missing method error includes `Run 'loushang method list' to inspect available methods.`
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q` and verify expected failure.
+- [x] Add a small formatter/helper for method lookup failures or special-case the `ValueError` from `CodingDomainApp`.
+- [x] Keep exit code `1`.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q`.
+- [x] Commit with `feat: add missing method cli hint`.
 
 ### Task 6: Regression And PR Prep
 

--- a/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
+++ b/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
@@ -17,13 +17,13 @@
 - Modify: `src/loushang/coding/domain/__init__.py`
 - Test: `tests/coding/domain/test_coding_domain_app.py`
 
-- [ ] Write failing tests for `MethodPolicy` defaults, `MethodPolicy.off()`, and `MethodPolicy.explicit("review")`.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q` and verify it fails because `MethodPolicy` does not exist.
-- [ ] Add frozen `MethodPolicy` dataclass with `mode: str = "explicit"` and `selected_method: str | None = None`.
-- [ ] Add `off()` and `explicit(selected_method)` classmethods.
-- [ ] Export `MethodPolicy` from `loushang.coding.domain`.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q`.
-- [ ] Commit with `feat: add coding method policy`.
+- [x] Write failing tests for `MethodPolicy` defaults, `MethodPolicy.off()`, and `MethodPolicy.explicit("review")`.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q` and verify it fails because `MethodPolicy` does not exist.
+- [x] Add frozen `MethodPolicy` dataclass with `mode: str = "explicit"` and `selected_method: str | None = None`.
+- [x] Add `off()` and `explicit(selected_method)` classmethods.
+- [x] Export `MethodPolicy` from `loushang.coding.domain`.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q`.
+- [x] Commit with `feat: add coding method policy`.
 
 ### Task 2: CodingDomainApp Policy Resolution
 

--- a/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
+++ b/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
@@ -32,17 +32,17 @@
 - Modify: `src/loushang/coding/domain/app.py`
 - Test: `tests/coding/domain/test_coding_domain_app.py`
 
-- [ ] Write failing tests for `CodingDomainRequest(method_policy=MethodPolicy.off())` suppressing a method, `method_policy` taking precedence over `method`, and unsupported policy mode raising `ValueError`.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q` and verify expected failures.
-- [ ] Add `method_policy: MethodPolicy | None = None` to `CodingDomainRequest`.
-- [ ] In `CodingDomainApp.prepare_turn(...)`, resolve policy as `request.method_policy or MethodPolicy.explicit(request.method)`.
-- [ ] Implement mode handling:
+- [x] Write failing tests for `CodingDomainRequest(method_policy=MethodPolicy.off())` suppressing a method, `method_policy` taking precedence over `method`, and unsupported policy mode raising `ValueError`.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q` and verify expected failures.
+- [x] Add `method_policy: MethodPolicy | None = None` to `CodingDomainRequest`.
+- [x] In `CodingDomainApp.prepare_turn(...)`, resolve policy as `request.method_policy or MethodPolicy.explicit(request.method)`.
+- [x] Implement mode handling:
   - `off`: return original prompt unchanged with no method metadata.
   - `explicit` with no selected method: return original prompt unchanged.
   - `explicit` with selected method: current P2 lookup/compile/project behavior.
   - otherwise raise `ValueError("unsupported method policy mode: <mode>")`.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py tests/method -q`.
-- [ ] Commit with `feat: apply method policy in coding domain app`.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py tests/method -q`.
+- [x] Commit with `feat: apply method policy in coding domain app`.
 
 ### Task 3: CLI `--no-method`
 

--- a/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
+++ b/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
@@ -1,0 +1,105 @@
+# MethodPolicy And Method Observability P2.5/P2.6 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-turn method policy controls and method observability for work-log inspection without changing default coding behavior.
+
+**Architecture:** Keep method resources in `loushang.method`; put usage policy in `loushang.coding.domain`. CLI maps flags to `MethodPolicy`, `CodingDomainApp` prepares the turn, and work-log inspect only reads existing event metadata.
+
+**Tech Stack:** Python dataclasses, existing CLI parser, existing `CodingDomainApp`, existing `JsonlEventLogBackend`, pytest, ruff.
+
+---
+
+### Task 1: MethodPolicy Core
+
+**Files:**
+- Modify: `src/loushang/coding/domain/types.py`
+- Modify: `src/loushang/coding/domain/__init__.py`
+- Test: `tests/coding/domain/test_coding_domain_app.py`
+
+- [ ] Write failing tests for `MethodPolicy` defaults, `MethodPolicy.off()`, and `MethodPolicy.explicit("review")`.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q` and verify it fails because `MethodPolicy` does not exist.
+- [ ] Add frozen `MethodPolicy` dataclass with `mode: str = "explicit"` and `selected_method: str | None = None`.
+- [ ] Add `off()` and `explicit(selected_method)` classmethods.
+- [ ] Export `MethodPolicy` from `loushang.coding.domain`.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q`.
+- [ ] Commit with `feat: add coding method policy`.
+
+### Task 2: CodingDomainApp Policy Resolution
+
+**Files:**
+- Modify: `src/loushang/coding/domain/types.py`
+- Modify: `src/loushang/coding/domain/app.py`
+- Test: `tests/coding/domain/test_coding_domain_app.py`
+
+- [ ] Write failing tests for `CodingDomainRequest(method_policy=MethodPolicy.off())` suppressing a method, `method_policy` taking precedence over `method`, and unsupported policy mode raising `ValueError`.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py -q` and verify expected failures.
+- [ ] Add `method_policy: MethodPolicy | None = None` to `CodingDomainRequest`.
+- [ ] In `CodingDomainApp.prepare_turn(...)`, resolve policy as `request.method_policy or MethodPolicy.explicit(request.method)`.
+- [ ] Implement mode handling:
+  - `off`: return original prompt unchanged with no method metadata.
+  - `explicit` with no selected method: return original prompt unchanged.
+  - `explicit` with selected method: current P2 lookup/compile/project behavior.
+  - otherwise raise `ValueError("unsupported method policy mode: <mode>")`.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain/test_coding_domain_app.py tests/method -q`.
+- [ ] Commit with `feat: apply method policy in coding domain app`.
+
+### Task 3: CLI `--no-method`
+
+**Files:**
+- Modify: `src/loushang/coding/cli/args.py`
+- Modify: `src/loushang/coding/cli/__main__.py`
+- Test: `tests/coding/test_cli.py`
+
+- [ ] Write failing parser test for `--no-method`.
+- [ ] Write failing CLI tests for:
+  - `--no-method -p "hello"` dispatches original prompt and `method_id is None`.
+  - `--method review --no-method -p "hello"` exits `2`.
+  - existing `--method review -p "hello"` still applies method guidance.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/domain -q` and verify expected failures.
+- [ ] Add `no_method: bool` to `CliArgs`.
+- [ ] Add `--no-method` to parser and `_BUILTIN_FLAG_NAMES`.
+- [ ] Add static conflict validation for `args.method and args.no_method`.
+- [ ] Map CLI flags to `MethodPolicy.off()` or `MethodPolicy.explicit(args.method)` before calling `CodingDomainApp.prepare_turn(...)`.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/domain -q`.
+- [ ] Commit with `feat: add no-method cli switch`.
+
+### Task 4: Work-Log Method Observability
+
+**Files:**
+- Modify: `src/loushang/coding/cli/__main__.py`
+- Test: `tests/coding/test_cli.py`
+
+- [ ] Write failing tests for `work-log inspect` text output including `method_id` when an operation or event payload contains method metadata.
+- [ ] Write failing test for `work-log inspect --work-log-inspect-format json` including `method_id` only when present.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q` and verify expected failures.
+- [ ] Add helper `_work_log_entry_method_id(entry) -> str`.
+- [ ] Add trailing `method_id` column to `_write_work_log_text(...)`.
+- [ ] Add `method_id` conditionally to `_work_log_entry_summary(...)`.
+- [ ] Keep entries without method metadata readable with an empty text column and no JSON key.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q`.
+- [ ] Commit with `feat: expose method id in work log inspect`.
+
+### Task 5: Missing Method Error Hint
+
+**Files:**
+- Modify: `src/loushang/coding/cli/__main__.py`
+- Test: `tests/coding/test_cli.py`
+
+- [ ] Write failing test asserting missing method error includes `Run 'loushang method list' to inspect available methods.`
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q` and verify expected failure.
+- [ ] Add a small formatter/helper for method lookup failures or special-case the `ValueError` from `CodingDomainApp`.
+- [ ] Keep exit code `1`.
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q`.
+- [ ] Commit with `feat: add missing method cli hint`.
+
+### Task 6: Regression And PR Prep
+
+**Files:**
+- Modify previous files only.
+
+- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q`.
+- [ ] Run `uv --cache-dir .uv-cache run ruff check src/loushang/coding/domain src/loushang/coding/cli tests/coding/domain tests/coding/test_cli.py`.
+- [ ] Run a manual CLI fake-runner or work-log focused verification if needed by changed behavior.
+- [ ] Commit any final fixes.
+- [ ] Push branch and create PR referencing issues #42 and #43.

--- a/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
+++ b/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
@@ -102,4 +102,4 @@
 - [x] Run `uv --cache-dir .uv-cache run ruff check src/loushang/coding/domain src/loushang/coding/cli tests/coding/domain tests/coding/test_cli.py`.
 - [x] Run a manual CLI fake-runner or work-log focused verification if needed by changed behavior.
 - [x] Commit any final fixes.
-- [ ] Push branch and create PR referencing issues #42 and #43.
+- [x] Push branch and create PR referencing issues #42 and #43.

--- a/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
+++ b/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
@@ -70,15 +70,15 @@
 - Modify: `src/loushang/coding/cli/__main__.py`
 - Test: `tests/coding/test_cli.py`
 
-- [ ] Write failing tests for `work-log inspect` text output including `method_id` when an operation or event payload contains method metadata.
-- [ ] Write failing test for `work-log inspect --work-log-inspect-format json` including `method_id` only when present.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q` and verify expected failures.
-- [ ] Add helper `_work_log_entry_method_id(entry) -> str`.
-- [ ] Add trailing `method_id` column to `_write_work_log_text(...)`.
-- [ ] Add `method_id` conditionally to `_work_log_entry_summary(...)`.
-- [ ] Keep entries without method metadata readable with an empty text column and no JSON key.
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q`.
-- [ ] Commit with `feat: expose method id in work log inspect`.
+- [x] Write failing tests for `work-log inspect` text output including `method_id` when an operation or event payload contains method metadata.
+- [x] Write failing test for `work-log inspect --work-log-inspect-format json` including `method_id` only when present.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q` and verify expected failures.
+- [x] Add helper `_work_log_entry_method_id(entry) -> str`.
+- [x] Add trailing `method_id` column to `_write_work_log_text(...)`.
+- [x] Add `method_id` conditionally to `_work_log_entry_summary(...)`.
+- [x] Keep entries without method metadata readable with an empty text column and no JSON key.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q`.
+- [x] Commit with `feat: expose method id in work log inspect`.
 
 ### Task 5: Missing Method Error Hint
 

--- a/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
+++ b/docs/superpowers/plans/2026-06-03-method-policy-observability-p2-5-p2-6.md
@@ -98,8 +98,8 @@
 **Files:**
 - Modify previous files only.
 
-- [ ] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q`.
-- [ ] Run `uv --cache-dir .uv-cache run ruff check src/loushang/coding/domain src/loushang/coding/cli tests/coding/domain tests/coding/test_cli.py`.
-- [ ] Run a manual CLI fake-runner or work-log focused verification if needed by changed behavior.
-- [ ] Commit any final fixes.
+- [x] Run `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q`.
+- [x] Run `uv --cache-dir .uv-cache run ruff check src/loushang/coding/domain src/loushang/coding/cli tests/coding/domain tests/coding/test_cli.py`.
+- [x] Run a manual CLI fake-runner or work-log focused verification if needed by changed behavior.
+- [x] Commit any final fixes.
 - [ ] Push branch and create PR referencing issues #42 and #43.

--- a/docs/superpowers/specs/2026-06-03-method-policy-observability-p2-5-p2-6-design.md
+++ b/docs/superpowers/specs/2026-06-03-method-policy-observability-p2-5-p2-6-design.md
@@ -1,0 +1,199 @@
+# MethodPolicy And Method Observability P2.5/P2.6 Design
+
+## Goal
+
+P2.5/P2.6 extends the P2 method-guided coding turn without entering P3 TaskFlow.
+
+P2 already supports explicit `--method <id-or-name>` for one prompt / print / json coding turn. This design adds two small missing pieces:
+
+- P2.5: make method usage an explicit per-turn policy so it can be turned off deliberately.
+- P2.6: make method usage visible in work-log inspection and make missing-method errors actionable.
+
+The default coding experience must remain unchanged.
+
+## Scope
+
+### In Scope
+
+- Add a small `MethodPolicy` value object in `loushang.coding.domain`.
+- Support P2.5 modes:
+  - `off`
+  - `explicit`
+- Keep `auto` out of runtime behavior for this phase.
+- Make `CodingDomainApp.prepare_turn(...)` consume `MethodPolicy`.
+- Keep backward-compatible request construction from `method: str | None`.
+- Add CLI `--no-method`.
+- Reject `--method <id-or-name>` together with `--no-method`.
+- Add `method_id` to `work-log inspect` text output when present.
+- Add `method_id` to `work-log inspect` JSON output when present.
+- Improve missing method errors with a hint to run `loushang method list`.
+
+### Out Of Scope
+
+- Automatic method selection.
+- Global / project / session method settings.
+- TUI / RPC method toggles.
+- Persisted selected method.
+- TaskFlow / multi-step MethodPlan.
+- Multi-agent execution.
+- METHOD.md / SOUR.md standards.
+
+## Architecture
+
+### MethodPolicy
+
+`MethodPolicy` belongs in `loushang.coding.domain`, not `loushang.method`.
+
+Reasoning:
+
+- `loushang.method` owns resources, selection, compile, and projection.
+- Whether a coding turn should use a method is a domain/run decision.
+- CLI is only an input channel and should not encode method semantics directly.
+
+Suggested shape:
+
+```python
+@dataclass(frozen=True)
+class MethodPolicy:
+    mode: str = "explicit"
+    selected_method: str | None = None
+
+    @classmethod
+    def off(cls) -> "MethodPolicy": ...
+
+    @classmethod
+    def explicit(cls, selected_method: str | None) -> "MethodPolicy": ...
+```
+
+P2.5 behavior:
+
+- `mode="off"`: return the original prompt unchanged and no `method_id`.
+- `mode="explicit", selected_method=None`: return the original prompt unchanged and no `method_id`.
+- `mode="explicit", selected_method="review"`: current P2 behavior.
+- Unknown mode: raise `ValueError("unsupported method policy mode: <mode>")`.
+
+This intentionally does not implement `auto`. The type can use `str` instead of a narrow `Literal` to avoid a future schema break, but runtime validation should only accept P2.5 modes.
+
+### Request Compatibility
+
+Existing `CodingDomainRequest(method=...)` should keep working.
+
+Recommended migration path:
+
+```python
+@dataclass(frozen=True)
+class CodingDomainRequest:
+    user_input: str
+    cwd: Path
+    method: str | None = None
+    method_policy: MethodPolicy | None = None
+```
+
+Resolution rule:
+
+- If `method_policy` is present, use it.
+- Else derive `MethodPolicy.explicit(method)` from the existing `method` field.
+
+This keeps P2 callers stable while making the policy explicit for P2.5+.
+
+### CLI Policy Mapping
+
+CLI maps user intent into a per-turn policy:
+
+```text
+no flags                 -> MethodPolicy.explicit(None)
+--method review          -> MethodPolicy.explicit("review")
+--no-method              -> MethodPolicy.off()
+--method review --no-method -> static CLI error, exit code 2
+```
+
+P2 unsupported paths remain unsupported:
+
+- `--method` with TUI: error
+- `--method` with RPC: error
+- `--no-method` with TUI/RPC is harmless but unnecessary; P2.5 should reject it in the same unsupported-method validation path only if it would otherwise affect a turn. The simplest behavior is to allow `--no-method` because it is a no-op for unsupported method paths.
+
+## Work-Log Observability
+
+P2 already writes `method_id` into operation payloads and run lifecycle event payloads when work logging is active.
+
+P2.6 should make this visible in inspect output.
+
+### Text Output
+
+Current columns:
+
+```text
+sequence kind run_id session_id delivery_hint
+```
+
+Add a trailing `method_id` column:
+
+```text
+sequence kind run_id session_id delivery_hint method_id
+```
+
+Rules:
+
+- If an entry has `payload.method_id`, print it.
+- If an operation has `payload.payload.method_id`, print it.
+- Otherwise print an empty field.
+
+Adding a trailing column is acceptable because inspect output is diagnostic and not a stable machine API. JSON remains the preferred structured format.
+
+### JSON Output
+
+Add `method_id` to each entry summary only when present.
+
+This keeps non-method entries stable and avoids noisy `null` fields.
+
+## Error Handling
+
+Missing method should remain exit code `1` because it is a runtime lookup failure, not a parser conflict.
+
+Message:
+
+```text
+Error: method not found: review
+Run 'loushang method list' to inspect available methods.
+```
+
+`--method` and `--no-method` together should return exit code `2`:
+
+```text
+Error: --method cannot be used with --no-method.
+```
+
+## Testing
+
+### Unit Tests
+
+- `MethodPolicy` defaults.
+- `MethodPolicy.off()`.
+- `MethodPolicy.explicit(...)`.
+- `CodingDomainApp.prepare_turn(...)` with:
+  - default policy and no method.
+  - explicit selected method.
+  - off policy suppressing a method.
+  - unsupported mode.
+
+### CLI Tests
+
+- Parser supports `--no-method`.
+- `--method review --no-method` exits 2.
+- `--no-method -p "hello"` dispatches original prompt and no `method_id`.
+- Missing method includes the method-list hint.
+
+### Work Tests
+
+- Text `work-log inspect` includes method_id when present.
+- JSON `work-log inspect` includes method_id when present.
+- Non-method inspect entries remain readable.
+
+## Implementation Notes
+
+- Keep `AgentSession` unchanged.
+- Keep `loushang.method` unchanged unless tests reveal a direct type/export need.
+- Do not add settings files or config persistence in this phase.
+- Keep prompt guidance template unchanged.
+- Keep current `method_id` work metadata plumbing unchanged.

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -475,7 +475,7 @@ async def run_cli(
                     )
                 )
             except ValueError as error:
-                stderr.write(f"Error: {_format_cli_error(error)}\n")
+                stderr.write(f"Error: {_format_method_cli_error(error)}\n")
                 return 1
 
             if args.prompt is not None:
@@ -883,6 +883,13 @@ def _format_cli_error(error: BaseException) -> str:
         if filename is not None and strerror:
             return f"{strerror}: {filename}"
     return str(error)
+
+
+def _format_method_cli_error(error: ValueError) -> str:
+    message = _format_cli_error(error)
+    if message.startswith("method not found:"):
+        return f"{message}\nRun 'loushang method list' to inspect available methods."
+    return message
 
 
 def _runtime_args_for_bootstrap(args: CliArgs) -> CliArgs:

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -30,7 +30,7 @@ from loushang.coding.control.settings_store import (
 )
 from loushang.coding.diag_export import export_diagnostics_bundle
 from loushang.coding.diagnostics import serialize_diagnostic
-from loushang.coding.domain import CodingDomainApp, CodingDomainRequest
+from loushang.coding.domain import CodingDomainApp, CodingDomainRequest, MethodPolicy
 from loushang.coding.extensions.types import ResolvedFlag
 from loushang.coding.mode import ModeConfig, run_mode, run_print_mode, run_rpc_mode
 from loushang.coding.observability import (
@@ -471,7 +471,7 @@ async def run_cli(
                     CodingDomainRequest(
                         user_input=print_input.user_input,
                         cwd=project_root,
-                        method=args.method,
+                        method_policy=_method_policy_from_args(args),
                     )
                 )
             except ValueError as error:
@@ -704,6 +704,8 @@ def _work_log_runtime_error(args: CliArgs, *, effective_tui: bool) -> str | None
 
 
 def _method_static_error(args: CliArgs) -> str | None:
+    if args.method is not None and args.no_method:
+        return "--method cannot be used with --no-method"
     if args.method is None:
         return None
     if args.tui:
@@ -721,6 +723,12 @@ def _method_runtime_error(args: CliArgs, *, effective_tui: bool) -> str | None:
     if effective_tui:
         return "--method is not supported in TUI mode"
     return None
+
+
+def _method_policy_from_args(args: CliArgs) -> MethodPolicy:
+    if args.no_method:
+        return MethodPolicy.off()
+    return MethodPolicy.explicit(args.method)
 
 
 def _resolve_work_event_log(raw_path: str | None, project_root: Path) -> JsonlEventLogBackend | None:

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -761,16 +761,16 @@ def _resolve_work_log_path(raw_path: str, project_root: Path) -> Path:
 
 
 def _write_work_log_text(entries: list[Any], stdout: TextIO) -> None:
-    stdout.write("sequence\tkind\trun_id\tsession_id\tdelivery_hint\n")
+    stdout.write("sequence\tkind\trun_id\tsession_id\tdelivery_hint\tmethod_id\n")
     for entry in entries:
         stdout.write(
             f"{entry.sequence}\t{_work_log_entry_kind(entry)}\t{entry.run_id}\t"
-            f"{entry.session_id}\t{_work_log_entry_delivery_hint(entry)}\n"
+            f"{entry.session_id}\t{_work_log_entry_delivery_hint(entry)}\t{_work_log_entry_method_id(entry)}\n"
         )
 
 
 def _work_log_entry_summary(entry: Any) -> dict[str, object]:
-    return {
+    summary: dict[str, object] = {
         "entry_id": entry.entry_id,
         "entry_type": entry.entry_type,
         "sequence": entry.sequence,
@@ -781,6 +781,10 @@ def _work_log_entry_summary(entry: Any) -> dict[str, object]:
         "event_id": entry.event_id,
         "delivery_hint": _work_log_entry_delivery_hint(entry),
     }
+    method_id = _work_log_entry_method_id(entry)
+    if method_id:
+        summary["method_id"] = method_id
+    return summary
 
 
 def _work_log_entry_kind(entry: Any) -> str:
@@ -794,6 +798,18 @@ def _work_log_entry_delivery_hint(entry: Any) -> str:
     delivery_hint = entry.payload.get("delivery_hint")
     if isinstance(delivery_hint, str):
         return delivery_hint
+    return ""
+
+
+def _work_log_entry_method_id(entry: Any) -> str:
+    method_id = entry.payload.get("method_id")
+    if isinstance(method_id, str):
+        return method_id
+    nested_payload = entry.payload.get("payload")
+    if isinstance(nested_payload, dict):
+        nested_method_id = nested_payload.get("method_id")
+        if isinstance(nested_method_id, str):
+            return nested_method_id
     return ""
 
 

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -27,6 +27,7 @@ _BUILTIN_FLAG_NAMES = frozenset(
         "version",
         "mode",
         "method",
+        "no-method",
         "prompt",
         "prompt-steps",
         "tui",
@@ -133,6 +134,7 @@ class CliArgs:
     version: bool
     mode: CliMode
     method: str | None
+    no_method: bool
     prompt: str | None
     prompt_steps: str | None
     tui: bool
@@ -290,6 +292,7 @@ def parse_args(
         version=namespace.version,
         mode=namespace.mode,
         method=namespace.method,
+        no_method=namespace.no_method,
         prompt=namespace.prompt,
         prompt_steps=namespace.prompt_steps,
         tui=namespace.tui,
@@ -402,6 +405,7 @@ def _build_parser() -> ArgumentParser:
     parser.add_argument("--version", "-v", action="store_true")
     parser.add_argument("--mode", choices=("text", "print", "json", "rpc"), default="text")
     parser.add_argument("--method", help="Guide one coding turn with a discovered method.")
+    parser.add_argument("--no-method", action="store_true", help="Run one coding turn without method guidance.")
     parser.add_argument(
         "--prompt",
         "-p",

--- a/src/loushang/coding/domain/__init__.py
+++ b/src/loushang/coding/domain/__init__.py
@@ -5,6 +5,7 @@ from loushang.coding.domain.app import (
 from loushang.coding.domain.types import (
     CodingDomainPreparedTurn,
     CodingDomainRequest,
+    MethodPolicy,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "CodingDomainPreparedTurn",
     "CodingDomainRequest",
     "DEFAULT_GUIDANCE_TEMPLATE",
+    "MethodPolicy",
 ]

--- a/src/loushang/coding/domain/app.py
+++ b/src/loushang/coding/domain/app.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from loushang.coding.domain.types import CodingDomainPreparedTurn, CodingDomainRequest, MethodPolicy
+from loushang.coding.domain.types import (
+    CodingDomainPreparedTurn,
+    CodingDomainRequest,
+    MethodPolicy,
+)
 from loushang.method import (
     MethodCompiler,
     MethodContext,

--- a/src/loushang/coding/domain/app.py
+++ b/src/loushang/coding/domain/app.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from loushang.coding.domain.types import CodingDomainPreparedTurn, CodingDomainRequest
+from loushang.coding.domain.types import CodingDomainPreparedTurn, CodingDomainRequest, MethodPolicy
 from loushang.method import (
     MethodCompiler,
     MethodContext,
@@ -30,7 +30,13 @@ class CodingDomainApp:
         self._method_projector = method_projector or MethodProjector()
 
     def prepare_turn(self, request: CodingDomainRequest) -> CodingDomainPreparedTurn:
-        method_name = request.method.strip() if request.method is not None else None
+        policy = request.method_policy or MethodPolicy.explicit(request.method)
+        if policy.mode == "off":
+            return CodingDomainPreparedTurn(prepared_prompt=request.user_input)
+        if policy.mode != "explicit":
+            raise ValueError(f"unsupported method policy mode: {policy.mode}")
+
+        method_name = policy.selected_method.strip() if policy.selected_method is not None else None
         if not method_name:
             return CodingDomainPreparedTurn(prepared_prompt=request.user_input)
 

--- a/src/loushang/coding/domain/types.py
+++ b/src/loushang/coding/domain/types.py
@@ -9,6 +9,20 @@ _EMPTY_METADATA: Mapping[str, object] = MappingProxyType({})
 
 
 @dataclass(frozen=True)
+class MethodPolicy:
+    mode: str = "explicit"
+    selected_method: str | None = None
+
+    @classmethod
+    def off(cls) -> MethodPolicy:
+        return cls(mode="off")
+
+    @classmethod
+    def explicit(cls, selected_method: str | None = None) -> MethodPolicy:
+        return cls(mode="explicit", selected_method=selected_method)
+
+
+@dataclass(frozen=True)
 class CodingDomainRequest:
     user_input: str
     cwd: Path
@@ -27,4 +41,5 @@ class CodingDomainPreparedTurn:
 __all__ = [
     "CodingDomainPreparedTurn",
     "CodingDomainRequest",
+    "MethodPolicy",
 ]

--- a/src/loushang/coding/domain/types.py
+++ b/src/loushang/coding/domain/types.py
@@ -27,6 +27,7 @@ class CodingDomainRequest:
     user_input: str
     cwd: Path
     method: str | None = None
+    method_policy: MethodPolicy | None = None
     metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
 
 

--- a/tests/coding/domain/test_coding_domain_app.py
+++ b/tests/coding/domain/test_coding_domain_app.py
@@ -100,6 +100,57 @@ def test_prepare_turn_with_skill_backed_method_adds_guidance(tmp_path: Path) -> 
     )
 
 
+def test_prepare_turn_method_policy_off_suppresses_method(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("Review code carefully.", encoding="utf-8")
+    request = CodingDomainRequest(
+        user_input="check src/app.py",
+        cwd=tmp_path,
+        method="review",
+        method_policy=MethodPolicy.off(),
+    )
+
+    prepared = CodingDomainApp().prepare_turn(request)
+
+    assert prepared.prepared_prompt == "check src/app.py"
+    assert prepared.method_id is None
+    assert prepared.method_guidance is None
+
+
+def test_prepare_turn_method_policy_takes_precedence_over_method(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "skills" / "review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("Review code carefully.", encoding="utf-8")
+    debug_dir = tmp_path / "skills" / "debug"
+    debug_dir.mkdir(parents=True)
+    (debug_dir / "SKILL.md").write_text("Debug failures carefully.", encoding="utf-8")
+    request = CodingDomainRequest(
+        user_input="check src/app.py",
+        cwd=tmp_path,
+        method="review",
+        method_policy=MethodPolicy.explicit("debug"),
+    )
+
+    prepared = CodingDomainApp().prepare_turn(request)
+
+    assert prepared.method_id == "skill:debug"
+    assert prepared.method_guidance is not None
+    assert "Debug failures carefully." in prepared.method_guidance
+    assert "Review code carefully." not in prepared.method_guidance
+
+
+def test_prepare_turn_unsupported_method_policy_mode_raises_value_error(tmp_path: Path) -> None:
+    request = CodingDomainRequest(
+        user_input="hello",
+        cwd=tmp_path,
+        method_policy=MethodPolicy(mode="auto", selected_method=None),
+    )
+
+    with pytest.raises(ValueError, match="unsupported method policy mode: auto"):
+        CodingDomainApp().prepare_turn(request)
+
+
 def test_prepare_turn_with_method_resource_adds_guidance(tmp_path: Path) -> None:
     method_dir = tmp_path / "methods" / "task" / "review"
     method_dir.mkdir(parents=True)

--- a/tests/coding/domain/test_coding_domain_app.py
+++ b/tests/coding/domain/test_coding_domain_app.py
@@ -8,6 +8,7 @@ from loushang.coding.domain import (
     CodingDomainApp,
     CodingDomainPreparedTurn,
     CodingDomainRequest,
+    MethodPolicy,
 )
 
 
@@ -37,6 +38,27 @@ def test_coding_domain_types_are_frozen() -> None:
 
     with pytest.raises(FrozenInstanceError):
         request.user_input = "changed"  # type: ignore[misc]
+
+
+def test_method_policy_defaults_to_explicit_without_selection() -> None:
+    policy = MethodPolicy()
+
+    assert policy.mode == "explicit"
+    assert policy.selected_method is None
+
+
+def test_method_policy_off_factory() -> None:
+    policy = MethodPolicy.off()
+
+    assert policy.mode == "off"
+    assert policy.selected_method is None
+
+
+def test_method_policy_explicit_factory() -> None:
+    policy = MethodPolicy.explicit("review")
+
+    assert policy.mode == "explicit"
+    assert policy.selected_method == "review"
 
 
 def test_prepare_turn_without_method_keeps_prompt_unchanged(tmp_path: Path) -> None:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -594,6 +594,7 @@ def test_parse_args_supports_prompt_alias_and_print_mode() -> None:
     short = parse_args(["-p", "hello"])
     long = parse_args(["--prompt", "hello"])
     method = parse_args(["--method", "review", "-p", "hello"])
+    no_method = parse_args(["--no-method", "-p", "hello"])
     print_mode = parse_args(["--mode", "print", "hello"])
     workflow = parse_args(["-ps", "scenarios/coding/bmi.workflow.yaml"])
 
@@ -602,7 +603,10 @@ def test_parse_args_supports_prompt_alias_and_print_mode() -> None:
     assert long.prompt == "hello"
     assert long.messages == ()
     assert method.method == "review"
+    assert method.no_method is False
     assert method.prompt == "hello"
+    assert no_method.no_method is True
+    assert no_method.prompt == "hello"
     assert print_mode.mode == "print"
     assert print_mode.messages == ("hello",)
     assert workflow.prompt_steps == "scenarios/coding/bmi.workflow.yaml"
@@ -2312,6 +2316,59 @@ def test_run_cli_dash_p_with_method_prepares_prompt_and_method_id(tmp_path) -> N
     assert call["method_id"] == "method:task:review"
     assert "Use concise review guidance." in call["prompt"]
     assert call["prompt"].endswith("User request:\n\ncheck src/app.py")
+
+
+def test_run_cli_dash_p_with_no_method_suppresses_method(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    _write_review_method(tmp_path)
+    runtime = FakeRuntime(FakeSession("session-1"))
+    prompt_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--no-method", "-p", "check src/app.py"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            prompt_runner=prompt_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    call = prompt_runner.calls[0]
+    assert call["prompt"] == "check src/app.py"
+    assert call["method_id"] is None
+
+
+def test_run_cli_rejects_method_and_no_method_conflict(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    stderr = StringIO()
+    prompt_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--method", "review", "--no-method", "-p", "hello"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            prompt_runner=prompt_runner,
+        )
+        assert exit_code == 2
+
+    asyncio.run(scenario())
+
+    assert prompt_runner.calls == []
+    assert "--method cannot be used with --no-method" in stderr.getvalue()
 
 
 def test_run_cli_dash_p_with_missing_method_reports_error(tmp_path) -> None:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -2398,6 +2398,7 @@ def test_run_cli_dash_p_with_missing_method_reports_error(tmp_path) -> None:
 
     assert prompt_runner.calls == []
     assert "method not found: missing" in stderr.getvalue()
+    assert "Run 'loushang method list' to inspect available methods." in stderr.getvalue()
 
 
 def test_run_cli_dash_p_passes_work_log_backend_to_prompt_command(tmp_path) -> None:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -247,12 +247,15 @@ def _append_work_log_inspect_entry(
     session_id: str = "session-1",
     entry_type: str = "event",
     delivery_hint: str | None = None,
+    method_id: str | None = None,
 ) -> None:
     from loushang.work import EventLogEntry
 
     payload: dict[str, object] = {"kind": kind}
     if delivery_hint is not None:
         payload["delivery_hint"] = delivery_hint
+    if method_id is not None:
+        payload["payload"] = {"method_id": method_id}
     event_log.append(
         EventLogEntry(
             entry_id=f"entry-{sequence}",
@@ -3446,11 +3449,54 @@ def test_run_cli_work_log_inspect_outputs_text_without_runtime(tmp_path) -> None
     asyncio.run(scenario())
 
     assert stdout.getvalue().splitlines() == [
-        "sequence\tkind\trun_id\tsession_id\tdelivery_hint",
-        "1\tSubmitCodingTurn\trun-1\tsession-1\t",
-        "2\tContentDelta\trun-1\tsession-1\tcoalesce",
+        "sequence\tkind\trun_id\tsession_id\tdelivery_hint\tmethod_id",
+        "1\tSubmitCodingTurn\trun-1\tsession-1\t\t",
+        "2\tContentDelta\trun-1\tsession-1\tcoalesce\t",
     ]
     assert stderr.getvalue() == ""
+
+
+def test_run_cli_work_log_inspect_text_includes_method_id(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=1,
+        kind="SubmitCodingTurn",
+        entry_type="operation",
+        method_id="method:task:review",
+    )
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=2,
+        kind="WorkRunStarted",
+        delivery_hint="immediate",
+        method_id="method:task:review",
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path)],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert stdout.getvalue().splitlines() == [
+        "sequence\tkind\trun_id\tsession_id\tdelivery_hint\tmethod_id",
+        "1\tSubmitCodingTurn\trun-1\tsession-1\t\tmethod:task:review",
+        "2\tWorkRunStarted\trun-1\tsession-1\timmediate\tmethod:task:review",
+    ]
 
 
 def test_run_cli_work_log_inspect_outputs_json_without_runtime(tmp_path) -> None:
@@ -3499,6 +3545,38 @@ def test_run_cli_work_log_inspect_outputs_json_without_runtime(tmp_path) -> None
     ]
 
 
+def test_run_cli_work_log_inspect_json_includes_method_id_when_present(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=3,
+        kind="WorkRunCompleted",
+        delivery_hint="immediate",
+        method_id="method:task:review",
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "json"],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert json.loads(stdout.getvalue())[0]["method_id"] == "method:task:review"
+
+
 def test_run_cli_work_log_inspect_filters_by_run(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.work import JsonlEventLogBackend
@@ -3524,8 +3602,8 @@ def test_run_cli_work_log_inspect_filters_by_run(tmp_path) -> None:
     asyncio.run(scenario())
 
     assert stdout.getvalue().splitlines() == [
-        "sequence\tkind\trun_id\tsession_id\tdelivery_hint",
-        "2\tApprovalRequested\trun-2\tsession-1\timmediate",
+        "sequence\tkind\trun_id\tsession_id\tdelivery_hint\tmethod_id",
+        "2\tApprovalRequested\trun-2\tsession-1\timmediate\t",
     ]
 
 


### PR DESCRIPTION
## Summary
- Add per-turn MethodPolicy for coding domain turns, including explicit and off modes.
- Add CLI --no-method plus conflict validation with --method.
- Surface method_id in work-log inspect text and JSON output, and add an actionable missing-method hint.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/method tests/work -q
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/domain src/loushang/coding/cli tests/coding/domain tests/coding/test_cli.py

Closes #42
Closes #43