### PR TITLE
P3 docs: publish fixed MethodPlan research and design

### DIFF
--- a/docs/architecture/drafts/p3-fixed-methodplan-flow-research.md
+++ b/docs/architecture/drafts/p3-fixed-methodplan-flow-research.md
@@ -1,0 +1,451 @@
+# P3 Fixed MethodPlan Flow 调研
+
+## 状态
+
+Draft.
+
+本调研用于支持 issue #46 的 P3 设计刷新。目标不是把外部 workflow
+系统搬进 `loushang`，而是在 P0-P2.7 已完成的边界上判断：
+
+- P3 是否应该引入 fixed multi-step `MethodPlan`。
+- `MethodPlan` 与 work/event/coding domain app 应如何衔接。
+- 哪些 flow 能力应在 P3 做，哪些应推迟到 P4+。
+
+## 当前 Loushang 约束
+
+P0-P2.7 已经形成以下约束：
+
+- `loushang.method` 负责方法资源、选择、编译和投影，不负责执行。
+- `loushang.coding.domain` 负责把 method projection 映射成 coding prompt。
+- `loushang.work` 负责 `WorkRun`、`WorkEvent`、event log 和 replay 入口。
+- `AgentSession` 仍保持原有单 turn 执行语义。
+- `CodingDomainApp.prepare_turn(...)` 当前只消费 `plan.steps[0]`，并把 guidance
+  prefix 到一次 user prompt。
+- `WorkRun` 当前只记录 `method_id`，还没有 `plan_id`、`step_id` 或 step lifecycle。
+
+因此 P3 的第一原则是：在不破坏单 turn 快速路径的前提下，把“一个 method 可以编译成固定步骤计划”
+变成可观察、可回放的 work 层能力。
+
+## 调研对象
+
+### Superpowers
+
+参考文件：
+
+- `/home/dev/workspace/superpowers/skills/writing-plans/SKILL.md`
+- `/home/dev/workspace/superpowers/skills/subagent-driven-development/SKILL.md`
+
+可采纳：
+
+- 计划首先应是线性、可执行、可验证的步骤列表。
+- 每一步应有明确动作、预期输出和验证方式。
+- 检查点、提交、回归验证是计划质量的一部分，不只是执行后的附属记录。
+
+不采纳到 P3：
+
+- 不在 P3 引入 subagent 调度。
+- 不把计划写成只适合人工阅读的 Markdown checklist；Loushang 需要结构化 plan，
+  Markdown/Mermaid 可以作为投影或资源格式。
+
+### gbrain
+
+参考文件：
+
+- `/home/dev/workspace/gbrain/docs/ethos/THIN_HARNESS_FAT_SKILLS.md`
+- `/home/dev/workspace/gbrain/docs/guides/scaling-skills.md`
+- `/home/dev/workspace/gbrain/docs/designs/SKILLPACK_REGISTRY_V1_SPEC.md`
+- `/home/dev/workspace/gbrain/docs/guides/skillpacks-as-scaffolding.md`
+- `/home/dev/workspace/gbrain/docs/guides/skillopt.md`
+- `/home/dev/workspace/gbrain/skills/skill-optimizer/SKILL.md`
+
+可采纳：
+
+- “Thin harness, fat skills”：runtime/work/harness 要薄，方法资产本身承载主要知识。
+- Skill/Method 资源应可被用户拥有、复制、改写和演进。
+- 自进化需要验证门槛和基准，不应隐式修改 method 资源。
+- resolver/trigger 可以后续用于自动选择 method，但 P3 不必做智能选择。
+
+不采纳到 P3：
+
+- 不做自动 skill/method 优化。
+- 不做长期 role 记忆或个人助理画像写入。
+- 不把 method registry 做成完整包管理器。
+
+### gstack
+
+参考文件：
+
+- `/home/dev/workspace/gstack/SKILL.md`
+- `/home/dev/workspace/gstack/spec/SKILL.md`
+- `/home/dev/workspace/gstack/autoplan/SKILL.md`
+- `/home/dev/workspace/gstack/plan-tune/SKILL.md`
+- `/home/dev/workspace/gstack/freeze/SKILL.md`
+- `/home/dev/workspace/gstack/docs/designs/SIDEBAR_MESSAGE_FLOW.md`
+
+可采纳：
+
+- 方法执行需要 preflight、gate、review、checkpoint 等外围约束。
+- flow 的状态应可显示、可检查、可恢复，而不是埋在 prompt 里。
+- hooks/gates 更适合作为 step metadata 与 work events，而不是 P3 核心控制流。
+
+不采纳到 P3：
+
+- 不引入 telemetry、learning、sidebar message flow 等产品化系统。
+- 不把 P3 设计成完整 agent coordination runtime。
+
+### Hermes Agent
+
+参考文件：
+
+- `/home/dev/workspace/hermes-agent/README.md`
+- `/home/dev/workspace/hermes-agent/hermes-already-has-routines.md`
+- `/home/dev/workspace/hermes-agent/batch_runner.py`
+- `/home/dev/workspace/hermes-agent/tests/test_batch_runner_checkpoint.py`
+- `/home/dev/workspace/hermes-agent/cron/jobs.py`
+- `/home/dev/workspace/hermes-agent/cron/scheduler.py`
+- `/home/dev/workspace/hermes-agent/hermes_cli/webhook.py`
+- `/home/dev/workspace/hermes-agent/hermes_cli/kanban_db.py`
+- `/home/dev/workspace/hermes-agent/hermes_cli/kanban_decompose.py`
+- `/home/dev/workspace/hermes-agent/agent/prompt_builder.py`
+- `/home/dev/workspace/hermes-agent/agent/curator.py`
+- `/home/dev/workspace/hermes-agent/skills/devops/kanban-orchestrator/SKILL.md`
+- `/home/dev/workspace/hermes-agent/skills/devops/kanban-worker/SKILL.md`
+
+可采纳：
+
+- Scheduled routines / webhook / API triggers 本质上是 `channel -> work`
+  的自动触发入口：触发源、prompt、skills、delivery、workdir、profile 等都应结构化记录。
+- Cron job 支持 script pre-processing、`context_from`、`no_agent`、`[SILENT]`
+  抑制交付和 delivery target，这些对后续 `SurfaceRequest`、`DeliveryPolicy`
+  和 background work 很有参考价值。
+- `batch_runner` 的 checkpoint/resume 值得借鉴：增量 checkpoint、失败项可重试、
+  按内容扫描已有输出恢复，避免只依赖易漂移的 index。
+- Kanban 的 task/run/event 分离、parent gating、heartbeat、blocked/complete、
+  structured handoff metadata 和 audit event 适合 P4 多 agent，但 P3 可以先借鉴
+  step lifecycle 和 handoff metadata 的形状。
+- `kanban_decompose` 说明“计划生成”可以独立于执行：先生成 2-6 个任务图，再原子落库。
+  P3 可以借鉴“先 compile plan，再执行”，但计划应固定，不在执行中动态改图。
+- Curator 的 self-improvement gate 值得保留为长期方向：idle/interval/dry-run、
+  archive instead of delete、pin、pre-run snapshot、report。Method evolution 应是受控后台任务，
+  不应混进 fixed plan executor。
+
+不采纳到 P3：
+
+- 不引入 Hermes Kanban 的完整 SQLite board、dispatcher、profile fleet 或 multi-board。
+- 不做 cron/webhook 平台，也不把 P3 变成 routines 系统。
+- 不做 LLM decomposer 生成动态 task graph。
+- 不做 goal-mode judge loop。
+- 不做 curator 式自动 skill/method 整理。
+
+### Kimi Agent Flow
+
+参考文件：
+
+- `/home/dev/workspace/kimi-cli/klips/klip-10-agent-flow.md`
+- `/home/dev/workspace/kimi-cli/tests/core/test_agent_flow.py`
+
+可采纳：
+
+- `type: flow` 的 SKILL 资源扩展思路有价值。
+- 从 Markdown 中解析 Mermaid/D2 flow 可作为资源兼容路径。
+- 最小 flow 可以只支持 BEGIN、END、task、decision 和 labeled edge。
+- `max_moves`、无效选择重试等安全阈值适合 P4+ branching flow。
+
+不采纳到 P3：
+
+- P3 不做 LLM-driven decision branching。
+- P3 不把 Mermaid/D2 作为内部 canonical schema。
+- P3 不支持循环、条件边和复杂 graph execution。
+
+### Dify Workflow
+
+参考文件：
+
+- `/home/dev/workspace/dify/api/core/workflow/workflow_entry.py`
+- `/home/dev/workspace/dify/api/core/workflow/node_runtime.py`
+- `/home/dev/workspace/dify/api/repositories/api_workflow_node_execution_repository.py`
+- `/home/dev/workspace/dify/api/core/repositories/sqlalchemy_workflow_execution_repository.py`
+
+可采纳：
+
+- workflow run 和 node/step execution 应分开记录。
+- 每个 step execution 应有 status、index、started_at、finished_at、elapsed 等可观测数据。
+- workflow 应有执行上限，避免无限执行。
+
+不采纳到 P3：
+
+- 不引入 GraphEngine、VariablePool、数据库 execution repository。
+- 不做 loop/iteration/child workflow。
+- 不把业务 node 类型硬编码进 work 层。
+
+### LangChain / LangGraph
+
+参考文件：
+
+- `/home/dev/workspace/langchain/libs/langchain_v1/langchain/agents/factory.py`
+- `/home/dev/workspace/langchain/libs/core/langchain_core/runnables/graph.py`
+
+可采纳：
+
+- state graph、checkpoint、middleware 是成熟 agent workflow 的长期方向。
+- graph 可以投影为 Mermaid，用于查看和调试。
+
+不采纳到 P3：
+
+- workspace 中没有独立 LangGraph 源码，P3 不依赖 LangGraph 语义。
+- 不在 P3 引入 state graph/checkpointer/middleware 链。
+- Mermaid 只作为展示或资源解析格式，不作为内部执行模型。
+
+### Mermaid
+
+本地没有单独 Mermaid 仓库；调研主要来自 Kimi 的 Mermaid flow 解析和 LangChain
+的 graph 可视化输出。
+
+可采纳：
+
+- Mermaid 适合作为 `MethodPlan` 的查看/导出格式。
+- 如果未来 `METHOD.md` 中出现 flow diagram，可以先解析有限子集。
+
+不采纳到 P3：
+
+- 不支持完整 Mermaid 语法。
+- 不让 Mermaid 控制 runtime 语义。
+
+## P3 建议决策
+
+### 1. P3 做 fixed linear plan，不做 full workflow graph
+
+P3 的最小能力应是：
+
+```text
+MethodDescriptor
+  -> MethodCompiler
+  -> MethodPlan(mode="fixed", steps=[step1, step2, ...])
+  -> Work executes step1..stepN
+  -> each step becomes one prepared coding turn
+```
+
+P3 不做：
+
+- branching decision
+- loops
+- dynamic graph rewrite
+- subagent lanes
+- cross-domain orchestration
+- variable pool
+- automatic method evolution
+- scheduled routines / webhook triggers
+
+这样能验证“方法指导多步骤 coding”的核心假设，同时避免把 P3 做成 Dify/LangGraph
+级别的 workflow runtime。
+
+### 2. Internal schema 使用 MethodPlan，Mermaid 只是投影
+
+`MethodPlan` 应保持 Loushang 内部 canonical schema。Mermaid/D2 可以：
+
+- 从 `METHOD.md` 或 `SKILL.md` 中作为可选资源内容被解析。
+- 从 `MethodPlan` 导出用于预览。
+- 在 P4+ 支持有限 flow graph。
+
+但 P3 不能让 Mermaid 语法决定执行模型。
+
+### 3. METHOD.md 可以保留为未来标准入口
+
+P1 已支持 `skills/**/SKILL.md` 和 `methods/**/SKILL.md`，这保证了现有 skill
+生态兼容。未来仍建议保留 `METHOD.md`，但它不应在 P3 成为必需条件。
+
+建议标准：
+
+- `SKILL.md`：单个可复用方法元素，适合 `task`、`role`、`guidance`、
+  `phase`、`workproduct`。
+- `METHOD.md`：组合型方法入口，适合声明一个完整 method、默认 phase/order、
+  固定 plan、资源依赖和导出视图。
+- `SOUR.md`：如果保留，应定位为长期演化 role/persona/source-of-role 资源，
+  不是 P3 fixed plan 的执行格式。
+
+P3 可以先实现 `SKILL.md` 编译 fixed plan 的能力，同时把 `METHOD.md` 列为
+P3.5/P4 的资源标准化工作。
+
+### 4. Step lifecycle 应落在 work 层
+
+`method` 编译 plan，但不执行 plan。P3 应让 `work` 对 step lifecycle 可观察：
+
+```text
+WorkRunStarted
+WorkStepStarted
+ContentDelta / ToolCallStarted / ToolCallCompleted / ...
+WorkStepCompleted
+WorkStepFailed
+WorkRunCompleted
+```
+
+每个 step event 至少携带：
+
+- `method_id`
+- `plan_id`
+- `step_id`
+- `step_index`
+- `step_title`
+
+这比只在 prompt 中写入 “Step 1/3” 更稳，因为 replay/search/audit 不需要解析自然语言。
+
+### 5. CodingDomainApp 负责准备 step，不负责调度全 plan
+
+P2 的 `CodingDomainApp.prepare_turn(...)` 已经验证了 method projection 到 prompt
+的边界。P3 建议新增或扩展：
+
+```python
+prepare_step(request, plan, step) -> CodingDomainPreparedTurn
+```
+
+调度顺序由 `work` 控制：
+
+- `work` 接收 operation。
+- `work` 选择/编译 method plan。
+- `work` 按 step 顺序调用 domain app 准备 prompt。
+- `work` 逐步交给 harness/AgentSession 执行。
+
+这样 domain app 不会变成 workflow manager，method 也不会变成 runtime。
+
+### 6. Single-turn 是 one-step fixed plan 的退化形态
+
+P3 不应分裂 single-turn 和 fixed-plan 两条路径。建议语义：
+
+- `mode="single_turn"`：P1/P2 兼容路径，可视为一个 `main` step。
+- `mode="fixed"`：按顺序执行多个 step。
+
+公共事件和 metadata 应统一携带 plan/step 信息；single-turn 可以使用：
+
+```text
+plan_id = method_id + ":single_turn"
+step_id = "main"
+step_index = 0
+```
+
+如果没有 method，则仍保持 P0/P2.7 当前行为，不强行生成 plan。
+
+### 7. Gates/hooks 先作为 metadata，不作为核心控制流
+
+P3 可以允许 step metadata 包含：
+
+- `approval_gates`
+- `expected_artifacts`
+- `verification`
+- `preflight`
+
+但 P3 不应实现完整 hook lifecycle。可做的最小落点是：
+
+- projection 中继续暴露 `approval_gates`。
+- work event payload 记录 gate metadata。
+- 对危险操作仍沿用现有 approval/policy 机制。
+
+## 建议的最小数据模型
+
+当前 `MethodStep` 已有：
+
+```python
+@dataclass(frozen=True)
+class MethodStep:
+    id: str
+    title: str
+    executor: str
+    role_variant: str | None = None
+    projection: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+```
+
+P3 可先不新增复杂字段，把 step 细节放到 `projection` / `metadata` 中；如果需要更清晰，
+可以 additive 增加：
+
+```python
+kind: str = "turn"
+description: str | None = None
+expected_artifacts: tuple[str, ...] = ()
+metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+```
+
+`WorkRun` 可 additive 增加：
+
+```python
+plan_id: str | None = None
+current_step_id: str | None = None
+```
+
+`WorkEvent.payload` 对 step events 增加：
+
+```python
+{
+    "method_id": "...",
+    "plan_id": "...",
+    "step_id": "...",
+    "step_index": 0,
+    "step_title": "...",
+}
+```
+
+暂不建议在 P3 引入 public `TaskFlow`、`AgentLane`、`CollaborationBus`。
+
+## P3 实施切片建议
+
+### P3.1 MethodPlan fixed schema (#48)
+
+- 让 `MethodCompiler` 能从 method metadata/body 生成多个 `MethodStep`。
+- 支持 `mode="fixed"`。
+- 保持 P1/P2 single-turn compiler 行为不变。
+- 测试 `MethodPlan` 解析、fallback、无 method 情况。
+
+### P3.2 Work step lifecycle (#51)
+
+- 增加 `WorkStepStarted`、`WorkStepCompleted`、`WorkStepFailed`。
+- event log 可回放完整 step 序列。
+- `WorkRun` 或 metadata 可记录 plan/step 状态。
+- 可借鉴 Hermes batch/Kanban：失败 step 可重试，step 结果和结构化 handoff
+  应作为事件/metadata 保存，而不是只写在自然语言回复里。
+
+### P3.3 CodingDomain step preparation (#50)
+
+- 新增 `prepare_step(...)` 或等价 facade。
+- 每个 step 仍映射为一次现有 AgentSession turn。
+- 不改 AgentSession 的核心 prompt assembly。
+
+### P3.4 CLI/manual validation path
+
+- 优先覆盖 headless `-p` / `--mode print` / JSON 路径。
+- 手工验证一个固定两步 coding method。
+- TUI/RPC 暂不进入 P3 首批。
+
+### P3.5 Optional Mermaid preview
+
+- 把 `MethodPlan` 导出 Mermaid，便于 review。
+- 不做 Mermaid 执行器。
+
+## 开放问题
+
+1. P3 的 fixed plan 资源应优先从 `SKILL.md` frontmatter、body 约定，还是新增
+   `METHOD.md` 组合入口？
+2. step event 命名使用 `WorkStepStarted` 还是 `PlanStepStarted`？
+3. `work` 是否负责 method select/compile，还是继续由 `CodingDomainApp` 内部完成？
+   架构上更推荐 work 控制 plan lifecycle，domain app 准备具体 turn。
+4. step 间上下文传递是否只依赖现有 session transcript？P3 建议先如此，暂不引入 variable pool。
+5. P3 是否允许 verification step 自动执行命令？建议首批只作为普通 coding turn 或 metadata，
+   不新增自动命令执行器。
+
+## 结论
+
+P3 应从“固定线性 MethodPlan”开始，而不是从 workflow graph 开始。
+
+最值得采纳的是：
+
+- Superpowers 的线性可执行计划与验证意识。
+- gbrain 的 thin harness / fat skills 和 method 可演进但需 gate 的原则。
+- gstack 的 gate/checkpoint 作为外围约束的思路。
+- Hermes 的 routines、checkpoint/resume、Kanban handoff、curator gate 经验。
+- Kimi 的 `type: flow` 与有限 Mermaid 解析经验。
+- Dify 的 step execution 可观测性。
+- LangChain/LangGraph 的长期 state graph/checkpoint 方向。
+
+最应该摈弃或延后的，是把 P3 做成 full graph runtime、LLM decision flow、
+variable pool、多 agent orchestration、自动自进化或产品化 workflow 平台。
+
+P3 的正确落点是：`MethodPlan(mode="fixed")` + work step lifecycle +
+coding domain step preparation。这样既能服务 coding domain 的快速可用，也不会堵死 P4+
+多 agent、跨 domain、branching flow 和自进化 method 的演进空间。

--- a/docs/superpowers/specs/2026-06-03-fixed-methodplan-p3-design.md
+++ b/docs/superpowers/specs/2026-06-03-fixed-methodplan-p3-design.md
@@ -1,0 +1,613 @@
+# Fixed MethodPlan P3 Design
+
+## Status
+
+Draft for P3.1+ implementation.
+
+Already landed before this spec is published:
+
+- P3.0: `MethodApplicability` data model and frontmatter parsing.
+- P3.0.1: method CLI JSON/text output exposes applicability metadata.
+
+The remaining P3 work starts from fixed `MethodPlan` compilation, then work step
+lifecycle events, then step-by-step coding-domain execution.
+
+## Goal
+
+P3 introduces the first multi-step method execution path while preserving the fast single-turn coding experience.
+
+The target is **fixed linear `MethodPlan` execution**:
+
+```text
+MethodDescriptor
+  -> MethodCompiler
+  -> MethodPlan(mode="fixed" | "single_turn")
+  -> WorkRun / WorkStepRun
+  -> CodingDomainApp prepares one coding turn per step
+  -> AgentSession still executes one prepared turn at a time
+```
+
+P3 should also make method metadata easier to evolve toward the long-term methodology standard. In particular, method resources need a multi-dimensional applicability/tag model so Loushang can later select or recommend methods for domains such as coding, presentation/PPT, cowork, research, and other task contexts.
+
+Success criteria:
+
+- Existing no-method and single-turn method behavior remains unchanged.
+- A method can compile into a fixed ordered list of steps.
+- Each step is observable through work events.
+- `WorkRun` records `method_id` and `plan_id`.
+- Step events record `step_id`, status, and useful metadata.
+- Method data structures keep the existing stable applicability/tag shape without requiring automatic selection in P3.
+- P3 public API does not expose graph workflows, subagents, conductor scheduling, or automatic method evolution.
+
+## Scope
+
+### In Scope
+
+- Extend `loushang.method` types for fixed plans.
+- Use the existing structured `MethodApplicability` data object.
+- Keep existing `MethodDescriptor.domain` for compatibility, but treat it as a legacy/convenience projection.
+- Extend `MethodStep` with method-aligned fields such as role, phase/activity/task references, expected artifacts, success criteria, and applicability hints.
+- Extend `MethodCompiler` to return `mode="fixed"` when method metadata declares fixed steps.
+- Keep `mode="single_turn"` as the default for existing skills and methods.
+- Extend `loushang.work` with step lifecycle concepts.
+- Add work events for step started/completed/failed.
+- Add P3 tests for method types, compiler behavior, work event projection, and coding work shell behavior.
+
+### Implementation Slices
+
+- P3.1 / issue #48: compile fixed `MethodPlan` steps from method metadata.
+- P3.2 / issue #51: add work plan and step lifecycle events.
+- P3.3 / issue #50: execute fixed `MethodPlan` steps through the coding domain app.
+
+The P3.0 applicability foundation is already part of main and is not repeated in
+these implementation slices.
+
+### Out Of Scope
+
+- Automatic method selection.
+- Fuzzy/semantic method routing.
+- Mermaid/D2 execution.
+- `METHOD.md` runtime implementation.
+- `SOUR.md` runtime implementation.
+- Graph workflows, branches, loops, joins, dynamic graph rewrite.
+- Subagent lanes, cross-domain execution, conductor scheduling.
+- Method evolution proposals or automatic method rewriting.
+- TUI/RPC method picker.
+- Rewriting `AgentSession` internals.
+
+## Design Principle
+
+P3 should be small in execution behavior and forward-looking in data shape.
+
+That means:
+
+- Execution behavior only supports fixed linear steps.
+- Data structures can already carry phase/activity/task/role/guidance/workproduct references.
+- Applicability tags should be structured enough for future selection, but P3 should not implement selection beyond existing explicit method id/name selection.
+
+## Domain And Multi-Tag Model
+
+The user-facing intuition is correct: `code`, `ppt`, `co-work`, `research`, etc. are domains or domain-adjacent application categories.
+
+However, they should not be the only tag dimension. Domain is one axis among several:
+
+```text
+Method applicability =
+  domain
+  + task type
+  + artifact type
+  + modality
+  + lifecycle
+  + complexity
+  + risk
+  + toolchain
+  + custom tags
+```
+
+This follows the existing experimental principle:
+
+```text
+Task = How x What x Who x In/Out
+```
+
+Recommended canonical examples:
+
+| Dimension | Examples | Meaning |
+| --- | --- | --- |
+| `domains` | `coding`, `software`, `ppt`, `presentation`, `cowork`, `research`, `business`, `product` | What kind of work/domain app the method fits |
+| `task_types` | `exploring`, `designing`, `coding`, `debugging`, `reviewing`, `writing`, `presenting` | What the user is trying to do |
+| `contexts` | `oss-library`, `enterprise`, `startup-mvp`, `legacy-system`, `personal-assistant` | Operating context |
+| `artifact_types` | `code`, `tests`, `architecture-doc`, `slides`, `research-report`, `decision-record` | Expected work products |
+| `modalities` | `text`, `code`, `slides`, `browser`, `voice`, `canvas` | Surface/media modality |
+| `toolchains` | `python`, `typescript`, `pytest`, `playwright`, `canva`, `github` | Tool or ecosystem hints |
+| `lifecycle` | `new-feature`, `maintenance`, `migration`, `incident`, `proposal` | Work lifecycle |
+| `complexity` | `quick`, `standard`, `deep` | Expected depth |
+| `risk` | `low`, `medium`, `high` | Operational risk |
+| `tags` | arbitrary dimension map | Future/custom project dimensions |
+
+P3 should not force a final ontology. The stable contract is the shape of the applicability object, not a closed enum list.
+
+### Current `MethodApplicability`
+
+```python
+@dataclass(frozen=True)
+class MethodApplicability:
+    domains: tuple[str, ...] = ()
+    task_types: tuple[str, ...] = ()
+    contexts: tuple[str, ...] = ()
+    artifact_types: tuple[str, ...] = ()
+    modalities: tuple[str, ...] = ()
+    toolchains: tuple[str, ...] = ()
+    lifecycle: tuple[str, ...] = ()
+    capabilities: tuple[str, ...] = ()
+    complexity: str | None = None
+    risk: str | None = None
+    tags: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+```
+
+Rules:
+
+- `domains` is multi-valued. A method can fit `("coding", "research")`.
+- `domain` on `MethodDescriptor` remains for compatibility and may mirror the first domain.
+- `tags` is the escape hatch for dimensions not yet standardized.
+- P3 stores and forwards applicability; it does not score or auto-select.
+- Future resolver can match explicit user prompts against these dimensions.
+
+Example:
+
+```python
+MethodApplicability(
+    domains=("coding", "research"),
+    task_types=("exploring", "designing"),
+    artifact_types=("architecture-doc", "test-plan"),
+    toolchains=("python", "pytest"),
+    complexity="standard",
+    risk="medium",
+    tags={
+        "domain_app": ("coding",),
+        "method_family": ("architecture-first",),
+    },
+)
+```
+
+## Method Type Changes
+
+### `MethodDescriptor`
+
+Already has:
+
+```python
+applicability: MethodApplicability = field(default_factory=MethodApplicability)
+```
+
+Keep existing fields:
+
+```python
+domain: str | None = None
+phase: str | None = None
+meta_role: str | None = None
+element_type: str | None = None
+metadata: Mapping[str, object] = ...
+```
+
+Compatibility rule:
+
+- If frontmatter has `domain`, map it to both `domain` and `applicability.domains`.
+- If frontmatter has `domains`, use it for `applicability.domains`; set `domain` to the first value for compatibility.
+- If frontmatter has `tags`, preserve it in `applicability.tags` when it is a mapping of string/list-like values.
+- Unknown frontmatter remains in `metadata["frontmatter"]`.
+
+### `MethodStep`
+
+Current shape:
+
+```python
+@dataclass(frozen=True)
+class MethodStep:
+    id: str
+    title: str
+    executor: str
+    role_variant: str | None = None
+    projection: Mapping[str, object] = ...
+    applicability: MethodApplicability = field(default_factory=MethodApplicability)
+```
+
+P3.1+ fixed-plan shape can add:
+
+```python
+@dataclass(frozen=True)
+class MethodStep:
+    id: str
+    title: str
+    executor: str = "current_agent"
+    phase: str | None = None
+    activity: str | None = None
+    task: str | None = None
+    role: str | None = None
+    role_variant: str | None = None
+    guidance_refs: tuple[str, ...] = ()
+    expected_artifacts: tuple[str, ...] = ()
+    success_criteria: tuple[str, ...] = ()
+    applicability: MethodApplicability = field(default_factory=MethodApplicability)
+    projection: Mapping[str, object] = ...
+```
+
+Notes:
+
+- `executor` stays `str`, not an enum, so P4 can add `agent_lane:<id>`, `role:<name>`, or remote executor references.
+- `role` and `role_variant` are hints for projection and future multi-agent routing.
+- `expected_artifacts` and `success_criteria` are P3-friendly and support future validation.
+- `applicability` on a step can narrow or override the plan-level applicability.
+
+### `MethodPlan`
+
+Already has:
+
+```python
+applicability: MethodApplicability = field(default_factory=MethodApplicability)
+```
+
+P3.1+ fixed-plan shape can add:
+
+```python
+expected_artifacts: tuple[str, ...] = ()
+success_criteria: tuple[str, ...] = ()
+```
+
+Keep:
+
+```python
+id: str
+method_id: str
+mode: str
+steps: tuple[MethodStep, ...]
+phase: str | None = None
+activity: str | None = None
+task: str | None = None
+metadata: Mapping[str, object] = ...
+```
+
+P3 accepted modes:
+
+- `single_turn`
+- `fixed`
+
+Other modes such as `autonomous`, `hybrid`, `graph`, or `conductor` remain future values and should fail clearly if encountered by a P3 executor.
+
+### `MethodContext`
+
+Already has applicability hints:
+
+```python
+@dataclass(frozen=True)
+class MethodContext:
+    domain: str | None = None
+    task: str | None = None
+    applicability: MethodApplicability = field(default_factory=MethodApplicability)
+    metadata: Mapping[str, object] = ...
+```
+
+P3 compiler/projector can pass this through. P3 selector does not use it for automatic selection.
+
+## Fixed Step Source
+
+P3 can support fixed steps from frontmatter or metadata without requiring `METHOD.md`.
+
+Example `methods/task/review/SKILL.md`:
+
+```markdown
+---
+name: review-with-tests
+description: Review code changes and verify with focused tests
+type: task
+domains: [coding]
+task_types: [reviewing, verifying]
+complexity: standard
+steps:
+  - id: inspect
+    title: Inspect current changes
+    phase: EXPLORE
+    role: EXPLORER
+    success_criteria:
+      - Changed files and intent are understood
+  - id: test
+    title: Run focused regression tests
+    phase: VERIFY
+    role: VALIDATOR
+    expected_artifacts:
+      - test-report
+    success_criteria:
+      - Relevant tests pass or failures are captured
+---
+
+Use this method to inspect changes before giving review findings.
+```
+
+Compiler behavior:
+
+- No `steps` -> existing `single_turn` plan.
+- `steps` present and valid -> `fixed` plan.
+- Invalid `steps` -> clear compiler error.
+
+P3 should keep parsing conservative:
+
+- `steps` must be a list of mappings.
+- Each step needs `id` and `title`.
+- Optional fields use string or list of strings.
+- Unknown step fields go into `projection` or step metadata only if explicitly supported; otherwise preserve in `projection["frontmatter"]` or plan metadata.
+
+## Work Type Changes
+
+### `WorkRun`
+
+Add:
+
+```python
+plan_id: str | None = None
+current_step_id: str | None = None
+```
+
+Existing:
+
+```python
+method_id: str | None = None
+```
+
+### `WorkStepRun`
+
+Add a new data object:
+
+```python
+WorkStepStatus = Literal[
+    "pending",
+    "running",
+    "completed",
+    "failed",
+    "skipped",
+    "cancelled",
+]
+
+@dataclass(frozen=True)
+class WorkStepRun:
+    run_id: str
+    plan_id: str
+    step_id: str
+    sequence: int
+    status: WorkStepStatus
+    method_id: str | None = None
+    title: str | None = None
+    phase: str | None = None
+    activity: str | None = None
+    task: str | None = None
+    role: str | None = None
+    expected_artifacts: tuple[str, ...] = ()
+    success_criteria: tuple[str, ...] = ()
+    metadata: Mapping[str, object] = field(default_factory=dict)
+```
+
+P3 does not need durable step store beyond event log unless implementation naturally benefits from in-memory tracking. The event log remains the replay source.
+
+### `WorkEvent`
+
+Add event kinds:
+
+- `WorkPlanStarted`
+- `WorkStepStarted`
+- `WorkStepCompleted`
+- `WorkStepFailed`
+- `WorkPlanCompleted`
+- `WorkPlanFailed`
+
+Payload examples:
+
+```python
+{
+    "plan_id": "plan:review-with-tests",
+    "method_id": "review-with-tests",
+    "step_id": "inspect",
+    "step_sequence": 1,
+    "step_title": "Inspect current changes",
+    "phase": "EXPLORE",
+    "role": "EXPLORER",
+    "expected_artifacts": [],
+    "success_criteria": ["Changed files and intent are understood"],
+}
+```
+
+Delivery hints:
+
+- `WorkPlanStarted`: `coalesce`
+- `WorkStepStarted`: `coalesce`
+- `WorkStepCompleted`: `coalesce`
+- `WorkStepFailed`: `immediate`
+- `WorkPlanCompleted`: `final_only`
+- `WorkPlanFailed`: `immediate`
+
+## Coding Domain Integration
+
+P3 should not make `CodingDomainApp` execute the whole plan. It should prepare one step at a time.
+
+Add a step-aware request path:
+
+```python
+@dataclass(frozen=True)
+class CodingDomainRequest:
+    user_input: str
+    method: str | None = None
+    cwd: Path | None = None
+    step_id: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+```
+
+Add to prepared turn metadata:
+
+```python
+plan_id: str | None
+step_id: str | None
+method_id: str | None
+```
+
+Behavior:
+
+- No method -> unchanged.
+- Single-turn method -> unchanged except optional `plan_id`.
+- Fixed plan + no `step_id` -> prepare first step.
+- Fixed plan + `step_id` -> prepare that step.
+- Invalid `step_id` -> clear error.
+
+The work layer can call `CodingDomainApp.prepare_turn(...)` for each step, or a thin P3 coordinator can do that. The domain app should remain a preparation boundary, not a scheduler.
+
+## P3 Execution Flow
+
+Minimal flow:
+
+```text
+CLI / caller submits prompt + method
+  -> MethodLoader/Selector finds descriptor
+  -> MethodCompiler compiles plan
+  -> CodingWorkShell creates WorkRun(method_id, plan_id)
+  -> if plan.mode == single_turn:
+       existing P2 behavior
+     else if plan.mode == fixed:
+       emit WorkPlanStarted
+       for each step in order:
+         emit WorkStepStarted
+         prepare step prompt
+         run one AgentSession prompt
+         if success: emit WorkStepCompleted
+         if failure: emit WorkStepFailed and WorkPlanFailed
+       emit WorkPlanCompleted
+```
+
+P3 can treat each step as one prepared coding turn. It does not need a separate planner/conductor loop.
+
+Failure behavior:
+
+- First failing step stops the plan.
+- Record failure payload with `step_id`, error message, and source event reference if available.
+- No automatic retry in P3.
+- User can rerun manually.
+
+## Method Selection Implications
+
+P3 still uses explicit selection:
+
+```text
+--method review-with-tests
+```
+
+The multi-dimensional tags are stored for future resolver work. Future automatic selection can do:
+
+```text
+prompt -> intent/domain classifier -> MethodContext(applicability=...)
+       -> MethodResolver.match(...)
+       -> selected MethodDescriptor
+```
+
+P3 should not implement this. It only makes the data available.
+
+## Relationship To Long-Term Standards
+
+### `SKILL.md`
+
+Still the atomic method element resource and P3 loader input.
+
+### `METHOD.md`
+
+Should be kept as the future composite method manifest. P3 should not require it, but the P3 `MethodPlan` shape should align with it:
+
+- imports
+- phase/activity/task/role/guidance/workproduct references
+- applicability
+- fixed plan template
+- gates
+- expected artifacts
+- evolution policy
+
+### `SOUR.md`
+
+Can remain a future role-source standard. It should not affect P3 execution.
+
+If introduced later, it should feed `role` / `role_variant` projection and method governance, not replace method plans or memory.
+
+### Mermaid / D2
+
+Not a runtime schema in P3.
+
+Future use:
+
+- render `MethodPlan` to Mermaid for visibility.
+- parse a limited Mermaid subset as a `METHOD.md` adapter.
+
+## Error Handling
+
+- Unsupported plan mode -> clear error before agent execution.
+- Invalid step schema -> compiler error with source path and step index.
+- Missing method -> existing P2 behavior.
+- Fixed plan with zero steps -> compiler error.
+- Step execution failure -> step failed + plan failed events.
+- Empty guidance on a step -> run original user input plus step context if available; do not fail only because guidance is empty.
+
+## Testing Strategy
+
+### Method Tests
+
+Already covered by P3.0/P3.0.1 and should remain regression coverage:
+
+- `MethodApplicability` defaults are empty.
+- Frontmatter `domain` maps into applicability domains.
+- Frontmatter `domains` maps into applicability domains.
+- Frontmatter tags map into `MethodApplicability.tags`.
+
+New P3.1+ method coverage:
+
+- Existing skill-backed methods still compile to `single_turn`.
+- Method with valid `steps` compiles to `fixed`.
+- Invalid steps fail clearly.
+- Fixed plan preserves phase/activity/task/role/expected artifacts/success criteria.
+
+### Work Tests
+
+- `WorkRun` can carry `plan_id` and `current_step_id`.
+- `WorkStepRun` serializes through event payloads.
+- Work event log records plan/step lifecycle.
+- Replay can recover the sequence of step events for a run.
+
+### Coding Domain Tests
+
+- Single-turn method behavior stays unchanged.
+- Fixed plan without `step_id` prepares first step.
+- Fixed plan with `step_id` prepares the requested step.
+- Missing step id fails clearly.
+- Prepared turn includes method/plan/step metadata.
+
+### Regression Tests
+
+- No method remains unchanged.
+- Existing `--method` single-turn path remains unchanged.
+- Method defaults from P2.7 still apply.
+- `--no-method` still disables all method behavior.
+
+## Implementation Notes
+
+- Keep new data classes frozen.
+- Prefer tuples for public sequence fields.
+- Keep `mode` as `str`, not a `Literal`, to avoid future breaking changes.
+- Keep tag values normalized to lowercase kebab-case where loader can do so safely; do not mutate arbitrary user metadata.
+- Do not add automatic resolver behavior in P3.
+- Do not add new CLI flags unless implementation needs a hidden test-only path.
+- Keep docs explicit that domain tags are not equivalent to domain apps, though they can use the same names.
+
+## Open Questions
+
+- Should `domain` become deprecated in docs once `applicability.domains` exists, or remain a convenience field permanently?
+- Should P3 expose a `method plan show` command to inspect compiled fixed plans before execution?
+- Should step success criteria be model-visible by default, or only included in work metadata?
+- Should P3 fixed plan execution run all steps automatically, or should the first version only prepare one selected step per operation?
+
+Recommended defaults:
+
+- Keep `domain` as convenience.
+- Defer `method plan show` unless implementation is trivial.
+- Include success criteria in both model-visible step guidance and work metadata.
+- Run fixed steps automatically in non-interactive prompt/print/json paths only after tests prove single-turn behavior is unchanged.


### PR DESCRIPTION
## Summary
- Add the P3 fixed MethodPlan flow research note.
- Add the P3.1+ fixed MethodPlan design spec aligned with the already-landed P3.0/P3.0.1 applicability work.
- Map the next implementation slices to #48, #51, and #50.

## Notes
- This PR intentionally keeps the broader methodology-system reference survey out of scope; that can be published separately if needed.
- No runtime behavior changes.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/method -q

Closes #55