### PR TITLE
fix(tui): correct cell width for text-presentation symbols

### DIFF
--- a/src/loushang/tui/cell_width.py
+++ b/src/loushang/tui/cell_width.py
@@ -544,6 +544,8 @@ def _cluster_width(cluster: str) -> int:
         return 0
     if all(_char_width(char) == 0 for char in cluster):
         return 0
+    if "\ufe0f" in cluster:
+        return 2
     if "\u200d" in cluster:
         return 2
     if any(_is_emoji_width(char) or _is_regional_indicator(char) for char in cluster):
@@ -584,11 +586,7 @@ def _is_regional_indicator(char: str) -> bool:
 
 def _is_emoji_width(char: str) -> bool:
     codepoint = ord(char)
-    return (
-        0x1F000 <= codepoint <= 0x1FBFF
-        or 0x2300 <= codepoint <= 0x23FF
-        or 0x2600 <= codepoint <= 0x27BF
-    )
+    return 0x1F000 <= codepoint <= 0x1FBFF
 
 
 class _StyleTracker:

--- a/tests/tui/test_cell_width.py
+++ b/tests/tui/test_cell_width.py
@@ -302,6 +302,24 @@ def test_truncate_to_width_matches_pi_large_unicode_and_malformed_escape_fixture
     assert no_ellipsis.endswith("\x1b[0m")
 
 
+def test_visible_width_distinguishes_text_and_emoji_presentation() -> None:
+    """Text-default symbols (Text_Presentation) are single-width;
+    the same symbol with U+FE0F (VS16) becomes emoji-width.
+    Symbols whose East_Asian_Width is W remain double-width.
+    """
+    # Text presentation (no VS16)
+    assert visible_width(chr(0x26A0)) == 1  # ⚠
+    assert visible_width(chr(0x2600)) == 1  # ☀
+    assert visible_width(chr(0x261A)) == 1  # ☚
+    # Emoji presentation (with VS16)
+    assert visible_width(chr(0x26A0) + chr(0xFE0F)) == 2  # ⚠️
+    assert visible_width(chr(0x2600) + chr(0xFE0F)) == 2  # ☀️
+    # Default double-width via East_Asian_Width=W
+    assert visible_width(chr(0x2615)) == 2  # ☕
+    assert visible_width(chr(0x26A1)) == 2  # ⚡
+    assert visible_width(chr(0x2705)) == 2  # ✅
+
+
 def test_wrap_cells_rejects_non_positive_width() -> None:
     try:
         wrap_cells("abc", width=0)


### PR DESCRIPTION
## Problem

`_is_emoji_width` incorrectly treated the entire `0x2300-0x23FF` and `0x2600-0x27BF` ranges as emoji-width (2 cells). Most symbols in these ranges default to **text presentation** (Text_Presentation) and should be single-width unless followed by U+FE0F (VS16).

For example, `⚠` (U+26A0, without VS16) was computed as width 2, but terminals render it as width 1. This caused table misalignment and incorrect cursor positioning.

## Changes

- **Narrow `_is_emoji_width`** to `0x1F000-0x1FBFF` only.
- **Add VS16 (U+FE0F) detection** in `_cluster_width` so symbols with explicit emoji presentation still render as double-width.
- **EAW=W symbols** (e.g. U+2615 ☕, U+26A1 ⚡) continue to be double-width via `_char_width`, unaffected by this change.

## Impact

Fixes **402 symbols** in `0x2600-0x27BF` and **246 symbols** in `0x2300-0x23FF` that were previously over-counted.

## Verification

- All existing tests pass: `2970 passed, 3 skipped`
- Added new test: `test_visible_width_distinguishes_text_and_emoji_presentation`

| Char | Before | After | Expected |
|------|--------|-------|----------|
| ⚠ (U+26A0) | 2 | **1** | 1 (text) |
| ⚠️ (U+26A0+VS16) | 2 | **2** | 2 (emoji) |
| ☕ (U+2615, EAW=W) | 2 | **2** | 2 (EAW=W) |
| ⚡ (U+26A1, EAW=W) | 2 | **2** | 2 (EAW=W) |
| 🙂 (U+1F642) | 2 | **2** | 2 (0x1F000+) |