### PR TITLE
feat(tui): add transcript reader surface

### DIFF
--- a/src/loushang/coding/ui/transcript_reader.py
+++ b/src/loushang/coding/ui/transcript_reader.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loushang.coding.ui.transcript_source import TranscriptSnapshot, TranscriptSource
+from loushang.tui.cell_width import truncate_to_width
+from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.input import InputEvent, InputIntent
+from loushang.tui.transcript import render_transcript_records
+
+_MAX_TRANSCRIPT_RENDER_HEIGHT = 1_000_000
+_FOOTER = "Ctrl+O/q/Esc close | PgUp/PgDn scroll | d detail | r raw"
+_CONSUMED = InputIntent(kind="consumed", note="transcript_reader")
+
+
+@dataclass(slots=True)
+class TranscriptReaderSurface:
+    source: TranscriptSource
+    focused: bool = False
+    raw_mode: bool = False
+    detail_mode: bool = False
+    _snapshot: TranscriptSnapshot = field(init=False, repr=False)
+    _scroll_offset: int = field(default=0, init=False, repr=False)
+    _max_scroll_offset: int = field(default=0, init=False, repr=False)
+    _last_body_height: int = field(default=1, init=False, repr=False)
+    _follow_tail: bool = field(default=True, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._snapshot = self.source.snapshot()
+
+    @property
+    def scroll_offset(self) -> int:
+        return self._scroll_offset
+
+    @property
+    def max_scroll_offset(self) -> int:
+        return self._max_scroll_offset
+
+    def focus(self) -> None:
+        self.focused = True
+
+    def blur(self) -> None:
+        self.focused = False
+
+    def handle_input(self, event: InputEvent) -> InputIntent:
+        if event.kind != "key":
+            return _CONSUMED
+        key = event.key
+        if key in {"q", "esc", "escape", "ctrl+c", "ctrl_c", "ctrl+o", "ctrl_o"}:
+            return InputIntent(kind="surface_close")
+        if key == "up":
+            self._scroll_by(-1)
+            return _CONSUMED
+        if key == "down":
+            self._scroll_by(1)
+            return _CONSUMED
+        if key == "pageUp":
+            self._scroll_by(-self._last_body_height)
+            return _CONSUMED
+        if key == "pageDown":
+            self._scroll_by(self._last_body_height)
+            return _CONSUMED
+        if key == "home":
+            self._scroll_to_start()
+            return _CONSUMED
+        if key == "end":
+            self._scroll_to_tail()
+            return _CONSUMED
+        if key == "d":
+            self.detail_mode = not self.detail_mode
+            return _CONSUMED
+        if key == "r":
+            self.raw_mode = not self.raw_mode
+            return _CONSUMED
+        return _CONSUMED
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        chrome = self._chrome_lines(constraints.width, constraints.max_height)
+        body_height = max(0, constraints.max_height - len(chrome))
+        self._last_body_height = max(1, body_height)
+        body = self._body_lines(width=constraints.width)
+        self._max_scroll_offset = max(0, len(body) - body_height)
+        if self._follow_tail:
+            self._scroll_offset = self._max_scroll_offset
+        else:
+            self._scroll_offset = _clamp(self._scroll_offset, 0, self._max_scroll_offset)
+
+        visible_body = body[self._scroll_offset : self._scroll_offset + body_height] if body_height else ()
+        lines = [*chrome[:-1], *visible_body, *chrome[-1:]]
+        if len(lines) < constraints.max_height and not visible_body:
+            insert_at = max(0, len(lines) - 1)
+            lines.insert(insert_at, RenderLine(truncate_to_width("No transcript records.", max_width=constraints.width)))
+        return RenderResult.from_lines(lines[: constraints.max_height], constraints=constraints)
+
+    def _chrome_lines(self, width: int, max_height: int) -> tuple[RenderLine, ...]:
+        lines = [RenderLine(truncate_to_width(self._snapshot.source_label, max_width=width))]
+        if self._snapshot.evicted_prefix_record_count > 0 and len(lines) < max_height - 1:
+            lines.append(RenderLine(truncate_to_width("Earlier transcript records were trimmed.", max_width=width)))
+        if len(lines) < max_height:
+            lines.append(RenderLine(truncate_to_width(_FOOTER, max_width=width)))
+        return tuple(lines[:max_height])
+
+    def _body_lines(self, *, width: int) -> tuple[RenderLine, ...]:
+        return render_transcript_records(
+            self._snapshot.records,
+            width=width,
+            max_height=_MAX_TRANSCRIPT_RENDER_HEIGHT,
+        )
+
+    def _scroll_by(self, delta: int) -> None:
+        self._follow_tail = False
+        self._scroll_offset = _clamp(self._scroll_offset + delta, 0, self._max_scroll_offset)
+        if self._scroll_offset >= self._max_scroll_offset and delta > 0:
+            self._follow_tail = True
+
+    def _scroll_to_start(self) -> None:
+        self._follow_tail = False
+        self._scroll_offset = 0
+
+    def _scroll_to_tail(self) -> None:
+        self._follow_tail = True
+        self._scroll_offset = self._max_scroll_offset
+
+
+def _clamp(value: int, minimum: int, maximum: int) -> int:
+    return max(minimum, min(value, maximum))
+
+
+__all__ = ["TranscriptReaderSurface"]

--- a/src/loushang/tui/__init__.py
+++ b/src/loushang/tui/__init__.py
@@ -227,6 +227,7 @@ from loushang.tui.transcript import (
     TranscriptView,
     UserPromptRecord,
     WorkedDividerRecord,
+    render_transcript_records,
 )
 from loushang.tui.tui import InputListener, Tui
 from loushang.tui.ui_parts import (
@@ -444,6 +445,7 @@ __all__ = [
     "set_ambiguous_width",
     "read_input_chunk",
     "read_input_chunk_or_render_tick",
+    "render_transcript_records",
     "render_terminal_image",
     "render_terminal_image_result",
     "slice_by_column",

--- a/src/loushang/tui/input.py
+++ b/src/loushang/tui/input.py
@@ -25,6 +25,7 @@ InputIntentKind = Literal[
     "reject",
     "dialog_confirm",
     "dialog_cancel",
+    "consumed",
 ]
 SubmitMode = Literal["submit", "follow_up", "steer"]
 KeyEventType = Literal["press", "repeat", "release"]

--- a/src/loushang/tui/transcript.py
+++ b/src/loushang/tui/transcript.py
@@ -272,6 +272,31 @@ class TranscriptView:
         return rendered
 
 
+def render_transcript_records(
+    records: tuple[DisplayRecord, ...] | list[DisplayRecord],
+    *,
+    width: int,
+    max_height: int,
+    draft: AssistantMessageRecord | None = None,
+    verbose_errors: bool = False,
+    theme: ThemeResolver | None = None,
+    capabilities: TerminalCapabilities | None = None,
+    code_highlighter: CodeHighlighterLike | None = None,
+    markdown_cache: MarkdownRenderCache | None = None,
+) -> tuple[RenderLine, ...]:
+    view = TranscriptView(
+        records,
+        draft=draft,
+        verbose_errors=verbose_errors,
+        theme=theme,
+        capabilities=capabilities,
+        code_highlighter=code_highlighter,
+        markdown_cache=markdown_cache,
+    )
+    rendered = view.render(RenderConstraints(width=width, max_height=max_height))
+    return rendered.lines
+
+
 def _record_is_transient(record: DisplayRecord) -> bool:
     return isinstance(record, AssistantMessageRecord) and not record.stable
 

--- a/tests/coding/test_native_tui_transcript_reader.py
+++ b/tests/coding/test_native_tui_transcript_reader.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.coding.ui.transcript_reader import TranscriptReaderSurface
+from loushang.coding.ui.transcript_source import TranscriptSnapshot
+from loushang.tui import RenderConstraints, strip_control_sequences
+from loushang.tui.input import InputEvent, InputIntent
+from loushang.tui.transcript import (
+    AssistantMessageRecord,
+    DisplayRecord,
+    UserPromptRecord,
+)
+
+
+@dataclass(slots=True)
+class _Source:
+    records: tuple[DisplayRecord, ...]
+    evicted_prefix_record_count: int = 0
+    snapshot_calls: int = 0
+
+    def snapshot(self) -> TranscriptSnapshot:
+        self.snapshot_calls += 1
+        return TranscriptSnapshot(
+            records=self.records,
+            evicted_prefix_record_count=self.evicted_prefix_record_count,
+            complete=False,
+            source_label="Transcript window",
+        )
+
+    def recent_assistant_texts(self) -> tuple[str, ...]:
+        return tuple(record.text for record in reversed(self.records) if isinstance(record, AssistantMessageRecord) and record.text)
+
+
+def _render_text(reader: TranscriptReaderSurface, *, width: int = 48, height: int = 6) -> tuple[str, ...]:
+    result = reader.render(RenderConstraints(width=width, max_height=height))
+    return tuple(strip_control_sequences(line.text) for line in result.lines)
+
+
+def test_transcript_reader_renders_frozen_snapshot_and_footer() -> None:
+    source = _Source((UserPromptRecord("hello"), AssistantMessageRecord("first")), evicted_prefix_record_count=2)
+    reader = TranscriptReaderSurface(source)
+
+    first = _render_text(reader, width=80, height=7)
+    source.records = (AssistantMessageRecord("second"),)
+    second = _render_text(reader, width=80, height=7)
+
+    assert source.snapshot_calls == 1
+    assert first == second
+    assert first[0] == "Transcript window"
+    assert "Earlier transcript records were trimmed." in first
+    assert first[-1] == "Ctrl+O/q/Esc close | PgUp/PgDn scroll | d detail | r raw"
+    assert any("first" in line for line in first)
+    assert all("second" not in line for line in first)
+
+
+def test_transcript_reader_opens_at_tail_and_scrolls_by_page() -> None:
+    source = _Source((AssistantMessageRecord("\n".join(f"line {index}" for index in range(8))),))
+    reader = TranscriptReaderSurface(source)
+
+    tail = _render_text(reader, height=5)
+    assert any("line 7" in line for line in tail)
+    assert all("line 0" not in line for line in tail)
+
+    assert reader.handle_input(InputEvent(kind="key", key="pageUp")) == InputIntent(kind="consumed", note="transcript_reader")
+    older = _render_text(reader, height=5)
+    assert any("line 4" in line for line in older)
+    assert reader.scroll_offset < reader.max_scroll_offset
+
+    assert reader.handle_input(InputEvent(kind="key", key="end")) == InputIntent(kind="consumed", note="transcript_reader")
+    assert any("line 7" in line for line in _render_text(reader, height=5))
+
+
+def test_transcript_reader_clamps_scroll_offset_after_resize() -> None:
+    source = _Source((AssistantMessageRecord("\n".join(f"line {index}" for index in range(6))),))
+    reader = TranscriptReaderSurface(source)
+
+    reader.handle_input(InputEvent(kind="key", key="home"))
+    _render_text(reader, height=5)
+    assert reader.scroll_offset == 0
+
+    reader.handle_input(InputEvent(kind="key", key="end"))
+    _render_text(reader, height=5)
+    assert reader.scroll_offset == reader.max_scroll_offset
+
+    _render_text(reader, height=12)
+    assert reader.scroll_offset == 0
+    assert reader.max_scroll_offset == 0
+
+
+def test_transcript_reader_close_keys_return_surface_close() -> None:
+    reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("answer"),)))
+
+    for key in ("q", "esc", "escape", "ctrl+c", "ctrl_c", "ctrl+o", "ctrl_o"):
+        assert reader.handle_input(InputEvent(kind="key", key=key)) == InputIntent(kind="surface_close")
+
+
+def test_transcript_reader_strictly_consumes_unrecognized_input() -> None:
+    reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("answer"),)))
+
+    assert reader.handle_input(InputEvent(kind="key", key="tab")) == InputIntent(kind="consumed", note="transcript_reader")
+    assert reader.handle_input(InputEvent(kind="text", text="x")) == InputIntent(kind="consumed", note="transcript_reader")
+
+
+def test_transcript_reader_detail_and_raw_toggles_are_stable() -> None:
+    reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("answer"),)))
+
+    assert reader.handle_input(InputEvent(kind="key", key="d")) == InputIntent(kind="consumed", note="transcript_reader")
+    assert reader.detail_mode is True
+    assert reader.handle_input(InputEvent(kind="key", key="d")) == InputIntent(kind="consumed", note="transcript_reader")
+    assert reader.detail_mode is False
+
+    assert reader.handle_input(InputEvent(kind="key", key="r")) == InputIntent(kind="consumed", note="transcript_reader")
+    assert reader.raw_mode is True
+    assert reader.handle_input(InputEvent(kind="key", key="r")) == InputIntent(kind="consumed", note="transcript_reader")
+    assert reader.raw_mode is False

--- a/tests/tui/test_transcript_records.py
+++ b/tests/tui/test_transcript_records.py
@@ -15,6 +15,7 @@ from loushang.tui import (
     TranscriptView,
     UserPromptRecord,
     WorkedDividerRecord,
+    render_transcript_records,
     strip_control_sequences,
 )
 
@@ -162,6 +163,17 @@ def test_transcript_view_reuses_stable_record_lines_while_draft_changes(monkeypa
         (AssistantMessageRecord("chunk 1", stable=False), 40, False),
         (AssistantMessageRecord("chunk 1 chunk 2", stable=False), 40, False),
     ]
+
+
+def test_render_transcript_records_matches_transcript_view_output() -> None:
+    records = (
+        UserPromptRecord("hello"),
+        AssistantMessageRecord("world"),
+    )
+
+    lines = render_transcript_records(records, width=40, max_height=20)
+
+    assert tuple(line.text for line in lines) == rendered_text(TranscriptView(records), width=40, height=20)
 
 
 def test_transcript_view_can_render_assistant_markdown_with_content_theme() -> None:


### PR DESCRIPTION
## Summary
- Add render_transcript_records as a reusable transcript render-to-lines boundary.
- Add TranscriptReaderSurface with frozen snapshots, tail-first rendering, scroll/page navigation, close keys, and strict input consumption.
- Add a consumed input intent for modal surfaces that swallow keys without business action.

## Tests
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_transcript_records.py tests/coding/test_native_tui_transcript_reader.py tests/coding/test_ui_transcript_source.py tests/tui/test_import_boundaries.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui tests/coding/test_native_tui_transcript_reader.py tests/coding/test_ui_transcript_source.py -q
- uv --cache-dir .uv-cache run ruff check src/loushang/tui/transcript.py src/loushang/tui/__init__.py src/loushang/tui/input.py src/loushang/coding/ui/transcript_reader.py tests/tui/test_transcript_records.py tests/coding/test_native_tui_transcript_reader.py

Closes #90
Refs #88