### PR TITLE
feat: tighten fixed plan work boundaries

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -497,6 +497,8 @@ async def run_cli(
                         step_id=prepared_turn.step_id,
                         step_index=prepared_turn.step_index,
                         step_title=prepared_turn.step_title,
+                        emit_plan_start=is_first_turn,
+                        emit_plan_completion=is_last_turn,
                         dispose=is_last_turn,
                     )
                     if exit_code != 0:
@@ -526,6 +528,8 @@ async def run_cli(
                         step_id=prepared_turn.step_id,
                         step_index=prepared_turn.step_index,
                         step_title=prepared_turn.step_title,
+                        emit_plan_start=is_first_turn,
+                        emit_plan_completion=is_last_turn,
                         dispose=is_last_turn,
                     )
                     if exit_code != 0:
@@ -556,6 +560,8 @@ async def run_cli(
                     step_id=prepared_turn.step_id,
                     step_index=prepared_turn.step_index,
                     step_title=prepared_turn.step_title,
+                    emit_plan_start=is_first_turn,
+                    emit_plan_completion=is_last_turn,
                     dispose=is_last_turn,
                 )
                 if exit_code != 0:

--- a/src/loushang/coding/mode/base.py
+++ b/src/loushang/coding/mode/base.py
@@ -136,6 +136,8 @@ def create_mode_adapter(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    emit_plan_start: bool = True,
+    emit_plan_completion: bool = True,
 ) -> ModeAdapter:
     """Create the concrete adapter for a configured coding mode."""
 
@@ -172,6 +174,8 @@ def create_mode_adapter(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        emit_plan_start=emit_plan_start,
+        emit_plan_completion=emit_plan_completion,
     )
 
 
@@ -192,6 +196,8 @@ async def run_mode(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    emit_plan_start: bool = True,
+    emit_plan_completion: bool = True,
     dispose: bool = True,
 ) -> int:
     adapter = create_mode_adapter(
@@ -207,6 +213,8 @@ async def run_mode(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        emit_plan_start=emit_plan_start,
+        emit_plan_completion=emit_plan_completion,
     )
     if config.mode == "rpc":
         return await adapter.start(user_input)

--- a/src/loushang/coding/mode/print_mode.py
+++ b/src/loushang/coding/mode/print_mode.py
@@ -36,6 +36,8 @@ class PrintMode(ModeAdapter):
         step_id: str | None = None,
         step_index: int | None = None,
         step_title: str | None = None,
+        emit_plan_start: bool = True,
+        emit_plan_completion: bool = True,
     ) -> None:
         if output_mode not in {"text", "json"}:
             raise ValueError(f"unsupported output mode: {output_mode}")
@@ -67,6 +69,8 @@ class PrintMode(ModeAdapter):
         self.step_id = step_id
         self.step_index = step_index
         self.step_title = step_title
+        self.emit_plan_start = emit_plan_start
+        self.emit_plan_completion = emit_plan_completion
         self._tool_render_runtime: ToolRenderRuntime | None = None
         self._tool_definition_resolver: ToolDefinitionResolver | None = None
         self._disposed = False
@@ -144,10 +148,19 @@ class PrintMode(ModeAdapter):
                 header = self.session.session_manager.get_header()
                 self._write_json_line(serialize_session_header(header))
             unsubscribe = self.session.subscribe(self._handle_event)
-            await self._prompt_session(user_input, images=images)
+            await self._prompt_session(
+                user_input,
+                images=images,
+                emit_plan_start=self.emit_plan_start,
+                emit_plan_completion=self.emit_plan_completion and not follow_up_messages,
+            )
             await self.session.wait_for_idle()
-            for message in follow_up_messages:
-                await self._prompt_session(message)
+            for follow_up_index, message in enumerate(follow_up_messages):
+                await self._prompt_session(
+                    message,
+                    emit_plan_start=False,
+                    emit_plan_completion=self.emit_plan_completion and follow_up_index == len(follow_up_messages) - 1,
+                )
                 await self.session.wait_for_idle()
             assistant_failure = _last_assistant_failure_message(self.session)
             if assistant_failure is not None:
@@ -254,7 +267,14 @@ class PrintMode(ModeAdapter):
         except TypeError:
             return repr(args)
 
-    async def _prompt_session(self, user_input: str, *, images: list[object] | None = None) -> None:
+    async def _prompt_session(
+        self,
+        user_input: str,
+        *,
+        images: list[object] | None = None,
+        emit_plan_start: bool = True,
+        emit_plan_completion: bool = True,
+    ) -> None:
         if self.work_event_log is None:
             await _prompt_session(self.session, user_input, images=images)
             return
@@ -268,6 +288,8 @@ class PrintMode(ModeAdapter):
             step_id=self.step_id,
             step_index=self.step_index,
             step_title=self.step_title,
+            emit_plan_start=emit_plan_start,
+            emit_plan_completion=emit_plan_completion,
         )
 
 
@@ -440,6 +462,8 @@ async def run_print_mode(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    emit_plan_start: bool = True,
+    emit_plan_completion: bool = True,
     dispose: bool = True,
 ) -> int:
     mode = PrintMode(
@@ -457,6 +481,8 @@ async def run_print_mode(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        emit_plan_start=emit_plan_start,
+        emit_plan_completion=emit_plan_completion,
     )
     return await mode.run_once(
         user_input,

--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -27,6 +27,8 @@ async def run_prompt_command(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    emit_plan_start: bool = True,
+    emit_plan_completion: bool = True,
     dispose: bool = True,
 ) -> int:
     """Run one product prompt and render the stable coding transcript."""
@@ -53,9 +55,11 @@ async def run_prompt_command(
             step_id=step_id,
             step_index=step_index,
             step_title=step_title,
+            emit_plan_start=emit_plan_start,
+            emit_plan_completion=emit_plan_completion and not follow_up_messages,
         )
         if exit_code == 0:
-            for message in follow_up_messages:
+            for follow_up_index, message in enumerate(follow_up_messages):
                 exit_code = await _run_turn(
                     session,
                     renderer,
@@ -67,6 +71,8 @@ async def run_prompt_command(
                     step_id=step_id,
                     step_index=step_index,
                     step_title=step_title,
+                    emit_plan_start=False,
+                    emit_plan_completion=emit_plan_completion and follow_up_index == len(follow_up_messages) - 1,
                 )
                 if exit_code != 0:
                     break
@@ -101,6 +107,8 @@ async def _run_turn(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    emit_plan_start: bool = True,
+    emit_plan_completion: bool = True,
 ) -> int:
     started_at = time.monotonic()
     previous_error = event_renderer.last_error_message
@@ -115,6 +123,8 @@ async def _run_turn(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        emit_plan_start=emit_plan_start,
+        emit_plan_completion=emit_plan_completion,
     )
     await session.wait_for_idle()
     assistant_failure = _last_assistant_failure_message(session)
@@ -137,6 +147,8 @@ async def _run_prompt_session(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    emit_plan_start: bool = True,
+    emit_plan_completion: bool = True,
 ) -> None:
     if work_event_log is None:
         await _prompt_session(session, user_input, images=images)
@@ -151,6 +163,8 @@ async def _run_prompt_session(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        emit_plan_start=emit_plan_start,
+        emit_plan_completion=emit_plan_completion,
     )
 
 

--- a/src/loushang/work/coding.py
+++ b/src/loushang/work/coding.py
@@ -41,6 +41,9 @@ class CodingWorkShell:
         step_title: str | None = None,
         operation_id: str | None = None,
         run_id: str | None = None,
+        emit_plan_start: bool = True,
+        emit_plan_completion: bool = True,
+        emit_plan_failure: bool = True,
     ) -> WorkRun:
         operation_id = operation_id or f"op-{uuid4().hex}"
         run_id = run_id or f"run-{uuid4().hex}"
@@ -82,7 +85,7 @@ class CodingWorkShell:
                 payload={"source_type": "work_shell"},
             ),
         )
-        if plan_id is not None:
+        if plan_id is not None and emit_plan_start:
             sequence += 1
             self._append_event(
                 _work_event(
@@ -163,7 +166,7 @@ class CodingWorkShell:
                     ),
                 )
                 sequence += 1
-            if plan_id is not None:
+            if plan_id is not None and emit_plan_failure:
                 self._append_event(
                     _work_event(
                         kind="WorkPlanFailed",
@@ -214,7 +217,7 @@ class CodingWorkShell:
                 ),
             )
             sequence += 1
-        if plan_id is not None:
+        if plan_id is not None and emit_plan_completion:
             self._append_event(
                 _work_event(
                     kind="WorkPlanCompleted",

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -2398,6 +2398,8 @@ def test_run_cli_dash_p_with_fixed_method_executes_each_step(tmp_path) -> None:
     assert first_call["step_id"] == "inspect"
     assert first_call["step_index"] == 0
     assert first_call["step_title"] == "Inspect current changes"
+    assert first_call["emit_plan_start"] is True
+    assert first_call["emit_plan_completion"] is False
     assert "Read changed files and summarize intent." in first_call["prompt"]
     assert first_call["prompt"].endswith("User request:\n\ncheck src/app.py")
     assert second_call["method_id"] == "method:task:review"
@@ -2405,6 +2407,8 @@ def test_run_cli_dash_p_with_fixed_method_executes_each_step(tmp_path) -> None:
     assert second_call["step_id"] == "verify"
     assert second_call["step_index"] == 1
     assert second_call["step_title"] == "Run focused checks"
+    assert second_call["emit_plan_start"] is False
+    assert second_call["emit_plan_completion"] is True
     assert "Run focused tests or explain why they cannot run." in second_call["prompt"]
     assert second_call["prompt"].endswith("User request:\n\ncheck src/app.py")
 
@@ -2998,6 +3002,8 @@ def test_run_cli_mode_print_with_fixed_method_executes_each_step(tmp_path) -> No
     assert first_call["step_id"] == "inspect"
     assert first_call["step_index"] == 0
     assert first_call["step_title"] == "Inspect current changes"
+    assert first_call["emit_plan_start"] is True
+    assert first_call["emit_plan_completion"] is False
     assert "Read changed files and summarize intent." in first_call["user_input"]
     assert first_call["user_input"].endswith("User request:\n\ncheck src/app.py")
     assert first_call["output_mode"] == "text"
@@ -3006,6 +3012,8 @@ def test_run_cli_mode_print_with_fixed_method_executes_each_step(tmp_path) -> No
     assert second_call["step_id"] == "verify"
     assert second_call["step_index"] == 1
     assert second_call["step_title"] == "Run focused checks"
+    assert second_call["emit_plan_start"] is False
+    assert second_call["emit_plan_completion"] is True
     assert "Run focused tests or explain why they cannot run." in second_call["user_input"]
     assert second_call["user_input"].endswith("User request:\n\ncheck src/app.py")
     assert second_call["output_mode"] == "text"
@@ -3757,6 +3765,8 @@ def test_run_cli_default_path_with_fixed_method_executes_each_step(tmp_path) -> 
     assert first_call["plan_id"] == "plan:method:task:review"
     assert first_call["step_id"] == "inspect"
     assert first_call["step_index"] == 0
+    assert first_call["emit_plan_start"] is True
+    assert first_call["emit_plan_completion"] is False
     assert "Read changed files and summarize intent." in first_call["user_input"]
     assert first_call["user_input"].endswith("User request:\n\ncheck src/app.py")
     assert second_call["config"].mode == "json"
@@ -3764,6 +3774,8 @@ def test_run_cli_default_path_with_fixed_method_executes_each_step(tmp_path) -> 
     assert second_call["plan_id"] == "plan:method:task:review"
     assert second_call["step_id"] == "verify"
     assert second_call["step_index"] == 1
+    assert second_call["emit_plan_start"] is False
+    assert second_call["emit_plan_completion"] is True
     assert "Run focused tests or explain why they cannot run." in second_call["user_input"]
     assert second_call["user_input"].endswith("User request:\n\ncheck src/app.py")
 

--- a/tests/work/test_coding_work_shell.py
+++ b/tests/work/test_coding_work_shell.py
@@ -242,6 +242,89 @@ def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
     asyncio.run(scenario())
 
 
+def test_coding_work_shell_can_suppress_plan_boundaries_for_middle_step() -> None:
+    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        session = FakePromptSession(events=[])
+        shell = CodingWorkShell(
+            session=session,
+            event_log=event_log,
+            clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        )
+
+        run = await shell.submit_coding_turn(
+            "verify current changes",
+            session_id="session-1",
+            operation_id="op-1",
+            run_id="run-1",
+            method_id="method:task:review",
+            plan_id="plan:method:task:review",
+            step_id="verify",
+            step_index=1,
+            step_title="Run focused checks",
+            emit_plan_start=False,
+            emit_plan_completion=False,
+        )
+
+        assert run.status == "completed"
+        entries = event_log.query(run_id="run-1")
+        assert [entry.payload["kind"] for entry in entries] == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "WorkStepStarted",
+            "WorkStepCompleted",
+            "WorkRunCompleted",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_coding_work_shell_records_plan_failure_even_when_plan_boundaries_are_suppressed() -> None:
+    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        session = FakePromptSession(events=[], error=RuntimeError("middle step failed"))
+        shell = CodingWorkShell(
+            session=session,
+            event_log=event_log,
+            clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        )
+
+        try:
+            await shell.submit_coding_turn(
+                "verify current changes",
+                session_id="session-1",
+                operation_id="op-1",
+                run_id="run-1",
+                method_id="method:task:review",
+                plan_id="plan:method:task:review",
+                step_id="verify",
+                step_index=1,
+                step_title="Run focused checks",
+                emit_plan_start=False,
+                emit_plan_completion=False,
+            )
+        except RuntimeError as error:
+            assert str(error) == "middle step failed"
+        else:
+            raise AssertionError("expected prompt failure")
+
+        entries = event_log.query(run_id="run-1")
+        assert [entry.payload["kind"] for entry in entries] == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "WorkStepStarted",
+            "WorkStepFailed",
+            "WorkPlanFailed",
+            "WorkRunFailed",
+        ]
+
+    asyncio.run(scenario())
+
+
 def test_coding_work_shell_records_step_and_plan_failures_before_run_failure() -> None:
     from loushang.work import CodingWorkShell, InMemoryEventLogBackend
 


### PR DESCRIPTION
## Summary
- Add explicit plan-boundary controls to CodingWorkShell and mode/prompt runners.
- Emit WorkPlanStarted only for the first fixed-plan step and WorkPlanCompleted only for the final step.
- Keep WorkPlanFailed emitted when any fixed-plan step fails, even if normal plan boundaries are suppressed.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/domain tests/coding/test_cli.py tests/coding/test_prompt_command.py tests/coding/test_print_mode.py tests/method tests/work -q
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/work/coding.py src/loushang/coding/cli/__main__.py src/loushang/coding/prompt_command.py src/loushang/coding/mode/base.py src/loushang/coding/mode/print_mode.py tests/work/test_coding_work_shell.py tests/coding/test_cli.py
- git diff --check