### PR TITLE
Project planned work step policy

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -482,6 +482,8 @@ async def run_cli(
                 for turn_index, prepared_turn in enumerate(prepared_turns):
                     is_first_turn = turn_index == 0
                     is_last_turn = turn_index == len(prepared_turns) - 1
+                    planned_constraint = _prepared_turn_policy_metadata(prepared_turn, "planned_constraint")
+                    audit_policy = _prepared_turn_policy_metadata(prepared_turn, "audit_policy")
                     exit_code = await prompt_runner(
                         runtime=runtime,
                         session=session,
@@ -497,6 +499,8 @@ async def run_cli(
                         step_id=prepared_turn.step_id,
                         step_index=prepared_turn.step_index,
                         step_title=prepared_turn.step_title,
+                        planned_constraint=planned_constraint,
+                        audit_policy=audit_policy,
                         emit_plan_start=is_first_turn,
                         emit_plan_completion=is_last_turn,
                         dispose=is_last_turn,
@@ -512,6 +516,8 @@ async def run_cli(
                 for turn_index, prepared_turn in enumerate(prepared_turns):
                     is_first_turn = turn_index == 0
                     is_last_turn = turn_index == len(prepared_turns) - 1
+                    planned_constraint = _prepared_turn_policy_metadata(prepared_turn, "planned_constraint")
+                    audit_policy = _prepared_turn_policy_metadata(prepared_turn, "audit_policy")
                     exit_code = await print_runner(
                         runtime=runtime,
                         session=session,
@@ -528,6 +534,8 @@ async def run_cli(
                         step_id=prepared_turn.step_id,
                         step_index=prepared_turn.step_index,
                         step_title=prepared_turn.step_title,
+                        planned_constraint=planned_constraint,
+                        audit_policy=audit_policy,
                         emit_plan_start=is_first_turn,
                         emit_plan_completion=is_last_turn,
                         dispose=is_last_turn,
@@ -541,6 +549,8 @@ async def run_cli(
             for turn_index, prepared_turn in enumerate(prepared_turns):
                 is_first_turn = turn_index == 0
                 is_last_turn = turn_index == len(prepared_turns) - 1
+                planned_constraint = _prepared_turn_policy_metadata(prepared_turn, "planned_constraint")
+                audit_policy = _prepared_turn_policy_metadata(prepared_turn, "audit_policy")
                 exit_code = await mode_runner(
                     config=ModeConfig(
                         mode=args.mode,
@@ -560,6 +570,8 @@ async def run_cli(
                     step_id=prepared_turn.step_id,
                     step_index=prepared_turn.step_index,
                     step_title=prepared_turn.step_title,
+                    planned_constraint=planned_constraint,
+                    audit_policy=audit_policy,
                     emit_plan_start=is_first_turn,
                     emit_plan_completion=is_last_turn,
                     dispose=is_last_turn,
@@ -580,6 +592,13 @@ async def _dispose_runtime_or_session(runtime: Any, session: Any) -> None:
     result = disposer()
     if inspect.isawaitable(result):
         await result
+
+
+def _prepared_turn_policy_metadata(prepared_turn: Any, key: str) -> Mapping[str, object] | None:
+    value = prepared_turn.metadata.get(key)
+    if isinstance(value, Mapping) and value:
+        return dict(value)
+    return None
 
 
 def _resolve_session_dir(args: CliArgs, project_root: Path, services: Any) -> Path:

--- a/src/loushang/coding/domain/app.py
+++ b/src/loushang/coding/domain/app.py
@@ -91,6 +91,12 @@ class CodingDomainApp:
             "plan_mode": plan.mode,
             "step_index": step_index,
         }
+        constraint = projection.metadata.get("source_constraint")
+        if isinstance(constraint, Mapping) and constraint:
+            metadata["planned_constraint"] = dict(constraint)
+        audit = projection.metadata.get("source_audit")
+        if isinstance(audit, Mapping) and audit:
+            metadata["audit_policy"] = dict(audit)
         if not _has_meaningful_guidance(descriptor, projection):
             return CodingDomainPreparedTurn(
                 prepared_prompt=request.user_input,

--- a/src/loushang/coding/mode/base.py
+++ b/src/loushang/coding/mode/base.py
@@ -3,7 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal, Protocol, Sequence, TextIO, TypedDict, cast, get_args
+from typing import (
+    Any,
+    Literal,
+    Mapping,
+    Protocol,
+    Sequence,
+    TextIO,
+    TypedDict,
+    cast,
+    get_args,
+)
 
 from loushang.coding.event import JsonEventView
 from loushang.work import EventLogBackend
@@ -136,6 +146,8 @@ def create_mode_adapter(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    planned_constraint: Mapping[str, object] | None = None,
+    audit_policy: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
 ) -> ModeAdapter:
@@ -174,6 +186,8 @@ def create_mode_adapter(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        planned_constraint=planned_constraint,
+        audit_policy=audit_policy,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )
@@ -196,6 +210,8 @@ async def run_mode(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    planned_constraint: Mapping[str, object] | None = None,
+    audit_policy: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
     dispose: bool = True,
@@ -213,6 +229,8 @@ async def run_mode(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        planned_constraint=planned_constraint,
+        audit_policy=audit_policy,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )

--- a/src/loushang/coding/mode/print_mode.py
+++ b/src/loushang/coding/mode/print_mode.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import json
 import sys
-from typing import Any, Literal, Sequence, TextIO
+from typing import Any, Literal, Mapping, Sequence, TextIO
 
 from loushang.coding.event import (
     SUPPORTED_JSON_EVENT_VIEWS,
@@ -36,6 +36,8 @@ class PrintMode(ModeAdapter):
         step_id: str | None = None,
         step_index: int | None = None,
         step_title: str | None = None,
+        planned_constraint: Mapping[str, object] | None = None,
+        audit_policy: Mapping[str, object] | None = None,
         emit_plan_start: bool = True,
         emit_plan_completion: bool = True,
     ) -> None:
@@ -69,6 +71,8 @@ class PrintMode(ModeAdapter):
         self.step_id = step_id
         self.step_index = step_index
         self.step_title = step_title
+        self.planned_constraint = planned_constraint
+        self.audit_policy = audit_policy
         self.emit_plan_start = emit_plan_start
         self.emit_plan_completion = emit_plan_completion
         self._tool_render_runtime: ToolRenderRuntime | None = None
@@ -288,6 +292,8 @@ class PrintMode(ModeAdapter):
             step_id=self.step_id,
             step_index=self.step_index,
             step_title=self.step_title,
+            planned_constraint=self.planned_constraint,
+            audit_policy=self.audit_policy,
             emit_plan_start=emit_plan_start,
             emit_plan_completion=emit_plan_completion,
         )
@@ -462,6 +468,8 @@ async def run_print_mode(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    planned_constraint: Mapping[str, object] | None = None,
+    audit_policy: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
     dispose: bool = True,
@@ -481,6 +489,8 @@ async def run_print_mode(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        planned_constraint=planned_constraint,
+        audit_policy=audit_policy,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )

--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import time
 import traceback
-from typing import Any, Sequence, TextIO
+from typing import Any, Mapping, Sequence, TextIO
 
 from loushang.coding.ui.events import CodingUiEventRenderer
 from loushang.coding.ui.model import ensure_usable_session_model
@@ -27,6 +27,8 @@ async def run_prompt_command(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    planned_constraint: Mapping[str, object] | None = None,
+    audit_policy: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
     dispose: bool = True,
@@ -55,6 +57,8 @@ async def run_prompt_command(
             step_id=step_id,
             step_index=step_index,
             step_title=step_title,
+            planned_constraint=planned_constraint,
+            audit_policy=audit_policy,
             emit_plan_start=emit_plan_start,
             emit_plan_completion=emit_plan_completion and not follow_up_messages,
         )
@@ -71,6 +75,8 @@ async def run_prompt_command(
                     step_id=step_id,
                     step_index=step_index,
                     step_title=step_title,
+                    planned_constraint=planned_constraint,
+                    audit_policy=audit_policy,
                     emit_plan_start=False,
                     emit_plan_completion=emit_plan_completion and follow_up_index == len(follow_up_messages) - 1,
                 )
@@ -107,6 +113,8 @@ async def _run_turn(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    planned_constraint: Mapping[str, object] | None = None,
+    audit_policy: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
 ) -> int:
@@ -123,6 +131,8 @@ async def _run_turn(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        planned_constraint=planned_constraint,
+        audit_policy=audit_policy,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )
@@ -147,6 +157,8 @@ async def _run_prompt_session(
     step_id: str | None = None,
     step_index: int | None = None,
     step_title: str | None = None,
+    planned_constraint: Mapping[str, object] | None = None,
+    audit_policy: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
 ) -> None:
@@ -163,6 +175,8 @@ async def _run_prompt_session(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        planned_constraint=planned_constraint,
+        audit_policy=audit_policy,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )

--- a/src/loushang/work/coding.py
+++ b/src/loushang/work/coding.py
@@ -39,6 +39,8 @@ class CodingWorkShell:
         step_id: str | None = None,
         step_index: int | None = None,
         step_title: str | None = None,
+        planned_constraint: Mapping[str, object] | None = None,
+        audit_policy: Mapping[str, object] | None = None,
         operation_id: str | None = None,
         run_id: str | None = None,
         emit_plan_start: bool = True,
@@ -61,6 +63,8 @@ class CodingWorkShell:
                 step_id=step_id,
                 step_index=step_index,
                 step_title=step_title,
+                planned_constraint=planned_constraint,
+                audit_policy=audit_policy,
             ),
         )
         self._append_operation(operation, run_id=run_id, sequence=sequence)
@@ -97,6 +101,8 @@ class CodingWorkShell:
                     payload=_step_payload(
                         step_index=step_index,
                         step_title=step_title,
+                        planned_constraint=planned_constraint,
+                        audit_policy=audit_policy,
                     ),
                 ),
             )
@@ -112,6 +118,8 @@ class CodingWorkShell:
                     payload=_step_payload(
                         step_index=step_index,
                         step_title=step_title,
+                        planned_constraint=planned_constraint,
+                        audit_policy=audit_policy,
                     ),
                 ),
             )
@@ -152,6 +160,8 @@ class CodingWorkShell:
             failure_payload = _step_payload(
                 step_index=step_index,
                 step_title=step_title,
+                planned_constraint=planned_constraint,
+                audit_policy=audit_policy,
                 error=error,
             )
             if step_id is not None:
@@ -213,6 +223,8 @@ class CodingWorkShell:
                     payload=_step_payload(
                         step_index=step_index,
                         step_title=step_title,
+                        planned_constraint=planned_constraint,
+                        audit_policy=audit_policy,
                     ),
                 ),
             )
@@ -228,6 +240,8 @@ class CodingWorkShell:
                     payload=_step_payload(
                         step_index=step_index,
                         step_title=step_title,
+                        planned_constraint=planned_constraint,
+                        audit_policy=audit_policy,
                     ),
                 ),
             )
@@ -305,6 +319,8 @@ def _operation_payload(
     step_id: str | None,
     step_index: int | None,
     step_title: str | None,
+    planned_constraint: Mapping[str, object] | None,
+    audit_policy: Mapping[str, object] | None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {"text": text}
     if images is not None:
@@ -319,6 +335,10 @@ def _operation_payload(
         payload["step_index"] = step_index
     if step_title is not None:
         payload["step_title"] = step_title
+    if planned_constraint:
+        payload["planned_constraint"] = dict(planned_constraint)
+    if audit_policy:
+        payload["audit_policy"] = dict(audit_policy)
     return payload
 
 
@@ -326,6 +346,8 @@ def _step_payload(
     *,
     step_index: int | None,
     step_title: str | None,
+    planned_constraint: Mapping[str, object] | None = None,
+    audit_policy: Mapping[str, object] | None = None,
     error: BaseException | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {"source_type": "work_shell"}
@@ -333,6 +355,10 @@ def _step_payload(
         payload["step_index"] = step_index
     if step_title is not None:
         payload["step_title"] = step_title
+    if planned_constraint:
+        payload["planned_constraint"] = dict(planned_constraint)
+    if audit_policy:
+        payload["audit_policy"] = dict(audit_policy)
     if error is not None:
         payload["error"] = str(error)
     return payload

--- a/src/loushang/work/plan_projection.py
+++ b/src/loushang/work/plan_projection.py
@@ -133,6 +133,8 @@ class _StepState:
     failed_sequence: int | None = None
     error: str | None = None
     deviation: WorkStepDeviation | None = None
+    planned_constraint: dict[str, object] | None = None
+    audit_policy: dict[str, object] | None = None
 
     def update_from_entry(
         self,
@@ -157,6 +159,12 @@ class _StepState:
         deviation = _entry_step_deviation(entry, step_id=self.step_id)
         if deviation is not None:
             self.deviation = deviation
+        planned_constraint = _entry_mapping_payload_value(entry, "planned_constraint")
+        if planned_constraint is not None:
+            self.planned_constraint = planned_constraint
+        audit_policy = _entry_mapping_payload_value(entry, "audit_policy")
+        if audit_policy is not None:
+            self.audit_policy = audit_policy
 
         if kind == "WorkStepStarted":
             self.status = "running"
@@ -179,6 +187,8 @@ class _StepState:
                 "failed_sequence": self.failed_sequence,
                 "error": self.error,
                 "deviation": asdict(self.deviation) if self.deviation is not None else None,
+                "planned_constraint": self.planned_constraint,
+                "audit_policy": self.audit_policy,
             }
         )
         return WorkStepRun(
@@ -236,6 +246,13 @@ def _entry_step_deviation(entry: EventLogEntry, *, step_id: str) -> WorkStepDevi
         outcome=_mapping_string_value(value, "outcome") or None,
         metadata=metadata,
     )
+
+
+def _entry_mapping_payload_value(entry: EventLogEntry, key: str) -> dict[str, object] | None:
+    value = _entry_payload_value(entry, key)
+    if not isinstance(value, Mapping):
+        return None
+    return dict(value)
 
 
 def _mapping_string_value(mapping: Mapping[str, object], key: str) -> str:

--- a/tests/coding/domain/test_coding_domain_app.py
+++ b/tests/coding/domain/test_coding_domain_app.py
@@ -203,6 +203,18 @@ def test_prepare_turns_with_fixed_method_prepares_each_step(tmp_path: Path) -> N
         "step_guidance:\n"
         "  inspect: Read changed files and summarize intent.\n"
         "  verify: Run focused tests or explain why they cannot run.\n"
+        "step_constraints:\n"
+        "  inspect:\n"
+        "    level: reasoned\n"
+        "    requires_reason: true\n"
+        "  verify:\n"
+        "    level: evidence\n"
+        "    requires_evidence: true\n"
+        "step_audit:\n"
+        "  inspect:\n"
+        "    record: [status, reason]\n"
+        "  verify:\n"
+        "    record: [status, reason, evidence]\n"
         "---\n\n"
         "Use the review method.",
         encoding="utf-8",
@@ -222,6 +234,16 @@ def test_prepare_turns_with_fixed_method_prepares_each_step(tmp_path: Path) -> N
     assert all(turn.method_id == "method:task:review" for turn in prepared_turns)
     assert all(turn.plan_id == "plan:method:task:review" for turn in prepared_turns)
     assert all(turn.plan_mode == "fixed" for turn in prepared_turns)
+    assert prepared_turns[0].metadata["planned_constraint"] == {
+        "level": "reasoned",
+        "requires_reason": True,
+    }
+    assert prepared_turns[0].metadata["audit_policy"] == {"record": ["status", "reason"]}
+    assert prepared_turns[1].metadata["planned_constraint"] == {
+        "level": "evidence",
+        "requires_evidence": True,
+    }
+    assert prepared_turns[1].metadata["audit_policy"] == {"record": ["status", "reason", "evidence"]}
     assert "Read changed files and summarize intent." in prepared_turns[0].prepared_prompt
     assert "Run focused tests or explain why they cannot run." in prepared_turns[1].prepared_prompt
     assert prepared_turns[0].prepared_prompt.endswith("User request:\n\ncheck src/app.py")

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -267,6 +267,8 @@ def _append_work_log_inspect_entry(
     step_index: int | None = None,
     step_title: str | None = None,
     deviation: dict[str, object] | None = None,
+    planned_constraint: dict[str, object] | None = None,
+    audit_policy: dict[str, object] | None = None,
 ) -> None:
     from loushang.work import EventLogEntry
 
@@ -286,6 +288,10 @@ def _append_work_log_inspect_entry(
         nested_payload["step_title"] = step_title
     if deviation is not None:
         nested_payload["deviation"] = deviation
+    if planned_constraint is not None:
+        nested_payload["planned_constraint"] = planned_constraint
+    if audit_policy is not None:
+        nested_payload["audit_policy"] = audit_policy
     if nested_payload:
         payload["payload"] = nested_payload
     event_log.append(
@@ -313,6 +319,8 @@ def _append_work_log_plan_step_entries(
     step_title: str,
     first: bool = False,
     last: bool = False,
+    planned_constraint: dict[str, object] | None = None,
+    audit_policy: dict[str, object] | None = None,
 ) -> int:
     sequence = start_sequence
     _append_work_log_inspect_entry(
@@ -326,6 +334,8 @@ def _append_work_log_plan_step_entries(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        planned_constraint=planned_constraint,
+        audit_policy=audit_policy,
     )
     sequence += 1
     if first:
@@ -339,6 +349,8 @@ def _append_work_log_plan_step_entries(
             step_id=step_id,
             step_index=step_index,
             step_title=step_title,
+            planned_constraint=planned_constraint,
+            audit_policy=audit_policy,
         )
         sequence += 1
     _append_work_log_inspect_entry(
@@ -351,6 +363,8 @@ def _append_work_log_plan_step_entries(
         step_id=step_id,
         step_index=step_index,
         step_title=step_title,
+        planned_constraint=planned_constraint,
+        audit_policy=audit_policy,
     )
     sequence += 1
     _append_work_log_inspect_entry(
@@ -376,6 +390,8 @@ def _append_work_log_plan_step_entries(
             step_id=step_id,
             step_index=step_index,
             step_title=step_title,
+            planned_constraint=planned_constraint,
+            audit_policy=audit_policy,
         )
         sequence += 1
     return sequence
@@ -2522,6 +2538,12 @@ def test_run_cli_dash_p_with_fixed_method_executes_each_step(tmp_path) -> None:
     assert first_call["step_id"] == "inspect"
     assert first_call["step_index"] == 0
     assert first_call["step_title"] == "Inspect current changes"
+    assert first_call["planned_constraint"] == {
+        "level": "reasoned",
+        "can_merge": True,
+        "requires_reason": True,
+    }
+    assert first_call["audit_policy"] == {"record": ["status", "reason"]}
     assert first_call["emit_plan_start"] is True
     assert first_call["emit_plan_completion"] is False
     assert "Read changed files and summarize intent." in first_call["prompt"]
@@ -2531,6 +2553,12 @@ def test_run_cli_dash_p_with_fixed_method_executes_each_step(tmp_path) -> None:
     assert second_call["step_id"] == "verify"
     assert second_call["step_index"] == 1
     assert second_call["step_title"] == "Run focused checks"
+    assert second_call["planned_constraint"] == {
+        "level": "evidence",
+        "can_skip": True,
+        "requires_evidence": True,
+    }
+    assert second_call["audit_policy"] == {"record": ["status", "reason", "evidence"]}
     assert second_call["emit_plan_start"] is False
     assert second_call["emit_plan_completion"] is True
     assert "Run focused tests or explain why they cannot run." in second_call["prompt"]
@@ -3126,6 +3154,12 @@ def test_run_cli_mode_print_with_fixed_method_executes_each_step(tmp_path) -> No
     assert first_call["step_id"] == "inspect"
     assert first_call["step_index"] == 0
     assert first_call["step_title"] == "Inspect current changes"
+    assert first_call["planned_constraint"] == {
+        "level": "reasoned",
+        "can_merge": True,
+        "requires_reason": True,
+    }
+    assert first_call["audit_policy"] == {"record": ["status", "reason"]}
     assert first_call["emit_plan_start"] is True
     assert first_call["emit_plan_completion"] is False
     assert "Read changed files and summarize intent." in first_call["user_input"]
@@ -3136,6 +3170,12 @@ def test_run_cli_mode_print_with_fixed_method_executes_each_step(tmp_path) -> No
     assert second_call["step_id"] == "verify"
     assert second_call["step_index"] == 1
     assert second_call["step_title"] == "Run focused checks"
+    assert second_call["planned_constraint"] == {
+        "level": "evidence",
+        "can_skip": True,
+        "requires_evidence": True,
+    }
+    assert second_call["audit_policy"] == {"record": ["status", "reason", "evidence"]}
     assert second_call["emit_plan_start"] is False
     assert second_call["emit_plan_completion"] is True
     assert "Run focused tests or explain why they cannot run." in second_call["user_input"]
@@ -4296,6 +4336,8 @@ def test_run_cli_work_log_inspect_plans_json_outputs_plan_projection(tmp_path) -
         step_title="Inspect current changes",
         first=True,
         last=True,
+        planned_constraint={"level": "reasoned", "requires_reason": True},
+        audit_policy={"record": ["status", "reason"]},
     )
     stdout = StringIO()
 
@@ -4325,6 +4367,11 @@ def test_run_cli_work_log_inspect_plans_json_outputs_plan_projection(tmp_path) -
     assert payload[0]["steps"][0]["status"] == "completed"
     assert payload[0]["steps"][0]["title"] == "Inspect current changes"
     assert payload[0]["steps"][0]["metadata"]["step_index"] == 0
+    assert payload[0]["steps"][0]["metadata"]["planned_constraint"] == {
+        "level": "reasoned",
+        "requires_reason": True,
+    }
+    assert payload[0]["steps"][0]["metadata"]["audit_policy"] == {"record": ["status", "reason"]}
 
 
 def test_run_cli_work_log_inspect_plans_json_includes_step_deviation(tmp_path) -> None:

--- a/tests/work/test_coding_work_shell.py
+++ b/tests/work/test_coding_work_shell.py
@@ -201,6 +201,8 @@ def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
             step_id="inspect",
             step_index=0,
             step_title="Inspect current changes",
+            planned_constraint={"level": "reasoned", "requires_reason": True},
+            audit_policy={"record": ["status", "reason"]},
         )
 
         assert run.status == "completed"
@@ -225,6 +227,8 @@ def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
             "step_id": "inspect",
             "step_index": 0,
             "step_title": "Inspect current changes",
+            "planned_constraint": {"level": "reasoned", "requires_reason": True},
+            "audit_policy": {"record": ["status", "reason"]},
         }
         assert entries[2].payload["delivery_hint"] == "coalesce"
         assert entries[3].payload["delivery_hint"] == "coalesce"
@@ -237,6 +241,8 @@ def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
             "step_id": "inspect",
             "step_index": 0,
             "step_title": "Inspect current changes",
+            "planned_constraint": {"level": "reasoned", "requires_reason": True},
+            "audit_policy": {"record": ["status", "reason"]},
         }
 
     asyncio.run(scenario())

--- a/tests/work/test_plan_projection.py
+++ b/tests/work/test_plan_projection.py
@@ -18,6 +18,8 @@ def _entry(
     step_title: str | None = None,
     error: str | None = None,
     deviation: dict[str, object] | None = None,
+    planned_constraint: dict[str, object] | None = None,
+    audit_policy: dict[str, object] | None = None,
 ) -> object:
     from loushang.work import EventLogEntry
 
@@ -37,6 +39,10 @@ def _entry(
         nested_payload["error"] = error
     if deviation is not None:
         nested_payload["deviation"] = deviation
+    if planned_constraint is not None:
+        nested_payload["planned_constraint"] = planned_constraint
+    if audit_policy is not None:
+        nested_payload["audit_policy"] = audit_policy
     if nested_payload:
         payload["payload"] = nested_payload
 
@@ -277,6 +283,45 @@ def test_project_work_plan_runs_replays_step_deviation_metadata() -> None:
         "outcome": "accepted",
         "metadata": {},
     }
+
+
+def test_project_work_plan_runs_replays_planned_step_policy_metadata() -> None:
+    from loushang.work import project_work_plan_runs
+
+    plans = project_work_plan_runs(
+        [
+            _entry(
+                "run-inspect-step-started",
+                kind="WorkStepStarted",
+                run_id="run-inspect",
+                sequence=1,
+                step_id="inspect",
+                step_index=0,
+                step_title="Inspect current changes",
+                planned_constraint={
+                    "level": "reasoned",
+                    "requires_reason": True,
+                },
+                audit_policy={"record": ["status", "reason"]},
+            ),
+            _entry(
+                "run-inspect-step-completed",
+                kind="WorkStepCompleted",
+                run_id="run-inspect",
+                sequence=2,
+                step_id="inspect",
+                step_index=0,
+                step_title="Inspect current changes",
+            ),
+        ]
+    )
+
+    metadata = plans[0].steps[0].metadata
+    assert metadata["planned_constraint"] == {
+        "level": "reasoned",
+        "requires_reason": True,
+    }
+    assert metadata["audit_policy"] == {"record": ["status", "reason"]}
 
 
 def test_project_work_plan_runs_ignores_entries_without_plan_id() -> None:


### PR DESCRIPTION
## Summary
- Carry fixed method step constraint/audit metadata into prepared coding turns.
- Record planned step policy in work shell lifecycle event payloads.
- Replay planned policy into work plan step metadata for plans-json inspection.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/method tests/coding/domain tests/coding/test_cli.py -q
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli/__main__.py src/loushang/coding/domain/app.py src/loushang/coding/mode/base.py src/loushang/coding/mode/print_mode.py src/loushang/coding/prompt_command.py src/loushang/work/coding.py src/loushang/work/plan_projection.py tests/coding/domain/test_coding_domain_app.py tests/coding/test_cli.py tests/work/test_coding_work_shell.py tests/work/test_plan_projection.py
- git diff --check