### PR TITLE
P3.1: compile fixed MethodPlan steps

### DIFF
--- a/src/loushang/method/compiler.py
+++ b/src/loushang/method/compiler.py
@@ -13,6 +13,12 @@ from loushang.method.types import (
 class MethodCompiler:
     def compile(self, descriptor: MethodDescriptor, context: MethodContext | None = None) -> MethodPlan:
         _ = context
+        frontmatter = _frontmatter_hint(descriptor.metadata)
+        plan_mode = _string_hint(frontmatter, "plan_mode")
+        if plan_mode == "fixed":
+            return _compile_fixed_plan(descriptor, frontmatter=frontmatter)
+        if plan_mode not in (None, "single_turn"):
+            raise ValueError(f"unsupported MethodPlan mode: {plan_mode}")
         step = MethodStep(
             id="main",
             title=descriptor.name,
@@ -33,13 +39,105 @@ class MethodCompiler:
                 "method_kind": descriptor.kind,
                 "element_type": descriptor.element_type,
             },
+            applicability=descriptor.applicability,
         )
 
 
-def _temperature_hint(metadata: MappingABC[str, object]) -> float | None:
+def _compile_fixed_plan(descriptor: MethodDescriptor, *, frontmatter: MappingABC[str, object]) -> MethodPlan:
+    step_ids = _fixed_step_ids(frontmatter, descriptor=descriptor)
+    step_titles = _string_map_hint(frontmatter, "step_titles")
+    step_guidance = _string_map_hint(frontmatter, "step_guidance")
+    temperature = _temperature_hint(descriptor.metadata)
+    steps = tuple(
+        MethodStep(
+            id=step_id,
+            title=step_titles.get(step_id) or step_id,
+            executor="current_agent",
+            projection={
+                "content": _fixed_step_content(
+                    method_content=descriptor.content,
+                    step_id=step_id,
+                    step_title=step_titles.get(step_id) or step_id,
+                    step_guidance=step_guidance.get(step_id),
+                ),
+                "method_content": descriptor.content,
+                "step_guidance": step_guidance.get(step_id),
+                "step_index": index,
+                "step_count": len(step_ids),
+                "meta_role": descriptor.meta_role,
+                "temperature": temperature,
+            },
+            applicability=descriptor.applicability,
+        )
+        for index, step_id in enumerate(step_ids)
+    )
+    return MethodPlan(
+        id=f"plan:{descriptor.id}",
+        method_id=descriptor.id,
+        mode="fixed",
+        steps=steps,
+        phase=descriptor.phase,
+        metadata={
+            "method_kind": descriptor.kind,
+            "element_type": descriptor.element_type,
+            "plan_mode": "fixed",
+            "step_count": len(steps),
+        },
+        applicability=descriptor.applicability,
+    )
+
+
+def _fixed_step_ids(frontmatter: MappingABC[str, object], *, descriptor: MethodDescriptor) -> tuple[str, ...]:
+    raw_steps = frontmatter.get("steps")
+    if not isinstance(raw_steps, list | tuple) or not raw_steps:
+        raise ValueError(f"fixed MethodPlan requires non-empty steps: {descriptor.id}")
+    if not all(isinstance(step_id, str) and step_id for step_id in raw_steps):
+        raise ValueError(f"fixed MethodPlan step ids must be strings: {descriptor.id}")
+    return tuple(raw_steps)
+
+
+def _fixed_step_content(
+    *,
+    method_content: str,
+    step_id: str,
+    step_title: str,
+    step_guidance: str | None,
+) -> str:
+    parts = [method_content]
+    if step_guidance:
+        parts.append(f"Step {step_id} - {step_title}:\n{step_guidance}")
+    else:
+        parts.append(f"Step {step_id} - {step_title}")
+    return "\n\n".join(part for part in parts if part)
+
+
+def _frontmatter_hint(metadata: MappingABC[str, object]) -> MappingABC[str, object]:
     frontmatter = metadata.get("frontmatter")
-    if not isinstance(frontmatter, MappingABC):
-        return None
+    if isinstance(frontmatter, MappingABC):
+        return frontmatter
+    return {}
+
+
+def _string_hint(frontmatter: MappingABC[str, object], key: str) -> str | None:
+    value = frontmatter.get(key)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _string_map_hint(frontmatter: MappingABC[str, object], key: str) -> dict[str, str]:
+    value = frontmatter.get(key)
+    if not isinstance(value, MappingABC):
+        return {}
+    return {
+        item_key: item_value
+        for item_key, item_value in value.items()
+        if isinstance(item_key, str) and item_key and isinstance(item_value, str) and item_value
+    }
+
+
+def _temperature_hint(metadata: MappingABC[str, object]) -> float | None:
+    frontmatter = _frontmatter_hint(metadata)
     value = frontmatter.get("temperature")
     if isinstance(value, bool):
         return None

--- a/tests/method/test_method_compiler.py
+++ b/tests/method/test_method_compiler.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from loushang.method import MethodCompiler, MethodContext, MethodDescriptor
+import pytest
+
+from loushang.method import (
+    MethodApplicability,
+    MethodCompiler,
+    MethodContext,
+    MethodDescriptor,
+)
 
 
 def test_method_compiler_returns_single_turn_plan_with_main_step() -> None:
@@ -49,3 +56,104 @@ def test_method_compiler_uses_none_for_missing_hints() -> None:
     assert plan.phase is None
     assert plan.steps[0].projection["meta_role"] is None
     assert plan.steps[0].projection["temperature"] is None
+
+
+def test_method_compiler_returns_fixed_plan_from_flat_step_metadata() -> None:
+    applicability = MethodApplicability(domains=("coding",), task_types=("reviewing",))
+    descriptor = MethodDescriptor(
+        id="method:task:review-with-tests",
+        name="review-with-tests",
+        description="Review and verify changes.",
+        content="Use the review method.",
+        kind="method_resource",
+        element_type="task",
+        meta_role="VALIDATOR",
+        phase="VERIFY",
+        metadata={
+            "frontmatter": {
+                "plan_mode": "fixed",
+                "steps": ["inspect", "verify"],
+                "step_titles": {
+                    "inspect": "Inspect current changes",
+                    "verify": "Run focused checks",
+                },
+                "step_guidance": {
+                    "inspect": "Read changed files and summarize intent.",
+                    "verify": "Run focused tests or explain why they cannot run.",
+                },
+                "temperature": "0.2",
+            },
+        },
+        applicability=applicability,
+    )
+
+    plan = MethodCompiler().compile(descriptor, MethodContext(domain="coding"))
+
+    assert plan.id == "plan:method:task:review-with-tests"
+    assert plan.method_id == "method:task:review-with-tests"
+    assert plan.mode == "fixed"
+    assert plan.phase == "VERIFY"
+    assert plan.applicability == applicability
+    assert plan.metadata["method_kind"] == "method_resource"
+    assert plan.metadata["element_type"] == "task"
+    assert plan.metadata["plan_mode"] == "fixed"
+    assert plan.metadata["step_count"] == 2
+    assert [step.id for step in plan.steps] == ["inspect", "verify"]
+    assert [step.title for step in plan.steps] == ["Inspect current changes", "Run focused checks"]
+
+    inspect, verify = plan.steps
+    assert inspect.executor == "current_agent"
+    assert inspect.projection["content"] == (
+        "Use the review method.\n\n"
+        "Step inspect - Inspect current changes:\n"
+        "Read changed files and summarize intent."
+    )
+    assert inspect.projection["method_content"] == "Use the review method."
+    assert inspect.projection["step_guidance"] == "Read changed files and summarize intent."
+    assert inspect.projection["step_index"] == 0
+    assert inspect.projection["step_count"] == 2
+    assert inspect.projection["meta_role"] == "VALIDATOR"
+    assert inspect.projection["temperature"] == 0.2
+    assert verify.projection["content"].endswith("Run focused tests or explain why they cannot run.")
+
+
+def test_method_compiler_rejects_fixed_plan_without_steps() -> None:
+    descriptor = MethodDescriptor(
+        id="method:task:broken",
+        name="broken",
+        description="",
+        content="Broken fixed plan.",
+        kind="method_resource",
+        metadata={"frontmatter": {"plan_mode": "fixed"}},
+    )
+
+    with pytest.raises(ValueError, match="fixed MethodPlan requires non-empty steps"):
+        MethodCompiler().compile(descriptor)
+
+
+def test_method_compiler_rejects_non_string_fixed_step_ids() -> None:
+    descriptor = MethodDescriptor(
+        id="method:task:broken",
+        name="broken",
+        description="",
+        content="Broken fixed plan.",
+        kind="method_resource",
+        metadata={"frontmatter": {"plan_mode": "fixed", "steps": ["inspect", 3]}},
+    )
+
+    with pytest.raises(ValueError, match="fixed MethodPlan step ids must be strings"):
+        MethodCompiler().compile(descriptor)
+
+
+def test_method_compiler_rejects_unsupported_plan_mode() -> None:
+    descriptor = MethodDescriptor(
+        id="method:task:graph",
+        name="graph",
+        description="",
+        content="Graph method.",
+        kind="method_resource",
+        metadata={"frontmatter": {"plan_mode": "graph"}},
+    )
+
+    with pytest.raises(ValueError, match="unsupported MethodPlan mode: graph"):
+        MethodCompiler().compile(descriptor)


### PR DESCRIPTION
## Summary
- Add fixed MethodPlan compilation behind explicit frontmatter plan_mode: fixed.
- Support flat step metadata via steps, step_titles, and step_guidance.
- Preserve existing single_turn compilation by default and reject unsupported plan modes clearly.

## Scope
- This is compile-only P3.1 work.
- No fixed plan execution.
- No work step lifecycle events.
- No CLI/runtime path changes beyond existing code receiving a compiled plan.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/method/test_method_compiler.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/method -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k "method" -q
- uv --cache-dir .uv-cache run ruff check src/loushang/method tests/method tests/coding/test_cli.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/method tests/coding/test_cli.py -q
- uv --cache-dir .uv-cache run --extra dev pytest -q

Closes #48