### PR TITLE
Resolve duplicate model endpoint selection

### DIFF
--- a/docs/en/getting-started/README.md
+++ b/docs/en/getting-started/README.md
@@ -44,7 +44,7 @@ loushang --list-commands
 loushang -p "Inspect this repository and summarize what it does."
 ```
 
-Use `--model` or provider-specific environment variables when you need to select a concrete model route. Project and example model catalog files can be placed under `.loushang/models/` or passed explicitly where supported.
+Use `--model` or provider-specific environment variables when you need to select a concrete model route. `--model provider/model` is a short form: it works when the model has one matching endpoint, or when the catalog documents one matching endpoint as preferred. If the same provider/model exists under multiple endpoints and no single preferred endpoint applies, the CLI reports an ambiguity and lists explicit `provider:endpoint:model` alternatives. Use `--model provider:endpoint:model` when you need to choose a specific endpoint, region, lane, or protocol. In catalog keys, `provider` and `model` ids cannot contain `:`, while endpoint ids may contain `:`. Project and example model catalog files can be placed under `.loushang/models/` or passed explicitly where supported.
 
 ## Next Steps
 

--- a/docs/zh-CN/getting-started/README.md
+++ b/docs/zh-CN/getting-started/README.md
@@ -44,7 +44,7 @@ loushang --list-commands
 loushang -p "Inspect this repository and summarize what it does."
 ```
 
-需要选择具体模型路线时，可以使用 `--model` 或 provider 相关环境变量。项目与示例模型 catalog 可以放在 `.loushang/models/`，也可以在支持的入口显式传入。
+需要选择具体模型路线时，可以使用 `--model` 或 provider 相关环境变量。`--model provider/model` 是短写：当该模型只匹配一个 endpoint，或 catalog 明确将其中一个匹配 endpoint 标为 preferred 时可用。如果同一个 provider/model 存在多个 endpoint 且没有唯一 preferred endpoint，CLI 会报告歧义并列出可显式选择的 `provider:endpoint:model` 候选。需要指定具体 endpoint、region、lane 或 protocol 时，使用 `--model provider:endpoint:model`。catalog key 中 `provider` 和 `model` id 不能包含 `:`，endpoint id 可以包含 `:`。项目与示例模型 catalog 可以放在 `.loushang/models/`，也可以在支持的入口显式传入。
 
 ## 下一步
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 
 [project.scripts]
 loushang = "loushang.coding.cli.__main__:main"
+loushang-ai = "loushang.ai.cli.__main__:main"
 loushang-tui = "loushang.coding.ui.cli:main"
 
 [project.optional-dependencies]

--- a/src/loushang/ai/auth/facade.py
+++ b/src/loushang/ai/auth/facade.py
@@ -54,8 +54,8 @@ def register_builtin_oauth_providers(
 
 
 def _register_builtin_oauth_providers(registry: OAuthProviderRegistry) -> None:
-    _register_builtin_anthropic(registry)
     _register_builtin_openai_codex(registry)
+    _register_builtin_anthropic(registry)
 
 
 def _register_builtin_anthropic(

--- a/src/loushang/ai/cli/README.md
+++ b/src/loushang/ai/cli/README.md
@@ -13,7 +13,7 @@
 推荐入口：
 
 ```bash
-uv run python -m loushang.ai.cli console
+uv run loushang-ai console
 ```
 
 ## Console 能力
@@ -63,9 +63,9 @@ uv run python -m loushang.ai.cli console
 示例：
 
 ```bash
-uv run python -m loushang.ai.cli auth providers
-uv run python -m loushang.ai.cli auth show openai-codex
-uv run python -m loushang.ai.cli auth login openai-codex
+uv run loushang-ai auth providers
+uv run loushang-ai auth show openai-codex
+uv run loushang-ai auth login openai-codex
 ```
 
 对于大多数验证场景，优先使用 `console`。

--- a/src/loushang/ai/cli/__main__.py
+++ b/src/loushang/ai/cli/__main__.py
@@ -31,7 +31,11 @@ from loushang.ai.auth import (
 )
 from loushang.ai.auth.support import merge_auth_config
 from loushang.ai.auth.types import OAuthAuthInfo, OAuthLoginCallbacks, OAuthPrompt
-from loushang.ai.model.registry import get_default_model_registry, resolve_model_api
+from loushang.ai.model.registry import (
+    get_default_model_registry,
+    resolve_model_api,
+    resolve_model_ref,
+)
 
 _OPTION_CLASS_BY_API = {
     "anthropic-messages": AnthropicOptions,
@@ -131,11 +135,15 @@ def cmd_models(args: argparse.Namespace) -> None:
         except (KeyError, ValueError) as error:
             print(str(error), file=sys.stderr)
             sys.exit(2)
+        endpoint_info = registry.get_endpoint(model.provider_id, model.endpoint_id)
         data = {
             "id": model.id,
             "provider": model.provider_id,
             "endpoint": model.endpoint_id,
             "api": resolve_model_api(model, registry=registry),
+            "region": endpoint_info.region if endpoint_info is not None else model.region,
+            "lane": endpoint_info.lane if endpoint_info is not None else None,
+            "preferredEndpoint": bool(endpoint_info.preferred) if endpoint_info is not None else False,
             "name": model.name,
             "family": model.family,
             "alias": model.alias,
@@ -151,8 +159,8 @@ def cmd_models(args: argparse.Namespace) -> None:
                 "stream": model.capabilities.stream,
                 "attachment": model.capabilities.attachment,
             },
-            "defaults": model.defaults,
-            "compat": model.compat,
+            "defaults": dict(model.defaults),
+            "compat": dict(model.compat),
         }
         _print(data, args.json)
         return
@@ -781,31 +789,13 @@ def _resolve_model_arg(
     endpoint: str | None,
     api: str | None,
 ):
-    if model_arg.count(":") == 2:
-        p, e, mid = model_arg.split(":", 2)
-        return registry.get_model(p, e, mid)
-    if provider and endpoint:
-        return registry.get_model(provider, endpoint, model_arg)
-    if api:
-        candidates = [
-            (model.provider_id, model.endpoint_id)
-            for model in registry.list_models(model_id=model_arg)
-            if resolve_model_api(model, registry=registry) == api
-        ]
-        if len(candidates) == 1:
-            p, e = candidates[0]
-            return registry.get_model(p, e, model_arg)
-        if len(candidates) > 1:
-            print(
-                "Ambiguous model for api; candidates:",
-                ", ".join(f"{p}:{e}:{model_arg}" for p, e in candidates),
-                file=sys.stderr,
-            )
-            sys.exit(2)
-    resolved = registry.find_model(model_arg)
-    if resolved is not None:
-        return resolved
-    return registry.get_model(model_arg)
+    return resolve_model_ref(
+        registry,
+        model_arg,
+        provider=provider,
+        endpoint=endpoint,
+        api=api,
+    )
 
 
 def _resolve_model_with_env_fallback(

--- a/src/loushang/ai/model/__init__.py
+++ b/src/loushang/ai/model/__init__.py
@@ -15,15 +15,21 @@ from loushang.ai.model.loader import (
     load_model_registry_from_file,
 )
 from loushang.ai.model.registry import (
+    AmbiguousModelReference,
+    AmbiguousPreferredModelReference,
     ModelRegistry,
     clear_default_model_registry,
+    format_model_ref,
     get_default_model_registry,
     reload_default_model_registry,
     resolve_model_api,
     resolve_model_endpoint,
+    resolve_model_ref,
 )
 
 __all__ = [
+    "AmbiguousModelReference",
+    "AmbiguousPreferredModelReference",
     "Auth",
     "Capabilities",
     "clear_default_model_registry",
@@ -34,6 +40,7 @@ __all__ = [
     "ModelRegistry",
     "Pricing",
     "Provider",
+    "format_model_ref",
     "get_default_model_registry",
     "load_builtin_model_registry",
     "load_model_registry",
@@ -42,4 +49,5 @@ __all__ = [
     "reload_default_model_registry",
     "resolve_model_api",
     "resolve_model_endpoint",
+    "resolve_model_ref",
 ]

--- a/src/loushang/ai/model/domain.py
+++ b/src/loushang/ai/model/domain.py
@@ -212,6 +212,8 @@ class Model:
     base_url: str | None = None
     base_url_env: str | None = None
     region: str | None = None
+    lane: str | None = None
+    preferred_endpoint: bool = False
     auth: Auth | None = None
     _auth_inherited: bool = False
     name: str | None = None
@@ -304,6 +306,8 @@ class Model:
             base_url=endpoint.base_url,
             base_url_env=endpoint.base_url_env,
             region=endpoint.region,
+            lane=endpoint.lane,
+            preferred_endpoint=endpoint.preferred,
             auth=auth,
             _auth_inherited=inherits_auth and auth is not None,
             compat=endpoint.compat.merged(self.compat),
@@ -359,6 +363,7 @@ class Endpoint:
     base_url_env: str | None = None
     region: str | None = None
     lane: str | None = None
+    preferred: bool = False
     docs: str | None = None
     auth: Auth | None = None
     compat: Compat = field(default_factory=Compat)
@@ -408,6 +413,8 @@ class Endpoint:
             raw["region"] = self.region
         if self.lane is not None:
             raw["lane"] = self.lane
+        if self.preferred:
+            raw["preferred"] = self.preferred
         if self.docs is not None:
             raw["docs"] = self.docs
         if self.auth is not None:

--- a/src/loushang/ai/model/loader.py
+++ b/src/loushang/ai/model/loader.py
@@ -69,6 +69,7 @@ def validate_model_registry_raw(raw: dict[str, Any]) -> None:
     providers = _require_mapping(root.get("providers"), "providers")
     for provider_id, provider_raw in providers.items():
         provider_path = f"providers.{provider_id}"
+        _validate_ref_segment_key(provider_id, provider_path)
         provider = _require_mapping(provider_raw, provider_path)
         _validate_auth_mapping(provider.get("auth"), f"{provider_path}.auth")
         endpoints = _require_mapping(
@@ -78,6 +79,7 @@ def validate_model_registry_raw(raw: dict[str, Any]) -> None:
             endpoint_path = f"{provider_path}.endpoints.{endpoint_key}"
             endpoint = _require_mapping(endpoint_raw, endpoint_path)
             _require_str(endpoint.get("api"), f"{endpoint_path}.api")
+            _validate_optional_bool(endpoint.get("preferred"), f"{endpoint_path}.preferred")
             _validate_auth_fields(endpoint, endpoint_path)
             _validate_keyed_mapping(
                 endpoint.get("compat"),
@@ -92,6 +94,7 @@ def validate_model_registry_raw(raw: dict[str, Any]) -> None:
             models = _require_mapping(endpoint.get("models"), f"{endpoint_path}.models")
             for model_id, model_raw in models.items():
                 model_path = f"{endpoint_path}.models.{model_id}"
+                _validate_ref_segment_key(model_id, model_path)
                 model = _require_mapping(model_raw, model_path)
                 _validate_auth_fields(model, model_path)
                 _validate_keyed_mapping(
@@ -141,6 +144,21 @@ def _require_str(value: object, path: str) -> str:
     if not isinstance(value, str) or not value:
         raise ValueError(f"models registry field must be a non-empty string: {path}")
     return value
+
+
+def _validate_optional_bool(value: object, path: str) -> None:
+    if value is not None and not isinstance(value, bool):
+        raise ValueError(f"models registry field must be a boolean: {path}")
+
+
+def _validate_ref_segment_key(value: object, path: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"models registry key must be a non-empty string: {path}")
+    if ":" in value:
+        raise ValueError(
+            "models registry provider and model keys must not contain ':': "
+            f"{path}"
+        )
 
 
 def _validate_keyed_mapping(
@@ -288,6 +306,7 @@ def _build_registry(raw: dict[str, Any]) -> ModelRegistry:
                 base_url_env=endpoint_raw.get("baseUrlEnv"),
                 region=endpoint_raw.get("region"),
                 lane=endpoint_raw.get("lane"),
+                preferred=bool(endpoint_raw.get("preferred", False)),
                 docs=endpoint_raw.get("docs"),
                 auth=endpoint_auth,
                 compat=_normalize_endpoint_compat(endpoint_raw),

--- a/src/loushang/ai/model/models.json
+++ b/src/loushang/ai/model/models.json
@@ -15,6 +15,7 @@
           "baseUrl": "https://api.moonshot.cn/v1",
           "baseUrlEnv": "MOONSHOT_COMPLETIONS_URL",
           "api": "openai-completions",
+          "preferred": true,
           "docs": "https://platform.moonshot.ai/docs/api/chat",
           "compat": {
             "thinkingFormat": "moonshot",
@@ -165,6 +166,7 @@
           "api": "anthropic-messages",
           "region": "cn",
           "lane": "coding",
+          "preferred": true,
           "docs": "https://www.kimi.com/code/docs/en/",
           "compat": {
             "supportsDeveloperRole": false
@@ -278,6 +280,7 @@
           "baseUrlEnv": "DASHSCOPE_CN_RESPONSES_URL",
           "api": "openai-responses",
           "region": "cn",
+          "preferred": true,
           "docs": "https://help.aliyun.com/zh/model-studio/",
           "compat": {
             "supportsDeveloperRole": true,

--- a/src/loushang/ai/model/registry.py
+++ b/src/loushang/ai/model/registry.py
@@ -67,6 +67,106 @@ def resolve_model_api(
     return endpoint.api
 
 
+def format_model_ref(model: Model) -> str:
+    return f"{model.provider_id}:{model.endpoint_id}:{model.id}"
+
+
+def _parse_explicit_model_ref(ref: str) -> tuple[str, str, str] | None:
+    if ref.count(":") < 2:
+        return None
+    provider, rest = ref.split(":", 1)
+    endpoint, model_id = rest.rsplit(":", 1)
+    if not provider or not endpoint or not model_id:
+        return None
+    return provider, endpoint, model_id
+
+
+class AmbiguousModelReference(ValueError):
+    def __init__(self, ref: str, candidates: list[Model]) -> None:
+        self.ref = ref
+        self.candidates = tuple(format_model_ref(model) for model in candidates)
+        message = (
+            f"Ambiguous model reference {ref!r}; use one of: "
+            + ", ".join(self.candidates)
+        )
+        super().__init__(message)
+
+
+class AmbiguousPreferredModelReference(ValueError):
+    def __init__(self, ref: str, candidates: list[Model]) -> None:
+        self.ref = ref
+        self.candidates = tuple(format_model_ref(model) for model in candidates)
+        message = (
+            f"Ambiguous preferred endpoint for model reference {ref!r}; "
+            "catalog marks multiple preferred endpoints: "
+            + ", ".join(self.candidates)
+        )
+        super().__init__(message)
+
+
+def resolve_model_ref(
+    registry: "ModelRegistry",
+    ref: str,
+    *,
+    provider: str | None = None,
+    endpoint: str | None = None,
+    api: str | None = None,
+) -> Model:
+    if explicit_ref := _parse_explicit_model_ref(ref):
+        p, e, mid = explicit_ref
+        return registry.get_model(p, e, mid)
+    if "/" in ref and provider is None and endpoint is None:
+        p, mid = ref.split("/", 1)
+        if p and mid:
+            return _resolve_provider_model_ref(registry, p, mid)
+    if provider and endpoint:
+        return registry.get_model(provider, endpoint, ref)
+    if provider:
+        return _resolve_provider_model_ref(registry, provider, ref)
+    if api:
+        candidates = [
+            model
+            for model in registry.list_models(model_id=ref)
+            if resolve_model_api(model, registry=registry) == api
+        ]
+        return _resolve_candidates(registry, ref, candidates)
+    return registry.get_model(ref)
+
+
+def _resolve_provider_model_ref(
+    registry: "ModelRegistry",
+    provider: str,
+    model_id: str,
+) -> Model:
+    candidates = registry.list_models(provider=provider, model_id=model_id)
+    return _resolve_candidates(registry, f"{provider}/{model_id}", candidates)
+
+
+def _resolve_candidates(
+    registry: "ModelRegistry",
+    ref: str,
+    candidates: list[Model],
+) -> Model:
+    if not candidates:
+        raise KeyError(ref)
+    if len(candidates) == 1:
+        return candidates[0]
+    preferred = [
+        model
+        for model in candidates
+        if (
+            endpoint := registry.get_endpoint(model.provider_id, model.endpoint_id)
+        )
+        is not None
+        and endpoint.preferred
+    ]
+    if len(preferred) == 1:
+        return preferred[0]
+    if len(preferred) > 1:
+        raise AmbiguousPreferredModelReference(ref, preferred)
+    raise AmbiguousModelReference(ref, candidates)
+
+
 class ModelRegistry:
     def __init__(self, providers: dict[str, Provider] | None = None) -> None:
         self._providers = dict(providers or {})

--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -760,9 +760,13 @@ def _scoped_models_from_enabled_patterns(
         selection = model_registry.get_model(model_name)
         if selection is None:
             continue
-        scoped: dict[str, object] = {
-            "model": {"provider": selection.provider, "model_id": selection.model_id},
+        model_payload: dict[str, object] = {
+            "provider": selection.provider,
+            "model_id": selection.model_id,
         }
+        if selection.endpoint_id:
+            model_payload["endpoint_id"] = selection.endpoint_id
+        scoped: dict[str, object] = {"model": model_payload}
         if thinking_level is not None:
             scoped["thinkingLevel"] = thinking_level
         scoped_models.append(scoped)

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -1359,13 +1359,21 @@ def _resolve_latest_session_file(runtime: Any) -> str | None:
 def _resolve_model_selection(args: CliArgs) -> ModelSelection | None:
     if args.provider is None and args.model is None:
         return None
+    if args.provider is None and args.model is not None and args.model.count(":") >= 2:
+        provider, rest = args.model.split(":", 1)
+        endpoint_id, model_id = rest.rsplit(":", 1)
+        if provider and endpoint_id and model_id:
+            return ModelSelection(provider=provider, endpoint_id=endpoint_id, model_id=model_id)
     if args.provider is not None and args.model is not None:
         return ModelSelection(provider=args.provider, model_id=args.model)
     if args.provider is None and args.model is not None and "/" in args.model:
         provider, model_id = args.model.split("/", 1)
         if provider and model_id:
             return ModelSelection(provider=provider, model_id=model_id)
-    raise ValueError("Model selection requires --provider and --model, or --model provider/model_id.")
+    raise ValueError(
+        "Model selection requires --provider and --model, "
+        "--model provider/model_id, or --model provider:endpoint:model_id."
+    )
 
 
 async def _apply_model_and_thinking_overrides(args: CliArgs, session: Any, stderr: TextIO) -> int | None:

--- a/src/loushang/coding/control/model_registry.py
+++ b/src/loushang/coding/control/model_registry.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 
 from loushang.ai.model import Model, Provider
-from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
-from loushang.ai.model.registry import get_default_model_registry
+from loushang.ai.model.registry import (
+    ModelRegistry as AiModelRegistry,
+)
+from loushang.ai.model.registry import (
+    get_default_model_registry,
+    resolve_model_ref,
+)
 from loushang.coding.types import ModelSelection
 from loushang.observability import get_log
 
@@ -43,7 +48,7 @@ class ModelRegistry:
 
     def get_model(self, name: str) -> ModelSelection | None:
         try:
-            model = self._ai_registry.get_model(name)
+            model = resolve_model_ref(self._ai_registry, name)
         except (KeyError, ValueError):
             return None
         return ModelSelection(provider=model.provider_id, model_id=model.id)
@@ -60,7 +65,7 @@ class ModelRegistry:
         if isinstance(selection_input, Model):
             return ModelSelection(provider=selection_input.provider_id, model_id=selection_input.id)
 
-        model = self._ai_registry.get_model(selection_input)
+        model = resolve_model_ref(self._ai_registry, selection_input)
         return ModelSelection(provider=model.provider_id, model_id=model.id)
 
     def build_model(self, selection_input: ModelSelection | str | Model) -> Model:
@@ -68,11 +73,18 @@ class ModelRegistry:
         return self._resolve_model(selection)
 
     def _resolve_model(self, selection: ModelSelection) -> Model:
-        matches = [
-            model
-            for model in self._ai_registry.list_models(provider=selection.provider, model_id=selection.model_id)
-        ]
-        if not matches:
+        if selection.endpoint_id:
+            return self._ai_registry.get_model(
+                selection.provider,
+                selection.endpoint_id,
+                selection.model_id,
+            )
+        try:
+            return resolve_model_ref(
+                self._ai_registry,
+                f"{selection.provider}/{selection.model_id}",
+            )
+        except KeyError:
             log.problem(
                 "model_selection_not_found",
                 source="config",
@@ -82,7 +94,11 @@ class ModelRegistry:
                 model_id=selection.model_id,
             )
             raise KeyError((selection.provider, selection.model_id))
-        if len(matches) > 1:
+        except ValueError as error:
+            matches = self._ai_registry.list_models(
+                provider=selection.provider,
+                model_id=selection.model_id,
+            )
             log.problem(
                 "model_selection_ambiguous",
                 source="config",
@@ -92,5 +108,6 @@ class ModelRegistry:
                 model_id=selection.model_id,
                 endpoint_ids=[model.endpoint_id for model in matches],
             )
-            raise ValueError(f"Ambiguous model selection: {selection.provider}:{selection.model_id}")
-        return matches[0]
+            raise ValueError(
+                f"Ambiguous model selection: {selection.provider}:{selection.model_id}; {error}"
+            ) from error

--- a/src/loushang/coding/control/settings_manager.py
+++ b/src/loushang/coding/control/settings_manager.py
@@ -108,7 +108,10 @@ def _serialize_package_source(source: PackageSourceConfig) -> str | dict[str, ob
 def _serialize_model_selection(selection: ModelSelection | None) -> dict[str, str] | None:
     if selection is None:
         return None
-    return {"provider": selection.provider, "model_id": selection.model_id}
+    payload = {"provider": selection.provider, "model_id": selection.model_id}
+    if selection.endpoint_id:
+        payload["endpoint_id"] = selection.endpoint_id
+    return payload
 
 
 def _deserialize_model_selection(value: object) -> ModelSelection | None:
@@ -120,7 +123,12 @@ def _deserialize_model_selection(value: object) -> ModelSelection | None:
     model_id = value.get("model_id")
     if not isinstance(provider, str) or not isinstance(model_id, str):
         raise TypeError("default_model must include string provider and model_id values")
-    return ModelSelection(provider=provider, model_id=model_id)
+    endpoint_id = value.get("endpoint_id") or value.get("endpointId")
+    return ModelSelection(
+        provider=provider,
+        model_id=model_id,
+        endpoint_id=endpoint_id if isinstance(endpoint_id, str) else None,
+    )
 
 
 def _deserialize_queue_mode(value: object, field_name: str) -> QueueMode:

--- a/src/loushang/coding/message/entries.py
+++ b/src/loushang/coding/message/entries.py
@@ -41,6 +41,7 @@ class ThinkingLevelChangeEntry(SessionEntryBase):
 class ModelChangeEntry(SessionEntryBase):
     provider: str
     model_id: str
+    endpoint_id: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/loushang/coding/mode/rpc_mode.py
+++ b/src/loushang/coding/mode/rpc_mode.py
@@ -47,6 +47,7 @@ class RpcModel(TypedDict, total=False):
     provider: Required[str]
     id: Required[str]
     name: Required[str]
+    endpointId: NotRequired[str]
     api: NotRequired[str]
     baseUrl: NotRequired[str]
     input: NotRequired[list[str]]
@@ -765,7 +766,12 @@ class RpcMode(ModeAdapter):
     async def _handle_set_model_command(self, command_id: str | None, payload: dict[str, Any]) -> None:
         provider = self._require_string(payload, "provider")
         model_id = self._require_string(payload, "modelId", "model_id")
-        selection = ModelSelection(provider=provider, model_id=model_id)
+        endpoint_id = payload.get("endpointId") or payload.get("endpoint_id")
+        selection = ModelSelection(
+            provider=provider,
+            model_id=model_id,
+            endpoint_id=endpoint_id if isinstance(endpoint_id, str) else None,
+        )
         try:
             available_models = self.session.get_available_models()
         except Exception as error:
@@ -2038,10 +2044,13 @@ class RpcMode(ModeAdapter):
     def _serialize_model_selection(self, selection: ModelSelection | None) -> dict[str, str] | None:
         if selection is None:
             return None
-        return {
+        payload = {
             "provider": selection.provider,
             "modelId": selection.model_id,
         }
+        if selection.endpoint_id:
+            payload["endpointId"] = selection.endpoint_id
+        return payload
 
     def _serialize_model_selection_as_model(self, selection: ModelSelection | None) -> RpcModel | None:
         if selection is None:
@@ -2053,10 +2062,11 @@ class RpcMode(ModeAdapter):
             model_id = self._safe_string(model_id) if model_id is not None else None
             if not provider or not model_id:
                 return None
-        return {
+        payload: RpcModel = {
             "provider": provider,
             "id": model_id,
         }
+        return payload
 
     def _serialize_model(self, session: Any, model: object) -> RpcModel | None:
         provider = self._safe_getattr(model, "provider_id", None) or self._safe_getattr(model, "provider", None)
@@ -2068,7 +2078,6 @@ class RpcMode(ModeAdapter):
             "provider": str(provider),
             "id": str(model_id),
         }
-
         name = self._safe_getattr(model, "name", None)
         if isinstance(name, str) and name:
             data["name"] = name

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -416,6 +416,7 @@ class AgentSession:
             selection = ModelSelection(
                 provider=session_context.model["provider"],
                 model_id=session_context.model["model_id"],
+                endpoint_id=session_context.model.get("endpoint_id"),
             )
             if self.get_model_selection() != selection and self.model_registry is not None:
                 try:

--- a/src/loushang/coding/session/extension_provider_controller.py
+++ b/src/loushang/coding/session/extension_provider_controller.py
@@ -163,6 +163,9 @@ def _native_endpoint_from_extension_dict(
         or (existing_endpoint.base_url_env if existing_endpoint is not None else None),
         region=_optional_string(config.get("region")) or (existing_endpoint.region if existing_endpoint is not None else None),
         lane=_optional_string(config.get("lane")) or (existing_endpoint.lane if existing_endpoint is not None else None),
+        preferred=_optional_bool(config.get("preferred"))
+        if "preferred" in config
+        else (existing_endpoint.preferred if existing_endpoint is not None else False),
         docs=_optional_string(config.get("docs")) or (existing_endpoint.docs if existing_endpoint is not None else None),
         auth=_auth_from_native_raw(
             config.get("auth") if "auth" in config else config.get("authOverride")
@@ -221,3 +224,7 @@ def _optional_mapping(value: object) -> Mapping[str, object] | None:
 
 def _optional_string(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _optional_bool(value: object) -> bool:
+    return value if isinstance(value, bool) else False

--- a/src/loushang/coding/session/selection_controller.py
+++ b/src/loushang/coding/session/selection_controller.py
@@ -52,7 +52,8 @@ class SelectionController:
     async def set_model(self, model: Model | ModelSelection, *, emit_refresh: bool, source: str = "set") -> None:
         previous_model = self.agent.model
         resolved_model = self._resolve_model(model)
-        self._apply_model(resolved_model)
+        explicit_endpoint_id = model.endpoint_id if isinstance(model, ModelSelection) else None
+        self._apply_model(resolved_model, endpoint_id=explicit_endpoint_id)
         if emit_refresh:
             await self.refresh_extension_runtime("model_selection_changed")
         runner = self.get_extension_runner()
@@ -69,7 +70,7 @@ class SelectionController:
 
     async def set_model_from_extension(self, selection: ModelSelection) -> None:
         resolved_model = self._resolve_model_from_selection(selection)
-        self._apply_model(resolved_model)
+        self._apply_model(resolved_model, endpoint_id=selection.endpoint_id)
         if not self.is_extension_runtime_refreshing():
             await self.refresh_extension_runtime("model_selection_changed")
 
@@ -123,8 +124,13 @@ class SelectionController:
         if isinstance(model, dict):
             provider = model.get("provider") or model.get("provider_id") or model.get("providerId")
             model_id = model.get("model_id") or model.get("modelId") or model.get("id")
+            endpoint_id = model.get("endpoint_id") or model.get("endpointId") or model.get("endpoint")
             if isinstance(provider, str) and isinstance(model_id, str):
-                return ModelSelection(provider=provider, model_id=model_id)
+                return ModelSelection(
+                    provider=provider,
+                    model_id=model_id,
+                    endpoint_id=endpoint_id if isinstance(endpoint_id, str) else None,
+                )
         return None
 
     def set_thinking_level(self, level: ThinkingLevel) -> None:
@@ -168,13 +174,17 @@ class SelectionController:
             raise RuntimeError("ModelSelection requires a model registry")
         return _validate_model(registry.build_model(selection))
 
-    def _apply_model(self, model: Model) -> None:
+    def _apply_model(self, model: Model, *, endpoint_id: str | None = None) -> None:
         provider = getattr(model, "provider_id", None) or getattr(model, "provider", None)
         model_id = getattr(model, "id", None)
         if not provider or not model_id:
             raise ValueError("Model updates require a provider and model id.")
         self.agent.model = model
-        self.session_manager.append_model_change(str(provider), str(model_id))
+        self.session_manager.append_model_change(
+            str(provider),
+            str(model_id),
+            endpoint_id=endpoint_id,
+        )
         self.record_model_auth_resolution(model)
 
 

--- a/src/loushang/coding/store/file_codec.py
+++ b/src/loushang/coding/store/file_codec.py
@@ -64,6 +64,8 @@ def _serialize_entry(entry: SessionEntry) -> dict[str, Any]:
     if isinstance(entry, ModelChangeEntry):
         data["provider"] = entry.provider
         data["modelId"] = entry.model_id
+        if entry.endpoint_id:
+            data["endpointId"] = entry.endpoint_id
         return data
     if isinstance(entry, CompactionEntry):
         data["summary"] = entry.summary
@@ -112,7 +114,12 @@ def _deserialize_entry(payload: dict[str, Any]) -> SessionEntry:
     if entry_type == "thinking_level_change":
         return ThinkingLevelChangeEntry(thinking_level=payload["thinkingLevel"], **common)
     if entry_type == "model_change":
-        return ModelChangeEntry(provider=payload["provider"], model_id=payload["modelId"], **common)
+        return ModelChangeEntry(
+            provider=payload["provider"],
+            model_id=payload["modelId"],
+            endpoint_id=payload.get("endpointId"),
+            **common,
+        )
     if entry_type == "compaction":
         return CompactionEntry(
             summary=payload["summary"],
@@ -208,4 +215,3 @@ def load_session_file(path: Path) -> tuple[SessionHeader, list[SessionEntry]]:
         except Exception:
             continue
     return header, entries
-

--- a/src/loushang/coding/store/session_manager.py
+++ b/src/loushang/coding/store/session_manager.py
@@ -286,7 +286,11 @@ def _model(value: object) -> dict[str, str] | None:
     provider = value.get("provider")
     model_id = value.get("model_id")
     if isinstance(provider, str) and isinstance(model_id, str):
-        return {"provider": provider, "model_id": model_id}
+        payload = {"provider": provider, "model_id": model_id}
+        endpoint_id = value.get("endpoint_id") or value.get("endpointId")
+        if isinstance(endpoint_id, str):
+            payload["endpoint_id"] = endpoint_id
+        return payload
     return None
 
 
@@ -356,6 +360,8 @@ def build_session_context(
             thinking_level = entry.thinking_level
         elif isinstance(entry, ModelChangeEntry):
             model = {"provider": entry.provider, "model_id": entry.model_id}
+            if entry.endpoint_id:
+                model["endpoint_id"] = entry.endpoint_id
         elif isinstance(entry, SessionMessageEntry) and isinstance(entry.message, AssistantMessage):
             model = {"provider": entry.message.provider, "model_id": entry.message.model}
         elif isinstance(entry, CompactionEntry):
@@ -774,7 +780,13 @@ class SessionManager:
             )
         )
 
-    def append_model_change(self, provider: str, model_id: str) -> str:
+    def append_model_change(
+        self,
+        provider: str,
+        model_id: str,
+        *,
+        endpoint_id: str | None = None,
+    ) -> str:
         return self.append_entry(
             ModelChangeEntry(
                 type="model_change",
@@ -783,6 +795,7 @@ class SessionManager:
                 timestamp=_now_iso(),
                 provider=provider,
                 model_id=model_id,
+                endpoint_id=endpoint_id,
             )
         )
 

--- a/src/loushang/coding/types.py
+++ b/src/loushang/coding/types.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 class ModelSelection:
     provider: str
     model_id: str
+    endpoint_id: str | None = None
 
 
 def __getattr__(name: str):

--- a/src/loushang/coding/ui/model.py
+++ b/src/loushang/coding/ui/model.py
@@ -28,9 +28,10 @@ def normalize_model_selection(selection: object | None) -> ModelSelection | None
         return None
     provider = _string_attr(selection, "provider", "provider_id", "providerId")
     model_id = _string_attr(selection, "model_id", "modelId", "id")
+    endpoint_id = _string_attr(selection, "endpoint_id", "endpoint", "endpointId")
     if provider is None or model_id is None:
         return None
-    return ModelSelection(provider=provider, model_id=model_id)
+    return ModelSelection(provider=provider, model_id=model_id, endpoint_id=endpoint_id)
 
 
 def is_usable_model_selection(selection: object | None) -> bool:
@@ -82,7 +83,7 @@ async def iter_available_model_selections(session: Any) -> list[ModelSelection]:
         selection = normalize_model_selection(raw_model)
         if selection is None or not is_usable_model_selection(selection):
             continue
-        key = (selection.provider, selection.model_id)
+        key = (selection.provider, selection.endpoint_id or "", selection.model_id)
         if key in seen:
             continue
         seen.add(key)
@@ -101,7 +102,7 @@ async def iter_scoped_model_selections(session: Any) -> list[ModelSelection]:
         selection = normalize_model_selection(scoped_model)
         if selection is None or not is_usable_model_selection(selection):
             continue
-        key = (selection.provider, selection.model_id)
+        key = (selection.provider, selection.endpoint_id or "", selection.model_id)
         if key in seen:
             continue
         seen.add(key)

--- a/src/loushang/coding/ui/model_list.py
+++ b/src/loushang/coding/ui/model_list.py
@@ -20,6 +20,10 @@ class ModelChoice:
     value: str
     selection: object
     endpoint_id: str = ""
+    region: str = ""
+    lane: str = ""
+    api: str = ""
+    preferred_endpoint: bool = False
     description: str = ""
 
 
@@ -104,6 +108,11 @@ async def select_available_model(session: Any, *, query: str = "", choose: Model
 async def available_model_choices(session: Any) -> list[ModelChoice]:
     current_identity = await _current_model_identity(session)
     detail_choices = _model_choices_from_details(await _available_model_details(session))
+    current_detail_value = _selected_current_choice_value(detail_choices, current_identity)
+    detail_choices = _dedupe_preferred_detail_choices(
+        detail_choices,
+        current_value=current_detail_value,
+    )
     selection_choices = [
         ModelChoice(label=label, value=label, selection=selection)
         for selection in await iter_available_model_selections(session)
@@ -239,10 +248,46 @@ def _model_choices_from_details(details: list[object]) -> list[ModelChoice]:
                 value=value,
                 selection=detail,
                 endpoint_id=endpoint_id or "",
+                region=_string_attr(detail, "region") or "",
+                lane=_string_attr(detail, "lane") or "",
+                api=_string_attr(detail, "api") or "",
+                preferred_endpoint=_bool_attr(
+                    detail,
+                    "preferred_endpoint",
+                    "preferredEndpoint",
+                    "preferred",
+                ),
                 description=_model_detail_description(detail),
             )
         )
     return choices
+
+
+def _dedupe_preferred_detail_choices(
+    choices: list[ModelChoice],
+    *,
+    current_value: str | None,
+) -> list[ModelChoice]:
+    by_label: dict[str, list[ModelChoice]] = {}
+    for choice in choices:
+        by_label.setdefault(choice.label, []).append(choice)
+
+    result: list[ModelChoice] = []
+    for choice in choices:
+        group = by_label[choice.label]
+        if len(group) == 1:
+            result.append(choice)
+            continue
+        preferred = [item for item in group if item.preferred_endpoint]
+        if len(preferred) != 1:
+            result.append(choice)
+            continue
+        keep_values = {preferred[0].value}
+        if current_value in {item.value for item in group}:
+            keep_values.add(str(current_value))
+        if choice.value in keep_values:
+            result.append(choice)
+    return result
 
 
 def _model_choice_value(
@@ -255,6 +300,14 @@ def _model_choice_value(
     if provider and endpoint_id and model_id:
         return f"{provider}:{endpoint_id}:{model_id}"
     return fallback
+
+
+def _bool_attr(value: object, *names: str) -> bool:
+    for name in names:
+        attr = getattr(value, name, None)
+        if isinstance(attr, bool):
+            return attr
+    return False
 
 
 def _choice_matches_text(choice: ModelChoice, needle: str) -> bool:
@@ -272,6 +325,12 @@ def _choice_description(choice: ModelChoice, *, current_value: str | None) -> st
         parts.append("current")
     if choice.endpoint_id:
         parts.append(f"endpoint: {choice.endpoint_id}")
+    if choice.region:
+        parts.append(f"region: {choice.region}")
+    if choice.lane:
+        parts.append(f"lane: {choice.lane}")
+    if choice.api:
+        parts.append(f"protocol: {choice.api}")
     if choice.description:
         parts.append(choice.description)
     return " - ".join(parts)

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -659,6 +659,12 @@ def _model_choice_selector_description(choice: ModelChoice, *, current_value: st
         parts.append("current")
     if choice.endpoint_id:
         parts.append(f"endpoint: {choice.endpoint_id}")
+    if choice.region:
+        parts.append(f"region: {choice.region}")
+    if choice.lane:
+        parts.append(f"lane: {choice.lane}")
+    if choice.api:
+        parts.append(f"protocol: {choice.api}")
     if choice.description:
         parts.append(choice.description)
     return " - ".join(parts)

--- a/tests/ai/test_cli_console.py
+++ b/tests/ai/test_cli_console.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from loushang.ai.cli.__main__ import _resolve_console_api_key, main
@@ -109,6 +111,18 @@ def test_console_uses_env_api_key_for_selected_binding(
         in output
     )
     assert "Current model: moonshot:openai-completions:kimi-a" in output
+
+
+def test_models_show_accepts_provider_model_reference(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    main(["--json", "models", "show", "moonshot/kimi-a"])
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["provider"] == "moonshot"
+    assert payload["endpoint"] == "openai-completions"
+    assert payload["id"] == "kimi-a"
 
 
 def test_console_prompts_for_api_key_when_env_missing(

--- a/tests/ai/test_model_catalog.py
+++ b/tests/ai/test_model_catalog.py
@@ -24,3 +24,22 @@ def test_builtin_catalog_resolves_kimi_coding_anthropic_model() -> None:
     assert model.id == "kimi-for-coding"
     assert model.supports_stream is True
     assert model.supports_tool_use is True
+
+
+def test_builtin_catalog_marks_duplicate_short_model_routes_as_preferred() -> None:
+    registry = load_builtin_model_registry()
+
+    assert registry.get_endpoint("moonshot", "openai-completions").preferred is True
+    assert registry.get_endpoint("moonshot", "kimi-code-anthropic").preferred is True
+    assert registry.get_endpoint("dashscope", "openai-responses").preferred is True
+
+
+def test_builtin_catalog_models_expose_endpoint_lane_and_preferred_metadata() -> None:
+    registry = load_builtin_model_registry()
+
+    model = registry.get_model("moonshot", "kimi-code-anthropic", "kimi-for-coding")
+
+    assert model.api == "anthropic-messages"
+    assert model.region == "cn"
+    assert model.lane == "coding"
+    assert model.preferred_endpoint is True

--- a/tests/ai/test_model_loader_schema.py
+++ b/tests/ai/test_model_loader_schema.py
@@ -98,6 +98,131 @@ def test_model_registry_schema_accepts_auth_on_provider_endpoint_and_model() -> 
     validate_model_registry_raw(raw)
 
 
+def test_model_registry_schema_accepts_endpoint_preferred_flag() -> None:
+    raw = {
+        "providers": {
+            "custom": {
+                "endpoints": {
+                    "openai-responses": {
+                        "api": "openai-responses",
+                        "preferred": True,
+                        "models": {
+                            "model-a": {
+                                "capabilities": {
+                                    "input": ["text"],
+                                    "output": ["text"],
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        }
+    }
+
+    validate_model_registry_raw(raw)
+
+
+def test_model_registry_schema_accepts_colons_in_endpoint_keys() -> None:
+    raw = {
+        "providers": {
+            "custom": {
+                "endpoints": {
+                    "openai-completions:cn:coding": {
+                        "api": "openai-completions",
+                        "models": {
+                            "model-a": {
+                                "capabilities": {
+                                    "input": ["text"],
+                                    "output": ["text"],
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        }
+    }
+
+    validate_model_registry_raw(raw)
+
+
+def test_model_registry_schema_rejects_colons_in_provider_keys() -> None:
+    raw = {
+        "providers": {
+            "custom:cn": {
+                "endpoints": {
+                    "openai-responses": {
+                        "api": "openai-responses",
+                        "models": {
+                            "model-a": {
+                                "capabilities": {
+                                    "input": ["text"],
+                                    "output": ["text"],
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="must not contain ':'"):
+        validate_model_registry_raw(raw)
+
+
+def test_model_registry_schema_rejects_colons_in_model_keys() -> None:
+    raw = {
+        "providers": {
+            "custom": {
+                "endpoints": {
+                    "openai-responses": {
+                        "api": "openai-responses",
+                        "models": {
+                            "model:a": {
+                                "capabilities": {
+                                    "input": ["text"],
+                                    "output": ["text"],
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="must not contain ':'"):
+        validate_model_registry_raw(raw)
+
+
+def test_model_registry_schema_rejects_non_boolean_endpoint_preferred_flag() -> None:
+    raw = {
+        "providers": {
+            "custom": {
+                "endpoints": {
+                    "openai-responses": {
+                        "api": "openai-responses",
+                        "preferred": "yes",
+                        "models": {
+                            "model-a": {
+                                "capabilities": {
+                                    "input": ["text"],
+                                    "output": ["text"],
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        }
+    }
+
+    with pytest.raises(ValueError, match="preferred"):
+        validate_model_registry_raw(raw)
+
+
 def test_model_registry_schema_accepts_legacy_auth_override() -> None:
     raw = {
         "providers": {

--- a/tests/ai/test_model_registry_resolution.py
+++ b/tests/ai/test_model_registry_resolution.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import pytest
+
+from loushang.ai.model import Capabilities, Endpoint, Model, Provider
+from loushang.ai.model.registry import (
+    AmbiguousModelReference,
+    AmbiguousPreferredModelReference,
+    ModelRegistry,
+    resolve_model_ref,
+)
+
+
+def _model(model_id: str, *, provider: str = "provider", endpoint: str = "primary") -> Model:
+    return Model(
+        id=model_id,
+        provider=provider,
+        endpoint=endpoint,
+        capabilities=Capabilities(input=("text",), output=("text",)),
+    )
+
+
+def _registry(*, primary_preferred: bool = False, secondary_preferred: bool = False) -> ModelRegistry:
+    primary = Endpoint(
+        id="primary",
+        provider="provider",
+        api="openai-responses",
+        preferred=primary_preferred,
+        models={"chat": _model("chat", endpoint="primary")},
+    )
+    secondary = Endpoint(
+        id="secondary",
+        provider="provider",
+        api="openai-completions",
+        preferred=secondary_preferred,
+        models={"chat": _model("chat", endpoint="secondary")},
+    )
+    return ModelRegistry.from_providers(
+        {
+            "provider": Provider(
+                id="provider",
+                endpoints={primary.id: primary, secondary.id: secondary},
+            )
+        }
+    )
+
+
+def test_resolve_model_ref_uses_explicit_endpoint_identity() -> None:
+    registry = _registry()
+
+    model = resolve_model_ref(registry, "provider:secondary:chat")
+
+    assert model.provider_id == "provider"
+    assert model.endpoint_id == "secondary"
+    assert model.id == "chat"
+
+
+def test_resolve_model_ref_accepts_endpoint_identity_with_colons() -> None:
+    endpoint = Endpoint(
+        id="openai-completions:cn:coding",
+        provider="provider",
+        api="openai-completions",
+        models={
+            "chat": _model("chat", endpoint="openai-completions:cn:coding"),
+        },
+    )
+    registry = ModelRegistry.from_providers(
+        {"provider": Provider(id="provider", endpoints={endpoint.id: endpoint})}
+    )
+
+    model = resolve_model_ref(registry, "provider:openai-completions:cn:coding:chat")
+
+    assert model.endpoint_id == "openai-completions:cn:coding"
+    assert model.id == "chat"
+
+
+def test_resolve_provider_model_ref_uses_single_matching_endpoint() -> None:
+    endpoint = Endpoint(
+        id="primary",
+        provider="provider",
+        api="openai-responses",
+        models={"chat": _model("chat", endpoint="primary")},
+    )
+    registry = ModelRegistry.from_providers(
+        {"provider": Provider(id="provider", endpoints={endpoint.id: endpoint})}
+    )
+
+    model = resolve_model_ref(registry, "provider/chat")
+
+    assert model.endpoint_id == "primary"
+
+
+def test_resolve_provider_model_ref_uses_preferred_endpoint_when_duplicated() -> None:
+    registry = _registry(primary_preferred=True)
+
+    model = resolve_model_ref(registry, "provider/chat")
+
+    assert model.endpoint_id == "primary"
+
+
+def test_resolve_provider_model_ref_lists_explicit_candidates_when_ambiguous() -> None:
+    registry = _registry()
+
+    with pytest.raises(AmbiguousModelReference) as exc_info:
+        resolve_model_ref(registry, "provider/chat")
+
+    assert exc_info.value.candidates == (
+        "provider:primary:chat",
+        "provider:secondary:chat",
+    )
+    assert "provider:primary:chat" in str(exc_info.value)
+    assert "provider:secondary:chat" in str(exc_info.value)
+
+
+def test_resolve_provider_model_ref_rejects_multiple_preferred_endpoints() -> None:
+    registry = _registry(primary_preferred=True, secondary_preferred=True)
+
+    with pytest.raises(AmbiguousPreferredModelReference) as exc_info:
+        resolve_model_ref(registry, "provider/chat")
+
+    assert exc_info.value.candidates == (
+        "provider:primary:chat",
+        "provider:secondary:chat",
+    )

--- a/tests/auth/test_anthropic_oauth.py
+++ b/tests/auth/test_anthropic_oauth.py
@@ -90,6 +90,7 @@ def test_login_rejects_state_mismatch() -> None:
 	provider = AnthropicOAuthProvider(
 		http_post_json=_unexpected_post,
 		pkce_generator=lambda: ("expected-state", "test-challenge"),
+		browser_opener=lambda _url: False,
 		callback_waiter=_return_wrong_state_url,
 	)
 	callbacks = _Callbacks()
@@ -118,6 +119,7 @@ def test_login_falls_back_to_manual_input_when_callback_waiter_fails() -> None:
 	provider = AnthropicOAuthProvider(
 		http_post_json=fake_post,
 		pkce_generator=lambda: ("test-verifier", "test-challenge"),
+		browser_opener=lambda _url: False,
 		callback_waiter=broken_callback_waiter,
 	)
 

--- a/tests/auth/test_openai_codex_oauth.py
+++ b/tests/auth/test_openai_codex_oauth.py
@@ -11,6 +11,7 @@ import pytest
 from loushang.ai.auth import (
     clear_oauth_providers,
     get_oauth_provider,
+    list_oauth_providers,
     register_builtin_oauth_providers,
     reset_oauth_providers,
 )
@@ -205,6 +206,18 @@ def test_register_builtin_oauth_providers_includes_openai_codex() -> None:
     clear_oauth_providers()
     register_builtin_oauth_providers()
     assert get_oauth_provider("openai-codex") is not None
+
+
+def test_register_builtin_oauth_providers_lists_openai_codex_first() -> None:
+    clear_oauth_providers()
+    register_builtin_oauth_providers()
+
+    providers = list_oauth_providers()
+
+    assert [provider.id for provider in providers] == [
+        "openai-codex",
+        "anthropic",
+    ]
 
 
 def test_reset_oauth_providers_restores_builtin_openai_codex() -> None:

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -2565,6 +2565,76 @@ def test_run_cli_dispatches_print_mode_with_restored_session_and_model_override(
     assert print_runner.calls[0]["session"] is runtime.get_current_session()
 
 
+def test_run_cli_accepts_explicit_endpoint_model_override(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.coding.types import ModelSelection
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    print_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            [
+                "--mode",
+                "json",
+                "--session",
+                "session-1",
+                "--model",
+                "faux:responses:beta",
+                "hello",
+            ],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(str(tmp_path / "sessions")),
+            runtime_builder=lambda **kwargs: runtime,
+            print_runner=print_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert runtime.get_current_session().set_model_calls == [
+        ModelSelection(provider="faux", endpoint_id="responses", model_id="beta")
+    ]
+
+
+def test_run_cli_accepts_explicit_endpoint_model_override_with_colon_endpoint(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+    from loushang.coding.types import ModelSelection
+
+    runtime = FakeRuntime(FakeSession("session-1"))
+    print_runner = FakeRunner()
+
+    async def scenario() -> None:
+        exit_code = await run_cli(
+            [
+                "--mode",
+                "json",
+                "--session",
+                "session-1",
+                "--model",
+                "faux:responses:cn:beta",
+                "hello",
+            ],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(str(tmp_path / "sessions")),
+            runtime_builder=lambda **kwargs: runtime,
+            print_runner=print_runner,
+        )
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+
+    assert runtime.get_current_session().set_model_calls == [
+        ModelSelection(provider="faux", endpoint_id="responses:cn", model_id="beta")
+    ]
+
+
 def test_run_cli_dash_p_dispatches_prompt_command(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
 

--- a/tests/coding/test_control_model_registry.py
+++ b/tests/coding/test_control_model_registry.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import pytest
+
+from loushang.ai.model import Capabilities, Endpoint, Model, Provider
+from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
+from loushang.coding.control.model_registry import ModelRegistry
+from loushang.coding.types import ModelSelection
+
+
+def _model(model_id: str, *, endpoint: str) -> Model:
+    return Model(
+        id=model_id,
+        provider="provider",
+        endpoint=endpoint,
+        capabilities=Capabilities(input=("text",), output=("text",)),
+    )
+
+
+def _registry(*, primary_preferred: bool = True) -> ModelRegistry:
+    primary = Endpoint(
+        id="primary",
+        provider="provider",
+        api="openai-responses",
+        preferred=primary_preferred,
+        models={"chat": _model("chat", endpoint="primary")},
+    )
+    secondary = Endpoint(
+        id="secondary",
+        provider="provider",
+        api="openai-completions",
+        models={"chat": _model("chat", endpoint="secondary")},
+    )
+    ai_registry = AiModelRegistry.from_providers(
+        {
+            "provider": Provider(
+                id="provider",
+                endpoints={primary.id: primary, secondary.id: secondary},
+            )
+        }
+    )
+    return ModelRegistry(ai_registry)
+
+
+def test_control_model_registry_resolves_provider_model_to_preferred_endpoint() -> None:
+    model = _registry().build_model(ModelSelection(provider="provider", model_id="chat"))
+
+    assert model.endpoint_id == "primary"
+
+
+def test_control_model_registry_resolves_explicit_endpoint_selection() -> None:
+    model = _registry().build_model(
+        ModelSelection(provider="provider", endpoint_id="secondary", model_id="chat")
+    )
+
+    assert model.endpoint_id == "secondary"
+
+
+def test_control_model_registry_ambiguity_error_lists_explicit_alternatives() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        _registry(primary_preferred=False).build_model(
+            ModelSelection(provider="provider", model_id="chat")
+        )
+
+    message = str(exc_info.value)
+    assert "provider:primary:chat" in message
+    assert "provider:secondary:chat" in message

--- a/tests/coding/test_ui_model_list.py
+++ b/tests/coding/test_ui_model_list.py
@@ -59,12 +59,18 @@ class _DuplicateEndpointSession(_Session):
                 provider_id="dashscope",
                 endpoint_id="openai-responses",
                 id="qwen3.6-plus",
+                api="openai-responses",
+                region="cn",
+                preferred_endpoint=True,
                 name="Qwen 3.6 Plus",
             ),
             SimpleNamespace(
                 provider_id="dashscope",
                 endpoint_id="openai-completions:cn",
                 id="qwen3.6-plus",
+                api="openai-completions",
+                region="cn",
+                lane="coding",
                 name="Qwen 3.6 Plus",
             ),
         ]
@@ -90,6 +96,13 @@ class _DuplicateEndpointAgentModelSession(_DuplicateEndpointSession):
         super().__init__()
         self.selection = ModelSelection(provider="dashscope", model_id="qwen3.6-plus")
         self.agent = SimpleNamespace(model=self.model_details[1])
+
+
+class _AmbiguousDuplicateEndpointSession(_DuplicateEndpointSession):
+    def __init__(self) -> None:
+        super().__init__()
+        for detail in self.model_details:
+            detail.preferred_endpoint = False
 
 
 def test_format_available_models_marks_current_model() -> None:
@@ -285,10 +298,20 @@ def test_select_available_model_uses_full_identity_for_duplicate_endpoint_choice
     assert session.set_model_calls == [session.model_details[0]]
 
 
-def test_select_available_model_reports_duplicate_endpoint_label_as_ambiguous() -> None:
+def test_select_available_model_uses_preferred_endpoint_for_duplicate_label() -> None:
     from loushang.coding.ui.model_list import select_available_model
 
     session = _DuplicateEndpointSession()
+    text = asyncio.run(select_available_model(session, query="dashscope/qwen3.6-plus"))
+
+    assert text == "Model set: dashscope/qwen3.6-plus (endpoint: openai-responses)"
+    assert session.set_model_calls == [session.model_details[0]]
+
+
+def test_select_available_model_reports_duplicate_endpoint_label_as_ambiguous_without_preferred() -> None:
+    from loushang.coding.ui.model_list import select_available_model
+
+    session = _AmbiguousDuplicateEndpointSession()
     text = asyncio.run(select_available_model(session, query="dashscope/qwen3.6-plus"))
 
     assert text == (
@@ -309,8 +332,14 @@ def test_available_model_completion_provider_marks_only_current_endpoint() -> No
         "dashscope:openai-completions:cn:qwen3.6-plus",
         "dashscope:openai-responses:qwen3.6-plus",
     ]
-    assert provider.items[0].description == "current - endpoint: openai-completions:cn - Qwen 3.6 Plus"
-    assert provider.items[1].description == "endpoint: openai-responses - Qwen 3.6 Plus"
+    assert (
+        provider.items[0].description
+        == "current - endpoint: openai-completions:cn - region: cn - lane: coding - protocol: openai-completions - Qwen 3.6 Plus"
+    )
+    assert (
+        provider.items[1].description
+        == "endpoint: openai-responses - region: cn - protocol: openai-responses - Qwen 3.6 Plus"
+    )
 
 
 def test_available_model_completion_provider_uses_agent_model_endpoint_for_current() -> None:
@@ -322,5 +351,25 @@ def test_available_model_completion_provider_uses_agent_model_endpoint_for_curre
         "dashscope:openai-completions:cn:qwen3.6-plus",
         "dashscope:openai-responses:qwen3.6-plus",
     ]
-    assert provider.items[0].description == "current - endpoint: openai-completions:cn - Qwen 3.6 Plus"
-    assert provider.items[1].description == "endpoint: openai-responses - Qwen 3.6 Plus"
+    assert (
+        provider.items[0].description
+        == "current - endpoint: openai-completions:cn - region: cn - lane: coding - protocol: openai-completions - Qwen 3.6 Plus"
+    )
+    assert (
+        provider.items[1].description
+        == "endpoint: openai-responses - region: cn - protocol: openai-responses - Qwen 3.6 Plus"
+    )
+
+
+def test_available_model_completion_provider_dedupes_to_preferred_endpoint() -> None:
+    from loushang.coding.ui.model_list import available_model_completion_provider
+
+    provider = asyncio.run(available_model_completion_provider(_DuplicateEndpointSession()))
+
+    assert [item.value for item in provider.items] == [
+        "dashscope:openai-responses:qwen3.6-plus",
+    ]
+    assert (
+        provider.items[0].description
+        == "endpoint: openai-responses - region: cn - protocol: openai-responses - Qwen 3.6 Plus"
+    )

--- a/tests/test_package_scripts.py
+++ b/tests/test_package_scripts.py
@@ -8,3 +8,4 @@ def test_package_exposes_loushang_console_script() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
     assert pyproject["project"]["scripts"]["loushang"] == "loushang.coding.cli.__main__:main"
+    assert pyproject["project"]["scripts"]["loushang-ai"] == "loushang.ai.cli.__main__:main"


### PR DESCRIPTION
## Summary

  - Add endpoint-level preferred routing and shared model reference resolution for duplicate provider/model endpoints.
  - Keep explicit provider:endpoint:model selection working, including endpoint ids that contain ':'.
  - Expose endpoint, region, lane, and protocol metadata in /model UI and completions, with preferred-route de-duplication.
  - Register the loushang-ai console script and make OAuth auth tests avoid launching real Claude browser windows while listing Codex first.

  ## Issue

  Closes #110.

  ## Validation

  - make check-ai
  - uv run pytest tests -q