### PR TITLE
Harden TUI composer selection playback

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-009-theme-resolution.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-009-theme-resolution.md
@@ -29,6 +29,7 @@ status.branch
 composer.prompt
 surface.border
 surface.selection.active
+editor.selection
 markdown.heading.1
 markdown.code.inline
 markdown.code.block

--- a/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
+++ b/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
@@ -63,6 +63,19 @@ Examples:
 - stacked surfaces restore focus in order
 - constrained-height bottom frame follows priority rules
 - concise error without traceback
+- composer selection stress with wide text, paste markers, kill/yank, undo,
+  completion refresh, and selection key priority
+
+Composer selection playback should be run directly when changing composer input,
+selection, paste marker, completion, keybinding, or render-highlight behavior:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner composer-selection-stress --artifacts /tmp/loushang-selection-playback --include-frames
+```
+
+The trace should include `composer-selection-stress` as a passing scenario. Use
+the generated JSONL artifact when diagnosing selection regressions because the
+final screen cannot show transient selected ranges after replacement or undo.
 
 ### 4. Boundary Tests
 
@@ -87,5 +100,14 @@ visually:
 - IME candidate window placement
 - terminal restoration after Ctrl-C, Esc abort, exception, and normal exit
 - narrow terminal status truncation
+- composer selection in a real terminal:
+  - type `abc`, press `Shift+Left`, verify the final `c` is visibly selected,
+    then type `x` and verify the draft becomes `abx`
+  - type `你🙂a`, press `Shift+Left` twice, type `x`, and verify the draft
+    becomes `你x` without splitting the emoji grapheme
+  - type a short draft, use `Shift+Home` and `Shift+End` from opposite line
+    ends, and verify typing replaces exactly the selected text
+  - press `Ctrl+-` after a selection replacement and verify undo restores the
+    previous content and clears the visible selection
 
 Manual smoke tests should be run after the playback harness and unit tests pass.

--- a/src/loushang/coding/ui/playback_scenarios/composer.py
+++ b/src/loushang/coding/ui/playback_scenarios/composer.py
@@ -12,7 +12,12 @@ from loushang.coding.ui.playback_fakes import (
 )
 from loushang.coding.ui.playback_scenarios.budgets import INTERACTION_FRAME_BUDGET
 from loushang.coding.ui.playback_suite import NativePlaybackScenarioSpec
-from loushang.tui import PlaybackEvent, RenderConstraints
+from loushang.tui import (
+    CompletionItem,
+    CompletionProvider,
+    PlaybackEvent,
+    RenderConstraints,
+)
 from loushang.tui.input import BRACKETED_PASTE_END, BRACKETED_PASTE_START
 
 
@@ -303,6 +308,77 @@ def _run_composer_selection_replace() -> NativeTuiInputPlaybackResult:
     return result
 
 
+def _run_composer_selection_stress() -> NativeTuiInputPlaybackResult:
+    scenario = NativeTuiInputScenario(width=80, height=12)
+    playback = scenario.playback
+
+    playback.play(
+        (
+            PlaybackEvent("render"),
+            PlaybackEvent.input("你🙂a"),
+            PlaybackEvent.input("\x1b[1;2D"),
+            PlaybackEvent.input("\x1b[1;2D"),
+            PlaybackEvent.input("x"),
+            PlaybackEvent.input("\x1b[1;2H"),
+            PlaybackEvent.input("wide"),
+            PlaybackEvent.input("\x1f"),
+            PlaybackEvent.input("\x01"),
+            PlaybackEvent.input("\x1b[1;2F"),
+            PlaybackEvent.input("\x0b"),
+            PlaybackEvent.input("\x19"),
+            PlaybackEvent.input("\x1f"),
+        )
+    )
+    assert scenario.app.composer.value == ""
+    assert [state["composer_text"] for state in playback.step_coding_states[1:8]] == [
+        "你🙂a",
+        "你🙂a",
+        "你🙂a",
+        "你x",
+        "你x",
+        "wide",
+        "你x",
+    ]
+
+    pasted = "\n".join(f"selected paste line {index}" for index in range(10))
+    playback.play((PlaybackEvent.input(f"{BRACKETED_PASTE_START}{pasted}{BRACKETED_PASTE_END}"),))
+    assert scenario.app.composer.value == pasted
+    assert scenario.app.composer.selected_range is None
+    assert "[paste #1 +10 lines]" in "\n".join(playback.port.screen.visible_lines)
+
+    playback.play((PlaybackEvent.input("\x1b[1;2D"),))
+    assert scenario.app.composer.selected_range == (0, 1)
+
+    playback.play((PlaybackEvent.input("\x7f"),))
+    assert scenario.app.composer.value == ""
+
+    playback.play((PlaybackEvent.input("\x1f"),))
+    assert scenario.app.composer.value == pasted
+    assert "[paste #1 +10 lines]" in "\n".join(playback.port.screen.visible_lines)
+
+    scenario.app.composer.clear()
+    scenario.app.composer.set_completion_provider(
+        CompletionProvider((CompletionItem(value="ax-alpha"), CompletionItem(value="ax-beta")))
+    )
+    playback.play(
+        (
+            PlaybackEvent.input("ab"),
+            PlaybackEvent.input("\x1b[1;2D"),
+            PlaybackEvent.input("x"),
+        )
+    )
+    assert scenario.app.composer.value == "ax"
+    assert scenario.app.composer.selected_range is None
+    assert scenario.app.composer.has_completions
+    assert "ax-alpha" in "\n".join(playback.port.screen.visible_lines)
+
+    result = _result_from_scenario(scenario)
+    result.assert_no_clear_screen()
+    result.assert_cursor_matches_diagnostics()
+    INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
 def _result_from_scenario(scenario: NativeTuiInputScenario) -> NativeTuiInputPlaybackResult:
     playback = scenario.playback
     return NativeTuiInputPlaybackResult(
@@ -398,5 +474,11 @@ COMPOSER_SCENARIOS = (
         description="Extend composer selection with Shift+Left and replace it through typed input.",
         run=_run_composer_selection_replace,
         tags=("editor", "selection", "composer"),
+    ),
+    NativePlaybackScenarioSpec(
+        name="composer-selection-stress",
+        description="Stress composer selection across wide text, paste markers, kill/yank, undo, and completions.",
+        run=_run_composer_selection_stress,
+        tags=("editor", "selection", "paste", "completion", "composer"),
     ),
 )

--- a/src/loushang/tui/ui_parts/composer.py
+++ b/src/loushang/tui/ui_parts/composer.py
@@ -51,7 +51,7 @@ from loushang.tui.core import (
 from loushang.tui.framework import surface_is_bottom_exclusive
 from loushang.tui.kill_ring import KillRing
 from loushang.tui.selection import SelectionRange
-from loushang.tui.theme import apply_theme_style
+from loushang.tui.theme import ThemeResolver, ThemeStyle, apply_theme_style
 
 from .layout import RegionRenderable, ScreenRegion, ScreenRegionStack, _part_has_content
 from .pending import PendingQueueView as PendingQueueView
@@ -59,6 +59,7 @@ from .status import StatusBar as StatusBar
 from .status import WorkingLine as WorkingLine
 
 _EditAction = str | None
+DEFAULT_COMPOSER_SELECTION_STYLE: ThemeStyle = {"reverse": True}
 
 
 @dataclass(frozen=True, slots=True)
@@ -94,6 +95,8 @@ class Composer:
     continuation_prompt: str = "  "
     large_paste_line_threshold: int = 8
     large_paste_char_threshold: int = 1000
+    theme: ThemeResolver | None = None
+    selection_theme_token: str = "editor.selection"
     completion_debounce_seconds: float = 0.05
     completion_min_interval_seconds: float = 0.05
     now: Callable[[], float] = field(default_factory=lambda: time.monotonic, repr=False)
@@ -569,6 +572,7 @@ class Composer:
             self._buffer.display_text,
             display_cursor=self._buffer.display_cursor,
             selection_display_range=self._selection_display_range(),
+            selection_style=self._selection_style(),
             prompt=self.prompt,
             continuation_prompt=self.continuation_prompt,
             width=constraints.width,
@@ -685,6 +689,13 @@ class Composer:
         if display_start == display_end:
             return None
         return display_start, display_end
+
+    def _selection_style(self) -> ThemeStyle:
+        if self.theme is not None and self.selection_theme_token:
+            resolved = self.theme.resolve(self.selection_theme_token)
+            if resolved:
+                return resolved
+        return DEFAULT_COMPOSER_SELECTION_STYLE
 
     def _line_start_index(self) -> int:
         return self._buffer.line_start_index()
@@ -1108,6 +1119,7 @@ def _render_composer_text(
     continuation_prompt: str,
     width: int,
     selection_display_range: tuple[int, int] | None = None,
+    selection_style: ThemeStyle | None = None,
 ) -> tuple[list[str], CursorDeclaration]:
     lines: list[str] = []
     cursor: CursorDeclaration | None = None
@@ -1128,6 +1140,7 @@ def _render_composer_text(
                 chunk_start=chunk_start,
                 chunk_end=chunk_end,
                 selection_display_range=selection_display_range,
+                selection_style=selection_style,
             )
             lines.append(truncate_to_width(row_prefix + chunk_text, max_width=line_width))
             if cursor is None and chunk_start <= display_cursor <= chunk_end:
@@ -1151,6 +1164,7 @@ def _highlight_selection_in_chunk(
     chunk_start: int,
     chunk_end: int,
     selection_display_range: tuple[int, int] | None,
+    selection_style: ThemeStyle | None,
 ) -> str:
     if selection_display_range is None:
         return text
@@ -1166,7 +1180,7 @@ def _highlight_selection_in_chunk(
     before = slice_by_column(text, start=0, length=before_width).text
     selected = slice_by_column(text, start=before_width, length=selected_width).text
     after = slice_by_column(text, start=after_start, length=max(0, chunk_width - after_start)).text
-    return before + apply_theme_style(selected, {"reverse": True}) + after
+    return before + apply_theme_style(selected, selection_style or DEFAULT_COMPOSER_SELECTION_STYLE) + after
 
 
 def _visual_segments(

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -64,6 +64,7 @@ def test_native_tui_playback_composer_scenarios_live_in_composer_module() -> Non
         "page-navigation",
         "paste-marker-delete-undo",
         "composer-selection-replace",
+        "composer-selection-stress",
     ]
 
 
@@ -230,6 +231,14 @@ def test_native_tui_playback_runner_runs_composer_selection_scenario(capsys) -> 
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS composer-selection-replace" in captured.out
+
+
+def test_native_tui_playback_runner_runs_composer_selection_stress_scenario(capsys) -> None:
+    exit_code = run_playback_cli(["composer-selection-stress"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS composer-selection-stress" in captured.out
 
 
 def test_native_tui_playback_runner_runs_lifecycle_scenario(capsys) -> None:

--- a/tests/tui/test_composer_bottom_frame.py
+++ b/tests/tui/test_composer_bottom_frame.py
@@ -23,6 +23,7 @@ from loushang.tui import (
     SlashCommandCompletionProvider,
     StatusBar,
     StatusField,
+    ThemeResolver,
     WorkingLine,
     strip_control_sequences,
     visible_width,
@@ -381,6 +382,20 @@ def test_composer_render_highlights_selected_text() -> None:
     composer.select_char_left()
 
     assert rendered_text(composer, width=20) == ("> ab\x1b[7mc\x1b[27m",)
+
+
+def test_composer_selection_highlight_uses_editor_selection_theme_token() -> None:
+    composer = Composer(
+        prompt="> ",
+        theme=ThemeResolver(defaults={"editor.selection": {"color": "cyan", "bold": True}}),
+    )
+    composer.insert_text("abc")
+    composer.select_char_left()
+
+    raw = rendered_text(composer, width=20)[0]
+
+    assert strip_control_sequences(raw) == "> abc"
+    assert "\x1b[1;36mc\x1b[22;39m" in raw
 
 
 def test_composer_completion_navigation_does_not_share_text_selection_state() -> None:

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_testing_strategy_documents_composer_selection_manual_smoke() -> None:
+    text = Path("docs/internals/architecture/tui/native-terminal-core/testing-strategy.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "composer-selection-stress" in text
+    assert "python -m loushang.coding.ui.playback_runner composer-selection-stress" in text
+    assert "Shift+Left" in text
+    assert "Shift+Home" in text
+    assert "Shift+End" in text
+    assert "Ctrl+-" in text
+
+
+def test_theme_key_design_lists_editor_selection_token() -> None:
+    text = Path("docs/internals/architecture/tui/native-terminal-core/key-designs/KD-009-theme-resolution.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "editor.selection" in text


### PR DESCRIPTION
## Summary
- Add composer-selection-stress playback for wide text, paste markers, kill/yank, undo, and completions
- Route composer selection highlight through the editor.selection theme token with reverse fallback
- Document manual selection smoke checks and guard the docs with tests

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest -q
- uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner composer-selection-stress --artifacts /tmp/loushang-selection-hardening --include-frames