### PR TITLE
feat(coding): add session /tools command / 增加会话级 /tools 命令

### DIFF
--- a/docs/en/reference/README.md
+++ b/docs/en/reference/README.md
@@ -79,7 +79,7 @@ Built-in interactive commands include:
 
 ```text
 /settings /model /scoped-models /export /import /share /copy /name
-/session /terminal /changelog /hotkeys /fork /clone /tree
+/session /terminal /tools /changelog /hotkeys /fork /clone /tree
 /login /logout /new /compact /resume /reload /quit
 ```
 

--- a/docs/en/user-guide/README.md
+++ b/docs/en/user-guide/README.md
@@ -35,13 +35,19 @@ loushang --resume
 loushang --export
 ```
 
-Inside the interactive surface, built-in slash commands include `/session`, `/resume`, `/fork`, `/clone`, `/tree`, `/export`, `/compact`, `/reload`, and `/quit`.
+Inside the interactive surface, built-in slash commands include `/session`, `/resume`, `/fork`, `/clone`, `/tree`, `/tools`, `/export`, `/compact`, `/reload`, and `/quit`.
 
 ## Tools
 
 Tools expose executable capabilities to the agent. The coding product includes built-in tool surfaces and options for enabling, disabling, and narrowing tools:
 
+New interactive sessions enable the built-in `read`, `ls`, `find`, `grep`, `bash`, `edit`, and `write` tools by default. Prefer `ls`, `find`, `grep`, and `read` for file exploration; keep `bash` for shell behavior such as pipelines, redirects, build commands, tests, and Git operations.
+
 ```bash
+/tools
+/tools off bash
+/tools only read,ls,find,grep
+/tools reset
 loushang --tools bash,write -p "Inspect this project."
 loushang --no-tools -p "Explain the repository from context only."
 ```

--- a/docs/internals/architecture/coding/component-interfaces/session.md
+++ b/docs/internals/architecture/coding/component-interfaces/session.md
@@ -128,8 +128,8 @@
 - 语义上对齐 `reference CLI` 的 `AgentSession`
 - 保留 session 作为业务中心与统一 orchestration center
 - session 拥有 active tool state，而不是让 registry 直接等同于当前正在使用的工具集
-- 默认 active tools 对齐 `reference CLI` 的核心 built-ins：`read`、`bash`、`edit`、`write`；
-  `ls`、`find`、`grep` 默认可见但不 active，custom/extension tools 默认 active；
+- 默认 active tools 包含核心编辑/执行工具与文件探索工具：`read`、`ls`、`find`、`grep`、`bash`、`edit`、`write`；
+  custom/extension tools 默认 active；
   `allowed_tool_names` 存在时默认 active set 为 allowlist 内所有可用工具
 - 将 compaction、policy、tools 等横切能力拆成协作者，而不是继续膨胀 session
 - 协作者的显式抽离不应削弱 `AgentSession` 作为 mode-neutral core facade 的主语义

--- a/docs/zh-CN/reference/README.md
+++ b/docs/zh-CN/reference/README.md
@@ -79,7 +79,7 @@ loushang --command <command-name> --command-result-format json
 
 ```text
 /settings /model /scoped-models /export /import /share /copy /name
-/session /terminal /changelog /hotkeys /fork /clone /tree
+/session /terminal /tools /changelog /hotkeys /fork /clone /tree
 /login /logout /new /compact /resume /reload /quit
 ```
 

--- a/docs/zh-CN/user-guide/README.md
+++ b/docs/zh-CN/user-guide/README.md
@@ -35,13 +35,19 @@ loushang --resume
 loushang --export
 ```
 
-在交互界面中，内置 slash commands 包括 `/session`、`/resume`、`/fork`、`/clone`、`/tree`、`/export`、`/compact`、`/reload` 和 `/quit`。
+在交互界面中，内置 slash commands 包括 `/session`、`/resume`、`/fork`、`/clone`、`/tree`、`/tools`、`/export`、`/compact`、`/reload` 和 `/quit`。
 
 ## 工具
 
 工具把可执行能力暴露给 agent。Coding 产品包含内置工具面，并支持启用、禁用和收窄工具范围：
 
+新的交互会话默认启用内置 `read`、`ls`、`find`、`grep`、`bash`、`edit` 和 `write` 工具。文件探索优先使用 `ls`、`find`、`grep` 和 `read`；`bash` 更适合 shell 管道、重定向、构建命令、测试和 Git 操作。
+
 ```bash
+/tools
+/tools off bash
+/tools only read,ls,find,grep
+/tools reset
 loushang --tools bash,write -p "Inspect this project."
 loushang --no-tools -p "Explain the repository from context only."
 ```

--- a/src/loushang/coding/commands/types.py
+++ b/src/loushang/coding/commands/types.py
@@ -47,6 +47,7 @@ BUILTIN_SLASH_COMMANDS: tuple[BuiltinSlashCommand, ...] = (
     BuiltinSlashCommand(name="name", description="Set session display name"),
     BuiltinSlashCommand(name="session", description="Show session info and stats"),
     BuiltinSlashCommand(name="terminal", description="Show terminal capabilities and protocol diagnostics"),
+    BuiltinSlashCommand(name="tools", description="Show or update active tools for this session"),
     BuiltinSlashCommand(name="changelog", description="Show changelog entries"),
     BuiltinSlashCommand(name="hotkeys", description="Show all keyboard shortcuts"),
     BuiltinSlashCommand(name="fork", description="Create a new fork from a previous user message"),

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -268,6 +268,10 @@ class AgentSession:
                 clone_session=self._clone_from_builtin,
                 navigate_tree=self._navigate_tree_from_extension,
                 import_session=self._import_from_builtin,
+                get_active_tool_names=self.get_active_tool_names,
+                get_all_tools=lambda: list(self.get_all_tools()),
+                set_active_tools=self.set_active_tools,
+                get_default_active_tool_names=self._default_active_tool_names,
             ),
         )
         self._extension_event_sink = ExtensionEventSink(

--- a/src/loushang/coding/session/builtin_commands.py
+++ b/src/loushang/coding/session/builtin_commands.py
@@ -40,6 +40,10 @@ class BuiltinCommandBackend:
     clone_session: Callable[[], object | Awaitable[object]] | None = None
     navigate_tree: Callable[[str, object | None], object | Awaitable[object]] | None = None
     import_session: Callable[[str, str | None], object | Awaitable[object]] | None = None
+    get_active_tool_names: Callable[[], list[str]] | None = None
+    get_all_tools: Callable[[], list[object]] | None = None
+    set_active_tools: Callable[[list[str]], object | Awaitable[object]] | None = None
+    get_default_active_tool_names: Callable[[], list[str]] | None = None
 
 
 def list_builtin_command_descriptors() -> list[SessionCommandDescriptor]:
@@ -79,6 +83,8 @@ async def execute_builtin_command_async(
             return _execute_copy(args, backend)
         case "changelog":
             return _execute_changelog(args, backend)
+        case "tools":
+            return await _execute_tools(args, backend)
         case "compact":
             return await _execute_compact(args, backend)
         case "reload":
@@ -189,6 +195,49 @@ def _execute_changelog(args: str, backend: BuiltinCommandBackend) -> CommandExec
     if backend.get_changelog is None:
         return _unsupported("changelog")
     return _ok("changelog", changelog=_to_plain_data(backend.get_changelog(args)))
+
+
+async def _execute_tools(args: str, backend: BuiltinCommandBackend) -> CommandExecutionResult:
+    if backend.get_active_tool_names is None or backend.get_all_tools is None:
+        return _unsupported("tools")
+    active_tools = list(backend.get_active_tool_names())
+    available_tools = _available_tool_entries(backend.get_all_tools(), active_tools)
+    available_names = [entry["name"] for entry in available_tools]
+    tokens = _split_args(args.strip()) if args.strip() else []
+    if not tokens:
+        return _tools_ok(active_tools, available_tools)
+
+    action = tokens[0]
+    if action == "reset":
+        if len(tokens) != 1:
+            return _error("tools", "Usage: /tools reset")
+        if backend.get_default_active_tool_names is None or backend.set_active_tools is None:
+            return _unsupported("tools")
+        next_tools = _filter_available_tools(backend.get_default_active_tool_names(), available_names)
+        await _maybe_await(backend.set_active_tools(next_tools))
+        return _tools_ok(next_tools, _available_tool_entries(backend.get_all_tools(), next_tools), action="reset")
+
+    if action not in {"on", "off", "only"}:
+        return _error("tools", "Usage: /tools [on|off|only <tool[,tool]...>|reset]")
+    if backend.set_active_tools is None:
+        return _unsupported("tools")
+    requested = _parse_tool_names(tokens[1:])
+    if not requested:
+        return _error("tools", f"Usage: /tools {action} <tool[,tool]...>")
+    unknown = [name for name in requested if name not in available_names]
+    if unknown:
+        return _error("tools", f"Unknown tool: {', '.join(unknown)}. Available tools: {', '.join(available_names)}")
+
+    if action == "on":
+        next_tools = [*active_tools, *(name for name in requested if name not in active_tools)]
+    elif action == "off":
+        remove = set(requested)
+        next_tools = [name for name in active_tools if name not in remove]
+    else:
+        next_tools = requested
+    next_tools = _filter_available_tools(next_tools, available_names)
+    await _maybe_await(backend.set_active_tools(next_tools))
+    return _tools_ok(next_tools, _available_tool_entries(backend.get_all_tools(), next_tools), action=action)
 
 
 async def _execute_compact(args: str, backend: BuiltinCommandBackend) -> CommandExecutionResult:
@@ -320,6 +369,17 @@ def _unsupported(command: str) -> CommandExecutionResult:
     )
 
 
+def _tools_ok(active_tools: list[str], available_tools: list[dict[str, object]], *, action: str | None = None) -> CommandExecutionResult:
+    fields: dict[str, object] = {
+        "active_tools": active_tools,
+        "available_tools": available_tools,
+        "message": f"Active tools: {', '.join(active_tools) if active_tools else '(none)'}",
+    }
+    if action is not None:
+        fields["action"] = action
+    return _ok("tools", **fields)
+
+
 async def _maybe_await(value: object | Awaitable[object]) -> object:
     if inspect.isawaitable(value):
         return await value
@@ -331,6 +391,46 @@ def _split_args(args: str) -> list[str]:
         return shlex.split(args)
     except ValueError:
         return args.split()
+
+
+def _parse_tool_names(tokens: list[str]) -> list[str]:
+    names: list[str] = []
+    for token in tokens:
+        for name in token.split(","):
+            cleaned = name.strip()
+            if cleaned and cleaned not in names:
+                names.append(cleaned)
+    return names
+
+
+def _available_tool_entries(tools: list[object], active_tools: list[str]) -> list[dict[str, object]]:
+    active_set = set(active_tools)
+    entries: list[dict[str, object]] = []
+    for tool in tools:
+        name = _tool_field(tool, "name")
+        if not name:
+            continue
+        entries.append(
+            {
+                "name": name,
+                "active": name in active_set,
+                "description": _tool_field(tool, "description"),
+            }
+        )
+    return entries
+
+
+def _tool_field(tool: object, field: str) -> str:
+    if isinstance(tool, Mapping):
+        value = tool.get(field)
+    else:
+        value = getattr(tool, field, None)
+    return value if isinstance(value, str) else ""
+
+
+def _filter_available_tools(tool_names: list[str], available_names: list[str]) -> list[str]:
+    available = set(available_names)
+    return [name for name in tool_names if name in available]
 
 
 def _parse_tree_options(tokens: list[str]) -> dict[str, object]:

--- a/tests/coding/test_agent_session_tools.py
+++ b/tests/coding/test_agent_session_tools.py
@@ -176,6 +176,58 @@ def test_agent_session_tracks_active_tool_names_and_runtime_tools(tmp_path) -> N
     )
 
 
+def test_agent_session_builtin_tools_command_can_restore_active_tools(tmp_path) -> None:
+    from pathlib import Path
+
+    from loushang.agent import Agent
+    from loushang.ai.model import Capabilities, Model
+    from loushang.coding import SessionManager, ToolRegistry, register_builtin_tools
+    from loushang.coding.loader import ResourceBundle
+    from loushang.coding.session import AgentSession
+
+    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    registry = ToolRegistry()
+    register_builtin_tools(registry)
+    model = Model(
+        id="faux-model",
+        name="Faux",
+        provider="faux",
+        endpoint="anthropic-messages",
+        capabilities=Capabilities(
+            reasoning=True,
+            input=("text",),
+            context_window=128000,
+            max_tokens=4096,
+        ),
+    )
+    session = AgentSession(
+        agent=Agent(
+            initial_state={
+                "system_prompt": "stale prompt",
+                "model": model,
+                "thinking_level": "off",
+                "tools": [],
+            },
+            convert_to_llm=lambda messages: [],
+        ),
+        session_manager=manager,
+        resource_bundle=ResourceBundle(cwd=Path("/tmp/project")),
+        tool_registry=registry,
+        active_tool_names=["bash"],
+        base_prompt="Base prompt.",
+    )
+
+    off_result = asyncio.run(session.execute_command_async("/tools", "off bash"))
+    reset_result = asyncio.run(session.execute_command_async("/tools", "reset"))
+
+    assert off_result is not None
+    assert off_result.result["active_tools"] == []
+    assert session.get_active_tool_names() == ["read", "ls", "find", "grep", "bash", "edit", "write"]
+    assert [tool.name for tool in session.agent.tools] == ["read", "ls", "find", "grep", "bash", "edit", "write"]
+    assert reset_result is not None
+    assert reset_result.result["active_tools"] == ["read", "ls", "find", "grep", "bash", "edit", "write"]
+
+
 def test_agent_session_exposes_pi_style_tool_surface_aliases(tmp_path) -> None:
     from pathlib import Path
 

--- a/tests/coding/test_commands.py
+++ b/tests/coding/test_commands.py
@@ -45,6 +45,7 @@ def test_builtin_slash_commands_match_pi_style_core_surface() -> None:
         "tree": "Navigate session tree (switch branches)",
         "login": "Configure provider authentication",
         "logout": "Remove provider authentication",
+        "tools": "Show or update active tools for this session",
         "new": "Start a new session",
         "compact": "Manually compact the session context",
         "resume": "Resume a different session",

--- a/tests/coding/test_session_command_controller.py
+++ b/tests/coding/test_session_command_controller.py
@@ -114,8 +114,8 @@ def test_command_controller_lists_builtin_commands_before_extension_and_resource
     commands = controller.list_commands()
 
     assert [command.name for command in commands[:4]] == ["settings", "model", "scoped-models", "export"]
-    assert {command.name for command in commands} >= {"copy", "name", "session", "terminal", "changelog", "deploy", "plan"}
-    assert all(command.source == "builtin" for command in commands[:22])
+    assert {command.name for command in commands} >= {"copy", "name", "session", "terminal", "changelog", "tools", "deploy", "plan"}
+    assert all(command.source == "builtin" for command in commands[:23])
     assert commands[0].source_info.source == "builtin"
 
 
@@ -220,6 +220,87 @@ def test_command_controller_executes_builtin_name_session_and_unsupported_comman
         "command": "model",
         "status": "unsupported",
         "message": 'Builtin command "/model" is handled by the interactive shell.',
+    }
+
+
+def test_command_controller_executes_builtin_tools_list_and_mutations(tmp_path) -> None:
+    active_tools = ["read", "grep"]
+    all_tools = [
+        {"name": "read", "description": "Read files"},
+        {"name": "grep", "description": "Search files"},
+        {"name": "bash", "description": "Run shell commands"},
+    ]
+    set_calls: list[list[str]] = []
+
+    async def _set_active_tools(tool_names: list[str]) -> None:
+        set_calls.append(list(tool_names))
+        active_tools[:] = list(tool_names)
+
+    controller = CommandController(
+        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False, session_id="session-1"),
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(
+            get_active_tool_names=lambda: list(active_tools),
+            get_all_tools=lambda: list(all_tools),
+            set_active_tools=_set_active_tools,
+            get_default_active_tool_names=lambda: ["read", "grep", "bash"],
+        ),
+    )
+
+    list_result = asyncio.run(controller.execute_command_async("/tools", ""))
+    off_result = asyncio.run(controller.execute_command_async("/tools", "off grep"))
+    on_result = asyncio.run(controller.execute_command_async("/tools", "on bash"))
+    only_result = asyncio.run(controller.execute_command_async("/tools", "only read"))
+    reset_result = asyncio.run(controller.execute_command_async("/tools", "reset"))
+
+    assert list_result is not None
+    assert list_result.result == {
+        "source": "builtin",
+        "command": "tools",
+        "status": "ok",
+        "active_tools": ["read", "grep"],
+        "available_tools": [
+            {"name": "read", "active": True, "description": "Read files"},
+            {"name": "grep", "active": True, "description": "Search files"},
+            {"name": "bash", "active": False, "description": "Run shell commands"},
+        ],
+        "message": "Active tools: read, grep",
+    }
+    assert off_result is not None
+    assert off_result.result["active_tools"] == ["read"]
+    assert on_result is not None
+    assert on_result.result["active_tools"] == ["read", "bash"]
+    assert only_result is not None
+    assert only_result.result["active_tools"] == ["read"]
+    assert reset_result is not None
+    assert reset_result.result["active_tools"] == ["read", "grep", "bash"]
+    assert set_calls == [["read"], ["read", "bash"], ["read"], ["read", "grep", "bash"]]
+
+
+def test_command_controller_builtin_tools_rejects_unknown_tool(tmp_path) -> None:
+    controller = CommandController(
+        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False, session_id="session-1"),
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(
+            get_active_tool_names=lambda: ["read"],
+            get_all_tools=lambda: [{"name": "read", "description": "Read files"}],
+            set_active_tools=lambda tool_names: None,
+            get_default_active_tool_names=lambda: ["read"],
+        ),
+    )
+
+    result = asyncio.run(controller.execute_command_async("/tools", "on bash"))
+
+    assert result is not None
+    assert result.result == {
+        "source": "builtin",
+        "command": "tools",
+        "status": "error",
+        "message": "Unknown tool: bash. Available tools: read",
     }
 
 


### PR DESCRIPTION
## Summary / 摘要
- Add builtin `/tools` command to list and update session active tools.
- Support `/tools on|off|only|reset` without relying on agent tools being active.
- Update English/Chinese docs for default tools and `/tools` examples.

- 增加内置 `/tools` 命令，用于查看和更新当前 session 的 active tools。
- 支持 `/tools on|off|only|reset`，不依赖 agent tool 本身处于 active 状态。
- 更新英文/中文文档，说明默认工具集和 `/tools` 示例。

Closes #134

## Test Plan / 测试计划
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_session_command_controller.py tests/coding/test_agent_session_tools.py tests/coding/test_commands.py -q`
- `uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/commands/types.py src/loushang/coding/session/agent_session.py src/loushang/coding/session/builtin_commands.py tests/coding/test_session_command_controller.py tests/coding/test_agent_session_tools.py tests/coding/test_commands.py`
- `git diff --check`