### PR TITLE
feat(tui): add copy transcript source foundation

### DIFF
--- a/src/loushang/coding/commands/types.py
+++ b/src/loushang/coding/commands/types.py
@@ -43,7 +43,7 @@ BUILTIN_SLASH_COMMANDS: tuple[BuiltinSlashCommand, ...] = (
     BuiltinSlashCommand(name="export", description="Export session (HTML default, or specify path: .html/.jsonl)"),
     BuiltinSlashCommand(name="import", description="Import and resume a session from a JSONL file"),
     BuiltinSlashCommand(name="share", description="Share session as a secret GitHub gist"),
-    BuiltinSlashCommand(name="copy", description="Copy last agent message to clipboard"),
+    BuiltinSlashCommand(name="copy", description="Copy an assistant message to clipboard"),
     BuiltinSlashCommand(name="name", description="Set session display name"),
     BuiltinSlashCommand(name="session", description="Show session info and stats"),
     BuiltinSlashCommand(name="terminal", description="Show terminal capabilities and protocol diagnostics"),

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -259,6 +259,7 @@ class AgentSession:
                 export_to_jsonl=self.export_to_jsonl,
                 compact=self.compact,
                 reload=self.reload_extension_runtime,
+                get_recent_assistant_texts=self.get_recent_assistant_texts,
                 get_last_assistant_text=self.get_last_assistant_text,
                 get_changelog=lambda args: read_changelog_for_cwd(self.session_manager.get_cwd(), args),
                 new_session=self._new_session_from_extension,
@@ -907,6 +908,9 @@ class AgentSession:
 
     def getLastAssistantText(self) -> str | None:
         return self.get_last_assistant_text()
+
+    def get_recent_assistant_texts(self) -> tuple[str, ...]:
+        return self._view_controller.get_recent_assistant_texts()
 
     # Public facade: bash execution.
 

--- a/src/loushang/coding/session/builtin_commands.py
+++ b/src/loushang/coding/session/builtin_commands.py
@@ -6,12 +6,18 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import asdict, dataclass, is_dataclass
 from pathlib import Path
 
-from loushang.coding.commands.types import BUILTIN_SLASH_COMMANDS, SessionCommandDescriptor
-from loushang.coding.platform.changelog import find_changelog_path, format_changelog_entries, parse_changelog
+from loushang.coding.commands.types import (
+    BUILTIN_SLASH_COMMANDS,
+    SessionCommandDescriptor,
+)
+from loushang.coding.platform.changelog import (
+    find_changelog_path,
+    format_changelog_entries,
+    parse_changelog,
+)
 from loushang.coding.platform.clipboard import ClipboardCopyResult, copy_to_clipboard
 from loushang.coding.session.types import CommandExecutionResult
 from loushang.coding.source_info import create_source_info
-
 
 BuiltinCallable = Callable[..., object | Awaitable[object]]
 
@@ -24,6 +30,7 @@ class BuiltinCommandBackend:
     export_to_jsonl: Callable[[str | None], str] | None = None
     compact: Callable[[str | None], object | Awaitable[object]] | None = None
     reload: Callable[[], object | Awaitable[object]] | None = None
+    get_recent_assistant_texts: Callable[[], tuple[str, ...]] | None = None
     get_last_assistant_text: Callable[[], str | None] | None = None
     copy_text: Callable[[str], ClipboardCopyResult] = copy_to_clipboard
     get_changelog: Callable[[str], object] | None = None
@@ -69,7 +76,7 @@ async def execute_builtin_command_async(
         case "export":
             return _execute_export(args, backend)
         case "copy":
-            return _execute_copy(backend)
+            return _execute_copy(args, backend)
         case "changelog":
             return _execute_changelog(args, backend)
         case "compact":
@@ -117,20 +124,65 @@ def _execute_export(args: str, backend: BuiltinCommandBackend) -> CommandExecuti
     return _ok("export", format=export_format, path=path)
 
 
-def _execute_copy(backend: BuiltinCommandBackend) -> CommandExecutionResult:
-    if backend.get_last_assistant_text is None:
-        return _unsupported("copy")
-    text = backend.get_last_assistant_text()
-    if not text:
-        return _ok("copy", copied=False, characters=0, message="No assistant text is available.")
+def _execute_copy(args: str, backend: BuiltinCommandBackend) -> CommandExecutionResult:
+    copy_index = _parse_copy_index(args)
+    if copy_index is None:
+        return _error("copy", "Usage: /copy [N], where N is a positive integer.")
+    texts = _recent_assistant_texts(backend)
+    if not texts:
+        if backend.get_recent_assistant_texts is None and backend.get_last_assistant_text is None:
+            return _unsupported("copy")
+        return _ok(
+            "copy",
+            copied=False,
+            characters=0,
+            message=f"No assistant text is available for /copy {copy_index}.",
+            index=copy_index,
+        )
+    text_index = copy_index - 1
+    if text_index >= len(texts):
+        return _ok(
+            "copy",
+            copied=False,
+            characters=0,
+            message=f"No assistant text is available for /copy {copy_index}.",
+            index=copy_index,
+        )
+    text = texts[text_index]
     result = backend.copy_text(text)
     return _ok(
         "copy",
         copied=result.ok,
         characters=len(text),
-        command=result.command,
+        command_backend=result.command,
         message=result.message,
+        index=copy_index,
     )
+
+
+def _parse_copy_index(args: str) -> int | None:
+    stripped = args.strip()
+    if not stripped:
+        return 1
+    tokens = _split_args(stripped)
+    if len(tokens) != 1:
+        return None
+    try:
+        value = int(tokens[0])
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _recent_assistant_texts(backend: BuiltinCommandBackend) -> tuple[str, ...]:
+    if backend.get_recent_assistant_texts is not None:
+        return tuple(backend.get_recent_assistant_texts())
+    if backend.get_last_assistant_text is None:
+        return ()
+    text = backend.get_last_assistant_text()
+    if not text:
+        return ()
+    return (text,)
 
 
 def _execute_changelog(args: str, backend: BuiltinCommandBackend) -> CommandExecutionResult:

--- a/src/loushang/coding/session/session_view_controller.py
+++ b/src/loushang/coding/session/session_view_controller.py
@@ -6,9 +6,19 @@ from dataclasses import dataclass
 from loushang.agent import Agent
 from loushang.ai.types import AssistantMessage, ToolCall, ToolResultMessage, UserMessage
 from loushang.coding.compaction import estimate_context_tokens
-from loushang.coding.message import CompactionEntry, CustomMessageEntry, SessionMessageEntry
+from loushang.coding.message import (
+    CompactionEntry,
+    CustomMessageEntry,
+    SessionMessageEntry,
+)
 from loushang.coding.session.context_usage import build_context_usage_snapshot
-from loushang.coding.session.types import AgentSessionState, ContextUsage, ModelSelection, RunState, SessionStats
+from loushang.coding.session.types import (
+    AgentSessionState,
+    ContextUsage,
+    ModelSelection,
+    RunState,
+    SessionStats,
+)
 from loushang.coding.session.usage_payload import serialize_context_usage_payload
 from loushang.coding.store import SessionManager
 
@@ -203,15 +213,18 @@ class SessionViewController:
         return None
 
     def get_last_assistant_text(self) -> str | None:
-        message = _last_assistant_message(self.agent.state.messages)
-        if message is None:
-            return None
-        content = getattr(message, "content", None)
-        if isinstance(content, str):
-            return content
-        if isinstance(content, list):
-            return "".join(block.text for block in content if getattr(block, "type", None) == "text")
-        return None
+        texts = self.get_recent_assistant_texts()
+        return texts[0] if texts else None
+
+    def get_recent_assistant_texts(self) -> tuple[str, ...]:
+        texts: list[str] = []
+        for message in reversed(self.agent.state.messages):
+            if not isinstance(message, AssistantMessage):
+                continue
+            text = _extract_assistant_message_text(message)
+            if text is not None:
+                texts.append(text)
+        return tuple(texts)
 
 
 def _count_leaf_branches(nodes: list[object]) -> int:
@@ -227,10 +240,13 @@ def _count_leaf_branches(nodes: list[object]) -> int:
     return sum(_count(node) for node in nodes)
 
 
-def _last_assistant_message(messages: list[object]) -> AssistantMessage | None:
-    for message in reversed(messages):
-        if isinstance(message, AssistantMessage):
-            return message
+def _extract_assistant_message_text(message: AssistantMessage) -> str | None:
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return content if content.strip() else None
+    if isinstance(content, list):
+        text = "".join(block.text for block in content if getattr(block, "type", None) == "text")
+        return text if text.strip() else None
     return None
 
 

--- a/src/loushang/coding/ui/transcript_source.py
+++ b/src/loushang/coding/ui/transcript_source.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from loushang.coding.ui.native_state import NativeCodingTuiState
+from loushang.tui.transcript import AssistantMessageRecord, DisplayRecord
+
+
+@dataclass(frozen=True, slots=True)
+class TranscriptSnapshot:
+    records: tuple[DisplayRecord, ...]
+    evicted_prefix_record_count: int = 0
+    complete: bool = False
+    source_label: str = "Transcript window"
+
+
+class TranscriptSource(Protocol):
+    def snapshot(self) -> TranscriptSnapshot: ...
+
+    def recent_assistant_texts(self) -> tuple[str, ...]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ActiveWindowTranscriptSource:
+    state: NativeCodingTuiState
+
+    def snapshot(self) -> TranscriptSnapshot:
+        return TranscriptSnapshot(
+            records=tuple(self.state.records),
+            evicted_prefix_record_count=max(0, self.state.evicted_prefix_record_count),
+            complete=False,
+            source_label="Transcript window",
+        )
+
+    def recent_assistant_texts(self) -> tuple[str, ...]:
+        texts: list[str] = []
+        for record in reversed(self.state.records):
+            if not isinstance(record, AssistantMessageRecord):
+                continue
+            if record.text.strip():
+                texts.append(record.text)
+        return tuple(texts)
+
+
+__all__ = ["ActiveWindowTranscriptSource", "TranscriptSnapshot", "TranscriptSource"]

--- a/tests/coding/test_agent_session.py
+++ b/tests/coding/test_agent_session.py
@@ -1936,6 +1936,24 @@ def test_agent_session_exposes_pi_style_last_assistant_text_alias(tmp_path) -> N
     assert session.getLastAssistantText() == "answer"
 
 
+def test_agent_session_exposes_recent_assistant_texts_newest_first(tmp_path) -> None:
+    from loushang.agent import Agent
+    from loushang.coding.session import AgentSession
+    from loushang.coding.store import SessionManager
+
+    session = AgentSession(agent=Agent(), session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False))
+    session.agent.state.set_messages(
+        [
+            _assistant_text_message("first"),
+            _assistant_text_message(""),
+            _user_message("hello"),
+            _assistant_text_message("second"),
+        ]
+    )
+
+    assert session.get_recent_assistant_texts() == ("second", "first")
+
+
 def test_agent_session_exposes_pi_style_state_property_aliases(tmp_path) -> None:
     from loushang.agent import Agent
     from loushang.coding.session import AgentSession

--- a/tests/coding/test_commands.py
+++ b/tests/coding/test_commands.py
@@ -34,7 +34,7 @@ def test_builtin_slash_commands_match_pi_style_core_surface() -> None:
         "export": "Export session (HTML default, or specify path: .html/.jsonl)",
         "import": "Import and resume a session from a JSONL file",
         "share": "Share session as a secret GitHub gist",
-        "copy": "Copy last agent message to clipboard",
+        "copy": "Copy an assistant message to clipboard",
         "name": "Set session display name",
         "session": "Show session info and stats",
         "terminal": "Show terminal capabilities and protocol diagnostics",

--- a/tests/coding/test_session_command_controller.py
+++ b/tests/coding/test_session_command_controller.py
@@ -16,6 +16,7 @@ from loushang.coding.loader import (
     ResourceBundle,
     SkillDescriptor,
 )
+from loushang.coding.platform.clipboard import ClipboardCopyResult
 from loushang.coding.session.builtin_commands import BuiltinCommandBackend
 from loushang.coding.session.command_controller import CommandController
 from loushang.coding.store import SessionManager
@@ -219,6 +220,115 @@ def test_command_controller_executes_builtin_name_session_and_unsupported_comman
         "command": "model",
         "status": "unsupported",
         "message": 'Builtin command "/model" is handled by the interactive shell.',
+    }
+
+
+def test_command_controller_executes_builtin_copy_by_recent_index(tmp_path) -> None:
+    copied: list[str] = []
+
+    def _copy_text(text: str) -> ClipboardCopyResult:
+        copied.append(text)
+        return ClipboardCopyResult(ok=True, command="fake-copy", message="copied")
+
+    controller = CommandController(
+        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(
+            get_recent_assistant_texts=lambda: ("latest answer", "previous answer"),
+            copy_text=_copy_text,
+        ),
+    )
+
+    latest_result = asyncio.run(controller.execute_command_async("/copy", ""))
+    previous_result = asyncio.run(controller.execute_command_async("/copy", "2"))
+
+    assert copied == ["latest answer", "previous answer"]
+    assert latest_result is not None
+    assert latest_result.result == {
+        "source": "builtin",
+        "command": "copy",
+        "status": "ok",
+        "copied": True,
+        "characters": len("latest answer"),
+        "command_backend": "fake-copy",
+        "message": "copied",
+        "index": 1,
+    }
+    assert previous_result is not None
+    assert previous_result.result == {
+        "source": "builtin",
+        "command": "copy",
+        "status": "ok",
+        "copied": True,
+        "characters": len("previous answer"),
+        "command_backend": "fake-copy",
+        "message": "copied",
+        "index": 2,
+    }
+
+
+def test_command_controller_rejects_invalid_builtin_copy_index(tmp_path) -> None:
+    controller = CommandController(
+        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(get_recent_assistant_texts=lambda: ("latest answer",)),
+    )
+
+    zero_result = asyncio.run(controller.execute_command_async("/copy", "0"))
+    bad_result = asyncio.run(controller.execute_command_async("/copy", "latest"))
+    missing_result = asyncio.run(controller.execute_command_async("/copy", "2"))
+
+    assert zero_result is not None
+    assert zero_result.result == {
+        "source": "builtin",
+        "command": "copy",
+        "status": "error",
+        "message": "Usage: /copy [N], where N is a positive integer.",
+    }
+    assert bad_result is not None
+    assert bad_result.result == zero_result.result
+    assert missing_result is not None
+    assert missing_result.result == {
+        "source": "builtin",
+        "command": "copy",
+        "status": "ok",
+        "copied": False,
+        "characters": 0,
+        "message": "No assistant text is available for /copy 2.",
+        "index": 2,
+    }
+
+
+def test_command_controller_keeps_legacy_builtin_copy_backend(tmp_path) -> None:
+    copied: list[str] = []
+    controller = CommandController(
+        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(
+            get_last_assistant_text=lambda: "legacy latest",
+            copy_text=lambda text: (copied.append(text) or ClipboardCopyResult(ok=True, command="fake-copy")),
+        ),
+    )
+
+    result = asyncio.run(controller.execute_command_async("/copy", ""))
+
+    assert copied == ["legacy latest"]
+    assert result is not None
+    assert result.result == {
+        "source": "builtin",
+        "command": "copy",
+        "status": "ok",
+        "copied": True,
+        "characters": len("legacy latest"),
+        "command_backend": "fake-copy",
+        "message": None,
+        "index": 1,
     }
 
 

--- a/tests/coding/test_session_view_controller.py
+++ b/tests/coding/test_session_view_controller.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from loushang.agent import Agent
 from loushang.ai.model import Capabilities, Model
-from loushang.ai.types import AssistantMessage, TextPart, ToolCall, ToolResultMessage, Usage, UserMessage
+from loushang.ai.types import (
+    AssistantMessage,
+    TextPart,
+    ToolCall,
+    ToolResultMessage,
+    Usage,
+    UserMessage,
+)
 from loushang.coding.message import BashExecutionMessage
 from loushang.coding.session.types import ModelSelection, RunState
 from loushang.coding.store import SessionManager
@@ -51,6 +58,21 @@ def _assistant_message(text: str = "answer", *, total_tokens: int = 17, stop_rea
         response_id=None,
         usage=_usage(total_tokens),
         stop_reason=stop_reason,
+        error_message=None,
+        timestamp=1.0,
+    )
+
+
+def _tool_only_assistant_message() -> AssistantMessage:
+    return AssistantMessage(
+        role="assistant",
+        content=[ToolCall(type="toolCall", id="tool-1", name="read", arguments={"path": "README.md"})],
+        api="anthropic-messages",
+        provider="faux",
+        model="faux-model",
+        response_id=None,
+        usage=_usage(),
+        stop_reason="toolUse",
         error_message=None,
         timestamp=1.0,
     )
@@ -265,6 +287,30 @@ def test_session_view_controller_reads_forking_entries_and_last_assistant_text(t
     ]
     assert controller.get_entry_text(second_id) == "second"
     assert controller.get_last_assistant_text() == "assistant"
+
+
+def test_session_view_controller_returns_recent_assistant_texts_newest_first(tmp_path) -> None:
+    from loushang.coding.session.session_view_controller import SessionViewController
+
+    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager.append_message(_assistant_message("first"))
+    manager.append_message(_assistant_message(""))
+    manager.append_message(_tool_only_assistant_message())
+    manager.append_message(_assistant_message("second"))
+    agent = Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"})
+    agent.state.set_messages(manager.build_session_context().messages)
+    controller = SessionViewController(
+        agent=agent,
+        session_manager=manager,
+        get_active_tool_names=lambda: [],
+        is_retrying=lambda: False,
+        is_compacting=lambda: False,
+        get_last_diagnostics=lambda limit=50: [],
+        get_model_selection=lambda: None,
+    )
+
+    assert controller.get_recent_assistant_texts() == ("second", "first")
+    assert controller.get_last_assistant_text() == "second"
 
 
 def test_session_view_controller_builds_state_snapshot(tmp_path) -> None:

--- a/tests/coding/test_ui_transcript_source.py
+++ b/tests/coding/test_ui_transcript_source.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from loushang.coding.ui.native_state import NativeCodingTuiState
+from loushang.coding.ui.transcript_source import ActiveWindowTranscriptSource
+from loushang.tui.transcript import (
+    AssistantMessageRecord,
+    ToolExecutionRecord,
+    UserPromptRecord,
+)
+
+
+def test_active_window_transcript_source_returns_snapshot_metadata() -> None:
+    state = NativeCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
+    state.replace_transcript_window(
+        (
+            UserPromptRecord("hello"),
+            AssistantMessageRecord("answer"),
+        ),
+        evicted_prefix_record_count=3,
+    )
+
+    snapshot = ActiveWindowTranscriptSource(state).snapshot()
+
+    assert snapshot.records == tuple(state.records)
+    assert snapshot.evicted_prefix_record_count == 3
+    assert snapshot.complete is False
+    assert snapshot.source_label == "Transcript window"
+
+
+def test_active_window_transcript_source_recent_assistant_texts_are_filtered_newest_first() -> None:
+    state = NativeCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
+    state.records.extend(
+        [
+            AssistantMessageRecord("first"),
+            AssistantMessageRecord(""),
+            ToolExecutionRecord(name="read", state="completed", elapsed_seconds=0.1),
+            AssistantMessageRecord("second"),
+        ]
+    )
+
+    assert ActiveWindowTranscriptSource(state).recent_assistant_texts() == ("second", "first")


### PR DESCRIPTION
## Summary
- Add /copy [N] support with positive-index validation and newest-first assistant response selection.
- Preserve legacy get_last_assistant_text compatibility while adding get_recent_assistant_texts.
- Add ActiveWindowTranscriptSource and TranscriptSnapshot foundation for the transcript reader.
- Keep /copy independent of screen rendering and source filtering centralized.

## Tests
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_session_command_controller.py tests/coding/test_session_view_controller.py tests/coding/test_ui_transcript_source.py tests/coding/test_commands.py tests/coding/test_agent_session.py -q
- uv --cache-dir .uv-cache run ruff check src/loushang/coding/session/builtin_commands.py src/loushang/coding/session/session_view_controller.py src/loushang/coding/session/agent_session.py src/loushang/coding/commands/types.py src/loushang/coding/ui/transcript_source.py tests/coding/test_session_command_controller.py tests/coding/test_session_view_controller.py tests/coding/test_ui_transcript_source.py tests/coding/test_commands.py
- uv --cache-dir .uv-cache run ruff check --ignore I001 tests/coding/test_agent_session.py

Closes #89
Refs #88