### PR TITLE
P3.0: add method applicability metadata

### DIFF
--- a/src/loushang/coding/frontmatter.py
+++ b/src/loushang/coding/frontmatter.py
@@ -61,9 +61,111 @@ def _parse_yaml_subset(yaml_text: str) -> dict[str, object]:
             block, index = _parse_block_scalar(lines, index + 1, chomp=value)
             values[key] = block
             continue
+        if not value and _next_line_is_indented(lines, index + 1):
+            collection, index = _parse_collection(lines, index + 1, parent_key=key)
+            values[key] = collection
+            continue
         values[key] = _parse_scalar(value, line_number=index, line=raw_line, key=key)
         index += 1
     return values
+
+
+def _next_line_is_indented(lines: list[str], index: int) -> bool:
+    while index < len(lines):
+        raw_line = lines[index]
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            index += 1
+            continue
+        return raw_line[:1].isspace()
+    return False
+
+
+def _parse_collection(lines: list[str], index: int, *, parent_key: str) -> tuple[object, int]:
+    index = _skip_ignored_lines(lines, index)
+    if index >= len(lines):
+        return "", index
+    raw_line = lines[index]
+    if raw_line.startswith("  - "):
+        return _parse_list(lines, index, indent=2, parent_key=parent_key)
+    if raw_line.startswith("  "):
+        return _parse_map(lines, index, indent=2, parent_key=parent_key)
+    return "", index
+
+
+def _parse_list(lines: list[str], index: int, *, indent: int, parent_key: str) -> tuple[list[object], int]:
+    values: list[object] = []
+    prefix = " " * indent
+    while index < len(lines):
+        raw_line = lines[index]
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            index += 1
+            continue
+        line_indent = _indent_width(raw_line)
+        if line_indent < indent:
+            break
+        if line_indent != indent or not raw_line.startswith(f"{prefix}- "):
+            raise _frontmatter_error(index, 1, raw_line, "unexpected indentation")
+        item_value = raw_line[indent + 2 :].strip()
+        values.append(_parse_scalar(item_value, line_number=index, line=raw_line, key=parent_key))
+        index += 1
+    return values, index
+
+
+def _parse_map(lines: list[str], index: int, *, indent: int, parent_key: str) -> tuple[dict[str, object], int]:
+    values: dict[str, object] = {}
+    prefix = " " * indent
+    while index < len(lines):
+        raw_line = lines[index]
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            index += 1
+            continue
+        line_indent = _indent_width(raw_line)
+        if line_indent < indent:
+            break
+        if line_indent != indent or not raw_line.startswith(prefix):
+            raise _frontmatter_error(index, 1, raw_line, "unexpected indentation")
+        line = raw_line[indent:]
+        if ":" not in line:
+            raise _frontmatter_error(index, indent + 1, raw_line, "expected key-value pair")
+        key, raw_value = line.split(":", 1)
+        key = key.strip()
+        if not key:
+            raise _frontmatter_error(index, indent + 1, raw_line, "expected key")
+        value = raw_value.strip()
+        if not value and _next_line_is_deeper(lines, index + 1, indent=indent):
+            nested, index = _parse_list(lines, index + 1, indent=indent + 2, parent_key=f"{parent_key}.{key}")
+            values[key] = nested
+            continue
+        values[key] = _parse_scalar(value, line_number=index, line=raw_line, key=key)
+        index += 1
+    return values, index
+
+
+def _skip_ignored_lines(lines: list[str], index: int) -> int:
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if stripped and not stripped.startswith("#"):
+            return index
+        index += 1
+    return index
+
+
+def _next_line_is_deeper(lines: list[str], index: int, *, indent: int) -> bool:
+    while index < len(lines):
+        raw_line = lines[index]
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            index += 1
+            continue
+        return _indent_width(raw_line) > indent
+    return False
+
+
+def _indent_width(raw_line: str) -> int:
+    return len(raw_line) - len(raw_line.lstrip(" "))
 
 
 def _parse_block_scalar(lines: list[str], index: int, *, chomp: str) -> tuple[str, int]:
@@ -93,15 +195,28 @@ def _parse_scalar(value: str, *, line_number: int, line: str, key: str) -> objec
         return False
     if lower in {"null", "~"}:
         return None
-    if value.startswith("[") and not value.endswith("]"):
-        column = line.index(value) + 1
-        raise _frontmatter_error(line_number, column, line, f'invalid value for "{key}"')
+    if value.startswith("["):
+        if not value.endswith("]"):
+            column = line.index(value) + 1
+            raise _frontmatter_error(line_number, column, line, f'invalid value for "{key}"')
+        return _parse_inline_list(value, line_number=line_number, line=line, key=key)
     if (value.startswith('"') and not value.endswith('"')) or (value.startswith("'") and not value.endswith("'")):
         column = line.index(value) + 1
         raise _frontmatter_error(line_number, column, line, f'unterminated quoted value for "{key}"')
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value
+
+
+def _parse_inline_list(value: str, *, line_number: int, line: str, key: str) -> list[object]:
+    items = value[1:-1].strip()
+    if not items:
+        return []
+    return [
+        _parse_scalar(item.strip(), line_number=line_number, line=line, key=key)
+        for item in items.split(",")
+        if item.strip()
+    ]
 
 
 def _frontmatter_error(line_number: int, column: int, line: str, reason: str) -> FrontmatterParseError:

--- a/src/loushang/method/__init__.py
+++ b/src/loushang/method/__init__.py
@@ -5,6 +5,7 @@ from loushang.method.registry import MethodRegistry
 from loushang.method.selector import MethodSelector
 from loushang.method.skill_adapter import method_from_skill
 from loushang.method.types import (
+    MethodApplicability,
     MethodContext,
     MethodDescriptor,
     MethodPlan,
@@ -18,6 +19,7 @@ __all__ = [
     "MethodProjector",
     "MethodRegistry",
     "MethodSelector",
+    "MethodApplicability",
     "MethodContext",
     "MethodDescriptor",
     "MethodPlan",

--- a/src/loushang/method/applicability.py
+++ b/src/loushang/method/applicability.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from collections.abc import Mapping as MappingABC
+
+from loushang.method.types import MethodApplicability
+
+
+def applicability_from_frontmatter(frontmatter: MappingABC[str, object]) -> MethodApplicability:
+    domains = _string_tuple_hint(frontmatter, ("domains", "domain"))
+    return MethodApplicability(
+        domains=domains,
+        task_types=_string_tuple_hint(frontmatter, ("task_types", "task-types", "task_type", "task-type")),
+        contexts=_string_tuple_hint(frontmatter, ("contexts", "context")),
+        artifact_types=_string_tuple_hint(
+            frontmatter,
+            ("artifact_types", "artifact-types", "artifact_type", "artifact-type"),
+        ),
+        modalities=_string_tuple_hint(frontmatter, ("modalities", "modality")),
+        toolchains=_string_tuple_hint(frontmatter, ("toolchains", "toolchain")),
+        lifecycle=_string_tuple_hint(frontmatter, ("lifecycle",)),
+        capabilities=_string_tuple_hint(frontmatter, ("capabilities", "capability")),
+        complexity=_string_hint(frontmatter, "complexity"),
+        risk=_string_hint(frontmatter, "risk"),
+        tags=_tags_hint(frontmatter.get("tags")),
+    )
+
+
+def primary_domain(
+    frontmatter: MappingABC[str, object],
+    applicability: MethodApplicability,
+) -> str | None:
+    return _string_hint(frontmatter, "domain") or _first(applicability.domains)
+
+
+def _string_tuple_hint(frontmatter: MappingABC[str, object], keys: tuple[str, ...]) -> tuple[str, ...]:
+    for key in keys:
+        values = _string_tuple(frontmatter.get(key))
+        if values:
+            return values
+    return ()
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, Iterable) and not isinstance(value, MappingABC):
+        values = tuple(item for item in value if isinstance(item, str) and item)
+        return values
+    return ()
+
+
+def _string_hint(frontmatter: MappingABC[str, object], key: str) -> str | None:
+    value = frontmatter.get(key)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _tags_hint(value: object) -> dict[str, tuple[str, ...]]:
+    if not isinstance(value, MappingABC):
+        return {}
+    tags: dict[str, tuple[str, ...]] = {}
+    for key, raw_values in value.items():
+        values = _string_tuple(raw_values)
+        if isinstance(key, str) and key and values:
+            tags[key] = values
+    return tags
+
+
+def _first(values: tuple[str, ...]) -> str | None:
+    if values:
+        return values[0]
+    return None
+
+
+__all__ = ["applicability_from_frontmatter", "primary_domain"]

--- a/src/loushang/method/loader.py
+++ b/src/loushang/method/loader.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from loushang.coding.frontmatter import FrontmatterParseError, parse_frontmatter
 from loushang.coding.loader import DefaultResourceLoader
+from loushang.method.applicability import applicability_from_frontmatter, primary_domain
 from loushang.method.skill_adapter import method_from_skill
 from loushang.method.types import MethodDescriptor
 
@@ -100,6 +101,7 @@ def _method_resource_from_file(
         return None
 
     frontmatter = parsed.frontmatter
+    applicability = applicability_from_frontmatter(frontmatter)
     relative_parts = skill_file.relative_to(methods_root).parts
     path_element_type = relative_parts[0] if relative_parts and relative_parts[0] in _METHOD_ELEMENT_TYPES else None
     element_type = _string_hint(frontmatter, "type") or path_element_type
@@ -121,12 +123,13 @@ def _method_resource_from_file(
         content=content,
         kind="method_resource",
         element_type=element_type,
-        domain=_string_hint(frontmatter, "domain"),
+        domain=primary_domain(frontmatter, applicability),
         meta_role=_first_string_hint(frontmatter, ("meta_role", "meta-role", "role")),
         phase=_string_hint(frontmatter, "phase"),
         source_path=skill_file.as_posix(),
         version=_string_hint(frontmatter, "version"),
         metadata=metadata,
+        applicability=applicability,
     )
 
 

--- a/src/loushang/method/skill_adapter.py
+++ b/src/loushang/method/skill_adapter.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from collections.abc import Mapping as MappingABC
 
 from loushang.coding.loader.types import SkillDescriptor
+from loushang.method.applicability import applicability_from_frontmatter, primary_domain
 from loushang.method.types import MethodDescriptor
 
 
 def method_from_skill(skill: SkillDescriptor) -> MethodDescriptor:
     frontmatter = _frontmatter(skill.metadata)
+    applicability = applicability_from_frontmatter(frontmatter)
     metadata = {
         **dict(skill.metadata),
         "source_kind": skill.source_kind,
@@ -23,12 +25,13 @@ def method_from_skill(skill: SkillDescriptor) -> MethodDescriptor:
         content=skill.content or "",
         kind="skill_backed",
         element_type=_string_hint(frontmatter, "type"),
-        domain=_string_hint(frontmatter, "domain"),
+        domain=primary_domain(frontmatter, applicability),
         meta_role=_first_string_hint(frontmatter, ("meta_role", "meta-role", "role")),
         phase=_string_hint(frontmatter, "phase"),
         source_path=skill.source_path.as_posix(),
         version=_string_hint(frontmatter, "version"),
         metadata=metadata,
+        applicability=applicability,
     )
 
 

--- a/src/loushang/method/types.py
+++ b/src/loushang/method/types.py
@@ -5,6 +5,22 @@ from types import MappingProxyType
 from typing import Mapping
 
 _EMPTY_METADATA: Mapping[str, object] = MappingProxyType({})
+_EMPTY_TAGS: Mapping[str, tuple[str, ...]] = MappingProxyType({})
+
+
+@dataclass(frozen=True)
+class MethodApplicability:
+    domains: tuple[str, ...] = ()
+    task_types: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    artifact_types: tuple[str, ...] = ()
+    modalities: tuple[str, ...] = ()
+    toolchains: tuple[str, ...] = ()
+    lifecycle: tuple[str, ...] = ()
+    capabilities: tuple[str, ...] = ()
+    complexity: str | None = None
+    risk: str | None = None
+    tags: Mapping[str, tuple[str, ...]] = field(default_factory=lambda: _EMPTY_TAGS)
 
 
 @dataclass(frozen=True)
@@ -21,6 +37,7 @@ class MethodDescriptor:
     source_path: str | None = None
     version: str | None = None
     metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+    applicability: MethodApplicability = field(default_factory=MethodApplicability)
 
 
 @dataclass(frozen=True)
@@ -28,6 +45,7 @@ class MethodContext:
     domain: str | None = None
     task: str | None = None
     metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+    applicability: MethodApplicability = field(default_factory=MethodApplicability)
 
 
 @dataclass(frozen=True)
@@ -37,6 +55,7 @@ class MethodStep:
     executor: str
     role_variant: str | None = None
     projection: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+    applicability: MethodApplicability = field(default_factory=MethodApplicability)
 
 
 @dataclass(frozen=True)
@@ -49,6 +68,7 @@ class MethodPlan:
     activity: str | None = None
     task: str | None = None
     metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+    applicability: MethodApplicability = field(default_factory=MethodApplicability)
 
 
 @dataclass(frozen=True)
@@ -68,6 +88,7 @@ class MethodProjection:
 
 
 __all__ = [
+    "MethodApplicability",
     "MethodContext",
     "MethodDescriptor",
     "MethodPlan",

--- a/tests/coding/test_frontmatter.py
+++ b/tests/coding/test_frontmatter.py
@@ -25,6 +25,31 @@ def test_parse_frontmatter_normalizes_crlf_and_block_scalars() -> None:
     assert result.body == "Run the review."
 
 
+def test_parse_frontmatter_supports_simple_lists_and_maps() -> None:
+    from loushang.coding.frontmatter import parse_frontmatter
+
+    result = parse_frontmatter(
+        "---\n"
+        "domains:\n"
+        "  - coding\n"
+        "  - research\n"
+        "tags:\n"
+        "  family: review-first\n"
+        "  phase:\n"
+        "    - verify\n"
+        "---\n\n"
+        "Run the review.\n"
+    )
+
+    assert result.frontmatter == {
+        "domains": ["coding", "research"],
+        "tags": {
+            "family": "review-first",
+            "phase": ["verify"],
+        },
+    }
+
+
 def test_parse_frontmatter_keeps_original_body_without_complete_frontmatter() -> None:
     from loushang.coding.frontmatter import parse_frontmatter, strip_frontmatter
 

--- a/tests/method/test_method_loader.py
+++ b/tests/method/test_method_loader.py
@@ -63,6 +63,28 @@ def test_method_loader_discovers_method_resources_and_ignores_future_manifests(t
         "description: Method review.\n"
         "type: task\n"
         "domain: coding\n"
+        "domains:\n"
+        "  - coding\n"
+        "  - research\n"
+        "task_types:\n"
+        "  - reviewing\n"
+        "contexts:\n"
+        "  - oss-library\n"
+        "artifact_types:\n"
+        "  - code\n"
+        "modalities:\n"
+        "  - text\n"
+        "toolchains:\n"
+        "  - python\n"
+        "lifecycle:\n"
+        "  - maintenance\n"
+        "capabilities:\n"
+        "  - diff-review\n"
+        "complexity: standard\n"
+        "risk: medium\n"
+        "tags:\n"
+        "  method_family:\n"
+        "    - review-first\n"
         "meta_role: VALIDATOR\n"
         "phase: VERIFY\n"
         "version: 1\n"
@@ -81,6 +103,17 @@ def test_method_loader_discovers_method_resources_and_ignores_future_manifests(t
     assert method.kind == "method_resource"
     assert method.element_type == "task"
     assert method.domain == "coding"
+    assert method.applicability.domains == ("coding", "research")
+    assert method.applicability.task_types == ("reviewing",)
+    assert method.applicability.contexts == ("oss-library",)
+    assert method.applicability.artifact_types == ("code",)
+    assert method.applicability.modalities == ("text",)
+    assert method.applicability.toolchains == ("python",)
+    assert method.applicability.lifecycle == ("maintenance",)
+    assert method.applicability.capabilities == ("diff-review",)
+    assert method.applicability.complexity == "standard"
+    assert method.applicability.risk == "medium"
+    assert method.applicability.tags == {"method_family": ("review-first",)}
     assert method.meta_role == "VALIDATOR"
     assert method.phase == "VERIFY"
     assert method.version == "1"

--- a/tests/method/test_method_types.py
+++ b/tests/method/test_method_types.py
@@ -5,6 +5,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 from loushang.method import (
+    MethodApplicability,
     MethodContext,
     MethodDescriptor,
     MethodPlan,
@@ -46,7 +47,30 @@ def test_method_context_defaults_are_small() -> None:
 
     assert context.domain is None
     assert context.task is None
+    assert context.applicability == MethodApplicability()
     assert context.metadata == {}
+
+
+def test_method_applicability_defaults_and_structured_tags() -> None:
+    applicability = MethodApplicability(
+        domains=("coding", "research"),
+        task_types=("reviewing",),
+        contexts=("oss-library",),
+        artifact_types=("code", "test-report"),
+        modalities=("text", "code"),
+        toolchains=("python", "pytest"),
+        lifecycle=("maintenance",),
+        capabilities=("diff-review",),
+        complexity="standard",
+        risk="medium",
+        tags={"method_family": ("architecture-first",)},
+    )
+
+    assert MethodApplicability().domains == ()
+    assert applicability.domains == ("coding", "research")
+    assert applicability.task_types == ("reviewing",)
+    assert applicability.artifact_types == ("code", "test-report")
+    assert applicability.tags["method_family"] == ("architecture-first",)
 
 
 def test_method_plan_and_step_support_single_turn_defaults() -> None:
@@ -57,7 +81,9 @@ def test_method_plan_and_step_support_single_turn_defaults() -> None:
     assert plan.phase is None
     assert plan.activity is None
     assert plan.task is None
+    assert plan.applicability == MethodApplicability()
     assert step.role_variant is None
+    assert step.applicability == MethodApplicability()
     assert step.projection == {}
 
 

--- a/tests/method/test_skill_adapter.py
+++ b/tests/method/test_skill_adapter.py
@@ -16,6 +16,20 @@ def test_method_from_skill_preserves_content_and_frontmatter_hints() -> None:
             "frontmatter": {
                 "type": "task",
                 "domain": "coding",
+                "domains": ["coding", "research"],
+                "task_types": ["reviewing", "verifying"],
+                "contexts": ["oss-library"],
+                "artifact_types": ["code", "test-report"],
+                "modalities": ["text", "code"],
+                "toolchains": ["python", "pytest"],
+                "lifecycle": ["maintenance"],
+                "capabilities": ["diff-review"],
+                "complexity": "standard",
+                "risk": "medium",
+                "tags": {
+                    "method_family": ["review-first"],
+                    "domain_app": "coding",
+                },
                 "meta_role": "VALIDATOR",
                 "phase": "VERIFY",
                 "temperature": 0.2,
@@ -34,6 +48,20 @@ def test_method_from_skill_preserves_content_and_frontmatter_hints() -> None:
     assert method.kind == "skill_backed"
     assert method.element_type == "task"
     assert method.domain == "coding"
+    assert method.applicability.domains == ("coding", "research")
+    assert method.applicability.task_types == ("reviewing", "verifying")
+    assert method.applicability.contexts == ("oss-library",)
+    assert method.applicability.artifact_types == ("code", "test-report")
+    assert method.applicability.modalities == ("text", "code")
+    assert method.applicability.toolchains == ("python", "pytest")
+    assert method.applicability.lifecycle == ("maintenance",)
+    assert method.applicability.capabilities == ("diff-review",)
+    assert method.applicability.complexity == "standard"
+    assert method.applicability.risk == "medium"
+    assert method.applicability.tags == {
+        "method_family": ("review-first",),
+        "domain_app": ("coding",),
+    }
     assert method.meta_role == "VALIDATOR"
     assert method.phase == "VERIFY"
     assert method.version == "1"
@@ -72,3 +100,18 @@ def test_method_from_skill_accepts_missing_optional_skill_fields() -> None:
     assert method.content == ""
     assert method.meta_role == "DESIGNER"
     assert method.element_type is None
+    assert method.applicability.domains == ()
+
+
+def test_method_from_skill_maps_legacy_domain_into_applicability_domains() -> None:
+    skill = SkillDescriptor(
+        name="legacy-domain",
+        source_path=Path("skills/legacy-domain/SKILL.md"),
+        content="Legacy domain content.",
+        metadata={"frontmatter": {"domain": "coding"}},
+    )
+
+    method = method_from_skill(skill)
+
+    assert method.domain == "coding"
+    assert method.applicability.domains == ("coding",)


### PR DESCRIPTION
## Summary
- Add MethodApplicability as the P3.0 data foundation for multidimensional method applicability metadata.
- Parse domain/task/context/artifact/modality/toolchain/lifecycle/capability/risk/complexity/tags from skills and method resources.
- Extend the frontmatter subset parser for simple lists/maps used by method metadata.

## Test Plan
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/frontmatter.py src/loushang/method tests/coding/test_frontmatter.py tests/method
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_frontmatter.py tests/coding/test_resource_loader.py tests/method -q
- uv --cache-dir .uv-cache run --extra dev pytest -q

Closes #49