### PR TITLE
feat(agent): add thin harness facade

### DIFF
--- a/docs/internals/architecture/agent/README.md
+++ b/docs/internals/architecture/agent/README.md
@@ -36,13 +36,17 @@ await agent.prompt("Hello")
 
 ## Harness Direction
 
-`loushang.agent.harness` is the planned headless execution scaffolding above the
+`loushang.agent.harness` is the headless execution scaffolding above the
 low-level loop. It is not a testing-only harness.
 
-The harness should expose a thin product-adapter surface such as
-`AgentRunSpec`, `AgentRunResult`, and `run_agent()`, while reusing the existing
-agent loop and keeping coding, work, method, research, ppt, and cowork product
+The initial harness exposes a thin product-adapter surface:
+`AgentRunSpec`, `AgentRunResult`, and `run_agent()`. It reuses the existing
+agent loop and keeps coding, work, method, research, ppt, and cowork product
 semantics outside `loushang.agent`.
+
+The harness API is intentionally imported from `loushang.agent.harness`; it is
+not re-exported from `loushang.agent.__init__` while the adapter contract
+settles.
 
 See [ARD-001: Agent Harness and Product Adapter Boundaries](ARD-001-agent-harness-and-product-adapters.md).
 The current P1 module ownership inventory is

--- a/src/loushang/agent/harness/__init__.py
+++ b/src/loushang/agent/harness/__init__.py
@@ -1,0 +1,15 @@
+from loushang.agent.harness.runner import run_agent
+from loushang.agent.harness.types import (
+    AgentRunMode,
+    AgentRunResult,
+    AgentRunSpec,
+    AgentRunStatus,
+)
+
+__all__ = [
+    "AgentRunMode",
+    "AgentRunResult",
+    "AgentRunSpec",
+    "AgentRunStatus",
+    "run_agent",
+]

--- a/src/loushang/agent/harness/runner.py
+++ b/src/loushang/agent/harness/runner.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from loushang.agent.agent_loop import run_agent_loop, run_agent_loop_continue
+from loushang.agent.harness.types import AgentRunResult, AgentRunSpec
+from loushang.agent.types import AgentEvent, AgentMessage
+
+
+async def run_agent(spec: AgentRunSpec) -> AgentRunResult:
+    events: list[AgentEvent] = []
+
+    async def emit(event: AgentEvent) -> None:
+        events.append(event)
+
+    try:
+        if spec.mode == "continue":
+            new_messages = await run_agent_loop_continue(
+                spec.context,
+                spec.config,
+                emit,
+                signal=spec.signal,
+                stream_fn=spec.stream_fn,
+            )
+        else:
+            new_messages = await run_agent_loop(
+                list(spec.prompts),
+                spec.context,
+                spec.config,
+                emit,
+                signal=spec.signal,
+                stream_fn=spec.stream_fn,
+            )
+    except Exception as error:  # noqa: BLE001 - harness returns failed run results for product adapters.
+        return AgentRunResult(
+            status="failed",
+            events=tuple(events),
+            error=error,
+        )
+
+    return AgentRunResult(
+        status="completed",
+        new_messages=tuple(new_messages),
+        events=tuple(events),
+        stop_reason=_stop_reason(new_messages),
+    )
+
+
+def _stop_reason(messages: list[AgentMessage]) -> str | None:
+    for message in reversed(messages):
+        stop_reason = getattr(message, "stop_reason", None)
+        if isinstance(stop_reason, str):
+            return stop_reason
+    return None

--- a/src/loushang/agent/harness/types.py
+++ b/src/loushang/agent/harness/types.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from loushang.agent.types import (
+    AgentContext,
+    AgentEvent,
+    AgentLoopConfig,
+    AgentMessage,
+    StreamFn,
+)
+
+AgentRunMode = Literal["prompt", "continue"]
+AgentRunStatus = Literal["completed", "failed"]
+
+
+@dataclass(frozen=True, kw_only=True)
+class AgentRunSpec:
+    context: AgentContext
+    config: AgentLoopConfig
+    prompts: tuple[AgentMessage, ...] = ()
+    mode: AgentRunMode = "prompt"
+    signal: object | None = None
+    stream_fn: StreamFn | None = None
+
+
+@dataclass(frozen=True)
+class AgentRunResult:
+    status: AgentRunStatus
+    new_messages: tuple[AgentMessage, ...] = ()
+    events: tuple[AgentEvent, ...] = ()
+    stop_reason: str | None = None
+    error: Exception | None = None

--- a/tests/agent/test_agent_harness.py
+++ b/tests/agent/test_agent_harness.py
@@ -1,0 +1,163 @@
+import asyncio
+
+from loushang.ai.event_stream.stream import AssistantMessageEventStream
+from loushang.ai.model import Capabilities, Model
+from loushang.ai.types import AssistantMessage, TextPart, Usage, UserMessage
+
+
+def _model() -> Model:
+    return Model(
+        id="faux-model",
+        name="Faux",
+        provider="faux",
+        endpoint="anthropic-messages",
+        capabilities=Capabilities(
+            reasoning=False,
+            input=("text",),
+            context_window=128000,
+            max_tokens=4096,
+        ),
+    )
+
+
+def _usage() -> Usage:
+    return Usage(
+        input=0,
+        output=0,
+        cache_read=0,
+        cache_write=0,
+        total_tokens=0,
+        cost={},
+    )
+
+
+def _assistant_text_message(text: str) -> AssistantMessage:
+    return AssistantMessage(
+        role="assistant",
+        content=[TextPart(type="text", text=text)],
+        api="anthropic-messages",
+        provider="faux",
+        model="faux-model",
+        response_id=None,
+        usage=_usage(),
+        stop_reason="stop",
+        error_message=None,
+        timestamp=0.0,
+    )
+
+
+def _stream_with_final_message(message: AssistantMessage) -> AssistantMessageEventStream:
+    stream = AssistantMessageEventStream()
+    stream.push({"type": "start", "partial": message})
+    stream.push({"type": "text_start", "content_index": 0, "partial": message})
+    stream.push({"type": "text_delta", "content_index": 0, "delta": message.content[0].text, "partial": message})
+    stream.push({"type": "text_end", "content_index": 0, "content": message.content[0].text, "partial": message})
+    stream.push({"type": "done", "reason": message.stop_reason, "message": message})  # type: ignore[typeddict-item]
+    return stream
+
+
+def _config():
+    from loushang.agent.types import AgentLoopConfig
+
+    return AgentLoopConfig(
+        model=_model(),
+        convert_to_llm=lambda messages: [
+            message
+            for message in messages
+            if isinstance(message, UserMessage) or isinstance(message, AssistantMessage)
+        ],
+        tool_execution="parallel",
+    )
+
+
+def test_run_agent_collects_events_and_new_messages_for_prompt_run() -> None:
+    from loushang.agent.harness import AgentRunSpec, run_agent
+    from loushang.agent.types import AgentContext
+
+    async def stream_fn(model, context, options=None):
+        assert context.system_prompt == "system"
+        assert [getattr(message, "role", None) for message in context.messages] == ["user"]
+        return _stream_with_final_message(_assistant_text_message("hello"))
+
+    prompt = UserMessage(role="user", content="hi", timestamp=0.0)
+    spec = AgentRunSpec(
+        prompts=(prompt,),
+        context=AgentContext(system_prompt="system", messages=()),
+        config=_config(),
+        stream_fn=stream_fn,
+    )
+
+    result = asyncio.run(run_agent(spec))
+
+    assert result.status == "completed"
+    assert result.error is None
+    assert result.stop_reason == "stop"
+    assert [event["type"] for event in result.events] == [
+        "agent_start",
+        "turn_start",
+        "message_start",
+        "message_end",
+        "message_start",
+        "message_update",
+        "message_update",
+        "message_update",
+        "message_end",
+        "turn_end",
+        "agent_end",
+    ]
+    assert [getattr(message, "role", None) for message in result.new_messages] == ["user", "assistant"]
+    assert result.new_messages[-1].content[0].text == "hello"
+
+
+def test_run_agent_can_continue_from_existing_context() -> None:
+    from loushang.agent.harness import AgentRunSpec, run_agent
+    from loushang.agent.types import AgentContext
+
+    async def stream_fn(model, context, options=None):
+        assert [getattr(message, "role", None) for message in context.messages] == ["user"]
+        return _stream_with_final_message(_assistant_text_message("continued"))
+
+    context = AgentContext(
+        system_prompt="system",
+        messages=(UserMessage(role="user", content="continue", timestamp=0.0),),
+    )
+    spec = AgentRunSpec(
+        mode="continue",
+        context=context,
+        config=_config(),
+        stream_fn=stream_fn,
+    )
+
+    result = asyncio.run(run_agent(spec))
+
+    assert result.status == "completed"
+    assert [getattr(message, "role", None) for message in result.new_messages] == ["assistant"]
+    assert result.new_messages[-1].content[0].text == "continued"
+
+
+def test_run_agent_returns_failed_result_when_loop_raises() -> None:
+    from loushang.agent.harness import AgentRunSpec, run_agent
+    from loushang.agent.types import AgentContext
+
+    async def stream_fn(model, context, options=None):
+        raise RuntimeError("provider unavailable")
+
+    spec = AgentRunSpec(
+        prompts=(UserMessage(role="user", content="hi", timestamp=0.0),),
+        context=AgentContext(system_prompt="system", messages=()),
+        config=_config(),
+        stream_fn=stream_fn,
+    )
+
+    result = asyncio.run(run_agent(spec))
+
+    assert result.status == "failed"
+    assert isinstance(result.error, RuntimeError)
+    assert str(result.error) == "provider unavailable"
+    assert [event["type"] for event in result.events] == [
+        "agent_start",
+        "turn_start",
+        "message_start",
+        "message_end",
+    ]
+    assert result.new_messages == ()


### PR DESCRIPTION
## Summary
- Add loushang.agent.harness with AgentRunSpec, AgentRunResult, and run_agent().
- Reuse the existing agent loop for prompt and continue runs.
- Keep the harness out of loushang.agent.__init__ while the adapter contract settles.

## 摘要
- 新增 loushang.agent.harness，包含 AgentRunSpec、AgentRunResult 和 run_agent()。
- 复用现有 agent loop，支持 prompt 和 continue 两种运行。
- 暂不从 loushang.agent.__init__ re-export，避免过早扩大稳定 API。

## Validation
- uv --cache-dir .uv-cache run ruff check src/loushang/agent tests/agent
- uv --cache-dir .uv-cache run --extra dev pytest tests/agent -q
- git diff --check