### PR TITLE
Add coding diagnostics identity signals

### DIFF
--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -9,25 +9,40 @@ from loushang.agent import Agent, AgentTool, StreamFn, ThinkingLevel
 from loushang.ai.model import Model
 from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
 from loushang.ai.types import Message, TextPart
-from loushang.coding.control import AuthManager, ControlConfig, ModelRegistry, SettingsManager
-from loushang.coding.control.settings_store import default_global_settings_path, default_project_settings_path
-from loushang.coding.diagnostics import DiagnosticRecord, DiagnosticsService, StartupCheckResult
+from loushang.coding.control import (
+    AuthManager,
+    ControlConfig,
+    ModelRegistry,
+    SettingsManager,
+)
+from loushang.coding.control.settings_store import (
+    default_global_settings_path,
+    default_project_settings_path,
+)
+from loushang.coding.diagnostics import (
+    DiagnosticRecord,
+    DiagnosticsService,
+    StartupCheckResult,
+)
 from loushang.coding.exec import ExecService
 from loushang.coding.extensions import ExtensionRunner
 from loushang.coding.extensions.types import SessionStartEvent
 from loushang.coding.loader import DefaultResourceLoader
 from loushang.coding.loader.types import ResourceBundle, ResourceDiagnostic
 from loushang.coding.message import convert_to_llm
-from loushang.coding.prompt import assemble_prompt
 from loushang.coding.package import GitPackageMaterializerBackend, PackageMaterializer
 from loushang.coding.package.resource_roots import resolve_package_resource_roots
-from loushang.coding.package.source_manager import PackageSourceResolver, package_source_scopes
+from loushang.coding.package.source_manager import (
+    PackageSourceResolver,
+    package_source_scopes,
+)
+from loushang.coding.prompt import assemble_prompt
 from loushang.coding.runtime import AgentSessionRuntime
 from loushang.coding.session import AgentSession
+from loushang.coding.source_info import executable_source_identity
 from loushang.coding.store import SessionManager
 from loushang.coding.tools import ToolRegistry
 from loushang.coding.types import ModelSelection
-
 
 AgentFactory = Callable[..., Agent]
 ServicesFactory = Callable[[str], "BootstrapServices"]
@@ -916,9 +931,21 @@ def _run_bootstrap_startup_checks(
             details={"cwd": str(cwd_path)},
         )
 
+    def executable_source_identity_check() -> StartupCheckResult:
+        return StartupCheckResult(
+            name="executable_source_identity",
+            ok=True,
+            code="executable_source_identity",
+            level="info",
+            message="Executable and import source identity captured.",
+            source_path=Path(__file__).resolve(strict=False),
+            details=executable_source_identity(cwd=cwd),
+        )
+
     checks = [cwd_check]
     for root in package_roots:
         checks.append(_package_root_check(root))
+    checks.append(executable_source_identity_check)
 
     diagnostics_service.run_startup_checks(
         checks,

--- a/src/loushang/coding/session/session_diagnostics_bridge.py
+++ b/src/loushang/coding/session/session_diagnostics_bridge.py
@@ -8,14 +8,13 @@ from loushang.coding.diagnostics import (
     DiagnosticLevel,
     DiagnosticPhase,
     DiagnosticRecord,
-    DiagnosticSummary,
     DiagnosticsQuery,
     DiagnosticsService,
+    DiagnosticSummary,
     ErrorReport,
 )
 from loushang.coding.loader import ResourceDiagnostic
 from loushang.coding.store import SessionManager
-
 
 _EXTENSION_ERROR_DIAGNOSTIC_CODES: frozenset[str] = frozenset(
     {
@@ -148,9 +147,11 @@ class SessionDiagnosticsBridge:
         if not isinstance(tool_call_id, str) or not isinstance(tool_name, str):
             return
         result = event.get("result")
+        message = _tool_result_error_message(result)
+        result_details = _tool_result_details(result)
         self.diagnostics_service.capture_failure(
             code="tool_execution_failed",
-            error=_tool_result_error_message(result),
+            error=message,
             phase="runtime",
             source="tool",
             session_id=self.session_manager.get_header().id,
@@ -159,9 +160,24 @@ class SessionDiagnosticsBridge:
                 "tool_call_id": tool_call_id,
                 "tool_name": tool_name,
                 "is_error": True,
-                "result_details": _tool_result_details(result),
+                "result_details": result_details,
             },
         )
+        if _is_policy_result_details(result_details):
+            self.diagnostics_service.capture_failure(
+                code=_policy_result_code(result_details),
+                error=message,
+                phase="runtime",
+                source="policy",
+                level="warning",
+                session_id=self.session_manager.get_header().id,
+                entry_id=self.session_manager.get_leaf_id(),
+                details=_policy_diagnostic_details(
+                    tool_call_id=tool_call_id,
+                    tool_name=tool_name,
+                    result_details=result_details,
+                ),
+            )
 
 
 def _extension_diagnostic_level(code: str) -> DiagnosticLevel:
@@ -191,3 +207,28 @@ def _tool_result_error_message(result: object) -> str:
 
 def _tool_result_details(result: object) -> object:
     return getattr(result, "details", None)
+
+
+def _is_policy_result_details(details: object) -> bool:
+    return isinstance(details, Mapping) and isinstance(details.get("policy_disposition"), str)
+
+
+def _policy_result_code(details: Mapping[str, object]) -> str:
+    code = details.get("policy_code")
+    return code if isinstance(code, str) and code else "tool_policy_denied"
+
+
+def _policy_diagnostic_details(
+    *,
+    tool_call_id: str,
+    tool_name: str,
+    result_details: Mapping[str, object],
+) -> dict[str, object]:
+    details = {
+        key: value
+        for key, value in result_details.items()
+        if isinstance(value, str | bool | int | float | list | tuple | dict) or value is None
+    }
+    details["tool_call_id"] = tool_call_id
+    details["tool_name"] = tool_name
+    return details

--- a/src/loushang/coding/source_info.py
+++ b/src/loushang/coding/source_info.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
+import sys
 from dataclasses import dataclass
+from importlib.metadata import PackageNotFoundError, distribution
+from importlib.metadata import version as package_version
 from pathlib import Path
 from typing import Literal, Protocol
 
@@ -52,6 +56,29 @@ def source_info_from_resource_descriptor(descriptor: SourceDescriptor) -> Source
     )
 
 
+def executable_source_identity(
+    *,
+    cwd: str | Path | None = None,
+    argv0: str | None = None,
+) -> dict[str, object]:
+    import loushang
+    import loushang.coding as loushang_coding
+
+    loushang_module_file = _module_file(loushang)
+    coding_module_file = _module_file(loushang_coding)
+    return {
+        "python_executable": sys.executable,
+        "python_version": sys.version.split()[0],
+        "argv0": argv0 if argv0 is not None else _argv0(),
+        "cwd": _path_text(Path.cwd() if cwd is None else Path(cwd).expanduser().resolve(strict=False)),
+        "package_name": "loushang",
+        "package_version": _package_version("loushang"),
+        "loushang_module_file": loushang_module_file,
+        "coding_module_file": coding_module_file,
+        "import_source": _import_source("loushang", loushang_module_file),
+    }
+
+
 def _scope_from_descriptor(*, source_scope: object, source_kind: object) -> SourceScope:
     if source_scope == "user":
         return "user"
@@ -72,3 +99,59 @@ def _path_text(path: str | Path | object) -> str:
     if isinstance(path, str):
         return path
     return str(path)
+
+
+def _argv0() -> str:
+    return sys.argv[0] if sys.argv else ""
+
+
+def _module_file(module: object) -> str:
+    module_file = getattr(module, "__file__", None)
+    if not module_file:
+        return ""
+    return Path(str(module_file)).expanduser().resolve(strict=False).as_posix()
+
+
+def _package_version(package_name: str) -> str:
+    try:
+        return package_version(package_name)
+    except PackageNotFoundError:
+        return "0.1.0"
+
+
+def _import_source(package_name: str, module_file: str) -> str:
+    if _distribution_is_editable(package_name):
+        return "editable"
+    if _module_file_is_source_tree(module_file):
+        return "source-tree"
+    if _module_file_is_installed(module_file):
+        return "installed"
+    return "unknown"
+
+
+def _distribution_is_editable(package_name: str) -> bool:
+    try:
+        direct_url = distribution(package_name).read_text("direct_url.json")
+    except PackageNotFoundError:
+        return False
+    if not direct_url:
+        return False
+    try:
+        payload = json.loads(direct_url)
+    except json.JSONDecodeError:
+        return False
+    dir_info = payload.get("dir_info") if isinstance(payload, dict) else None
+    return isinstance(dir_info, dict) and dir_info.get("editable") is True
+
+
+def _module_file_is_source_tree(module_file: str) -> bool:
+    if not module_file:
+        return False
+    path = Path(module_file)
+    return any(parent.name == "src" for parent in path.parents)
+
+
+def _module_file_is_installed(module_file: str) -> bool:
+    if not module_file:
+        return False
+    return any(parent.name in {"site-packages", "dist-packages"} for parent in Path(module_file).parents)

--- a/tests/coding/test_bootstrap.py
+++ b/tests/coding/test_bootstrap.py
@@ -138,7 +138,7 @@ def test_create_agent_session_result_returns_sdk_creation_snapshot(tmp_path) -> 
     assert result.session.session_manager is manager
     assert result.resource_bundle is result.session.resource_bundle
     assert result.cwd_bound_services_audit is result.session.cwd_bound_services_audit
-    assert [record.code for record in result.diagnostics if record.phase == "startup"] == [
+    assert [record.code for record in result.diagnostics if record.phase == "startup" and record.type != "info"] == [
         "package_root_unavailable"
     ]
 
@@ -151,7 +151,7 @@ def test_create_agent_session_result_returns_sdk_creation_snapshot(tmp_path) -> 
         session_id=result.session.session_id,
     )
 
-    assert [record.code for record in result.diagnostics if record.phase == "startup"] == [
+    assert [record.code for record in result.diagnostics if record.phase == "startup" and record.type != "info"] == [
         "package_root_unavailable"
     ]
 
@@ -1344,7 +1344,7 @@ def test_runtime_tool_failures_still_surface_as_tool_result_errors(tmp_path) -> 
     assert tool_results[0].tool_name == "runtime_tool"
     assert tool_results[0].is_error is True
     assert tool_results[0].content[0].text == "runtime tool exploded"
-    diagnostics = session.get_last_diagnostics()
+    diagnostics = [record for record in session.get_last_diagnostics() if record.code == "tool_execution_failed"]
     assert len(diagnostics) == 1
     assert diagnostics[0].code == "tool_execution_failed"
     assert diagnostics[0].source == "tool"
@@ -1884,7 +1884,11 @@ def test_create_agent_session_records_startup_package_root_diagnostics(tmp_path)
         model=_model(),
     )
 
-    diagnostics = services.diagnostics_service.get_diagnostics(phase="startup", source="bootstrap")
+    diagnostics = services.diagnostics_service.get_diagnostics(
+        phase="startup",
+        source="bootstrap",
+        code="package_root_unavailable",
+    )
 
     assert [record.code for record in diagnostics] == ["package_root_unavailable"]
     assert diagnostics[0].type == "warning"
@@ -1894,6 +1898,37 @@ def test_create_agent_session_records_startup_package_root_diagnostics(tmp_path)
         "ok": False,
         "package_root": str(missing_package_root),
     }
+
+
+def test_create_agent_session_records_executable_source_identity_diagnostic(tmp_path) -> None:
+    from loushang.coding.bootstrap import create_agent_session, create_services
+    from loushang.coding.store import SessionManager
+
+    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    services = create_services()
+
+    create_agent_session(
+        session_manager=manager,
+        services=services,
+        model=_model(),
+    )
+
+    diagnostics = services.diagnostics_service.get_diagnostics(
+        phase="startup",
+        source="bootstrap",
+        code="executable_source_identity",
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].type == "info"
+    assert diagnostics[0].session_id == manager.get_header().id
+    assert diagnostics[0].source_path is not None
+    assert diagnostics[0].details["check"] == "executable_source_identity"
+    assert diagnostics[0].details["ok"] is True
+    assert diagnostics[0].details["cwd"] == str(tmp_path)
+    assert isinstance(diagnostics[0].details["python_executable"], str)
+    assert isinstance(diagnostics[0].details["loushang_module_file"], str)
+    assert isinstance(diagnostics[0].details["coding_module_file"], str)
 
 
 def test_create_agent_session_records_package_lockfile_diagnostics(tmp_path) -> None:

--- a/tests/coding/test_session_diagnostics_bridge.py
+++ b/tests/coding/test_session_diagnostics_bridge.py
@@ -116,3 +116,48 @@ def test_session_diagnostics_bridge_records_runtime_errors_with_session_context(
     assert records[1].details["response_id"] == "resp_1"
     assert records[2].message == "tool failed"
     assert records[2].details["tool_call_id"] == "tc1"
+
+
+def test_session_diagnostics_bridge_records_policy_tool_errors_with_correlation(tmp_path) -> None:
+    diagnostics = DiagnosticsService()
+    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    bridge = SessionDiagnosticsBridge(
+        diagnostics_service=diagnostics,
+        session_manager=manager,
+        get_extension_runner=lambda: None,
+    )
+    tool_result = SimpleNamespace(
+        content=[TextPart(type="text", text="Tool write is blocked by policy")],
+        details={
+            "tool_name": "write",
+            "policy_disposition": "deny",
+            "policy_code": "tool_blocked",
+            "policy_reason": "Tool write is blocked by policy",
+            "approval_required": False,
+            "argument_keys": ["content", "path"],
+            "path": "/tmp/project/blocked.txt",
+        },
+    )
+
+    bridge.record_tool_execution_error(
+        {
+            "tool_call_id": "tc-policy-1",
+            "tool_name": "write",
+            "result": tool_result,
+        }
+    )
+
+    records = diagnostics.get_diagnostics()
+    assert [record.code for record in records] == ["tool_execution_failed", "tool_blocked"]
+    policy_records = diagnostics.get_diagnostics(query=DiagnosticsQuery(tool_call_id="tc-policy-1", code="tool_blocked"))
+    assert len(policy_records) == 1
+    assert policy_records[0].type == "warning"
+    assert policy_records[0].source == "policy"
+    assert policy_records[0].phase == "runtime"
+    assert policy_records[0].message == "Tool write is blocked by policy"
+    assert policy_records[0].session_id == manager.get_header().id
+    assert policy_records[0].details["tool_call_id"] == "tc-policy-1"
+    assert policy_records[0].details["tool_name"] == "write"
+    assert policy_records[0].details["policy_disposition"] == "deny"
+    assert policy_records[0].details["policy_reason"] == "Tool write is blocked by policy"
+    assert policy_records[0].details["path"] == "/tmp/project/blocked.txt"

--- a/tests/coding/test_source_info.py
+++ b/tests/coding/test_source_info.py
@@ -3,6 +3,26 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def test_executable_source_identity_projects_stable_runtime_details(monkeypatch, tmp_path) -> None:
+    import sys
+
+    from loushang.coding.source_info import executable_source_identity
+
+    monkeypatch.setattr(sys, "executable", "/tmp/python")
+    monkeypatch.setattr(sys, "argv", ["/tmp/bin/loushang", "--list-diagnostics"])
+
+    details = executable_source_identity(cwd=tmp_path)
+
+    assert details["python_executable"] == "/tmp/python"
+    assert details["argv0"] == "/tmp/bin/loushang"
+    assert details["cwd"] == str(tmp_path)
+    assert details["package_name"] == "loushang"
+    assert isinstance(details["package_version"], str)
+    assert isinstance(details["loushang_module_file"], str)
+    assert isinstance(details["coding_module_file"], str)
+    assert details["import_source"] in {"editable", "installed", "source-tree", "unknown"}
+
+
 def test_source_info_from_resource_descriptor_projects_package_provenance() -> None:
     from loushang.coding.loader import PromptFragmentDescriptor
     from loushang.coding.source_info import source_info_from_resource_descriptor


### PR DESCRIPTION
## Summary
- Add startup executable/source identity diagnostics for coding sessions.
- Surface policy-correlated runtime diagnostics for tool policy failures while preserving tool_call_id correlation.
- Keep changes scoped to CLI/runtime/session/tool/policy/diagnostics code paths; no Native TUI renderer/playback or method runtime changes.

## Test Plan
- [x] uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/test_bootstrap.py -q
- [x] uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_session_diagnostics_bridge.py tests/coding/test_tool_policy_integration.py tests/coding/test_agent_session_tools.py -q
- [x] uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev ruff check src/loushang/coding/session/session_diagnostics_bridge.py tests/coding/test_session_diagnostics_bridge.py src/loushang/coding/bootstrap.py src/loushang/coding/source_info.py tests/coding/test_source_info.py
- [x] git diff --check