### PR TITLE
test(tui): add playback cursor diagnostics

### DIFF
--- a/docs/internals/testing/native-tui-playback.md
+++ b/docs/internals/testing/native-tui-playback.md
@@ -22,8 +22,15 @@ Useful assertions:
 - `assert_operation_class(step, "...")` for differential update expectations
 - `assert_visible_contains(text)` and `assert_visible_not_contains(text)` for visible terminal output
 - `assert_cursor_matches_diagnostics(step)` when cursor anchoring is part of the behavior
+- `assert_last_cursor_on_visible_line(text, column=n)` when a long transcript
+  makes logical cursor rows differ from visible screen rows
 
 Avoid broad snapshot-only tests. Prefer targeted assertions on terminal operations, diagnostics, visible text, and cursor/viewport invariants.
+
+JSONL traces include `logical_cursor`, `viewport`, `hardware_cursor`, and
+`screen_cursor`. Use `screen_cursor` for the fake terminal's final physical
+cursor position, and keep `logical_cursor`/`viewport` for diagnosing render-loop
+line mapping.
 
 Useful direct smoke commands:
 

--- a/src/loushang/coding/ui/playback_scenarios/product.py
+++ b/src/loushang/coding/ui/playback_scenarios/product.py
@@ -78,6 +78,7 @@ def _run_product_composed_interaction() -> NativeTuiInputPlaybackResult:
     assert result.app.state.pending_followups == ["follow one"]
     result.assert_composer_text("/model gpx")
     result.assert_visible_contains("› /model gpx")
+    result.assert_last_cursor_on_visible_line("› /model gpx", column=12)
     result.assert_visible_contains("queued=1 steer=0")
     result.assert_no_clear_screen()
     PRODUCT_COMPOSED_FRAME_BUDGET.assert_result(result, skip_first=True)

--- a/src/loushang/tui/playback.py
+++ b/src/loushang/tui/playback.py
@@ -75,7 +75,9 @@ class PlaybackStep:
     def assert_operation_class(self, expected: str) -> None:
         actual = self.diagnostics.operation_class
         if actual != expected:
-            raise AssertionError(f"expected operation_class {expected!r}, got {actual!r}")
+            raise AssertionError(
+                f"expected operation_class {expected!r}, got {actual!r}"
+            )
 
     def assert_no_clear_scrollback(self) -> None:
         if self.diagnostics.clear_scrollback_emitted:
@@ -90,7 +92,9 @@ class PlaybackStep:
             raise AssertionError("expected frame to emit clear scrollback")
 
 
-PlaybackRender = Callable[[PlaybackEvent, TerminalSize, RenderDiagnostics | None], RenderDiagnostics]
+PlaybackRender = Callable[
+    [PlaybackEvent, TerminalSize, RenderDiagnostics | None], RenderDiagnostics
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,21 +168,29 @@ class PlaybackResult:
             raise AssertionError(f"expected step index {step_index} to exist")
         step = self.steps[step_index]
         if step.frame is None:
-            raise AssertionError(f"expected step {step_index} to record a terminal frame")
+            raise AssertionError(
+                f"expected step {step_index} to record a terminal frame"
+            )
         if expected not in step.frame.serialized_output:
-            raise AssertionError(f"expected step {step_index} frame output to contain {expected!r}")
+            raise AssertionError(
+                f"expected step {step_index} frame output to contain {expected!r}"
+            )
 
     def assert_any_frame_output_contains(self, expected: str) -> None:
         for step in self.steps:
             if step.frame is not None and expected in step.frame.serialized_output:
                 return
-        raise AssertionError(f"expected at least one frame output to contain {expected!r}")
+        raise AssertionError(
+            f"expected at least one frame output to contain {expected!r}"
+        )
 
     def assert_last_operation_class_not_in(self, *unexpected: str) -> None:
         assert self.steps
         assert self.steps[-1].diagnostics.operation_class not in unexpected
 
-    def assert_operation_classes_not_in(self, *unexpected: str, skip_first: bool = False) -> None:
+    def assert_operation_classes_not_in(
+        self, *unexpected: str, skip_first: bool = False
+    ) -> None:
         unexpected_set = set(unexpected)
         steps = self.steps[1:] if skip_first else self.steps
         for step in steps:
@@ -188,7 +200,9 @@ class PlaybackResult:
                     f"step {step.index} used disallowed operation_class {operation_class!r}"
                 )
 
-    def assert_max_operations_per_step(self, max_operations: int, *, skip_first: bool = False) -> None:
+    def assert_max_operations_per_step(
+        self, max_operations: int, *, skip_first: bool = False
+    ) -> None:
         steps = self.steps[1:] if skip_first else self.steps
         for step in steps:
             operation_count = len(step.diagnostics.operations)
@@ -208,7 +222,9 @@ class PlaybackResult:
             if step.frame is None:
                 if step.flush_error is not None:
                     continue
-                raise AssertionError(f"step {step.index} did not record a terminal frame")
+                raise AssertionError(
+                    f"step {step.index} did not record a terminal frame"
+                )
             byte_count = len(step.frame.serialized_output.encode("utf-8"))
             if byte_count > max_bytes:
                 raise AssertionError(
@@ -226,7 +242,9 @@ class PlaybackResult:
             if step.frame is None:
                 if step.flush_error is not None:
                     continue
-                raise AssertionError(f"step {step.index} did not record a terminal frame")
+                raise AssertionError(
+                    f"step {step.index} did not record a terminal frame"
+                )
             changed_lines = _changed_visible_line_count(step.frame)
             if changed_lines > max_changed_lines:
                 raise AssertionError(
@@ -245,11 +263,15 @@ class PlaybackResult:
             raise AssertionError("expected at least one playback step")
         baseline = _screen_anchor_row(steps[0], anchor, occurrence=occurrence)
         if baseline is None:
-            raise AssertionError(f"anchor {anchor!r} was not visible at step {steps[0].index}")
+            raise AssertionError(
+                f"anchor {anchor!r} was not visible at step {steps[0].index}"
+            )
         for step in steps[1:]:
             row = _screen_anchor_row(step, anchor, occurrence=occurrence)
             if row is None:
-                raise AssertionError(f"anchor {anchor!r} was not visible at step {step.index}")
+                raise AssertionError(
+                    f"anchor {anchor!r} was not visible at step {step.index}"
+                )
             if row != baseline:
                 raise AssertionError(
                     f"anchor {anchor!r} moved from row {baseline} to row {row} at step {step.index}"
@@ -261,7 +283,9 @@ class PlaybackResult:
             if step.frame is None:
                 if step.flush_error is not None:
                     continue
-                raise AssertionError(f"step {step.index} did not record a terminal frame")
+                raise AssertionError(
+                    f"step {step.index} did not record a terminal frame"
+                )
             if not step.frame.synchronized:
                 raise AssertionError(f"step {step.index} was not synchronized")
 
@@ -287,22 +311,66 @@ class PlaybackResult:
     def assert_cursor_matches_diagnostics(self) -> None:
         for step in self.steps:
             assert step.frame is not None
-            assert step.frame.screen_after.cursor_row == step.diagnostics.hardware_cursor_row
-            assert step.frame.screen_after.cursor_column == step.diagnostics.hardware_cursor_column
+            assert (
+                step.frame.screen_after.cursor_row
+                == step.diagnostics.hardware_cursor_row
+            )
+            assert (
+                step.frame.screen_after.cursor_column
+                == step.diagnostics.hardware_cursor_column
+            )
 
     def assert_last_cursor_matches_diagnostics(self) -> None:
         assert self.steps
         step = self.steps[-1]
         assert step.frame is not None
-        assert step.frame.screen_after.cursor_row == step.diagnostics.hardware_cursor_row
-        assert step.frame.screen_after.cursor_column == step.diagnostics.hardware_cursor_column
+        assert (
+            step.frame.screen_after.cursor_row == step.diagnostics.hardware_cursor_row
+        )
+        assert (
+            step.frame.screen_after.cursor_column
+            == step.diagnostics.hardware_cursor_column
+        )
+
+    def assert_last_cursor_on_visible_line(
+        self,
+        anchor: str,
+        *,
+        column: int | None = None,
+        occurrence: str = "last",
+    ) -> None:
+        assert self.steps
+        step = self.steps[-1]
+        if step.frame is None:
+            raise AssertionError(
+                f"expected step {step.index} to record a terminal frame"
+            )
+        row = _screen_anchor_row(step, anchor, occurrence=occurrence)
+        if row is None:
+            raise AssertionError(
+                f"anchor {anchor!r} was not visible at step {step.index}"
+            )
+        cursor_row = step.frame.screen_after.cursor_row
+        if cursor_row != row:
+            raise AssertionError(
+                f"expected cursor row {cursor_row} to be visible anchor row {row} for {anchor!r}"
+            )
+        if column is not None and step.frame.screen_after.cursor_column != column:
+            raise AssertionError(
+                f"expected cursor column {step.frame.screen_after.cursor_column} to be {column}"
+            )
 
     def write_jsonl(self, path: str | Path, *, include_frames: bool = False) -> None:
         output_path = Path(path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with output_path.open("w", encoding="utf-8") as stream:
             for step in self.steps:
-                stream.write(json.dumps(self._jsonl_row(step, include_frames=include_frames), ensure_ascii=False))
+                stream.write(
+                    json.dumps(
+                        self._jsonl_row(step, include_frames=include_frames),
+                        ensure_ascii=False,
+                    )
+                )
                 stream.write("\n")
 
     def write_artifacts(
@@ -331,7 +399,9 @@ class PlaybackResult:
         try:
             yield
         except Exception:
-            self.write_artifacts(directory, basename=basename, include_frames=include_frames)
+            self.write_artifacts(
+                directory, basename=basename, include_frames=include_frames
+            )
             raise
 
     @contextmanager
@@ -346,11 +416,15 @@ class PlaybackResult:
             yield
         except Exception:
             if directory := playback_artifacts_directory_from_env(env):
-                self.write_artifacts(directory, basename=basename, include_frames=include_frames)
+                self.write_artifacts(
+                    directory, basename=basename, include_frames=include_frames
+                )
             raise
 
     def _jsonl_row(self, step: PlaybackStep, *, include_frames: bool) -> dict[str, Any]:
-        serialized_output = step.frame.serialized_output if step.frame is not None else None
+        serialized_output = (
+            step.frame.serialized_output if step.frame is not None else None
+        )
         row = {
             "index": step.index,
             "event": _event_payload(step.event),
@@ -359,23 +433,47 @@ class PlaybackResult:
             "changed_line_range": list(step.diagnostics.changed_line_range)
             if step.diagnostics.changed_line_range is not None
             else None,
+            "logical_cursor": {
+                "row": step.diagnostics.logical_cursor_row,
+                "column": step.diagnostics.logical_cursor_column,
+            },
+            "viewport": {
+                "top": step.diagnostics.viewport_top,
+                "previous_top": step.diagnostics.previous_viewport_top,
+            },
             "hardware_cursor": {
                 "row": step.diagnostics.hardware_cursor_row,
                 "column": step.diagnostics.hardware_cursor_column,
             },
+            "screen_cursor": (
+                {
+                    "row": step.frame.screen_after.cursor_row,
+                    "column": step.frame.screen_after.cursor_column,
+                }
+                if step.frame is not None
+                else None
+            ),
             "flush_succeeded": step.flush_succeeded,
             "flush_error": step.flush_error,
             "operation_count": len(step.diagnostics.operations),
             "operations": [operation.kind for operation in step.diagnostics.operations],
-            "serialized_output_bytes": len(serialized_output.encode("utf-8")) if serialized_output is not None else None,
-            "changed_visible_lines": _changed_visible_line_count(step.frame) if step.frame is not None else None,
+            "serialized_output_bytes": len(serialized_output.encode("utf-8"))
+            if serialized_output is not None
+            else None,
+            "changed_visible_lines": _changed_visible_line_count(step.frame)
+            if step.frame is not None
+            else None,
             "synchronized": step.frame.synchronized if step.frame is not None else None,
             "clear_scrollback_emitted": (
                 step.frame.clear_scrollback_emitted
                 if step.frame is not None
                 else step.diagnostics.clear_scrollback_emitted
             ),
-            "visible_lines": list(step.frame.screen_after.visible_lines if step.frame is not None else self.port.screen.visible_lines),
+            "visible_lines": list(
+                step.frame.screen_after.visible_lines
+                if step.frame is not None
+                else self.port.screen.visible_lines
+            ),
         }
         if include_frames:
             row["serialized_output"] = serialized_output
@@ -390,11 +488,17 @@ class PlaybackFrameBudget:
     max_changed_visible_lines: int | None = None
     require_synchronized: bool = False
 
-    def assert_result(self, result: PlaybackResult, *, skip_first: bool = False) -> None:
+    def assert_result(
+        self, result: PlaybackResult, *, skip_first: bool = False
+    ) -> None:
         if self.disallowed_operation_classes:
-            result.assert_operation_classes_not_in(*self.disallowed_operation_classes, skip_first=skip_first)
+            result.assert_operation_classes_not_in(
+                *self.disallowed_operation_classes, skip_first=skip_first
+            )
         if self.max_operations is not None:
-            result.assert_max_operations_per_step(self.max_operations, skip_first=skip_first)
+            result.assert_max_operations_per_step(
+                self.max_operations, skip_first=skip_first
+            )
         if self.max_serialized_output_bytes is not None:
             result.assert_max_serialized_output_bytes_per_step(
                 self.max_serialized_output_bytes,
@@ -452,13 +556,17 @@ class PlaybackScenario:
 
 
 def _normalize_diagnostics(diagnostics: RenderDiagnostics) -> RenderDiagnostics:
-    clear_scrollback_emitted = any(operation.kind == "clear_scrollback" for operation in diagnostics.operations)
+    clear_scrollback_emitted = any(
+        operation.kind == "clear_scrollback" for operation in diagnostics.operations
+    )
     if diagnostics.clear_scrollback_emitted == clear_scrollback_emitted:
         return diagnostics
     return replace(diagnostics, clear_scrollback_emitted=clear_scrollback_emitted)
 
 
-def _screen_anchor_row(step: PlaybackStep, anchor: str, *, occurrence: str) -> int | None:
+def _screen_anchor_row(
+    step: PlaybackStep, anchor: str, *, occurrence: str
+) -> int | None:
     if occurrence not in {"first", "last"}:
         raise ValueError("occurrence must be 'first' or 'last'")
     if step.frame is None:
@@ -483,7 +591,9 @@ def _changed_visible_line_count(frame: TerminalFrame) -> int:
     )
 
 
-def playback_artifacts_directory_from_env(env: Mapping[str, str] | None = None) -> Path | None:
+def playback_artifacts_directory_from_env(
+    env: Mapping[str, str] | None = None,
+) -> Path | None:
     environment = os.environ if env is None else env
     raw_path = environment.get(PLAYBACK_ARTIFACTS_ENV, "").strip()
     if not raw_path:
@@ -491,7 +601,9 @@ def playback_artifacts_directory_from_env(env: Mapping[str, str] | None = None) 
     return Path(raw_path).expanduser()
 
 
-def _assert_synchronized_or_noop_frames(result: PlaybackResult, *, skip_first: bool = False) -> None:
+def _assert_synchronized_or_noop_frames(
+    result: PlaybackResult, *, skip_first: bool = False
+) -> None:
     steps = result.steps[1:] if skip_first else result.steps
     for step in steps:
         if step.frame is None:

--- a/tests/tui/test_playback_harness.py
+++ b/tests/tui/test_playback_harness.py
@@ -58,7 +58,9 @@ def test_fake_terminal_port_can_bound_recorded_history() -> None:
 
 
 def test_playback_harness_records_diagnostics_for_scripted_events() -> None:
-    def render(event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None) -> RenderDiagnostics:
+    def render(
+        event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         previous_lines = previous.current_logical_lines if previous is not None else ()
         text = f"{event.kind}:{event.payload}@{size.columns}x{size.rows}"
         return RenderDiagnostics(
@@ -70,7 +72,9 @@ def test_playback_harness_records_diagnostics_for_scripted_events() -> None:
             operations=(TerminalOperation.write(text),),
         )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=40, rows=10)))
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=40, rows=10))
+    )
 
     steps = harness.play([PlaybackEvent("key", "a"), PlaybackEvent("stream", "chunk")])
 
@@ -86,14 +90,20 @@ def test_playback_harness_records_diagnostics_for_scripted_events() -> None:
 def test_playback_harness_resize_event_updates_terminal_size_before_render() -> None:
     seen_sizes: list[TerminalSize] = []
 
-    def render(event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None) -> RenderDiagnostics:
+    def render(
+        event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         seen_sizes.append(size)
         return RenderDiagnostics(
             current_logical_lines=(event.kind,),
-            previous_rendered_lines=previous.current_logical_lines if previous is not None else (),
+            previous_rendered_lines=previous.current_logical_lines
+            if previous is not None
+            else (),
         )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=80, rows=24)))
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=80, rows=24))
+    )
 
     steps = harness.play([PlaybackEvent.resize(columns=100, rows=40)])
 
@@ -109,7 +119,15 @@ def test_playback_event_input_carries_raw_terminal_input_chunk() -> None:
 
 
 def test_playback_scenario_scripts_common_terminal_events() -> None:
-    scenario = PlaybackScenario().type_text("hello").enter().tab().escape().resize(width=42, height=8).render()
+    scenario = (
+        PlaybackScenario()
+        .type_text("hello")
+        .enter()
+        .tab()
+        .escape()
+        .resize(width=42, height=8)
+        .render()
+    )
 
     assert scenario.events == (
         PlaybackEvent.input("hello"),
@@ -140,7 +158,9 @@ def test_playback_result_asserts_visible_text_and_flush_policy() -> None:
         port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
     )
 
-    result = PlaybackResult(steps=harness.play([PlaybackEvent("render")]), port=harness.port)
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent("render")]), port=harness.port
+    )
 
     result.assert_all_flush_succeeded()
     result.assert_visible_contains("hello")
@@ -156,7 +176,9 @@ def test_playback_result_asserts_frame_output_contains_ansi_style_sequence() -> 
         ),
         port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
     )
-    result = PlaybackResult(steps=harness.play([PlaybackEvent.input("select")]), port=harness.port)
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent.input("select")]), port=harness.port
+    )
 
     result.assert_frame_output_contains(0, "\x1b[7mb\x1b[27m")
     result.assert_any_frame_output_contains("\x1b[7mb\x1b[27m")
@@ -176,7 +198,9 @@ def test_playback_result_writes_jsonl_for_manual_inspection(tmp_path) -> None:
         ),
         port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
     )
-    result = PlaybackResult(steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port)
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port
+    )
     path = tmp_path / "playback.jsonl"
 
     result.write_jsonl(path)
@@ -189,7 +213,10 @@ def test_playback_result_writes_jsonl_for_manual_inspection(tmp_path) -> None:
             "size": {"columns": 20, "rows": 5},
             "operation_class": "changed_range_update",
             "changed_line_range": None,
+            "logical_cursor": {"row": 0, "column": 0},
+            "viewport": {"top": 0, "previous_top": 0},
             "hardware_cursor": {"row": 0, "column": 5},
+            "screen_cursor": {"row": 0, "column": 5},
             "flush_succeeded": True,
             "flush_error": None,
             "operation_count": 1,
@@ -204,6 +231,35 @@ def test_playback_result_writes_jsonl_for_manual_inspection(tmp_path) -> None:
     assert "serialized_output" not in rows[0]
 
 
+def test_playback_result_asserts_last_cursor_on_visible_line() -> None:
+    harness = PlaybackHarness(
+        render=lambda _event, _size, _previous: RenderDiagnostics(
+            current_logical_lines=("status", "› hello"),
+            logical_cursor_row=1,
+            logical_cursor_column=7,
+            hardware_cursor_row=1,
+            hardware_cursor_column=7,
+            operations=(
+                TerminalOperation.write("status"),
+                TerminalOperation.newline(),
+                TerminalOperation.write("› hello"),
+                TerminalOperation.move_column(column=7),
+            ),
+        ),
+        port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
+    )
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port
+    )
+
+    result.assert_last_cursor_on_visible_line("› hello", column=7)
+
+    with pytest.raises(AssertionError, match="expected cursor row"):
+        result.assert_last_cursor_on_visible_line("status", column=7)
+    with pytest.raises(AssertionError, match="expected cursor column"):
+        result.assert_last_cursor_on_visible_line("› hello", column=6)
+
+
 def test_playback_result_can_include_raw_frame_output_in_jsonl(tmp_path) -> None:
     harness = PlaybackHarness(
         render=lambda _event, _size, _previous: RenderDiagnostics(
@@ -212,7 +268,9 @@ def test_playback_result_can_include_raw_frame_output_in_jsonl(tmp_path) -> None
         ),
         port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
     )
-    result = PlaybackResult(steps=harness.play([PlaybackEvent("render")]), port=harness.port)
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent("render")]), port=harness.port
+    )
     path = tmp_path / "playback.jsonl"
 
     result.write_jsonl(path, include_frames=True)
@@ -230,9 +288,13 @@ def test_playback_result_writes_trace_and_final_screen_artifacts(tmp_path) -> No
         ),
         port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
     )
-    result = PlaybackResult(steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port)
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port
+    )
 
-    artifacts = result.write_artifacts(tmp_path / "artifacts", basename="long-transcript", include_frames=True)
+    artifacts = result.write_artifacts(
+        tmp_path / "artifacts", basename="long-transcript", include_frames=True
+    )
 
     assert artifacts.trace == tmp_path / "artifacts" / "long-transcript.jsonl"
     assert artifacts.screen == tmp_path / "artifacts" / "long-transcript-screen.txt"
@@ -242,7 +304,9 @@ def test_playback_result_writes_trace_and_final_screen_artifacts(tmp_path) -> No
     assert artifacts.screen.read_text(encoding="utf-8") == "hello\n\n\n\n"
 
 
-def test_playback_result_writes_artifacts_when_wrapped_assertion_fails(tmp_path) -> None:
+def test_playback_result_writes_artifacts_when_wrapped_assertion_fails(
+    tmp_path,
+) -> None:
     harness = PlaybackHarness(
         render=lambda _event, _size, _previous: RenderDiagnostics(
             current_logical_lines=("hello",),
@@ -250,10 +314,14 @@ def test_playback_result_writes_artifacts_when_wrapped_assertion_fails(tmp_path)
         ),
         port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
     )
-    result = PlaybackResult(steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port)
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port
+    )
 
     with pytest.raises(AssertionError):
-        with result.write_artifacts_on_failure(tmp_path / "failures", basename="missing-text", include_frames=True):
+        with result.write_artifacts_on_failure(
+            tmp_path / "failures", basename="missing-text", include_frames=True
+        ):
             result.assert_visible_contains("missing")
 
     trace = tmp_path / "failures" / "missing-text.jsonl"
@@ -264,7 +332,9 @@ def test_playback_result_writes_artifacts_when_wrapped_assertion_fails(tmp_path)
     assert screen.read_text(encoding="utf-8") == "hello\n\n\n\n"
 
 
-def test_playback_result_does_not_write_artifacts_when_wrapped_assertion_passes(tmp_path) -> None:
+def test_playback_result_does_not_write_artifacts_when_wrapped_assertion_passes(
+    tmp_path,
+) -> None:
     harness = PlaybackHarness(
         render=lambda _event, _size, _previous: RenderDiagnostics(
             current_logical_lines=("hello",),
@@ -272,7 +342,9 @@ def test_playback_result_does_not_write_artifacts_when_wrapped_assertion_passes(
         ),
         port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
     )
-    result = PlaybackResult(steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port)
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port
+    )
 
     with result.write_artifacts_on_failure(tmp_path / "failures", basename="passing"):
         result.assert_visible_contains("hello")
@@ -288,7 +360,9 @@ def test_playback_result_writes_failure_artifacts_to_env_directory(tmp_path) -> 
         ),
         port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
     )
-    result = PlaybackResult(steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port)
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port
+    )
     artifact_root = tmp_path / "env-artifacts"
 
     with pytest.raises(AssertionError):
@@ -305,7 +379,9 @@ def test_playback_result_writes_failure_artifacts_to_env_directory(tmp_path) -> 
     assert screen.read_text(encoding="utf-8") == "hello\n\n\n\n"
 
 
-def test_playback_result_skips_env_artifacts_when_env_directory_is_unset(tmp_path) -> None:
+def test_playback_result_skips_env_artifacts_when_env_directory_is_unset(
+    tmp_path,
+) -> None:
     harness = PlaybackHarness(
         render=lambda _event, _size, _previous: RenderDiagnostics(
             current_logical_lines=("hello",),
@@ -313,7 +389,9 @@ def test_playback_result_skips_env_artifacts_when_env_directory_is_unset(tmp_pat
         ),
         port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
     )
-    result = PlaybackResult(steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port)
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent.input("hello")]), port=harness.port
+    )
 
     with pytest.raises(AssertionError):
         with result.write_artifacts_on_failure_from_env(basename="missing", env={}):
@@ -322,48 +400,84 @@ def test_playback_result_skips_env_artifacts_when_env_directory_is_unset(tmp_pat
     assert not (tmp_path / "missing.jsonl").exists()
 
 
-def test_playback_artifacts_directory_from_env_respects_explicit_empty_env(monkeypatch, tmp_path) -> None:
+def test_playback_artifacts_directory_from_env_respects_explicit_empty_env(
+    monkeypatch, tmp_path
+) -> None:
     monkeypatch.setenv(PLAYBACK_ARTIFACTS_ENV, str(tmp_path / "ambient"))
 
     assert playback_artifacts_directory_from_env({}) is None
 
 
 def test_playback_result_asserts_operation_class_budget_after_initial_frame() -> None:
-    operation_classes = iter(("first_render", "changed_range_update", "baseline_repaint"))
+    operation_classes = iter(
+        ("first_render", "changed_range_update", "baseline_repaint")
+    )
 
-    def render(_event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None) -> RenderDiagnostics:
+    def render(
+        _event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         return RenderDiagnostics(
             current_logical_lines=("hello",),
             operation_class=next(operation_classes),
             operations=(TerminalOperation.write("hello"),),
         )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)))
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5))
+    )
     result = PlaybackResult(
-        steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("a"), PlaybackEvent.input("b")]),
+        steps=harness.play(
+            [
+                PlaybackEvent("render"),
+                PlaybackEvent.input("a"),
+                PlaybackEvent.input("b"),
+            ]
+        ),
         port=harness.port,
     )
 
     with pytest.raises(AssertionError, match="baseline_repaint"):
-        result.assert_operation_classes_not_in("baseline_repaint", "recovery_repaint", skip_first=True)
+        result.assert_operation_classes_not_in(
+            "baseline_repaint", "recovery_repaint", skip_first=True
+        )
 
 
 def test_playback_result_asserts_max_operations_per_step_after_initial_frame() -> None:
     operation_batches = iter(
         (
-            (TerminalOperation.write("initial"), TerminalOperation.newline(), TerminalOperation.write("frame")),
+            (
+                TerminalOperation.write("initial"),
+                TerminalOperation.newline(),
+                TerminalOperation.write("frame"),
+            ),
             (TerminalOperation.write("ok"), TerminalOperation.move_column(column=1)),
-            (TerminalOperation.write("too"), TerminalOperation.newline(), TerminalOperation.write("many")),
+            (
+                TerminalOperation.write("too"),
+                TerminalOperation.newline(),
+                TerminalOperation.write("many"),
+            ),
         )
     )
 
-    def render(_event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None) -> RenderDiagnostics:
+    def render(
+        _event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         operations = next(operation_batches)
-        return RenderDiagnostics(current_logical_lines=("hello",), operations=operations)
+        return RenderDiagnostics(
+            current_logical_lines=("hello",), operations=operations
+        )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)))
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5))
+    )
     result = PlaybackResult(
-        steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("a"), PlaybackEvent.input("b")]),
+        steps=harness.play(
+            [
+                PlaybackEvent("render"),
+                PlaybackEvent.input("a"),
+                PlaybackEvent.input("b"),
+            ]
+        ),
         port=harness.port,
     )
 
@@ -379,11 +493,20 @@ def test_playback_result_asserts_max_serialized_output_bytes_per_step() -> None:
         )
     )
 
-    def render(_event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None) -> RenderDiagnostics:
-        return RenderDiagnostics(current_logical_lines=("frame",), operations=next(frames))
+    def render(
+        _event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
+        return RenderDiagnostics(
+            current_logical_lines=("frame",), operations=next(frames)
+        )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=80, rows=24)))
-    result = PlaybackResult(steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("x")]), port=harness.port)
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=80, rows=24))
+    )
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("x")]),
+        port=harness.port,
+    )
 
     with pytest.raises(AssertionError, match="step 1 emitted 40 serialized bytes"):
         result.assert_max_serialized_output_bytes_per_step(20, skip_first=True)
@@ -409,11 +532,20 @@ def test_playback_result_asserts_max_changed_visible_lines_per_step() -> None:
         )
     )
 
-    def render(_event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None) -> RenderDiagnostics:
-        return RenderDiagnostics(current_logical_lines=("frame",), operations=next(frames))
+    def render(
+        _event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
+        return RenderDiagnostics(
+            current_logical_lines=("frame",), operations=next(frames)
+        )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)))
-    result = PlaybackResult(steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("x")]), port=harness.port)
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5))
+    )
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("x")]),
+        port=harness.port,
+    )
 
     with pytest.raises(AssertionError, match="step 1 changed 2 visible lines"):
         result.assert_max_changed_visible_lines_per_step(1, skip_first=True)
@@ -437,13 +569,24 @@ def test_playback_result_asserts_screen_anchor_row_stability() -> None:
         )
     )
 
-    def render(_event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None) -> RenderDiagnostics:
-        return RenderDiagnostics(current_logical_lines=("frame",), operations=next(frames))
+    def render(
+        _event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
+        return RenderDiagnostics(
+            current_logical_lines=("frame",), operations=next(frames)
+        )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)))
-    result = PlaybackResult(steps=harness.play([PlaybackEvent("render"), PlaybackEvent("render")]), port=harness.port)
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5))
+    )
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent("render"), PlaybackEvent("render")]),
+        port=harness.port,
+    )
 
-    with pytest.raises(AssertionError, match="anchor 'anchor' moved from row 1 to row 0 at step 1"):
+    with pytest.raises(
+        AssertionError, match="anchor 'anchor' moved from row 1 to row 0 at step 1"
+    ):
         result.assert_screen_anchor_stable("anchor")
 
 
@@ -459,11 +602,20 @@ def test_playback_result_asserts_synchronized_frames() -> None:
         )
     )
 
-    def render(_event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None) -> RenderDiagnostics:
-        return RenderDiagnostics(current_logical_lines=("frame",), operations=next(frames))
+    def render(
+        _event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
+        return RenderDiagnostics(
+            current_logical_lines=("frame",), operations=next(frames)
+        )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)))
-    result = PlaybackResult(steps=harness.play([PlaybackEvent("render"), PlaybackEvent("render")]), port=harness.port)
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5))
+    )
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent("render"), PlaybackEvent("render")]),
+        port=harness.port,
+    )
 
     with pytest.raises(AssertionError, match="step 1 was not synchronized"):
         result.assert_synchronized_frames()
@@ -486,15 +638,22 @@ def test_playback_frame_budget_asserts_incremental_render_contract() -> None:
     )
     operation_classes = iter(("first_render", "changed_range_update"))
 
-    def render(_event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None) -> RenderDiagnostics:
+    def render(
+        _event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         return RenderDiagnostics(
             current_logical_lines=("frame",),
             operation_class=next(operation_classes),
             operations=next(frames),
         )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)))
-    result = PlaybackResult(steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("!")]), port=harness.port)
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5))
+    )
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("!")]),
+        port=harness.port,
+    )
     budget = PlaybackFrameBudget(
         disallowed_operation_classes=("baseline_repaint", "recovery_repaint"),
         max_operations=3,
@@ -523,21 +682,30 @@ def test_playback_frame_budget_reports_operation_count_violation() -> None:
         )
     )
 
-    def render(_event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None) -> RenderDiagnostics:
+    def render(
+        _event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         return RenderDiagnostics(
             current_logical_lines=("frame",),
             operation_class="changed_range_update",
             operations=next(frames),
         )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)))
-    result = PlaybackResult(steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("!")]), port=harness.port)
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5))
+    )
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("!")]),
+        port=harness.port,
+    )
 
     with pytest.raises(AssertionError, match="step 1 emitted 4 operations"):
         PlaybackFrameBudget(max_operations=3).assert_result(result, skip_first=True)
 
 
-def test_playback_frame_budget_allows_noop_frames_when_requiring_synchronization() -> None:
+def test_playback_frame_budget_allows_noop_frames_when_requiring_synchronization() -> (
+    None
+):
     frames = iter(
         (
             (
@@ -550,21 +718,34 @@ def test_playback_frame_budget_allows_noop_frames_when_requiring_synchronization
     )
     operation_classes = iter(("first_render", "noop"))
 
-    def render(_event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None) -> RenderDiagnostics:
+    def render(
+        _event: PlaybackEvent, _size: TerminalSize, _previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         return RenderDiagnostics(
             current_logical_lines=("frame",),
             operation_class=next(operation_classes),
             operations=next(frames),
         )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)))
-    result = PlaybackResult(steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("noop")]), port=harness.port)
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5))
+    )
+    result = PlaybackResult(
+        steps=harness.play([PlaybackEvent("render"), PlaybackEvent.input("noop")]),
+        port=harness.port,
+    )
 
-    PlaybackFrameBudget(require_synchronized=True).assert_result(result, skip_first=True)
+    PlaybackFrameBudget(require_synchronized=True).assert_result(
+        result, skip_first=True
+    )
 
 
-def test_playback_harness_failed_flush_does_not_advance_successful_diagnostics() -> None:
-    def render(event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None) -> RenderDiagnostics:
+def test_playback_harness_failed_flush_does_not_advance_successful_diagnostics() -> (
+    None
+):
+    def render(
+        event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         previous_lines = previous.current_logical_lines if previous is not None else ()
         return RenderDiagnostics(
             current_logical_lines=(str(event.payload),),
@@ -587,7 +768,9 @@ def test_playback_harness_failed_flush_does_not_advance_successful_diagnostics()
     assert harness.previous_successful_diagnostics.current_logical_lines == ("third",)
 
 
-def test_terminal_frame_records_serialized_synchronized_flush_and_screen_snapshots() -> None:
+def test_terminal_frame_records_serialized_synchronized_flush_and_screen_snapshots() -> (
+    None
+):
     port = FakeTerminalPort(size=TerminalSize(columns=8, rows=3))
 
     frame = port.flush(
@@ -610,7 +793,9 @@ def test_terminal_frame_records_serialized_synchronized_flush_and_screen_snapsho
     assert frame.screen_after.cursor_column == 3
 
 
-def test_terminal_frame_treats_pi_style_cursor_after_sync_as_synchronized_render() -> None:
+def test_terminal_frame_treats_pi_style_cursor_after_sync_as_synchronized_render() -> (
+    None
+):
     port = FakeTerminalPort(size=TerminalSize(columns=8, rows=3))
 
     frame = port.flush(
@@ -625,7 +810,9 @@ def test_terminal_frame_treats_pi_style_cursor_after_sync_as_synchronized_render
     )
 
     assert frame.synchronized is True
-    assert frame.serialized_output == "\x1b[?25l\x1b[?2026habc\x1b[?2026l\x1b[2G\x1b[?25h"
+    assert (
+        frame.serialized_output == "\x1b[?25l\x1b[?2026habc\x1b[?2026l\x1b[2G\x1b[?25h"
+    )
     assert frame.screen_after.visible_lines[0] == "abc"
     assert frame.screen_after.cursor_row == 0
     assert frame.screen_after.cursor_column == 1
@@ -685,7 +872,9 @@ def test_fake_screen_wraps_before_next_printable_after_full_width_write() -> Non
     assert port.screen.cursor_column == 1
 
 
-def test_fake_screen_tracks_sgr_cell_styles_and_resets_them_after_terminal_resets() -> None:
+def test_fake_screen_tracks_sgr_cell_styles_and_resets_them_after_terminal_resets() -> (
+    None
+):
     port = FakeTerminalPort(size=TerminalSize(columns=20, rows=3))
 
     port.flush([TerminalOperation.write("\x1b[3;90mthink\x1b[23;39m\ninput")])
@@ -696,26 +885,37 @@ def test_fake_screen_tracks_sgr_cell_styles_and_resets_them_after_terminal_reset
     assert port.screen.cell_style(row=1, column=0).foreground is None
 
 
-def test_fake_screen_proves_markdown_heading_underline_does_not_leak_into_following_cells() -> None:
+def test_fake_screen_proves_markdown_heading_underline_does_not_leak_into_following_cells() -> (
+    None
+):
     theme = ThemeResolver(defaults={"markdown.heading.level1": {"color": "cyan"}})
-    heading = MarkdownRenderer("# Important distinction from `open()`", theme=theme).render(
-        RenderConstraints(width=80, max_height=3)
-    ).lines[0].text
+    heading = (
+        MarkdownRenderer("# Important distinction from `open()`", theme=theme)
+        .render(RenderConstraints(width=80, max_height=3))
+        .lines[0]
+        .text
+    )
     port = FakeTerminalPort(size=TerminalSize(columns=80, rows=3))
 
     port.flush([TerminalOperation.write(heading), TerminalOperation.write(" plain")])
 
     plain_column = len("Important distinction from open() ")
-    assert port.screen.visible_lines[0].startswith("Important distinction from open() plain")
+    assert port.screen.visible_lines[0].startswith(
+        "Important distinction from open() plain"
+    )
     assert port.screen.cell_style(row=0, column=0).underline is True
     assert port.screen.cell_style(row=0, column=plain_column).underline is False
 
 
 def test_playback_step_asserts_operation_class_and_scrollback_policy() -> None:
-    def render(event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None) -> RenderDiagnostics:
+    def render(
+        event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         return RenderDiagnostics(
             current_logical_lines=("resized",),
-            previous_rendered_lines=previous.current_logical_lines if previous is not None else (),
+            previous_rendered_lines=previous.current_logical_lines
+            if previous is not None
+            else (),
             operation_class="resize_repaint",
             width_changed=True,
             height_changed=True,
@@ -729,7 +929,9 @@ def test_playback_step_asserts_operation_class_and_scrollback_policy() -> None:
             ),
         )
 
-    harness = PlaybackHarness(render=render, port=FakeTerminalPort(size=TerminalSize(columns=80, rows=24)))
+    harness = PlaybackHarness(
+        render=render, port=FakeTerminalPort(size=TerminalSize(columns=80, rows=24))
+    )
 
     step = harness.play([PlaybackEvent.resize(columns=100, rows=30)])[0]
 
@@ -742,7 +944,9 @@ def test_playback_step_asserts_operation_class_and_scrollback_policy() -> None:
 
 
 def test_playback_step_asserts_explicit_clear_scrollback() -> None:
-    def render(event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None) -> RenderDiagnostics:
+    def render(
+        event: PlaybackEvent, size: TerminalSize, previous: RenderDiagnostics | None
+    ) -> RenderDiagnostics:
         return RenderDiagnostics(
             current_logical_lines=("panic repaint",),
             operation_class="recovery_repaint",

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -30,6 +30,10 @@ def test_testing_strategy_documents_product_composed_playback() -> None:
         assert "product-composed-interaction" in text
         assert "loushang-product-playback" in text
 
+    assert "assert_last_cursor_on_visible_line" in playback
+    assert "logical_cursor" in playback
+    assert "screen_cursor" in playback
+
 
 def test_theme_key_design_lists_editor_selection_token() -> None:
     text = Path(


### PR DESCRIPTION
## Summary
- Add playback JSONL cursor diagnostics for logical cursor, viewport, hardware cursor, and fake-screen cursor positions.
- Add assert_last_cursor_on_visible_line(...) for long-transcript playback cases where logical rows differ from visible screen rows.
- Use the new assertion in product-composed-interaction and document the trace fields.

## Test Plan
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python -m ruff check src/loushang/tui/playback.py src/loushang/coding/ui/playback_scenarios/product.py tests/tui/test_playback_harness.py tests/tui/test_tui_testing_strategy_docs.py
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python -m pytest tests/tui/test_playback_harness.py tests/tui/test_tui_testing_strategy_docs.py tests/coding/test_native_tui_playback_runner.py tests/coding/test_native_tui_playback_harness.py tests/coding/test_native_coding_tui_playback.py -q
- PYTHONPATH=src /home/dev/workspace/loushang/.venv/bin/python -m loushang.coding.ui.playback_runner product-composed-interaction --json
- git diff --check