### PR TITLE
Define method facts contract / 定义 method facts 契约

### DIFF
--- a/docs/internals/architecture/coding/component-interfaces/domain.md
+++ b/docs/internals/architecture/coding/component-interfaces/domain.md
@@ -71,6 +71,11 @@ Method-driven non-interactive runs are observed through `loushang.work`:
 Step deviation is represented as `WorkStepDeviation` metadata, not as a separate
 `step_deviation` event kind.
 
+Method `plan_facts` and `step_facts` are defined by
+[`loushang.method`'s facts contract](../method-facts-contract.md). The coding
+domain bridge only carries those facts from method projection to runner/work-log
+parameters; it does not redefine their semantics.
+
 ## Key Data
 
 - `CodingDomainRequest`

--- a/docs/internals/architecture/coding/component-interfaces/method.md
+++ b/docs/internals/architecture/coding/component-interfaces/method.md
@@ -19,5 +19,6 @@ The full boundary is documented in [domain.md](domain.md).
 
 ## Related Architecture Decisions
 
+- [Method Facts Contract](../method-facts-contract.md)
 - [ARD-006: TUI Method Integration Constraints](../ARD-006-tui-method-integration-constraints.md)
 - [Coding Product Boundaries](../ARD-001-coding-product-boundaries.md)

--- a/docs/internals/architecture/coding/method-facts-contract.md
+++ b/docs/internals/architecture/coding/method-facts-contract.md
@@ -1,0 +1,142 @@
+# Method Facts Contract
+
+## Scope
+
+Method facts are structured metadata emitted by `MethodProjector` so a prepared
+coding turn and its work log can preserve method, plan, and step identity without
+re-parsing method assets.
+
+The facts flow is:
+
+```text
+MethodProjector
+  -> CodingDomainPreparedTurn.metadata
+  -> prompt/print/mode runner parameters
+  -> CodingWorkShell operation and lifecycle payloads
+  -> work-log JSONL
+  -> project_work_plan_runs / plans-json inspect output
+```
+
+`loushang.method` owns the meaning and shape of these facts. `loushang.coding`
+and `loushang.work` treat them as opaque mappings to persist and replay.
+
+## Stable Public Fields
+
+`plan_facts` has these stable fields:
+
+- `plan_id`
+- `method_id`
+- `mode`
+- `phase`
+- `activity`
+- `task`
+- `metadata`
+- `applicability`
+
+`step_facts` has these stable fields:
+
+- `step_id`
+- `title`
+- `executor`
+- `role_variant`
+- `step_index`
+- `step_count`
+- `applicability`
+
+Downstream code may depend on these field names. Adding a new top-level fact is
+allowed when it is documented here and covered by projector tests. Removing or
+renaming a stable field is a compatibility change.
+
+## Plan Metadata
+
+`plan_facts["metadata"]` is a stable whitelist, not a dump of
+`MethodPlan.metadata`.
+
+Currently exposed keys:
+
+- `method_kind`
+- `element_type`
+- `plan_mode`
+- `step_count`
+
+These keys are always present in `plan_facts["metadata"]`. A missing or
+unsupported source value is projected as null.
+
+Raw frontmatter, loader-local metadata, internal objects, and experimental
+metadata do not belong in `plan_facts`. If a downstream consumer needs a new
+metadata value, promote it to this whitelist with a projector test and update
+this document.
+
+## JSON Safety
+
+Facts must be JSON-safe before they leave `MethodProjector`.
+
+Allowed values are:
+
+- strings
+- numbers
+- booleans
+- null
+- dictionaries with string keys
+- lists containing allowed values
+
+Tuple-like method data is projected as JSON arrays. Unsupported internal objects
+are not exposed through stable facts. This keeps JSONL work logs and plans-json
+inspect output serializable without downstream cleanup.
+
+## Applicability
+
+`applicability` is projected as a JSON-safe mapping with these keys:
+
+- `domains`
+- `task_types`
+- `contexts`
+- `artifact_types`
+- `modalities`
+- `toolchains`
+- `lifecycle`
+- `capabilities`
+- `complexity`
+- `risk`
+- `tags`
+
+Sequence fields are lists. `tags` maps string keys to lists of strings.
+
+## Downstream Responsibilities
+
+`CodingDomainApp.prepare_turns()` copies facts from `MethodProjection.metadata`
+into `CodingDomainPreparedTurn.metadata`.
+
+The CLI, prompt command, and non-RPC mode bridges pass those mappings to
+`CodingWorkShell.submit_coding_turn()`.
+
+`CodingWorkShell` persists facts in:
+
+- `SubmitCodingTurn`
+- `WorkPlanStarted`
+- `WorkStepStarted`
+- `WorkStepCompleted`
+- `WorkPlanCompleted`
+- `WorkStepFailed`
+- `WorkPlanFailed`
+
+`project_work_plan_runs()` replays `plan_facts` into `WorkPlanRun.metadata` and
+`step_facts` into `WorkStepRun.metadata`.
+
+Downstream layers should not infer new semantics from the internal structure of
+method assets. They should only persist, replay, and inspect the stable facts.
+
+## Non-Goals
+
+This contract is not TUI or RPC method integration.
+
+It does not:
+
+- enable `--method` in Native TUI
+- enable `--method` in RPC mode
+- add TUI method pickers or step status rendering
+- change agent-loop or multi-agent scheduling semantics
+- rewrite method asset formats
+
+TUI and RPC method integration remain governed by
+[ARD-006: TUI Method Integration Constraints](ARD-006-tui-method-integration-constraints.md).

--- a/src/loushang/method/projection.py
+++ b/src/loushang/method/projection.py
@@ -8,6 +8,15 @@ from loushang.method.types import (
     MethodStep,
 )
 
+_PLAN_METADATA_FACT_KEYS = frozenset(
+    {
+        "method_kind",
+        "element_type",
+        "plan_mode",
+        "step_count",
+    }
+)
+
 
 class MethodProjector:
     def project(
@@ -60,7 +69,7 @@ def _plan_facts(plan: MethodPlan) -> dict[str, object]:
         "phase": plan.phase,
         "activity": plan.activity,
         "task": plan.task,
-        "metadata": dict(plan.metadata),
+        "metadata": _stable_plan_metadata_facts(plan),
         "applicability": _applicability_facts(plan.applicability),
     }
 
@@ -94,18 +103,43 @@ def _step_index(plan: MethodPlan, step: MethodStep) -> int | None:
 
 def _applicability_facts(applicability: MethodApplicability) -> dict[str, object]:
     return {
-        "domains": applicability.domains,
-        "task_types": applicability.task_types,
-        "contexts": applicability.contexts,
-        "artifact_types": applicability.artifact_types,
-        "modalities": applicability.modalities,
-        "toolchains": applicability.toolchains,
-        "lifecycle": applicability.lifecycle,
-        "capabilities": applicability.capabilities,
+        "domains": list(applicability.domains),
+        "task_types": list(applicability.task_types),
+        "contexts": list(applicability.contexts),
+        "artifact_types": list(applicability.artifact_types),
+        "modalities": list(applicability.modalities),
+        "toolchains": list(applicability.toolchains),
+        "lifecycle": list(applicability.lifecycle),
+        "capabilities": list(applicability.capabilities),
         "complexity": applicability.complexity,
         "risk": applicability.risk,
-        "tags": {key: tuple(values) for key, values in applicability.tags.items()},
+        "tags": {key: list(values) for key, values in applicability.tags.items()},
     }
+
+
+def _stable_plan_metadata_facts(plan: MethodPlan) -> dict[str, object]:
+    facts: dict[str, object] = {}
+    for key in _PLAN_METADATA_FACT_KEYS:
+        value = plan.metadata.get(key)
+        facts[key] = _json_safe_fact_value(value)
+    return facts
+
+
+def _json_safe_fact_value(value: object) -> object | None:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, tuple | list):
+        return [_json_safe_fact_value(item) for item in value]
+    if isinstance(value, dict):
+        result: dict[str, object] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                continue
+            normalized = _json_safe_fact_value(item)
+            if normalized is not None:
+                result[key] = normalized
+        return result
+    return None
 
 
 __all__ = ["MethodProjector"]

--- a/tests/method/test_method_projection.py
+++ b/tests/method/test_method_projection.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
+
 from loushang.method import (
     MethodApplicability,
     MethodCompiler,
     MethodDescriptor,
+    MethodPlan,
     MethodProjector,
+    MethodStep,
 )
 
 
@@ -113,17 +117,17 @@ def test_method_projector_exposes_structured_plan_and_step_facts() -> None:
             "step_count": 2,
         },
         "applicability": {
-            "domains": ("coding",),
-            "task_types": ("reviewing",),
-            "contexts": (),
-            "artifact_types": (),
-            "modalities": (),
-            "toolchains": (),
-            "lifecycle": (),
-            "capabilities": (),
+            "domains": ["coding"],
+            "task_types": ["reviewing"],
+            "contexts": [],
+            "artifact_types": [],
+            "modalities": [],
+            "toolchains": [],
+            "lifecycle": [],
+            "capabilities": [],
             "complexity": None,
             "risk": None,
-            "tags": {"method_family": ("verification",)},
+            "tags": {"method_family": ["verification"]},
         },
     }
     assert projection.metadata["step_facts"] == {
@@ -134,19 +138,113 @@ def test_method_projector_exposes_structured_plan_and_step_facts() -> None:
         "step_index": 1,
         "step_count": 2,
         "applicability": {
-            "domains": ("coding",),
-            "task_types": ("reviewing",),
-            "contexts": (),
-            "artifact_types": (),
-            "modalities": (),
-            "toolchains": (),
-            "lifecycle": (),
-            "capabilities": (),
+            "domains": ["coding"],
+            "task_types": ["reviewing"],
+            "contexts": [],
+            "artifact_types": [],
+            "modalities": [],
+            "toolchains": [],
+            "lifecycle": [],
+            "capabilities": [],
             "complexity": None,
             "risk": None,
-            "tags": {"method_family": ("verification",)},
+            "tags": {"method_family": ["verification"]},
         },
     }
+
+
+def test_method_projector_facts_use_stable_json_safe_contract() -> None:
+    plan = MethodPlan(
+        id="plan:method:task:review",
+        method_id="method:task:review",
+        mode="fixed",
+        phase="VERIFY",
+        activity="review",
+        task="check change",
+        steps=(
+            MethodStep(
+                id="inspect",
+                title="Inspect current changes",
+                executor="current_agent",
+                projection={"content": "Inspect.", "step_index": 0},
+                applicability=MethodApplicability(
+                    domains=("coding",),
+                    task_types=("reviewing",),
+                    tags={"method_family": ("verification",)},
+                ),
+            ),
+        ),
+        metadata={
+            "method_kind": "method_resource",
+            "element_type": "task",
+            "plan_mode": "fixed",
+            "step_count": 1,
+            "internal_object": object(),
+            "frontmatter": {"raw": object()},
+        },
+        applicability=MethodApplicability(
+            domains=("coding",),
+            task_types=("reviewing",),
+            tags={"method_family": ("verification",)},
+        ),
+    )
+
+    projection = MethodProjector().project(plan, plan.steps[0])
+
+    assert projection.metadata["plan_facts"] == {
+        "plan_id": "plan:method:task:review",
+        "method_id": "method:task:review",
+        "mode": "fixed",
+        "phase": "VERIFY",
+        "activity": "review",
+        "task": "check change",
+        "metadata": {
+            "method_kind": "method_resource",
+            "element_type": "task",
+            "plan_mode": "fixed",
+            "step_count": 1,
+        },
+        "applicability": {
+            "domains": ["coding"],
+            "task_types": ["reviewing"],
+            "contexts": [],
+            "artifact_types": [],
+            "modalities": [],
+            "toolchains": [],
+            "lifecycle": [],
+            "capabilities": [],
+            "complexity": None,
+            "risk": None,
+            "tags": {"method_family": ["verification"]},
+        },
+    }
+    assert projection.metadata["step_facts"]["applicability"]["domains"] == ["coding"]
+    assert projection.metadata["step_facts"]["applicability"]["tags"] == {
+        "method_family": ["verification"],
+    }
+    json.dumps(projection.metadata["plan_facts"])
+    json.dumps(projection.metadata["step_facts"])
+
+
+def test_method_projector_plan_metadata_facts_include_stable_keys_with_nulls() -> None:
+    descriptor = MethodDescriptor(
+        id="method:task:single",
+        name="single",
+        description="Review once.",
+        content="Review once.",
+        kind="method_resource",
+    )
+    plan = MethodCompiler().compile(descriptor)
+
+    projection = MethodProjector().project(plan, plan.steps[0])
+
+    assert projection.metadata["plan_facts"]["metadata"] == {
+        "method_kind": "method_resource",
+        "element_type": None,
+        "plan_mode": None,
+        "step_count": None,
+    }
+    json.dumps(projection.metadata["plan_facts"])
 
 
 def test_method_projector_handles_empty_content() -> None:


### PR DESCRIPTION
## Summary / 摘要
- EN: Defines the stable public contract for MethodProjector plan_facts and step_facts.
- 中文：定义 MethodProjector 的 plan_facts 与 step_facts 稳定公共契约。
- EN: Whitelists plan_facts.metadata to stable keys instead of exposing all MethodPlan.metadata.
- 中文：将 plan_facts.metadata 收紧为稳定字段白名单，不再整体暴露 MethodPlan.metadata。
- EN: Normalizes applicability sequence fields and tags to JSON-safe lists before facts enter coding/work logs.
- 中文：在 facts 进入 coding/work log 前，将 applicability 序列字段和 tags 规范化为 JSON-safe list。
- EN: Adds internal documentation for the projector -> prepared turn -> work-log facts chain and non-goals.
- 中文：补充 projector -> prepared turn -> work-log facts 链路与非目标的内部文档。

## Contract Decisions / 契约决策
- EN: Stable plan_facts fields are plan_id, method_id, mode, phase, activity, task, metadata, and applicability.
- 中文：稳定 plan_facts 字段为 plan_id、method_id、mode、phase、activity、task、metadata、applicability。
- EN: Stable step_facts fields are step_id, title, executor, role_variant, step_index, step_count, and applicability.
- 中文：稳定 step_facts 字段为 step_id、title、executor、role_variant、step_index、step_count、applicability。
- EN: plan_facts.metadata currently exposes only method_kind, element_type, plan_mode, and step_count.
- 中文：plan_facts.metadata 当前只暴露 method_kind、element_type、plan_mode、step_count。
- EN: Facts are method-owned semantics; coding/work only persist and replay opaque mappings.
- 中文：facts 语义归 method 所有；coding/work 只透传、持久化和回放 opaque mapping。

## Human Review Notes / 给人工 Review 的说明
- EN: Please review the compatibility decision to convert applicability tuples to JSON arrays in facts.
- 中文：请重点 review 将 facts 中的 applicability tuple 转为 JSON array 的兼容性决策。
- EN: Please confirm the metadata whitelist is sufficient for current downstream consumers.
- 中文：请确认 metadata 白名单足够覆盖当前下游消费者需求。
- EN: This PR does not enable Native TUI/RPC --method behavior.
- 中文：本 PR 不启用 Native TUI/RPC 的 --method 行为。

## Agent Review Brief / 给 Agent Review 的说明
- EN: Verify projector tests prove unsupported internal metadata is excluded from plan_facts.metadata.
- 中文：请验证 projector 测试已证明内部 metadata 不会进入 plan_facts.metadata。
- EN: Verify facts are JSON serializable and downstream tests still pass with list-shaped applicability fields.
- 中文：请验证 facts 可 JSON 序列化，且下游测试在 applicability 字段为 list 形态时仍通过。
- EN: Check documentation links from component-interfaces/method.md and domain.md to method-facts-contract.md.
- 中文：请检查 component-interfaces/method.md 与 domain.md 到 method-facts-contract.md 的文档链接。

## Test Plan / 测试计划
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/method/test_method_projection.py -q
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/method tests/work tests/coding/domain/test_coding_domain_app.py tests/coding/test_prompt_command.py -q
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k "method or work_log" -q
- [x] uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/method src/loushang/work src/loushang/coding/domain tests/method tests/work tests/coding/domain

## Draft Status / Draft 状态
- EN: Draft until human/agent review confirms the metadata whitelist and JSON-array compatibility choice.
- 中文：在人工/agent review 确认 metadata 白名单和 JSON array 兼容性选择前保持 draft。