### PR TITLE
test(tui): add product composed playback

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
+++ b/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
@@ -65,6 +65,8 @@ Examples:
 - concise error without traceback
 - composer selection stress with wide text, paste markers, kill/yank, undo,
   completion refresh, and selection key priority
+- product-composed interaction with long transcript, running queue state,
+  settings search, completion, and composer selection in one playback
 
 Composer selection playback should be run directly when changing composer input,
 selection, paste marker, completion, keybinding, or render-highlight behavior:
@@ -76,6 +78,18 @@ uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_r
 The trace should include `composer-selection-stress` as a passing scenario. Use
 the generated JSONL artifact when diagnosing selection regressions because the
 final screen cannot show transient selected ranges after replacement or undo.
+
+Product-composed playback should be run when changing bottom-frame composition,
+pending queue state, transcript viewport behavior, settings search, completion,
+or cross-feature input routing:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner product-composed-interaction --artifacts /tmp/loushang-product-playback --include-frames
+```
+
+The trace should include `product-composed-interaction` as a passing scenario.
+This scenario protects cross-feature regressions that are easy to miss when
+composer, surface, lifecycle, and transcript tests are run only in isolation.
 
 ### 4. Boundary Tests
 

--- a/docs/internals/testing/native-tui-playback.md
+++ b/docs/internals/testing/native-tui-playback.md
@@ -11,6 +11,8 @@ Good candidates include:
 - overlay and surface interactions
 - viewport or cursor positioning
 - long transcript resume behavior
+- product-composed interactions that combine transcript, running state,
+  pending queues, surfaces, completion, and composer selection
 
 Prefer focused component tests for pure rendering functions. Use the playback harness when the test needs a `NativeCodingTuiApp`, `TuiRuntime`, and `FakeTerminalPort` together.
 
@@ -22,3 +24,10 @@ Useful assertions:
 - `assert_cursor_matches_diagnostics(step)` when cursor anchoring is part of the behavior
 
 Avoid broad snapshot-only tests. Prefer targeted assertions on terminal operations, diagnostics, visible text, and cursor/viewport invariants.
+
+Useful direct smoke commands:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner composer-selection-stress --artifacts /tmp/loushang-selection-playback --include-frames
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner product-composed-interaction --artifacts /tmp/loushang-product-playback --include-frames
+```

--- a/src/loushang/coding/ui/playback_runner.py
+++ b/src/loushang/coding/ui/playback_runner.py
@@ -10,6 +10,7 @@ from typing import TextIO
 from loushang.coding.ui.playback_scenarios.command import COMMAND_ROUTING_SCENARIOS
 from loushang.coding.ui.playback_scenarios.composer import COMPOSER_SCENARIOS
 from loushang.coding.ui.playback_scenarios.lifecycle import LIFECYCLE_SCENARIOS
+from loushang.coding.ui.playback_scenarios.product import PRODUCT_SCENARIOS
 from loushang.coding.ui.playback_scenarios.surface import SURFACE_SCENARIOS
 from loushang.coding.ui.playback_scenarios.terminal import TERMINAL_SCENARIOS
 from loushang.coding.ui.playback_scenarios.transcript import TRANSCRIPT_SCENARIOS
@@ -102,16 +103,35 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="python -m loushang.coding.ui.playback_runner",
         description="Run native TUI playback regression scenarios.",
     )
-    parser.add_argument("scenarios", nargs="*", help="Scenario names to run. Defaults to all scenarios.")
+    parser.add_argument(
+        "scenarios", nargs="*", help="Scenario names to run. Defaults to all scenarios."
+    )
     parser.add_argument("--list", action="store_true", help="List available scenarios.")
-    parser.add_argument("--tag", action="append", default=None, help="Run or list scenarios matching this tag. Repeatable.")
-    parser.add_argument("--artifacts", help="Directory for manual inspection artifacts.")
-    parser.add_argument("--include-frames", action="store_true", help="Include visible frames in JSONL artifacts.")
-    parser.add_argument("--json", action="store_true", help="Write a machine-readable JSON summary to stdout.")
+    parser.add_argument(
+        "--tag",
+        action="append",
+        default=None,
+        help="Run or list scenarios matching this tag. Repeatable.",
+    )
+    parser.add_argument(
+        "--artifacts", help="Directory for manual inspection artifacts."
+    )
+    parser.add_argument(
+        "--include-frames",
+        action="store_true",
+        help="Include visible frames in JSONL artifacts.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Write a machine-readable JSON summary to stdout.",
+    )
     return parser
 
 
-def _write_scenario_list(suite: NativePlaybackSuite, stdout: TextIO, *, tags: Sequence[str] = ()) -> None:
+def _write_scenario_list(
+    suite: NativePlaybackSuite, stdout: TextIO, *, tags: Sequence[str] = ()
+) -> None:
     for scenario in suite.selected((), tags=tags):
         stdout.write(f"{scenario.name}\t{scenario.description}\n")
 
@@ -136,6 +156,7 @@ DEFAULT_SUITE = NativePlaybackSuite(
     (
         *COMPOSER_SCENARIOS,
         *LIFECYCLE_SCENARIOS,
+        *PRODUCT_SCENARIOS,
         *COMMAND_ROUTING_SCENARIOS,
         *SURFACE_SCENARIOS,
         *TRANSCRIPT_SCENARIOS,

--- a/src/loushang/coding/ui/playback_scenarios/product.py
+++ b/src/loushang/coding/ui/playback_scenarios/product.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from loushang.coding.ui.perf_probe import build_synthetic_long_transcript_records
+from loushang.coding.ui.playback import (
+    NativeTuiInputPlaybackResult,
+    NativeTuiInputScenario,
+)
+from loushang.coding.ui.playback_suite import NativePlaybackScenarioSpec
+from loushang.tui import (
+    PlaybackEvent,
+    PlaybackFrameBudget,
+    SettingItem,
+    SettingsSurface,
+    strip_control_sequences,
+)
+
+PRODUCT_COMPOSED_FRAME_BUDGET = PlaybackFrameBudget(
+    disallowed_operation_classes=("baseline_repaint", "recovery_repaint"),
+    max_operations=64,
+    max_serialized_output_bytes=3_000,
+    max_changed_visible_lines=20,
+    require_synchronized=True,
+)
+
+
+def _run_product_composed_interaction() -> NativeTuiInputPlaybackResult:
+    scenario = (
+        NativeTuiInputScenario(width=100, height=18)
+        .with_records(
+            build_synthetic_long_transcript_records(
+                turns=24, tail_tool_output_lines=120
+            )
+        )
+        .with_running_prompt("investigate product playback")
+        .with_completion_items("/model", "/models")
+    )
+
+    scenario.playback.play(
+        (
+            PlaybackEvent("render"),
+            PlaybackEvent.input("follow one"),
+            PlaybackEvent.input("\x1b\r"),
+        )
+    )
+    assert scenario.app.state.pending_followups == ["follow one"]
+    _assert_visible_contains(scenario, "Queued follow-up inputs")
+    _assert_visible_contains(scenario, "follow one")
+
+    scenario.app.active_surface = SettingsSurface(
+        (
+            SettingItem(id="memory", label="Memory", current_value="on"),
+            SettingItem(id="model", label="Model", current_value="kimi"),
+        ),
+        enable_search=True,
+    )
+    scenario.playback.play(
+        (
+            PlaybackEvent("render"),
+            PlaybackEvent.input("mo\x1b[Dx"),
+        )
+    )
+    _assert_visible_contains(scenario, "Search: mxo")
+    _assert_visible_contains(scenario, "No matching settings")
+
+    scenario.app.active_surface = None
+    scenario.playback.play(
+        (
+            PlaybackEvent("render"),
+            PlaybackEvent.input("/mod"),
+            PlaybackEvent.input("\t"),
+            PlaybackEvent.input("gpt"),
+            PlaybackEvent.input("\x1b[1;2D"),
+            PlaybackEvent.input("x"),
+        )
+    )
+
+    result = _result_from_scenario(scenario)
+    assert result.app.state.pending_followups == ["follow one"]
+    result.assert_composer_text("/model gpx")
+    result.assert_visible_contains("› /model gpx")
+    result.assert_visible_contains("queued=1 steer=0")
+    result.assert_no_clear_screen()
+    PRODUCT_COMPOSED_FRAME_BUDGET.assert_result(result, skip_first=True)
+    return result
+
+
+def _result_from_scenario(
+    scenario: NativeTuiInputScenario,
+) -> NativeTuiInputPlaybackResult:
+    return NativeTuiInputPlaybackResult(
+        steps=scenario.playback.harness.steps,
+        port=scenario.playback.port,
+        input_results=tuple(scenario.playback.input_results),
+        step_input_results=tuple(scenario.playback.step_input_results),
+        step_coding_states=tuple(scenario.playback.step_coding_states),
+        app=scenario.app,
+    )
+
+
+def _assert_visible_contains(scenario: NativeTuiInputScenario, expected: str) -> None:
+    visible = strip_control_sequences(
+        "\n".join(scenario.playback.port.screen.visible_lines)
+    )
+    assert expected in visible
+
+
+PRODUCT_SCENARIOS = (
+    NativePlaybackScenarioSpec(
+        name="product-composed-interaction",
+        description="Exercise long transcript, running queue, settings search, completion, and selection in one playback.",
+        run=_run_product_composed_interaction,
+        tags=(
+            "product",
+            "transcript",
+            "lifecycle",
+            "surface",
+            "completion",
+            "selection",
+        ),
+    ),
+)
+
+
+__all__ = ["PRODUCT_SCENARIOS"]

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -14,13 +14,16 @@ from loushang.coding.ui.playback_runner import (
 from loushang.coding.ui.playback_scenarios.command import COMMAND_ROUTING_SCENARIOS
 from loushang.coding.ui.playback_scenarios.composer import COMPOSER_SCENARIOS
 from loushang.coding.ui.playback_scenarios.lifecycle import LIFECYCLE_SCENARIOS
+from loushang.coding.ui.playback_scenarios.product import PRODUCT_SCENARIOS
 from loushang.coding.ui.playback_scenarios.surface import SURFACE_SCENARIOS
 from loushang.coding.ui.playback_scenarios.terminal import TERMINAL_SCENARIOS
 from loushang.coding.ui.playback_scenarios.transcript import TRANSCRIPT_SCENARIOS
 from loushang.coding.ui.playback_suite import NativePlaybackSuite as SuiteFromModule
 
 
-def test_native_tui_playback_runner_reexports_suite_types_from_playback_suite_module() -> None:
+def test_native_tui_playback_runner_reexports_suite_types_from_playback_suite_module() -> (
+    None
+):
     assert NativePlaybackSuite is SuiteFromModule
 
 
@@ -102,6 +105,12 @@ def test_native_tui_playback_lifecycle_scenarios_live_in_lifecycle_module() -> N
     ]
 
 
+def test_native_tui_playback_product_scenarios_live_in_product_module() -> None:
+    assert [scenario.name for scenario in PRODUCT_SCENARIOS] == [
+        "product-composed-interaction",
+    ]
+
+
 def test_native_tui_playback_terminal_scenarios_live_in_terminal_module() -> None:
     assert [scenario.name for scenario in TERMINAL_SCENARIOS] == [
         "native-loop-split-bracketed-paste",
@@ -167,6 +176,7 @@ def test_native_tui_playback_runner_lists_default_scenarios(capsys) -> None:
     assert "native-loop-split-bracketed-paste" in captured.out
     assert "native-loop-terminal-session-cleanup" in captured.out
     assert "native-loop-ctrl-c-abort-running" in captured.out
+    assert "product-composed-interaction" in captured.out
 
 
 def test_native_tui_playback_runner_runs_named_scenario(capsys) -> None:
@@ -190,6 +200,15 @@ def test_native_tui_playback_runner_runs_tagged_command_scenarios(capsys) -> Non
     assert "PASS long-transcript-input" not in captured.out
 
 
+def test_native_tui_playback_runner_runs_tagged_product_scenarios(capsys) -> None:
+    exit_code = run_playback_cli(["--tag", "product"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS product-composed-interaction" in captured.out
+    assert "PASS completion-tab" not in captured.out
+
+
 def test_native_tui_playback_runner_lists_tagged_command_scenarios(capsys) -> None:
     exit_code = run_playback_cli(["--list", "--tag", "command"])
 
@@ -201,7 +220,9 @@ def test_native_tui_playback_runner_lists_tagged_command_scenarios(capsys) -> No
     assert "long-transcript-input" not in captured.out
 
 
-def test_native_tui_playback_runner_runs_completion_session_command_scenario(capsys) -> None:
+def test_native_tui_playback_runner_runs_completion_session_command_scenario(
+    capsys,
+) -> None:
     exit_code = run_playback_cli(["completion-session-command"])
 
     captured = capsys.readouterr()
@@ -233,12 +254,24 @@ def test_native_tui_playback_runner_runs_composer_selection_scenario(capsys) -> 
     assert "PASS composer-selection-replace" in captured.out
 
 
-def test_native_tui_playback_runner_runs_composer_selection_stress_scenario(capsys) -> None:
+def test_native_tui_playback_runner_runs_composer_selection_stress_scenario(
+    capsys,
+) -> None:
     exit_code = run_playback_cli(["composer-selection-stress"])
 
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS composer-selection-stress" in captured.out
+
+
+def test_native_tui_playback_runner_runs_product_composed_interaction_scenario(
+    capsys,
+) -> None:
+    exit_code = run_playback_cli(["product-composed-interaction"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS product-composed-interaction" in captured.out
 
 
 def test_native_tui_playback_runner_runs_lifecycle_scenario(capsys) -> None:
@@ -274,7 +307,9 @@ def test_native_tui_playback_runner_runs_unknown_slash_prompt_scenario(capsys) -
     assert "PASS unknown-slash-prompt" in captured.out
 
 
-def test_native_tui_playback_runner_runs_non_executable_session_command_scenario(capsys) -> None:
+def test_native_tui_playback_runner_runs_non_executable_session_command_scenario(
+    capsys,
+) -> None:
     exit_code = run_playback_cli(["non-executable-session-command"])
 
     captured = capsys.readouterr()
@@ -299,7 +334,9 @@ def test_native_tui_playback_runner_runs_info_surface_scenarios(capsys) -> None:
     assert "PASS commands-info-surface" in captured.out
 
 
-def test_native_tui_playback_runner_runs_commands_info_session_command_scenario(capsys) -> None:
+def test_native_tui_playback_runner_runs_commands_info_session_command_scenario(
+    capsys,
+) -> None:
     exit_code = run_playback_cli(["commands-info-session-command"])
 
     captured = capsys.readouterr()
@@ -315,7 +352,9 @@ def test_native_tui_playback_runner_runs_statusline_command_scenario(capsys) -> 
     assert "PASS statusline-command" in captured.out
 
 
-def test_native_tui_playback_runner_runs_command_palette_select_scenario(capsys) -> None:
+def test_native_tui_playback_runner_runs_command_palette_select_scenario(
+    capsys,
+) -> None:
     exit_code = run_playback_cli(["command-palette-select"])
 
     captured = capsys.readouterr()
@@ -323,7 +362,9 @@ def test_native_tui_playback_runner_runs_command_palette_select_scenario(capsys)
     assert "PASS command-palette-select" in captured.out
 
 
-def test_native_tui_playback_runner_runs_command_palette_session_command_scenario(capsys) -> None:
+def test_native_tui_playback_runner_runs_command_palette_session_command_scenario(
+    capsys,
+) -> None:
     exit_code = run_playback_cli(["command-palette-session-command"])
 
     captured = capsys.readouterr()
@@ -355,7 +396,9 @@ def test_native_tui_playback_runner_runs_approval_surface_scenario(capsys) -> No
     assert "PASS approval-surface" in captured.out
 
 
-def test_native_tui_playback_runner_runs_approval_reject_surface_scenario(capsys) -> None:
+def test_native_tui_playback_runner_runs_approval_reject_surface_scenario(
+    capsys,
+) -> None:
     exit_code = run_playback_cli(["approval-reject-surface"])
 
     captured = capsys.readouterr()
@@ -372,19 +415,25 @@ def test_native_tui_playback_runner_runs_dialog_surface_scenario(capsys) -> None
 
 
 def test_native_tui_playback_runner_writes_artifacts(tmp_path, capsys) -> None:
-    exit_code = run_playback_cli(["completion-tab", "--artifacts", str(tmp_path), "--include-frames"])
+    exit_code = run_playback_cli(
+        ["completion-tab", "--artifacts", str(tmp_path), "--include-frames"]
+    )
 
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS completion-tab" in captured.out
     assert (tmp_path / "completion-tab.jsonl").exists()
     assert (tmp_path / "completion-tab-screen.txt").exists()
-    row = json.loads((tmp_path / "completion-tab.jsonl").read_text(encoding="utf-8").splitlines()[0])
+    row = json.loads(
+        (tmp_path / "completion-tab.jsonl").read_text(encoding="utf-8").splitlines()[0]
+    )
     assert "visible_lines" in row
 
 
 def test_native_tui_playback_runner_writes_json_summary(tmp_path, capsys) -> None:
-    exit_code = run_playback_cli(["completion-tab", "--json", "--artifacts", str(tmp_path)])
+    exit_code = run_playback_cli(
+        ["completion-tab", "--json", "--artifacts", str(tmp_path)]
+    )
 
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
@@ -409,7 +458,9 @@ def test_native_tui_playback_runner_writes_json_summary(tmp_path, capsys) -> Non
     assert "PASS completion-tab" not in captured.out
 
 
-def test_native_tui_playback_runner_writes_artifacts_for_all_default_scenarios(tmp_path, capsys) -> None:
+def test_native_tui_playback_runner_writes_artifacts_for_all_default_scenarios(
+    tmp_path, capsys
+) -> None:
     exit_code = run_playback_cli(["--artifacts", str(tmp_path), "--include-frames"])
 
     captured = capsys.readouterr()
@@ -454,10 +505,14 @@ def test_native_tui_playback_runner_reports_failed_scenario(tmp_path, capsys) ->
     assert len(results) == 1
     assert results[0].ok is False
     assert results[0].error == "forced failure"
-    assert (tmp_path / "forced-failure-error.txt").read_text(encoding="utf-8") == "forced failure\n"
+    assert (tmp_path / "forced-failure-error.txt").read_text(
+        encoding="utf-8"
+    ) == "forced failure\n"
 
 
-def test_native_tui_playback_runner_writes_failed_json_summary(tmp_path, capsys) -> None:
+def test_native_tui_playback_runner_writes_failed_json_summary(
+    tmp_path, capsys
+) -> None:
     def failing_run() -> None:
         raise AssertionError("forced failure")
 

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -18,6 +18,19 @@ def test_testing_strategy_documents_composer_selection_manual_smoke() -> None:
     assert "Ctrl+-" in text
 
 
+def test_testing_strategy_documents_product_composed_playback() -> None:
+    strategy = Path(
+        "docs/internals/architecture/tui/native-terminal-core/testing-strategy.md"
+    ).read_text(encoding="utf-8")
+    playback = Path("docs/internals/testing/native-tui-playback.md").read_text(
+        encoding="utf-8"
+    )
+
+    for text in (strategy, playback):
+        assert "product-composed-interaction" in text
+        assert "loushang-product-playback" in text
+
+
 def test_theme_key_design_lists_editor_selection_token() -> None:
     text = Path(
         "docs/internals/architecture/tui/native-terminal-core/key-designs/KD-009-theme-resolution.md"


### PR DESCRIPTION
## Summary
- Add a product-composed native TUI playback scenario covering long transcript, running queue state, settings search, completion, and composer selection together.
- Register the scenario in the default playback suite and add runner/tag coverage.
- Document when to run the composed playback smoke and preserve docs assertions.

## Test Plan
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python -m ruff check src/loushang/coding/ui/playback_scenarios/product.py src/loushang/coding/ui/playback_runner.py tests/coding/test_native_tui_playback_runner.py tests/tui/test_tui_testing_strategy_docs.py
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python -m pytest tests/coding/test_native_tui_playback_runner.py tests/tui/test_tui_testing_strategy_docs.py -q
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python -m pytest tests/coding/test_native_coding_tui_playback.py -q
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python -m loushang.coding.ui.playback_runner product-composed-interaction --json
- git diff --check