### PR TITLE
feat(channel): add envelope json codec

### DIFF
--- a/docs/internals/architecture/channel/README.md
+++ b/docs/internals/architecture/channel/README.md
@@ -16,6 +16,7 @@ Current code package:
 ```text
 src/loushang/channel/
   __init__.py
+  json_codec.py
   types.py
 ```
 
@@ -26,12 +27,18 @@ Current public types:
 - `ChannelEnvelopeKind`
 - `ChannelPayload`
 
+Current public codec helpers:
+
+- `channel_envelope_to_json`
+- `channel_envelope_from_json`
+
 `ChannelEnvelope` accepts only two payload families:
 
 - `kind="operation"` with a `WorkOperation`
 - `kind="event"` with a `WorkEvent`
 
-This first surface is a protocol skeleton, not a transport implementation.
+`json_codec.py` converts those envelopes to and from JSON-compatible Python
+dicts. This is still a protocol skeleton, not a transport implementation.
 
 ## Ownership
 

--- a/src/loushang/channel/__init__.py
+++ b/src/loushang/channel/__init__.py
@@ -1,5 +1,9 @@
 """Channel boundary protocol primitives."""
 
+from loushang.channel.json_codec import (
+    channel_envelope_from_json,
+    channel_envelope_to_json,
+)
 from loushang.channel.types import (
     ChannelEndpoint,
     ChannelEnvelope,
@@ -12,4 +16,6 @@ __all__ = [
     "ChannelEnvelope",
     "ChannelEnvelopeKind",
     "ChannelPayload",
+    "channel_envelope_from_json",
+    "channel_envelope_to_json",
 ]

--- a/src/loushang/channel/json_codec.py
+++ b/src/loushang/channel/json_codec.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Literal, cast
+
+from loushang.channel.types import ChannelEndpoint, ChannelEnvelope
+from loushang.work import WorkEvent, WorkOperation
+
+
+def channel_envelope_to_json(envelope: ChannelEnvelope) -> dict[str, object]:
+    return {
+        "envelope_id": envelope.envelope_id,
+        "kind": envelope.kind,
+        "payload": _payload_to_json(envelope.payload),
+        "source": _endpoint_to_json(envelope.source),
+        "target": _endpoint_to_json(envelope.target),
+        "created_at": envelope.created_at.isoformat() if envelope.created_at is not None else None,
+        "metadata": _to_json_mapping(envelope.metadata),
+    }
+
+
+def channel_envelope_from_json(data: Mapping[str, object]) -> ChannelEnvelope:
+    kind = cast(Literal["operation", "event"], data["kind"])
+    if kind not in ("operation", "event"):
+        raise ValueError("channel envelope kind must be 'operation' or 'event'")
+    payload_data = _require_mapping(data["payload"], "payload")
+    return ChannelEnvelope(
+        envelope_id=str(data["envelope_id"]),
+        kind=kind,
+        payload=_payload_from_json(kind, payload_data),
+        source=_endpoint_from_json(data.get("source")),
+        target=_endpoint_from_json(data.get("target")),
+        created_at=_datetime_from_json(data.get("created_at")),
+        metadata=_mapping_or_empty(data.get("metadata")),
+    )
+
+
+def _payload_to_json(payload: WorkOperation | WorkEvent) -> dict[str, object]:
+    if isinstance(payload, WorkOperation):
+        return {
+            "operation_id": payload.operation_id,
+            "kind": payload.kind,
+            "session_id": payload.session_id,
+            "domain": payload.domain,
+            "payload": _to_json_mapping(payload.payload),
+            "source": _to_json_mapping(payload.source),
+        }
+    return {
+        "event_id": payload.event_id,
+        "kind": payload.kind,
+        "run_id": payload.run_id,
+        "session_id": payload.session_id,
+        "domain": payload.domain,
+        "operation_id": payload.operation_id,
+        "sequence": payload.sequence,
+        "created_at": payload.created_at.isoformat(),
+        "delivery_hint": payload.delivery_hint,
+        "payload": _to_json_mapping(payload.payload),
+        "source_event_ref": payload.source_event_ref,
+    }
+
+
+def _payload_from_json(kind: Literal["operation", "event"], data: Mapping[str, object]) -> WorkOperation | WorkEvent:
+    if kind == "operation":
+        return WorkOperation(
+            operation_id=str(data["operation_id"]),
+            kind=str(data["kind"]),
+            session_id=cast(str | None, data["session_id"]),
+            domain=str(data["domain"]),
+            payload=_mapping_or_empty(data.get("payload")),
+            source=_mapping_or_empty(data.get("source")),
+        )
+    return WorkEvent(
+        event_id=str(data["event_id"]),
+        kind=str(data["kind"]),
+        run_id=str(data["run_id"]),
+        session_id=str(data["session_id"]),
+        domain=str(data["domain"]),
+        operation_id=str(data["operation_id"]),
+        sequence=int(cast(int, data["sequence"])),
+        created_at=_required_datetime_from_json(data["created_at"]),
+        delivery_hint=cast(Literal["immediate", "coalesce", "final_only"], data["delivery_hint"]),
+        payload=_mapping_or_empty(data.get("payload")),
+        source_event_ref=cast(str | None, data.get("source_event_ref")),
+    )
+
+
+def _endpoint_to_json(endpoint: ChannelEndpoint | None) -> dict[str, object] | None:
+    if endpoint is None:
+        return None
+    return {
+        "endpoint_id": endpoint.endpoint_id,
+        "kind": endpoint.kind,
+        "session_id": endpoint.session_id,
+        "metadata": _to_json_mapping(endpoint.metadata),
+    }
+
+
+def _endpoint_from_json(value: object) -> ChannelEndpoint | None:
+    if value is None:
+        return None
+    data = _require_mapping(value, "endpoint")
+    return ChannelEndpoint(
+        endpoint_id=str(data["endpoint_id"]),
+        kind=str(data["kind"]),
+        session_id=cast(str | None, data.get("session_id")),
+        metadata=_mapping_or_empty(data.get("metadata")),
+    )
+
+
+def _datetime_from_json(value: object) -> datetime | None:
+    if value is None:
+        return None
+    return _required_datetime_from_json(value)
+
+
+def _required_datetime_from_json(value: object) -> datetime:
+    return datetime.fromisoformat(str(value))
+
+
+def _mapping_or_empty(value: object) -> Mapping[str, object]:
+    if value is None:
+        return {}
+    return _require_mapping(value, "mapping")
+
+
+def _require_mapping(value: object, field_name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field_name} must be a JSON object")
+    return value
+
+
+def _to_json_mapping(value: Mapping[str, object]) -> dict[str, object]:
+    return {str(key): _to_json_value(item) for key, item in value.items()}
+
+
+def _to_json_value(value: object) -> object:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return _to_json_mapping(value)
+    if isinstance(value, list | tuple):
+        return [_to_json_value(item) for item in value]
+    return repr(value)
+
+
+__all__ = [
+    "channel_envelope_from_json",
+    "channel_envelope_to_json",
+]

--- a/tests/channel/test_channel_types.py
+++ b/tests/channel/test_channel_types.py
@@ -14,6 +14,8 @@ def test_channel_public_api_exposes_minimal_boundary_surface() -> None:
         "ChannelEnvelope",
         "ChannelEnvelopeKind",
         "ChannelPayload",
+        "channel_envelope_from_json",
+        "channel_envelope_to_json",
     }
 
 

--- a/tests/channel/test_json_codec.py
+++ b/tests/channel/test_json_codec.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+
+def test_channel_envelope_json_round_trips_work_operation() -> None:
+    from loushang.channel import (
+        ChannelEndpoint,
+        ChannelEnvelope,
+        channel_envelope_from_json,
+        channel_envelope_to_json,
+    )
+    from loushang.work import WorkOperation
+
+    created_at = datetime(2026, 6, 10, 13, 0, tzinfo=UTC)
+    envelope = ChannelEnvelope(
+        envelope_id="env-1",
+        kind="operation",
+        payload=WorkOperation(
+            operation_id="op-1",
+            kind="SubmitCodingTurn",
+            session_id="session-1",
+            domain="coding",
+            payload={"text": "inspect", "paths": ("src", "tests")},
+            source={"client": "tui"},
+        ),
+        source=ChannelEndpoint(endpoint_id="client:tui", kind="tui", session_id="session-1"),
+        target=ChannelEndpoint(endpoint_id="host:local", kind="host", metadata={"pid": 123}),
+        created_at=created_at,
+        metadata={"trace_id": "trace-1"},
+    )
+
+    data = channel_envelope_to_json(envelope)
+
+    assert json.loads(json.dumps(data, sort_keys=True)) == data
+    assert data == {
+        "envelope_id": "env-1",
+        "kind": "operation",
+        "payload": {
+            "operation_id": "op-1",
+            "kind": "SubmitCodingTurn",
+            "session_id": "session-1",
+            "domain": "coding",
+            "payload": {"text": "inspect", "paths": ["src", "tests"]},
+            "source": {"client": "tui"},
+        },
+        "source": {
+            "endpoint_id": "client:tui",
+            "kind": "tui",
+            "session_id": "session-1",
+            "metadata": {},
+        },
+        "target": {
+            "endpoint_id": "host:local",
+            "kind": "host",
+            "session_id": None,
+            "metadata": {"pid": 123},
+        },
+        "created_at": "2026-06-10T13:00:00+00:00",
+        "metadata": {"trace_id": "trace-1"},
+    }
+
+    decoded = channel_envelope_from_json(data)
+
+    assert decoded == ChannelEnvelope(
+        envelope_id="env-1",
+        kind="operation",
+        payload=WorkOperation(
+            operation_id="op-1",
+            kind="SubmitCodingTurn",
+            session_id="session-1",
+            domain="coding",
+            payload={"text": "inspect", "paths": ["src", "tests"]},
+            source={"client": "tui"},
+        ),
+        source=ChannelEndpoint(endpoint_id="client:tui", kind="tui", session_id="session-1"),
+        target=ChannelEndpoint(endpoint_id="host:local", kind="host", metadata={"pid": 123}),
+        created_at=created_at,
+        metadata={"trace_id": "trace-1"},
+    )
+
+
+def test_channel_envelope_json_round_trips_work_event() -> None:
+    from loushang.channel import (
+        ChannelEnvelope,
+        channel_envelope_from_json,
+        channel_envelope_to_json,
+    )
+    from loushang.work import WorkEvent
+
+    event_created_at = datetime(2026, 6, 10, 13, 1, tzinfo=UTC)
+    envelope_created_at = datetime(2026, 6, 10, 13, 2, tzinfo=UTC)
+    envelope = ChannelEnvelope(
+        envelope_id="env-2",
+        kind="event",
+        payload=WorkEvent(
+            event_id="event-1",
+            kind="ContentDelta",
+            run_id="run-1",
+            session_id="session-1",
+            domain="coding",
+            operation_id="op-1",
+            sequence=7,
+            created_at=event_created_at,
+            delivery_hint="coalesce",
+            payload={"text": "hello"},
+            source_event_ref="agent:event:1",
+        ),
+        created_at=envelope_created_at,
+    )
+
+    data = channel_envelope_to_json(envelope)
+
+    assert data["payload"] == {
+        "event_id": "event-1",
+        "kind": "ContentDelta",
+        "run_id": "run-1",
+        "session_id": "session-1",
+        "domain": "coding",
+        "operation_id": "op-1",
+        "sequence": 7,
+        "created_at": "2026-06-10T13:01:00+00:00",
+        "delivery_hint": "coalesce",
+        "payload": {"text": "hello"},
+        "source_event_ref": "agent:event:1",
+    }
+    assert channel_envelope_from_json(data) == envelope
+
+
+def test_channel_envelope_json_decode_rejects_unknown_kind() -> None:
+    from loushang.channel import channel_envelope_from_json
+
+    with pytest.raises(ValueError, match="kind"):
+        channel_envelope_from_json(
+            {
+                "envelope_id": "env-1",
+                "kind": "response",
+                "payload": {},
+                "source": None,
+                "target": None,
+                "created_at": None,
+                "metadata": {},
+            }
+        )


### PR DESCRIPTION
## Summary
- Add `channel_envelope_to_json()` and `channel_envelope_from_json()` for `ChannelEnvelope` JSON-compatible dict conversion.
- Cover both `WorkOperation` and `WorkEvent` payload families, endpoints, metadata, and datetimes.
- Update channel architecture docs to distinguish JSON dict codec from future JSONL transport adapters.

## 摘要
- 新增 `channel_envelope_to_json()` / `channel_envelope_from_json()`，用于 `ChannelEnvelope` 和 JSON-compatible dict 互转。
- 覆盖 `WorkOperation`、`WorkEvent`、endpoint、metadata 和 datetime。
- 更新 channel 架构文档，明确本次是 JSON dict codec，不是 JSONL transport adapter。

## Test Plan / 验证
- `uv --cache-dir .uv-cache run --extra dev pytest tests/channel tests/work/test_public_api.py tests/work/test_work_types.py -q` -> 15 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/channel tests/channel` -> All checks passed
- `git diff --check` -> no output