### PR TITLE
feat(tui): improve transcript reader hints and source coverage / 改进 TUI transcript reader 提示与数据源覆盖

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-018-transcript-reader-and-copy-semantics.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-018-transcript-reader-and-copy-semantics.md
@@ -265,12 +265,18 @@ Earlier transcript records were trimmed. Export may include more history.
 
 ... rendered transcript lines ...
 
-Ctrl+O/q/Esc close | PgUp/PgDn scroll | d detail | r raw
+────────────────────────────────────────────────────────────────
+↑/↓ scroll   PgUp/Ctrl+B · PgDn/Ctrl+F page   Home/End jump
+Ctrl+O/q/Esc close
 ```
 
 Rules:
 
 - The header and footer are reader chrome, not transcript records.
+- The footer separator and hint lines should use dim gray styling so they read as
+  chrome rather than transcript content.
+- The reader surface should fill the visible terminal height; short transcript
+  bodies are padded so the footer remains anchored at the bottom.
 - The body is clipped to the available reader height.
 - The scroll offset is bounded after resize and source refresh.
 - If `complete=False`, the reader must not label itself "Full transcript".
@@ -281,7 +287,8 @@ Rules:
   either omit `d` from the footer or treat it as a visibly unsupported no-op.
 
 The footer should only advertise keys that the current reader implementation
-actually handles.
+actually handles. `d` detail and `r` raw may remain internal toggles until they
+produce a visible rendering difference.
 
 ## Export Semantics
 

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -95,6 +95,7 @@ async def _run_native_interactive_tui(
     app.transcript_source_factory = lambda: SessionTranscriptSource(
         session,
         tool_definition_resolver=tool_definition_resolver,
+        active_window_state=app.state,
     )
     history_records = session_history_records(session, tool_definition_resolver=tool_definition_resolver)
     if history_records:

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -29,6 +29,7 @@ from loushang.coding.ui.startup import (
     load_coding_tui_startup_snapshot,
 )
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+from loushang.coding.ui.transcript_source import SessionTranscriptSource
 from loushang.observability import get_log, log_context
 from loushang.tui import CompletionProvider
 from loushang.tui.prompt import run_non_interactive_prompt_loop
@@ -90,7 +91,12 @@ async def _run_native_interactive_tui(
         session_label=snapshot.session_label,
         now=time.monotonic,
     )
-    history_records = session_history_records(session, tool_definition_resolver=_tool_definition_resolver(session))
+    tool_definition_resolver = _tool_definition_resolver(session)
+    app.transcript_source_factory = lambda: SessionTranscriptSource(
+        session,
+        tool_definition_resolver=tool_definition_resolver,
+    )
+    history_records = session_history_records(session, tool_definition_resolver=tool_definition_resolver)
     if history_records:
         app.replace_transcript_window(history_records, reason="resume")
         app.trim_active_transcript_window()

--- a/src/loushang/coding/ui/native_app.py
+++ b/src/loushang/coding/ui/native_app.py
@@ -15,7 +15,10 @@ from loushang.coding.tools.output_preview import (
 )
 from loushang.coding.ui.native_state import NativeCodingTuiState, NativeTranscriptWindow
 from loushang.coding.ui.transcript_reader import TranscriptReaderSurface
-from loushang.coding.ui.transcript_source import ActiveWindowTranscriptSource
+from loushang.coding.ui.transcript_source import (
+    ActiveWindowTranscriptSource,
+    TranscriptSource,
+)
 from loushang.coding.ui.transcript_style import apply_coding_transcript_style
 from loushang.tui import (
     BottomFrame,
@@ -102,6 +105,7 @@ class NativeCodingTuiApp:
     render_requester: Callable[[RenderRequestKind], object] | None = None
     terminal_diagnostics_provider: Callable[[], str] | None = None
     terminal_capabilities: TerminalRuntimeCapabilities | None = None
+    transcript_source_factory: Callable[[], TranscriptSource] | None = None
     _transcript_region: _NativeTranscriptRegion = field(init=False, repr=False)
     _bottom_frame_component: BottomFrame = field(init=False, repr=False)
     _render_baseline_reset_reason: str | None = field(default=None, init=False, repr=False)
@@ -173,7 +177,12 @@ class NativeCodingTuiApp:
     def open_transcript_reader(self) -> bool:
         if self.surface_host is None:
             return False
-        reader = TranscriptReaderSurface(ActiveWindowTranscriptSource(self.state))
+        source = (
+            self.transcript_source_factory()
+            if self.transcript_source_factory is not None
+            else ActiveWindowTranscriptSource(self.state)
+        )
+        reader = TranscriptReaderSurface(source)
         self.surface_host.open_surface(
             Surface(
                 renderable=reader,

--- a/src/loushang/coding/ui/playback_scenarios/transcript.py
+++ b/src/loushang/coding/ui/playback_scenarios/transcript.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from io import StringIO
+from types import SimpleNamespace
+
+from loushang.coding.ui.controller import CodingUiController
+from loushang.coding.ui.mode import _native_prompt_handler
 from loushang.coding.ui.perf_probe import build_synthetic_long_transcript_records
 from loushang.coding.ui.playback import (
     NativeTuiInputPlaybackResult,
     NativeTuiInputScenario,
+    NativeTuiLoopPlayback,
 )
 from loushang.coding.ui.playback_scenarios.budgets import (
     INTERACTION_FRAME_BUDGET,
@@ -103,10 +109,89 @@ def _run_transcript_reader_modal() -> NativeTuiInputPlaybackResult:
     return result
 
 
+def _run_transcript_reader_copy_command() -> object:
+    playback = NativeTuiLoopPlayback(width=72, height=9)
+    playback.app.state.records.extend(
+        (
+            AssistantMessageRecord("reader-visible latest answer"),
+            AssistantMessageRecord("reader-visible older answer"),
+        )
+    )
+    session = _CopyCommandPlaybackSession(
+        recent_texts=(
+            "latest structured answer",
+            "previous structured answer",
+        )
+    )
+    controller = CodingUiController(session=session)
+
+    result = playback.run(
+        (0.00, "\x0f"),
+        (0.01, "\x02"),
+        (0.02, "\x0f"),
+        (0.03, "/copy 2\r"),
+        (0.05, ""),
+        handle_prompt=_native_prompt_handler(
+            app=playback.app,
+            controller=controller,
+            stderr=StringIO(),
+            verbose=False,
+        ),
+    )
+
+    result.assert_exit_code(0)
+    result.assert_text_contains("Transcript window")
+    result.assert_text_contains("Ctrl+O/q/Esc close")
+    result.assert_text_contains("Copied /copy 2 from structured source.")
+    result.assert_no_clear_screen()
+    assert session.commands == [("copy", "2")]
+    assert session.prompts == []
+    assert session.copied == ["previous structured answer"]
+    return result
+
+
 def _step_screen(result: NativeTuiInputPlaybackResult, step_index: int) -> str:
     step = result.steps[step_index]
     assert step.frame is not None
     return strip_control_sequences("\n".join(step.frame.screen_after.visible_lines))
+
+
+class _CopyCommandPlaybackSession:
+    def __init__(self, *, recent_texts: tuple[str, ...]) -> None:
+        self.recent_texts = recent_texts
+        self.commands: list[tuple[str, str]] = []
+        self.prompts: list[str] = []
+        self.copied: list[str] = []
+
+    def list_commands(self) -> list[object]:
+        return [
+            SimpleNamespace(
+                name="copy",
+                description="Copy an assistant message to clipboard",
+                source="builtin",
+                argument_hint="[N]",
+            )
+        ]
+
+    async def execute_command_async(self, invocation_name: str, args: str) -> object:
+        self.commands.append((invocation_name, args))
+        copy_index = int(args.strip() or "1")
+        text = self.recent_texts[copy_index - 1]
+        self.copied.append(text)
+        return SimpleNamespace(
+            invocation_name=invocation_name,
+            result={
+                "source": "builtin",
+                "command": invocation_name,
+                "status": "ok",
+                "message": f"Copied /copy {copy_index} from structured source.",
+                "index": copy_index,
+                "characters": len(text),
+            },
+        )
+
+    async def prompt(self, text: str, **_kwargs: object) -> None:
+        self.prompts.append(text)
 
 
 TRANSCRIPT_SCENARIOS = (
@@ -124,6 +209,12 @@ TRANSCRIPT_SCENARIOS = (
         name="transcript-reader-modal",
         description="Open the transcript reader, keep input modal, close it, and resume composing.",
         run=_run_transcript_reader_modal,
+    ),
+    NativePlaybackScenarioSpec(
+        name="transcript-reader-copy-command",
+        description="Open and close the transcript reader, then copy the second assistant response from structured history.",
+        run=_run_transcript_reader_copy_command,
+        tags=("transcript", "command"),
     ),
 )
 

--- a/src/loushang/coding/ui/playback_scenarios/transcript.py
+++ b/src/loushang/coding/ui/playback_scenarios/transcript.py
@@ -75,7 +75,8 @@ def _run_transcript_reader_modal() -> NativeTuiInputPlaybackResult:
         .render()
         .key("\x0f")
         .tab()
-        .key("\x1b[5~")
+        .key("\x02")
+        .key("\x06")
         .ctrl_c()
         .type_text("!")
         .run()
@@ -90,12 +91,15 @@ def _run_transcript_reader_modal() -> NativeTuiInputPlaybackResult:
 
     opened_screen = _step_screen(result, 1)
     tab_screen = _step_screen(result, 2)
-    page_up_screen = _step_screen(result, 3)
+    ctrl_b_screen = _step_screen(result, 3)
+    ctrl_f_screen = _step_screen(result, 4)
     assert "Ctrl+O/q/Esc close" in opened_screen
+    assert "PgUp/Ctrl+B · PgDn/Ctrl+F page" in opened_screen
     assert "answer line 11" in opened_screen
     assert "Ctrl+O/q/Esc close" in tab_screen
     assert result.step_coding_states[2]["composer_text"] == "draft"
-    assert "answer line 0" in page_up_screen
+    assert "answer line 4" in ctrl_b_screen
+    assert "answer line 11" in ctrl_f_screen
     return result
 
 

--- a/src/loushang/coding/ui/transcript_reader.py
+++ b/src/loushang/coding/ui/transcript_reader.py
@@ -6,10 +6,15 @@ from loushang.coding.ui.transcript_source import TranscriptSnapshot, TranscriptS
 from loushang.tui.cell_width import truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
 from loushang.tui.input import InputEvent, InputIntent
+from loushang.tui.theme import apply_theme_style
 from loushang.tui.transcript import render_transcript_records
 
 _MAX_TRANSCRIPT_RENDER_HEIGHT = 1_000_000
-_FOOTER = "Ctrl+O/q/Esc close | PgUp/PgDn scroll | d detail | r raw"
+_FOOTER_STYLE = {"color": "bright_black", "dim": True}
+_FOOTER_LINES = (
+    "↑/↓ scroll   PgUp/Ctrl+B · PgDn/Ctrl+F page   Home/End jump",
+    "Ctrl+O/q/Esc close",
+)
 _CONSUMED = InputIntent(kind="consumed", note="transcript_reader")
 
 
@@ -54,10 +59,10 @@ class TranscriptReaderSurface:
         if key == "down":
             self._scroll_by(1)
             return _CONSUMED
-        if key == "pageUp":
+        if key in {"pageUp", "ctrl+b", "ctrl_b"}:
             self._scroll_by(-self._last_body_height)
             return _CONSUMED
-        if key == "pageDown":
+        if key in {"pageDown", "ctrl+f", "ctrl_f"}:
             self._scroll_by(self._last_body_height)
             return _CONSUMED
         if key == "home":
@@ -75,8 +80,9 @@ class TranscriptReaderSurface:
         return _CONSUMED
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
-        chrome = self._chrome_lines(constraints.width, constraints.max_height)
-        body_height = max(0, constraints.max_height - len(chrome))
+        top_chrome = self._top_chrome_lines(constraints.width, constraints.max_height)
+        footer = self._footer_lines(constraints.width, max_height=constraints.max_height - len(top_chrome))
+        body_height = max(0, constraints.max_height - len(top_chrome) - len(footer))
         self._last_body_height = max(1, body_height)
         body = self._body_lines(width=constraints.width)
         self._max_scroll_offset = max(0, len(body) - body_height)
@@ -85,20 +91,26 @@ class TranscriptReaderSurface:
         else:
             self._scroll_offset = _clamp(self._scroll_offset, 0, self._max_scroll_offset)
 
-        visible_body = body[self._scroll_offset : self._scroll_offset + body_height] if body_height else ()
-        lines = [*chrome[:-1], *visible_body, *chrome[-1:]]
-        if len(lines) < constraints.max_height and not visible_body:
-            insert_at = max(0, len(lines) - 1)
-            lines.insert(insert_at, RenderLine(truncate_to_width("No transcript records.", max_width=constraints.width)))
+        visible_body = list(body[self._scroll_offset : self._scroll_offset + body_height]) if body_height else []
+        if body_height and not visible_body:
+            visible_body.append(RenderLine(truncate_to_width("No transcript records.", max_width=constraints.width)))
+        padding = [RenderLine("") for _ in range(max(0, body_height - len(visible_body)))]
+        lines = [*top_chrome, *visible_body, *padding, *footer]
         return RenderResult.from_lines(lines[: constraints.max_height], constraints=constraints)
 
-    def _chrome_lines(self, width: int, max_height: int) -> tuple[RenderLine, ...]:
+    def _top_chrome_lines(self, width: int, max_height: int) -> tuple[RenderLine, ...]:
         lines = [RenderLine(truncate_to_width(self._snapshot.source_label, max_width=width))]
         if self._snapshot.evicted_prefix_record_count > 0 and len(lines) < max_height - 1:
             lines.append(RenderLine(truncate_to_width("Earlier transcript records were trimmed.", max_width=width)))
-        if len(lines) < max_height:
-            lines.append(RenderLine(truncate_to_width(_FOOTER, max_width=width)))
         return tuple(lines[:max_height])
+
+    def _footer_lines(self, width: int, *, max_height: int) -> tuple[RenderLine, ...]:
+        if max_height <= 0:
+            return ()
+        separator = "─" * max(0, width)
+        raw_lines = (separator, *_FOOTER_LINES)
+        selected = raw_lines[-max_height:]
+        return tuple(RenderLine(_footer_text(line, width=width)) for line in selected)
 
     def _body_lines(self, *, width: int) -> tuple[RenderLine, ...]:
         return render_transcript_records(
@@ -124,6 +136,10 @@ class TranscriptReaderSurface:
 
 def _clamp(value: int, minimum: int, maximum: int) -> int:
     return max(minimum, min(value, maximum))
+
+
+def _footer_text(text: str, *, width: int) -> str:
+    return apply_theme_style(truncate_to_width(text, max_width=width), _FOOTER_STYLE)
 
 
 __all__ = ["TranscriptReaderSurface"]

--- a/src/loushang/coding/ui/transcript_reader.py
+++ b/src/loushang/coding/ui/transcript_reader.py
@@ -3,17 +3,28 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from loushang.coding.ui.transcript_source import TranscriptSnapshot, TranscriptSource
-from loushang.tui.cell_width import truncate_to_width
+from loushang.tui.cell_width import truncate_to_width, wrap_cells
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
 from loushang.tui.input import InputEvent, InputIntent
 from loushang.tui.theme import apply_theme_style
-from loushang.tui.transcript import render_transcript_records
+from loushang.tui.transcript import (
+    AssistantMessageRecord,
+    ContextCompactionRecord,
+    DisplayRecord,
+    ErrorRecord,
+    ThinkingRecord,
+    ThinkingVisibility,
+    ToolExecutionRecord,
+    UserPromptRecord,
+    WorkedDividerRecord,
+    render_transcript_records,
+)
 
 _MAX_TRANSCRIPT_RENDER_HEIGHT = 1_000_000
 _FOOTER_STYLE = {"color": "bright_black", "dim": True}
 _FOOTER_LINES = (
     "↑/↓ scroll   PgUp/Ctrl+B · PgDn/Ctrl+F page   Home/End jump",
-    "Ctrl+O/q/Esc close",
+    "Ctrl+O/q/Esc close   d detail   r raw",
 )
 _CONSUMED = InputIntent(kind="consumed", note="transcript_reader")
 
@@ -113,10 +124,18 @@ class TranscriptReaderSurface:
         return tuple(RenderLine(_footer_text(line, width=width)) for line in selected)
 
     def _body_lines(self, *, width: int) -> tuple[RenderLine, ...]:
+        if self.raw_mode:
+            return _render_raw_transcript_records(
+                self._snapshot.records,
+                width=width,
+                detail=self.detail_mode,
+                max_height=_MAX_TRANSCRIPT_RENDER_HEIGHT,
+            )
         return render_transcript_records(
             self._snapshot.records,
             width=width,
             max_height=_MAX_TRANSCRIPT_RENDER_HEIGHT,
+            verbose_errors=self.detail_mode,
         )
 
     def _scroll_by(self, delta: int) -> None:
@@ -140,6 +159,87 @@ def _clamp(value: int, minimum: int, maximum: int) -> int:
 
 def _footer_text(text: str, *, width: int) -> str:
     return apply_theme_style(truncate_to_width(text, max_width=width), _FOOTER_STYLE)
+
+
+def _render_raw_transcript_records(
+    records: tuple[DisplayRecord, ...],
+    *,
+    width: int,
+    detail: bool,
+    max_height: int,
+) -> tuple[RenderLine, ...]:
+    lines: list[str] = []
+    for record in records:
+        if lines:
+            lines.append("")
+        lines.extend(_raw_record_lines(record, width=width, detail=detail))
+        if len(lines) >= max_height:
+            break
+    return tuple(RenderLine(line) for line in lines[:max_height])
+
+
+def _raw_record_lines(record: DisplayRecord, *, width: int, detail: bool) -> list[str]:
+    if isinstance(record, UserPromptRecord):
+        return _raw_labeled_text("User", record.text, width=width)
+    if isinstance(record, AssistantMessageRecord):
+        return _raw_labeled_text("Assistant", record.text, width=width)
+    if isinstance(record, ToolExecutionRecord):
+        return _raw_tool_lines(record, width=width)
+    if isinstance(record, ThinkingRecord):
+        return _raw_thinking_lines(record, width=width)
+    if isinstance(record, ErrorRecord):
+        text = record.summary
+        if detail and record.diagnostics:
+            text = f"{text}\n{record.diagnostics}"
+        return _raw_labeled_text("Error", text, width=width)
+    if isinstance(record, ContextCompactionRecord):
+        summary = record.summary.strip()
+        text = summary or "Context compacted"
+        if record.tokens_before is not None:
+            text = f"{text}\n{record.tokens_before} tokens before compaction"
+        return _raw_labeled_text("Context", text, width=width)
+    if isinstance(record, WorkedDividerRecord):
+        return _raw_wrapped_lines(f"Worked for {record.elapsed_seconds:.2f}s", width=width)
+    return []
+
+
+def _raw_tool_lines(record: ToolExecutionRecord, *, width: int) -> list[str]:
+    elapsed = f"{record.elapsed_seconds:.2f}s"
+    lines = _raw_wrapped_lines(f"Tool: {record.name} {record.state} in {elapsed}", width=width)
+    if record.command:
+        lines.extend(_raw_wrapped_lines(f"command: {record.command}", width=width))
+    if record.output:
+        lines.extend(_raw_wrapped_lines(record.output, width=width))
+    if record.stderr:
+        lines.extend(_raw_wrapped_lines(f"stderr: {record.stderr}", width=width))
+    if record.exit_code is not None:
+        lines.extend(_raw_wrapped_lines(f"exit code: {record.exit_code}", width=width))
+    return lines
+
+
+def _raw_thinking_lines(record: ThinkingRecord, *, width: int) -> list[str]:
+    if record.visibility is ThinkingVisibility.HIDDEN:
+        return []
+    if record.visibility is ThinkingVisibility.UNAVAILABLE:
+        return _raw_wrapped_lines("Thinking unavailable", width=width)
+    if record.visibility is ThinkingVisibility.COLLAPSED:
+        return _raw_wrapped_lines("Thinking collapsed", width=width)
+    return _raw_labeled_text("Thinking", record.text, width=width)
+
+
+def _raw_labeled_text(label: str, text: str, *, width: int) -> list[str]:
+    lines = _raw_wrapped_lines(label, width=width)
+    if text:
+        lines.extend(_raw_wrapped_lines(text, width=width))
+    return lines
+
+
+def _raw_wrapped_lines(text: str, *, width: int) -> list[str]:
+    target_width = max(1, width)
+    lines: list[str] = []
+    for logical_line in text.splitlines() or [""]:
+        lines.extend(wrap_cells(logical_line, width=target_width) or [""])
+    return [truncate_to_width(line, max_width=target_width) for line in lines]
 
 
 __all__ = ["TranscriptReaderSurface"]

--- a/src/loushang/coding/ui/transcript_source.py
+++ b/src/loushang/coding/ui/transcript_source.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 from loushang.coding.ui.native_state import NativeCodingTuiState
+from loushang.coding.ui.session_history import session_history_records
 from loushang.tui.transcript import AssistantMessageRecord, DisplayRecord
 
 
@@ -34,13 +36,45 @@ class ActiveWindowTranscriptSource:
         )
 
     def recent_assistant_texts(self) -> tuple[str, ...]:
-        texts: list[str] = []
-        for record in reversed(self.state.records):
-            if not isinstance(record, AssistantMessageRecord):
-                continue
-            if record.text.strip():
-                texts.append(record.text)
-        return tuple(texts)
+        return _recent_assistant_texts(self.state.records)
 
 
-__all__ = ["ActiveWindowTranscriptSource", "TranscriptSnapshot", "TranscriptSource"]
+@dataclass(frozen=True, slots=True)
+class SessionTranscriptSource:
+    session: Any
+    tool_definition_resolver: Any | None = None
+    max_tool_body_lines: int = 8
+    source_label: str = "Full transcript"
+
+    def snapshot(self) -> TranscriptSnapshot:
+        return TranscriptSnapshot(
+            records=session_history_records(
+                self.session,
+                tool_definition_resolver=self.tool_definition_resolver,
+                max_tool_body_lines=self.max_tool_body_lines,
+            ),
+            evicted_prefix_record_count=0,
+            complete=True,
+            source_label=self.source_label,
+        )
+
+    def recent_assistant_texts(self) -> tuple[str, ...]:
+        return _recent_assistant_texts(self.snapshot().records)
+
+
+def _recent_assistant_texts(records: Iterable[DisplayRecord]) -> tuple[str, ...]:
+    texts: list[str] = []
+    for record in reversed(tuple(records)):
+        if not isinstance(record, AssistantMessageRecord):
+            continue
+        if record.text.strip():
+            texts.append(record.text)
+    return tuple(texts)
+
+
+__all__ = [
+    "ActiveWindowTranscriptSource",
+    "SessionTranscriptSource",
+    "TranscriptSnapshot",
+    "TranscriptSource",
+]

--- a/src/loushang/coding/ui/transcript_source.py
+++ b/src/loushang/coding/ui/transcript_source.py
@@ -45,17 +45,29 @@ class SessionTranscriptSource:
     tool_definition_resolver: Any | None = None
     max_tool_body_lines: int = 8
     source_label: str = "Full transcript"
+    active_window_state: NativeCodingTuiState | None = None
 
     def snapshot(self) -> TranscriptSnapshot:
+        session_records = session_history_records(
+            self.session,
+            tool_definition_resolver=self.tool_definition_resolver,
+            max_tool_body_lines=self.max_tool_body_lines,
+        )
+        records = session_records
+        complete = True
+        source_label = self.source_label
+        if self.active_window_state is not None:
+            active_records = tuple(self.active_window_state.records)
+            merged_records = _merge_active_window_records(session_records, active_records)
+            if merged_records != session_records:
+                records = merged_records
+                complete = False
+                source_label = f"{self.source_label} + live window"
         return TranscriptSnapshot(
-            records=session_history_records(
-                self.session,
-                tool_definition_resolver=self.tool_definition_resolver,
-                max_tool_body_lines=self.max_tool_body_lines,
-            ),
+            records=records,
             evicted_prefix_record_count=0,
-            complete=True,
-            source_label=self.source_label,
+            complete=complete,
+            source_label=source_label,
         )
 
     def recent_assistant_texts(self) -> tuple[str, ...]:
@@ -70,6 +82,29 @@ def _recent_assistant_texts(records: Iterable[DisplayRecord]) -> tuple[str, ...]
         if record.text.strip():
             texts.append(record.text)
     return tuple(texts)
+
+
+def _merge_active_window_records(
+    session_records: tuple[DisplayRecord, ...],
+    active_records: tuple[DisplayRecord, ...],
+) -> tuple[DisplayRecord, ...]:
+    if not active_records:
+        return session_records
+    overlap_count = _suffix_prefix_overlap_count(session_records, active_records)
+    if overlap_count == len(active_records):
+        return session_records
+    return (*session_records, *active_records[overlap_count:])
+
+
+def _suffix_prefix_overlap_count(
+    left: tuple[DisplayRecord, ...],
+    right: tuple[DisplayRecord, ...],
+) -> int:
+    max_overlap = min(len(left), len(right))
+    for overlap_count in range(max_overlap, 0, -1):
+        if left[-overlap_count:] == right[:overlap_count]:
+            return overlap_count
+    return 0
 
 
 __all__ = [

--- a/tests/coding/test_native_coding_tui_input.py
+++ b/tests/coding/test_native_coding_tui_input.py
@@ -442,6 +442,40 @@ def test_native_input_router_ctrl_o_opens_transcript_reader_overlay() -> None:
     assert app.state.records[-1] == AssistantMessageRecord("answer")
 
 
+def test_native_input_router_ctrl_o_uses_transcript_source_factory() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_input import NativeInputRouter
+    from loushang.coding.ui.transcript_reader import TranscriptReaderSurface
+    from loushang.coding.ui.transcript_source import TranscriptSnapshot
+    from loushang.tui import SurfaceHost
+    from loushang.tui.transcript import AssistantMessageRecord
+
+    class _Source:
+        def snapshot(self) -> TranscriptSnapshot:
+            return TranscriptSnapshot(
+                records=(AssistantMessageRecord("full session answer"),),
+                complete=True,
+                source_label="Full transcript",
+            )
+
+        def recent_assistant_texts(self) -> tuple[str, ...]:
+            return ("full session answer",)
+
+    source = _Source()
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 10.0)
+    app.surface_host = SurfaceHost()
+    app.transcript_source_factory = lambda: source
+    app.state.records.append(AssistantMessageRecord("active window answer"))
+
+    result = NativeInputRouter(app, should_exit=lambda text: False).handle(InputEvent(kind="key", key="ctrl+o"))
+
+    assert result.render_requested is True
+    assert app.surface_host.entries
+    reader = app.surface_host.entries[0].surface.renderable
+    assert isinstance(reader, TranscriptReaderSurface)
+    assert reader.source is source
+
+
 def test_native_input_router_reader_strict_modal_consumes_tab_without_completion() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_input import NativeInputRouter

--- a/tests/coding/test_native_coding_tui_input.py
+++ b/tests/coding/test_native_coding_tui_input.py
@@ -476,6 +476,68 @@ def test_native_input_router_ctrl_o_uses_transcript_source_factory() -> None:
     assert reader.source is source
 
 
+def test_native_input_router_ctrl_o_session_reader_includes_running_tool_record() -> None:
+    from dataclasses import dataclass
+
+    from loushang.ai.types import AssistantMessage, TextPart, Usage, UserMessage
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_input import NativeInputRouter
+    from loushang.coding.ui.transcript_reader import TranscriptReaderSurface
+    from loushang.coding.ui.transcript_source import SessionTranscriptSource
+    from loushang.tui import RenderConstraints, SurfaceHost, strip_control_sequences
+    from loushang.tui.transcript import (
+        AssistantMessageRecord,
+        ToolExecutionRecord,
+        UserPromptRecord,
+    )
+
+    @dataclass(slots=True)
+    class _Session:
+        messages: list[object]
+
+    session = _Session(
+        messages=[
+            UserMessage(role="user", content=[TextPart(type="text", text="full question")], timestamp=1.0),
+            AssistantMessage(
+                role="assistant",
+                content=[TextPart(type="text", text="full answer")],
+                api="openai",
+                provider="moonshot",
+                model="kimi",
+                response_id=None,
+                usage=Usage(input=0, output=0, cache_read=0, cache_write=0, total_tokens=0, cost={}),
+                stop_reason="stop",
+                error_message=None,
+                timestamp=2.0,
+            ),
+        ]
+    )
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 10.0)
+    app.surface_host = SurfaceHost()
+    app.replace_transcript_window(
+        (
+            UserPromptRecord("full question"),
+            AssistantMessageRecord("full answer", stable=True),
+            ToolExecutionRecord(name="bash run-tests", state="running", elapsed_seconds=0.1, output="live output"),
+        ),
+        reason="test",
+    )
+    app.begin_run(started_at=3.0)
+    app.transcript_source_factory = lambda: SessionTranscriptSource(session, active_window_state=app.state)
+
+    result = NativeInputRouter(app, should_exit=lambda text: False).handle(InputEvent(kind="key", key="ctrl+o"))
+
+    assert result.render_requested is True
+    assert app.surface_host.entries
+    reader = app.surface_host.entries[0].surface.renderable
+    assert isinstance(reader, TranscriptReaderSurface)
+    reader.raw_mode = True
+    rendered = reader.render(RenderConstraints(width=100, max_height=12))
+    lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
+    assert any("Tool: bash run-tests running in 0.10s" in line for line in lines)
+    assert any("live output" in line for line in lines)
+
+
 def test_native_input_router_reader_strict_modal_consumes_tab_without_completion() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_input import NativeInputRouter

--- a/tests/coding/test_native_coding_tui_mode.py
+++ b/tests/coding/test_native_coding_tui_mode.py
@@ -245,8 +245,14 @@ def test_run_coding_tui_interactive_replays_resumed_session_history(monkeypatch)
         )
     )
 
-    records = getattr(captured["app"], "state").records
+    app = captured["app"]
+    records = getattr(app, "state").records
+    reader_source = getattr(app, "transcript_source_factory")()
+    reader_snapshot = reader_source.snapshot()
     assert exit_code == 0
+    assert reader_snapshot.complete is True
+    assert reader_snapshot.source_label == "Full transcript"
+    assert reader_snapshot.records == tuple(records)
     assert isinstance(records[0], UserPromptRecord)
     assert records[0].text == "previous question"
     assert isinstance(records[1], AssistantMessageRecord)

--- a/tests/coding/test_native_tui_playback_harness.py
+++ b/tests/coding/test_native_tui_playback_harness.py
@@ -16,7 +16,9 @@ from loushang.tui import (
     PlaybackFrameBudget,
     SelectionSurface,
     SelectItem,
+    strip_control_sequences,
 )
+from loushang.tui.transcript import AssistantMessageRecord
 
 INTERACTION_FRAME_BUDGET = PlaybackFrameBudget(
     disallowed_operation_classes=("baseline_repaint", "recovery_repaint"),
@@ -255,6 +257,27 @@ def test_native_tui_input_scenario_echoes_input_after_long_transcript_without_re
         result.assert_screen_anchor_stable("›", occurrence="last")
 
 
+def test_native_tui_input_scenario_reader_short_content_restores_bottom_frame() -> None:
+    result = (
+        NativeTuiInputScenario(width=72, height=8)
+        .with_records((AssistantMessageRecord("short answer"),))
+        .with_composer_text("draft")
+        .render()
+        .key("\x0f")
+        .ctrl_c()
+        .run()
+    )
+
+    open_screen = _step_visible_text(result, 1)
+    close_screen = _step_visible_text(result, 2)
+
+    assert open_screen.splitlines()[-1] == "Ctrl+O/q/Esc close"
+    assert "› draft" not in open_screen
+    assert "› draft" in close_screen
+    assert "kimi | repo | main | abcd | idle" in close_screen
+    result.assert_cursor_matches_diagnostics()
+
+
 def test_native_tui_loop_playback_drives_running_steer_then_escape() -> None:
     scenario = NativeTuiLoopScenario()
     prompts: list[str] = []
@@ -295,6 +318,12 @@ def test_native_tui_loop_playback_drives_running_steer_then_escape() -> None:
         result.assert_text_contains("fresh change")
         result.assert_text_contains("Conversation interrupted")
         result.assert_no_clear_screen()
+
+
+def _step_visible_text(result, step_index: int) -> str:
+    step = result.steps[step_index]
+    assert step.frame is not None
+    return strip_control_sequences("\n".join(step.frame.screen_after.visible_lines))
 
 
 def test_native_tui_loop_playback_writes_artifacts_for_manual_inspection(tmp_path) -> None:

--- a/tests/coding/test_native_tui_playback_harness.py
+++ b/tests/coding/test_native_tui_playback_harness.py
@@ -271,7 +271,7 @@ def test_native_tui_input_scenario_reader_short_content_restores_bottom_frame() 
     open_screen = _step_visible_text(result, 1)
     close_screen = _step_visible_text(result, 2)
 
-    assert open_screen.splitlines()[-1] == "Ctrl+O/q/Esc close"
+    assert open_screen.splitlines()[-1] == "Ctrl+O/q/Esc close   d detail   r raw"
     assert "› draft" not in open_screen
     assert "› draft" in close_screen
     assert "kimi | repo | main | abcd | idle" in close_screen

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -125,6 +125,7 @@ def test_native_tui_playback_transcript_scenarios_live_in_transcript_module() ->
         "long-transcript-input",
         "tool-output-preview",
         "transcript-reader-modal",
+        "transcript-reader-copy-command",
     ]
 
 
@@ -143,6 +144,7 @@ def test_native_tui_playback_runner_lists_default_scenarios(capsys) -> None:
     assert "idle-escape-clears-draft" in captured.out
     assert "long-transcript-input" in captured.out
     assert "transcript-reader-modal" in captured.out
+    assert "transcript-reader-copy-command" in captured.out
     assert "escape-pending-steer" in captured.out
     assert "running-steer-queued" in captured.out
     assert "running-escape-keeps-queued-steer" in captured.out
@@ -272,6 +274,16 @@ def test_native_tui_playback_runner_runs_transcript_reader_scenario(capsys) -> N
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS transcript-reader-modal" in captured.out
+
+
+def test_native_tui_playback_runner_runs_transcript_reader_copy_scenario(
+    capsys,
+) -> None:
+    exit_code = run_playback_cli(["transcript-reader-copy-command"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS transcript-reader-copy-command" in captured.out
 
 
 def test_native_tui_playback_runner_runs_product_composed_interaction_scenario(

--- a/tests/coding/test_native_tui_transcript_reader.py
+++ b/tests/coding/test_native_tui_transcript_reader.py
@@ -37,38 +37,87 @@ def _render_text(reader: TranscriptReaderSurface, *, width: int = 48, height: in
     return tuple(strip_control_sequences(line.text) for line in result.lines)
 
 
+def _render_raw(reader: TranscriptReaderSurface, *, width: int = 48, height: int = 6) -> tuple[str, ...]:
+    result = reader.render(RenderConstraints(width=width, max_height=height))
+    return tuple(line.text for line in result.lines)
+
+
 def test_transcript_reader_renders_frozen_snapshot_and_footer() -> None:
     source = _Source((UserPromptRecord("hello"), AssistantMessageRecord("first")), evicted_prefix_record_count=2)
     reader = TranscriptReaderSurface(source)
 
-    first = _render_text(reader, width=80, height=7)
+    first = _render_text(reader, width=80, height=9)
     source.records = (AssistantMessageRecord("second"),)
-    second = _render_text(reader, width=80, height=7)
+    second = _render_text(reader, width=80, height=9)
 
     assert source.snapshot_calls == 1
     assert first == second
     assert first[0] == "Transcript window"
     assert "Earlier transcript records were trimmed." in first
-    assert first[-1] == "Ctrl+O/q/Esc close | PgUp/PgDn scroll | d detail | r raw"
+    assert first[-3] == "─" * 80
+    assert first[-2] == "↑/↓ scroll   PgUp/Ctrl+B · PgDn/Ctrl+F page   Home/End jump"
+    assert first[-1] == "Ctrl+O/q/Esc close"
     assert any("first" in line for line in first)
     assert all("second" not in line for line in first)
+
+
+def test_transcript_reader_footer_chrome_is_dim_gray() -> None:
+    reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("answer"),)))
+
+    raw = _render_raw(reader, width=80, height=6)
+
+    assert raw[-3].startswith("\x1b[2;90m")
+    assert raw[-2].startswith("\x1b[2;90m")
+    assert raw[-1].startswith("\x1b[2;90m")
+
+
+def test_transcript_reader_short_content_fills_full_height_with_footer_at_bottom() -> None:
+    reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("short answer"),)))
+
+    rendered = _render_text(reader, width=40, height=8)
+
+    assert len(rendered) == 8
+    assert rendered[0] == "Transcript window"
+    assert any("short answer" in line for line in rendered)
+    assert rendered[-3] == "─" * 40
+    assert rendered[-2].startswith("↑/↓ scroll   PgUp/Ctrl+B")
+    assert "PgDn/Ctrl" in rendered[-2]
+    assert rendered[-1] == "Ctrl+O/q/Esc close"
 
 
 def test_transcript_reader_opens_at_tail_and_scrolls_by_page() -> None:
     source = _Source((AssistantMessageRecord("\n".join(f"line {index}" for index in range(8))),))
     reader = TranscriptReaderSurface(source)
 
-    tail = _render_text(reader, height=5)
+    tail = _render_text(reader, height=7)
     assert any("line 7" in line for line in tail)
     assert all("line 0" not in line for line in tail)
 
     assert reader.handle_input(InputEvent(kind="key", key="pageUp")) == InputIntent(kind="consumed", note="transcript_reader")
-    older = _render_text(reader, height=5)
+    older = _render_text(reader, height=7)
     assert any("line 4" in line for line in older)
     assert reader.scroll_offset < reader.max_scroll_offset
 
     assert reader.handle_input(InputEvent(kind="key", key="end")) == InputIntent(kind="consumed", note="transcript_reader")
-    assert any("line 7" in line for line in _render_text(reader, height=5))
+    assert any("line 7" in line for line in _render_text(reader, height=7))
+
+
+def test_transcript_reader_ctrl_b_and_ctrl_f_page_backward_and_forward() -> None:
+    source = _Source((AssistantMessageRecord("\n".join(f"line {index}" for index in range(12))),))
+    reader = TranscriptReaderSurface(source)
+
+    tail = _render_text(reader, height=12)
+    assert any("line 11" in line for line in tail)
+
+    assert reader.handle_input(InputEvent(kind="key", key="ctrl+b")) == InputIntent(kind="consumed", note="transcript_reader")
+    older = _render_text(reader, height=12)
+    assert any("line 0" in line for line in older)
+    assert reader.scroll_offset < reader.max_scroll_offset
+
+    assert reader.handle_input(InputEvent(kind="key", key="ctrl+f")) == InputIntent(kind="consumed", note="transcript_reader")
+    newer = _render_text(reader, height=12)
+    assert any("line 11" in line for line in newer)
+    assert reader.scroll_offset == reader.max_scroll_offset
 
 
 def test_transcript_reader_clamps_scroll_offset_after_resize() -> None:

--- a/tests/coding/test_native_tui_transcript_reader.py
+++ b/tests/coding/test_native_tui_transcript_reader.py
@@ -9,6 +9,10 @@ from loushang.tui.input import InputEvent, InputIntent
 from loushang.tui.transcript import (
     AssistantMessageRecord,
     DisplayRecord,
+    ErrorRecord,
+    ThinkingRecord,
+    ThinkingVisibility,
+    ToolExecutionRecord,
     UserPromptRecord,
 )
 
@@ -56,7 +60,7 @@ def test_transcript_reader_renders_frozen_snapshot_and_footer() -> None:
     assert "Earlier transcript records were trimmed." in first
     assert first[-3] == "─" * 80
     assert first[-2] == "↑/↓ scroll   PgUp/Ctrl+B · PgDn/Ctrl+F page   Home/End jump"
-    assert first[-1] == "Ctrl+O/q/Esc close"
+    assert first[-1] == "Ctrl+O/q/Esc close   d detail   r raw"
     assert any("first" in line for line in first)
     assert all("second" not in line for line in first)
 
@@ -82,7 +86,7 @@ def test_transcript_reader_short_content_fills_full_height_with_footer_at_bottom
     assert rendered[-3] == "─" * 40
     assert rendered[-2].startswith("↑/↓ scroll   PgUp/Ctrl+B")
     assert "PgDn/Ctrl" in rendered[-2]
-    assert rendered[-1] == "Ctrl+O/q/Esc close"
+    assert rendered[-1] == "Ctrl+O/q/Esc close   d detail   r raw"
 
 
 def test_transcript_reader_opens_at_tail_and_scrolls_by_page() -> None:
@@ -163,3 +167,64 @@ def test_transcript_reader_detail_and_raw_toggles_are_stable() -> None:
     assert reader.raw_mode is True
     assert reader.handle_input(InputEvent(kind="key", key="r")) == InputIntent(kind="consumed", note="transcript_reader")
     assert reader.raw_mode is False
+
+
+def test_transcript_reader_raw_mode_renders_copy_friendly_logical_text() -> None:
+    reader = TranscriptReaderSurface(
+        _Source(
+            (
+                UserPromptRecord("show status"),
+                AssistantMessageRecord("Use **markdown** literally."),
+                ToolExecutionRecord(
+                    name="pytest",
+                    state="completed",
+                    elapsed_seconds=1.25,
+                    command="uv run pytest",
+                    output="2 passed",
+                ),
+            )
+        )
+    )
+
+    reader.handle_input(InputEvent(kind="key", key="r"))
+    rendered = _render_text(reader, width=80, height=14)
+
+    assert "User" in rendered
+    assert "show status" in rendered
+    assert "Assistant" in rendered
+    assert "Use **markdown** literally." in rendered
+    assert "Tool: pytest completed in 1.25s" in rendered
+    assert "command: uv run pytest" in rendered
+    assert "2 passed" in rendered
+    assert not any(line.startswith(("> ", "* ", "- Ran ")) for line in rendered)
+
+
+def test_transcript_reader_detail_mode_includes_error_diagnostics() -> None:
+    reader = TranscriptReaderSurface(
+        _Source((ErrorRecord(summary="Request failed", diagnostics="Traceback line"),))
+    )
+
+    compact = _render_text(reader, width=80, height=8)
+    reader.handle_input(InputEvent(kind="key", key="d"))
+    detailed = _render_text(reader, width=80, height=8)
+
+    assert any("Request failed" in line for line in compact)
+    assert all("Traceback line" not in line for line in compact)
+    assert any("Traceback line" in line for line in detailed)
+
+
+def test_transcript_reader_raw_mode_does_not_expose_hidden_thinking() -> None:
+    reader = TranscriptReaderSurface(
+        _Source(
+            (
+                ThinkingRecord("hidden reasoning", ThinkingVisibility.HIDDEN),
+                ThinkingRecord("visible thinking", ThinkingVisibility.VISIBLE),
+            )
+        )
+    )
+
+    reader.handle_input(InputEvent(kind="key", key="r"))
+    rendered = _render_text(reader, width=80, height=10)
+
+    assert all("hidden reasoning" not in line for line in rendered)
+    assert any("visible thinking" in line for line in rendered)

--- a/tests/coding/test_ui_transcript_source.py
+++ b/tests/coding/test_ui_transcript_source.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from loushang.ai.types import AssistantMessage, TextPart, Usage, UserMessage
 from loushang.coding.ui.native_state import NativeCodingTuiState
-from loushang.coding.ui.transcript_source import ActiveWindowTranscriptSource
+from loushang.coding.ui.transcript_source import (
+    ActiveWindowTranscriptSource,
+    SessionTranscriptSource,
+)
 from loushang.tui.transcript import (
     AssistantMessageRecord,
     ToolExecutionRecord,
     UserPromptRecord,
 )
+
+
+@dataclass(slots=True)
+class _Session:
+    messages: list[object]
 
 
 def test_active_window_transcript_source_returns_snapshot_metadata() -> None:
@@ -39,3 +50,50 @@ def test_active_window_transcript_source_recent_assistant_texts_are_filtered_new
     )
 
     assert ActiveWindowTranscriptSource(state).recent_assistant_texts() == ("second", "first")
+
+
+def test_session_transcript_source_returns_complete_session_snapshot() -> None:
+    session = _Session(
+        messages=[
+            UserMessage(role="user", content=[TextPart(type="text", text="full question")], timestamp=1.0),
+            _assistant_message("full answer", timestamp=2.0),
+        ]
+    )
+
+    snapshot = SessionTranscriptSource(session).snapshot()
+
+    assert snapshot.complete is True
+    assert snapshot.evicted_prefix_record_count == 0
+    assert snapshot.source_label == "Full transcript"
+    assert snapshot.records == (
+        UserPromptRecord("full question"),
+        AssistantMessageRecord("full answer", stable=True),
+    )
+
+
+def test_session_transcript_source_recent_assistant_texts_are_filtered_newest_first() -> None:
+    session = _Session(
+        messages=[
+            _assistant_message("first", timestamp=1.0),
+            _assistant_message("   ", timestamp=2.0),
+            UserMessage(role="user", content=[TextPart(type="text", text="next")], timestamp=3.0),
+            _assistant_message("second", timestamp=4.0),
+        ]
+    )
+
+    assert SessionTranscriptSource(session).recent_assistant_texts() == ("second", "first")
+
+
+def _assistant_message(text: str, *, timestamp: float) -> AssistantMessage:
+    return AssistantMessage(
+        role="assistant",
+        content=[TextPart(type="text", text=text)],
+        api="openai",
+        provider="moonshot",
+        model="kimi",
+        response_id=None,
+        usage=Usage(input=0, output=0, cache_read=0, cache_write=0, total_tokens=0, cost={}),
+        stop_reason="stop",
+        error_message=None,
+        timestamp=timestamp,
+    )

--- a/tests/coding/test_ui_transcript_source.py
+++ b/tests/coding/test_ui_transcript_source.py
@@ -84,6 +84,34 @@ def test_session_transcript_source_recent_assistant_texts_are_filtered_newest_fi
     assert SessionTranscriptSource(session).recent_assistant_texts() == ("second", "first")
 
 
+def test_session_transcript_source_merges_live_active_window_records() -> None:
+    session = _Session(
+        messages=[
+            UserMessage(role="user", content=[TextPart(type="text", text="full question")], timestamp=1.0),
+            _assistant_message("full answer", timestamp=2.0),
+        ]
+    )
+    state = NativeCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
+    state.replace_transcript_window(
+        (
+            UserPromptRecord("full question"),
+            AssistantMessageRecord("full answer", stable=True),
+            ToolExecutionRecord(name="bash run-tests", state="running", elapsed_seconds=0.1, output="live output"),
+        )
+    )
+    state.begin_run(started_at=3.0)
+
+    snapshot = SessionTranscriptSource(session, active_window_state=state).snapshot()
+
+    assert snapshot.complete is False
+    assert snapshot.source_label == "Full transcript + live window"
+    assert snapshot.records == (
+        UserPromptRecord("full question"),
+        AssistantMessageRecord("full answer", stable=True),
+        ToolExecutionRecord(name="bash run-tests", state="running", elapsed_seconds=0.1, output="live output"),
+    )
+
+
 def _assistant_message(text: str, *, timestamp: float) -> AssistantMessage:
     return AssistantMessage(
         role="assistant",


### PR DESCRIPTION

## Summary / 摘要
- Adds transcript reader footer hints for close, detail, and raw mode controls.
- Adds copy-reader playback coverage so `/copy N` semantics are verified after opening and closing the reader.
- Adds reader raw and detail modes, including copy-friendly logical text and verbose error diagnostics.
- Adds a session-backed transcript source so the native reader can inspect the full session transcript while the active window remains trimmed for performance.

## Scope / 范围
- Touched only TUI/product adapter/playback/transcript reader related files.
- No code lane or method lane changes.
- Visual parity with `pi.tui` is not the target; review semantic behavior and workflow coverage.

## Review Guidance For Humans / 给人类 Reviewer 的说明
- Please review behavior first: Ctrl+O opens the reader, footer hints match available keys, `d` toggles detail diagnostics, and `r` toggles raw logical text.
- Check that `/copy N` still copies from recent assistant messages after a reader open/close cycle.
- Check that hidden thinking remains hidden in raw mode, while unavailable or collapsed thinking is represented only as status text.
- Check that resumed native TUI sessions still keep active rendering bounded, while the reader uses the full session transcript source.

## Review Guidance For Agents / 给 Agent Reviewer 的说明
- Branch: `feature/tui-reader-footer-hints`; base: `main`.
- Stay within TUI/product adapter/playback/transcript reader files. Do not edit code lane or method lane files during review fixes.
- Primary files to inspect: `src/loushang/coding/ui/transcript_reader.py`, `src/loushang/coding/ui/transcript_source.py`, `src/loushang/coding/ui/native_app.py`, `src/loushang/coding/ui/mode.py`, and transcript playback scenario/tests.
- Review focus: footer hint accuracy, raw/detail rendering semantics, privacy around hidden thinking, full-session source behavior, copy-reader playback coverage, and bounded active transcript rendering.
- Required validation command:
  `uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py -q`

## Test Plan / 验证
- `uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py -q` -> 33 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_ui_transcript_source.py tests/coding/test_native_coding_tui_input.py tests/coding/test_native_coding_tui_mode.py tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py tests/coding/test_native_tui_playback_runner.py -q` -> 120 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/transcript_source.py src/loushang/coding/ui/native_app.py src/loushang/coding/ui/mode.py tests/coding/test_ui_transcript_source.py tests/coding/test_native_coding_tui_input.py tests/coding/test_native_coding_tui_mode.py` -> passed
- `git diff --check` -> passed

## Related Issues / 关联 Issue
Related: #88, #96, #97, #98, #99
