### PR TITLE
Execute fixed MethodPlan steps

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -467,7 +467,7 @@ async def run_cli(
                 return 2
 
             try:
-                prepared_turn = CodingDomainApp(cwd=project_root).prepare_turn(
+                prepared_turns = CodingDomainApp(cwd=project_root).prepare_turns(
                     CodingDomainRequest(
                         user_input=print_input.user_input,
                         cwd=project_root,
@@ -479,51 +479,101 @@ async def run_cli(
                 return 1
 
             if args.prompt is not None:
-                return await prompt_runner(
-                    runtime=runtime,
-                    session=session,
-                    prompt=prepared_turn.prepared_prompt,
-                    stdout=stdout,
-                    stderr=stderr,
-                    images=print_input.images,
-                    follow_up_messages=print_input.follow_up_messages,
-                    verbose=args.verbose,
-                    work_event_log=work_event_log,
-                    method_id=prepared_turn.method_id,
-                )
+                for turn_index, prepared_turn in enumerate(prepared_turns):
+                    is_first_turn = turn_index == 0
+                    is_last_turn = turn_index == len(prepared_turns) - 1
+                    exit_code = await prompt_runner(
+                        runtime=runtime,
+                        session=session,
+                        prompt=prepared_turn.prepared_prompt,
+                        stdout=stdout,
+                        stderr=stderr,
+                        images=print_input.images if is_first_turn else None,
+                        follow_up_messages=print_input.follow_up_messages if is_last_turn else (),
+                        verbose=args.verbose,
+                        work_event_log=work_event_log,
+                        method_id=prepared_turn.method_id,
+                        plan_id=prepared_turn.plan_id,
+                        step_id=prepared_turn.step_id,
+                        step_index=prepared_turn.step_index,
+                        step_title=prepared_turn.step_title,
+                        dispose=is_last_turn,
+                    )
+                    if exit_code != 0:
+                        if not is_last_turn:
+                            await _dispose_runtime_or_session(runtime, session)
+                        return exit_code
+                return 0
 
             output_mode = "text" if args.mode == "print" else args.mode
             if print_runner is not run_print_mode:
-                return await print_runner(
+                for turn_index, prepared_turn in enumerate(prepared_turns):
+                    is_first_turn = turn_index == 0
+                    is_last_turn = turn_index == len(prepared_turns) - 1
+                    exit_code = await print_runner(
+                        runtime=runtime,
+                        session=session,
+                        user_input=prepared_turn.prepared_prompt,
+                        stdout=stdout,
+                        stderr=stderr,
+                        images=print_input.images if is_first_turn else None,
+                        follow_up_messages=print_input.follow_up_messages if is_last_turn else (),
+                        output_mode=output_mode,
+                        render_tool_events=args.render_tool_events,
+                        work_event_log=work_event_log,
+                        method_id=prepared_turn.method_id,
+                        plan_id=prepared_turn.plan_id,
+                        step_id=prepared_turn.step_id,
+                        step_index=prepared_turn.step_index,
+                        step_title=prepared_turn.step_title,
+                        dispose=is_last_turn,
+                    )
+                    if exit_code != 0:
+                        if not is_last_turn:
+                            await _dispose_runtime_or_session(runtime, session)
+                        return exit_code
+                return 0
+
+            for turn_index, prepared_turn in enumerate(prepared_turns):
+                is_first_turn = turn_index == 0
+                is_last_turn = turn_index == len(prepared_turns) - 1
+                exit_code = await mode_runner(
+                    config=ModeConfig(
+                        mode=args.mode,
+                        render_tool_events=args.render_tool_events,
+                    ),
                     runtime=runtime,
                     session=session,
                     user_input=prepared_turn.prepared_prompt,
+                    images=print_input.images if is_first_turn else None,
+                    follow_up_messages=print_input.follow_up_messages if is_last_turn else (),
+                    stdin=stdin,
                     stdout=stdout,
                     stderr=stderr,
-                    images=print_input.images,
-                    follow_up_messages=print_input.follow_up_messages,
-                    output_mode=output_mode,
-                    render_tool_events=args.render_tool_events,
                     work_event_log=work_event_log,
                     method_id=prepared_turn.method_id,
+                    plan_id=prepared_turn.plan_id,
+                    step_id=prepared_turn.step_id,
+                    step_index=prepared_turn.step_index,
+                    step_title=prepared_turn.step_title,
+                    dispose=is_last_turn,
                 )
+                if exit_code != 0:
+                    if not is_last_turn:
+                        await _dispose_runtime_or_session(runtime, session)
+                    return exit_code
+            return 0
 
-            return await mode_runner(
-                config=ModeConfig(
-                    mode=args.mode,
-                    render_tool_events=args.render_tool_events,
-                ),
-                runtime=runtime,
-                session=session,
-                user_input=prepared_turn.prepared_prompt,
-                images=print_input.images,
-                follow_up_messages=print_input.follow_up_messages,
-                stdin=stdin,
-                stdout=stdout,
-                stderr=stderr,
-                work_event_log=work_event_log,
-                method_id=prepared_turn.method_id,
-            )
+
+async def _dispose_runtime_or_session(runtime: Any, session: Any) -> None:
+    disposer = getattr(runtime, "dispose", None)
+    if not callable(disposer):
+        disposer = getattr(session, "dispose", None)
+    if not callable(disposer):
+        return
+    result = disposer()
+    if inspect.isawaitable(result):
+        await result
 
 
 def _resolve_session_dir(args: CliArgs, project_root: Path, services: Any) -> Path:

--- a/src/loushang/coding/domain/app.py
+++ b/src/loushang/coding/domain/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
 from loushang.coding.domain.types import (
@@ -14,7 +15,12 @@ from loushang.method import (
     MethodProjector,
     MethodSelector,
 )
-from loushang.method.types import MethodDescriptor, MethodProjection
+from loushang.method.types import (
+    MethodDescriptor,
+    MethodPlan,
+    MethodProjection,
+    MethodStep,
+)
 
 DEFAULT_GUIDANCE_TEMPLATE = "{guidance}\n\nUser request:\n\n{user_input}"
 
@@ -34,15 +40,18 @@ class CodingDomainApp:
         self._method_projector = method_projector or MethodProjector()
 
     def prepare_turn(self, request: CodingDomainRequest) -> CodingDomainPreparedTurn:
+        return self.prepare_turns(request)[0]
+
+    def prepare_turns(self, request: CodingDomainRequest) -> tuple[CodingDomainPreparedTurn, ...]:
         policy = request.method_policy or MethodPolicy.explicit(request.method)
         if policy.mode == "off":
-            return CodingDomainPreparedTurn(prepared_prompt=request.user_input)
+            return (CodingDomainPreparedTurn(prepared_prompt=request.user_input),)
         if policy.mode != "explicit":
             raise ValueError(f"unsupported method policy mode: {policy.mode}")
 
         method_name = policy.selected_method.strip() if policy.selected_method is not None else None
         if not method_name:
-            return CodingDomainPreparedTurn(prepared_prompt=request.user_input)
+            return (CodingDomainPreparedTurn(prepared_prompt=request.user_input),)
 
         cwd = request.cwd or self._cwd or Path.cwd()
         methods = self._method_loader.discover_methods(cwd)
@@ -52,12 +61,46 @@ class CodingDomainApp:
 
         context = MethodContext(domain="coding", metadata=request.metadata)
         plan = self._method_compiler.compile(descriptor, context=context)
-        step = plan.steps[0]
+        return tuple(
+            self._prepare_step_turn(
+                request=request,
+                descriptor=descriptor,
+                plan=plan,
+                step=step,
+                step_index=step_index,
+                context=context,
+            )
+            for step_index, step in enumerate(plan.steps)
+        )
+
+    def _prepare_step_turn(
+        self,
+        *,
+        request: CodingDomainRequest,
+        descriptor: MethodDescriptor,
+        plan: MethodPlan,
+        step: MethodStep,
+        step_index: int,
+        context: MethodContext,
+    ) -> CodingDomainPreparedTurn:
         projection = self._method_projector.project(plan, step, context=context)
+        metadata = {
+            "meta_role": projection.meta_role,
+            "role_variant": projection.role_variant,
+            "temperature": projection.temperature,
+            "plan_mode": plan.mode,
+            "step_index": step_index,
+        }
         if not _has_meaningful_guidance(descriptor, projection):
             return CodingDomainPreparedTurn(
                 prepared_prompt=request.user_input,
                 method_id=descriptor.id,
+                plan_id=plan.id,
+                plan_mode=plan.mode,
+                step_id=step.id,
+                step_index=step_index,
+                step_title=step.title,
+                metadata=metadata,
             )
 
         guidance = projection.system_guidance
@@ -67,16 +110,22 @@ class CodingDomainApp:
                 user_input=request.user_input,
             ),
             method_id=projection.method_id,
+            plan_id=plan.id,
+            plan_mode=plan.mode,
+            step_id=step.id,
+            step_index=step_index,
+            step_title=step.title,
             method_guidance=guidance,
-            metadata={
-                "meta_role": projection.meta_role,
-                "role_variant": projection.role_variant,
-                "temperature": projection.temperature,
-            },
+            metadata=metadata,
         )
 
 
 def _has_meaningful_guidance(descriptor: MethodDescriptor, projection: MethodProjection) -> bool:
+    source_projection = projection.metadata.get("source_projection")
+    if isinstance(source_projection, Mapping):
+        content = source_projection.get("content")
+        if isinstance(content, str):
+            return bool(content.strip() and projection.system_guidance.strip())
     return bool(descriptor.content.strip() and projection.system_guidance.strip())
 
 

--- a/src/loushang/coding/domain/types.py
+++ b/src/loushang/coding/domain/types.py
@@ -35,6 +35,11 @@ class CodingDomainRequest:
 class CodingDomainPreparedTurn:
     prepared_prompt: str
     method_id: str | None = None
+    plan_id: str | None = None
+    plan_mode: str | None = None
+    step_id: str | None = None
+    step_index: int | None = None
+    step_title: str | None = None
     method_guidance: str | None = None
     metadata: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
 

--- a/src/loushang/coding/mode/base.py
+++ b/src/loushang/coding/mode/base.py
@@ -132,6 +132,10 @@ def create_mode_adapter(
     session: Any | None = None,
     work_event_log: EventLogBackend | None = None,
     method_id: str | None = None,
+    plan_id: str | None = None,
+    step_id: str | None = None,
+    step_index: int | None = None,
+    step_title: str | None = None,
 ) -> ModeAdapter:
     """Create the concrete adapter for a configured coding mode."""
 
@@ -164,6 +168,10 @@ def create_mode_adapter(
         render_tool_events=config.render_tool_events,
         work_event_log=work_event_log,
         method_id=method_id,
+        plan_id=plan_id,
+        step_id=step_id,
+        step_index=step_index,
+        step_title=step_title,
     )
 
 
@@ -180,6 +188,11 @@ async def run_mode(
     follow_up_messages: Sequence[str] = (),
     work_event_log: EventLogBackend | None = None,
     method_id: str | None = None,
+    plan_id: str | None = None,
+    step_id: str | None = None,
+    step_index: int | None = None,
+    step_title: str | None = None,
+    dispose: bool = True,
 ) -> int:
     adapter = create_mode_adapter(
         config,
@@ -190,7 +203,16 @@ async def run_mode(
         stderr=stderr,
         work_event_log=work_event_log,
         method_id=method_id,
+        plan_id=plan_id,
+        step_id=step_id,
+        step_index=step_index,
+        step_title=step_title,
     )
     if config.mode == "rpc":
         return await adapter.start(user_input)
-    return await adapter.start(user_input, images=images, follow_up_messages=follow_up_messages)
+    return await adapter.start(
+        user_input,
+        images=images,
+        follow_up_messages=follow_up_messages,
+        dispose=dispose,
+    )

--- a/src/loushang/coding/mode/print_mode.py
+++ b/src/loushang/coding/mode/print_mode.py
@@ -32,6 +32,10 @@ class PrintMode(ModeAdapter):
         render_tool_events: bool = False,
         work_event_log: EventLogBackend | None = None,
         method_id: str | None = None,
+        plan_id: str | None = None,
+        step_id: str | None = None,
+        step_index: int | None = None,
+        step_title: str | None = None,
     ) -> None:
         if output_mode not in {"text", "json"}:
             raise ValueError(f"unsupported output mode: {output_mode}")
@@ -59,6 +63,10 @@ class PrintMode(ModeAdapter):
         self.render_tool_events = render_tool_events
         self.work_event_log = work_event_log
         self.method_id = method_id
+        self.plan_id = plan_id
+        self.step_id = step_id
+        self.step_index = step_index
+        self.step_title = step_title
         self._tool_render_runtime: ToolRenderRuntime | None = None
         self._tool_definition_resolver: ToolDefinitionResolver | None = None
         self._disposed = False
@@ -70,10 +78,16 @@ class PrintMode(ModeAdapter):
         *,
         images: list[object] | None = None,
         follow_up_messages: Sequence[str] = (),
+        dispose: bool = True,
     ) -> int:
         if user_input is None:
             raise ValueError("Print mode requires a user input")
-        return await self.run_once(user_input, images=images, follow_up_messages=follow_up_messages)
+        return await self.run_once(
+            user_input,
+            images=images,
+            follow_up_messages=follow_up_messages,
+            dispose=dispose,
+        )
 
     async def stop(self) -> int:
         return 0
@@ -119,6 +133,7 @@ class PrintMode(ModeAdapter):
         *,
         images: list[object] | None = None,
         follow_up_messages: Sequence[str] = (),
+        dispose: bool = True,
     ) -> int:
         def unsubscribe() -> None:
             return None
@@ -143,11 +158,12 @@ class PrintMode(ModeAdapter):
             exit_code = 1
         finally:
             unsubscribe()
-            try:
-                await self.dispose()
-            except Exception as exc:
-                self.stderr.write(f"Error: {exc}\n")
-                exit_code = 1
+            if dispose:
+                try:
+                    await self.dispose()
+                except Exception as exc:
+                    self.stderr.write(f"Error: {exc}\n")
+                    exit_code = 1
         return exit_code
 
     def get_mode_state(self) -> ModeState:
@@ -248,6 +264,10 @@ class PrintMode(ModeAdapter):
             session_id=_work_session_id(self.session),
             images=images,
             method_id=self.method_id,
+            plan_id=self.plan_id,
+            step_id=self.step_id,
+            step_index=self.step_index,
+            step_title=self.step_title,
         )
 
 
@@ -416,6 +436,11 @@ async def run_print_mode(
     render_tool_events: bool = False,
     work_event_log: EventLogBackend | None = None,
     method_id: str | None = None,
+    plan_id: str | None = None,
+    step_id: str | None = None,
+    step_index: int | None = None,
+    step_title: str | None = None,
+    dispose: bool = True,
 ) -> int:
     mode = PrintMode(
         runtime=runtime,
@@ -428,8 +453,17 @@ async def run_print_mode(
         render_tool_events=render_tool_events,
         work_event_log=work_event_log,
         method_id=method_id,
+        plan_id=plan_id,
+        step_id=step_id,
+        step_index=step_index,
+        step_title=step_title,
     )
-    return await mode.run_once(user_input, images=images, follow_up_messages=follow_up_messages)
+    return await mode.run_once(
+        user_input,
+        images=images,
+        follow_up_messages=follow_up_messages,
+        dispose=dispose,
+    )
 
 
 async def _prompt_session(session: Any, user_input: str, *, images: list[object] | None = None) -> None:

--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -23,6 +23,11 @@ async def run_prompt_command(
     verbose: bool = False,
     work_event_log: EventLogBackend | None = None,
     method_id: str | None = None,
+    plan_id: str | None = None,
+    step_id: str | None = None,
+    step_index: int | None = None,
+    step_title: str | None = None,
+    dispose: bool = True,
 ) -> int:
     """Run one product prompt and render the stable coding transcript."""
 
@@ -44,6 +49,10 @@ async def run_prompt_command(
             images=images,
             work_event_log=work_event_log,
             method_id=method_id,
+            plan_id=plan_id,
+            step_id=step_id,
+            step_index=step_index,
+            step_title=step_title,
         )
         if exit_code == 0:
             for message in follow_up_messages:
@@ -54,6 +63,10 @@ async def run_prompt_command(
                     message,
                     work_event_log=work_event_log,
                     method_id=method_id,
+                    plan_id=plan_id,
+                    step_id=step_id,
+                    step_index=step_index,
+                    step_title=step_title,
                 )
                 if exit_code != 0:
                     break
@@ -64,13 +77,14 @@ async def run_prompt_command(
         exit_code = 1
     finally:
         unsubscribe()
-        try:
-            await _dispose_runtime_or_session(runtime, session)
-        except Exception as exc:
-            renderer.render_error(str(exc) or exc.__class__.__name__)
-            if verbose:
-                traceback.print_exception(type(exc), exc, exc.__traceback__, file=stderr)
-            exit_code = 1
+        if dispose:
+            try:
+                await _dispose_runtime_or_session(runtime, session)
+            except Exception as exc:
+                renderer.render_error(str(exc) or exc.__class__.__name__)
+                if verbose:
+                    traceback.print_exception(type(exc), exc, exc.__traceback__, file=stderr)
+                exit_code = 1
     return exit_code
 
 
@@ -83,11 +97,25 @@ async def _run_turn(
     images: list[object] | None = None,
     work_event_log: EventLogBackend | None = None,
     method_id: str | None = None,
+    plan_id: str | None = None,
+    step_id: str | None = None,
+    step_index: int | None = None,
+    step_title: str | None = None,
 ) -> int:
     started_at = time.monotonic()
     previous_error = event_renderer.last_error_message
     renderer.render_user(prompt)
-    await _run_prompt_session(session, prompt, images=images, work_event_log=work_event_log, method_id=method_id)
+    await _run_prompt_session(
+        session,
+        prompt,
+        images=images,
+        work_event_log=work_event_log,
+        method_id=method_id,
+        plan_id=plan_id,
+        step_id=step_id,
+        step_index=step_index,
+        step_title=step_title,
+    )
     await session.wait_for_idle()
     assistant_failure = _last_assistant_failure_message(session)
     if assistant_failure is None and event_renderer.last_error_message != previous_error:
@@ -105,6 +133,10 @@ async def _run_prompt_session(
     images: list[object] | None = None,
     work_event_log: EventLogBackend | None = None,
     method_id: str | None = None,
+    plan_id: str | None = None,
+    step_id: str | None = None,
+    step_index: int | None = None,
+    step_title: str | None = None,
 ) -> None:
     if work_event_log is None:
         await _prompt_session(session, user_input, images=images)
@@ -115,6 +147,10 @@ async def _run_prompt_session(
         session_id=_work_session_id(session),
         images=images,
         method_id=method_id,
+        plan_id=plan_id,
+        step_id=step_id,
+        step_index=step_index,
+        step_title=step_title,
     )
 
 

--- a/tests/coding/domain/test_coding_domain_app.py
+++ b/tests/coding/domain/test_coding_domain_app.py
@@ -29,6 +29,11 @@ def test_coding_domain_prepared_turn_defaults() -> None:
 
     assert prepared.prepared_prompt == "review this change"
     assert prepared.method_id is None
+    assert prepared.plan_id is None
+    assert prepared.plan_mode is None
+    assert prepared.step_id is None
+    assert prepared.step_index is None
+    assert prepared.step_title is None
     assert prepared.method_guidance is None
     assert prepared.metadata == {}
 
@@ -177,6 +182,49 @@ def test_prepare_turn_with_method_resource_adds_guidance(tmp_path: Path) -> None
     assert "Use the review method." in prepared.method_guidance
     assert prepared.metadata["meta_role"] == "VALIDATOR"
     assert prepared.prepared_prompt.endswith("User request:\n\ncheck src/app.py")
+
+
+def test_prepare_turns_with_fixed_method_prepares_each_step(tmp_path: Path) -> None:
+    method_dir = tmp_path / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "meta_role: VALIDATOR\n"
+        "plan_mode: fixed\n"
+        "steps:\n"
+        "  - inspect\n"
+        "  - verify\n"
+        "step_titles:\n"
+        "  inspect: Inspect current changes\n"
+        "  verify: Run focused checks\n"
+        "step_guidance:\n"
+        "  inspect: Read changed files and summarize intent.\n"
+        "  verify: Run focused tests or explain why they cannot run.\n"
+        "---\n\n"
+        "Use the review method.",
+        encoding="utf-8",
+    )
+    request = CodingDomainRequest(
+        user_input="check src/app.py",
+        cwd=tmp_path,
+        method="review",
+    )
+
+    prepared_turns = CodingDomainApp().prepare_turns(request)
+
+    assert len(prepared_turns) == 2
+    assert [turn.step_id for turn in prepared_turns] == ["inspect", "verify"]
+    assert [turn.step_index for turn in prepared_turns] == [0, 1]
+    assert [turn.step_title for turn in prepared_turns] == ["Inspect current changes", "Run focused checks"]
+    assert all(turn.method_id == "method:task:review" for turn in prepared_turns)
+    assert all(turn.plan_id == "plan:method:task:review" for turn in prepared_turns)
+    assert all(turn.plan_mode == "fixed" for turn in prepared_turns)
+    assert "Read changed files and summarize intent." in prepared_turns[0].prepared_prompt
+    assert "Run focused tests or explain why they cannot run." in prepared_turns[1].prepared_prompt
+    assert prepared_turns[0].prepared_prompt.endswith("User request:\n\ncheck src/app.py")
 
 
 def test_prepare_turn_missing_method_raises_value_error(tmp_path: Path) -> None:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -319,6 +319,31 @@ def _write_debug_method(project_root: Path) -> None:
     )
 
 
+def _write_fixed_review_method(project_root: Path) -> None:
+    method_dir = project_root / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "meta_role: VALIDATOR\n"
+        "plan_mode: fixed\n"
+        "steps:\n"
+        "  - inspect\n"
+        "  - verify\n"
+        "step_titles:\n"
+        "  inspect: Inspect current changes\n"
+        "  verify: Run focused checks\n"
+        "step_guidance:\n"
+        "  inspect: Read changed files and summarize intent.\n"
+        "  verify: Run focused tests or explain why they cannot run.\n"
+        "---\n\n"
+        "Use concise review guidance.",
+        encoding="utf-8",
+    )
+
+
 def test_parse_args_supports_modes_sessions_and_overrides() -> None:
     from loushang.coding.cli.args import parse_args
 
@@ -2338,6 +2363,47 @@ def test_run_cli_dash_p_with_method_prepares_prompt_and_method_id(tmp_path) -> N
     assert call["prompt"].endswith("User request:\n\ncheck src/app.py")
 
 
+def test_run_cli_dash_p_with_fixed_method_executes_each_step(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    _write_fixed_review_method(tmp_path)
+    runtime = FakeRuntime(FakeSession("session-1"))
+    prompt_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--method", "review", "-p", "check src/app.py"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            prompt_runner=prompt_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert len(prompt_runner.calls) == 2
+    first_call = prompt_runner.calls[0]
+    second_call = prompt_runner.calls[1]
+    assert first_call["method_id"] == "method:task:review"
+    assert first_call["plan_id"] == "plan:method:task:review"
+    assert first_call["step_id"] == "inspect"
+    assert first_call["step_index"] == 0
+    assert first_call["step_title"] == "Inspect current changes"
+    assert "Read changed files and summarize intent." in first_call["prompt"]
+    assert first_call["prompt"].endswith("User request:\n\ncheck src/app.py")
+    assert second_call["method_id"] == "method:task:review"
+    assert second_call["plan_id"] == "plan:method:task:review"
+    assert second_call["step_id"] == "verify"
+    assert second_call["step_index"] == 1
+    assert second_call["step_title"] == "Run focused checks"
+    assert "Run focused tests or explain why they cannot run." in second_call["prompt"]
+    assert second_call["prompt"].endswith("User request:\n\ncheck src/app.py")
+
+
 def test_run_cli_dash_p_with_no_method_suppresses_method(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
@@ -2895,6 +2961,49 @@ def test_run_cli_mode_print_with_method_prepares_prompt_and_method_id(tmp_path) 
     assert "Use concise review guidance." in call["user_input"]
     assert call["user_input"].endswith("User request:\n\ncheck src/app.py")
     assert call["output_mode"] == "text"
+
+
+def test_run_cli_mode_print_with_fixed_method_executes_each_step(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    _write_fixed_review_method(tmp_path)
+    runtime = FakeRuntime(FakeSession("session-1"))
+    print_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--method", "review", "--mode", "print", "check src/app.py"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            print_runner=print_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert len(print_runner.calls) == 2
+    first_call = print_runner.calls[0]
+    second_call = print_runner.calls[1]
+    assert first_call["method_id"] == "method:task:review"
+    assert first_call["plan_id"] == "plan:method:task:review"
+    assert first_call["step_id"] == "inspect"
+    assert first_call["step_index"] == 0
+    assert first_call["step_title"] == "Inspect current changes"
+    assert "Read changed files and summarize intent." in first_call["user_input"]
+    assert first_call["user_input"].endswith("User request:\n\ncheck src/app.py")
+    assert first_call["output_mode"] == "text"
+    assert second_call["method_id"] == "method:task:review"
+    assert second_call["plan_id"] == "plan:method:task:review"
+    assert second_call["step_id"] == "verify"
+    assert second_call["step_index"] == 1
+    assert second_call["step_title"] == "Run focused checks"
+    assert "Run focused tests or explain why they cannot run." in second_call["user_input"]
+    assert second_call["user_input"].endswith("User request:\n\ncheck src/app.py")
+    assert second_call["output_mode"] == "text"
 
 
 def test_run_cli_mode_print_uses_method_default_from_settings(tmp_path) -> None:
@@ -3611,6 +3720,47 @@ def test_run_cli_default_path_with_method_prepares_prompt_and_method_id(tmp_path
     assert call["method_id"] == "method:task:review"
     assert "Use concise review guidance." in call["user_input"]
     assert call["user_input"].endswith("User request:\n\ncheck src/app.py")
+
+
+def test_run_cli_default_path_with_fixed_method_executes_each_step(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    _write_fixed_review_method(tmp_path)
+    runtime = FakeRuntime(FakeSession("session-1"))
+    mode_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--mode", "json", "--method", "review", "check src/app.py"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+            mode_runner=mode_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert len(mode_runner.calls) == 2
+    first_call = mode_runner.calls[0]
+    second_call = mode_runner.calls[1]
+    assert first_call["config"].mode == "json"
+    assert first_call["method_id"] == "method:task:review"
+    assert first_call["plan_id"] == "plan:method:task:review"
+    assert first_call["step_id"] == "inspect"
+    assert first_call["step_index"] == 0
+    assert "Read changed files and summarize intent." in first_call["user_input"]
+    assert first_call["user_input"].endswith("User request:\n\ncheck src/app.py")
+    assert second_call["config"].mode == "json"
+    assert second_call["method_id"] == "method:task:review"
+    assert second_call["plan_id"] == "plan:method:task:review"
+    assert second_call["step_id"] == "verify"
+    assert second_call["step_index"] == 1
+    assert "Run focused tests or explain why they cannot run." in second_call["user_input"]
+    assert second_call["user_input"].endswith("User request:\n\ncheck src/app.py")
 
 
 def test_run_cli_default_path_passes_work_log_backend_to_unified_mode_runner(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add CodingDomainApp.prepare_turns() to expand fixed MethodPlan steps into prepared coding turns
- execute prepared turns sequentially for -p, --mode print, and unified text/json headless paths
- thread plan_id and step metadata through prompt/print/mode runners into CodingWorkShell work events

## Scope
- P3.3 fixed MethodPlan execution only
- no automatic method selection, graph scheduler, TUI/RPC support, or multi-agent behavior

## Verification
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/domain src/loushang/coding/cli/__main__.py src/loushang/coding/prompt_command.py src/loushang/coding/mode tests/coding/domain/test_coding_domain_app.py tests/coding/test_cli.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/method tests/work tests/coding/domain/test_coding_domain_app.py tests/coding/test_cli.py -q
- uv --cache-dir .uv-cache run --extra dev pytest -q

Closes #50