### PR TITLE
refactor: reuse tui runner helpers in native loop

### DIFF
--- a/src/loushang/coding/ui/native_loop.py
+++ b/src/loushang/coding/ui/native_loop.py
@@ -10,13 +10,14 @@ from typing import Any, TextIO
 from loushang.ai.types import ImagePart
 from loushang.coding.ui.native_app import NativeCodingTuiApp
 from loushang.coding.ui.native_input import NativeInputRouter
+from loushang.tui import _runner_utils
 from loushang.tui.core import RenderConstraints
 from loushang.tui.input import InputIntent, InputReader
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
 from loushang.tui.render_loop import RenderLoop
 from loushang.tui.runtime import TuiRuntime
 from loushang.tui.scheduler import RenderRequestKind
-from loushang.tui.terminal import ProcessTerminalPort, TerminalOperation, TerminalSize
+from loushang.tui.terminal import ProcessTerminalPort, TerminalSize
 from loushang.tui.terminal_capabilities import format_terminal_capability_diagnostics
 from loushang.tui.terminal_input import (
     read_input_chunk_or_render_tick,
@@ -31,6 +32,13 @@ ShouldExit = Callable[[str], bool]
 LocalCommandPredicate = Callable[[str], bool]
 TerminalModeFactory = Callable[[TextIO, TextIO], AbstractContextManager[object]]
 TerminalSizeProvider = Callable[[], TerminalSize]
+
+_finish_tui_exit = _runner_utils.finish_tui_exit
+_flush_pending_input = _runner_utils.flush_pending_input
+_input_events_for_chunk = _runner_utils.input_events_for_chunk
+_poll_terminal_runtime = _runner_utils.poll_terminal_runtime
+_request_runtime_render = _runner_utils.request_runtime_render
+_terminal_runtime_wakeup_ms = _runner_utils.terminal_runtime_wakeup_ms
 
 
 async def run_native_coding_tui(
@@ -206,12 +214,6 @@ async def _finish_active_task(
     return result if isinstance(result, int) else None
 
 
-def _request_runtime_render(runtime: TuiRuntime, kind: RenderRequestKind) -> None:
-    decision = runtime.request_render(kind)
-    if decision.render_now:
-        runtime.render_now()
-
-
 def _write_startup_welcome(*, app: NativeCodingTuiApp, runtime: TuiRuntime, stdout: TextIO) -> None:
     if app.state.records or app.state.running or app.state.assistant_draft_buffer is not None:
         return
@@ -226,105 +228,11 @@ def _write_startup_welcome(*, app: NativeCodingTuiApp, runtime: TuiRuntime, stdo
     stdout.flush()
 
 
-def _input_events_for_chunk(reader: InputReader, data: str, *, terminal_context: object | None = None) -> tuple[Any, ...]:
-    data = _normalize_terminal_input(data, terminal_context=terminal_context)
-    batch = reader.feed_batch(data)
-    _consume_terminal_control_events(batch.control_events, terminal_context=terminal_context)
-    return batch.app_events
-
-
-def _flush_pending_input(reader: InputReader, *, terminal_context: object | None = None) -> tuple[Any, ...]:
-    pending = reader.flush_pending_batch()
-    _consume_terminal_control_events(pending.control_events, terminal_context=terminal_context)
-    return pending.app_events
-
-
-def _consume_terminal_control_events(events: tuple[Any, ...], *, terminal_context: object | None = None) -> None:
-    consumer = getattr(terminal_context, "consume_control_events", None)
-    if callable(consumer):
-        consumer(events)
-
-
-def _terminal_runtime_wakeup_ms(terminal_context: object | None) -> int | None:
-    wakeup = getattr(terminal_context, "next_wakeup_delay_ms", None)
-    if not callable(wakeup):
-        return None
-    delay = wakeup()
-    return delay if isinstance(delay, int) else None
-
-
-def _poll_terminal_runtime(terminal_context: object | None) -> bool:
-    poll = getattr(terminal_context, "flush_keyboard_protocol_fallback_if_due", None)
-    if not callable(poll):
-        return False
-    return bool(poll())
-
-
-def _normalize_terminal_input(data: str, *, terminal_context: object | None = None) -> str:
-    normalizer = getattr(terminal_context, "normalize_input_chunk", None)
-    if not callable(normalizer):
-        return data
-    normalized = normalizer(data)
-    return normalized if isinstance(normalized, str) else data
-
-
 def _configure_runtime_for_terminal_context(runtime: TuiRuntime, app: NativeCodingTuiApp, terminal_context: object) -> None:
     capabilities = getattr(terminal_context, "capabilities", None)
     if capabilities is not None:
         app.terminal_capabilities = capabilities
-    runtime.render_loop.termux_session = bool(getattr(capabilities, "termux_session", False))
-
-
-def _finish_tui_exit(*, runtime: TuiRuntime, stdout: TextIO, exit_code: int) -> int:
-    if _clear_runtime_bottom_frame_for_exit(runtime):
-        return exit_code
-    stdout.write("\r\x1b[2K\n")
-    stdout.flush()
-    return exit_code
-
-
-def _clear_runtime_bottom_frame_for_exit(runtime: TuiRuntime) -> bool:
-    render_loop = runtime.render_loop
-    current_lines = render_loop.previous_rendered_lines
-    if not current_lines:
-        return False
-
-    cursor_row = render_loop.previous_cursor_row
-    viewport_top = render_loop.previous_viewport_top
-    if cursor_row < viewport_top or cursor_row >= len(current_lines):
-        return False
-
-    screen_row = cursor_row - viewport_top
-    terminal_rows = runtime.terminal.size().rows
-    clear_count = min(len(current_lines) - cursor_row, terminal_rows - screen_row)
-    if clear_count <= 0:
-        return False
-
-    runtime.terminal.flush(_exit_bottom_frame_cleanup_operations(clear_count))
-    return True
-
-
-def _exit_bottom_frame_cleanup_operations(line_count: int) -> tuple[TerminalOperation, ...]:
-    line_count = max(1, line_count)
-    operations: list[TerminalOperation] = [
-        TerminalOperation.hide_cursor(),
-        TerminalOperation.begin_synchronized_update(),
-        TerminalOperation.carriage_return(),
-    ]
-    for index in range(line_count):
-        operations.append(TerminalOperation.clear_line())
-        if index < line_count - 1:
-            operations.append(TerminalOperation.newline())
-    if line_count > 1:
-        operations.append(TerminalOperation.move_relative(lines=-(line_count - 1)))
-    operations.extend(
-        (
-            TerminalOperation.carriage_return(),
-            TerminalOperation.end_synchronized_update(),
-            TerminalOperation.show_cursor(),
-        )
-    )
-    return tuple(operations)
+    _runner_utils.configure_runtime_for_terminal_context(runtime, terminal_context)
 
 
 def _format_terminal_diagnostics(terminal_context: object) -> str:


### PR DESCRIPTION
## Summary
- Reuse `loushang.tui._runner_utils` from the native coding TUI loop.
- Keep the existing native loop private helper names as compatibility aliases.
- Remove duplicated input/control-event/render/exit-cleanup helper implementations from `native_loop.py`.

## Test Plan
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/native_loop.py src/loushang/tui/_runner_utils.py src/loushang/tui/runner.py`
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_playback.py tests/coding/test_native_coding_tui_loop.py tests/coding/test_native_coding_tui_terminal_playback.py tests/tui/test_runner.py -q`