### PR TITLE
feat(work): add artifact references

### DIFF
--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -12,6 +12,8 @@ from loushang.work.projection import (
     project_agent_event_to_work_events,
 )
 from loushang.work.types import (
+    ArtifactRef,
+    ArtifactStatus,
     DeliveryHint,
     WorkEvent,
     WorkOperation,
@@ -24,6 +26,8 @@ from loushang.work.types import (
 )
 
 __all__ = [
+    "ArtifactRef",
+    "ArtifactStatus",
     "CodingWorkShell",
     "DeliveryHint",
     "EventLogBackend",

--- a/src/loushang/work/types.py
+++ b/src/loushang/work/types.py
@@ -24,6 +24,22 @@ WorkStepStatus: TypeAlias = Literal[
 ]
 
 DeliveryHint: TypeAlias = Literal["immediate", "coalesce", "final_only"]
+ArtifactStatus: TypeAlias = Literal["planned", "created", "updated", "deleted", "failed"]
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    artifact_id: str
+    kind: str
+    uri: str | None = None
+    title: str | None = None
+    domain: str | None = None
+    produced_by_run_id: str | None = None
+    produced_by_step_id: str | None = None
+    expected_artifact: str | None = None
+    media_type: str | None = None
+    status: ArtifactStatus = "created"
+    metadata: Mapping[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -109,6 +125,8 @@ class WorkEvent:
 
 
 __all__ = [
+    "ArtifactRef",
+    "ArtifactStatus",
     "DeliveryHint",
     "WorkEvent",
     "WorkOperation",

--- a/tests/work/test_artifact_ref.py
+++ b/tests/work/test_artifact_ref.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+
+def test_artifact_ref_records_actual_artifact_reference_without_product_behavior() -> None:
+    from loushang.work import ArtifactRef
+
+    ref = ArtifactRef(
+        artifact_id="artifact-1",
+        kind="plan",
+        uri="docs/plan.md",
+        title="Implementation plan",
+        domain="coding",
+        produced_by_run_id="run-1",
+        produced_by_step_id="inspect",
+        expected_artifact="implementation-plan",
+        media_type="text/markdown",
+        metadata={"sha256": "abc123"},
+    )
+
+    assert ref.artifact_id == "artifact-1"
+    assert ref.kind == "plan"
+    assert ref.uri == "docs/plan.md"
+    assert ref.title == "Implementation plan"
+    assert ref.domain == "coding"
+    assert ref.produced_by_run_id == "run-1"
+    assert ref.produced_by_step_id == "inspect"
+    assert ref.expected_artifact == "implementation-plan"
+    assert ref.media_type == "text/markdown"
+    assert ref.status == "created"
+    assert ref.metadata == {"sha256": "abc123"}
+    assert not hasattr(ref, "load")
+    assert not hasattr(ref, "render")
+    assert not hasattr(ref, "materialize")
+
+    with pytest.raises(FrozenInstanceError):
+        ref.status = "updated"  # type: ignore[misc]
+
+
+def test_artifact_ref_can_represent_planned_or_failed_artifacts_without_uri() -> None:
+    from loushang.work import ArtifactRef
+
+    planned = ArtifactRef(
+        artifact_id="artifact-planned",
+        kind="review",
+        expected_artifact="review-notes",
+        status="planned",
+    )
+    failed = ArtifactRef(
+        artifact_id="artifact-failed",
+        kind="test-report",
+        expected_artifact="validation-result",
+        status="failed",
+        metadata={"reason": "tests failed before report materialized"},
+    )
+
+    assert planned.uri is None
+    assert planned.status == "planned"
+    assert failed.uri is None
+    assert failed.status == "failed"
+    assert failed.metadata == {"reason": "tests failed before report materialized"}

--- a/tests/work/test_public_api.py
+++ b/tests/work/test_public_api.py
@@ -5,6 +5,8 @@ def test_work_public_api_exposes_current_work_surface_without_multi_agent_types(
     import loushang.work as work
 
     assert set(work.__all__) == {
+        "ArtifactRef",
+        "ArtifactStatus",
         "CodingWorkShell",
         "DeliveryHint",
         "EventLogBackend",


### PR DESCRIPTION
## Summary
- Add ArtifactRef and ArtifactStatus to the work package.
- Export the new reference type from loushang.work.
- Cover the lightweight artifact-reference contract without product loading/rendering behavior.

## 摘要
- 在 work 包中新增 ArtifactRef 和 ArtifactStatus。
- 从 loushang.work 导出新的工件引用类型。
- 用测试固定轻量 artifact reference 契约，不引入产品侧加载/渲染行为。

## Validation
- uv --cache-dir .uv-cache run --extra dev pytest tests/work -q
- uv --cache-dir .uv-cache run ruff check src/loushang/work tests/work
- git diff --check