### PR TITLE
Improve /models info panel UX

### DIFF
--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -43,6 +43,7 @@ from loushang.tui import (
     ApprovalSurface,
     CommandPalette,
     CommandSurface,
+    CursorDeclaration,
     FocusableMixin,
     InfoPanel,
     InputEvent,
@@ -81,6 +82,9 @@ class NativeSurfaceView(FocusableMixin):
     subtitle: str = ""
     presentation: NativeSurfacePresentation = "bottom"
     _last_content_start_row: int = field(default=0, init=False, repr=False)
+    _info_scroll_offset: int = field(default=0, init=False, repr=False)
+    _last_info_body_height: int = field(default=0, init=False, repr=False)
+    _last_info_body_line_count: int = field(default=0, init=False, repr=False)
 
     def __post_init__(self) -> None:
         FocusableMixin.__init__(self)
@@ -95,6 +99,8 @@ class NativeSurfaceView(FocusableMixin):
         if self.purpose == "info":
             if event.kind == "key" and event.key in {"enter", "space"}:
                 return InputIntent(kind="surface_close")
+            if event.kind == "key":
+                return self._handle_info_scroll_input(event.key)
             return None
         handler = getattr(self.content, "handle_input", None)
         if callable(handler):
@@ -104,6 +110,7 @@ class NativeSurfaceView(FocusableMixin):
     def render(self, constraints: RenderConstraints) -> RenderResult:
         width = constraints.width
         lines = [truncate_to_width(self.title, max_width=width)]
+        cursor: CursorDeclaration | None = None
         if self.subtitle:
             lines.append(truncate_to_width(self.subtitle, max_width=width))
         lines.append("")
@@ -113,21 +120,74 @@ class NativeSurfaceView(FocusableMixin):
             max_height=max(1, constraints.max_height - len(lines) - reserved_footer_lines),
         )
         if isinstance(self.content, InfoPanel):
+            body_lines: list[str] = []
             for raw_line in self.content.text.splitlines():
-                lines.extend(wrap_cells(raw_line, width=width) or [""])
+                body_lines.extend(wrap_cells(raw_line, width=width) or [""])
+            self._last_info_body_height = body_constraints.max_height
+            self._last_info_body_line_count = len(body_lines)
+            max_offset = self._max_info_scroll_offset()
+            self._info_scroll_offset = max(0, min(self._info_scroll_offset, max_offset))
+            visible_body_lines = body_lines[self._info_scroll_offset : self._info_scroll_offset + body_constraints.max_height]
+            body_start_row = len(lines)
+            lines.extend(visible_body_lines)
+            if visible_body_lines:
+                cursor = CursorDeclaration(row=body_start_row + len(visible_body_lines) - 1, column=0)
         else:
             self._last_content_start_row = len(lines)
             result = self.content.render(body_constraints)
             lines.extend(line.text for line in result.lines)
-        if self.footer and len(lines) < constraints.max_height:
-            lines.append("")
-            lines.append(truncate_to_width(self.footer, max_width=width))
-        return RenderResult.from_lines([RenderLine(line) for line in lines[: constraints.max_height]], constraints=constraints)
+        footer = self._footer_text()
+        if footer and len(lines) < constraints.max_height:
+            if len(lines) + 1 < constraints.max_height:
+                lines.append("")
+            lines.append(truncate_to_width(footer, max_width=width))
+        return RenderResult.from_lines(
+            [RenderLine(line) for line in lines[: constraints.max_height]],
+            constraints=constraints,
+            cursor=cursor,
+        )
 
     def _translate_content_input_event(self, event: InputEvent) -> InputEvent:
         if event.kind != "mouse" or event.mouse_row is None:
             return event
         return replace(event, mouse_row=event.mouse_row - self._last_content_start_row)
+
+    def _handle_info_scroll_input(self, key: str) -> InputIntent | None:
+        page = max(1, self._last_info_body_height)
+        if key == "down":
+            return self._scroll_info(1)
+        if key == "up":
+            return self._scroll_info(-1)
+        if key == "pageDown":
+            return self._scroll_info(page)
+        if key == "pageUp":
+            return self._scroll_info(-page)
+        if key == "home":
+            return self._set_info_scroll(0)
+        if key == "end":
+            return self._set_info_scroll(self._max_info_scroll_offset())
+        return None
+
+    def _scroll_info(self, delta: int) -> InputIntent | None:
+        return self._set_info_scroll(self._info_scroll_offset + delta)
+
+    def _set_info_scroll(self, offset: int) -> InputIntent | None:
+        max_offset = self._max_info_scroll_offset()
+        next_offset = max(0, min(offset, max_offset))
+        if next_offset == self._info_scroll_offset:
+            return None
+        self._info_scroll_offset = next_offset
+        return InputIntent(kind="consumed", note="info_scroll")
+
+    def _max_info_scroll_offset(self) -> int:
+        return max(0, self._last_info_body_line_count - self._last_info_body_height)
+
+    def _footer_text(self) -> str:
+        if not self.footer:
+            return ""
+        if self.purpose == "info" and self._max_info_scroll_offset() > 0:
+            return f"Up/Down/Page to scroll - {self.footer}"
+        return self.footer
 
 
 @dataclass(frozen=True, slots=True)
@@ -344,7 +404,12 @@ class NativeSurfaceManager:
         if command.name == "model" and isinstance(intent, ModelSelectIntent):
             await self._handle_model_intent(intent)
         elif command.name == "models" and isinstance(intent, ModelsIntent):
-            self._open_info("Models", await format_available_models(self.session, query=intent.query))
+            models_text = await format_available_models(self.session, query=intent.query)
+            self._open_info(
+                "Available Models",
+                _models_info_body(models_text),
+                presentation="bottom-exclusive",
+            )
         elif command.name == "command" and isinstance(intent, CommandSelectIntent):
             await self._handle_command_intent(intent)
         elif command.name == "commands" and isinstance(intent, CommandsIntent):
@@ -526,13 +591,20 @@ class NativeSurfaceManager:
             )
         )
 
-    def _open_info(self, title: str, text: str) -> None:
+    def _open_info(
+        self,
+        title: str,
+        text: str,
+        *,
+        presentation: NativeSurfacePresentation = "bottom",
+    ) -> None:
         self._open_surface(
             NativeSurfaceView(
                 title=title,
                 purpose="info",
                 content=InfoPanel.from_text(title=title, text=text, footer=""),
                 footer="Enter/Esc to close",
+                presentation=presentation,
             )
         )
 
@@ -682,6 +754,13 @@ def _selected_model_item_index(items: tuple[SelectItem, ...], selected_value: st
 def _recoverable_surface_error(error: Exception) -> str:
     message = str(error).strip() or error.__class__.__name__
     return f"Error: {message}"
+
+
+def _models_info_body(text: str) -> str:
+    prefix = "Available models:\n"
+    if text.startswith(prefix):
+        return text[len(prefix) :]
+    return text
 
 
 def _session_commands_provider(session: Any) -> Callable[[], Any] | None:

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -209,6 +209,102 @@ def test_native_surface_manager_opens_non_model_surfaces_in_runtime_overlay_host
         assert app.surface_host.entries == []
 
 
+def test_native_surface_manager_opens_models_info_in_bottom_frame_with_runtime_overlay_host() -> None:
+    app = _app()
+    app.surface_host = SurfaceHost()
+    manager = _manager(app, _Session())
+
+    asyncio.run(manager.handle_text("/models"))
+
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    assert app.active_surface.title == "Available Models"
+    assert app.active_surface.presentation == "bottom-exclusive"
+    assert app.active_surface.exclusive_bottom is True
+    assert app.surface_host.entries == []
+
+    rendered = app.active_surface.render(RenderConstraints(width=100, max_height=10))
+    plain_lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
+    assert plain_lines[0] == "Available Models"
+    assert "Available models:" not in plain_lines
+    assert any("moonshot/kimi-for-coding" in line for line in plain_lines)
+    assert plain_lines[-1] == "Enter/Esc to close"
+
+
+def test_native_surface_models_info_keeps_footer_when_content_overflows() -> None:
+    session = _Session()
+    session.models = [
+        ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
+        *(ModelSelection(provider="provider", model_id=f"model-{index:02d}") for index in range(12)),
+    ]
+    app = _app()
+    app.surface_host = SurfaceHost()
+    manager = _manager(app, session)
+
+    asyncio.run(manager.handle_text("/models"))
+
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    rendered = app.active_surface.render(RenderConstraints(width=100, max_height=8))
+    plain_lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
+
+    assert plain_lines[-2:] == ("", "Up/Down/Page to scroll - Enter/Esc to close")
+    assert any("provider/model-00" in line for line in plain_lines)
+    assert not any("provider/model-08" in line for line in plain_lines)
+
+
+def test_native_surface_models_info_scrolls_with_page_keys() -> None:
+    session = _Session()
+    session.models = [
+        ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
+        *(ModelSelection(provider="provider", model_id=f"model-{index:02d}") for index in range(12)),
+    ]
+    app = _app()
+    app.surface_host = SurfaceHost()
+    manager = _manager(app, session)
+
+    asyncio.run(manager.handle_text("/models"))
+
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    before = tuple(
+        strip_control_sequences(line.text)
+        for line in app.active_surface.render(RenderConstraints(width=100, max_height=8)).lines
+    )
+    intent = app.active_surface.handle_input(InputEvent(kind="key", key="pageDown"))
+    after = tuple(
+        strip_control_sequences(line.text)
+        for line in app.active_surface.render(RenderConstraints(width=100, max_height=8)).lines
+    )
+
+    assert intent == InputIntent(kind="consumed", note="info_scroll")
+    assert any("provider/model-00" in line for line in before)
+    assert not any("provider/model-00" in line for line in after)
+    assert any("provider/model-03" in line for line in after)
+    assert after[-2:] == ("", "Up/Down/Page to scroll - Enter/Esc to close")
+
+
+def test_native_surface_models_info_cursor_stays_on_last_visible_body_line() -> None:
+    session = _Session()
+    session.models = [
+        ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
+        *(ModelSelection(provider="provider", model_id=f"model-{index:02d}") for index in range(12)),
+    ]
+    app = _app()
+    app.surface_host = SurfaceHost()
+    manager = _manager(app, session)
+
+    asyncio.run(manager.handle_text("/models"))
+
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    before = app.active_surface.render(RenderConstraints(width=100, max_height=8))
+    intent = app.active_surface.handle_input(InputEvent(kind="key", key="down"))
+    after = app.active_surface.render(RenderConstraints(width=100, max_height=8))
+
+    assert intent == InputIntent(kind="consumed", note="info_scroll")
+    assert before.cursor is not None
+    assert after.cursor is not None
+    assert before.cursor.row == 5
+    assert after.cursor.row == 5
+
+
 def test_native_surface_manager_opens_settings_in_bottom_frame_with_runtime_overlay_host() -> None:
     app = _app()
     app.surface_host = SurfaceHost()


### PR DESCRIPTION
## Summary
- Open /models as a bottom-exclusive info panel instead of a runtime overlay.
- Make long info panels scrollable with a persistent footer and stable cursor placement.
- Simplify /models copy to use an Available Models title without a duplicate body heading.

## Test Plan
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -q
- [x] uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/ui/native_surfaces.py tests/coding/test_native_coding_tui_surfaces.py