### PR TITLE
Propagate method facts into work logs / 将 method facts 接入 work logs

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -495,6 +495,8 @@ async def run_cli(
                     is_last_turn = turn_index == len(prepared_turns) - 1
                     planned_constraint = _prepared_turn_policy_metadata(prepared_turn, "planned_constraint")
                     audit_policy = _prepared_turn_policy_metadata(prepared_turn, "audit_policy")
+                    plan_facts = _prepared_turn_policy_metadata(prepared_turn, "plan_facts")
+                    step_facts = _prepared_turn_policy_metadata(prepared_turn, "step_facts")
                     exit_code = await prompt_runner(
                         runtime=runtime,
                         session=session,
@@ -512,6 +514,8 @@ async def run_cli(
                         step_title=prepared_turn.step_title,
                         planned_constraint=planned_constraint,
                         audit_policy=audit_policy,
+                        plan_facts=plan_facts,
+                        step_facts=step_facts,
                         emit_plan_start=is_first_turn,
                         emit_plan_completion=is_last_turn,
                         dispose=is_last_turn,
@@ -529,6 +533,8 @@ async def run_cli(
                     is_last_turn = turn_index == len(prepared_turns) - 1
                     planned_constraint = _prepared_turn_policy_metadata(prepared_turn, "planned_constraint")
                     audit_policy = _prepared_turn_policy_metadata(prepared_turn, "audit_policy")
+                    plan_facts = _prepared_turn_policy_metadata(prepared_turn, "plan_facts")
+                    step_facts = _prepared_turn_policy_metadata(prepared_turn, "step_facts")
                     exit_code = await print_runner(
                         runtime=runtime,
                         session=session,
@@ -547,6 +553,8 @@ async def run_cli(
                         step_title=prepared_turn.step_title,
                         planned_constraint=planned_constraint,
                         audit_policy=audit_policy,
+                        plan_facts=plan_facts,
+                        step_facts=step_facts,
                         emit_plan_start=is_first_turn,
                         emit_plan_completion=is_last_turn,
                         dispose=is_last_turn,
@@ -562,6 +570,8 @@ async def run_cli(
                 is_last_turn = turn_index == len(prepared_turns) - 1
                 planned_constraint = _prepared_turn_policy_metadata(prepared_turn, "planned_constraint")
                 audit_policy = _prepared_turn_policy_metadata(prepared_turn, "audit_policy")
+                plan_facts = _prepared_turn_policy_metadata(prepared_turn, "plan_facts")
+                step_facts = _prepared_turn_policy_metadata(prepared_turn, "step_facts")
                 exit_code = await mode_runner(
                     config=ModeConfig(
                         mode=args.mode,
@@ -583,6 +593,8 @@ async def run_cli(
                     step_title=prepared_turn.step_title,
                     planned_constraint=planned_constraint,
                     audit_policy=audit_policy,
+                    plan_facts=plan_facts,
+                    step_facts=step_facts,
                     emit_plan_start=is_first_turn,
                     emit_plan_completion=is_last_turn,
                     dispose=is_last_turn,

--- a/src/loushang/coding/domain/app.py
+++ b/src/loushang/coding/domain/app.py
@@ -97,6 +97,12 @@ class CodingDomainApp:
         audit = projection.metadata.get("source_audit")
         if isinstance(audit, Mapping) and audit:
             metadata["audit_policy"] = dict(audit)
+        plan_facts = projection.metadata.get("plan_facts")
+        if isinstance(plan_facts, Mapping) and plan_facts:
+            metadata["plan_facts"] = dict(plan_facts)
+        step_facts = projection.metadata.get("step_facts")
+        if isinstance(step_facts, Mapping) and step_facts:
+            metadata["step_facts"] = dict(step_facts)
         if not _has_meaningful_guidance(descriptor, projection):
             return CodingDomainPreparedTurn(
                 prepared_prompt=request.user_input,

--- a/src/loushang/coding/mode/base.py
+++ b/src/loushang/coding/mode/base.py
@@ -148,6 +148,8 @@ def create_mode_adapter(
     step_title: str | None = None,
     planned_constraint: Mapping[str, object] | None = None,
     audit_policy: Mapping[str, object] | None = None,
+    plan_facts: Mapping[str, object] | None = None,
+    step_facts: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
 ) -> ModeAdapter:
@@ -188,6 +190,8 @@ def create_mode_adapter(
         step_title=step_title,
         planned_constraint=planned_constraint,
         audit_policy=audit_policy,
+        plan_facts=plan_facts,
+        step_facts=step_facts,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )
@@ -212,6 +216,8 @@ async def run_mode(
     step_title: str | None = None,
     planned_constraint: Mapping[str, object] | None = None,
     audit_policy: Mapping[str, object] | None = None,
+    plan_facts: Mapping[str, object] | None = None,
+    step_facts: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
     dispose: bool = True,
@@ -231,6 +237,8 @@ async def run_mode(
         step_title=step_title,
         planned_constraint=planned_constraint,
         audit_policy=audit_policy,
+        plan_facts=plan_facts,
+        step_facts=step_facts,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )

--- a/src/loushang/coding/mode/print_mode.py
+++ b/src/loushang/coding/mode/print_mode.py
@@ -38,6 +38,8 @@ class PrintMode(ModeAdapter):
         step_title: str | None = None,
         planned_constraint: Mapping[str, object] | None = None,
         audit_policy: Mapping[str, object] | None = None,
+        plan_facts: Mapping[str, object] | None = None,
+        step_facts: Mapping[str, object] | None = None,
         emit_plan_start: bool = True,
         emit_plan_completion: bool = True,
     ) -> None:
@@ -73,6 +75,8 @@ class PrintMode(ModeAdapter):
         self.step_title = step_title
         self.planned_constraint = planned_constraint
         self.audit_policy = audit_policy
+        self.plan_facts = plan_facts
+        self.step_facts = step_facts
         self.emit_plan_start = emit_plan_start
         self.emit_plan_completion = emit_plan_completion
         self._tool_render_runtime: ToolRenderRuntime | None = None
@@ -294,6 +298,8 @@ class PrintMode(ModeAdapter):
             step_title=self.step_title,
             planned_constraint=self.planned_constraint,
             audit_policy=self.audit_policy,
+            plan_facts=self.plan_facts,
+            step_facts=self.step_facts,
             emit_plan_start=emit_plan_start,
             emit_plan_completion=emit_plan_completion,
         )
@@ -470,6 +476,8 @@ async def run_print_mode(
     step_title: str | None = None,
     planned_constraint: Mapping[str, object] | None = None,
     audit_policy: Mapping[str, object] | None = None,
+    plan_facts: Mapping[str, object] | None = None,
+    step_facts: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
     dispose: bool = True,
@@ -491,6 +499,8 @@ async def run_print_mode(
         step_title=step_title,
         planned_constraint=planned_constraint,
         audit_policy=audit_policy,
+        plan_facts=plan_facts,
+        step_facts=step_facts,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )

--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -29,6 +29,8 @@ async def run_prompt_command(
     step_title: str | None = None,
     planned_constraint: Mapping[str, object] | None = None,
     audit_policy: Mapping[str, object] | None = None,
+    plan_facts: Mapping[str, object] | None = None,
+    step_facts: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
     dispose: bool = True,
@@ -59,6 +61,8 @@ async def run_prompt_command(
             step_title=step_title,
             planned_constraint=planned_constraint,
             audit_policy=audit_policy,
+            plan_facts=plan_facts,
+            step_facts=step_facts,
             emit_plan_start=emit_plan_start,
             emit_plan_completion=emit_plan_completion and not follow_up_messages,
         )
@@ -77,6 +81,8 @@ async def run_prompt_command(
                     step_title=step_title,
                     planned_constraint=planned_constraint,
                     audit_policy=audit_policy,
+                    plan_facts=plan_facts,
+                    step_facts=step_facts,
                     emit_plan_start=False,
                     emit_plan_completion=emit_plan_completion and follow_up_index == len(follow_up_messages) - 1,
                 )
@@ -115,6 +121,8 @@ async def _run_turn(
     step_title: str | None = None,
     planned_constraint: Mapping[str, object] | None = None,
     audit_policy: Mapping[str, object] | None = None,
+    plan_facts: Mapping[str, object] | None = None,
+    step_facts: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
 ) -> int:
@@ -133,6 +141,8 @@ async def _run_turn(
         step_title=step_title,
         planned_constraint=planned_constraint,
         audit_policy=audit_policy,
+        plan_facts=plan_facts,
+        step_facts=step_facts,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )
@@ -159,6 +169,8 @@ async def _run_prompt_session(
     step_title: str | None = None,
     planned_constraint: Mapping[str, object] | None = None,
     audit_policy: Mapping[str, object] | None = None,
+    plan_facts: Mapping[str, object] | None = None,
+    step_facts: Mapping[str, object] | None = None,
     emit_plan_start: bool = True,
     emit_plan_completion: bool = True,
 ) -> None:
@@ -177,6 +189,8 @@ async def _run_prompt_session(
         step_title=step_title,
         planned_constraint=planned_constraint,
         audit_policy=audit_policy,
+        plan_facts=plan_facts,
+        step_facts=step_facts,
         emit_plan_start=emit_plan_start,
         emit_plan_completion=emit_plan_completion,
     )

--- a/src/loushang/work/coding.py
+++ b/src/loushang/work/coding.py
@@ -41,6 +41,8 @@ class CodingWorkShell:
         step_title: str | None = None,
         planned_constraint: Mapping[str, object] | None = None,
         audit_policy: Mapping[str, object] | None = None,
+        plan_facts: Mapping[str, object] | None = None,
+        step_facts: Mapping[str, object] | None = None,
         operation_id: str | None = None,
         run_id: str | None = None,
         emit_plan_start: bool = True,
@@ -65,6 +67,8 @@ class CodingWorkShell:
                 step_title=step_title,
                 planned_constraint=planned_constraint,
                 audit_policy=audit_policy,
+                plan_facts=plan_facts,
+                step_facts=step_facts,
             ),
         )
         self._append_operation(operation, run_id=run_id, sequence=sequence)
@@ -103,6 +107,8 @@ class CodingWorkShell:
                         step_title=step_title,
                         planned_constraint=planned_constraint,
                         audit_policy=audit_policy,
+                        plan_facts=plan_facts,
+                        step_facts=step_facts,
                     ),
                 ),
             )
@@ -120,6 +126,8 @@ class CodingWorkShell:
                         step_title=step_title,
                         planned_constraint=planned_constraint,
                         audit_policy=audit_policy,
+                        plan_facts=plan_facts,
+                        step_facts=step_facts,
                     ),
                 ),
             )
@@ -162,6 +170,8 @@ class CodingWorkShell:
                 step_title=step_title,
                 planned_constraint=planned_constraint,
                 audit_policy=audit_policy,
+                plan_facts=plan_facts,
+                step_facts=step_facts,
                 error=error,
             )
             if step_id is not None:
@@ -225,6 +235,8 @@ class CodingWorkShell:
                         step_title=step_title,
                         planned_constraint=planned_constraint,
                         audit_policy=audit_policy,
+                        plan_facts=plan_facts,
+                        step_facts=step_facts,
                     ),
                 ),
             )
@@ -242,6 +254,8 @@ class CodingWorkShell:
                         step_title=step_title,
                         planned_constraint=planned_constraint,
                         audit_policy=audit_policy,
+                        plan_facts=plan_facts,
+                        step_facts=step_facts,
                     ),
                 ),
             )
@@ -321,6 +335,8 @@ def _operation_payload(
     step_title: str | None,
     planned_constraint: Mapping[str, object] | None,
     audit_policy: Mapping[str, object] | None,
+    plan_facts: Mapping[str, object] | None,
+    step_facts: Mapping[str, object] | None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {"text": text}
     if images is not None:
@@ -339,6 +355,10 @@ def _operation_payload(
         payload["planned_constraint"] = dict(planned_constraint)
     if audit_policy:
         payload["audit_policy"] = dict(audit_policy)
+    if plan_facts:
+        payload["plan_facts"] = dict(plan_facts)
+    if step_facts:
+        payload["step_facts"] = dict(step_facts)
     return payload
 
 
@@ -348,6 +368,8 @@ def _step_payload(
     step_title: str | None,
     planned_constraint: Mapping[str, object] | None = None,
     audit_policy: Mapping[str, object] | None = None,
+    plan_facts: Mapping[str, object] | None = None,
+    step_facts: Mapping[str, object] | None = None,
     error: BaseException | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {"source_type": "work_shell"}
@@ -359,6 +381,10 @@ def _step_payload(
         payload["planned_constraint"] = dict(planned_constraint)
     if audit_policy:
         payload["audit_policy"] = dict(audit_policy)
+    if plan_facts:
+        payload["plan_facts"] = dict(plan_facts)
+    if step_facts:
+        payload["step_facts"] = dict(step_facts)
     if error is not None:
         payload["error"] = str(error)
     return payload

--- a/src/loushang/work/plan_projection.py
+++ b/src/loushang/work/plan_projection.py
@@ -49,6 +49,7 @@ class _PlanState:
     method_id: str | None = None
     current_step_id: str | None = None
     error: str | None = None
+    plan_facts: dict[str, object] | None = None
     operation_ids: list[str] = field(default_factory=list)
     steps: dict[str, _StepState] = field(default_factory=dict)
     step_order: list[str] = field(default_factory=list)
@@ -59,6 +60,9 @@ class _PlanState:
             self.method_id = method_id
         if entry.operation_id and entry.operation_id not in self.operation_ids:
             self.operation_ids.append(entry.operation_id)
+        plan_facts = _entry_mapping_payload_value(entry, "plan_facts")
+        if plan_facts is not None:
+            self.plan_facts = plan_facts
 
         if kind == "WorkPlanStarted":
             self.status = "running"
@@ -91,6 +95,8 @@ class _PlanState:
         metadata: dict[str, object] = {"operation_ids": tuple(self.operation_ids)}
         if self.error is not None:
             metadata["error"] = self.error
+        if self.plan_facts is not None:
+            metadata["plan_facts"] = self.plan_facts
         return WorkPlanRun(
             plan_id=self.plan_id,
             status=self.status,
@@ -135,6 +141,7 @@ class _StepState:
     deviation: WorkStepDeviation | None = None
     planned_constraint: dict[str, object] | None = None
     audit_policy: dict[str, object] | None = None
+    step_facts: dict[str, object] | None = None
 
     def update_from_entry(
         self,
@@ -165,6 +172,9 @@ class _StepState:
         audit_policy = _entry_mapping_payload_value(entry, "audit_policy")
         if audit_policy is not None:
             self.audit_policy = audit_policy
+        step_facts = _entry_mapping_payload_value(entry, "step_facts")
+        if step_facts is not None:
+            self.step_facts = step_facts
 
         if kind == "WorkStepStarted":
             self.status = "running"
@@ -189,6 +199,7 @@ class _StepState:
                 "deviation": asdict(self.deviation) if self.deviation is not None else None,
                 "planned_constraint": self.planned_constraint,
                 "audit_policy": self.audit_policy,
+                "step_facts": self.step_facts,
             }
         )
         return WorkStepRun(

--- a/tests/coding/domain/test_coding_domain_app.py
+++ b/tests/coding/domain/test_coding_domain_app.py
@@ -239,11 +239,24 @@ def test_prepare_turns_with_fixed_method_prepares_each_step(tmp_path: Path) -> N
         "requires_reason": True,
     }
     assert prepared_turns[0].metadata["audit_policy"] == {"record": ["status", "reason"]}
+    assert prepared_turns[0].metadata["plan_facts"]["plan_id"] == "plan:method:task:review"
+    assert prepared_turns[0].metadata["plan_facts"]["method_id"] == "method:task:review"
+    assert prepared_turns[0].metadata["plan_facts"]["mode"] == "fixed"
+    assert prepared_turns[0].metadata["plan_facts"]["metadata"]["step_count"] == 2
+    assert prepared_turns[0].metadata["step_facts"]["step_id"] == "inspect"
+    assert prepared_turns[0].metadata["step_facts"]["title"] == "Inspect current changes"
+    assert prepared_turns[0].metadata["step_facts"]["step_index"] == 0
+    assert prepared_turns[0].metadata["step_facts"]["step_count"] == 2
     assert prepared_turns[1].metadata["planned_constraint"] == {
         "level": "evidence",
         "requires_evidence": True,
     }
     assert prepared_turns[1].metadata["audit_policy"] == {"record": ["status", "reason", "evidence"]}
+    assert prepared_turns[1].metadata["plan_facts"]["plan_id"] == "plan:method:task:review"
+    assert prepared_turns[1].metadata["step_facts"]["step_id"] == "verify"
+    assert prepared_turns[1].metadata["step_facts"]["title"] == "Run focused checks"
+    assert prepared_turns[1].metadata["step_facts"]["step_index"] == 1
+    assert prepared_turns[1].metadata["step_facts"]["step_count"] == 2
     assert "Read changed files and summarize intent." in prepared_turns[0].prepared_prompt
     assert "Run focused tests or explain why they cannot run." in prepared_turns[1].prepared_prompt
     assert prepared_turns[0].prepared_prompt.endswith("User request:\n\ncheck src/app.py")

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -269,6 +269,8 @@ def _append_work_log_inspect_entry(
     deviation: dict[str, object] | None = None,
     planned_constraint: dict[str, object] | None = None,
     audit_policy: dict[str, object] | None = None,
+    plan_facts: dict[str, object] | None = None,
+    step_facts: dict[str, object] | None = None,
     extra_payload: dict[str, object] | None = None,
 ) -> None:
     from loushang.work import EventLogEntry
@@ -293,6 +295,10 @@ def _append_work_log_inspect_entry(
         nested_payload["planned_constraint"] = planned_constraint
     if audit_policy is not None:
         nested_payload["audit_policy"] = audit_policy
+    if plan_facts is not None:
+        nested_payload["plan_facts"] = plan_facts
+    if step_facts is not None:
+        nested_payload["step_facts"] = step_facts
     if extra_payload is not None:
         nested_payload.update(extra_payload)
     if nested_payload:
@@ -324,6 +330,8 @@ def _append_work_log_plan_step_entries(
     last: bool = False,
     planned_constraint: dict[str, object] | None = None,
     audit_policy: dict[str, object] | None = None,
+    plan_facts: dict[str, object] | None = None,
+    step_facts: dict[str, object] | None = None,
 ) -> int:
     sequence = start_sequence
     _append_work_log_inspect_entry(
@@ -339,6 +347,8 @@ def _append_work_log_plan_step_entries(
         step_title=step_title,
         planned_constraint=planned_constraint,
         audit_policy=audit_policy,
+        plan_facts=plan_facts,
+        step_facts=step_facts,
     )
     sequence += 1
     if first:
@@ -354,6 +364,8 @@ def _append_work_log_plan_step_entries(
             step_title=step_title,
             planned_constraint=planned_constraint,
             audit_policy=audit_policy,
+            plan_facts=plan_facts,
+            step_facts=step_facts,
         )
         sequence += 1
     _append_work_log_inspect_entry(
@@ -368,6 +380,8 @@ def _append_work_log_plan_step_entries(
         step_title=step_title,
         planned_constraint=planned_constraint,
         audit_policy=audit_policy,
+        plan_facts=plan_facts,
+        step_facts=step_facts,
     )
     sequence += 1
     _append_work_log_inspect_entry(
@@ -395,6 +409,8 @@ def _append_work_log_plan_step_entries(
             step_title=step_title,
             planned_constraint=planned_constraint,
             audit_policy=audit_policy,
+            plan_facts=plan_facts,
+            step_facts=step_facts,
         )
         sequence += 1
     return sequence
@@ -2645,6 +2661,12 @@ def test_run_cli_dash_p_with_fixed_method_executes_each_step(tmp_path) -> None:
         "requires_reason": True,
     }
     assert first_call["audit_policy"] == {"record": ["status", "reason"]}
+    assert first_call["plan_facts"]["plan_id"] == "plan:method:task:review"
+    assert first_call["plan_facts"]["method_id"] == "method:task:review"
+    assert first_call["plan_facts"]["mode"] == "fixed"
+    assert first_call["step_facts"]["step_id"] == "inspect"
+    assert first_call["step_facts"]["title"] == "Inspect current changes"
+    assert first_call["step_facts"]["step_index"] == 0
     assert first_call["emit_plan_start"] is True
     assert first_call["emit_plan_completion"] is False
     assert "Read changed files and summarize intent." in first_call["prompt"]
@@ -2660,6 +2682,10 @@ def test_run_cli_dash_p_with_fixed_method_executes_each_step(tmp_path) -> None:
         "requires_evidence": True,
     }
     assert second_call["audit_policy"] == {"record": ["status", "reason", "evidence"]}
+    assert second_call["plan_facts"]["plan_id"] == "plan:method:task:review"
+    assert second_call["step_facts"]["step_id"] == "verify"
+    assert second_call["step_facts"]["title"] == "Run focused checks"
+    assert second_call["step_facts"]["step_index"] == 1
     assert second_call["emit_plan_start"] is False
     assert second_call["emit_plan_completion"] is True
     assert "Run focused tests or explain why they cannot run." in second_call["prompt"]
@@ -3261,6 +3287,12 @@ def test_run_cli_mode_print_with_fixed_method_executes_each_step(tmp_path) -> No
         "requires_reason": True,
     }
     assert first_call["audit_policy"] == {"record": ["status", "reason"]}
+    assert first_call["plan_facts"]["plan_id"] == "plan:method:task:review"
+    assert first_call["plan_facts"]["method_id"] == "method:task:review"
+    assert first_call["plan_facts"]["mode"] == "fixed"
+    assert first_call["step_facts"]["step_id"] == "inspect"
+    assert first_call["step_facts"]["title"] == "Inspect current changes"
+    assert first_call["step_facts"]["step_index"] == 0
     assert first_call["emit_plan_start"] is True
     assert first_call["emit_plan_completion"] is False
     assert "Read changed files and summarize intent." in first_call["user_input"]
@@ -3277,6 +3309,10 @@ def test_run_cli_mode_print_with_fixed_method_executes_each_step(tmp_path) -> No
         "requires_evidence": True,
     }
     assert second_call["audit_policy"] == {"record": ["status", "reason", "evidence"]}
+    assert second_call["plan_facts"]["plan_id"] == "plan:method:task:review"
+    assert second_call["step_facts"]["step_id"] == "verify"
+    assert second_call["step_facts"]["title"] == "Run focused checks"
+    assert second_call["step_facts"]["step_index"] == 1
     assert second_call["emit_plan_start"] is False
     assert second_call["emit_plan_completion"] is True
     assert "Run focused tests or explain why they cannot run." in second_call["user_input"]
@@ -4428,6 +4464,17 @@ def test_run_cli_work_log_inspect_plans_json_outputs_plan_projection(tmp_path) -
 
     log_path = tmp_path / "events.jsonl"
     event_log = JsonlEventLogBackend(log_path)
+    plan_facts = {
+        "plan_id": "plan:method:task:review",
+        "method_id": "method:task:review",
+        "mode": "fixed",
+    }
+    step_facts = {
+        "step_id": "inspect",
+        "title": "Inspect current changes",
+        "step_index": 0,
+        "step_count": 1,
+    }
     _append_work_log_plan_step_entries(
         event_log,
         start_sequence=1,
@@ -4439,6 +4486,8 @@ def test_run_cli_work_log_inspect_plans_json_outputs_plan_projection(tmp_path) -
         last=True,
         planned_constraint={"level": "reasoned", "requires_reason": True},
         audit_policy={"record": ["status", "reason"]},
+        plan_facts=plan_facts,
+        step_facts=step_facts,
     )
     stdout = StringIO()
 
@@ -4473,6 +4522,8 @@ def test_run_cli_work_log_inspect_plans_json_outputs_plan_projection(tmp_path) -
         "requires_reason": True,
     }
     assert payload[0]["steps"][0]["metadata"]["audit_policy"] == {"record": ["status", "reason"]}
+    assert payload[0]["metadata"]["plan_facts"] == plan_facts
+    assert payload[0]["steps"][0]["metadata"]["step_facts"] == step_facts
 
 
 def test_run_cli_work_log_inspect_plans_json_includes_step_deviation(tmp_path) -> None:

--- a/tests/work/test_coding_work_shell.py
+++ b/tests/work/test_coding_work_shell.py
@@ -262,6 +262,17 @@ def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
             event_log=event_log,
             clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
         )
+        plan_facts = {
+            "plan_id": "plan:method:task:review",
+            "method_id": "method:task:review",
+            "mode": "fixed",
+        }
+        step_facts = {
+            "step_id": "inspect",
+            "title": "Inspect current changes",
+            "step_index": 0,
+            "step_count": 2,
+        }
 
         run = await shell.submit_coding_turn(
             "inspect current changes",
@@ -275,6 +286,8 @@ def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
             step_title="Inspect current changes",
             planned_constraint={"level": "reasoned", "requires_reason": True},
             audit_policy={"record": ["status", "reason"]},
+            plan_facts=plan_facts,
+            step_facts=step_facts,
         )
 
         assert run.status == "completed"
@@ -301,6 +314,8 @@ def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
             "step_title": "Inspect current changes",
             "planned_constraint": {"level": "reasoned", "requires_reason": True},
             "audit_policy": {"record": ["status", "reason"]},
+            "plan_facts": plan_facts,
+            "step_facts": step_facts,
         }
         assert entries[2].payload["delivery_hint"] == "coalesce"
         assert entries[3].payload["delivery_hint"] == "coalesce"
@@ -315,7 +330,15 @@ def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
             "step_title": "Inspect current changes",
             "planned_constraint": {"level": "reasoned", "requires_reason": True},
             "audit_policy": {"record": ["status", "reason"]},
+            "plan_facts": plan_facts,
+            "step_facts": step_facts,
         }
+        assert entries[2].payload["payload"]["plan_facts"] == plan_facts
+        assert entries[2].payload["payload"]["step_facts"] == step_facts
+        assert entries[4].payload["payload"]["plan_facts"] == plan_facts
+        assert entries[4].payload["payload"]["step_facts"] == step_facts
+        assert entries[5].payload["payload"]["plan_facts"] == plan_facts
+        assert entries[5].payload["payload"]["step_facts"] == step_facts
 
     asyncio.run(scenario())
 
@@ -414,6 +437,8 @@ def test_coding_work_shell_records_step_and_plan_failures_before_run_failure() -
             event_log=event_log,
             clock=lambda: datetime(2026, 6, 1, 10, 30, tzinfo=UTC),
         )
+        plan_facts = {"plan_id": "plan:method:task:review", "method_id": "method:task:review"}
+        step_facts = {"step_id": "inspect", "step_index": 0}
 
         try:
             await shell.submit_coding_turn(
@@ -426,6 +451,8 @@ def test_coding_work_shell_records_step_and_plan_failures_before_run_failure() -
                 step_id="inspect",
                 step_index=0,
                 step_title="Inspect current changes",
+                plan_facts=plan_facts,
+                step_facts=step_facts,
             )
         except RuntimeError as error:
             assert str(error) == "agent failed"
@@ -446,6 +473,10 @@ def test_coding_work_shell_records_step_and_plan_failures_before_run_failure() -
         assert entries[5].payload["delivery_hint"] == "immediate"
         assert entries[4].payload["payload"]["error"] == "agent failed"
         assert entries[5].payload["payload"]["error"] == "agent failed"
+        assert entries[4].payload["payload"]["plan_facts"] == plan_facts
+        assert entries[4].payload["payload"]["step_facts"] == step_facts
+        assert entries[5].payload["payload"]["plan_facts"] == plan_facts
+        assert entries[5].payload["payload"]["step_facts"] == step_facts
         assert entries[6].payload["payload"]["method_id"] == "method:task:review"
         assert entries[6].payload["payload"]["plan_id"] == "plan:method:task:review"
         assert entries[6].payload["payload"]["step_id"] == "inspect"

--- a/tests/work/test_plan_projection.py
+++ b/tests/work/test_plan_projection.py
@@ -20,6 +20,8 @@ def _entry(
     deviation: dict[str, object] | None = None,
     planned_constraint: dict[str, object] | None = None,
     audit_policy: dict[str, object] | None = None,
+    plan_facts: dict[str, object] | None = None,
+    step_facts: dict[str, object] | None = None,
 ) -> object:
     from loushang.work import EventLogEntry
 
@@ -43,6 +45,10 @@ def _entry(
         nested_payload["planned_constraint"] = planned_constraint
     if audit_policy is not None:
         nested_payload["audit_policy"] = audit_policy
+    if plan_facts is not None:
+        nested_payload["plan_facts"] = plan_facts
+    if step_facts is not None:
+        nested_payload["step_facts"] = step_facts
     if nested_payload:
         payload["payload"] = nested_payload
 
@@ -322,6 +328,52 @@ def test_project_work_plan_runs_replays_planned_step_policy_metadata() -> None:
         "requires_reason": True,
     }
     assert metadata["audit_policy"] == {"record": ["status", "reason"]}
+
+
+def test_project_work_plan_runs_replays_plan_and_step_facts() -> None:
+    from loushang.work import project_work_plan_runs
+
+    plan_facts = {
+        "plan_id": "plan:method:task:review",
+        "method_id": "method:task:review",
+        "mode": "fixed",
+        "phase": "VERIFY",
+    }
+    step_facts = {
+        "step_id": "inspect",
+        "title": "Inspect current changes",
+        "executor": "current_agent",
+        "step_index": 0,
+        "step_count": 2,
+    }
+
+    plans = project_work_plan_runs(
+        [
+            _entry(
+                "run-inspect-plan-started",
+                kind="WorkPlanStarted",
+                run_id="run-inspect",
+                sequence=1,
+                step_id="inspect",
+                step_index=0,
+                step_title="Inspect current changes",
+                plan_facts=plan_facts,
+                step_facts=step_facts,
+            ),
+            _entry(
+                "run-inspect-step-completed",
+                kind="WorkStepCompleted",
+                run_id="run-inspect",
+                sequence=2,
+                step_id="inspect",
+                step_index=0,
+                step_title="Inspect current changes",
+            ),
+        ]
+    )
+
+    assert plans[0].metadata["plan_facts"] == plan_facts
+    assert plans[0].steps[0].metadata["step_facts"] == step_facts
 
 
 def test_project_work_plan_runs_ignores_entries_without_plan_id() -> None:


### PR DESCRIPTION
## Summary / 摘要
- EN: Propagates MethodProjector plan_facts and step_facts through coding prepared-turn metadata, prompt/print/mode runners, and CodingWorkShell payloads.
- 中文：将 MethodProjector 的 plan_facts 和 step_facts 接入 coding prepared-turn metadata、prompt/print/mode runner，以及 CodingWorkShell payload。
- EN: Preserves facts in WorkOperation plus plan/step lifecycle events, including success and failure paths.
- 中文：在 WorkOperation 以及 plan/step 生命周期事件中保留 facts，覆盖成功和失败路径。
- EN: Exposes facts naturally in plans-json via WorkPlanRun.metadata and WorkStepRun.metadata.
- 中文：通过 WorkPlanRun.metadata 和 WorkStepRun.metadata 在 plans-json 中自然暴露 facts。

## Linked Issue / 关联 Issue
- Closes #115

## Human Review Notes / 给人工 Review 的说明
- EN: Review the fact chain end-to-end: MethodProjector metadata -> CodingDomainPreparedTurn.metadata -> runner parameters -> CodingWorkShell JSONL payloads -> project_work_plan_runs/plans-json.
- 中文：请端到端检查 facts 链路：MethodProjector metadata -> CodingDomainPreparedTurn.metadata -> runner 参数 -> CodingWorkShell JSONL payload -> project_work_plan_runs/plans-json。
- EN: The extra touched files under coding/cli, coding/prompt_command, and coding/mode are bridge layers needed to pass prepared-turn facts into the work shell. This PR does not enable Native TUI or RPC --method behavior.
- 中文：coding/cli、coding/prompt_command、coding/mode 下的额外改动是把 prepared-turn facts 传入 work shell 的桥接层。本 PR 不启用 Native TUI 或 RPC 的 --method 行为。

## Agent Review Brief / 给 Agent Review 的说明
- EN: Check that only mapping-shaped plan_facts and step_facts are copied, and that they are persisted in SubmitCodingTurn, WorkPlanStarted, WorkStepStarted, WorkStepCompleted, WorkPlanCompleted, WorkStepFailed, and WorkPlanFailed payloads.
- 中文：请检查仅复制 mapping 形态的 plan_facts / step_facts，并确认它们在 SubmitCodingTurn、WorkPlanStarted、WorkStepStarted、WorkStepCompleted、WorkPlanCompleted、WorkStepFailed、WorkPlanFailed payload 中被持久化。
- EN: Verify plans-json exposure comes from the existing projection metadata path, without expanding public projection types or touching TUI/RPC/agent-loop internals.
- 中文：请确认 plans-json 通过现有 projection metadata 路径暴露 facts，没有扩展公共 projection 类型，也没有触碰 TUI/RPC/agent-loop 内部逻辑。
- EN: Suggested review commands are the Test Plan commands below.
- 中文：建议使用下方 Test Plan 命令进行 review 验证。

## Test Plan / 测试计划
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/method tests/work tests/coding/domain/test_coding_domain_app.py tests/coding/test_prompt_command.py -q
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k "method or work_log" -q
- [x] uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/method src/loushang/work src/loushang/coding/domain tests/method tests/work tests/coding/domain
- [x] uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/cli/__main__.py src/loushang/coding/prompt_command.py src/loushang/coding/mode/base.py src/loushang/coding/mode/print_mode.py tests/coding/test_cli.py