### PR TITLE
Harden TUI P0A widget rendering

### DIFF
--- a/docs/en/reference/tui-widgets.md
+++ b/docs/en/reference/tui-widgets.md
@@ -67,6 +67,25 @@ The dialog handles `escape` and `ctrl+c` before delegating to nested fields. It
 also delegates `editor_input_target()` to the active editable body child while
 body focus is active.
 
+## Theme Tokens
+
+P0A widgets accept `ThemeResolver` where styling is supported. Initial stable
+tokens are:
+
+| Token | Applies to |
+| --- | --- |
+| `widget.focus` | Focused enabled controls or rows. |
+| `widget.disabled` | Disabled controls or disabled radio options. |
+| `widget.error` | `TextField` and `FormRow` error lines. |
+| `widget.field.label` | `TextField` labels. |
+| `widget.field.help` | `TextField` help lines. |
+| `widget.button.default` | Default buttons. |
+| `widget.button.primary` | Primary buttons. |
+| `widget.button.danger` | Danger buttons. |
+| `widget.button.ghost` | Ghost buttons. |
+| `widget.dialog.title` | Dialog titles. |
+| `widget.dialog.action` | Dialog action rows. |
+
 ## Planned Catalog
 
 `Toolbar`, `Menu`, `Popover`, `ProgressBar`, `Spinner`, `Badge`, `StatusPill`,

--- a/docs/superpowers/plans/2026-06-10-tui-widgets-p0a-hardening-implementation.md
+++ b/docs/superpowers/plans/2026-06-10-tui-widgets-p0a-hardening-implementation.md
@@ -1,0 +1,765 @@
+# TUI Widgets P0A Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden the existing P0A TUI widgets by locking down theme, render-constraint, and modal routing behavior.
+
+**Architecture:** Keep widgets as plain `Renderable`/`Focusable` UI parts. Add shared styling helpers in `widgets/_utils.py`, apply them narrowly inside existing widget render paths, and verify behavior through focused headless tests. `SelectList` continues delegating to `SelectionSurface`; modal behavior stays owned by `SurfaceHost` and `Dialog`.
+
+**Tech Stack:** Python 3.11 dataclasses, `pytest`, `uv`, Ruff, existing `loushang.tui` render/input/theme primitives.
+
+---
+
+## File Structure
+
+- Modify `src/loushang/tui/ui_parts/widgets/_utils.py`
+  - Add shared theme resolution helpers used only by P0A widgets.
+  - Keep input helpers (`is_activation_event`, `callback_result`) unchanged.
+- Modify `src/loushang/tui/ui_parts/widgets/button.py`
+  - Apply `widget.button.<kind>`, optional `theme_token`, `widget.focus`, and `widget.disabled` styles without changing visible text.
+- Modify `src/loushang/tui/ui_parts/widgets/choice.py`
+  - Apply focus and disabled styles for `Checkbox`, `Toggle`, and `RadioGroup`.
+- Modify `src/loushang/tui/ui_parts/widgets/field.py`
+  - Apply `widget.field.label`, `widget.field.help`, and `widget.error`.
+  - Preserve all editing behavior through `TextInput`.
+- Modify `src/loushang/tui/ui_parts/widgets/form.py`
+  - Add `theme: ThemeResolver | None = None`.
+  - Apply `widget.error` to rendered `FormRow.error`.
+- Modify `src/loushang/tui/ui_parts/widgets/dialog.py`
+  - Add `theme: ThemeResolver | None = None` to `Dialog` and inherited `ConfirmDialog`.
+  - Apply `widget.dialog.title` and `widget.dialog.action`.
+- Add `tests/tui/test_widgets_hardening.py`
+  - Keep hardening tests separate from the foundation behavior tests.
+- Modify `docs/en/reference/tui-widgets.md`
+  - Document initial widget theme tokens and modal focus reminder.
+- Modify `docs/zh-CN/reference/tui-widgets.md`
+  - Mirror the English reference update.
+
+Do not modify public exports unless a test proves a new export is required. Do
+not add P0B/P1 widgets in this plan.
+
+## Task 1: Add Hardening Test Helpers And Button Theme Red Tests
+
+**Files:**
+- Create: `tests/tui/test_widgets_hardening.py`
+- Modify: none
+- Test: `tests/tui/test_widgets_hardening.py`
+
+- [ ] **Step 1: Write the failing test module skeleton**
+
+Add helpers and the first button tests:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from loushang.tui import (
+    Button,
+    InputEvent,
+    RenderConstraints,
+    ThemeResolver,
+    strip_control_sequences,
+    visible_width,
+)
+
+
+def render_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
+    result = part.render(RenderConstraints(width=width, max_height=height))
+    return tuple(line.text for line in result.lines)
+
+
+def plain_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
+    return tuple(strip_control_sequences(line) for line in render_lines(part, width=width, height=height))
+
+
+def assert_widths_within(lines: tuple[str, ...], width: int) -> None:
+    assert all(visible_width(line) <= width for line in lines)
+
+
+def test_button_kind_focus_and_disabled_theme_tokens_preserve_visible_width() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.button.primary": {"color": "green"},
+            "widget.focus": {"bold": True},
+            "widget.disabled": {"dim": True},
+        }
+    )
+    button = Button("Save", kind="primary", theme=theme)
+
+    raw = render_lines(button, width=12)
+    assert raw[0].startswith("\x1b[32m")
+    assert strip_control_sequences(raw[0]) == "  [Save]"
+    assert visible_width(raw[0]) == len("  [Save]")
+
+    button.focus()
+    focused = render_lines(button, width=12)
+    assert focused[0].startswith("\x1b[1;32m")
+    assert strip_control_sequences(focused[0]) == "> [Save]"
+    assert visible_width(focused[0]) == len("> [Save]")
+
+    disabled = Button("Save", kind="primary", disabled=True, theme=theme)
+    disabled.focus()
+    disabled_raw = render_lines(disabled, width=12)
+    assert disabled_raw[0].startswith("\x1b[2;32m")
+    assert strip_control_sequences(disabled_raw[0]) == "> [Save]"
+    assert disabled.handle_input(InputEvent(kind="key", key="enter")) is None
+```
+
+- [ ] **Step 2: Add button override precedence test**
+
+Append:
+
+```python
+def test_button_theme_token_overrides_kind_before_focus_style() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.button.danger": {"color": "red"},
+            "custom.button": {"color": "cyan"},
+            "widget.focus": {"underline": True},
+        }
+    )
+    button = Button("Delete", kind="danger", theme=theme, theme_token="custom.button", focused=True)
+
+    raw = render_lines(button, width=16)
+
+    assert raw[0].startswith("\x1b[4;36m")
+    assert strip_control_sequences(raw[0]) == "> [Delete]"
+```
+
+- [ ] **Step 3: Run tests to verify red**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_hardening.py -q
+```
+
+Expected: FAIL because `Button.render()` does not yet apply theme styles.
+
+- [ ] **Step 4: Commit red tests**
+
+Do not commit red tests by themselves. Continue to Task 2 and commit once green.
+
+## Task 2: Implement Shared Widget Theme Helpers And Button Styling
+
+**Files:**
+- Modify: `src/loushang/tui/ui_parts/widgets/_utils.py`
+- Modify: `src/loushang/tui/ui_parts/widgets/button.py`
+- Test: `tests/tui/test_widgets_hardening.py`
+
+- [ ] **Step 1: Add theme helper functions**
+
+In `widgets/_utils.py`, keep existing helpers and add:
+
+```python
+from loushang.tui.theme import ThemeResolver, ThemeStyle, apply_theme_style
+
+
+def merge_theme_styles(*styles: ThemeStyle | None) -> ThemeStyle | None:
+    merged: ThemeStyle = {}
+    for style in styles:
+        if style:
+            merged.update(style)
+    return merged or None
+
+
+def resolve_theme_style(theme: ThemeResolver | None, token: str | None) -> ThemeStyle | None:
+    if theme is None or not token:
+        return None
+    return theme.resolve(token)
+
+
+def style_text(text: str, theme: ThemeResolver | None, *tokens: str | None) -> str:
+    style = merge_theme_styles(*(resolve_theme_style(theme, token) for token in tokens))
+    return apply_theme_style(text, style)
+```
+
+- [ ] **Step 2: Apply button styles**
+
+In `button.py`:
+
+```python
+from loushang.tui.ui_parts.widgets._utils import (
+    callback_result,
+    is_activation_event,
+    style_text,
+)
+
+
+def _button_base_token(kind: ButtonKind) -> str:
+    return f"widget.button.{kind}"
+```
+
+Update `render()` after truncation:
+
+```python
+base_token = self.theme_token or _button_base_token(self.kind)
+state_token = "widget.disabled" if self.disabled else "widget.focus" if self.focused else None
+rendered = style_text(rendered, self.theme, base_token, state_token)
+```
+
+- [ ] **Step 3: Run focused hardening tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_hardening.py -q
+```
+
+Expected: PASS for the current two tests.
+
+- [ ] **Step 4: Run existing widget foundation tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_foundation.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/tui/test_widgets_hardening.py src/loushang/tui/ui_parts/widgets/_utils.py src/loushang/tui/ui_parts/widgets/button.py
+git commit -m "test(tui): harden button widget theming"
+```
+
+## Task 3: Add Choice Widget Theme And Constraint Tests
+
+**Files:**
+- Modify: `tests/tui/test_widgets_hardening.py`
+- Modify: `src/loushang/tui/ui_parts/widgets/choice.py`
+- Test: `tests/tui/test_widgets_hardening.py`
+
+- [ ] **Step 1: Write failing tests for checkbox, toggle, radio group, and constraints**
+
+Append to `test_widgets_hardening.py` imports:
+
+```python
+    Checkbox,
+    Choice,
+    ConfirmDialog,
+    Dialog,
+    Form,
+    FormRow,
+    IconButton,
+    RadioGroup,
+    SelectItem,
+    SelectList,
+    TextField,
+    Toggle,
+```
+
+Append tests:
+
+```python
+def test_choice_widgets_apply_focus_and_disabled_theme_without_text_changes() -> None:
+    theme = ThemeResolver(defaults={"widget.focus": {"bold": True}, "widget.disabled": {"dim": True}})
+
+    checkbox = Checkbox("Enabled", checked=True, focused=True, theme=theme)
+    toggle = Toggle("Auto", value=False, disabled=True, focused=True, theme=theme)
+    radio = RadioGroup(
+        [Choice("fast", "Fast"), Choice("slow", "Slow", disabled=True)],
+        value="fast",
+        theme=theme,
+        focused=True,
+    )
+
+    assert render_lines(checkbox)[0].startswith("\x1b[1m")
+    assert plain_lines(checkbox) == ("> [x] Enabled",)
+    assert render_lines(toggle)[0].startswith("\x1b[2m")
+    assert plain_lines(toggle) == ("> [off] Auto",)
+
+    radio_lines = render_lines(radio, width=20, height=3)
+    assert radio_lines[0].startswith("\x1b[1m")
+    assert radio_lines[1].startswith("\x1b[2m")
+    assert tuple(strip_control_sequences(line) for line in radio_lines) == ("> (x) Fast", "  ( ) Slow")
+
+
+def p0a_constraint_cases() -> list[object]:
+    return [
+        Button("Very long label", focused=True),
+        IconButton("*", label="Very long label", focused=True),
+        Checkbox("Very long label", focused=True),
+        Toggle("Very long label", focused=True),
+        RadioGroup([Choice("a", "Very long label")], value="a", focused=True),
+        TextField(label="Very long label", value="Very long value", help_text="Very long help"),
+        SelectList([SelectItem("Very long label")], max_visible=1),
+        Form([FormRow("name", TextField(label="Very long label", value="Very long value"))]),
+        Dialog(title="Very long dialog title", body="Very long dialog body"),
+        ConfirmDialog(title="Very long confirm title", body="Very long confirm body"),
+    ]
+
+
+def test_all_p0a_widgets_respect_small_valid_render_constraints() -> None:
+    for control in p0a_constraint_cases():
+        lines = render_lines(control, width=1, height=1)
+        assert len(lines) <= 1
+        assert_widths_within(lines, 1)
+
+
+def test_all_p0a_widgets_respect_narrow_short_render_constraints() -> None:
+    for control in p0a_constraint_cases():
+        lines = render_lines(control, width=6, height=2)
+        assert len(lines) <= 2
+        assert_widths_within(lines, 6)
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_hardening.py -q
+```
+
+Expected: FAIL because `choice.py` does not apply theme styles yet.
+
+- [ ] **Step 3: Apply styles in choice widgets**
+
+In `choice.py`, import `style_text`:
+
+```python
+from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event, style_text
+```
+
+For `Checkbox.render()` and `Toggle.render()`, style the truncated line:
+
+```python
+rendered = truncate_to_width(line, max_width=target_width, ellipsis="")
+state_token = "widget.disabled" if self.disabled else "widget.focus" if self.focused else None
+rendered = style_text(rendered, self.theme, state_token)
+return RenderResult.from_lines([RenderLine(rendered)][: constraints.max_height], constraints=constraints)
+```
+
+For `RadioGroup.render()`, after truncating each row:
+
+```python
+state_token = "widget.disabled" if option.disabled else "widget.focus" if self.focused and index == self._active_index else None
+lines.append(RenderLine(style_text(rendered, self.theme, state_token)))
+```
+
+Keep `_single_line_result()` unthemed or replace it with a helper that accepts
+`theme` and `state_token`; avoid duplicating truncation logic more than needed.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_hardening.py tests/tui/test_widgets_foundation.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/tui/test_widgets_hardening.py src/loushang/tui/ui_parts/widgets/choice.py
+git commit -m "test(tui): harden choice widget rendering"
+```
+
+## Task 4: Add TextField And Form Theme Tests And Implementation
+
+**Files:**
+- Modify: `tests/tui/test_widgets_hardening.py`
+- Modify: `src/loushang/tui/ui_parts/widgets/field.py`
+- Modify: `src/loushang/tui/ui_parts/widgets/form.py`
+- Test: `tests/tui/test_widgets_hardening.py`
+
+- [ ] **Step 1: Write failing TextField and Form tests**
+
+`Form`, `FormRow`, and `TextField` were imported in Task 3 for full P0A
+constraint coverage. If this task is run independently, add those imports before
+adding these tests.
+
+Append tests:
+
+```python
+def test_text_field_themes_label_help_and_error_with_error_precedence() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.field.label": {"color": "cyan"},
+            "widget.field.help": {"dim": True},
+            "widget.error": {"color": "red"},
+        }
+    )
+    field = TextField(label="Name", value="tower", help_text="Helpful", error="Required", theme=theme)
+    field.focus()
+
+    raw = render_lines(field, width=24, height=4)
+
+    assert raw[0].startswith("\x1b[36m")
+    assert raw[2].startswith("\x1b[31m")
+    assert tuple(strip_control_sequences(line) for line in raw) == ("Name", "tower", "Required")
+    assert all(visible_width(line) <= 24 for line in raw)
+
+
+def test_text_field_cursor_row_stays_on_input_when_height_truncates_detail() -> None:
+    field = TextField(label="Name", value="tower", help_text="Helpful")
+    field.focus()
+
+    result = field.render(RenderConstraints(width=24, max_height=2))
+
+    assert tuple(strip_control_sequences(line.text) for line in result.lines) == ("Name", "tower")
+    assert result.cursor is not None
+    assert (result.cursor.row, result.cursor.column) == (1, len("tower"))
+
+
+def test_form_themes_validation_errors_without_changing_values() -> None:
+    theme = ThemeResolver(defaults={"widget.error": {"color": "red"}})
+    form = Form(
+        [FormRow("name", TextField(value=""), validator=lambda value: "Name required" if not value else None)],
+        theme=theme,
+    )
+
+    result = form.validate()
+    raw = render_lines(form, width=24, height=4)
+
+    assert result.errors == {"name": "Name required"}
+    assert raw[-1].startswith("\x1b[31m")
+    assert strip_control_sequences(raw[-1]) == "Name required"
+    assert form.values() == {"name": ""}
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_hardening.py -q
+```
+
+Expected: FAIL because `TextField` detail lines and `FormRow.error` are not yet themed, and `Form` lacks a `theme` parameter.
+
+- [ ] **Step 3: Theme TextField lines**
+
+In `field.py`, import `style_text`:
+
+```python
+from loushang.tui.ui_parts.widgets._utils import style_text
+```
+
+Apply label and detail styles after truncation:
+
+```python
+label = truncate_to_width(self.label, max_width=target_width, ellipsis="")
+lines.append(RenderLine(style_text(label, self.theme, "widget.field.label")))
+```
+
+For `detail`:
+
+```python
+detail_token = "widget.error" if self.error else "widget.field.help"
+rendered_detail = truncate_to_width(detail, max_width=target_width, ellipsis="")
+lines.append(RenderLine(style_text(rendered_detail, self.theme, detail_token)))
+```
+
+- [ ] **Step 4: Add Form theme field and style row errors**
+
+In `form.py`, import `ThemeResolver` and `style_text`:
+
+```python
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.widgets._utils import style_text
+```
+
+Add a dataclass field:
+
+```python
+theme: ThemeResolver | None = None
+```
+
+When rendering `row.error`:
+
+```python
+error = truncate_to_width(row.error, max_width=target_width, ellipsis="")
+lines.append(RenderLine(style_text(error, self.theme, "widget.error")))
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_hardening.py tests/tui/test_widgets_foundation.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/tui/test_widgets_hardening.py src/loushang/tui/ui_parts/widgets/field.py src/loushang/tui/ui_parts/widgets/form.py
+git commit -m "test(tui): harden field and form rendering"
+```
+
+## Task 5: Add Dialog Theme And SurfaceHost Modal Integration Tests
+
+**Files:**
+- Modify: `tests/tui/test_widgets_hardening.py`
+- Modify: `src/loushang/tui/ui_parts/widgets/dialog.py`
+- Test: `tests/tui/test_widgets_hardening.py`
+
+- [ ] **Step 1: Write failing dialog theme test**
+
+Append imports:
+
+```python
+    Surface,
+    SurfaceHost,
+```
+
+`ConfirmDialog` was imported in Task 3 for full P0A constraint coverage. If this
+task is run independently, add it here too.
+
+Append:
+
+```python
+def intent_tuple(intent: object) -> tuple[str, str, str]:
+    return (getattr(intent, "kind", ""), getattr(intent, "text", ""), getattr(intent, "note", ""))
+
+
+def test_dialog_themes_title_and_actions() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.dialog.title": {"bold": True},
+            "widget.dialog.action": {"color": "cyan"},
+        }
+    )
+    dialog = ConfirmDialog(title="Apply?", body="Changes", theme=theme)
+
+    raw = render_lines(dialog, width=30, height=4)
+
+    assert raw[0].startswith("\x1b[1m")
+    assert raw[-1].startswith("\x1b[36m")
+    assert tuple(strip_control_sequences(line) for line in raw) == ("Apply?", "Changes", "[Confirm]  [Cancel]")
+```
+
+- [ ] **Step 2: Write modal integration tests**
+
+Append:
+
+```python
+def test_confirm_dialog_modal_routes_editor_target_and_confirm_closes_surface() -> None:
+    field = TextField(value="")
+    form = Form([FormRow("name", field)])
+    dialog = ConfirmDialog(title="Edit", body=form)
+    host = SurfaceHost()
+
+    host.open_surface(Surface(renderable=dialog, focus_target=dialog, presentation="modal"))
+
+    assert dialog.focused is True
+    assert form.focused is True
+    target = host.current_editor_target()
+    assert target is not None
+    target.insert_text("abc")
+    assert field.value == "abc"
+
+    assert host.route_input(InputEvent(kind="key", key="tab")) == ()
+    assert host.current_editor_target() is None
+
+    intents = host.route_input(InputEvent(kind="key", key="enter"))
+    assert tuple(intent_tuple(intent) for intent in intents) == (
+        ("dialog_confirm", "", ""),
+        ("surface_close", "", ""),
+    )
+    assert host.current_focus() is None
+
+
+def test_confirm_dialog_modal_cancel_closes_before_text_field_escape() -> None:
+    seen_escape: list[str] = []
+    field = TextField(value="", on_escape=lambda: seen_escape.append("field"))
+    form = Form([FormRow("name", field)])
+    dialog = ConfirmDialog(title="Edit", body=form)
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=dialog, focus_target=dialog, presentation="modal"))
+
+    intents = host.route_input(InputEvent(kind="key", key="escape"))
+
+    assert tuple(intent_tuple(intent) for intent in intents) == (("dialog_cancel", "", ""),)
+    assert seen_escape == []
+    assert host.current_focus() is None
+```
+
+- [ ] **Step 3: Run tests to verify red**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_hardening.py -q
+```
+
+Expected: FAIL because `Dialog`/`ConfirmDialog` lack `theme`; modal integration may already pass. If modal tests pass on the first run, keep them as regression coverage and only implement the theme gap.
+
+- [ ] **Step 4: Add Dialog theme field and action styling**
+
+In `dialog.py`, import `ThemeResolver` and `style_text`:
+
+```python
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.widgets._utils import style_text
+```
+
+Add `theme` to `Dialog`:
+
+```python
+theme: ThemeResolver | None = None
+```
+
+Pass theme into `_dialog_result()` from `Dialog.render()` and `ConfirmDialog.render()`:
+
+```python
+theme=self.theme,
+```
+
+Update helper signature:
+
+```python
+def _dialog_result(
+    *,
+    title: str,
+    body: object | str | None,
+    action_labels: tuple[str, ...],
+    constraints: RenderConstraints,
+    theme: ThemeResolver | None = None,
+) -> RenderResult:
+```
+
+Style title and action line:
+
+```python
+title_line = truncate_to_width(title, max_width=target_width, ellipsis="")
+lines = [RenderLine(style_text(title_line, theme, "widget.dialog.title"))]
+...
+action_line = truncate_to_width(action_line, max_width=target_width, ellipsis="")
+lines.append(RenderLine(style_text(action_line, theme, "widget.dialog.action")))
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_hardening.py tests/tui/test_widgets_foundation.py tests/tui/test_surfaces.py tests/tui/test_input_routing.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/tui/test_widgets_hardening.py src/loushang/tui/ui_parts/widgets/dialog.py
+git commit -m "test(tui): harden dialog modal routing"
+```
+
+## Task 6: Update Widget Reference Docs
+
+**Files:**
+- Modify: `docs/en/reference/tui-widgets.md`
+- Modify: `docs/zh-CN/reference/tui-widgets.md`
+- Test: none
+
+- [ ] **Step 1: Update English docs**
+
+Add a short section after "Dialogs":
+
+```markdown
+## Theme Tokens
+
+P0A widgets accept `ThemeResolver` where styling is supported. Initial stable
+tokens are:
+
+| Token | Applies to |
+| --- | --- |
+| `widget.focus` | Focused enabled controls or rows. |
+| `widget.disabled` | Disabled controls or disabled radio options. |
+| `widget.error` | `TextField` and `FormRow` error lines. |
+| `widget.field.label` | `TextField` labels. |
+| `widget.field.help` | `TextField` help lines. |
+| `widget.button.default` | Default buttons. |
+| `widget.button.primary` | Primary buttons. |
+| `widget.button.danger` | Danger buttons. |
+| `widget.button.ghost` | Ghost buttons. |
+| `widget.dialog.title` | Dialog titles. |
+| `widget.dialog.action` | Dialog action rows. |
+```
+
+- [ ] **Step 2: Update Chinese docs**
+
+Mirror the section in `docs/zh-CN/reference/tui-widgets.md` with Chinese
+descriptions and identical token names.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/en/reference/tui-widgets.md docs/zh-CN/reference/tui-widgets.md
+git commit -m "docs(tui): document widget theme tokens"
+```
+
+## Task 7: Full Verification And Cleanup
+
+**Files:**
+- Modify only if verification finds issues.
+
+- [ ] **Step 1: Run focused widget tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_foundation.py tests/tui/test_widgets_hardening.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run adjacent TUI tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_basic_theme_compliance.py tests/tui/test_surfaces.py tests/tui/test_input_routing.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full TUI suite**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run Ruff**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui tests/tui docs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate -8
+```
+
+Expected: branch contains the spec commit plus implementation commits, with no
+uncommitted changes.
+
+## Completion Criteria
+
+- P0A widgets have hardening tests for theming, constraints, and modal routing.
+- No new P0B/P1 controls are added.
+- `Form(theme=...)`, `Dialog(theme=...)`, and inherited `ConfirmDialog(theme=...)`
+  are the only public API additions.
+- All focused, adjacent, full TUI, and Ruff checks pass.

--- a/docs/superpowers/specs/2026-06-10-tui-widgets-p0a-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-10-tui-widgets-p0a-hardening-design.md
@@ -1,0 +1,268 @@
+# TUI Widgets P0A Hardening Design
+
+## Status
+
+Draft for spec review.
+
+## Context
+
+PR #145 added the first reusable `loushang.tui` widget batch:
+
+- `Button` / `IconButton`
+- `Checkbox`
+- `Toggle`
+- `RadioGroup`
+- `TextField`
+- `SelectList`
+- `Form` / `FormRow`
+- `Dialog` / `ConfirmDialog`
+
+The foundation is intentionally small and compatible with the existing
+`Renderable`, `Focusable`, `EditorInputTargetProvider`, `SurfaceHost`, and
+`TextInput` contracts. The current tests cover public exports, basic activation,
+local form focus, editor target delegation, select-list escape behavior, and
+confirm/cancel intent shape.
+
+The remaining risk is not missing catalog breadth. It is contract drift in the
+widgets that already exist. The foundation design promised width and height
+compliance, theme-token support, visible disabled/error states, and modal
+integration through `SurfaceHost`. Those promises should be converted into
+focused regression tests before adding P0B controls such as toolbar, menu,
+progress, badges, or status pills.
+
+## Goals
+
+- Harden the existing P0A widget batch without expanding the widget catalog.
+- Add regression tests for `RenderConstraints` compliance on narrow and short
+  renders.
+- Apply theme tokens consistently where widgets already expose `theme` or
+  `theme_token` parameters, and add narrow optional theme parameters to
+  `Form`/`Dialog` where this is required for documented P0A states.
+- Ensure themed output keeps the same visible width as unthemed output.
+- Make disabled, focused, help, error, selected, and action states visibly
+  stable and testable.
+- Add `Dialog` + `Form` + `SurfaceHost` modal routing tests using the dialog as
+  the surface `focus_target`.
+- Preserve current public class names, callback semantics, intent kinds, and
+  input routing contracts.
+
+## Non-Goals
+
+- Do not add P0B or P1 controls in this slice.
+- Do not introduce a layout engine, retained tree, CSS layer, or global focus
+  manager.
+- Do not replace `TextInput`, `SelectionSurface`, `DialogSurface`, or
+  `SurfaceHost`.
+- Do not add product-specific coding-session behavior to core `loushang.tui`
+  widgets.
+- Do not add new global `InputIntentKind` values unless a failing integration
+  test proves the existing intent vocabulary cannot express the behavior.
+- Do not redesign visual styling. This slice should make the current ASCII-first
+  rendering deterministic and theme-aware.
+
+## Design
+
+### Theme Resolution
+
+Widgets that already accept `ThemeResolver` should resolve and apply structured
+theme tokens during rendering. `Form`, `Dialog`, and `ConfirmDialog` may gain
+backward-compatible optional `theme: ThemeResolver | None = None` fields because
+they render form errors, dialog titles, and dialog actions. Theme application
+must use the existing `apply_theme_style()` helper so ANSI reset behavior
+matches the rest of the TUI.
+
+The first hardening pass should keep token names simple and local:
+
+| Widget area | Token |
+| --- | --- |
+| Focus indicator or focused row | `widget.focus` |
+| Disabled control text | `widget.disabled` |
+| Field or form error text | `widget.error` |
+| Field label | `widget.field.label` |
+| Field help text | `widget.field.help` |
+| Button default kind | `widget.button.default` |
+| Button primary kind | `widget.button.primary` |
+| Button danger kind | `widget.button.danger` |
+| Button ghost kind | `widget.button.ghost` |
+| Dialog title | `widget.dialog.title` |
+| Dialog actions | `widget.dialog.action` |
+
+State precedence is explicit so tests do not encode accidental behavior:
+
+1. Base style comes from the kind-derived token, such as
+   `widget.button.primary`.
+2. For `Button`, `theme_token` is a base-style override and replaces the
+   kind-derived token when set.
+3. Focus style from `widget.focus` is merged over the base style for focused
+   enabled controls.
+4. Disabled style from `widget.disabled` wins over focus and base styles.
+5. Error style from `widget.error` wins for field and form error lines.
+
+When multiple resolved styles are merged, later styles override earlier styles
+for the same style keys. If no theme is provided, rendering stays unchanged.
+
+`SelectList` should continue delegating theme behavior to `SelectionSurface`
+rather than duplicating selection styling.
+
+### Constraint Compliance
+
+Every P0A widget render path must obey:
+
+- No rendered line exceeds `constraints.width` after stripping control
+  sequences.
+- No render returns more than `constraints.max_height` lines.
+- The smallest valid constraints, `width=1` and `max_height=1`, remain safe and
+  deterministic. Non-positive constraints are out of scope because
+  `RenderConstraints` already rejects them during construction.
+- Focus and disabled state changes do not alter visible width for the same
+  content and constraints.
+- Cursor declarations are emitted only by editable widgets, and `TextField`
+  cursor rows remain correct when label/help/error lines are present or
+  truncated by height.
+
+The hardening implementation should prefer tests first. If a widget already
+passes, no production code should change.
+
+### State Rendering
+
+Disabled controls currently ignore activation input. This slice should also
+make their rendered disabled state themeable. The underlying ASCII text should
+stay stable so non-ANSI tests can still assert intent:
+
+- `Button`: same bracketed label, themed by disabled or kind token.
+- `Checkbox`: same `[x]` / `[ ]` marker, themed by disabled token.
+- `Toggle`: same `[on ]` / `[off]` marker, themed by disabled token.
+- `RadioGroup`: disabled options render with the disabled token while active and
+  selected indicators remain textual.
+
+`TextField` should prefer `error` over `help_text`, as it does today, and should
+make both states themeable. `Form.validate()` currently stores row errors on
+`FormRow.error`; those rendered form errors should use the same `widget.error`
+token as field-level errors.
+
+### Modal Integration
+
+The foundation documentation says modal dialogs should be opened with the dialog
+itself as the `Surface.focus_target`:
+
+```python
+dialog = ConfirmDialog(title="Apply changes?", body=form)
+host.open_surface(Surface(renderable=dialog, focus_target=dialog, presentation="modal"))
+```
+
+This slice should add integration tests that prove:
+
+- Opening the modal focuses the dialog and the dialog focuses its nested form
+  body.
+- `SurfaceHost.current_editor_target()` returns the active `TextField` target
+  while body focus is active.
+- Text input routed through the editor target mutates the nested field.
+- `tab` can move from the last form field to dialog actions.
+- Confirm returns `dialog_confirm` followed by `surface_close`, and
+  `SurfaceHost` closes the modal because `surface_close` is in the default close
+  list.
+- `escape` returns `dialog_cancel` and closes the modal before a nested
+  `TextField` can consume escape.
+
+This should remain a routing test, not a new modal framework.
+
+## Files In Scope
+
+Likely implementation files:
+
+- `src/loushang/tui/ui_parts/widgets/_utils.py`
+- `src/loushang/tui/ui_parts/widgets/button.py`
+- `src/loushang/tui/ui_parts/widgets/choice.py`
+- `src/loushang/tui/ui_parts/widgets/field.py`
+- `src/loushang/tui/ui_parts/widgets/form.py`
+- `src/loushang/tui/ui_parts/widgets/dialog.py`
+
+Allowed public API additions are limited to optional theme plumbing for existing
+widgets:
+
+- `Form(theme: ThemeResolver | None = None)` for `FormRow.error` rendering.
+- `Dialog(theme: ThemeResolver | None = None)` for title and action rendering.
+- `ConfirmDialog` inherits the dialog theme field.
+
+No required constructor parameters or callback signatures may change.
+
+Likely test files:
+
+- `tests/tui/test_widgets_foundation.py`
+- a new `tests/tui/test_widgets_hardening.py` if the test set becomes easier to
+  scan as a separate file
+- `tests/tui/test_basic_theme_compliance.py` only if shared theme assertions
+  belong beside existing theme tests
+
+Likely docs:
+
+- `docs/en/reference/tui-widgets.md`
+- `docs/zh-CN/reference/tui-widgets.md`
+
+Docs should be updated only where the hardening changes user-facing behavior,
+for example documenting widget theme tokens. No broad documentation rewrite is
+needed.
+
+## Testing Strategy
+
+Use TDD for the implementation slice:
+
+1. Add focused failing tests for theme application and visible-width stability.
+2. Add focused failing tests for narrow and short `RenderConstraints`.
+3. Add focused failing tests for `TextField` help/error priority and cursor row
+   stability.
+4. Add focused failing tests for `Dialog` + `Form` + `SurfaceHost` modal
+   integration.
+5. Implement the smallest changes needed to pass those tests.
+6. Run adjacent widget/theme/surface tests.
+7. Run the full TUI suite and Ruff on the touched TUI files.
+
+Expected verification commands:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_foundation.py tests/tui/test_widgets_hardening.py -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_basic_theme_compliance.py tests/tui/test_surfaces.py tests/tui/test_input_routing.py -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui tests/tui docs
+```
+
+If the hardening tests stay inside `test_widgets_foundation.py`, omit
+`test_widgets_hardening.py` from the first command.
+
+## Rollout Plan
+
+This should be one small PR with cohesive commits:
+
+1. Add hardening tests for constraints and theme behavior.
+2. Apply shared widget theme helpers and fix only failing render paths.
+3. Add modal integration tests and fix only failing routing behavior.
+4. Update widget reference docs if theme-token behavior becomes user-facing.
+5. Run focused checks, then full TUI checks.
+
+The PR should not include new catalog controls. If implementation discovers a
+larger design problem, stop and write a follow-up spec instead of expanding this
+slice.
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Theme tokens create a hidden styling API too early. | Use obvious token names already proposed by the foundation design and document them as initial stable tokens only for existing widgets. |
+| ANSI styling breaks width calculations. | Assert both raw ANSI presence and stripped visible width in tests. |
+| Hardening turns into a visual redesign. | Keep underlying ASCII text and existing layout unchanged unless a constraint test fails. |
+| Modal integration tests become brittle by overchecking internals. | Assert public `SurfaceHost` routing results, focus flags, editor target behavior, and emitted intents instead of private fields. |
+| Production changes touch too many modules. | Put shared styling helpers in `widgets/_utils.py` and keep each widget change narrow. |
+
+## Success Criteria
+
+- Existing P0A widgets render within width and height budgets across narrow and
+  short constraints.
+- Theme tokens apply to focused, disabled, field help/error, button kind, form
+  error, and dialog title/action states without changing visible width.
+- `TextField` keeps editor behavior delegated to `TextInput` while rendering
+  help and error states predictably.
+- `Dialog` + `Form` works as a real modal `SurfaceHost` focus target with editor
+  routing, tab-to-actions, confirm-close, and cancel-close behavior covered by
+  tests.
+- No P0B/P1 widgets or unrelated framework abstractions are introduced.
+- `tests/tui` and Ruff pass after implementation.

--- a/docs/zh-CN/reference/tui-widgets.md
+++ b/docs/zh-CN/reference/tui-widgets.md
@@ -64,6 +64,24 @@ tui.show_overlay(dialog, focus_target=dialog, presentation="modal", anchor="cent
 Dialog 会先处理 `escape` 和 `ctrl+c`，再委派给内部字段。body 焦点处于激活状态时，
 它也会把 `editor_input_target()` 委派给当前可编辑子控件。
 
+## 主题 Token
+
+支持样式的 P0A 控件可以接收 `ThemeResolver`。第一批稳定 token 如下：
+
+| Token | 作用范围 |
+| --- | --- |
+| `widget.focus` | 获得焦点且未禁用的控件或行。 |
+| `widget.disabled` | 禁用控件或禁用的 radio 选项。 |
+| `widget.error` | `TextField` 与 `FormRow` 的错误行。 |
+| `widget.field.label` | `TextField` 标签。 |
+| `widget.field.help` | `TextField` 帮助信息行。 |
+| `widget.button.default` | default button。 |
+| `widget.button.primary` | primary button。 |
+| `widget.button.danger` | danger button。 |
+| `widget.button.ghost` | ghost button。 |
+| `widget.dialog.title` | dialog 标题。 |
+| `widget.dialog.action` | dialog action 行。 |
+
 ## 计划中的控件目录
 
 `Toolbar`、`Menu`、`Popover`、`ProgressBar`、`Spinner`、`Badge`、`StatusPill`、

--- a/src/loushang/tui/ui_parts/widgets/_utils.py
+++ b/src/loushang/tui/ui_parts/widgets/_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from loushang.tui.theme import ThemeResolver, ThemeStyle, apply_theme_style
+
 
 def is_activation_event(event: object) -> bool:
     return (
@@ -12,3 +14,22 @@ def is_activation_event(event: object) -> bool:
 
 def callback_result(result: object) -> object:
     return True if result is None else result
+
+
+def merge_theme_styles(*styles: ThemeStyle | None) -> ThemeStyle | None:
+    merged: ThemeStyle = {}
+    for style in styles:
+        if style:
+            merged.update(style)
+    return merged or None
+
+
+def resolve_theme_style(theme: ThemeResolver | None, token: str | None) -> ThemeStyle | None:
+    if theme is None or not token:
+        return None
+    return theme.resolve(token)
+
+
+def style_text(text: str, theme: ThemeResolver | None, *tokens: str | None) -> str:
+    style = merge_theme_styles(*(resolve_theme_style(theme, token) for token in tokens))
+    return apply_theme_style(text, style)

--- a/src/loushang/tui/ui_parts/widgets/button.py
+++ b/src/loushang/tui/ui_parts/widgets/button.py
@@ -7,7 +7,11 @@ from typing import Literal
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
 from loushang.tui.theme import ThemeResolver
-from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event, style_text
+from loushang.tui.ui_parts.widgets._utils import (
+    callback_result,
+    is_activation_event,
+    style_text,
+)
 
 ButtonKind = Literal["default", "primary", "danger", "ghost"]
 

--- a/src/loushang/tui/ui_parts/widgets/button.py
+++ b/src/loushang/tui/ui_parts/widgets/button.py
@@ -7,7 +7,7 @@ from typing import Literal
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
 from loushang.tui.theme import ThemeResolver
-from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event
+from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event, style_text
 
 ButtonKind = Literal["default", "primary", "danger", "ghost"]
 
@@ -41,7 +41,15 @@ class Button:
         label = self.label if not self.icon else f"{self.icon} {self.label}".strip()
         line = f"{'> ' if self.focused else '  '}[{label}]"
         rendered = truncate_to_width(line, max_width=target_width, ellipsis="")
+        base_token = self.theme_token or _button_base_token(self.kind)
+        state_token = "widget.disabled" if self.disabled else "widget.focus" if self.focused else None
+        rendered = style_text(rendered, self.theme, base_token, state_token)
         return RenderResult.from_lines([RenderLine(rendered)][: constraints.max_height], constraints=constraints)
+
 
 def IconButton(icon: str, *, label: str = "", **kwargs: object) -> Button:
     return Button(label=label, icon=icon, **kwargs)
+
+
+def _button_base_token(kind: ButtonKind) -> str:
+    return f"widget.button.{kind}"

--- a/src/loushang/tui/ui_parts/widgets/choice.py
+++ b/src/loushang/tui/ui_parts/widgets/choice.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
 from loushang.tui.theme import ThemeResolver
-from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event
+from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event, style_text
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,7 +47,8 @@ class Checkbox:
     def render(self, constraints: RenderConstraints) -> RenderResult:
         marker = "x" if self.checked else " "
         line = f"{_focus_prefix(self.focused)}[{marker}] {self.label}"
-        return _single_line_result(line, constraints)
+        state_token = "widget.disabled" if self.disabled else "widget.focus" if self.focused else None
+        return _single_line_result(line, constraints, theme=self.theme, state_token=state_token)
 
 
 @dataclass(slots=True)
@@ -77,7 +78,8 @@ class Toggle:
     def render(self, constraints: RenderConstraints) -> RenderResult:
         marker = "on " if self.value else "off"
         line = f"{_focus_prefix(self.focused)}[{marker}] {self.label}"
-        return _single_line_result(line, constraints)
+        state_token = "widget.disabled" if self.disabled else "widget.focus" if self.focused else None
+        return _single_line_result(line, constraints, theme=self.theme, state_token=state_token)
 
 
 @dataclass(slots=True)
@@ -122,7 +124,15 @@ class RadioGroup:
             text = f"{prefix}({marker}) {option.label}"
             if option.description:
                 text = f"{text}  {option.description}"
-            lines.append(RenderLine(truncate_to_width(text, max_width=target_width, ellipsis="")))
+            rendered = truncate_to_width(text, max_width=target_width, ellipsis="")
+            state_token = (
+                "widget.disabled"
+                if option.disabled
+                else "widget.focus"
+                if self.focused and index == self._active_index
+                else None
+            )
+            lines.append(RenderLine(style_text(rendered, self.theme, state_token)))
             if len(lines) >= constraints.max_height:
                 break
         return RenderResult.from_lines(lines, constraints=constraints)
@@ -166,7 +176,14 @@ def _focus_prefix(focused: bool) -> str:
     return "> " if focused else "  "
 
 
-def _single_line_result(line: str, constraints: RenderConstraints) -> RenderResult:
+def _single_line_result(
+    line: str,
+    constraints: RenderConstraints,
+    *,
+    theme: ThemeResolver | None = None,
+    state_token: str | None = None,
+) -> RenderResult:
     target_width = autowrap_safe_width(constraints.width)
     rendered = truncate_to_width(line, max_width=target_width, ellipsis="")
+    rendered = style_text(rendered, theme, state_token)
     return RenderResult.from_lines([RenderLine(rendered)][: constraints.max_height], constraints=constraints)

--- a/src/loushang/tui/ui_parts/widgets/choice.py
+++ b/src/loushang/tui/ui_parts/widgets/choice.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass, field
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
 from loushang.tui.theme import ThemeResolver
-from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event, style_text
+from loushang.tui.ui_parts.widgets._utils import (
+    callback_result,
+    is_activation_event,
+    style_text,
+)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/loushang/tui/ui_parts/widgets/dialog.py
+++ b/src/loushang/tui/ui_parts/widgets/dialog.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.widgets._utils import style_text
 
 
 @dataclass(frozen=True, slots=True)
@@ -19,6 +21,7 @@ class Dialog:
     body: object | str | None = None
     actions: list[DialogAction] | tuple[DialogAction, ...] = ()
     focused: bool = False
+    theme: ThemeResolver | None = field(default=None, kw_only=True)
     _focus_slot: str = field(default="body", init=False, repr=False)
 
     def focus(self) -> None:
@@ -78,6 +81,7 @@ class Dialog:
             body=self.body,
             action_labels=tuple(action.label for action in self.actions),
             constraints=constraints,
+            theme=self.theme,
         )
 
 
@@ -114,6 +118,7 @@ class ConfirmDialog(Dialog):
             body=self.body,
             action_labels=(self.confirm_label, self.cancel_label),
             constraints=constraints,
+            theme=self.theme,
         )
 
 
@@ -129,9 +134,11 @@ def _dialog_result(
     body: object | str | None,
     action_labels: tuple[str, ...],
     constraints: RenderConstraints,
+    theme: ThemeResolver | None = None,
 ) -> RenderResult:
     target_width = autowrap_safe_width(constraints.width)
-    lines = [RenderLine(truncate_to_width(title, max_width=target_width, ellipsis=""))]
+    title_line = truncate_to_width(title, max_width=target_width, ellipsis="")
+    lines = [RenderLine(style_text(title_line, theme, "widget.dialog.title"))]
     if isinstance(body, str) and body:
         lines.append(RenderLine(truncate_to_width(body, max_width=target_width, ellipsis="")))
     elif body is not None:
@@ -141,7 +148,8 @@ def _dialog_result(
             lines.extend(body_result.lines[: constraints.max_height - len(lines)])
     if action_labels:
         action_line = "  ".join(f"[{label}]" for label in action_labels)
-        lines.append(RenderLine(truncate_to_width(action_line, max_width=target_width, ellipsis="")))
+        action_line = truncate_to_width(action_line, max_width=target_width, ellipsis="")
+        lines.append(RenderLine(style_text(action_line, theme, "widget.dialog.action")))
     return RenderResult.from_lines(lines[: constraints.max_height], constraints=constraints)
 
 

--- a/src/loushang/tui/ui_parts/widgets/field.py
+++ b/src/loushang/tui/ui_parts/widgets/field.py
@@ -12,6 +12,7 @@ from loushang.tui.core import (
 )
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.ui_parts.text_input import TextInput
+from loushang.tui.ui_parts.widgets._utils import style_text
 
 
 @dataclass(init=False, slots=True)
@@ -95,7 +96,8 @@ class TextField:
         cursor: CursorDeclaration | None = None
 
         if self.label and len(lines) < constraints.max_height:
-            lines.append(RenderLine(truncate_to_width(self.label, max_width=target_width, ellipsis="")))
+            label = truncate_to_width(self.label, max_width=target_width, ellipsis="")
+            lines.append(RenderLine(style_text(label, self.theme, "widget.field.label")))
 
         if len(lines) < constraints.max_height:
             input_row = len(lines)
@@ -109,6 +111,8 @@ class TextField:
 
         detail = self.error or self.help_text
         if detail and len(lines) < constraints.max_height:
-            lines.append(RenderLine(truncate_to_width(detail, max_width=target_width, ellipsis="")))
+            detail_token = "widget.error" if self.error else "widget.field.help"
+            rendered_detail = truncate_to_width(detail, max_width=target_width, ellipsis="")
+            lines.append(RenderLine(style_text(rendered_detail, self.theme, detail_token)))
 
         return RenderResult.from_lines(lines, constraints=constraints, cursor=cursor)

--- a/src/loushang/tui/ui_parts/widgets/form.py
+++ b/src/loushang/tui/ui_parts/widgets/form.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.widgets._utils import style_text
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,6 +31,7 @@ class FormRow:
 class Form:
     rows: list[FormRow] | tuple[FormRow, ...]
     focused: bool = False
+    theme: ThemeResolver | None = None
     _active_index: int = field(default=0, init=False, repr=False)
 
     def focus(self) -> None:
@@ -95,7 +98,8 @@ class Form:
                 result = render(RenderConstraints(width=constraints.width, max_height=constraints.max_height - len(lines)))
                 lines.extend(result.lines[: constraints.max_height - len(lines)])
             if row.error and len(lines) < constraints.max_height:
-                lines.append(RenderLine(truncate_to_width(row.error, max_width=target_width, ellipsis="")))
+                error = truncate_to_width(row.error, max_width=target_width, ellipsis="")
+                lines.append(RenderLine(style_text(error, self.theme, "widget.error")))
         return RenderResult.from_lines(lines, constraints=constraints)
 
     def _active_control(self) -> object | None:

--- a/src/loushang/tui/ui_parts/widgets/form.py
+++ b/src/loushang/tui/ui_parts/widgets/form.py
@@ -31,7 +31,7 @@ class FormRow:
 class Form:
     rows: list[FormRow] | tuple[FormRow, ...]
     focused: bool = False
-    theme: ThemeResolver | None = None
+    theme: ThemeResolver | None = field(default=None, kw_only=True)
     _active_index: int = field(default=0, init=False, repr=False)
 
     def focus(self) -> None:

--- a/tests/tui/test_widgets_hardening.py
+++ b/tests/tui/test_widgets_hardening.py
@@ -132,3 +132,49 @@ def test_all_p0a_widgets_respect_narrow_short_render_constraints() -> None:
         lines = render_lines(control, width=6, height=2)
         assert len(lines) <= 2
         assert_widths_within(lines, 6)
+
+
+def test_text_field_themes_label_help_and_error_with_error_precedence() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.field.label": {"color": "cyan"},
+            "widget.field.help": {"dim": True},
+            "widget.error": {"color": "red"},
+        }
+    )
+    field = TextField(label="Name", value="tower", help_text="Helpful", error="Required", theme=theme)
+    field.focus()
+
+    raw = render_lines(field, width=24, height=4)
+
+    assert raw[0].startswith("\x1b[36m")
+    assert raw[2].startswith("\x1b[31m")
+    assert tuple(strip_control_sequences(line) for line in raw) == ("Name", "tower", "Required")
+    assert all(visible_width(line) <= 24 for line in raw)
+
+
+def test_text_field_cursor_row_stays_on_input_when_height_truncates_detail() -> None:
+    field = TextField(label="Name", value="tower", help_text="Helpful")
+    field.focus()
+
+    result = field.render(RenderConstraints(width=24, max_height=2))
+
+    assert tuple(strip_control_sequences(line.text) for line in result.lines) == ("Name", "tower")
+    assert result.cursor is not None
+    assert (result.cursor.row, result.cursor.column) == (1, len("tower"))
+
+
+def test_form_themes_validation_errors_without_changing_values() -> None:
+    theme = ThemeResolver(defaults={"widget.error": {"color": "red"}})
+    form = Form(
+        [FormRow("name", TextField(value=""), validator=lambda value: "Name required" if not value else None)],
+        theme=theme,
+    )
+
+    result = form.validate()
+    raw = render_lines(form, width=24, height=4)
+
+    assert result.errors == {"name": "Name required"}
+    assert raw[-1].startswith("\x1b[31m")
+    assert strip_control_sequences(raw[-1]) == "Name required"
+    assert form.values() == {"name": ""}

--- a/tests/tui/test_widgets_hardening.py
+++ b/tests/tui/test_widgets_hardening.py
@@ -4,9 +4,21 @@ from typing import Any
 
 from loushang.tui import (
     Button,
+    Checkbox,
+    Choice,
+    ConfirmDialog,
+    Dialog,
+    Form,
+    FormRow,
+    IconButton,
     InputEvent,
+    RadioGroup,
     RenderConstraints,
+    SelectItem,
+    SelectList,
+    TextField,
     ThemeResolver,
+    Toggle,
     strip_control_sequences,
     visible_width,
 )
@@ -68,3 +80,55 @@ def test_button_theme_token_overrides_kind_before_focus_style() -> None:
 
     assert raw[0].startswith("\x1b[4;36m")
     assert strip_control_sequences(raw[0]) == "> [Delete]"
+
+
+def test_choice_widgets_apply_focus_and_disabled_theme_without_text_changes() -> None:
+    theme = ThemeResolver(defaults={"widget.focus": {"bold": True}, "widget.disabled": {"dim": True}})
+
+    checkbox = Checkbox("Enabled", checked=True, focused=True, theme=theme)
+    toggle = Toggle("Auto", value=False, disabled=True, focused=True, theme=theme)
+    radio = RadioGroup(
+        [Choice("fast", "Fast"), Choice("slow", "Slow", disabled=True)],
+        value="fast",
+        theme=theme,
+        focused=True,
+    )
+
+    assert render_lines(checkbox)[0].startswith("\x1b[1m")
+    assert plain_lines(checkbox) == ("> [x] Enabled",)
+    assert render_lines(toggle)[0].startswith("\x1b[2m")
+    assert plain_lines(toggle) == ("> [off] Auto",)
+
+    radio_lines = render_lines(radio, width=20, height=3)
+    assert radio_lines[0].startswith("\x1b[1m")
+    assert radio_lines[1].startswith("\x1b[2m")
+    assert tuple(strip_control_sequences(line) for line in radio_lines) == ("> (x) Fast", "  ( ) Slow")
+
+
+def p0a_constraint_cases() -> list[object]:
+    return [
+        Button("Very long label", focused=True),
+        IconButton("*", label="Very long label", focused=True),
+        Checkbox("Very long label", focused=True),
+        Toggle("Very long label", focused=True),
+        RadioGroup([Choice("a", "Very long label")], value="a", focused=True),
+        TextField(label="Very long label", value="Very long value", help_text="Very long help"),
+        SelectList([SelectItem("Very long label")], max_visible=1),
+        Form([FormRow("name", TextField(label="Very long label", value="Very long value"))]),
+        Dialog(title="Very long dialog title", body="Very long dialog body"),
+        ConfirmDialog(title="Very long confirm title", body="Very long confirm body"),
+    ]
+
+
+def test_all_p0a_widgets_respect_small_valid_render_constraints() -> None:
+    for control in p0a_constraint_cases():
+        lines = render_lines(control, width=1, height=1)
+        assert len(lines) <= 1
+        assert_widths_within(lines, 1)
+
+
+def test_all_p0a_widgets_respect_narrow_short_render_constraints() -> None:
+    for control in p0a_constraint_cases():
+        lines = render_lines(control, width=6, height=2)
+        assert len(lines) <= 2
+        assert_widths_within(lines, 6)

--- a/tests/tui/test_widgets_hardening.py
+++ b/tests/tui/test_widgets_hardening.py
@@ -16,6 +16,8 @@ from loushang.tui import (
     RenderConstraints,
     SelectItem,
     SelectList,
+    Surface,
+    SurfaceHost,
     TextField,
     ThemeResolver,
     Toggle,
@@ -178,3 +180,64 @@ def test_form_themes_validation_errors_without_changing_values() -> None:
     assert raw[-1].startswith("\x1b[31m")
     assert strip_control_sequences(raw[-1]) == "Name required"
     assert form.values() == {"name": ""}
+
+
+def intent_tuple(intent: object) -> tuple[str, str, str]:
+    return (getattr(intent, "kind", ""), getattr(intent, "text", ""), getattr(intent, "note", ""))
+
+
+def test_dialog_themes_title_and_actions() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.dialog.title": {"bold": True},
+            "widget.dialog.action": {"color": "cyan"},
+        }
+    )
+    dialog = ConfirmDialog(title="Apply?", body="Changes", theme=theme)
+
+    raw = render_lines(dialog, width=30, height=4)
+
+    assert raw[0].startswith("\x1b[1m")
+    assert raw[-1].startswith("\x1b[36m")
+    assert tuple(strip_control_sequences(line) for line in raw) == ("Apply?", "Changes", "[Confirm]  [Cancel]")
+
+
+def test_confirm_dialog_modal_routes_editor_target_and_confirm_closes_surface() -> None:
+    field = TextField(value="")
+    form = Form([FormRow("name", field)])
+    dialog = ConfirmDialog(title="Edit", body=form)
+    host = SurfaceHost()
+
+    host.open_surface(Surface(renderable=dialog, focus_target=dialog, presentation="modal"))
+
+    assert dialog.focused is True
+    assert form.focused is True
+    target = host.current_editor_target()
+    assert target is not None
+    target.insert_text("abc")
+    assert field.value == "abc"
+
+    assert host.route_input(InputEvent(kind="key", key="tab")) == ()
+    assert host.current_editor_target() is None
+
+    intents = host.route_input(InputEvent(kind="key", key="enter"))
+    assert tuple(intent_tuple(intent) for intent in intents) == (
+        ("dialog_confirm", "", ""),
+        ("surface_close", "", ""),
+    )
+    assert host.current_focus() is None
+
+
+def test_confirm_dialog_modal_cancel_closes_before_text_field_escape() -> None:
+    seen_escape: list[str] = []
+    field = TextField(value="", on_escape=lambda: seen_escape.append("field"))
+    form = Form([FormRow("name", field)])
+    dialog = ConfirmDialog(title="Edit", body=form)
+    host = SurfaceHost()
+    host.open_surface(Surface(renderable=dialog, focus_target=dialog, presentation="modal"))
+
+    intents = host.route_input(InputEvent(kind="key", key="escape"))
+
+    assert tuple(intent_tuple(intent) for intent in intents) == (("dialog_cancel", "", ""),)
+    assert seen_escape == []
+    assert host.current_focus() is None

--- a/tests/tui/test_widgets_hardening.py
+++ b/tests/tui/test_widgets_hardening.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+from loushang.tui import (
+    Button,
+    InputEvent,
+    RenderConstraints,
+    ThemeResolver,
+    strip_control_sequences,
+    visible_width,
+)
+
+
+def render_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
+    result = part.render(RenderConstraints(width=width, max_height=height))
+    return tuple(line.text for line in result.lines)
+
+
+def plain_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
+    return tuple(strip_control_sequences(line) for line in render_lines(part, width=width, height=height))
+
+
+def assert_widths_within(lines: tuple[str, ...], width: int) -> None:
+    assert all(visible_width(line) <= width for line in lines)
+
+
+def test_button_kind_focus_and_disabled_theme_tokens_preserve_visible_width() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.button.primary": {"color": "green"},
+            "widget.focus": {"bold": True},
+            "widget.disabled": {"dim": True},
+        }
+    )
+    button = Button("Save", kind="primary", theme=theme)
+
+    raw = render_lines(button, width=12)
+    assert raw[0].startswith("\x1b[32m")
+    assert strip_control_sequences(raw[0]) == "  [Save]"
+    assert visible_width(raw[0]) == len("  [Save]")
+
+    button.focus()
+    focused = render_lines(button, width=12)
+    assert focused[0].startswith("\x1b[1;32m")
+    assert strip_control_sequences(focused[0]) == "> [Save]"
+    assert visible_width(focused[0]) == len("> [Save]")
+
+    disabled = Button("Save", kind="primary", disabled=True, theme=theme)
+    disabled.focus()
+    disabled_raw = render_lines(disabled, width=12)
+    assert disabled_raw[0].startswith("\x1b[2;32m")
+    assert strip_control_sequences(disabled_raw[0]) == "> [Save]"
+    assert disabled.handle_input(InputEvent(kind="key", key="enter")) is None
+
+
+def test_button_theme_token_overrides_kind_before_focus_style() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.button.danger": {"color": "red"},
+            "custom.button": {"color": "cyan"},
+            "widget.focus": {"underline": True},
+        }
+    )
+    button = Button("Delete", kind="danger", theme=theme, theme_token="custom.button", focused=True)
+
+    raw = render_lines(button, width=16)
+
+    assert raw[0].startswith("\x1b[4;36m")
+    assert strip_control_sequences(raw[0]) == "> [Delete]"


### PR DESCRIPTION
## Summary
- Add a TUI P0A widgets hardening spec and implementation plan.
- Apply theme token rendering to existing P0A widgets: buttons, choice controls, fields, forms, and dialogs.
- Add regression coverage for render constraints, visible-width stability, TextField/Form errors, and Dialog + Form + SurfaceHost modal routing.
- Document initial widget theme tokens in English and Chinese reference docs.

## Test Plan
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
- [x] uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui tests/tui docs