### PR TITLE
Record tool approval audit events

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -1011,6 +1011,24 @@ def _work_log_entry_summary(entry: Any) -> dict[str, object]:
     step_title = _work_log_entry_step_title(entry)
     if step_title:
         summary["step_title"] = step_title
+    for key in (
+        "tool_call_id",
+        "tool_name",
+        "action_id",
+        "policy_disposition",
+        "policy_code",
+        "policy_reason",
+        "approval_required",
+        "approval_decision",
+        "approval_reason",
+        "argument_keys",
+        "path",
+        "file_path",
+        "command",
+    ):
+        value = _work_log_entry_payload_value(entry, key)
+        if isinstance(value, str | bool | int | float | list | tuple):
+            summary[key] = value
     return summary
 
 

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -4,11 +4,20 @@ import asyncio
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
 
-from loushang.agent import AbortController, AbortSignal, Agent, AgentEvent, ThinkingLevel
-from loushang.ai.types import AssistantMessage
-from loushang.ai.api_registry import ApiProviderRegistry, get_default_api_provider_registry
+from loushang.agent import (
+    AbortController,
+    AbortSignal,
+    Agent,
+    AgentEvent,
+    ThinkingLevel,
+)
+from loushang.ai.api_registry import (
+    ApiProviderRegistry,
+    get_default_api_provider_registry,
+)
 from loushang.ai.auth.registry import OAuthProviderRegistry, get_default_oauth_registry
 from loushang.ai.model import Model, Provider
+from loushang.ai.types import AssistantMessage, ImagePart
 from loushang.coding.compaction import (
     CompactionResult,
     CompactionStatus,
@@ -16,31 +25,92 @@ from loushang.coding.compaction import (
     generate_branch_summary,
     prepare_compaction,
 )
-from loushang.coding.control import AuthManager, CompactionSettings, ModelRegistry, RetrySettings, SettingsManager
+from loushang.coding.control import (
+    AuthManager,
+    CompactionSettings,
+    ModelRegistry,
+    RetrySettings,
+    SettingsManager,
+)
 from loushang.coding.diagnostics import (
     DiagnosticRecord,
-    DiagnosticSummary,
     DiagnosticsQuery,
     DiagnosticsService,
+    DiagnosticSummary,
     ErrorReport,
 )
-from loushang.coding.exec import ExecOutputChunk, ExecRequest, ExecResult, ExecService, ExecUpdateCallback
+from loushang.coding.event import AgentSessionEvent
+from loushang.coding.exec import (
+    ExecOutputChunk,
+    ExecRequest,
+    ExecResult,
+    ExecService,
+    ExecUpdateCallback,
+)
 from loushang.coding.extensions import (
     ExtensionRunner,
     ReplacedSessionContext,
     SessionShutdownEvent,
     SessionStartEvent,
 )
-from loushang.coding.loader import DefaultResourceLoader, PromptFragmentDescriptor, ResourceBundle, ResourceDiagnostic
-from loushang.ai.types import ImagePart
-from loushang.coding.event import AgentSessionEvent
-from loushang.coding.policy import InteractiveApprovalResolver
+from loushang.coding.loader import (
+    DefaultResourceLoader,
+    PromptFragmentDescriptor,
+    ResourceBundle,
+    ResourceDiagnostic,
+)
 from loushang.coding.message import SessionContext
-from loushang.coding.package.materializer import PackageMaterializer, PackageProgressEvent
+from loushang.coding.package.materializer import (
+    PackageMaterializer,
+    PackageProgressEvent,
+)
 from loushang.coding.platform.footer_data_provider import FooterDataProvider
+from loushang.coding.policy import InteractiveApprovalResolver
+from loushang.coding.session.agent_event_router import AgentEventRouter
+from loushang.coding.session.auth_bridge_controller import AuthBridgeController
+from loushang.coding.session.bash_controller import BashController
+from loushang.coding.session.builtin_commands import (
+    BuiltinCommandBackend,
+    read_changelog_for_cwd,
+)
+from loushang.coding.session.command_controller import CommandController
+from loushang.coding.session.compaction_controller import CompactionController
 from loushang.coding.session.export_html import export_session_to_html
 from loushang.coding.session.export_jsonl import export_session_to_jsonl
-from loushang.coding.store import SessionManager, SessionRecord
+from loushang.coding.session.extension_event_sink import ExtensionEventSink
+from loushang.coding.session.extension_hooks import ExtensionHooks
+from loushang.coding.session.extension_message_controller import (
+    ExtensionMessageController,
+)
+from loushang.coding.session.extension_provider_controller import (
+    ExtensionProviderController,
+)
+from loushang.coding.session.extension_replacement_controller import (
+    ExtensionReplacementController,
+)
+from loushang.coding.session.extension_runtime_bindings import (
+    ExtensionRuntimeBindingFactory,
+)
+from loushang.coding.session.extension_runtime_controller import (
+    ExtensionRuntimeController,
+)
+from loushang.coding.session.package_controller import PackageController
+from loushang.coding.session.prompt_controller import PromptController
+from loushang.coding.session.queue_controller import QueueController
+from loushang.coding.session.resource_refresh_controller import (
+    ResourceRefreshController,
+)
+from loushang.coding.session.resource_watcher import ResourceChangeWatcher
+from loushang.coding.session.retry_controller import RetryController
+from loushang.coding.session.selection_controller import SelectionController
+from loushang.coding.session.session_diagnostics_bridge import SessionDiagnosticsBridge
+from loushang.coding.session.session_event_bus import SessionEventBus
+from loushang.coding.session.session_settings_controller import (
+    SessionSettingsController,
+)
+from loushang.coding.session.session_view_controller import SessionViewController
+from loushang.coding.session.tool_controller import ToolController
+from loushang.coding.session.tree_controller import TreeController
 from loushang.coding.session.types import (
     AgentSessionState,
     CommandExecutionResult,
@@ -48,35 +118,9 @@ from loushang.coding.session.types import (
     SessionCommandDescriptor,
     TreeNavigationResult,
 )
-from loushang.coding.session.agent_event_router import AgentEventRouter
-from loushang.coding.session.auth_bridge_controller import AuthBridgeController
-from loushang.coding.session.bash_controller import BashController
-from loushang.coding.session.builtin_commands import BuiltinCommandBackend, read_changelog_for_cwd
-from loushang.coding.session.command_controller import CommandController
-from loushang.coding.session.compaction_controller import CompactionController
-from loushang.coding.session.extension_event_sink import ExtensionEventSink
-from loushang.coding.session.extension_hooks import ExtensionHooks
-from loushang.coding.session.extension_message_controller import ExtensionMessageController
-from loushang.coding.session.extension_provider_controller import ExtensionProviderController
-from loushang.coding.session.extension_replacement_controller import ExtensionReplacementController
-from loushang.coding.session.extension_runtime_bindings import ExtensionRuntimeBindingFactory
-from loushang.coding.session.extension_runtime_controller import ExtensionRuntimeController
-from loushang.coding.session.package_controller import PackageController
-from loushang.coding.session.prompt_controller import PromptController
-from loushang.coding.session.queue_controller import QueueController
-from loushang.coding.session.resource_refresh_controller import ResourceRefreshController
-from loushang.coding.session.resource_watcher import ResourceChangeWatcher
-from loushang.coding.session.retry_controller import RetryController
-from loushang.coding.session.selection_controller import SelectionController
-from loushang.coding.session.session_diagnostics_bridge import SessionDiagnosticsBridge
-from loushang.coding.session.session_event_bus import SessionEventBus
-from loushang.coding.session.session_settings_controller import SessionSettingsController
-from loushang.coding.session.session_view_controller import SessionViewController
-from loushang.coding.session.tool_controller import ToolController
-from loushang.coding.session.tree_controller import TreeController
 from loushang.coding.session.usage_payload import serialize_context_usage_payload
+from loushang.coding.store import SessionManager, SessionRecord
 from loushang.coding.tools import ToolDefinition, ToolRegistry
-
 
 SessionEventListener = Callable[[AgentSessionEvent], Awaitable[None] | None]
 
@@ -153,6 +197,7 @@ class AgentSession:
             base_prompt=self._base_prompt,
             get_resource_bundle=lambda: self.resource_bundle,
             get_diagnostics_service=lambda: self.diagnostics_service,
+            emit_tool_audit_event=self._dispatch_event,
         )
         self._resource_refresh_controller = ResourceRefreshController(
             get_resource_loader=lambda: self._resource_loader,

--- a/src/loushang/coding/session/tool_controller.py
+++ b/src/loushang/coding/session/tool_controller.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -9,8 +9,13 @@ from loushang.coding.diagnostics import DiagnosticsService
 from loushang.coding.loader import ResourceBundle
 from loushang.coding.prompt import assemble_prompt
 from loushang.coding.store import SessionManager
-from loushang.coding.tools import ToolContext, ToolDefinition, ToolRegistry, create_tool_definition_from_tool, tool_to_definition
-
+from loushang.coding.tools import (
+    ToolContext,
+    ToolDefinition,
+    ToolRegistry,
+    create_tool_definition_from_tool,
+    tool_to_definition,
+)
 
 _DEFAULT_ACTIVE_TOOL_NAMES: tuple[str, ...] = ("read", "bash", "edit", "write")
 _BUILTIN_TOOL_NAMES: frozenset[str] = frozenset(("bash", "read", "ls", "find", "grep", "write", "edit"))
@@ -26,6 +31,7 @@ class ToolController:
     base_prompt: str
     get_resource_bundle: Callable[[], ResourceBundle | None]
     get_diagnostics_service: Callable[[], DiagnosticsService | None]
+    emit_tool_audit_event: Callable[[dict[str, object]], Awaitable[None]] | None = None
     default_activate_new_tools: bool = False
     show_empty_tool_prompt: bool = False
     _active_tool_names: list[str] = field(init=False)
@@ -95,6 +101,7 @@ class ToolController:
             cwd=self.session_manager.get_cwd(),
             diagnostics=self.get_diagnostics_service(),
             model=getattr(self.agent, "model", None),
+            event_sink=self.emit_tool_audit_event,
         )
 
     def resolve_active_tool_definitions(self, tool_names: list[str]) -> tuple[list[ToolDefinition], list[str]]:

--- a/src/loushang/coding/tools/bash.py
+++ b/src/loushang/coding/tools/bash.py
@@ -4,8 +4,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import Any, NotRequired, Protocol, TypedDict
 
-from loushang.ai.types import TextPart
 from loushang.agent.types import AgentToolResult
+from loushang.ai.types import TextPart
 from loushang.coding.diagnostics import DiagnosticsService
 from loushang.coding.exec import ExecOutputChunk, ExecRequest, ExecService
 from loushang.coding.exec.types import ExecResult
@@ -14,7 +14,11 @@ from loushang.coding.policy import ApprovalResolver, PolicyEngine
 from .builtin_renderers import render_bash_call, render_bash_result
 from .context import ToolContextProvider
 from .policy import enforce_tool_policy
-from .runtime import emit_tool_update, pi_truncation_details, resolve_tool_argument_alias
+from .runtime import (
+    emit_tool_update,
+    pi_truncation_details,
+    resolve_tool_argument_alias,
+)
 from .truncate import TruncationResult, truncate_tail, truncation_details
 from .types import PiTruncationDetails, ToolDefinition
 
@@ -220,9 +224,11 @@ class _BashToolExecute:
         signal: object | None = None,
         on_update: object | None = None,
     ) -> AgentToolResult[dict[str, Any]]:
+        context = None
         default_cwd = None
         if self.context_provider is not None:
-            default_cwd = self.context_provider(tool_call_id=tool_call_id).cwd
+            context = self.context_provider(tool_call_id=tool_call_id)
+            default_cwd = context.cwd
 
         request_params = dict(params)
         runtime_operations = request_params.pop("__operations", None)
@@ -237,9 +243,11 @@ class _BashToolExecute:
         )
         await _enforce_bash_policy(
             self.policy_engine,
+            tool_call_id=tool_call_id,
             exec_request=exec_request,
             arguments=request_params,
             approval_resolver=self.approval_resolver,
+            audit_sink=getattr(context, "event_sink", None),
         )
 
         await emit_tool_update(on_update, AgentToolResult(content=[], details=None))
@@ -322,9 +330,11 @@ def _shell_command(command: str, *, shell_path: str | None = None) -> tuple[str,
 async def _enforce_bash_policy(
     policy_engine: PolicyEngine | None,
     *,
+    tool_call_id: str,
     exec_request: ExecRequest,
     arguments: dict[str, Any],
     approval_resolver: ApprovalResolver | None,
+    audit_sink: object | None = None,
 ) -> None:
     if policy_engine is None:
         return
@@ -336,6 +346,8 @@ async def _enforce_bash_policy(
             arguments=arguments,
             cwd=exec_request.cwd,
             approval_resolver=approval_resolver,
+            tool_call_id=tool_call_id,
+            audit_sink=audit_sink,
         )
         return
     evaluate_action = getattr(policy_engine, "evaluate_action", None)

--- a/src/loushang/coding/tools/context.py
+++ b/src/loushang/coding/tools/context.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Awaitable, Callable, Mapping, Protocol
 
 from loushang.coding.diagnostics import DiagnosticsService
+
+ToolEventSink = Callable[[Mapping[str, object]], Awaitable[None] | None]
 
 
 @dataclass(frozen=True)
@@ -13,6 +15,7 @@ class ToolContext:
     diagnostics: DiagnosticsService | None = None
     signal: object | None = None
     model: object | None = None
+    event_sink: ToolEventSink | None = None
 
 
 class ToolContextProvider(Protocol):

--- a/src/loushang/coding/tools/edit.py
+++ b/src/loushang/coding/tools/edit.py
@@ -3,17 +3,27 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, NotRequired, TypedDict
 
-from loushang.ai.types import TextPart
 from loushang.agent.types import AgentToolResult
+from loushang.ai.types import TextPart
 from loushang.coding.policy import ApprovalResolver, PolicyEngine
 
 from .authoring import tool
 from .builtin_renderers import render_edit_call, render_edit_result
 from .context import ToolContext
-from .edit_diff import EditEntry, apply_text_edits, build_unified_diff, first_changed_line
+from .edit_diff import (
+    EditEntry,
+    apply_text_edits,
+    build_unified_diff,
+    first_changed_line,
+)
 from .file_mutation_queue import with_file_mutation_queue
 from .normalize import tool_to_definition
-from .operations import EditOperations, normalize_edit_operations, raise_if_operation_aborted, resolve_operation
+from .operations import (
+    EditOperations,
+    normalize_edit_operations,
+    raise_if_operation_aborted,
+    resolve_operation,
+)
 from .path_utils import resolve_tool_path
 from .policy import enforce_tool_policy
 from .runtime import prepare_tool_arguments
@@ -73,6 +83,8 @@ def create_edit_tool_definition(
             arguments={"path": str(resolved), "edits": validated_edits},
             cwd=ctx.cwd,
             approval_resolver=resolved_approval_resolver,
+            tool_call_id=ctx.tool_call_id,
+            audit_sink=ctx.event_sink,
         )
         raise_if_operation_aborted(ctx.signal)
         async with with_file_mutation_queue(str(resolved)):

--- a/src/loushang/coding/tools/find.py
+++ b/src/loushang/coding/tools/find.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, NotRequired, TypedDict
 
-from loushang.ai.types import TextPart
 from loushang.agent.types import AgentToolResult
+from loushang.ai.types import TextPart
 from loushang.coding.policy import ApprovalResolver, PolicyEngine
 
 from .authoring import tool
@@ -25,14 +25,18 @@ from .external_tools import (
 )
 from .ignore import load_ignore_matcher
 from .normalize import tool_to_definition
-from .operations import FindOperations, normalize_find_operations, raise_if_operation_aborted, resolve_operation
+from .operations import (
+    FindOperations,
+    normalize_find_operations,
+    raise_if_operation_aborted,
+    resolve_operation,
+)
 from .path_utils import resolve_tool_path
 from .policy import enforce_tool_policy
-from .runtime import coerce_int_parameter, pi_truncation_details, prepare_tool_arguments
 from .process import run_external_process
+from .runtime import coerce_int_parameter, pi_truncation_details, prepare_tool_arguments
 from .truncate import truncate_head, truncation_details
 from .types import PiTruncationDetails, ToolDefinition
-
 
 DEFAULT_FIND_LIMIT = 1000
 
@@ -130,6 +134,8 @@ def create_find_tool_definition(
             arguments={"path": str(resolved_root), "pattern": pattern},
             cwd=ctx.cwd,
             approval_resolver=resolved_approval_resolver,
+            tool_call_id=ctx.tool_call_id,
+            audit_sink=ctx.event_sink,
         )
         effective_limit = _effective_limit(limit)
         matches, result_limit_reached = await _walk_matching_paths(

--- a/src/loushang/coding/tools/grep.py
+++ b/src/loushang/coding/tools/grep.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, NotRequired, TypedDict
 
-from loushang.ai.types import TextPart
 from loushang.agent.types import AgentToolResult
+from loushang.ai.types import TextPart
 from loushang.coding.policy import ApprovalResolver, PolicyEngine
 
 from .authoring import tool
@@ -27,14 +27,23 @@ from .external_tools import (
 )
 from .ignore import load_ignore_matcher
 from .normalize import tool_to_definition
-from .operations import GrepOperations, normalize_grep_operations, raise_if_operation_aborted, resolve_operation
+from .operations import (
+    GrepOperations,
+    normalize_grep_operations,
+    raise_if_operation_aborted,
+    resolve_operation,
+)
 from .path_utils import resolve_tool_path
 from .policy import enforce_tool_policy
-from .runtime import coerce_int_parameter, pi_truncation_details, prepare_tool_arguments
 from .process import run_external_process_lines
-from .truncate import GREP_MAX_LINE_LENGTH, truncate_head, truncate_line, truncation_details
+from .runtime import coerce_int_parameter, pi_truncation_details, prepare_tool_arguments
+from .truncate import (
+    GREP_MAX_LINE_LENGTH,
+    truncate_head,
+    truncate_line,
+    truncation_details,
+)
 from .types import PiTruncationDetails, ToolDefinition
-
 
 DEFAULT_GREP_LIMIT = 100
 
@@ -145,6 +154,8 @@ def create_grep_tool_definition(
             arguments={"path": str(search_path), "pattern": pattern},
             cwd=ctx.cwd,
             approval_resolver=resolved_approval_resolver,
+            tool_call_id=ctx.tool_call_id,
+            audit_sink=ctx.event_sink,
         )
         effective_limit = _effective_limit(limit)
         matches, match_limit_reached = await _search_contents(

--- a/src/loushang/coding/tools/ls.py
+++ b/src/loushang/coding/tools/ls.py
@@ -2,21 +2,25 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, NotRequired, TypedDict
 
-from loushang.ai.types import TextPart
 from loushang.agent.types import AgentToolResult
+from loushang.ai.types import TextPart
 from loushang.coding.policy import ApprovalResolver, PolicyEngine
 
 from .authoring import tool
 from .builtin_renderers import render_find_or_ls_result, render_ls_call
 from .context import ToolContext
 from .normalize import tool_to_definition
-from .operations import LsOperations, normalize_ls_operations, raise_if_operation_aborted, resolve_operation
+from .operations import (
+    LsOperations,
+    normalize_ls_operations,
+    raise_if_operation_aborted,
+    resolve_operation,
+)
 from .path_utils import resolve_tool_path
 from .policy import enforce_tool_policy
 from .runtime import coerce_int_parameter, pi_truncation_details, prepare_tool_arguments
 from .truncate import truncate_head, truncation_details
 from .types import PiTruncationDetails, ToolDefinition
-
 
 DEFAULT_LS_LIMIT = 500
 
@@ -82,6 +86,8 @@ def create_ls_tool_definition(
             arguments={"path": str(resolved)},
             cwd=ctx.cwd,
             approval_resolver=resolved_approval_resolver,
+            tool_call_id=ctx.tool_call_id,
+            audit_sink=ctx.event_sink,
         )
         effective_limit = _effective_limit(limit)
         lines, entry_limit_reached = await _list_entries(resolved, limit=effective_limit, operations=ops)

--- a/src/loushang/coding/tools/policy.py
+++ b/src/loushang/coding/tools/policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from collections.abc import Mapping
 from typing import Any
 from uuid import uuid4
@@ -22,6 +23,8 @@ async def enforce_tool_policy(
     arguments: Mapping[str, Any],
     cwd: str | None = None,
     approval_resolver: ApprovalResolver | None = None,
+    tool_call_id: str | None = None,
+    audit_sink: Any = None,
 ) -> None:
     if policy_engine is None:
         return
@@ -29,6 +32,20 @@ async def enforce_tool_policy(
     if not callable(evaluate_tool_call):
         return
     decision = evaluate_tool_call(tool_name=tool_name, arguments=arguments, cwd=cwd)
+    await _emit_policy_audit_event(
+        audit_sink,
+        {
+            "type": "tool_policy_evaluated",
+            **_policy_audit_details(
+                tool_name=tool_name,
+                arguments=arguments,
+                cwd=cwd,
+                decision=decision,
+                approval_required=decision.disposition == "ask",
+                tool_call_id=tool_call_id,
+            ),
+        },
+    )
     if decision.disposition == "allow":
         return
     if decision.disposition == "deny":
@@ -44,6 +61,7 @@ async def enforce_tool_policy(
             ),
         )
     if decision.disposition == "ask":
+        action_id = f"policy-{uuid4().hex}"
         request = ApprovalRequest(
             tool_name=tool_name,
             arguments=arguments,
@@ -51,11 +69,40 @@ async def enforce_tool_policy(
             reason=decision.reason,
             policy_code=decision.code,
             policy_decision=decision,
-            action_id=f"policy-{uuid4().hex}",
+            action_id=action_id,
+        )
+        await _emit_policy_audit_event(
+            audit_sink,
+            {
+                "type": "tool_approval_requested",
+                **_approval_audit_details(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    cwd=cwd,
+                    decision=decision,
+                    action_id=action_id,
+                    tool_call_id=tool_call_id,
+                ),
+            },
         )
         approval = await resolve_approval(
             approval_resolver,
             request,
+        )
+        await _emit_policy_audit_event(
+            audit_sink,
+            {
+                "type": "tool_approval_resolved",
+                **_approval_audit_details(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    cwd=cwd,
+                    decision=decision,
+                    action_id=action_id,
+                    tool_call_id=tool_call_id,
+                    approval=approval,
+                ),
+            },
         )
         if approval.disposition == "allow":
             return
@@ -109,3 +156,66 @@ def _policy_error_details(
         if isinstance(value, str):
             details[key] = value
     return details
+
+
+def _policy_audit_details(
+    *,
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    cwd: str | None,
+    decision: PolicyDecision,
+    approval_required: bool,
+    tool_call_id: str | None,
+) -> dict[str, Any]:
+    details = _policy_error_details(
+        tool_name=tool_name,
+        arguments=arguments,
+        cwd=cwd,
+        decision=decision,
+        approval_required=approval_required,
+    )
+    if tool_call_id is not None:
+        details["tool_call_id"] = tool_call_id
+    return details
+
+
+def _approval_audit_details(
+    *,
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    cwd: str | None,
+    decision: PolicyDecision,
+    action_id: str,
+    tool_call_id: str | None,
+    approval: ApprovalDecision | None = None,
+) -> dict[str, Any]:
+    details: dict[str, Any] = {
+        "tool_name": tool_name,
+        "action_id": action_id,
+        "argument_keys": sorted(str(key) for key in arguments.keys()),
+    }
+    if tool_call_id is not None:
+        details["tool_call_id"] = tool_call_id
+    if cwd is not None:
+        details["cwd"] = cwd
+    if decision.code is not None:
+        details["policy_code"] = decision.code
+    if decision.reason is not None:
+        details["policy_reason"] = decision.reason
+    if approval is not None:
+        details["approval_decision"] = approval.disposition
+        if approval.reason is not None:
+            details["approval_reason"] = approval.reason
+    for key in ("path", "file_path", "command"):
+        value = arguments.get(key)
+        if isinstance(value, str):
+            details[key] = value
+    return details
+
+
+async def _emit_policy_audit_event(audit_sink: Any, event: Mapping[str, Any]) -> None:
+    if audit_sink is None:
+        return
+    result = audit_sink(dict(event))
+    if inspect.isawaitable(result):
+        await result

--- a/src/loushang/coding/tools/read.py
+++ b/src/loushang/coding/tools/read.py
@@ -5,15 +5,20 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, NotRequired, Protocol, TypedDict
 
-from loushang.ai.types import ImagePart, TextPart
 from loushang.agent.types import AgentToolResult
+from loushang.ai.types import ImagePart, TextPart
 from loushang.coding.policy import ApprovalResolver, PolicyEngine
 
 from .authoring import tool
 from .builtin_renderers import render_read_call, render_read_result
 from .context import ToolContext
 from .normalize import tool_to_definition
-from .operations import ReadOperations, normalize_read_operations, raise_if_operation_aborted, resolve_operation
+from .operations import (
+    ReadOperations,
+    normalize_read_operations,
+    raise_if_operation_aborted,
+    resolve_operation,
+)
 from .path_utils import resolve_tool_path
 from .policy import enforce_tool_policy
 from .runtime import (
@@ -25,7 +30,6 @@ from .runtime import (
 )
 from .truncate import DEFAULT_MAX_BYTES, format_size, truncate_head, truncation_details
 from .types import PiTruncationDetails, ToolDefinition
-
 
 MAX_INLINE_IMAGE_BASE64_BYTES = int(4.5 * 1024 * 1024)
 MAX_INLINE_IMAGE_DIMENSION = 2000
@@ -137,6 +141,8 @@ def create_read_tool_definition(
             arguments={"path": str(resolved)},
             cwd=ctx.cwd,
             approval_resolver=resolved_approval_resolver,
+            tool_call_id=ctx.tool_call_id,
+            audit_sink=ctx.event_sink,
         )
         payload = await resolve_operation(ops.read_bytes(resolved))
         raise_if_operation_aborted(ctx.signal)

--- a/src/loushang/coding/tools/write.py
+++ b/src/loushang/coding/tools/write.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, NotRequired, TypedDict
 
-from loushang.ai.types import TextPart
 from loushang.agent.types import AgentToolResult
+from loushang.ai.types import TextPart
 from loushang.coding.policy import ApprovalResolver, PolicyEngine
 
 from .authoring import tool
@@ -11,7 +11,12 @@ from .builtin_renderers import render_write_call, render_write_result
 from .context import ToolContext
 from .file_mutation_queue import with_file_mutation_queue
 from .normalize import tool_to_definition
-from .operations import WriteOperations, normalize_write_operations, raise_if_operation_aborted, resolve_operation
+from .operations import (
+    WriteOperations,
+    normalize_write_operations,
+    raise_if_operation_aborted,
+    resolve_operation,
+)
 from .path_utils import resolve_tool_path
 from .policy import enforce_tool_policy
 from .runtime import prepare_tool_arguments
@@ -68,6 +73,8 @@ def create_write_tool_definition(
             arguments={"path": str(resolved), "content": content},
             cwd=ctx.cwd,
             approval_resolver=resolved_approval_resolver,
+            tool_call_id=ctx.tool_call_id,
+            audit_sink=ctx.event_sink,
         )
         raise_if_operation_aborted(ctx.signal)
         async with with_file_mutation_queue(str(resolved)):

--- a/src/loushang/work/projection.py
+++ b/src/loushang/work/projection.py
@@ -60,6 +60,54 @@ def project_agent_event_to_work_events(
         payload = _payload(event, "tool_call_id", "tool_name", "result", "is_error", "duration_ms")
         delivery_hint: DeliveryHint = "immediate" if event.get("is_error") is True else "coalesce"
         return [_event(context, kind="ToolCallCompleted", delivery_hint=delivery_hint, payload=payload)]
+    if source_type == "tool_policy_evaluated":
+        payload = _payload(
+            event,
+            "tool_call_id",
+            "tool_name",
+            "cwd",
+            "policy_disposition",
+            "policy_code",
+            "policy_reason",
+            "approval_required",
+            "argument_keys",
+            "path",
+            "file_path",
+            "command",
+        )
+        return [_event(context, kind="ToolPolicyEvaluated", delivery_hint="immediate", payload=payload)]
+    if source_type == "tool_approval_requested":
+        payload = _payload(
+            event,
+            "tool_call_id",
+            "tool_name",
+            "cwd",
+            "action_id",
+            "policy_code",
+            "policy_reason",
+            "argument_keys",
+            "path",
+            "file_path",
+            "command",
+        )
+        return [_event(context, kind="ToolApprovalRequested", delivery_hint="immediate", payload=payload)]
+    if source_type == "tool_approval_resolved":
+        payload = _payload(
+            event,
+            "tool_call_id",
+            "tool_name",
+            "cwd",
+            "action_id",
+            "approval_decision",
+            "approval_reason",
+            "policy_code",
+            "policy_reason",
+            "argument_keys",
+            "path",
+            "file_path",
+            "command",
+        )
+        return [_event(context, kind="ToolApprovalResolved", delivery_hint="immediate", payload=payload)]
     if source_type == "queue_update":
         payload = _payload(event, "steering", "follow_up")
         return [_event(context, kind="QueueUpdated", delivery_hint="coalesce", payload=payload)]

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -269,6 +269,7 @@ def _append_work_log_inspect_entry(
     deviation: dict[str, object] | None = None,
     planned_constraint: dict[str, object] | None = None,
     audit_policy: dict[str, object] | None = None,
+    extra_payload: dict[str, object] | None = None,
 ) -> None:
     from loushang.work import EventLogEntry
 
@@ -292,6 +293,8 @@ def _append_work_log_inspect_entry(
         nested_payload["planned_constraint"] = planned_constraint
     if audit_policy is not None:
         nested_payload["audit_policy"] = audit_policy
+    if extra_payload is not None:
+        nested_payload.update(extra_payload)
     if nested_payload:
         payload["payload"] = nested_payload
     event_log.append(
@@ -4544,6 +4547,55 @@ def test_run_cli_work_log_inspect_json_includes_plan_step_metadata(tmp_path) -> 
     assert summary["step_id"] == "inspect"
     assert summary["step_index"] == 0
     assert summary["step_title"] == "Inspect current changes"
+
+
+def test_run_cli_work_log_inspect_json_includes_tool_approval_audit_metadata(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.work import JsonlEventLogBackend
+
+    log_path = tmp_path / "events.jsonl"
+    event_log = JsonlEventLogBackend(log_path)
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=3,
+        kind="ToolApprovalResolved",
+        delivery_hint="immediate",
+        extra_payload={
+            "tool_call_id": "tool-1",
+            "tool_name": "write",
+            "action_id": "approval-1",
+            "approval_decision": "allow",
+            "policy_code": "tool_requires_approval",
+            "policy_reason": "Tool write requires approval",
+            "argument_keys": ["content", "path"],
+            "path": "/repo/approved.txt",
+        },
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "json"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    summary = json.loads(stdout.getvalue())[0]
+    assert summary["tool_call_id"] == "tool-1"
+    assert summary["tool_name"] == "write"
+    assert summary["action_id"] == "approval-1"
+    assert summary["approval_decision"] == "allow"
+    assert summary["policy_code"] == "tool_requires_approval"
+    assert summary["policy_reason"] == "Tool write requires approval"
+    assert summary["argument_keys"] == ["content", "path"]
+    assert summary["path"] == "/repo/approved.txt"
 
 
 def test_run_cli_work_log_inspect_filters_by_run(tmp_path) -> None:

--- a/tests/coding/test_tool_policy_integration.py
+++ b/tests/coding/test_tool_policy_integration.py
@@ -14,6 +14,18 @@ def _tool_context_provider(*, cwd: str):
     return _provider
 
 
+def _tool_context_provider_with_events(*, cwd: str, events: list[dict[str, object]]):
+    from loushang.coding.tools import ToolContext
+
+    async def emit_event(event: dict[str, object]) -> None:
+        events.append(event)
+
+    def _provider(*, tool_call_id: str) -> ToolContext:
+        return ToolContext(tool_call_id=tool_call_id, cwd=cwd, event_sink=emit_event)
+
+    return _provider
+
+
 def test_global_policy_engine_blocks_write_tool_before_mutation(tmp_path) -> None:
     from loushang.coding.policy import PolicyEngine
     from loushang.coding.tools import ToolRegistry, register_builtin_tools
@@ -140,6 +152,105 @@ def test_sync_approval_resolver_can_allow_ask_policy_for_write(tmp_path) -> None
     assert resolver.requests[0].tool_name == "write"
     assert resolver.requests[0].policy_code == "tool_requires_approval"
     assert "approved.txt" in str(resolver.requests[0].arguments["path"])
+
+
+def test_ask_policy_allow_emits_tool_approval_audit_events(tmp_path) -> None:
+    from loushang.coding.policy import ApprovalDecision, PolicyEngine
+    from loushang.coding.tools import ToolRegistry, register_builtin_tools
+
+    class AllowingResolver:
+        def resolve(self, request):
+            return ApprovalDecision.allow()
+
+    events: list[dict[str, object]] = []
+    registry = ToolRegistry()
+    register_builtin_tools(
+        registry,
+        policy_engine=PolicyEngine(ask_tools=["write"]),
+        approval_resolver=AllowingResolver(),
+    )
+    runtime_tool = registry.materialize_tool(
+        "write",
+        context_provider=_tool_context_provider_with_events(cwd=str(tmp_path), events=events),
+    )
+
+    asyncio.run(
+        runtime_tool.execute("call-write-approval-audit", {"path": "approved-audit.txt", "content": "approved"})
+    )
+
+    assert [event["type"] for event in events] == [
+        "tool_policy_evaluated",
+        "tool_approval_requested",
+        "tool_approval_resolved",
+    ]
+    assert events[0] == {
+        "type": "tool_policy_evaluated",
+        "tool_call_id": "call-write-approval-audit",
+        "tool_name": "write",
+        "cwd": str(tmp_path),
+        "policy_disposition": "ask",
+        "policy_code": "tool_requires_approval",
+        "policy_reason": "Tool write requires approval",
+        "approval_required": True,
+        "argument_keys": ["content", "path"],
+        "path": str(tmp_path / "approved-audit.txt"),
+    }
+    action_id = events[1].get("action_id")
+    assert isinstance(action_id, str)
+    assert events[1] == {
+        "type": "tool_approval_requested",
+        "tool_call_id": "call-write-approval-audit",
+        "tool_name": "write",
+        "cwd": str(tmp_path),
+        "action_id": action_id,
+        "policy_code": "tool_requires_approval",
+        "policy_reason": "Tool write requires approval",
+        "argument_keys": ["content", "path"],
+        "path": str(tmp_path / "approved-audit.txt"),
+    }
+    assert events[2] == {
+        "type": "tool_approval_resolved",
+        "tool_call_id": "call-write-approval-audit",
+        "tool_name": "write",
+        "cwd": str(tmp_path),
+        "action_id": action_id,
+        "approval_decision": "allow",
+        "policy_code": "tool_requires_approval",
+        "policy_reason": "Tool write requires approval",
+        "argument_keys": ["content", "path"],
+        "path": str(tmp_path / "approved-audit.txt"),
+    }
+
+
+def test_deny_policy_emits_tool_policy_evaluated_audit_event(tmp_path) -> None:
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import ToolRegistry, register_builtin_tools
+
+    events: list[dict[str, object]] = []
+    registry = ToolRegistry()
+    register_builtin_tools(registry, policy_engine=PolicyEngine(blocked_tools=["write"]))
+    runtime_tool = registry.materialize_tool(
+        "write",
+        context_provider=_tool_context_provider_with_events(cwd=str(tmp_path), events=events),
+    )
+
+    with pytest.raises(PermissionError):
+        asyncio.run(runtime_tool.execute("call-write-deny-audit", {"path": "blocked-audit.txt", "content": "blocked"}))
+
+    assert events == [
+        {
+            "type": "tool_policy_evaluated",
+            "tool_call_id": "call-write-deny-audit",
+            "tool_name": "write",
+            "cwd": str(tmp_path),
+            "policy_disposition": "deny",
+            "policy_code": "tool_blocked",
+            "policy_reason": "Tool write is blocked by policy",
+            "approval_required": False,
+            "argument_keys": ["content", "path"],
+            "path": str(tmp_path / "blocked-audit.txt"),
+        }
+    ]
 
 
 def test_async_approval_resolver_can_deny_ask_policy_for_write(tmp_path) -> None:

--- a/tests/work/test_agent_event_projection.py
+++ b/tests/work/test_agent_event_projection.py
@@ -95,6 +95,70 @@ def test_project_tool_events_to_tool_call_work_events() -> None:
     assert completed[0].payload["duration_ms"] == 50
 
 
+def test_project_tool_policy_and_approval_events_to_audit_work_events() -> None:
+    from loushang.work import project_agent_event_to_work_events
+
+    evaluated = project_agent_event_to_work_events(
+        {
+            "type": "tool_policy_evaluated",
+            "tool_call_id": "tool-1",
+            "tool_name": "write",
+            "policy_disposition": "ask",
+            "policy_code": "tool_requires_approval",
+            "policy_reason": "Tool write requires approval",
+            "approval_required": True,
+            "argument_keys": ["content", "path"],
+            "path": "/repo/approved.txt",
+        },
+        context=_context(6),
+    )
+    requested = project_agent_event_to_work_events(
+        {
+            "type": "tool_approval_requested",
+            "tool_call_id": "tool-1",
+            "tool_name": "write",
+            "action_id": "approval-1",
+            "policy_code": "tool_requires_approval",
+            "policy_reason": "Tool write requires approval",
+            "argument_keys": ["content", "path"],
+            "path": "/repo/approved.txt",
+        },
+        context=_context(7),
+    )
+    resolved = project_agent_event_to_work_events(
+        {
+            "type": "tool_approval_resolved",
+            "tool_call_id": "tool-1",
+            "tool_name": "write",
+            "action_id": "approval-1",
+            "approval_decision": "allow",
+            "policy_code": "tool_requires_approval",
+            "policy_reason": "Tool write requires approval",
+        },
+        context=_context(8),
+    )
+
+    assert [event.kind for event in [*evaluated, *requested, *resolved]] == [
+        "ToolPolicyEvaluated",
+        "ToolApprovalRequested",
+        "ToolApprovalResolved",
+    ]
+    assert all(event.delivery_hint == "immediate" for event in [*evaluated, *requested, *resolved])
+    assert evaluated[0].payload == {
+        "source_type": "tool_policy_evaluated",
+        "tool_call_id": "tool-1",
+        "tool_name": "write",
+        "policy_disposition": "ask",
+        "policy_code": "tool_requires_approval",
+        "policy_reason": "Tool write requires approval",
+        "approval_required": True,
+        "argument_keys": ["content", "path"],
+        "path": "/repo/approved.txt",
+    }
+    assert requested[0].payload["action_id"] == "approval-1"
+    assert resolved[0].payload["approval_decision"] == "allow"
+
+
 def test_project_queue_update_to_coalesced_queue_metadata_event() -> None:
     from loushang.work import project_agent_event_to_work_events
 

--- a/tests/work/test_coding_work_shell.py
+++ b/tests/work/test_coding_work_shell.py
@@ -90,6 +90,78 @@ def test_coding_work_shell_wraps_prompt_and_logs_operation_run_and_projected_eve
     asyncio.run(scenario())
 
 
+def test_coding_work_shell_logs_tool_policy_and_approval_audit_events() -> None:
+    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        session = FakePromptSession(
+            events=[
+                {
+                    "type": "tool_policy_evaluated",
+                    "tool_call_id": "tool-1",
+                    "tool_name": "write",
+                    "policy_disposition": "ask",
+                    "policy_code": "tool_requires_approval",
+                    "policy_reason": "Tool write requires approval",
+                    "approval_required": True,
+                    "argument_keys": ["content", "path"],
+                    "path": "/repo/approved.txt",
+                },
+                {
+                    "type": "tool_approval_requested",
+                    "tool_call_id": "tool-1",
+                    "tool_name": "write",
+                    "action_id": "approval-1",
+                    "policy_code": "tool_requires_approval",
+                    "policy_reason": "Tool write requires approval",
+                    "argument_keys": ["content", "path"],
+                    "path": "/repo/approved.txt",
+                },
+                {
+                    "type": "tool_approval_resolved",
+                    "tool_call_id": "tool-1",
+                    "tool_name": "write",
+                    "action_id": "approval-1",
+                    "approval_decision": "allow",
+                    "policy_code": "tool_requires_approval",
+                    "policy_reason": "Tool write requires approval",
+                },
+            ],
+        )
+        shell = CodingWorkShell(
+            session=session,
+            event_log=event_log,
+            clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
+        )
+
+        await shell.submit_coding_turn(
+            "write approved file",
+            session_id="session-1",
+            operation_id="op-1",
+            run_id="run-1",
+        )
+
+        entries = event_log.query(run_id="run-1")
+        assert [entry.payload["kind"] for entry in entries] == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "ToolPolicyEvaluated",
+            "ToolApprovalRequested",
+            "ToolApprovalResolved",
+            "WorkRunCompleted",
+        ]
+        assert entries[2].payload["payload"]["tool_call_id"] == "tool-1"
+        assert entries[2].payload["payload"]["policy_disposition"] == "ask"
+        assert entries[3].payload["payload"]["action_id"] == "approval-1"
+        assert entries[4].payload["payload"]["approval_decision"] == "allow"
+        assert entries[2].payload["delivery_hint"] == "immediate"
+        assert entries[3].payload["delivery_hint"] == "immediate"
+        assert entries[4].payload["delivery_hint"] == "immediate"
+
+    asyncio.run(scenario())
+
+
 def test_coding_work_shell_jsonl_log_can_replay_persisted_turn(tmp_path) -> None:
     from loushang.ai.types import AssistantMessage, TextPart, Usage
     from loushang.work import CodingWorkShell, JsonlEventLogBackend


### PR DESCRIPTION
## Summary
- Emit audit events when tool policy is evaluated and when approvals are requested or resolved.
- Project tool policy and approval session events into durable work-log `WorkEvent` records.
- Include relevant audit metadata in `work-log-inspect json` output.

## Test Plan
- `uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/agent/test_agent_loop.py tests/coding/test_tool_policy_integration.py tests/coding/test_tool_registry.py tests/coding/test_tool_operations.py tests/coding/test_tool_pi_golden_behavior.py tests/coding/test_agent_session_tools.py tests/coding/test_session_tool_controller.py tests/coding/test_cli.py tests/tui -q` (`1020 passed`)
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli/__main__.py src/loushang/coding/session/agent_session.py src/loushang/coding/session/tool_controller.py src/loushang/coding/tools/bash.py src/loushang/coding/tools/context.py src/loushang/coding/tools/edit.py src/loushang/coding/tools/find.py src/loushang/coding/tools/grep.py src/loushang/coding/tools/ls.py src/loushang/coding/tools/policy.py src/loushang/coding/tools/read.py src/loushang/coding/tools/write.py src/loushang/work/projection.py tests/coding/test_cli.py tests/coding/test_tool_policy_integration.py tests/work/test_agent_event_projection.py tests/work/test_coding_work_shell.py` (`All checks passed!`)
- `git diff --check`

Closes #69