### PR TITLE
docs: record agent harness boundaries

### DIFF
--- a/docs/internals/architecture/README.md
+++ b/docs/internals/architecture/README.md
@@ -16,6 +16,7 @@ Read in this order for current implementation decisions:
 1. [Architecture Overview](architecture-overview.md)
 2. [Subsystems](subsystem.md)
 3. Accepted ARDs under subsystem directories, especially
+   [agent harness boundaries](agent/ARD-001-agent-harness-and-product-adapters.md) and
    [coding](coding/ARD-001-coding-product-boundaries.md)
 4. Component interfaces and core data object notes for the subsystem being edited
 5. Draft/history/reference material only when extra rationale is needed

--- a/docs/internals/architecture/agent/ARD-001-agent-harness-and-product-adapters.md
+++ b/docs/internals/architecture/agent/ARD-001-agent-harness-and-product-adapters.md
@@ -1,0 +1,246 @@
+# ARD-001: Agent Harness and Product Adapter Boundaries
+
+## Status
+
+Accepted
+
+## Context
+
+`loushang.agent` already provides the stable low-level agent runtime surface:
+
+- `Agent`
+- `agent_loop`
+- agent messages
+- agent tools
+- agent events
+- abort / cancellation primitives
+
+`loushang.coding` currently contains the V1 product assembly around that runtime,
+including sessions, prompts, coding tools, slash commands, extensions, package /
+plugin integration, TUI adapters, work projection, and method integration.
+
+Future product lines such as `research`, `ppt`, and `cowork` need the same
+agent execution foundation without inheriting coding-specific semantics. The
+shared layer must therefore be explicit before coding grows more product
+behavior around the low-level loop.
+
+## Decision
+
+### 1. Preserve `loushang.agent` as the stable primitive layer
+
+`loushang.agent` remains the low-level agent runtime package.
+
+It owns:
+
+- agent message, tool, event, and abort primitives
+- the stateful `Agent` facade
+- the low-level agent loop
+- model streaming integration through `loushang.ai`
+
+It must not own:
+
+- coding tools or workspace semantics
+- slash commands
+- TUI state
+- AGENTS.md or product prompt assembly
+- package / plugin / extension product policy
+- work or method domain projection
+- research, ppt, or cowork product semantics
+
+### 2. Add `loushang.agent.harness` as the headless execution scaffolding
+
+`harness` here means execution scaffolding / carrying structure, not a
+test-only harness.
+
+`loushang.agent.harness` is the layer above the low-level loop that prepares and
+runs a headless agent execution for product adapters.
+
+The initial surface should be intentionally thin:
+
+```text
+AgentRunSpec
+AgentRunResult
+run_agent(spec)
+```
+
+`run_agent()` must reuse the existing low-level loop instead of implementing a
+second loop. The first implementation should not be re-exported from
+`loushang.agent.__init__`, so the public stability commitment stays narrow while
+the adapter contract settles.
+
+### 3. Treat coding, research, ppt, and cowork as product adapters
+
+The product line packages are peers:
+
+```text
+loushang.coding
+loushang.research   # future
+loushang.ppt        # future
+loushang.cowork     # future
+```
+
+Each product adapter may provide its own:
+
+- tools
+- prompts
+- commands or product controls
+- session / artifact model
+- UI and protocol surfaces
+- extension policy
+- projection back into product state
+
+Product adapters may use `loushang.agent.harness` directly for ordinary agent
+runs.
+
+### 4. Keep `loushang.work` as the cross-product work abstraction
+
+`loushang.work` models work execution facts and projections:
+
+- `WorkOperation`
+- `WorkRun`
+- `WorkEvent`
+- future `ArtifactRef`
+- artifact references / work product projections
+- work logs
+- work projections
+
+It is not a product package and must not depend on `coding`, `research`, `ppt`,
+or `cowork`.
+
+Product adapters may write to or project through `work` directly.
+
+Artifact ownership is split across three layers:
+
+```text
+method
+  defines expected artifacts
+
+work
+  records actual artifact references
+
+coding / research / ppt / cowork
+  define concrete artifact types and content
+```
+
+The first shared work artifact object should be an `ArtifactRef`, not an
+abstract `Artifact` base class. Product-specific packages own loading,
+rendering, validation, and materialization behavior. If a common behavior
+contract becomes necessary later, add an artifact provider protocol instead of
+moving product behavior into `work`.
+
+### 5. Keep `loushang.method` optional and above `work`
+
+`loushang.method` describes structured ways to organize work:
+
+- method resources
+- `MethodPlan`
+- `MethodStep`
+- method compile / projection
+- method policy hints and gates
+
+`method` is optional for product execution. A product adapter can bypass
+`method` and call `agent.harness` plus `work` directly for lightweight runs.
+
+Use `method` for structured or guided work, such as planning, staged execution,
+review gates, or method-specific acceptance criteria. Do not force every
+ordinary product turn through `method`.
+
+### 6. Define the dependency direction
+
+Target dependency direction:
+
+```text
+loushang.ai
+  <- loushang.agent
+  <- loushang.agent.harness
+  <- product adapters
+
+loushang.work
+  <- loushang.method
+  <- product adapters
+
+loushang.work
+  <- product adapters
+```
+
+Expanded product view:
+
+```text
+coding / research / ppt / cowork
+  -> loushang.agent.harness
+  -> loushang.work
+  -> loushang.method   # optional, only for structured work
+```
+
+Forbidden directions:
+
+```text
+loushang.agent -> loushang.coding / work / method / research / ppt / cowork
+loushang.agent.harness -> product packages
+loushang.work -> product packages
+loushang.work -> loushang.method
+product package -> peer product package, unless through an explicit adapter/protocol
+```
+
+### 7. Keep `loushang.channel` as protocol and transport, not UI or product runtime
+
+`loushang.channel` remains a target package for cross-client operation/event
+delivery. It should support TUI, WebUI, AppUI, SDK, and RPC clients by carrying
+work operations and work events across transports such as in-process calls,
+stdio/JSONL, HTTP, or WebSocket.
+
+`channel` must not own UI layout, product session internals, agent loop state, or
+method planning. It should not directly import every product package. A host
+assembly layer registers product adapters and exposes them through the channel
+protocol.
+
+Target shape:
+
+```text
+UI client / SDK / RPC client
+  -> channel client
+  -> channel server / host assembly
+  -> WorkOperation / WorkEvent
+  -> product adapter
+  -> agent.harness
+```
+
+## Consequences
+
+### Positive
+
+- Product lines can share agent execution without inheriting coding semantics.
+- Coding can keep lightweight turns fast by using harness and work directly.
+- Method remains a structured-work layer instead of becoming mandatory runtime
+  plumbing.
+- Work remains a stable cross-product event/projection layer.
+- The first implementation can be incremental: add a thin harness facade and
+  connect one narrow coding path later.
+
+### Negative
+
+- Product adapters must do their own domain projection from `AgentRunResult`.
+- Some temporary duplication may remain in coding until the harness contract is
+  proven.
+- Naming can be misunderstood: `harness` must be documented as execution
+  scaffolding, not testing-only infrastructure.
+
+## Initial Implementation Scope
+
+The first implementation phase should only include:
+
+1. Boundary documentation and dependency direction.
+2. A module ownership inventory for current `coding`, `agent`, `work`, and
+   `method` code.
+3. A thin `loushang.agent.harness` facade with `AgentRunSpec`,
+   `AgentRunResult`, and `run_agent()`.
+
+It should not include:
+
+- large file moves
+- new product packages
+- moving coding tools into agent
+- moving slash commands into agent
+- moving AGENTS.md prompt assembly into agent
+- top-level extension marketplace or dependency isolation
+- work/method projection inside `agent`

--- a/docs/internals/architecture/agent/README.md
+++ b/docs/internals/architecture/agent/README.md
@@ -34,6 +34,18 @@ await agent.prompt("Hello")
 - `AgentLoopConfig`: loop execution config
 - `AgentEvent`: lifecycle and tool execution events
 
+## Harness Direction
+
+`loushang.agent.harness` is the planned headless execution scaffolding above the
+low-level loop. It is not a testing-only harness.
+
+The harness should expose a thin product-adapter surface such as
+`AgentRunSpec`, `AgentRunResult`, and `run_agent()`, while reusing the existing
+agent loop and keeping coding, work, method, research, ppt, and cowork product
+semantics outside `loushang.agent`.
+
+See [ARD-001: Agent Harness and Product Adapter Boundaries](ARD-001-agent-harness-and-product-adapters.md).
+
 ## Event Flow
 
 Calling `await agent.prompt(...)` emits events in this shape:

--- a/docs/internals/architecture/coding/ARD-001-coding-product-boundaries.md
+++ b/docs/internals/architecture/coding/ARD-001-coding-product-boundaries.md
@@ -193,6 +193,24 @@ prompt-toolkit/Rich 设计只保留在 TUI history 文档中。
 - 不要求逐字 API 兼容
 - 更强调语义兼容与 Python 化实现
 
+### 10. `coding` 是产品线，不是通用 agent/work/method 层
+
+`loushang-coding` 与 future `loushang.research`、`loushang.ppt`、
+`loushang.cowork` 是并列产品线。`cowork` 在这里表示一个 future product
+vertical，不是 `work` 的协作语义层名称。
+
+因此：
+
+- `coding` 可以直接使用 `loushang.agent.harness` 执行普通 headless agent run
+  （该 harness 引入后）
+- `coding` 可以直接写入或投影到 `loushang.work`
+- `method` 是结构化 / guided work 的可选组织层，不是所有 coding turn 的必经层
+- `coding` 不应把自己的 tools、slash commands、AGENTS.md prompt assembly、TUI
+  adapter、package/plugin/extension policy 上提到 `agent`
+
+详见
+[Agent Harness and Product Adapter Boundaries](../agent/ARD-001-agent-harness-and-product-adapters.md)。
+
 ## Rationale
 
 本次决定采用“先稳住产品骨架，再后置跨边界协议层”的策略，理由是：

--- a/docs/internals/architecture/method/README.md
+++ b/docs/internals/architecture/method/README.md
@@ -54,6 +54,36 @@ Work   = Runtime event, log, and projection layer
 Coding-specific method usage is bridged through `loushang.coding.domain`.
 Runtime execution observability is projected through `loushang.work`.
 
+## Relation To Agent Harness And Products
+
+`loushang.method` is optional for product execution.
+
+Product packages such as `loushang.coding`, and future `loushang.research`,
+`loushang.ppt`, and `loushang.cowork`, may call `loushang.agent.harness`
+directly for lightweight turns. They may also write or project through
+`loushang.work` directly.
+
+Use `method` when the product needs structured work: planning, staged execution,
+review gates, method-specific constraints, or acceptance criteria. Do not route
+every product turn through method by default.
+
+`cowork` is treated as a future product line, parallel to `coding`, `research`,
+and `ppt`; it is not the name of the shared work or collaboration abstraction.
+
+## Artifact Boundary
+
+Method defines expected artifacts: what a structured workflow or method step
+should produce.
+
+`loushang.work` records actual artifact references: what was produced, where it
+is, which run or step produced it, and how it relates to the expected artifact.
+
+Product packages such as `coding`, `research`, `ppt`, and `cowork` own concrete
+artifact types, content, loading, rendering, validation, and materialization.
+
+Therefore the shared work layer should prefer a lightweight `ArtifactRef` over a
+shared abstract `Artifact` base class.
+
 ## Field Mapping
 
 The work-contract definition maps to current method data objects as follows:

--- a/docs/internals/architecture/subsystem.md
+++ b/docs/internals/architecture/subsystem.md
@@ -22,6 +22,12 @@
 - `loushang.observability`
 - `loushang.ontology`
 
+目标产品线概念包括：
+
+- `loushang.research`
+- `loushang.ppt`
+- `loushang.cowork`
+
 目标架构仍保留 `loushang.channel`，但当前没有 package-level
 implementation。现有 RPC mode 是 coding-local transitional adapter，不等于
 长期 channel surface。
@@ -62,12 +68,19 @@ agent 运行内核。
 - `AgentTool`
 - `AgentContext`
 - `AgentState`
+- `agent.harness` headless 执行脚手架
 
 不负责：
 
 - provider 接入细节
 - UI 渲染
 - 跨边界 transport
+- coding / research / ppt / cowork 产品语义
+- work / method 投影语义
+
+`agent.harness` 的职责是承载跨产品的 headless agent run 编排。它位于
+low-level agent loop 之上，复用现有 loop，不另写第二套 loop。详见
+[Agent Harness and Product Adapter Boundaries](./agent/ARD-001-agent-harness-and-product-adapters.md)。
 
 ### loushang-channel (target)
 
@@ -75,21 +88,28 @@ agent 运行内核。
 
 负责：
 
-- `event`
-- `request`
-- `response`
-- `notification`
-- `protocol`
-- `transport`
+- operation / event protocol
+- request / response correlation
+- notification / subscription
+- transport adapters, such as in-process, stdio/JSONL, HTTP, WebSocket
 - capability negotiation
-- replay
+- delivery policy, such as immediate / coalesce / final-only
+- replay / resume
 - channel audit trail
+- multi-client access to the same work run
 
 不负责：
 
 - agent 内核状态机
 - 本地 UI 组件实现
 - 方法层调度
+- coding / research / ppt / cowork 产品内部 session
+- 产品 adapter 注册之外的业务执行
+
+`channel` 面向多客户端和多 UI：TUI、WebUI、AppUI、SDK host、RPC client
+都应通过 channel 发送 operation、订阅 event、恢复和回放状态。channel core
+承载 `WorkOperation` / `WorkEvent` 的边界传输语义；具体产品 adapter 由
+host 装配，不由 channel core 直接 import。
 
 ### loushang-tui
 
@@ -137,16 +157,23 @@ agent 运行内核。
 - 边界协议承载
 - TUI 交互实现
 - 通用 work lifecycle
+- 普通产品 turn 的强制执行路径
+
+`method` 是可选的结构化工作组织层。产品线可以在 plan / guided / staged
+workflows 中使用 `method`，但轻量 turn 可以直接使用 `agent.harness` 和
+`work`。
 
 ### loushang-work
 
-工作运行语义、事件日志与 projection 层。
+跨产品工作运行语义、事件日志与 projection 层。
 
 负责：
 
 - `WorkOperation`
 - `WorkRun`
 - `WorkEvent`
+- future `ArtifactRef`
+- artifact references / work product projections
 - work event log
 - plan/step lifecycle projection
 - method run replay / inspect 的基础语义
@@ -157,6 +184,21 @@ agent 运行内核。
 - method resource 编译
 - TUI 呈现
 - 外部 transport
+- coding / research / ppt / cowork 产品语义
+
+`work` 是 coding、research、ppt、cowork 等产品线共享的工作事实与投影抽象。
+它不依赖这些产品线，也不依赖 `method`。
+
+Artifact 分层规则：
+
+- `method` 定义 expected artifact，即结构化工作“应该产出什么”
+- `work` 记录 actual artifact reference，即“实际产出了什么、在哪里、状态如何”
+- `coding` / `research` / `ppt` / `cowork` 定义具体 artifact 类型、内容、
+  加载、渲染、校验和物化逻辑
+
+因此 `work` 层优先引入 `ArtifactRef`，而不是抽象 `Artifact` ABC。若未来需要
+统一加载或渲染行为，应通过 provider/protocol 接口扩展，不把产品行为塞进
+`work`。
 
 ### loushang-coding
 
@@ -180,6 +222,9 @@ agent 运行内核。
 - 通用边界协议定义
 - 通用 terminal UI primitives
 
+`coding` 可以直接依赖 `agent.harness` 和 `work` 处理普通 coding turn；只有
+结构化 / guided 工作需要通过 `method`。
+
 ## Layer Relationship
 
 当前 V1 coding 产品的主链路为：
@@ -197,6 +242,26 @@ loushang.method -> loushang.coding -> loushang.work
 loushang.coding.ui -> loushang.tui
 ```
 
+跨产品执行目标链路为：
+
+```text
+loushang.ai
+  <- loushang.agent
+  <- loushang.agent.harness
+  <- loushang.coding / loushang.research / loushang.ppt / loushang.cowork
+```
+
+跨产品工作抽象链路为：
+
+```text
+loushang.work
+  <- loushang.coding / loushang.research / loushang.ppt / loushang.cowork
+
+loushang.work
+  <- loushang.method
+  <- product adapters, only for structured work
+```
+
 长期目标边界为：
 
 ```text
@@ -207,8 +272,70 @@ external host/client -> loushang.channel -> loushang.work -> domain app
 
 - `ai` 提供模型接入能力
 - `agent` 提供运行语义
+- `agent.harness` 提供跨产品 headless 执行脚手架
 - `channel` 提供目标边界通信，当前未作为源码包落地
 - `tui` 提供通用终端交互原语
-- `method` 提供方法组织与 plan/projection
+- `method` 提供可选的方法组织与 plan/projection
 - `work` 提供运行、事件、日志与 projection
-- `coding` 提供场景装配，并通过 `loushang.coding.ui` 调用 `loushang.tui`
+- `coding` 提供 coding 产品装配，并通过 `loushang.coding.ui` 调用
+  `loushang.tui`
+- `research`、`ppt`、`cowork` 是目标产品线概念，和 `coding` 并列，而不是
+  `work` 或 `agent` 的子层
+
+## Future Dependency Map
+
+目标二级组件依赖关系。本节中 `A -> B` 表示 `A` 可以依赖 / 调用 `B`。
+
+```text
+all packages -> observability
+
+method / work / product packages -> ontology
+  # only when semantic typing is needed
+
+agent -> ai
+product packages -> ai
+  # only for product-level helper AI calls
+
+agent.harness -> agent
+product packages -> agent.harness
+product packages -> agent
+  # only through stable agent primitives when bypassing harness is justified
+
+method -> work
+product packages -> work
+channel -> work
+
+product packages -> method
+  # optional and only for structured work
+
+product TUI adapters -> tui
+
+UI clients / SDK hosts / RPC clients -> channel
+```
+
+Product packages are peers:
+
+```text
+coding
+research
+ppt
+cowork
+```
+
+Product packages should not depend on each other directly. Cross-product
+coordination should go through explicit adapters, `work` events, `channel`
+protocol, or a future host-level orchestration layer.
+
+Multi-UI target shape:
+
+```text
+TUI / WebUI / AppUI / SDK / RPC client
+  -> channel client
+  -> channel server / host assembly
+  -> WorkOperation / WorkEvent
+  -> product adapter
+  -> agent.harness
+```
+
+The channel core transports and replays work operations/events. It does not
+render UI and does not own product execution internals.


### PR DESCRIPTION
## Summary
- Define loushang.agent.harness as the cross-product headless execution scaffolding.
- Clarify product adapter relationships for coding, research, ppt, and cowork.
- Record future channel, work, method, and ArtifactRef boundaries.

## 摘要
- 明确 loushang.agent.harness 是跨产品 headless 执行脚手架。
- 明确 coding、research、ppt、cowork 是并列产品线。
- 记录 channel 多 UI、work/method、ArtifactRef 的未来边界。

## Validation
- git diff --check