### PR TITLE
P3.0.1: expose method applicability in CLI output

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -1895,7 +1895,48 @@ def _normalize_method_entry(method: Any) -> dict[str, object]:
         "meta_role": _safe_getattr(method, "meta_role", None),
         "phase": _safe_getattr(method, "phase", None),
         "path": _safe_getattr(method, "source_path", "") or "",
+        "applicability": _normalize_method_applicability(_safe_getattr(method, "applicability", None)),
     }
+
+
+def _normalize_method_applicability(applicability: Any) -> dict[str, object]:
+    return {
+        "domains": _string_list(_safe_getattr(applicability, "domains", ())),
+        "task_types": _string_list(_safe_getattr(applicability, "task_types", ())),
+        "contexts": _string_list(_safe_getattr(applicability, "contexts", ())),
+        "artifact_types": _string_list(_safe_getattr(applicability, "artifact_types", ())),
+        "modalities": _string_list(_safe_getattr(applicability, "modalities", ())),
+        "toolchains": _string_list(_safe_getattr(applicability, "toolchains", ())),
+        "lifecycle": _string_list(_safe_getattr(applicability, "lifecycle", ())),
+        "capabilities": _string_list(_safe_getattr(applicability, "capabilities", ())),
+        "complexity": _optional_string(_safe_getattr(applicability, "complexity", None)),
+        "risk": _optional_string(_safe_getattr(applicability, "risk", None)),
+        "tags": _normalize_method_tags(_safe_getattr(applicability, "tags", {})),
+    }
+
+
+def _normalize_method_tags(tags: Any) -> dict[str, list[str]]:
+    if not isinstance(tags, Mapping):
+        return {}
+    return {
+        key: _string_list(value)
+        for key, value in sorted(tags.items())
+        if isinstance(key, str) and key and _string_list(value)
+    }
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, list | tuple):
+        return [item for item in value if isinstance(item, str) and item]
+    return []
+
+
+def _optional_string(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
 
 
 def _format_method_detail(method: Mapping[str, object]) -> str:
@@ -1908,11 +1949,45 @@ def _format_method_detail(method: Mapping[str, object]) -> str:
         value = method.get(key)
         if value:
             lines.append(f"{key}: {value}")
+    applicability_lines = _format_method_applicability_lines(method.get("applicability"))
+    if applicability_lines:
+        lines.append("applicability:")
+        lines.extend(applicability_lines)
     lines.append("")
     lines.append(str(method.get("content", "")))
     if not lines[-1].endswith("\n"):
         lines[-1] = f"{lines[-1]}\n"
     return "\n".join(lines)
+
+
+def _format_method_applicability_lines(applicability: object) -> list[str]:
+    if not isinstance(applicability, Mapping):
+        return []
+    lines: list[str] = []
+    for key in (
+        "domains",
+        "task_types",
+        "contexts",
+        "artifact_types",
+        "modalities",
+        "toolchains",
+        "lifecycle",
+        "capabilities",
+    ):
+        values = _string_list(applicability.get(key))
+        if values:
+            lines.append(f"  {key}: {', '.join(values)}")
+    for key in ("complexity", "risk"):
+        value = applicability.get(key)
+        if isinstance(value, str) and value:
+            lines.append(f"  {key}: {value}")
+    tags = applicability.get("tags")
+    if isinstance(tags, Mapping):
+        for key, raw_values in sorted(tags.items()):
+            values = _string_list(raw_values)
+            if isinstance(key, str) and key and values:
+                lines.append(f"  tags.{key}: {', '.join(values)}")
+    return lines
 
 
 def _run_list_plugins(

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -5051,6 +5051,29 @@ def test_run_cli_lists_methods_as_json(tmp_path) -> None:
         "description: Review changes.\n"
         "type: task\n"
         "domain: coding\n"
+        "domains:\n"
+        "  - coding\n"
+        "  - research\n"
+        "task_types:\n"
+        "  - reviewing\n"
+        "contexts:\n"
+        "  - oss-library\n"
+        "artifact_types:\n"
+        "  - code\n"
+        "modalities:\n"
+        "  - text\n"
+        "toolchains:\n"
+        "  - python\n"
+        "lifecycle:\n"
+        "  - maintenance\n"
+        "capabilities:\n"
+        "  - diff-review\n"
+        "complexity: standard\n"
+        "risk: medium\n"
+        "tags:\n"
+        "  method_family:\n"
+        "    - review-first\n"
+        "  domain_app: coding\n"
         "meta_role: VALIDATOR\n"
         "phase: VERIFY\n"
         "---\n\n"
@@ -5087,8 +5110,90 @@ def test_run_cli_lists_methods_as_json(tmp_path) -> None:
             "meta_role": "VALIDATOR",
             "phase": "VERIFY",
             "path": str(method_dir / "SKILL.md"),
+            "applicability": {
+                "domains": ["coding", "research"],
+                "task_types": ["reviewing"],
+                "contexts": ["oss-library"],
+                "artifact_types": ["code"],
+                "modalities": ["text"],
+                "toolchains": ["python"],
+                "lifecycle": ["maintenance"],
+                "capabilities": ["diff-review"],
+                "complexity": "standard",
+                "risk": "medium",
+                "tags": {
+                    "method_family": ["review-first"],
+                    "domain_app": ["coding"],
+                },
+            },
         }
     ]
+    assert stderr.getvalue() == ""
+
+
+def test_run_cli_shows_method_json_with_applicability(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    method_dir = tmp_path / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "domains: [coding, research]\n"
+        "task_types: [reviewing]\n"
+        "tags:\n"
+        "  method_family: review-first\n"
+        "---\n\n"
+        "Review the diff carefully.",
+        encoding="utf-8",
+    )
+    session = FakeSession("session-1")
+    runtime = FakeRuntime(session)
+    stdout = StringIO()
+    stderr = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["method", "show", "review", "--show-method-format", "json"],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["applicability"] == {
+        "domains": ["coding", "research"],
+        "task_types": ["reviewing"],
+        "contexts": [],
+        "artifact_types": [],
+        "modalities": [],
+        "toolchains": [],
+        "lifecycle": [],
+        "capabilities": [],
+        "complexity": None,
+        "risk": None,
+        "tags": {"method_family": ["review-first"]},
+    }
+    assert payload["content"] == (
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "domains: [coding, research]\n"
+        "task_types: [reviewing]\n"
+        "tags:\n"
+        "  method_family: review-first\n"
+        "---\n\n"
+        "Review the diff carefully."
+    )
     assert stderr.getvalue() == ""
 
 
@@ -5098,7 +5203,17 @@ def test_run_cli_shows_method_as_text(tmp_path) -> None:
     skill_dir = tmp_path / "skills" / "debug"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
-        "---\nname: debug\ndescription: Debug failures.\ntype: task\n---\n\nDebug failures carefully.",
+        "---\n"
+        "name: debug\n"
+        "description: Debug failures.\n"
+        "type: task\n"
+        "domain: coding\n"
+        "task_types: [debugging]\n"
+        "risk: medium\n"
+        "tags:\n"
+        "  method_family: debug-first\n"
+        "---\n\n"
+        "Debug failures carefully.",
         encoding="utf-8",
     )
     session = FakeSession("session-1")
@@ -5124,6 +5239,11 @@ def test_run_cli_shows_method_as_text(tmp_path) -> None:
     assert "id: skill:debug" in output
     assert "kind: skill_backed" in output
     assert "element_type: task" in output
+    assert "applicability:" in output
+    assert "  domains: coding" in output
+    assert "  task_types: debugging" in output
+    assert "  risk: medium" in output
+    assert "  tags.method_family: debug-first" in output
     assert "Debug failures carefully." in output
     assert stderr.getvalue() == ""
 


### PR DESCRIPTION
## Summary
- Include MethodApplicability in method list/show JSON output.
- Render a compact non-empty applicability section in method show text output.
- Add CLI coverage for list JSON, show JSON, and show text applicability metadata.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k "method" -q
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli/__main__.py tests/coding/test_cli.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/method tests/coding/test_cli.py -q
- uv --cache-dir .uv-cache run --extra dev pytest -q

Closes #53