### PR TITLE
docs(coding): plan extension platform integration

### DIFF
--- a/docs/internals/plans/2026-06-08-loushang-coding-extension-platform-integration-plan.md
+++ b/docs/internals/plans/2026-06-08-loushang-coding-extension-platform-integration-plan.md
@@ -1,0 +1,269 @@
+# Loushang Coding Extension Platform Integration Plan
+
+## Goal
+
+Implement the extension platform in phases, using
+`docs/internals/specs/2026-06-08-loushang-coding-extension-platform-integration-design.md`
+as the source of architectural decisions.
+
+This plan intentionally starts with design and projection layers before
+expanding runtime behavior. The aim is to avoid coupling extension loading,
+package management, hook execution, and TUI integration into one large change.
+
+## P0: Inventory And Design Lock
+
+### Objective
+
+Create the baseline inventory and decision record that later PRs use as their
+contract.
+
+### Implementation
+
+- Add or update an extension platform inventory document covering:
+  - `src/loushang/coding/extensions`
+  - `src/loushang/coding/plugin`
+  - `src/loushang/coding/package`
+  - `src/loushang/coding/commands`
+  - `src/loushang/coding/tools`
+  - `src/loushang/tui/extensions.py`
+- Record the contribution matrix:
+  - current support
+  - target support
+  - owner subsystem
+  - diagnostics source
+  - policy gate
+- Record final decisions for:
+  - manifest format
+  - permission model
+  - contribution conflicts
+  - hook classes
+  - UI bridge boundary
+  - dependency scope
+  - future-only capabilities
+
+### Tests
+
+- Documentation review against the design spec.
+- No runtime tests required unless code changes are introduced.
+
+### Not In Scope
+
+- New runtime behavior.
+- New manifest parser.
+- New UI.
+
+## P1: Manifest, Policy, And Contribution Registry Skeleton
+
+### Objective
+
+Add structured extension metadata and contribution projection without changing
+user-visible runtime behavior.
+
+### Implementation
+
+- Add an internal extension manifest model for `loushang-extension.toml`.
+- Add parser diagnostics for invalid TOML, unknown required fields, unsupported
+  contribution sections, and invalid permission levels.
+- Add `ExtensionPolicy` or equivalent evaluation object with:
+  - `enabled`
+  - permission level
+  - internal capabilities
+  - managed-hooks-only decision
+- Add `ContributionRegistry` or equivalent projection with contribution
+  descriptors for commands, tools, prompts, skills, hooks, models/providers,
+  UI, autocomplete, and resource roots.
+- Wire the loader to produce contribution descriptors in addition to existing
+  loaded extension data.
+- Keep existing `register(api)` runtime compatibility.
+
+### Tests
+
+- Manifest parser accepts minimal valid TOML.
+- Invalid manifest produces extension diagnostics, not an uncaught exception.
+- Policy-disabled extension remains visible but contributes no active entries.
+- Registry records source info and inactive reasons.
+
+### Not In Scope
+
+- Installing dependencies.
+- Reworking hook dispatch.
+- TUI management UI beyond diagnostics projection.
+
+## P2: Commands, Tools, Prompts, And Skills Mounting
+
+### Objective
+
+Route the main user-facing contribution types through the registry.
+
+### Implementation
+
+- Mount extension commands through the command catalog using contribution
+  metadata and source diagnostics.
+- Mount extension tools only after policy evaluation, conflict resolution, and
+  denied-tool filtering.
+- Preserve existing prompt and skill resource loader precedence; add registry
+  diagnostics that explain collisions and inactive resources.
+- Add `/extensions` as the first management surface.
+  - It should list active tools, commands, hooks, prompts, skills, permissions,
+    conflicts, and load warnings.
+  - It should not install, update, or remove extensions in this phase.
+
+### Tests
+
+- Duplicate extension tool name is rejected unless explicit override support
+  exists.
+- Denied tool does not appear in model-visible tool list.
+- Duplicate command names are visible with disambiguation diagnostics.
+- `/extensions` prints active tools and inactive reasons without the
+  `? thinking:` transcript artifact.
+
+### Not In Scope
+
+- `/plan` command work.
+- Full plugin management UI.
+- Marketplace behavior.
+
+## P3: Hook Semantics Consolidation
+
+### Objective
+
+Make hook semantics explicit and centrally dispatched while preserving current
+event names.
+
+### Implementation
+
+- Add hook metadata classes:
+  - `observe`
+  - `transform`
+  - `intercept`
+  - `augment`
+- Split hook concerns into:
+  - schema/manifest declarations
+  - event payload definitions
+  - hook registry
+  - dispatcher/engine
+  - result parsing
+  - diagnostics
+- Route existing session/tool/provider hook calls through the dispatcher.
+- Preserve current event names and compatibility wrappers.
+- Add policy support for managed-hooks-only mode.
+
+### Tests
+
+- Observe hook cannot mutate or block.
+- Transform hook result is applied in deterministic order.
+- Intercept hook can block with a diagnostic reason.
+- Augment hook can append context/diagnostics.
+- Managed-hooks-only mode ignores unmanaged hook sources.
+
+### Not In Scope
+
+- New large hook catalog.
+- Extension-to-extension communication.
+- Shell-level hook command runner unless explicitly required by existing hooks.
+
+## P4: UI And Autocomplete Bridge
+
+### Objective
+
+Expose extension UI integration through controlled bridge APIs.
+
+### Implementation
+
+- Extend the existing TUI extension host into an `ExtensionUiBridge`-style
+  runtime surface.
+- Allow extension contributions for:
+  - status
+  - footer/header
+  - surfaces/modals
+  - notifications
+  - select/confirm/input/editor prompts
+  - autocomplete
+  - action/command palette entries
+  - message renderers
+- Route keyboard and command palette integration through an action registry.
+- Keep raw screen/layout/key access private to the TUI implementation.
+- Surface UI contribution diagnostics in `/extensions`.
+
+### Tests
+
+- Extension status/footer widgets dispose cleanly on unload/reload.
+- Autocomplete provider failure records diagnostics without breaking editor
+  input.
+- Extension action appears only in allowed UI contexts.
+- Raw key/listener APIs are not part of the public extension bridge.
+
+### Not In Scope
+
+- A visual marketplace.
+- Arbitrary TUI layout mutation.
+- Direct render-loop control.
+
+## P5: Dependency Productization
+
+### Objective
+
+Add dependency semantics with conservative installation boundaries.
+
+### Implementation
+
+- Add manifest dependency sections for:
+  - Python packages
+  - external binaries
+  - system capabilities
+- Implement Python package installation only into Loushang-managed isolated
+  targets.
+- Add binary detection with actionable diagnostics.
+- Add system capability checks as diagnostic-only.
+- Project the dependency state in `/extensions`.
+
+### Tests
+
+- Python dependency install target is not the project venv, active venv, or
+  global environment.
+- Missing binary produces a non-fatal diagnostic.
+- Unsupported system capability produces diagnostic-only status.
+- Dependency failures disable dependent contributions without hiding the whole
+  extension.
+
+### Not In Scope
+
+- Automatic OS package installation.
+- Arbitrary shell install scripts.
+- Network access unless package policy explicitly allows it.
+
+## Future
+
+Future designs may add:
+
+- marketplace and signing
+- extension-to-extension bus
+- LSP lifecycle
+- app/channel connectors
+- richer managed enterprise policy
+- stronger sandboxing
+
+These should not block P0-P5.
+
+## Rollout
+
+Use one PR per phase after this documentation PR.
+
+Each implementation PR should include:
+
+- behavior-focused tests
+- diagnostics snapshots or assertions where applicable
+- compatibility notes for existing extension APIs
+- updates to examples only after the API surface is stable for that phase
+
+## Acceptance Criteria
+
+The platform integration work is complete when:
+
+- `/extensions` can explain enabled extensions, inactive contributions,
+  permissions, conflicts, dependencies, and hook declarations.
+- Extension tools are filtered before model exposure.
+- Hook semantics are centrally declared and dispatched.
+- UI integration goes through a bridge/action registry.
+- Dependency handling respects Loushang-managed isolation.
+- Existing package/plugin/extension boundaries remain intact.

--- a/docs/internals/plans/2026-06-08-loushang-coding-extension-platform-integration-plan.md
+++ b/docs/internals/plans/2026-06-08-loushang-coding-extension-platform-integration-plan.md
@@ -64,6 +64,10 @@ user-visible runtime behavior.
 - Add an internal extension manifest model for `loushang-extension.toml`.
 - Add parser diagnostics for invalid TOML, unknown required fields, unsupported
   contribution sections, and invalid permission levels.
+- Parse and store dependency declarations, but do not install or resolve them in
+  P1.
+- Reserve internal dependency resolution state for future isolated import paths;
+  do not put resolved paths in the author manifest.
 - Add `ExtensionPolicy` or equivalent evaluation object with:
   - `enabled`
   - permission level
@@ -104,6 +108,10 @@ Route the main user-facing contribution types through the registry.
 - Preserve existing prompt and skill resource loader precedence; add registry
   diagnostics that explain collisions and inactive resources.
 - Add `/extensions` as the first management surface.
+  - Register it as a built-in core management command, not as an
+    extension-contributed command.
+  - Route its output through the existing command plane and diagnostics
+    projection.
   - It should list active tools, commands, hooks, prompts, skills, permissions,
     conflicts, and load warnings.
   - It should not install, update, or remove extensions in this phase.
@@ -132,6 +140,9 @@ event names.
 
 ### Implementation
 
+- Audit current hook call sites before rerouting them. The audit should list
+  session, tool, provider, resource, and shutdown hook entrypoints that need to
+  move through the dispatcher.
 - Add hook metadata classes:
   - `observe`
   - `transform`
@@ -212,7 +223,11 @@ Add dependency semantics with conservative installation boundaries.
   - external binaries
   - system capabilities
 - Implement Python package installation only into Loushang-managed isolated
-  targets.
+  targets. The default candidate is `uv pip install --target` into a
+  Loushang-owned extension package directory.
+- Expose isolated Python dependencies to extension imports through explicit
+  loader-managed import paths, not through the project virtualenv or global
+  `PYTHONPATH`.
 - Add binary detection with actionable diagnostics.
 - Add system capability checks as diagnostic-only.
 - Project the dependency state in `/extensions`.
@@ -255,6 +270,38 @@ Each implementation PR should include:
 - diagnostics snapshots or assertions where applicable
 - compatibility notes for existing extension APIs
 - updates to examples only after the API surface is stable for that phase
+
+## Rollback And Compatibility
+
+Each phase should keep a narrow rollback path:
+
+- P1 can disable the new manifest and contribution projection while leaving
+  existing `register(api)` loading active.
+- P2 can hide `/extensions` and fall back to current command/tool/resource
+  registration paths.
+- P3 must keep compatibility wrappers around existing hook event names until
+  all call sites are routed through the dispatcher and tested.
+- P4 can disable UI bridge contributions while preserving non-UI extension
+  runtime behavior.
+- P5 can disable dependency resolution and leave dependency declarations as
+  diagnostics-only metadata.
+
+Policy switches should prefer disabling new platform layers over changing
+extension author APIs during rollback.
+
+## Performance Baseline
+
+Implementation PRs should include lightweight performance checks or explicit
+review evidence for hot paths:
+
+- contribution lookup is indexed by contribution type and id
+- tool exposure is recomputed on extension/tool state changes, not per render
+  frame
+- hook dispatch has deterministic ordering and timeout behavior for blocking
+  hooks
+- `/extensions` reads projected state and should remain interactive with dozens
+  of loaded extensions
+- UI bridge failures are isolated from the main TUI render loop
 
 ## Acceptance Criteria
 

--- a/docs/internals/specs/2026-06-08-loushang-coding-extension-platform-integration-design.md
+++ b/docs/internals/specs/2026-06-08-loushang-coding-extension-platform-integration-design.md
@@ -40,6 +40,24 @@ Authors and users need a unified mental model, and the runtime needs a single
 place to project extension contributions, conflicts, permissions, and
 diagnostics.
 
+## Relationship To Existing Designs
+
+This design consolidates and extends existing accepted designs. It does not
+supersede them.
+
+- Extension API v1 remains the author-facing runtime API baseline.
+- Extensions Runtime V2 remains the binding and rebinding lifecycle baseline.
+- The package/plugin boundary remains authoritative for distribution and source
+  management.
+- The command-plane design remains authoritative for built-in command
+  registration and command execution semantics.
+- Resource loader precedence and collision rules remain authoritative for
+  prompts, skills, themes, and resource roots.
+
+This design adds the missing platform layer above those documents: a manifest,
+policy, contribution registry, diagnostics projection, and staged integration
+plan that tie the existing subsystems together.
+
 ## Boundary Decisions
 
 ### Package
@@ -179,8 +197,15 @@ enabled = true
 allow_managed_hooks_only = false
 ```
 
-When `allow_managed_hooks_only` is true, user/project/session hook definitions
-are ignored while managed extension hooks remain eligible.
+When `allow_managed_hooks_only` is true, unmanaged hook definitions are ignored
+while managed extension hooks remain eligible.
+
+For this policy:
+
+- managed hooks are hook declarations loaded from enabled extensions delivered
+  by accepted plugin/package sources or managed configuration
+- unmanaged hooks are local project, user, or session hook definitions that are
+  not tied to a loaded extension contribution
 
 ## Contribution Registry
 
@@ -263,6 +288,13 @@ Hook classes:
 - `intercept`: may block, approve, deny, or replace an operation
 - `augment`: may add context, messages, diagnostics, or side effects
 
+`transform` and `augment` are mutually exclusive for one handler result.
+`transform` is replacement-style: it returns the next payload for the pipeline.
+`augment` is append-style: it may add messages, context, diagnostics, or
+side-effect requests, but it must not replace the event payload. If both are
+needed, they should be expressed as separate hook handlers so ordering remains
+explicit.
+
 The hook subsystem should be split into:
 
 - hook schema and manifest parsing
@@ -290,6 +322,11 @@ Allowed bridge capabilities:
 - command/action palette entries
 - message renderers
 - controlled editor text actions
+
+Message renderers are constrained renderers, not arbitrary output channels.
+They should receive structured message data and return only renderer-approved
+objects or an allowed markup subset. They must not emit raw terminal control
+sequences, arbitrary ANSI, or executable markdown side effects.
 
 Disallowed:
 
@@ -321,6 +358,30 @@ Supported semantics:
 
 Extensions must not install dependencies into the user's project virtualenv,
 global Python environment, or active shell environment.
+
+The preferred Python dependency installation candidate is
+`uv pip install --target <loushang-managed-extension-site>`, with the target
+owned by Loushang package state. Runtime import exposure should be explicit,
+for example by adding the resolved target through a controlled import path
+mechanism during extension loading. The author manifest declares dependencies;
+resolved paths belong to internal package/extension state, not to the author
+manifest.
+
+## Performance Constraints
+
+Extension platform plumbing sits near hot paths, so implementation phases should
+keep these constraints visible:
+
+- contribution lookup should use indexed maps rather than repeated linear scans
+  over all extensions
+- model-visible tool filtering should be computed when extension/tool state
+  changes, not on every token or render event
+- hook dispatch should run with deterministic ordering and explicit timeouts for
+  blocking/intercept hooks
+- UI bridge rendering should isolate extension failures and avoid blocking the
+  main TUI render loop
+- `/extensions` should be cheap enough for interactive use by reading projected
+  state instead of reloading extensions
 
 ## Diagnostics And Management Surface
 

--- a/docs/internals/specs/2026-06-08-loushang-coding-extension-platform-integration-design.md
+++ b/docs/internals/specs/2026-06-08-loushang-coding-extension-platform-integration-design.md
@@ -1,0 +1,371 @@
+# Loushang Coding Extension Platform Integration Design
+
+## Goal
+
+Turn the existing `loushang-coding` extension substrate into a coherent
+extension platform.
+
+The platform should make extensions a first-class product surface across:
+
+- commands
+- tools
+- prompts and skills
+- model/provider contributions
+- runtime hooks
+- TUI UI and autocomplete
+- plugin/package distribution
+- diagnostics and policy
+
+This design is a consolidation spec. It does not replace the accepted
+package/plugin/extension boundary, and it does not attempt to implement all
+capabilities in one phase.
+
+## Current Baseline
+
+`loushang-coding` already has the important lower layers:
+
+- `package` as the resource distribution unit
+- `plugin` as a manifest-backed package source view
+- `extension` as the executable runtime programmability surface
+- `ExtensionAPI`, `ExtensionLoader`, `ExtensionRunner`, and runtime bindings
+- extension-contributed tools
+- resource discovery hooks
+- command registration
+- TUI extension host primitives
+- unified diagnostics with an `extensions` source
+
+The current gap is not whether extensions can run. The gap is that extension
+capabilities are still registered and surfaced through several separate paths.
+Authors and users need a unified mental model, and the runtime needs a single
+place to project extension contributions, conflicts, permissions, and
+diagnostics.
+
+## Boundary Decisions
+
+### Package
+
+`package` remains the distribution and materialization layer.
+
+It owns:
+
+- package roots
+- remote materialization
+- update/remove lifecycle
+- package resource summaries
+- package trust and source policy
+
+It does not own runtime extension APIs.
+
+### Plugin
+
+`plugin` remains a manifest-backed source view.
+
+It owns:
+
+- plugin source registration
+- plugin manifest parsing
+- plugin enable/disable state
+- plugin identity and metadata
+- package root resolution
+
+A plugin may carry extensions, but not every plugin is an extension.
+
+### Extension
+
+`extension` remains the runtime programmability surface.
+
+It owns:
+
+- author-facing registration APIs
+- runtime hooks
+- command/tool/UI/model/prompt/skill contributions
+- extension diagnostics
+- extension policy and permissions
+
+Packages and plugins deliver extensions. They do not replace the extension
+boundary.
+
+## Manifest
+
+### Author Format
+
+Use `loushang-extension.toml` as the extension author manifest.
+
+The manifest is separate from plugin/package manifests. `plugin.json` continues
+to describe plugin source identity and package root resolution. It should not
+become the extension capability manifest.
+
+The loader should parse TOML into an internal structured model such as a
+dataclass or Pydantic model. Runtime code should consume the structured model,
+not raw TOML dictionaries.
+
+### Initial Manifest Areas
+
+The manifest should reserve stable areas for:
+
+- metadata
+- permissions
+- dependencies
+- commands
+- tools
+- prompts
+- skills
+- hooks
+- models/providers
+- UI/autocomplete
+- configuration
+
+The first implementation may support only a subset, but unsupported sections
+must produce clear diagnostics rather than being silently ignored.
+
+### Example Shape
+
+```toml
+[extension]
+id = "acme.review"
+name = "Acme Review"
+version = "0.1.0"
+description = "Adds project-specific review commands and hooks."
+
+[permissions]
+level = "standard"
+capabilities = ["filesystem", "model"]
+
+[[commands]]
+name = "acme-review"
+description = "Run the Acme review workflow."
+
+[[hooks]]
+event = "before_agent_start"
+kind = "augment"
+handler = "extension:before_agent_start"
+
+[[tools]]
+name = "acme_lookup"
+description = "Look up Acme domain metadata."
+
+[dependencies.python]
+packages = ["acme-sdk>=0.3"]
+```
+
+## Permissions And Policy
+
+Use a hybrid permission model:
+
+- user-facing level: `safe`, `standard`, `powerful`
+- internal capabilities: `exec`, `filesystem`, `network`, `model`,
+  `session_mutation`, `ui_mutation`, `tool_mutation`
+
+The level is what users and management UI should display. The capabilities are
+what loader, registry, and runtime enforcement should use.
+
+Recommended default mapping:
+
+- `safe`: read-only metadata, prompts, skills, passive UI, observe hooks
+- `standard`: `safe` plus model access, filesystem reads, commands, tools that
+  still use normal tool permission gates
+- `powerful`: `standard` plus exec, network, session mutation, tool mutation, or
+  provider/model mutation
+
+Policy should be evaluated before contributions become active. A denied
+extension should remain visible in diagnostics and management surfaces, but its
+runtime contributions should not be exposed.
+
+Add a policy switch equivalent in meaning to:
+
+```toml
+[extensions]
+enabled = true
+allow_managed_hooks_only = false
+```
+
+When `allow_managed_hooks_only` is true, user/project/session hook definitions
+are ignored while managed extension hooks remain eligible.
+
+## Contribution Registry
+
+Introduce a `ContributionRegistry` as the central projection of extension
+capabilities.
+
+It should store normalized contributions with:
+
+- contribution id
+- contribution type
+- extension id
+- source info
+- scope
+- priority
+- permission requirements
+- conflict policy
+- diagnostics
+
+The registry should not execute extension code. It is a projection and
+arbitration layer between extension loading and product/runtime surfaces.
+
+### Contribution Types
+
+Initial contribution types:
+
+- command
+- tool
+- prompt
+- skill
+- hook
+- model_provider
+- ui
+- autocomplete
+- resource_root
+
+### Conflict Policy
+
+Use contribution-type-specific policies:
+
+- commands: allow duplicate display names; disambiguate in UI and diagnostics;
+  allow user-configured default winner later
+- tools: reject duplicate tool names unless an explicit override is configured
+- prompts and skills: use existing resource precedence and collision
+  diagnostics
+- hooks: chain in deterministic order
+- UI/autocomplete: merge by placement/trigger with diagnostics on incompatible
+  targets
+- model/provider entries: require explicit override for duplicate ids
+
+Never drop an entire extension solely because one contribution conflicts. Drop
+or disable the conflicting contribution and keep the rest of the extension
+visible.
+
+## Tools
+
+Extension tools must pass through policy filtering before they are exposed to
+the model.
+
+The required order is:
+
+1. load extension
+2. normalize tool contribution
+3. evaluate extension policy and permission capabilities
+4. resolve tool conflicts
+5. filter denied tools
+6. expose active tools to the model/tool registry
+
+Call-time permission checks remain necessary, but they are not sufficient. A
+tool denied by policy should not appear in the model-visible tool list.
+
+## Hooks
+
+Keep existing lifecycle event names for compatibility. Add hook metadata that
+declares the hook capability class.
+
+Hook classes:
+
+- `observe`: read event state, cannot mutate or block
+- `transform`: returns a modified input/output payload
+- `intercept`: may block, approve, deny, or replace an operation
+- `augment`: may add context, messages, diagnostics, or side effects
+
+The hook subsystem should be split into:
+
+- hook schema and manifest parsing
+- typed event payloads
+- hook declarations and registry
+- dispatcher/engine
+- output/result parser
+- diagnostics
+
+Session and runner code should call into the hook dispatcher instead of owning
+hook semantics directly.
+
+## UI And Autocomplete Bridge
+
+Extensions may integrate with UI only through an explicit bridge.
+
+Allowed bridge capabilities:
+
+- status fields
+- footer/header widgets
+- surfaces/modals
+- notifications
+- select/confirm/input/editor prompts
+- autocomplete providers
+- command/action palette entries
+- message renderers
+- controlled editor text actions
+
+Disallowed:
+
+- direct screen buffer access
+- direct layout tree mutation
+- raw key listener registration as a public extension API
+- direct ownership of render loop state
+- mutation of TUI internals outside bridge methods
+
+Keyboard and command palette integration should go through an action registry.
+Extensions register actions; the UI decides whether and where actions are
+invocable.
+
+## Dependencies
+
+Dependency support should be productized incrementally.
+
+### V1 Commitment
+
+V1 may define dependency metadata and diagnostics but should not promise full
+automatic installation for every dependency class.
+
+Supported semantics:
+
+- Python packages: declared in manifest and installed only into
+  Loushang-managed isolated targets when installation support lands
+- external binaries: presence detection and friendly diagnostics
+- system capabilities: diagnostic-only checks
+
+Extensions must not install dependencies into the user's project virtualenv,
+global Python environment, or active shell environment.
+
+## Diagnostics And Management Surface
+
+The platform should expose extension state through diagnostics and a management
+surface.
+
+Minimum visible fields:
+
+- extension id
+- display name
+- source
+- enabled/disabled state
+- permission level
+- active contributions
+- inactive contributions with reasons
+- conflicts
+- dependency diagnostics
+- hook declarations
+- load/runtime warnings
+
+The initial product surface can be a slash command such as `/extensions` plus
+CLI/JSON projection where appropriate.
+
+## Out Of Scope For Mainline P0-P5
+
+These capabilities should remain future work unless a later design promotes
+them:
+
+- extension marketplace
+- extension signing
+- automatic non-Python dependency installation
+- unrestricted extension-to-extension import or RPC
+- LSP server lifecycle
+- background channel/app connector ecosystem
+- raw TUI keybinding APIs
+- sandbox isolation beyond current process and package isolation guarantees
+
+## Acceptance Criteria
+
+The integrated platform design is complete when:
+
+- package/plugin/extension boundaries remain intact
+- extension manifest, permission, conflict, hook, UI bridge, dependency, and
+  diagnostics decisions are documented
+- a phased implementation plan exists
+- no runtime implementation is required to merge the design PR
+- future implementation PRs can reference this design without re-deciding the
+  platform boundaries


### PR DESCRIPTION
## Summary
- Add a design spec for the Loushang coding extension platform integration.
- Add a phased implementation plan covering manifest, policy, contribution registry, tools, hooks, UI bridge, and dependency boundaries.
- Keep package/plugin/extension responsibilities separated and mark marketplace/inter-extension communication as future work.

## 摘要
- 新增 Loushang coding extension 平台整合设计文档。
- 新增分阶段实现计划，覆盖 manifest、policy、contribution registry、tools、hooks、UI bridge 和 dependency 边界。
- 保持 package / plugin / extension 三层职责分离，并将 marketplace、extension 间通信列为未来工作。

## Test Plan
- [x] `uv --cache-dir .uv-cache run --extra dev pytest tests/coding -q`

## 测试
- [x] `uv --cache-dir .uv-cache run --extra dev pytest tests/coding -q`