### PR TITLE
feat(tui): add transcript reader search / 增加 transcript reader 搜索

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-018-transcript-reader-and-copy-semantics.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-018-transcript-reader-and-copy-semantics.md
@@ -8,10 +8,12 @@ Implemented:
 - `TranscriptReaderSurface`.
 - Native TUI transcript reader entry and modal input routing.
 - Playback coverage for `transcript-reader-modal`.
+- Full-session, active-window, and full-session-plus-live-window transcript
+  sources.
+- Detail/raw reader modes, reader mode title indicators, and reader search.
 
 Still future/deferred:
 
-- full session transcript loading beyond the active window
 - reader-local export convenience
 - screen-buffer selection/copy
 - code-block picker
@@ -161,13 +163,31 @@ class TranscriptSource(Protocol):
 excludes tool-only turns, empty assistant messages, and unavailable responses.
 The `/copy [N]` caller should not apply a second, divergent filter.
 
-The first implementation may provide `ActiveWindowTranscriptSource`, backed by
-`NativeCodingTuiApp.state.records` and
-`NativeCodingTuiApp.state.evicted_prefix_record_count`.
+`ActiveWindowTranscriptSource` is backed by the bounded native TUI active
+window. It includes `NativeCodingTuiState.records` plus the current
+`assistant_draft` when streaming is active. It sets `complete=False` because the
+active window may have evicted earlier records.
 
-Future implementations may provide `SessionTranscriptSource`, backed by the
-session JSONL/session manager. That source can set `complete=True` when it can
-prove that all persisted transcript records are available.
+`SessionTranscriptSource` is backed by persisted/session materialized history.
+When used alone, it sets `complete=True` because it is presenting the full
+available session projection.
+
+`SessionTranscriptSource(..., active_window_state=...)` presents full session
+history plus active UI-only suffix records. This is the normal interactive TUI
+reader source. It keeps session history as the base, appends active-window
+records not already covered by the session projection, and includes the current
+assistant draft. When any live suffix is appended, it sets `complete=False` and
+labels the snapshot `Full transcript + live window`.
+
+Boundary matrix:
+
+| Source shape | Includes | `complete` | Label |
+| --- | --- | --- | --- |
+| Active window only | bounded UI records + current assistant draft | `False` | `Transcript window` |
+| Session only | full materialized session projection | `True` | `Full transcript` |
+| Session + running tool | session projection + active UI-only tool record | `False` | `Full transcript + live window` |
+| Session + assistant draft | session projection + current streaming draft | `False` | `Full transcript + live window` |
+| Fallback active reader + draft | bounded UI records + draft, no session factory | `False` | `Transcript window` |
 
 The reader holds a reference to `TranscriptSource`, not only a one-time
 `TranscriptSnapshot`. The first implementation may freeze the first snapshot for

--- a/src/loushang/coding/ui/playback_scenarios/transcript.py
+++ b/src/loushang/coding/ui/playback_scenarios/transcript.py
@@ -19,6 +19,7 @@ from loushang.coding.ui.playback_suite import NativePlaybackScenarioSpec
 from loushang.tui import strip_control_sequences
 from loushang.tui.transcript import (
     AssistantMessageRecord,
+    ErrorRecord,
     ToolExecutionRecord,
     UserPromptRecord,
 )
@@ -192,6 +193,103 @@ def _run_transcript_reader_live_draft() -> NativeTuiInputPlaybackResult:
     return result
 
 
+def _run_transcript_reader_render_modes() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=88, height=12)
+        .with_records(
+            (
+                AssistantMessageRecord("Use **markdown** literally.", stable=True),
+                ErrorRecord(summary="Request failed", diagnostics="Traceback detail"),
+            )
+        )
+        .with_composer_text("draft")
+        .render()
+        .key("\x0f")
+        .type_text("d")
+        .type_text("r")
+        .key("\x0f")
+        .type_text("!")
+        .run()
+    )
+
+    result.assert_composer_text("draft!")
+    result.assert_no_clear_screen()
+    result.assert_visible_contains("› draft!")
+    result.assert_visible_not_contains("Ctrl+O/q/Esc close")
+
+    opened_screen = _step_screen(result, 1)
+    detail_screen = _step_screen(result, 2)
+    raw_detail_screen = _step_screen(result, 3)
+    closed_screen = _step_screen(result, 4)
+    assert "Transcript window" in opened_screen
+    assert "Traceback detail" not in opened_screen
+    assert "Transcript window · detail" in detail_screen
+    assert "Traceback detail" in detail_screen
+    assert "Transcript window · raw+detail" in raw_detail_screen
+    assert "Assistant" in raw_detail_screen
+    assert "Use **markdown** literally." in raw_detail_screen
+    assert "Error" in raw_detail_screen
+    assert "Traceback detail" in raw_detail_screen
+    assert "Ctrl+O/q/Esc close" not in closed_screen
+    assert "› draft" in closed_screen
+    return result
+
+
+def _run_transcript_reader_search() -> NativeTuiInputPlaybackResult:
+    result = (
+        NativeTuiInputScenario(width=82, height=10)
+        .with_records(
+            (
+                AssistantMessageRecord(
+                    "\n".join(
+                        (
+                            "alpha one",
+                            "beta first match",
+                            "middle line",
+                            "beta second match",
+                        )
+                    ),
+                    stable=True,
+                ),
+            )
+        )
+        .with_composer_text("draft")
+        .render()
+        .key("\x0f")
+        .type_chars("/beta")
+        .enter()
+        .type_chars("n")
+        .type_chars("N")
+        .escape()
+        .key("\x0f")
+        .type_text("!")
+        .run()
+    )
+
+    result.assert_composer_text("draft!")
+    result.assert_no_clear_screen()
+    result.assert_visible_contains("› draft!")
+    result.assert_visible_not_contains("Ctrl+O/q/Esc close")
+
+    search_input_screen = _step_screen(result, 6)
+    first_match_screen = _step_screen(result, 7)
+    next_match_screen = _step_screen(result, 8)
+    previous_match_screen = _step_screen(result, 9)
+    cleared_search_screen = _step_screen(result, 10)
+    closed_screen = _step_screen(result, 11)
+    assert "Search: beta" in search_input_screen
+    assert "Transcript window · search beta 1/2" in first_match_screen
+    assert "beta first match" in first_match_screen
+    assert "Transcript window · search beta 2/2" in next_match_screen
+    assert "beta second match" in next_match_screen
+    assert "Transcript window · search beta 1/2" in previous_match_screen
+    assert "Transcript window · search" not in cleared_search_screen
+    assert "Ctrl+O/q/Esc close" in cleared_search_screen
+    assert "Ctrl+O/q/Esc close" not in closed_screen
+    assert "› draft" in closed_screen
+    return result
+
+
 def _step_screen(result: NativeTuiInputPlaybackResult, step_index: int) -> str:
     step = result.steps[step_index]
     assert step.frame is not None
@@ -262,6 +360,18 @@ TRANSCRIPT_SCENARIOS = (
         name="transcript-reader-live-draft",
         description="Open the transcript reader during assistant streaming and keep the live draft visible.",
         run=_run_transcript_reader_live_draft,
+        tags=("transcript",),
+    ),
+    NativePlaybackScenarioSpec(
+        name="transcript-reader-render-modes",
+        description="Toggle transcript reader detail and raw modes without changing the composer.",
+        run=_run_transcript_reader_render_modes,
+        tags=("transcript",),
+    ),
+    NativePlaybackScenarioSpec(
+        name="transcript-reader-search",
+        description="Search within the transcript reader, navigate matches, and return to composing.",
+        run=_run_transcript_reader_search,
         tags=("transcript",),
     ),
 )

--- a/src/loushang/coding/ui/transcript_reader.py
+++ b/src/loushang/coding/ui/transcript_reader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 
 from loushang.coding.ui.transcript_source import TranscriptSnapshot, TranscriptSource
@@ -22,6 +23,7 @@ from loushang.tui.transcript import (
 
 _MAX_TRANSCRIPT_RENDER_HEIGHT = 1_000_000
 _FOOTER_STYLE = {"color": "bright_black", "dim": True}
+_SEARCH_HIGHLIGHT_STYLE = {"bold": True, "reverse": True}
 _FOOTER_LINES = (
     "↑/↓ scroll   PgUp/Ctrl+B · PgDn/Ctrl+F page   Home/End jump",
     "Ctrl+O/q/Esc close   / search   n/N next   d detail   r raw",
@@ -130,6 +132,8 @@ class TranscriptReaderSurface:
             self._scroll_offset = _clamp(self._scroll_offset, 0, self._max_scroll_offset)
 
         visible_body = list(body[self._scroll_offset : self._scroll_offset + body_height]) if body_height else []
+        if self.search_query:
+            visible_body = [RenderLine(_highlight_search_matches(line.text, self.search_query)) for line in visible_body]
         if body_height and not visible_body:
             visible_body.append(RenderLine(truncate_to_width("No transcript records.", max_width=constraints.width)))
         padding = [RenderLine("") for _ in range(max(0, body_height - len(visible_body)))]
@@ -260,6 +264,24 @@ def _clamp(value: int, minimum: int, maximum: int) -> int:
 
 def _footer_text(text: str, *, width: int) -> str:
     return apply_theme_style(truncate_to_width(text, max_width=width), _FOOTER_STYLE)
+
+
+def _highlight_search_matches(text: str, query: str) -> str:
+    if not query:
+        return text
+    pattern = re.compile(re.escape(query), re.IGNORECASE)
+    parts: list[str] = []
+    last_end = 0
+    for match in pattern.finditer(text):
+        start, end = match.span()
+        if start > last_end:
+            parts.append(text[last_end:start])
+        parts.append(apply_theme_style(text[start:end], _SEARCH_HIGHLIGHT_STYLE))
+        last_end = end
+    if not parts:
+        return text
+    parts.append(text[last_end:])
+    return "".join(parts)
 
 
 def _title_text(

--- a/src/loushang/coding/ui/transcript_reader.py
+++ b/src/loushang/coding/ui/transcript_reader.py
@@ -24,7 +24,7 @@ _MAX_TRANSCRIPT_RENDER_HEIGHT = 1_000_000
 _FOOTER_STYLE = {"color": "bright_black", "dim": True}
 _FOOTER_LINES = (
     "↑/↓ scroll   PgUp/Ctrl+B · PgDn/Ctrl+F page   Home/End jump",
-    "Ctrl+O/q/Esc close   d detail   r raw",
+    "Ctrl+O/q/Esc close   / search   n/N next   d detail   r raw",
 )
 _CONSUMED = InputIntent(kind="consumed", note="transcript_reader")
 
@@ -35,11 +35,16 @@ class TranscriptReaderSurface:
     focused: bool = False
     raw_mode: bool = False
     detail_mode: bool = False
+    search_query: str = ""
     _snapshot: TranscriptSnapshot = field(init=False, repr=False)
     _scroll_offset: int = field(default=0, init=False, repr=False)
     _max_scroll_offset: int = field(default=0, init=False, repr=False)
     _last_body_height: int = field(default=1, init=False, repr=False)
     _follow_tail: bool = field(default=True, init=False, repr=False)
+    _search_draft: str = field(default="", init=False, repr=False)
+    _search_editing: bool = field(default=False, init=False, repr=False)
+    _search_matches: tuple[int, ...] = field(default=(), init=False, repr=False)
+    _search_match_index: int = field(default=0, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._snapshot = self.source.snapshot()
@@ -59,9 +64,18 @@ class TranscriptReaderSurface:
         self.focused = False
 
     def handle_input(self, event: InputEvent) -> InputIntent:
+        if self._search_editing:
+            return self._handle_search_input(event)
+        if event.kind == "text":
+            if len(event.text) == 1:
+                return self.handle_input(InputEvent(kind="key", key=event.text, raw=event.raw))
+            return _CONSUMED
         if event.kind != "key":
             return _CONSUMED
         key = event.key
+        if key in {"esc", "escape"} and self.search_query:
+            self._clear_search()
+            return _CONSUMED
         if key in {"q", "esc", "escape", "ctrl+c", "ctrl_c", "ctrl+o", "ctrl_o"}:
             return InputIntent(kind="surface_close")
         if key == "up":
@@ -82,6 +96,15 @@ class TranscriptReaderSurface:
         if key == "end":
             self._scroll_to_tail()
             return _CONSUMED
+        if key == "/":
+            self._begin_search()
+            return _CONSUMED
+        if key == "n":
+            self._move_search_match(1)
+            return _CONSUMED
+        if key == "N":
+            self._move_search_match(-1)
+            return _CONSUMED
         if key == "d":
             self.detail_mode = not self.detail_mode
             return _CONSUMED
@@ -91,13 +114,17 @@ class TranscriptReaderSurface:
         return _CONSUMED
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
+        body = self._body_lines(width=constraints.width)
+        self._sync_search_matches(body)
         top_chrome = self._top_chrome_lines(constraints.width, constraints.max_height)
         footer = self._footer_lines(constraints.width, max_height=constraints.max_height - len(top_chrome))
         body_height = max(0, constraints.max_height - len(top_chrome) - len(footer))
         self._last_body_height = max(1, body_height)
-        body = self._body_lines(width=constraints.width)
         self._max_scroll_offset = max(0, len(body) - body_height)
-        if self._follow_tail:
+        if self.search_query and self._search_matches:
+            self._follow_tail = False
+            self._scroll_offset = _clamp(self._search_matches[self._search_match_index], 0, self._max_scroll_offset)
+        elif self._follow_tail:
             self._scroll_offset = self._max_scroll_offset
         else:
             self._scroll_offset = _clamp(self._scroll_offset, 0, self._max_scroll_offset)
@@ -110,7 +137,21 @@ class TranscriptReaderSurface:
         return RenderResult.from_lines(lines[: constraints.max_height], constraints=constraints)
 
     def _top_chrome_lines(self, width: int, max_height: int) -> tuple[RenderLine, ...]:
-        lines = [RenderLine(truncate_to_width(self._snapshot.source_label, max_width=width))]
+        lines = [
+            RenderLine(
+                truncate_to_width(
+                    _title_text(
+                        self._snapshot.source_label,
+                        raw=self.raw_mode,
+                        detail=self.detail_mode,
+                        search_query=self.search_query,
+                        search_match_index=self._search_match_index,
+                        search_match_count=len(self._search_matches),
+                    ),
+                    max_width=width,
+                )
+            )
+        ]
         if self._snapshot.evicted_prefix_record_count > 0 and len(lines) < max_height - 1:
             lines.append(RenderLine(truncate_to_width("Earlier transcript records were trimmed.", max_width=width)))
         return tuple(lines[:max_height])
@@ -119,7 +160,10 @@ class TranscriptReaderSurface:
         if max_height <= 0:
             return ()
         separator = "─" * max(0, width)
-        raw_lines = (separator, *_FOOTER_LINES)
+        mode_lines = _FOOTER_LINES
+        if self._search_editing:
+            mode_lines = (_FOOTER_LINES[0], f"Search: {self._search_draft}")
+        raw_lines = (separator, *mode_lines)
         selected = raw_lines[-max_height:]
         return tuple(RenderLine(_footer_text(line, width=width)) for line in selected)
 
@@ -152,6 +196,63 @@ class TranscriptReaderSurface:
         self._follow_tail = True
         self._scroll_offset = self._max_scroll_offset
 
+    def _begin_search(self) -> None:
+        self._search_editing = True
+        self._search_draft = ""
+        self.search_query = ""
+        self._search_matches = ()
+        self._search_match_index = 0
+
+    def _handle_search_input(self, event: InputEvent) -> InputIntent:
+        if event.kind == "text":
+            self._search_draft += event.text
+            return _CONSUMED
+        if event.kind != "key":
+            return _CONSUMED
+        key = event.key
+        if key in {"esc", "escape"}:
+            self._search_editing = False
+            self._search_draft = ""
+            self._clear_search()
+            return _CONSUMED
+        if key == "enter":
+            self._search_editing = False
+            self.search_query = self._search_draft.strip()
+            self._search_draft = ""
+            self._search_matches = ()
+            self._search_match_index = 0
+            return _CONSUMED
+        if key in {"backspace", "delete"}:
+            self._search_draft = self._search_draft[:-1]
+            return _CONSUMED
+        return _CONSUMED
+
+    def _sync_search_matches(self, body: tuple[RenderLine, ...]) -> None:
+        if not self.search_query:
+            self._search_matches = ()
+            self._search_match_index = 0
+            return
+        needle = self.search_query.lower()
+        matches = tuple(index for index, line in enumerate(body) if needle in line.text.lower())
+        self._search_matches = matches
+        if matches:
+            self._search_match_index = _clamp(self._search_match_index, 0, len(matches) - 1)
+        else:
+            self._search_match_index = 0
+
+    def _move_search_match(self, delta: int) -> None:
+        if not self.search_query:
+            return
+        if not self._search_matches:
+            return
+        self._search_match_index = (self._search_match_index + delta) % len(self._search_matches)
+        self._follow_tail = False
+
+    def _clear_search(self) -> None:
+        self.search_query = ""
+        self._search_matches = ()
+        self._search_match_index = 0
+
 
 def _clamp(value: int, minimum: int, maximum: int) -> int:
     return max(minimum, min(value, maximum))
@@ -159,6 +260,29 @@ def _clamp(value: int, minimum: int, maximum: int) -> int:
 
 def _footer_text(text: str, *, width: int) -> str:
     return apply_theme_style(truncate_to_width(text, max_width=width), _FOOTER_STYLE)
+
+
+def _title_text(
+    source_label: str,
+    *,
+    raw: bool,
+    detail: bool,
+    search_query: str,
+    search_match_index: int,
+    search_match_count: int,
+) -> str:
+    suffixes: list[str] = []
+    if raw and detail:
+        suffixes.append("raw+detail")
+    elif raw:
+        suffixes.append("raw")
+    elif detail:
+        suffixes.append("detail")
+    if search_query:
+        suffixes.append(f"search {search_query} {search_match_index + 1 if search_match_count else 0}/{search_match_count}")
+    if not suffixes:
+        return source_label
+    return f"{source_label} · {' · '.join(suffixes)}"
 
 
 def _render_raw_transcript_records(

--- a/tests/coding/test_native_coding_tui_input.py
+++ b/tests/coding/test_native_coding_tui_input.py
@@ -470,7 +470,7 @@ def test_native_input_router_ctrl_o_fallback_reader_includes_streaming_assistant
     reader.raw_mode = True
     rendered = reader.render(RenderConstraints(width=100, max_height=12))
     lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
-    assert "Transcript window" in lines
+    assert lines[0] == "Transcript window · raw"
     assert any("streaming fallback draft" in line for line in lines)
 
 
@@ -624,7 +624,7 @@ def test_native_input_router_ctrl_o_session_reader_includes_streaming_assistant_
     reader.raw_mode = True
     rendered = reader.render(RenderConstraints(width=100, max_height=12))
     lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
-    assert "Full transcript + live window" in lines
+    assert lines[0] == "Full transcript + live window · raw"
     assert any("streaming draft" in line for line in lines)
 
 

--- a/tests/coding/test_native_tui_playback_harness.py
+++ b/tests/coding/test_native_tui_playback_harness.py
@@ -271,7 +271,7 @@ def test_native_tui_input_scenario_reader_short_content_restores_bottom_frame() 
     open_screen = _step_visible_text(result, 1)
     close_screen = _step_visible_text(result, 2)
 
-    assert open_screen.splitlines()[-1] == "Ctrl+O/q/Esc close   d detail   r raw"
+    assert open_screen.splitlines()[-1] == "Ctrl+O/q/Esc close   / search   n/N next   d detail   r raw"
     assert "› draft" not in open_screen
     assert "› draft" in close_screen
     assert "kimi | repo | main | abcd | idle" in close_screen

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -127,6 +127,8 @@ def test_native_tui_playback_transcript_scenarios_live_in_transcript_module() ->
         "transcript-reader-modal",
         "transcript-reader-copy-command",
         "transcript-reader-live-draft",
+        "transcript-reader-render-modes",
+        "transcript-reader-search",
     ]
 
 
@@ -147,6 +149,8 @@ def test_native_tui_playback_runner_lists_default_scenarios(capsys) -> None:
     assert "transcript-reader-modal" in captured.out
     assert "transcript-reader-copy-command" in captured.out
     assert "transcript-reader-live-draft" in captured.out
+    assert "transcript-reader-render-modes" in captured.out
+    assert "transcript-reader-search" in captured.out
     assert "escape-pending-steer" in captured.out
     assert "running-steer-queued" in captured.out
     assert "running-escape-keeps-queued-steer" in captured.out
@@ -296,6 +300,26 @@ def test_native_tui_playback_runner_runs_transcript_reader_live_draft_scenario(
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS transcript-reader-live-draft" in captured.out
+
+
+def test_native_tui_playback_runner_runs_transcript_reader_render_modes_scenario(
+    capsys,
+) -> None:
+    exit_code = run_playback_cli(["transcript-reader-render-modes"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS transcript-reader-render-modes" in captured.out
+
+
+def test_native_tui_playback_runner_runs_transcript_reader_search_scenario(
+    capsys,
+) -> None:
+    exit_code = run_playback_cli(["transcript-reader-search"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS transcript-reader-search" in captured.out
 
 
 def test_native_tui_playback_runner_runs_product_composed_interaction_scenario(

--- a/tests/coding/test_native_tui_transcript_reader.py
+++ b/tests/coding/test_native_tui_transcript_reader.py
@@ -271,6 +271,29 @@ def test_transcript_reader_search_finds_matches_and_navigates_without_closing() 
     assert previous[0] == "Transcript window · search beta 1/2"
 
 
+def test_transcript_reader_search_highlights_matches_without_changing_text() -> None:
+    reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("alpha beta beta"),)))
+
+    reader.handle_input(InputEvent(kind="text", text="/"))
+    reader.handle_input(InputEvent(kind="text", text="beta"))
+    reader.handle_input(InputEvent(kind="key", key="enter"))
+
+    raw = _render_raw(reader, width=80, height=7)
+    stripped = tuple(strip_control_sequences(line) for line in raw)
+    match_line = next(line for line in raw if strip_control_sequences(line).endswith("alpha beta beta"))
+
+    assert "\x1b[" in match_line
+    assert any(line.endswith("alpha beta beta") for line in stripped)
+
+
+def test_transcript_reader_search_does_not_highlight_without_query() -> None:
+    reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("alpha beta"),)))
+
+    raw = _render_raw(reader, width=80, height=7)
+
+    assert all("\x1b[" not in line for line in raw[:-3])
+
+
 def test_transcript_reader_search_escape_exits_search_input_without_closing() -> None:
     reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("alpha beta"),)))
 

--- a/tests/coding/test_native_tui_transcript_reader.py
+++ b/tests/coding/test_native_tui_transcript_reader.py
@@ -60,7 +60,7 @@ def test_transcript_reader_renders_frozen_snapshot_and_footer() -> None:
     assert "Earlier transcript records were trimmed." in first
     assert first[-3] == "─" * 80
     assert first[-2] == "↑/↓ scroll   PgUp/Ctrl+B · PgDn/Ctrl+F page   Home/End jump"
-    assert first[-1] == "Ctrl+O/q/Esc close   d detail   r raw"
+    assert first[-1] == "Ctrl+O/q/Esc close   / search   n/N next   d detail   r raw"
     assert any("first" in line for line in first)
     assert all("second" not in line for line in first)
 
@@ -86,7 +86,7 @@ def test_transcript_reader_short_content_fills_full_height_with_footer_at_bottom
     assert rendered[-3] == "─" * 40
     assert rendered[-2].startswith("↑/↓ scroll   PgUp/Ctrl+B")
     assert "PgDn/Ctrl" in rendered[-2]
-    assert rendered[-1] == "Ctrl+O/q/Esc close   d detail   r raw"
+    assert rendered[-1].startswith("Ctrl+O/q/Esc close   / search")
 
 
 def test_transcript_reader_opens_at_tail_and_scrolls_by_page() -> None:
@@ -169,6 +169,21 @@ def test_transcript_reader_detail_and_raw_toggles_are_stable() -> None:
     assert reader.raw_mode is False
 
 
+def test_transcript_reader_title_shows_current_render_mode() -> None:
+    reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("answer"),)))
+
+    assert _render_text(reader, width=80, height=6)[0] == "Transcript window"
+
+    reader.handle_input(InputEvent(kind="key", key="d"))
+    assert _render_text(reader, width=80, height=6)[0] == "Transcript window · detail"
+
+    reader.handle_input(InputEvent(kind="key", key="r"))
+    assert _render_text(reader, width=80, height=6)[0] == "Transcript window · raw+detail"
+
+    reader.handle_input(InputEvent(kind="key", key="d"))
+    assert _render_text(reader, width=80, height=6)[0] == "Transcript window · raw"
+
+
 def test_transcript_reader_raw_mode_renders_copy_friendly_logical_text() -> None:
     reader = TranscriptReaderSurface(
         _Source(
@@ -228,3 +243,41 @@ def test_transcript_reader_raw_mode_does_not_expose_hidden_thinking() -> None:
 
     assert all("hidden reasoning" not in line for line in rendered)
     assert any("visible thinking" in line for line in rendered)
+
+
+def test_transcript_reader_search_finds_matches_and_navigates_without_closing() -> None:
+    reader = TranscriptReaderSurface(
+        _Source((AssistantMessageRecord("\n".join(("alpha one", "beta two", "gamma beta three"))),))
+    )
+    _render_text(reader, width=80, height=7)
+
+    assert reader.handle_input(InputEvent(kind="text", text="/")) == InputIntent(kind="consumed", note="transcript_reader")
+    assert reader.handle_input(InputEvent(kind="text", text="beta")) == InputIntent(kind="consumed", note="transcript_reader")
+    editing = _render_text(reader, width=80, height=7)
+    assert editing[-1] == "Search: beta"
+
+    assert reader.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(kind="consumed", note="transcript_reader")
+    first = _render_text(reader, width=80, height=7)
+    assert first[0] == "Transcript window · search beta 1/2"
+    assert any("beta two" in line for line in first)
+
+    assert reader.handle_input(InputEvent(kind="text", text="n")) == InputIntent(kind="consumed", note="transcript_reader")
+    second = _render_text(reader, width=80, height=7)
+    assert second[0] == "Transcript window · search beta 2/2"
+    assert any("gamma beta three" in line for line in second)
+
+    assert reader.handle_input(InputEvent(kind="text", text="N")) == InputIntent(kind="consumed", note="transcript_reader")
+    previous = _render_text(reader, width=80, height=7)
+    assert previous[0] == "Transcript window · search beta 1/2"
+
+
+def test_transcript_reader_search_escape_exits_search_input_without_closing() -> None:
+    reader = TranscriptReaderSurface(_Source((AssistantMessageRecord("alpha beta"),)))
+
+    reader.handle_input(InputEvent(kind="text", text="/"))
+    reader.handle_input(InputEvent(kind="text", text="beta"))
+
+    assert reader.handle_input(InputEvent(kind="key", key="esc")) == InputIntent(kind="consumed", note="transcript_reader")
+    rendered = _render_text(reader, width=80, height=7)
+    assert rendered[0] == "Transcript window"
+    assert "Search: beta" not in rendered

--- a/tests/coding/test_ui_transcript_source.py
+++ b/tests/coding/test_ui_transcript_source.py
@@ -162,6 +162,62 @@ def test_session_transcript_source_merges_live_assistant_draft() -> None:
     )
 
 
+def test_transcript_source_boundary_matrix() -> None:
+    session = _Session(
+        messages=[
+            UserMessage(role="user", content=[TextPart(type="text", text="full question")], timestamp=1.0),
+            _assistant_message("full answer", timestamp=2.0),
+        ]
+    )
+    active_state = NativeCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
+    active_state.replace_transcript_window((AssistantMessageRecord("active answer"),))
+    active_state.begin_run(started_at=3.0)
+    active_state.append_assistant_chunk("active draft")
+
+    running_tool_state = NativeCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
+    running_tool_state.replace_transcript_window(
+        (
+            UserPromptRecord("full question"),
+            AssistantMessageRecord("full answer", stable=True),
+            ToolExecutionRecord(name="bash test", state="running", elapsed_seconds=0.1),
+        )
+    )
+
+    draft_state = NativeCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
+    draft_state.replace_transcript_window(
+        (
+            UserPromptRecord("full question"),
+            AssistantMessageRecord("full answer", stable=True),
+        )
+    )
+    draft_state.begin_run(started_at=4.0)
+    draft_state.append_assistant_chunk("streaming draft")
+
+    cases = (
+        ("active", ActiveWindowTranscriptSource(active_state).snapshot(), False, "Transcript window", "active draft"),
+        ("session", SessionTranscriptSource(session).snapshot(), True, "Full transcript", "full answer"),
+        (
+            "session+tool",
+            SessionTranscriptSource(session, active_window_state=running_tool_state).snapshot(),
+            False,
+            "Full transcript + live window",
+            "bash test",
+        ),
+        (
+            "session+draft",
+            SessionTranscriptSource(session, active_window_state=draft_state).snapshot(),
+            False,
+            "Full transcript + live window",
+            "streaming draft",
+        ),
+    )
+
+    for name, snapshot, complete, label, expected_text in cases:
+        assert snapshot.complete is complete, name
+        assert snapshot.source_label == label, name
+        assert _snapshot_text(snapshot.records).find(expected_text) >= 0, name
+
+
 def _assistant_message(text: str, *, timestamp: float) -> AssistantMessage:
     return AssistantMessage(
         role="assistant",
@@ -175,3 +231,15 @@ def _assistant_message(text: str, *, timestamp: float) -> AssistantMessage:
         error_message=None,
         timestamp=timestamp,
     )
+
+
+def _snapshot_text(records: tuple[object, ...]) -> str:
+    parts: list[str] = []
+    for record in records:
+        text = getattr(record, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+        name = getattr(record, "name", None)
+        if isinstance(name, str):
+            parts.append(name)
+    return "\n".join(parts)


### PR DESCRIPTION

## Summary / 摘要
- Adds transcript reader mode indicators in the title for detail/raw/raw+detail states.
- Adds playback coverage for reader detail/raw mode toggles and composer restoration.
- Adds reader-local search: `/` starts search input, Enter applies, `n/N` navigates matches, Esc clears search without closing the reader.
- Documents transcript source boundary semantics and adds a source boundary matrix test.

## Scope / 范围
- TUI/product adapter/playback/transcript reader related files only.
- No code lane or method lane changes.
- This PR focuses on semantic behavior rather than visual parity with another TUI.

## Review Guidance For Humans / 给人类 Reviewer 的说明
- Check that reader title state is clear but not noisy: normal, detail, raw, raw+detail, and search states.
- Check search semantics: `/query`, Enter, `n/N`, Esc clearing search while keeping the reader open, Ctrl+O closing.
- Check that printable `d/r/n/N//` routing does not leak into the composer while the reader is open.
- Check that playback coverage is behavior-focused and not overly tied to exact visual styling.

## Review Guidance For Agents / 给 Agent Reviewer 的说明
- Branch: `feature/tui-reader-mode-search-docs`; base: `main`.
- Keep fixes scoped to TUI reader/source/playback/docs/tests.
- Primary files: `src/loushang/coding/ui/transcript_reader.py`, `src/loushang/coding/ui/playback_scenarios/transcript.py`, `src/loushang/coding/ui/transcript_source.py`, `tests/coding/test_native_tui_transcript_reader.py`, `tests/coding/test_native_tui_playback_runner.py`, `tests/coding/test_ui_transcript_source.py`.
- Review focus: reader modal input routing, search state cleanup, scroll-to-match behavior, raw/detail title indicators, and source boundary documentation accuracy.
- Required validation command:
  `uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py -q`

## Test Plan / 验证
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_ui_transcript_source.py tests/coding/test_native_coding_tui_input.py tests/coding/test_native_coding_tui_mode.py tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py tests/coding/test_native_tui_playback_runner.py -q` -> 133 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/transcript_reader.py src/loushang/coding/ui/transcript_source.py src/loushang/coding/ui/playback_scenarios/transcript.py tests/coding/test_native_tui_transcript_reader.py tests/coding/test_ui_transcript_source.py tests/coding/test_native_tui_playback_runner.py tests/coding/test_native_coding_tui_input.py tests/coding/test_native_tui_playback_harness.py` -> passed
- `uv --cache-dir /home/dev/workspace/loushang/.uv-cache run --extra dev pytest tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py -q` -> 36 passed
- `git diff --check` -> passed

## Related / 关联
Related: #88, #96, #97, #99, #122
