### PR TITLE
Refactor TUI render planning into strategies

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/render-framework/README.md
+++ b/docs/internals/architecture/tui/native-terminal-core/render-framework/README.md
@@ -1,10 +1,15 @@
 # Render Framework Spec Inventory
 
-This directory will hold detailed API specs for framework-level render contracts.
-Until those specs are written, this inventory defines the required initial
-surface.
+This directory holds detailed API specs for framework-level render contracts.
 
-## Required Specs
+## Available Specs
+
+| Spec | Purpose | Depends On |
+| --- | --- | --- |
+| `render-loop.md` | Logical screen diffing, strategy selection, operations, synchronized flush. | terminal-port, screen-root |
+| `managed-viewport.md` | Viewport top, previous viewport top, recovery rules, protected append. | render-loop |
+
+## Remaining Required Specs
 
 | Spec | Purpose | Depends On |
 | --- | --- | --- |
@@ -12,8 +17,6 @@ surface.
 | `container.md` | Ordered child renderables, constraint propagation, focus traversal. | renderable |
 | `focusable.md` | Routed input handling and cursor declaration. | renderable, input events |
 | `terminal-port.md` | The only terminal writer abstraction. | terminal capability model |
-| `render-loop.md` | Logical screen diffing, operations, synchronized flush. | terminal-port, screen-root |
-| `managed-viewport.md` | Viewport top, previous viewport top, recovery rules. | render-loop |
 | `repaint-policy.md` | Full repaint, resize repaint, recovery repaint, and clear-scrollback policy. | render-loop, managed-viewport |
 | `screen-root.md` | Screen region stack composition. | container, bottom-frame |
 | `surface-host.md` | Surface lifecycle, focus capture, overlay stack. | focusable, container |

--- a/docs/internals/architecture/tui/native-terminal-core/render-framework/managed-viewport.md
+++ b/docs/internals/architecture/tui/native-terminal-core/render-framework/managed-viewport.md
@@ -1,0 +1,114 @@
+# Managed Viewport
+
+## Purpose
+
+Define when the render loop may update terminal rows in place and when it must
+repaint runtime-owned visible rows.
+
+The managed viewport is the range of terminal rows that the runtime can still
+reason about after a successful frame. It is not the user's full terminal
+scrollback and it is not the product transcript source of truth.
+
+## Core Terms
+
+- `viewport_top`: logical row shown at the top of the visible terminal viewport
+  for the current frame.
+- `previous_viewport_top`: viewport top from the last committed frame.
+- `differential_viewport_top`: viewport top selected for partial diff updates
+  that preserve the previous physical mapping when safe.
+- managed viewport repaint: rewrite runtime-owned visible rows without clearing
+  scrollback.
+- resize repaint: rewrite runtime-owned visible rows after terminal size change;
+  default policy may clear scrollback.
+- recovery repaint: rewrite runtime-owned visible rows after an unsafe
+  non-resize condition.
+
+## Unsafe Partial Diff Cases
+
+Partial changed-range updates are unsafe when the render loop cannot prove that
+old logical rows still map to the same physical terminal rows.
+
+Important unsafe cases:
+
+- external stdout writes
+- inferred user scrollback movement
+- terminal width change
+- non-Termux terminal height change
+- changed range above the previous viewport top
+- shrink that would move the natural viewport top upward
+- explicit baseline reset from application state
+
+## Repaint Trigger Classes
+
+Internal triggers come from application state:
+
+- transcript window replaced
+- transcript window trimmed
+- context compaction replacement
+- explicit baseline reset
+
+External triggers come from terminal or environment state:
+
+- terminal resize
+- external stdout
+- inferred user scrollback movement
+- explicit unsafe viewport marker
+
+The distinction matters for diagnostics. Internal transcript-window trimming
+uses `managed_viewport_repaint`, ordinary baseline reset uses
+`baseline_repaint`, resize uses `resize_repaint`, and unsafe viewport recovery
+uses `recovery_repaint`.
+
+## Protected Append Admission
+
+`protected_append_update` inserts newly appended rows above protected bottom
+content, usually the composer or status area, while preserving bottom-frame
+cursor placement.
+
+All conditions must hold:
+
+1. A cursor is declared.
+2. `appended_lines > 0`.
+3. `len(current_lines) >= size.rows`.
+4. `inserted_start = first_changed`.
+5. `inserted_end = inserted_start + appended_lines`.
+6. `inserted_start > 0`.
+7. `inserted_end < len(current_lines)`.
+8. `inserted_start <= len(previous_lines)`.
+9. `protected_start = inserted_end`.
+10. `protected_height = len(current_lines) - protected_start`.
+11. `protected_height > 0`.
+12. `protected_height < size.rows`.
+13. `cursor.row >= protected_start`.
+14. The previous and current prefixes before `inserted_start` are equal.
+
+If any condition fails, the render loop must continue to later strategies.
+
+## Shrink Behavior
+
+Shrinks have two distinct paths:
+
+- `ShrinkViewportRepaintStrategy` uses `managed_viewport_repaint` when content
+  shrink would move the natural viewport top above the previous viewport top.
+  This avoids rewriting rows against a stale physical mapping.
+- `ShrinkClearStrategy` uses `shrink_clear` when the changed range starts beyond
+  the current line end and stale trailing rows must be cleared.
+
+These paths remain separate because one protects viewport mapping, while the
+other clears stale rows after a safe shrink.
+
+## Changed Range Above Viewport
+
+If the first changed row is above `previous_viewport_top`, partial diffing would
+depend on rows that may no longer be visible or writable at the expected
+physical position. The render loop must use `managed_viewport_repaint` with
+reason `changed_range_above_viewport`.
+
+## Clear Scrollback Policy
+
+Steady-state managed viewport repaint and recovery repaint must not clear
+scrollback unless policy explicitly allows it. Resize repaint may clear
+scrollback by default for deterministic visual recovery.
+
+Clear scrollback must remain visible in diagnostics through both policy and
+whether the operation was emitted.

--- a/docs/internals/architecture/tui/native-terminal-core/render-framework/render-loop.md
+++ b/docs/internals/architecture/tui/native-terminal-core/render-framework/render-loop.md
@@ -1,0 +1,128 @@
+# Render Loop
+
+## Purpose
+
+Define how the native terminal core turns a renderable tree into a stable
+terminal frame.
+
+The render loop owns render planning and terminal operation selection. It does
+not own product state, transcript history, input routing, or terminal writes.
+Terminal writes remain the responsibility of the runtime and terminal port.
+
+## Responsibilities
+
+Each frame:
+
+1. Renders the screen root with terminal width and visible height.
+2. Captures raw rendered lines from the `RenderResult`.
+3. Finalizes lines by preserving terminal reset state across frames.
+4. Normalizes the declared cursor into a logical cursor.
+5. Computes changed-line facts against the previous successful frame.
+6. Selects one render planning strategy in priority order.
+7. Returns `RenderDiagnostics` with terminal operations and frame metadata.
+
+`RenderLoop.commit()` is the only step that advances render-loop state. A plan
+that is never flushed or never committed must not update previous rendered
+lines, viewport tracking, hardware cursor tracking, or reset reasons.
+
+## Frame Facts
+
+`RenderPlanContext` contains facts about the current frame:
+
+- current and previous logical lines
+- current and previous terminal size
+- declared cursor and normalized logical cursor
+- changed-line range
+- append counts and append start
+- natural viewport top and differential viewport top
+- resize flags
+- previous Kitty image cleanup sequences
+
+These are facts, not decisions. Strategy code may consume them, but should not
+recompute them independently.
+
+`RenderPlanRuntime` exposes prior loop state and diagnostic builders:
+
+- previous viewport top
+- previous logical cursor position
+- previous hardware cursor position
+- clear-scrollback policy
+- baseline reset reason
+- unsafe viewport reason
+- diagnostic construction helpers
+
+Strategies must be stateless and must not mutate `RenderLoop`.
+
+## Strategy Order
+
+Render strategy priority is explicit:
+
+| Order | Strategy | operation_class |
+| --- | --- | --- |
+| 1 | `FirstRenderStrategy` | `first_render` |
+| 2 | `TranscriptWindowTrimmedResetStrategy` | `managed_viewport_repaint` |
+| 3 | `BaselineResetStrategy` | `baseline_repaint` |
+| 4 | `ResizeRepaintStrategy` | `resize_repaint` |
+| 5 | `UnsafeViewportStrategy` | `recovery_repaint` |
+| 6 | `NoChangeStrategy` | `cursor_update` or `noop` |
+| 7 | `AppendStrategy` | `append_update` |
+| 8 | `ProtectedAppendStrategy` | `protected_append_update` |
+| 9 | `ShrinkViewportRepaintStrategy` | `managed_viewport_repaint` |
+| 10 | `ShrinkClearStrategy` | `shrink_clear` |
+| 11 | `ChangedAboveViewportStrategy` | `managed_viewport_repaint` |
+| 12 | `ChangedRangeStrategy` | `changed_range_update` |
+
+The default strategy registry must not include an emergency fallback strategy.
+If no default strategy matches, the render loop should raise an assertion. That
+exposes missing coverage instead of silently turning logic gaps into repaint
+behavior.
+
+## Decision Cheat Sheet
+
+| Scenario | Strategy | Key condition |
+| --- | --- | --- |
+| First render | `FirstRenderStrategy` | `previous_size is None` |
+| Trimmed transcript reset | `TranscriptWindowTrimmedResetStrategy` | reset reason starts with `transcript_window_trimmed:` |
+| Ordinary baseline reset | `BaselineResetStrategy` | reset reason exists and is not a trimmed transcript reset |
+| Terminal resize | `ResizeRepaintStrategy` | width changed, or height changed outside Termux |
+| Unsafe viewport | `UnsafeViewportStrategy` | unsafe viewport reason exists |
+| Cursor-only update | `NoChangeStrategy` | no changed range and logical cursor changed |
+| No-op | `NoChangeStrategy` | no changed range and logical cursor stayed put |
+| Pure append | `AppendStrategy` | append starts exactly at the old line count |
+| Protected append | `ProtectedAppendStrategy` | appended content fits above protected bottom rows |
+| Shrink moves viewport up | `ShrinkViewportRepaintStrategy` | line count shrank and natural viewport top decreased |
+| Shrink clears stale rows | `ShrinkClearStrategy` | changed range starts beyond current line end after shrink |
+| Change above viewport | `ChangedAboveViewportStrategy` | first changed row is above previous viewport top |
+| Ordinary diff | `ChangedRangeStrategy` | changed range remains after earlier strategies decline |
+
+## Cursor Model
+
+Renderable output may declare a cursor in `RenderResult`. The render loop also
+normalizes a missing cursor to the end of the last logical line so cursor-only
+updates can be compared consistently.
+
+Hardware cursor movement is planned after render writes. Cursor row placement is
+viewport-relative: the logical cursor row is mapped through the selected
+viewport top before terminal cursor movement is emitted.
+
+## Kitty Image Cleanup
+
+Changed and repaint paths must delete previous Kitty image placements that can
+be invalidated by the planned frame. Repaint paths use cleanup sequences from
+the previous frame. Changed-range and shrink paths use range-specific cleanup.
+
+## Failure And Commit Semantics
+
+Planning is side-effect-light. It may cache the raw planned lines for a future
+commit, but it must not advance previous rendered lines or clear reset reasons.
+
+Only `commit()` updates:
+
+- previous rendered lines
+- previous raw lines
+- previous terminal size
+- previous viewport top
+- hardware cursor row and column
+- previous logical cursor row and column
+- working-area high-water mark
+- baseline reset and unsafe viewport reasons

--- a/docs/superpowers/plans/2026-06-09-tui-render-loop-strategy-implementation.md
+++ b/docs/superpowers/plans/2026-06-09-tui-render-loop-strategy-implementation.md
@@ -53,7 +53,7 @@ def test_render_plan_context_carries_cursor_and_diff_facts() -> None:
     root.lines = ("alpha", "beta" + CURSOR_MARKER)
     context = loop._build_plan_context(size)
 
-    assert context.raw_current_lines == ("alpha", "beta" + CURSOR_MARKER)
+    assert context.raw_current_lines == ("alpha", "beta")
     assert context.current_lines == ("alpha", "beta")
     assert context.declared_cursor == CursorDeclaration(row=1, column=4)
     assert context.cursor == CursorDeclaration(row=1, column=4)

--- a/docs/superpowers/plans/2026-06-09-tui-render-loop-strategy-implementation.md
+++ b/docs/superpowers/plans/2026-06-09-tui-render-loop-strategy-implementation.md
@@ -1,0 +1,512 @@
+# TUI RenderLoop Strategy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `RenderLoop.plan()` into an explicit, stateless strategy pipeline while preserving existing terminal behavior and diagnostics.
+
+**Architecture:** Build an eager `RenderPlanContext` with frame facts, expose loop state through a narrow `RenderPlanRuntime`, and migrate existing render-path branches into stateless strategies ordered by `DEFAULT_STRATEGY_ORDER`. Existing operation helpers stay in `render_loop.py` unless moving them clearly reduces coupling.
+
+**Tech Stack:** Python 3.11+, dataclasses, pytest, existing `loushang.tui` fake terminal/playback tests, `uv --cache-dir .uv-cache run --extra dev pytest`.
+
+---
+
+## Reference Documents
+
+- Spec: `docs/superpowers/specs/2026-06-09-tui-render-loop-strategy-design.md`
+- Current implementation: `src/loushang/tui/render_loop.py`
+- Core render tests: `tests/tui/test_render_loop.py`
+- Long-session perf probes: `tests/coding/test_native_coding_tui_perf_probe.py`
+
+## File Structure
+
+- Modify `src/loushang/tui/render_loop.py`
+  - Owns `RenderLoop`, `RenderPlanContext`, `RenderPlanRuntime`, strategy kinds, strategy registry, and extracted strategies.
+  - Keep this in one file for the first refactor to minimize import churn. Split later only if the strategy section becomes difficult to navigate.
+- Modify `tests/tui/test_render_loop.py`
+  - Add strategy order and priority regression tests.
+  - Keep existing operation-class tests as behavior coverage.
+- Modify `tests/coding/test_native_coding_tui_perf_probe.py`
+  - Tighten active-window bounded render-loop assertions.
+- Create `docs/internals/architecture/tui/native-terminal-core/render-framework/render-loop.md`
+  - Product-neutral render-loop strategy and operation-class documentation.
+- Create `docs/internals/architecture/tui/native-terminal-core/render-framework/managed-viewport.md`
+  - Managed viewport repaint, shrink, and protected append admission documentation.
+
+## Task 1: Extract RenderPlanContext Without Strategy Dispatch
+
+**Files:**
+- Modify: `src/loushang/tui/render_loop.py`
+- Test: `tests/tui/test_render_loop.py`
+
+- [ ] **Step 1: Add a failing context contract test**
+
+Add a test near the render-loop diagnostics tests:
+
+```python
+def test_render_plan_context_carries_cursor_and_diff_facts() -> None:
+    root = SequenceRoot(["alpha"], ["alpha", "beta"])
+    loop = RenderLoop(root)
+    first = loop.plan(TerminalSize(columns=20, rows=5))
+    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+
+    second = loop.plan(TerminalSize(columns=20, rows=5))
+
+    assert second.operation_class == "append_update"
+    assert second.appended_lines == 1
+    assert second.append_start == 1
+```
+
+Use existing test helpers in `tests/tui/test_render_loop.py` where possible. If `SequenceRoot` does not exist, add the smallest local renderable helper matching current test style.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py::test_render_plan_context_carries_cursor_and_diff_facts -q
+```
+
+Expected: FAIL because the new helper/test is not yet wired to a context extraction behavior or because helper names need implementation.
+
+- [ ] **Step 3: Add internal dataclasses**
+
+In `src/loushang/tui/render_loop.py`, add:
+
+```python
+@dataclass(frozen=True, slots=True)
+class RenderPlanContext:
+    size: TerminalSize
+    result: RenderResult
+    raw_current_lines: tuple[str, ...]
+    current_lines: tuple[str, ...]
+    previous_lines: tuple[str, ...]
+    previous_size: TerminalSize | None
+    declared_cursor: CursorDeclaration | None
+    cursor: CursorDeclaration
+    changed_range: tuple[int, int] | None
+    first_changed: int | None
+    last_changed: int | None
+    appended_lines: int
+    append_start: int | None
+    viewport_top: int
+    differential_viewport_top: int
+    width_changed: bool
+    height_changed: bool
+    previous_kitty_delete_sequences: tuple[str, ...]
+```
+
+Add `RenderLoop._build_plan_context(size)` and move current local frame fact construction from `plan()` into it. Preserve `self._planned_raw_lines = raw_current_lines`.
+
+Use `first_changed = None`, `last_changed = None`, and `append_start = None` when `changed_range is None`. Compute `differential_viewport_top` eagerly using the existing `_differential_viewport_top()` helper.
+
+- [ ] **Step 4: Rewrite `plan()` to use context fields only**
+
+Keep all existing branch logic in `plan()`, but replace local variables with `context.<field>`. Do not introduce strategy dispatch yet.
+
+- [ ] **Step 5: Run focused render-loop tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git add src/loushang/tui/render_loop.py tests/tui/test_render_loop.py
+git commit -m "refactor(tui): extract render plan context"
+```
+
+## Task 2: Add Strategy Kind, Runtime Facade, and Order Tests
+
+**Files:**
+- Modify: `src/loushang/tui/render_loop.py`
+- Modify: `tests/tui/test_render_loop.py`
+
+- [ ] **Step 1: Write failing strategy order test**
+
+Add:
+
+```python
+def test_default_render_strategy_order_matches_design() -> None:
+    assert DEFAULT_STRATEGY_ORDER == (
+        RenderPlanStrategyKind.FIRST_RENDER,
+        RenderPlanStrategyKind.TRANSCRIPT_WINDOW_TRIMMED_RESET,
+        RenderPlanStrategyKind.BASELINE_RESET,
+        RenderPlanStrategyKind.RESIZE_REPAINT,
+        RenderPlanStrategyKind.UNSAFE_VIEWPORT,
+        RenderPlanStrategyKind.NO_CHANGE,
+        RenderPlanStrategyKind.APPEND,
+        RenderPlanStrategyKind.PROTECTED_APPEND,
+        RenderPlanStrategyKind.SHRINK_VIEWPORT_REPAINT,
+        RenderPlanStrategyKind.SHRINK_CLEAR,
+        RenderPlanStrategyKind.CHANGED_ABOVE_VIEWPORT,
+        RenderPlanStrategyKind.CHANGED_RANGE,
+    )
+```
+
+- [ ] **Step 2: Run order test and verify RED**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py::test_default_render_strategy_order_matches_design -q
+```
+
+Expected: FAIL because `RenderPlanStrategyKind` and `DEFAULT_STRATEGY_ORDER` do not exist.
+
+- [ ] **Step 3: Add enum, protocol, runtime facade, and registry skeleton**
+
+In `render_loop.py`:
+
+```python
+class RenderPlanStrategyKind(Enum): ...
+
+DEFAULT_STRATEGY_ORDER = (...)
+
+class RenderPlanStrategy(Protocol): ...
+
+@dataclass(frozen=True, slots=True)
+class RenderPlanRuntime:
+    previous_viewport_top: int
+    previous_cursor_row: int
+    previous_cursor_column: int
+    hardware_cursor_row: int
+    hardware_cursor_column: int
+    working_area_high_water_mark: int
+    termux_session: bool
+    clear_scrollback_policy: ClearScrollbackPolicy
+    baseline_reset_reason: str | None
+    unsafe_viewport_reason: str | None
+```
+
+Add `RenderLoop._plan_runtime()`.
+
+Do not change `plan()` dispatch yet.
+
+- [ ] **Step 4: Run order test and full render-loop tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add src/loushang/tui/render_loop.py tests/tui/test_render_loop.py
+git commit -m "refactor(tui): declare render plan strategy order"
+```
+
+## Task 3: Extract Simple Strategies
+
+**Files:**
+- Modify: `src/loushang/tui/render_loop.py`
+- Modify: `tests/tui/test_render_loop.py`
+
+- [ ] **Step 1: Write priority tests for simple strategies**
+
+Add tests:
+
+```python
+def test_resize_repaint_precedes_changed_range_strategy() -> None:
+    root = MutableRoot(["one"])
+    loop = RenderLoop(root)
+    first = loop.plan(TerminalSize(columns=20, rows=5))
+    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+
+    root.lines = ["two"]
+    step = loop.plan(TerminalSize(columns=30, rows=5))
+
+    assert step.operation_class == "resize_repaint"
+
+
+def test_unsafe_viewport_precedes_append_strategy() -> None:
+    root = MutableRoot(["one"])
+    loop = RenderLoop(root)
+    first = loop.plan(TerminalSize(columns=20, rows=5))
+    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+
+    root.lines = ["one", "two"]
+    loop.mark_viewport_unsafe("external_stdout")
+    step = loop.plan(TerminalSize(columns=20, rows=5))
+
+    assert step.operation_class == "recovery_repaint"
+    assert step.repaint_reason == "external_stdout"
+```
+
+Use existing mutable renderable helpers if present.
+
+- [ ] **Step 2: Run priority tests and verify RED or existing PASS**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py::test_resize_repaint_precedes_changed_range_strategy tests/tui/test_render_loop.py::test_unsafe_viewport_precedes_append_strategy -q
+```
+
+Expected: These may PASS on existing code. If they pass, keep them as characterization tests before refactor.
+
+- [ ] **Step 3: Implement simple strategy classes**
+
+Extract these classes:
+
+- `FirstRenderStrategy`
+- `ResizeRepaintStrategy`
+- `UnsafeViewportStrategy`
+- `NoChangeStrategy`
+
+Each class must be stateless and call existing operation/diagnostic helpers through minimal runtime/loop builder methods. If passing builders through `RenderPlanRuntime` becomes awkward, keep private helper calls in `RenderLoop` and make strategy `plan()` return an internal `RenderPlanDecision` for the loop to materialize. Choose the smaller implementation that preserves the spec boundary.
+
+- [ ] **Step 4: Add dispatch for extracted strategies only**
+
+`RenderLoop.plan()` should:
+
+1. Build context and runtime.
+2. Try extracted strategies in order.
+3. Fall through to the existing inline baseline reset and complex diff code.
+
+Do not extract baseline reset in this task.
+
+- [ ] **Step 5: Run render-loop tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add src/loushang/tui/render_loop.py tests/tui/test_render_loop.py
+git commit -m "refactor(tui): extract simple render plan strategies"
+```
+
+## Task 4: Extract Baseline Reset and Complex Diff Strategies
+
+**Files:**
+- Modify: `src/loushang/tui/render_loop.py`
+- Modify: `tests/tui/test_render_loop.py`
+
+- [ ] **Step 1: Write baseline reset priority tests**
+
+Add:
+
+```python
+def test_transcript_window_trimmed_reset_precedes_resize_repaint() -> None:
+    root = MutableRoot(["one"])
+    loop = RenderLoop(root)
+    first = loop.plan(TerminalSize(columns=20, rows=5))
+    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+
+    root.lines = ["one", "two"]
+    loop.reset_baseline("transcript_window_trimmed:active_line_budget")
+    step = loop.plan(TerminalSize(columns=30, rows=5))
+
+    assert step.operation_class == "managed_viewport_repaint"
+    assert step.repaint_reason == "transcript_window_trimmed:active_line_budget"
+
+
+def test_ordinary_baseline_reset_precedes_resize_repaint() -> None:
+    root = MutableRoot(["one"])
+    loop = RenderLoop(root)
+    first = loop.plan(TerminalSize(columns=20, rows=5))
+    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+
+    root.lines = ["one", "two"]
+    loop.reset_baseline("transcript_window_replaced:resume")
+    step = loop.plan(TerminalSize(columns=30, rows=5))
+
+    assert step.operation_class == "baseline_repaint"
+    assert step.repaint_reason == "transcript_window_replaced:resume"
+```
+
+- [ ] **Step 2: Run tests and verify characterization**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py::test_transcript_window_trimmed_reset_precedes_resize_repaint tests/tui/test_render_loop.py::test_ordinary_baseline_reset_precedes_resize_repaint -q
+```
+
+Expected: PASS on existing code or after minor helper setup.
+
+- [ ] **Step 3: Extract remaining strategies**
+
+Extract:
+
+- `TranscriptWindowTrimmedResetStrategy`
+- `BaselineResetStrategy`
+- `AppendStrategy`
+- `ProtectedAppendStrategy`
+- `ShrinkViewportRepaintStrategy`
+- `ShrinkClearStrategy`
+- `ChangedAboveViewportStrategy`
+- `ChangedRangeStrategy`
+
+Then make `RenderLoop.plan()` dispatch through `DEFAULT_STRATEGY_ORDER` without inline branch leftovers.
+
+Do not include `FallbackRepaintStrategy` in default order.
+
+- [ ] **Step 4: Run full render-loop tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src/loushang/tui/render_loop.py tests/tui/test_render_loop.py
+git commit -m "refactor(tui): route render planning through strategies"
+```
+
+## Task 5: Tighten Long-Session Performance Guards
+
+**Files:**
+- Modify: `tests/coding/test_native_coding_tui_perf_probe.py`
+
+- [ ] **Step 1: Write bounded active-window assertion**
+
+In `test_long_transcript_probe_stays_bounded_after_active_window_trim`, add:
+
+```python
+assert second_metrics.render_loop_logical_line_count == first_metrics.render_loop_logical_line_count
+```
+
+If current bottom-frame behavior makes exact equality too brittle, assert:
+
+```python
+assert second_metrics.render_loop_logical_line_count <= first_metrics.render_loop_logical_line_count + 5
+```
+
+Prefer equality unless the test shows a legitimate small bottom-frame growth.
+
+- [ ] **Step 2: Run perf probe**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_perf_probe.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run focused TUI and perf tests together**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py tests/coding/test_native_coding_tui_perf_probe.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 5**
+
+```bash
+git add tests/coding/test_native_coding_tui_perf_probe.py
+git commit -m "test(tui): tighten active window render planning guard"
+```
+
+## Task 6: Add Render Framework Docs
+
+**Files:**
+- Create: `docs/internals/architecture/tui/native-terminal-core/render-framework/render-loop.md`
+- Create: `docs/internals/architecture/tui/native-terminal-core/render-framework/managed-viewport.md`
+- Modify: `docs/internals/architecture/tui/native-terminal-core/render-framework/README.md`
+
+- [ ] **Step 1: Create `render-loop.md`**
+
+Include:
+
+- RenderLoop responsibilities
+- frame construction
+- strategy ordering table
+- Decision Cheat Sheet from the spec
+- commit/failure semantics
+- cursor positioning model
+- Kitty image cleanup interaction
+
+- [ ] **Step 2: Create `managed-viewport.md`**
+
+Include:
+
+- viewport top and previous viewport top
+- unsafe partial diff cases
+- protected append admission rules
+- managed viewport repaint triggers
+- shrink clear behavior
+- resize repaint versus recovery repaint policy
+- internal versus external repaint triggers
+
+- [ ] **Step 3: Update render framework README**
+
+Change `render-loop.md` and `managed-viewport.md` entries from inventory-only to available specs if the README format supports it. Keep unrelated inventory entries unchanged.
+
+- [ ] **Step 4: Run documentation sanity checks**
+
+Run:
+
+```bash
+rg -n "TO""DO|TB""D|FIX""ME|XX""X" docs/internals/architecture/tui/native-terminal-core/render-framework docs/superpowers/specs/2026-06-09-tui-render-loop-strategy-design.md
+git diff --check
+```
+
+Expected: no placeholder matches and no whitespace errors.
+
+- [ ] **Step 5: Commit Task 6**
+
+```bash
+git add docs/internals/architecture/tui/native-terminal-core/render-framework/render-loop.md docs/internals/architecture/tui/native-terminal-core/render-framework/managed-viewport.md docs/internals/architecture/tui/native-terminal-core/render-framework/README.md
+git commit -m "docs(tui): document render planning strategies"
+```
+
+## Task 7: Final Verification
+
+**Files:**
+- No planned edits unless verification exposes issues.
+
+- [ ] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py tests/coding/test_native_coding_tui_perf_probe.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run broader TUI tests if focused tests pass**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect final diff**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline -8
+```
+
+Expected: working tree clean after commits; branch contains the spec, plan, and implementation commits.

--- a/docs/superpowers/plans/2026-06-09-tui-render-loop-strategy-implementation.md
+++ b/docs/superpowers/plans/2026-06-09-tui-render-loop-strategy-implementation.md
@@ -44,19 +44,28 @@ Add a test near the render-loop diagnostics tests:
 
 ```python
 def test_render_plan_context_carries_cursor_and_diff_facts() -> None:
-    root = SequenceRoot(["alpha"], ["alpha", "beta"])
+    root = StaticRoot(("alpha",))
     loop = RenderLoop(root)
-    first = loop.plan(TerminalSize(columns=20, rows=5))
-    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+    size = TerminalSize(columns=20, rows=5)
+    first = loop.plan(size)
+    loop.commit(first, size=size)
 
-    second = loop.plan(TerminalSize(columns=20, rows=5))
+    root.lines = ("alpha", "beta" + CURSOR_MARKER)
+    context = loop._build_plan_context(size)
 
-    assert second.operation_class == "append_update"
-    assert second.appended_lines == 1
-    assert second.append_start == 1
+    assert context.raw_current_lines == ("alpha", "beta" + CURSOR_MARKER)
+    assert context.current_lines == ("alpha", "beta")
+    assert context.declared_cursor == CursorDeclaration(row=1, column=4)
+    assert context.cursor == CursorDeclaration(row=1, column=4)
+    assert context.changed_range == (1, 1)
+    assert context.first_changed == 1
+    assert context.last_changed == 1
+    assert context.appended_lines == 1
+    assert context.append_start == 1
 ```
 
-Use existing test helpers in `tests/tui/test_render_loop.py` where possible. If `SequenceRoot` does not exist, add the smallest local renderable helper matching current test style.
+Add `CursorDeclaration` to the existing `loushang.tui` imports in
+`tests/tui/test_render_loop.py`.
 
 - [ ] **Step 2: Run the focused test and verify RED**
 
@@ -66,7 +75,7 @@ Run:
 uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py::test_render_plan_context_carries_cursor_and_diff_facts -q
 ```
 
-Expected: FAIL because the new helper/test is not yet wired to a context extraction behavior or because helper names need implementation.
+Expected: FAIL because `RenderLoop._build_plan_context` does not exist yet.
 
 - [ ] **Step 3: Add internal dataclasses**
 

--- a/docs/superpowers/specs/2026-06-09-tui-render-loop-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-09-tui-render-loop-strategy-design.md
@@ -76,6 +76,7 @@ construction:
 ```python
 class RenderPlanStrategyKind(Enum):
     FIRST_RENDER = auto()
+    TRANSCRIPT_WINDOW_TRIMMED_RESET = auto()
     BASELINE_RESET = auto()
     RESIZE_REPAINT = auto()
     UNSAFE_VIEWPORT = auto()
@@ -90,6 +91,7 @@ class RenderPlanStrategyKind(Enum):
 
 DEFAULT_STRATEGY_ORDER: tuple[RenderPlanStrategyKind, ...] = (
     RenderPlanStrategyKind.FIRST_RENDER,
+    RenderPlanStrategyKind.TRANSCRIPT_WINDOW_TRIMMED_RESET,
     RenderPlanStrategyKind.BASELINE_RESET,
     RenderPlanStrategyKind.RESIZE_REPAINT,
     RenderPlanStrategyKind.UNSAFE_VIEWPORT,
@@ -110,6 +112,9 @@ would make priority more fragmented without improving clarity.
 `SHRINK_VIEWPORT_REPAINT` covers the current
 `viewport_top_decreased_after_shrink` managed viewport repaint path.
 `SHRINK_CLEAR` covers the existing `operation_class="shrink_clear"` path.
+`TRANSCRIPT_WINDOW_TRIMMED_RESET` is separate from ordinary baseline reset
+because trimmed transcript windows currently use `managed_viewport_repaint`,
+while other baseline resets use `baseline_repaint`.
 
 ## Strategy Contract
 
@@ -156,15 +161,25 @@ class RenderPlanContext:
     current_lines: tuple[str, ...]
     previous_lines: tuple[str, ...]
     previous_size: TerminalSize | None
+    declared_cursor: CursorDeclaration | None
+    cursor: CursorDeclaration
     changed_range: tuple[int, int] | None
+    first_changed: int | None
+    last_changed: int | None
+    appended_lines: int
+    append_start: int | None
     viewport_top: int
+    differential_viewport_top: int
     width_changed: bool
     height_changed: bool
     previous_kitty_delete_sequences: tuple[str, ...]
 ```
 
 The context contains facts only. It should not expose helper methods that encode
-strategy decisions.
+strategy decisions. Derived fields such as `first_changed`, `last_changed`,
+`appended_lines`, `append_start`, and `differential_viewport_top` are still facts:
+they describe the frame once, so individual strategies do not recompute them and
+accidentally drift from one another.
 
 ## RenderPlanRuntime
 
@@ -175,6 +190,8 @@ mutate unrelated internals.
 It exposes:
 
 - `previous_viewport_top`
+- `previous_cursor_row`
+- `previous_cursor_column`
 - `hardware_cursor_row`
 - `hardware_cursor_column`
 - `working_area_high_water_mark`
@@ -192,7 +209,8 @@ refactor. The important boundary is that strategies do not mutate loop state.
 | Scenario | Strategy | operation_class | Key condition |
 | --- | --- | --- | --- |
 | First render | `FirstRenderStrategy` | `first_render` | `previous_size is None` |
-| Internal baseline reset | `BaselineResetStrategy` | `baseline_repaint` or `managed_viewport_repaint` | `baseline_reset_reason is not None` |
+| Trimmed transcript reset | `TranscriptWindowTrimmedResetStrategy` | `managed_viewport_repaint` | `baseline_reset_reason.startswith("transcript_window_trimmed:")` |
+| Ordinary internal baseline reset | `BaselineResetStrategy` | `baseline_repaint` | `baseline_reset_reason is not None` and not a trimmed transcript reset |
 | Terminal resize | `ResizeRepaintStrategy` | `resize_repaint` | `width_changed or height_changed`, except Termux height-only |
 | External unsafe viewport | `UnsafeViewportStrategy` | `recovery_repaint` | `unsafe_viewport_reason is not None` |
 | No content change, cursor moved | `NoChangeStrategy` | `cursor_update` | `changed_range is None` and cursor differs |
@@ -204,10 +222,12 @@ refactor. The important boundary is that strategies do not mutate loop state.
 | Changed row above visible viewport | `ChangedAboveViewportStrategy` | `managed_viewport_repaint` | `first_changed < previous_viewport_top` |
 | Ordinary changed range | `ChangedRangeStrategy` | `changed_range_update` | normal diff path after earlier strategies decline |
 
-Priority matters. For example, `baseline_reset + resize` must use the baseline
-reset path because internal transcript-window replacement is a stronger signal
-than terminal-size repaint. `unsafe_viewport + append` must use recovery repaint
-because appending against an unsafe physical viewport can corrupt managed rows.
+Priority matters. For example, `transcript_window_trimmed + resize` must use the
+trimmed-window managed repaint path, and ordinary `baseline_reset + resize` must
+use baseline repaint, because internal transcript-window replacement is a
+stronger signal than terminal-size repaint. `unsafe_viewport + append` must use
+recovery repaint because appending against an unsafe physical viewport can
+corrupt managed rows.
 
 ## Repaint Trigger Classes
 
@@ -301,7 +321,9 @@ Existing operation-class assertions should continue to pass.
 Add focused tests for:
 
 - `DEFAULT_STRATEGY_ORDER` matches the documented order.
-- `baseline_reset + resize` chooses baseline reset before resize.
+- `transcript_window_trimmed + resize` chooses trimmed-window managed repaint
+  before resize.
+- ordinary `baseline_reset + resize` chooses baseline reset before resize.
 - `unsafe_viewport + append` chooses recovery repaint before append.
 - `changed_range is None` chooses `cursor_update` or `noop`.
 - protected append admission conditions, preferably parameterized around the
@@ -333,15 +355,19 @@ Phase 1: Extract facts.
 Phase 2: Extract simple strategies.
 
 - Add strategy kinds, default order, and stateless strategy protocol.
-- Extract first render, baseline reset, resize repaint, unsafe viewport, and
-  no-change strategies.
-- Keep complex diff paths inline until the simple path is proven.
+- Extract first render, resize repaint, unsafe viewport, and no-change
+  strategies.
+- Keep baseline reset and complex diff paths inline until the simple path is
+  proven. Baseline reset is intentionally delayed because trimmed transcript
+  reset uses managed viewport repaint while ordinary baseline reset uses
+  baseline repaint.
 - Run render-loop tests after each extraction.
 
 Phase 3: Extract complex strategies and docs.
 
-- Extract append, protected append, shrink viewport repaint, shrink clear,
-  changed-above-viewport, and changed-range strategies.
+- Extract transcript-window-trimmed reset, ordinary baseline reset, append,
+  protected append, shrink viewport repaint, shrink clear, changed-above-viewport,
+  and changed-range strategies.
 - Add render-loop and managed-viewport docs.
 - Add strategy boundary tests and performance guards.
 - Run targeted TUI tests and coding perf probes.

--- a/docs/superpowers/specs/2026-06-09-tui-render-loop-strategy-design.md
+++ b/docs/superpowers/specs/2026-06-09-tui-render-loop-strategy-design.md
@@ -1,0 +1,357 @@
+# TUI RenderLoop Strategy Design
+
+## Status
+
+Draft for implementation planning.
+
+## Context
+
+`loushang.tui` already has a strong native terminal rendering model: line-level
+diffing, managed viewport tracking, append fast paths, protected append for
+streaming content above a bottom frame, cursor-only updates, synchronized flushes,
+and playback-based tests. The main maintainability issue is that
+`RenderLoop.plan()` encodes all render-path selection in one long decision chain.
+
+That shape makes the behavior hard to change safely. The implementation works,
+but the priority order between repaint, append, protected append, shrink, and
+changed-range paths is implicit in source order. New contributors must read a
+large function and several helpers to understand why a frame used a given
+`operation_class`.
+
+Long-session rendering is no longer the primary blocker. Coding mode now trims
+the active transcript window on resume and renders active transcript tail rows
+with stable line caches. The remaining performance work is regression protection,
+not a full reactive render rewrite.
+
+## Goals
+
+- Make render-path selection explicit, testable, and easier to review.
+- Preserve all existing terminal behavior and `operation_class` values.
+- Keep `RenderLoop.commit()` as the only state-advancing step.
+- Make strategy priority visible in one ordered declaration.
+- Document the decision model well enough that a maintainer can diagnose a frame
+  from `operation_class` without first reading `render_loop.py`.
+- Add regression guards for active-window long-session rendering.
+
+## Non-Goals
+
+- Do not change public TUI APIs.
+- Do not introduce character-level diffing.
+- Do not rewrite the render system into a reactive framework.
+- Do not refactor `Composer`, `InputRouter`, `SurfaceHost`, or widget APIs in
+  this slice.
+- Do not enable a production fallback that silently hides missing strategy
+  coverage.
+
+## Design Summary
+
+Split `RenderLoop.plan()` into two phases:
+
+1. Build a `RenderPlanContext` containing facts about the current frame.
+2. Select a stateless strategy from an explicit `DEFAULT_STRATEGY_ORDER`.
+
+The final shape is:
+
+```python
+def plan(self, size: TerminalSize) -> RenderDiagnostics:
+    context = self._build_plan_context(size)
+    runtime = self._plan_runtime()
+    for kind in DEFAULT_STRATEGY_ORDER:
+        strategy = DEFAULT_STRATEGIES[kind]
+        if strategy.match(context, runtime=runtime):
+            return strategy.plan(context, runtime=runtime)
+    raise AssertionError("no render strategy matched")
+```
+
+The strategies are behavioral extraction, not a semantic rewrite. Existing helper
+functions such as `_protected_append_plan()`, `_append_operations()`,
+`_managed_viewport_repaint_operations()`, and `_changed_range_operations()` remain
+available and should be moved only when doing so reduces coupling.
+
+## Strategy Ordering
+
+The priority order must be declared as data rather than hidden in list
+construction:
+
+```python
+class RenderPlanStrategyKind(Enum):
+    FIRST_RENDER = auto()
+    BASELINE_RESET = auto()
+    RESIZE_REPAINT = auto()
+    UNSAFE_VIEWPORT = auto()
+    NO_CHANGE = auto()
+    APPEND = auto()
+    PROTECTED_APPEND = auto()
+    SHRINK_VIEWPORT_REPAINT = auto()
+    SHRINK_CLEAR = auto()
+    CHANGED_ABOVE_VIEWPORT = auto()
+    CHANGED_RANGE = auto()
+
+
+DEFAULT_STRATEGY_ORDER: tuple[RenderPlanStrategyKind, ...] = (
+    RenderPlanStrategyKind.FIRST_RENDER,
+    RenderPlanStrategyKind.BASELINE_RESET,
+    RenderPlanStrategyKind.RESIZE_REPAINT,
+    RenderPlanStrategyKind.UNSAFE_VIEWPORT,
+    RenderPlanStrategyKind.NO_CHANGE,
+    RenderPlanStrategyKind.APPEND,
+    RenderPlanStrategyKind.PROTECTED_APPEND,
+    RenderPlanStrategyKind.SHRINK_VIEWPORT_REPAINT,
+    RenderPlanStrategyKind.SHRINK_CLEAR,
+    RenderPlanStrategyKind.CHANGED_ABOVE_VIEWPORT,
+    RenderPlanStrategyKind.CHANGED_RANGE,
+)
+```
+
+`NO_CHANGE` intentionally covers both `cursor_update` and `noop`. Both paths
+share the same admission condition, `changed_range is None`, and splitting them
+would make priority more fragmented without improving clarity.
+
+`SHRINK_VIEWPORT_REPAINT` covers the current
+`viewport_top_decreased_after_shrink` managed viewport repaint path.
+`SHRINK_CLEAR` covers the existing `operation_class="shrink_clear"` path.
+
+## Strategy Contract
+
+Strategies must be stateless. They can be shared across `RenderLoop` instances
+and tests.
+
+```python
+class RenderPlanStrategy(Protocol):
+    kind: ClassVar[RenderPlanStrategyKind]
+    name: ClassVar[str]
+
+    def match(
+        self,
+        context: RenderPlanContext,
+        *,
+        runtime: RenderPlanRuntime,
+    ) -> bool: ...
+
+    def plan(
+        self,
+        context: RenderPlanContext,
+        *,
+        runtime: RenderPlanRuntime,
+    ) -> RenderDiagnostics: ...
+```
+
+Strategies may read runtime state through `RenderPlanRuntime`, but must not
+mutate `RenderLoop`. They must not call `commit()`, clear reset reasons, or
+advance cursor tracking. State changes remain in `RenderLoop.commit()`.
+
+## RenderPlanContext
+
+`RenderPlanContext` is eager in the first implementation. Lazy properties are not
+part of this slice because active-window trimming already bounds the important
+long-session path, and lazy cached properties would add complexity before a
+measured need.
+
+```python
+@dataclass(frozen=True, slots=True)
+class RenderPlanContext:
+    size: TerminalSize
+    result: RenderResult
+    raw_current_lines: tuple[str, ...]
+    current_lines: tuple[str, ...]
+    previous_lines: tuple[str, ...]
+    previous_size: TerminalSize | None
+    changed_range: tuple[int, int] | None
+    viewport_top: int
+    width_changed: bool
+    height_changed: bool
+    previous_kitty_delete_sequences: tuple[str, ...]
+```
+
+The context contains facts only. It should not expose helper methods that encode
+strategy decisions.
+
+## RenderPlanRuntime
+
+`RenderPlanRuntime` is a narrow facade over the loop. Passing the full
+`RenderLoop` into strategies would make it too easy for strategies to rely on or
+mutate unrelated internals.
+
+It exposes:
+
+- `previous_viewport_top`
+- `hardware_cursor_row`
+- `hardware_cursor_column`
+- `working_area_high_water_mark`
+- `termux_session`
+- `clear_scrollback_policy`
+- `baseline_reset_reason`
+- `unsafe_viewport_reason`
+- diagnostics builders for existing repaint and operation paths
+
+The facade may delegate to private `RenderLoop` helpers during the initial
+refactor. The important boundary is that strategies do not mutate loop state.
+
+## Decision Cheat Sheet
+
+| Scenario | Strategy | operation_class | Key condition |
+| --- | --- | --- | --- |
+| First render | `FirstRenderStrategy` | `first_render` | `previous_size is None` |
+| Internal baseline reset | `BaselineResetStrategy` | `baseline_repaint` or `managed_viewport_repaint` | `baseline_reset_reason is not None` |
+| Terminal resize | `ResizeRepaintStrategy` | `resize_repaint` | `width_changed or height_changed`, except Termux height-only |
+| External unsafe viewport | `UnsafeViewportStrategy` | `recovery_repaint` | `unsafe_viewport_reason is not None` |
+| No content change, cursor moved | `NoChangeStrategy` | `cursor_update` | `changed_range is None` and cursor differs |
+| No content change, cursor stable | `NoChangeStrategy` | `noop` | `changed_range is None` and cursor stable |
+| Pure tail append | `AppendStrategy` | `append_update` | first changed row is the old line count |
+| Insert above protected bottom frame | `ProtectedAppendStrategy` | `protected_append_update` | protected append admission passes |
+| Shrink would move viewport upward | `ShrinkViewportRepaintStrategy` | `managed_viewport_repaint` | current line count shrank and viewport top decreased |
+| Shrink leaves stale trailing rows | `ShrinkClearStrategy` | `shrink_clear` | changed range starts past current line end after shrink |
+| Changed row above visible viewport | `ChangedAboveViewportStrategy` | `managed_viewport_repaint` | `first_changed < previous_viewport_top` |
+| Ordinary changed range | `ChangedRangeStrategy` | `changed_range_update` | normal diff path after earlier strategies decline |
+
+Priority matters. For example, `baseline_reset + resize` must use the baseline
+reset path because internal transcript-window replacement is a stronger signal
+than terminal-size repaint. `unsafe_viewport + append` must use recovery repaint
+because appending against an unsafe physical viewport can corrupt managed rows.
+
+## Repaint Trigger Classes
+
+Internal triggers come from application state:
+
+- baseline reset requested by the app
+- transcript window replaced
+- transcript window trimmed
+- compaction replacement
+
+External triggers come from terminal or environment state:
+
+- terminal resize
+- inferred user scrollback movement
+- external stdout writes
+- any explicit viewport-unsafe marker
+
+Docs and diagnostics should preserve this distinction. It explains why
+`baseline_repaint`, `managed_viewport_repaint`, `resize_repaint`, and
+`recovery_repaint` are separate even when they all rewrite runtime-owned rows.
+
+## Protected Append Admission
+
+`ProtectedAppendStrategy` uses the existing `_protected_append_plan()` rules.
+All conditions must hold:
+
+1. A cursor is declared.
+2. `appended_lines > 0`.
+3. `len(current_lines) >= size.rows`.
+4. `inserted_start = first_changed`.
+5. `inserted_end = inserted_start + appended_lines`.
+6. `inserted_start > 0`.
+7. `inserted_end < len(current_lines)`.
+8. `inserted_start <= len(previous_lines)`.
+9. `protected_start = inserted_end`.
+10. `protected_height = len(current_lines) - protected_start`.
+11. `protected_height > 0`.
+12. `protected_height < size.rows`.
+13. `cursor.row >= protected_start`.
+14. `previous_lines[:inserted_start] == current_lines[:inserted_start]`.
+
+If any condition fails, the render plan must continue to the next strategy.
+
+## Fallback Strategy
+
+Do not include fallback repaint in `DEFAULT_STRATEGY_ORDER`.
+
+A `FallbackRepaintStrategy` may exist for explicit emergency or debug use, but a
+missing match in the default registry should raise `AssertionError`. Silent
+fallback repaint would hide strategy coverage bugs and make regressions harder to
+find. Tests must prove the default registry is complete for the supported frame
+states.
+
+If implemented, fallback diagnostics should use
+`operation_class="fallback_repaint"` and `repaint_reason="strategy_fallback"` so
+it is visible in telemetry and playback output.
+
+## Documentation Work
+
+Add or update:
+
+- `docs/internals/architecture/tui/native-terminal-core/render-framework/render-loop.md`
+- `docs/internals/architecture/tui/native-terminal-core/render-framework/managed-viewport.md`
+
+`render-loop.md` must cover:
+
+- RenderLoop responsibilities
+- frame construction
+- strategy ordering
+- Decision Cheat Sheet
+- each `operation_class`
+- failure and commit semantics
+- cursor positioning model
+- Kitty image cleanup interaction
+
+`managed-viewport.md` must cover:
+
+- viewport top and previous viewport top
+- when partial diffing is unsafe
+- protected append admission
+- managed viewport repaint triggers
+- shrink clear behavior
+- resize repaint versus recovery repaint policy
+- internal versus external repaint triggers
+
+## Test Plan
+
+Keep `tests/tui/test_render_loop.py` as the primary behavior regression suite.
+Existing operation-class assertions should continue to pass.
+
+Add focused tests for:
+
+- `DEFAULT_STRATEGY_ORDER` matches the documented order.
+- `baseline_reset + resize` chooses baseline reset before resize.
+- `unsafe_viewport + append` chooses recovery repaint before append.
+- `changed_range is None` chooses `cursor_update` or `noop`.
+- protected append admission conditions, preferably parameterized around the
+  existing `_protected_append_plan()` rule set.
+- shrink viewport repaint and shrink clear stay distinct.
+- default strategy registry is complete for existing supported scenarios.
+- optional `FallbackRepaintStrategy` is not in the default order.
+
+Add or tighten performance guards in
+`tests/coding/test_native_coding_tui_perf_probe.py`:
+
+- after active window trim, composer input does not increase render-loop logical
+  line count
+- after active window trim, logical line count remains bounded by a fixed budget
+  derived from `active_transcript_line_budget`
+- stable historical transcript blocks are not re-rendered during ordinary
+  composer edits or timer ticks, where that can be asserted without fragile
+  timing thresholds
+
+## Implementation Phases
+
+Phase 1: Extract facts.
+
+- Introduce `RenderPlanContext`.
+- Keep `RenderLoop.plan()` behavior in one function.
+- Replace local variables with context fields.
+- Run render-loop and coding perf tests.
+
+Phase 2: Extract simple strategies.
+
+- Add strategy kinds, default order, and stateless strategy protocol.
+- Extract first render, baseline reset, resize repaint, unsafe viewport, and
+  no-change strategies.
+- Keep complex diff paths inline until the simple path is proven.
+- Run render-loop tests after each extraction.
+
+Phase 3: Extract complex strategies and docs.
+
+- Extract append, protected append, shrink viewport repaint, shrink clear,
+  changed-above-viewport, and changed-range strategies.
+- Add render-loop and managed-viewport docs.
+- Add strategy boundary tests and performance guards.
+- Run targeted TUI tests and coding perf probes.
+
+## Success Criteria
+
+- `RenderLoop.plan()` is small and delegates strategy selection.
+- Strategy order is visible in one declaration and tested.
+- Every existing `operation_class` remains compatible.
+- Existing playback and render-loop tests pass.
+- Long-session perf probes pass and include bounded logical-line assertions.
+- A maintainer can map any frame's `operation_class` to the responsible strategy
+  and key admission condition from docs without first reading `render_loop.py`.

--- a/src/loushang/tui/render_loop.py
+++ b/src/loushang/tui/render_loop.py
@@ -22,6 +22,28 @@ class ScreenRoot(Protocol):
     def render(self, constraints: RenderConstraints) -> RenderResult: ...
 
 
+@dataclass(frozen=True, slots=True)
+class RenderPlanContext:
+    size: TerminalSize
+    result: RenderResult
+    raw_current_lines: tuple[str, ...]
+    current_lines: tuple[str, ...]
+    previous_lines: tuple[str, ...]
+    previous_size: TerminalSize | None
+    declared_cursor: CursorDeclaration | None
+    cursor: CursorDeclaration
+    changed_range: tuple[int, int] | None
+    first_changed: int | None
+    last_changed: int | None
+    appended_lines: int
+    append_start: int | None
+    viewport_top: int
+    differential_viewport_top: int
+    width_changed: bool
+    height_changed: bool
+    previous_kitty_delete_sequences: tuple[str, ...]
+
+
 @dataclass(slots=True)
 class RenderLoop:
     screen_root: ScreenRoot
@@ -46,7 +68,7 @@ class RenderLoop:
     def reset_baseline(self, reason: str = "baseline_reset") -> None:
         self._baseline_reset_reason = reason
 
-    def plan(self, size: TerminalSize) -> RenderDiagnostics:
+    def _build_plan_context(self, size: TerminalSize) -> RenderPlanContext:
         result = self.screen_root.render(
             RenderConstraints(width=size.columns, max_height=1_000_000, visible_height=size.rows)
         )
@@ -66,8 +88,58 @@ class RenderLoop:
             previous_lines,
             _changed_line_range(previous_lines, current_lines),
         )
+        first_changed: int | None = None
+        last_changed: int | None = None
+        appended_lines = max(0, len(current_lines) - len(previous_lines))
+        append_start: int | None = None
+        if changed_range is not None:
+            first_changed, last_changed = changed_range
+            append_start = (
+                first_changed
+                if appended_lines > 0 and first_changed == len(previous_lines) and first_changed > 0
+                else None
+            )
         viewport_top = _viewport_top(current_lines, size)
+        differential_viewport_top = _differential_viewport_top(
+            previous_viewport_top=self.previous_viewport_top,
+            natural_viewport_top=viewport_top,
+            previous_line_count=len(previous_lines),
+            current_line_count=len(current_lines),
+        )
         previous_kitty_delete_sequences = _kitty_delete_sequences(previous_lines)
+        return RenderPlanContext(
+            size=size,
+            result=result,
+            raw_current_lines=raw_current_lines,
+            current_lines=current_lines,
+            previous_lines=previous_lines,
+            previous_size=previous_size,
+            declared_cursor=result.cursor,
+            cursor=cursor,
+            changed_range=changed_range,
+            first_changed=first_changed,
+            last_changed=last_changed,
+            appended_lines=appended_lines,
+            append_start=append_start,
+            viewport_top=viewport_top,
+            differential_viewport_top=differential_viewport_top,
+            width_changed=width_changed,
+            height_changed=height_changed,
+            previous_kitty_delete_sequences=previous_kitty_delete_sequences,
+        )
+
+    def plan(self, size: TerminalSize) -> RenderDiagnostics:
+        context = self._build_plan_context(size)
+        result = context.result
+        current_lines = context.current_lines
+        cursor = context.cursor
+        previous_lines = context.previous_lines
+        previous_size = context.previous_size
+        width_changed = context.width_changed
+        height_changed = context.height_changed
+        changed_range = context.changed_range
+        viewport_top = context.viewport_top
+        previous_kitty_delete_sequences = context.previous_kitty_delete_sequences
 
         if previous_size is None:
             return self._diagnostics(
@@ -171,9 +243,12 @@ class RenderLoop:
                 hardware_cursor_column=self.hardware_cursor_column,
             )
 
-        first_changed, last_changed = changed_range
-        appended_lines = max(0, len(current_lines) - len(previous_lines))
-        append_start = first_changed if appended_lines > 0 and first_changed == len(previous_lines) and first_changed > 0 else None
+        first_changed = context.first_changed
+        last_changed = context.last_changed
+        appended_lines = context.appended_lines
+        append_start = context.append_start
+        if first_changed is None or last_changed is None:
+            raise AssertionError("changed range facts missing for changed render plan")
         if append_start is not None:
             return self._diagnostics(
                 current_lines=current_lines,
@@ -231,12 +306,7 @@ class RenderLoop:
                 hardware_cursor_column=cursor.column,
             )
 
-        differential_viewport_top = _differential_viewport_top(
-            previous_viewport_top=self.previous_viewport_top,
-            natural_viewport_top=viewport_top,
-            previous_line_count=len(previous_lines),
-            current_line_count=len(current_lines),
-        )
+        differential_viewport_top = context.differential_viewport_top
         if len(current_lines) < len(previous_lines) and viewport_top < self.previous_viewport_top:
             return self._managed_viewport_repaint_diagnostics(
                 current_lines=current_lines,

--- a/src/loushang/tui/render_loop.py
+++ b/src/loushang/tui/render_loop.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from enum import Enum, auto
+from typing import ClassVar, Literal, Protocol
 
 from loushang.tui.cell_width import normalize_terminal_output, visible_width
 from loushang.tui.core import CursorDeclaration, RenderConstraints, RenderResult
@@ -20,6 +21,37 @@ SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07"
 
 class ScreenRoot(Protocol):
     def render(self, constraints: RenderConstraints) -> RenderResult: ...
+
+
+class RenderPlanStrategyKind(Enum):
+    FIRST_RENDER = auto()
+    TRANSCRIPT_WINDOW_TRIMMED_RESET = auto()
+    BASELINE_RESET = auto()
+    RESIZE_REPAINT = auto()
+    UNSAFE_VIEWPORT = auto()
+    NO_CHANGE = auto()
+    APPEND = auto()
+    PROTECTED_APPEND = auto()
+    SHRINK_VIEWPORT_REPAINT = auto()
+    SHRINK_CLEAR = auto()
+    CHANGED_ABOVE_VIEWPORT = auto()
+    CHANGED_RANGE = auto()
+
+
+DEFAULT_STRATEGY_ORDER: tuple[RenderPlanStrategyKind, ...] = (
+    RenderPlanStrategyKind.FIRST_RENDER,
+    RenderPlanStrategyKind.TRANSCRIPT_WINDOW_TRIMMED_RESET,
+    RenderPlanStrategyKind.BASELINE_RESET,
+    RenderPlanStrategyKind.RESIZE_REPAINT,
+    RenderPlanStrategyKind.UNSAFE_VIEWPORT,
+    RenderPlanStrategyKind.NO_CHANGE,
+    RenderPlanStrategyKind.APPEND,
+    RenderPlanStrategyKind.PROTECTED_APPEND,
+    RenderPlanStrategyKind.SHRINK_VIEWPORT_REPAINT,
+    RenderPlanStrategyKind.SHRINK_CLEAR,
+    RenderPlanStrategyKind.CHANGED_ABOVE_VIEWPORT,
+    RenderPlanStrategyKind.CHANGED_RANGE,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,6 +74,29 @@ class RenderPlanContext:
     width_changed: bool
     height_changed: bool
     previous_kitty_delete_sequences: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RenderPlanRuntime:
+    previous_viewport_top: int
+    previous_cursor_row: int
+    previous_cursor_column: int
+    hardware_cursor_row: int
+    hardware_cursor_column: int
+    working_area_high_water_mark: int
+    termux_session: bool
+    clear_scrollback_policy: ClearScrollbackPolicy
+    baseline_reset_reason: str | None
+    unsafe_viewport_reason: str | None
+
+
+class RenderPlanStrategy(Protocol):
+    kind: ClassVar[RenderPlanStrategyKind]
+    name: ClassVar[str]
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool: ...
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics: ...
 
 
 @dataclass(slots=True)
@@ -126,6 +181,20 @@ class RenderLoop:
             width_changed=width_changed,
             height_changed=height_changed,
             previous_kitty_delete_sequences=previous_kitty_delete_sequences,
+        )
+
+    def _plan_runtime(self) -> RenderPlanRuntime:
+        return RenderPlanRuntime(
+            previous_viewport_top=self.previous_viewport_top,
+            previous_cursor_row=self.previous_cursor_row,
+            previous_cursor_column=self.previous_cursor_column,
+            hardware_cursor_row=self.hardware_cursor_row,
+            hardware_cursor_column=self.hardware_cursor_column,
+            working_area_high_water_mark=self.working_area_high_water_mark,
+            termux_session=self.termux_session,
+            clear_scrollback_policy=self.clear_scrollback_policy,
+            baseline_reset_reason=self._baseline_reset_reason,
+            unsafe_viewport_reason=self._unsafe_viewport_reason,
         )
 
     def plan(self, size: TerminalSize) -> RenderDiagnostics:

--- a/src/loushang/tui/render_loop.py
+++ b/src/loushang/tui/render_loop.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import ClassVar, Literal, Protocol
@@ -88,6 +89,8 @@ class RenderPlanRuntime:
     clear_scrollback_policy: ClearScrollbackPolicy
     baseline_reset_reason: str | None
     unsafe_viewport_reason: str | None
+    diagnostics: Callable[..., RenderDiagnostics]
+    repaint_diagnostics: Callable[..., RenderDiagnostics]
 
 
 class RenderPlanStrategy(Protocol):
@@ -97,6 +100,136 @@ class RenderPlanStrategy(Protocol):
     def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool: ...
 
     def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics: ...
+
+
+@dataclass(frozen=True, slots=True)
+class FirstRenderStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.FIRST_RENDER
+    name: ClassVar[str] = "first_render"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return context.previous_size is None
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        return runtime.diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            operation_class="first_render",
+            operations=_full_write_operations(
+                context.current_lines,
+                cursor=context.declared_cursor,
+                viewport_top=context.viewport_top,
+            ),
+            changed_range=context.changed_range,
+            viewport_top=context.viewport_top,
+            cursor=context.cursor,
+            hardware_cursor_row=_hardware_row_after_write(context.current_lines, cursor=context.declared_cursor),
+            hardware_cursor_column=context.cursor.column,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResizeRepaintStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.RESIZE_REPAINT
+    name: ClassVar[str] = "resize_repaint"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return context.width_changed or (context.height_changed and not runtime.termux_session)
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        return runtime.repaint_diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            changed_range=context.changed_range,
+            cursor=context.cursor,
+            declared_cursor=context.declared_cursor,
+            operation_class="resize_repaint",
+            repaint_kind="resize",
+            repaint_reason="terminal_size_changed",
+            width_changed=context.width_changed,
+            height_changed=context.height_changed,
+            delete_kitty_image_sequences=context.previous_kitty_delete_sequences,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class UnsafeViewportStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.UNSAFE_VIEWPORT
+    name: ClassVar[str] = "unsafe_viewport"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return runtime.unsafe_viewport_reason is not None
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        if runtime.unsafe_viewport_reason is None:
+            raise AssertionError("unsafe viewport strategy planned without a reason")
+        return runtime.repaint_diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            changed_range=context.changed_range,
+            cursor=context.cursor,
+            declared_cursor=context.declared_cursor,
+            operation_class="recovery_repaint",
+            repaint_kind="recovery",
+            repaint_reason=runtime.unsafe_viewport_reason,
+            delete_kitty_image_sequences=context.previous_kitty_delete_sequences,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NoChangeStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.NO_CHANGE
+    name: ClassVar[str] = "no_change"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return context.changed_range is None
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        if (context.cursor.row, context.cursor.column) != (
+            runtime.previous_cursor_row,
+            runtime.previous_cursor_column,
+        ):
+            return runtime.diagnostics(
+                current_lines=context.current_lines,
+                previous_lines=context.previous_lines,
+                size=context.size,
+                operation_class="cursor_update",
+                operations=_cursor_update_operations(
+                    context.cursor,
+                    viewport_top=context.viewport_top,
+                    hardware_cursor_row=runtime.hardware_cursor_row,
+                ),
+                viewport_top=context.viewport_top,
+                width_changed=context.width_changed,
+                height_changed=context.height_changed,
+                cursor=context.cursor,
+                hardware_cursor_row=context.cursor.row,
+                hardware_cursor_column=context.cursor.column,
+            )
+        return runtime.diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            operation_class="noop",
+            operations=(),
+            viewport_top=context.viewport_top,
+            width_changed=context.width_changed,
+            height_changed=context.height_changed,
+            cursor=context.cursor,
+            hardware_cursor_row=runtime.hardware_cursor_row,
+            hardware_cursor_column=runtime.hardware_cursor_column,
+        )
+
+
+FIRST_RENDER_STRATEGY = FirstRenderStrategy()
+POST_BASELINE_SIMPLE_STRATEGIES: tuple[RenderPlanStrategy, ...] = (
+    ResizeRepaintStrategy(),
+    UnsafeViewportStrategy(),
+    NoChangeStrategy(),
+)
 
 
 @dataclass(slots=True)
@@ -195,34 +328,23 @@ class RenderLoop:
             clear_scrollback_policy=self.clear_scrollback_policy,
             baseline_reset_reason=self._baseline_reset_reason,
             unsafe_viewport_reason=self._unsafe_viewport_reason,
+            diagnostics=self._diagnostics,
+            repaint_diagnostics=self._repaint_diagnostics,
         )
 
     def plan(self, size: TerminalSize) -> RenderDiagnostics:
         context = self._build_plan_context(size)
+        runtime = self._plan_runtime()
         result = context.result
         current_lines = context.current_lines
         cursor = context.cursor
         previous_lines = context.previous_lines
-        previous_size = context.previous_size
-        width_changed = context.width_changed
-        height_changed = context.height_changed
         changed_range = context.changed_range
         viewport_top = context.viewport_top
         previous_kitty_delete_sequences = context.previous_kitty_delete_sequences
 
-        if previous_size is None:
-            return self._diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                operation_class="first_render",
-                operations=_full_write_operations(current_lines, cursor=result.cursor, viewport_top=viewport_top),
-                changed_range=changed_range,
-                viewport_top=viewport_top,
-                cursor=cursor,
-                hardware_cursor_row=_hardware_row_after_write(current_lines, cursor=result.cursor),
-                hardware_cursor_column=cursor.column,
-            )
+        if FIRST_RENDER_STRATEGY.match(context, runtime=runtime):
+            return FIRST_RENDER_STRATEGY.plan(context, runtime=runtime)
 
         if self._baseline_reset_reason is not None:
             if self._baseline_reset_reason.startswith("transcript_window_trimmed:"):
@@ -249,68 +371,9 @@ class RenderLoop:
                 delete_kitty_image_sequences=previous_kitty_delete_sequences,
             )
 
-        if width_changed or (height_changed and not self.termux_session):
-            return self._repaint_diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                changed_range=changed_range,
-                cursor=cursor,
-                declared_cursor=result.cursor,
-                operation_class="resize_repaint",
-                repaint_kind="resize",
-                repaint_reason="terminal_size_changed",
-                width_changed=width_changed,
-                height_changed=height_changed,
-                delete_kitty_image_sequences=previous_kitty_delete_sequences,
-            )
-
-        if self._unsafe_viewport_reason is not None:
-            return self._repaint_diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                changed_range=changed_range,
-                cursor=cursor,
-                declared_cursor=result.cursor,
-                operation_class="recovery_repaint",
-                repaint_kind="recovery",
-                repaint_reason=self._unsafe_viewport_reason,
-                delete_kitty_image_sequences=previous_kitty_delete_sequences,
-            )
-
-        if changed_range is None:
-            if (cursor.row, cursor.column) != (self.previous_cursor_row, self.previous_cursor_column):
-                return self._diagnostics(
-                    current_lines=current_lines,
-                    previous_lines=previous_lines,
-                    size=size,
-                    operation_class="cursor_update",
-                    operations=_cursor_update_operations(
-                        cursor,
-                        viewport_top=viewport_top,
-                        hardware_cursor_row=self.hardware_cursor_row,
-                    ),
-                    viewport_top=viewport_top,
-                    width_changed=width_changed,
-                    height_changed=height_changed,
-                    cursor=cursor,
-                    hardware_cursor_row=cursor.row,
-                    hardware_cursor_column=cursor.column,
-                )
-            return self._diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                operation_class="noop",
-                operations=(),
-                viewport_top=viewport_top,
-                width_changed=width_changed,
-                height_changed=height_changed,
-                cursor=cursor,
-                hardware_cursor_row=self.hardware_cursor_row,
-                hardware_cursor_column=self.hardware_cursor_column,
-            )
+        for strategy in POST_BASELINE_SIMPLE_STRATEGIES:
+            if strategy.match(context, runtime=runtime):
+                return strategy.plan(context, runtime=runtime)
 
         first_changed = context.first_changed
         last_changed = context.last_changed

--- a/src/loushang/tui/render_loop.py
+++ b/src/loushang/tui/render_loop.py
@@ -91,6 +91,7 @@ class RenderPlanRuntime:
     unsafe_viewport_reason: str | None
     diagnostics: Callable[..., RenderDiagnostics]
     repaint_diagnostics: Callable[..., RenderDiagnostics]
+    managed_viewport_repaint_diagnostics: Callable[..., RenderDiagnostics]
 
 
 class RenderPlanStrategy(Protocol):
@@ -224,12 +225,300 @@ class NoChangeStrategy:
         )
 
 
-FIRST_RENDER_STRATEGY = FirstRenderStrategy()
-POST_BASELINE_SIMPLE_STRATEGIES: tuple[RenderPlanStrategy, ...] = (
-    ResizeRepaintStrategy(),
-    UnsafeViewportStrategy(),
-    NoChangeStrategy(),
-)
+@dataclass(frozen=True, slots=True)
+class TranscriptWindowTrimmedResetStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.TRANSCRIPT_WINDOW_TRIMMED_RESET
+    name: ClassVar[str] = "transcript_window_trimmed_reset"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return bool(
+            runtime.baseline_reset_reason is not None
+            and runtime.baseline_reset_reason.startswith("transcript_window_trimmed:")
+        )
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        if runtime.baseline_reset_reason is None:
+            raise AssertionError("trimmed transcript reset strategy planned without a reason")
+        return runtime.managed_viewport_repaint_diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            changed_range=context.changed_range,
+            cursor=context.cursor,
+            declared_cursor=context.declared_cursor,
+            repaint_reason=runtime.baseline_reset_reason,
+            delete_kitty_image_sequences=context.previous_kitty_delete_sequences,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BaselineResetStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.BASELINE_RESET
+    name: ClassVar[str] = "baseline_reset"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return bool(
+            runtime.baseline_reset_reason is not None
+            and not runtime.baseline_reset_reason.startswith("transcript_window_trimmed:")
+        )
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        if runtime.baseline_reset_reason is None:
+            raise AssertionError("baseline reset strategy planned without a reason")
+        return runtime.repaint_diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            changed_range=context.changed_range,
+            cursor=context.cursor,
+            declared_cursor=context.declared_cursor,
+            operation_class="baseline_repaint",
+            repaint_kind="recovery",
+            repaint_reason=runtime.baseline_reset_reason,
+            delete_kitty_image_sequences=context.previous_kitty_delete_sequences,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AppendStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.APPEND
+    name: ClassVar[str] = "append"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return context.append_start is not None
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        if context.append_start is None or context.last_changed is None:
+            raise AssertionError("append strategy planned without append facts")
+        return runtime.diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            operation_class="append_update",
+            operations=_append_operations(
+                context.current_lines[context.append_start :],
+                append_start=context.append_start,
+                hardware_cursor_row=runtime.hardware_cursor_row,
+                cursor=context.declared_cursor,
+                viewport_top=context.viewport_top,
+            ),
+            changed_range=context.changed_range,
+            viewport_top=context.viewport_top,
+            append_start=context.append_start,
+            appended_lines=context.appended_lines,
+            render_end=context.last_changed,
+            cursor=context.cursor,
+            hardware_cursor_row=_hardware_row_after_write(context.current_lines, cursor=context.declared_cursor),
+            hardware_cursor_column=context.cursor.column,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProtectedAppendStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.PROTECTED_APPEND
+    name: ClassVar[str] = "protected_append"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        if context.first_changed is None:
+            return False
+        return (
+            _protected_append_plan(
+                current_lines=context.current_lines,
+                previous_lines=context.previous_lines,
+                first_changed=context.first_changed,
+                appended_lines=context.appended_lines,
+                cursor=context.declared_cursor,
+                size=context.size,
+            )
+            is not None
+        )
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        if context.first_changed is None:
+            raise AssertionError("protected append strategy planned without changed range facts")
+        protected_append = _protected_append_plan(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            first_changed=context.first_changed,
+            appended_lines=context.appended_lines,
+            cursor=context.declared_cursor,
+            size=context.size,
+        )
+        if protected_append is None:
+            raise AssertionError("protected append strategy planned without an admissible append")
+        inserted_start, inserted_end, protected_start = protected_append
+        return runtime.diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            operation_class="protected_append_update",
+            operations=_protected_append_operations(
+                current_lines=context.current_lines,
+                inserted_range=(inserted_start, inserted_end),
+                protected_start=protected_start,
+                cursor=context.declared_cursor,
+                viewport_top=context.viewport_top,
+                size=context.size,
+                delete_kitty_image_sequences=_kitty_delete_sequences(context.previous_lines[inserted_start:]),
+            ),
+            changed_range=context.changed_range,
+            viewport_top=context.viewport_top,
+            append_start=inserted_start,
+            appended_lines=context.appended_lines,
+            render_end=len(context.current_lines) - 1,
+            cursor=context.cursor,
+            hardware_cursor_row=context.cursor.row,
+            hardware_cursor_column=context.cursor.column,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ShrinkViewportRepaintStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.SHRINK_VIEWPORT_REPAINT
+    name: ClassVar[str] = "shrink_viewport_repaint"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return (
+            len(context.current_lines) < len(context.previous_lines)
+            and context.viewport_top < runtime.previous_viewport_top
+        )
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        return runtime.managed_viewport_repaint_diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            changed_range=context.changed_range,
+            cursor=context.cursor,
+            declared_cursor=context.declared_cursor,
+            repaint_reason="viewport_top_decreased_after_shrink",
+            delete_kitty_image_sequences=context.previous_kitty_delete_sequences,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ShrinkClearStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.SHRINK_CLEAR
+    name: ClassVar[str] = "shrink_clear"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return bool(
+            context.first_changed is not None
+            and context.first_changed >= len(context.current_lines)
+            and len(context.previous_lines) > len(context.current_lines)
+        )
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        if context.first_changed is None or context.last_changed is None:
+            raise AssertionError("shrink clear strategy planned without changed range facts")
+        target_row = max(0, len(context.current_lines) - 1)
+        return runtime.diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            operation_class="shrink_clear",
+            operations=_shrink_clear_operations(
+                previous_lines=context.previous_lines,
+                current_lines=context.current_lines,
+                target_row=target_row,
+                hardware_cursor_row=runtime.hardware_cursor_row,
+                delete_kitty_image_sequences=_kitty_delete_sequences_in_range(
+                    context.previous_lines,
+                    context.first_changed,
+                    context.last_changed,
+                ),
+            ),
+            changed_range=context.changed_range,
+            viewport_top=context.differential_viewport_top,
+            render_end=target_row,
+            cursor=context.cursor,
+            hardware_cursor_row=target_row,
+            hardware_cursor_column=context.cursor.column,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ChangedAboveViewportStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.CHANGED_ABOVE_VIEWPORT
+    name: ClassVar[str] = "changed_above_viewport"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return bool(context.first_changed is not None and context.first_changed < runtime.previous_viewport_top)
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        return runtime.managed_viewport_repaint_diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            changed_range=context.changed_range,
+            cursor=context.cursor,
+            declared_cursor=context.declared_cursor,
+            repaint_reason="changed_range_above_viewport",
+            delete_kitty_image_sequences=context.previous_kitty_delete_sequences,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ChangedRangeStrategy:
+    kind: ClassVar[RenderPlanStrategyKind] = RenderPlanStrategyKind.CHANGED_RANGE
+    name: ClassVar[str] = "changed_range"
+
+    def match(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> bool:
+        return context.changed_range is not None
+
+    def plan(self, context: RenderPlanContext, *, runtime: RenderPlanRuntime) -> RenderDiagnostics:
+        if context.changed_range is None or context.last_changed is None or context.first_changed is None:
+            raise AssertionError("changed range strategy planned without changed range facts")
+        render_end = min(context.last_changed, len(context.current_lines) - 1)
+        hardware_cursor_row, hardware_cursor_column = _changed_range_hardware_cursor(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            render_end=render_end,
+            declared_cursor=context.declared_cursor,
+            size=context.size,
+        )
+        return runtime.diagnostics(
+            current_lines=context.current_lines,
+            previous_lines=context.previous_lines,
+            size=context.size,
+            operation_class="changed_range_update",
+            operations=_changed_range_operations(
+                current_lines=context.current_lines,
+                previous_lines=context.previous_lines,
+                changed_range=context.changed_range,
+                previous_viewport_top=runtime.previous_viewport_top,
+                hardware_cursor_row=runtime.hardware_cursor_row,
+                cursor=context.declared_cursor,
+                viewport_top=context.differential_viewport_top,
+                delete_kitty_image_sequences=_kitty_delete_sequences_in_range(
+                    context.previous_lines,
+                    context.first_changed,
+                    context.last_changed,
+                ),
+            ),
+            changed_range=context.changed_range,
+            viewport_top=context.differential_viewport_top,
+            render_end=render_end,
+            cursor=context.cursor,
+            hardware_cursor_row=hardware_cursor_row,
+            hardware_cursor_column=hardware_cursor_column,
+        )
+
+
+DEFAULT_STRATEGIES: dict[RenderPlanStrategyKind, RenderPlanStrategy] = {
+    RenderPlanStrategyKind.FIRST_RENDER: FirstRenderStrategy(),
+    RenderPlanStrategyKind.TRANSCRIPT_WINDOW_TRIMMED_RESET: TranscriptWindowTrimmedResetStrategy(),
+    RenderPlanStrategyKind.BASELINE_RESET: BaselineResetStrategy(),
+    RenderPlanStrategyKind.RESIZE_REPAINT: ResizeRepaintStrategy(),
+    RenderPlanStrategyKind.UNSAFE_VIEWPORT: UnsafeViewportStrategy(),
+    RenderPlanStrategyKind.NO_CHANGE: NoChangeStrategy(),
+    RenderPlanStrategyKind.APPEND: AppendStrategy(),
+    RenderPlanStrategyKind.PROTECTED_APPEND: ProtectedAppendStrategy(),
+    RenderPlanStrategyKind.SHRINK_VIEWPORT_REPAINT: ShrinkViewportRepaintStrategy(),
+    RenderPlanStrategyKind.SHRINK_CLEAR: ShrinkClearStrategy(),
+    RenderPlanStrategyKind.CHANGED_ABOVE_VIEWPORT: ChangedAboveViewportStrategy(),
+    RenderPlanStrategyKind.CHANGED_RANGE: ChangedRangeStrategy(),
+}
 
 
 @dataclass(slots=True)
@@ -330,191 +619,17 @@ class RenderLoop:
             unsafe_viewport_reason=self._unsafe_viewport_reason,
             diagnostics=self._diagnostics,
             repaint_diagnostics=self._repaint_diagnostics,
+            managed_viewport_repaint_diagnostics=self._managed_viewport_repaint_diagnostics,
         )
 
     def plan(self, size: TerminalSize) -> RenderDiagnostics:
         context = self._build_plan_context(size)
         runtime = self._plan_runtime()
-        result = context.result
-        current_lines = context.current_lines
-        cursor = context.cursor
-        previous_lines = context.previous_lines
-        changed_range = context.changed_range
-        viewport_top = context.viewport_top
-        previous_kitty_delete_sequences = context.previous_kitty_delete_sequences
-
-        if FIRST_RENDER_STRATEGY.match(context, runtime=runtime):
-            return FIRST_RENDER_STRATEGY.plan(context, runtime=runtime)
-
-        if self._baseline_reset_reason is not None:
-            if self._baseline_reset_reason.startswith("transcript_window_trimmed:"):
-                return self._managed_viewport_repaint_diagnostics(
-                    current_lines=current_lines,
-                    previous_lines=previous_lines,
-                    size=size,
-                    changed_range=changed_range,
-                    cursor=cursor,
-                    declared_cursor=result.cursor,
-                    repaint_reason=self._baseline_reset_reason,
-                    delete_kitty_image_sequences=previous_kitty_delete_sequences,
-                )
-            return self._repaint_diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                changed_range=changed_range,
-                cursor=cursor,
-                declared_cursor=result.cursor,
-                operation_class="baseline_repaint",
-                repaint_kind="recovery",
-                repaint_reason=self._baseline_reset_reason,
-                delete_kitty_image_sequences=previous_kitty_delete_sequences,
-            )
-
-        for strategy in POST_BASELINE_SIMPLE_STRATEGIES:
+        for kind in DEFAULT_STRATEGY_ORDER:
+            strategy = DEFAULT_STRATEGIES[kind]
             if strategy.match(context, runtime=runtime):
                 return strategy.plan(context, runtime=runtime)
-
-        first_changed = context.first_changed
-        last_changed = context.last_changed
-        appended_lines = context.appended_lines
-        append_start = context.append_start
-        if first_changed is None or last_changed is None:
-            raise AssertionError("changed range facts missing for changed render plan")
-        if append_start is not None:
-            return self._diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                operation_class="append_update",
-                operations=_append_operations(
-                    current_lines[append_start:],
-                    append_start=append_start,
-                    hardware_cursor_row=self.hardware_cursor_row,
-                    cursor=result.cursor,
-                    viewport_top=viewport_top,
-                ),
-                changed_range=changed_range,
-                viewport_top=viewport_top,
-                append_start=append_start,
-                appended_lines=appended_lines,
-                render_end=last_changed,
-                cursor=cursor,
-                hardware_cursor_row=_hardware_row_after_write(current_lines, cursor=result.cursor),
-                hardware_cursor_column=cursor.column,
-            )
-
-        protected_append = _protected_append_plan(
-            current_lines=current_lines,
-            previous_lines=previous_lines,
-            first_changed=first_changed,
-            appended_lines=appended_lines,
-            cursor=result.cursor,
-            size=size,
-        )
-        if protected_append is not None:
-            inserted_start, inserted_end, protected_start = protected_append
-            return self._diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                operation_class="protected_append_update",
-                operations=_protected_append_operations(
-                    current_lines=current_lines,
-                    inserted_range=(inserted_start, inserted_end),
-                    protected_start=protected_start,
-                    cursor=result.cursor,
-                    viewport_top=viewport_top,
-                    size=size,
-                    delete_kitty_image_sequences=_kitty_delete_sequences(previous_lines[inserted_start:]),
-                ),
-                changed_range=changed_range,
-                viewport_top=viewport_top,
-                append_start=inserted_start,
-                appended_lines=appended_lines,
-                render_end=len(current_lines) - 1,
-                cursor=cursor,
-                hardware_cursor_row=cursor.row,
-                hardware_cursor_column=cursor.column,
-            )
-
-        differential_viewport_top = context.differential_viewport_top
-        if len(current_lines) < len(previous_lines) and viewport_top < self.previous_viewport_top:
-            return self._managed_viewport_repaint_diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                changed_range=changed_range,
-                cursor=cursor,
-                declared_cursor=result.cursor,
-                repaint_reason="viewport_top_decreased_after_shrink",
-                delete_kitty_image_sequences=previous_kitty_delete_sequences,
-            )
-
-        if first_changed >= len(current_lines) and len(previous_lines) > len(current_lines):
-            target_row = max(0, len(current_lines) - 1)
-            return self._diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                operation_class="shrink_clear",
-                operations=_shrink_clear_operations(
-                    previous_lines=previous_lines,
-                    current_lines=current_lines,
-                    target_row=target_row,
-                    hardware_cursor_row=self.hardware_cursor_row,
-                    delete_kitty_image_sequences=_kitty_delete_sequences_in_range(previous_lines, first_changed, last_changed),
-                ),
-                changed_range=changed_range,
-                viewport_top=differential_viewport_top,
-                render_end=target_row,
-                cursor=cursor,
-                hardware_cursor_row=target_row,
-                hardware_cursor_column=cursor.column,
-            )
-
-        if first_changed < self.previous_viewport_top:
-            return self._managed_viewport_repaint_diagnostics(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                size=size,
-                changed_range=changed_range,
-                cursor=cursor,
-                declared_cursor=result.cursor,
-                repaint_reason="changed_range_above_viewport",
-                delete_kitty_image_sequences=previous_kitty_delete_sequences,
-            )
-
-        render_end = min(last_changed, len(current_lines) - 1)
-        hardware_cursor_row, hardware_cursor_column = _changed_range_hardware_cursor(
-            current_lines=current_lines,
-            previous_lines=previous_lines,
-            render_end=render_end,
-            declared_cursor=result.cursor,
-            size=size,
-        )
-        return self._diagnostics(
-            current_lines=current_lines,
-            previous_lines=previous_lines,
-            size=size,
-            operation_class="changed_range_update",
-            operations=_changed_range_operations(
-                current_lines=current_lines,
-                previous_lines=previous_lines,
-                changed_range=changed_range,
-                previous_viewport_top=self.previous_viewport_top,
-                hardware_cursor_row=self.hardware_cursor_row,
-                cursor=result.cursor,
-                viewport_top=differential_viewport_top,
-                delete_kitty_image_sequences=_kitty_delete_sequences_in_range(previous_lines, first_changed, last_changed),
-            ),
-            changed_range=changed_range,
-            viewport_top=differential_viewport_top,
-            render_end=render_end,
-            cursor=cursor,
-            hardware_cursor_row=hardware_cursor_row,
-            hardware_cursor_column=hardware_cursor_column,
-        )
+        raise AssertionError("no render strategy matched")
 
     def _managed_viewport_repaint_diagnostics(
         self,

--- a/tests/coding/test_native_coding_tui_perf_probe.py
+++ b/tests/coding/test_native_coding_tui_perf_probe.py
@@ -77,5 +77,6 @@ def test_long_transcript_probe_stays_bounded_after_active_window_trim() -> None:
     assert second_metrics.visible_render_ms < 1_000
     assert first_metrics.render_loop_logical_line_count <= app.active_transcript_line_budget + 60
     assert second_metrics.render_loop_logical_line_count <= app.active_transcript_line_budget + 60
+    assert second_metrics.render_loop_logical_line_count == first_metrics.render_loop_logical_line_count
     assert second_metrics.render_loop_operation_class == "changed_range_update"
     assert second_metrics.changed_line_range is not None

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -134,6 +134,32 @@ def test_default_render_strategy_order_matches_design() -> None:
     )
 
 
+def test_resize_repaint_precedes_changed_range_strategy() -> None:
+    root = StaticRoot(("one",))
+    loop = RenderLoop(root)
+    first = loop.plan(TerminalSize(columns=20, rows=5))
+    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+
+    root.lines = ("two",)
+    step = loop.plan(TerminalSize(columns=30, rows=5))
+
+    assert step.operation_class == "resize_repaint"
+
+
+def test_unsafe_viewport_precedes_append_strategy() -> None:
+    root = StaticRoot(("one",))
+    loop = RenderLoop(root)
+    first = loop.plan(TerminalSize(columns=20, rows=5))
+    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+
+    root.lines = ("one", "two")
+    loop.mark_viewport_unsafe("external_stdout")
+    step = loop.plan(TerminalSize(columns=20, rows=5))
+
+    assert step.operation_class == "recovery_repaint"
+    assert step.repaint_reason == "external_stdout"
+
+
 def test_runtime_render_now_does_not_emit_tui_render_frame_when_scope_is_disabled() -> None:
     sink = RecordingDebugSink()
     reset_observability()

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -8,6 +8,7 @@ import pytest
 from loushang.observability import configure_debug_logging, reset_observability
 from loushang.tui import (
     CURSOR_MARKER,
+    CursorDeclaration,
     FakeTerminalPort,
     ProcessTerminalPort,
     RenderConstraints,
@@ -92,6 +93,27 @@ def test_runtime_render_now_emits_tui_render_frame_diagnostics() -> None:
     assert event.data["plan_ms"] >= 0
     assert event.data["flush_ms"] >= 0
     assert event.data["total_ms"] >= 0
+
+
+def test_render_plan_context_carries_cursor_and_diff_facts() -> None:
+    root = StaticRoot(("alpha",))
+    loop = RenderLoop(root)
+    size = TerminalSize(columns=20, rows=5)
+    first = loop.plan(size)
+    loop.commit(first, size=size)
+
+    root.lines = ("alpha", "beta" + CURSOR_MARKER)
+    context = loop._build_plan_context(size)
+
+    assert context.raw_current_lines == ("alpha", "beta")
+    assert context.current_lines == ("alpha", "beta")
+    assert context.declared_cursor == CursorDeclaration(row=1, column=4)
+    assert context.cursor == CursorDeclaration(row=1, column=4)
+    assert context.changed_range == (1, 1)
+    assert context.first_changed == 1
+    assert context.last_changed == 1
+    assert context.appended_lines == 1
+    assert context.append_start == 1
 
 
 def test_runtime_render_now_does_not_emit_tui_render_frame_when_scope_is_disabled() -> None:

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -160,6 +160,34 @@ def test_unsafe_viewport_precedes_append_strategy() -> None:
     assert step.repaint_reason == "external_stdout"
 
 
+def test_transcript_window_trimmed_reset_precedes_resize_repaint() -> None:
+    root = StaticRoot(("one",))
+    loop = RenderLoop(root)
+    first = loop.plan(TerminalSize(columns=20, rows=5))
+    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+
+    root.lines = ("one", "two")
+    loop.reset_baseline("transcript_window_trimmed:active_line_budget")
+    step = loop.plan(TerminalSize(columns=30, rows=5))
+
+    assert step.operation_class == "managed_viewport_repaint"
+    assert step.repaint_reason == "transcript_window_trimmed:active_line_budget"
+
+
+def test_ordinary_baseline_reset_precedes_resize_repaint() -> None:
+    root = StaticRoot(("one",))
+    loop = RenderLoop(root)
+    first = loop.plan(TerminalSize(columns=20, rows=5))
+    loop.commit(first, size=TerminalSize(columns=20, rows=5))
+
+    root.lines = ("one", "two")
+    loop.reset_baseline("transcript_window_replaced:resume")
+    step = loop.plan(TerminalSize(columns=30, rows=5))
+
+    assert step.operation_class == "baseline_repaint"
+    assert step.repaint_reason == "transcript_window_replaced:resume"
+
+
 def test_runtime_render_now_does_not_emit_tui_render_frame_when_scope_is_disabled() -> None:
     sink = RecordingDebugSink()
     reset_observability()

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -23,6 +23,7 @@ from loushang.tui import (
     delete_kitty_image,
     wrap_tmux_passthrough,
 )
+from loushang.tui.render_loop import DEFAULT_STRATEGY_ORDER, RenderPlanStrategyKind
 
 
 class StaticRoot:
@@ -114,6 +115,23 @@ def test_render_plan_context_carries_cursor_and_diff_facts() -> None:
     assert context.last_changed == 1
     assert context.appended_lines == 1
     assert context.append_start == 1
+
+
+def test_default_render_strategy_order_matches_design() -> None:
+    assert DEFAULT_STRATEGY_ORDER == (
+        RenderPlanStrategyKind.FIRST_RENDER,
+        RenderPlanStrategyKind.TRANSCRIPT_WINDOW_TRIMMED_RESET,
+        RenderPlanStrategyKind.BASELINE_RESET,
+        RenderPlanStrategyKind.RESIZE_REPAINT,
+        RenderPlanStrategyKind.UNSAFE_VIEWPORT,
+        RenderPlanStrategyKind.NO_CHANGE,
+        RenderPlanStrategyKind.APPEND,
+        RenderPlanStrategyKind.PROTECTED_APPEND,
+        RenderPlanStrategyKind.SHRINK_VIEWPORT_REPAINT,
+        RenderPlanStrategyKind.SHRINK_CLEAR,
+        RenderPlanStrategyKind.CHANGED_ABOVE_VIEWPORT,
+        RenderPlanStrategyKind.CHANGED_RANGE,
+    )
 
 
 def test_runtime_render_now_does_not_emit_tui_render_frame_when_scope_is_disabled() -> None:


### PR DESCRIPTION
## Summary
- Add RenderLoop strategy design and implementation plan docs
- Refactor RenderLoop planning through explicit stateless strategies while preserving operation_class behavior
- Add render-loop/managed-viewport docs and tighten active-window perf guard

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_loop.py tests/coding/test_native_coding_tui_perf_probe.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
- uv --cache-dir .uv-cache run ruff check src/loushang/tui/render_loop.py tests/tui/test_render_loop.py tests/coding/test_native_coding_tui_perf_probe.py