### PR TITLE
Refactor TUI input routing for focused editor targets

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md
@@ -23,6 +23,16 @@ operations through target adapters such as `ComposerInputTarget`. Product
 adapters may reuse target helper functions, but they keep their own routing
 order when product semantics differ.
 
+Focused surface editors may expose an editor target through
+`editor_input_target()`. `SurfaceHost.route_input_result()` distinguishes
+surface intents from consumed events without changing the compatibility
+`route_input()` return value. Generic `InputRouter` routing stays
+surface-first: surface intents win, consumed surface events stop fallback, and
+only declined events may route ordinary text, paste, selection, and editing keys
+to the focused editor target. Prompt-only actions such as submit, newline,
+history, completion, queue editing, and jump setup do not mutate prompt state
+while a focused editor target owns the editing lane.
+
 Keybindings are configuration-owned by the runtime or product adapter. The
 coding product adapter loads configured keybindings from settings and passes
 them into the native input router. UI parts may handle routed events, but they
@@ -105,3 +115,7 @@ adapter receives a submit, steer, or follow-up intent.
 - capability query responses do not leak as prompt text
 - composer cursor mapping remains correct after wrapping
 - resize signals trigger render invalidation, not prompt submission
+- focused surface editor targets receive ordinary text/editing only after the
+  surface declines the event
+- consumed surface text, search, and navigation events do not leak into prompt
+  editing

--- a/docs/superpowers/plans/2026-06-10-tui-focused-editor-target-routing-implementation.md
+++ b/docs/superpowers/plans/2026-06-10-tui-focused-editor-target-routing-implementation.md
@@ -1,0 +1,848 @@
+# TUI Focused Editor Target Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let focused surface editors reuse generic `InputRouter` editor-key routing without leaking consumed surface input into prompt editing.
+
+**Architecture:** Add an explicit consumed/declined result path to `SurfaceHost`, then layer focused editor target discovery on top of existing surface focus. `TextInput` exposes a high-level editor target adapter so routed edits preserve callbacks and undo, while `InputRouter` keeps prompt-only actions on the prompt lane only when no focused editor target owns editing.
+
+**Tech Stack:** Python 3.11+, dataclasses, typing `Protocol`, pytest, existing `loushang.tui` surface/input tests, `uv --cache-dir .uv-cache run --extra dev pytest`.
+
+---
+
+## Reference Documents
+
+- Spec: `docs/superpowers/specs/2026-06-10-tui-focused-editor-target-routing-design.md`
+- Prior input target spec: `docs/superpowers/specs/2026-06-09-tui-input-router-decouple-design.md`
+- Input routing design note: `docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md`
+- Framework implementation: `src/loushang/tui/framework.py`
+- Generic input routing: `src/loushang/tui/input.py`
+- Text input implementation: `src/loushang/tui/ui_parts/text_input.py`
+- Stateful surfaces: `src/loushang/tui/surfaces.py`
+- Framework tests: `tests/tui/test_render_framework.py`
+- Surface tests: `tests/tui/test_surfaces.py`
+- Text input tests: `tests/tui/test_text_input.py`
+- Input routing tests: `tests/tui/test_input_routing.py`
+
+## File Structure
+
+- Modify `src/loushang/tui/framework.py`
+  - Add `EditorInputTargetProvider`.
+  - Add `SurfaceInputRouteResult`.
+  - Add `SurfaceHost.route_input_result()`.
+  - Add `SurfaceHost.current_editor_target()`.
+  - Keep `SurfaceHost.route_input()` as a compatibility wrapper.
+- Modify `src/loushang/tui/surfaces.py`
+  - Return `True` from existing stateful consumed-without-intent paths in `SelectionSurface` and `SettingsSurface`.
+  - Keep intent-producing paths unchanged.
+- Modify `src/loushang/tui/ui_parts/text_input.py`
+  - Add a private `_TextInputEditorTarget` adapter.
+  - Add `TextInput.editor_input_target()` returning the adapter.
+  - Do not change direct low-level `TextInput.insert_text()` undo semantics.
+- Modify `src/loushang/tui/input.py`
+  - Teach `InputRouter` to read surface consumed state.
+  - Add focused editor fallback after surface decline and before prompt editing.
+  - Keep active prompt jump-mode text handling before focused editor insertion.
+- Modify `tests/tui/test_render_framework.py`
+  - Cover consumed route results and focused editor target discovery.
+- Modify `tests/tui/test_surfaces.py`
+  - Cover `True` returns from stateful consumed surface paths.
+- Modify `tests/tui/test_text_input.py`
+  - Cover adapter methods, callbacks, undo/redo, and direct low-level edit compatibility.
+- Modify `tests/tui/test_input_routing.py`
+  - Cover focused editor fallback, no double insertion, surface intent priority, prompt submit suppression, jump-mode priority, and unchanged no-focus prompt behavior.
+- Modify `docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md`
+  - Document focused editor target routing and surface consumed semantics.
+
+## Task 1: SurfaceHost Consumed Route Result
+
+**Files:**
+- Modify: `tests/tui/test_render_framework.py`
+- Modify: `src/loushang/tui/framework.py`
+
+- [ ] **Step 1: Write failing tests for consumed route results**
+
+Add near the existing `FocusTarget` helper:
+
+```python
+class ReturningFocusTarget(FocusableMixin):
+    def __init__(self, result: Any) -> None:
+        super().__init__()
+        self.result = result
+        self.events: list[Any] = []
+
+    def handle_input(self, event: Any) -> Any:
+        self.events.append(event)
+        return self.result
+```
+
+Add tests:
+
+```python
+def test_surface_host_route_input_result_preserves_consumption_without_changing_route_input() -> None:
+    cases: tuple[tuple[Any, tuple[Any, ...], bool], ...] = (
+        (None, (), False),
+        (False, (), False),
+        (True, (), True),
+        ("handled", ("handled",), True),
+        (("handled",), ("handled",), True),
+    )
+    for result, expected_intents, expected_consumed in cases:
+        target = ReturningFocusTarget(result)
+        host = SurfaceHost()
+        host.open_surface(Surface(renderable=TextRenderable(("surface",), []), focus_target=target))
+
+        routed = host.route_input_result("x")
+
+        assert routed.intents == expected_intents
+        assert routed.consumed is expected_consumed
+        assert host.route_input("x") == expected_intents
+```
+
+Add close-intent coverage:
+
+```python
+def test_surface_host_route_input_result_closes_on_close_intent() -> None:
+    target = ReturningFocusTarget(InputIntent(kind="surface_close"))
+    host = SurfaceHost()
+    handle = host.open_surface(Surface(renderable=TextRenderable(("surface",), []), focus_target=target))
+
+    routed = host.route_input_result(InputEvent(kind="key", key="escape"))
+
+    assert routed.intents == (InputIntent(kind="surface_close"),)
+    assert routed.consumed is True
+    assert host.entries == []
+    assert handle.entry.close_reason == "surface_close"
+```
+
+- [ ] **Step 2: Run red test**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_framework.py::test_surface_host_route_input_result_preserves_consumption_without_changing_route_input tests/tui/test_render_framework.py::test_surface_host_route_input_result_closes_on_close_intent -q
+```
+
+Expected: fail because `SurfaceHost.route_input_result` does not exist.
+
+- [ ] **Step 3: Implement `SurfaceInputRouteResult` and wrapper**
+
+In `src/loushang/tui/framework.py`, add:
+
+```python
+@runtime_checkable
+class EditorInputTargetProvider(Protocol):
+    def editor_input_target(self) -> Any: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SurfaceInputRouteResult:
+    intents: tuple[Any, ...]
+    consumed: bool
+```
+
+Add helper:
+
+```python
+def _surface_input_consumed(result: Any, intents: tuple[Any, ...]) -> bool:
+    if isinstance(result, bool):
+        return result
+    if result is None:
+        return False
+    if isinstance(result, tuple):
+        return bool(result)
+    return True
+```
+
+Refactor `SurfaceHost.route_input()` into:
+
+```python
+def route_input_result(
+    self,
+    event: Any,
+    *,
+    close_on_intents: tuple[str, ...] = ("surface_close", "dialog_cancel"),
+) -> SurfaceInputRouteResult:
+    self._sync_focus_for_visible_entries(self._last_known_size())
+    entry = self._current_focus_entry()
+    if entry is None:
+        result = self.handle_input(event)
+    else:
+        result = self._handle_entry_input(entry, event)
+    intents = _normalize_surface_input_result(result)
+    if entry is not None:
+        for intent in intents:
+            if getattr(intent, "kind", None) in close_on_intents:
+                self.close_surface(entry, reason=getattr(intent, "kind", "closed"))
+                break
+    return SurfaceInputRouteResult(
+        intents=intents,
+        consumed=_surface_input_consumed(result, intents),
+    )
+
+
+def route_input(
+    self,
+    event: Any,
+    *,
+    close_on_intents: tuple[str, ...] = ("surface_close", "dialog_cancel"),
+) -> tuple[Any, ...]:
+    return self.route_input_result(
+        event,
+        close_on_intents=close_on_intents,
+    ).intents
+```
+
+- [ ] **Step 4: Run green test**
+
+Run the same focused pytest command. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/loushang/tui/framework.py tests/tui/test_render_framework.py
+git commit -m "feat(tui): expose surface input consumption"
+```
+
+## Task 2: Stateful Surfaces Return True For Consumed Paths
+
+**Files:**
+- Modify: `tests/tui/test_surfaces.py`
+- Modify: `src/loushang/tui/surfaces.py`
+
+- [ ] **Step 1: Write failing tests for consumed-without-intent returns**
+
+Update existing assertions or add focused tests:
+
+```python
+def test_selection_surface_consumed_paths_return_true_without_intents() -> None:
+    surface = SelectionSurface(
+        [SelectItem("Alpha"), SelectItem("Model")],
+        enable_search=True,
+        filter_mode="contains",
+    )
+
+    assert surface.handle_input(InputEvent(kind="text", text="mo")) is True
+    assert surface.handle_input(InputEvent(kind="key", key="backspace")) is True
+    assert surface.handle_input(InputEvent(kind="key", key="down")) is True
+
+
+def test_selection_surface_empty_owned_enter_and_mouse_return_true() -> None:
+    surface = SelectionSurface([], empty_text="No items")
+
+    assert surface.handle_input(InputEvent(kind="key", key="enter")) is True
+    assert surface.handle_input(InputEvent(kind="mouse", mouse_button=0, mouse_row=0, mouse_action="press")) is True
+```
+
+Add settings tests:
+
+```python
+def test_settings_surface_consumed_paths_return_true_without_intents() -> None:
+    surface = SettingsSurface(
+        [
+            SettingItem(id="theme", label="Theme", current_value="dark"),
+            SettingItem(id="model", label="Model", current_value="kimi"),
+        ],
+        enable_search=True,
+    )
+
+    assert surface.handle_input(InputEvent(kind="text", text="mo")) is True
+    assert surface.handle_input(InputEvent(kind="key", key="backspace")) is True
+    assert surface.handle_input(InputEvent(kind="key", key="down")) is True
+```
+
+Update `test_settings_surface_can_delegate_value_selection_to_submenu` first Enter assertion from `is None` to `is True`.
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_surfaces.py -q
+```
+
+Expected: fail on `is True` assertions.
+
+- [ ] **Step 3: Return `True` from stateful consumed paths**
+
+In `SelectionSurface.handle_input`, change consumed-without-intent branches:
+
+- search text after `_apply_filter(...)`: `return True`
+- mouse event after `_handle_mouse(...)`: `return True`
+- search editing key after `_apply_filter(...)`: `return True`
+- `up`, `down`, `pageUp`, `pageDown`, `home`, `end`: return `True`
+- Enter with no selected item: return `True`
+
+In `SettingsSurface.handle_input`, change consumed-without-intent branches:
+
+- search text after mutation: `return True`
+- search editing key after mutation: `return True`
+- settings navigation keys: return `True`
+- activation paths where `_activate_setting()` opens a submenu or owns an empty activation: return `True`
+
+In `_handle_submenu_input`, return `True` when the submenu consumed an event but produced only a close/cancel side effect or a boolean true.
+
+Widen annotations from `InputIntent | None` to `InputIntent | bool | None` for the changed methods.
+
+- [ ] **Step 4: Run green tests**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_surfaces.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/loushang/tui/surfaces.py tests/tui/test_surfaces.py
+git commit -m "fix(tui): mark stateful surface inputs consumed"
+```
+
+## Task 3: Focused Editor Target Discovery
+
+**Files:**
+- Modify: `tests/tui/test_render_framework.py`
+- Modify: `src/loushang/tui/framework.py`
+
+- [ ] **Step 1: Write failing tests for current editor target**
+
+Add helper:
+
+```python
+class EditorProviderFocusTarget(FocusTarget):
+    def __init__(self, name: str, target: object | None) -> None:
+        super().__init__(name)
+        self.target = target
+
+    def editor_input_target(self) -> object | None:
+        return self.target
+```
+
+Add tests:
+
+```python
+def test_surface_host_returns_current_visible_surface_editor_target() -> None:
+    editor_target = object()
+    focus = EditorProviderFocusTarget("editor", editor_target)
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=TextRenderable(("editor",), []), focus_target=focus))
+
+    assert host.current_editor_target() is editor_target
+
+
+def test_surface_host_ignores_base_hidden_and_closed_editor_targets() -> None:
+    base_target = object()
+    base = EditorProviderFocusTarget("base", base_target)
+    base.focus()
+    focus = EditorProviderFocusTarget("editor", object())
+    host = SurfaceHost(base_focus=base)
+
+    assert host.current_editor_target() is None
+
+    handle = host.open_surface(Surface(renderable=TextRenderable(("editor",), []), focus_target=focus))
+    assert host.current_editor_target() is focus.target
+
+    handle.set_hidden(True)
+    assert host.current_editor_target() is None
+
+    handle.set_hidden(False)
+    assert host.current_editor_target() is focus.target
+
+    handle.close("done")
+    assert host.current_editor_target() is None
+```
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_framework.py::test_surface_host_returns_current_visible_surface_editor_target tests/tui/test_render_framework.py::test_surface_host_ignores_base_hidden_and_closed_editor_targets -q
+```
+
+Expected: fail because `current_editor_target()` does not exist.
+
+- [ ] **Step 3: Implement discovery**
+
+In `SurfaceHost`, add:
+
+```python
+def current_editor_target(self) -> Any | None:
+    self._sync_focus_for_visible_entries(self._last_known_size())
+    entry = self._current_focus_entry()
+    if entry is None:
+        return None
+    focus_target = entry.surface.focus_target
+    if not isinstance(focus_target, EditorInputTargetProvider):
+        return None
+    target = focus_target.editor_input_target()
+    return target if target is not None else None
+```
+
+Keep this surface-only; do not inspect `base_focus`.
+
+- [ ] **Step 4: Run green tests**
+
+Run the same focused pytest command. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/loushang/tui/framework.py tests/tui/test_render_framework.py
+git commit -m "feat(tui): expose focused editor targets"
+```
+
+## Task 4: TextInput High-Level Editor Target Adapter
+
+**Files:**
+- Modify: `tests/tui/test_text_input.py`
+- Modify: `src/loushang/tui/ui_parts/text_input.py`
+
+- [ ] **Step 1: Write failing tests for adapter behavior**
+
+Add:
+
+```python
+def test_text_input_editor_input_target_routes_high_level_text_edits() -> None:
+    changes: list[str] = []
+    field = TextInput(on_change=changes.append)
+    target = field.editor_input_target()
+
+    target.insert_text("ab")
+    target.paste("c\nd")
+
+    assert field.value == "abc d"
+    assert changes == ["ab", "abc d"]
+    assert field.undo()
+    assert field.value == "ab"
+    assert field.undo()
+    assert field.value == ""
+
+
+def test_text_input_editor_input_target_routes_destructive_edits_with_undo() -> None:
+    changes: list[str] = []
+    field = TextInput(on_change=changes.append)
+    target = field.editor_input_target()
+
+    target.insert_text("abc")
+    target.delete_backward()
+
+    assert field.value == "ab"
+    assert changes == ["abc", "ab"]
+    assert field.undo()
+    assert field.value == "abc"
+```
+
+Add alias coverage:
+
+```python
+def test_text_input_editor_input_target_exposes_shared_editor_operations() -> None:
+    field = TextInput()
+    target = field.editor_input_target()
+
+    target.insert_text("alpha beta")
+    target.move_to_line_start()
+    target.move_word_right()
+    target.kill_to_line_end()
+
+    assert field.value == "alpha"
+    assert field.kill_ring == (" beta",)
+```
+
+Keep `test_text_input_direct_edits_preserve_existing_undo_boundary` unchanged.
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_text_input.py::test_text_input_editor_input_target_routes_high_level_text_edits tests/tui/test_text_input.py::test_text_input_editor_input_target_routes_destructive_edits_with_undo tests/tui/test_text_input.py::test_text_input_editor_input_target_exposes_shared_editor_operations -q
+```
+
+Expected: fail because `editor_input_target()` does not exist.
+
+- [ ] **Step 3: Implement adapter**
+
+In `src/loushang/tui/ui_parts/text_input.py`, add:
+
+```python
+def editor_input_target(self) -> object:
+    return _TextInputEditorTarget(self)
+```
+
+Add a private dataclass after `TextInput`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class _TextInputEditorTarget:
+    field: TextInput
+
+    def insert_text(self, text: str) -> None:
+        changed = self.field._apply_edit(lambda: self.field.insert_text(text))
+        if changed:
+            self.field._last_action = "type-word"
+
+    def paste(self, text: str) -> None:
+        changed = self.field._apply_edit(lambda: self.field.insert_text(text))
+        if changed:
+            self.field._last_action = None
+```
+
+Implement the remaining protocol methods by delegating to existing `TextInput`
+methods. Character deletes must call `_apply_edit()` around `delete_backward`
+and `delete_forward`; kill/yank/undo/redo can call existing high-level methods.
+
+- [ ] **Step 4: Run green tests**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_text_input.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add src/loushang/tui/ui_parts/text_input.py tests/tui/test_text_input.py
+git commit -m "feat(tui): add text input editor target adapter"
+```
+
+## Task 5: InputRouter Focused Editor Fallback
+
+**Files:**
+- Modify: `tests/tui/test_input_routing.py`
+- Modify: `src/loushang/tui/input.py`
+
+- [ ] **Step 1: Write focused editor routing tests**
+
+Add `CommandSurface`, `SelectItem`, and `TextInput` to the top-level
+`loushang.tui` import in `tests/tui/test_input_routing.py`.
+
+Add helper:
+
+```python
+class DecliningEditorFocus(FocusableMixin):
+    def __init__(self, target: object) -> None:
+        super().__init__()
+        self.target = target
+
+    def editor_input_target(self) -> object:
+        return self.target
+
+    def handle_input(self, event: Any) -> bool:
+        return False
+```
+
+Add:
+
+```python
+def test_input_router_routes_text_and_paste_to_declined_focused_editor_target() -> None:
+    prompt = Composer(prompt="> ")
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(
+        Surface(
+            renderable=DummyRenderable(),
+            focus_target=DecliningEditorFocus(field.editor_input_target()),
+        )
+    )
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="text", text="ab")) == ()
+    assert router.route(InputEvent(kind="paste", text="c\nd")) == ()
+
+    assert field.value == "abc d"
+    assert prompt.value == ""
+```
+
+Add:
+
+```python
+def test_input_router_does_not_double_insert_direct_focused_text_input_surface() -> None:
+    changes: list[str] = []
+    prompt = Composer(prompt="> ")
+    field = TextInput(on_change=changes.append)
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=field))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="text", text="a")) == ()
+
+    assert field.value == "a"
+    assert changes == ["a"]
+    assert prompt.value == ""
+```
+
+Add:
+
+```python
+def test_input_router_routes_focused_editor_selection_and_editing_keys() -> None:
+    prompt = Composer(prompt="> ")
+    field = TextInput()
+    target = field.editor_input_target()
+    target.insert_text("abc")
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=DecliningEditorFocus(target)))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="key", key="shift+left")) == ()
+    assert field.selected_range == (2, 3)
+    assert router.route(InputEvent(kind="key", key="backspace")) == ()
+
+    assert field.value == "ab"
+    assert prompt.value == ""
+```
+
+Add priority and prompt-lane tests:
+
+```python
+def test_input_router_surface_intent_wins_before_focused_editor_fallback() -> None:
+    class ClosingEditorFocus(DecliningEditorFocus):
+        def handle_input(self, event: Any) -> InputIntent | None:
+            if isinstance(event, InputEvent) and event.kind == "key":
+                return InputIntent(kind="surface_close")
+            return None
+
+    prompt = Composer(prompt="> ")
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=ClosingEditorFocus(field.editor_input_target())))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="key", key="left")) == (InputIntent(kind="surface_close"),)
+    assert field.value == ""
+    assert host.entries == []
+```
+
+```python
+def test_input_router_does_not_submit_prompt_while_focused_editor_target_is_active() -> None:
+    prompt = Composer(prompt="> ")
+    prompt.insert_text("prompt")
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=DecliningEditorFocus(field.editor_input_target())))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="key", key="enter")) == ()
+    assert prompt.value == "prompt"
+```
+
+Add explicit cancel suppression coverage:
+
+```python
+def test_input_router_does_not_abort_running_prompt_while_focused_editor_target_is_active() -> None:
+    prompt = Composer(prompt="> ")
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=DecliningEditorFocus(field.editor_input_target())))
+    router = InputRouter(composer=prompt, surface_host=host, running=True)
+
+    assert router.route(InputEvent(kind="key", key="escape")) == ()
+```
+
+```python
+def test_input_router_prompt_jump_text_wins_before_focused_editor_fallback() -> None:
+    prompt = Composer(prompt="> ")
+    prompt.insert_text("abc def")
+    prompt.move_to_line_start()
+    router = InputRouter(composer=prompt)
+    assert router.route(InputEvent(kind="key", key="ctrl+]")) == ()
+
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=DecliningEditorFocus(field.editor_input_target())))
+    router.surface_host = host
+
+    assert router.route(InputEvent(kind="text", text="d")) == ()
+    prompt.delete_forward()
+
+    assert prompt.value == "abc ef"
+    assert field.value == ""
+```
+
+Add a surface-consumed regression:
+
+```python
+def test_input_router_does_not_leak_searchable_surface_text_to_prompt() -> None:
+    prompt = Composer(prompt="> ")
+    host = SurfaceHost()
+    surface = CommandSurface([SelectItem("/status", value="/status")])
+    host.open_surface(Surface(renderable=surface, focus_target=surface))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="text", text="sta")) == ()
+
+    assert prompt.value == ""
+    assert tuple(item.selected_value for item in surface._filtered_items) == ("/status",)
+```
+
+- [ ] **Step 2: Run red tests**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_input_routing.py -q
+```
+
+Expected: focused editor tests fail because `InputRouter` has no focused editor fallback and no consumed route handling.
+
+- [ ] **Step 3: Add private surface route result to `InputRouter`**
+
+In `src/loushang/tui/input.py`, add a private dataclass:
+
+```python
+@dataclass(frozen=True, slots=True)
+class _SurfaceRoute:
+    intents: tuple[InputIntent, ...] = ()
+    consumed: bool = False
+```
+
+Update `_route_surface_first()` to return `_SurfaceRoute`:
+
+- Prefer `surface_host.route_input_result(_legacy_event(event))`.
+- Filter returned values to `InputIntent` before returning to app code.
+- Preserve `consumed=True` from the host even when there are no `InputIntent` values.
+- Keep a compatibility path for hosts that only expose `route_input()` or `handle_input()`.
+
+- [ ] **Step 4: Add focused editor target lookup**
+
+Add:
+
+```python
+def _focused_editor_target(self) -> EditorInputTarget | None:
+    if self.surface_host is None:
+        return None
+    current = getattr(self.surface_host, "current_editor_target", None)
+    if not callable(current):
+        return None
+    target = current()
+    return target if target is not None else None
+```
+
+Use structural typing; no runtime `isinstance` protocol check is needed.
+
+- [ ] **Step 5: Update route ordering**
+
+For key events:
+
+1. Keep key release return.
+2. Keep existing jump-mode cleanup for key events.
+3. Call `_route_surface_first(event)`.
+4. Return surface intents if present.
+5. Return `()` if surface consumed.
+6. If a focused editor target exists:
+   - route selection keys to it
+   - route ordinary editing keys to it
+   - return `()` for all remaining key events so prompt submit/newline/history/completion does not run while focused editor owns editing
+7. Continue existing prompt routing when no focused editor target exists.
+
+For text events:
+
+1. If `_jump_mode` is active, route to prompt `jump_to_char()`, clear jump, and return.
+2. Route surface first.
+3. Stop on surface intents or consumed.
+4. Insert into focused editor target when present.
+5. Otherwise insert into prompt target.
+
+For paste events:
+
+1. Clear `_jump_mode`.
+2. Route surface first.
+3. Stop on surface intents or consumed.
+4. Paste into focused editor target when present.
+5. Otherwise paste into prompt target.
+
+- [ ] **Step 6: Run green tests**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_input_routing.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add src/loushang/tui/input.py tests/tui/test_input_routing.py
+git commit -m "feat(tui): route input to focused editor targets"
+```
+
+## Task 6: Documentation And Verification
+
+**Files:**
+- Modify: `docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md`
+
+- [ ] **Step 1: Write documentation update**
+
+In `KD-002`, extend the generic prompt target paragraph with:
+
+```markdown
+Focused surface editors may expose an editor target through `editor_input_target()`.
+`SurfaceHost.route_input_result()` distinguishes surface intents from consumed
+events without changing the compatibility `route_input()` return value. Generic
+`InputRouter` routing stays surface-first: surface intents win, consumed surface
+events stop fallback, and only declined events may route ordinary text, paste,
+selection, and editing keys to the focused editor target. Prompt-only actions
+such as submit, newline, history, completion, queue editing, and jump setup do
+not mutate prompt state while a focused editor target owns the editing lane.
+```
+
+In the test obligations list, add:
+
+```markdown
+- focused surface editor targets receive ordinary text/editing only after the surface declines the event
+- consumed surface text, search, and navigation events do not leak into prompt editing
+```
+
+- [ ] **Step 2: Run focused verification**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_render_framework.py tests/tui/test_surfaces.py tests/tui/test_text_input.py tests/tui/test_input_routing.py -q
+uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/framework.py src/loushang/tui/input.py src/loushang/tui/surfaces.py src/loushang/tui/ui_parts/text_input.py tests/tui/test_render_framework.py tests/tui/test_surfaces.py tests/tui/test_text_input.py tests/tui/test_input_routing.py
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run broader TUI verification**
+
+Run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+```
+
+Expected: all TUI tests pass.
+
+- [ ] **Step 4: Commit docs and any final cleanup**
+
+```sh
+git add docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md
+git commit -m "docs(tui): document focused editor input routing"
+```
+
+If final cleanup changed code or tests, include those files in the commit with the same message only if they are strictly related to documentation wording or lint cleanup. Otherwise create a separate targeted commit.
+
+## Final Verification
+
+Before opening a PR or reporting completion, run:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/framework.py src/loushang/tui/input.py src/loushang/tui/surfaces.py src/loushang/tui/ui_parts/text_input.py tests/tui/test_render_framework.py tests/tui/test_surfaces.py tests/tui/test_text_input.py tests/tui/test_input_routing.py
+git status --short
+```
+
+Expected:
+
+- TUI tests pass.
+- Ruff passes.
+- Working tree is clean except for intentional untracked files outside this branch, if any.

--- a/docs/superpowers/specs/2026-06-10-tui-focused-editor-target-routing-design.md
+++ b/docs/superpowers/specs/2026-06-10-tui-focused-editor-target-routing-design.md
@@ -50,11 +50,14 @@ Add an optional editor-target discovery path to `SurfaceHost`.
 1. A focused object may expose an editor target through `editor_input_target()`.
 2. `SurfaceHost.current_editor_target()` returns that target only when the
    current focus is a visible surface focus target.
-3. `InputRouter` continues to route surface intents first.
-4. If the focused surface did not consume the event and a focused editor target
-   exists, `InputRouter` routes generic editor text, paste, selection, and
-   editing keys to that editor target.
-5. Prompt-only routes still fall back to the prompt target.
+3. `InputRouter` continues to route surface input first.
+4. `SurfaceHost` exposes whether the focused surface consumed the event, even
+   when it did not emit `InputIntent` values.
+5. If the focused surface declined the event and a focused editor target exists,
+   `InputRouter` routes generic editor text, paste, selection, and editing keys
+   to that editor target.
+6. Prompt-only routes still use the prompt target only when no focused editor
+   target owns the editing lane.
 
 This preserves the existing contract: surfaces get first chance to handle
 submit, escape, custom commands, and close intents. The focused editor fallback
@@ -88,39 +91,103 @@ targets are deferred because the prompt already has an explicit prompt target
 and base-focus fallback would blur the boundary between prompt and surface
 editing.
 
-## TextInput Target
+## Surface Consumption Contract
 
-`TextInput` should expose itself as its editor target:
+`SurfaceHost.route_input()` currently returns only normalized surface values:
+`None` and boolean results collapse to `()`. That public behavior must remain
+unchanged.
+
+Add a narrow result API for routers that need to know whether the focus target
+handled the event:
 
 ```python
-def editor_input_target(self) -> TextInput:
-    return self
+@dataclass(frozen=True, slots=True)
+class SurfaceInputRouteResult:
+    intents: tuple[Any, ...]
+    consumed: bool
 ```
 
-To satisfy `EditorInputTarget`, add compatibility aliases whose names match the
-shared helper interface:
+`SurfaceHost.route_input_result()` should share the same routing and close logic
+as `route_input()`, but preserve consumption:
+
+- `None` means `consumed=False`
+- `False` means `consumed=False`
+- `True` means `consumed=True`
+- any non-empty tuple means `consumed=True`
+- any non-`None` non-bool scalar means `consumed=True`
+
+`route_input()` becomes a compatibility wrapper returning
+`route_input_result(...).intents`.
+
+Consumption is explicit. `route_input_result()` should not try to detect state
+mutation by diffing arbitrary surface objects. Existing surfaces that currently
+mutate state and return `None` must be updated in this slice to return `True`
+for consumed-without-intent paths. In particular:
+
+- `SelectionSurface` search text, search editing keys, mouse presses, selection
+  navigation keys, and owned-but-empty Enter paths
+- `SettingsSurface` search text, search editing keys, settings navigation keys,
+  submenu open/close paths, and owned-but-empty activation paths
+
+Those `True` returns remain invisible to existing callers because
+`route_input()` still normalizes booleans to `()`, but they let
+`InputRouter` avoid falling through to prompt/focused-editor fallback.
+
+`InputRouter._route_surface_first()` should use `route_input_result()` when
+available. It should return the `InputIntent` subset to application code, but
+use `consumed=True` to stop prompt/editor fallback. This prevents a focused
+`TextInput.handle_input()` edit from being applied once by the surface route and
+a second time by the focused editor fallback.
+
+## TextInput Target
+
+`TextInput` should expose a small adapter as its editor target:
+
+```python
+def editor_input_target(self) -> object:
+    return _TextInputEditorTarget(self)
+```
+
+The adapter, not `TextInput` itself, satisfies `EditorInputTarget`. This keeps
+the existing low-level `TextInput.insert_text()`, `delete_backward()`, and
+`delete_forward()` methods unchanged; tests currently rely on direct low-level
+edits not creating undo boundaries. The `object` annotation avoids importing
+`EditorInputTarget` into `text_input.py`; the router uses the returned object
+structurally.
+
+The adapter methods are high-level user edit operations:
+
+- `insert_text()` calls `_apply_edit(lambda: field.insert_text(text))`, sets
+  `_last_action="type-word"` when the value changed, and triggers `on_change`.
+- `paste()` calls `_apply_edit(lambda: field.insert_text(text))`, clears
+  `_last_action` when the value changed, normalizes single-line paste through
+  `TextInput.insert_text()`, and triggers `on_change`.
+- destructive character edits call `_apply_edit()` around the low-level delete
+  primitives.
+- kill, yank, undo, redo, cursor movement, and selection methods delegate to the
+  existing high-level `TextInput` methods.
+
+The adapter should expose compatibility methods whose names match the shared
+helper interface:
 
 ```python
 def move_to_line_start(self) -> None:
-    self.move_to_start()
+    self.field.move_to_start()
 
 def move_to_line_end(self) -> None:
-    self.move_to_end()
+    self.field.move_to_end()
 
 def kill_to_line_start(self) -> None:
-    self.kill_to_start()
+    self.field.kill_to_start()
 
 def kill_to_line_end(self) -> None:
-    self.kill_to_end()
+    self.field.kill_to_end()
 ```
 
-`TextInput.paste()` should normalize pasted text the same way direct
-`handle_input(kind="paste")` does today: insert `_single_line_text(text)`.
-This can be implemented as a direct alias to `insert_text()`.
-
-`TextInput` already has the remaining editing and selection operations:
-`insert_text`, cursor movement, word movement, delete, kill, yank, undo, redo,
-and selection extension.
+`TextInput.handle_input()` remains the direct focused-surface path. When a
+`TextInput` is used directly as the surface focus target, `InputRouter` should
+see `consumed=True` from `route_input_result()` and must not call the adapter
+again.
 
 ## InputRouter Data Flow
 
@@ -129,28 +196,38 @@ For key events:
 1. Keep the existing key release and jump-mode cleanup behavior.
 2. Route surface input first through `_route_surface_first(event)`.
 3. If a surface emitted `InputIntent` values, return them unchanged.
-4. Ask `surface_host.current_editor_target()` for a focused editor target.
-5. If a focused editor target exists:
+4. If the surface consumed the event without emitting intents, return `()`.
+5. Ask `surface_host.current_editor_target()` for a focused editor target.
+6. If a focused editor target exists:
    - route selection keys with `route_editor_selection_key()`
    - route ordinary editing keys with `route_editor_editing_key()`
    - do not route submit, escape, completion, history, jump, page movement,
      queue edit, or prompt newline to the focused editor
-6. Continue with existing prompt-target routing.
+   - do not let submit, escape, completion, history, jump, page movement, queue
+     edit, or prompt newline fall through to the prompt target while the focused
+     editor target owns the editing lane
+7. Continue with existing prompt-target routing only when no focused editor
+   target is active.
 
 For text and paste events:
 
-1. Route surface input first.
-2. If surface intents are returned, return them.
-3. If there is a focused editor target, insert text or paste into that target.
-4. Otherwise keep the existing prompt-target behavior.
+1. For text, if prompt jump mode is active, route the character to the prompt
+   target's `jump_to_char()`, clear jump mode, and return. Jump remains
+   prompt-only and must not insert into a focused editor.
+2. For paste, clear jump mode as today.
+3. Route surface input first through `_route_surface_first(event)`.
+4. If a surface emitted `InputIntent` values, return them unchanged.
+5. If the surface consumed the event without emitting intents, return `()`.
+6. If there is a focused editor target, insert text or paste into that target.
+7. Otherwise keep the existing prompt-target behavior.
 
 Resize and SIGWINCH continue to return `invalidate_render` and do not route to
 focused editors.
 
 ## Surface Intent Semantics
 
-Focused editor fallback only runs when the surface did not emit intents. This
-keeps existing surfaces authoritative for:
+Focused editor fallback only runs when the surface declined the event:
+`consumed=False` and no intents. This keeps existing surfaces authoritative for:
 
 - `surface_close`
 - `dialog_cancel`
@@ -159,9 +236,12 @@ keeps existing surfaces authoritative for:
 - selection surfaces and modal command surfaces
 
 If a surface wants `TextInput` submit or escape callbacks, it can continue to
-handle those through `TextInput.handle_input()`. The generic `InputRouter`
-fallback is only for ordinary editing operations that are currently duplicated
-or unavailable when custom surface handlers decline an event.
+handle those through `TextInput.handle_input()`. A focused editor target should
+also block prompt submit/escape fallback while it owns focus, so pressing Enter
+inside a focused editor cannot submit unrelated prompt text. The generic
+`InputRouter` fallback is only for ordinary editing operations that are
+currently duplicated or unavailable when custom surface handlers decline an
+event.
 
 ## Error Handling
 
@@ -170,8 +250,9 @@ or unavailable when custom surface handlers decline an event.
 - A provider returning `None` is treated as no focused editor.
 - A provider returning an incomplete editor target should fail normally when the
   helper calls a missing method; do not silently fall back to prompt editing.
-- Surface routing remains defensive: non-`InputIntent` surface return values are
-  ignored as they are today.
+- Surface routing remains defensive for application intents: non-`InputIntent`
+  surface return values are not returned by `InputRouter`, but they still count
+  as consumed when `route_input_result()` says the surface handled the event.
 
 ## Testing
 
@@ -179,14 +260,26 @@ Add focused tests before implementation:
 
 - `SurfaceHost.current_editor_target()` returns a focused surface target exposed
   by `editor_input_target()`.
+- `SurfaceHost.route_input_result()` reports `consumed=True` for boolean `True`,
+  non-empty tuples, and scalar results while `route_input()` keeps its existing
+  normalized return value.
+- Existing stateful surfaces that consume input without emitting intents return
+  `True`; searchable `SelectionSurface` and `SettingsSurface` text/filter
+  edits must not fall through to prompt editing.
 - Hidden or closed surface focus targets no longer provide an editor target.
-- `TextInput.editor_input_target()` returns the field itself.
-- `TextInput` exposes the alias methods required by `EditorInputTarget`.
+- `TextInput.editor_input_target()` returns a high-level adapter.
+- The `TextInput` adapter exposes the methods required by `EditorInputTarget`.
+- The `TextInput` adapter preserves `on_change` callbacks and undo/redo
+  boundaries for routed text, paste, and destructive edits.
+- Direct `TextInput` surfaces do not double-insert when routed through
+  `InputRouter`.
 - `InputRouter` routes text and paste to a focused `TextInput` after the surface
   declines the event, without changing the prompt target.
 - `InputRouter` routes selection and editing keys to a focused `TextInput`.
 - `InputRouter` still lets surface intents win before focused editor fallback.
-- `InputRouter` still submits prompt text when no focused editor target exists.
+- Prompt jump mode consumes the next text event before focused editor fallback.
+- `InputRouter` still submits prompt text when no focused editor target exists,
+  and does not submit prompt text while a focused editor target is active.
 - Resize/SIGWINCH still invalidate render instead of touching focused editors.
 
 Focused verification:
@@ -199,12 +292,15 @@ uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/framework.p
 
 ## Rollout Plan
 
-1. Add `TextInput` editor target compatibility methods and tests.
-2. Add `SurfaceHost.current_editor_target()` and focused target tests.
-3. Route generic `InputRouter` text, paste, selection, and editing keys through
+1. Add `SurfaceHost.route_input_result()` and consumption tests.
+2. Update existing stateful surface handlers to return `True` for
+   consumed-without-intent paths and add regression tests.
+3. Add `SurfaceHost.current_editor_target()` and focused target tests.
+4. Add the `TextInput` editor target adapter and tests.
+5. Route generic `InputRouter` text, paste, selection, and editing keys through
    the focused editor fallback.
-4. Keep prompt-only behavior and native routing unchanged.
-5. Document the focused editor target boundary in `KD-002`.
+6. Keep prompt-only behavior unchanged when no focused editor target exists.
+7. Document the focused editor target boundary in `KD-002`.
 
 Stop after this slice. A future spec can decide whether `SurfaceHost` should
 support base-focus editor targets or whether a higher-level focus registry is
@@ -215,7 +311,12 @@ needed for richer widgets.
 - Existing prompt `InputRouter(composer=...)` behavior remains unchanged.
 - Focused `TextInput` can receive ordinary text, paste, selection, and editing
   keys through `InputRouter`.
+- Focused `TextInput` never receives the same text or paste event twice.
+- Routed `TextInput` edits preserve `on_change` and undo/redo behavior.
 - Surface intents still win over editor fallback.
 - Submit and escape for focused surfaces remain surface-owned.
+- Existing searchable/selection/settings surfaces do not leak consumed input to
+  prompt editing.
+- Prompt jump mode remains prompt-owned.
 - `NativeInputRouter` behavior remains unchanged.
 - The implementation does not introduce a full widget or focus-manager system.

--- a/docs/superpowers/specs/2026-06-10-tui-focused-editor-target-routing-design.md
+++ b/docs/superpowers/specs/2026-06-10-tui-focused-editor-target-routing-design.md
@@ -1,0 +1,221 @@
+# TUI Focused Editor Target Routing Design
+
+## Status
+
+Draft for implementation planning.
+
+## Context
+
+`InputRouter` now routes generic prompt editing through a `PromptInputTarget`
+instead of calling `Composer` directly. That made the prompt editor replaceable,
+but it did not yet let focused surface editors reuse the same input policy.
+
+`SurfaceHost` already owns focus capture and restoration. It can route events to
+the currently focused surface, and `TextInput` already works as a focused
+overlay through its own `handle_input()` implementation. The missing boundary is
+a way for focused editors to opt into shared editor-key routing without making
+`InputRouter` understand concrete widget classes or rewriting surface submit and
+escape semantics.
+
+The next slice should prove the target boundary with `TextInput`, because it is
+the smallest existing non-Composer editor and already shares most editing
+primitives with `Composer`.
+
+## Goals
+
+- Let a focused surface editor opt into generic editor key routing.
+- Keep `InputRouter` responsible for keybinding policy and editing operations.
+- Preserve surface-first intent routing and close behavior.
+- Preserve prompt submit, follow-up, steer, history, completion, and jump
+  semantics.
+- Prove the model with `TextInput` without building a full widget ecosystem.
+- Keep existing `TextInput.handle_input()` behavior working for `Tui.handle_input`
+  and direct surface routing.
+
+## Non-Goals
+
+- Do not introduce a global focus manager beyond `SurfaceHost`.
+- Do not make focused `TextInput` submit prompt text.
+- Do not route prompt-only actions such as history, completions, page movement,
+  queue editing, steer, or follow-up to ordinary focused editors.
+- Do not remove `TextInput.handle_input()`.
+- Do not change `NativeInputRouter` product-specific routing order.
+- Do not add new widgets such as button, tree, list, or dialog containers in this
+  slice.
+
+## Design Summary
+
+Add an optional editor-target discovery path to `SurfaceHost`.
+
+1. A focused object may expose an editor target through `editor_input_target()`.
+2. `SurfaceHost.current_editor_target()` returns that target only when the
+   current focus is a visible surface focus target.
+3. `InputRouter` continues to route surface intents first.
+4. If the focused surface did not consume the event and a focused editor target
+   exists, `InputRouter` routes generic editor text, paste, selection, and
+   editing keys to that editor target.
+5. Prompt-only routes still fall back to the prompt target.
+
+This preserves the existing contract: surfaces get first chance to handle
+submit, escape, custom commands, and close intents. The focused editor fallback
+only handles ordinary editing when the surface did not consume the event.
+
+## Editor Target Discovery
+
+Add a runtime-checkable protocol in `framework.py`:
+
+```python
+@runtime_checkable
+class EditorInputTargetProvider(Protocol):
+    def editor_input_target(self) -> Any: ...
+```
+
+`Any` avoids importing `EditorInputTarget` into `framework.py` and creating a
+cycle from `framework -> input -> framework`. The input module can cast or use
+the returned object structurally.
+
+`SurfaceHost.current_editor_target()` should:
+
+- call `_sync_focus_for_visible_entries(self._last_known_size())`
+- inspect `self._current_focus_entry()`
+- return `None` when focus is only `base_focus`
+- return `None` when the surface focus target does not expose
+  `editor_input_target()`
+- return the provider result when it is not `None`
+
+Only surface focus targets participate in this first slice. Base focus editor
+targets are deferred because the prompt already has an explicit prompt target
+and base-focus fallback would blur the boundary between prompt and surface
+editing.
+
+## TextInput Target
+
+`TextInput` should expose itself as its editor target:
+
+```python
+def editor_input_target(self) -> TextInput:
+    return self
+```
+
+To satisfy `EditorInputTarget`, add compatibility aliases whose names match the
+shared helper interface:
+
+```python
+def move_to_line_start(self) -> None:
+    self.move_to_start()
+
+def move_to_line_end(self) -> None:
+    self.move_to_end()
+
+def kill_to_line_start(self) -> None:
+    self.kill_to_start()
+
+def kill_to_line_end(self) -> None:
+    self.kill_to_end()
+```
+
+`TextInput.paste()` should normalize pasted text the same way direct
+`handle_input(kind="paste")` does today: insert `_single_line_text(text)`.
+This can be implemented as a direct alias to `insert_text()`.
+
+`TextInput` already has the remaining editing and selection operations:
+`insert_text`, cursor movement, word movement, delete, kill, yank, undo, redo,
+and selection extension.
+
+## InputRouter Data Flow
+
+For key events:
+
+1. Keep the existing key release and jump-mode cleanup behavior.
+2. Route surface input first through `_route_surface_first(event)`.
+3. If a surface emitted `InputIntent` values, return them unchanged.
+4. Ask `surface_host.current_editor_target()` for a focused editor target.
+5. If a focused editor target exists:
+   - route selection keys with `route_editor_selection_key()`
+   - route ordinary editing keys with `route_editor_editing_key()`
+   - do not route submit, escape, completion, history, jump, page movement,
+     queue edit, or prompt newline to the focused editor
+6. Continue with existing prompt-target routing.
+
+For text and paste events:
+
+1. Route surface input first.
+2. If surface intents are returned, return them.
+3. If there is a focused editor target, insert text or paste into that target.
+4. Otherwise keep the existing prompt-target behavior.
+
+Resize and SIGWINCH continue to return `invalidate_render` and do not route to
+focused editors.
+
+## Surface Intent Semantics
+
+Focused editor fallback only runs when the surface did not emit intents. This
+keeps existing surfaces authoritative for:
+
+- `surface_close`
+- `dialog_cancel`
+- submit callbacks handled by `TextInput.handle_input()`
+- escape callbacks handled by `TextInput.handle_input()`
+- selection surfaces and modal command surfaces
+
+If a surface wants `TextInput` submit or escape callbacks, it can continue to
+handle those through `TextInput.handle_input()`. The generic `InputRouter`
+fallback is only for ordinary editing operations that are currently duplicated
+or unavailable when custom surface handlers decline an event.
+
+## Error Handling
+
+- `current_editor_target()` returns `None` when no visible focused surface editor
+  is available.
+- A provider returning `None` is treated as no focused editor.
+- A provider returning an incomplete editor target should fail normally when the
+  helper calls a missing method; do not silently fall back to prompt editing.
+- Surface routing remains defensive: non-`InputIntent` surface return values are
+  ignored as they are today.
+
+## Testing
+
+Add focused tests before implementation:
+
+- `SurfaceHost.current_editor_target()` returns a focused surface target exposed
+  by `editor_input_target()`.
+- Hidden or closed surface focus targets no longer provide an editor target.
+- `TextInput.editor_input_target()` returns the field itself.
+- `TextInput` exposes the alias methods required by `EditorInputTarget`.
+- `InputRouter` routes text and paste to a focused `TextInput` after the surface
+  declines the event, without changing the prompt target.
+- `InputRouter` routes selection and editing keys to a focused `TextInput`.
+- `InputRouter` still lets surface intents win before focused editor fallback.
+- `InputRouter` still submits prompt text when no focused editor target exists.
+- Resize/SIGWINCH still invalidate render instead of touching focused editors.
+
+Focused verification:
+
+```sh
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_text_input.py tests/tui/test_input_routing.py -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/framework.py src/loushang/tui/input.py src/loushang/tui/ui_parts/text_input.py tests/tui/test_text_input.py tests/tui/test_input_routing.py
+```
+
+## Rollout Plan
+
+1. Add `TextInput` editor target compatibility methods and tests.
+2. Add `SurfaceHost.current_editor_target()` and focused target tests.
+3. Route generic `InputRouter` text, paste, selection, and editing keys through
+   the focused editor fallback.
+4. Keep prompt-only behavior and native routing unchanged.
+5. Document the focused editor target boundary in `KD-002`.
+
+Stop after this slice. A future spec can decide whether `SurfaceHost` should
+support base-focus editor targets or whether a higher-level focus registry is
+needed for richer widgets.
+
+## Success Criteria
+
+- Existing prompt `InputRouter(composer=...)` behavior remains unchanged.
+- Focused `TextInput` can receive ordinary text, paste, selection, and editing
+  keys through `InputRouter`.
+- Surface intents still win over editor fallback.
+- Submit and escape for focused surfaces remain surface-owned.
+- `NativeInputRouter` behavior remains unchanged.
+- The implementation does not introduce a full widget or focus-manager system.

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -98,7 +98,7 @@ class NativeSurfaceView(FocusableMixin):
             return None
         handler = getattr(self.content, "handle_input", None)
         if callable(handler):
-            return handler(self._translate_content_input_event(event))
+            return _native_input_intent_or_none(handler(self._translate_content_input_event(event)))
         return None
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
@@ -179,7 +179,7 @@ class ModelSelectorSurface:
             self._pending_ordinal = ""
         intent = self._surface.handle_input(event)
         self._filter_text = self._surface.filter_text
-        return intent
+        return _native_input_intent_or_none(intent)
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         if not self.scoped_items:
@@ -689,6 +689,19 @@ def _session_commands_provider(session: Any) -> Callable[[], Any] | None:
     if not callable(getter):
         return None
     return getter
+
+
+def _native_input_intent_or_none(result: object) -> InputIntent | None:
+    if isinstance(result, InputIntent):
+        return result
+    kind = getattr(result, "kind", None)
+    if not isinstance(kind, str):
+        return None
+    return InputIntent(
+        kind=kind,
+        text=str(getattr(result, "text", "")),
+        note=str(getattr(result, "note", "")),
+    )
 
 
 __all__ = ["NativeSurfaceManager", "NativeSurfaceView"]

--- a/src/loushang/tui/framework.py
+++ b/src/loushang/tui/framework.py
@@ -52,6 +52,11 @@ class Focusable(Protocol):
     def handle_input(self, event: Any) -> Any: ...
 
 
+@runtime_checkable
+class EditorInputTargetProvider(Protocol):
+    def editor_input_target(self) -> Any: ...
+
+
 class FocusableMixin:
     def __init__(self) -> None:
         self.focused = False
@@ -148,6 +153,12 @@ class SurfaceEntry:
     last_column: int | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class SurfaceInputRouteResult:
+    intents: tuple[Any, ...]
+    consumed: bool
+
+
 @dataclass(slots=True)
 class SurfaceHost:
     base_focus: Focusable | None = None
@@ -232,6 +243,14 @@ class SurfaceHost:
         *,
         close_on_intents: tuple[str, ...] = ("surface_close", "dialog_cancel"),
     ) -> tuple[Any, ...]:
+        return self.route_input_result(event, close_on_intents=close_on_intents).intents
+
+    def route_input_result(
+        self,
+        event: Any,
+        *,
+        close_on_intents: tuple[str, ...] = ("surface_close", "dialog_cancel"),
+    ) -> SurfaceInputRouteResult:
         self._sync_focus_for_visible_entries(self._last_known_size())
         entry = self._current_focus_entry()
         if entry is None:
@@ -244,7 +263,7 @@ class SurfaceHost:
                 if getattr(intent, "kind", None) in close_on_intents:
                     self.close_surface(entry, reason=getattr(intent, "kind", "closed"))
                     break
-        return intents
+        return SurfaceInputRouteResult(intents=intents, consumed=_surface_input_consumed(result, intents))
 
     def compose(self, base: RenderResult, constraints: RenderConstraints) -> RenderResult:
         visible_height = constraints.visible_height or constraints.max_height
@@ -407,6 +426,16 @@ def _normalize_surface_input_result(result: Any) -> tuple[Any, ...]:
     if isinstance(result, tuple):
         return result
     return (result,)
+
+
+def _surface_input_consumed(result: Any, intents: tuple[Any, ...]) -> bool:
+    if isinstance(result, bool):
+        return result
+    if result is None:
+        return False
+    if isinstance(result, tuple):
+        return bool(result)
+    return True
 
 
 def _translate_surface_input_event(entry: SurfaceEntry, event: Any) -> Any:

--- a/src/loushang/tui/framework.py
+++ b/src/loushang/tui/framework.py
@@ -231,6 +231,17 @@ class SurfaceHost:
             return self.base_focus
         return None
 
+    def current_editor_target(self) -> Any | None:
+        self._sync_focus_for_visible_entries(self._last_known_size())
+        entry = self._current_focus_entry()
+        if entry is None:
+            return None
+        focus_target = entry.surface.focus_target
+        if not isinstance(focus_target, EditorInputTargetProvider):
+            return None
+        target = focus_target.editor_input_target()
+        return target if target is not None else None
+
     def handle_input(self, event: Any) -> Any:
         focus_target = self.current_focus()
         if focus_target is None:

--- a/src/loushang/tui/input.py
+++ b/src/loushang/tui/input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 from dataclasses import InitVar, dataclass, field
-from typing import Literal, Protocol
+from typing import Literal, Protocol, cast
 
 from loushang.tui.framework import SurfaceHost
 from loushang.tui.keybindings import KeybindingManager, normalize_key_id
@@ -683,6 +683,12 @@ class InputReader:
         return InputEvent(kind="text", text=sequence)
 
 
+@dataclass(frozen=True, slots=True)
+class _SurfaceRoute:
+    intents: tuple[InputIntent, ...] = ()
+    consumed: bool = False
+
+
 @dataclass(slots=True)
 class InputRouter:
     composer: Composer | None = None
@@ -722,9 +728,18 @@ class InputRouter:
                     return ()
                 self._jump_mode = None
             keybindings = self._keybindings()
-            surface_intents = self._route_surface_first(event)
-            if surface_intents:
-                return surface_intents
+            surface_route = self._route_surface_first(event)
+            if surface_route.intents:
+                return surface_route.intents
+            if surface_route.consumed:
+                return ()
+            focused_target = self._focused_editor_target()
+            if focused_target is not None:
+                if route_editor_selection_key(focused_target, event.key, keybindings=keybindings):
+                    return ()
+                if route_editor_editing_key(focused_target, event.key, keybindings=keybindings):
+                    return ()
+                return ()
             if route_editor_selection_key(target, event.key, keybindings=keybindings):
                 return ()
             if target.has_completions and route_prompt_completion_key(target, event.key, keybindings=keybindings):
@@ -765,12 +780,30 @@ class InputRouter:
                 return ()
         if event.kind == "paste":
             self._jump_mode = None
+            surface_route = self._route_surface_first(event)
+            if surface_route.intents:
+                return surface_route.intents
+            if surface_route.consumed:
+                return ()
+            focused_target = self._focused_editor_target()
+            if focused_target is not None:
+                focused_target.paste(event.text)
+                return ()
             target.paste(event.text)
             return ()
         if event.kind == "text":
             if self._jump_mode is not None:
                 target.jump_to_char(event.text, direction=self._jump_mode)
                 self._jump_mode = None
+                return ()
+            surface_route = self._route_surface_first(event)
+            if surface_route.intents:
+                return surface_route.intents
+            if surface_route.consumed:
+                return ()
+            focused_target = self._focused_editor_target()
+            if focused_target is not None:
+                focused_target.insert_text(event.text)
                 return ()
             target.insert_text(event.text)
             return ()
@@ -793,21 +826,31 @@ class InputRouter:
             return (InputIntent(kind="follow_up", text=text, note="steer_unavailable"),)
         return (InputIntent(kind="follow_up", text=text),)
 
-    def _route_surface_first(self, event: InputEvent) -> tuple[InputIntent, ...]:
+    def _route_surface_first(self, event: InputEvent) -> _SurfaceRoute:
         if self.surface_host is None:
-            return ()
+            return _SurfaceRoute()
+        route_input_result = getattr(self.surface_host, "route_input_result", None)
+        if callable(route_input_result):
+            result = route_input_result(_legacy_event(event))
+            return _SurfaceRoute(
+                intents=_input_intents(getattr(result, "intents", None)),
+                consumed=bool(getattr(result, "consumed", False)),
+            )
         route_input = getattr(self.surface_host, "route_input", None)
         if callable(route_input):
             result = route_input(_legacy_event(event))
         else:
             result = self.surface_host.handle_input(_legacy_event(event))
-        if result is None:
-            return ()
-        if isinstance(result, InputIntent):
-            return (result,)
-        if isinstance(result, tuple) and all(isinstance(item, InputIntent) for item in result):
-            return result
-        return ()
+        return _SurfaceRoute(intents=_input_intents(result), consumed=_input_result_consumed(result))
+
+    def _focused_editor_target(self) -> EditorInputTarget | None:
+        if self.surface_host is None:
+            return None
+        current = getattr(self.surface_host, "current_editor_target", None)
+        if not callable(current):
+            return None
+        target = current()
+        return cast(EditorInputTarget, target) if target is not None else None
 
     def _move_up_or_history(self) -> None:
         target = self._target
@@ -830,6 +873,26 @@ class InputRouter:
 
     def _composer_page_lines(self) -> int:
         return max(2, min(10, self.height))
+
+
+def _input_intents(result: object) -> tuple[InputIntent, ...]:
+    if result is None:
+        return ()
+    if isinstance(result, InputIntent):
+        return (result,)
+    if isinstance(result, tuple):
+        return tuple(item for item in result if isinstance(item, InputIntent))
+    return ()
+
+
+def _input_result_consumed(result: object) -> bool:
+    if isinstance(result, bool):
+        return result
+    if result is None:
+        return False
+    if isinstance(result, tuple):
+        return bool(result)
+    return True
 
 
 def sanitize_paste_text(text: str) -> str:

--- a/src/loushang/tui/surfaces.py
+++ b/src/loushang/tui/surfaces.py
@@ -86,42 +86,42 @@ class SelectionSurface:
             return ""
         return self._filter_input.value
 
-    def handle_input(self, event: InputEvent) -> InputIntent | None:
+    def handle_input(self, event: InputEvent) -> InputIntent | bool | None:
         if self.enable_search and event.kind == "text":
             filter_input = self._ensure_filter_input()
             filter_input.handle_input(event)
             self._apply_filter(filter_input.value)
-            return None
+            return True
         if event.kind == "mouse":
             self._handle_mouse(event)
-            return None
+            return True
         if event.kind != "key":
             return None
         if self._search_accepts_editing_keys() and _handle_text_input_key(self._filter_input, event.key):
             self._apply_filter(self._filter_input.value if self._filter_input is not None else "")
-            return None
+            return True
         if event.key == "up":
             self._move(-1)
-            return None
+            return True
         if event.key == "down":
             self._move(1)
-            return None
+            return True
         if event.key == "pageUp":
             self._move(-max(1, self.max_visible))
-            return None
+            return True
         if event.key == "pageDown":
             self._move(max(1, self.max_visible))
-            return None
+            return True
         if event.key == "home":
             self._move_to_edge("first")
-            return None
+            return True
         if event.key == "end":
             self._move_to_edge("last")
-            return None
+            return True
         if event.key == "enter":
             selected = self.selected_item()
             if selected is None:
-                return None
+                return True
             return InputIntent(kind=self.select_kind, text=selected.selected_value)
         if event.key in {"esc", "escape"}:
             return InputIntent(kind="surface_close")
@@ -330,7 +330,7 @@ class SettingsSurface(SelectionSurface):
             return
         super().set_filter(query)
 
-    def handle_input(self, event: InputEvent) -> InputIntent | None:
+    def handle_input(self, event: InputEvent) -> InputIntent | bool | None:
         if self._submenu_component is not None:
             return self._handle_submenu_input(event)
         if not self._settings_items:
@@ -341,26 +341,26 @@ class SettingsSurface(SelectionSurface):
             if self._search_input is not None:
                 self._search_input.insert_text(event.text)
             self.selected_index = 0
-            return None
+            return True
         if event.kind != "key":
             return None
         if self._search_enabled and _handle_text_input_key(self._search_input, event.key):
             self.selected_index = 0
-            return None
+            return True
         if event.key == "up":
             self._move_settings(-1)
-            return None
+            return True
         if event.key == "down":
             self._move_settings(1)
-            return None
+            return True
         if event.key == "pageUp":
             self._move_settings(-max(1, self.max_visible))
-            return None
+            return True
         if event.key == "pageDown":
             self._move_settings(max(1, self.max_visible))
-            return None
+            return True
         if event.key in {"enter", "space"} or event.text == " ":
-            return self._activate_setting()
+            return self._activate_setting() or True
         if event.key in {"esc", "escape"}:
             return InputIntent(kind="surface_close")
         return None
@@ -482,7 +482,7 @@ class SettingsSurface(SelectionSurface):
             return InputIntent(kind="setting", text=selected.id, note=selected.current_value)
         return InputIntent(kind="setting", text=selected.id, note="true" if selected.enabled else "false")
 
-    def _handle_submenu_input(self, event: InputEvent) -> InputIntent | None:
+    def _handle_submenu_input(self, event: InputEvent) -> InputIntent | bool | None:
         component = self._submenu_component
         handle_input = getattr(component, "handle_input", None)
         result = handle_input(event) if callable(handle_input) else None
@@ -496,7 +496,9 @@ class SettingsSurface(SelectionSurface):
                 return self._complete_submenu(selected_value)
             if intent.kind in {"surface_close", "dialog_cancel"}:
                 self._close_submenu()
-                return None
+                return True
+        if result is True:
+            return True
         return result if isinstance(result, InputIntent) else None
 
     def _complete_submenu_from_callback(self, selected_value: str | None = None) -> None:

--- a/src/loushang/tui/ui_parts/text_input.py
+++ b/src/loushang/tui/ui_parts/text_input.py
@@ -92,6 +92,9 @@ class TextInput:
     def clear_selection(self) -> None:
         self._selection_controller.clear()
 
+    def editor_input_target(self) -> object:
+        return _TextInputEditorTarget(self)
+
     def handle_input(
         self,
         event: Any,
@@ -478,6 +481,89 @@ class TextInput:
             if resolved:
                 return resolved
         return DEFAULT_SELECTION_STYLE
+
+
+@dataclass(frozen=True, slots=True)
+class _TextInputEditorTarget:
+    field: TextInput
+
+    def insert_text(self, text: str) -> None:
+        changed = self.field._apply_edit(lambda: self.field.insert_text(text))
+        if changed:
+            self.field._last_action = "type-word"
+
+    def paste(self, text: str) -> None:
+        changed = self.field._apply_edit(lambda: self.field.insert_text(text))
+        if changed:
+            self.field._last_action = None
+
+    def move_left(self) -> None:
+        self.field.move_left()
+
+    def move_right(self) -> None:
+        self.field.move_right()
+
+    def move_word_left(self) -> None:
+        self.field.move_word_left()
+
+    def move_word_right(self) -> None:
+        self.field.move_word_right()
+
+    def move_to_line_start(self) -> None:
+        self.field.move_to_start()
+
+    def move_to_line_end(self) -> None:
+        self.field.move_to_end()
+
+    def select_char_left(self) -> None:
+        self.field.select_char_left()
+
+    def select_char_right(self) -> None:
+        self.field.select_char_right()
+
+    def select_word_left(self) -> None:
+        self.field.select_word_left()
+
+    def select_word_right(self) -> None:
+        self.field.select_word_right()
+
+    def select_line_start(self) -> None:
+        self.field.select_line_start()
+
+    def select_line_end(self) -> None:
+        self.field.select_line_end()
+
+    def delete_backward(self) -> None:
+        self.field._last_action = None
+        self.field._apply_edit(self.field.delete_backward)
+
+    def delete_forward(self) -> None:
+        self.field._last_action = None
+        self.field._apply_edit(self.field.delete_forward)
+
+    def delete_word_backward(self) -> None:
+        self.field.delete_word_backward()
+
+    def delete_word_forward(self) -> None:
+        self.field.delete_word_forward()
+
+    def kill_to_line_start(self) -> None:
+        self.field.kill_to_start()
+
+    def kill_to_line_end(self) -> None:
+        self.field.kill_to_end()
+
+    def yank(self) -> None:
+        self.field.yank()
+
+    def yank_pop(self) -> None:
+        self.field.yank_pop()
+
+    def undo(self) -> None:
+        self.field.undo()
+
+    def redo(self) -> None:
+        self.field.redo()
 
 
 def _single_line_text(text: str) -> str:

--- a/tests/tui/test_input_routing.py
+++ b/tests/tui/test_input_routing.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 import pytest
 
 from loushang.tui import (
+    CommandSurface,
     CompletionItem,
     CompletionProvider,
     Composer,
@@ -19,8 +20,10 @@ from loushang.tui import (
     RenderConstraints,
     RenderLine,
     RenderResult,
+    SelectItem,
     Surface,
     SurfaceHost,
+    TextInput,
 )
 from loushang.tui.input import (
     route_editor_editing_key,
@@ -41,6 +44,18 @@ class EscConsumer(FocusableMixin):
         if isinstance(event, InputEvent) and event.kind == "key" and event.key == "esc":
             return InputIntent(kind="surface_close")
         return None
+
+
+class DecliningEditorFocus(FocusableMixin):
+    def __init__(self, target: object) -> None:
+        super().__init__()
+        self.target = target
+
+    def editor_input_target(self) -> object:
+        return self.target
+
+    def handle_input(self, event: Any) -> bool:
+        return False
 
 
 @dataclass(slots=True)
@@ -863,6 +878,129 @@ def test_surface_receives_escape_before_active_run_abort() -> None:
     assert intents == (InputIntent(kind="surface_close"),)
     assert host.entries == []
     assert focus.focused is False
+
+
+def test_input_router_routes_text_and_paste_to_declined_focused_editor_target() -> None:
+    prompt = Composer(prompt="> ")
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(
+        Surface(
+            renderable=DummyRenderable(),
+            focus_target=DecliningEditorFocus(field.editor_input_target()),
+        )
+    )
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="text", text="ab")) == ()
+    assert router.route(InputEvent(kind="paste", text="c\nd")) == ()
+
+    assert field.value == "abc d"
+    assert prompt.value == ""
+
+
+def test_input_router_does_not_double_insert_direct_focused_text_input_surface() -> None:
+    changes: list[str] = []
+    prompt = Composer(prompt="> ")
+    field = TextInput(on_change=changes.append)
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=field))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="text", text="a")) == ()
+
+    assert field.value == "a"
+    assert changes == ["a"]
+    assert prompt.value == ""
+
+
+def test_input_router_routes_focused_editor_selection_and_editing_keys() -> None:
+    prompt = Composer(prompt="> ")
+    field = TextInput()
+    target = field.editor_input_target()
+    target.insert_text("abc")
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=DecliningEditorFocus(target)))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="key", key="shift+left")) == ()
+    assert field.selected_range == (2, 3)
+    assert router.route(InputEvent(kind="key", key="backspace")) == ()
+
+    assert field.value == "ab"
+    assert prompt.value == ""
+
+
+def test_input_router_surface_intent_wins_before_focused_editor_fallback() -> None:
+    class ClosingEditorFocus(DecliningEditorFocus):
+        def handle_input(self, event: Any) -> InputIntent | None:
+            if isinstance(event, InputEvent) and event.kind == "key":
+                return InputIntent(kind="surface_close")
+            return None
+
+    prompt = Composer(prompt="> ")
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=ClosingEditorFocus(field.editor_input_target())))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="key", key="left")) == (InputIntent(kind="surface_close"),)
+    assert field.value == ""
+    assert host.entries == []
+
+
+def test_input_router_does_not_submit_prompt_while_focused_editor_target_is_active() -> None:
+    prompt = Composer(prompt="> ")
+    prompt.insert_text("prompt")
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=DecliningEditorFocus(field.editor_input_target())))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="key", key="enter")) == ()
+    assert prompt.value == "prompt"
+
+
+def test_input_router_does_not_abort_running_prompt_while_focused_editor_target_is_active() -> None:
+    prompt = Composer(prompt="> ")
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=DecliningEditorFocus(field.editor_input_target())))
+    router = InputRouter(composer=prompt, surface_host=host, running=True)
+
+    assert router.route(InputEvent(kind="key", key="escape")) == ()
+
+
+def test_input_router_prompt_jump_text_wins_before_focused_editor_fallback() -> None:
+    prompt = Composer(prompt="> ")
+    prompt.insert_text("abc def")
+    prompt.move_to_line_start()
+    router = InputRouter(composer=prompt)
+    assert router.route(InputEvent(kind="key", key="ctrl+]")) == ()
+
+    field = TextInput()
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=DecliningEditorFocus(field.editor_input_target())))
+    router.surface_host = host
+
+    assert router.route(InputEvent(kind="text", text="d")) == ()
+    prompt.delete_forward()
+
+    assert prompt.value == "abc ef"
+    assert field.value == ""
+
+
+def test_input_router_does_not_leak_searchable_surface_text_to_prompt() -> None:
+    prompt = Composer(prompt="> ")
+    host = SurfaceHost()
+    surface = CommandSurface([SelectItem("/status", value="/status")])
+    host.open_surface(Surface(renderable=surface, focus_target=surface))
+    router = InputRouter(composer=prompt, surface_host=host)
+
+    assert router.route(InputEvent(kind="text", text="sta")) == ()
+
+    assert prompt.value == ""
+    assert tuple(item.selected_value for item in surface._filtered_items) == ("/status",)
 
 
 def test_ctrl_c_during_running_turn_routes_abort_intent() -> None:

--- a/tests/tui/test_render_framework.py
+++ b/tests/tui/test_render_framework.py
@@ -62,6 +62,15 @@ class ReturningFocusTarget(FocusableMixin):
         return self.result
 
 
+class EditorProviderFocusTarget(FocusTarget):
+    def __init__(self, name: str, target: object | None) -> None:
+        super().__init__(name)
+        self.target = target
+
+    def editor_input_target(self) -> object | None:
+        return self.target
+
+
 @dataclass
 class BaselineResetRenderable(TextRenderable):
     reset_reason: str | None = None
@@ -194,6 +203,37 @@ def test_surface_host_route_input_result_closes_on_close_intent() -> None:
     assert routed.consumed is True
     assert host.entries == []
     assert handle.entry.close_reason == "surface_close"
+
+
+def test_surface_host_returns_current_visible_surface_editor_target() -> None:
+    editor_target = object()
+    focus = EditorProviderFocusTarget("editor", editor_target)
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=TextRenderable(("editor",), []), focus_target=focus))
+
+    assert host.current_editor_target() is editor_target
+
+
+def test_surface_host_ignores_base_hidden_and_closed_editor_targets() -> None:
+    base_target = object()
+    base = EditorProviderFocusTarget("base", base_target)
+    base.focus()
+    focus = EditorProviderFocusTarget("editor", object())
+    host = SurfaceHost(base_focus=base)
+
+    assert host.current_editor_target() is None
+
+    handle = host.open_surface(Surface(renderable=TextRenderable(("editor",), []), focus_target=focus))
+    assert host.current_editor_target() is focus.target
+
+    handle.set_hidden(True)
+    assert host.current_editor_target() is None
+
+    handle.set_hidden(False)
+    assert host.current_editor_target() is focus.target
+
+    handle.close("done")
+    assert host.current_editor_target() is None
 
 
 def test_surface_host_translates_overlay_mouse_coordinates_to_focus_target() -> None:

--- a/tests/tui/test_render_framework.py
+++ b/tests/tui/test_render_framework.py
@@ -51,6 +51,17 @@ class FocusTarget(FocusableMixin):
         return f"{self.name}:{event}"
 
 
+class ReturningFocusTarget(FocusableMixin):
+    def __init__(self, result: Any) -> None:
+        super().__init__()
+        self.result = result
+        self.events: list[Any] = []
+
+    def handle_input(self, event: Any) -> Any:
+        self.events.append(event)
+        return self.result
+
+
 @dataclass
 class BaselineResetRenderable(TextRenderable):
     reset_reason: str | None = None
@@ -149,6 +160,39 @@ def test_surface_host_routes_close_intent_and_restores_base_focus() -> None:
     assert host.entries == []
     assert command.focused is False
     assert composer.focused is True
+    assert handle.entry.close_reason == "surface_close"
+
+
+def test_surface_host_route_input_result_preserves_consumption_without_changing_route_input() -> None:
+    cases: tuple[tuple[Any, tuple[Any, ...], bool], ...] = (
+        (None, (), False),
+        (False, (), False),
+        (True, (), True),
+        ("handled", ("handled",), True),
+        (("handled",), ("handled",), True),
+    )
+    for result, expected_intents, expected_consumed in cases:
+        target = ReturningFocusTarget(result)
+        host = SurfaceHost()
+        host.open_surface(Surface(renderable=TextRenderable(("surface",), []), focus_target=target))
+
+        routed = host.route_input_result("x")
+
+        assert routed.intents == expected_intents
+        assert routed.consumed is expected_consumed
+        assert host.route_input("x") == expected_intents
+
+
+def test_surface_host_route_input_result_closes_on_close_intent() -> None:
+    target = ReturningFocusTarget(InputIntent(kind="surface_close"))
+    host = SurfaceHost()
+    handle = host.open_surface(Surface(renderable=TextRenderable(("surface",), []), focus_target=target))
+
+    routed = host.route_input_result(InputEvent(kind="key", key="escape"))
+
+    assert routed.intents == (InputIntent(kind="surface_close"),)
+    assert routed.consumed is True
+    assert host.entries == []
     assert handle.entry.close_reason == "surface_close"
 
 

--- a/tests/tui/test_surfaces.py
+++ b/tests/tui/test_surfaces.py
@@ -188,6 +188,18 @@ def test_selection_surface_search_can_use_fuzzy_filtering() -> None:
     assert lines[:3] == ("Search: ms", "", "> Model Selection")
 
 
+def test_selection_surface_consumed_paths_return_true_without_intents() -> None:
+    surface = SelectionSurface(
+        [SelectItem("Alpha"), SelectItem("Model")],
+        enable_search=True,
+        filter_mode="contains",
+    )
+
+    assert surface.handle_input(InputEvent(kind="text", text="mo")) is True
+    assert surface.handle_input(InputEvent(kind="key", key="backspace")) is True
+    assert surface.handle_input(InputEvent(kind="key", key="down")) is True
+
+
 def test_selection_surface_page_navigation_keeps_selected_item_visible() -> None:
     surface = SelectionSurface([SelectItem(f"item-{index}") for index in range(8)], max_visible=3)
 
@@ -264,7 +276,7 @@ def test_selection_surface_mouse_press_selects_visible_row_after_render() -> Non
         )
     )
 
-    assert intent is None
+    assert intent is True
     assert surface.selected_index == 4
     assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(kind="select", text="item-4")
 
@@ -273,8 +285,8 @@ def test_selection_surface_empty_state_ignores_enter_and_mouse() -> None:
     surface = SelectionSurface([], empty_text="No items")
 
     assert tuple(strip_control_sequences(line) for line in rendered_text(surface, width=20, height=4)) == ("No items",)
-    assert surface.handle_input(InputEvent(kind="key", key="enter")) is None
-    assert surface.handle_input(InputEvent(kind="mouse", mouse_button=0, mouse_row=0, mouse_action="press")) is None
+    assert surface.handle_input(InputEvent(kind="key", key="enter")) is True
+    assert surface.handle_input(InputEvent(kind="mouse", mouse_button=0, mouse_row=0, mouse_action="press")) is True
     assert surface.selected_item() is None
 
 
@@ -395,7 +407,7 @@ def test_settings_surface_can_delegate_value_selection_to_submenu() -> None:
         ],
     )
 
-    assert surface.handle_input(InputEvent(kind="key", key="enter")) is None
+    assert surface.handle_input(InputEvent(kind="key", key="enter")) is True
     assert tuple(strip_control_sequences(line) for line in rendered_text(surface, width=20, height=3)) == ("> GPT",)
     assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
         kind="setting",
@@ -434,6 +446,20 @@ def test_settings_surface_search_filters_with_text_and_backspace() -> None:
         "",
         "> Theme  dark",
     )
+
+
+def test_settings_surface_consumed_paths_return_true_without_intents() -> None:
+    surface = SettingsSurface(
+        [
+            SettingItem(id="theme", label="Theme", current_value="dark"),
+            SettingItem(id="model", label="Model", current_value="kimi"),
+        ],
+        enable_search=True,
+    )
+
+    assert surface.handle_input(InputEvent(kind="text", text="mo")) is True
+    assert surface.handle_input(InputEvent(kind="key", key="backspace")) is True
+    assert surface.handle_input(InputEvent(kind="key", key="down")) is True
 
 
 def test_settings_surface_search_uses_fuzzy_matching() -> None:

--- a/tests/tui/test_text_input.py
+++ b/tests/tui/test_text_input.py
@@ -61,6 +61,49 @@ def test_text_input_direct_edits_preserve_existing_undo_boundary() -> None:
     assert field.value == "ab"
 
 
+def test_text_input_editor_input_target_routes_high_level_text_edits() -> None:
+    changes: list[str] = []
+    field = TextInput(on_change=changes.append)
+    target = field.editor_input_target()
+
+    target.insert_text("ab")
+    target.paste("c\nd")
+
+    assert field.value == "abc d"
+    assert changes == ["ab", "abc d"]
+    assert field.undo()
+    assert field.value == "ab"
+    assert field.undo()
+    assert field.value == ""
+
+
+def test_text_input_editor_input_target_routes_destructive_edits_with_undo() -> None:
+    changes: list[str] = []
+    field = TextInput(on_change=changes.append)
+    target = field.editor_input_target()
+
+    target.insert_text("abc")
+    target.delete_backward()
+
+    assert field.value == "ab"
+    assert changes == ["abc", "ab"]
+    assert field.undo()
+    assert field.value == "abc"
+
+
+def test_text_input_editor_input_target_exposes_shared_editor_operations() -> None:
+    field = TextInput()
+    target = field.editor_input_target()
+
+    target.insert_text("alpha beta")
+    target.move_to_line_start()
+    target.move_word_right()
+    target.kill_to_line_end()
+
+    assert field.value == "alpha"
+    assert field.kill_ring == (" beta",)
+
+
 def test_text_input_can_be_focused_as_a_standalone_overlay() -> None:
     tui = Tui()
     field = TextInput(prompt="Search: ")


### PR DESCRIPTION
## Summary
- Add explicit SurfaceHost consumed/declined routing and focused editor target discovery.
- Route declined focused surface editor text, paste, selection, and editing keys through InputRouter.
- Add a high-level TextInput editor target adapter and preserve native surface compatibility.

## Test Plan
- uv --cache-dir .uv-cache run --extra dev pytest tests -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui tests/coding/test_native_coding_tui_surfaces.py -q
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/framework.py src/loushang/tui/input.py src/loushang/tui/surfaces.py src/loushang/tui/ui_parts/text_input.py src/loushang/coding/ui/native_surfaces.py tests/tui/test_render_framework.py tests/tui/test_surfaces.py tests/tui/test_text_input.py tests/tui/test_input_routing.py tests/coding/test_native_coding_tui_surfaces.py

## Review
- Spec review: Approved
- Plan review: Approved
- Code review: Approved after native surface compatibility fix