### PR TITLE
feat(coding): add extension platform P1 skeleton

### DIFF
--- a/src/loushang/coding/extensions/__init__.py
+++ b/src/loushang/coding/extensions/__init__.py
@@ -1,5 +1,21 @@
 from loushang.coding.extensions.api import ExtensionAPI
+from loushang.coding.extensions.contributions import (
+    ContributionDescriptor,
+    ContributionRegistry,
+)
 from loushang.coding.extensions.loader import ExtensionLoader
+from loushang.coding.extensions.manifest import (
+    ExtensionDependencyDeclaration,
+    ExtensionHookDeclaration,
+    ExtensionManifest,
+    ExtensionManifestParseResult,
+    ExtensionPermissionDeclaration,
+    parse_extension_manifest,
+)
+from loushang.coding.extensions.policy import (
+    ExtensionPolicyDecision,
+    policy_from_manifest,
+)
 from loushang.coding.extensions.runner import ExtensionRunner
 from loushang.coding.extensions.types import (
     VALID_EXTENSION_EVENTS,
@@ -39,11 +55,19 @@ from loushang.coding.extensions.types import (
 __all__ = [
     "BeforeAgentStartResult",
     "ContextResult",
+    "ContributionDescriptor",
+    "ContributionRegistry",
     "ExtensionAPI",
     "ExtensionContext",
     "ExtensionCommandContext",
+    "ExtensionDependencyDeclaration",
+    "ExtensionHookDeclaration",
     "ReplacedSessionContext",
     "ExtensionLoader",
+    "ExtensionManifest",
+    "ExtensionManifestParseResult",
+    "ExtensionPermissionDeclaration",
+    "ExtensionPolicyDecision",
     "ExtensionResourceContribution",
     "ExtensionRuntimeBindings",
     "InputEvent",
@@ -72,4 +96,6 @@ __all__ = [
     "ToolCallDecision",
     "ToolResultDecision",
     "VALID_EXTENSION_EVENTS",
+    "parse_extension_manifest",
+    "policy_from_manifest",
 ]

--- a/src/loushang/coding/extensions/contributions.py
+++ b/src/loushang/coding/extensions/contributions.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from loushang.coding.loader import ResourceDiagnostic
+
+ContributionType = Literal[
+    "command",
+    "tool",
+    "prompt",
+    "skill",
+    "hook",
+    "model_provider",
+    "ui",
+    "autocomplete",
+    "resource_root",
+]
+
+
+@dataclass(frozen=True)
+class ContributionDescriptor:
+    type: ContributionType
+    name: str
+    extension_id: str
+    source_path: Path
+    active: bool = True
+    priority: int = 0
+    permission_requirements: tuple[str, ...] = ()
+    diagnostics: tuple[ResourceDiagnostic, ...] = ()
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass
+class ContributionRegistry:
+    _contributions: list[ContributionDescriptor] = field(default_factory=list)
+    _by_type: dict[str, list[ContributionDescriptor]] = field(default_factory=lambda: defaultdict(list))
+    _by_extension: dict[str, list[ContributionDescriptor]] = field(default_factory=lambda: defaultdict(list))
+    _by_key: dict[tuple[str, str], ContributionDescriptor] = field(default_factory=dict)
+
+    @classmethod
+    def from_extensions(cls, extensions: Iterable[object]) -> "ContributionRegistry":
+        registry = cls()
+        for extension in extensions:
+            for contribution in getattr(extension, "contributions", ()):
+                registry.add(contribution)
+        return registry
+
+    def add(self, contribution: ContributionDescriptor) -> None:
+        self._contributions.append(contribution)
+        self._by_type[contribution.type].append(contribution)
+        self._by_extension[contribution.extension_id].append(contribution)
+        self._by_key[(contribution.type, contribution.name)] = contribution
+
+    def all(self) -> list[ContributionDescriptor]:
+        return list(self._contributions)
+
+    def by_type(self, contribution_type: str) -> list[ContributionDescriptor]:
+        return list(self._by_type.get(contribution_type, ()))
+
+    def by_extension(self, extension_id: str) -> list[ContributionDescriptor]:
+        return list(self._by_extension.get(extension_id, ()))
+
+    def get(self, contribution_type: str, name: str) -> ContributionDescriptor:
+        return self._by_key[(contribution_type, name)]
+
+
+def contributions_from_loaded_extension(extension: object) -> tuple[ContributionDescriptor, ...]:
+    extension_id = _extension_id(extension)
+    source_path = getattr(extension, "entry_path", None) or getattr(extension, "source_path")
+    contributions: list[ContributionDescriptor] = []
+
+    manifest = getattr(extension, "manifest", None)
+    if manifest is not None:
+        contributions.extend(
+            ContributionDescriptor(
+                type="command",
+                name=command.name,
+                extension_id=extension_id,
+                source_path=source_path,
+                metadata={"source": "manifest"},
+            )
+            for command in manifest.commands
+        )
+        contributions.extend(
+            ContributionDescriptor(
+                type="tool",
+                name=tool.name,
+                extension_id=extension_id,
+                source_path=source_path,
+                metadata={"source": "manifest"},
+            )
+            for tool in manifest.tools
+        )
+        contributions.extend(
+            ContributionDescriptor(
+                type="hook",
+                name=hook.event,
+                extension_id=extension_id,
+                source_path=source_path,
+                metadata={"source": "manifest", "kind": hook.kind},
+            )
+            for hook in manifest.hooks
+        )
+
+    contributions.extend(
+        ContributionDescriptor(
+            type="command",
+            name=name,
+            extension_id=extension_id,
+            source_path=source_path,
+            metadata={"source": "runtime"},
+        )
+        for name in getattr(extension, "commands", {})
+    )
+    contributions.extend(
+        ContributionDescriptor(
+            type="tool",
+            name=tool.name,
+            extension_id=extension_id,
+            source_path=source_path,
+            metadata={"source": "runtime"},
+        )
+        for tool in getattr(extension, "tool_definitions", ())
+    )
+    contributions.extend(
+        ContributionDescriptor(
+            type="hook",
+            name=event_name,
+            extension_id=extension_id,
+            source_path=source_path,
+            metadata={"source": "runtime"},
+        )
+        for event_name in getattr(extension, "hooks", {})
+    )
+    return tuple(contributions)
+
+
+def _extension_id(extension: object) -> str:
+    manifest = getattr(extension, "manifest", None)
+    if manifest is not None:
+        return manifest.id
+    return str(getattr(extension, "name"))

--- a/src/loushang/coding/extensions/contributions.py
+++ b/src/loushang/coding/extensions/contributions.py
@@ -34,12 +34,20 @@ class ContributionDescriptor:
     metadata: dict[str, object] = field(default_factory=dict)
 
 
+class DuplicateContributionKeyError(KeyError):
+    def __init__(self, contribution_type: str, name: str, contributions: list[ContributionDescriptor]) -> None:
+        super().__init__(f"Duplicate contribution key: {contribution_type}:{name}")
+        self.contribution_type = contribution_type
+        self.name = name
+        self.contributions = list(contributions)
+
+
 @dataclass
 class ContributionRegistry:
     _contributions: list[ContributionDescriptor] = field(default_factory=list)
     _by_type: dict[str, list[ContributionDescriptor]] = field(default_factory=lambda: defaultdict(list))
     _by_extension: dict[str, list[ContributionDescriptor]] = field(default_factory=lambda: defaultdict(list))
-    _by_key: dict[tuple[str, str], ContributionDescriptor] = field(default_factory=dict)
+    _by_key: dict[tuple[str, str], list[ContributionDescriptor]] = field(default_factory=lambda: defaultdict(list))
 
     @classmethod
     def from_extensions(cls, extensions: Iterable[object]) -> "ContributionRegistry":
@@ -53,7 +61,7 @@ class ContributionRegistry:
         self._contributions.append(contribution)
         self._by_type[contribution.type].append(contribution)
         self._by_extension[contribution.extension_id].append(contribution)
-        self._by_key[(contribution.type, contribution.name)] = contribution
+        self._by_key[(contribution.type, contribution.name)].append(contribution)
 
     def all(self) -> list[ContributionDescriptor]:
         return list(self._contributions)
@@ -64,8 +72,14 @@ class ContributionRegistry:
     def by_extension(self, extension_id: str) -> list[ContributionDescriptor]:
         return list(self._by_extension.get(extension_id, ()))
 
+    def by_key(self, contribution_type: str, name: str) -> list[ContributionDescriptor]:
+        return list(self._by_key.get((contribution_type, name), ()))
+
     def get(self, contribution_type: str, name: str) -> ContributionDescriptor:
-        return self._by_key[(contribution_type, name)]
+        contributions = self._by_key[(contribution_type, name)]
+        if len(contributions) > 1:
+            raise DuplicateContributionKeyError(contribution_type, name, contributions)
+        return contributions[0]
 
 
 def contributions_from_loaded_extension(extension: object) -> tuple[ContributionDescriptor, ...]:

--- a/src/loushang/coding/extensions/loader.py
+++ b/src/loushang/coding/extensions/loader.py
@@ -9,6 +9,9 @@ from dataclasses import replace
 from pathlib import Path
 
 from loushang.coding.extensions.api import ExtensionAPI
+from loushang.coding.extensions.contributions import contributions_from_loaded_extension
+from loushang.coding.extensions.manifest import parse_extension_manifest
+from loushang.coding.extensions.policy import policy_from_manifest
 from loushang.coding.extensions.types import LoadedExtension
 from loushang.coding.loader import ExtensionDescriptor, ResourceDiagnostic
 from loushang.coding.tools import ToolDefinition
@@ -31,16 +34,22 @@ class ExtensionLoader:
         return loaded_extensions
 
     def load_extension(self, descriptor: ExtensionDescriptor) -> LoadedExtension | None:
+        manifest, manifest_diagnostics = _load_descriptor_manifest(descriptor)
+        self._diagnostics.extend(manifest_diagnostics)
         metadata = descriptor.metadata if isinstance(descriptor.metadata, Mapping) else {}
         if "extension" in metadata:
             try:
-                return _with_descriptor_source_info(
-                    _adapt_legacy_extension_object(
-                        descriptor=descriptor,
-                        entry_path=descriptor.entry_path or descriptor.source_path,
-                        extension_object=metadata["extension"],
+                return _finalize_loaded_extension(
+                    _with_descriptor_source_info(
+                        _adapt_legacy_extension_object(
+                            descriptor=descriptor,
+                            entry_path=descriptor.entry_path or descriptor.source_path,
+                            extension_object=metadata["extension"],
+                        ),
+                        descriptor,
                     ),
-                    descriptor,
+                    manifest=manifest,
+                    enabled=descriptor.enabled,
                 )
             except Exception as exc:
                 self._diagnostics.append(
@@ -90,7 +99,11 @@ class ExtensionLoader:
                 )
                 return None
             if loaded is not None:
-                return _with_descriptor_source_info(loaded, descriptor)
+                return _finalize_loaded_extension(
+                    _with_descriptor_source_info(loaded, descriptor),
+                    manifest=manifest,
+                    enabled=descriptor.enabled,
+                )
             return None
 
         builder = getattr(module, "build_extension", None)
@@ -116,13 +129,17 @@ class ExtensionLoader:
                 )
                 return None
             try:
-                return _with_descriptor_source_info(
-                    _adapt_legacy_extension_object(
-                        descriptor=descriptor,
-                        entry_path=entry_path,
-                        extension_object=extension_object,
+                return _finalize_loaded_extension(
+                    _with_descriptor_source_info(
+                        _adapt_legacy_extension_object(
+                            descriptor=descriptor,
+                            entry_path=entry_path,
+                            extension_object=extension_object,
+                        ),
+                        descriptor,
                     ),
-                    descriptor,
+                    manifest=manifest,
+                    enabled=descriptor.enabled,
                 )
             except Exception as exc:
                 self._diagnostics.append(
@@ -136,13 +153,17 @@ class ExtensionLoader:
 
         if hasattr(module, "EXTENSION"):
             try:
-                return _with_descriptor_source_info(
-                    _adapt_legacy_extension_object(
-                        descriptor=descriptor,
-                        entry_path=entry_path,
-                        extension_object=getattr(module, "EXTENSION"),
+                return _finalize_loaded_extension(
+                    _with_descriptor_source_info(
+                        _adapt_legacy_extension_object(
+                            descriptor=descriptor,
+                            entry_path=entry_path,
+                            extension_object=getattr(module, "EXTENSION"),
+                        ),
+                        descriptor,
                     ),
-                    descriptor,
+                    manifest=manifest,
+                    enabled=descriptor.enabled,
                 )
             except Exception as exc:
                 self._diagnostics.append(
@@ -179,6 +200,42 @@ def _with_descriptor_source_info(loaded: LoadedExtension, descriptor: ExtensionD
         source_scope=descriptor.source_scope,
         source_root=descriptor.source_root,
     )
+
+
+def _finalize_loaded_extension(
+    loaded: LoadedExtension,
+    *,
+    manifest,
+    enabled: bool,
+) -> LoadedExtension:
+    with_policy = replace(
+        loaded,
+        manifest=manifest,
+        policy=policy_from_manifest(manifest, enabled=enabled),
+    )
+    return replace(with_policy, contributions=list(contributions_from_loaded_extension(with_policy)))
+
+
+def _load_descriptor_manifest(descriptor: ExtensionDescriptor):
+    manifest_path = _descriptor_manifest_path(descriptor)
+    if manifest_path is None:
+        return None, []
+    result = parse_extension_manifest(manifest_path)
+    return result.manifest, result.diagnostics
+
+
+def _descriptor_manifest_path(descriptor: ExtensionDescriptor) -> Path | None:
+    candidates: list[Path] = []
+    if descriptor.source_path.is_dir():
+        candidates.append(descriptor.source_path / "loushang-extension.toml")
+    if descriptor.entry_path is not None:
+        candidates.append(descriptor.entry_path.parent / "loushang-extension.toml")
+    if descriptor.source_path.is_file():
+        candidates.append(descriptor.source_path.with_name("loushang-extension.toml"))
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def _adapt_legacy_extension_object(

--- a/src/loushang/coding/extensions/manifest.py
+++ b/src/loushang/coding/extensions/manifest.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from loushang.coding.loader import ResourceDiagnostic
+
+PermissionLevel = Literal["safe", "standard", "powerful"]
+HookKind = Literal["observe", "transform", "intercept", "augment"]
+
+_VALID_PERMISSION_LEVELS = frozenset({"safe", "standard", "powerful"})
+_VALID_HOOK_KINDS = frozenset({"observe", "transform", "intercept", "augment"})
+_SUPPORTED_TOP_LEVEL_SECTIONS = frozenset(
+    {
+        "extension",
+        "permissions",
+        "dependencies",
+        "commands",
+        "tools",
+        "prompts",
+        "skills",
+        "hooks",
+        "models",
+        "providers",
+        "ui",
+        "autocomplete",
+        "configuration",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ExtensionPermissionDeclaration:
+    level: PermissionLevel = "safe"
+    capabilities: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ExtensionCommandDeclaration:
+    name: str
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class ExtensionToolDeclaration:
+    name: str
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class ExtensionHookDeclaration:
+    event: str
+    kind: HookKind = "observe"
+    handler: str | None = None
+
+
+@dataclass(frozen=True)
+class PythonDependencyDeclaration:
+    packages: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ExtensionDependencyDeclaration:
+    python: PythonDependencyDeclaration = field(default_factory=PythonDependencyDeclaration)
+
+
+@dataclass(frozen=True)
+class ExtensionManifest:
+    id: str
+    name: str
+    version: str | None = None
+    description: str | None = None
+    permissions: ExtensionPermissionDeclaration = field(default_factory=ExtensionPermissionDeclaration)
+    dependencies: ExtensionDependencyDeclaration = field(default_factory=ExtensionDependencyDeclaration)
+    commands: tuple[ExtensionCommandDeclaration, ...] = ()
+    tools: tuple[ExtensionToolDeclaration, ...] = ()
+    hooks: tuple[ExtensionHookDeclaration, ...] = ()
+
+
+@dataclass(frozen=True)
+class ExtensionManifestParseResult:
+    manifest: ExtensionManifest | None = None
+    diagnostics: list[ResourceDiagnostic] = field(default_factory=list)
+
+
+def parse_extension_manifest(path: Path) -> ExtensionManifestParseResult:
+    diagnostics: list[ResourceDiagnostic] = []
+    try:
+        with path.open("rb") as stream:
+            data = tomllib.load(stream)
+    except tomllib.TOMLDecodeError as exc:
+        return ExtensionManifestParseResult(
+            diagnostics=[
+                _diagnostic(
+                    "invalid_extension_manifest_toml",
+                    f"Failed to parse extension manifest TOML: {exc}",
+                    path,
+                )
+            ]
+        )
+    except OSError as exc:
+        return ExtensionManifestParseResult(
+            diagnostics=[
+                _diagnostic(
+                    "unreadable_extension_manifest",
+                    f"Failed to read extension manifest: {exc}",
+                    path,
+                )
+            ]
+        )
+
+    if not isinstance(data, dict):
+        return ExtensionManifestParseResult(
+            diagnostics=[
+                _diagnostic(
+                    "invalid_extension_manifest",
+                    "Extension manifest must be a TOML table.",
+                    path,
+                )
+            ]
+        )
+
+    for section in data:
+        if section not in _SUPPORTED_TOP_LEVEL_SECTIONS:
+            diagnostics.append(
+                _diagnostic(
+                    "unsupported_extension_manifest_section",
+                    f"Unsupported extension manifest section: {section}",
+                    path,
+                    metadata={"section": section},
+                )
+            )
+
+    extension = data.get("extension")
+    if not isinstance(extension, dict):
+        diagnostics.append(
+            _diagnostic(
+                "missing_extension_manifest_metadata",
+                'Extension manifest must include an [extension] section.',
+                path,
+            )
+        )
+        return ExtensionManifestParseResult(diagnostics=diagnostics)
+
+    extension_id = _string_or_none(extension.get("id"))
+    name = _string_or_none(extension.get("name"))
+    if not extension_id:
+        diagnostics.append(
+            _diagnostic(
+                "missing_extension_manifest_id",
+                'Extension manifest [extension].id is required.',
+                path,
+            )
+        )
+    if not name:
+        diagnostics.append(
+            _diagnostic(
+                "missing_extension_manifest_name",
+                'Extension manifest [extension].name is required.',
+                path,
+            )
+        )
+
+    permissions = _parse_permissions(data.get("permissions"), path, diagnostics)
+    commands = _parse_named_declarations(data.get("commands"), path, "command", diagnostics)
+    tools = _parse_named_declarations(data.get("tools"), path, "tool", diagnostics)
+    hooks = _parse_hooks(data.get("hooks"), path, diagnostics)
+    dependencies = _parse_dependencies(data.get("dependencies"))
+
+    if any(diagnostic.code.startswith(("missing_", "invalid_extension_permission_level")) for diagnostic in diagnostics):
+        return ExtensionManifestParseResult(diagnostics=diagnostics)
+
+    return ExtensionManifestParseResult(
+        manifest=ExtensionManifest(
+            id=extension_id or "",
+            name=name or extension_id or "",
+            version=_string_or_none(extension.get("version")),
+            description=_string_or_none(extension.get("description")),
+            permissions=permissions,
+            dependencies=dependencies,
+            commands=tuple(
+                ExtensionCommandDeclaration(name=declaration.name, description=declaration.description)
+                for declaration in commands
+            ),
+            tools=tuple(
+                ExtensionToolDeclaration(name=declaration.name, description=declaration.description)
+                for declaration in tools
+            ),
+            hooks=hooks,
+        ),
+        diagnostics=diagnostics,
+    )
+
+
+@dataclass(frozen=True)
+class _NamedDeclaration:
+    name: str
+    description: str | None = None
+
+
+def _parse_permissions(
+    value: object,
+    path: Path,
+    diagnostics: list[ResourceDiagnostic],
+) -> ExtensionPermissionDeclaration:
+    if value is None:
+        return ExtensionPermissionDeclaration()
+    if not isinstance(value, dict):
+        diagnostics.append(
+            _diagnostic(
+                "invalid_extension_permissions",
+                "Extension manifest [permissions] must be a table.",
+                path,
+            )
+        )
+        return ExtensionPermissionDeclaration()
+
+    level = value.get("level", "safe")
+    if level not in _VALID_PERMISSION_LEVELS:
+        diagnostics.append(
+            _diagnostic(
+                "invalid_extension_permission_level",
+                f"Unsupported extension permission level: {level}",
+                path,
+                metadata={"level": str(level)},
+            )
+        )
+        return ExtensionPermissionDeclaration()
+    return ExtensionPermissionDeclaration(
+        level=level,  # type: ignore[arg-type]
+        capabilities=_string_tuple(value.get("capabilities")),
+    )
+
+
+def _parse_named_declarations(
+    value: object,
+    path: Path,
+    resource_name: str,
+    diagnostics: list[ResourceDiagnostic],
+) -> tuple[_NamedDeclaration, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        diagnostics.append(
+            _diagnostic(
+                f"invalid_extension_{resource_name}_declarations",
+                f"Extension manifest {resource_name} declarations must be an array of tables.",
+                path,
+            )
+        )
+        return ()
+
+    declarations: list[_NamedDeclaration] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            diagnostics.append(
+                _diagnostic(
+                    f"invalid_extension_{resource_name}_declaration",
+                    f"Extension manifest {resource_name} declaration must be a table.",
+                    path,
+                    metadata={"index": index},
+                )
+            )
+            continue
+        name = _string_or_none(item.get("name"))
+        if not name:
+            diagnostics.append(
+                _diagnostic(
+                    f"missing_extension_{resource_name}_name",
+                    f"Extension manifest {resource_name} declaration requires a name.",
+                    path,
+                    metadata={"index": index},
+                )
+            )
+            continue
+        declarations.append(
+            _NamedDeclaration(
+                name=name,
+                description=_string_or_none(item.get("description")),
+            )
+        )
+    return tuple(declarations)
+
+
+def _parse_hooks(
+    value: object,
+    path: Path,
+    diagnostics: list[ResourceDiagnostic],
+) -> tuple[ExtensionHookDeclaration, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        diagnostics.append(
+            _diagnostic(
+                "invalid_extension_hook_declarations",
+                "Extension manifest hook declarations must be an array of tables.",
+                path,
+            )
+        )
+        return ()
+
+    hooks: list[ExtensionHookDeclaration] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            diagnostics.append(
+                _diagnostic(
+                    "invalid_extension_hook_declaration",
+                    "Extension manifest hook declaration must be a table.",
+                    path,
+                    metadata={"index": index},
+                )
+            )
+            continue
+        event = _string_or_none(item.get("event"))
+        if not event:
+            diagnostics.append(
+                _diagnostic(
+                    "missing_extension_hook_event",
+                    "Extension manifest hook declaration requires an event.",
+                    path,
+                    metadata={"index": index},
+                )
+            )
+            continue
+        kind = item.get("kind", "observe")
+        if kind not in _VALID_HOOK_KINDS:
+            diagnostics.append(
+                _diagnostic(
+                    "invalid_extension_hook_kind",
+                    f"Unsupported extension hook kind: {kind}",
+                    path,
+                    metadata={"index": index, "kind": str(kind)},
+                )
+            )
+            continue
+        hooks.append(
+            ExtensionHookDeclaration(
+                event=event,
+                kind=kind,  # type: ignore[arg-type]
+                handler=_string_or_none(item.get("handler")),
+            )
+        )
+    return tuple(hooks)
+
+
+def _parse_dependencies(value: object) -> ExtensionDependencyDeclaration:
+    if not isinstance(value, dict):
+        return ExtensionDependencyDeclaration()
+    python = value.get("python")
+    if not isinstance(python, dict):
+        return ExtensionDependencyDeclaration()
+    return ExtensionDependencyDeclaration(
+        python=PythonDependencyDeclaration(packages=_string_tuple(python.get("packages")))
+    )
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list | tuple):
+        return ()
+    return tuple(item for item in value if isinstance(item, str) and item)
+
+
+def _diagnostic(
+    code: str,
+    message: str,
+    source_path: Path,
+    *,
+    metadata: dict[str, object] | None = None,
+) -> ResourceDiagnostic:
+    return ResourceDiagnostic(
+        code=code,
+        message=message,
+        source_path=source_path,
+        resource_type="extension",
+        metadata=metadata or {},
+    )

--- a/src/loushang/coding/extensions/manifest.py
+++ b/src/loushang/coding/extensions/manifest.py
@@ -12,6 +12,14 @@ HookKind = Literal["observe", "transform", "intercept", "augment"]
 
 _VALID_PERMISSION_LEVELS = frozenset({"safe", "standard", "powerful"})
 _VALID_HOOK_KINDS = frozenset({"observe", "transform", "intercept", "augment"})
+_FATAL_DIAGNOSTIC_CODES = frozenset(
+    {
+        "missing_extension_manifest_metadata",
+        "missing_extension_manifest_id",
+        "missing_extension_manifest_name",
+        "invalid_extension_permission_level",
+    }
+)
 _SUPPORTED_TOP_LEVEL_SECTIONS = frozenset(
     {
         "extension",
@@ -169,7 +177,7 @@ def parse_extension_manifest(path: Path) -> ExtensionManifestParseResult:
     hooks = _parse_hooks(data.get("hooks"), path, diagnostics)
     dependencies = _parse_dependencies(data.get("dependencies"))
 
-    if any(diagnostic.code.startswith(("missing_", "invalid_extension_permission_level")) for diagnostic in diagnostics):
+    if any(diagnostic.code in _FATAL_DIAGNOSTIC_CODES for diagnostic in diagnostics):
         return ExtensionManifestParseResult(diagnostics=diagnostics)
 
     return ExtensionManifestParseResult(

--- a/src/loushang/coding/extensions/policy.py
+++ b/src/loushang/coding/extensions/policy.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from loushang.coding.extensions.manifest import ExtensionManifest, PermissionLevel
+
+ExtensionCapability = Literal[
+    "exec",
+    "filesystem",
+    "network",
+    "model",
+    "session_mutation",
+    "ui_mutation",
+    "tool_mutation",
+]
+
+_DEFAULT_CAPABILITIES: dict[PermissionLevel, tuple[str, ...]] = {
+    "safe": (),
+    "standard": ("filesystem", "model"),
+    "powerful": (
+        "exec",
+        "filesystem",
+        "network",
+        "model",
+        "session_mutation",
+        "ui_mutation",
+        "tool_mutation",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ExtensionPolicyDecision:
+    enabled: bool = True
+    permission_level: PermissionLevel = "safe"
+    capabilities: tuple[str, ...] = ()
+    allow_managed_hooks_only: bool = False
+
+    @property
+    def active(self) -> bool:
+        return self.enabled
+
+
+def policy_from_manifest(
+    manifest: ExtensionManifest | None,
+    *,
+    enabled: bool = True,
+    allow_managed_hooks_only: bool = False,
+) -> ExtensionPolicyDecision:
+    if manifest is None:
+        return ExtensionPolicyDecision(
+            enabled=enabled,
+            allow_managed_hooks_only=allow_managed_hooks_only,
+        )
+    capabilities = (
+        manifest.permissions.capabilities
+        if manifest.permissions.capabilities
+        else _DEFAULT_CAPABILITIES[manifest.permissions.level]
+    )
+    return ExtensionPolicyDecision(
+        enabled=enabled,
+        permission_level=manifest.permissions.level,
+        capabilities=tuple(capabilities),
+        allow_managed_hooks_only=allow_managed_hooks_only,
+    )

--- a/src/loushang/coding/extensions/types.py
+++ b/src/loushang/coding/extensions/types.py
@@ -10,6 +10,9 @@ from loushang.agent import AgentMessage, ThinkingLevel
 from loushang.coding.commands import SessionCommandDescriptor
 from loushang.coding.compaction import BranchSummaryResult, CompactionResult
 from loushang.coding.exec import ExecResult, ExecUpdateCallback
+from loushang.coding.extensions.contributions import ContributionDescriptor
+from loushang.coding.extensions.manifest import ExtensionManifest
+from loushang.coding.extensions.policy import ExtensionPolicyDecision
 from loushang.coding.loader import (
     ExtensionDescriptor,
     PromptFragmentDescriptor,
@@ -770,6 +773,9 @@ class LoadedExtension:
     diagnostics: list[ResourceDiagnostic] = field(default_factory=list)
     metadata: dict[str, object] = field(default_factory=dict)
     api: object | None = None
+    manifest: ExtensionManifest | None = None
+    policy: ExtensionPolicyDecision | None = None
+    contributions: list[ContributionDescriptor] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/tests/coding/test_extension_platform.py
+++ b/tests/coding/test_extension_platform.py
@@ -80,6 +80,37 @@ level = "root"
     assert result.diagnostics[0].resource_type == "extension"
 
 
+def test_extension_manifest_parser_keeps_manifest_for_partial_contribution_errors(tmp_path) -> None:
+    from loushang.coding.extensions.manifest import parse_extension_manifest
+
+    manifest_path = tmp_path / "loushang-extension.toml"
+    manifest_path.write_text(
+        """
+[extension]
+id = "demo.partial"
+name = "Demo Partial"
+
+[[commands]]
+description = "missing name"
+
+[[tools]]
+name = "valid_tool"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = parse_extension_manifest(manifest_path)
+
+    assert result.manifest is not None
+    assert result.manifest.id == "demo.partial"
+    assert result.manifest.commands == ()
+    assert [tool.name for tool in result.manifest.tools] == ["valid_tool"]
+    assert [diagnostic.code for diagnostic in result.diagnostics] == [
+        "missing_extension_command_name"
+    ]
+
+
 def test_extension_loader_attaches_manifest_policy_and_contributions(tmp_path) -> None:
     from loushang.coding.extensions.loader import ExtensionLoader
     from loushang.coding.loader import ExtensionDescriptor
@@ -201,3 +232,39 @@ def test_contribution_registry_indexes_loaded_extension_contributions(tmp_path) 
         "review",
     ]
     assert registry.get("tool", "lookup").extension_id == "review"
+
+
+def test_contribution_registry_does_not_silently_overwrite_duplicate_keys() -> None:
+    from pathlib import Path
+
+    import pytest
+
+    from loushang.coding.extensions.contributions import (
+        ContributionDescriptor,
+        ContributionRegistry,
+        DuplicateContributionKeyError,
+    )
+
+    first = ContributionDescriptor(
+        type="command",
+        name="review",
+        extension_id="one",
+        source_path=Path("/tmp/one.py"),
+    )
+    second = ContributionDescriptor(
+        type="command",
+        name="review",
+        extension_id="two",
+        source_path=Path("/tmp/two.py"),
+    )
+
+    registry = ContributionRegistry()
+    registry.add(first)
+    registry.add(second)
+
+    assert [contribution.extension_id for contribution in registry.by_key("command", "review")] == [
+        "one",
+        "two",
+    ]
+    with pytest.raises(DuplicateContributionKeyError):
+        registry.get("command", "review")

--- a/tests/coding/test_extension_platform.py
+++ b/tests/coding/test_extension_platform.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+
+def test_extension_manifest_parser_accepts_capability_manifest(tmp_path) -> None:
+    from loushang.coding.extensions.manifest import parse_extension_manifest
+
+    manifest_path = tmp_path / "loushang-extension.toml"
+    manifest_path.write_text(
+        """
+[extension]
+id = "acme.review"
+name = "Acme Review"
+version = "0.1.0"
+description = "Review helpers"
+
+[permissions]
+level = "standard"
+capabilities = ["filesystem", "model"]
+
+[[commands]]
+name = "acme-review"
+description = "Run review"
+
+[[tools]]
+name = "acme_lookup"
+description = "Look up metadata"
+
+[[hooks]]
+event = "before_agent_start"
+kind = "augment"
+handler = "extension:before_agent_start"
+
+[dependencies.python]
+packages = ["acme-sdk>=0.3"]
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = parse_extension_manifest(manifest_path)
+
+    assert result.manifest is not None
+    assert result.diagnostics == []
+    assert result.manifest.id == "acme.review"
+    assert result.manifest.name == "Acme Review"
+    assert result.manifest.permissions.level == "standard"
+    assert result.manifest.permissions.capabilities == ("filesystem", "model")
+    assert [command.name for command in result.manifest.commands] == ["acme-review"]
+    assert [tool.name for tool in result.manifest.tools] == ["acme_lookup"]
+    assert [(hook.event, hook.kind) for hook in result.manifest.hooks] == [
+        ("before_agent_start", "augment")
+    ]
+    assert result.manifest.dependencies.python.packages == ("acme-sdk>=0.3",)
+
+
+def test_extension_manifest_parser_reports_invalid_input_without_throwing(tmp_path) -> None:
+    from loushang.coding.extensions.manifest import parse_extension_manifest
+
+    manifest_path = tmp_path / "loushang-extension.toml"
+    manifest_path.write_text(
+        """
+[extension]
+id = "bad.extension"
+name = "Bad Extension"
+
+[permissions]
+level = "root"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = parse_extension_manifest(manifest_path)
+
+    assert result.manifest is None
+    assert [diagnostic.code for diagnostic in result.diagnostics] == [
+        "invalid_extension_permission_level"
+    ]
+    assert result.diagnostics[0].source_path == manifest_path
+    assert result.diagnostics[0].resource_type == "extension"
+
+
+def test_extension_loader_attaches_manifest_policy_and_contributions(tmp_path) -> None:
+    from loushang.coding.extensions.loader import ExtensionLoader
+    from loushang.coding.loader import ExtensionDescriptor
+
+    extension_dir = tmp_path / "review"
+    extension_dir.mkdir()
+    extension_file = extension_dir / "extension.py"
+    extension_file.write_text(
+        """
+from loushang.coding.tools import ToolDefinition
+
+
+async def _execute_tool(tool_name, arguments, context, signal):
+    return {"ok": True}
+
+
+def register(api):
+    api.on("session_start", lambda event, ctx: None)
+    api.register_tool(
+        ToolDefinition(
+            name="runtime_lookup",
+            label="Runtime Lookup",
+            description="runtime tool",
+            parameters={},
+            execute=_execute_tool,
+        )
+    )
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (extension_dir / "loushang-extension.toml").write_text(
+        """
+[extension]
+id = "acme.review"
+name = "Acme Review"
+
+[permissions]
+level = "standard"
+capabilities = ["filesystem"]
+
+[[commands]]
+name = "acme-review"
+
+[[tools]]
+name = "manifest_lookup"
+
+[[hooks]]
+event = "before_agent_start"
+kind = "augment"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    loader = ExtensionLoader()
+    loaded = loader.load_extensions(
+        [
+            ExtensionDescriptor(
+                name="review",
+                source_path=extension_dir,
+                entry_path=extension_file,
+            )
+        ]
+    )
+
+    assert len(loaded) == 1
+    extension = loaded[0]
+    assert extension.name == "review"
+    assert [tool.name for tool in extension.tool_definitions] == ["runtime_lookup"]
+    assert extension.manifest is not None
+    assert extension.manifest.id == "acme.review"
+    assert extension.policy is not None
+    assert extension.policy.permission_level == "standard"
+    assert extension.policy.capabilities == ("filesystem",)
+    assert sorted((contribution.type, contribution.name) for contribution in extension.contributions) == [
+        ("command", "acme-review"),
+        ("hook", "before_agent_start"),
+        ("hook", "session_start"),
+        ("tool", "manifest_lookup"),
+        ("tool", "runtime_lookup"),
+    ]
+    assert loader.get_diagnostics() == []
+
+
+def test_contribution_registry_indexes_loaded_extension_contributions(tmp_path) -> None:
+    from pathlib import Path
+
+    from loushang.coding.extensions.contributions import (
+        ContributionDescriptor,
+        ContributionRegistry,
+    )
+    from loushang.coding.extensions.types import LoadedExtension
+
+    extension = LoadedExtension(
+        name="review",
+        source_path=Path("/tmp/review/extension.py"),
+        contributions=[
+            ContributionDescriptor(
+                type="tool",
+                name="lookup",
+                extension_id="review",
+                source_path=Path("/tmp/review/extension.py"),
+            ),
+            ContributionDescriptor(
+                type="command",
+                name="review",
+                extension_id="review",
+                source_path=Path("/tmp/review/extension.py"),
+            ),
+        ],
+    )
+
+    registry = ContributionRegistry.from_extensions([extension])
+
+    assert [contribution.name for contribution in registry.by_type("tool")] == ["lookup"]
+    assert [contribution.name for contribution in registry.by_extension("review")] == [
+        "lookup",
+        "review",
+    ]
+    assert registry.get("tool", "lookup").extension_id == "review"


### PR DESCRIPTION
## Summary
- Add structured `loushang-extension.toml` parsing for extension capability manifests.
- Add extension policy decisions and contribution registry projection types.
- Attach optional manifest, policy, and contribution projection to loaded extensions without changing existing runtime behavior.

## Notes
- Stacked on #138 (`feature/extension-platform-integration-docs`).
- P1 parses and stores dependency declarations only; it does not install or resolve dependencies.

## Test Plan
- [x] `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_extension_platform.py -q`
- [x] `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_extension_platform.py tests/coding/test_extension_loader.py tests/coding/test_extension_api.py tests/coding/test_extension_runner.py tests/coding/test_resource_loader.py -q`
- [x] `uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/extensions tests/coding/test_extension_platform.py`
- [x] `uv --cache-dir .uv-cache run --extra dev pytest tests/coding -q`