### PR TITLE
feat(channel): add boundary envelope types

### DIFF
--- a/docs/internals/architecture/README.md
+++ b/docs/internals/architecture/README.md
@@ -28,6 +28,7 @@ history, experimental notes, or legacy documents.
 
 - [AI](ai/README.md)
 - [Agent](agent/README.md)
+- [Channel](channel/README.md)
 - [Coding](coding/loushang-coding-system-context.md)
 - [Method](method/README.md)
 - [TUI](tui/README.md)

--- a/docs/internals/architecture/architecture-overview.md
+++ b/docs/internals/architecture/architecture-overview.md
@@ -19,6 +19,7 @@
 
 - `loushang.ai`
 - `loushang.agent`
+- `loushang.channel`
 - `loushang.coding`
 - `loushang.method`
 - `loushang.tui`
@@ -27,10 +28,10 @@
 - `loushang.observability`
 - `loushang.ontology`
 
-`loushang.channel` 仍是重要的目标架构层，但当前没有 `src/loushang/channel/`
-包。现有 RPC/JSONL 能力先作为 `loushang.coding.mode.RpcMode` 的
-transitional surface 存在；后续 channel 层成熟后再上提为
-`loushang.channel.rpc_jsonl` 等 adapter。
+`loushang.channel` 已有最小协议类型包，用于承载 `WorkOperation` /
+`WorkEvent` 边界消息。现有 RPC/JSONL 能力仍先作为
+`loushang.coding.mode.RpcMode` 的 transitional surface 存在；后续 channel
+层成熟后再上提为 `loushang.channel.rpc_jsonl` 等 adapter。
 
 当前仓库结构应按已落地包理解：
 
@@ -41,6 +42,7 @@ loushang/
     loushang/
       ai/
       agent/
+      channel/
       coding/
       method/
       tui/
@@ -79,7 +81,7 @@ CLI / TUI
   log 与 plan/step projection
 - `loushang.tui` 提供通用 terminal-native UI primitives，`loushang.coding.ui`
   将 coding session 状态适配到 TUI
-- `loushang.channel` 是未来边界协议层，不是当前 V1 起步前置条件
+- `loushang.channel` 提供最小边界协议类型；具体 transport adapter 仍是后续工作
 
 其中：
 
@@ -89,13 +91,14 @@ CLI / TUI
 - `work` 提供 run/event/log/projection
 - `tui` 提供通用终端 UI primitives
 - `coding` 提供产品化装配，并通过 `loushang.coding.ui` 连接 coding core 与 `loushang.tui`
-- `channel` 定义目标边界通信协议，待独立落地
+- `channel` 定义边界通信协议类型，当前已落地最小 envelope / endpoint surface
 
 ## Agent and Channel Documentation
 
 当前 agent / channel 相关文档包括：
 
 - [Loushang-AI Architecture](./ai/README.md)
+- [Loushang Channel Architecture](./channel/README.md)
 - [Loushang AI Glossary](../glossary/loushang-ai.md)
 - [Loushang AI Types](../glossary/loushang-ai-types.md)
 - [Loushang Agent](../glossary/loushang-agent.md)
@@ -108,6 +111,6 @@ CLI / TUI
 下一步建议继续完善：
 
 1. `loushang.work` 与 method plan/step failure projection 的硬化
-2. `loushang.channel` 的最小边界协议和 `rpc_jsonl` adapter 草案
+2. `loushang.channel.rpc_jsonl` adapter 草案和 operation/event delivery 行为
 3. TUI method status layer 与 `WorkEvent` / `WorkPlanRun` projection
 4. public CLI reference 对 method/work/package surface 的补齐

--- a/docs/internals/architecture/channel/README.md
+++ b/docs/internals/architecture/channel/README.md
@@ -1,0 +1,65 @@
+# Loushang Channel Architecture
+
+## Scope
+
+`loushang.channel` owns boundary protocol primitives for clients, hosts, SDKs,
+RPC surfaces, and future WebUI/AppUI adapters.
+
+The current implementation is intentionally small. It defines endpoint and
+envelope types that can carry `loushang.work.WorkOperation` and
+`loushang.work.WorkEvent` across a boundary.
+
+## Current Package Surface
+
+Current code package:
+
+```text
+src/loushang/channel/
+  __init__.py
+  types.py
+```
+
+Current public types:
+
+- `ChannelEndpoint`
+- `ChannelEnvelope`
+- `ChannelEnvelopeKind`
+- `ChannelPayload`
+
+`ChannelEnvelope` accepts only two payload families:
+
+- `kind="operation"` with a `WorkOperation`
+- `kind="event"` with a `WorkEvent`
+
+This first surface is a protocol skeleton, not a transport implementation.
+
+## Ownership
+
+`loushang.channel` may depend on `loushang.work` because the channel boundary
+carries work operations and work events.
+
+`loushang.channel` must not depend on:
+
+- `loushang.agent`
+- `loushang.coding`
+- `loushang.method`
+- `loushang.tui`
+
+Product packages remain responsible for turning domain-specific input into
+`WorkOperation` objects and for projecting `WorkEvent` objects into product or UI
+state.
+
+## Not In Scope
+
+The current channel package does not implement:
+
+- JSONL, HTTP, WebSocket, or in-process transport adapters
+- request/response correlation
+- capability negotiation
+- replay or audit storage
+- UI layout, widgets, or rendering
+- direct agent loop or product session control
+
+The next likely implementation step is a small `rpc_jsonl` adapter design that
+maps JSONL framing onto `ChannelEnvelope` without reusing the legacy
+coding-specific RPC command table.

--- a/docs/internals/architecture/subsystem-diagram.md
+++ b/docs/internals/architecture/subsystem-diagram.md
@@ -12,7 +12,7 @@ graph TD
     METHOD[loushang-method]
     WORK[loushang-work]
     TUI[loushang-tui<br/>generic terminal UI]
-    CHANNEL[loushang-channel<br/>target only]
+    CHANNEL[loushang-channel<br/>boundary protocol]
 
     subgraph CODING[loushang-coding]
         CODING_CORE[coding core<br/>runtime / session / tools]
@@ -27,13 +27,14 @@ graph TD
     CODING_UI --> CODING_CORE
     CODING_UI --> TUI
 
-    CHANNEL -. future protocol boundary .-> WORK
+    CHANNEL --> WORK
 ```
 
 `loushang-tui` is a generic terminal UI subsystem. Coding-specific terminal behavior lives in
 `loushang.coding.ui`, which depends on both `loushang-tui` and the headless
 `loushang-coding` core.
 
-`loushang-channel` is target architecture only. The current RPC implementation is the
-`loushang.coding.mode.RpcMode` surface, not a package-level `src/loushang/channel/`
-implementation.
+`loushang-channel` currently owns the minimal boundary protocol types for carrying
+`WorkOperation` and `WorkEvent`. The current RPC implementation remains the
+transitional `loushang.coding.mode.RpcMode` surface; future transport adapters
+should live under `loushang.channel`.

--- a/src/loushang/channel/__init__.py
+++ b/src/loushang/channel/__init__.py
@@ -1,0 +1,15 @@
+"""Channel boundary protocol primitives."""
+
+from loushang.channel.types import (
+    ChannelEndpoint,
+    ChannelEnvelope,
+    ChannelEnvelopeKind,
+    ChannelPayload,
+)
+
+__all__ = [
+    "ChannelEndpoint",
+    "ChannelEnvelope",
+    "ChannelEnvelopeKind",
+    "ChannelPayload",
+]

--- a/src/loushang/channel/types.py
+++ b/src/loushang/channel/types.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal, TypeAlias
+
+from loushang.work import WorkEvent, WorkOperation
+
+ChannelEnvelopeKind: TypeAlias = Literal["operation", "event"]
+ChannelPayload: TypeAlias = WorkOperation | WorkEvent
+
+
+@dataclass(frozen=True)
+class ChannelEndpoint:
+    endpoint_id: str
+    kind: str
+    session_id: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ChannelEnvelope:
+    envelope_id: str
+    kind: ChannelEnvelopeKind
+    payload: ChannelPayload
+    source: ChannelEndpoint | None = None
+    target: ChannelEndpoint | None = None
+    created_at: datetime | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.kind not in ("operation", "event"):
+            raise ValueError("channel envelope kind must be 'operation' or 'event'")
+        if self.kind == "operation" and not isinstance(self.payload, WorkOperation):
+            actual = _payload_name(self.payload)
+            raise TypeError(f"operation channel envelopes cannot carry {actual} payload")
+        if self.kind == "event" and not isinstance(self.payload, WorkEvent):
+            actual = _payload_name(self.payload)
+            raise TypeError(f"event channel envelopes cannot carry {actual} payload")
+
+
+def _payload_name(payload: object) -> str:
+    if isinstance(payload, WorkOperation):
+        return "operation"
+    if isinstance(payload, WorkEvent):
+        return "event"
+    return type(payload).__name__
+
+
+__all__ = [
+    "ChannelEndpoint",
+    "ChannelEnvelope",
+    "ChannelEnvelopeKind",
+    "ChannelPayload",
+]

--- a/tests/channel/test_channel_types.py
+++ b/tests/channel/test_channel_types.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime
+
+import pytest
+
+
+def test_channel_public_api_exposes_minimal_boundary_surface() -> None:
+    import loushang.channel as channel
+
+    assert set(channel.__all__) == {
+        "ChannelEndpoint",
+        "ChannelEnvelope",
+        "ChannelEnvelopeKind",
+        "ChannelPayload",
+    }
+
+
+def test_channel_envelope_carries_work_operation_between_endpoints() -> None:
+    from loushang.channel import ChannelEndpoint, ChannelEnvelope
+    from loushang.work import WorkOperation
+
+    operation = WorkOperation(
+        operation_id="op-1",
+        kind="SubmitCodingTurn",
+        session_id="session-1",
+        domain="coding",
+        payload={"text": "inspect the repository"},
+    )
+    source = ChannelEndpoint(
+        endpoint_id="client:tui",
+        kind="tui",
+        session_id="session-1",
+        metadata={"transport": "in_process"},
+    )
+    target = ChannelEndpoint(endpoint_id="host:local", kind="host")
+
+    envelope = ChannelEnvelope(
+        envelope_id="env-1",
+        kind="operation",
+        payload=operation,
+        source=source,
+        target=target,
+        metadata={"trace_id": "trace-1"},
+    )
+
+    assert envelope.kind == "operation"
+    assert envelope.payload is operation
+    assert envelope.source is source
+    assert envelope.target is target
+    assert envelope.metadata == {"trace_id": "trace-1"}
+    assert envelope.created_at is None
+    assert source.metadata == {"transport": "in_process"}
+    assert not hasattr(envelope, "render")
+    assert not hasattr(envelope, "execute")
+
+    with pytest.raises(FrozenInstanceError):
+        envelope.kind = "event"  # type: ignore[misc]
+
+
+def test_channel_envelope_carries_work_event_for_client_delivery() -> None:
+    from loushang.channel import ChannelEnvelope
+    from loushang.work import WorkEvent
+
+    created_at = datetime(2026, 6, 10, 12, 30, tzinfo=UTC)
+    event = WorkEvent(
+        event_id="event-1",
+        kind="ContentDelta",
+        run_id="run-1",
+        session_id="session-1",
+        domain="coding",
+        operation_id="op-1",
+        sequence=1,
+        created_at=created_at,
+        delivery_hint="coalesce",
+        payload={"text": "hello"},
+    )
+
+    envelope = ChannelEnvelope(
+        envelope_id="env-2",
+        kind="event",
+        payload=event,
+        created_at=created_at,
+    )
+
+    assert envelope.kind == "event"
+    assert envelope.payload is event
+    assert envelope.created_at is created_at
+
+
+def test_channel_envelope_rejects_mismatched_payload_kind() -> None:
+    from loushang.channel import ChannelEnvelope
+    from loushang.work import WorkOperation
+
+    operation = WorkOperation(
+        operation_id="op-1",
+        kind="SubmitCodingTurn",
+        session_id="session-1",
+        domain="coding",
+        payload={"text": "inspect the repository"},
+    )
+
+    with pytest.raises(TypeError, match="operation"):
+        ChannelEnvelope(envelope_id="env-1", kind="event", payload=operation)
+
+
+def test_channel_envelope_rejects_unknown_kind_at_runtime() -> None:
+    from loushang.channel import ChannelEnvelope
+    from loushang.work import WorkOperation
+
+    operation = WorkOperation(
+        operation_id="op-1",
+        kind="SubmitCodingTurn",
+        session_id="session-1",
+        domain="coding",
+        payload={"text": "inspect the repository"},
+    )
+
+    with pytest.raises(ValueError, match="kind"):
+        ChannelEnvelope(
+            envelope_id="env-1",
+            kind="response",  # type: ignore[arg-type]
+            payload=operation,
+        )

--- a/tests/channel/test_package_boundaries.py
+++ b/tests/channel/test_package_boundaries.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_channel_package_does_not_import_product_or_runtime_layers() -> None:
+    source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in Path("src/loushang/channel").glob("*.py")
+        if path.name != "__pycache__"
+    )
+
+    assert "loushang.agent" not in source
+    assert "loushang.coding" not in source
+    assert "loushang.method" not in source
+    assert "loushang.tui" not in source


### PR DESCRIPTION
## Summary
- Add the initial `loushang.channel` package with `ChannelEndpoint` and `ChannelEnvelope` boundary types.
- Restrict envelopes to `WorkOperation` and `WorkEvent` payloads with runtime validation.
- Document the current channel boundary and update architecture overview/diagram.

## 摘要
- 新增最小 `loushang.channel` 包，提供 `ChannelEndpoint` 和 `ChannelEnvelope` 边界类型。
- envelope 仅承载 `WorkOperation` / `WorkEvent`，并做运行时校验。
- 补充 channel 架构说明，并同步总览与子系统关系图。

## Test Plan / 验证
- `uv --cache-dir .uv-cache run --extra dev pytest tests/channel tests/work/test_public_api.py tests/work/test_work_types.py -q` -> 12 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/channel tests/channel` -> All checks passed
- `git diff --check` -> no output