### PR TITLE
Project work plan runs from event logs

### DIFF
--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -6,6 +6,7 @@ from loushang.work.event_log import (
     InMemoryEventLogBackend,
     JsonlEventLogBackend,
 )
+from loushang.work.plan_projection import project_work_plan_runs
 from loushang.work.projection import (
     WorkEventProjectionContext,
     project_agent_event_to_work_events,
@@ -14,6 +15,7 @@ from loushang.work.types import (
     DeliveryHint,
     WorkEvent,
     WorkOperation,
+    WorkPlanRun,
     WorkRun,
     WorkRunStatus,
     WorkStepRun,
@@ -31,9 +33,11 @@ __all__ = [
     "WorkEventProjectionContext",
     "WorkEvent",
     "WorkOperation",
+    "WorkPlanRun",
     "WorkRun",
     "WorkRunStatus",
     "WorkStepRun",
     "WorkStepStatus",
     "project_agent_event_to_work_events",
+    "project_work_plan_runs",
 ]

--- a/src/loushang/work/plan_projection.py
+++ b/src/loushang/work/plan_projection.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+
+from loushang.work.event_log import EventLogEntry
+from loushang.work.types import WorkPlanRun, WorkRunStatus, WorkStepRun, WorkStepStatus
+
+
+def project_work_plan_runs(entries: Iterable[EventLogEntry]) -> tuple[WorkPlanRun, ...]:
+    plan_states: list[_PlanState] = []
+    active_by_plan_id: dict[str, _PlanState] = {}
+
+    for entry in entries:
+        plan_id = _entry_string_payload_value(entry, "plan_id")
+        if not plan_id:
+            continue
+
+        kind = _entry_kind(entry)
+        plan_state = active_by_plan_id.get(plan_id)
+        if plan_state is None or _starts_new_plan_attempt(kind, plan_state):
+            plan_state = _PlanState(
+                plan_id=plan_id,
+                method_id=_entry_string_payload_value(entry, "method_id") or None,
+                status="accepted",
+            )
+            active_by_plan_id[plan_id] = plan_state
+            plan_states.append(plan_state)
+
+        plan_state.update_from_entry(entry, kind=kind)
+
+    return tuple(plan_state.to_plan_run() for plan_state in plan_states)
+
+
+def _starts_new_plan_attempt(kind: str, plan_state: _PlanState) -> bool:
+    return plan_state.status in {"completed", "failed", "cancelled"} and kind in {"SubmitCodingTurn", "WorkPlanStarted"}
+
+
+@dataclass
+class _PlanState:
+    plan_id: str
+    status: WorkRunStatus
+    method_id: str | None = None
+    current_step_id: str | None = None
+    error: str | None = None
+    operation_ids: list[str] = field(default_factory=list)
+    steps: dict[str, _StepState] = field(default_factory=dict)
+    step_order: list[str] = field(default_factory=list)
+
+    def update_from_entry(self, entry: EventLogEntry, *, kind: str) -> None:
+        method_id = _entry_string_payload_value(entry, "method_id")
+        if method_id:
+            self.method_id = method_id
+        if entry.operation_id and entry.operation_id not in self.operation_ids:
+            self.operation_ids.append(entry.operation_id)
+
+        if kind == "WorkPlanStarted":
+            self.status = "running"
+        elif kind == "WorkPlanCompleted":
+            self.status = "completed"
+        elif kind == "WorkPlanFailed":
+            self.status = "failed"
+            self.error = _entry_string_payload_value(entry, "error") or self.error
+        elif self.status == "accepted" and kind != "SubmitCodingTurn":
+            self.status = "running"
+
+        step_id = _entry_string_payload_value(entry, "step_id")
+        if not step_id:
+            return
+        self.current_step_id = step_id
+        step_state = self._step_state(step_id)
+        step_state.update_from_entry(entry, kind=kind, method_id=self.method_id, plan_id=self.plan_id)
+
+    def _step_state(self, step_id: str) -> _StepState:
+        step_state = self.steps.get(step_id)
+        if step_state is not None:
+            return step_state
+        step_state = _StepState(step_id=step_id)
+        self.steps[step_id] = step_state
+        self.step_order.append(step_id)
+        return step_state
+
+    def to_plan_run(self) -> WorkPlanRun:
+        steps = tuple(self.steps[step_id].to_step_run() for step_id in self._ordered_step_ids())
+        metadata: dict[str, object] = {"operation_ids": tuple(self.operation_ids)}
+        if self.error is not None:
+            metadata["error"] = self.error
+        return WorkPlanRun(
+            plan_id=self.plan_id,
+            status=self.status,
+            method_id=self.method_id,
+            current_step_id=self.current_step_id,
+            steps=steps,
+            step_count=len(steps),
+            completed_step_count=sum(1 for step in steps if step.status == "completed"),
+            failed_step_count=sum(1 for step in steps if step.status == "failed"),
+            metadata=metadata,
+        )
+
+    def _ordered_step_ids(self) -> tuple[str, ...]:
+        order_index = {step_id: index for index, step_id in enumerate(self.step_order)}
+        return tuple(
+            sorted(
+                self.step_order,
+                key=lambda step_id: (
+                    self.steps[step_id].step_index is None,
+                    self.steps[step_id].step_index if self.steps[step_id].step_index is not None else order_index[step_id],
+                    order_index[step_id],
+                ),
+            )
+        )
+
+
+@dataclass
+class _StepState:
+    step_id: str
+    status: WorkStepStatus = "pending"
+    run_id: str | None = None
+    plan_id: str | None = None
+    method_id: str | None = None
+    operation_id: str | None = None
+    title: str | None = None
+    step_index: int | None = None
+    first_sequence: int | None = None
+    started_sequence: int | None = None
+    completed_sequence: int | None = None
+    failed_sequence: int | None = None
+    error: str | None = None
+
+    def update_from_entry(
+        self,
+        entry: EventLogEntry,
+        *,
+        kind: str,
+        method_id: str | None,
+        plan_id: str,
+    ) -> None:
+        self.run_id = self.run_id or entry.run_id
+        self.operation_id = self.operation_id or entry.operation_id
+        self.method_id = method_id or self.method_id
+        self.plan_id = plan_id
+        self.first_sequence = self.first_sequence if self.first_sequence is not None else entry.sequence
+
+        step_title = _entry_string_payload_value(entry, "step_title")
+        if step_title:
+            self.title = step_title
+        step_index = _entry_step_index(entry)
+        if step_index is not None:
+            self.step_index = step_index
+
+        if kind == "WorkStepStarted":
+            self.status = "running"
+            self.started_sequence = entry.sequence
+        elif kind == "WorkStepCompleted":
+            self.status = "completed"
+            self.completed_sequence = entry.sequence
+        elif kind == "WorkStepFailed":
+            self.status = "failed"
+            self.failed_sequence = entry.sequence
+            self.error = _entry_string_payload_value(entry, "error") or self.error
+
+    def to_step_run(self) -> WorkStepRun:
+        metadata = _without_none(
+            {
+                "step_index": self.step_index,
+                "operation_id": self.operation_id,
+                "started_sequence": self.started_sequence,
+                "completed_sequence": self.completed_sequence,
+                "failed_sequence": self.failed_sequence,
+                "error": self.error,
+            }
+        )
+        return WorkStepRun(
+            run_id=self.run_id or "",
+            plan_id=self.plan_id or "",
+            step_id=self.step_id,
+            sequence=self.started_sequence if self.started_sequence is not None else self.first_sequence or 0,
+            status=self.status,
+            method_id=self.method_id,
+            title=self.title,
+            metadata=metadata,
+        )
+
+
+def _entry_kind(entry: EventLogEntry) -> str:
+    kind = entry.payload.get("kind")
+    if isinstance(kind, str) and kind:
+        return kind
+    return str(entry.entry_type)
+
+
+def _entry_string_payload_value(entry: EventLogEntry, key: str) -> str:
+    value = _entry_payload_value(entry, key)
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _entry_step_index(entry: EventLogEntry) -> int | None:
+    value = _entry_payload_value(entry, "step_index")
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _entry_payload_value(entry: EventLogEntry, key: str) -> object | None:
+    value = entry.payload.get(key)
+    if value is not None:
+        return value
+    nested_payload = entry.payload.get("payload")
+    if isinstance(nested_payload, Mapping):
+        return nested_payload.get(key)
+    return None
+
+
+def _without_none(values: Mapping[str, object | None]) -> dict[str, object]:
+    return {key: value for key, value in values.items() if value is not None}
+
+
+__all__ = ["project_work_plan_runs"]

--- a/src/loushang/work/types.py
+++ b/src/loushang/work/types.py
@@ -67,6 +67,19 @@ class WorkStepRun:
 
 
 @dataclass(frozen=True)
+class WorkPlanRun:
+    plan_id: str
+    status: WorkRunStatus
+    steps: tuple[WorkStepRun, ...] = ()
+    method_id: str | None = None
+    current_step_id: str | None = None
+    step_count: int = 0
+    completed_step_count: int = 0
+    failed_step_count: int = 0
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class WorkEvent:
     event_id: str
     kind: str
@@ -85,6 +98,7 @@ __all__ = [
     "DeliveryHint",
     "WorkEvent",
     "WorkOperation",
+    "WorkPlanRun",
     "WorkRun",
     "WorkRunStatus",
     "WorkStepRun",

--- a/tests/work/test_plan_projection.py
+++ b/tests/work/test_plan_projection.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def _entry(
+    entry_id: str,
+    *,
+    kind: str,
+    run_id: str,
+    sequence: int,
+    operation_id: str | None = None,
+    entry_type: str = "event",
+    method_id: str | None = "method:task:review",
+    plan_id: str | None = "plan:method:task:review",
+    step_id: str | None = None,
+    step_index: int | None = None,
+    step_title: str | None = None,
+    error: str | None = None,
+) -> object:
+    from loushang.work import EventLogEntry
+
+    payload: dict[str, object] = {"kind": kind}
+    nested_payload: dict[str, object] = {}
+    if method_id is not None:
+        nested_payload["method_id"] = method_id
+    if plan_id is not None:
+        nested_payload["plan_id"] = plan_id
+    if step_id is not None:
+        nested_payload["step_id"] = step_id
+    if step_index is not None:
+        nested_payload["step_index"] = step_index
+    if step_title is not None:
+        nested_payload["step_title"] = step_title
+    if error is not None:
+        nested_payload["error"] = error
+    if nested_payload:
+        payload["payload"] = nested_payload
+
+    return EventLogEntry(
+        entry_id=entry_id,
+        entry_type=entry_type,
+        operation_id=operation_id or f"op-{run_id}",
+        event_id=None if entry_type == "operation" else f"event-{entry_id}",
+        run_id=run_id,
+        session_id="session-1",
+        sequence=sequence,
+        payload=payload,
+        created_at=datetime(2026, 6, 1, 10, 30, sequence, tzinfo=UTC),
+    )
+
+
+def _step_entries(
+    *,
+    run_id: str,
+    step_id: str,
+    step_index: int,
+    step_title: str,
+    first: bool = False,
+    last: bool = False,
+    failed: bool = False,
+) -> list[object]:
+    entries = [
+        _entry(
+            f"{run_id}-operation",
+            kind="SubmitCodingTurn",
+            run_id=run_id,
+            sequence=0,
+            entry_type="operation",
+            step_id=step_id,
+            step_index=step_index,
+            step_title=step_title,
+        ),
+        _entry(f"{run_id}-run-started", kind="WorkRunStarted", run_id=run_id, sequence=1, step_id=step_id),
+    ]
+    if first:
+        entries.append(
+            _entry(
+                f"{run_id}-plan-started",
+                kind="WorkPlanStarted",
+                run_id=run_id,
+                sequence=2,
+                step_id=step_id,
+                step_index=step_index,
+                step_title=step_title,
+            )
+        )
+    entries.append(
+        _entry(
+            f"{run_id}-step-started",
+            kind="WorkStepStarted",
+            run_id=run_id,
+            sequence=3,
+            step_id=step_id,
+            step_index=step_index,
+            step_title=step_title,
+        )
+    )
+    if failed:
+        entries.extend(
+            [
+                _entry(
+                    f"{run_id}-step-failed",
+                    kind="WorkStepFailed",
+                    run_id=run_id,
+                    sequence=4,
+                    step_id=step_id,
+                    step_index=step_index,
+                    step_title=step_title,
+                    error="step failed",
+                ),
+                _entry(
+                    f"{run_id}-plan-failed",
+                    kind="WorkPlanFailed",
+                    run_id=run_id,
+                    sequence=5,
+                    step_id=step_id,
+                    step_index=step_index,
+                    step_title=step_title,
+                    error="step failed",
+                ),
+            ]
+        )
+    else:
+        entries.append(
+            _entry(
+                f"{run_id}-step-completed",
+                kind="WorkStepCompleted",
+                run_id=run_id,
+                sequence=4,
+                step_id=step_id,
+                step_index=step_index,
+                step_title=step_title,
+            )
+        )
+        if last:
+            entries.append(
+                _entry(
+                    f"{run_id}-plan-completed",
+                    kind="WorkPlanCompleted",
+                    run_id=run_id,
+                    sequence=5,
+                    step_id=step_id,
+                    step_index=step_index,
+                    step_title=step_title,
+                )
+            )
+    entries.append(_entry(f"{run_id}-run-completed", kind="WorkRunCompleted", run_id=run_id, sequence=6, step_id=step_id))
+    return entries
+
+
+def test_project_work_plan_runs_replays_completed_steps_across_turn_runs() -> None:
+    from loushang.work import project_work_plan_runs
+
+    plans = project_work_plan_runs(
+        [
+            *_step_entries(
+                run_id="run-inspect",
+                step_id="inspect",
+                step_index=0,
+                step_title="Inspect current changes",
+                first=True,
+            ),
+            *_step_entries(
+                run_id="run-verify",
+                step_id="verify",
+                step_index=1,
+                step_title="Run focused checks",
+                last=True,
+            ),
+        ]
+    )
+
+    assert len(plans) == 1
+    plan = plans[0]
+    assert plan.plan_id == "plan:method:task:review"
+    assert plan.method_id == "method:task:review"
+    assert plan.status == "completed"
+    assert plan.step_count == 2
+    assert plan.completed_step_count == 2
+    assert plan.failed_step_count == 0
+    assert plan.current_step_id == "verify"
+    assert plan.metadata["operation_ids"] == ("op-run-inspect", "op-run-verify")
+
+    assert [(step.step_id, step.status, step.run_id, step.title) for step in plan.steps] == [
+        ("inspect", "completed", "run-inspect", "Inspect current changes"),
+        ("verify", "completed", "run-verify", "Run focused checks"),
+    ]
+    assert plan.steps[0].metadata == {
+        "step_index": 0,
+        "operation_id": "op-run-inspect",
+        "started_sequence": 3,
+        "completed_sequence": 4,
+    }
+
+
+def test_project_work_plan_runs_replays_failed_step_and_plan_error() -> None:
+    from loushang.work import project_work_plan_runs
+
+    plans = project_work_plan_runs(
+        _step_entries(
+            run_id="run-verify",
+            step_id="verify",
+            step_index=1,
+            step_title="Run focused checks",
+            first=True,
+            failed=True,
+        )
+    )
+
+    assert len(plans) == 1
+    plan = plans[0]
+    assert plan.status == "failed"
+    assert plan.completed_step_count == 0
+    assert plan.failed_step_count == 1
+    assert plan.current_step_id == "verify"
+    assert plan.metadata["error"] == "step failed"
+    assert plan.steps[0].status == "failed"
+    assert plan.steps[0].metadata["error"] == "step failed"
+    assert plan.steps[0].metadata["failed_sequence"] == 4
+
+
+def test_project_work_plan_runs_ignores_entries_without_plan_id() -> None:
+    from loushang.work import project_work_plan_runs
+
+    plans = project_work_plan_runs(
+        [
+            _entry(
+                "run-1-operation",
+                kind="SubmitCodingTurn",
+                run_id="run-1",
+                sequence=0,
+                entry_type="operation",
+                method_id=None,
+                plan_id=None,
+            ),
+            _entry("run-1-started", kind="WorkRunStarted", run_id="run-1", sequence=1, method_id=None, plan_id=None),
+        ]
+    )
+
+    assert plans == ()

--- a/tests/work/test_public_api.py
+++ b/tests/work/test_public_api.py
@@ -15,11 +15,13 @@ def test_work_public_api_exposes_current_work_surface_without_multi_agent_types(
         "WorkEvent",
         "WorkEventProjectionContext",
         "WorkOperation",
+        "WorkPlanRun",
         "WorkRun",
         "WorkRunStatus",
         "WorkStepRun",
         "WorkStepStatus",
         "project_agent_event_to_work_events",
+        "project_work_plan_runs",
     }
 
     assert not hasattr(work, "AgentLane")


### PR DESCRIPTION
## Summary
- Add WorkPlanRun as the replay projection for fixed method plan execution.
- Add project_work_plan_runs to reconstruct plan and step status from work event log entries.
- Cover completed, failed, and non-plan replay behavior with work tests.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/coding/test_cli.py tests/method -q
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/work/plan_projection.py src/loushang/work/types.py src/loushang/work/__init__.py tests/work/test_plan_projection.py tests/work/test_public_api.py
- git diff --check HEAD