### PR TITLE
Refactor TUI input routing through prompt targets

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md
@@ -17,6 +17,12 @@ in this order:
 4. product adapter command routing
 5. global keybindings
 
+The generic prompt route uses a `PromptInputTarget` boundary. `InputRouter`
+owns routing priority and prompt intents, while concrete editors provide
+operations through target adapters such as `ComposerInputTarget`. Product
+adapters may reuse target helper functions, but they keep their own routing
+order when product semantics differ.
+
 Keybindings are configuration-owned by the runtime or product adapter. The
 coding product adapter loads configured keybindings from settings and passes
 them into the native input router. UI parts may handle routed events, but they
@@ -82,7 +88,7 @@ normalized input events:
 - paste marker is an editor atom that may stand in for a large payload while the
   full payload remains available for submission
 
-These editor primitives are local to the focused composer until the product
+These editor primitives are local to the focused prompt target until the product
 adapter receives a submit, steer, or follow-up intent.
 
 ## Test Obligations

--- a/docs/superpowers/plans/2026-06-09-tui-input-router-target-decoupling-implementation.md
+++ b/docs/superpowers/plans/2026-06-09-tui-input-router-target-decoupling-implementation.md
@@ -1,0 +1,782 @@
+# TUI InputRouter Target Decoupling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor generic TUI input routing so `InputRouter` routes through a prompt target adapter instead of directly depending on concrete `Composer` methods.
+
+**Architecture:** Keep the first slice behavior-preserving. Define target protocols and `ComposerInputTarget` in `src/loushang/tui/input.py`, route generic `InputRouter` through an internal `_target`, and keep `InputRouter(composer=...)` as the compatibility path. Native coding input may reuse target helpers only where that does not change its product-specific routing order.
+
+**Tech Stack:** Python 3.11+, dataclasses, typing `Protocol`, pytest, existing `loushang.tui` input tests, `uv --cache-dir .uv-cache run --extra dev pytest`.
+
+---
+
+## Reference Documents
+
+- Spec: `docs/superpowers/specs/2026-06-09-tui-input-router-decouple-design.md`
+- Generic input implementation: `src/loushang/tui/input.py`
+- Native coding input implementation: `src/loushang/coding/ui/native_input.py`
+- Generic input tests: `tests/tui/test_input_routing.py`
+- Native input tests: `tests/coding/test_native_coding_tui_input.py`
+- Existing routing design note: `docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md`
+
+## File Structure
+
+- Modify `src/loushang/tui/input.py`
+  - Add `EditorInputTarget`, `PromptInputTarget`, `ComposerInputTarget`, generic route helper functions, and `InputRouter` target construction.
+  - Keep these in `input.py` for this slice to avoid import churn. Split to a new `input_targets.py` only in a later cleanup if the module becomes harder to navigate.
+- Modify `tests/tui/test_input_routing.py`
+  - Add fake target tests for constructor rules and protocol routing.
+  - Keep existing Composer-backed tests as behavior parity coverage.
+- Modify `src/loushang/coding/ui/native_input.py`
+  - Reuse target helpers for ordinary selection/editing/completion routing without changing native priority order.
+- Modify `tests/coding/test_native_coding_tui_input.py`
+  - Add behavior coverage that proves native slash-command selected completion stays native-only.
+- Modify `docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md`
+  - Document the new target boundary and generic/native routing distinction.
+
+## Task 1: Add Red Tests for Target Construction and Helper Routing
+
+**Files:**
+- Modify: `tests/tui/test_input_routing.py`
+
+- [ ] **Step 1: Add pytest import**
+
+At the top of `tests/tui/test_input_routing.py`, add:
+
+```python
+import pytest
+```
+
+- [ ] **Step 2: Add imports for new symbols**
+
+Extend the existing `from loushang.tui.input import ...` usage or add a direct import:
+
+```python
+from loushang.tui.input import (
+    route_editor_editing_key,
+    route_editor_selection_key,
+)
+```
+
+Do not import these from `loushang.tui.__init__`; this slice does not need to expand the top-level public API.
+
+- [ ] **Step 3: Add a fake prompt target test double**
+
+Add this helper near the existing test helper classes:
+
+```python
+@dataclass(slots=True)
+class FakePromptTarget:
+    value: str = ""
+    browsing_history: bool = False
+    has_completions: bool = False
+    calls: list[str] = field(default_factory=list)
+    history: list[str] = field(default_factory=list)
+
+    def insert_text(self, text: str) -> None:
+        self.calls.append(f"insert_text:{text}")
+        self.value += text
+
+    def paste(self, text: str) -> None:
+        self.calls.append(f"paste:{text}")
+        self.value += text
+
+    def clear(self) -> None:
+        self.calls.append("clear")
+        self.value = ""
+
+    def add_history(self, text: str) -> None:
+        self.calls.append(f"add_history:{text}")
+        self.history.append(text)
+
+    def insert_newline(self) -> None:
+        self.calls.append("insert_newline")
+        self.value += "\n"
+
+    def _record(self, name: str) -> None:
+        self.calls.append(name)
+
+    def move_left(self) -> None:
+        self._record("move_left")
+
+    def move_right(self) -> None:
+        self._record("move_right")
+
+    def move_word_left(self) -> None:
+        self._record("move_word_left")
+
+    def move_word_right(self) -> None:
+        self._record("move_word_right")
+
+    def move_to_line_start(self) -> None:
+        self._record("move_to_line_start")
+
+    def move_to_line_end(self) -> None:
+        self._record("move_to_line_end")
+
+    def select_char_left(self) -> None:
+        self._record("select_char_left")
+
+    def select_char_right(self) -> None:
+        self._record("select_char_right")
+
+    def select_word_left(self) -> None:
+        self._record("select_word_left")
+
+    def select_word_right(self) -> None:
+        self._record("select_word_right")
+
+    def select_line_start(self) -> None:
+        self._record("select_line_start")
+
+    def select_line_end(self) -> None:
+        self._record("select_line_end")
+
+    def delete_backward(self) -> None:
+        self._record("delete_backward")
+
+    def delete_forward(self) -> None:
+        self._record("delete_forward")
+
+    def delete_word_backward(self) -> None:
+        self._record("delete_word_backward")
+
+    def delete_word_forward(self) -> None:
+        self._record("delete_word_forward")
+
+    def kill_to_line_start(self) -> None:
+        self._record("kill_to_line_start")
+
+    def kill_to_line_end(self) -> None:
+        self._record("kill_to_line_end")
+
+    def yank(self) -> None:
+        self._record("yank")
+
+    def yank_pop(self) -> None:
+        self._record("yank_pop")
+
+    def undo(self) -> None:
+        self._record("undo")
+
+    def redo(self) -> None:
+        self._record("redo")
+
+    def history_previous(self) -> None:
+        self._record("history_previous")
+
+    def history_next(self) -> None:
+        self._record("history_next")
+
+    def move_visual_up(self, *, width: int) -> bool:
+        self.calls.append(f"move_visual_up:{width}")
+        return False
+
+    def move_visual_down(self, *, width: int) -> bool:
+        self.calls.append(f"move_visual_down:{width}")
+        return False
+
+    def move_visual_page_up(self, *, width: int, visible_lines: int) -> None:
+        self.calls.append(f"move_visual_page_up:{width}:{visible_lines}")
+
+    def move_visual_page_down(self, *, width: int, visible_lines: int) -> None:
+        self.calls.append(f"move_visual_page_down:{width}:{visible_lines}")
+
+    def jump_to_char(self, text: str, *, direction: Literal["forward", "backward"]) -> None:
+        self.calls.append(f"jump_to_char:{direction}:{text}")
+
+    def refresh_completions(self, *, force: bool = False, explicit: bool = False) -> None:
+        self.calls.append(f"refresh_completions:{force}:{explicit}")
+        self.has_completions = True
+
+    def apply_selected_completion(self) -> None:
+        self.calls.append("apply_selected_completion")
+
+    def select_previous_completion(self) -> None:
+        self.calls.append("select_previous_completion")
+
+    def select_next_completion(self) -> None:
+        self.calls.append("select_next_completion")
+
+    def clear_completion_items(self) -> None:
+        self.calls.append("clear_completion_items")
+        self.has_completions = False
+```
+
+Also add these imports to the test file:
+
+```python
+from dataclasses import dataclass, field
+from typing import Literal
+```
+
+If `dataclass` is already imported, only add `field`.
+
+- [ ] **Step 4: Add constructor and target routing tests**
+
+Add:
+
+```python
+def test_input_router_rejects_missing_prompt_target() -> None:
+    with pytest.raises(TypeError, match="requires composer or target"):
+        InputRouter()
+
+
+def test_input_router_rejects_composer_and_target_together() -> None:
+    with pytest.raises(TypeError, match="composer or target"):
+        InputRouter(composer=Composer(prompt="> "), target=FakePromptTarget())
+
+
+def test_input_router_routes_text_paste_and_submit_through_target() -> None:
+    target = FakePromptTarget()
+    router = InputRouter(target=target)
+
+    assert router.route(InputEvent(kind="text", text="he")) == ()
+    assert router.route(InputEvent(kind="paste", text="llo")) == ()
+    assert router.route(InputEvent(kind="key", key="enter")) == (InputIntent(kind="submit", text="hello"),)
+
+    assert target.calls == [
+        "insert_text:he",
+        "paste:llo",
+        "add_history:hello",
+        "clear",
+    ]
+    assert target.history == ["hello"]
+    assert target.value == ""
+```
+
+- [ ] **Step 5: Add helper routing tests**
+
+Add:
+
+```python
+def test_editor_key_helpers_route_to_target_operations() -> None:
+    target = FakePromptTarget()
+
+    assert route_editor_editing_key(target, "left")
+    assert route_editor_selection_key(target, "shift+left")
+
+    assert target.calls == ["move_left", "select_char_left"]
+```
+
+- [ ] **Step 6: Run new tests and verify RED**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest \
+  tests/tui/test_input_routing.py::test_input_router_rejects_missing_prompt_target \
+  tests/tui/test_input_routing.py::test_input_router_rejects_composer_and_target_together \
+  tests/tui/test_input_routing.py::test_input_router_routes_text_paste_and_submit_through_target \
+  tests/tui/test_input_routing.py::test_editor_key_helpers_route_to_target_operations \
+  -q
+```
+
+Expected: FAIL because `InputRouter(target=...)`, constructor validation, and `route_editor_*` helpers do not exist yet.
+
+- [ ] **Step 7: Leave red tests uncommitted**
+
+Do not commit Task 1 by itself. Continue to Tasks 2 and 3, then commit the tests
+and green implementation together.
+
+## Task 2: Add Target Protocols, Composer Adapter, and Helper Functions
+
+**Files:**
+- Modify: `src/loushang/tui/input.py`
+- Test: `tests/tui/test_input_routing.py`
+
+- [ ] **Step 1: Add typing and dataclass imports**
+
+Change imports in `src/loushang/tui/input.py`:
+
+```python
+from dataclasses import InitVar, dataclass, field
+from typing import Literal, Protocol
+```
+
+Use only the imports actually needed after implementation.
+
+- [ ] **Step 2: Add target protocols**
+
+Place these above `InputRouter`:
+
+```python
+class EditorInputTarget(Protocol):
+    def insert_text(self, text: str) -> None: ...
+    def paste(self, text: str) -> None: ...
+    def move_left(self) -> None: ...
+    def move_right(self) -> None: ...
+    def move_word_left(self) -> None: ...
+    def move_word_right(self) -> None: ...
+    def move_to_line_start(self) -> None: ...
+    def move_to_line_end(self) -> None: ...
+    def select_char_left(self) -> None: ...
+    def select_char_right(self) -> None: ...
+    def select_word_left(self) -> None: ...
+    def select_word_right(self) -> None: ...
+    def select_line_start(self) -> None: ...
+    def select_line_end(self) -> None: ...
+    def delete_backward(self) -> None: ...
+    def delete_forward(self) -> None: ...
+    def delete_word_backward(self) -> None: ...
+    def delete_word_forward(self) -> None: ...
+    def kill_to_line_start(self) -> None: ...
+    def kill_to_line_end(self) -> None: ...
+    def yank(self) -> None: ...
+    def yank_pop(self) -> None: ...
+    def undo(self) -> None: ...
+    def redo(self) -> None: ...
+
+
+class PromptInputTarget(EditorInputTarget, Protocol):
+    @property
+    def value(self) -> str: ...
+
+    @property
+    def browsing_history(self) -> bool: ...
+
+    @property
+    def has_completions(self) -> bool: ...
+
+    def clear(self) -> None: ...
+    def add_history(self, text: str) -> None: ...
+    def insert_newline(self) -> None: ...
+    def history_previous(self) -> None: ...
+    def history_next(self) -> None: ...
+    def move_visual_up(self, *, width: int) -> bool: ...
+    def move_visual_down(self, *, width: int) -> bool: ...
+    def move_visual_page_up(self, *, width: int, visible_lines: int) -> None: ...
+    def move_visual_page_down(self, *, width: int, visible_lines: int) -> None: ...
+    def jump_to_char(self, text: str, *, direction: Literal["forward", "backward"]) -> None: ...
+    def refresh_completions(self, *, force: bool = False, explicit: bool = False) -> None: ...
+    def apply_selected_completion(self) -> None: ...
+    def select_previous_completion(self) -> None: ...
+    def select_next_completion(self) -> None: ...
+    def clear_completion_items(self) -> None: ...
+```
+
+- [ ] **Step 3: Add ComposerInputTarget**
+
+Add below the protocols:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ComposerInputTarget:
+    composer: Composer
+
+    @property
+    def value(self) -> str:
+        return self.composer.value
+
+    @property
+    def browsing_history(self) -> bool:
+        return self.composer.browsing_history
+
+    @property
+    def has_completions(self) -> bool:
+        return self.composer.has_completions
+```
+
+Then implement all protocol methods as direct delegations to `self.composer`.
+Do not add new behavior or validation in the adapter.
+
+- [ ] **Step 4: Add generic helper functions**
+
+Rename the helper bodies by introducing these target-based helper signatures:
+
+```python
+def route_editor_editing_key(
+    target: EditorInputTarget,
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> bool: ...
+
+
+def route_editor_selection_key(
+    target: EditorInputTarget,
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> bool: ...
+
+
+def route_prompt_completion_key(
+    target: PromptInputTarget,
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> bool: ...
+```
+
+Move the current `route_composer_editing_key()` and `route_composer_selection_key()` bodies into the first two helpers, replacing `composer` with `target`.
+
+`route_prompt_completion_key()` must contain only this completion navigation/cancel/apply logic:
+
+```python
+def route_prompt_completion_key(
+    target: PromptInputTarget,
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> bool:
+    keybindings = keybindings or KeybindingManager()
+    if keybindings.matches(key, "tui.select.up"):
+        target.select_previous_completion()
+        return True
+    if keybindings.matches(key, "tui.select.down"):
+        target.select_next_completion()
+        return True
+    if keybindings.matches(key, "tui.input.tab"):
+        target.apply_selected_completion()
+        return True
+    if keybindings.matches(key, "tui.select.cancel"):
+        target.clear_completion_items()
+        return True
+    return False
+```
+
+- [ ] **Step 5: Keep compatibility wrappers**
+
+Replace old helpers with wrappers:
+
+```python
+def route_composer_editing_key(
+    composer: Composer,
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> bool:
+    return route_editor_editing_key(ComposerInputTarget(composer), key, keybindings=keybindings)
+```
+
+Do the same for `route_composer_selection_key()`.
+
+- [ ] **Step 6: Run helper tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest \
+  tests/tui/test_input_routing.py::test_editor_key_helpers_route_to_target_operations \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run existing input routing tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_input_routing.py -q
+```
+
+Expected: constructor target tests still FAIL until Task 3; existing Composer-backed tests should not regress.
+
+## Task 3: Route Generic InputRouter Through `_target`
+
+**Files:**
+- Modify: `src/loushang/tui/input.py`
+- Test: `tests/tui/test_input_routing.py`
+
+- [ ] **Step 1: Change InputRouter fields and post-init**
+
+Change the dataclass fields:
+
+```python
+@dataclass(slots=True)
+class InputRouter:
+    composer: Composer | None = None
+    target: InitVar[PromptInputTarget | None] = None
+    surface_host: SurfaceHost | None = None
+    running: bool = False
+    steering_supported: bool = False
+    width: int = 80
+    height: int = 24
+    keybindings: KeybindingManager | None = None
+    _target: PromptInputTarget = field(init=False, repr=False)
+    _jump_mode: Literal["forward", "backward"] | None = None
+```
+
+Add:
+
+```python
+def __post_init__(self, target: PromptInputTarget | None) -> None:
+    if self.composer is not None and target is not None:
+        raise TypeError("InputRouter accepts composer or target, not both")
+    if target is not None:
+        self._target = target
+        return
+    if self.composer is not None:
+        self._target = ComposerInputTarget(self.composer)
+        return
+    raise TypeError("InputRouter requires composer or target")
+```
+
+Do not expose `target` as a public property in this task. Tests should verify behavior, not internals.
+
+- [ ] **Step 2: Replace concrete composer calls in generic route path**
+
+Inside `InputRouter.route()`, assign:
+
+```python
+target = self._target
+```
+
+Replace direct generic routing calls:
+
+- `route_composer_selection_key(self.composer, ...)` -> `route_editor_selection_key(target, ...)`
+- completion navigation block -> `target.has_completions and route_prompt_completion_key(target, ...)`
+- `self.composer.refresh_completions(...)` -> `target.refresh_completions(...)`
+- `self.composer.apply_selected_completion()` -> `target.apply_selected_completion()`
+- `self.composer.insert_newline()` -> `target.insert_newline()`
+- `route_composer_editing_key(self.composer, ...)` -> `route_editor_editing_key(target, ...)`
+- paste/text/jump operations -> `target.*`
+
+Do not add the native slash-command submit behavior to generic `InputRouter`. Existing `test_input_router_enter_submits_text_without_applying_completion` must keep passing.
+
+- [ ] **Step 3: Replace submit and visual movement internals**
+
+Update `submit()`, `_move_up_or_history()`, and `_move_down_or_history()` to use `self._target`.
+
+`submit()` must still:
+
+1. Read `text = self._target.value`.
+2. Return `()` if `not text`.
+3. Call `self._target.add_history(text)`.
+4. Call `self._target.clear()`.
+5. Return `submit`, `steer`, or `follow_up` intents exactly as today.
+
+- [ ] **Step 4: Run new target constructor tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest \
+  tests/tui/test_input_routing.py::test_input_router_rejects_missing_prompt_target \
+  tests/tui/test_input_routing.py::test_input_router_rejects_composer_and_target_together \
+  tests/tui/test_input_routing.py::test_input_router_routes_text_paste_and_submit_through_target \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run generic behavior tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_input_routing.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Tasks 1-3**
+
+Commit the red tests and green implementation together:
+
+```bash
+git add src/loushang/tui/input.py tests/tui/test_input_routing.py
+git commit -m "refactor(tui): route input through prompt targets"
+```
+
+## Task 4: Reuse Safe Target Helpers in NativeInputRouter
+
+**Files:**
+- Modify: `src/loushang/coding/ui/native_input.py`
+- Test: `tests/coding/test_native_coding_tui_input.py`
+
+- [ ] **Step 1: Add native slash-completion submit regression test**
+
+Add this test near the other native completion tests:
+
+```python
+def test_native_input_router_enter_applies_slash_completion_before_submit() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_input import NativeInputRouter
+
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 12.0)
+    app.composer.set_text("/mo")
+    app.composer.set_completion_items((CompletionItem(value="/model", label="/model"),))
+
+    result = NativeInputRouter(
+        app,
+        should_exit=lambda text: False,
+        is_local_command=lambda text: text == "/model",
+    ).handle(InputEvent(kind="key", key="enter"))
+
+    assert result.local_text == "/model"
+    assert app.composer.value == ""
+```
+
+- [ ] **Step 2: Run the native regression test**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest \
+  tests/coding/test_native_coding_tui_input.py::test_native_input_router_enter_applies_slash_completion_before_submit \
+  -q
+```
+
+Expected: PASS before and after the helper refactor. This is a characterization
+test for existing native-only behavior, not a red test.
+
+- [ ] **Step 3: Add imports**
+
+Change the input imports:
+
+```python
+from loushang.tui.input import (
+    ComposerInputTarget,
+    InputEvent,
+    InputIntent,
+    route_editor_editing_key,
+    route_editor_selection_key,
+    route_prompt_completion_key,
+)
+```
+
+Remove `route_composer_editing_key` and `route_composer_selection_key` imports if no longer used.
+
+- [ ] **Step 4: Store a ComposerInputTarget**
+
+Add a private field:
+
+```python
+_composer_target: ComposerInputTarget = field(init=False, repr=False)
+```
+
+In `__post_init__()`:
+
+```python
+self._composer_target = ComposerInputTarget(self.app.composer)
+```
+
+Keep the existing keybinding manager normalization unchanged.
+
+- [ ] **Step 5: Replace safe helper usage only**
+
+Replace:
+
+```python
+route_composer_selection_key(self.app.composer, event.key, keybindings=keybindings)
+route_composer_editing_key(self.app.composer, event.key, keybindings=keybindings)
+```
+
+with:
+
+```python
+route_editor_selection_key(self._composer_target, event.key, keybindings=keybindings)
+route_editor_editing_key(self._composer_target, event.key, keybindings=keybindings)
+```
+
+In `_route_completion_key()`, replace the hand-written completion navigation body with:
+
+```python
+return route_prompt_completion_key(self._composer_target, event.key, keybindings=keybindings)
+```
+
+Do not move `_submit_selected_completion()`, `follow_up_keys`, clipboard image handling, transcript commands, active surface routing, or runtime surface routing.
+
+- [ ] **Step 6: Run native input tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_input.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git add src/loushang/coding/ui/native_input.py tests/coding/test_native_coding_tui_input.py
+git commit -m "refactor(tui): reuse input target helpers in native router"
+```
+
+The native regression test is part of this task, so include the native test file
+in the commit.
+
+## Task 5: Document the Target Boundary and Run Final Verification
+
+**Files:**
+- Modify: `docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md`
+- Verify: `src/loushang/tui/input.py`
+- Verify: `src/loushang/coding/ui/native_input.py`
+- Verify: `tests/tui/test_input_routing.py`
+- Verify: `tests/coding/test_native_coding_tui_input.py`
+
+- [ ] **Step 1: Update KD-002**
+
+In the `Design` section, add a short paragraph after the routing-order list:
+
+```markdown
+The generic prompt route uses a `PromptInputTarget` boundary. `InputRouter`
+owns routing priority and prompt intents, while concrete editors provide
+operations through target adapters such as `ComposerInputTarget`. Product
+adapters may reuse target helper functions, but they keep their own routing
+order when product semantics differ.
+```
+
+In `Editor State Model`, replace "focused composer" wording where appropriate with "focused prompt target" while preserving references that are specifically about the Composer UI part.
+
+- [ ] **Step 2: Run focused generic and native tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest \
+  tests/tui/test_input_routing.py \
+  tests/tui/test_text_input.py \
+  tests/coding/test_native_coding_tui_input.py \
+  -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run broader TUI tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint on changed files**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev ruff check \
+  src/loushang/tui/input.py \
+  src/loushang/coding/ui/native_input.py \
+  tests/tui/test_input_routing.py \
+  tests/coding/test_native_coding_tui_input.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 5: Commit Task 5**
+
+```bash
+git add docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md
+git commit -m "docs(tui): document input target routing boundary"
+```
+
+Make this a separate documentation commit.
+
+## Final Acceptance Criteria
+
+- `InputRouter(composer=...)` remains compatible with existing callers.
+- `InputRouter(target=...)` works with a fake prompt target and no `Composer`.
+- Passing both `composer` and `target` raises `TypeError`.
+- Generic enter with active completion submits raw text and does not apply completion.
+- Native slash-command selected-completion submit remains native-only.
+- `route_composer_editing_key()` and `route_composer_selection_key()` remain compatibility wrappers.
+- Native router helper reuse does not reorder runtime surface, active surface, text/paste/resize, transcript, clipboard, follow-up, or slash-command submit behavior.
+- Focused verification and ruff commands pass.

--- a/docs/superpowers/specs/2026-06-09-tui-input-router-decouple-design.md
+++ b/docs/superpowers/specs/2026-06-09-tui-input-router-decouple-design.md
@@ -1,0 +1,363 @@
+# TUI InputRouter Target Decoupling Design
+
+## Status
+
+Draft for implementation planning.
+
+## Context
+
+`loushang.tui` has a mature terminal input stack: `InputReader` normalizes
+terminal byte streams into `InputEvent`, `InputRouter` turns those events into
+editor mutations or `InputIntent`, and `SurfaceHost` can route events to focused
+surfaces. The rendering layer now has an explicit strategy pipeline, so the next
+maintainability issue is input routing.
+
+The current `InputRouter` is coupled directly to `Composer`. It stores
+`composer: Composer`, calls many concrete `composer.*` methods, and exposes
+helper functions named `route_composer_editing_key()` and
+`route_composer_selection_key()`. This works for the prompt composer, but it
+makes multiple editor instances awkward. Any future search field, dialog input,
+tree filter, or inline editor either needs to bypass `InputRouter` or grow more
+Composer-specific conditionals.
+
+The codebase already has the pieces for a cleaner model. `SurfaceHost` tracks a
+focused `Focusable`, translates mouse coordinates for surface entries, and routes
+surface events before the composer. `TextInput` already implements its own
+`handle_input()` and has focused rendering. The gap is a narrow target boundary
+between generic router decisions and prompt-specific Composer behavior.
+
+## Goals
+
+- Remove `InputRouter`'s hard dependency on the concrete `Composer` type.
+- Preserve all existing key behavior, `InputIntent` values, and routing priority.
+- Keep `composer=` construction working for existing callers and tests.
+- Make prompt-specific behavior explicit instead of pretending every editor has
+  history, completions, steering, and queued follow-up semantics.
+- Create a path for multiple editable widgets without introducing a full focus
+  manager in this slice.
+- Reduce duplicated Composer key routing between `InputRouter` and
+  `NativeInputRouter` in a later implementation phase.
+
+## Non-Goals
+
+- Do not change `InputReader` parsing, key names, paste sanitization, or Kitty
+  input protocol handling.
+- Do not change submit, follow-up, steer, completion, history, or abort
+  semantics.
+- Do not introduce a widget ecosystem, dialog framework, or global focus manager.
+- Do not make `TextInput` the prompt composer.
+- Do not require existing callers to replace `InputRouter(composer=...)` in the
+  first implementation.
+- Do not move product-specific native coding behavior into `loushang.tui`.
+
+## Design Summary
+
+Introduce a target adapter layer between `InputRouter` and editable state.
+`InputRouter` continues to own global routing order, running-state abort rules,
+surface-first dispatch, resize invalidation, and prompt submission decisions.
+Editor operations are delegated to a target interface.
+
+The first implementation keeps behavior unchanged:
+
+1. Add a generic editor target protocol for text insertion, paste, cursor
+   movement, selection, kill-ring operations, undo/redo, and visual navigation.
+2. Add a prompt target protocol for Composer-only features: value submission,
+   history browsing, completions, explicit newlines, and jump-to-character mode.
+3. Add `ComposerInputTarget`, a stateless adapter over a `Composer` instance.
+4. Update `InputRouter` to use a target internally while preserving the public
+   `composer` field or property for compatibility.
+5. Generalize composer key helpers to target key helpers, leaving the old helper
+   names as compatibility wrappers.
+
+This is adapter-first, not focus-manager-first. Surfaces still receive events
+before the prompt target. A later slice can let `SurfaceHost` expose an active
+editor target when a focused surface wants shared router behavior.
+
+## Target Types
+
+The target API should be small enough to describe input behavior, not the entire
+Composer object.
+
+```python
+class EditorInputTarget(Protocol):
+    @property
+    def value(self) -> str: ...
+
+    @property
+    def selected_range(self) -> tuple[int, int] | None: ...
+
+    def has_selection(self) -> bool: ...
+
+    def insert_text(self, text: str) -> None: ...
+    def paste(self, text: str) -> None: ...
+    def move_left(self) -> None: ...
+    def move_right(self) -> None: ...
+    def move_word_left(self) -> None: ...
+    def move_word_right(self) -> None: ...
+    def move_to_line_start(self) -> None: ...
+    def move_to_line_end(self) -> None: ...
+    def select_char_left(self) -> None: ...
+    def select_char_right(self) -> None: ...
+    def select_word_left(self) -> None: ...
+    def select_word_right(self) -> None: ...
+    def select_line_start(self) -> None: ...
+    def select_line_end(self) -> None: ...
+    def delete_backward(self) -> None: ...
+    def delete_forward(self) -> None: ...
+    def delete_word_backward(self) -> None: ...
+    def delete_word_forward(self) -> None: ...
+    def kill_to_line_start(self) -> None: ...
+    def kill_to_line_end(self) -> None: ...
+    def yank(self) -> None: ...
+    def yank_pop(self) -> None: ...
+    def undo(self) -> None: ...
+    def redo(self) -> None: ...
+```
+
+The prompt target extends this with behavior that should not be assumed for
+ordinary fields:
+
+```python
+class PromptInputTarget(EditorInputTarget, Protocol):
+    @property
+    def browsing_history(self) -> bool: ...
+
+    @property
+    def has_completions(self) -> bool: ...
+
+    def clear(self) -> None: ...
+    def add_history(self, text: str) -> None: ...
+    def insert_newline(self) -> None: ...
+    def history_previous(self) -> None: ...
+    def history_next(self) -> None: ...
+    def move_visual_up(self, *, width: int) -> bool: ...
+    def move_visual_down(self, *, width: int) -> bool: ...
+    def move_visual_page_up(self, *, width: int, visible_lines: int) -> None: ...
+    def move_visual_page_down(self, *, width: int, visible_lines: int) -> None: ...
+    def jump_to_char(self, text: str, *, direction: Literal["forward", "backward"]) -> None: ...
+    def refresh_completions(self, *, force: bool = False, explicit: bool = False) -> None: ...
+    def apply_selected_completion(self) -> None: ...
+    def select_previous_completion(self) -> None: ...
+    def select_next_completion(self) -> None: ...
+    def clear_completion_items(self) -> None: ...
+```
+
+The interface intentionally remains method-oriented. A single
+`handle_input(event)` callback would align with `TextInput`, but it would move
+too much routing policy into every target and make global priority rules harder
+to audit.
+
+## InputRouter Construction
+
+The first implementation should preserve the existing constructor shape:
+
+```python
+@dataclass(slots=True)
+class InputRouter:
+    composer: Composer | None = None
+    target: PromptInputTarget | None = None
+    ...
+
+    def __post_init__(self) -> None:
+        if self.target is None:
+            if self.composer is None:
+                raise TypeError("InputRouter requires composer or target")
+            self.target = ComposerInputTarget(self.composer)
+```
+
+If keeping both as dataclass fields creates awkward typing or initialization
+edge cases, use an internal `_target` field and expose a read-only `target`
+property. The compatibility rule is what matters: existing
+`InputRouter(composer=composer)` callers continue to work.
+
+The public `composer` attribute may remain during the transition. It should be
+documented as a compatibility attribute for prompt routers, not as the router's
+long-term extension point.
+
+## Routing Order
+
+Routing priority must not change. The target refactor should keep this order:
+
+1. Ignore key release events.
+2. For key events, clear jump-to-character mode before continuing. If the key is
+   another jump-mode key, clear the mode and consume the event.
+3. For key events, route active runtime surfaces and return if they emit
+   `InputIntent` values.
+4. Route selection keys before completion handling.
+5. Submit the selected slash-command completion on submit.
+6. Route completion navigation and cancellation.
+7. Convert cancel to abort only when the app is running and completion did not
+   consume it.
+8. Enter jump-to-character mode.
+9. Emit queue-edit command intents.
+10. Force and apply completion on tab.
+11. Submit prompt text.
+12. Insert explicit newline.
+13. Move visual cursor or browse history.
+14. Route page movement.
+15. Route ordinary editing keys.
+16. Route paste and text insertion.
+17. Emit render invalidation for resize and SIGWINCH.
+
+The adapter should not reorder these checks. Tests should assert the most fragile
+crossovers: completion cancel before running abort, selection before completion,
+surface escape before running abort, and submit without applying an active
+completion.
+
+## Key Helper Extraction
+
+Rename helper internals around editor targets:
+
+- `route_editor_editing_key(target, key, *, keybindings=None) -> bool`
+- `route_editor_selection_key(target, key, *, keybindings=None) -> bool`
+- `route_prompt_completion_key(target, key, *, keybindings=None) -> bool`
+
+Keep compatibility wrappers:
+
+```python
+def route_composer_editing_key(composer: Composer, key: str, *, keybindings=None) -> bool:
+    return route_editor_editing_key(ComposerInputTarget(composer), key, keybindings=keybindings)
+```
+
+The wrapper creation cost is negligible for compatibility callers. If this
+becomes a hot path in `NativeInputRouter`, it should store and reuse a target
+adapter instead of calling the wrapper repeatedly.
+
+## NativeInputRouter Reuse
+
+`NativeInputRouter` is product-specific and should remain in
+`loushang.coding.ui.native_input`, but it currently duplicates much of the
+Composer routing chain. After `InputRouter` has target helpers, native input can
+incrementally reuse:
+
+- `ComposerInputTarget` for prompt editing.
+- `route_editor_selection_key()` and `route_editor_editing_key()` for ordinary
+  editing behavior.
+- `route_prompt_completion_key()` for completion navigation if the native
+  submit-after-slash-command rule stays local.
+
+Native-only behavior remains local:
+
+- clipboard image attachment
+- local command detection
+- queued steer/follow-up integration
+- transcript reader command
+- restoring queued messages
+- exit command mapping
+
+This keeps `loushang.tui` general while reducing duplicated editor semantics.
+
+## Surface and TextInput Path
+
+The first slice should not make surfaces use `InputRouter`. `SurfaceHost` already
+routes focused surface input before the prompt, and `TextInput.handle_input()`
+already works for standalone overlays.
+
+The target layer prepares the next slice:
+
+- A focused surface may optionally expose an `EditorInputTarget`.
+- `SurfaceHost` may later expose `current_editor_target()`.
+- `InputRouter` may later route shared editor keys to that focused editor before
+  falling back to the prompt target.
+
+That later focus integration needs its own spec because it will define how
+surface-local submit, escape, and consumed intents interact with global prompt
+submission.
+
+## Error Handling
+
+- Constructing `InputRouter` without either `composer` or `target` should fail
+  early with a clear `TypeError`.
+- A target missing required prompt behavior should fail at construction or first
+  use, not silently fall back to Composer.
+- Existing surface input normalization should remain defensive: non-`InputIntent`
+  surface results are ignored unless already supported.
+- The compatibility wrappers should remain thin. They should not catch errors
+  from target methods because those errors indicate broken editor state or an
+  incomplete adapter.
+
+## Testing
+
+Focused tests should come before implementation.
+
+Add target-level tests:
+
+- `InputRouter(composer=composer)` creates a Composer-backed target and preserves
+  existing text, paste, submit, and clear behavior.
+- `InputRouter(target=fake_prompt_target)` routes ordinary editing keys without
+  importing or constructing `Composer`.
+- Selection keys call target selection methods before completion routing.
+- Completion cancel still closes completion before running abort.
+- Tab still forces completions and applies the selected completion.
+- Resize and SIGWINCH still emit `invalidate_render` without touching the target.
+
+Keep existing behavior tests:
+
+- `tests/tui/test_input_routing.py` should remain green.
+- Text input overlay tests should remain green, proving surface-first routing is
+  unchanged.
+- Native input focused tests should remain green after helper reuse.
+
+The implementation should run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_input_routing.py tests/tui/test_text_input.py -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_input.py -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/input.py src/loushang/coding/ui/native_input.py tests/tui/test_input_routing.py
+```
+
+Adjust the native input test path if the current repository names it
+differently.
+
+## Rollout Plan
+
+Use small behavior-preserving commits:
+
+1. Add target protocols, `ComposerInputTarget`, and target key helper tests.
+2. Route `InputRouter` through the target adapter while keeping `composer=`
+   compatibility.
+3. Keep old composer helper names as wrappers and update tests to cover both
+   compatibility and target paths.
+4. Reuse target helpers inside `NativeInputRouter` where this does not change
+   native coding behavior.
+5. Document the input routing order and target boundary in the TUI internals
+   docs.
+
+Stop after step 3 if native reuse begins to require product behavior changes.
+The main value is decoupling the generic router; native deduplication is useful
+but secondary.
+
+## Rejected Approaches
+
+### Make Composer Implement a Large Protocol Directly
+
+This is the smallest edit, but it leaves `InputRouter` conceptually coupled to
+Composer. The protocol would become a renamed copy of Composer's public surface,
+and future editors would need to grow prompt-only methods they do not support.
+
+### Give Every Editor `handle_input(event)`
+
+This matches `TextInput`, but it pushes routing policy into each editable widget.
+Global rules such as surface-first dispatch, completion-before-abort, and
+running submit modes would become harder to verify. `InputRouter` should keep
+the policy; targets should provide operations.
+
+### Build a Full Focus Manager Now
+
+A focus manager is likely needed eventually, but it is larger than the immediate
+problem. The current `SurfaceHost` already handles focused surfaces. The first
+slice should make prompt routing replaceable, then the next slice can decide how
+focused editor targets interact with prompt submission and surface intents.
+
+## Success Criteria
+
+- Existing `InputRouter(composer=...)` callers keep working.
+- `InputRouter` can be tested with a fake prompt target and no `Composer`
+  instance.
+- Composer-specific methods are isolated in `ComposerInputTarget`.
+- Existing input routing behavior and priority tests pass unchanged.
+- Future editor widgets can reuse router key policy without pretending to be a
+  Composer.
+- A contributor can understand where generic input policy ends and prompt
+  behavior begins without reading all of `input.py`.

--- a/docs/superpowers/specs/2026-06-09-tui-input-router-decouple-design.md
+++ b/docs/superpowers/specs/2026-06-09-tui-input-router-decouple-design.md
@@ -80,14 +80,6 @@ Composer object.
 
 ```python
 class EditorInputTarget(Protocol):
-    @property
-    def value(self) -> str: ...
-
-    @property
-    def selected_range(self) -> tuple[int, int] | None: ...
-
-    def has_selection(self) -> bool: ...
-
     def insert_text(self, text: str) -> None: ...
     def paste(self, text: str) -> None: ...
     def move_left(self) -> None: ...
@@ -120,6 +112,9 @@ ordinary fields:
 ```python
 class PromptInputTarget(EditorInputTarget, Protocol):
     @property
+    def value(self) -> str: ...
+
+    @property
     def browsing_history(self) -> bool: ...
 
     @property
@@ -145,7 +140,9 @@ class PromptInputTarget(EditorInputTarget, Protocol):
 The interface intentionally remains method-oriented. A single
 `handle_input(event)` callback would align with `TextInput`, but it would move
 too much routing policy into every target and make global priority rules harder
-to audit.
+to audit. Read-only state is kept on `PromptInputTarget` unless generic key
+helpers need it. Fake-target tests may expose their own inspection fields without
+widening the production protocol.
 
 ## InputRouter Construction
 
@@ -155,20 +152,26 @@ The first implementation should preserve the existing constructor shape:
 @dataclass(slots=True)
 class InputRouter:
     composer: Composer | None = None
-    target: PromptInputTarget | None = None
+    target: InitVar[PromptInputTarget | None] = None
+    _target: PromptInputTarget = field(init=False, repr=False)
     ...
 
-    def __post_init__(self) -> None:
-        if self.target is None:
-            if self.composer is None:
-                raise TypeError("InputRouter requires composer or target")
-            self.target = ComposerInputTarget(self.composer)
+    def __post_init__(self, target: PromptInputTarget | None) -> None:
+        if self.composer is not None and target is not None:
+            raise TypeError("InputRouter accepts composer or target, not both")
+        if target is not None:
+            self._target = target
+        elif self.composer is not None:
+            self._target = ComposerInputTarget(self.composer)
+        else:
+            raise TypeError("InputRouter requires composer or target")
 ```
 
-If keeping both as dataclass fields creates awkward typing or initialization
-edge cases, use an internal `_target` field and expose a read-only `target`
-property. The compatibility rule is what matters: existing
-`InputRouter(composer=composer)` callers continue to work.
+`composer` and `target` are intentionally mutually exclusive. This avoids two
+sources of editable state drifting apart. Existing `InputRouter(composer=...)`
+callers continue to work; new callers use `InputRouter(target=...)`. The router
+uses `_target` internally and may expose a read-only `target` property for tests
+and diagnostics.
 
 The public `composer` attribute may remain during the transition. It should be
 documented as a compatibility attribute for prompt routers, not as the router's
@@ -176,7 +179,8 @@ long-term extension point.
 
 ## Routing Order
 
-Routing priority must not change. The target refactor should keep this order:
+This order describes the generic `InputRouter` only. Routing priority must not
+change:
 
 1. Ignore key release events.
 2. For key events, clear jump-to-character mode before continuing. If the key is
@@ -184,20 +188,20 @@ Routing priority must not change. The target refactor should keep this order:
 3. For key events, route active runtime surfaces and return if they emit
    `InputIntent` values.
 4. Route selection keys before completion handling.
-5. Submit the selected slash-command completion on submit.
-6. Route completion navigation and cancellation.
-7. Convert cancel to abort only when the app is running and completion did not
+5. Route completion navigation and cancellation.
+6. Convert cancel to abort only when the app is running and completion did not
    consume it.
-8. Enter jump-to-character mode.
-9. Emit queue-edit command intents.
-10. Force and apply completion on tab.
-11. Submit prompt text.
-12. Insert explicit newline.
-13. Move visual cursor or browse history.
-14. Route page movement.
-15. Route ordinary editing keys.
-16. Route paste and text insertion.
-17. Emit render invalidation for resize and SIGWINCH.
+7. Enter jump-to-character mode.
+8. Emit queue-edit command intents.
+9. Force and apply completion on tab.
+10. Submit prompt text exactly as typed. Do not apply an active completion on
+    generic submit.
+11. Insert explicit newline.
+12. Move visual cursor or browse history.
+13. Route page movement.
+14. Route ordinary editing keys.
+15. Route paste and text insertion.
+16. Emit render invalidation for resize and SIGWINCH.
 
 The adapter should not reorder these checks. Tests should assert the most fragile
 crossovers: completion cancel before running abort, selection before completion,
@@ -247,6 +251,14 @@ Native-only behavior remains local:
 
 This keeps `loushang.tui` general while reducing duplicated editor semantics.
 
+Native routing order is not the generic `InputRouter` order. It must keep its
+existing product-specific priority: runtime surfaces and active surfaces route
+before text/paste/resize/key-release handling, transcript and queued-message
+commands stay native, `follow_up_keys` keep their current position, and
+slash-command selected-completion submit remains native-only. If helper reuse
+would reorder any of those checks, stop at generic router decoupling and leave
+native routing unchanged.
+
 ## Surface and TextInput Path
 
 The first slice should not make surfaces use `InputRouter`. `SurfaceHost` already
@@ -268,6 +280,8 @@ submission.
 
 - Constructing `InputRouter` without either `composer` or `target` should fail
   early with a clear `TypeError`.
+- Constructing `InputRouter` with both `composer` and `target` should fail early
+  with a clear `TypeError`.
 - A target missing required prompt behavior should fail at construction or first
   use, not silently fall back to Composer.
 - Existing surface input normalization should remain defensive: non-`InputIntent`
@@ -286,9 +300,13 @@ Add target-level tests:
   existing text, paste, submit, and clear behavior.
 - `InputRouter(target=fake_prompt_target)` routes ordinary editing keys without
   importing or constructing `Composer`.
+- Passing both `composer` and `target` raises `TypeError`.
 - Selection keys call target selection methods before completion routing.
 - Completion cancel still closes completion before running abort.
 - Tab still forces completions and applies the selected completion.
+- Enter with active completion in generic `InputRouter` still submits raw text
+  without applying completion.
+- Native slash-command completion submit stays covered by native input tests.
 - Resize and SIGWINCH still emit `invalidate_render` without touching the target.
 
 Keep existing behavior tests:

--- a/src/loushang/coding/ui/native_input.py
+++ b/src/loushang/coding/ui/native_input.py
@@ -14,10 +14,12 @@ from loushang.coding.platform.clipboard_image import (
 )
 from loushang.coding.ui.native_app import NativeCodingTuiApp
 from loushang.tui.input import (
+    ComposerInputTarget,
     InputEvent,
     InputIntent,
-    route_composer_editing_key,
-    route_composer_selection_key,
+    route_editor_editing_key,
+    route_editor_selection_key,
+    route_prompt_completion_key,
 )
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
 
@@ -62,10 +64,12 @@ class NativeInputRouter:
     clipboard_image_name_factory: ClipboardImageNameFactory = field(default_factory=lambda: lambda: uuid.uuid4().hex)
     _jump_mode: Literal["forward", "backward"] | None = None
     _pending_clipboard_images: list[_PendingClipboardImage] = field(default_factory=list, init=False, repr=False)
+    _composer_target: ComposerInputTarget = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         if not isinstance(self.keybindings, KeybindingManager):
             self.keybindings = KeybindingManager(self.keybindings)
+        self._composer_target = ComposerInputTarget(self.app.composer)
 
     def handle(self, event: InputEvent) -> NativeInputResult:
         if self._runtime_surface_active():
@@ -106,7 +110,7 @@ class NativeInputRouter:
             return NativeInputResult()
         if keybindings.matches(event.key, "tui.transcript.open"):
             return NativeInputResult(render_requested=self.app.open_transcript_reader())
-        if route_composer_selection_key(self.app.composer, event.key, keybindings=keybindings):
+        if route_editor_selection_key(self._composer_target, event.key, keybindings=keybindings):
             return NativeInputResult()
         if self.app.composer.has_completions and keybindings.matches(event.key, "tui.input.submit"):
             return self._submit_selected_completion()
@@ -152,24 +156,12 @@ class NativeInputRouter:
             return NativeInputResult()
         if keybindings.matches(event.key, "tui.input.submit"):
             return self._submit()
-        if route_composer_editing_key(self.app.composer, event.key, keybindings=keybindings):
+        if route_editor_editing_key(self._composer_target, event.key, keybindings=keybindings):
             return NativeInputResult()
         return NativeInputResult(render_requested=False)
 
     def _route_completion_key(self, event: InputEvent, keybindings: KeybindingManager) -> bool:
-        if keybindings.matches(event.key, "tui.select.up"):
-            self.app.composer.select_previous_completion()
-            return True
-        if keybindings.matches(event.key, "tui.select.down"):
-            self.app.composer.select_next_completion()
-            return True
-        if keybindings.matches(event.key, "tui.input.tab"):
-            self.app.composer.apply_selected_completion()
-            return True
-        if keybindings.matches(event.key, "tui.select.cancel"):
-            self.app.composer.clear_completion_items()
-            return True
-        return False
+        return route_prompt_completion_key(self._composer_target, event.key, keybindings=keybindings)
 
     def _submit_selected_completion(self) -> NativeInputResult:
         should_submit_after_completion = self.app.composer.value.lstrip().startswith("/")

--- a/src/loushang/tui/input.py
+++ b/src/loushang/tui/input.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import dataclass
-from typing import Literal
+from dataclasses import InitVar, dataclass, field
+from typing import Literal, Protocol
 
 from loushang.tui.framework import SurfaceHost
 from loushang.tui.keybindings import KeybindingManager, normalize_key_id
@@ -297,6 +297,231 @@ class InputBatch:
     has_pending: bool = False
 
 
+class EditorInputTarget(Protocol):
+    def insert_text(self, text: str) -> None: ...
+
+    def paste(self, text: str) -> None: ...
+
+    def move_left(self) -> None: ...
+
+    def move_right(self) -> None: ...
+
+    def move_word_left(self) -> None: ...
+
+    def move_word_right(self) -> None: ...
+
+    def move_to_line_start(self) -> None: ...
+
+    def move_to_line_end(self) -> None: ...
+
+    def select_char_left(self) -> None: ...
+
+    def select_char_right(self) -> None: ...
+
+    def select_word_left(self) -> None: ...
+
+    def select_word_right(self) -> None: ...
+
+    def select_line_start(self) -> None: ...
+
+    def select_line_end(self) -> None: ...
+
+    def delete_backward(self) -> None: ...
+
+    def delete_forward(self) -> None: ...
+
+    def delete_word_backward(self) -> None: ...
+
+    def delete_word_forward(self) -> None: ...
+
+    def kill_to_line_start(self) -> None: ...
+
+    def kill_to_line_end(self) -> None: ...
+
+    def yank(self) -> None: ...
+
+    def yank_pop(self) -> None: ...
+
+    def undo(self) -> None: ...
+
+    def redo(self) -> None: ...
+
+
+class PromptInputTarget(EditorInputTarget, Protocol):
+    @property
+    def value(self) -> str: ...
+
+    @property
+    def browsing_history(self) -> bool: ...
+
+    @property
+    def has_completions(self) -> bool: ...
+
+    def clear(self) -> None: ...
+
+    def add_history(self, text: str) -> None: ...
+
+    def insert_newline(self) -> None: ...
+
+    def history_previous(self) -> None: ...
+
+    def history_next(self) -> None: ...
+
+    def move_visual_up(self, *, width: int) -> bool: ...
+
+    def move_visual_down(self, *, width: int) -> bool: ...
+
+    def move_visual_page_up(self, *, width: int, visible_lines: int) -> None: ...
+
+    def move_visual_page_down(self, *, width: int, visible_lines: int) -> None: ...
+
+    def jump_to_char(self, text: str, *, direction: Literal["forward", "backward"]) -> None: ...
+
+    def refresh_completions(self, *, force: bool = False, explicit: bool = False) -> None: ...
+
+    def apply_selected_completion(self) -> None: ...
+
+    def select_previous_completion(self) -> None: ...
+
+    def select_next_completion(self) -> None: ...
+
+    def clear_completion_items(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ComposerInputTarget:
+    composer: Composer
+
+    @property
+    def value(self) -> str:
+        return self.composer.value
+
+    @property
+    def browsing_history(self) -> bool:
+        return self.composer.browsing_history
+
+    @property
+    def has_completions(self) -> bool:
+        return self.composer.has_completions
+
+    def insert_text(self, text: str) -> None:
+        self.composer.insert_text(text)
+
+    def paste(self, text: str) -> None:
+        self.composer.paste(text)
+
+    def move_left(self) -> None:
+        self.composer.move_left()
+
+    def move_right(self) -> None:
+        self.composer.move_right()
+
+    def move_word_left(self) -> None:
+        self.composer.move_word_left()
+
+    def move_word_right(self) -> None:
+        self.composer.move_word_right()
+
+    def move_to_line_start(self) -> None:
+        self.composer.move_to_line_start()
+
+    def move_to_line_end(self) -> None:
+        self.composer.move_to_line_end()
+
+    def select_char_left(self) -> None:
+        self.composer.select_char_left()
+
+    def select_char_right(self) -> None:
+        self.composer.select_char_right()
+
+    def select_word_left(self) -> None:
+        self.composer.select_word_left()
+
+    def select_word_right(self) -> None:
+        self.composer.select_word_right()
+
+    def select_line_start(self) -> None:
+        self.composer.select_line_start()
+
+    def select_line_end(self) -> None:
+        self.composer.select_line_end()
+
+    def delete_backward(self) -> None:
+        self.composer.delete_backward()
+
+    def delete_forward(self) -> None:
+        self.composer.delete_forward()
+
+    def delete_word_backward(self) -> None:
+        self.composer.delete_word_backward()
+
+    def delete_word_forward(self) -> None:
+        self.composer.delete_word_forward()
+
+    def kill_to_line_start(self) -> None:
+        self.composer.kill_to_line_start()
+
+    def kill_to_line_end(self) -> None:
+        self.composer.kill_to_line_end()
+
+    def yank(self) -> None:
+        self.composer.yank()
+
+    def yank_pop(self) -> None:
+        self.composer.yank_pop()
+
+    def undo(self) -> None:
+        self.composer.undo()
+
+    def redo(self) -> None:
+        self.composer.redo()
+
+    def clear(self) -> None:
+        self.composer.clear()
+
+    def add_history(self, text: str) -> None:
+        self.composer.add_history(text)
+
+    def insert_newline(self) -> None:
+        self.composer.insert_newline()
+
+    def history_previous(self) -> None:
+        self.composer.history_previous()
+
+    def history_next(self) -> None:
+        self.composer.history_next()
+
+    def move_visual_up(self, *, width: int) -> bool:
+        return self.composer.move_visual_up(width=width)
+
+    def move_visual_down(self, *, width: int) -> bool:
+        return self.composer.move_visual_down(width=width)
+
+    def move_visual_page_up(self, *, width: int, visible_lines: int) -> None:
+        self.composer.move_visual_page_up(width=width, visible_lines=visible_lines)
+
+    def move_visual_page_down(self, *, width: int, visible_lines: int) -> None:
+        self.composer.move_visual_page_down(width=width, visible_lines=visible_lines)
+
+    def jump_to_char(self, text: str, *, direction: Literal["forward", "backward"]) -> None:
+        self.composer.jump_to_char(text, direction=direction)
+
+    def refresh_completions(self, *, force: bool = False, explicit: bool = False) -> None:
+        self.composer.refresh_completions(force=force, explicit=explicit)
+
+    def apply_selected_completion(self) -> None:
+        self.composer.apply_selected_completion()
+
+    def select_previous_completion(self) -> None:
+        self.composer.select_previous_completion()
+
+    def select_next_completion(self) -> None:
+        self.composer.select_next_completion()
+
+    def clear_completion_items(self) -> None:
+        self.composer.clear_completion_items()
+
+
 @dataclass(slots=True)
 class InputReader:
     _buffer: str = ""
@@ -460,7 +685,7 @@ class InputReader:
 
 @dataclass(slots=True)
 class InputRouter:
-    composer: Composer
+    composer: Composer | None = None
     surface_host: SurfaceHost | None = None
     running: bool = False
     steering_supported: bool = False
@@ -468,8 +693,22 @@ class InputRouter:
     height: int = 24
     keybindings: KeybindingManager | None = None
     _jump_mode: Literal["forward", "backward"] | None = None
+    target: InitVar[PromptInputTarget | None] = None
+    _target: PromptInputTarget = field(init=False, repr=False)
+
+    def __post_init__(self, target: PromptInputTarget | None) -> None:
+        if self.composer is not None and target is not None:
+            raise TypeError("InputRouter accepts composer or target, not both")
+        if target is not None:
+            self._target = target
+            return
+        if self.composer is not None:
+            self._target = ComposerInputTarget(self.composer)
+            return
+        raise TypeError("InputRouter requires composer or target")
 
     def route(self, event: InputEvent) -> tuple[InputIntent, ...]:
+        target = self._target
         if event.kind == "key" and event.event_type == "release":
             return ()
         if event.kind == "key":
@@ -486,21 +725,10 @@ class InputRouter:
             surface_intents = self._route_surface_first(event)
             if surface_intents:
                 return surface_intents
-            if route_composer_selection_key(self.composer, event.key, keybindings=keybindings):
+            if route_editor_selection_key(target, event.key, keybindings=keybindings):
                 return ()
-            if self.composer.has_completions:
-                if keybindings.matches(event.key, "tui.select.up"):
-                    self.composer.select_previous_completion()
-                    return ()
-                if keybindings.matches(event.key, "tui.select.down"):
-                    self.composer.select_next_completion()
-                    return ()
-                if keybindings.matches(event.key, "tui.input.tab"):
-                    self.composer.apply_selected_completion()
-                    return ()
-                if keybindings.matches(event.key, "tui.select.cancel"):
-                    self.composer.clear_completion_items()
-                    return ()
+            if target.has_completions and route_prompt_completion_key(target, event.key, keybindings=keybindings):
+                return ()
             if keybindings.matches(event.key, "tui.select.cancel") and self.running:
                 return (InputIntent(kind="abort"),)
             if keybindings.matches(event.key, "tui.editor.jumpForward"):
@@ -512,14 +740,14 @@ class InputRouter:
             if keybindings.matches(event.key, "tui.queue.editLast"):
                 return (InputIntent(kind="command", note="edit_last_queued_prompt"),)
             if keybindings.matches(event.key, "tui.input.tab"):
-                self.composer.refresh_completions(force=True, explicit=True)
-                if self.composer.has_completions:
-                    self.composer.apply_selected_completion()
+                target.refresh_completions(force=True, explicit=True)
+                if target.has_completions:
+                    target.apply_selected_completion()
                 return ()
             if keybindings.matches(event.key, "tui.input.submit"):
                 return self.submit()
             if keybindings.matches(event.key, "tui.input.newLine"):
-                self.composer.insert_newline()
+                target.insert_newline()
                 return ()
             if keybindings.matches(event.key, "tui.editor.cursorUp"):
                 self._move_up_or_history()
@@ -528,34 +756,35 @@ class InputRouter:
                 self._move_down_or_history()
                 return ()
             if keybindings.matches(event.key, "tui.editor.pageUp"):
-                self.composer.move_visual_page_up(width=self.width, visible_lines=self._composer_page_lines())
+                target.move_visual_page_up(width=self.width, visible_lines=self._composer_page_lines())
                 return ()
             if keybindings.matches(event.key, "tui.editor.pageDown"):
-                self.composer.move_visual_page_down(width=self.width, visible_lines=self._composer_page_lines())
+                target.move_visual_page_down(width=self.width, visible_lines=self._composer_page_lines())
                 return ()
-            if route_composer_editing_key(self.composer, event.key, keybindings=keybindings):
+            if route_editor_editing_key(target, event.key, keybindings=keybindings):
                 return ()
         if event.kind == "paste":
             self._jump_mode = None
-            self.composer.paste(event.text)
+            target.paste(event.text)
             return ()
         if event.kind == "text":
             if self._jump_mode is not None:
-                self.composer.jump_to_char(event.text, direction=self._jump_mode)
+                target.jump_to_char(event.text, direction=self._jump_mode)
                 self._jump_mode = None
                 return ()
-            self.composer.insert_text(event.text)
+            target.insert_text(event.text)
             return ()
         if event.kind == "resize" or (event.kind == "signal" and event.signal == "sigwinch"):
             return (InputIntent(kind="invalidate_render"),)
         return ()
 
     def submit(self, *, mode: SubmitMode = "submit") -> tuple[InputIntent, ...]:
-        text = self.composer.value
+        target = self._target
+        text = target.value
         if not text:
             return ()
-        self.composer.add_history(text)
-        self.composer.clear()
+        target.add_history(text)
+        target.clear()
         if not self.running:
             return (InputIntent(kind="submit", text=text),)
         if mode == "steer":
@@ -581,16 +810,18 @@ class InputRouter:
         return ()
 
     def _move_up_or_history(self) -> None:
-        if self.composer.browsing_history:
-            self.composer.history_previous()
-        elif not self.composer.value or not self.composer.move_visual_up(width=self.width):
-            self.composer.history_previous()
+        target = self._target
+        if target.browsing_history:
+            target.history_previous()
+        elif not target.value or not target.move_visual_up(width=self.width):
+            target.history_previous()
 
     def _move_down_or_history(self) -> None:
-        if self.composer.browsing_history:
-            self.composer.history_next()
-        elif not self.composer.value or not self.composer.move_visual_down(width=self.width):
-            self.composer.history_next()
+        target = self._target
+        if target.browsing_history:
+            target.history_next()
+        elif not target.value or not target.move_visual_down(width=self.width):
+            target.history_next()
 
     def _keybindings(self) -> KeybindingManager:
         if self.keybindings is None:
@@ -637,62 +868,121 @@ def _split_paste_payload_and_pending_end_marker(text: str) -> tuple[str, str]:
     return text, ""
 
 
-def route_composer_editing_key(
-    composer: Composer,
+def route_editor_editing_key(
+    target: EditorInputTarget,
     key: str,
     *,
     keybindings: KeybindingManager | None = None,
 ) -> bool:
     keybindings = keybindings or KeybindingManager()
     if keybindings.matches(key, "tui.editor.cursorLeft"):
-        composer.move_left()
+        target.move_left()
         return True
     if keybindings.matches(key, "tui.editor.cursorRight"):
-        composer.move_right()
+        target.move_right()
         return True
     if keybindings.matches(key, "tui.editor.cursorWordLeft"):
-        composer.move_word_left()
+        target.move_word_left()
         return True
     if keybindings.matches(key, "tui.editor.cursorWordRight"):
-        composer.move_word_right()
+        target.move_word_right()
         return True
     if keybindings.matches(key, "tui.editor.deleteCharBackward"):
-        composer.delete_backward()
+        target.delete_backward()
         return True
     if keybindings.matches(key, "tui.editor.deleteCharForward"):
-        composer.delete_forward()
+        target.delete_forward()
         return True
     if keybindings.matches(key, "tui.editor.cursorLineStart"):
-        composer.move_to_line_start()
+        target.move_to_line_start()
         return True
     if keybindings.matches(key, "tui.editor.cursorLineEnd"):
-        composer.move_to_line_end()
+        target.move_to_line_end()
         return True
     if keybindings.matches(key, "tui.editor.deleteToLineEnd"):
-        composer.kill_to_line_end()
+        target.kill_to_line_end()
         return True
     if keybindings.matches(key, "tui.editor.deleteToLineStart"):
-        composer.kill_to_line_start()
+        target.kill_to_line_start()
         return True
     if keybindings.matches(key, "tui.editor.deleteWordBackward"):
-        composer.delete_word_backward()
+        target.delete_word_backward()
         return True
     if keybindings.matches(key, "tui.editor.deleteWordForward"):
-        composer.delete_word_forward()
+        target.delete_word_forward()
         return True
     if keybindings.matches(key, "tui.editor.yank"):
-        composer.yank()
+        target.yank()
         return True
     if keybindings.matches(key, "tui.editor.yankPop"):
-        composer.yank_pop()
+        target.yank_pop()
         return True
     if keybindings.matches(key, "tui.editor.undo"):
-        composer.undo()
+        target.undo()
         return True
     if keybindings.matches(key, "tui.editor.redo"):
-        composer.redo()
+        target.redo()
         return True
     return False
+
+
+def route_editor_selection_key(
+    target: EditorInputTarget,
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> bool:
+    keybindings = keybindings or KeybindingManager()
+    if keybindings.matches(key, "tui.editor.selectCharLeft"):
+        target.select_char_left()
+        return True
+    if keybindings.matches(key, "tui.editor.selectCharRight"):
+        target.select_char_right()
+        return True
+    if keybindings.matches(key, "tui.editor.selectWordLeft"):
+        target.select_word_left()
+        return True
+    if keybindings.matches(key, "tui.editor.selectWordRight"):
+        target.select_word_right()
+        return True
+    if keybindings.matches(key, "tui.editor.selectLineStart"):
+        target.select_line_start()
+        return True
+    if keybindings.matches(key, "tui.editor.selectLineEnd"):
+        target.select_line_end()
+        return True
+    return False
+
+
+def route_prompt_completion_key(
+    target: PromptInputTarget,
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> bool:
+    keybindings = keybindings or KeybindingManager()
+    if keybindings.matches(key, "tui.select.up"):
+        target.select_previous_completion()
+        return True
+    if keybindings.matches(key, "tui.select.down"):
+        target.select_next_completion()
+        return True
+    if keybindings.matches(key, "tui.input.tab"):
+        target.apply_selected_completion()
+        return True
+    if keybindings.matches(key, "tui.select.cancel"):
+        target.clear_completion_items()
+        return True
+    return False
+
+
+def route_composer_editing_key(
+    composer: Composer,
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> bool:
+    return route_editor_editing_key(ComposerInputTarget(composer), key, keybindings=keybindings)
 
 
 def route_composer_selection_key(
@@ -701,26 +991,7 @@ def route_composer_selection_key(
     *,
     keybindings: KeybindingManager | None = None,
 ) -> bool:
-    keybindings = keybindings or KeybindingManager()
-    if keybindings.matches(key, "tui.editor.selectCharLeft"):
-        composer.select_char_left()
-        return True
-    if keybindings.matches(key, "tui.editor.selectCharRight"):
-        composer.select_char_right()
-        return True
-    if keybindings.matches(key, "tui.editor.selectWordLeft"):
-        composer.select_word_left()
-        return True
-    if keybindings.matches(key, "tui.editor.selectWordRight"):
-        composer.select_word_right()
-        return True
-    if keybindings.matches(key, "tui.editor.selectLineStart"):
-        composer.select_line_start()
-        return True
-    if keybindings.matches(key, "tui.editor.selectLineEnd"):
-        composer.select_line_end()
-        return True
-    return False
+    return route_editor_selection_key(ComposerInputTarget(composer), key, keybindings=keybindings)
 
 
 def _extract_complete_sequences(buffer: str) -> tuple[tuple[str, ...], str]:

--- a/tests/coding/test_native_coding_tui_input.py
+++ b/tests/coding/test_native_coding_tui_input.py
@@ -100,6 +100,24 @@ def test_native_input_router_escape_closes_completion_before_running_abort() -> 
     assert not app.composer.has_completions
 
 
+def test_native_input_router_enter_applies_slash_completion_before_submit() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+    from loushang.coding.ui.native_input import NativeInputRouter
+
+    app = NativeCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 12.0)
+    app.composer.set_text("/mo")
+    app.composer.set_completion_items((CompletionItem(value="/model", label="/model"),))
+
+    result = NativeInputRouter(
+        app,
+        should_exit=lambda text: False,
+        is_local_command=lambda text: text == "/model",
+    ).handle(InputEvent(kind="key", key="enter"))
+
+    assert result.local_text == "/model"
+    assert app.composer.value == ""
+
+
 def test_native_input_router_restores_queued_messages_to_composer() -> None:
     from loushang.coding.ui.native_app import NativeCodingTuiApp
     from loushang.coding.ui.native_input import NativeInputRouter

--- a/tests/tui/test_input_routing.py
+++ b/tests/tui/test_input_routing.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import pytest
 
 from loushang.tui import (
     CompletionItem,
@@ -20,6 +22,10 @@ from loushang.tui import (
     Surface,
     SurfaceHost,
 )
+from loushang.tui.input import (
+    route_editor_editing_key,
+    route_editor_selection_key,
+)
 
 
 @dataclass(slots=True)
@@ -35,6 +41,144 @@ class EscConsumer(FocusableMixin):
         if isinstance(event, InputEvent) and event.kind == "key" and event.key == "esc":
             return InputIntent(kind="surface_close")
         return None
+
+
+@dataclass(slots=True)
+class FakePromptTarget:
+    value: str = ""
+    browsing_history: bool = False
+    has_completions: bool = False
+    calls: list[str] = field(default_factory=list)
+    history: list[str] = field(default_factory=list)
+
+    def insert_text(self, text: str) -> None:
+        self.calls.append(f"insert_text:{text}")
+        self.value += text
+
+    def paste(self, text: str) -> None:
+        self.calls.append(f"paste:{text}")
+        self.value += text
+
+    def clear(self) -> None:
+        self.calls.append("clear")
+        self.value = ""
+
+    def add_history(self, text: str) -> None:
+        self.calls.append(f"add_history:{text}")
+        self.history.append(text)
+
+    def insert_newline(self) -> None:
+        self.calls.append("insert_newline")
+        self.value += "\n"
+
+    def _record(self, name: str) -> None:
+        self.calls.append(name)
+
+    def move_left(self) -> None:
+        self._record("move_left")
+
+    def move_right(self) -> None:
+        self._record("move_right")
+
+    def move_word_left(self) -> None:
+        self._record("move_word_left")
+
+    def move_word_right(self) -> None:
+        self._record("move_word_right")
+
+    def move_to_line_start(self) -> None:
+        self._record("move_to_line_start")
+
+    def move_to_line_end(self) -> None:
+        self._record("move_to_line_end")
+
+    def select_char_left(self) -> None:
+        self._record("select_char_left")
+
+    def select_char_right(self) -> None:
+        self._record("select_char_right")
+
+    def select_word_left(self) -> None:
+        self._record("select_word_left")
+
+    def select_word_right(self) -> None:
+        self._record("select_word_right")
+
+    def select_line_start(self) -> None:
+        self._record("select_line_start")
+
+    def select_line_end(self) -> None:
+        self._record("select_line_end")
+
+    def delete_backward(self) -> None:
+        self._record("delete_backward")
+
+    def delete_forward(self) -> None:
+        self._record("delete_forward")
+
+    def delete_word_backward(self) -> None:
+        self._record("delete_word_backward")
+
+    def delete_word_forward(self) -> None:
+        self._record("delete_word_forward")
+
+    def kill_to_line_start(self) -> None:
+        self._record("kill_to_line_start")
+
+    def kill_to_line_end(self) -> None:
+        self._record("kill_to_line_end")
+
+    def yank(self) -> None:
+        self._record("yank")
+
+    def yank_pop(self) -> None:
+        self._record("yank_pop")
+
+    def undo(self) -> None:
+        self._record("undo")
+
+    def redo(self) -> None:
+        self._record("redo")
+
+    def history_previous(self) -> None:
+        self._record("history_previous")
+
+    def history_next(self) -> None:
+        self._record("history_next")
+
+    def move_visual_up(self, *, width: int) -> bool:
+        self.calls.append(f"move_visual_up:{width}")
+        return False
+
+    def move_visual_down(self, *, width: int) -> bool:
+        self.calls.append(f"move_visual_down:{width}")
+        return False
+
+    def move_visual_page_up(self, *, width: int, visible_lines: int) -> None:
+        self.calls.append(f"move_visual_page_up:{width}:{visible_lines}")
+
+    def move_visual_page_down(self, *, width: int, visible_lines: int) -> None:
+        self.calls.append(f"move_visual_page_down:{width}:{visible_lines}")
+
+    def jump_to_char(self, text: str, *, direction: Literal["forward", "backward"]) -> None:
+        self.calls.append(f"jump_to_char:{direction}:{text}")
+
+    def refresh_completions(self, *, force: bool = False, explicit: bool = False) -> None:
+        self.calls.append(f"refresh_completions:{force}:{explicit}")
+        self.has_completions = True
+
+    def apply_selected_completion(self) -> None:
+        self.calls.append("apply_selected_completion")
+
+    def select_previous_completion(self) -> None:
+        self.calls.append("select_previous_completion")
+
+    def select_next_completion(self) -> None:
+        self.calls.append("select_next_completion")
+
+    def clear_completion_items(self) -> None:
+        self.calls.append("clear_completion_items")
+        self.has_completions = False
 
 
 def test_input_reader_groups_bracketed_paste_as_single_paste_event() -> None:
@@ -283,6 +427,45 @@ def test_keybinding_manager_matches_terminal_underscore_undo_alias() -> None:
 
     assert manager.matches("ctrl+_", "tui.editor.undo")
     assert manager.matches("alt+u", "tui.editor.undo")
+
+
+def test_input_router_rejects_missing_prompt_target() -> None:
+    with pytest.raises(TypeError, match="requires composer or target"):
+        InputRouter()
+
+
+def test_input_router_rejects_composer_and_target_together() -> None:
+    with pytest.raises(TypeError, match="composer or target"):
+        InputRouter(composer=Composer(prompt="> "), target=FakePromptTarget())
+
+
+def test_input_router_routes_text_paste_and_submit_through_target() -> None:
+    target = FakePromptTarget()
+    router = InputRouter(target=target)
+
+    assert router.route(InputEvent(kind="text", text="he")) == ()
+    assert router.route(InputEvent(kind="paste", text="llo")) == ()
+    assert router.route(InputEvent(kind="key", key="enter")) == (
+        InputIntent(kind="submit", text="hello"),
+    )
+
+    assert target.calls == [
+        "insert_text:he",
+        "paste:llo",
+        "add_history:hello",
+        "clear",
+    ]
+    assert target.history == ["hello"]
+    assert target.value == ""
+
+
+def test_editor_key_helpers_route_to_target_operations() -> None:
+    target = FakePromptTarget()
+
+    assert route_editor_editing_key(target, "left")
+    assert route_editor_selection_key(target, "shift+left")
+
+    assert target.calls == ["move_left", "select_char_left"]
 
 
 def test_input_router_alt_angle_moves_to_line_boundaries() -> None:


### PR DESCRIPTION
## Summary
- Add InputRouter target decoupling spec and implementation plan.
- Introduce prompt/editor target protocols and ComposerInputTarget adapter for generic TUI input routing.
- Preserve native coding input behavior while reusing safe target helpers, including slash-command completion submit coverage.
- Document the PromptInputTarget boundary in KD-002.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_input_routing.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_input.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_input_routing.py tests/tui/test_text_input.py tests/coding/test_native_coding_tui_input.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/input.py src/loushang/coding/ui/native_input.py tests/tui/test_input_routing.py tests/coding/test_native_coding_tui_input.py