### PR TITLE
feat: show compiled method plans

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -65,7 +65,7 @@ from loushang.coding.workflow import (
     resolve_workflow_files,
     run_prompt_steps_workflow,
 )
-from loushang.method import MethodLoader
+from loushang.method import MethodCompiler, MethodContext, MethodLoader
 from loushang.work import JsonlEventLogBackend
 
 _MISSING = object()
@@ -665,6 +665,7 @@ def _stdout_guard_enabled(args: CliArgs) -> bool:
         or (args.list_skills and args.list_skills_format == "json")
         or (args.list_methods and args.list_methods_format == "json")
         or (args.show_method is not None and args.show_method_format == "json")
+        or (args.show_method_plan is not None and args.show_method_plan_format == "json")
         or (args.list_plugins and args.list_plugins_format == "json")
         or (args.list_packages and args.list_packages_format == "json")
         or (args.export is not None and args.export_result_format == "json")
@@ -896,6 +897,7 @@ def _has_command_style_operation(args: CliArgs) -> bool:
         or args.list_skills
         or args.list_methods
         or args.show_method is not None
+        or args.show_method_plan is not None
         or args.list_plugins
         or args.list_packages
         or args.export is not None
@@ -973,6 +975,7 @@ def _runtime_args_for_bootstrap(args: CliArgs) -> CliArgs:
         or args.list_skills
         or args.list_methods
         or args.show_method is not None
+        or args.show_method_plan is not None
         or args.list_plugins
         or args.list_packages
         or args.list_models is not False
@@ -1893,7 +1896,7 @@ def _run_method_visibility(
     stdout: TextIO,
     stderr: TextIO,
 ) -> int | None:
-    if not args.list_methods and args.show_method is None:
+    if not args.list_methods and args.show_method is None and args.show_method_plan is None:
         return None
 
     try:
@@ -1912,6 +1915,23 @@ def _run_method_visibility(
                 f"{method['id']}\t{method['name']}\t{method['kind']}\t"
                 f"{method['element_type']}\t{method['path']}\n"
             )
+        return 0
+
+    if args.show_method_plan is not None:
+        method = _find_method(methods, args.show_method_plan)
+        if method is None:
+            stderr.write(f"Error: method not found: {args.show_method_plan}\n")
+            return 1
+        try:
+            plan = MethodCompiler().compile(method, context=MethodContext(domain="coding"))
+        except Exception as error:
+            stderr.write(f"Error: {_format_cli_error(error)}\n")
+            return 1
+        payload = _normalize_method_plan(method, plan)
+        if args.show_method_plan_format == "json":
+            stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+            return 0
+        stdout.write(_format_method_plan_detail(payload))
         return 0
 
     method = _find_method(methods, args.show_method or "")
@@ -1965,6 +1985,44 @@ def _normalize_method_applicability(applicability: Any) -> dict[str, object]:
     }
 
 
+def _normalize_method_plan(method: Any, plan: Any) -> dict[str, object]:
+    return {
+        "method": _normalize_method_entry(method),
+        "plan": {
+            "id": _safe_getattr(plan, "id", "") or "",
+            "method_id": _safe_getattr(plan, "method_id", "") or "",
+            "mode": _safe_getattr(plan, "mode", "") or "",
+            "phase": _safe_getattr(plan, "phase", None),
+            "activity": _safe_getattr(plan, "activity", None),
+            "task": _safe_getattr(plan, "task", None),
+            "metadata": _json_safe(_safe_getattr(plan, "metadata", {})),
+            "applicability": _normalize_method_applicability(_safe_getattr(plan, "applicability", None)),
+        },
+        "steps": [_normalize_method_plan_step(step) for step in _safe_getattr(plan, "steps", ())],
+    }
+
+
+def _normalize_method_plan_step(step: Any) -> dict[str, object]:
+    return {
+        "id": _safe_getattr(step, "id", "") or "",
+        "title": _safe_getattr(step, "title", "") or "",
+        "executor": _safe_getattr(step, "executor", "") or "",
+        "role_variant": _safe_getattr(step, "role_variant", None),
+        "projection": _json_safe(_safe_getattr(step, "projection", {})),
+        "applicability": _normalize_method_applicability(_safe_getattr(step, "applicability", None)),
+    }
+
+
+def _json_safe(value: Any) -> object:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
 def _normalize_method_tags(tags: Any) -> dict[str, list[str]]:
     if not isinstance(tags, Mapping):
         return {}
@@ -2008,6 +2066,46 @@ def _format_method_detail(method: Mapping[str, object]) -> str:
     if not lines[-1].endswith("\n"):
         lines[-1] = f"{lines[-1]}\n"
     return "\n".join(lines)
+
+
+def _format_method_plan_detail(payload: Mapping[str, object]) -> str:
+    method = payload.get("method")
+    plan = payload.get("plan")
+    steps = payload.get("steps")
+    method_mapping = method if isinstance(method, Mapping) else {}
+    plan_mapping = plan if isinstance(plan, Mapping) else {}
+    lines = [
+        f"method_id: {method_mapping.get('id', '')}",
+        f"method_name: {method_mapping.get('name', '')}",
+        f"plan_id: {plan_mapping.get('id', '')}",
+        f"mode: {plan_mapping.get('mode', '')}",
+        "steps:",
+    ]
+    if isinstance(steps, list):
+        for index, raw_step in enumerate(steps, start=1):
+            if not isinstance(raw_step, Mapping):
+                continue
+            step_id = raw_step.get("id", "")
+            title = raw_step.get("title", "")
+            lines.append(f"  {index}. {step_id} - {title}")
+            guidance = _method_plan_step_guidance(raw_step)
+            if guidance:
+                lines.append(f"     guidance: {guidance}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _method_plan_step_guidance(step: Mapping[str, object]) -> str:
+    projection = step.get("projection")
+    if not isinstance(projection, Mapping):
+        return ""
+    step_guidance = projection.get("step_guidance")
+    if isinstance(step_guidance, str):
+        return step_guidance.strip()
+    content = projection.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    return ""
 
 
 def _format_method_applicability_lines(applicability: object) -> list[str]:

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -14,6 +14,7 @@ SessionListFormat = Literal["tsv", "json"]
 SkillListFormat = Literal["tsv", "json"]
 MethodListFormat = Literal["tsv", "json"]
 MethodShowFormat = Literal["text", "json"]
+MethodPlanShowFormat = Literal["text", "json"]
 PluginListFormat = Literal["tsv", "json"]
 PackageListFormat = Literal["text", "tsv", "json"]
 ExportFormat = Literal["html", "jsonl"]
@@ -96,6 +97,8 @@ _BUILTIN_FLAG_NAMES = frozenset(
         "list-methods-format",
         "show-method",
         "show-method-format",
+        "show-method-plan",
+        "show-method-plan-format",
         "enable-skill",
         "disable-skill",
         "list-plugins",
@@ -178,6 +181,8 @@ class CliArgs:
     list_methods_format: MethodListFormat
     show_method: str | None
     show_method_format: MethodShowFormat
+    show_method_plan: str | None
+    show_method_plan_format: MethodPlanShowFormat
     enable_skills: tuple[str, ...]
     disable_skills: tuple[str, ...]
     list_plugins: bool
@@ -336,6 +341,8 @@ def parse_args(
         list_methods_format=namespace.list_methods_format,
         show_method=namespace.show_method,
         show_method_format=namespace.show_method_format,
+        show_method_plan=namespace.show_method_plan,
+        show_method_plan_format=namespace.show_method_plan_format,
         enable_skills=tuple(namespace.enable_skill),
         disable_skills=tuple(namespace.disable_skill),
         list_plugins=namespace.list_plugins,
@@ -507,6 +514,8 @@ def _build_parser() -> ArgumentParser:
     parser.add_argument("--list-methods-format", choices=("tsv", "json"), default="tsv")
     parser.add_argument("--show-method")
     parser.add_argument("--show-method-format", choices=("text", "json"), default="text")
+    parser.add_argument("--show-method-plan")
+    parser.add_argument("--show-method-plan-format", choices=("text", "json"), default="text")
     parser.add_argument("--enable-skill", action="append", default=[])
     parser.add_argument("--disable-skill", action="append", default=[])
     parser.add_argument("--list-plugins", action="store_true")
@@ -612,7 +621,25 @@ def _rewrite_method_subcommands(argv: list[str]) -> list[str]:
         return [*prefix, "--list-methods", *suffix]
     if command == "show" and suffix:
         return [*prefix, "--show-method", suffix[0], *suffix[1:]]
+    if command == "plan" and len(suffix) >= 2 and suffix[0] == "show":
+        return [*prefix, "--show-method-plan", suffix[1], *_rewrite_method_plan_show_options(suffix[2:])]
     return argv
+
+
+def _rewrite_method_plan_show_options(argv: list[str]) -> list[str]:
+    rewritten: list[str] = []
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if token == "--format":
+            rewritten.append("--show-method-plan-format")
+            if index + 1 < len(argv):
+                rewritten.append(argv[index + 1])
+                index += 2
+                continue
+        rewritten.append(token)
+        index += 1
+    return rewritten
 
 
 def _method_subcommand_index(argv: list[str]) -> int | None:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -449,6 +449,11 @@ def test_parse_args_accepts_method_visibility_flags_and_subcommands() -> None:
     assert show_args.show_method == "method:task:review"
     assert show_args.show_method_format == "json"
 
+    plan_show_args = parse_args(["method", "plan", "show", "review", "--format", "json"])
+
+    assert plan_show_args.show_method_plan == "review"
+    assert plan_show_args.show_method_plan_format == "json"
+
     list_args = parse_args(["method", "list"])
 
     assert list_args.list_methods is True
@@ -5395,6 +5400,134 @@ def test_run_cli_shows_method_as_text(tmp_path) -> None:
     assert "  risk: medium" in output
     assert "  tags.method_family: debug-first" in output
     assert "Debug failures carefully." in output
+    assert stderr.getvalue() == ""
+
+
+def test_run_cli_shows_fixed_method_plan_as_json(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    method_dir = tmp_path / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "domains: [coding, research]\n"
+        "task_types: [reviewing]\n"
+        "meta_role: VALIDATOR\n"
+        "phase: VERIFY\n"
+        "plan_mode: fixed\n"
+        "steps:\n"
+        "  - inspect\n"
+        "  - verify\n"
+        "step_titles:\n"
+        "  inspect: Inspect current changes\n"
+        "  verify: Run focused checks\n"
+        "step_guidance:\n"
+        "  inspect: Read changed files and summarize intent.\n"
+        "  verify: Run focused tests or explain why they cannot run.\n"
+        "---\n\n"
+        "Use concise review guidance.",
+        encoding="utf-8",
+    )
+    session = FakeSession("session-1")
+    runtime = FakeRuntime(session)
+    stdout = StringIO()
+    stderr = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+                ["method", "plan", "show", "review", "--format", "json"],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["method"]["id"] == "method:task:review"
+    assert payload["method"]["name"] == "review"
+    assert payload["method"]["applicability"]["domains"] == ["coding", "research"]
+    assert payload["plan"]["id"] == "plan:method:task:review"
+    assert payload["plan"]["method_id"] == "method:task:review"
+    assert payload["plan"]["mode"] == "fixed"
+    assert payload["plan"]["metadata"]["step_count"] == 2
+    assert [step["id"] for step in payload["steps"]] == ["inspect", "verify"]
+    assert [step["title"] for step in payload["steps"]] == ["Inspect current changes", "Run focused checks"]
+    first_projection = payload["steps"][0]["projection"]
+    second_projection = payload["steps"][1]["projection"]
+    assert first_projection["step_guidance"] == "Read changed files and summarize intent."
+    assert first_projection["step_index"] == 0
+    assert first_projection["step_count"] == 2
+    assert first_projection["meta_role"] == "VALIDATOR"
+    assert "Step inspect - Inspect current changes" in first_projection["content"]
+    assert second_projection["step_guidance"] == "Run focused tests or explain why they cannot run."
+    assert second_projection["step_index"] == 1
+    assert second_projection["step_count"] == 2
+    assert "Step verify - Run focused checks" in second_projection["content"]
+    assert payload["steps"][0]["applicability"]["domains"] == ["coding", "research"]
+    assert payload["steps"][0]["applicability"]["task_types"] == ["reviewing"]
+    assert stderr.getvalue() == ""
+
+
+def test_run_cli_shows_fixed_method_plan_as_text(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    method_dir = tmp_path / "methods" / "task" / "review"
+    method_dir.mkdir(parents=True)
+    (method_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: review\n"
+        "description: Review changes.\n"
+        "type: task\n"
+        "plan_mode: fixed\n"
+        "steps:\n"
+        "  - inspect\n"
+        "  - verify\n"
+        "step_titles:\n"
+        "  inspect: Inspect current changes\n"
+        "  verify: Run focused checks\n"
+        "step_guidance:\n"
+        "  inspect: Read changed files and summarize intent.\n"
+        "  verify: Run focused tests or explain why they cannot run.\n"
+        "---\n\n"
+        "Use concise review guidance.",
+        encoding="utf-8",
+    )
+    session = FakeSession("session-1")
+    runtime = FakeRuntime(session)
+    stdout = StringIO()
+    stderr = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["method", "plan", "show", "review"],
+            stdin=StringIO(""),
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: runtime,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    output = stdout.getvalue()
+    assert "method_id: method:task:review" in output
+    assert "plan_id: plan:method:task:review" in output
+    assert "mode: fixed" in output
+    assert "steps:" in output
+    assert "  1. inspect - Inspect current changes" in output
+    assert "     guidance: Read changed files and summarize intent." in output
+    assert "  2. verify - Run focused checks" in output
+    assert "     guidance: Run focused tests or explain why they cannot run." in output
     assert stderr.getvalue() == ""
 
 


### PR DESCRIPTION
## Summary
- Add method plan preview flags and the `method plan show <method>` subcommand.
- Compile selected methods into MethodPlan previews without executing any step.
- Support text and JSON output, including plan metadata, step order, step guidance, projection, and applicability.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/method -q
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/cli/args.py src/loushang/coding/cli/__main__.py tests/coding/test_cli.py
- git diff --check