### PR TITLE
test(tui): cover live draft reader playback / 补充 reader live draft playback 覆盖

### DIFF
--- a/src/loushang/coding/ui/playback_scenarios/transcript.py
+++ b/src/loushang/coding/ui/playback_scenarios/transcript.py
@@ -17,7 +17,11 @@ from loushang.coding.ui.playback_scenarios.budgets import (
 )
 from loushang.coding.ui.playback_suite import NativePlaybackScenarioSpec
 from loushang.tui import strip_control_sequences
-from loushang.tui.transcript import AssistantMessageRecord, ToolExecutionRecord
+from loushang.tui.transcript import (
+    AssistantMessageRecord,
+    ToolExecutionRecord,
+    UserPromptRecord,
+)
 
 
 def _run_long_transcript_input() -> NativeTuiInputPlaybackResult:
@@ -150,6 +154,44 @@ def _run_transcript_reader_copy_command() -> object:
     return result
 
 
+def _run_transcript_reader_live_draft() -> NativeTuiInputPlaybackResult:
+    scenario = (
+        NativeTuiInputScenario(width=78, height=10)
+        .with_records(
+            (
+                UserPromptRecord("previous question"),
+                AssistantMessageRecord("previous answer", stable=True),
+            )
+        )
+        .with_composer_text("draft")
+    )
+    scenario.app.begin_run(started_at=0.0)
+    scenario.app.begin_assistant()
+    scenario.app.append_assistant_chunk("streaming live draft")
+
+    result = (
+        scenario.render()
+        .key("\x0f")
+        .key("\x0f")
+        .type_text("!")
+        .run()
+    )
+
+    result.assert_composer_text("draft!")
+    result.assert_no_clear_screen()
+    result.assert_visible_contains("› draft!")
+    result.assert_visible_not_contains("Ctrl+O/q/Esc close")
+
+    opened_screen = _step_screen(result, 1)
+    closed_screen = _step_screen(result, 2)
+    assert "Transcript window" in opened_screen
+    assert "streaming live draft" in opened_screen
+    assert "Ctrl+O/q/Esc close" in opened_screen
+    assert "Ctrl+O/q/Esc close" not in closed_screen
+    assert "› draft" in closed_screen
+    return result
+
+
 def _step_screen(result: NativeTuiInputPlaybackResult, step_index: int) -> str:
     step = result.steps[step_index]
     assert step.frame is not None
@@ -215,6 +257,12 @@ TRANSCRIPT_SCENARIOS = (
         description="Open and close the transcript reader, then copy the second assistant response from structured history.",
         run=_run_transcript_reader_copy_command,
         tags=("transcript", "command"),
+    ),
+    NativePlaybackScenarioSpec(
+        name="transcript-reader-live-draft",
+        description="Open the transcript reader during assistant streaming and keep the live draft visible.",
+        run=_run_transcript_reader_live_draft,
+        tags=("transcript",),
     ),
 )
 

--- a/src/loushang/coding/ui/transcript_source.py
+++ b/src/loushang/coding/ui/transcript_source.py
@@ -23,6 +23,10 @@ class TranscriptSource(Protocol):
     def recent_assistant_texts(self) -> tuple[str, ...]: ...
 
 
+# Transcript reader sources intentionally separate three data shapes:
+# - active window: bounded UI records plus current assistant draft.
+# - session history: full materialized session projection.
+# - session + live window: full history with active UI-only suffix records.
 @dataclass(frozen=True, slots=True)
 class ActiveWindowTranscriptSource:
     state: NativeCodingTuiState

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -126,6 +126,7 @@ def test_native_tui_playback_transcript_scenarios_live_in_transcript_module() ->
         "tool-output-preview",
         "transcript-reader-modal",
         "transcript-reader-copy-command",
+        "transcript-reader-live-draft",
     ]
 
 
@@ -145,6 +146,7 @@ def test_native_tui_playback_runner_lists_default_scenarios(capsys) -> None:
     assert "long-transcript-input" in captured.out
     assert "transcript-reader-modal" in captured.out
     assert "transcript-reader-copy-command" in captured.out
+    assert "transcript-reader-live-draft" in captured.out
     assert "escape-pending-steer" in captured.out
     assert "running-steer-queued" in captured.out
     assert "running-escape-keeps-queued-steer" in captured.out
@@ -284,6 +286,16 @@ def test_native_tui_playback_runner_runs_transcript_reader_copy_scenario(
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS transcript-reader-copy-command" in captured.out
+
+
+def test_native_tui_playback_runner_runs_transcript_reader_live_draft_scenario(
+    capsys,
+) -> None:
+    exit_code = run_playback_cli(["transcript-reader-live-draft"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS transcript-reader-live-draft" in captured.out
 
 
 def test_native_tui_playback_runner_runs_product_composed_interaction_scenario(


### PR DESCRIPTION

## Summary / 摘要
- Adds a transcript playback scenario for opening Ctrl+O reader while an assistant draft is streaming.
- Verifies the live draft is visible in the reader, the reader can close, and composer input resumes without screen clearing.
- Documents the transcript source data shapes: active window, full session history, and session + live window suffix.

## Scope / 范围
- TUI/product adapter/playback/transcript reader files only.
- No code lane or method lane changes.
- This is a follow-up after #116 and #119 merged.

## Review Guidance For Humans / 给人类 Reviewer 的说明
- Check that the new playback scenario covers the real regression shape from the recent reader source reviews.
- Confirm the source semantics comment is accurate and not over-prescriptive.
- Confirm the scenario is narrow enough: it should not depend on visual parity, only semantic reader behavior.

## Review Guidance For Agents / 给 Agent Reviewer 的说明
- Branch: `feature/tui-reader-live-playback-docs`; base: `main`.
- Keep fixes scoped to TUI playback/transcript reader/source files.
- Main files: `src/loushang/coding/ui/playback_scenarios/transcript.py`, `src/loushang/coding/ui/transcript_source.py`, `tests/coding/test_native_tui_playback_runner.py`.
- Review focus: playback stability, live draft visibility, close/resume composer behavior, and transcript source semantics.
- Required validation command:
  `uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py -q`

## Test Plan / 验证
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_tui_playback_runner.py -k "transcript_scenarios_live or lists_default_scenarios or transcript_reader_live_draft" -q` -> 3 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_ui_transcript_source.py tests/coding/test_native_coding_tui_input.py tests/coding/test_native_coding_tui_mode.py tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py tests/coding/test_native_tui_playback_runner.py -q` -> 127 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/transcript_source.py src/loushang/coding/ui/playback_scenarios/transcript.py tests/coding/test_native_tui_playback_runner.py` -> passed
- `uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py -q` -> 33 passed
- `git diff --check` -> passed

## Related / 关联
Follow-up to #116 and #119.
Related: #88, #96, #97, #99
