### PR TITLE
feat: project work step deviations

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -899,6 +899,7 @@ def _write_work_log_plan_summary(entries: list[Any], stdout: TextIO) -> None:
                 "failed_steps",
                 "current_step",
                 "title",
+                "deviation",
             ]
         )
         + "\n"
@@ -916,6 +917,7 @@ def _write_work_log_plan_summary(entries: list[Any], stdout: TextIO) -> None:
                     f"{plan.completed_step_count}/{plan.step_count}",
                     str(plan.failed_step_count),
                     plan.current_step_id or "",
+                    "",
                     "",
                 ]
             )
@@ -935,6 +937,7 @@ def _write_work_log_plan_summary(entries: list[Any], stdout: TextIO) -> None:
                         "",
                         "",
                         step.title or "",
+                        _work_log_plan_step_deviation_summary(step.deviation),
                     ]
                 )
                 + "\n"
@@ -946,6 +949,20 @@ def _work_log_plan_step_index(metadata: Mapping[str, object], fallback_index: in
     if isinstance(step_index, int) and not isinstance(step_index, bool):
         return str(step_index + 1)
     return str(fallback_index)
+
+
+def _work_log_plan_step_deviation_summary(deviation: Any) -> str:
+    if deviation is None:
+        return ""
+    deviation_type = getattr(deviation, "deviation_type", "")
+    reason = getattr(deviation, "reason", "")
+    if deviation_type and reason:
+        return f"{deviation_type}: {reason}"
+    if deviation_type:
+        return str(deviation_type)
+    if reason:
+        return str(reason)
+    return ""
 
 
 def _work_log_entry_summary(entry: Any) -> dict[str, object]:

--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -18,6 +18,7 @@ from loushang.work.types import (
     WorkPlanRun,
     WorkRun,
     WorkRunStatus,
+    WorkStepDeviation,
     WorkStepRun,
     WorkStepStatus,
 )
@@ -36,6 +37,7 @@ __all__ = [
     "WorkPlanRun",
     "WorkRun",
     "WorkRunStatus",
+    "WorkStepDeviation",
     "WorkStepRun",
     "WorkStepStatus",
     "project_agent_event_to_work_events",

--- a/src/loushang/work/plan_projection.py
+++ b/src/loushang/work/plan_projection.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 
 from loushang.work.event_log import EventLogEntry
-from loushang.work.types import WorkPlanRun, WorkRunStatus, WorkStepRun, WorkStepStatus
+from loushang.work.types import (
+    WorkPlanRun,
+    WorkRunStatus,
+    WorkStepDeviation,
+    WorkStepRun,
+    WorkStepStatus,
+)
 
 
 def project_work_plan_runs(entries: Iterable[EventLogEntry]) -> tuple[WorkPlanRun, ...]:
@@ -126,6 +132,7 @@ class _StepState:
     completed_sequence: int | None = None
     failed_sequence: int | None = None
     error: str | None = None
+    deviation: WorkStepDeviation | None = None
 
     def update_from_entry(
         self,
@@ -147,6 +154,9 @@ class _StepState:
         step_index = _entry_step_index(entry)
         if step_index is not None:
             self.step_index = step_index
+        deviation = _entry_step_deviation(entry, step_id=self.step_id)
+        if deviation is not None:
+            self.deviation = deviation
 
         if kind == "WorkStepStarted":
             self.status = "running"
@@ -168,6 +178,7 @@ class _StepState:
                 "completed_sequence": self.completed_sequence,
                 "failed_sequence": self.failed_sequence,
                 "error": self.error,
+                "deviation": asdict(self.deviation) if self.deviation is not None else None,
             }
         )
         return WorkStepRun(
@@ -178,6 +189,7 @@ class _StepState:
             status=self.status,
             method_id=self.method_id,
             title=self.title,
+            deviation=self.deviation,
             metadata=metadata,
         )
 
@@ -201,6 +213,44 @@ def _entry_step_index(entry: EventLogEntry) -> int | None:
     if isinstance(value, int) and not isinstance(value, bool):
         return value
     return None
+
+
+def _entry_step_deviation(entry: EventLogEntry, *, step_id: str) -> WorkStepDeviation | None:
+    value = _entry_payload_value(entry, "deviation")
+    if not isinstance(value, Mapping):
+        return None
+    deviation_type = _mapping_string_value(value, "deviation_type") or _mapping_string_value(value, "type")
+    if not deviation_type:
+        return None
+    reason = _mapping_string_value(value, "reason")
+    metadata_value = value.get("metadata")
+    metadata = dict(metadata_value) if isinstance(metadata_value, Mapping) else {}
+    return WorkStepDeviation(
+        step_id=_mapping_string_value(value, "step_id") or step_id,
+        deviation_type=deviation_type,
+        reason=reason,
+        policy_level=_mapping_string_value(value, "policy_level") or None,
+        evidence_refs=_mapping_string_tuple(value.get("evidence_refs")),
+        approval_ref=_mapping_string_value(value, "approval_ref") or None,
+        risk=_mapping_string_value(value, "risk") or None,
+        outcome=_mapping_string_value(value, "outcome") or None,
+        metadata=metadata,
+    )
+
+
+def _mapping_string_value(mapping: Mapping[str, object], key: str) -> str:
+    value = mapping.get(key)
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _mapping_string_tuple(value: object) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, list | tuple):
+        return tuple(item for item in value if isinstance(item, str) and item)
+    return ()
 
 
 def _entry_payload_value(entry: EventLogEntry, key: str) -> object | None:

--- a/src/loushang/work/types.py
+++ b/src/loushang/work/types.py
@@ -49,6 +49,19 @@ class WorkRun:
 
 
 @dataclass(frozen=True)
+class WorkStepDeviation:
+    step_id: str
+    deviation_type: str
+    reason: str
+    policy_level: str | None = None
+    evidence_refs: tuple[str, ...] = ()
+    approval_ref: str | None = None
+    risk: str | None = None
+    outcome: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
 class WorkStepRun:
     run_id: str
     plan_id: str
@@ -63,6 +76,7 @@ class WorkStepRun:
     role: str | None = None
     expected_artifacts: tuple[str, ...] = ()
     success_criteria: tuple[str, ...] = ()
+    deviation: WorkStepDeviation | None = None
     metadata: Mapping[str, object] = field(default_factory=dict)
 
 
@@ -101,6 +115,7 @@ __all__ = [
     "WorkPlanRun",
     "WorkRun",
     "WorkRunStatus",
+    "WorkStepDeviation",
     "WorkStepRun",
     "WorkStepStatus",
 ]

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -266,6 +266,7 @@ def _append_work_log_inspect_entry(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    deviation: dict[str, object] | None = None,
 ) -> None:
     from loushang.work import EventLogEntry
 
@@ -283,6 +284,8 @@ def _append_work_log_inspect_entry(
         nested_payload["step_index"] = step_index
     if step_title is not None:
         nested_payload["step_title"] = step_title
+    if deviation is not None:
+        nested_payload["deviation"] = deviation
     if nested_payload:
         payload["payload"] = nested_payload
     event_log.append(
@@ -4110,10 +4113,10 @@ def test_run_cli_work_log_inspect_plans_outputs_plan_summary_without_runtime(tmp
     asyncio.run(scenario())
 
     assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
-        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title"],
-        ["plan", "", "plan:method:task:review", "completed", "", "method:task:review", "2/2", "0", "verify", ""],
-        ["step", "1", "inspect", "completed", "run-inspect", "method:task:review", "", "", "", "Inspect current changes"],
-        ["step", "2", "verify", "completed", "run-verify", "method:task:review", "", "", "", "Run focused checks"],
+        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title", "deviation"],
+        ["plan", "", "plan:method:task:review", "completed", "", "method:task:review", "2/2", "0", "verify", "", ""],
+        ["step", "1", "inspect", "completed", "run-inspect", "method:task:review", "", "", "", "Inspect current changes", ""],
+        ["step", "2", "verify", "completed", "run-verify", "method:task:review", "", "", "", "Run focused checks", ""],
     ]
 
 
@@ -4169,9 +4172,67 @@ def test_run_cli_work_log_inspect_plans_respects_run_filter(tmp_path) -> None:
     asyncio.run(scenario())
 
     assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
-        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title"],
-        ["plan", "", "plan:method:task:review", "running", "", "method:task:review", "0/1", "1", "verify", ""],
-        ["step", "2", "verify", "failed", "run-verify", "method:task:review", "", "", "", "Run focused checks"],
+        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title", "deviation"],
+        ["plan", "", "plan:method:task:review", "running", "", "method:task:review", "0/1", "1", "verify", "", ""],
+        ["step", "2", "verify", "failed", "run-verify", "method:task:review", "", "", "", "Run focused checks", ""],
+    ]
+
+
+def test_run_cli_work_log_inspect_plans_shows_step_deviation(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=1,
+        kind="WorkStepCompleted",
+        run_id="run-inspect",
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        step_id="inspect",
+        step_index=0,
+        step_title="Inspect current changes",
+        deviation={
+            "deviation_type": "adapted",
+            "reason": "Only documentation files changed.",
+            "policy_level": "reasoned",
+            "evidence_refs": ["git-diff"],
+        },
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "plans"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
+        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title", "deviation"],
+        ["plan", "", "plan:method:task:review", "running", "", "method:task:review", "1/1", "0", "inspect", "", ""],
+        [
+            "step",
+            "1",
+            "inspect",
+            "completed",
+            "run-inspect",
+            "method:task:review",
+            "",
+            "",
+            "",
+            "Inspect current changes",
+            "adapted: Only documentation files changed.",
+        ],
     ]
 
 
@@ -4215,8 +4276,8 @@ def test_run_cli_work_log_inspect_plans_projects_full_log_not_tail_limit(tmp_pat
     asyncio.run(scenario())
 
     assert [line.split("\t") for line in stdout.getvalue().splitlines()][1:] == [
-        ["plan", "", "plan:method:task:review", "completed", "", "method:task:review", "1/1", "0", "inspect", ""],
-        ["step", "1", "inspect", "completed", "run-inspect", "method:task:review", "", "", "", "Inspect current changes"],
+        ["plan", "", "plan:method:task:review", "completed", "", "method:task:review", "1/1", "0", "inspect", "", ""],
+        ["step", "1", "inspect", "completed", "run-inspect", "method:task:review", "", "", "", "Inspect current changes", ""],
     ]
 
 
@@ -4264,6 +4325,59 @@ def test_run_cli_work_log_inspect_plans_json_outputs_plan_projection(tmp_path) -
     assert payload[0]["steps"][0]["status"] == "completed"
     assert payload[0]["steps"][0]["title"] == "Inspect current changes"
     assert payload[0]["steps"][0]["metadata"]["step_index"] == 0
+
+
+def test_run_cli_work_log_inspect_plans_json_includes_step_deviation(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=1,
+        kind="WorkStepCompleted",
+        run_id="run-inspect",
+        method_id="method:task:review",
+        plan_id="plan:method:task:review",
+        step_id="inspect",
+        step_index=0,
+        step_title="Inspect current changes",
+        deviation={
+            "deviation_type": "adapted",
+            "reason": "Only documentation files changed.",
+            "policy_level": "reasoned",
+            "evidence_refs": ["git-diff"],
+        },
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "plans-json"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    deviation = json.loads(stdout.getvalue())[0]["steps"][0]["deviation"]
+    assert deviation == {
+        "step_id": "inspect",
+        "deviation_type": "adapted",
+        "reason": "Only documentation files changed.",
+        "policy_level": "reasoned",
+        "evidence_refs": ["git-diff"],
+        "approval_ref": None,
+        "risk": None,
+        "outcome": None,
+        "metadata": {},
+    }
 
 
 def test_run_cli_work_log_inspect_outputs_json_without_runtime(tmp_path) -> None:

--- a/tests/work/test_plan_projection.py
+++ b/tests/work/test_plan_projection.py
@@ -17,6 +17,7 @@ def _entry(
     step_index: int | None = None,
     step_title: str | None = None,
     error: str | None = None,
+    deviation: dict[str, object] | None = None,
 ) -> object:
     from loushang.work import EventLogEntry
 
@@ -34,6 +35,8 @@ def _entry(
         nested_payload["step_title"] = step_title
     if error is not None:
         nested_payload["error"] = error
+    if deviation is not None:
+        nested_payload["deviation"] = deviation
     if nested_payload:
         payload["payload"] = nested_payload
 
@@ -218,6 +221,62 @@ def test_project_work_plan_runs_replays_failed_step_and_plan_error() -> None:
     assert plan.steps[0].status == "failed"
     assert plan.steps[0].metadata["error"] == "step failed"
     assert plan.steps[0].metadata["failed_sequence"] == 4
+
+
+def test_project_work_plan_runs_replays_step_deviation_metadata() -> None:
+    from loushang.work import project_work_plan_runs
+
+    plans = project_work_plan_runs(
+        [
+            _entry(
+                "run-inspect-step-started",
+                kind="WorkStepStarted",
+                run_id="run-inspect",
+                sequence=1,
+                step_id="inspect",
+                step_index=0,
+                step_title="Inspect current changes",
+            ),
+            _entry(
+                "run-inspect-step-completed",
+                kind="WorkStepCompleted",
+                run_id="run-inspect",
+                sequence=2,
+                step_id="inspect",
+                step_index=0,
+                step_title="Inspect current changes",
+                deviation={
+                    "deviation_type": "adapted",
+                    "reason": "Only documentation files changed.",
+                    "policy_level": "reasoned",
+                    "evidence_refs": ["git-diff"],
+                    "risk": "low",
+                    "outcome": "accepted",
+                },
+            ),
+        ]
+    )
+
+    deviation = plans[0].steps[0].deviation
+    assert deviation is not None
+    assert deviation.step_id == "inspect"
+    assert deviation.deviation_type == "adapted"
+    assert deviation.reason == "Only documentation files changed."
+    assert deviation.policy_level == "reasoned"
+    assert deviation.evidence_refs == ("git-diff",)
+    assert deviation.risk == "low"
+    assert deviation.outcome == "accepted"
+    assert plans[0].steps[0].metadata["deviation"] == {
+        "step_id": "inspect",
+        "deviation_type": "adapted",
+        "reason": "Only documentation files changed.",
+        "policy_level": "reasoned",
+        "evidence_refs": ("git-diff",),
+        "approval_ref": None,
+        "risk": "low",
+        "outcome": "accepted",
+        "metadata": {},
+    }
 
 
 def test_project_work_plan_runs_ignores_entries_without_plan_id() -> None:

--- a/tests/work/test_public_api.py
+++ b/tests/work/test_public_api.py
@@ -18,6 +18,7 @@ def test_work_public_api_exposes_current_work_surface_without_multi_agent_types(
         "WorkPlanRun",
         "WorkRun",
         "WorkRunStatus",
+        "WorkStepDeviation",
         "WorkStepRun",
         "WorkStepStatus",
         "project_agent_event_to_work_events",

--- a/tests/work/test_work_types.py
+++ b/tests/work/test_work_types.py
@@ -75,7 +75,17 @@ def test_work_run_tracks_plan_and_current_step_metadata_without_multi_agent_surf
 
 
 def test_work_step_run_tracks_step_lifecycle_metadata() -> None:
-    from loushang.work import WorkStepRun
+    from loushang.work import WorkStepDeviation, WorkStepRun
+
+    deviation = WorkStepDeviation(
+        step_id="inspect",
+        deviation_type="adapted",
+        reason="Repository state made the default inspection path too broad.",
+        policy_level="reasoned",
+        evidence_refs=("changed-files",),
+        risk="low",
+        outcome="accepted",
+    )
 
     step_run = WorkStepRun(
         run_id="run-1",
@@ -89,6 +99,7 @@ def test_work_step_run_tracks_step_lifecycle_metadata() -> None:
         role="EXPLORER",
         expected_artifacts=("review-notes",),
         success_criteria=("Changed files are understood",),
+        deviation=deviation,
         metadata={"step_index": 0},
     )
 
@@ -105,6 +116,15 @@ def test_work_step_run_tracks_step_lifecycle_metadata() -> None:
     assert step_run.role == "EXPLORER"
     assert step_run.expected_artifacts == ("review-notes",)
     assert step_run.success_criteria == ("Changed files are understood",)
+    assert step_run.deviation == deviation
+    assert deviation.step_id == "inspect"
+    assert deviation.deviation_type == "adapted"
+    assert deviation.reason == "Repository state made the default inspection path too broad."
+    assert deviation.policy_level == "reasoned"
+    assert deviation.evidence_refs == ("changed-files",)
+    assert deviation.approval_ref is None
+    assert deviation.risk == "low"
+    assert deviation.outcome == "accepted"
     assert step_run.metadata == {"step_index": 0}
 
     with pytest.raises(FrozenInstanceError):


### PR DESCRIPTION
## Summary
- Add WorkStepDeviation and attach optional deviation metadata to WorkStepRun.
- Replay step deviation payloads through project_work_plan_runs.
- Show deviation summaries in work-log plans TSV and full deviation data in plans-json.

## Notes
- This records and projects deviation facts only.
- It does not enforce method constraints or change method execution behavior.

## Test Plan
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/coding/test_cli.py -q
- [x] uv --cache-dir .uv-cache run ruff check src/loushang/work/types.py src/loushang/work/__init__.py src/loushang/work/plan_projection.py src/loushang/coding/cli/__main__.py tests/work tests/coding/test_cli.py
- [x] git diff --check