### PR TITLE
docs(tui): document editing capability snapshot

### DIFF
--- a/docs/en/reference/README.md
+++ b/docs/en/reference/README.md
@@ -42,3 +42,4 @@ Built-in interactive commands include:
 ## TUI
 
 - [TUI Runner](tui-runner.md): public lifecycle entry point for terminal apps built with `loushang.tui`.
+- [TUI Editing](tui-editing.md): reusable TextInput, Composer, selection-aware editing, keybindings, and playback smoke checks.

--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -1,0 +1,146 @@
+# TUI Editing
+
+English | [中文](../../zh-CN/reference/tui-editing.md)
+
+`loushang.tui` provides reusable editing primitives for terminal inputs. Use
+them when a surface needs cursor movement, selection, undo, kill/yank, paste,
+or completion behavior without carrying bespoke edit state.
+
+For lifecycle wiring, see [TUI Runner](tui-runner.md).
+
+## Components
+
+| Component | Use it for | Index unit |
+| --- | --- | --- |
+| `TextInput` | Single-line fields such as search, filters, and small prompts. | Grapheme cluster |
+| `Composer` | Multi-line prompt editors, bottom-frame composers, paste markers, history, and completions. | Composer atom |
+| `InputRouter` | User-like routing for Composer key, text, paste, completion, history, submit, and surface events. | Composer atom |
+| `SelectionRange` / `SelectionController` | Reusable anchor/focus selection state. | Supplied by the owning buffer |
+
+Editing indexes are not terminal cell columns. Wide CJK, emoji, combining
+marks, and paste markers keep stable logical indexes; display width remains a
+rendering and hit-test concern.
+
+## TextInput
+
+`TextInput` is a focusable single-line editor. It owns an `EditorBuffer`,
+selection state, undo/redo stacks, and a kill ring.
+
+```python
+from loushang.tui import InputEvent, RenderConstraints, TextInput
+
+
+field = TextInput(prompt="Search: ", placeholder="type to filter")
+field.focus()
+
+field.handle_input(InputEvent(kind="text", text="hello world"))
+field.handle_input(InputEvent(kind="key", key="ctrl+shift+left"))
+assert field.selected_range == (6, 11)
+
+field.handle_input(InputEvent(kind="text", text="loushang"))
+assert field.value == "hello loushang"
+
+field.handle_input(InputEvent(kind="key", key="ctrl+-"))
+assert field.value == "hello world"
+
+result = field.render(RenderConstraints(width=40, max_height=1))
+```
+
+Prefer `handle_input()` for user keystrokes because it records undo boundaries
+and invokes callbacks. `set_text()` and `clear()` are programmatic resets and
+clear undo/redo history. `selected_range` is `None` when there is no active
+non-empty selection.
+
+## Composer
+
+`Composer` is the multi-line editor used by prompt and bottom-frame UIs. It
+adds atom-aware editing, paste-marker safety, history, completion refresh, and
+rendered selection highlighting.
+
+Use `InputRouter` when you want behavior equivalent to normal terminal input:
+
+```python
+from loushang.tui import Composer, InputEvent, InputRouter, RenderConstraints
+
+
+composer = Composer(prompt="> ")
+router = InputRouter(composer, width=72, height=12)
+
+router.route(InputEvent(kind="text", text="alpha beta"))
+router.route(InputEvent(kind="key", key="shift+left"))
+assert composer.selected_range == (9, 10)
+
+router.route(InputEvent(kind="key", key="ctrl+k"))
+assert composer.value == "alpha bet"
+assert composer.kill_ring[0] == "a"
+
+router.route(InputEvent(kind="key", key="ctrl+y"))
+assert composer.value == "alpha beta"
+
+result = composer.render(RenderConstraints(width=72, max_height=6))
+```
+
+Composer selections use atom indexes. Normal text is split into grapheme-like
+text atoms; large paste markers are single atoms and are never split by range
+editing.
+
+## Default Editing Keys
+
+| Action | Default keys |
+| --- | --- |
+| Move left / right | `left`, `right`, `ctrl+b`, `ctrl+f` |
+| Move by word | `alt+left`, `ctrl+left`, `alt+b`, `alt+right`, `ctrl+right`, `alt+f` |
+| Move to line start / end | `home`, `ctrl+a`, `alt+<`, `end`, `ctrl+e`, `alt+>` |
+| Select char | `shift+left`, `shift+right` |
+| Select word | `ctrl+shift+left`, `alt+shift+b`, `ctrl+shift+right`, `alt+shift+f` |
+| Select line range | `shift+home`, `shift+end` |
+| Delete char | `backspace`, `delete`, `ctrl+d` |
+| Delete word | `ctrl+w`, `alt+backspace`, `alt+d`, `alt+delete` |
+| Kill to line start / end | `ctrl+u`, `ctrl+k` |
+| Yank / yank-pop | `ctrl+y`, `alt+y` |
+| Undo | `ctrl+-` |
+| New line / submit | `shift+enter`, `alt+enter`, `ctrl+j`, `enter` |
+
+Redo storage exists in the edit buffers, but no default redo key is currently
+documented for terminal use.
+
+## Selection-Aware Edits
+
+When a selection exists:
+
+- typing and paste replace the selected range in one undoable edit
+- Backspace and Delete remove the selected range without deleting adjacent text
+- kill commands kill the selected range instead of also applying line or word
+  boundaries
+- yank replaces the selected range
+- completion application clears text selection
+- undo and redo restore content and cursor, then clear selection
+
+Completion-list selection and composer text selection are independent. Selection
+keybindings route before completion-list navigation, while unmodified
+completion keys such as `up`, `down`, `tab`, and `enter` keep their completion
+behavior.
+
+## Playback Smoke Cookbook
+
+Run playback before changing composer input, selection, paste marker,
+completion, keybinding, or render-highlight behavior:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner --list
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner composer-selection-stress --artifacts /tmp/loushang-selection-playback --include-frames
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner --tag composer --json
+```
+
+Use `--include-frames` when diagnosing transient selection rendering. The final
+screen often cannot show a selection after replacement, kill, yank, or undo
+because those operations intentionally clear selection.
+
+## Examples
+
+- [examples/tui/41_editing_foundation.py](../../../examples/tui/41_editing_foundation.py):
+  deterministic TextInput and Composer editing walkthrough.
+- [examples/tui/35_completion_providers.py](../../../examples/tui/35_completion_providers.py):
+  completion provider behavior in Composer.
+- [examples/tui/40_runner_basic.py](../../../examples/tui/40_runner_basic.py):
+  `TuiRunner` lifecycle and top-level input handling.

--- a/docs/en/user-guide/tui.md
+++ b/docs/en/user-guide/tui.md
@@ -2,7 +2,7 @@
 
 English | [中文](../../zh-CN/user-guide/tui.md)
 
-This guide shows how to build a small terminal UI with `loushang.tui`. Use it when you want a product-facing interactive terminal surface. For exact API details, see the [TUI Runner reference](../reference/tui-runner.md).
+This guide shows how to build a small terminal UI with `loushang.tui`. Use it when you want a product-facing interactive terminal surface. For exact lifecycle details, see the [TUI Runner reference](../reference/tui-runner.md). For reusable input editing, see [TUI Editing](../reference/tui-editing.md).
 
 ## Choose The Entry Point
 
@@ -89,7 +89,31 @@ handle = tui.show_overlay(dialog, focus_target=dialog, presentation="modal", anc
 
 Close the returned handle when the surface is no longer needed.
 
+## Reuse Editing Primitives
+
+Use `TextInput` for single-line inputs such as search fields and filters. Use `Composer` plus `InputRouter` for multi-line prompt editors with history, paste markers, completion, selection, undo, and kill/yank behavior.
+
+```python
+from loushang.tui import Composer, InputEvent, InputRouter, TextInput
+
+
+field = TextInput(prompt="Search: ")
+field.handle_input(InputEvent(kind="text", text="hello world"))
+field.handle_input(InputEvent(kind="key", key="ctrl+shift+left"))
+field.handle_input(InputEvent(kind="text", text="loushang"))
+
+composer = Composer(prompt="> ")
+router = InputRouter(composer, width=80, height=24)
+router.route(InputEvent(kind="text", text="alpha beta"))
+router.route(InputEvent(kind="key", key="shift+left"))
+router.route(InputEvent(kind="key", key="ctrl+k"))
+```
+
+`TextInput` selection indexes are grapheme clusters. `Composer` selection indexes are composer atoms, so paste markers remain atomic. Display width is handled by rendering.
+
 ## Examples
 
 - [examples/tui/40_runner_basic.py](../../../examples/tui/40_runner_basic.py): small interactive counter using `TuiRunner`.
+- [examples/tui/41_editing_foundation.py](../../../examples/tui/41_editing_foundation.py): TextInput and Composer editing walkthrough.
 - [TUI Runner reference](../reference/tui-runner.md): lifecycle API details.
+- [TUI Editing reference](../reference/tui-editing.md): editing primitives, keybindings, and playback smoke checks.

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-017-composer-selection-and-selected-range.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-017-composer-selection-and-selected-range.md
@@ -1,6 +1,7 @@
 # KD-017: Composer Selection And Selected Range
 
-Status: Proposed
+Status: Accepted. Initial keyboard selection and shared edit foundation are
+implemented as of 2026-06-05.
 
 ## Purpose
 
@@ -9,6 +10,35 @@ Define the editing selection model for the native TUI composer.
 This design covers text selected inside the editable composer buffer. It does
 not redefine command-list selection, completion-menu selection, transcript copy
 selection, or terminal-native mouse selection.
+
+## Implementation Status
+
+The first implementation has landed in the native TUI core:
+
+- `SelectionRange` provides anchor/focus bounds, normalized start/end, and
+  empty-selection handling.
+- `SelectionController` owns reusable selection state and is shared by Composer
+  and TextInput.
+- `EditorBuffer` provides grapheme-indexed text editing for reusable text
+  inputs.
+- `ComposerEditBuffer` provides atom-indexed editing for composer text and
+  paste markers.
+- `UndoStack` and `KillRing` are reusable editing infrastructure.
+- Composer supports keyboard selection, selected-range replace/delete,
+  kill-selection, yank-over-selection, selection-aware undo boundaries,
+  completion refresh after selected-range replacement, and selection highlight
+  rendering.
+- TextInput uses the shared editing and selection primitives for the same
+  index-unit discipline.
+- Playback covers completion interaction and composer-selection stress,
+  including visible frame-output assertions.
+
+The following items remain outside the initial implementation:
+
+- mouse-driven composer selection
+- transcript or screen-buffer copy selection
+- restoring selection through undo/redo snapshots
+- changing the default redo keybinding policy
 
 ## Reference Observations
 
@@ -19,15 +49,15 @@ separate in Loushang:
 - visual or screen-buffer selection
 - menu/list selection
 
-The Codex textarea keeps a cursor-oriented editable buffer with byte-range
-replacement, element-aware range expansion, kill operations, and render-only
-highlight ranges. It does not require a persistent text `selected_range` field
-in the core textarea to support range edits.
+One textarea-style implementation keeps a cursor-oriented editable buffer with
+range replacement, element-aware range expansion, kill operations, and
+render-only highlight ranges. It does not require a persistent text
+`selected_range` field in the core textarea to support range edits.
 
-The Claude Code fullscreen selection model uses `anchor` and `focus` points and
-normalizes them only for rendering and copy extraction. That model is screen
-coordinate based and includes scrollback bookkeeping. It is useful for
-selection semantics, but it is too screen-specific for composer text editing.
+One fullscreen selection model uses `anchor` and `focus` points and normalizes
+them only for rendering and copy extraction. That model is screen-coordinate
+based and includes scrollback bookkeeping. It is useful for selection semantics,
+but it is too screen-specific for composer text editing.
 
 Loushang should borrow the anchor/focus semantics, but keep composer selection
 in buffer index space. Screen coordinates should appear only when converting
@@ -138,8 +168,15 @@ of the buffer avoids mixing UI interaction state with reusable range editing.
 This keeps selection close to completion, history, kill-ring, render, and
 bottom-frame behavior.
 
-If another editable widget later needs the same behavior, extract the selection
-state machine into a reusable `SelectionController`.
+The shared selection state machine now lives in `SelectionController`. Composer
+owns product-specific selection behavior, while `SelectionController` remains
+small enough for other editable widgets to reuse.
+
+### TextInput
+
+`TextInput` stores editable content in `EditorBuffer` and selection state in
+`SelectionController`. It uses grapheme cluster indexes for editing and
+selection. Display width remains a rendering and horizontal-scroll concern.
 
 ## Editing Semantics
 
@@ -225,15 +262,16 @@ If no selection exists, existing insert and paste behavior remains unchanged.
 
 ### Centralized Edit Application
 
-Implementation should centralize selection-aware edit bookkeeping instead of
+Implementation centralizes selection-aware edit bookkeeping instead of
 spreading it across every editing method.
 
 Recommended internal pattern:
 
 ```python
-def _replace_selection_or_insert(atoms, *, action_kind): ...
-def _delete_selection_or_none(*, push_to_kill_ring: bool) -> bool: ...
-def _after_buffer_edit(*, clear_selection: bool = True, refresh_completion: bool = True): ...
+def _replace_selection_with_atoms(atoms, *, last_action): ...
+def _delete_selection_or_none() -> bool: ...
+def _kill_selection_or_none(*, prepend: bool) -> bool: ...
+def _apply_buffer_edit(edit, *, last_action, refresh_completion): ...
 ```
 
 The helper is responsible for:
@@ -315,8 +353,7 @@ not in `ComposerEditBuffer`.
 
 ## Rendering
 
-The first implementation may land editing behavior before visual highlight, but
-any user-exposed keyboard selection should quickly gain visible highlighting.
+The first implementation includes visible highlighting for keyboard selection.
 
 The highlight contract:
 
@@ -330,6 +367,8 @@ The highlight contract:
 - clip selection to the visible composer viewport
 - close and reopen ANSI style on each rendered line so soft-wrapped multi-line
   selection cannot leak styling into later rows
+- use the shared `highlight_selection_by_columns()` helper for column-range
+  highlighting
 
 Recommended theme token:
 
@@ -422,16 +461,15 @@ Selection keybindings can be overridden by configuration.
 ## Implementation Sequence
 
 1. Add `SelectionRange` and focused unit tests for normalization, clamping, and
-   empty-range behavior.
-2. Add composer selection state and selection movement methods without render
-   highlighting.
+   empty-range behavior. Done.
+2. Add composer selection state and selection movement methods. Done.
 3. Add centralized selection-aware edit helpers for insert, paste, Backspace,
-   Delete, kill, yank, and yank-pop.
+   Delete, kill, yank, and yank-pop. Done.
 4. Make all cursor/content-changing Composer methods obey the default
-   selection lifecycle rule.
-5. Add keybinding actions and input-router priority coverage.
-6. Add render highlighting and playback tests.
-7. Add mouse selection only after keyboard selection is stable.
+   selection lifecycle rule. Done.
+5. Add keybinding actions and input-router priority coverage. Done.
+6. Add render highlighting and playback tests. Done.
+7. Add mouse selection only after keyboard selection is stable. Future work.
 
 This sequence keeps range editing testable before rendering and avoids mixing
 mouse coordinate work into the initial selection state machine.

--- a/docs/internals/architecture/tui/native-terminal-core/reference/terminal-ux-feature-alignment.md
+++ b/docs/internals/architecture/tui/native-terminal-core/reference/terminal-ux-feature-alignment.md
@@ -6,9 +6,27 @@ This is an internal alignment note. It records capabilities observed in mature
 native terminal assistants so loushang can build comparable user-facing behavior
 with its own terminology, APIs, and Python implementation.
 
-The mapping is based on observed behavior as of 2026-05-23. It is not a
-compatibility contract and should not be treated as a public claim about another
-project's internal implementation.
+The mapping is based on local reference surveys and loushang `main` as of
+2026-06-05. It is not a compatibility contract and should not be treated as a
+public claim about another project's internal implementation.
+
+## Current Completion Snapshot
+
+These percentages are qualitative engineering completion estimates against the
+native terminal UX target in this document. They are not public compatibility
+scores.
+
+| Area | Loushang status | Completion |
+| --- | --- | --- |
+| Runtime, render loop, and terminal lifecycle | Public `TuiRunner`, managed runtime, terminal sessions, resize repaint, synchronized flush fallback, bottom-frame cleanup, and fake-terminal playback are in place. | 88% |
+| Terminal input and protocol handling | Raw input parsing, bracketed paste, keybinding routing, control-event consumption, keyboard-protocol fallback, and playback coverage exist; terminal-specific edge cases still need broader live-terminal coverage. | 84% |
+| Composer and editing foundation | `EditorBuffer`, `ComposerEditBuffer`, `UndoStack`, `KillRing`, word navigation, paste markers, completion refresh, and keyboard selection are reusable and tested. | 87% |
+| Surfaces, overlays, and product UI patterns | Surface host, dialogs, selectors, overlays, status/footer, pending and working regions, and completion menus exist; product adapters still need more consistent reuse and smoke coverage. | 80% |
+| Content, theme, and media rendering | Markdown, code, diff, thinking, tool records, structured theme tokens, image fallback, and selection highlighting exist; advanced terminal image/protocol paths remain partial. | 78% |
+| Regression harness and playback | Native playback covers composer editing, completion, selection stress, fake terminal frames, and manual smoke paths; more consumer-specific playback remains useful. | 88% |
+| Public API and reference documentation | Core exports and reference docs exist, including public lifecycle entry and editing primitives; public examples and consumer migration notes are still thin. | 82% |
+
+Overall qualitative completion: about **84%**.
 
 ## Runtime Mechanisms
 
@@ -25,6 +43,7 @@ project's internal implementation.
 | Cursor marker inside focused render output | Cursor marker extracted by runtime for IME-aware hardware cursor placement. |
 | Overlay stack and focus handling | SurfaceHost with surface area and overlay presentation modes. |
 | Terminal raw input and restoration | InputReader plus terminal restoration on exit, error, cancellation, and interrupt. |
+| Public lifecycle runner | `TuiRunner` as the reusable application lifecycle entry point. |
 
 ## Product UI Patterns
 
@@ -36,7 +55,7 @@ project's internal implementation.
 | Status/loading container | Working line area for transient run progress. |
 | Widget containers above/below editor | Extension widget slots above or below composer. |
 | Editor container | Composer area and focused composer UI part. |
-| Editor soft wrap, paste marker, undo, kill ring | Composer wrapping, paste marker representation, undo stack, and kill ring. |
+| Editor soft wrap, paste marker, undo, kill ring, and selection | Composer wrapping, paste marker representation, reusable edit buffers, undo/redo stacks, kill ring, selection controller, and selection highlight rendering. |
 | Footer | Status area as the bottom row by default. |
 | Selectors and dialogs | Selection, settings, approval, dialog, help, and changelog surfaces. |
 
@@ -50,6 +69,40 @@ project's internal implementation.
 | Diff and code renderers | DiffBlock and CodeBlock UI parts with theme-controlled styles. |
 | Terminal images with fallback | ImageBlock with text fallback and optional protocol adapters. |
 | Structured themes | Theme tokens for markdown, status, thinking, tools, surfaces, and code. |
+| Editor selection style | `editor.selection` token separate from list-selection styling. |
+
+## Recently Closed Gaps
+
+As of 2026-06-05, these gaps are no longer open in the native TUI core:
+
+- public lifecycle entry through `TuiRunner`
+- shared `EditorBuffer` for grapheme-indexed text editing
+- reusable `UndoStack` and `KillRing`
+- atom-aware `ComposerEditBuffer` for paste markers and composer text
+- Composer migration onto the shared editing foundation
+- `SelectionRange` and `SelectionController` for text selection state
+- keyboard selection, range replacement/delete, kill/yank interaction, and undo
+  interaction in Composer
+- TextInput migration to shared selection and editing primitives
+- frame-level playback for completion and composer-selection stress scenarios
+
+## Remaining Gaps
+
+- Broader consumers such as command search, settings search, and model search
+  should continue migrating toward the shared text-input and selection
+  primitives instead of carrying bespoke edit state.
+- Screen-buffer copy selection and mouse-driven transcript selection remain
+  intentionally separate from composer text selection and are not implemented
+  in the first keyboard-selection pass.
+- Redo storage exists in editing buffers, but the public/default redo keybinding
+  policy is still unresolved.
+- Live-terminal coverage should be broadened for modifier-key variants,
+  keyboard-protocol negotiation, IME cursor behavior, and image protocols.
+- Public reference docs should add more small examples for `TuiRunner`,
+  TextInput, Composer, selection-aware editing, and playback smoke tests.
+- Product adapters still need additional manual smoke and playback coverage for
+  long streaming transcripts, interruption, queued steering, and extension
+  widgets.
 
 ## Loushang Differences
 

--- a/docs/zh-CN/reference/README.md
+++ b/docs/zh-CN/reference/README.md
@@ -42,3 +42,4 @@ loushang --export session.jsonl --export-format jsonl
 ## TUI
 
 - [TUI Runner](tui-runner.md)：使用 `loushang.tui` 构建终端应用的公共生命周期入口。
+- [TUI 编辑能力](tui-editing.md)：可复用的 TextInput、Composer、selection-aware editing、快捷键和 playback smoke 检查。

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -1,0 +1,123 @@
+# TUI 编辑能力
+
+[English](../../en/reference/tui-editing.md) | 中文
+
+`loushang.tui` 提供可复用的终端编辑基础设施。当 surface 需要光标移动、选择、undo、kill/yank、粘贴或 completion 行为时，应优先复用这些组件，而不是维护各自的编辑状态。
+
+生命周期入口见 [TUI Runner](tui-runner.md)。
+
+## 组件
+
+| 组件 | 适用场景 | 索引单位 |
+| --- | --- | --- |
+| `TextInput` | 搜索、过滤、小型 prompt 等单行输入。 | Grapheme cluster |
+| `Composer` | 多行 prompt 编辑器、bottom-frame composer、paste marker、历史和 completion。 | Composer atom |
+| `InputRouter` | 按真实用户输入路径路由 Composer 的 key、text、paste、completion、history、submit 和 surface event。 | Composer atom |
+| `SelectionRange` / `SelectionController` | 可复用的 anchor/focus selection 状态。 | 由所属 buffer 决定 |
+
+编辑索引不是终端显示列。CJK、emoji、组合字符和 paste marker 都保持稳定的逻辑索引；显示宽度只属于渲染和 hit-test 层。
+
+## TextInput
+
+`TextInput` 是可聚焦的单行编辑器。它内部使用 `EditorBuffer`、selection 状态、undo/redo stack 和 kill ring。
+
+```python
+from loushang.tui import InputEvent, RenderConstraints, TextInput
+
+
+field = TextInput(prompt="Search: ", placeholder="type to filter")
+field.focus()
+
+field.handle_input(InputEvent(kind="text", text="hello world"))
+field.handle_input(InputEvent(kind="key", key="ctrl+shift+left"))
+assert field.selected_range == (6, 11)
+
+field.handle_input(InputEvent(kind="text", text="loushang"))
+assert field.value == "hello loushang"
+
+field.handle_input(InputEvent(kind="key", key="ctrl+-"))
+assert field.value == "hello world"
+
+result = field.render(RenderConstraints(width=40, max_height=1))
+```
+
+用户按键优先走 `handle_input()`，因为它会记录 undo 边界并触发回调。`set_text()` 和 `clear()` 是程序化 reset，会清理 undo/redo 历史。没有活跃非空 selection 时，`selected_range` 返回 `None`。
+
+## Composer
+
+`Composer` 是 prompt 和 bottom-frame UI 使用的多行编辑器。它提供 atom-aware editing、paste marker 安全性、历史、completion refresh 和 selection 高亮渲染。
+
+希望得到接近真实终端输入的行为时，使用 `InputRouter`：
+
+```python
+from loushang.tui import Composer, InputEvent, InputRouter, RenderConstraints
+
+
+composer = Composer(prompt="> ")
+router = InputRouter(composer, width=72, height=12)
+
+router.route(InputEvent(kind="text", text="alpha beta"))
+router.route(InputEvent(kind="key", key="shift+left"))
+assert composer.selected_range == (9, 10)
+
+router.route(InputEvent(kind="key", key="ctrl+k"))
+assert composer.value == "alpha bet"
+assert composer.kill_ring[0] == "a"
+
+router.route(InputEvent(kind="key", key="ctrl+y"))
+assert composer.value == "alpha beta"
+
+result = composer.render(RenderConstraints(width=72, max_height=6))
+```
+
+Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文本 atom；大型 paste marker 是单个 atom，range edit 不会把它拆开。
+
+## 默认编辑快捷键
+
+| 动作 | 默认按键 |
+| --- | --- |
+| 左右移动 | `left`, `right`, `ctrl+b`, `ctrl+f` |
+| 按词移动 | `alt+left`, `ctrl+left`, `alt+b`, `alt+right`, `ctrl+right`, `alt+f` |
+| 移到行首/行尾 | `home`, `ctrl+a`, `alt+<`, `end`, `ctrl+e`, `alt+>` |
+| 按字符选择 | `shift+left`, `shift+right` |
+| 按词选择 | `ctrl+shift+left`, `alt+shift+b`, `ctrl+shift+right`, `alt+shift+f` |
+| 按行范围选择 | `shift+home`, `shift+end` |
+| 删除字符 | `backspace`, `delete`, `ctrl+d` |
+| 删除词 | `ctrl+w`, `alt+backspace`, `alt+d`, `alt+delete` |
+| kill 到行首/行尾 | `ctrl+u`, `ctrl+k` |
+| Yank / yank-pop | `ctrl+y`, `alt+y` |
+| Undo | `ctrl+-` |
+| 换行/提交 | `shift+enter`, `alt+enter`, `ctrl+j`, `enter` |
+
+编辑 buffer 里已有 redo 存储，但当前还没有为终端使用文档化默认 redo 快捷键。
+
+## Selection-Aware Edit
+
+存在 selection 时：
+
+- 输入文本和粘贴会用一次 undoable edit 替换选中范围
+- Backspace 和 Delete 删除选中范围，不会额外删除相邻文本
+- kill 命令只 kill 选中范围，不再继续应用行/词边界
+- yank 会替换选中范围
+- 应用 completion 会清除文本 selection
+- undo 和 redo 恢复内容与光标，然后清除 selection
+
+completion 列表 selection 和 composer 文本 selection 相互独立。selection 快捷键优先于 completion 列表导航；未加修饰的 `up`、`down`、`tab`、`enter` 仍保持 completion 行为。
+
+## Playback Smoke Cookbook
+
+修改 composer 输入、selection、paste marker、completion、keybinding 或 render highlight 行为前，运行 playback：
+
+```bash
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner --list
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner composer-selection-stress --artifacts /tmp/loushang-selection-playback --include-frames
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner --tag composer --json
+```
+
+排查瞬时 selection 渲染时使用 `--include-frames`。replacement、kill、yank 或 undo 后 selection 会被刻意清除，最终屏幕通常看不到先前选中状态。
+
+## 示例
+
+- [examples/tui/41_editing_foundation.py](../../../examples/tui/41_editing_foundation.py)：确定性的 TextInput 和 Composer 编辑 walkthrough。
+- [examples/tui/35_completion_providers.py](../../../examples/tui/35_completion_providers.py)：Composer completion provider 行为。
+- [examples/tui/40_runner_basic.py](../../../examples/tui/40_runner_basic.py)：`TuiRunner` 生命周期和顶层输入处理。

--- a/docs/zh-CN/user-guide/tui.md
+++ b/docs/zh-CN/user-guide/tui.md
@@ -2,7 +2,7 @@
 
 [English](../../en/user-guide/tui.md) | 中文
 
-本文说明如何用 `loushang.tui` 构建小型终端 UI。需要产品化的交互式终端界面时，可以从这里开始。精确 API 细节见 [TUI Runner 参考](../reference/tui-runner.md)。
+本文说明如何用 `loushang.tui` 构建小型终端 UI。需要产品化的交互式终端界面时，可以从这里开始。生命周期细节见 [TUI Runner 参考](../reference/tui-runner.md)。可复用输入编辑能力见 [TUI 编辑能力](../reference/tui-editing.md)。
 
 ## 选择入口
 
@@ -89,7 +89,31 @@ handle = tui.show_overlay(dialog, focus_target=dialog, presentation="modal", anc
 
 临时 UI 不再需要时，关闭返回的 handle。
 
+## 复用编辑基础设施
+
+单行搜索、过滤等输入使用 `TextInput`。多行 prompt 编辑器使用 `Composer` 配合 `InputRouter`，以获得历史、paste marker、completion、selection、undo 和 kill/yank 行为。
+
+```python
+from loushang.tui import Composer, InputEvent, InputRouter, TextInput
+
+
+field = TextInput(prompt="Search: ")
+field.handle_input(InputEvent(kind="text", text="hello world"))
+field.handle_input(InputEvent(kind="key", key="ctrl+shift+left"))
+field.handle_input(InputEvent(kind="text", text="loushang"))
+
+composer = Composer(prompt="> ")
+router = InputRouter(composer, width=80, height=24)
+router.route(InputEvent(kind="text", text="alpha beta"))
+router.route(InputEvent(kind="key", key="shift+left"))
+router.route(InputEvent(kind="key", key="ctrl+k"))
+```
+
+`TextInput` selection 索引用 grapheme cluster。`Composer` selection 索引用 composer atom，因此 paste marker 会保持原子性。显示宽度由渲染层处理。
+
 ## 示例
 
 - [examples/tui/40_runner_basic.py](../../../examples/tui/40_runner_basic.py)：使用 `TuiRunner` 的小型交互计数器。
+- [examples/tui/41_editing_foundation.py](../../../examples/tui/41_editing_foundation.py)：TextInput 和 Composer 编辑 walkthrough。
 - [TUI Runner 参考](../reference/tui-runner.md)：生命周期 API 细节。
+- [TUI 编辑能力参考](../reference/tui-editing.md)：编辑基础设施、快捷键和 playback smoke 检查。

--- a/examples/tui/41_editing_foundation.py
+++ b/examples/tui/41_editing_foundation.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from loushang.tui import (
+    Composer,
+    InputEvent,
+    InputRouter,
+    RenderConstraints,
+    TextInput,
+    strip_control_sequences,
+)
+
+
+def main() -> int:
+    print("Loushang TUI editing foundation")
+    print("")
+    _text_input_walkthrough()
+    print("")
+    _composer_walkthrough()
+    return 0
+
+
+def _text_input_walkthrough() -> None:
+    field = TextInput(prompt="Search: ", placeholder="type to filter")
+    field.focus()
+    field.handle_input(InputEvent(kind="text", text="hello world"))
+    field.handle_input(InputEvent(kind="key", key="ctrl+shift+left"))
+    selected = field.selected_range
+    selected_text = _slice_text(field.value, selected)
+    field.handle_input(InputEvent(kind="text", text="loushang"))
+    replaced = field.value
+    field.handle_input(InputEvent(kind="key", key="ctrl+-"))
+
+    print("## TextInput")
+    print(f"selection: {selected!r} -> {selected_text!r}")
+    print(f"replace:   {replaced!r}")
+    print(f"undo:      {field.value!r}")
+    _print_rendered(field.render(RenderConstraints(width=40, max_height=1)))
+
+
+def _composer_walkthrough() -> None:
+    composer = Composer(prompt="> ")
+    router = InputRouter(composer, width=72, height=12)
+    router.route(InputEvent(kind="text", text="alpha beta"))
+    router.route(InputEvent(kind="key", key="shift+left"))
+    selected = composer.selected_range
+    router.route(InputEvent(kind="key", key="ctrl+k"))
+    killed = composer.value
+    kill_ring = composer.kill_ring
+    router.route(InputEvent(kind="key", key="ctrl+y"))
+    yanked = composer.value
+    router.route(InputEvent(kind="text", text=" "))
+    router.route(
+        InputEvent(
+            kind="paste", text="\n".join(f"line {index}" for index in range(1, 11))
+        )
+    )
+
+    print("## Composer")
+    print(f"selection: {selected!r}")
+    print(f"kill:      {killed!r}")
+    print(f"kill ring: {kill_ring!r}")
+    print(f"yank:      {yanked!r}")
+    print(f"paste:     {composer.value!r}")
+    _print_rendered(composer.render(RenderConstraints(width=72, max_height=6)))
+
+
+def _slice_text(text: str, selected_range: tuple[int, int] | None) -> str:
+    if selected_range is None:
+        return ""
+    start, end = selected_range
+    return text[start:end]
+
+
+def _print_rendered(result: object) -> None:
+    print("render:")
+    for line in getattr(result, "lines"):
+        print(f"  {strip_control_sequences(line.text)}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -4,12 +4,14 @@ from pathlib import Path
 
 
 def test_testing_strategy_documents_composer_selection_manual_smoke() -> None:
-    text = Path("docs/internals/architecture/tui/native-terminal-core/testing-strategy.md").read_text(
-        encoding="utf-8"
-    )
+    text = Path(
+        "docs/internals/architecture/tui/native-terminal-core/testing-strategy.md"
+    ).read_text(encoding="utf-8")
 
     assert "composer-selection-stress" in text
-    assert "python -m loushang.coding.ui.playback_runner composer-selection-stress" in text
+    assert (
+        "python -m loushang.coding.ui.playback_runner composer-selection-stress" in text
+    )
     assert "Shift+Left" in text
     assert "Shift+Home" in text
     assert "Shift+End" in text
@@ -17,8 +19,47 @@ def test_testing_strategy_documents_composer_selection_manual_smoke() -> None:
 
 
 def test_theme_key_design_lists_editor_selection_token() -> None:
-    text = Path("docs/internals/architecture/tui/native-terminal-core/key-designs/KD-009-theme-resolution.md").read_text(
-        encoding="utf-8"
-    )
+    text = Path(
+        "docs/internals/architecture/tui/native-terminal-core/key-designs/KD-009-theme-resolution.md"
+    ).read_text(encoding="utf-8")
 
     assert "editor.selection" in text
+
+
+def test_terminal_ux_alignment_documents_current_capability_snapshot() -> None:
+    text = Path(
+        "docs/internals/architecture/tui/native-terminal-core/reference/terminal-ux-feature-alignment.md"
+    ).read_text(encoding="utf-8")
+
+    assert "2026-06-05" in text
+    assert "Overall qualitative completion" in text
+    assert "SelectionController" in text
+    assert "Redo storage exists" in text
+
+
+def test_composer_selection_key_design_records_implemented_status() -> None:
+    text = Path(
+        "docs/internals/architecture/tui/native-terminal-core/key-designs/KD-017-composer-selection-and-selected-range.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Status: Accepted" in text
+    assert "implemented as of 2026-06-05" in text
+    assert "SelectionController" in text
+    assert "TextInput" in text
+
+
+def test_public_tui_reference_documents_editing_foundation() -> None:
+    english = Path("docs/en/reference/tui-editing.md").read_text(encoding="utf-8")
+    chinese = Path("docs/zh-CN/reference/tui-editing.md").read_text(encoding="utf-8")
+    english_index = Path("docs/en/reference/README.md").read_text(encoding="utf-8")
+    chinese_index = Path("docs/zh-CN/reference/README.md").read_text(encoding="utf-8")
+
+    for text in (english, chinese):
+        assert "TextInput" in text
+        assert "Composer" in text
+        assert "SelectionController" in text
+        assert "composer-selection-stress" in text
+        assert "examples/tui/41_editing_foundation.py" in text
+
+    assert "tui-editing.md" in english_index
+    assert "tui-editing.md" in chinese_index


### PR DESCRIPTION
## Summary
- update native TUI capability alignment with a 2026-06-05 qualitative completion snapshot and remaining gaps
- mark KD-017 composer selection as accepted/initially implemented and document shared selection/editing infrastructure
- add bilingual TUI editing reference docs plus a deterministic editing foundation example

## Test Plan
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python -m pytest tests/tui/test_tui_testing_strategy_docs.py -q
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python -m ruff check tests/tui/test_tui_testing_strategy_docs.py examples/tui/41_editing_foundation.py
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python examples/tui/41_editing_foundation.py
- git diff --check