### PR TITLE
P3.2: add work plan and step lifecycle events

### DIFF
--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -16,6 +16,8 @@ from loushang.work.types import (
     WorkOperation,
     WorkRun,
     WorkRunStatus,
+    WorkStepRun,
+    WorkStepStatus,
 )
 
 __all__ = [
@@ -31,5 +33,7 @@ __all__ = [
     "WorkOperation",
     "WorkRun",
     "WorkRunStatus",
+    "WorkStepRun",
+    "WorkStepStatus",
     "project_agent_event_to_work_events",
 ]

--- a/src/loushang/work/coding.py
+++ b/src/loushang/work/coding.py
@@ -35,6 +35,10 @@ class CodingWorkShell:
         session_id: str,
         images: Sequence[object] | None = None,
         method_id: str | None = None,
+        plan_id: str | None = None,
+        step_id: str | None = None,
+        step_index: int | None = None,
+        step_title: str | None = None,
         operation_id: str | None = None,
         run_id: str | None = None,
     ) -> WorkRun:
@@ -46,7 +50,15 @@ class CodingWorkShell:
             kind="SubmitCodingTurn",
             session_id=session_id,
             domain="coding",
-            payload=_operation_payload(text=text, images=images, method_id=method_id),
+            payload=_operation_payload(
+                text=text,
+                images=images,
+                method_id=method_id,
+                plan_id=plan_id,
+                step_id=step_id,
+                step_index=step_index,
+                step_title=step_title,
+            ),
         )
         self._append_operation(operation, run_id=run_id, sequence=sequence)
 
@@ -57,6 +69,8 @@ class CodingWorkShell:
             domain="coding",
             status="running",
             method_id=method_id,
+            plan_id=plan_id,
+            current_step_id=step_id,
         )
         sequence += 1
         self._append_event(
@@ -68,6 +82,36 @@ class CodingWorkShell:
                 payload={"source_type": "work_shell"},
             ),
         )
+        if plan_id is not None:
+            sequence += 1
+            self._append_event(
+                _work_event(
+                    kind="WorkPlanStarted",
+                    run=run,
+                    sequence=sequence,
+                    created_at=self.clock(),
+                    delivery_hint="coalesce",
+                    payload=_step_payload(
+                        step_index=step_index,
+                        step_title=step_title,
+                    ),
+                ),
+            )
+        if step_id is not None:
+            sequence += 1
+            self._append_event(
+                _work_event(
+                    kind="WorkStepStarted",
+                    run=run,
+                    sequence=sequence,
+                    created_at=self.clock(),
+                    delivery_hint="coalesce",
+                    payload=_step_payload(
+                        step_index=step_index,
+                        step_title=step_title,
+                    ),
+                ),
+            )
 
         async def listener(event: Mapping[str, object]) -> None:
             nonlocal sequence
@@ -90,7 +134,7 @@ class CodingWorkShell:
                 await self.session.prompt(text)
             else:
                 await self.session.prompt(text, images=images)
-        except Exception:
+        except Exception as error:
             sequence += 1
             failed_run = WorkRun(
                 run_id=run_id,
@@ -99,7 +143,38 @@ class CodingWorkShell:
                 domain="coding",
                 status="failed",
                 method_id=method_id,
+                plan_id=plan_id,
+                current_step_id=step_id,
             )
+            failure_payload = _step_payload(
+                step_index=step_index,
+                step_title=step_title,
+                error=error,
+            )
+            if step_id is not None:
+                self._append_event(
+                    _work_event(
+                        kind="WorkStepFailed",
+                        run=failed_run,
+                        sequence=sequence,
+                        created_at=self.clock(),
+                        delivery_hint="immediate",
+                        payload=failure_payload,
+                    ),
+                )
+                sequence += 1
+            if plan_id is not None:
+                self._append_event(
+                    _work_event(
+                        kind="WorkPlanFailed",
+                        run=failed_run,
+                        sequence=sequence,
+                        created_at=self.clock(),
+                        delivery_hint="immediate",
+                        payload=failure_payload,
+                    ),
+                )
+                sequence += 1
             self._append_event(
                 _work_event(
                     kind="WorkRunFailed",
@@ -121,7 +196,39 @@ class CodingWorkShell:
             domain="coding",
             status="completed",
             method_id=method_id,
+            plan_id=plan_id,
+            current_step_id=step_id,
         )
+        if step_id is not None:
+            self._append_event(
+                _work_event(
+                    kind="WorkStepCompleted",
+                    run=completed_run,
+                    sequence=sequence,
+                    created_at=self.clock(),
+                    delivery_hint="coalesce",
+                    payload=_step_payload(
+                        step_index=step_index,
+                        step_title=step_title,
+                    ),
+                ),
+            )
+            sequence += 1
+        if plan_id is not None:
+            self._append_event(
+                _work_event(
+                    kind="WorkPlanCompleted",
+                    run=completed_run,
+                    sequence=sequence,
+                    created_at=self.clock(),
+                    delivery_hint="final_only",
+                    payload=_step_payload(
+                        step_index=step_index,
+                        step_title=step_title,
+                    ),
+                ),
+            )
+            sequence += 1
         self._append_event(
             _work_event(
                 kind="WorkRunCompleted",
@@ -163,10 +270,15 @@ def _work_event(
     sequence: int,
     created_at: datetime,
     payload: Mapping[str, object],
+    delivery_hint: str = "immediate",
 ) -> WorkEvent:
     event_payload = dict(payload)
     if run.method_id is not None:
         event_payload["method_id"] = run.method_id
+    if run.plan_id is not None:
+        event_payload["plan_id"] = run.plan_id
+    if run.current_step_id is not None:
+        event_payload["step_id"] = run.current_step_id
     return WorkEvent(
         event_id=f"{run.run_id}-event-{sequence}",
         kind=kind,
@@ -176,17 +288,50 @@ def _work_event(
         operation_id=run.operation_id,
         sequence=sequence,
         created_at=created_at,
-        delivery_hint="immediate",
+        delivery_hint=delivery_hint,
         payload=event_payload,
     )
 
 
-def _operation_payload(*, text: str, images: Sequence[object] | None, method_id: str | None) -> dict[str, object]:
+def _operation_payload(
+    *,
+    text: str,
+    images: Sequence[object] | None,
+    method_id: str | None,
+    plan_id: str | None,
+    step_id: str | None,
+    step_index: int | None,
+    step_title: str | None,
+) -> dict[str, object]:
     payload: dict[str, object] = {"text": text}
     if images is not None:
         payload["image_count"] = len(images)
     if method_id is not None:
         payload["method_id"] = method_id
+    if plan_id is not None:
+        payload["plan_id"] = plan_id
+    if step_id is not None:
+        payload["step_id"] = step_id
+    if step_index is not None:
+        payload["step_index"] = step_index
+    if step_title is not None:
+        payload["step_title"] = step_title
+    return payload
+
+
+def _step_payload(
+    *,
+    step_index: int | None,
+    step_title: str | None,
+    error: BaseException | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {"source_type": "work_shell"}
+    if step_index is not None:
+        payload["step_index"] = step_index
+    if step_title is not None:
+        payload["step_title"] = step_title
+    if error is not None:
+        payload["error"] = str(error)
     return payload
 
 

--- a/src/loushang/work/types.py
+++ b/src/loushang/work/types.py
@@ -14,6 +14,15 @@ WorkRunStatus: TypeAlias = Literal[
     "cancelled",
 ]
 
+WorkStepStatus: TypeAlias = Literal[
+    "pending",
+    "running",
+    "completed",
+    "failed",
+    "skipped",
+    "cancelled",
+]
+
 DeliveryHint: TypeAlias = Literal["immediate", "coalesce", "final_only"]
 
 
@@ -35,6 +44,26 @@ class WorkRun:
     domain: str
     status: WorkRunStatus
     method_id: str | None = None
+    plan_id: str | None = None
+    current_step_id: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkStepRun:
+    run_id: str
+    plan_id: str
+    step_id: str
+    sequence: int
+    status: WorkStepStatus
+    method_id: str | None = None
+    title: str | None = None
+    phase: str | None = None
+    activity: str | None = None
+    task: str | None = None
+    role: str | None = None
+    expected_artifacts: tuple[str, ...] = ()
+    success_criteria: tuple[str, ...] = ()
+    metadata: Mapping[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -58,4 +87,6 @@ __all__ = [
     "WorkOperation",
     "WorkRun",
     "WorkRunStatus",
+    "WorkStepRun",
+    "WorkStepStatus",
 ]

--- a/tests/work/test_coding_work_shell.py
+++ b/tests/work/test_coding_work_shell.py
@@ -6,8 +6,9 @@ from datetime import UTC, datetime
 
 
 class FakePromptSession:
-    def __init__(self, events: list[dict[str, object]]) -> None:
+    def __init__(self, events: list[dict[str, object]], *, error: Exception | None = None) -> None:
         self.events = events
+        self.error = error
         self.prompts: list[str] = []
         self.listeners: list[Callable[[dict[str, object]], Awaitable[None] | None]] = []
 
@@ -22,6 +23,8 @@ class FakePromptSession:
 
     async def prompt(self, text: str) -> None:
         self.prompts.append(text)
+        if self.error is not None:
+            raise self.error
         for event in self.events:
             for listener in list(self.listeners):
                 result = listener(event)
@@ -172,5 +175,118 @@ def test_coding_work_shell_records_method_id_as_metadata_only() -> None:
         assert entries[0].payload["payload"]["method_id"] == "method:task:review"
         assert entries[1].payload["payload"]["method_id"] == "method:task:review"
         assert entries[2].payload["payload"]["method_id"] == "method:task:review"
+
+    asyncio.run(scenario())
+
+
+def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
+    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        session = FakePromptSession(events=[])
+        shell = CodingWorkShell(
+            session=session,
+            event_log=event_log,
+            clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        )
+
+        run = await shell.submit_coding_turn(
+            "inspect current changes",
+            session_id="session-1",
+            operation_id="op-1",
+            run_id="run-1",
+            method_id="method:task:review",
+            plan_id="plan:method:task:review",
+            step_id="inspect",
+            step_index=0,
+            step_title="Inspect current changes",
+        )
+
+        assert run.status == "completed"
+        assert run.method_id == "method:task:review"
+        assert run.plan_id == "plan:method:task:review"
+        assert run.current_step_id == "inspect"
+
+        entries = event_log.query(run_id="run-1")
+        assert [entry.payload["kind"] for entry in entries] == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "WorkPlanStarted",
+            "WorkStepStarted",
+            "WorkStepCompleted",
+            "WorkPlanCompleted",
+            "WorkRunCompleted",
+        ]
+        assert entries[0].payload["payload"] == {
+            "text": "inspect current changes",
+            "method_id": "method:task:review",
+            "plan_id": "plan:method:task:review",
+            "step_id": "inspect",
+            "step_index": 0,
+            "step_title": "Inspect current changes",
+        }
+        assert entries[2].payload["delivery_hint"] == "coalesce"
+        assert entries[3].payload["delivery_hint"] == "coalesce"
+        assert entries[4].payload["delivery_hint"] == "coalesce"
+        assert entries[5].payload["delivery_hint"] == "final_only"
+        assert entries[3].payload["payload"] == {
+            "source_type": "work_shell",
+            "method_id": "method:task:review",
+            "plan_id": "plan:method:task:review",
+            "step_id": "inspect",
+            "step_index": 0,
+            "step_title": "Inspect current changes",
+        }
+
+    asyncio.run(scenario())
+
+
+def test_coding_work_shell_records_step_and_plan_failures_before_run_failure() -> None:
+    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        session = FakePromptSession(events=[], error=RuntimeError("agent failed"))
+        shell = CodingWorkShell(
+            session=session,
+            event_log=event_log,
+            clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        )
+
+        try:
+            await shell.submit_coding_turn(
+                "inspect current changes",
+                session_id="session-1",
+                operation_id="op-1",
+                run_id="run-1",
+                method_id="method:task:review",
+                plan_id="plan:method:task:review",
+                step_id="inspect",
+                step_index=0,
+                step_title="Inspect current changes",
+            )
+        except RuntimeError as error:
+            assert str(error) == "agent failed"
+        else:
+            raise AssertionError("expected prompt failure")
+
+        entries = event_log.query(run_id="run-1")
+        assert [entry.payload["kind"] for entry in entries] == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "WorkPlanStarted",
+            "WorkStepStarted",
+            "WorkStepFailed",
+            "WorkPlanFailed",
+            "WorkRunFailed",
+        ]
+        assert entries[4].payload["delivery_hint"] == "immediate"
+        assert entries[5].payload["delivery_hint"] == "immediate"
+        assert entries[4].payload["payload"]["error"] == "agent failed"
+        assert entries[5].payload["payload"]["error"] == "agent failed"
+        assert entries[6].payload["payload"]["method_id"] == "method:task:review"
+        assert entries[6].payload["payload"]["plan_id"] == "plan:method:task:review"
+        assert entries[6].payload["payload"]["step_id"] == "inspect"
 
     asyncio.run(scenario())

--- a/tests/work/test_public_api.py
+++ b/tests/work/test_public_api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-def test_work_public_api_exposes_only_p0_surface() -> None:
+def test_work_public_api_exposes_current_work_surface_without_multi_agent_types() -> None:
     import loushang.work as work
 
     assert set(work.__all__) == {
@@ -17,6 +17,8 @@ def test_work_public_api_exposes_only_p0_surface() -> None:
         "WorkOperation",
         "WorkRun",
         "WorkRunStatus",
+        "WorkStepRun",
+        "WorkStepStatus",
         "project_agent_event_to_work_events",
     }
 

--- a/tests/work/test_work_types.py
+++ b/tests/work/test_work_types.py
@@ -45,9 +45,70 @@ def test_work_run_tracks_p0_single_turn_metadata_without_multi_agent_surface() -
     assert run.domain == "coding"
     assert run.status == "accepted"
     assert run.method_id is None
+    assert run.plan_id is None
+    assert run.current_step_id is None
     assert not hasattr(run, "agent_lane")
     assert not hasattr(run, "task_ledger")
     assert not hasattr(run, "collaboration_bus")
+
+
+def test_work_run_tracks_plan_and_current_step_metadata_without_multi_agent_surface() -> None:
+    from loushang.work import WorkRun
+
+    run = WorkRun(
+        run_id="run-1",
+        operation_id="op-1",
+        session_id="session-1",
+        domain="coding",
+        status="running",
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        current_step_id="inspect",
+    )
+
+    assert run.method_id == "method:task:review"
+    assert run.plan_id == "plan:method:task:review"
+    assert run.current_step_id == "inspect"
+    assert not hasattr(run, "agent_lane")
+    assert not hasattr(run, "task_ledger")
+    assert not hasattr(run, "collaboration_bus")
+
+
+def test_work_step_run_tracks_step_lifecycle_metadata() -> None:
+    from loushang.work import WorkStepRun
+
+    step_run = WorkStepRun(
+        run_id="run-1",
+        plan_id="plan:method:task:review",
+        step_id="inspect",
+        sequence=1,
+        status="running",
+        method_id="method:task:review",
+        title="Inspect current changes",
+        phase="EXPLORE",
+        role="EXPLORER",
+        expected_artifacts=("review-notes",),
+        success_criteria=("Changed files are understood",),
+        metadata={"step_index": 0},
+    )
+
+    assert step_run.run_id == "run-1"
+    assert step_run.plan_id == "plan:method:task:review"
+    assert step_run.step_id == "inspect"
+    assert step_run.sequence == 1
+    assert step_run.status == "running"
+    assert step_run.method_id == "method:task:review"
+    assert step_run.title == "Inspect current changes"
+    assert step_run.phase == "EXPLORE"
+    assert step_run.activity is None
+    assert step_run.task is None
+    assert step_run.role == "EXPLORER"
+    assert step_run.expected_artifacts == ("review-notes",)
+    assert step_run.success_criteria == ("Changed files are understood",)
+    assert step_run.metadata == {"step_index": 0}
+
+    with pytest.raises(FrozenInstanceError):
+        step_run.status = "completed"  # type: ignore[misc]
 
 
 def test_work_event_carries_delivery_hint_and_optional_source_event_ref() -> None:


### PR DESCRIPTION
## Summary
- Add plan_id/current_step_id metadata to WorkRun and expose WorkStepRun/WorkStepStatus.
- Record WorkPlanStarted/Completed/Failed and WorkStepStarted/Completed/Failed events when a prepared coding turn carries plan/step metadata.
- Preserve existing no-plan coding work behavior while making plan/step lifecycle replayable through the event log.

## Scope
- This is P3.2 work-layer observability only.
- No fixed MethodPlan execution.
- No CodingDomainApp step scheduling.
- No multi-agent, graph, or automatic method selection behavior.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/work -q
- uv --cache-dir .uv-cache run ruff check src/loushang/work tests/work tests/coding/test_cli.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/coding/test_cli.py -q
- uv --cache-dir .uv-cache run --extra dev pytest -q

Closes #51