### PR TITLE
feat: summarize work log plan runs

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -8,7 +8,7 @@ import os
 import sys
 from collections.abc import Callable
 from contextlib import contextmanager, nullcontext, redirect_stderr
-from dataclasses import dataclass, replace
+from dataclasses import asdict, dataclass, replace
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
 from pathlib import Path
@@ -66,7 +66,7 @@ from loushang.coding.workflow import (
     run_prompt_steps_workflow,
 )
 from loushang.method import MethodCompiler, MethodContext, MethodLoader
-from loushang.work import JsonlEventLogBackend
+from loushang.work import JsonlEventLogBackend, project_work_plan_runs
 
 _MISSING = object()
 _WORK_LOG_INSPECT_LIMIT = 20
@@ -823,14 +823,19 @@ def _run_work_log_inspect(args: CliArgs, project_root: Path, stdout: TextIO, std
         return None
     try:
         event_log = JsonlEventLogBackend(_resolve_work_log_path(args.work_log_inspect, project_root))
-        entries = event_log.query(run_id=args.work_log_run)[-_WORK_LOG_INSPECT_LIMIT:]
+        entries = event_log.query(run_id=args.work_log_run)
     except Exception as error:
         stderr.write(f"Error: {_format_cli_error(error)}\n")
         return 1
     if args.work_log_inspect_format == "json":
-        stdout.write(json.dumps([_work_log_entry_summary(entry) for entry in entries], ensure_ascii=False) + "\n")
+        raw_entries = entries[-_WORK_LOG_INSPECT_LIMIT:]
+        stdout.write(json.dumps([_work_log_entry_summary(entry) for entry in raw_entries], ensure_ascii=False) + "\n")
+    elif args.work_log_inspect_format == "plans-json":
+        stdout.write(json.dumps([asdict(plan) for plan in project_work_plan_runs(entries)], ensure_ascii=False) + "\n")
+    elif args.work_log_inspect_format == "plans":
+        _write_work_log_plan_summary(entries, stdout)
     else:
-        _write_work_log_text(entries, stdout)
+        _write_work_log_text(entries[-_WORK_LOG_INSPECT_LIMIT:], stdout)
     return 0
 
 
@@ -878,6 +883,69 @@ def _write_work_log_text(entries: list[Any], stdout: TextIO) -> None:
             )
             + "\n"
         )
+
+
+def _write_work_log_plan_summary(entries: list[Any], stdout: TextIO) -> None:
+    stdout.write(
+        "\t".join(
+            [
+                "type",
+                "index",
+                "id",
+                "status",
+                "run_id",
+                "method_id",
+                "completed_steps",
+                "failed_steps",
+                "current_step",
+                "title",
+            ]
+        )
+        + "\n"
+    )
+    for plan in project_work_plan_runs(entries):
+        stdout.write(
+            "\t".join(
+                [
+                    "plan",
+                    "",
+                    plan.plan_id,
+                    plan.status,
+                    "",
+                    plan.method_id or "",
+                    f"{plan.completed_step_count}/{plan.step_count}",
+                    str(plan.failed_step_count),
+                    plan.current_step_id or "",
+                    "",
+                ]
+            )
+            + "\n"
+        )
+        for fallback_index, step in enumerate(plan.steps, start=1):
+            stdout.write(
+                "\t".join(
+                    [
+                        "step",
+                        _work_log_plan_step_index(step.metadata, fallback_index),
+                        step.step_id,
+                        step.status,
+                        step.run_id,
+                        step.method_id or plan.method_id or "",
+                        "",
+                        "",
+                        "",
+                        step.title or "",
+                    ]
+                )
+                + "\n"
+            )
+
+
+def _work_log_plan_step_index(metadata: Mapping[str, object], fallback_index: int) -> str:
+    step_index = metadata.get("step_index")
+    if isinstance(step_index, int) and not isinstance(step_index, bool):
+        return str(step_index + 1)
+    return str(fallback_index)
 
 
 def _work_log_entry_summary(entry: Any) -> dict[str, object]:

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -20,7 +20,7 @@ PackageListFormat = Literal["text", "tsv", "json"]
 ExportFormat = Literal["html", "jsonl"]
 ExportResultFormat = Literal["text", "json"]
 CommandResultFormat = Literal["raw", "json"]
-WorkLogInspectFormat = Literal["text", "json"]
+WorkLogInspectFormat = Literal["text", "json", "plans", "plans-json"]
 ExtensionFlag: TypeAlias = RegisteredFlag | ResolvedFlag
 _BUILTIN_FLAG_NAMES = frozenset(
     {
@@ -490,7 +490,7 @@ def _build_parser() -> ArgumentParser:
         help="Inspect a work event JSONL log without starting a session.",
     )
     parser.add_argument("--work-log-run", help="Filter --work-log-inspect output to one run id.")
-    parser.add_argument("--work-log-inspect-format", choices=("text", "json"), default="text")
+    parser.add_argument("--work-log-inspect-format", choices=("text", "json", "plans", "plans-json"), default="text")
     parser.add_argument("--message", dest="message_prompts", action="append", default=[])
     parser.add_argument("--tool", dest="tool_flags", action="append", default=[])
     parser.add_argument("--tools", "-t", dest="tools", action="append", default=[])

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -300,6 +300,84 @@ def _append_work_log_inspect_entry(
     )
 
 
+def _append_work_log_plan_step_entries(
+    event_log: object,
+    *,
+    start_sequence: int,
+    run_id: str,
+    step_id: str,
+    step_index: int,
+    step_title: str,
+    first: bool = False,
+    last: bool = False,
+) -> int:
+    sequence = start_sequence
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=sequence,
+        kind="SubmitCodingTurn",
+        run_id=run_id,
+        entry_type="operation",
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        step_id=step_id,
+        step_index=step_index,
+        step_title=step_title,
+    )
+    sequence += 1
+    if first:
+        _append_work_log_inspect_entry(
+            event_log,
+            sequence=sequence,
+            kind="WorkPlanStarted",
+            run_id=run_id,
+            method_id="method:task:review",
+            plan_id="plan:method:task:review",
+            step_id=step_id,
+            step_index=step_index,
+            step_title=step_title,
+        )
+        sequence += 1
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=sequence,
+        kind="WorkStepStarted",
+        run_id=run_id,
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        step_id=step_id,
+        step_index=step_index,
+        step_title=step_title,
+    )
+    sequence += 1
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=sequence,
+        kind="WorkStepCompleted",
+        run_id=run_id,
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        step_id=step_id,
+        step_index=step_index,
+        step_title=step_title,
+    )
+    sequence += 1
+    if last:
+        _append_work_log_inspect_entry(
+            event_log,
+            sequence=sequence,
+            kind="WorkPlanCompleted",
+            run_id=run_id,
+            method_id="method:task:review",
+            plan_id="plan:method:task:review",
+            step_id=step_id,
+            step_index=step_index,
+            step_title=step_title,
+        )
+        sequence += 1
+    return sequence
+
+
 def _fake_services(
     session_dir: str | None = None,
     package_roots: tuple[str, ...] = (),
@@ -456,13 +534,13 @@ def test_parse_args_accepts_work_log_inspect_flags() -> None:
             "--work-log-run",
             "run-1",
             "--work-log-inspect-format",
-            "json",
+            "plans",
         ]
     )
 
     assert args.work_log_inspect == ".loushang/work/events.jsonl"
     assert args.work_log_run == "run-1"
-    assert args.work_log_inspect_format == "json"
+    assert args.work_log_inspect_format == "plans"
 
 
 def test_parse_args_accepts_method_visibility_flags_and_subcommands() -> None:
@@ -3975,6 +4053,203 @@ def test_run_cli_work_log_inspect_text_includes_plan_step_metadata(tmp_path) -> 
             "Inspect current changes",
         ],
     ]
+
+
+def test_run_cli_work_log_inspect_plans_outputs_plan_summary_without_runtime(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    next_sequence = _append_work_log_plan_step_entries(
+        event_log,
+        start_sequence=1,
+        run_id="run-inspect",
+        step_id="inspect",
+        step_index=0,
+        step_title="Inspect current changes",
+        first=True,
+    )
+    _append_work_log_plan_step_entries(
+        event_log,
+        start_sequence=next_sequence,
+        run_id="run-verify",
+        step_id="verify",
+        step_index=1,
+        step_title="Run focused checks",
+        last=True,
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "plans"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
+        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title"],
+        ["plan", "", "plan:method:task:review", "completed", "", "method:task:review", "2/2", "0", "verify", ""],
+        ["step", "1", "inspect", "completed", "run-inspect", "method:task:review", "", "", "", "Inspect current changes"],
+        ["step", "2", "verify", "completed", "run-verify", "method:task:review", "", "", "", "Run focused checks"],
+    ]
+
+
+def test_run_cli_work_log_inspect_plans_respects_run_filter(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=1,
+        kind="WorkStepCompleted",
+        run_id="run-inspect",
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        step_id="inspect",
+        step_index=0,
+        step_title="Inspect current changes",
+    )
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=2,
+        kind="WorkStepFailed",
+        run_id="run-verify",
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        step_id="verify",
+        step_index=1,
+        step_title="Run focused checks",
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            [
+                "--work-log-inspect",
+                str(log_path),
+                "--work-log-run",
+                "run-verify",
+                "--work-log-inspect-format",
+                "plans",
+            ],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
+        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title"],
+        ["plan", "", "plan:method:task:review", "running", "", "method:task:review", "0/1", "1", "verify", ""],
+        ["step", "2", "verify", "failed", "run-verify", "method:task:review", "", "", "", "Run focused checks"],
+    ]
+
+
+def test_run_cli_work_log_inspect_plans_projects_full_log_not_tail_limit(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    next_sequence = _append_work_log_plan_step_entries(
+        event_log,
+        start_sequence=1,
+        run_id="run-inspect",
+        step_id="inspect",
+        step_index=0,
+        step_title="Inspect current changes",
+        first=True,
+        last=True,
+    )
+    for offset in range(20):
+        _append_work_log_inspect_entry(
+            event_log,
+            sequence=next_sequence + offset,
+            kind="ContentDelta",
+            run_id=f"run-tail-{offset}",
+        )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "plans"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert [line.split("\t") for line in stdout.getvalue().splitlines()][1:] == [
+        ["plan", "", "plan:method:task:review", "completed", "", "method:task:review", "1/1", "0", "inspect", ""],
+        ["step", "1", "inspect", "completed", "run-inspect", "method:task:review", "", "", "", "Inspect current changes"],
+    ]
+
+
+def test_run_cli_work_log_inspect_plans_json_outputs_plan_projection(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_plan_step_entries(
+        event_log,
+        start_sequence=1,
+        run_id="run-inspect",
+        step_id="inspect",
+        step_index=0,
+        step_title="Inspect current changes",
+        first=True,
+        last=True,
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "plans-json"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    payload = json.loads(stdout.getvalue())
+    assert payload[0]["plan_id"] == "plan:method:task:review"
+    assert payload[0]["status"] == "completed"
+    assert payload[0]["method_id"] == "method:task:review"
+    assert payload[0]["current_step_id"] == "inspect"
+    assert payload[0]["step_count"] == 1
+    assert payload[0]["completed_step_count"] == 1
+    assert payload[0]["failed_step_count"] == 0
+    assert payload[0]["steps"][0]["step_id"] == "inspect"
+    assert payload[0]["steps"][0]["status"] == "completed"
+    assert payload[0]["steps"][0]["title"] == "Inspect current changes"
+    assert payload[0]["steps"][0]["metadata"]["step_index"] == 0
 
 
 def test_run_cli_work_log_inspect_outputs_json_without_runtime(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Add work-log inspect formats for projected plan summaries: plans TSV and plans-json.
- Reuse work plan replay projection to show plan status, step counts, current step, and step rows.
- Keep raw text/json inspect output tail-limited while projecting plans from the full queried log.

## Test Plan
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/work tests/method -q
- [x] uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli/__main__.py src/loushang/coding/cli/args.py tests/coding/test_cli.py
- [x] git diff --check