### PR TITLE
refactor(coding): add work shell adapter

### DIFF
--- a/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
+++ b/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
@@ -140,17 +140,17 @@ independent from product packages.
 
 | Module | Current responsibility | Ownership | Follow-up |
 | --- | --- | --- | --- |
-| `work/types.py` | `WorkOperation`, `WorkRun`, `WorkEvent`, plan/step run data | Work primitive | Add `ArtifactRef` in a later focused PR. |
+| `work/types.py` | `WorkOperation`, `WorkRun`, `WorkEvent`, plan/step run data, `ArtifactRef` | Work primitive | Keep artifact references generic; product packages own concrete artifact content. |
 | `work/event_log.py` | Event log protocol, in-memory backend, JSONL backend | Work primitive | Keep. |
 | `work/projection.py` | Generic mapping from agent-like events to `WorkEvent` | Work primitive | Keep. It accepts mappings and does not need product imports. |
 | `work/plan_projection.py` | Plan/step run projection from work log entries | Work primitive | Keep. |
-| `work/coding.py` | `CodingWorkShell` for `SubmitCodingTurn` | Transitional coupling | Do not expand. Later move to `loushang.coding` adapter or replace with generic work runner. |
-| `work/__init__.py` | Work exports | Work primitive | Avoid expanding coding-specific exports. |
+| `work/coding.py` | `CodingWorkShell` for `SubmitCodingTurn` | Transitional compatibility | Do not expand. Coding runtime should import through `loushang.coding.work_shell`. |
+| `work/__init__.py` | Work exports | Work primitive plus compatibility exports | Avoid expanding coding-specific exports. |
 
-`CodingWorkShell` is useful but product-specific. Its existence under `work`
-should be treated as a compatibility bridge, not a pattern for future
-`ResearchWorkShell`, `PptWorkShell`, or `CoworkWorkShell` modules inside
-`loushang.work`.
+`CodingWorkShell` is useful but product-specific. `loushang.coding.work_shell`
+is the coding-owned entrypoint. The `loushang.work` export is retained as a
+compatibility bridge, not a pattern for future `ResearchWorkShell`,
+`PptWorkShell`, or `CoworkWorkShell` modules inside `loushang.work`.
 
 ## `loushang.method`
 
@@ -228,10 +228,10 @@ These names are intentionally excluded from `loushang.agent.harness`:
 - coding package/plugin materialization
 - TUI playback and UI controllers
 
-## Recommended Follow-up Sequence
+## Current Follow-up Sequence
 
-1. Add thin `loushang.agent.harness` facade and tests.
-2. Let one narrow headless coding path call the harness.
-3. Add `loushang.work.ArtifactRef`.
-4. Move or replace `work.coding.CodingWorkShell` with a product adapter boundary.
-5. Isolate method resource loading from `loushang.coding.loader`.
+1. Completed: add thin `loushang.agent.harness` facade and tests.
+2. Completed: add `loushang.work.ArtifactRef`.
+3. Completed: move coding runtime imports to the `loushang.coding.work_shell` adapter.
+4. Next: let one narrow headless coding path call the harness.
+5. Next: isolate method resource loading from `loushang.coding.loader`.

--- a/src/loushang/coding/mode/print_mode.py
+++ b/src/loushang/coding/mode/print_mode.py
@@ -15,7 +15,8 @@ from loushang.coding.event import (
 from loushang.coding.message.json_codec import serialize_session_header
 from loushang.coding.mode.base import ModeAdapter, ModeState
 from loushang.coding.tools import ToolDefinitionResolver, ToolRenderRuntime
-from loushang.work import CodingWorkShell, EventLogBackend
+from loushang.coding.work_shell import CodingWorkShell
+from loushang.work import EventLogBackend
 
 
 class PrintMode(ModeAdapter):

--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -8,7 +8,8 @@ from typing import Any, Mapping, Sequence, TextIO
 from loushang.coding.ui.events import CodingUiEventRenderer
 from loushang.coding.ui.model import ensure_usable_session_model
 from loushang.coding.ui.renderer import CodingUiRenderer
-from loushang.work import CodingWorkShell, EventLogBackend
+from loushang.coding.work_shell import CodingWorkShell
+from loushang.work import EventLogBackend
 
 
 async def run_prompt_command(

--- a/src/loushang/coding/work_shell.py
+++ b/src/loushang/coding/work_shell.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from loushang.work import CodingWorkShell
+
+__all__ = ["CodingWorkShell"]

--- a/tests/coding/test_work_shell_adapter.py
+++ b/tests/coding/test_work_shell_adapter.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+
+def test_coding_work_shell_adapter_exposes_coding_owned_entrypoint() -> None:
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import CodingWorkShell as CompatCodingWorkShell
+
+    assert CodingWorkShell is CompatCodingWorkShell


### PR DESCRIPTION
## Summary
- Add `loushang.coding.work_shell` as the coding-owned entrypoint for `CodingWorkShell`.
- Route prompt and print coding runtime imports through the new adapter while keeping the `loushang.work` compatibility export.
- Update the architecture ownership inventory to reflect the current boundary.

## 中文说明
- 新增 `loushang.coding.work_shell`，作为 coding 产品侧拥有的 `CodingWorkShell` 入口。
- 将 prompt/print 运行路径改为从 coding adapter 导入，同时保留 `loushang.work` 兼容导出。
- 更新 ownership inventory，记录当前边界和后续推进顺序。

## Validation
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_work_shell_adapter.py tests/coding/test_prompt_command.py tests/coding/test_print_mode.py tests/work/test_public_api.py tests/work/test_coding_work_shell.py -q`
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/work_shell.py src/loushang/coding/prompt_command.py src/loushang/coding/mode/print_mode.py tests/coding/test_work_shell_adapter.py`
- `git diff --check origin/main...HEAD`