### PR TITLE
refactor(agent): route runtime through harness

### DIFF
--- a/docs/internals/architecture/agent/README.md
+++ b/docs/internals/architecture/agent/README.md
@@ -40,9 +40,11 @@ await agent.prompt("Hello")
 low-level loop. It is not a testing-only harness.
 
 The initial harness exposes a thin product-adapter surface:
-`AgentRunSpec`, `AgentRunResult`, and `run_agent()`. It reuses the existing
-agent loop and keeps coding, work, method, research, ppt, and cowork product
-semantics outside `loushang.agent`.
+`AgentRunSpec`, `AgentRunResult`, and `run_agent()`. `AgentRunSpec` may carry an
+`event_sink` so stateful hosts can keep their existing event lifecycle while
+delegating loop execution to the harness. The harness reuses the existing agent
+loop and keeps coding, work, method, research, ppt, and cowork product semantics
+outside `loushang.agent`.
 
 The harness API is intentionally imported from `loushang.agent.harness`; it is
 not re-exported from `loushang.agent.__init__` while the adapter contract

--- a/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
+++ b/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
@@ -74,7 +74,7 @@ resource-loader / product-adapter cleanup.
 | --- | --- | --- | --- |
 | `agent/types.py` | Agent messages, tool protocols, loop config, event types, state types | Keep / Harness input | Reuse types from harness. Do not move. |
 | `agent/agent_loop.py` | Low-level run loop, event emission, model stream and tool execution orchestration | Keep / Harness input | `run_agent()` should call existing loop functions. Do not duplicate the loop. |
-| `agent/agent.py` | Stateful `Agent` facade, queues, active run lifecycle, subscriptions | Keep | Do not rewrite for P2. Harness may bypass it and call the loop directly. |
+| `agent/agent.py` | Stateful `Agent` facade, queues, active run lifecycle, subscriptions | Keep / Harness host | Keep lifecycle here; delegate prompt and continuation loop execution through `agent.harness`. |
 | `agent/proxy.py` | Proxy stream adapter | Keep | No P2 change. |
 | `agent/__init__.py` | Stable public exports | Keep | Do not re-export harness API in P2. |
 | `agent/harness/*` | Headless run scaffolding for product adapters | Harness candidate | Add in P2 as a thin facade only. |
@@ -233,5 +233,5 @@ These names are intentionally excluded from `loushang.agent.harness`:
 1. Completed: add thin `loushang.agent.harness` facade and tests.
 2. Completed: add `loushang.work.ArtifactRef`.
 3. Completed: move coding runtime imports to the `loushang.coding.work_shell` adapter.
-4. Next: let one narrow headless coding path call the harness.
+4. Completed: route `Agent` prompt and continuation execution through `agent.harness` while preserving the stateful lifecycle.
 5. Next: isolate method resource loading from `loushang.coding.loader`.

--- a/src/loushang/agent/agent.py
+++ b/src/loushang/agent/agent.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Mapping
 from typing import Any, Awaitable, Callable
 
-from loushang.agent.agent_loop import run_agent_loop, run_agent_loop_continue
+from loushang.agent.harness import AgentRunResult, AgentRunSpec, run_agent
 from loushang.agent.types import (
     AfterToolCallContext,
     AfterToolCallResult,
@@ -83,6 +83,14 @@ def _default_convert_to_llm(messages: list[AgentMessage]) -> list[Message]:
         or isinstance(message, AssistantMessage)
         or getattr(message, "role", None) == "toolResult"
     ]
+
+
+def _raise_failed_run(result: AgentRunResult) -> None:
+    if result.status != "failed":
+        return
+    if result.error is not None:
+        raise result.error
+    raise RuntimeError("Agent run failed")
 
 
 class AbortSignal:
@@ -431,26 +439,33 @@ class Agent:
 
     async def _run_prompt_messages(self, messages: list[AgentMessage], skip_initial_steering_poll: bool = False) -> None:
         async def executor(signal: AbortSignal) -> None:
-            await run_agent_loop(
-                messages,
-                self._create_context_snapshot(),
-                self._create_loop_config(skip_initial_steering_poll=skip_initial_steering_poll),
-                self._process_event,
-                signal=signal,
-                stream_fn=self.stream_fn,
+            result = await run_agent(
+                AgentRunSpec(
+                    prompts=tuple(messages),
+                    context=self._create_context_snapshot(),
+                    config=self._create_loop_config(skip_initial_steering_poll=skip_initial_steering_poll),
+                    signal=signal,
+                    stream_fn=self.stream_fn,
+                    event_sink=self._process_event,
+                )
             )
+            _raise_failed_run(result)
 
         await self._run_with_lifecycle(executor)
 
     async def _run_continuation(self) -> None:
         async def executor(signal: AbortSignal) -> None:
-            await run_agent_loop_continue(
-                self._create_context_snapshot(),
-                self._create_loop_config(),
-                self._process_event,
-                signal=signal,
-                stream_fn=self.stream_fn,
+            result = await run_agent(
+                AgentRunSpec(
+                    context=self._create_context_snapshot(),
+                    config=self._create_loop_config(),
+                    mode="continue",
+                    signal=signal,
+                    stream_fn=self.stream_fn,
+                    event_sink=self._process_event,
+                )
             )
+            _raise_failed_run(result)
 
         await self._run_with_lifecycle(executor)
 

--- a/src/loushang/agent/harness/runner.py
+++ b/src/loushang/agent/harness/runner.py
@@ -10,6 +10,10 @@ async def run_agent(spec: AgentRunSpec) -> AgentRunResult:
 
     async def emit(event: AgentEvent) -> None:
         events.append(event)
+        if spec.event_sink is not None:
+            result = spec.event_sink(event)
+            if result is not None:
+                await result
 
     try:
         if spec.mode == "continue":

--- a/src/loushang/agent/harness/types.py
+++ b/src/loushang/agent/harness/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -13,6 +14,7 @@ from loushang.agent.types import (
 
 AgentRunMode = Literal["prompt", "continue"]
 AgentRunStatus = Literal["completed", "failed"]
+AgentEventSink = Callable[[AgentEvent], Awaitable[None] | None]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -23,6 +25,7 @@ class AgentRunSpec:
     mode: AgentRunMode = "prompt"
     signal: object | None = None
     stream_fn: StreamFn | None = None
+    event_sink: AgentEventSink | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/agent/test_agent_harness.py
+++ b/tests/agent/test_agent_harness.py
@@ -109,6 +109,33 @@ def test_run_agent_collects_events_and_new_messages_for_prompt_run() -> None:
     assert result.new_messages[-1].content[0].text == "hello"
 
 
+def test_run_agent_forwards_events_to_external_sink() -> None:
+    from loushang.agent.harness import AgentRunSpec, run_agent
+    from loushang.agent.types import AgentContext
+
+    forwarded_events: list[str] = []
+
+    async def stream_fn(model, context, options=None):
+        return _stream_with_final_message(_assistant_text_message("hello"))
+
+    async def event_sink(event):
+        forwarded_events.append(event["type"])
+
+    prompt = UserMessage(role="user", content="hi", timestamp=0.0)
+    spec = AgentRunSpec(
+        prompts=(prompt,),
+        context=AgentContext(system_prompt="system", messages=()),
+        config=_config(),
+        stream_fn=stream_fn,
+        event_sink=event_sink,
+    )
+
+    result = asyncio.run(run_agent(spec))
+
+    assert result.status == "completed"
+    assert forwarded_events == [event["type"] for event in result.events]
+
+
 def test_run_agent_can_continue_from_existing_context() -> None:
     from loushang.agent.harness import AgentRunSpec, run_agent
     from loushang.agent.types import AgentContext

--- a/tests/agent/test_agent_runtime.py
+++ b/tests/agent/test_agent_runtime.py
@@ -164,6 +164,43 @@ def test_prompt_updates_state_and_notifies_subscribers() -> None:
     asyncio.run(scenario())
 
 
+def test_prompt_routes_execution_through_harness(monkeypatch) -> None:
+    import loushang.agent.agent as agent_module
+    from loushang.agent import Agent
+    from loushang.agent.harness import AgentRunResult
+
+    calls: list[object] = []
+
+    async def fake_run_agent(spec):
+        calls.append(spec)
+        assert [getattr(message, "role", None) for message in spec.prompts] == ["user"]
+        assert spec.mode == "prompt"
+
+        assistant = _assistant_text_message("via harness")
+        assert spec.event_sink is not None
+        await spec.event_sink({"type": "message_end", "message": spec.prompts[0]})
+        await spec.event_sink({"type": "message_end", "message": assistant})
+        return AgentRunResult(
+            status="completed",
+            new_messages=(*spec.prompts, assistant),
+            events=(),
+            stop_reason="stop",
+        )
+
+    monkeypatch.setattr(agent_module, "run_agent", fake_run_agent)
+
+    async def scenario() -> None:
+        agent = Agent()
+
+        await agent.prompt("hi")
+
+        assert len(calls) == 1
+        assert [getattr(message, "role", None) for message in agent.state.messages] == ["user", "assistant"]
+        assert agent.state.messages[-1].content[0].text == "via harness"
+
+    asyncio.run(scenario())
+
+
 def test_subscribe_deduplicates_same_listener() -> None:
     from loushang.agent import Agent
 


### PR DESCRIPTION
## Summary
- Add an optional `event_sink` to `AgentRunSpec` so stateful hosts can reuse the harness while preserving event lifecycle handling.
- Route `Agent.prompt()` and continuation execution through `loushang.agent.harness.run_agent()` instead of calling the low-level loop directly.
- Update agent architecture docs to reflect the harness-host boundary.

## 中文说明
- 为 `AgentRunSpec` 增加可选 `event_sink`，让有状态 host 可以复用 harness，同时保留原有事件生命周期处理。
- 将 `Agent.prompt()` 和 continuation 执行路径改为通过 `loushang.agent.harness.run_agent()`，不再直接调用低层 loop。
- 更新 agent 架构文档，记录当前 harness-host 边界。

## Validation
- `uv --cache-dir .uv-cache run --extra dev pytest tests/agent -q`
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_prompt_command.py tests/coding/test_print_mode.py -q`
- `uv --cache-dir .uv-cache run ruff check src/loushang/agent tests/agent`
- `git diff --check origin/main...HEAD`