### PR TITLE
feat(coding): expose extension visibility command

### DIFF
--- a/docs/en/user-guide/README.md
+++ b/docs/en/user-guide/README.md
@@ -35,7 +35,7 @@ loushang --resume
 loushang --export
 ```
 
-Inside the interactive surface, built-in slash commands include `/session`, `/resume`, `/fork`, `/clone`, `/tree`, `/tools`, `/export`, `/compact`, `/reload`, and `/quit`.
+Inside the interactive surface, built-in slash commands include `/session`, `/resume`, `/fork`, `/clone`, `/tree`, `/tools`, `/extensions`, `/export`, `/compact`, `/reload`, and `/quit`.
 
 ## Tools
 
@@ -55,6 +55,8 @@ loushang --no-tools -p "Explain the repository from context only."
 ## Extensions
 
 Extensions are Python files that can register lifecycle hooks, tools, dynamic resources, commands, and flags. Start with the runnable extension examples in [examples/coding/extensions](../../../examples/coding/extensions/).
+
+An extension may include an adjacent `loushang-extension.toml` manifest to declare identity, permission level, dependencies, and expected contributions. Use `/extensions` to inspect loaded extensions, contribution summaries, and diagnostics; use `/extensions <id>` for one extension. `/tools` includes source information for extension-provided tools when available.
 
 ## Packages And Plugins
 

--- a/docs/zh-CN/user-guide/README.md
+++ b/docs/zh-CN/user-guide/README.md
@@ -35,7 +35,7 @@ loushang --resume
 loushang --export
 ```
 
-在交互界面中，内置 slash commands 包括 `/session`、`/resume`、`/fork`、`/clone`、`/tree`、`/tools`、`/export`、`/compact`、`/reload` 和 `/quit`。
+在交互界面中，内置 slash commands 包括 `/session`、`/resume`、`/fork`、`/clone`、`/tree`、`/tools`、`/extensions`、`/export`、`/compact`、`/reload` 和 `/quit`。
 
 ## 工具
 
@@ -55,6 +55,8 @@ loushang --no-tools -p "Explain the repository from context only."
 ## 扩展
 
 扩展是可以注册生命周期 hooks、工具、动态资源、命令和 flags 的 Python 文件。可以先阅读 [examples/coding/extensions](../../../examples/coding/extensions/) 中的可运行扩展示例。
+
+扩展可以携带相邻的 `loushang-extension.toml` manifest，用来声明身份、权限等级、依赖和预期贡献。使用 `/extensions` 查看已加载扩展、贡献摘要和诊断；使用 `/extensions <id>` 查看单个扩展详情。`/tools` 会在可用时展示 extension tool 的来源信息。
 
 ## 包与插件
 

--- a/examples/coding/example-manifest.toml
+++ b/examples/coding/example-manifest.toml
@@ -432,6 +432,18 @@ requires_api_key = false
 tags = ["coding", "extensions", "existing", "guard"]
 
 [[example]]
+id = "legacy-ext-05"
+slug = "extensions/05_manifest_visibility.py"
+title = "extensions/05_manifest_visibility.py - Manifest 与可见性"
+category = "extensions"
+description = "演示 loushang-extension.toml、/extensions 和 extension tool 来源信息。"
+runtime = "offline"
+entrypoint = "extensions/05_manifest_visibility.py"
+model_profile = "coding_primary"
+requires_api_key = false
+tags = ["coding", "extensions", "existing", "manifest", "visibility"]
+
+[[example]]
 id = "legacy-ext-11"
 slug = "extensions/11_online_tool_guard.py"
 title = "extensions/11_online_tool_guard.py - 在线工具拦截"

--- a/examples/coding/extensions/05_manifest_visibility.py
+++ b/examples/coding/extensions/05_manifest_visibility.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from pprint import pprint
+from tempfile import TemporaryDirectory
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _support import assistant_text_message, build_runtime, stream_with_final_message
+
+EXTENSION_SOURCE = """
+from loushang.coding.tools import tool
+
+
+@tool(label="Manifest Echo")
+async def manifest_echo(message: str) -> str:
+    '''Echo a message from a manifest-backed extension tool.'''
+    return f"manifest-echo: {message}"
+
+
+def register(api):
+    api.register_tool(manifest_echo)
+"""
+
+MANIFEST_SOURCE = """
+[extension]
+id = "examples.manifest-visibility"
+name = "Manifest Visibility"
+version = "0.1.0"
+description = "Demonstrates /extensions visibility."
+
+[permissions]
+level = "safe"
+
+[[tools]]
+name = "manifest_echo"
+description = "Echo a message from a manifest-backed extension tool."
+"""
+
+
+async def main() -> None:
+    with TemporaryDirectory(prefix="loushang-ext-manifest-") as tmpdir:
+        project_root = Path(tmpdir)
+        extension_dir = project_root / "extensions" / "manifest_visibility"
+        extension_dir.mkdir(parents=True)
+        extension_file = extension_dir / "extension.py"
+        manifest_file = extension_dir / "loushang-extension.toml"
+        extension_file.write_text(EXTENSION_SOURCE.strip() + "\n", encoding="utf-8")
+        manifest_file.write_text(MANIFEST_SOURCE.strip() + "\n", encoding="utf-8")
+
+        async def stream_fn(model, context, options=None):
+            return stream_with_final_message(assistant_text_message("Manifest visibility example ready."))
+
+        runtime = build_runtime(
+            session_dir=project_root / ".loushang-sessions",
+            stream_fn=stream_fn,
+            system_prompt="Manifest visibility extension example.",
+        )
+        session = await runtime.create_session(cwd=str(project_root))
+
+        print("=== Extension Example: Manifest Visibility ===")
+        print(f"Project root: {project_root}")
+        print(f"Extension file: {extension_file}")
+        print(f"Manifest file: {manifest_file}")
+        print()
+
+        extensions_result = await session.execute_command_async("/extensions", "")
+        tools_result = await session.execute_command_async("/tools", "")
+
+        print("/extensions result:")
+        pprint(extensions_result.result if extensions_result is not None else None)
+        print()
+
+        print("/tools extension entry:")
+        tools_payload = tools_result.result if tools_result is not None else {}
+        available_tools = tools_payload.get("available_tools", []) if isinstance(tools_payload, dict) else []
+        pprint([tool for tool in available_tools if tool.get("name") == "manifest_echo"])
+
+        await session.dispose()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        raise SystemExit(130)

--- a/examples/coding/extensions/README.md
+++ b/examples/coding/extensions/README.md
@@ -12,6 +12,7 @@ These examples demonstrate the current `loushang-coding` `ExtensionAPI v1` surfa
 - `02_dynamic_resources.py`: `resources_discover` with prompt and skill contributions
 - `03_custom_tool.py`: `@tool` and tool execution through a session
 - `04_tool_guard.py`: `tool_call` and `tool_result` interception
+- `05_manifest_visibility.py`: `loushang-extension.toml`, `/extensions`, and extension tool source visibility
 - `11_online_tool_guard.py`: extension interception on top of the real built-in `bash` tool
 - `12_online_dynamic_resources.py`: dynamic prompt/skill resources against a real model
 - `13_online_resume_with_extension.py`: persisted online session + restore with extension resources still active

--- a/src/loushang/coding/commands/types.py
+++ b/src/loushang/coding/commands/types.py
@@ -48,6 +48,7 @@ BUILTIN_SLASH_COMMANDS: tuple[BuiltinSlashCommand, ...] = (
     BuiltinSlashCommand(name="session", description="Show session info and stats"),
     BuiltinSlashCommand(name="terminal", description="Show terminal capabilities and protocol diagnostics"),
     BuiltinSlashCommand(name="tools", description="Show or update active tools for this session"),
+    BuiltinSlashCommand(name="extensions", description="Show loaded extensions and diagnostics"),
     BuiltinSlashCommand(name="changelog", description="Show changelog entries"),
     BuiltinSlashCommand(name="hotkeys", description="Show all keyboard shortcuts"),
     BuiltinSlashCommand(name="fork", description="Create a new fork from a previous user message"),

--- a/src/loushang/coding/extensions/runner.py
+++ b/src/loushang/coding/extensions/runner.py
@@ -1451,6 +1451,15 @@ class ExtensionRunner:
             ],
         }
 
+    def list_extensions(self) -> list[dict[str, object]]:
+        return [
+            _extension_visibility_snapshot(extension, diagnostics=self._diagnostics)
+            for extension in self._extensions
+        ]
+
+    def listExtensions(self) -> list[dict[str, object]]:
+        return self.list_extensions()
+
     def discover_resources(self, bundle: ResourceBundle, *, reason: str = "refresh") -> ResourceBundle:
         del reason
         merged = bundle
@@ -2269,6 +2278,150 @@ def _normalize_provider_response_headers(headers: object) -> dict[str, str]:
     for key, value in items:
         normalized[str(key)] = str(value)
     return normalized
+
+
+def _extension_visibility_snapshot(
+    extension: LoadedExtension,
+    *,
+    diagnostics: list[ResourceDiagnostic],
+) -> dict[str, object]:
+    manifest = extension.manifest
+    policy = extension.policy
+    source_info = _source_info_from_extension(extension)
+    extension_id = manifest.id if manifest is not None else extension.name
+    extension_name = manifest.name if manifest is not None else extension.name
+    manifest_path = _extension_manifest_path(extension)
+    return {
+        "id": extension_id,
+        "name": extension_name,
+        "runtimeName": extension.name,
+        "version": manifest.version if manifest is not None else None,
+        "description": manifest.description if manifest is not None else None,
+        "sourcePath": source_info.path.as_posix(),
+        "manifestPath": manifest_path.as_posix() if manifest_path is not None else None,
+        "enabled": policy.enabled if policy is not None else True,
+        "permissionLevel": (
+            policy.permission_level
+            if policy is not None
+            else manifest.permissions.level
+            if manifest is not None
+            else "safe"
+        ),
+        "capabilities": list(
+            policy.capabilities
+            if policy is not None
+            else manifest.permissions.capabilities
+            if manifest is not None
+            else ()
+        ),
+        "contributions": [
+            _serialize_contribution(contribution)
+            for contribution in extension.contributions
+        ],
+        "diagnostics": [
+            _serialize_diagnostic(diagnostic)
+            for diagnostic in _extension_visibility_diagnostics(
+                extension,
+                diagnostics=diagnostics,
+                manifest_path=manifest_path,
+            )
+        ],
+    }
+
+
+def _serialize_contribution(contribution: object) -> dict[str, object]:
+    metadata = getattr(contribution, "metadata", {})
+    source = metadata.get("source") if isinstance(metadata, dict) else None
+    return {
+        "type": str(getattr(contribution, "type", "")),
+        "name": str(getattr(contribution, "name", "")),
+        "active": bool(getattr(contribution, "active", True)),
+        "priority": int(getattr(contribution, "priority", 0)),
+        "source": source if isinstance(source, str) else "",
+        "sourcePath": _path_text(getattr(contribution, "source_path", None)),
+        "diagnostics": [
+            _serialize_diagnostic(diagnostic)
+            for diagnostic in getattr(contribution, "diagnostics", ())
+            if isinstance(diagnostic, ResourceDiagnostic)
+        ],
+    }
+
+
+def _extension_visibility_diagnostics(
+    extension: LoadedExtension,
+    *,
+    diagnostics: list[ResourceDiagnostic],
+    manifest_path: Path | None,
+) -> list[ResourceDiagnostic]:
+    source_paths = {
+        path
+        for path in (
+            extension.source_path,
+            extension.entry_path,
+            manifest_path,
+            *_extension_manifest_candidate_paths(extension),
+        )
+        if path is not None
+    }
+    result: list[ResourceDiagnostic] = []
+    seen: set[tuple[str, str, str | None]] = set()
+    for diagnostic in extension.diagnostics:
+        result, seen = _append_extension_diagnostic(result, seen, diagnostic)
+    for diagnostic in diagnostics:
+        if diagnostic.source_path is None or diagnostic.source_path not in source_paths:
+            continue
+        result, seen = _append_extension_diagnostic(result, seen, diagnostic)
+    return result
+
+
+def _append_extension_diagnostic(
+    result: list[ResourceDiagnostic],
+    seen: set[tuple[str, str, str | None]],
+    diagnostic: ResourceDiagnostic,
+) -> tuple[list[ResourceDiagnostic], set[tuple[str, str, str | None]]]:
+    key = (
+        diagnostic.code,
+        diagnostic.message,
+        diagnostic.source_path.as_posix() if diagnostic.source_path is not None else None,
+    )
+    if key not in seen:
+        seen.add(key)
+        result.append(diagnostic)
+    return result, seen
+
+
+def _serialize_diagnostic(diagnostic: ResourceDiagnostic) -> dict[str, object]:
+    return {
+        "code": diagnostic.code,
+        "message": diagnostic.message,
+        "sourcePath": diagnostic.source_path.as_posix() if diagnostic.source_path is not None else None,
+        "resourceId": diagnostic.resource_id,
+        "resourceType": diagnostic.resource_type,
+        "sourceKind": diagnostic.source_kind,
+        "metadata": dict(diagnostic.metadata),
+    }
+
+
+def _extension_manifest_path(extension: LoadedExtension) -> Path | None:
+    for candidate in _extension_manifest_candidate_paths(extension):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _extension_manifest_candidate_paths(extension: LoadedExtension) -> tuple[Path, ...]:
+    candidates: list[Path] = []
+    if extension.source_path.suffix:
+        candidates.append(extension.source_path.with_name("loushang-extension.toml"))
+    else:
+        candidates.append(extension.source_path / "loushang-extension.toml")
+    if extension.entry_path is not None:
+        candidates.append(extension.entry_path.parent / "loushang-extension.toml")
+    return tuple(dict.fromkeys(candidates))
+
+
+def _path_text(value: object) -> str:
+    return value.as_posix() if isinstance(value, Path) else str(value or "")
 
 
 def _source_info_from_extension(extension: LoadedExtension) -> SourceInfo:

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -269,9 +269,10 @@ class AgentSession:
                 navigate_tree=self._navigate_tree_from_extension,
                 import_session=self._import_from_builtin,
                 get_active_tool_names=self.get_active_tool_names,
-                get_all_tools=lambda: list(self.get_all_tools()),
+                get_all_tools=self.getAllTools,
                 set_active_tools=self.set_active_tools,
                 get_default_active_tool_names=self._default_active_tool_names,
+                get_extensions=self.list_extensions,
             ),
         )
         self._extension_event_sink = ExtensionEventSink(
@@ -498,6 +499,12 @@ class AgentSession:
 
     def list_commands(self) -> list[SessionCommandDescriptor]:
         return self._command_controller.list_commands()
+
+    def list_extensions(self) -> list[dict[str, object]]:
+        return self._extension_runner.list_extensions()
+
+    def listExtensions(self) -> list[dict[str, object]]:
+        return self.list_extensions()
 
     async def execute_command_async(self, invocation_name: str, args: str) -> CommandExecutionResult | None:
         return await self._command_controller.execute_command_async(invocation_name, args)

--- a/src/loushang/coding/session/builtin_commands.py
+++ b/src/loushang/coding/session/builtin_commands.py
@@ -259,6 +259,7 @@ def _execute_extensions(args: str, backend: BuiltinCommandBackend) -> CommandExe
         "extensions",
         extension=extension,
         message=f"Extension {_extension_id(extension)}: {_extension_name(extension)}",
+        display=_extension_detail_display(extension),
     )
 
 
@@ -465,6 +466,7 @@ def _extensions_ok(extensions: list[dict[str, object]]) -> CommandExecutionResul
         "extensions",
         extensions=extensions,
         message=_extensions_summary_message(extensions),
+        display=_extensions_display(extensions),
     )
 
 
@@ -483,6 +485,108 @@ def _extension_summary(extension: Mapping[str, object]) -> str:
     if diagnostic_count:
         details.append(f"{diagnostic_count} {_pluralize('diagnostic', diagnostic_count)}")
     return f"{_extension_id(extension)} ({', '.join(details)})"
+
+
+def _extensions_display(extensions: list[dict[str, object]]) -> str:
+    if not extensions:
+        return "Extensions:\n(none)"
+    lines = ["Extensions:"]
+    for extension in extensions:
+        lines.extend(_extension_list_display_lines(extension))
+    return "\n".join(lines)
+
+
+def _extension_list_display_lines(extension: Mapping[str, object]) -> list[str]:
+    lines = [
+        f"- {_extension_id(extension)} - {_extension_name(extension)} [{_string_mapping_field(extension, 'permissionLevel', default='safe')}]"
+    ]
+    source_path = _string_mapping_field(extension, "sourcePath")
+    if source_path:
+        lines.append(f"  Source: {source_path}")
+    contributions = _list_field(extension, "contributions")
+    if contributions:
+        lines.append(f"  Contributions: {_contributions_summary(contributions)}")
+    diagnostics = _list_field(extension, "diagnostics")
+    if diagnostics:
+        lines.append(f"  Diagnostics: {len(diagnostics)}")
+    return lines
+
+
+def _extension_detail_display(extension: Mapping[str, object]) -> str:
+    lines = [
+        f"Extension {_extension_id(extension)}",
+        f"Name: {_extension_name(extension)}",
+    ]
+    for label, field in (
+        ("Version", "version"),
+        ("Description", "description"),
+    ):
+        value = _string_mapping_field(extension, field)
+        if value:
+            lines.append(f"{label}: {value}")
+    lines.append(f"Permission: {_string_mapping_field(extension, 'permissionLevel', default='safe')}")
+    lines.append(f"Capabilities: {_capabilities_text(extension)}")
+    source_path = _string_mapping_field(extension, "sourcePath")
+    if source_path:
+        lines.append(f"Source: {source_path}")
+    manifest_path = _string_mapping_field(extension, "manifestPath")
+    if manifest_path:
+        lines.append(f"Manifest: {manifest_path}")
+    lines.extend(_contributions_detail_lines(_list_field(extension, "contributions")))
+    lines.extend(_diagnostic_detail_lines(_list_field(extension, "diagnostics")))
+    return "\n".join(lines)
+
+
+def _contributions_summary(contributions: list[object]) -> str:
+    parts: list[str] = []
+    for contribution in contributions:
+        if not isinstance(contribution, Mapping):
+            continue
+        contribution_type = _string_mapping_field(contribution, "type", default="contribution")
+        name = _string_mapping_field(contribution, "name")
+        if name:
+            parts.append(f"{contribution_type} {name}")
+    return ", ".join(parts) if parts else "(none)"
+
+
+def _contributions_detail_lines(contributions: list[object]) -> list[str]:
+    if not contributions:
+        return ["Contributions:", "- (none)"]
+    lines = ["Contributions:"]
+    for contribution in contributions:
+        if not isinstance(contribution, Mapping):
+            continue
+        contribution_type = _string_mapping_field(contribution, "type", default="contribution")
+        name = _string_mapping_field(contribution, "name", default="(unnamed)")
+        source = _string_mapping_field(contribution, "source")
+        suffix = f" ({source})" if source else ""
+        lines.append(f"- {contribution_type} {name}{suffix}")
+    return lines
+
+
+def _diagnostic_detail_lines(diagnostics: list[object]) -> list[str]:
+    if not diagnostics:
+        return ["Diagnostics:", "- (none)"]
+    lines = ["Diagnostics:"]
+    for diagnostic in diagnostics:
+        if not isinstance(diagnostic, Mapping):
+            continue
+        code = _string_mapping_field(diagnostic, "code", default="diagnostic")
+        message = _string_mapping_field(diagnostic, "message")
+        if message:
+            lines.append(f"- {code}: {message}")
+        else:
+            lines.append(f"- {code}")
+    return lines
+
+
+def _capabilities_text(extension: Mapping[str, object]) -> str:
+    capabilities = [
+        item
+        for item in _list_field(extension, "capabilities")
+        if isinstance(item, str) and item
+    ]
+    return ", ".join(capabilities) if capabilities else "(none)"
 
 
 def _find_extension(extensions: list[dict[str, object]], query: str) -> dict[str, object] | None:

--- a/src/loushang/coding/session/builtin_commands.py
+++ b/src/loushang/coding/session/builtin_commands.py
@@ -44,6 +44,7 @@ class BuiltinCommandBackend:
     get_all_tools: Callable[[], list[object]] | None = None
     set_active_tools: Callable[[list[str]], object | Awaitable[object]] | None = None
     get_default_active_tool_names: Callable[[], list[str]] | None = None
+    get_extensions: Callable[[], list[object]] | None = None
 
 
 def list_builtin_command_descriptors() -> list[SessionCommandDescriptor]:
@@ -85,6 +86,8 @@ async def execute_builtin_command_async(
             return _execute_changelog(args, backend)
         case "tools":
             return await _execute_tools(args, backend)
+        case "extensions":
+            return _execute_extensions(args, backend)
         case "compact":
             return await _execute_compact(args, backend)
         case "reload":
@@ -238,6 +241,25 @@ async def _execute_tools(args: str, backend: BuiltinCommandBackend) -> CommandEx
     next_tools = _filter_available_tools(next_tools, available_names)
     await _maybe_await(backend.set_active_tools(next_tools))
     return _tools_ok(next_tools, _available_tool_entries(backend.get_all_tools(), next_tools), action=action)
+
+
+def _execute_extensions(args: str, backend: BuiltinCommandBackend) -> CommandExecutionResult:
+    if backend.get_extensions is None:
+        return _unsupported("extensions")
+    extensions = [_extension_entry(extension) for extension in backend.get_extensions()]
+    query = args.strip()
+    if not query:
+        return _extensions_ok(extensions)
+
+    extension = _find_extension(extensions, query)
+    if extension is None:
+        available = ", ".join(_extension_id(extension) for extension in extensions) or "(none)"
+        return _error("extensions", f"Unknown extension: {query}. Loaded extensions: {available}")
+    return _ok(
+        "extensions",
+        extension=extension,
+        message=f"Extension {_extension_id(extension)}: {_extension_name(extension)}",
+    )
 
 
 async def _execute_compact(args: str, backend: BuiltinCommandBackend) -> CommandExecutionResult:
@@ -410,13 +432,15 @@ def _available_tool_entries(tools: list[object], active_tools: list[str]) -> lis
         name = _tool_field(tool, "name")
         if not name:
             continue
-        entries.append(
-            {
-                "name": name,
-                "active": name in active_set,
-                "description": _tool_field(tool, "description"),
-            }
-        )
+        entry: dict[str, object] = {
+            "name": name,
+            "active": name in active_set,
+            "description": _tool_field(tool, "description"),
+        }
+        source_info = _tool_source_info(tool)
+        if source_info is not None:
+            entry["sourceInfo"] = dict(source_info)
+        entries.append(entry)
     return entries
 
 
@@ -426,6 +450,86 @@ def _tool_field(tool: object, field: str) -> str:
     else:
         value = getattr(tool, field, None)
     return value if isinstance(value, str) else ""
+
+
+def _tool_source_info(tool: object) -> object | None:
+    if isinstance(tool, Mapping):
+        value = tool.get("sourceInfo") or tool.get("source_info")
+    else:
+        value = getattr(tool, "sourceInfo", None) or getattr(tool, "source_info", None)
+    return value if isinstance(value, Mapping) else None
+
+
+def _extensions_ok(extensions: list[dict[str, object]]) -> CommandExecutionResult:
+    return _ok(
+        "extensions",
+        extensions=extensions,
+        message=_extensions_summary_message(extensions),
+    )
+
+
+def _extensions_summary_message(extensions: list[dict[str, object]]) -> str:
+    if not extensions:
+        return "Extensions: (none)"
+    parts = [_extension_summary(extension) for extension in extensions]
+    return f"Extensions: {'; '.join(parts)}"
+
+
+def _extension_summary(extension: Mapping[str, object]) -> str:
+    contribution_count = len(_list_field(extension, "contributions"))
+    diagnostic_count = len(_list_field(extension, "diagnostics"))
+    details = [_string_mapping_field(extension, "permissionLevel", default="safe")]
+    details.append(f"{contribution_count} {_pluralize('contribution', contribution_count)}")
+    if diagnostic_count:
+        details.append(f"{diagnostic_count} {_pluralize('diagnostic', diagnostic_count)}")
+    return f"{_extension_id(extension)} ({', '.join(details)})"
+
+
+def _find_extension(extensions: list[dict[str, object]], query: str) -> dict[str, object] | None:
+    for extension in extensions:
+        if query in {_extension_id(extension), _extension_name(extension), _runtime_name(extension)}:
+            return extension
+    return None
+
+
+def _extension_entry(extension: object) -> dict[str, object]:
+    if isinstance(extension, Mapping):
+        return dict(extension)
+    return {
+        "id": _string_object_field(extension, "id", default=_string_object_field(extension, "name")),
+        "name": _string_object_field(extension, "name"),
+    }
+
+
+def _extension_id(extension: Mapping[str, object]) -> str:
+    return _string_mapping_field(extension, "id", default=_extension_name(extension))
+
+
+def _extension_name(extension: Mapping[str, object]) -> str:
+    return _string_mapping_field(extension, "name", default=_runtime_name(extension))
+
+
+def _runtime_name(extension: Mapping[str, object]) -> str:
+    return _string_mapping_field(extension, "runtimeName")
+
+
+def _string_mapping_field(value: Mapping[str, object], field: str, *, default: str = "") -> str:
+    raw = value.get(field)
+    return raw if isinstance(raw, str) and raw else default
+
+
+def _string_object_field(value: object, field: str, *, default: str = "") -> str:
+    raw = getattr(value, field, None)
+    return raw if isinstance(raw, str) and raw else default
+
+
+def _list_field(value: Mapping[str, object], field: str) -> list[object]:
+    raw = value.get(field)
+    return list(raw) if isinstance(raw, list | tuple) else []
+
+
+def _pluralize(word: str, count: int) -> str:
+    return word if count == 1 else f"{word}s"
 
 
 def _filter_available_tools(tool_names: list[str], available_names: list[str]) -> list[str]:

--- a/src/loushang/coding/ui/controller.py
+++ b/src/loushang/coding/ui/controller.py
@@ -225,6 +225,9 @@ def _controller_result_from_command_execution(execution: object, *, invocation_n
     if result is None and not hasattr(execution, "result"):
         result = execution
     if isinstance(result, dict):
+        display = result.get("display")
+        if isinstance(display, str) and display:
+            return ControllerResult(status_message=display)
         message = result.get("message")
         if isinstance(message, str) and message:
             if result.get("status") == "error":

--- a/tests/coding/test_commands.py
+++ b/tests/coding/test_commands.py
@@ -46,6 +46,7 @@ def test_builtin_slash_commands_match_pi_style_core_surface() -> None:
         "login": "Configure provider authentication",
         "logout": "Remove provider authentication",
         "tools": "Show or update active tools for this session",
+        "extensions": "Show loaded extensions and diagnostics",
         "new": "Start a new session",
         "compact": "Manually compact the session context",
         "resume": "Resume a different session",

--- a/tests/coding/test_extension_platform.py
+++ b/tests/coding/test_extension_platform.py
@@ -196,6 +196,105 @@ kind = "augment"
     assert loader.get_diagnostics() == []
 
 
+def test_extension_runner_lists_extension_visibility_snapshot() -> None:
+    from pathlib import Path
+
+    from loushang.coding.extensions import (
+        ContributionDescriptor,
+        ExtensionManifest,
+        ExtensionPermissionDeclaration,
+        ExtensionPolicyDecision,
+        ExtensionRunner,
+        LoadedExtension,
+    )
+    from loushang.coding.loader import ResourceDiagnostic
+
+    manifest = ExtensionManifest(
+        id="acme.review",
+        name="Acme Review",
+        version="0.1.0",
+        description="Review helpers",
+        permissions=ExtensionPermissionDeclaration(level="standard", capabilities=("filesystem",)),
+    )
+    extension = LoadedExtension(
+        name="review",
+        source_path=Path("/tmp/project/extensions/review/extension.py"),
+        manifest=manifest,
+        policy=ExtensionPolicyDecision(permission_level="standard", capabilities=("filesystem",)),
+        contributions=[
+            ContributionDescriptor(
+                type="command",
+                name="acme-review",
+                extension_id="acme.review",
+                source_path=Path("/tmp/project/extensions/review/extension.py"),
+                metadata={"source": "manifest"},
+            ),
+            ContributionDescriptor(
+                type="tool",
+                name="review_lookup",
+                extension_id="acme.review",
+                source_path=Path("/tmp/project/extensions/review/extension.py"),
+                metadata={"source": "runtime"},
+            ),
+        ],
+        diagnostics=[
+            ResourceDiagnostic(
+                code="missing_extension_hook_event",
+                message="Extension manifest hook declaration requires an event.",
+                source_path=Path("/tmp/project/extensions/review/loushang-extension.toml"),
+            )
+        ],
+    )
+
+    snapshot = ExtensionRunner([extension]).list_extensions()
+
+    assert snapshot == [
+        {
+            "id": "acme.review",
+            "name": "Acme Review",
+            "runtimeName": "review",
+            "version": "0.1.0",
+            "description": "Review helpers",
+            "sourcePath": "/tmp/project/extensions/review/extension.py",
+            "manifestPath": None,
+            "enabled": True,
+            "permissionLevel": "standard",
+            "capabilities": ["filesystem"],
+            "contributions": [
+                {
+                    "type": "command",
+                    "name": "acme-review",
+                    "active": True,
+                    "priority": 0,
+                    "source": "manifest",
+                    "sourcePath": "/tmp/project/extensions/review/extension.py",
+                    "diagnostics": [],
+                },
+                {
+                    "type": "tool",
+                    "name": "review_lookup",
+                    "active": True,
+                    "priority": 0,
+                    "source": "runtime",
+                    "sourcePath": "/tmp/project/extensions/review/extension.py",
+                    "diagnostics": [],
+                },
+            ],
+            "diagnostics": [
+                {
+                    "code": "missing_extension_hook_event",
+                    "message": "Extension manifest hook declaration requires an event.",
+                    "sourcePath": "/tmp/project/extensions/review/loushang-extension.toml",
+                    "resourceId": None,
+                    "resourceType": None,
+                    "sourceKind": None,
+                    "metadata": {},
+                }
+            ],
+        }
+    ]
+
+
 def test_contribution_registry_indexes_loaded_extension_contributions(tmp_path) -> None:
     from pathlib import Path
 

--- a/tests/coding/test_session_command_controller.py
+++ b/tests/coding/test_session_command_controller.py
@@ -279,6 +279,121 @@ def test_command_controller_executes_builtin_tools_list_and_mutations(tmp_path) 
     assert set_calls == [["read"], ["read", "bash"], ["read"], ["read", "grep", "bash"]]
 
 
+def test_command_controller_builtin_tools_preserves_tool_source_info(tmp_path) -> None:
+    controller = CommandController(
+        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False, session_id="session-1"),
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(
+            get_active_tool_names=lambda: ["review_lookup"],
+            get_all_tools=lambda: [
+                {
+                    "name": "review_lookup",
+                    "description": "Look up review metadata",
+                    "sourceInfo": {
+                        "path": "/tmp/project/extensions/review/extension.py",
+                        "source": "filesystem",
+                        "scope": "project",
+                        "origin": "package",
+                        "baseDir": "/tmp/project/extensions/review",
+                    },
+                }
+            ],
+        ),
+    )
+
+    result = asyncio.run(controller.execute_command_async("/tools", ""))
+
+    assert result is not None
+    assert result.result["available_tools"] == [
+        {
+            "name": "review_lookup",
+            "active": True,
+            "description": "Look up review metadata",
+            "sourceInfo": {
+                "path": "/tmp/project/extensions/review/extension.py",
+                "source": "filesystem",
+                "scope": "project",
+                "origin": "package",
+                "baseDir": "/tmp/project/extensions/review",
+            },
+        }
+    ]
+
+
+def test_command_controller_executes_builtin_extensions_list_and_detail(tmp_path) -> None:
+    extensions = [
+        {
+            "id": "acme.review",
+            "name": "Acme Review",
+            "version": "0.1.0",
+            "description": "Review helpers",
+            "sourcePath": "/tmp/project/extensions/review/extension.py",
+            "permissionLevel": "standard",
+            "capabilities": ["filesystem"],
+            "contributions": [
+                {"type": "command", "name": "acme-review", "active": True, "source": "manifest"},
+                {"type": "tool", "name": "review_lookup", "active": True, "source": "runtime"},
+            ],
+            "diagnostics": [
+                {
+                    "code": "missing_extension_hook_event",
+                    "message": "Extension manifest hook declaration requires an event.",
+                    "sourcePath": "/tmp/project/extensions/review/loushang-extension.toml",
+                }
+            ],
+        }
+    ]
+    controller = CommandController(
+        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False, session_id="session-1"),
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(get_extensions=lambda: extensions),
+    )
+
+    list_result = asyncio.run(controller.execute_command_async("/extensions", ""))
+    detail_result = asyncio.run(controller.execute_command_async("/extensions", "acme.review"))
+
+    assert list_result is not None
+    assert list_result.result == {
+        "source": "builtin",
+        "command": "extensions",
+        "status": "ok",
+        "extensions": extensions,
+        "message": "Extensions: acme.review (standard, 2 contributions, 1 diagnostic)",
+    }
+    assert detail_result is not None
+    assert detail_result.result == {
+        "source": "builtin",
+        "command": "extensions",
+        "status": "ok",
+        "extension": extensions[0],
+        "message": "Extension acme.review: Acme Review",
+    }
+
+
+def test_command_controller_builtin_extensions_reports_unknown_extension(tmp_path) -> None:
+    controller = CommandController(
+        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False, session_id="session-1"),
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(get_extensions=lambda: [{"id": "acme.review", "name": "Acme Review"}]),
+    )
+
+    result = asyncio.run(controller.execute_command_async("/extensions", "missing.ext"))
+
+    assert result is not None
+    assert result.result == {
+        "source": "builtin",
+        "command": "extensions",
+        "status": "error",
+        "message": "Unknown extension: missing.ext. Loaded extensions: acme.review",
+    }
+
+
 def test_command_controller_builtin_tools_rejects_unknown_tool(tmp_path) -> None:
     controller = CommandController(
         session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False, session_id="session-1"),

--- a/tests/coding/test_session_command_controller.py
+++ b/tests/coding/test_session_command_controller.py
@@ -363,6 +363,13 @@ def test_command_controller_executes_builtin_extensions_list_and_detail(tmp_path
         "status": "ok",
         "extensions": extensions,
         "message": "Extensions: acme.review (standard, 2 contributions, 1 diagnostic)",
+        "display": (
+            "Extensions:\n"
+            "- acme.review - Acme Review [standard]\n"
+            "  Source: /tmp/project/extensions/review/extension.py\n"
+            "  Contributions: command acme-review, tool review_lookup\n"
+            "  Diagnostics: 1"
+        ),
     }
     assert detail_result is not None
     assert detail_result.result == {
@@ -371,6 +378,20 @@ def test_command_controller_executes_builtin_extensions_list_and_detail(tmp_path
         "status": "ok",
         "extension": extensions[0],
         "message": "Extension acme.review: Acme Review",
+        "display": (
+            "Extension acme.review\n"
+            "Name: Acme Review\n"
+            "Version: 0.1.0\n"
+            "Description: Review helpers\n"
+            "Permission: standard\n"
+            "Capabilities: filesystem\n"
+            "Source: /tmp/project/extensions/review/extension.py\n"
+            "Contributions:\n"
+            "- command acme-review (manifest)\n"
+            "- tool review_lookup (runtime)\n"
+            "Diagnostics:\n"
+            "- missing_extension_hook_event: Extension manifest hook declaration requires an event."
+        ),
     }
 
 

--- a/tests/coding/test_ui_controller.py
+++ b/tests/coding/test_ui_controller.py
@@ -197,6 +197,44 @@ def test_controller_dispatches_catalog_session_command_without_prompting_agent()
     assert session.prompts == []
 
 
+def test_controller_prefers_session_command_display_text_for_status() -> None:
+    from loushang.coding.ui.controller import CodingUiController
+    from loushang.coding.ui.intent import PromptIntent
+
+    class CommandSession(_Session):
+        def list_commands(self) -> list[object]:
+            return [
+                SimpleNamespace(
+                    name="extensions",
+                    description="Show loaded extensions and diagnostics",
+                    source="builtin",
+                )
+            ]
+
+        async def execute_command_async(self, invocation_name: str, args: str) -> object:
+            return SimpleNamespace(
+                invocation_name=invocation_name,
+                result={
+                    "source": "builtin",
+                    "command": invocation_name,
+                    "status": "ok",
+                    "message": "Extensions: acme.review (standard, 2 contributions)",
+                    "display": "Extensions:\n- acme.review - Acme Review [standard]\n  Contributions: command acme-review, tool review_lookup",
+                },
+            )
+
+    controller = CodingUiController(session=CommandSession())
+
+    result = asyncio.run(controller.dispatch(PromptIntent(text="/extensions")))
+
+    assert result.error_message is None
+    assert result.status_message == (
+        "Extensions:\n"
+        "- acme.review - Acme Review [standard]\n"
+        "  Contributions: command acme-review, tool review_lookup"
+    )
+
+
 def test_controller_leaves_prompt_resource_commands_on_prompt_path() -> None:
     from loushang.coding.ui.controller import CodingUiController
     from loushang.coding.ui.intent import PromptIntent


### PR DESCRIPTION
## Summary / 摘要
- Add a read-only /extensions builtin command for loaded extension visibility and details.
- Expose ExtensionRunner.list_extensions() snapshots with manifest, policy, contribution, and diagnostic data.
- Preserve sourceInfo for extension-provided tools in /tools output.
- Add an offline manifest visibility example and update EN/ZH user docs.

## Validation / 验证
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/commands/types.py src/loushang/coding/session/builtin_commands.py src/loushang/coding/session/agent_session.py src/loushang/coding/extensions/runner.py tests/coding/test_commands.py tests/coding/test_session_command_controller.py tests/coding/test_extension_platform.py examples/coding/extensions/05_manifest_visibility.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_commands.py tests/coding/test_session_command_controller.py tests/coding/test_extension_platform.py tests/coding/test_extension_runner.py tests/coding/test_extension_loader.py tests/coding/test_extension_api.py tests/coding/test_agent_session_tools.py tests/coding/test_ui_command_list.py -q
- uv --cache-dir .uv-cache run --extra dev python examples/coding/extensions/05_manifest_visibility.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding -q