### PR TITLE
feat(auth): scope oauth credentials

### DIFF
--- a/src/loushang/ai/auth/__init__.py
+++ b/src/loushang/ai/auth/__init__.py
@@ -1,6 +1,7 @@
 from loushang.ai.auth.env import get_env_api_key, get_env_oauth_credentials
 from loushang.ai.auth.facade import (
     clear_oauth_providers,
+    ensure_builtin_oauth_providers,
     get_oauth_provider,
     list_oauth_providers,
     oauth_login,
@@ -47,6 +48,7 @@ __all__ = [
     "OpenAICodexOAuthProvider",
     "OAuthProviderRegistry",
     "clear_oauth_providers",
+    "ensure_builtin_oauth_providers",
     "get_env_api_key",
     "get_env_oauth_credentials",
     "get_default_oauth_registry",

--- a/src/loushang/ai/auth/facade.py
+++ b/src/loushang/ai/auth/facade.py
@@ -59,6 +59,16 @@ def register_builtin_oauth_providers(
     _register_builtin_oauth_providers(resolved_registry)
 
 
+def ensure_builtin_oauth_providers(
+    *, registry: OAuthProviderRegistry | None = None
+) -> None:
+    resolved_registry = registry or get_default_oauth_registry()
+    if resolved_registry.get_oauth_provider("openai-codex") is None:
+        _register_builtin_openai_codex(resolved_registry)
+    if resolved_registry.get_oauth_provider("anthropic") is None:
+        _register_builtin_anthropic(resolved_registry)
+
+
 def _register_builtin_oauth_providers(registry: OAuthProviderRegistry) -> None:
     _register_builtin_openai_codex(registry)
     _register_builtin_anthropic(registry)

--- a/src/loushang/ai/auth/facade.py
+++ b/src/loushang/ai/auth/facade.py
@@ -6,7 +6,13 @@ from loushang.ai.auth.oauth import GetOAuthApiKeyResult
 from loushang.ai.auth.providers.anthropic import AnthropicOAuthProvider
 from loushang.ai.auth.providers.openai_codex import OpenAICodexOAuthProvider
 from loushang.ai.auth.registry import OAuthProviderRegistry, get_default_oauth_registry
-from loushang.ai.auth.storage import load_credentials, save_credentials
+from loushang.ai.auth.storage import (
+    find_scoped_credential,
+    load_credential_store,
+    save_credential_store,
+    save_credentials,
+    set_scoped_credential,
+)
 from loushang.ai.auth.types import (
     OAuthCredentials,
     OAuthLoginCallbacks,
@@ -91,6 +97,8 @@ async def oauth_login(
     *,
     registry: OAuthProviderRegistry | None = None,
     credentials: Mapping[str, OAuthCredentials] | None = None,
+    endpoint_id: str | None = None,
+    model_id: str | None = None,
     persist: bool = True,
 ) -> OAuthCredentials:
     provider = get_oauth_provider(provider_id, registry=registry)
@@ -98,9 +106,19 @@ async def oauth_login(
         raise ValueError(f"OAuth provider not found: {provider_id}")
     next_credentials = await provider.login(callbacks)
     if persist:
-        stored = dict(load_credentials() if credentials is None else credentials)
-        stored[provider_id] = next_credentials
-        save_credentials(stored)
+        if credentials is not None:
+            stored = dict(credentials)
+            stored[provider_id] = next_credentials
+            save_credentials(stored)
+        else:
+            store = load_credential_store()
+            set_scoped_credential(
+                store,
+                next_credentials,
+                endpoint_id=endpoint_id,
+                model_id=model_id,
+            )
+            save_credential_store(store)
     return next_credentials
 
 
@@ -109,19 +127,35 @@ async def oauth_refresh(
     credentials: OAuthCredentials | None = None,
     *,
     registry: OAuthProviderRegistry | None = None,
+    endpoint_id: str | None = None,
+    model_id: str | None = None,
     persist: bool = True,
 ) -> OAuthCredentials:
     provider = get_oauth_provider(provider_id, registry=registry)
     if provider is None:
         raise ValueError(f"OAuth provider not found: {provider_id}")
-    stored = load_credentials() if (persist or credentials is None) else {}
-    current = credentials or stored.get(provider_id)
+    store = load_credential_store() if (persist or credentials is None) else None
+    current = credentials
+    if current is None and store is not None:
+        current = find_scoped_credential(
+            store,
+            provider_id,
+            endpoint_id=endpoint_id,
+            model_id=model_id,
+        )
     if current is None:
         raise ValueError(f"OAuth credentials not found for provider: {provider_id}")
     refreshed = await provider.refresh_token(current)
     if persist:
-        stored[provider_id] = refreshed
-        save_credentials(stored)
+        if store is None:
+            store = load_credential_store()
+        set_scoped_credential(
+            store,
+            refreshed,
+            endpoint_id=endpoint_id,
+            model_id=model_id,
+        )
+        save_credential_store(store)
     return refreshed
 
 
@@ -129,15 +163,40 @@ def resolve_oauth_api_key(
     provider_id: str,
     *,
     credentials: Mapping[str, OAuthCredentials] | None = None,
+    endpoint_id: str | None = None,
+    model_id: str | None = None,
     persist_refresh: bool = True,
 ) -> GetOAuthApiKeyResult | None:
-    stored = dict(load_credentials() if credentials is None else credentials)
     from loushang.ai.auth.oauth import get_oauth_api_key
 
-    result = get_oauth_api_key(provider_id, stored)
+    if credentials is not None:
+        stored = dict(credentials)
+        result = get_oauth_api_key(provider_id, stored)
+        if result is None:
+            return None
+        if persist_refresh:
+            stored[provider_id] = result["newCredentials"]
+            save_credentials(stored)
+        return result
+
+    store = load_credential_store()
+    credential = find_scoped_credential(
+        store,
+        provider_id,
+        endpoint_id=endpoint_id,
+        model_id=model_id,
+    )
+    if credential is None:
+        return None
+    result = get_oauth_api_key(provider_id, {provider_id: credential})
     if result is None:
         return None
     if persist_refresh:
-        stored[provider_id] = result["newCredentials"]
-        save_credentials(stored)
+        set_scoped_credential(
+            store,
+            result["newCredentials"],
+            endpoint_id=endpoint_id,
+            model_id=model_id,
+        )
+        save_credential_store(store)
     return result

--- a/src/loushang/ai/auth/storage.py
+++ b/src/loushang/ai/auth/storage.py
@@ -3,9 +3,17 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import asdict, is_dataclass
-from typing import Any, Dict
+from typing import Any, Dict, Literal, TypedDict
 
 from loushang.ai.auth.types import OAuthCredentials
+
+CredentialScope = Literal["provider", "endpoint", "model"]
+
+
+class OAuthCredentialStore(TypedDict):
+    providers: dict[str, OAuthCredentials]
+    endpoints: dict[str, OAuthCredentials]
+    models: dict[str, OAuthCredentials]
 
 
 def _storage_path() -> str:
@@ -16,36 +24,126 @@ def _storage_path() -> str:
 
 
 def load_credentials() -> Dict[str, OAuthCredentials]:
-    path = _storage_path()
-    if not os.path.exists(path):
-        return {}
-    try:
-        with open(path, "r", encoding="utf-8") as f:
-            raw = json.load(f)
-        result: Dict[str, OAuthCredentials] = {}
-        for k, v in raw.items() if isinstance(raw, dict) else []:
-            if isinstance(v, dict):
-                result[k] = OAuthCredentials(
-                    provider=v.get("provider") or k,
-                    access_token=v.get("access_token") or v.get("access") or "",
-                    refresh_token=v.get("refresh_token") or v.get("refresh"),
-                    expires_at=v.get("expires_at") or v.get("expires"),
-                    extra=v.get("extra"),
-                )
-        return result
-    except Exception:
-        return {}
+    return load_credential_store()["providers"]
 
 
 def save_credentials(creds: Dict[str, OAuthCredentials]) -> None:
+    save_credential_store({"providers": dict(creds), "endpoints": {}, "models": {}})
+
+
+def load_credential_store() -> OAuthCredentialStore:
     path = _storage_path()
-    serializable: Dict[str, Any] = {}
-    for k, v in creds.items():
-        if is_dataclass(v):
-            serializable[k] = asdict(v)
-        else:
-            serializable[k] = dict(v)  # type: ignore[arg-type]
+    if not os.path.exists(path):
+        return _empty_store()
+    with open(path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    if not isinstance(raw, dict):
+        raise ValueError(f"OAuth credential store must be an object: {path}")
+    return {
+        "providers": _load_credential_bucket(raw.get("providers"), "providers"),
+        "endpoints": _load_credential_bucket(raw.get("endpoints"), "endpoints"),
+        "models": _load_credential_bucket(raw.get("models"), "models"),
+    }
+
+
+def save_credential_store(store: OAuthCredentialStore) -> None:
+    path = _storage_path()
+    serializable = {
+        "providers": _dump_credential_bucket(store.get("providers", {})),
+        "endpoints": _dump_credential_bucket(store.get("endpoints", {})),
+        "models": _dump_credential_bucket(store.get("models", {})),
+    }
     tmp = path + ".tmp"
     with open(tmp, "w", encoding="utf-8") as f:
         json.dump(serializable, f, ensure_ascii=False, indent=2)
     os.replace(tmp, path)
+
+
+def find_scoped_credential(
+    store: OAuthCredentialStore,
+    provider: str,
+    *,
+    endpoint_id: str | None = None,
+    model_id: str | None = None,
+) -> OAuthCredentials | None:
+    if model_id and not endpoint_id:
+        raise ValueError("OAuth model credential scope requires endpoint_id")
+    if endpoint_id and model_id:
+        credential = store["models"].get(model_scope_key(provider, endpoint_id, model_id))
+        if credential is not None:
+            return credential
+    if endpoint_id:
+        credential = store["endpoints"].get(endpoint_scope_key(provider, endpoint_id))
+        if credential is not None:
+            return credential
+    return store["providers"].get(provider)
+
+
+def set_scoped_credential(
+    store: OAuthCredentialStore,
+    credential: OAuthCredentials,
+    *,
+    endpoint_id: str | None = None,
+    model_id: str | None = None,
+) -> None:
+    provider = credential.provider
+    if model_id and not endpoint_id:
+        raise ValueError("OAuth model credential scope requires endpoint_id")
+    if endpoint_id and model_id:
+        store["models"][model_scope_key(provider, endpoint_id, model_id)] = credential
+    elif endpoint_id:
+        store["endpoints"][endpoint_scope_key(provider, endpoint_id)] = credential
+    else:
+        store["providers"][provider] = credential
+
+
+def endpoint_scope_key(provider: str, endpoint_id: str) -> str:
+    return f"{provider}:{endpoint_id}"
+
+
+def model_scope_key(provider: str, endpoint_id: str, model_id: str) -> str:
+    return f"{provider}:{endpoint_id}:{model_id}"
+
+
+def _empty_store() -> OAuthCredentialStore:
+    return {"providers": {}, "endpoints": {}, "models": {}}
+
+
+def _load_credential_bucket(value: object, name: str) -> dict[str, OAuthCredentials]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"OAuth credential bucket must be an object: {name}")
+    result: dict[str, OAuthCredentials] = {}
+    for key, raw_credential in value.items():
+        if not isinstance(key, str) or not isinstance(raw_credential, dict):
+            continue
+        result[key] = OAuthCredentials(
+            provider=str(raw_credential.get("provider") or _provider_from_scope_key(key)),
+            access_token=str(raw_credential.get("access_token") or raw_credential.get("access") or ""),
+            refresh_token=_optional_str(raw_credential.get("refresh_token") or raw_credential.get("refresh")),
+            expires_at=raw_credential.get("expires_at") or raw_credential.get("expires"),
+            extra=raw_credential.get("extra") if isinstance(raw_credential.get("extra"), dict) else None,
+        )
+    return result
+
+
+def _dump_credential_bucket(creds: dict[str, OAuthCredentials]) -> dict[str, Any]:
+    serializable: dict[str, Any] = {}
+    for key, value in creds.items():
+        if not isinstance(key, str):
+            continue
+        v = value
+        if is_dataclass(v):
+            serializable[key] = asdict(v)
+        else:
+            serializable[key] = dict(v)  # type: ignore[arg-type]
+    return serializable
+
+
+def _provider_from_scope_key(key: str) -> str:
+    return key.split(":", 1)[0]
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None

--- a/src/loushang/ai/auth/support.py
+++ b/src/loushang/ai/auth/support.py
@@ -159,16 +159,29 @@ def _resolve_env_oauth_auth_view(
     return _resolve_oauth_auth_view(provider, {provider: credentials})
 
 
-def _resolve_stored_oauth_auth_view(provider: str) -> AuthView | None:
+def _resolve_stored_oauth_auth_view(
+    provider: str,
+    *,
+    endpoint_id: str | None = None,
+    model_id: str | None = None,
+) -> AuthView | None:
     try:
-        from loushang.ai.auth.storage import load_credentials
+        from loushang.ai.auth.storage import (
+            find_scoped_credential,
+            load_credential_store,
+        )
 
-        stored = load_credentials()
+        credential = find_scoped_credential(
+            load_credential_store(),
+            provider,
+            endpoint_id=endpoint_id,
+            model_id=model_id,
+        )
     except Exception:
         return None
-    if not stored:
+    if credential is None:
         return None
-    return _resolve_oauth_auth_view(provider, stored)
+    return _resolve_oauth_auth_view(provider, {provider: credential})
 
 
 def resolve_auth_for_model(
@@ -202,7 +215,11 @@ def resolve_auth_for_model(
     if oauth_view is not None:
         return oauth_view
 
-    oauth_view = _resolve_stored_oauth_auth_view(provider)
+    oauth_view = _resolve_stored_oauth_auth_view(
+        provider,
+        endpoint_id=getattr(model, "endpoint_id", None),
+        model_id=getattr(model, "id", None),
+    )
     if oauth_view is not None:
         return oauth_view
 

--- a/src/loushang/ai/cli/__main__.py
+++ b/src/loushang/ai/cli/__main__.py
@@ -25,10 +25,10 @@ from loushang.ai.auth import (
     get_env_oauth_credentials,
     get_oauth_provider,
     list_oauth_providers,
-    load_credentials,
     oauth_login,
     register_builtin_oauth_providers,
 )
+from loushang.ai.auth.storage import find_scoped_credential, load_credential_store
 from loushang.ai.auth.support import merge_auth_config
 from loushang.ai.auth.types import OAuthAuthInfo, OAuthLoginCallbacks, OAuthPrompt
 from loushang.ai.model.registry import (
@@ -287,11 +287,17 @@ def cmd_auth(args: argparse.Namespace) -> None:
         if provider is None:
             print(f"OAuth provider not found: {args.provider}", file=sys.stderr)
             sys.exit(2)
-        stored = load_credentials().get(args.provider)
+        stored = find_scoped_credential(
+            load_credential_store(),
+            args.provider,
+            endpoint_id=getattr(args, "endpoint", None),
+            model_id=getattr(args, "model", None),
+        )
         source = "stored" if stored is not None else None
         data = {
             "id": provider.id,
             "name": provider.name,
+            "scope": _auth_scope_payload(args.provider, getattr(args, "endpoint", None), getattr(args, "model", None)),
             "uses_callback_server": provider.uses_callback_server(),
             "has_credentials": stored is not None,
             "source": source,
@@ -339,11 +345,14 @@ def cmd_auth(args: argparse.Namespace) -> None:
             lambda: oauth_login(
                 provider_id,
                 _CliOAuthCallbacks(),
+                endpoint_id=getattr(args, "endpoint", None),
+                model_id=getattr(args, "model", None),
                 persist=True,
             )
         )
         output = {
             "provider": credentials.provider,
+            "scope": _auth_scope_payload(provider_id, getattr(args, "endpoint", None), getattr(args, "model", None)),
             "stored": True,
             "source": "stored",
             "expires_at": credentials.expires_at,
@@ -351,6 +360,14 @@ def cmd_auth(args: argparse.Namespace) -> None:
         }
         _print(output, args.json)
         return
+
+
+def _auth_scope_payload(provider: str, endpoint: str | None, model: str | None) -> dict[str, str | None]:
+    return {
+        "provider": provider,
+        "endpoint": endpoint,
+        "model": model,
+    }
 
 
 def cmd_console(args: argparse.Namespace) -> None:
@@ -664,7 +681,7 @@ def _prepare_console_auth(
     option_kwargs: dict[str, object] = {}
     auth_source = "none"
     if getattr(auth_config, "kind", "apiKey") == "oauth":
-        oauth_credentials, auth_source = _resolve_console_oauth_credentials(provider.id)
+        oauth_credentials, auth_source = _resolve_console_oauth_credentials(provider.id, endpoint_id=endpoint.id)
         if oauth_credentials is not None:
             option_kwargs["oauth_credentials"] = oauth_credentials
     else:
@@ -691,12 +708,18 @@ def _build_console_options(model, *, api: str, auth_result, debug: bool = False)
 
 def _resolve_console_oauth_credentials(
     provider_id: str,
+    *,
+    endpoint_id: str | None = None,
 ) -> tuple[dict[str, object] | None, str]:
     env_credentials = get_env_oauth_credentials(provider_id)
     if env_credentials is not None:
         return {provider_id: env_credentials}, "env-oauth"
 
-    stored = load_credentials().get(provider_id)
+    stored = find_scoped_credential(
+        load_credential_store(),
+        provider_id,
+        endpoint_id=endpoint_id,
+    )
     if stored is not None:
         return {provider_id: stored}, "stored-oauth"
 
@@ -898,8 +921,12 @@ def main(argv: list[str] | None = None) -> None:
     sauth.add_parser("providers")
     p_auth_show = sauth.add_parser("show")
     p_auth_show.add_argument("provider")
+    p_auth_show.add_argument("--endpoint")
+    p_auth_show.add_argument("--model")
     p_auth_login = sauth.add_parser("login")
     p_auth_login.add_argument("provider", nargs="?")
+    p_auth_login.add_argument("--endpoint")
+    p_auth_login.add_argument("--model")
     p_auth.set_defaults(func=cmd_auth)
 
     p_console = sub.add_parser("console")

--- a/src/loushang/ai/model/domain.py
+++ b/src/loushang/ai/model/domain.py
@@ -366,6 +366,7 @@ class Endpoint:
     preferred: bool = False
     docs: str | None = None
     auth: Auth | None = None
+    _auth_inherited: bool = False
     compat: Compat = field(default_factory=Compat)
     defaults: Defaults = field(default_factory=Defaults)
     models: dict[str, Model] = field(default_factory=dict)
@@ -417,7 +418,7 @@ class Endpoint:
             raw["preferred"] = self.preferred
         if self.docs is not None:
             raw["docs"] = self.docs
-        if self.auth is not None:
+        if self.auth is not None and not self._auth_inherited:
             raw["auth"] = self.auth.to_raw()
         return raw
 

--- a/src/loushang/ai/model/loader.py
+++ b/src/loushang/ai/model/loader.py
@@ -292,9 +292,10 @@ def _build_registry(raw: dict[str, Any]) -> ModelRegistry:
                 endpoint_raw.get("lane"),
                 endpoint_raw.get("region"),
             )
+            endpoint_specific_auth_raw = _auth_raw(endpoint_raw)
             endpoint_auth_raw = _merge_auth_raw(
                 provider_auth_raw,
-                _auth_raw(endpoint_raw),
+                endpoint_specific_auth_raw,
             )
             endpoint_auth = Auth.from_raw(endpoint_auth_raw)
             endpoint = Endpoint(
@@ -309,6 +310,7 @@ def _build_registry(raw: dict[str, Any]) -> ModelRegistry:
                 preferred=bool(endpoint_raw.get("preferred", False)),
                 docs=endpoint_raw.get("docs"),
                 auth=endpoint_auth,
+                _auth_inherited=endpoint_specific_auth_raw is None and endpoint_auth is not None,
                 compat=_normalize_endpoint_compat(endpoint_raw),
                 defaults=Defaults.from_raw(endpoint_raw.get("defaults")),
             )

--- a/src/loushang/coding/control/auth_manager.py
+++ b/src/loushang/coding/control/auth_manager.py
@@ -57,10 +57,17 @@ class AuthManager:
         auth_required = auth_config is not None and getattr(auth_config, "kind", "apiKey") != "none"
         env = os.environ if self._env is None else self._env
 
-        stored_credentials = self.load_stored_oauth_credentials()
-        oauth_credentials = stored_credentials.get(model.provider_id)
+        oauth_credentials = self._resolve_oauth_credentials(
+            model.provider_id,
+            endpoint_id=model.endpoint_id,
+            model_id=model.id,
+        )
         if oauth_credentials is not None:
-            oauth_api_key = self._resolve_oauth_api_key(model.provider_id, stored_credentials)
+            oauth_api_key = self._resolve_oauth_api_key(
+                model.provider_id,
+                endpoint_id=model.endpoint_id,
+                model_id=model.id,
+            )
             if oauth_api_key is not None:
                 return AuthResolution(
                     provider=model.provider_id,
@@ -118,16 +125,44 @@ class AuthManager:
     def _resolve_oauth_api_key(
         self,
         provider: str,
-        credentials: Mapping[str, OAuthCredentials],
+        *,
+        endpoint_id: str | None,
+        model_id: str | None,
     ) -> str | None:
         try:
-            from loushang.ai.auth.oauth import get_oauth_api_key
+            from loushang.ai.auth.facade import resolve_oauth_api_key
 
-            result = get_oauth_api_key(provider, credentials)  # type: ignore[arg-type]
+            result = resolve_oauth_api_key(
+                provider,
+                endpoint_id=endpoint_id,
+                model_id=model_id,
+            )
         except Exception:
             return None
         api_key = result.get("apiKey") if isinstance(result, Mapping) else None
         return api_key if isinstance(api_key, str) and api_key else None
+
+    def _resolve_oauth_credentials(
+        self,
+        provider: str,
+        *,
+        endpoint_id: str | None,
+        model_id: str | None,
+    ) -> OAuthCredentials | None:
+        try:
+            from loushang.ai.auth.storage import (
+                find_scoped_credential,
+                load_credential_store,
+            )
+
+            return find_scoped_credential(
+                load_credential_store(),
+                provider,
+                endpoint_id=endpoint_id,
+                model_id=model_id,
+            )
+        except Exception:
+            return None
 
 
 def _build_missing_auth_message(

--- a/src/loushang/coding/control/auth_manager.py
+++ b/src/loushang/coding/control/auth_manager.py
@@ -53,33 +53,41 @@ class AuthManager:
 
     def resolve_for_model(self, model: Model) -> AuthResolution:
         endpoint = self._ai_registry.get_endpoint(model.provider_id, model.endpoint_id)
-        auth_config = getattr(model, "auth", None) or (endpoint.auth if endpoint is not None else None)
-        auth_required = auth_config is not None and getattr(auth_config, "kind", "apiKey") != "none"
+        provider = self._ai_registry.get_provider(model.provider_id)
+        auth_config = (
+            getattr(model, "auth", None)
+            or (endpoint.auth if endpoint is not None else None)
+            or (provider.auth if provider is not None else None)
+        )
+        auth_kind = getattr(auth_config, "kind", "apiKey")
+        auth_required = auth_config is not None and auth_kind != "none"
         env = os.environ if self._env is None else self._env
 
-        oauth_credentials = self._resolve_oauth_credentials(
-            model.provider_id,
-            endpoint_id=model.endpoint_id,
-            model_id=model.id,
-        )
-        if oauth_credentials is not None:
-            oauth_api_key = self._resolve_oauth_api_key(
+        oauth_credentials: OAuthCredentials | None = None
+        if auth_kind == "oauth":
+            oauth_credentials = self._resolve_oauth_credentials(
                 model.provider_id,
                 endpoint_id=model.endpoint_id,
                 model_id=model.id,
             )
-            if oauth_api_key is not None:
-                return AuthResolution(
-                    provider=model.provider_id,
-                    model_id=model.id,
+            if oauth_credentials is not None:
+                oauth_api_key = self._resolve_oauth_api_key(
+                    model.provider_id,
                     endpoint_id=model.endpoint_id,
-                    auth_required=auth_required,
-                    satisfied=True,
-                    api_key=oauth_api_key,
-                    api_key_env=getattr(auth_config, "api_key_env", None),
-                    source="stored_oauth",
-                    headers=resolve_auth_material(bearer_token=oauth_api_key).headers,
+                    model_id=model.id,
                 )
+                if oauth_api_key is not None:
+                    return AuthResolution(
+                        provider=model.provider_id,
+                        model_id=model.id,
+                        endpoint_id=model.endpoint_id,
+                        auth_required=auth_required,
+                        satisfied=True,
+                        api_key=oauth_api_key,
+                        api_key_env=getattr(auth_config, "api_key_env", None),
+                        source="stored_oauth",
+                        headers=resolve_auth_material(bearer_token=oauth_api_key).headers,
+                    )
 
         api_key_env = _primary_api_key_env(auth_config)
         api_key = _resolve_api_key_from_env(auth_config, env)

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -68,6 +68,12 @@ from loushang.coding.platform.footer_data_provider import FooterDataProvider
 from loushang.coding.policy import InteractiveApprovalResolver
 from loushang.coding.session.agent_event_router import AgentEventRouter
 from loushang.coding.session.auth_bridge_controller import AuthBridgeController
+from loushang.coding.session.auth_commands import (
+    SessionOAuthLoginCallbacks,
+    login_scope_kwargs,
+    resolve_auth_login_target,
+    validate_oauth_login_target,
+)
 from loushang.coding.session.bash_controller import BashController
 from loushang.coding.session.builtin_commands import (
     BuiltinCommandBackend,
@@ -273,6 +279,7 @@ class AgentSession:
                 set_active_tools=self.set_active_tools,
                 get_default_active_tool_names=self._default_active_tool_names,
                 get_extensions=self.list_extensions,
+                login_provider=self._login_from_builtin,
             ),
         )
         self._extension_event_sink = ExtensionEventSink(
@@ -800,6 +807,41 @@ class AgentSession:
         return self.clear_queue()
 
     # Public facade: model, thinking, tools, and session metadata.
+
+    async def _login_from_builtin(self, raw_target: str | None) -> dict[str, object]:
+        if self.model_registry is None:
+            raise RuntimeError("Model registry is not available.")
+        from loushang.ai.auth import ensure_builtin_oauth_providers, oauth_login
+
+        target = resolve_auth_login_target(
+            raw_target,
+            current_model=getattr(self.agent, "model", None),
+            registry=self.model_registry.ai_registry,
+        )
+        validate_oauth_login_target(target)
+        ensure_builtin_oauth_providers(registry=self.oauth_provider_registry)
+        callbacks = SessionOAuthLoginCallbacks()
+        scope_kwargs = login_scope_kwargs(target)
+        credentials = await oauth_login(
+            target.provider,
+            callbacks,
+            registry=self.oauth_provider_registry,
+            endpoint_id=scope_kwargs["endpoint_id"],
+            model_id=scope_kwargs["model_id"],
+            persist=True,
+        )
+        current_model = getattr(self.agent, "model", None)
+        if isinstance(current_model, Model):
+            self._auth_bridge_controller.record_model_auth_resolution(current_model)
+        return {
+            "provider": credentials.provider,
+            "scope": target.scope,
+            "endpoint_id": target.endpoint_id,
+            "model_id": target.model_id,
+            "message": _login_success_message(target.provider, target.scope),
+            "auth_url": (callbacks.auth_info or {}).get("url"),
+            "progress": list(callbacks.progress),
+        }
 
     async def set_model(self, model: Model | ModelSelection) -> None:
         await self._set_model_internal(model, emit_refresh=True, source="set")
@@ -1667,6 +1709,10 @@ def _resolve_extension_exec_cwd(session_cwd: str, cwd: str | Path | None) -> str
 
 def _optional_string(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _login_success_message(provider: str, scope: str) -> str:
+    return f"Login complete for {provider} ({scope} scope)."
 
 
 def _model_selection_payload(selection: ModelSelection | None) -> dict[str, str] | None:

--- a/src/loushang/coding/session/auth_commands.py
+++ b/src/loushang/coding/session/auth_commands.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from loushang.ai.auth.types import OAuthAuthInfo, OAuthLoginCallbacks, OAuthPrompt
+from loushang.ai.model import Model
+from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
+
+AuthScope = Literal["provider", "endpoint", "model"]
+
+
+@dataclass(frozen=True)
+class AuthLoginTarget:
+    provider: str
+    endpoint_id: str | None = None
+    model_id: str | None = None
+    scope: AuthScope = "provider"
+    auth_kind: str | None = None
+
+
+@dataclass
+class SessionOAuthLoginCallbacks(OAuthLoginCallbacks):
+    auth_info: OAuthAuthInfo | None = None
+    progress: list[str] = field(default_factory=list)
+
+    def on_auth(self, info: OAuthAuthInfo) -> None:
+        self.auth_info = cast(OAuthAuthInfo, dict(info))
+
+    async def on_prompt(self, prompt: OAuthPrompt) -> str:
+        message = prompt.get("message") or "OAuth login requires manual code input."
+        raise RuntimeError(self._manual_input_unavailable_message(str(message)))
+
+    def on_progress(self, message: str) -> None:
+        self.progress.append(message)
+
+    async def on_manual_code_input(self) -> str:
+        return ""
+
+    @property
+    def signal(self) -> object | None:
+        return None
+
+    def _manual_input_unavailable_message(self, message: str) -> str:
+        auth_url = (self.auth_info or {}).get("url")
+        if isinstance(auth_url, str) and auth_url:
+            return f"{message} TUI manual code entry is not available yet. Open this URL and retry if needed: {auth_url}"
+        return f"{message} TUI manual code entry is not available yet."
+
+
+def resolve_auth_login_target(
+    raw_target: str | None,
+    *,
+    current_model: Model | None,
+    registry: AiModelRegistry,
+) -> AuthLoginTarget:
+    if raw_target is None:
+        if current_model is None:
+            raise ValueError("No active model is available for /login.")
+        return _target_from_current_model(current_model, registry=registry)
+
+    parts = raw_target.split(":")
+    if len(parts) == 1:
+        provider = _require_part(parts[0], "provider")
+        auth_kind = _provider_auth_kind(registry, provider)
+        return AuthLoginTarget(provider=provider, scope="provider", auth_kind=auth_kind)
+    if len(parts) == 2:
+        provider = _require_part(parts[0], "provider")
+        endpoint_id = _require_part(parts[1], "endpoint")
+        endpoint = registry.get_endpoint(provider, endpoint_id)
+        if endpoint is None:
+            raise ValueError(f"Endpoint not found: {provider}:{endpoint_id}")
+        return AuthLoginTarget(
+            provider=provider,
+            endpoint_id=endpoint_id,
+            scope="endpoint",
+            auth_kind=_auth_kind(getattr(endpoint, "auth", None))
+            or _provider_auth_kind(registry, provider),
+        )
+    if len(parts) == 3:
+        provider = _require_part(parts[0], "provider")
+        endpoint_id = _require_part(parts[1], "endpoint")
+        model_id = _require_part(parts[2], "model")
+        model = registry.find_model(provider, endpoint_id, model_id)
+        if model is None:
+            raise ValueError(f"Model not found: {provider}:{endpoint_id}:{model_id}")
+        return AuthLoginTarget(
+            provider=provider,
+            endpoint_id=endpoint_id,
+            model_id=model_id,
+            scope="model",
+            auth_kind=_auth_kind(getattr(model, "auth", None))
+            or _endpoint_auth_kind(registry, provider, endpoint_id)
+            or _provider_auth_kind(registry, provider),
+        )
+    raise ValueError("Usage: /login [provider[:endpoint[:model]]]")
+
+
+def validate_oauth_login_target(target: AuthLoginTarget) -> None:
+    if target.auth_kind != "oauth":
+        ref = target.provider
+        if target.endpoint_id:
+            ref = f"{ref}:{target.endpoint_id}"
+        if target.model_id:
+            ref = f"{ref}:{target.model_id}"
+        raise ValueError(f"OAuth login is not configured for {ref}.")
+
+
+def login_scope_kwargs(target: AuthLoginTarget) -> dict[str, str | None]:
+    if target.scope == "model":
+        return {"endpoint_id": target.endpoint_id, "model_id": target.model_id}
+    if target.scope == "endpoint":
+        return {"endpoint_id": target.endpoint_id, "model_id": None}
+    return {"endpoint_id": None, "model_id": None}
+
+
+def _target_from_current_model(model: Model, *, registry: AiModelRegistry) -> AuthLoginTarget:
+    provider = model.provider_id
+    endpoint_id = model.endpoint_id
+    model_id = model.id
+    model_auth = getattr(model, "auth", None)
+    if model_auth is not None and not bool(getattr(model, "_auth_inherited", False)):
+        return AuthLoginTarget(
+            provider=provider,
+            endpoint_id=endpoint_id,
+            model_id=model_id,
+            scope="model",
+            auth_kind=_auth_kind(model_auth),
+        )
+
+    endpoint = registry.get_endpoint(provider, endpoint_id)
+    provider_auth_kind = _provider_auth_kind(registry, provider)
+    endpoint_auth = getattr(endpoint, "auth", None) if endpoint is not None else None
+    if endpoint_auth is not None and not bool(getattr(endpoint, "_auth_inherited", False)):
+        return AuthLoginTarget(
+            provider=provider,
+            endpoint_id=endpoint_id,
+            scope="endpoint",
+            auth_kind=_auth_kind(endpoint_auth),
+        )
+    if provider_auth_kind is not None:
+        return AuthLoginTarget(provider=provider, scope="provider", auth_kind=provider_auth_kind)
+    if endpoint_auth is not None:
+        return AuthLoginTarget(
+            provider=provider,
+            endpoint_id=endpoint_id,
+            scope="endpoint",
+            auth_kind=_auth_kind(endpoint_auth),
+        )
+    return AuthLoginTarget(provider=provider, scope="provider", auth_kind=None)
+
+
+def _provider_auth_kind(registry: AiModelRegistry, provider: str) -> str | None:
+    resolved = registry.get_provider(provider)
+    if resolved is None:
+        raise ValueError(f"Provider not found: {provider}")
+    return _auth_kind(getattr(resolved, "auth", None))
+
+
+def _endpoint_auth_kind(
+    registry: AiModelRegistry,
+    provider: str,
+    endpoint_id: str,
+) -> str | None:
+    endpoint = registry.get_endpoint(provider, endpoint_id)
+    if endpoint is None:
+        raise ValueError(f"Endpoint not found: {provider}:{endpoint_id}")
+    return _auth_kind(getattr(endpoint, "auth", None))
+
+
+def _auth_kind(auth: Any) -> str | None:
+    kind = getattr(auth, "kind", None)
+    return kind if isinstance(kind, str) and kind else None
+
+
+def _require_part(value: str, label: str) -> str:
+    if not value:
+        raise ValueError(f"Login target requires {label}.")
+    return value
+
+
+__all__ = [
+    "AuthLoginTarget",
+    "SessionOAuthLoginCallbacks",
+    "login_scope_kwargs",
+    "resolve_auth_login_target",
+    "validate_oauth_login_target",
+]

--- a/src/loushang/coding/session/builtin_commands.py
+++ b/src/loushang/coding/session/builtin_commands.py
@@ -45,6 +45,7 @@ class BuiltinCommandBackend:
     set_active_tools: Callable[[list[str]], object | Awaitable[object]] | None = None
     get_default_active_tool_names: Callable[[], list[str]] | None = None
     get_extensions: Callable[[], list[object]] | None = None
+    login_provider: Callable[[str | None], object | Awaitable[object]] | None = None
 
 
 def list_builtin_command_descriptors() -> list[SessionCommandDescriptor]:
@@ -104,6 +105,8 @@ async def execute_builtin_command_async(
             return await _execute_tree(args, backend)
         case "import":
             return await _execute_import(args, backend)
+        case "login":
+            return await _execute_login(args, backend)
         case _:
             return _unsupported(invocation_name)
 
@@ -340,6 +343,28 @@ async def _execute_import(args: str, backend: BuiltinCommandBackend) -> CommandE
         return _error("import", "Usage: /import <jsonl-path> [cwd]")
     result = await _maybe_await(backend.import_session(tokens[0], tokens[1] if len(tokens) > 1 else None))
     return _ok("import", result=_to_plain_data(result))
+
+
+async def _execute_login(args: str, backend: BuiltinCommandBackend) -> CommandExecutionResult:
+    if backend.login_provider is None:
+        return _unsupported("login")
+    tokens = _split_args(args.strip()) if args.strip() else []
+    if len(tokens) > 1:
+        return _error("login", "Usage: /login [provider[:endpoint[:model]]]")
+    result = await _maybe_await(backend.login_provider(tokens[0] if tokens else None))
+    return _ok("login", result=_to_plain_data(result), message=_login_message(result))
+
+
+def _login_message(result: object) -> str:
+    if isinstance(result, Mapping):
+        message = result.get("message")
+        if isinstance(message, str) and message:
+            return message
+        provider = result.get("provider")
+        scope = result.get("scope")
+        if isinstance(provider, str) and isinstance(scope, str):
+            return f"Login complete for {provider} ({scope} scope)."
+    return "Login complete."
 
 
 def read_changelog_for_cwd(cwd: str | Path, args: str = "") -> dict[str, object]:

--- a/tests/ai/test_cli_auth.py
+++ b/tests/ai/test_cli_auth.py
@@ -61,14 +61,18 @@ def test_auth_show_outputs_stored_flag(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     monkeypatch.setattr(
-        "loushang.ai.cli.__main__.load_credentials",
+        "loushang.ai.cli.__main__.load_credential_store",
         lambda: {
-            "openai-codex": OAuthCredentials(
-                provider="openai-codex",
-                access_token="token",
-                expires_at=123.0,
-                extra={"account_id": "acc_1"},
-            )
+            "providers": {
+                "openai-codex": OAuthCredentials(
+                    provider="openai-codex",
+                    access_token="token",
+                    expires_at=123.0,
+                    extra={"account_id": "acc_1"},
+                )
+            },
+            "endpoints": {},
+            "models": {},
         },
     )
 
@@ -86,8 +90,10 @@ def test_auth_login_uses_oauth_login(
 ) -> None:
     monkeypatch.setattr("builtins.input", lambda _prompt="": "")
 
-    async def _fake_login(provider_id, callbacks, *, persist=True):
+    async def _fake_login(provider_id, callbacks, *, endpoint_id=None, model_id=None, persist=True):
         assert provider_id == "openai-codex"
+        assert endpoint_id is None
+        assert model_id is None
         assert persist is True
         callbacks.on_auth({"url": "https://chatgpt.com", "instructions": "Sign in"})
         callbacks.on_progress("Waiting")
@@ -116,8 +122,10 @@ def test_auth_login_can_prompt_for_provider_selection(
     responses = iter(["1", ""])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
 
-    async def _fake_login(provider_id, callbacks, *, persist=True):
+    async def _fake_login(provider_id, callbacks, *, endpoint_id=None, model_id=None, persist=True):
         assert provider_id == "openai-codex"
+        assert endpoint_id is None
+        assert model_id is None
         assert persist is True
         return OAuthCredentials(
             provider="openai-codex",

--- a/tests/auth/test_oauth_facade.py
+++ b/tests/auth/test_oauth_facade.py
@@ -6,7 +6,12 @@ from dataclasses import asdict
 import pytest
 
 from loushang.ai.auth import facade
-from loushang.ai.auth.facade import oauth_login, oauth_refresh, resolve_oauth_api_key
+from loushang.ai.auth.facade import (
+    ensure_builtin_oauth_providers,
+    oauth_login,
+    oauth_refresh,
+    resolve_oauth_api_key,
+)
 from loushang.ai.auth.registry import OAuthProviderRegistry
 from loushang.ai.auth.types import OAuthCredentials
 
@@ -65,6 +70,16 @@ def _registry() -> OAuthProviderRegistry:
     registry = OAuthProviderRegistry()
     registry.register_oauth_provider(_FakeProvider(), source_id="test")
     return registry
+
+
+def test_ensure_builtin_oauth_providers_does_not_reset_registry() -> None:
+    registry = _registry()
+
+    ensure_builtin_oauth_providers(registry=registry)
+
+    assert registry.get_oauth_provider("demo") is not None
+    assert registry.get_oauth_provider("openai-codex") is not None
+    assert registry.get_oauth_provider("anthropic") is not None
 
 
 def test_oauth_login_persists_into_explicit_credentials_map(

--- a/tests/auth/test_oauth_facade.py
+++ b/tests/auth/test_oauth_facade.py
@@ -73,7 +73,7 @@ def test_oauth_login_persists_into_explicit_credentials_map(
     save_calls: list[dict[str, OAuthCredentials]] = []
     monkeypatch.setattr(
         facade,
-        "load_credentials",
+        "load_credential_store",
         lambda: pytest.fail("explicit credentials should not load storage"),
     )
     monkeypatch.setattr(facade, "save_credentials", lambda data: save_calls.append(data))
@@ -92,17 +92,55 @@ def test_oauth_login_persists_into_explicit_credentials_map(
     assert [asdict(saved["demo"]) for saved in save_calls] == [asdict(result)]
 
 
+def test_oauth_login_persists_provider_scope_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = {"providers": {}, "endpoints": {}, "models": {}}
+    save_calls: list[dict[str, dict[str, OAuthCredentials]]] = []
+    monkeypatch.setattr(facade, "load_credential_store", lambda: store)
+    monkeypatch.setattr(facade, "save_credential_store", lambda data: save_calls.append(data))
+
+    result = asyncio.run(oauth_login("demo", _Callbacks(), registry=_registry(), persist=True))
+
+    assert result.access_token == "login-token"
+    assert save_calls[0]["providers"]["demo"] == result
+    assert save_calls[0]["endpoints"] == {}
+    assert save_calls[0]["models"] == {}
+
+
+def test_oauth_login_persists_model_scope_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = {"providers": {}, "endpoints": {}, "models": {}}
+    save_calls: list[dict[str, dict[str, OAuthCredentials]]] = []
+    monkeypatch.setattr(facade, "load_credential_store", lambda: store)
+    monkeypatch.setattr(facade, "save_credential_store", lambda data: save_calls.append(data))
+
+    result = asyncio.run(
+        oauth_login(
+            "demo",
+            _Callbacks(),
+            registry=_registry(),
+            endpoint_id="responses",
+            model_id="chat",
+            persist=True,
+        )
+    )
+
+    assert save_calls[0]["models"]["demo:responses:chat"] == result
+
+
 def test_oauth_login_without_persist_does_not_touch_storage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         facade,
-        "load_credentials",
+        "load_credential_store",
         lambda: pytest.fail("non-persistent login should not load storage"),
     )
     monkeypatch.setattr(
         facade,
-        "save_credentials",
+        "save_credential_store",
         lambda _data: pytest.fail("non-persistent login should not save storage"),
     )
 
@@ -122,14 +160,15 @@ def test_oauth_refresh_persists_refreshed_stored_credentials(
         access_token="old-token",
         refresh_token="refresh-token",
     )
-    save_calls: list[dict[str, OAuthCredentials]] = []
-    monkeypatch.setattr(facade, "load_credentials", lambda: {"demo": original})
-    monkeypatch.setattr(facade, "save_credentials", lambda data: save_calls.append(data))
+    store = {"providers": {"demo": original}, "endpoints": {}, "models": {}}
+    save_calls: list[dict[str, dict[str, OAuthCredentials]]] = []
+    monkeypatch.setattr(facade, "load_credential_store", lambda: store)
+    monkeypatch.setattr(facade, "save_credential_store", lambda data: save_calls.append(data))
 
     result = asyncio.run(oauth_refresh("demo", registry=_registry(), persist=True))
 
     assert result.access_token == "refreshed-token"
-    assert [asdict(saved["demo"]) for saved in save_calls] == [asdict(result)]
+    assert [asdict(saved["providers"]["demo"]) for saved in save_calls] == [asdict(result)]
 
 
 def test_oauth_refresh_explicit_credentials_without_persist_does_not_touch_storage(
@@ -137,12 +176,12 @@ def test_oauth_refresh_explicit_credentials_without_persist_does_not_touch_stora
 ) -> None:
     monkeypatch.setattr(
         facade,
-        "load_credentials",
+        "load_credential_store",
         lambda: pytest.fail("explicit non-persistent refresh should not load storage"),
     )
     monkeypatch.setattr(
         facade,
-        "save_credentials",
+        "save_credential_store",
         lambda _data: pytest.fail("explicit non-persistent refresh should not save storage"),
     )
 
@@ -167,8 +206,36 @@ def test_resolve_oauth_api_key_uses_explicit_empty_credentials_map(
 ) -> None:
     monkeypatch.setattr(
         facade,
-        "load_credentials",
+        "load_credential_store",
         lambda: pytest.fail("explicit credentials should not load storage"),
     )
 
     assert resolve_oauth_api_key("demo", credentials={}) is None
+
+
+def test_resolve_oauth_api_key_prefers_model_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = OAuthCredentials(provider="demo", access_token="provider-token")
+    endpoint = OAuthCredentials(provider="demo", access_token="endpoint-token")
+    model = OAuthCredentials(provider="demo", access_token="model-token")
+    monkeypatch.setattr(
+        facade,
+        "load_credential_store",
+        lambda: {
+            "providers": {"demo": provider},
+            "endpoints": {"demo:responses": endpoint},
+            "models": {"demo:responses:chat": model},
+        },
+    )
+    monkeypatch.setattr(facade, "save_credential_store", lambda _data: None)
+
+    result = resolve_oauth_api_key(
+        "demo",
+        endpoint_id="responses",
+        model_id="chat",
+        persist_refresh=False,
+    )
+
+    assert result is not None
+    assert result["apiKey"] == "model-token"

--- a/tests/coding/test_bootstrap.py
+++ b/tests/coding/test_bootstrap.py
@@ -1195,7 +1195,7 @@ def test_create_agent_session_uses_stored_oauth_credentials_for_auth_bridge(tmp_
             id="responses",
             api="responses",
             provider="demo",
-            auth=Auth(api_key_env="LOUSHANG_TEST_DEMO_KEY"),
+            auth=Auth(kind="oauth"),
         ),
     )
     ai_registry.register_model(
@@ -1208,13 +1208,19 @@ def test_create_agent_session_uses_stored_oauth_credentials_for_auth_bridge(tmp_
         )
     )
 
-    monkeypatch.setattr(
-        "loushang.ai.auth.storage.load_credentials",
-        lambda: {"demo": OAuthCredentials(provider="demo", access_token="oauth-token")},
-    )
+    credential_store = {
+        "providers": {"demo": OAuthCredentials(provider="demo", access_token="oauth-token")},
+        "endpoints": {},
+        "models": {},
+    }
+    monkeypatch.setattr("loushang.ai.auth.storage.load_credential_store", lambda: credential_store)
+    monkeypatch.setattr("loushang.ai.auth.facade.load_credential_store", lambda: credential_store)
     monkeypatch.setattr(
         "loushang.ai.auth.oauth.get_oauth_api_key",
-        lambda provider, credentials: {"apiKey": f"{provider}-oauth-key"},
+        lambda provider, credentials: {
+            "apiKey": f"{provider}-oauth-key",
+            "newCredentials": credentials[provider],
+        },
     )
 
     services = create_services(

--- a/tests/coding/test_session_auth_commands.py
+++ b/tests/coding/test_session_auth_commands.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from loushang.ai.model import Auth, Endpoint, Model, Provider
+from loushang.ai.model.loader import load_model_registry_from_file
+from loushang.ai.model.registry import ModelRegistry
+from loushang.coding.session.auth_commands import (
+    SessionOAuthLoginCallbacks,
+    login_scope_kwargs,
+    resolve_auth_login_target,
+    validate_oauth_login_target,
+)
+
+
+def _registry(
+    *,
+    provider_auth: Auth | None = None,
+    endpoint_auth: Auth | None = None,
+    model_auth: Auth | None = None,
+) -> tuple[ModelRegistry, Model]:
+    model = Model(id="chat", provider="demo", endpoint="responses", auth=model_auth)
+    endpoint = Endpoint(
+        id="responses",
+        provider="demo",
+        api="demo-api",
+        auth=endpoint_auth,
+        models={"chat": model},
+    )
+    registry = ModelRegistry.from_providers(
+        {
+            "demo": Provider(
+                id="demo",
+                auth=provider_auth,
+                endpoints={"responses": endpoint},
+            )
+        }
+    )
+    return registry, registry.get_model("demo", "responses", "chat")
+
+
+def test_current_model_login_uses_provider_scope_for_provider_auth() -> None:
+    auth = Auth(kind="oauth")
+    registry, model = _registry(provider_auth=auth, endpoint_auth=auth)
+    endpoint = registry.get_endpoint("demo", "responses")
+    assert endpoint is not None
+    object.__setattr__(endpoint, "_auth_inherited", True)
+
+    target = resolve_auth_login_target(None, current_model=model, registry=registry)
+
+    assert target.scope == "provider"
+    assert target.provider == "demo"
+    assert login_scope_kwargs(target) == {"endpoint_id": None, "model_id": None}
+
+
+def test_current_model_login_uses_endpoint_scope_for_endpoint_auth() -> None:
+    registry, model = _registry(
+        provider_auth=Auth(kind="apiKey"),
+        endpoint_auth=Auth(kind="oauth"),
+    )
+
+    target = resolve_auth_login_target(None, current_model=model, registry=registry)
+
+    assert target.scope == "endpoint"
+    assert target.endpoint_id == "responses"
+    assert login_scope_kwargs(target) == {"endpoint_id": "responses", "model_id": None}
+
+
+def test_current_model_login_uses_model_scope_for_model_auth() -> None:
+    registry, model = _registry(
+        provider_auth=Auth(kind="apiKey"),
+        endpoint_auth=Auth(kind="apiKey"),
+        model_auth=Auth(kind="oauth"),
+    )
+
+    target = resolve_auth_login_target(None, current_model=model, registry=registry)
+
+    assert target.scope == "model"
+    assert target.endpoint_id == "responses"
+    assert target.model_id == "chat"
+    assert login_scope_kwargs(target) == {"endpoint_id": "responses", "model_id": "chat"}
+
+
+def test_explicit_login_target_uses_requested_scope() -> None:
+    registry, model = _registry(provider_auth=Auth(kind="oauth"), endpoint_auth=Auth(kind="oauth"))
+
+    provider_target = resolve_auth_login_target("demo", current_model=model, registry=registry)
+    endpoint_target = resolve_auth_login_target("demo:responses", current_model=model, registry=registry)
+    model_target = resolve_auth_login_target("demo:responses:chat", current_model=model, registry=registry)
+
+    assert provider_target.scope == "provider"
+    assert endpoint_target.scope == "endpoint"
+    assert model_target.scope == "model"
+
+
+def test_explicit_model_login_target_reports_missing_model() -> None:
+    registry, model = _registry(provider_auth=Auth(kind="oauth"), endpoint_auth=Auth(kind="oauth"))
+
+    with pytest.raises(ValueError, match="Model not found: demo:responses:missing"):
+        resolve_auth_login_target("demo:responses:missing", current_model=model, registry=registry)
+
+
+def test_validate_oauth_login_target_rejects_non_oauth_auth() -> None:
+    registry, model = _registry(provider_auth=Auth(kind="apiKey"), endpoint_auth=Auth(kind="apiKey"))
+    target = resolve_auth_login_target(None, current_model=model, registry=registry)
+
+    with pytest.raises(ValueError, match="OAuth login is not configured"):
+        validate_oauth_login_target(target)
+
+
+def test_oauth_callbacks_raise_actionable_manual_input_error() -> None:
+    callbacks = SessionOAuthLoginCallbacks()
+    callbacks.on_auth({"url": "https://example.test/login"})
+
+    with pytest.raises(RuntimeError, match="https://example.test/login"):
+        asyncio.run(callbacks.on_prompt({"message": "Paste the authorization code"}))
+
+
+def test_loaded_provider_auth_defaults_to_provider_scope(tmp_path) -> None:
+    registry = _loaded_registry(tmp_path, provider_auth={"kind": "oauth"})
+    model = registry.get_model("demo", "responses", "chat")
+
+    target = resolve_auth_login_target(None, current_model=model, registry=registry)
+
+    assert target.scope == "provider"
+
+
+def test_loaded_endpoint_auth_defaults_to_endpoint_scope(tmp_path) -> None:
+    registry = _loaded_registry(
+        tmp_path,
+        provider_auth={"kind": "apiKey"},
+        endpoint_auth={"kind": "oauth"},
+    )
+    model = registry.get_model("demo", "responses", "chat")
+
+    target = resolve_auth_login_target(None, current_model=model, registry=registry)
+
+    assert target.scope == "endpoint"
+    assert target.endpoint_id == "responses"
+
+
+def test_loaded_model_auth_defaults_to_model_scope(tmp_path) -> None:
+    registry = _loaded_registry(
+        tmp_path,
+        provider_auth={"kind": "apiKey"},
+        endpoint_auth={"kind": "apiKey"},
+        model_auth={"kind": "oauth"},
+    )
+    model = registry.get_model("demo", "responses", "chat")
+
+    target = resolve_auth_login_target(None, current_model=model, registry=registry)
+
+    assert target.scope == "model"
+    assert target.endpoint_id == "responses"
+    assert target.model_id == "chat"
+
+
+def test_loaded_endpoint_explicit_same_auth_still_uses_endpoint_scope(tmp_path) -> None:
+    oauth_auth = {"kind": "oauth"}
+    registry = _loaded_registry(
+        tmp_path,
+        provider_auth=oauth_auth,
+        endpoint_auth=oauth_auth,
+    )
+    model = registry.get_model("demo", "responses", "chat")
+
+    target = resolve_auth_login_target(None, current_model=model, registry=registry)
+
+    assert target.scope == "endpoint"
+
+
+def _loaded_registry(
+    tmp_path,
+    *,
+    provider_auth: dict[str, object] | None = None,
+    endpoint_auth: dict[str, object] | None = None,
+    model_auth: dict[str, object] | None = None,
+) -> ModelRegistry:
+    model_raw: dict[str, object] = {
+        "displayName": "Chat",
+        "capabilities": {
+            "input": ["text"],
+            "output": ["text"],
+        },
+    }
+    if model_auth is not None:
+        model_raw["auth"] = model_auth
+    endpoint_raw: dict[str, object] = {
+        "api": "demo-api",
+        "models": {"chat": model_raw},
+    }
+    if endpoint_auth is not None:
+        endpoint_raw["auth"] = endpoint_auth
+    provider_raw: dict[str, object] = {
+        "endpoints": {"responses": endpoint_raw},
+    }
+    if provider_auth is not None:
+        provider_raw["auth"] = provider_auth
+    path = tmp_path / "models.json"
+    path.write_text(json.dumps({"providers": {"demo": provider_raw}}), encoding="utf-8")
+    return load_model_registry_from_file(path)

--- a/tests/coding/test_session_command_controller.py
+++ b/tests/coding/test_session_command_controller.py
@@ -187,6 +187,47 @@ def test_command_controller_executes_extension_command_before_resource_command(t
     assert calls == [("now", "/tmp/project")]
 
 
+def test_command_controller_executes_builtin_login(tmp_path) -> None:
+    calls: list[str | None] = []
+    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    controller = CommandController(
+        session_manager=manager,
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(
+            login_provider=lambda target: calls.append(target)
+            or {"provider": "demo", "scope": "provider", "message": "Login complete."}
+        ),
+    )
+
+    result = asyncio.run(controller.execute_command_async("login", "demo"))
+
+    assert calls == ["demo"]
+    assert result is not None
+    assert result.result["status"] == "ok"
+    assert result.result["message"] == "Login complete."
+
+
+def test_command_controller_rejects_builtin_login_extra_args(tmp_path) -> None:
+    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    controller = CommandController(
+        session_manager=manager,
+        get_extension_runner=lambda: None,
+        get_resource_bundle=lambda: None,
+        get_diagnostics_service=lambda: None,
+        builtin_backend=BuiltinCommandBackend(
+            login_provider=lambda _target: pytest.fail("login should not execute")
+        ),
+    )
+
+    result = asyncio.run(controller.execute_command_async("login", "one two"))
+
+    assert result is not None
+    assert result.result["status"] == "error"
+    assert result.result["message"] == "Usage: /login [provider[:endpoint[:model]]]"
+
+
 def test_command_controller_executes_builtin_name_session_and_unsupported_commands(tmp_path) -> None:
     names: list[str | None] = []
     controller = CommandController(


### PR DESCRIPTION
## Summary

- Store OAuth credentials by provider, endpoint, and model scope.
- Resolve stored OAuth credentials with model -> endpoint -> provider fallback.
- Add CLI flags for scoped auth login/show.

## Validation

- uv run ruff check src/loushang/ai/auth src/loushang/ai/cli/__main__.py src/loushang/coding/control/auth_manager.py tests/auth/test_oauth_facade.py tests/ai/test_cli_auth.py
- uv run pytest tests/auth/test_oauth_facade.py tests/ai/test_cli_auth.py tests/ai/test_cli_console.py tests/ai/test_provider_resolution.py tests/coding/test_control_services.py tests/coding/test_session_selection_controller.py -q
