### PR TITLE
Add shared TUI edit selection foundation

### DIFF
--- a/src/loushang/coding/ui/playback_scenarios/composer.py
+++ b/src/loushang/coding/ui/playback_scenarios/composer.py
@@ -375,6 +375,7 @@ def _run_composer_selection_stress() -> NativeTuiInputPlaybackResult:
     result = _result_from_scenario(scenario)
     result.assert_no_clear_screen()
     result.assert_cursor_matches_diagnostics()
+    result.assert_any_frame_output_contains("\x1b[7m")
     INTERACTION_FRAME_BUDGET.assert_result(result, skip_first=True)
     return result
 

--- a/src/loushang/tui/__init__.py
+++ b/src/loushang/tui/__init__.py
@@ -130,6 +130,11 @@ from loushang.tui.scheduler import (
     RenderSchedulerConfig,
 )
 from loushang.tui.selection import SelectionRange
+from loushang.tui.selection_controller import SelectionController
+from loushang.tui.selection_rendering import (
+    DEFAULT_SELECTION_STYLE,
+    highlight_selection_by_columns,
+)
 from loushang.tui.surfaces import (
     ApprovalSurface,
     AutocompleteSurface,
@@ -278,6 +283,7 @@ __all__ = [
     "DialogSurface",
     "DiffBlock",
     "DefaultTerminalPlatformAdapter",
+    "DEFAULT_SELECTION_STYLE",
     "AssistantMessageRecord",
     "DynamicBorder",
     "ErrorRecord",
@@ -353,6 +359,7 @@ __all__ = [
     "ScreenRoot",
     "SelectItem",
     "SelectionRange",
+    "SelectionController",
     "SelectionSurface",
     "SettingsSurface",
     "SettingItem",
@@ -426,6 +433,7 @@ __all__ = [
     "get_png_dimensions",
     "get_webp_dimensions",
     "hyperlink",
+    "highlight_selection_by_columns",
     "get_completion_suggestions",
     "grapheme_clusters",
     "image_fallback",

--- a/src/loushang/tui/composer_edit_buffer.py
+++ b/src/loushang/tui/composer_edit_buffer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 
 from loushang.tui.cell_width import grapheme_clusters, visible_width
@@ -311,6 +311,16 @@ class ComposerEditBuffer:
 
     def clear_redo(self) -> None:
         self._redo_stack.clear()
+
+    def apply_edit(self, edit: Callable[[], object]) -> bool:
+        snapshot = self._snapshot()
+        previous_atoms = snapshot[0]
+        edit()
+        if tuple(self._atoms) == previous_atoms:
+            return False
+        self._undo_stack.push(snapshot)
+        self._redo_stack.clear()
+        return True
 
     def _clamp_range(self, start: int, end: int) -> tuple[int, int]:
         length = len(self._atoms)

--- a/src/loushang/tui/editor_buffer.py
+++ b/src/loushang/tui/editor_buffer.py
@@ -140,6 +140,13 @@ class EditorBuffer:
         self._cursor = end
         return True
 
+    def move_cursor_to(self, index: int) -> bool:
+        target = max(0, min(index, len(self._clusters)))
+        if target == self._cursor:
+            return False
+        self._cursor = target
+        return True
+
     def move_to_line_start(self) -> bool:
         target = self._line_start_index()
         if target == self._cursor:

--- a/src/loushang/tui/playback.py
+++ b/src/loushang/tui/playback.py
@@ -159,6 +159,21 @@ class PlaybackResult:
     def assert_visible_not_contains(self, unexpected: str) -> None:
         assert unexpected not in self.visible_text
 
+    def assert_frame_output_contains(self, step_index: int, expected: str) -> None:
+        if step_index < 0 or step_index >= len(self.steps):
+            raise AssertionError(f"expected step index {step_index} to exist")
+        step = self.steps[step_index]
+        if step.frame is None:
+            raise AssertionError(f"expected step {step_index} to record a terminal frame")
+        if expected not in step.frame.serialized_output:
+            raise AssertionError(f"expected step {step_index} frame output to contain {expected!r}")
+
+    def assert_any_frame_output_contains(self, expected: str) -> None:
+        for step in self.steps:
+            if step.frame is not None and expected in step.frame.serialized_output:
+                return
+        raise AssertionError(f"expected at least one frame output to contain {expected!r}")
+
     def assert_last_operation_class_not_in(self, *unexpected: str) -> None:
         assert self.steps
         assert self.steps[-1].diagnostics.operation_class not in unexpected

--- a/src/loushang/tui/selection_controller.py
+++ b/src/loushang/tui/selection_controller.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from loushang.tui.selection import SelectionRange
+
+__all__ = ["SelectionController"]
+
+
+@dataclass(slots=True)
+class SelectionController:
+    length: Callable[[], int]
+    cursor: Callable[[], int]
+    set_cursor: Callable[[int], None]
+    _selection: SelectionRange | None = None
+
+    @property
+    def selected_range(self) -> tuple[int, int] | None:
+        selection = self._selection
+        if selection is None:
+            return None
+        start, end = selection.normalized(self.length())
+        if start == end:
+            return None
+        return start, end
+
+    @property
+    def raw_selection(self) -> SelectionRange | None:
+        return self._selection
+
+    def has_selection(self) -> bool:
+        return self.selected_range is not None
+
+    def set(self, anchor: int, focus: int) -> None:
+        anchor = self.clamp_index(anchor)
+        focus = self.clamp_index(focus)
+        self.set_cursor(focus)
+        self._selection = None if anchor == focus else SelectionRange(anchor=anchor, focus=focus)
+
+    def clear(self) -> None:
+        self._selection = None
+
+    def extend_to(self, target: int) -> None:
+        previous_cursor = self.cursor()
+        target = self.clamp_index(target)
+        anchor = self._selection.anchor if self._selection is not None else previous_cursor
+        self.set(anchor, target)
+
+    def clamp_index(self, index: int) -> int:
+        return max(0, min(index, self.length()))

--- a/src/loushang/tui/selection_rendering.py
+++ b/src/loushang/tui/selection_rendering.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from loushang.tui.cell_width import slice_by_column, visible_width
+from loushang.tui.theme import ThemeStyle, apply_theme_style
+
+__all__ = ["DEFAULT_SELECTION_STYLE", "highlight_selection_by_columns"]
+
+DEFAULT_SELECTION_STYLE: ThemeStyle = {"reverse": True}
+
+
+def highlight_selection_by_columns(
+    text: str,
+    *,
+    selection_range: tuple[int, int] | None,
+    selection_style: ThemeStyle | None = None,
+) -> str:
+    if selection_range is None:
+        return text
+    selection_start, selection_end = selection_range
+    if selection_start >= selection_end:
+        return text
+    text_width = visible_width(text)
+    overlap_start = max(0, min(selection_start, text_width))
+    overlap_end = max(0, min(selection_end, text_width))
+    if overlap_start >= overlap_end:
+        return text
+    selected_width = overlap_end - overlap_start
+    after_start = overlap_start + selected_width
+    before = slice_by_column(text, start=0, length=overlap_start).text
+    selected = slice_by_column(text, start=overlap_start, length=selected_width).text
+    after = slice_by_column(text, start=after_start, length=max(0, text_width - after_start)).text
+    return before + apply_theme_style(selected, selection_style or DEFAULT_SELECTION_STYLE) + after

--- a/src/loushang/tui/ui_parts/composer.py
+++ b/src/loushang/tui/ui_parts/composer.py
@@ -50,7 +50,11 @@ from loushang.tui.core import (
 )
 from loushang.tui.framework import surface_is_bottom_exclusive
 from loushang.tui.kill_ring import KillRing
-from loushang.tui.selection import SelectionRange
+from loushang.tui.selection_controller import SelectionController
+from loushang.tui.selection_rendering import (
+    DEFAULT_SELECTION_STYLE,
+    highlight_selection_by_columns,
+)
 from loushang.tui.theme import ThemeResolver, ThemeStyle, apply_theme_style
 
 from .layout import RegionRenderable, ScreenRegion, ScreenRegionStack, _part_has_content
@@ -59,7 +63,7 @@ from .status import StatusBar as StatusBar
 from .status import WorkingLine as WorkingLine
 
 _EditAction = str | None
-DEFAULT_COMPOSER_SELECTION_STYLE: ThemeStyle = {"reverse": True}
+DEFAULT_COMPOSER_SELECTION_STYLE: ThemeStyle = DEFAULT_SELECTION_STYLE
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,7 +106,7 @@ class Composer:
     now: Callable[[], float] = field(default_factory=lambda: time.monotonic, repr=False)
     submitted: bool = False
     _buffer: ComposerEditBuffer = field(default_factory=ComposerEditBuffer, repr=False)
-    _selection: SelectionRange | None = None
+    _selection_controller: SelectionController = field(init=False, repr=False)
     _kill_ring: KillRing = field(default_factory=KillRing)
     _last_action: _EditAction = None
     _history: list[str] = field(default_factory=list)
@@ -120,6 +124,13 @@ class Composer:
     _completion_pending: _CompletionRefreshRequest | None = None
     _completion_request_token: int = 0
     _completion_last_started_at: float | None = None
+
+    def __post_init__(self) -> None:
+        self._selection_controller = SelectionController(
+            length=lambda: len(self._buffer),
+            cursor=lambda: self._buffer.cursor,
+            set_cursor=self._set_cursor_index,
+        )
 
     @property
     def value(self) -> str:
@@ -139,27 +150,16 @@ class Composer:
 
     @property
     def selected_range(self) -> tuple[int, int] | None:
-        if self._selection is None:
-            return None
-        start, end = self._selection.normalized(len(self._buffer))
-        if start == end:
-            return None
-        return start, end
+        return self._selection_controller.selected_range
 
     def has_selection(self) -> bool:
-        return self.selected_range is not None
+        return self._selection_controller.has_selection()
 
     def set_selection(self, anchor: int, focus: int) -> None:
-        anchor = self._clamp_selection_index(anchor)
-        focus = self._clamp_selection_index(focus)
-        self._set_cursor_index(focus)
-        if anchor == focus:
-            self._selection = None
-            return
-        self._selection = SelectionRange(anchor=anchor, focus=focus)
+        self._selection_controller.set(anchor, focus)
 
     def clear_selection(self) -> None:
-        self._selection = None
+        self._selection_controller.clear()
 
     def next_frame_due_ms(self, *, after_ms: int) -> int | None:
         del after_ms
@@ -198,7 +198,6 @@ class Composer:
         selection = self.selected_range
         insert_at = self._buffer.cursor if selection is None else selection[0]
         text = _prefix_space_before_path_paste(self._buffer.atoms, insert_at, text)
-        self._buffer.push_undo()
         line_count = text.count("\n") + 1
         char_count = len(text)
         if line_count > self.large_paste_line_threshold or char_count > self.large_paste_char_threshold:
@@ -214,41 +213,32 @@ class Composer:
                 ),
             )
             self._next_paste_marker_id += 1
-            if selection is not None:
-                self._buffer.replace_atoms(selection[0], selection[1], [marker], record=False)
-                self._after_buffer_content_edit(last_action=None)
-                return
-            self._insert_atoms([marker])
-            self._last_action = None
+            self._apply_buffer_content_edit(
+                lambda: self._replace_or_insert_atoms(selection, [marker]),
+                last_action=None,
+            )
             return
         if selection is not None:
-            self._buffer.replace_range(selection[0], selection[1], text, record=False)
-            self._after_buffer_content_edit(last_action=None)
+            self._apply_buffer_content_edit(
+                lambda: self._buffer.replace_range(selection[0], selection[1], text, record=False),
+                last_action=None,
+            )
             return
-        self._insert_atoms(_text_atoms(text))
-        self._last_action = None
+        self._apply_buffer_content_edit(lambda: self._buffer.insert_atoms(_text_atoms(text), record=False), last_action=None)
 
     def delete_backward(self) -> None:
         if self._delete_selection_or_none():
             return
         if self._buffer.cursor == 0:
             return
-        self._buffer.delete_backward()
-        self._last_action = None
-        self.clear_selection()
-        self._preferred_visual_column = None
-        self._refresh_completion_items()
+        self._apply_buffer_content_edit(lambda: self._buffer.delete_backward(record=False), last_action=None)
 
     def delete_forward(self) -> None:
         if self._delete_selection_or_none():
             return
         if self._buffer.cursor >= len(self._buffer):
             return
-        self._buffer.delete_forward()
-        self._last_action = None
-        self.clear_selection()
-        self._preferred_visual_column = None
-        self._refresh_completion_items()
+        self._apply_buffer_content_edit(lambda: self._buffer.delete_forward(record=False), last_action=None)
 
     def move_left(self) -> None:
         self._buffer.move_left()
@@ -340,11 +330,10 @@ class Composer:
             return
         killed = "".join(_atom_value(atom) for atom in self._buffer.atoms[start:cursor])
         was_kill = self._last_action == "kill"
-        self._buffer.push_undo()
-        self._push_kill(killed, prepend=True, accumulate=was_kill)
-        self._buffer.delete_range(start, cursor, record=False)
-        self._preferred_visual_column = None
-        self._refresh_completion_items()
+        self._apply_buffer_content_edit(
+            lambda: self._delete_range_to_kill_ring(start, cursor, killed, prepend=True, accumulate=was_kill),
+            last_action="kill",
+        )
 
     def delete_word_forward(self) -> None:
         if self._kill_selection_or_none(prepend=False):
@@ -355,11 +344,10 @@ class Composer:
             return
         killed = "".join(_atom_value(atom) for atom in self._buffer.atoms[cursor:end])
         was_kill = self._last_action == "kill"
-        self._buffer.push_undo()
-        self._push_kill(killed, prepend=False, accumulate=was_kill)
-        self._buffer.delete_range(cursor, end, record=False)
-        self._preferred_visual_column = None
-        self._refresh_completion_items()
+        self._apply_buffer_content_edit(
+            lambda: self._delete_range_to_kill_ring(cursor, end, killed, prepend=False, accumulate=was_kill),
+            last_action="kill",
+        )
 
     def move_cursor_to(self, value_index: int) -> None:
         self._buffer.move_cursor_to_value_index(value_index)
@@ -492,11 +480,11 @@ class Composer:
         killed = "".join(_atom_value(atom) for atom in self._buffer.atoms[cursor:end])
         if not killed:
             return
-        self._buffer.push_undo()
-        self._push_kill(killed, prepend=False, accumulate=self._last_action == "kill")
-        self._buffer.delete_range(cursor, end, record=False)
-        self._preferred_visual_column = None
-        self._refresh_completion_items()
+        was_kill = self._last_action == "kill"
+        self._apply_buffer_content_edit(
+            lambda: self._delete_range_to_kill_ring(cursor, end, killed, prepend=False, accumulate=was_kill),
+            last_action="kill",
+        )
 
     def kill_to_line_start(self) -> None:
         if self._kill_selection_or_none(prepend=True):
@@ -506,11 +494,11 @@ class Composer:
         killed = "".join(_atom_value(atom) for atom in self._buffer.atoms[start:cursor])
         if not killed:
             return
-        self._buffer.push_undo()
-        self._push_kill(killed, prepend=True, accumulate=self._last_action == "kill")
-        self._buffer.delete_range(start, cursor, record=False)
-        self._preferred_visual_column = None
-        self._refresh_completion_items()
+        was_kill = self._last_action == "kill"
+        self._apply_buffer_content_edit(
+            lambda: self._delete_range_to_kill_ring(start, cursor, killed, prepend=True, accumulate=was_kill),
+            last_action="kill",
+        )
 
     def yank(self) -> None:
         text = self._kill_ring.peek()
@@ -518,9 +506,7 @@ class Composer:
             return
         if self._replace_selection_with_atoms(_text_atoms(text), last_action="yank"):
             return
-        self._buffer.push_undo()
-        self._insert_atoms(_text_atoms(text))
-        self._last_action = "yank"
+        self._apply_buffer_content_edit(lambda: self._buffer.insert_atoms(_text_atoms(text), record=False), last_action="yank")
 
     def yank_pop(self) -> None:
         if self._last_action != "yank" or len(self._kill_ring) <= 1:
@@ -535,13 +521,15 @@ class Composer:
         cursor = self._buffer.cursor
         if "".join(_atom_value(atom) for atom in self._buffer.atoms[start:cursor]) != previous_text:
             return
-        self._buffer.push_undo()
-        self._buffer.delete_range(start, cursor, record=False)
-        self._rotate_kill_ring()
-        replacement = self._kill_ring.peek()
-        if replacement is not None:
-            self._insert_atoms(_text_atoms(replacement))
-        self._last_action = "yank"
+
+        def edit() -> None:
+            self._buffer.delete_range(start, cursor, record=False)
+            self._rotate_kill_ring()
+            replacement = self._kill_ring.peek()
+            if replacement is not None:
+                self._buffer.insert_atoms(_text_atoms(replacement), record=False)
+
+        self._apply_buffer_content_edit(edit, last_action="yank")
 
     def undo(self) -> None:
         if not self._buffer.undo():
@@ -617,11 +605,7 @@ class Composer:
         self._buffer.set_atoms(self._buffer.atoms, cursor=self._clamp_selection_index(index), record=False)
 
     def _extend_selection_to(self, target: int) -> None:
-        previous_cursor = self._buffer.cursor
-        target = self._clamp_selection_index(target)
-        anchor = self._selection.anchor if self._selection is not None else previous_cursor
-        self._set_cursor_index(target)
-        self.set_selection(anchor, target)
+        self._selection_controller.extend_to(target)
         self._last_action = None
         self._preferred_visual_column = None
         self._refresh_completion_items()
@@ -640,23 +624,48 @@ class Composer:
         self._last_action = last_action
         self._refresh_completion_items()
 
+    def _apply_buffer_content_edit(self, edit: Callable[[], object], *, last_action: _EditAction) -> bool:
+        changed = self._buffer.apply_edit(edit)
+        if not changed:
+            return False
+        self._after_buffer_content_edit(last_action=last_action)
+        return True
+
+    def _replace_or_insert_atoms(self, selection: tuple[int, int] | None, atoms: list[_Atom]) -> None:
+        if selection is None:
+            self._buffer.insert_atoms(atoms, record=False)
+            return
+        self._buffer.replace_atoms(selection[0], selection[1], atoms, record=False)
+
+    def _delete_range_to_kill_ring(
+        self,
+        start: int,
+        end: int,
+        killed: str,
+        *,
+        prepend: bool,
+        accumulate: bool,
+    ) -> None:
+        self._push_kill(killed, prepend=prepend, accumulate=accumulate)
+        self._buffer.delete_range(start, end, record=False)
+
     def _replace_selection_with_atoms(self, atoms: list[_Atom], *, last_action: _EditAction) -> bool:
         selection = self.selected_range
         if selection is None:
             return False
-        self._buffer.push_undo()
-        self._buffer.replace_atoms(selection[0], selection[1], atoms, record=False)
-        self._after_buffer_content_edit(last_action=last_action)
-        return True
+        return self._apply_buffer_content_edit(
+            lambda: self._buffer.replace_atoms(selection[0], selection[1], atoms, record=False),
+            last_action=last_action,
+        )
 
     def _delete_selection_or_none(self) -> bool:
         selection = self.selected_range
         if selection is None:
             return False
-        self._buffer.push_undo()
-        self._buffer.delete_range(selection[0], selection[1], record=False)
-        self._after_buffer_content_edit(last_action=None)
-        return True
+        return self._apply_buffer_content_edit(
+            lambda: self._buffer.delete_range(selection[0], selection[1], record=False),
+            last_action=None,
+        )
 
     def _kill_selection_or_none(self, *, prepend: bool) -> bool:
         selection = self.selected_range
@@ -667,13 +676,16 @@ class Composer:
             self.clear_selection()
             return True
         was_kill = self._last_action == "kill"
-        self._buffer.push_undo()
-        self._push_kill(killed, prepend=prepend, accumulate=was_kill)
-        self._buffer.delete_range(selection[0], selection[1], record=False)
-        self.clear_selection()
-        self._preferred_visual_column = None
-        self._refresh_completion_items()
-        return True
+        return self._apply_buffer_content_edit(
+            lambda: self._delete_range_to_kill_ring(
+                selection[0],
+                selection[1],
+                killed,
+                prepend=prepend,
+                accumulate=was_kill,
+            ),
+            last_action="kill",
+        )
 
     def _display_cursor(self) -> int:
         return self._buffer.display_cursor
@@ -1173,14 +1185,11 @@ def _highlight_selection_in_chunk(
     overlap_end = min(selection_end, chunk_end)
     if overlap_start >= overlap_end:
         return text
-    chunk_width = visible_width(text)
-    before_width = max(0, overlap_start - chunk_start)
-    selected_width = max(0, overlap_end - overlap_start)
-    after_start = before_width + selected_width
-    before = slice_by_column(text, start=0, length=before_width).text
-    selected = slice_by_column(text, start=before_width, length=selected_width).text
-    after = slice_by_column(text, start=after_start, length=max(0, chunk_width - after_start)).text
-    return before + apply_theme_style(selected, selection_style or DEFAULT_COMPOSER_SELECTION_STYLE) + after
+    return highlight_selection_by_columns(
+        text,
+        selection_range=(overlap_start - chunk_start, overlap_end - chunk_start),
+        selection_style=selection_style or DEFAULT_COMPOSER_SELECTION_STYLE,
+    )
 
 
 def _visual_segments(

--- a/src/loushang/tui/ui_parts/text_input.py
+++ b/src/loushang/tui/ui_parts/text_input.py
@@ -20,6 +20,12 @@ from loushang.tui.core import (
 from loushang.tui.editor_buffer import EditorBuffer
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
 from loushang.tui.kill_ring import KillRing
+from loushang.tui.selection_controller import SelectionController
+from loushang.tui.selection_rendering import (
+    DEFAULT_SELECTION_STYLE,
+    highlight_selection_by_columns,
+)
+from loushang.tui.theme import ThemeResolver, ThemeStyle
 
 __all__ = ["TextInput"]
 
@@ -31,15 +37,33 @@ class TextInput:
     on_submit: Callable[[str], object] | None = None
     on_escape: Callable[[], object] | None = None
     on_change: Callable[[str], object] | None = None
+    theme: ThemeResolver | None = None
+    selection_theme_token: str = "editor.selection"
     focused: bool = False
     _buffer: EditorBuffer = field(default_factory=lambda: EditorBuffer(max_undo_depth=100), repr=False)
+    _selection_controller: SelectionController = field(init=False, repr=False)
     _scroll_column: int = 0
     _kill_ring: KillRing = field(default_factory=KillRing)
     _last_action: Literal["kill", "yank", "type-word"] | None = None
 
+    def __post_init__(self) -> None:
+        self._selection_controller = SelectionController(
+            length=lambda: len(self._buffer),
+            cursor=lambda: self._buffer.cursor,
+            set_cursor=self._buffer.move_cursor_to,
+        )
+
     @property
     def value(self) -> str:
         return self._buffer.value
+
+    @property
+    def selected_range(self) -> tuple[int, int] | None:
+        return self._selection_controller.selected_range
+
+    @property
+    def kill_ring(self) -> tuple[str, ...]:
+        return tuple(self._kill_ring)
 
     def focus(self) -> None:
         self.focused = True
@@ -49,13 +73,24 @@ class TextInput:
 
     def set_text(self, text: str) -> None:
         self._buffer.set_text(_single_line_text(text))
+        self.clear_selection()
         self._scroll_column = 0
         self._last_action = None
 
     def clear(self) -> None:
         self._buffer.clear()
+        self.clear_selection()
         self._scroll_column = 0
         self._last_action = None
+
+    def has_selection(self) -> bool:
+        return self._selection_controller.has_selection()
+
+    def set_selection(self, anchor: int, focus: int) -> None:
+        self._selection_controller.set(anchor, focus)
+
+    def clear_selection(self) -> None:
+        self._selection_controller.clear()
 
     def handle_input(
         self,
@@ -108,6 +143,24 @@ class TextInput:
             return self.yank()
         if manager.matches(key, "tui.editor.yankPop"):
             return self.yank_pop()
+        if manager.matches(key, "tui.editor.selectCharLeft"):
+            self.select_char_left()
+            return True
+        if manager.matches(key, "tui.editor.selectCharRight"):
+            self.select_char_right()
+            return True
+        if manager.matches(key, "tui.editor.selectWordLeft"):
+            self.select_word_left()
+            return True
+        if manager.matches(key, "tui.editor.selectWordRight"):
+            self.select_word_right()
+            return True
+        if manager.matches(key, "tui.editor.selectLineStart"):
+            self.select_line_start()
+            return True
+        if manager.matches(key, "tui.editor.selectLineEnd"):
+            self.select_line_end()
+            return True
         if manager.matches(key, "tui.editor.cursorLeft"):
             self.move_left()
             return True
@@ -143,33 +196,69 @@ class TextInput:
         return False
 
     def insert_text(self, text: str) -> None:
-        self._buffer.insert_text(_single_line_text(text), record=False)
+        text = _single_line_text(text)
+        selection = self.selected_range
+        if selection is not None:
+            self._buffer.replace_range(selection[0], selection[1], text, record=False)
+            self.clear_selection()
+            return
+        self._buffer.insert_text(text, record=False)
 
     def delete_backward(self) -> None:
+        if self._delete_selection_or_none():
+            return
         self._buffer.delete_backward(record=False)
 
     def delete_forward(self) -> None:
+        if self._delete_selection_or_none():
+            return
         self._buffer.delete_forward(record=False)
 
     def move_left(self) -> None:
         self._buffer.move_left()
+        self._after_cursor_move()
 
     def move_right(self) -> None:
         self._buffer.move_right()
+        self._after_cursor_move()
 
     def move_to_start(self) -> None:
         self._buffer.move_to_start()
+        self._after_cursor_move()
 
     def move_to_end(self) -> None:
         self._buffer.move_to_end()
+        self._after_cursor_move()
 
     def move_word_left(self) -> None:
         self._buffer.move_word_left()
+        self._after_cursor_move()
 
     def move_word_right(self) -> None:
         self._buffer.move_word_right()
+        self._after_cursor_move()
+
+    def select_char_left(self) -> None:
+        self._extend_selection_to(self._buffer.cursor - 1)
+
+    def select_char_right(self) -> None:
+        self._extend_selection_to(self._buffer.cursor + 1)
+
+    def select_word_left(self) -> None:
+        self._extend_selection_to(self._word_left_index())
+
+    def select_word_right(self) -> None:
+        self._extend_selection_to(self._word_right_index())
+
+    def select_line_start(self) -> None:
+        self._extend_selection_to(0)
+
+    def select_line_end(self) -> None:
+        self._extend_selection_to(len(self._buffer))
 
     def kill_to_start(self) -> bool:
+        if self._kill_selection_or_none(prepend=True):
+            return True
         if self._buffer.cursor <= 0:
             return False
         killed = self._buffer.text_before_cursor
@@ -182,6 +271,8 @@ class TextInput:
         return self._apply_edit(edit)
 
     def kill_to_end(self) -> bool:
+        if self._kill_selection_or_none(prepend=False):
+            return True
         if self._buffer.cursor >= len(self._buffer):
             return False
         killed = self._buffer.text_after_cursor
@@ -194,6 +285,8 @@ class TextInput:
         return self._apply_edit(edit)
 
     def delete_word_backward(self) -> bool:
+        if self._kill_selection_or_none(prepend=True):
+            return True
         start = self._word_left_index()
         cursor = self._buffer.cursor
         if start == cursor:
@@ -208,6 +301,8 @@ class TextInput:
         return self._apply_edit(edit)
 
     def delete_word_forward(self) -> bool:
+        if self._kill_selection_or_none(prepend=False):
+            return True
         end = self._word_right_index()
         cursor = self._buffer.cursor
         if end == cursor:
@@ -258,6 +353,7 @@ class TextInput:
         before = self.value
         if not self._buffer.undo():
             return False
+        self.clear_selection()
         self._last_action = None
         self._notify_change_if_needed(before)
         return True
@@ -266,6 +362,7 @@ class TextInput:
         before = self.value
         if not self._buffer.redo():
             return False
+        self.clear_selection()
         self._last_action = None
         self._notify_change_if_needed(before)
         return True
@@ -282,6 +379,13 @@ class TextInput:
         self._ensure_cursor_visible(cursor_column_in_text, width=input_width)
         if self.value:
             visible = slice_by_column(self.value, start=self._scroll_column, length=input_width).text
+            selection = self._selection_display_range()
+            if selection is not None:
+                visible = highlight_selection_by_columns(
+                    visible,
+                    selection_range=(selection[0] - self._scroll_column, selection[1] - self._scroll_column),
+                    selection_style=self._selection_style(),
+                )
         else:
             visible = truncate_to_width(self.placeholder, max_width=input_width, ellipsis="")
         line = truncate_to_width(f"{self.prompt}{visible}", max_width=target_width, ellipsis="")
@@ -302,6 +406,31 @@ class TextInput:
         self._notify_change_if_needed(before)
         return True
 
+    def _delete_selection_or_none(self) -> bool:
+        selection = self.selected_range
+        if selection is None:
+            return False
+        self._buffer.delete_range(selection[0], selection[1], record=False)
+        self.clear_selection()
+        self._last_action = None
+        return True
+
+    def _kill_selection_or_none(self, *, prepend: bool) -> bool:
+        selection = self.selected_range
+        if selection is None:
+            return False
+        killed = self._range_text(*selection)
+        if not killed:
+            self.clear_selection()
+            return True
+
+        def edit() -> None:
+            self._buffer.delete_range(selection[0], selection[1], record=False)
+            self._push_kill(killed, prepend=prepend)
+            self.clear_selection()
+
+        return self._apply_edit(edit)
+
     def _notify_change_if_needed(self, before: str) -> None:
         if self.value != before and self.on_change is not None:
             self.on_change(self.value)
@@ -317,6 +446,36 @@ class TextInput:
 
     def _word_right_index(self) -> int:
         return self._buffer.word_right_index()
+
+    def _extend_selection_to(self, target: int) -> None:
+        self._selection_controller.extend_to(target)
+        self._last_action = None
+
+    def _after_cursor_move(self) -> None:
+        self.clear_selection()
+        self._last_action = None
+
+    def _range_text(self, start: int, end: int) -> str:
+        return "".join(grapheme_clusters(self.value)[start:end])
+
+    def _selection_display_range(self) -> tuple[int, int] | None:
+        selection = self.selected_range
+        if selection is None:
+            return None
+        start, end = selection
+        clusters = list(grapheme_clusters(self.value))
+        display_start = visible_width("".join(clusters[:start]))
+        display_end = visible_width("".join(clusters[:end]))
+        if display_start == display_end:
+            return None
+        return display_start, display_end
+
+    def _selection_style(self) -> ThemeStyle:
+        if self.theme is not None and self.selection_theme_token:
+            resolved = self.theme.resolve(self.selection_theme_token)
+            if resolved:
+                return resolved
+        return DEFAULT_SELECTION_STYLE
 
 
 def _single_line_text(text: str) -> str:

--- a/tests/tui/test_composer_bottom_frame.py
+++ b/tests/tui/test_composer_bottom_frame.py
@@ -159,6 +159,17 @@ def test_multiline_paste_inserts_text_without_submitting_and_undoes_as_one_step(
     assert composer.value == ""
 
 
+def test_paste_records_single_undo_snapshot_for_redo_after_extra_undo() -> None:
+    composer = Composer(prompt="> ")
+
+    composer.paste("a\nb")
+    composer.undo()
+    composer.undo()
+    composer.redo()
+
+    assert composer.value == "a\nb"
+
+
 def test_paste_normalizes_line_endings_and_tabs_atomically() -> None:
     composer = Composer(prompt="> ")
 

--- a/tests/tui/test_composer_edit_buffer.py
+++ b/tests/tui/test_composer_edit_buffer.py
@@ -87,3 +87,36 @@ def test_composer_edit_buffer_replaces_completion_prefix() -> None:
     assert buffer.cursor == 5
     assert buffer.undo()
     assert buffer.value == "/he"
+
+
+def test_composer_edit_buffer_apply_edit_records_composite_change_as_one_undo_step() -> None:
+    buffer = ComposerEditBuffer()
+    buffer.insert_text("abcdef")
+
+    changed = buffer.apply_edit(
+        lambda: (
+            buffer.delete_range(1, 4, record=False),
+            buffer.insert_text("X", record=False),
+        )
+    )
+
+    assert changed
+    assert buffer.value == "aXef"
+
+    assert buffer.undo()
+    assert buffer.value == "abcdef"
+
+    assert buffer.redo()
+    assert buffer.value == "aXef"
+
+
+def test_composer_edit_buffer_apply_edit_ignores_cursor_only_changes() -> None:
+    buffer = ComposerEditBuffer()
+    buffer.insert_text("abc")
+
+    changed = buffer.apply_edit(buffer.move_to_start)
+
+    assert not changed
+    assert buffer.cursor == 0
+    assert buffer.undo()
+    assert buffer.value == ""

--- a/tests/tui/test_playback_harness.py
+++ b/tests/tui/test_playback_harness.py
@@ -148,6 +148,23 @@ def test_playback_result_asserts_visible_text_and_flush_policy() -> None:
     result.assert_no_clear_screen()
 
 
+def test_playback_result_asserts_frame_output_contains_ansi_style_sequence() -> None:
+    harness = PlaybackHarness(
+        render=lambda _event, _size, _previous: RenderDiagnostics(
+            current_logical_lines=("selected",),
+            operations=(TerminalOperation.write("a\x1b[7mb\x1b[27mc"),),
+        ),
+        port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
+    )
+    result = PlaybackResult(steps=harness.play([PlaybackEvent.input("select")]), port=harness.port)
+
+    result.assert_frame_output_contains(0, "\x1b[7mb\x1b[27m")
+    result.assert_any_frame_output_contains("\x1b[7mb\x1b[27m")
+
+    with pytest.raises(AssertionError, match="expected step 0 frame output"):
+        result.assert_frame_output_contains(0, "\x1b[1;36m")
+
+
 def test_playback_result_writes_jsonl_for_manual_inspection(tmp_path) -> None:
     harness = PlaybackHarness(
         render=lambda _event, _size, _previous: RenderDiagnostics(

--- a/tests/tui/test_selection_range.py
+++ b/tests/tui/test_selection_range.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from loushang.tui.selection import SelectionRange
+from loushang.tui.selection_controller import SelectionController
 
 
 def test_selection_range_normalizes_forward_and_backward_bounds() -> None:
@@ -16,3 +17,32 @@ def test_selection_range_clamps_to_buffer_length_and_detects_empty() -> None:
     assert selection.normalized(5) == (0, 5)
     assert not selection.is_empty
     assert SelectionRange(anchor=3, focus=3).is_empty
+
+
+def test_selection_controller_tracks_anchor_focus_and_moves_cursor() -> None:
+    cursor = 3
+
+    def set_cursor(value: int) -> None:
+        nonlocal cursor
+        cursor = value
+
+    controller = SelectionController(
+        length=lambda: 5,
+        cursor=lambda: cursor,
+        set_cursor=set_cursor,
+    )
+
+    controller.extend_to(1)
+
+    assert cursor == 1
+    assert controller.selected_range == (1, 3)
+
+    controller.extend_to(-10)
+
+    assert cursor == 0
+    assert controller.selected_range == (0, 3)
+
+    controller.set(2, 2)
+
+    assert cursor == 2
+    assert controller.selected_range is None

--- a/tests/tui/test_selection_rendering.py
+++ b/tests/tui/test_selection_rendering.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from loushang.tui import (
+    DEFAULT_SELECTION_STYLE,
+    SelectionController,
+)
+from loushang.tui import (
+    highlight_selection_by_columns as exported_highlight_selection_by_columns,
+)
+from loushang.tui.cell_width import strip_control_sequences
+from loushang.tui.selection_rendering import highlight_selection_by_columns
+
+
+def test_highlight_selection_by_columns_applies_style_at_display_boundaries() -> None:
+    rendered = highlight_selection_by_columns(
+        "你🙂ab",
+        selection_range=(2, 4),
+        selection_style={"reverse": True},
+    )
+
+    assert rendered == "你\x1b[7m🙂\x1b[27mab"
+    assert strip_control_sequences(rendered) == "你🙂ab"
+
+
+def test_highlight_selection_by_columns_ignores_empty_or_missing_selection() -> None:
+    assert highlight_selection_by_columns("abc", selection_range=None) == "abc"
+    assert highlight_selection_by_columns("abc", selection_range=(1, 1)) == "abc"
+
+
+def test_selection_foundation_helpers_are_exported_from_tui_package() -> None:
+    assert DEFAULT_SELECTION_STYLE == {"reverse": True}
+    assert SelectionController.__module__ == "loushang.tui.selection_controller"
+    assert exported_highlight_selection_by_columns is highlight_selection_by_columns

--- a/tests/tui/test_text_input.py
+++ b/tests/tui/test_text_input.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from loushang.tui import InputEvent, RenderConstraints, TextInput, Tui
+from loushang.tui import (
+    InputEvent,
+    RenderConstraints,
+    TextInput,
+    ThemeResolver,
+    Tui,
+    strip_control_sequences,
+)
 from loushang.tui.editor_buffer import EditorBuffer
 from loushang.tui.ui_parts import TextInput as ReexportedTextInput
 from loushang.tui.ui_parts.text_input import TextInput as ModuleTextInput
@@ -150,3 +157,53 @@ def test_text_input_handles_line_editing_keys() -> None:
     assert field.handle_input(InputEvent(kind="key", key="ctrl+e"))
     assert field.handle_input(InputEvent(kind="key", key="ctrl+u"))
     assert field.value == ""
+
+
+def test_text_input_selection_replaces_text_and_undoes_atomically() -> None:
+    field = TextInput()
+    field.handle_input(InputEvent(kind="text", text="你🙂a"))
+
+    assert field.handle_input(InputEvent(kind="key", key="shift+left"))
+    assert field.handle_input(InputEvent(kind="key", key="shift+left"))
+    assert field.selected_range == (1, 3)
+
+    assert field.handle_input(InputEvent(kind="text", text="x"))
+
+    assert field.value == "你x"
+    assert field.selected_range is None
+
+    assert field.undo()
+
+    assert field.value == "你🙂a"
+    assert field.selected_range is None
+
+
+def test_text_input_kill_and_yank_operate_on_selection_first() -> None:
+    field = TextInput()
+    field.handle_input(InputEvent(kind="text", text="alpha beta"))
+
+    assert field.handle_input(InputEvent(kind="key", key="shift+left"))
+    assert field.handle_input(InputEvent(kind="key", key="ctrl+w"))
+
+    assert field.value == "alpha bet"
+    assert field.kill_ring == ("a",)
+
+    assert field.handle_input(InputEvent(kind="text", text="Z"))
+    assert field.handle_input(InputEvent(kind="key", key="shift+left"))
+    assert field.handle_input(InputEvent(kind="key", key="ctrl+y"))
+
+    assert field.value == "alpha beta"
+
+
+def test_text_input_selection_highlight_uses_editor_selection_theme_token() -> None:
+    field = TextInput(
+        prompt="> ",
+        theme=ThemeResolver(defaults={"editor.selection": {"color": "cyan", "bold": True}}),
+    )
+    field.handle_input(InputEvent(kind="text", text="abc"))
+    field.handle_input(InputEvent(kind="key", key="shift+left"))
+
+    raw = rendered_text(field, width=20)[0]
+
+    assert strip_control_sequences(raw) == "> abc"
+    assert "\x1b[1;36mc\x1b[22;39m" in raw


### PR DESCRIPTION
## Summary
- Add shared SelectionController and selection rendering helpers for reusable edit selection behavior
- Wire Composer and TextInput through shared selection/edit transaction paths, including selection replace/delete/kill/yank and theme-based highlights
- Add playback frame-output assertions and enforce selection styling in composer-selection-stress playback

## Test Plan
- uv --cache-dir .uv-cache run ruff check src/loushang/tui src/loushang/coding/ui/playback_scenarios/composer.py tests/tui tests/coding/test_native_tui_playback_runner.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_tui_playback_runner.py tests/coding/test_native_coding_tui_playback.py tests/coding/test_native_coding_tui_input.py -q
- uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner composer-selection-stress --artifacts /tmp/loushang-edit-foundation-playback --include-frames
- uv --cache-dir .uv-cache run --extra dev pytest -q