### PR TITLE
fix(tui): include streaming draft in transcript reader source / 补齐 transcript reader 流式草稿数据源

### DIFF
--- a/src/loushang/coding/ui/transcript_source.py
+++ b/src/loushang/coding/ui/transcript_source.py
@@ -57,7 +57,7 @@ class SessionTranscriptSource:
         complete = True
         source_label = self.source_label
         if self.active_window_state is not None:
-            active_records = tuple(self.active_window_state.records)
+            active_records = _active_window_records(self.active_window_state)
             merged_records = _merge_active_window_records(session_records, active_records)
             if merged_records != session_records:
                 records = merged_records
@@ -82,6 +82,14 @@ def _recent_assistant_texts(records: Iterable[DisplayRecord]) -> tuple[str, ...]
         if record.text.strip():
             texts.append(record.text)
     return tuple(texts)
+
+
+def _active_window_records(state: NativeCodingTuiState) -> tuple[DisplayRecord, ...]:
+    records = tuple(state.records)
+    assistant_draft = state.assistant_draft
+    if assistant_draft is not None:
+        return (*records, assistant_draft)
+    return records
 
 
 def _merge_active_window_records(

--- a/src/loushang/coding/ui/transcript_source.py
+++ b/src/loushang/coding/ui/transcript_source.py
@@ -29,14 +29,14 @@ class ActiveWindowTranscriptSource:
 
     def snapshot(self) -> TranscriptSnapshot:
         return TranscriptSnapshot(
-            records=tuple(self.state.records),
+            records=_active_window_records(self.state),
             evicted_prefix_record_count=max(0, self.state.evicted_prefix_record_count),
             complete=False,
             source_label="Transcript window",
         )
 
     def recent_assistant_texts(self) -> tuple[str, ...]:
-        return _recent_assistant_texts(self.state.records)
+        return _recent_assistant_texts(_active_window_records(self.state))
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/coding/test_native_coding_tui_input.py
+++ b/tests/coding/test_native_coding_tui_input.py
@@ -538,6 +538,64 @@ def test_native_input_router_ctrl_o_session_reader_includes_running_tool_record(
     assert any("live output" in line for line in lines)
 
 
+def test_native_input_router_ctrl_o_session_reader_includes_streaming_assistant_draft() -> None:
+    from dataclasses import dataclass
+
+    from loushang.ai.types import AssistantMessage, TextPart, Usage, UserMessage
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_input import NativeInputRouter
+    from loushang.coding.ui.transcript_reader import TranscriptReaderSurface
+    from loushang.coding.ui.transcript_source import SessionTranscriptSource
+    from loushang.tui import RenderConstraints, SurfaceHost, strip_control_sequences
+    from loushang.tui.transcript import AssistantMessageRecord, UserPromptRecord
+
+    @dataclass(slots=True)
+    class _Session:
+        messages: list[object]
+
+    session = _Session(
+        messages=[
+            UserMessage(role="user", content=[TextPart(type="text", text="full question")], timestamp=1.0),
+            AssistantMessage(
+                role="assistant",
+                content=[TextPart(type="text", text="full answer")],
+                api="openai",
+                provider="moonshot",
+                model="kimi",
+                response_id=None,
+                usage=Usage(input=0, output=0, cache_read=0, cache_write=0, total_tokens=0, cost={}),
+                stop_reason="stop",
+                error_message=None,
+                timestamp=2.0,
+            ),
+        ]
+    )
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 10.0)
+    app.surface_host = SurfaceHost()
+    app.replace_transcript_window(
+        (
+            UserPromptRecord("full question"),
+            AssistantMessageRecord("full answer", stable=True),
+        ),
+        reason="test",
+    )
+    app.begin_run(started_at=3.0)
+    app.append_assistant_chunk("streaming draft")
+    app.transcript_source_factory = lambda: SessionTranscriptSource(session, active_window_state=app.state)
+
+    result = NativeInputRouter(app, should_exit=lambda text: False).handle(InputEvent(kind="key", key="ctrl+o"))
+
+    assert result.render_requested is True
+    assert app.surface_host.entries
+    reader = app.surface_host.entries[0].surface.renderable
+    assert isinstance(reader, TranscriptReaderSurface)
+    reader.raw_mode = True
+    rendered = reader.render(RenderConstraints(width=100, max_height=12))
+    lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
+    assert "Full transcript + live window" in lines
+    assert any("streaming draft" in line for line in lines)
+
+
 def test_native_input_router_reader_strict_modal_consumes_tab_without_completion() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_input import NativeInputRouter

--- a/tests/coding/test_native_coding_tui_input.py
+++ b/tests/coding/test_native_coding_tui_input.py
@@ -442,6 +442,38 @@ def test_native_input_router_ctrl_o_opens_transcript_reader_overlay() -> None:
     assert app.state.records[-1] == AssistantMessageRecord("answer")
 
 
+def test_native_input_router_ctrl_o_fallback_reader_includes_streaming_assistant_draft() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_input import NativeInputRouter
+    from loushang.coding.ui.transcript_reader import TranscriptReaderSurface
+    from loushang.tui import RenderConstraints, SurfaceHost, strip_control_sequences
+    from loushang.tui.transcript import AssistantMessageRecord, UserPromptRecord
+
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 10.0)
+    app.surface_host = SurfaceHost()
+    app.replace_transcript_window(
+        (
+            UserPromptRecord("full question"),
+            AssistantMessageRecord("full answer", stable=True),
+        ),
+        reason="test",
+    )
+    app.begin_run(started_at=3.0)
+    app.append_assistant_chunk("streaming fallback draft")
+
+    result = NativeInputRouter(app, should_exit=lambda text: False).handle(InputEvent(kind="key", key="ctrl+o"))
+
+    assert result.render_requested is True
+    assert app.surface_host.entries
+    reader = app.surface_host.entries[0].surface.renderable
+    assert isinstance(reader, TranscriptReaderSurface)
+    reader.raw_mode = True
+    rendered = reader.render(RenderConstraints(width=100, max_height=12))
+    lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
+    assert "Transcript window" in lines
+    assert any("streaming fallback draft" in line for line in lines)
+
+
 def test_native_input_router_ctrl_o_uses_transcript_source_factory() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_input import NativeInputRouter

--- a/tests/coding/test_ui_transcript_source.py
+++ b/tests/coding/test_ui_transcript_source.py
@@ -112,6 +112,34 @@ def test_session_transcript_source_merges_live_active_window_records() -> None:
     )
 
 
+def test_session_transcript_source_merges_live_assistant_draft() -> None:
+    session = _Session(
+        messages=[
+            UserMessage(role="user", content=[TextPart(type="text", text="full question")], timestamp=1.0),
+            _assistant_message("full answer", timestamp=2.0),
+        ]
+    )
+    state = NativeCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
+    state.replace_transcript_window(
+        (
+            UserPromptRecord("full question"),
+            AssistantMessageRecord("full answer", stable=True),
+        )
+    )
+    state.begin_run(started_at=3.0)
+    state.append_assistant_chunk("streaming draft")
+
+    snapshot = SessionTranscriptSource(session, active_window_state=state).snapshot()
+
+    assert snapshot.complete is False
+    assert snapshot.source_label == "Full transcript + live window"
+    assert snapshot.records == (
+        UserPromptRecord("full question"),
+        AssistantMessageRecord("full answer", stable=True),
+        AssistantMessageRecord("streaming draft", stable=False),
+    )
+
+
 def _assistant_message(text: str, *, timestamp: float) -> AssistantMessage:
     return AssistantMessage(
         role="assistant",

--- a/tests/coding/test_ui_transcript_source.py
+++ b/tests/coding/test_ui_transcript_source.py
@@ -38,6 +38,28 @@ def test_active_window_transcript_source_returns_snapshot_metadata() -> None:
     assert snapshot.source_label == "Transcript window"
 
 
+def test_active_window_transcript_source_includes_live_assistant_draft() -> None:
+    state = NativeCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
+    state.replace_transcript_window(
+        (
+            UserPromptRecord("hello"),
+            AssistantMessageRecord("answer"),
+        ),
+    )
+    state.begin_run(started_at=1.0)
+    state.append_assistant_chunk("streaming draft")
+
+    snapshot = ActiveWindowTranscriptSource(state).snapshot()
+
+    assert snapshot.records == (
+        UserPromptRecord("hello"),
+        AssistantMessageRecord("answer"),
+        AssistantMessageRecord("streaming draft", stable=False),
+    )
+    assert snapshot.complete is False
+    assert snapshot.source_label == "Transcript window"
+
+
 def test_active_window_transcript_source_recent_assistant_texts_are_filtered_newest_first() -> None:
     state = NativeCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
     state.records.extend(


### PR DESCRIPTION

## Summary / 摘要
- Follow-up to merged PR #116.
- Includes `NativeCodingTuiState.assistant_draft` in `SessionTranscriptSource` live-window merge.
- Marks snapshots as `complete=False` and labels them `Full transcript + live window` when a streaming draft is present.
- Adds regression coverage for source snapshots and Ctrl+O reader rendering during assistant streaming.

## Context / 背景
PR #116 has already been merged. This PR fixes the remaining live source boundary: #116 covered running tool records from `active_window_state.records`, but streaming assistant output lives in `assistant_draft_buffer` / `assistant_draft` until `end_assistant()` materializes it into records.

## Review Guidance / Review 说明
- Scope is limited to TUI transcript reader source behavior and tests.
- Check that live assistant drafts are appended after active window records and deduped through the existing session/live merge path.
- Check that snapshots stay `Full transcript` / `complete=True` when there are no live-only records.
- Check that raw reader mode shows the streaming draft when opened via Ctrl+O during an active assistant stream.

## Test Plan / 验证
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_ui_transcript_source.py tests/coding/test_native_coding_tui_input.py -k "merges_live_assistant_draft or session_reader_includes_streaming_assistant_draft" -q` -> 2 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_ui_transcript_source.py tests/coding/test_native_coding_tui_input.py tests/coding/test_native_coding_tui_mode.py tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py tests/coding/test_native_tui_playback_runner.py -q` -> 124 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/transcript_source.py tests/coding/test_ui_transcript_source.py tests/coding/test_native_coding_tui_input.py` -> passed
- `uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py -q` -> 33 passed
- `git diff --check` -> passed

## Related / 关联
Follow-up to #116.
Related: #88, #96, #97, #99
