### PR TITLE
feat(tui): add default redo keybinding

### DIFF
--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -101,11 +101,13 @@ editing.
 | Delete word | `ctrl+w`, `alt+backspace`, `alt+d`, `alt+delete` |
 | Kill to line start / end | `ctrl+u`, `ctrl+k` |
 | Yank / yank-pop | `ctrl+y`, `alt+y` |
-| Undo | `ctrl+-` |
+| Undo | `ctrl+-`, `ctrl+_` |
 | Redo | `ctrl+shift+z` |
 | New line / submit | `shift+enter`, `alt+enter`, `ctrl+j`, `enter` |
 
-Redo uses `ctrl+shift+z` by default because `ctrl+y` is reserved for yank.
+Some terminals report `ctrl+-` as `ctrl+_`; both are treated as undo. Redo
+uses `ctrl+shift+z` by default because `ctrl+y` is reserved for yank and
+`ctrl+shift+-` is not distinguishable from undo in every terminal.
 
 ## Selection-Aware Edits
 

--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -43,6 +43,9 @@ assert field.value == "hello loushang"
 field.handle_input(InputEvent(kind="key", key="ctrl+-"))
 assert field.value == "hello world"
 
+field.handle_input(InputEvent(kind="key", key="ctrl+shift+z"))
+assert field.value == "hello loushang"
+
 result = field.render(RenderConstraints(width=40, max_height=1))
 ```
 
@@ -99,10 +102,10 @@ editing.
 | Kill to line start / end | `ctrl+u`, `ctrl+k` |
 | Yank / yank-pop | `ctrl+y`, `alt+y` |
 | Undo | `ctrl+-` |
+| Redo | `ctrl+shift+z` |
 | New line / submit | `shift+enter`, `alt+enter`, `ctrl+j`, `enter` |
 
-Redo storage exists in the edit buffers, but no default redo key is currently
-documented for terminal use.
+Redo uses `ctrl+shift+z` by default because `ctrl+y` is reserved for yank.
 
 ## Selection-Aware Edits
 

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-017-composer-selection-and-selected-range.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-017-composer-selection-and-selected-range.md
@@ -38,7 +38,8 @@ The following items remain outside the initial implementation:
 - mouse-driven composer selection
 - transcript or screen-buffer copy selection
 - restoring selection through undo/redo snapshots
-- changing the default redo keybinding policy
+- changing the default redo keybinding policy. This was handled later as a
+  separate follow-up with `ctrl+shift+z`.
 
 ## Reference Observations
 

--- a/docs/internals/architecture/tui/native-terminal-core/reference/terminal-ux-feature-alignment.md
+++ b/docs/internals/architecture/tui/native-terminal-core/reference/terminal-ux-feature-alignment.md
@@ -85,6 +85,7 @@ As of 2026-06-05, these gaps are no longer open in the native TUI core:
   interaction in Composer
 - TextInput migration to shared selection and editing primitives
 - frame-level playback for completion and composer-selection stress scenarios
+- default redo keybinding policy through `ctrl+shift+z`
 
 ## Remaining Gaps
 
@@ -94,8 +95,6 @@ As of 2026-06-05, these gaps are no longer open in the native TUI core:
 - Screen-buffer copy selection and mouse-driven transcript selection remain
   intentionally separate from composer text selection and are not implemented
   in the first keyboard-selection pass.
-- Redo storage exists in editing buffers, but the public/default redo keybinding
-  policy is still unresolved.
 - Live-terminal coverage should be broadened for modifier-key variants,
   keyboard-protocol negotiation, IME cursor behavior, and image protocols.
 - Public reference docs should add more small examples for `TuiRunner`,

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -89,11 +89,13 @@ Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文
 | 删除词 | `ctrl+w`, `alt+backspace`, `alt+d`, `alt+delete` |
 | kill 到行首/行尾 | `ctrl+u`, `ctrl+k` |
 | Yank / yank-pop | `ctrl+y`, `alt+y` |
-| Undo | `ctrl+-` |
+| Undo | `ctrl+-`, `ctrl+_` |
 | Redo | `ctrl+shift+z` |
 | 换行/提交 | `shift+enter`, `alt+enter`, `ctrl+j`, `enter` |
 
-默认 redo 使用 `ctrl+shift+z`，因为 `ctrl+y` 已保留给 yank。
+部分终端会把 `ctrl+-` 上报为 `ctrl+_`，两者都会触发 undo。默认 redo
+使用 `ctrl+shift+z`，因为 `ctrl+y` 已保留给 yank，而 `ctrl+shift+-`
+在部分终端里无法和 undo 稳定区分。
 
 ## Selection-Aware Edit
 

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -38,6 +38,9 @@ assert field.value == "hello loushang"
 field.handle_input(InputEvent(kind="key", key="ctrl+-"))
 assert field.value == "hello world"
 
+field.handle_input(InputEvent(kind="key", key="ctrl+shift+z"))
+assert field.value == "hello loushang"
+
 result = field.render(RenderConstraints(width=40, max_height=1))
 ```
 
@@ -87,9 +90,10 @@ Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文
 | kill 到行首/行尾 | `ctrl+u`, `ctrl+k` |
 | Yank / yank-pop | `ctrl+y`, `alt+y` |
 | Undo | `ctrl+-` |
+| Redo | `ctrl+shift+z` |
 | 换行/提交 | `shift+enter`, `alt+enter`, `ctrl+j`, `enter` |
 
-编辑 buffer 里已有 redo 存储，但当前还没有为终端使用文档化默认 redo 快捷键。
+默认 redo 使用 `ctrl+shift+z`，因为 `ctrl+y` 已保留给 yank。
 
 ## Selection-Aware Edit
 

--- a/examples/tui/41_editing_foundation.py
+++ b/examples/tui/41_editing_foundation.py
@@ -29,11 +29,14 @@ def _text_input_walkthrough() -> None:
     field.handle_input(InputEvent(kind="text", text="loushang"))
     replaced = field.value
     field.handle_input(InputEvent(kind="key", key="ctrl+-"))
+    undone = field.value
+    field.handle_input(InputEvent(kind="key", key="ctrl+shift+z"))
 
     print("## TextInput")
     print(f"selection: {selected!r} -> {selected_text!r}")
     print(f"replace:   {replaced!r}")
-    print(f"undo:      {field.value!r}")
+    print(f"undo:      {undone!r}")
+    print(f"redo:      {field.value!r}")
     _print_rendered(field.render(RenderConstraints(width=40, max_height=1)))
 
 
@@ -48,6 +51,10 @@ def _composer_walkthrough() -> None:
     kill_ring = composer.kill_ring
     router.route(InputEvent(kind="key", key="ctrl+y"))
     yanked = composer.value
+    router.route(InputEvent(kind="key", key="ctrl+-"))
+    undo = composer.value
+    router.route(InputEvent(kind="key", key="ctrl+shift+z"))
+    redo = composer.value
     router.route(InputEvent(kind="text", text=" "))
     router.route(
         InputEvent(
@@ -60,6 +67,8 @@ def _composer_walkthrough() -> None:
     print(f"kill:      {killed!r}")
     print(f"kill ring: {kill_ring!r}")
     print(f"yank:      {yanked!r}")
+    print(f"undo:      {undo!r}")
+    print(f"redo:      {redo!r}")
     print(f"paste:     {composer.value!r}")
     _print_rendered(composer.render(RenderConstraints(width=72, max_height=6)))
 

--- a/src/loushang/tui/input.py
+++ b/src/loushang/tui/input.py
@@ -689,6 +689,9 @@ def route_composer_editing_key(
     if keybindings.matches(key, "tui.editor.undo"):
         composer.undo()
         return True
+    if keybindings.matches(key, "tui.editor.redo"):
+        composer.redo()
+        return True
     return False
 
 

--- a/src/loushang/tui/keybindings.py
+++ b/src/loushang/tui/keybindings.py
@@ -35,7 +35,7 @@ DEFAULT_KEYBINDINGS: dict[KeybindingAction, tuple[KeyId, ...]] = {
     "tui.editor.deleteToLineEnd": ("ctrl+k",),
     "tui.editor.yank": ("ctrl+y",),
     "tui.editor.yankPop": ("alt+y",),
-    "tui.editor.undo": ("ctrl+-",),
+    "tui.editor.undo": ("ctrl+-", "ctrl+_"),
     "tui.editor.redo": ("ctrl+shift+z",),
     "tui.input.newLine": ("shift+enter", "alt+enter", "ctrl+j"),
     "tui.input.submit": ("enter",),

--- a/src/loushang/tui/keybindings.py
+++ b/src/loushang/tui/keybindings.py
@@ -36,6 +36,7 @@ DEFAULT_KEYBINDINGS: dict[KeybindingAction, tuple[KeyId, ...]] = {
     "tui.editor.yank": ("ctrl+y",),
     "tui.editor.yankPop": ("alt+y",),
     "tui.editor.undo": ("ctrl+-",),
+    "tui.editor.redo": ("ctrl+shift+z",),
     "tui.input.newLine": ("shift+enter", "alt+enter", "ctrl+j"),
     "tui.input.submit": ("enter",),
     "tui.input.tab": ("tab",),

--- a/src/loushang/tui/ui_parts/text_input.py
+++ b/src/loushang/tui/ui_parts/text_input.py
@@ -139,6 +139,8 @@ class TextInput:
         manager = keybindings if isinstance(keybindings, KeybindingManager) else KeybindingManager(keybindings)
         if manager.matches(key, "tui.editor.undo"):
             return self.undo()
+        if manager.matches(key, "tui.editor.redo"):
+            return self.redo()
         if manager.matches(key, "tui.editor.yank"):
             return self.yank()
         if manager.matches(key, "tui.editor.yankPop"):

--- a/tests/tui/test_input_routing.py
+++ b/tests/tui/test_input_routing.py
@@ -129,10 +129,11 @@ def test_input_reader_buffers_incomplete_escape_until_flush() -> None:
 def test_input_reader_normalizes_csi_u_and_modify_other_keys() -> None:
     reader = InputReader()
 
-    events = reader.feed("\x1b[97;5u\x1b[90;6u\x1b[1;5D\x1b[27;3;127~\x1b[13;2u")
+    events = reader.feed("\x1b[97;5u\x1b[95;5u\x1b[90;6u\x1b[1;5D\x1b[27;3;127~\x1b[13;2u")
 
     assert events == (
         InputEvent(kind="key", key="ctrl+a", raw="\x1b[97;5u"),
+        InputEvent(kind="key", key="ctrl+_", raw="\x1b[95;5u"),
         InputEvent(kind="key", key="ctrl+shift+z", raw="\x1b[90;6u"),
         InputEvent(kind="key", key="ctrl+left", raw="\x1b[1;5D"),
         InputEvent(kind="key", key="alt+backspace", raw="\x1b[27;3;127~"),
@@ -274,6 +275,12 @@ def test_keybinding_manager_matches_default_redo_key() -> None:
     assert manager.matches("shift+ctrl+z", "tui.editor.redo")
 
 
+def test_keybinding_manager_matches_terminal_underscore_undo_alias() -> None:
+    manager = KeybindingManager()
+
+    assert manager.matches("ctrl+_", "tui.editor.undo")
+
+
 def test_input_router_alt_angle_moves_to_line_boundaries() -> None:
     composer = Composer(prompt="> ")
     composer.insert_text("alpha beta")
@@ -376,6 +383,16 @@ def test_input_router_routes_default_redo_to_composer() -> None:
     router.route(InputEvent(kind="key", key="ctrl+shift+z"))
 
     assert composer.value == "abc"
+
+
+def test_input_router_routes_terminal_underscore_undo_alias_to_composer() -> None:
+    composer = Composer(prompt="> ")
+    router = InputRouter(composer=composer)
+
+    router.route(InputEvent(kind="text", text="abc"))
+    router.route(InputEvent(kind="key", key="ctrl+_"))
+
+    assert composer.value == ""
 
 
 def test_input_router_alt_y_routes_yank_pop() -> None:

--- a/tests/tui/test_input_routing.py
+++ b/tests/tui/test_input_routing.py
@@ -129,10 +129,11 @@ def test_input_reader_buffers_incomplete_escape_until_flush() -> None:
 def test_input_reader_normalizes_csi_u_and_modify_other_keys() -> None:
     reader = InputReader()
 
-    events = reader.feed("\x1b[97;5u\x1b[1;5D\x1b[27;3;127~\x1b[13;2u")
+    events = reader.feed("\x1b[97;5u\x1b[90;6u\x1b[1;5D\x1b[27;3;127~\x1b[13;2u")
 
     assert events == (
         InputEvent(kind="key", key="ctrl+a", raw="\x1b[97;5u"),
+        InputEvent(kind="key", key="ctrl+shift+z", raw="\x1b[90;6u"),
         InputEvent(kind="key", key="ctrl+left", raw="\x1b[1;5D"),
         InputEvent(kind="key", key="alt+backspace", raw="\x1b[27;3;127~"),
         InputEvent(kind="key", key="shift+enter", raw="\x1b[13;2u"),
@@ -266,6 +267,13 @@ def test_keybinding_manager_matches_transcript_reader_alias() -> None:
     assert manager.matches("ctrl+o", "tui.transcript.open")
 
 
+def test_keybinding_manager_matches_default_redo_key() -> None:
+    manager = KeybindingManager()
+
+    assert manager.keys_for("tui.editor.redo") == ("ctrl+shift+z",)
+    assert manager.matches("shift+ctrl+z", "tui.editor.redo")
+
+
 def test_input_router_alt_angle_moves_to_line_boundaries() -> None:
     composer = Composer(prompt="> ")
     composer.insert_text("alpha beta")
@@ -354,6 +362,20 @@ def test_input_router_routes_common_editor_actions_to_composer() -> None:
     router.route(InputEvent(kind="key", key="ctrl_y"))
 
     assert composer.value == "helo"
+
+
+def test_input_router_routes_default_redo_to_composer() -> None:
+    composer = Composer(prompt="> ")
+    router = InputRouter(composer=composer)
+
+    router.route(InputEvent(kind="text", text="abc"))
+    router.route(InputEvent(kind="key", key="ctrl+-"))
+
+    assert composer.value == ""
+
+    router.route(InputEvent(kind="key", key="ctrl+shift+z"))
+
+    assert composer.value == "abc"
 
 
 def test_input_router_alt_y_routes_yank_pop() -> None:

--- a/tests/tui/test_text_input.py
+++ b/tests/tui/test_text_input.py
@@ -145,6 +145,17 @@ def test_text_input_handles_word_kill_yank_and_undo() -> None:
     assert field.value == "alpha "
 
 
+def test_text_input_routes_default_redo_key() -> None:
+    field = TextInput()
+
+    assert field.handle_input(InputEvent(kind="text", text="abc"))
+    assert field.handle_input(InputEvent(kind="key", key="ctrl+-"))
+    assert field.value == ""
+
+    assert field.handle_input(InputEvent(kind="key", key="ctrl+shift+z"))
+    assert field.value == "abc"
+
+
 def test_text_input_handles_line_editing_keys() -> None:
     field = TextInput()
     field.handle_input(InputEvent(kind="text", text="alpha beta"))

--- a/tests/tui/test_text_input.py
+++ b/tests/tui/test_text_input.py
@@ -156,6 +156,14 @@ def test_text_input_routes_default_redo_key() -> None:
     assert field.value == "abc"
 
 
+def test_text_input_routes_terminal_underscore_undo_alias() -> None:
+    field = TextInput()
+
+    assert field.handle_input(InputEvent(kind="text", text="abc"))
+    assert field.handle_input(InputEvent(kind="key", key="ctrl+_"))
+    assert field.value == ""
+
+
 def test_text_input_handles_line_editing_keys() -> None:
     field = TextInput()
     field.handle_input(InputEvent(kind="text", text="alpha beta"))

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -68,7 +68,7 @@ def test_terminal_ux_alignment_documents_current_capability_snapshot() -> None:
     assert "2026-06-05" in text
     assert "Overall qualitative completion" in text
     assert "SelectionController" in text
-    assert "Redo storage exists" in text
+    assert "default redo keybinding policy through `ctrl+shift+z`" in text
 
 
 def test_composer_selection_key_design_records_implemented_status() -> None:
@@ -92,6 +92,7 @@ def test_public_tui_reference_documents_editing_foundation() -> None:
         assert "TextInput" in text
         assert "Composer" in text
         assert "SelectionController" in text
+        assert "ctrl+shift+z" in text
         assert "composer-selection-stress" in text
         assert "examples/tui/41_editing_foundation.py" in text
 

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -92,6 +92,7 @@ def test_public_tui_reference_documents_editing_foundation() -> None:
         assert "TextInput" in text
         assert "Composer" in text
         assert "SelectionController" in text
+        assert "ctrl+_" in text
         assert "ctrl+shift+z" in text
         assert "composer-selection-stress" in text
         assert "examples/tui/41_editing_foundation.py" in text


### PR DESCRIPTION
## Summary / 摘要

English:
- Define `ctrl+shift+z` as the default TUI redo keybinding.
- Route redo through shared Composer and TextInput editing paths.
- Document the policy in English/Chinese TUI editing docs and update the editing example.

中文：
- 将 `ctrl+shift+z` 定义为 TUI 默认 redo 快捷键。
- 在共享 Composer 和 TextInput 编辑路径中接入 redo。
- 更新英文/中文 TUI editing 文档和 editing 示例。

## Scope / 范围

- TUI editing/keybinding/docs/tests/examples only.
- No code/method lane behavior changes.
- Does not migrate selector/settings/model picker edit state.

## Notes for agents / 给 agent 的说明

- Default keybinding is `tui.editor.redo -> ctrl+shift+z`.
- `ctrl+y` remains yank and is intentionally not reused for redo.
- InputReader already normalizes enhanced keyboard protocol CSI-u `ESC [ 90 ; 6 u` to `ctrl+shift+z`; this PR adds explicit coverage.
- Main behavior entry points: `src/loushang/tui/keybindings.py`, `src/loushang/tui/input.py`, and `src/loushang/tui/ui_parts/text_input.py`.

## Notes for human reviewers / 给人的说明

- This PR completes the previously unresolved redo keybinding policy.
- User-visible behavior: after `ctrl+-` undo, `ctrl+shift+z` redo restores the undone edit in TextInput and Composer.
- The policy avoids `ctrl+y` because that key is already yank in the editing foundation.

## Related / 关联

Closes #132.

## Validation / 验证

- `uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_input_routing.py tests/tui/test_text_input.py tests/tui/test_tui_testing_strategy_docs.py -q` -> 75 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_tui_transcript_reader.py tests/coding/test_native_tui_playback_harness.py -q` -> 38 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q` -> 673 passed
- `uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/keybindings.py src/loushang/tui/input.py src/loushang/tui/ui_parts/text_input.py tests/tui/test_input_routing.py tests/tui/test_text_input.py tests/tui/test_tui_testing_strategy_docs.py examples/tui/41_editing_foundation.py` -> All checks passed
- `uv --cache-dir .uv-cache run --extra dev python examples/tui/41_editing_foundation.py` -> ran and printed TextInput/Composer redo walkthrough
