### PR TITLE
Add source identity CLI diagnostics / 新增运行来源诊断 CLI

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -49,6 +49,10 @@ from loushang.coding.policy import (
     PolicyEngine,
 )
 from loushang.coding.prompt_command import run_prompt_command
+from loushang.coding.source_info import (
+    executable_source_identity,
+    format_source_identity_text,
+)
 from loushang.coding.store import SessionQuery
 from loushang.coding.tools import ToolRegistry, register_builtin_tools
 from loushang.coding.tools.path_utils import resolve_tool_path
@@ -231,6 +235,13 @@ async def run_cli(
         return 0
     if bootstrap_args.version:
         stdout.write(f"{_package_version()}\n")
+        return 0
+    if bootstrap_args.source_info:
+        source_identity = executable_source_identity(cwd=project_root)
+        if bootstrap_args.source_info_format == "json":
+            stdout.write(json.dumps(source_identity, ensure_ascii=False) + "\n")
+        else:
+            stdout.write(format_source_identity_text(source_identity) + "\n")
         return 0
 
     if bootstrap_args.tui and bootstrap_args.no_tui:
@@ -1089,6 +1100,7 @@ def _work_log_entry_payload_value(entry: Any, key: str) -> object | None:
 def _has_command_style_operation(args: CliArgs) -> bool:
     return bool(
         args.list_sessions
+        or args.source_info
         or args.list_models is not False
         or args.list_commands
         or args.list_diagnostics

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -9,6 +9,7 @@ from loushang.coding.extensions.types import RegisteredFlag, ResolvedFlag
 CliMode = Literal["text", "print", "json", "rpc"]
 CommandListFormat = Literal["tsv", "json"]
 DiagnosticListFormat = Literal["tsv", "json"]
+SourceInfoFormat = Literal["text", "json"]
 ModelListFormat = Literal["text", "json"]
 SessionListFormat = Literal["tsv", "json"]
 SkillListFormat = Literal["tsv", "json"]
@@ -26,6 +27,8 @@ _BUILTIN_FLAG_NAMES = frozenset(
     {
         "help",
         "version",
+        "source-info",
+        "source-info-format",
         "mode",
         "method",
         "no-method",
@@ -135,6 +138,8 @@ _BUILTIN_FLAG_NAMES = frozenset(
 class CliArgs:
     help: bool
     version: bool
+    source_info: bool
+    source_info_format: SourceInfoFormat
     mode: CliMode
     method: str | None
     no_method: bool
@@ -295,6 +300,8 @@ def parse_args(
     return CliArgs(
         help=namespace.help,
         version=namespace.version,
+        source_info=namespace.source_info,
+        source_info_format=namespace.source_info_format,
         mode=namespace.mode,
         method=namespace.method,
         no_method=namespace.no_method,
@@ -410,6 +417,8 @@ def _build_parser() -> ArgumentParser:
     parser.add_argument("messages", nargs="*")
     parser.add_argument("--help", "-h", action="store_true")
     parser.add_argument("--version", "-v", action="store_true")
+    parser.add_argument("--source-info", action="store_true")
+    parser.add_argument("--source-info-format", choices=("text", "json"), default="text")
     parser.add_argument("--mode", choices=("text", "print", "json", "rpc"), default="text")
     parser.add_argument("--method", help="Guide one coding turn with a discovered method.")
     parser.add_argument("--no-method", action="store_true", help="Run one coding turn without method guidance.")

--- a/src/loushang/coding/source_info.py
+++ b/src/loushang/coding/source_info.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
 import sys
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, distribution
 from importlib.metadata import version as package_version
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import Literal, Mapping, Protocol
 
 SourceScope = Literal["user", "project", "temporary"]
 SourceOrigin = Literal["package", "top-level"]
@@ -60,23 +63,75 @@ def executable_source_identity(
     *,
     cwd: str | Path | None = None,
     argv0: str | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> dict[str, object]:
     import loushang
     import loushang.coding as loushang_coding
 
+    resolved_env = env if env is not None else os.environ
+    resolved_cwd = Path.cwd() if cwd is None else Path(cwd).expanduser().resolve(strict=False)
+    resolved_argv0 = argv0 if argv0 is not None else _argv0()
     loushang_module_file = _module_file(loushang)
     coding_module_file = _module_file(loushang_coding)
+    git_info = _git_identity(resolved_cwd)
     return {
+        "entrypoint": _resolve_entrypoint(resolved_argv0, resolved_env),
         "python_executable": sys.executable,
         "python_version": sys.version.split()[0],
-        "argv0": argv0 if argv0 is not None else _argv0(),
-        "cwd": _path_text(Path.cwd() if cwd is None else Path(cwd).expanduser().resolve(strict=False)),
+        "argv0": resolved_argv0,
+        "cwd": _path_text(resolved_cwd),
         "package_name": "loushang",
         "package_version": _package_version("loushang"),
+        "module_file": loushang_module_file,
+        "package_root": _package_root_from_module_file(loushang_module_file),
         "loushang_module_file": loushang_module_file,
         "coding_module_file": coding_module_file,
+        "project_root": git_info["project_root"],
+        "git_branch": git_info["git_branch"],
+        "git_commit": git_info["git_commit"],
+        "virtual_env": resolved_env.get("VIRTUAL_ENV"),
+        "sys_prefix": sys.prefix,
+        "sys_base_prefix": sys.base_prefix,
+        "is_virtual_env": sys.prefix != sys.base_prefix,
+        "path_candidates": _path_candidates(resolved_env),
         "import_source": _import_source("loushang", loushang_module_file),
+        "install_mode": _install_mode("loushang", loushang_module_file),
     }
+
+
+def format_source_identity_text(identity: Mapping[str, object]) -> str:
+    lines = ["loushang source info"]
+    for key in (
+        "entrypoint",
+        "python_executable",
+        "python_version",
+        "module_file",
+        "package_root",
+        "project_root",
+        "git_branch",
+        "git_commit",
+        "cwd",
+        "virtual_env",
+        "sys_prefix",
+        "sys_base_prefix",
+        "package_version",
+        "install_mode",
+    ):
+        lines.append(f"{key}: {_display_value(identity.get(key))}")
+
+    lines.append("path_candidates:")
+    candidates = identity.get("path_candidates")
+    if isinstance(candidates, list) and candidates:
+        for candidate in candidates:
+            if not isinstance(candidate, Mapping):
+                continue
+            lines.append(
+                f"  - {_display_value(candidate.get('path'))} "
+                f"[{_display_value(candidate.get('status'))}]"
+            )
+    else:
+        lines.append("  <none>")
+    return "\n".join(lines)
 
 
 def _scope_from_descriptor(*, source_scope: object, source_kind: object) -> SourceScope:
@@ -112,6 +167,15 @@ def _module_file(module: object) -> str:
     return Path(str(module_file)).expanduser().resolve(strict=False).as_posix()
 
 
+def _package_root_from_module_file(module_file: str) -> str | None:
+    if not module_file:
+        return None
+    path = Path(module_file)
+    if path.name == "__init__.py" and path.parent.name == "loushang":
+        return path.parent.parent.as_posix()
+    return path.parent.as_posix()
+
+
 def _package_version(package_name: str) -> str:
     try:
         return package_version(package_name)
@@ -126,6 +190,16 @@ def _import_source(package_name: str, module_file: str) -> str:
         return "source-tree"
     if _module_file_is_installed(module_file):
         return "installed"
+    return "unknown"
+
+
+def _install_mode(package_name: str, module_file: str) -> str:
+    if _distribution_is_editable(package_name):
+        return "editable"
+    if _module_file_is_source_tree(module_file):
+        return "source-tree"
+    if _module_file_is_installed(module_file):
+        return "package"
     return "unknown"
 
 
@@ -155,3 +229,78 @@ def _module_file_is_installed(module_file: str) -> bool:
     if not module_file:
         return False
     return any(parent.name in {"site-packages", "dist-packages"} for parent in Path(module_file).parents)
+
+
+def _resolve_entrypoint(argv0: str, env: Mapping[str, str]) -> str | None:
+    if not argv0:
+        return None
+    if _looks_like_path(argv0):
+        return Path(argv0).expanduser().resolve(strict=False).as_posix()
+    resolved = shutil.which(argv0, path=env.get("PATH"))
+    if resolved:
+        return Path(resolved).expanduser().resolve(strict=False).as_posix()
+    return argv0
+
+
+def _looks_like_path(value: str) -> bool:
+    return os.sep in value or (os.altsep is not None and os.altsep in value)
+
+
+def _path_candidates(env: Mapping[str, str]) -> list[dict[str, object]]:
+    candidates: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for directory in os.get_exec_path(dict(env)):
+        candidate = Path(directory or ".") / "loushang"
+        if not candidate.is_file() or not os.access(candidate, os.X_OK):
+            continue
+        path = candidate.expanduser().resolve(strict=False).as_posix()
+        if path in seen:
+            continue
+        seen.add(path)
+        active = not candidates
+        candidates.append(
+            {
+                "path": path,
+                "status": "active" if active else "shadowed",
+                "active": active,
+            }
+        )
+    return candidates
+
+
+def _git_identity(cwd: Path) -> dict[str, str | None]:
+    project_root = _run_git(cwd, "rev-parse", "--show-toplevel")
+    if project_root is None:
+        return {"project_root": None, "git_branch": None, "git_commit": None}
+    branch = _run_git(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+    if branch == "HEAD":
+        branch = None
+    return {
+        "project_root": project_root,
+        "git_branch": branch,
+        "git_commit": _run_git(cwd, "rev-parse", "HEAD"),
+    }
+
+
+def _run_git(cwd: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd.as_posix(), *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    output = result.stdout.strip()
+    return output or None
+
+
+def _display_value(value: object) -> str:
+    if value is None or value == "":
+        return "<unknown>"
+    return str(value)

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -1092,6 +1092,9 @@ def test_parse_args_supports_command_dispatch_flags() -> None:
 
     args = parse_args(
         [
+            "--source-info",
+            "--source-info-format",
+            "json",
             "--list-commands",
             "--list-commands-format",
             "json",
@@ -1133,6 +1136,8 @@ def test_parse_args_supports_command_dispatch_flags() -> None:
         ]
     )
 
+    assert args.source_info is True
+    assert args.source_info_format == "json"
     assert args.list_commands is True
     assert args.list_commands_format == "json"
     assert args.list_diagnostics is True
@@ -1411,6 +1416,99 @@ def test_run_cli_prints_version_and_exits_before_runtime(tmp_path) -> None:
         assert stdout.getvalue().strip() != ""
 
     asyncio.run(scenario())
+
+
+def test_run_cli_prints_source_info_and_exits_before_runtime(tmp_path, monkeypatch) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    bin_dir = tmp_path / "bin"
+    shadow_dir = tmp_path / "shadow"
+    bin_dir.mkdir()
+    shadow_dir.mkdir()
+    active = bin_dir / "loushang"
+    shadowed = shadow_dir / "loushang"
+    active.write_text("#!/bin/sh\n", encoding="utf-8")
+    shadowed.write_text("#!/bin/sh\n", encoding="utf-8")
+    active.chmod(0o755)
+    shadowed.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{shadow_dir}")
+    monkeypatch.setattr(sys, "argv", ["loushang", "--source-info"])
+
+    def runtime_builder(**kwargs):
+        del kwargs
+        raise AssertionError("source-info should exit before runtime creation")
+
+    stdout = StringIO()
+    stderr = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--source-info"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+            runtime_builder=runtime_builder,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    output = stdout.getvalue()
+    assert "loushang source info" in output
+    assert "entrypoint:" in output
+    assert "python_executable:" in output
+    assert "module_file:" in output
+    assert "package_root:" in output
+    assert "project_root:" in output
+    assert "git_branch:" in output
+    assert "git_commit:" in output
+    assert "cwd:" in output
+    assert "virtual_env:" in output
+    assert "sys_prefix:" in output
+    assert "package_version:" in output
+    assert "install_mode:" in output
+    assert f"{active} [active]" in output
+    assert f"{shadowed} [shadowed]" in output
+    assert stderr.getvalue() == ""
+
+
+def test_run_cli_prints_source_info_as_json(tmp_path, monkeypatch) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    active = bin_dir / "loushang"
+    active.write_text("#!/bin/sh\n", encoding="utf-8")
+    active.chmod(0o755)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.setattr(sys, "argv", ["loushang", "--source-info", "--source-info-format", "json"])
+
+    stdout = StringIO()
+    stderr = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            ["--source-info", "--source-info-format", "json"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=stderr,
+            cwd=tmp_path,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    payload = json.loads(stdout.getvalue())
+    assert payload["entrypoint"] == str(active)
+    assert payload["cwd"] == str(tmp_path)
+    assert isinstance(payload["python_executable"], str)
+    assert payload["path_candidates"][0] == {
+        "path": str(active),
+        "status": "active",
+        "active": True,
+    }
+    assert stderr.getvalue() == ""
 
 
 def test_run_cli_reports_parse_errors_to_provided_stderr(tmp_path) -> None:

--- a/tests/coding/test_source_info.py
+++ b/tests/coding/test_source_info.py
@@ -13,14 +13,62 @@ def test_executable_source_identity_projects_stable_runtime_details(monkeypatch,
 
     details = executable_source_identity(cwd=tmp_path)
 
+    assert details["entrypoint"] == "/tmp/bin/loushang"
     assert details["python_executable"] == "/tmp/python"
     assert details["argv0"] == "/tmp/bin/loushang"
     assert details["cwd"] == str(tmp_path)
     assert details["package_name"] == "loushang"
     assert isinstance(details["package_version"], str)
+    assert isinstance(details["module_file"], str)
+    assert isinstance(details["package_root"], str)
     assert isinstance(details["loushang_module_file"], str)
     assert isinstance(details["coding_module_file"], str)
+    assert "project_root" in details
+    assert "git_branch" in details
+    assert "git_commit" in details
+    assert "virtual_env" in details
+    assert isinstance(details["sys_prefix"], str)
+    assert isinstance(details["sys_base_prefix"], str)
     assert details["import_source"] in {"editable", "installed", "source-tree", "unknown"}
+    assert details["install_mode"] in {"editable", "source-tree", "package", "unknown"}
+
+
+def test_executable_source_identity_marks_path_candidates_active_and_shadowed(tmp_path) -> None:
+    from loushang.coding.source_info import executable_source_identity
+
+    first_bin = tmp_path / "first" / "bin"
+    second_bin = tmp_path / "second" / "bin"
+    first_bin.mkdir(parents=True)
+    second_bin.mkdir(parents=True)
+    first_candidate = first_bin / "loushang"
+    second_candidate = second_bin / "loushang"
+    first_candidate.write_text("#!/bin/sh\n", encoding="utf-8")
+    second_candidate.write_text("#!/bin/sh\n", encoding="utf-8")
+    first_candidate.chmod(0o755)
+    second_candidate.chmod(0o755)
+
+    details = executable_source_identity(
+        cwd=tmp_path,
+        argv0="loushang",
+        env={"PATH": f"{first_bin}:{second_bin}"},
+    )
+
+    assert details["entrypoint"] == str(first_candidate)
+    assert details["path_candidates"] == [
+        {"path": str(first_candidate), "status": "active", "active": True},
+        {"path": str(second_candidate), "status": "shadowed", "active": False},
+    ]
+
+
+def test_executable_source_identity_gracefully_degrades_outside_git(tmp_path) -> None:
+    from loushang.coding.source_info import executable_source_identity
+
+    details = executable_source_identity(cwd=tmp_path, env={"PATH": ""})
+
+    assert details["project_root"] is None
+    assert details["git_branch"] is None
+    assert details["git_commit"] is None
+    assert details["path_candidates"] == []
 
 
 def test_source_info_from_resource_descriptor_projects_package_provenance() -> None:


### PR DESCRIPTION
## Summary / 摘要
- Add loushang --source-info with text output for bug reports. / 新增 loushang --source-info，提供适合粘贴到 bug report 的文本输出。
- Add --source-info-format text|json so the same structured source identity object can be emitted as JSON. / 新增 --source-info-format text|json，同一份结构化运行来源对象也可输出为 JSON。
- Include entrypoint, Python executable, package/module roots, project root, git branch/commit, virtualenv/sys prefix, install mode, and PATH candidates with active/shadowed status. / 输出 entrypoint、Python executable、package/module root、project root、git branch/commit、virtualenv/sys prefix、install mode，以及 PATH 中 active/shadowed 的候选 loushang。

## Scope / 范围
- Scoped to coding CLI/source identity diagnostics only. / 范围仅限 coding CLI 与 source identity diagnostics。
- No Native TUI renderer/playback or method/work runtime changes. / 未修改 Native TUI renderer/playback，也未修改 method/work runtime。

## Test Plan / 测试计划
- [x] uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_source_info.py tests/coding/test_cli.py -q
- [x] uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev ruff check src/loushang/coding/source_info.py tests/coding/test_source_info.py tests/coding/test_cli.py
- [x] uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev ruff check src/loushang/coding/cli/args.py src/loushang/coding/cli/__main__.py
- [x] git diff --check