### PR TITLE
fix(coding): tighten exploration discipline / 收紧探索纪律

### DIFF
--- a/src/loushang/coding/prompt/assembler.py
+++ b/src/loushang/coding/prompt/assembler.py
@@ -17,6 +17,11 @@ You are an expert coding assistant operating inside loushang, a coding agent har
 Guidelines:
 - Be concise in your responses
 - Show file paths clearly when working with files
+- 首次探索工具调用前，必须先用一句话说明本轮要验证什么；不要直接开始扫描。
+- 连续执行 3 次探索工具调用后，必须先汇总已确认信息，再决定是否继续。
+- 避免无明确目标地批量列目录、搜索和读取文件；证据足够时停止探索并回答。
+- 进度说明只在目标变化、关键证据、阶段切换或需用户决策时发送，保持简短。
+- 多步骤任务阶段结束时说明结果、验证和下一步或阻塞。
 - Prefer specialized tools over bash for file exploration when available
 - Always read files completely before editing
 - Follow project-specific instructions in <project_context> when present

--- a/src/loushang/coding/session/tool_controller.py
+++ b/src/loushang/coding/session/tool_controller.py
@@ -17,7 +17,7 @@ from loushang.coding.tools import (
     tool_to_definition,
 )
 
-_DEFAULT_ACTIVE_TOOL_NAMES: tuple[str, ...] = ("read", "bash", "edit", "write")
+_DEFAULT_ACTIVE_TOOL_NAMES: tuple[str, ...] = ("read", "ls", "find", "grep", "bash", "edit", "write")
 _BUILTIN_TOOL_NAMES: frozenset[str] = frozenset(("bash", "read", "ls", "find", "grep", "write", "edit"))
 
 

--- a/tests/coding/test_bootstrap.py
+++ b/tests/coding/test_bootstrap.py
@@ -1027,7 +1027,7 @@ def test_create_agent_session_synthesizes_definitions_from_legacy_tools(tmp_path
         tools=registry.list_enabled_tools(),
     )
 
-    assert session.get_active_tool_names() == ["read", "bash", "edit", "write"]
+    assert session.get_active_tool_names() == ["read", "ls", "find", "grep", "bash", "edit", "write"]
     assert [definition.name for definition in session.get_all_tools()] == [
         "bash",
         "read",
@@ -1075,7 +1075,7 @@ def test_create_agent_session_defaults_custom_tools_active_without_defaulting_al
         tool_registry=registry,
     )
 
-    assert session.get_active_tool_names() == ["read", "bash", "edit", "write", "custom_tool"]
+    assert session.get_active_tool_names() == ["read", "ls", "find", "grep", "bash", "edit", "write", "custom_tool"]
     assert [definition.name for definition in session.get_all_tools()] == [
         "bash",
         "read",
@@ -1087,7 +1087,7 @@ def test_create_agent_session_defaults_custom_tools_active_without_defaulting_al
         "custom_tool",
     ]
     assert "- custom_tool:" not in session.agent.system_prompt
-    assert "- grep:" not in session.agent.system_prompt
+    assert "- grep:" in session.agent.system_prompt
 
 
 def test_create_agent_session_marks_failing_builtin_tool_result_as_error(tmp_path) -> None:

--- a/tests/coding/test_prompt_assembly.py
+++ b/tests/coding/test_prompt_assembly.py
@@ -8,6 +8,18 @@ def _runtime_footer(cwd: str) -> str:
     return f"Current date: {date.today().isoformat()}\nCurrent working directory: {cwd}"
 
 
+def test_default_system_prompt_includes_exploration_progress_guidelines() -> None:
+    from loushang.coding.prompt import assemble_prompt
+
+    system_prompt = assemble_prompt().system_prompt
+
+    assert "首次探索工具调用前，必须先用一句话说明本轮要验证什么；不要直接开始扫描。" in system_prompt
+    assert "连续执行 3 次探索工具调用后，必须先汇总已确认信息，再决定是否继续。" in system_prompt
+    assert "避免无明确目标地批量列目录、搜索和读取文件；证据足够时停止探索并回答。" in system_prompt
+    assert "进度说明只在目标变化、关键证据、阶段切换或需用户决策时发送，保持简短。" in system_prompt
+    assert "多步骤任务阶段结束时说明结果、验证和下一步或阻塞。" in system_prompt
+
+
 def test_assemble_prompt_returns_prompt_assembly() -> None:
     from pathlib import Path
 


### PR DESCRIPTION
## Summary / 摘要
- Tighten the default system prompt so exploratory tool use declares a verification target, summarizes after repeated exploration, and stops when evidence is sufficient.
- Enable ls/find/grep by default alongside read/bash/edit/write so file exploration can use specialized tools instead of shell scans.
- Update prompt and bootstrap tests for the new defaults.

- 收紧默认系统提示词：探索工具调用前说明验证目标，多次探索后先汇总，证据足够时停止。
- 默认启用 ls/find/grep，与 read/bash/edit/write 一起可用，减少用 bash 做文件盘点式扫描。
- 更新 prompt 和 bootstrap 测试覆盖新默认行为。

Closes #124

## Test Plan / 测试计划
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_prompt_assembly.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_session_tool_controller.py tests/coding/test_bootstrap.py -q