### PR TITLE
Expand composer native playback coverage

### DIFF
--- a/src/loushang/coding/ui/native_input.py
+++ b/src/loushang/coding/ui/native_input.py
@@ -51,6 +51,7 @@ class NativeInputRouter:
     running_submit_mode: RunningSubmitMode = "steer"
     follow_up_keys: tuple[str, ...] = ("alt+enter",)
     width: int = 80
+    height: int = 12
     clipboard_image_reader: ClipboardImageReader = read_clipboard_image
     clipboard_image_dir: Path | str | None = None
     clipboard_image_name_factory: ClipboardImageNameFactory = field(default_factory=lambda: lambda: uuid.uuid4().hex)
@@ -80,6 +81,8 @@ class NativeInputRouter:
         if event.kind == "resize":
             if event.columns:
                 self.width = event.columns
+            if event.rows:
+                self.height = event.rows
             return NativeInputResult()
         if event.kind != "key" or event.event_type == "release":
             return NativeInputResult(render_requested=False)
@@ -126,6 +129,12 @@ class NativeInputRouter:
                 self.app.composer.history_next()
             elif not self.app.composer.value or not self.app.composer.move_visual_down(width=self.width):
                 self.app.composer.history_next()
+            return NativeInputResult()
+        if keybindings.matches(event.key, "tui.editor.pageUp"):
+            self.app.composer.move_visual_page_up(width=self.width, visible_lines=self._composer_page_lines())
+            return NativeInputResult()
+        if keybindings.matches(event.key, "tui.editor.pageDown"):
+            self.app.composer.move_visual_page_down(width=self.width, visible_lines=self._composer_page_lines())
             return NativeInputResult()
         if self.app.state.running and event.key in self.follow_up_keys:
             return self._submit_running(mode="follow_up")
@@ -212,6 +221,9 @@ class NativeInputRouter:
 
     def _keybindings(self) -> KeybindingManager:
         return self.keybindings if isinstance(self.keybindings, KeybindingManager) else KeybindingManager(self.keybindings)
+
+    def _composer_page_lines(self) -> int:
+        return max(2, min(10, self.height))
 
     def _route_active_surface(self, event: InputEvent) -> NativeInputResult:
         handler = getattr(self.app.active_surface, "handle_input", None)

--- a/src/loushang/coding/ui/native_loop.py
+++ b/src/loushang/coding/ui/native_loop.py
@@ -67,6 +67,7 @@ async def run_native_coding_tui(
         is_local_command=is_local_command or (lambda _text: False),
         keybindings=keybindings,
         width=initial_size.columns,
+        height=initial_size.rows,
     )
     runtime = TuiRuntime(
         render_loop=RenderLoop(app),

--- a/src/loushang/coding/ui/playback.py
+++ b/src/loushang/coding/ui/playback.py
@@ -122,6 +122,8 @@ class NativeTuiInputPlayback:
             app,
             should_exit=should_exit or (lambda _text: False),
             is_local_command=is_local_command or (lambda _text: False),
+            width=columns,
+            height=rows,
         )
         self.render_loop = RenderLoop(app, clear_scrollback_policy="disabled")
         self.harness = PlaybackHarness(
@@ -143,7 +145,10 @@ class NativeTuiInputPlayback:
         _previous: RenderDiagnostics | None,
     ) -> RenderDiagnostics:
         step_input_results: list[NativeInputResult] = []
-        if event.kind == "input":
+        if event.kind == "resize":
+            self.router.width = size.columns
+            self.router.height = size.rows
+        elif event.kind == "input":
             if not isinstance(event.payload, str):
                 raise TypeError("input playback event payload must be str")
             batch = self.reader.feed_batch(event.payload)

--- a/src/loushang/coding/ui/playback_scenarios/composer.py
+++ b/src/loushang/coding/ui/playback_scenarios/composer.py
@@ -12,6 +12,7 @@ from loushang.coding.ui.playback_fakes import (
 )
 from loushang.coding.ui.playback_scenarios.budgets import INTERACTION_FRAME_BUDGET
 from loushang.coding.ui.playback_suite import NativePlaybackScenarioSpec
+from loushang.tui import PlaybackEvent, RenderConstraints
 from loushang.tui.input import BRACKETED_PASTE_END, BRACKETED_PASTE_START
 
 
@@ -165,6 +166,77 @@ def _run_keyboard_shift_enter_newline() -> NativeTuiInputPlaybackResult:
     return result
 
 
+def _run_editor_key_editing() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .render()
+        .type_text("alpha beta gamma")
+        .key("\x01say ")
+        .key("\x05\x17")
+        .key("\x19")
+        .key("\x1f")
+        .run()
+    )
+    result.assert_composer_text("say alpha beta ")
+    result.assert_visible_contains("› say alpha beta")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_page_navigation() -> NativeTuiInputPlaybackResult:
+    scenario = NativeTuiInputScenario(width=20, height=3).with_composer_text("one\ntwo\nthree\nfour\nfive")
+    playback = scenario.playback
+
+    playback.play((PlaybackEvent("render"), PlaybackEvent.input("\x1b[5~")))
+    page_up = scenario.app.composer.render(RenderConstraints(width=20, max_height=5))
+    assert page_up.cursor is not None
+    assert (page_up.cursor.row, page_up.cursor.column) == (2, 6)
+
+    playback.play((PlaybackEvent.input("\x1b[6~"),))
+    page_down = scenario.app.composer.render(RenderConstraints(width=20, max_height=5))
+    assert page_down.cursor is not None
+    assert (page_down.cursor.row, page_down.cursor.column) == (4, 6)
+
+    result = _result_from_scenario(scenario)
+    result.assert_composer_text("one\ntwo\nthree\nfour\nfive")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_paste_marker_delete_undo() -> NativeTuiInputPlaybackResult:
+    pasted = "\n".join(f"line {index}" for index in range(10))
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .render()
+        .key(f"{BRACKETED_PASTE_START}{pasted}{BRACKETED_PASTE_END}")
+        .key("\x7f")
+        .key("\x1f")
+        .run()
+    )
+    result.assert_composer_text(pasted)
+    result.assert_visible_contains("[paste #1 +10 lines]")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _result_from_scenario(scenario: NativeTuiInputScenario) -> NativeTuiInputPlaybackResult:
+    playback = scenario.playback
+    return NativeTuiInputPlaybackResult(
+        steps=playback.harness.steps,
+        port=playback.port,
+        input_results=tuple(playback.input_results),
+        step_input_results=tuple(playback.step_input_results),
+        step_coding_states=tuple(playback.step_coding_states),
+        app=scenario.app,
+    )
+
+
 COMPOSER_SCENARIOS = (
     NativePlaybackScenarioSpec(
         name="completion-tab",
@@ -206,5 +278,23 @@ COMPOSER_SCENARIOS = (
         name="keyboard-shift-enter-newline",
         description="Route raw Shift+Enter to composer newline before submission.",
         run=_run_keyboard_shift_enter_newline,
+    ),
+    NativePlaybackScenarioSpec(
+        name="editor-key-editing",
+        description="Route common editor keys for line movement, kill/yank, and undo.",
+        run=_run_editor_key_editing,
+        tags=("editor", "composer"),
+    ),
+    NativePlaybackScenarioSpec(
+        name="page-navigation",
+        description="Route composer PageUp and PageDown using playback terminal dimensions.",
+        run=_run_page_navigation,
+        tags=("editor", "composer"),
+    ),
+    NativePlaybackScenarioSpec(
+        name="paste-marker-delete-undo",
+        description="Delete a large paste marker atomically and restore it with undo.",
+        run=_run_paste_marker_delete_undo,
+        tags=("editor", "paste", "composer"),
     ),
 )

--- a/src/loushang/coding/ui/playback_scenarios/composer.py
+++ b/src/loushang/coding/ui/playback_scenarios/composer.py
@@ -69,6 +69,65 @@ def _run_completion_navigation_priority() -> NativeTuiInputPlaybackResult:
     return result
 
 
+def _run_completion_escape_cancel() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .with_completion_items("/help", "/history")
+        .render()
+        .type_text("/h")
+        .escape()
+        .run()
+    )
+    result.assert_composer_text("/h")
+    result.assert_visible_contains("› /h")
+    result.assert_visible_not_contains("  /help")
+    result.assert_visible_not_contains("  /history")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_completion_prefix_refresh() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .with_completion_items("/help", "/history", "/model")
+        .render()
+        .type_text("/")
+        .type_text("m")
+        .run()
+    )
+    result.assert_composer_text("/m")
+    result.assert_visible_contains("› /m")
+    result.assert_visible_contains("  /model")
+    result.assert_visible_not_contains("  /help")
+    result.assert_visible_not_contains("  /history")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _run_completion_enter_submits_command() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=80, height=12)
+        .with_completion_items("/model", "/models")
+        .with_local_commands("/model")
+        .render()
+        .type_text("/mod")
+        .enter()
+        .run()
+    )
+    result.assert_local_texts("/model")
+    result.assert_composer_text("")
+    result.assert_visible_not_contains("  /model")
+    result.assert_visible_not_contains("  /models")
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
 def _run_history_navigation() -> NativeTuiInputPlaybackResult:
     result = (
         NativeTuiInputScenario(width=80, height=12)
@@ -253,6 +312,24 @@ COMPOSER_SCENARIOS = (
         name="completion-navigation-priority",
         description="Route completion navigation before history navigation.",
         run=_run_completion_navigation_priority,
+    ),
+    NativePlaybackScenarioSpec(
+        name="completion-escape-cancel",
+        description="Cancel visible completions without clearing the composer draft.",
+        run=_run_completion_escape_cancel,
+        tags=("completion", "editor", "composer"),
+    ),
+    NativePlaybackScenarioSpec(
+        name="completion-prefix-refresh",
+        description="Refresh visible completions when the composer prefix changes.",
+        run=_run_completion_prefix_refresh,
+        tags=("completion", "editor", "composer"),
+    ),
+    NativePlaybackScenarioSpec(
+        name="completion-enter-submits-command",
+        description="Apply a selected slash command completion before local command submission.",
+        run=_run_completion_enter_submits_command,
+        tags=("completion", "command", "composer"),
     ),
     NativePlaybackScenarioSpec(
         name="history-navigation",

--- a/tests/coding/test_native_coding_tui_playback.py
+++ b/tests/coding/test_native_coding_tui_playback.py
@@ -28,6 +28,7 @@ from loushang.tui import (
     PlaybackHarness,
     PlaybackStep,
     Renderable,
+    RenderConstraints,
     RenderDiagnostics,
     RenderLoop,
     SettingItem,
@@ -121,6 +122,28 @@ def test_native_tui_playback_uses_visual_up_before_history_for_multiline_draft()
     ]
     assert app.composer.value == "previous prompt"
     for step in result:
+        step.assert_no_clear_scrollback()
+
+
+def test_native_tui_playback_routes_composer_page_keys() -> None:
+    app = _app()
+    app.composer.set_text("one\ntwo\nthree\nfour\nfive")
+    playback = NativeTuiInputPlayback(app, columns=20, rows=3)
+
+    page_up_steps = playback.play([PlaybackEvent.input("\x1b[5~")])
+    page_up = app.composer.render(RenderConstraints(width=20, max_height=5))
+
+    assert all(step.flush_succeeded for step in page_up_steps)
+    assert page_up.cursor is not None
+    assert (page_up.cursor.row, page_up.cursor.column) == (2, 6)
+
+    page_down_steps = playback.play([PlaybackEvent.input("\x1b[6~")])
+    page_down = app.composer.render(RenderConstraints(width=20, max_height=5))
+
+    assert all(step.flush_succeeded for step in page_down_steps)
+    assert page_down.cursor is not None
+    assert (page_down.cursor.row, page_down.cursor.column) == (4, 6)
+    for step in (*page_up_steps, *page_down_steps):
         step.assert_no_clear_scrollback()
 
 
@@ -499,6 +522,7 @@ class _NativeInteractivePlayback:
             should_exit=lambda _text: False,
             is_local_command=surface_manager.is_local_command,
             width=columns,
+            height=rows,
         )
 
     def play(self, events: list[PlaybackEvent]) -> tuple[PlaybackStep, ...]:
@@ -508,6 +532,8 @@ class _NativeInteractivePlayback:
                 if not isinstance(event.payload, TerminalSize):
                     raise TypeError("resize event payload must be TerminalSize")
                 self.terminal.resize(event.payload)
+                self.router.width = event.payload.columns
+                self.router.height = event.payload.rows
             elif event.kind == "input":
                 if not isinstance(event.payload, str):
                     raise TypeError("input playback event payload must be str")

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -52,6 +52,9 @@ def test_native_tui_playback_composer_scenarios_live_in_composer_module() -> Non
         "completion-tab",
         "completion-session-command",
         "completion-navigation-priority",
+        "completion-escape-cancel",
+        "completion-prefix-refresh",
+        "completion-enter-submits-command",
         "history-navigation",
         "bracketed-paste-large-marker",
         "resize-reflow-stable",
@@ -121,6 +124,9 @@ def test_native_tui_playback_runner_lists_default_scenarios(capsys) -> None:
     assert "completion-tab" in captured.out
     assert "completion-session-command" in captured.out
     assert "completion-navigation-priority" in captured.out
+    assert "completion-escape-cancel" in captured.out
+    assert "completion-prefix-refresh" in captured.out
+    assert "completion-enter-submits-command" in captured.out
     assert "history-navigation" in captured.out
     assert "idle-escape-clears-draft" in captured.out
     assert "long-transcript-input" in captured.out
@@ -199,6 +205,22 @@ def test_native_tui_playback_runner_runs_completion_session_command_scenario(cap
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS completion-session-command" in captured.out
+
+
+def test_native_tui_playback_runner_runs_completion_detail_scenarios(capsys) -> None:
+    exit_code = run_playback_cli(
+        [
+            "completion-escape-cancel",
+            "completion-prefix-refresh",
+            "completion-enter-submits-command",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS completion-escape-cancel" in captured.out
+    assert "PASS completion-prefix-refresh" in captured.out
+    assert "PASS completion-enter-submits-command" in captured.out
 
 
 def test_native_tui_playback_runner_runs_lifecycle_scenario(capsys) -> None:

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -57,6 +57,9 @@ def test_native_tui_playback_composer_scenarios_live_in_composer_module() -> Non
         "resize-reflow-stable",
         "wide-char-input-cursor",
         "keyboard-shift-enter-newline",
+        "editor-key-editing",
+        "page-navigation",
+        "paste-marker-delete-undo",
     ]
 
 


### PR DESCRIPTION
## Summary
- Route native composer PageUp/PageDown using terminal dimensions and keep playback router size in sync.
- Add native composer playback coverage for editor keys, page navigation, paste marker undo, and completion interaction details.
- Update playback runner coverage for the new composer scenarios.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_tui_playback_runner.py tests/coding/test_native_coding_tui_playback.py tests/coding/test_native_tui_playback_harness.py tests/tui/test_composer_bottom_frame.py tests/tui/test_composer_edit_buffer.py tests/coding/test_native_coding_tui_input.py tests/tui/test_input_routing.py -q
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/native_input.py src/loushang/coding/ui/native_loop.py src/loushang/coding/ui/playback.py src/loushang/coding/ui/playback_scenarios/composer.py tests/coding/test_native_coding_tui_playback.py tests/coding/test_native_tui_playback_runner.py
- uv --cache-dir .uv-cache run --extra dev python scripts/run_native_tui_playback.py completion-tab completion-session-command completion-navigation-priority completion-escape-cancel completion-prefix-refresh completion-enter-submits-command history-navigation bracketed-paste-large-marker resize-reflow-stable wide-char-input-cursor keyboard-shift-enter-newline editor-key-editing page-navigation paste-marker-delete-undo