### PR TITLE
test(tui): harden playback review coverage

### DIFF
--- a/docs/en/reference/tui-runner.md
+++ b/docs/en/reference/tui-runner.md
@@ -79,4 +79,10 @@ During `run()`, `TuiRunner` temporarily owns `tui.terminal`, `tui._runtime`, `tu
 
 Do not run the same `TuiRunner` concurrently. Reentrant `run()` calls raise `RuntimeError`.
 
-See [examples/tui/40_runner_basic.py](../../../examples/tui/40_runner_basic.py) for a small interactive example.
+## Examples
+
+- [examples/tui/40_runner_basic.py](../../../examples/tui/40_runner_basic.py):
+  small interactive `TuiRunner` app with focused input handling.
+- [examples/tui/42_playback_smoke.py](../../../examples/tui/42_playback_smoke.py):
+  product-neutral `PlaybackHarness` smoke test that writes JSONL and screen
+  artifacts for review.

--- a/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
+++ b/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
@@ -85,11 +85,16 @@ or cross-feature input routing:
 
 ```bash
 uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner product-composed-interaction --artifacts /tmp/loushang-product-playback --include-frames
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner product-streaming-control-flow --artifacts /tmp/loushang-product-streaming-playback --include-frames
 ```
 
-The trace should include `product-composed-interaction` as a passing scenario.
-This scenario protects cross-feature regressions that are easy to miss when
-composer, surface, lifecycle, and transcript tests are run only in isolation.
+The trace should include `product-composed-interaction` and
+`product-streaming-control-flow` as passing scenarios. These scenarios protect
+cross-feature regressions that are easy to miss when composer, surface,
+lifecycle, resize, streaming transcript, and pending queue tests are run only in
+isolation. When a scenario fails, inspect the JSONL trace and screen artifact;
+review-oriented failures should preserve enough last frames to explain the
+visible state at the failure point.
 
 ### 4. Boundary Tests
 
@@ -103,7 +108,7 @@ Examples:
 - extensions receive normalized input events rather than raw terminal bytes
 - v1 prompt_toolkit modules are not on the new public API path
 
-## Manual Smoke Tests
+## Live Terminal Smoke Checklist
 
 Manual testing should focus on terminal behavior that is hard to assert
 visually:
@@ -114,6 +119,12 @@ visually:
 - IME candidate window placement
 - terminal restoration after Ctrl-C, Esc abort, exception, and normal exit
 - narrow terminal status truncation
+- modifier-key variants for Shift+Enter, Alt+Enter, Ctrl+Shift+Left/Right, and
+  terminal-specific option/meta behavior
+- keyboard-protocol negotiation in terminals that support enhanced key reporting
+- image fallback and image protocol behavior when Kitty, iTerm2, WezTerm,
+  Ghostty, VS Code terminal, tmux, or SSH changes runtime capabilities. The
+  baseline manual matrix should include Kitty, iTerm2, WezTerm, Ghostty, VS Code terminal.
 - composer selection in a real terminal:
   - type `abc`, press `Shift+Left`, verify the final `c` is visibly selected,
     then type `x` and verify the draft becomes `abx`

--- a/docs/internals/testing/native-tui-playback.md
+++ b/docs/internals/testing/native-tui-playback.md
@@ -13,6 +13,8 @@ Good candidates include:
 - long transcript resume behavior
 - product-composed interactions that combine transcript, running state,
   pending queues, surfaces, completion, and composer selection
+- streaming product control flows that combine long transcripts, live assistant
+  draft, follow-up queueing, steering, resize, surfaces, and abort
 
 Prefer focused component tests for pure rendering functions. Use the playback harness when the test needs a `NativeCodingTuiApp`, `TuiRuntime`, and `FakeTerminalPort` together.
 
@@ -32,9 +34,18 @@ JSONL traces include `logical_cursor`, `viewport`, `hardware_cursor`, and
 cursor position, and keep `logical_cursor`/`viewport` for diagnosing render-loop
 line mapping.
 
+If a playback scenario fails after producing a `PlaybackResult`, attach that
+result to the `AssertionError` as `playback_result`. The scenario runner will
+write the normal error file plus the JSONL trace and final screen artifact, so
+reviewers can inspect the last frames without rerunning the scenario locally.
+
 Useful direct smoke commands:
 
 ```bash
 uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner composer-selection-stress --artifacts /tmp/loushang-selection-playback --include-frames
 uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner product-composed-interaction --artifacts /tmp/loushang-product-playback --include-frames
+uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner product-streaming-control-flow --artifacts /tmp/loushang-product-streaming-playback --include-frames
 ```
+
+For a public, product-neutral playback example, see
+`examples/tui/42_playback_smoke.py`.

--- a/docs/zh-CN/reference/tui-runner.md
+++ b/docs/zh-CN/reference/tui-runner.md
@@ -79,4 +79,10 @@ factory 会收到当前 `stdin` 和 `stdout`，并且必须返回一个 context 
 
 不要并发运行同一个 `TuiRunner`。重入调用 `run()` 会抛出 `RuntimeError`。
 
-小型交互示例见 [examples/tui/40_runner_basic.py](../../../examples/tui/40_runner_basic.py)。
+## 示例
+
+- [examples/tui/40_runner_basic.py](../../../examples/tui/40_runner_basic.py)：
+  小型交互式 `TuiRunner` 应用，展示 focus 和输入处理。
+- [examples/tui/42_playback_smoke.py](../../../examples/tui/42_playback_smoke.py)：
+  与产品无关的 `PlaybackHarness` smoke 示例，会写出 JSONL 和 screen
+  artifact，便于 review。

--- a/examples/tui/42_playback_smoke.py
+++ b/examples/tui/42_playback_smoke.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loushang.tui import (
+    FakeTerminalPort,
+    PlaybackEvent,
+    PlaybackFrameBudget,
+    PlaybackHarness,
+    PlaybackResult,
+    RenderDiagnostics,
+    TerminalOperation,
+    TerminalSize,
+)
+
+
+def main() -> int:
+    state = {"text": "ready"}
+
+    def render(
+        event: PlaybackEvent,
+        size: TerminalSize,
+        previous: RenderDiagnostics | None,
+    ) -> RenderDiagnostics:
+        if event.kind == "input":
+            state["text"] = f"input: {event.payload}"
+        elif event.kind == "resize":
+            state["text"] = f"resized to {size.columns}x{size.rows}"
+
+        previous_lines = previous.current_logical_lines if previous is not None else ()
+        line = state["text"][: size.columns]
+        return RenderDiagnostics(
+            current_logical_lines=(line,),
+            previous_rendered_lines=previous_lines,
+            changed_line_range=(0, 0),
+            logical_cursor_row=0,
+            logical_cursor_column=len(line),
+            hardware_cursor_row=0,
+            hardware_cursor_column=len(line),
+            operations=(
+                TerminalOperation.move_cursor(row=0, column=0),
+                TerminalOperation.clear_line(),
+                TerminalOperation.write(line),
+            ),
+        )
+
+    port = FakeTerminalPort(size=TerminalSize(columns=40, rows=8))
+    harness = PlaybackHarness(render=render, port=port)
+    result = PlaybackResult(
+        steps=harness.play(
+            [
+                PlaybackEvent("render"),
+                PlaybackEvent.input("hello"),
+                PlaybackEvent.resize(columns=32, rows=6),
+            ]
+        ),
+        port=port,
+    )
+
+    PlaybackFrameBudget(max_operations=3).assert_result(result)
+
+    artifacts = result.write_artifacts(
+        Path("/tmp/loushang-public-playback-smoke"),
+        basename="public-playback-smoke",
+        include_frames=True,
+    )
+    print(
+        json.dumps(
+            {
+                "visible": result.visible_text,
+                "artifacts": [str(artifacts.trace), str(artifacts.screen)],
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/loushang/coding/ui/playback_scenarios/product.py
+++ b/src/loushang/coding/ui/playback_scenarios/product.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from loushang.coding.ui.perf_probe import build_synthetic_long_transcript_records
 from loushang.coding.ui.playback import (
     NativeTuiInputPlaybackResult,
@@ -19,6 +21,14 @@ PRODUCT_COMPOSED_FRAME_BUDGET = PlaybackFrameBudget(
     max_operations=64,
     max_serialized_output_bytes=3_000,
     max_changed_visible_lines=20,
+    require_synchronized=True,
+)
+
+PRODUCT_STREAMING_CONTROL_FRAME_BUDGET = PlaybackFrameBudget(
+    disallowed_operation_classes=("baseline_repaint", "recovery_repaint"),
+    max_operations=1_500,
+    max_serialized_output_bytes=90_000,
+    max_changed_visible_lines=18,
     require_synchronized=True,
 )
 
@@ -81,7 +91,92 @@ def _run_product_composed_interaction() -> NativeTuiInputPlaybackResult:
     result.assert_last_cursor_on_visible_line("› /model gpx", column=12)
     result.assert_visible_contains("queued=1 steer=0")
     result.assert_no_clear_screen()
-    PRODUCT_COMPOSED_FRAME_BUDGET.assert_result(result, skip_first=True)
+    _assert_with_review_artifacts(
+        result,
+        lambda: PRODUCT_COMPOSED_FRAME_BUDGET.assert_result(result, skip_first=True),
+    )
+    return result
+
+
+def _run_product_streaming_control_flow() -> NativeTuiInputPlaybackResult:
+    scenario = (
+        NativeTuiInputScenario(width=104, height=20)
+        .with_records(
+            build_synthetic_long_transcript_records(
+                turns=36,
+                tail_tool_output_lines=180,
+            )
+        )
+        .with_running_prompt("investigate live product controls")
+    )
+    scenario.app.begin_assistant()
+    scenario.app.append_assistant_chunk("streaming answer chunk one")
+
+    scenario.playback.play(
+        (
+            PlaybackEvent("render"),
+            PlaybackEvent.input("follow after current run"),
+            PlaybackEvent.input("\x1b\r"),
+        )
+    )
+    assert scenario.app.state.pending_followups == ["follow after current run"]
+    _assert_visible_contains(scenario, "streaming answer chunk one")
+    _assert_visible_contains(scenario, "Queued follow-up inputs")
+
+    scenario.app.append_assistant_chunk(" and chunk two")
+    scenario.playback.play(
+        (
+            PlaybackEvent("render"),
+            PlaybackEvent.resize(columns=72, rows=12),
+            PlaybackEvent.input("steer before next tool"),
+            PlaybackEvent.input("\r"),
+        )
+    )
+    assert scenario.app.state.pending_steers == ["steer before next tool"]
+    _assert_visible_contains(scenario, "Messages to be submitted after next tool call")
+    _assert_visible_contains(scenario, "steer before next tool")
+
+    scenario.app.active_surface = SettingsSurface(
+        (
+            SettingItem(id="memory", label="Memory", current_value="on"),
+            SettingItem(id="model", label="Model", current_value="kimi"),
+            SettingItem(id="theme", label="Theme", current_value="system"),
+        ),
+        enable_search=True,
+    )
+    scenario.playback.play(
+        (
+            PlaybackEvent("render"),
+            PlaybackEvent.input("mem"),
+        )
+    )
+    _assert_visible_contains(scenario, "Search: mem")
+    _assert_visible_contains(scenario, "Memory")
+
+    scenario.app.active_surface = None
+    scenario.playback.play(
+        (
+            PlaybackEvent("render"),
+            PlaybackEvent.input("\x1b"),
+        )
+    )
+
+    result = _result_from_scenario(scenario)
+    result.assert_abort_requested()
+    result.assert_pending_steers("steer before next tool")
+    assert result.app.state.pending_followups == ["follow after current run"]
+    draft = result.app.state.assistant_draft
+    assert draft is not None
+    assert draft.text == "streaming answer chunk one and chunk two"
+    result.assert_visible_contains("queued=1 steer=1")
+    result.assert_no_clear_scrollback()
+    _assert_with_review_artifacts(
+        result,
+        lambda: PRODUCT_STREAMING_CONTROL_FRAME_BUDGET.assert_result(
+            result,
+            skip_first=True,
+        ),
+    )
     return result
 
 
@@ -105,6 +200,17 @@ def _assert_visible_contains(scenario: NativeTuiInputScenario, expected: str) ->
     assert expected in visible
 
 
+def _assert_with_review_artifacts(
+    result: NativeTuiInputPlaybackResult,
+    assertion: Callable[[], None],
+) -> None:
+    try:
+        assertion()
+    except AssertionError as error:
+        error.playback_result = result
+        raise
+
+
 PRODUCT_SCENARIOS = (
     NativePlaybackScenarioSpec(
         name="product-composed-interaction",
@@ -117,6 +223,19 @@ PRODUCT_SCENARIOS = (
             "surface",
             "completion",
             "selection",
+        ),
+    ),
+    NativePlaybackScenarioSpec(
+        name="product-streaming-control-flow",
+        description="Exercise long streaming transcript controls with follow-up, steer, settings surface, resize, and abort.",
+        run=_run_product_streaming_control_flow,
+        tags=(
+            "product",
+            "transcript",
+            "streaming",
+            "lifecycle",
+            "surface",
+            "resize",
         ),
     ),
 )

--- a/src/loushang/coding/ui/playback_suite.py
+++ b/src/loushang/coding/ui/playback_suite.py
@@ -78,7 +78,12 @@ def run_playback_scenarios(
                 )
             )
         except AssertionError as error:
-            artifacts = _write_error_artifact(scenario.name, error, artifacts_dir=artifacts_dir)
+            artifacts = _write_error_artifacts(
+                scenario.name,
+                error,
+                artifacts_dir=artifacts_dir,
+                include_frames=include_frames,
+            )
             results.append(
                 NativePlaybackScenarioResult(
                     name=scenario.name,
@@ -114,11 +119,12 @@ def _write_artifacts(
     return tuple(Path(getattr(artifacts, field.name)) for field in fields(artifacts))
 
 
-def _write_error_artifact(
+def _write_error_artifacts(
     name: str,
     error: AssertionError,
     *,
     artifacts_dir: str | Path | None,
+    include_frames: bool,
 ) -> tuple[Path, ...]:
     if artifacts_dir is None:
         return ()
@@ -126,7 +132,31 @@ def _write_error_artifact(
     output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / f"{name}-error.txt"
     path.write_text(f"{error}\n", encoding="utf-8")
-    return (path,)
+    playback_artifacts = _write_failure_playback_artifacts(
+        name,
+        error,
+        artifacts_dir=artifacts_dir,
+        include_frames=include_frames,
+    )
+    return (path, *playback_artifacts)
+
+
+def _write_failure_playback_artifacts(
+    name: str,
+    error: AssertionError,
+    *,
+    artifacts_dir: str | Path,
+    include_frames: bool,
+) -> tuple[Path, ...]:
+    result = getattr(error, "playback_result", None)
+    if result is None:
+        return ()
+    return _write_artifacts(
+        name,
+        result,
+        artifacts_dir=artifacts_dir,
+        include_frames=include_frames,
+    )
 
 
 def _elapsed_ms(started: float) -> float:

--- a/tests/coding/test_native_tui_playback_runner.py
+++ b/tests/coding/test_native_tui_playback_runner.py
@@ -19,6 +19,15 @@ from loushang.coding.ui.playback_scenarios.surface import SURFACE_SCENARIOS
 from loushang.coding.ui.playback_scenarios.terminal import TERMINAL_SCENARIOS
 from loushang.coding.ui.playback_scenarios.transcript import TRANSCRIPT_SCENARIOS
 from loushang.coding.ui.playback_suite import NativePlaybackSuite as SuiteFromModule
+from loushang.tui import (
+    FakeTerminalPort,
+    PlaybackEvent,
+    PlaybackHarness,
+    PlaybackResult,
+    RenderDiagnostics,
+    TerminalOperation,
+    TerminalSize,
+)
 
 
 def test_native_tui_playback_runner_reexports_suite_types_from_playback_suite_module() -> (
@@ -108,6 +117,7 @@ def test_native_tui_playback_lifecycle_scenarios_live_in_lifecycle_module() -> N
 def test_native_tui_playback_product_scenarios_live_in_product_module() -> None:
     assert [scenario.name for scenario in PRODUCT_SCENARIOS] == [
         "product-composed-interaction",
+        "product-streaming-control-flow",
     ]
 
 
@@ -187,6 +197,7 @@ def test_native_tui_playback_runner_lists_default_scenarios(capsys) -> None:
     assert "native-loop-terminal-session-cleanup" in captured.out
     assert "native-loop-ctrl-c-abort-running" in captured.out
     assert "product-composed-interaction" in captured.out
+    assert "product-streaming-control-flow" in captured.out
 
 
 def test_native_tui_playback_runner_runs_named_scenario(capsys) -> None:
@@ -216,6 +227,7 @@ def test_native_tui_playback_runner_runs_tagged_product_scenarios(capsys) -> Non
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS product-composed-interaction" in captured.out
+    assert "PASS product-streaming-control-flow" in captured.out
     assert "PASS completion-tab" not in captured.out
 
 
@@ -330,6 +342,16 @@ def test_native_tui_playback_runner_runs_product_composed_interaction_scenario(
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS product-composed-interaction" in captured.out
+
+
+def test_native_tui_playback_runner_runs_product_streaming_control_flow_scenario(
+    capsys,
+) -> None:
+    exit_code = run_playback_cli(["product-streaming-control-flow"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS product-streaming-control-flow" in captured.out
 
 
 def test_native_tui_playback_runner_runs_lifecycle_scenario(capsys) -> None:
@@ -568,6 +590,55 @@ def test_native_tui_playback_runner_reports_failed_scenario(tmp_path, capsys) ->
     ) == "forced failure\n"
 
 
+def test_native_tui_playback_runner_writes_review_artifacts_for_playback_failure(
+    tmp_path,
+) -> None:
+    def failing_run() -> None:
+        result = _single_frame_result("reviewable failure frame")
+        error = AssertionError("forced review failure")
+        error.playback_result = result
+        raise error
+
+    suite = NativePlaybackSuite(
+        (
+            NativePlaybackScenarioSpec(
+                name="forced-review-failure",
+                description="Fails after producing playback frames.",
+                run=failing_run,
+            ),
+        )
+    )
+
+    results = run_playback_scenarios(
+        ["forced-review-failure"],
+        suite=suite,
+        artifacts_dir=tmp_path,
+        include_frames=True,
+    )
+
+    assert len(results) == 1
+    assert results[0].ok is False
+    assert results[0].error == "forced review failure"
+    assert [path.name for path in results[0].artifacts] == [
+        "forced-review-failure-error.txt",
+        "forced-review-failure.jsonl",
+        "forced-review-failure-screen.txt",
+    ]
+    assert "forced review failure" in (
+        tmp_path / "forced-review-failure-error.txt"
+    ).read_text(encoding="utf-8")
+    assert "reviewable failure frame" in (
+        tmp_path / "forced-review-failure-screen.txt"
+    ).read_text(encoding="utf-8")
+    row = json.loads(
+        (tmp_path / "forced-review-failure.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()[0]
+    )
+    assert row["visible_lines"][0] == "reviewable failure frame"
+    assert row["serialized_output"] == "reviewable failure frame"
+
+
 def test_native_tui_playback_runner_writes_failed_json_summary(
     tmp_path, capsys
 ) -> None:
@@ -653,3 +724,22 @@ def test_native_tui_playback_runner_main_can_emit_json(monkeypatch, capsys) -> N
     assert payload["ok"] is True
     assert payload["results"][0]["name"] == "completion-tab"
     assert "PASS completion-tab" not in captured.out
+
+
+def _single_frame_result(text: str) -> PlaybackResult:
+    def render(
+        _event: PlaybackEvent,
+        _size: TerminalSize,
+        _previous: RenderDiagnostics | None,
+    ) -> RenderDiagnostics:
+        return RenderDiagnostics(
+            current_logical_lines=(text,),
+            changed_line_range=(0, 0),
+            logical_cursor_row=0,
+            hardware_cursor_row=0,
+            operations=(TerminalOperation.write(text),),
+        )
+
+    port = FakeTerminalPort(size=TerminalSize(columns=80, rows=4))
+    harness = PlaybackHarness(render=render, port=port)
+    return PlaybackResult(steps=harness.play([PlaybackEvent("render")]), port=port)

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -35,6 +35,23 @@ def test_testing_strategy_documents_product_composed_playback() -> None:
     assert "screen_cursor" in playback
 
 
+def test_testing_strategy_documents_streaming_control_and_live_smoke() -> None:
+    strategy = Path(
+        "docs/internals/architecture/tui/native-terminal-core/testing-strategy.md"
+    ).read_text(encoding="utf-8")
+    playback = Path("docs/internals/testing/native-tui-playback.md").read_text(
+        encoding="utf-8"
+    )
+
+    for text in (strategy, playback):
+        assert "product-streaming-control-flow" in text
+        assert "last frames" in text
+
+    assert "Live Terminal Smoke Checklist" in strategy
+    assert "IME candidate window" in strategy
+    assert "Kitty, iTerm2, WezTerm, Ghostty, VS Code terminal" in strategy
+
+
 def test_theme_key_design_lists_editor_selection_token() -> None:
     text = Path(
         "docs/internals/architecture/tui/native-terminal-core/key-designs/KD-009-theme-resolution.md"
@@ -80,3 +97,17 @@ def test_public_tui_reference_documents_editing_foundation() -> None:
 
     assert "tui-editing.md" in english_index
     assert "tui-editing.md" in chinese_index
+
+
+def test_public_tui_reference_documents_runner_and_playback_examples() -> None:
+    english_runner = Path("docs/en/reference/tui-runner.md").read_text(
+        encoding="utf-8"
+    )
+    chinese_runner = Path("docs/zh-CN/reference/tui-runner.md").read_text(
+        encoding="utf-8"
+    )
+
+    for text in (english_runner, chinese_runner):
+        assert "examples/tui/40_runner_basic.py" in text
+        assert "examples/tui/42_playback_smoke.py" in text
+        assert "PlaybackHarness" in text


### PR DESCRIPTION
## Summary / 摘要

English:
- Add a product-composed playback scenario for long streaming control flow: live assistant draft, follow-up queue, running steer, settings surface, resize, and abort.
- Let playback scenario failures attach a playback result so the runner writes error + JSONL + screen artifacts for review.
- Add a product-neutral public playback smoke example and update TUI runner/playback docs plus live-terminal smoke checklist.

中文：
- 新增 product 组合 playback 场景，覆盖长 streaming、assistant draft、follow-up queue、running steer、settings surface、resize 和 abort。
- playback 场景失败时可携带 playback result，runner 会写出 error、JSONL trace 和 screen artifact，方便 review。
- 新增与产品无关的 public playback smoke 示例，并更新 TUI runner/playback 文档和 live-terminal smoke checklist。

## Scope / 范围

- TUI/product adapter/playback/docs/examples only.
- No code/method lane changes.
- Reader-local copy/export remains deferred. Related tracking issue: #129.

## Notes for agents / 给 agent 的说明

- Main behavior entry points: src/loushang/coding/ui/playback_scenarios/product.py and src/loushang/coding/ui/playback_suite.py.
- product-streaming-control-flow intentionally allows resize repaint cost; its budget rejects baseline/recovery repaint and clear scrollback, but does not require tiny diff operations during resize.
- Review failure artifacts depend on attaching playback_result to an AssertionError; existing failures without that attribute keep the previous error-only behavior.
- Public example: examples/tui/42_playback_smoke.py. It is product-neutral and uses PlaybackHarness, not coding UI internals.

## Notes for human reviewers / 给人的说明

- This PR is mostly regression hardening and docs. It should not change interactive product behavior.
- The most useful manual check is running the new scenario with --artifacts and opening the generated JSONL/screen files if a failure happens.
- The live-terminal checklist documents manual checks for IME, modifier keys, terminal protocol negotiation, image fallback, and terminal-family differences.

## Validation / 验证

- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_tui_playback_runner.py -q -> 51 passed
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_tui_testing_strategy_docs.py -q -> 8 passed
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py -q -> 38 passed
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/ui/playback_suite.py src/loushang/coding/ui/playback_scenarios/product.py tests/coding/test_native_tui_playback_runner.py tests/tui/test_tui_testing_strategy_docs.py examples/tui/42_playback_smoke.py -> All checks passed
- uv --cache-dir .uv-cache run --extra dev python examples/tui/42_playback_smoke.py -> ran and wrote playback artifacts
- uv --cache-dir .uv-cache run --extra dev python -m loushang.coding.ui.playback_runner product-streaming-control-flow --artifacts /tmp/loushang-product-streaming-playback --include-frames -> PASS
