### PR TITLE
feat: expose method step policy metadata

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -2153,6 +2153,8 @@ def _normalize_method_plan_step(step: Any) -> dict[str, object]:
         "executor": _safe_getattr(step, "executor", "") or "",
         "role_variant": _safe_getattr(step, "role_variant", None),
         "projection": _json_safe(_safe_getattr(step, "projection", {})),
+        "constraint": _json_safe(_safe_getattr(step, "constraint", {})),
+        "audit": _json_safe(_safe_getattr(step, "audit", {})),
         "applicability": _normalize_method_applicability(_safe_getattr(step, "applicability", None)),
     }
 
@@ -2235,6 +2237,12 @@ def _format_method_plan_detail(payload: Mapping[str, object]) -> str:
             guidance = _method_plan_step_guidance(raw_step)
             if guidance:
                 lines.append(f"     guidance: {guidance}")
+            constraint = _method_plan_step_mapping(raw_step, "constraint")
+            if constraint:
+                lines.append(f"     constraint: {json.dumps(constraint, ensure_ascii=False)}")
+            audit = _method_plan_step_mapping(raw_step, "audit")
+            if audit:
+                lines.append(f"     audit: {json.dumps(audit, ensure_ascii=False)}")
     lines.append("")
     return "\n".join(lines)
 
@@ -2250,6 +2258,13 @@ def _method_plan_step_guidance(step: Mapping[str, object]) -> str:
     if isinstance(content, str):
         return content.strip()
     return ""
+
+
+def _method_plan_step_mapping(step: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = step.get(key)
+    if isinstance(value, Mapping):
+        return value
+    return {}
 
 
 def _format_method_applicability_lines(applicability: object) -> list[str]:

--- a/src/loushang/coding/frontmatter.py
+++ b/src/loushang/coding/frontmatter.py
@@ -82,14 +82,25 @@ def _next_line_is_indented(lines: list[str], index: int) -> bool:
 
 
 def _parse_collection(lines: list[str], index: int, *, parent_key: str) -> tuple[object, int]:
+    return _parse_collection_at_indent(lines, index, indent=2, parent_key=parent_key)
+
+
+def _parse_collection_at_indent(
+    lines: list[str],
+    index: int,
+    *,
+    indent: int,
+    parent_key: str,
+) -> tuple[object, int]:
     index = _skip_ignored_lines(lines, index)
     if index >= len(lines):
         return "", index
     raw_line = lines[index]
-    if raw_line.startswith("  - "):
-        return _parse_list(lines, index, indent=2, parent_key=parent_key)
-    if raw_line.startswith("  "):
-        return _parse_map(lines, index, indent=2, parent_key=parent_key)
+    prefix = " " * indent
+    if raw_line.startswith(f"{prefix}- "):
+        return _parse_list(lines, index, indent=indent, parent_key=parent_key)
+    if raw_line.startswith(prefix):
+        return _parse_map(lines, index, indent=indent, parent_key=parent_key)
     return "", index
 
 
@@ -136,7 +147,12 @@ def _parse_map(lines: list[str], index: int, *, indent: int, parent_key: str) ->
             raise _frontmatter_error(index, indent + 1, raw_line, "expected key")
         value = raw_value.strip()
         if not value and _next_line_is_deeper(lines, index + 1, indent=indent):
-            nested, index = _parse_list(lines, index + 1, indent=indent + 2, parent_key=f"{parent_key}.{key}")
+            nested, index = _parse_collection_at_indent(
+                lines,
+                index + 1,
+                indent=indent + 2,
+                parent_key=f"{parent_key}.{key}",
+            )
             values[key] = nested
             continue
         values[key] = _parse_scalar(value, line_number=index, line=raw_line, key=key)

--- a/src/loushang/method/compiler.py
+++ b/src/loushang/method/compiler.py
@@ -47,6 +47,8 @@ def _compile_fixed_plan(descriptor: MethodDescriptor, *, frontmatter: MappingABC
     step_ids = _fixed_step_ids(frontmatter, descriptor=descriptor)
     step_titles = _string_map_hint(frontmatter, "step_titles")
     step_guidance = _string_map_hint(frontmatter, "step_guidance")
+    step_constraints = _mapping_map_hint(frontmatter, "step_constraints")
+    step_audit = _mapping_map_hint(frontmatter, "step_audit")
     temperature = _temperature_hint(descriptor.metadata)
     steps = tuple(
         MethodStep(
@@ -67,6 +69,8 @@ def _compile_fixed_plan(descriptor: MethodDescriptor, *, frontmatter: MappingABC
                 "meta_role": descriptor.meta_role,
                 "temperature": temperature,
             },
+            constraint=step_constraints.get(step_id, {}),
+            audit=step_audit.get(step_id, {}),
             applicability=descriptor.applicability,
         )
         for index, step_id in enumerate(step_ids)
@@ -133,6 +137,17 @@ def _string_map_hint(frontmatter: MappingABC[str, object], key: str) -> dict[str
         item_key: item_value
         for item_key, item_value in value.items()
         if isinstance(item_key, str) and item_key and isinstance(item_value, str) and item_value
+    }
+
+
+def _mapping_map_hint(frontmatter: MappingABC[str, object], key: str) -> dict[str, dict[str, object]]:
+    value = frontmatter.get(key)
+    if not isinstance(value, MappingABC):
+        return {}
+    return {
+        item_key: dict(item_value)
+        for item_key, item_value in value.items()
+        if isinstance(item_key, str) and item_key and isinstance(item_value, MappingABC)
     }
 
 

--- a/src/loushang/method/projection.py
+++ b/src/loushang/method/projection.py
@@ -25,7 +25,11 @@ class MethodProjector:
             meta_role=_string_projection_value(step, "meta_role"),
             role_variant=step.role_variant,
             temperature=_float_projection_value(step, "temperature"),
-            metadata={"source_projection": dict(step.projection)},
+            metadata={
+                "source_projection": dict(step.projection),
+                "source_constraint": dict(step.constraint),
+                "source_audit": dict(step.audit),
+            },
         )
 
 

--- a/src/loushang/method/types.py
+++ b/src/loushang/method/types.py
@@ -55,6 +55,8 @@ class MethodStep:
     executor: str
     role_variant: str | None = None
     projection: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+    constraint: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
+    audit: Mapping[str, object] = field(default_factory=lambda: _EMPTY_METADATA)
     applicability: MethodApplicability = field(default_factory=MethodApplicability)
 
 

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -445,6 +445,20 @@ def _write_fixed_review_method(project_root: Path) -> None:
         "step_guidance:\n"
         "  inspect: Read changed files and summarize intent.\n"
         "  verify: Run focused tests or explain why they cannot run.\n"
+        "step_constraints:\n"
+        "  inspect:\n"
+        "    level: reasoned\n"
+        "    can_merge: true\n"
+        "    requires_reason: true\n"
+        "  verify:\n"
+        "    level: evidence\n"
+        "    can_skip: true\n"
+        "    requires_evidence: true\n"
+        "step_audit:\n"
+        "  inspect:\n"
+        "    record: [status, reason]\n"
+        "  verify:\n"
+        "    record: [status, reason, evidence]\n"
         "---\n\n"
         "Use concise review guidance.",
         encoding="utf-8",
@@ -5834,6 +5848,20 @@ def test_run_cli_shows_fixed_method_plan_as_json(tmp_path) -> None:
         "step_guidance:\n"
         "  inspect: Read changed files and summarize intent.\n"
         "  verify: Run focused tests or explain why they cannot run.\n"
+        "step_constraints:\n"
+        "  inspect:\n"
+        "    level: reasoned\n"
+        "    can_merge: true\n"
+        "    requires_reason: true\n"
+        "  verify:\n"
+        "    level: evidence\n"
+        "    can_skip: true\n"
+        "    requires_evidence: true\n"
+        "step_audit:\n"
+        "  inspect:\n"
+        "    record: [status, reason]\n"
+        "  verify:\n"
+        "    record: [status, reason, evidence]\n"
         "---\n\n"
         "Use concise review guidance.",
         encoding="utf-8",
@@ -5878,6 +5906,18 @@ def test_run_cli_shows_fixed_method_plan_as_json(tmp_path) -> None:
     assert second_projection["step_index"] == 1
     assert second_projection["step_count"] == 2
     assert "Step verify - Run focused checks" in second_projection["content"]
+    assert payload["steps"][0]["constraint"] == {
+        "level": "reasoned",
+        "can_merge": True,
+        "requires_reason": True,
+    }
+    assert payload["steps"][0]["audit"] == {"record": ["status", "reason"]}
+    assert payload["steps"][1]["constraint"] == {
+        "level": "evidence",
+        "can_skip": True,
+        "requires_evidence": True,
+    }
+    assert payload["steps"][1]["audit"] == {"record": ["status", "reason", "evidence"]}
     assert payload["steps"][0]["applicability"]["domains"] == ["coding", "research"]
     assert payload["steps"][0]["applicability"]["task_types"] == ["reviewing"]
     assert stderr.getvalue() == ""
@@ -5903,6 +5943,13 @@ def test_run_cli_shows_fixed_method_plan_as_text(tmp_path) -> None:
         "step_guidance:\n"
         "  inspect: Read changed files and summarize intent.\n"
         "  verify: Run focused tests or explain why they cannot run.\n"
+        "step_constraints:\n"
+        "  inspect:\n"
+        "    level: reasoned\n"
+        "    requires_reason: true\n"
+        "step_audit:\n"
+        "  inspect:\n"
+        "    record: [status, reason]\n"
         "---\n\n"
         "Use concise review guidance.",
         encoding="utf-8",
@@ -5933,6 +5980,8 @@ def test_run_cli_shows_fixed_method_plan_as_text(tmp_path) -> None:
     assert "steps:" in output
     assert "  1. inspect - Inspect current changes" in output
     assert "     guidance: Read changed files and summarize intent." in output
+    assert '     constraint: {"level": "reasoned", "requires_reason": true}' in output
+    assert '     audit: {"record": ["status", "reason"]}' in output
     assert "  2. verify - Run focused checks" in output
     assert "     guidance: Run focused tests or explain why they cannot run." in output
     assert stderr.getvalue() == ""

--- a/tests/coding/test_frontmatter.py
+++ b/tests/coding/test_frontmatter.py
@@ -50,6 +50,36 @@ def test_parse_frontmatter_supports_simple_lists_and_maps() -> None:
     }
 
 
+def test_parse_frontmatter_supports_nested_maps() -> None:
+    from loushang.coding.frontmatter import parse_frontmatter
+
+    result = parse_frontmatter(
+        "---\n"
+        "step_constraints:\n"
+        "  inspect:\n"
+        "    level: reasoned\n"
+        "    requires_reason: true\n"
+        "  verify:\n"
+        "    level: evidence\n"
+        "    required_evidence:\n"
+        "      - tests\n"
+        "      - logs\n"
+        "---\n\n"
+        "Run the review.\n"
+    )
+
+    assert result.frontmatter["step_constraints"] == {
+        "inspect": {
+            "level": "reasoned",
+            "requires_reason": True,
+        },
+        "verify": {
+            "level": "evidence",
+            "required_evidence": ["tests", "logs"],
+        },
+    }
+
+
 def test_parse_frontmatter_keeps_original_body_without_complete_frontmatter() -> None:
     from loushang.coding.frontmatter import parse_frontmatter, strip_frontmatter
 

--- a/tests/method/test_method_compiler.py
+++ b/tests/method/test_method_compiler.py
@@ -81,6 +81,26 @@ def test_method_compiler_returns_fixed_plan_from_flat_step_metadata() -> None:
                     "inspect": "Read changed files and summarize intent.",
                     "verify": "Run focused tests or explain why they cannot run.",
                 },
+                "step_constraints": {
+                    "inspect": {
+                        "level": "reasoned",
+                        "can_merge": True,
+                        "requires_reason": True,
+                    },
+                    "verify": {
+                        "level": "evidence",
+                        "can_skip": True,
+                        "requires_evidence": True,
+                    },
+                },
+                "step_audit": {
+                    "inspect": {
+                        "record": ["status", "reason"],
+                    },
+                    "verify": {
+                        "record": ["status", "reason", "evidence"],
+                    },
+                },
                 "temperature": "0.2",
             },
         },
@@ -114,7 +134,19 @@ def test_method_compiler_returns_fixed_plan_from_flat_step_metadata() -> None:
     assert inspect.projection["step_count"] == 2
     assert inspect.projection["meta_role"] == "VALIDATOR"
     assert inspect.projection["temperature"] == 0.2
+    assert inspect.constraint == {
+        "level": "reasoned",
+        "can_merge": True,
+        "requires_reason": True,
+    }
+    assert inspect.audit == {"record": ["status", "reason"]}
     assert verify.projection["content"].endswith("Run focused tests or explain why they cannot run.")
+    assert verify.constraint == {
+        "level": "evidence",
+        "can_skip": True,
+        "requires_evidence": True,
+    }
+    assert verify.audit == {"record": ["status", "reason", "evidence"]}
 
 
 def test_method_compiler_rejects_fixed_plan_without_steps() -> None:

--- a/tests/method/test_method_projection.py
+++ b/tests/method/test_method_projection.py
@@ -28,6 +28,41 @@ def test_method_projector_builds_stable_system_guidance() -> None:
     assert projection.temperature == 0.2
 
 
+def test_method_projector_preserves_step_policy_metadata() -> None:
+    descriptor = MethodDescriptor(
+        id="method:task:review",
+        name="review",
+        description="Review changes.",
+        content="Review the diff carefully.",
+        kind="method_resource",
+        metadata={
+            "frontmatter": {
+                "plan_mode": "fixed",
+                "steps": ["inspect"],
+                "step_constraints": {
+                    "inspect": {
+                        "level": "reasoned",
+                        "requires_reason": True,
+                    },
+                },
+                "step_audit": {
+                    "inspect": {
+                        "record": ["status", "reason"],
+                    },
+                },
+            },
+        },
+    )
+    plan = MethodCompiler().compile(descriptor)
+    projection = MethodProjector().project(plan, plan.steps[0])
+
+    assert projection.metadata["source_constraint"] == {
+        "level": "reasoned",
+        "requires_reason": True,
+    }
+    assert projection.metadata["source_audit"] == {"record": ["status", "reason"]}
+
+
 def test_method_projector_handles_empty_content() -> None:
     descriptor = MethodDescriptor(id="skill:empty", name="empty", description="", content="", kind="skill_backed")
     plan = MethodCompiler().compile(descriptor)

--- a/tests/method/test_method_types.py
+++ b/tests/method/test_method_types.py
@@ -85,6 +85,8 @@ def test_method_plan_and_step_support_single_turn_defaults() -> None:
     assert step.role_variant is None
     assert step.applicability == MethodApplicability()
     assert step.projection == {}
+    assert step.constraint == {}
+    assert step.audit == {}
 
 
 def test_method_projection_defaults_and_optional_role_hints() -> None:


### PR DESCRIPTION
## Summary
- Add read-only constraint/audit metadata to MethodStep and fixed MethodPlan compilation.
- Expose step policy metadata through method projection and method plan show text/json output.
- Extend frontmatter parsing for nested maps needed by step policy metadata.

## Notes
- This does not enforce constraints or alter method execution behavior.
- This is a read-only metadata foundation for later work-step deviation/audit support.

## Test Plan
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_frontmatter.py tests/coding/test_resource_loader.py tests/method tests/coding/test_cli.py -q
- [x] uv --cache-dir .uv-cache run ruff check src/loushang/coding/frontmatter.py src/loushang/method/types.py src/loushang/method/compiler.py src/loushang/method/projection.py src/loushang/coding/cli/__main__.py tests/coding/test_frontmatter.py tests/method tests/coding/test_cli.py
- [x] git diff --check