### PR TITLE
Expose method projector facts / 暴露 method projector facts

### DIFF
--- a/src/loushang/method/projection.py
+++ b/src/loushang/method/projection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from loushang.method.types import (
+    MethodApplicability,
     MethodContext,
     MethodPlan,
     MethodProjection,
@@ -26,6 +27,8 @@ class MethodProjector:
             role_variant=step.role_variant,
             temperature=_float_projection_value(step, "temperature"),
             metadata={
+                "plan_facts": _plan_facts(plan),
+                "step_facts": _step_facts(plan, step),
                 "source_projection": dict(step.projection),
                 "source_constraint": dict(step.constraint),
                 "source_audit": dict(step.audit),
@@ -47,6 +50,62 @@ def _float_projection_value(step: MethodStep, key: str) -> float | None:
     if isinstance(value, int | float):
         return float(value)
     return None
+
+
+def _plan_facts(plan: MethodPlan) -> dict[str, object]:
+    return {
+        "plan_id": plan.id,
+        "method_id": plan.method_id,
+        "mode": plan.mode,
+        "phase": plan.phase,
+        "activity": plan.activity,
+        "task": plan.task,
+        "metadata": dict(plan.metadata),
+        "applicability": _applicability_facts(plan.applicability),
+    }
+
+
+def _step_facts(plan: MethodPlan, step: MethodStep) -> dict[str, object]:
+    return {
+        "step_id": step.id,
+        "title": step.title,
+        "executor": step.executor,
+        "role_variant": step.role_variant,
+        "step_index": _step_index(plan, step),
+        "step_count": len(plan.steps),
+        "applicability": _applicability_facts(step.applicability),
+    }
+
+
+def _step_index(plan: MethodPlan, step: MethodStep) -> int | None:
+    for index, candidate in enumerate(plan.steps):
+        if candidate is step:
+            return index
+    for index, candidate in enumerate(plan.steps):
+        if candidate.id == step.id:
+            return index
+    value = step.projection.get("step_index")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _applicability_facts(applicability: MethodApplicability) -> dict[str, object]:
+    return {
+        "domains": applicability.domains,
+        "task_types": applicability.task_types,
+        "contexts": applicability.contexts,
+        "artifact_types": applicability.artifact_types,
+        "modalities": applicability.modalities,
+        "toolchains": applicability.toolchains,
+        "lifecycle": applicability.lifecycle,
+        "capabilities": applicability.capabilities,
+        "complexity": applicability.complexity,
+        "risk": applicability.risk,
+        "tags": {key: tuple(values) for key, values in applicability.tags.items()},
+    }
 
 
 __all__ = ["MethodProjector"]

--- a/tests/method/test_method_projection.py
+++ b/tests/method/test_method_projection.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from loushang.method import MethodCompiler, MethodDescriptor, MethodProjector
+from loushang.method import (
+    MethodApplicability,
+    MethodCompiler,
+    MethodDescriptor,
+    MethodProjector,
+)
 
 
 def test_method_projector_builds_stable_system_guidance() -> None:
@@ -61,6 +66,87 @@ def test_method_projector_preserves_step_policy_metadata() -> None:
         "requires_reason": True,
     }
     assert projection.metadata["source_audit"] == {"record": ["status", "reason"]}
+
+
+def test_method_projector_exposes_structured_plan_and_step_facts() -> None:
+    applicability = MethodApplicability(
+        domains=("coding",),
+        task_types=("reviewing",),
+        tags={"method_family": ("verification",)},
+    )
+    descriptor = MethodDescriptor(
+        id="method:task:review",
+        name="review",
+        description="Review changes.",
+        content="Review the diff carefully.",
+        kind="method_resource",
+        element_type="task",
+        meta_role="VALIDATOR",
+        phase="VERIFY",
+        metadata={
+            "frontmatter": {
+                "plan_mode": "fixed",
+                "steps": ["inspect", "verify"],
+                "step_titles": {
+                    "inspect": "Inspect current changes",
+                    "verify": "Run focused checks",
+                },
+            },
+        },
+        applicability=applicability,
+    )
+    plan = MethodCompiler().compile(descriptor)
+
+    projection = MethodProjector().project(plan, plan.steps[1])
+
+    assert projection.metadata["plan_facts"] == {
+        "plan_id": "plan:method:task:review",
+        "method_id": "method:task:review",
+        "mode": "fixed",
+        "phase": "VERIFY",
+        "activity": None,
+        "task": None,
+        "metadata": {
+            "method_kind": "method_resource",
+            "element_type": "task",
+            "plan_mode": "fixed",
+            "step_count": 2,
+        },
+        "applicability": {
+            "domains": ("coding",),
+            "task_types": ("reviewing",),
+            "contexts": (),
+            "artifact_types": (),
+            "modalities": (),
+            "toolchains": (),
+            "lifecycle": (),
+            "capabilities": (),
+            "complexity": None,
+            "risk": None,
+            "tags": {"method_family": ("verification",)},
+        },
+    }
+    assert projection.metadata["step_facts"] == {
+        "step_id": "verify",
+        "title": "Run focused checks",
+        "executor": "current_agent",
+        "role_variant": None,
+        "step_index": 1,
+        "step_count": 2,
+        "applicability": {
+            "domains": ("coding",),
+            "task_types": ("reviewing",),
+            "contexts": (),
+            "artifact_types": (),
+            "modalities": (),
+            "toolchains": (),
+            "lifecycle": (),
+            "capabilities": (),
+            "complexity": None,
+            "risk": None,
+            "tags": {"method_family": ("verification",)},
+        },
+    }
 
 
 def test_method_projector_handles_empty_content() -> None:


### PR DESCRIPTION
## Summary / 摘要
- EN: Add structured plan_facts and step_facts to MethodProjector metadata for downstream method/work runtime projection.
- 中文：在 MethodProjector metadata 中加入结构化 plan_facts 和 step_facts，供后续 method/work runtime 投影消费。
- EN: Preserve existing source_projection, source_constraint, and source_audit metadata while exposing stable plan, step, and applicability facts.
- 中文：保留现有 source_projection、source_constraint、source_audit 元数据，同时暴露稳定的 plan、step 与 applicability facts。

## Test Plan / 测试计划
- [x] uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/method tests/work tests/coding/domain/test_coding_domain_app.py tests/coding/test_prompt_command.py -q