### PR TITLE
Show plan step metadata in work log inspect

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -842,11 +842,41 @@ def _resolve_work_log_path(raw_path: str, project_root: Path) -> Path:
 
 
 def _write_work_log_text(entries: list[Any], stdout: TextIO) -> None:
-    stdout.write("sequence\tkind\trun_id\tsession_id\tdelivery_hint\tmethod_id\n")
+    stdout.write(
+        "\t".join(
+            [
+                "sequence",
+                "kind",
+                "run_id",
+                "session_id",
+                "delivery_hint",
+                "method_id",
+                "plan_id",
+                "step_id",
+                "step_index",
+                "step_title",
+            ]
+        )
+        + "\n"
+    )
     for entry in entries:
+        step_index = _work_log_entry_step_index(entry)
         stdout.write(
-            f"{entry.sequence}\t{_work_log_entry_kind(entry)}\t{entry.run_id}\t"
-            f"{entry.session_id}\t{_work_log_entry_delivery_hint(entry)}\t{_work_log_entry_method_id(entry)}\n"
+            "\t".join(
+                [
+                    str(entry.sequence),
+                    _work_log_entry_kind(entry),
+                    entry.run_id,
+                    entry.session_id,
+                    _work_log_entry_delivery_hint(entry),
+                    _work_log_entry_method_id(entry),
+                    _work_log_entry_plan_id(entry),
+                    _work_log_entry_step_id(entry),
+                    "" if step_index is None else str(step_index),
+                    _work_log_entry_step_title(entry),
+                ]
+            )
+            + "\n"
         )
 
 
@@ -865,6 +895,18 @@ def _work_log_entry_summary(entry: Any) -> dict[str, object]:
     method_id = _work_log_entry_method_id(entry)
     if method_id:
         summary["method_id"] = method_id
+    plan_id = _work_log_entry_plan_id(entry)
+    if plan_id:
+        summary["plan_id"] = plan_id
+    step_id = _work_log_entry_step_id(entry)
+    if step_id:
+        summary["step_id"] = step_id
+    step_index = _work_log_entry_step_index(entry)
+    if step_index is not None:
+        summary["step_index"] = step_index
+    step_title = _work_log_entry_step_title(entry)
+    if step_title:
+        summary["step_title"] = step_title
     return summary
 
 
@@ -883,15 +925,43 @@ def _work_log_entry_delivery_hint(entry: Any) -> str:
 
 
 def _work_log_entry_method_id(entry: Any) -> str:
-    method_id = entry.payload.get("method_id")
-    if isinstance(method_id, str):
-        return method_id
+    return _work_log_entry_string_payload_value(entry, "method_id")
+
+
+def _work_log_entry_plan_id(entry: Any) -> str:
+    return _work_log_entry_string_payload_value(entry, "plan_id")
+
+
+def _work_log_entry_step_id(entry: Any) -> str:
+    return _work_log_entry_string_payload_value(entry, "step_id")
+
+
+def _work_log_entry_step_title(entry: Any) -> str:
+    return _work_log_entry_string_payload_value(entry, "step_title")
+
+
+def _work_log_entry_step_index(entry: Any) -> int | None:
+    step_index = _work_log_entry_payload_value(entry, "step_index")
+    if isinstance(step_index, int) and not isinstance(step_index, bool):
+        return step_index
+    return None
+
+
+def _work_log_entry_string_payload_value(entry: Any, key: str) -> str:
+    value = _work_log_entry_payload_value(entry, key)
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _work_log_entry_payload_value(entry: Any, key: str) -> object | None:
+    value = entry.payload.get(key)
+    if value is not None:
+        return value
     nested_payload = entry.payload.get("payload")
     if isinstance(nested_payload, dict):
-        nested_method_id = nested_payload.get("method_id")
-        if isinstance(nested_method_id, str):
-            return nested_method_id
-    return ""
+        return nested_payload.get(key)
+    return None
 
 
 def _has_command_style_operation(args: CliArgs) -> bool:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -218,6 +218,20 @@ class TtyStringIO(StringIO):
         return True
 
 
+_WORK_LOG_INSPECT_COLUMNS = [
+    "sequence",
+    "kind",
+    "run_id",
+    "session_id",
+    "delivery_hint",
+    "method_id",
+    "plan_id",
+    "step_id",
+    "step_index",
+    "step_title",
+]
+
+
 def _append_work_log_marker(event_log: object) -> Path:
     from loushang.work import EventLogEntry
 
@@ -248,14 +262,29 @@ def _append_work_log_inspect_entry(
     entry_type: str = "event",
     delivery_hint: str | None = None,
     method_id: str | None = None,
+    plan_id: str | None = None,
+    step_id: str | None = None,
+    step_index: int | None = None,
+    step_title: str | None = None,
 ) -> None:
     from loushang.work import EventLogEntry
 
     payload: dict[str, object] = {"kind": kind}
     if delivery_hint is not None:
         payload["delivery_hint"] = delivery_hint
+    nested_payload: dict[str, object] = {}
     if method_id is not None:
-        payload["payload"] = {"method_id": method_id}
+        nested_payload["method_id"] = method_id
+    if plan_id is not None:
+        nested_payload["plan_id"] = plan_id
+    if step_id is not None:
+        nested_payload["step_id"] = step_id
+    if step_index is not None:
+        nested_payload["step_index"] = step_index
+    if step_title is not None:
+        nested_payload["step_title"] = step_title
+    if nested_payload:
+        payload["payload"] = nested_payload
     event_log.append(
         EventLogEntry(
             entry_id=f"entry-{sequence}",
@@ -3847,10 +3876,10 @@ def test_run_cli_work_log_inspect_outputs_text_without_runtime(tmp_path) -> None
 
     asyncio.run(scenario())
 
-    assert stdout.getvalue().splitlines() == [
-        "sequence\tkind\trun_id\tsession_id\tdelivery_hint\tmethod_id",
-        "1\tSubmitCodingTurn\trun-1\tsession-1\t\t",
-        "2\tContentDelta\trun-1\tsession-1\tcoalesce\t",
+    assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
+        _WORK_LOG_INSPECT_COLUMNS,
+        ["1", "SubmitCodingTurn", "run-1", "session-1", "", "", "", "", "", ""],
+        ["2", "ContentDelta", "run-1", "session-1", "coalesce", "", "", "", "", ""],
     ]
     assert stderr.getvalue() == ""
 
@@ -3891,10 +3920,60 @@ def test_run_cli_work_log_inspect_text_includes_method_id(tmp_path) -> None:
 
     asyncio.run(scenario())
 
-    assert stdout.getvalue().splitlines() == [
-        "sequence\tkind\trun_id\tsession_id\tdelivery_hint\tmethod_id",
-        "1\tSubmitCodingTurn\trun-1\tsession-1\t\tmethod:task:review",
-        "2\tWorkRunStarted\trun-1\tsession-1\timmediate\tmethod:task:review",
+    assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
+        _WORK_LOG_INSPECT_COLUMNS,
+        ["1", "SubmitCodingTurn", "run-1", "session-1", "", "method:task:review", "", "", "", ""],
+        ["2", "WorkRunStarted", "run-1", "session-1", "immediate", "method:task:review", "", "", "", ""],
+    ]
+
+
+def test_run_cli_work_log_inspect_text_includes_plan_step_metadata(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=1,
+        kind="SubmitCodingTurn",
+        entry_type="operation",
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        step_id="inspect",
+        step_index=0,
+        step_title="Inspect current changes",
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path)],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
+        _WORK_LOG_INSPECT_COLUMNS,
+        [
+            "1",
+            "SubmitCodingTurn",
+            "run-1",
+            "session-1",
+            "",
+            "method:task:review",
+            "plan:method:task:review",
+            "inspect",
+            "0",
+            "Inspect current changes",
+        ],
     ]
 
 
@@ -3976,6 +4055,47 @@ def test_run_cli_work_log_inspect_json_includes_method_id_when_present(tmp_path)
     assert json.loads(stdout.getvalue())[0]["method_id"] == "method:task:review"
 
 
+def test_run_cli_work_log_inspect_json_includes_plan_step_metadata(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=3,
+        kind="WorkRunStarted",
+        delivery_hint="immediate",
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        step_id="inspect",
+        step_index=0,
+        step_title="Inspect current changes",
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "json"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    summary = json.loads(stdout.getvalue())[0]
+    assert summary["method_id"] == "method:task:review"
+    assert summary["plan_id"] == "plan:method:task:review"
+    assert summary["step_id"] == "inspect"
+    assert summary["step_index"] == 0
+    assert summary["step_title"] == "Inspect current changes"
+
+
 def test_run_cli_work_log_inspect_filters_by_run(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.work import JsonlEventLogBackend
@@ -4000,9 +4120,9 @@ def test_run_cli_work_log_inspect_filters_by_run(tmp_path) -> None:
 
     asyncio.run(scenario())
 
-    assert stdout.getvalue().splitlines() == [
-        "sequence\tkind\trun_id\tsession_id\tdelivery_hint\tmethod_id",
-        "2\tApprovalRequested\trun-2\tsession-1\timmediate\t",
+    assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
+        _WORK_LOG_INSPECT_COLUMNS,
+        ["2", "ApprovalRequested", "run-2", "session-1", "immediate", "", "", "", "", ""],
     ]
 
 


### PR DESCRIPTION
## Summary
- Add plan_id, step_id, step_index, and step_title columns to text work-log inspect output.
- Include plan and step metadata in JSON inspect summaries when present.
- Extend CLI tests for empty metadata, text output, JSON output, and run filtering.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/work -q
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/cli/__main__.py tests/coding/test_cli.py
- git diff --check HEAD