### PR TITLE
docs: update public docs quick start and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ For local development in this repository, use the project virtual environment in
 - [AI SDK](./docs/en/sdk/)
 - [Examples](./docs/en/examples/)
 - [Reference](./docs/en/reference/)
-- [Internal Architecture And Design Notes](./docs/internals/)
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -29,15 +29,17 @@ Loushang is in early development. The recommended path is to run it from source.
 git clone https://github.com/<owner>/loushang.git
 cd loushang
 
-python -m venv .venv
+uv venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 
 loushang --help
 loushang --list-models
 loushang --list-commands
 loushang -p "Inspect this repository and summarize what it does."
 ```
+
+You can also run `make bootstrap`, which creates `.venv/` with `uv` and installs the project in editable development mode. The Makefile does not currently provide a `make install` target; use `make bootstrap` for local development or `make install-binary` for a local binary install.
 
 For local development in this repository, use the project virtual environment in `.venv/`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,6 @@ loushang -p "Inspect this repository and summarize what it does."
 - [AI SDK](./docs/zh-CN/sdk/)
 - [示例](./docs/zh-CN/examples/)
 - [参考手册](./docs/zh-CN/reference/)
-- [内部架构与设计笔记](./docs/internals/)
 
 ## 示例
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,15 +29,17 @@ Loushang 目前处于早期开发阶段。推荐从源码运行。
 git clone https://github.com/<owner>/loushang.git
 cd loushang
 
-python -m venv .venv
+uv venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 
 loushang --help
 loushang --list-models
 loushang --list-commands
 loushang -p "Inspect this repository and summarize what it does."
 ```
+
+也可以运行 `make bootstrap`；它会用 `uv` 创建 `.venv/` 并以 editable development mode 安装项目。当前 Makefile 没有 `make install` 目标；本地开发使用 `make bootstrap`，本地二进制安装使用 `make install-binary`。
 
 在本仓库做本地开发时，请使用项目虚拟环境 `.venv/`。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,5 +6,3 @@ Choose a documentation language:
 
 - [English documentation](./en/)
 - [中文文档](./zh-CN/)
-
-Internal architecture notes, design records, glossary drafts, implementation specs, and historical plans are kept under [Internals](./internals/).

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -14,7 +14,3 @@ Loushang is a method-native AI work system. This documentation focuses on what c
 - [Reference](./reference/) - look up CLI flags, configuration, environment variables, model catalog shape, slash commands, and session files.
 - [Roadmap](./roadmap.md) - understand current focus and future product surfaces.
 - [Contributing](./contributing.md) - understand contribution expectations for this early project.
-
-## Internal Notes
-
-Design and implementation history lives in [Internal Architecture And Design Notes](../internals/). Those documents are useful for contributors, but they are not the recommended first path for users trying Loushang.

--- a/docs/en/contributing.md
+++ b/docs/en/contributing.md
@@ -7,10 +7,12 @@ Loushang is in active early development. Contributions should keep the current p
 ## Local Development
 
 ```bash
-python -m venv .venv
+uv venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 ```
+
+The equivalent shortcut is `make bootstrap`.
 
 For Python work in this repository, use the local virtual environment in `.venv/`.
 

--- a/docs/en/getting-started/README.md
+++ b/docs/en/getting-started/README.md
@@ -16,10 +16,19 @@ This guide gets you from a fresh clone to a first `loushang code` run.
 git clone https://github.com/<owner>/loushang.git
 cd loushang
 
-python -m venv .venv
+uv venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 ```
+
+Equivalent Makefile shortcut:
+
+```bash
+make bootstrap
+source .venv/bin/activate
+```
+
+`make bootstrap` creates `.venv/` with `uv` and installs the project in editable development mode. There is no `make install` target today; `make install-binary` is reserved for building and installing a local binary.
 
 ## Check The CLI
 

--- a/docs/en/reference/README.md
+++ b/docs/en/reference/README.md
@@ -38,7 +38,3 @@ Built-in interactive commands include:
 /session /terminal /changelog /hotkeys /fork /clone /tree
 /login /logout /new /compact /resume /reload /quit
 ```
-
-## Internal Reference Material
-
-Detailed architecture, data object drafts, component interfaces, and design decisions live under [Internal Architecture And Design Notes](../../internals/).

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -14,7 +14,3 @@ Loushang 是一个把复杂工作变成可运行流程的智能工作系统。�
 - [参考手册](./reference/)：查询 CLI flags、配置、环境变量、模型 catalog、slash commands 和 session 文件。
 - [路线图](./roadmap.md)：了解当前重点和后续产品面。
 - [贡献指南](./contributing.md)：了解这个早期项目的贡献约定。
-
-## 内部笔记
-
-设计与实现历史保存在 [内部架构与设计笔记](../internals/) 中。这些文档对贡献者有价值，但不是新用户试用 Loushang 的推荐第一路径。

--- a/docs/zh-CN/contributing.md
+++ b/docs/zh-CN/contributing.md
@@ -7,10 +7,12 @@ Loushang 目前处于早期活跃开发阶段。贡献应保持当前公开产�
 ## 本地开发
 
 ```bash
-python -m venv .venv
+uv venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 ```
+
+等价的便捷命令是 `make bootstrap`。
 
 在本仓库做 Python 工作时，请使用本地虚拟环境 `.venv/`。
 

--- a/docs/zh-CN/getting-started/README.md
+++ b/docs/zh-CN/getting-started/README.md
@@ -16,10 +16,19 @@
 git clone https://github.com/<owner>/loushang.git
 cd loushang
 
-python -m venv .venv
+uv venv .venv
 source .venv/bin/activate
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 ```
+
+等价的 Makefile 便捷命令：
+
+```bash
+make bootstrap
+source .venv/bin/activate
+```
+
+`make bootstrap` 会用 `uv` 创建 `.venv/` 并以 editable development mode 安装项目。当前没有 `make install` 目标；`make install-binary` 用于构建并安装本地二进制。
 
 ## 检查 CLI
 

--- a/docs/zh-CN/reference/README.md
+++ b/docs/zh-CN/reference/README.md
@@ -38,7 +38,3 @@ loushang --export session.jsonl --export-format jsonl
 /session /terminal /changelog /hotkeys /fork /clone /tree
 /login /logout /new /compact /resume /reload /quit
 ```
-
-## 内部参考材料
-
-详细架构、数据对象草案、组件接口和设计决策保存在[内部架构与设计笔记](../../internals/)中。


### PR DESCRIPTION
## Summary
- Prefer uv in the English and Chinese quick start / contributing setup commands.
- Document make bootstrap as the local development shortcut and clarify that there is no make install target today.
- Remove docs/internals links from public README and public docs navigation.

## Verification
- git diff --check
- Checked 24 markdown files; all relative links resolve.