### PR TITLE
feat(tui): add TreeView widget

### DIFF
--- a/docs/en/reference/tui-widgets.md
+++ b/docs/en/reference/tui-widgets.md
@@ -122,6 +122,30 @@ dialog = QuestionDialog(
 dialog.focus()
 ```
 
+## P1D Tree Controls
+
+| Widget | Use it for |
+| --- | --- |
+| `TreeNode` / `TreeView` | Static hierarchical data with local active-row navigation and expansion state. |
+
+`TreeView` flattens visible nodes in preorder. `right` expands a collapsed
+branch or moves to the first enabled direct child; `left` collapses an expanded
+branch or moves to the nearest enabled visible parent. Activating an enabled
+node returns `InputIntent(kind="select", text=value)` unless the node defines
+`on_select`.
+
+```python
+from loushang.tui import TreeNode, TreeView
+
+tree = TreeView(
+    (
+        TreeNode("src", "src", expanded=True, children=(TreeNode("widgets", "widgets"),)),
+        TreeNode("tests", "tests"),
+    )
+)
+tree.focus()
+```
+
 ## Forms
 
 ```python
@@ -222,6 +246,10 @@ supported. Initial stable tokens are:
 | `widget.table.focus` | Focused active table row. |
 | `widget.table.disabled` | Disabled table rows. |
 | `widget.table.empty` | Table empty-state text. |
+| `widget.tree.row` | Enabled inactive tree rows. |
+| `widget.tree.focus` | Focused active tree row. |
+| `widget.tree.disabled` | Disabled tree rows. |
+| `widget.tree.empty` | Tree empty-state text. |
 | `widget.textArea.label` | `TextArea` label rows. |
 | `widget.textArea.placeholder` | `TextArea` placeholder text. |
 | `widget.textArea.text` | `TextArea` body text. |
@@ -230,8 +258,8 @@ supported. Initial stable tokens are:
 
 ## Planned Catalog
 
-`Popover`, `TreeView`, and `Toast` are planned catalog entries. They are not
-part of the current widget implementation.
+`Popover` and `Toast` are planned catalog entries. They are not part of the
+current widget implementation.
 
 ## Example
 
@@ -247,3 +275,5 @@ part of the current widget implementation.
   multi-line text entry inside a small form.
 - [examples/tui/48_widgets_question_dialog.py](../../../examples/tui/48_widgets_question_dialog.py):
   multi-line question dialog with structured submit and cancel intents.
+- [examples/tui/49_widgets_tree.py](../../../examples/tui/49_widgets_tree.py):
+  static hierarchical tree with keyboard expansion and selection.

--- a/docs/superpowers/plans/2026-06-11-tui-widgets-p1d-treeview-implementation.md
+++ b/docs/superpowers/plans/2026-06-11-tui-widgets-p1d-treeview-implementation.md
@@ -1,0 +1,1214 @@
+# TUI Widgets P1D TreeView Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reusable `TreeNode` / `TreeView` widget for static hierarchical data with deterministic keyboard navigation, expansion state, selection intents, rendering, docs, and examples.
+
+**Architecture:** Implement `TreeView` as one focused widget module under `src/loushang/tui/ui_parts/widgets/tree.py`. It normalizes a static `TreeNode` hierarchy into immutable internal entries, tracks expanded values and active value by node value, derives visible rows in preorder, and follows existing `Menu`/`Table` patterns for focus, activation, viewport, width constraints, theme tokens, tests, docs, and public exports.
+
+**Tech Stack:** Python 3.11+, dataclasses with slots, existing `InputIntent`, `RenderResult`, `cell_width` helpers, `callback_result`, `is_activation_event`, `ThemeResolver`, pytest, Ruff.
+
+---
+
+## Reference Documents
+
+- Spec: `docs/superpowers/specs/2026-06-11-tui-widgets-p1d-treeview-design.md`
+- Existing patterns:
+  - `src/loushang/tui/ui_parts/widgets/menu.py`
+  - `src/loushang/tui/ui_parts/widgets/table.py`
+  - `src/loushang/tui/ui_parts/widgets/selection.py`
+  - `src/loushang/tui/ui_parts/widgets/_utils.py`
+  - `src/loushang/tui/input.py`
+  - `tests/tui/test_widgets_light_controls.py`
+  - `tests/tui/test_widgets_table.py`
+  - `tests/tui/test_widgets_hardening.py`
+
+## File Structure
+
+Create:
+
+- `src/loushang/tui/ui_parts/widgets/tree.py`
+  - Owns public `TreeNode` and `TreeView`.
+  - Owns internal normalized entries, flattening, expansion state, active-state fallback, input handling, activation, viewport, and row rendering.
+- `tests/tui/test_widgets_tree.py`
+  - Focused tests for exports, construction, duplicate handling, expansion normalization, navigation, expand/collapse, activation, rendering, theme tokens, and example importability.
+- `examples/tui/49_widgets_tree.py`
+  - Small runnable tree navigation example.
+
+Modify:
+
+- `src/loushang/tui/ui_parts/widgets/__init__.py`
+  - Re-export `TreeNode` and `TreeView`.
+- `src/loushang/tui/ui_parts/__init__.py`
+  - Re-export `TreeNode` and `TreeView`.
+- `src/loushang/tui/__init__.py`
+  - Re-export `TreeNode` and `TreeView`.
+- `docs/en/reference/tui-widgets.md`
+  - Add P1D TreeView entry, usage snippet, theme tokens, planned catalog update, and example link.
+- `docs/zh-CN/reference/tui-widgets.md`
+  - Mirror the English reference update.
+- `tests/tui/test_widgets_hardening.py`
+  - Add `TreeView` to small-constraint/theme coverage only if focused tests do not already cover those constraints clearly.
+
+Do not modify:
+
+- `InputIntentKind`, `InputRouter`, `SurfaceHost`, `Menu`, `Table`, `SelectList`, or global keybindings.
+
+---
+
+### Task 1: Add Failing Export And Construction Tests
+
+**Files:**
+- Create: `tests/tui/test_widgets_tree.py`
+
+- [ ] **Step 1: Create the focused test file with shared helpers**
+
+Use the helper style from `tests/tui/test_widgets_table.py`:
+
+```python
+from __future__ import annotations
+
+import runpy
+from typing import Any
+
+import pytest
+
+from loushang.tui import (
+    InputEvent,
+    RenderConstraints,
+    ThemeResolver,
+    TreeNode,
+    TreeView,
+    strip_control_sequences,
+    visible_width,
+)
+from loushang.tui.ui_parts import TreeNode as UiTreeNode
+from loushang.tui.ui_parts import TreeView as UiTreeView
+from loushang.tui.ui_parts.widgets import TreeNode as WidgetTreeNode
+from loushang.tui.ui_parts.widgets import TreeView as WidgetTreeView
+
+
+def render_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
+    result = part.render(RenderConstraints(width=width, max_height=height))
+    return tuple(line.text for line in result.lines)
+
+
+def plain_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
+    return tuple(strip_control_sequences(line) for line in render_lines(part, width=width, height=height))
+
+
+def assert_widths_within(lines: tuple[str, ...], width: int) -> None:
+    assert all(visible_width(line) <= width for line in lines)
+
+
+def intent_tuple(intent: object) -> tuple[str, str, str]:
+    return (getattr(intent, "kind", ""), getattr(intent, "text", ""), getattr(intent, "note", ""))
+
+
+def sample_nodes() -> tuple[TreeNode, ...]:
+    return (
+        TreeNode(
+            "src",
+            "src",
+            expanded=True,
+            children=(
+                TreeNode("widgets", "widgets"),
+                TreeNode("runtime", "runtime", disabled=True),
+            ),
+        ),
+        TreeNode(
+            "tests",
+            "tests",
+            children=(
+                TreeNode("unit", "unit"),
+                TreeNode("integration", "integration"),
+            ),
+        ),
+    )
+```
+
+- [ ] **Step 2: Add failing public export tests**
+
+```python
+def test_tree_widgets_are_reexported_from_public_modules() -> None:
+    assert TreeNode is UiTreeNode
+    assert TreeNode is WidgetTreeNode
+    assert TreeView is UiTreeView
+    assert TreeView is WidgetTreeView
+    assert TreeNode("src", "src").value == "src"
+```
+
+- [ ] **Step 3: Add failing construction and normalization tests**
+
+```python
+def test_tree_view_normalizes_expansion_and_active_state() -> None:
+    tree = TreeView(sample_nodes(), expanded_values=("tests", "unit"), active_value="missing")
+
+    assert tree.expanded_value_set == frozenset({"src", "tests"})
+    assert tree.is_expanded("src") is True
+    assert tree.is_expanded("widgets") is False
+    assert tree.visible_values == ("src", "widgets", "runtime", "tests", "unit", "integration")
+    assert tree.active_value == "src"
+
+
+def test_tree_view_rejects_duplicate_values_and_unknown_expanded_values() -> None:
+    with pytest.raises(ValueError):
+        TreeView((TreeNode("dup", "One"), TreeNode("dup", "Two")))
+
+    with pytest.raises(ValueError):
+        TreeView(sample_nodes(), expanded_values=("missing",))
+
+
+def test_tree_view_initial_active_falls_back_to_first_enabled_visible_node() -> None:
+    tree = TreeView(
+        (
+            TreeNode("disabled", "Disabled", disabled=True),
+            TreeNode("enabled", "Enabled"),
+        ),
+        active_value="disabled",
+    )
+
+    assert tree.active_value == "enabled"
+```
+
+- [ ] **Step 4: Run focused tests to verify failure**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+```
+
+Expected: FAIL during import because `TreeNode` and `TreeView` do not exist.
+
+- [ ] **Step 5: Commit the failing tests**
+
+```bash
+git add tests/tui/test_widgets_tree.py
+git commit -m "test(tui): add treeview api tests"
+```
+
+---
+
+### Task 2: Implement Tree Skeleton, Normalization, And Public Exports
+
+**Files:**
+- Create: `src/loushang/tui/ui_parts/widgets/tree.py`
+- Modify: `src/loushang/tui/ui_parts/widgets/__init__.py`
+- Modify: `src/loushang/tui/ui_parts/__init__.py`
+- Modify: `src/loushang/tui/__init__.py`
+- Test: `tests/tui/test_widgets_tree.py`
+
+- [ ] **Step 1: Create `tree.py` with public classes and internal entry type**
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
+from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event, style_text
+
+__all__ = ["TreeNode", "TreeView"]
+
+
+@dataclass(frozen=True, slots=True)
+class TreeNode:
+    value: str
+    label: str
+    children: Sequence["TreeNode"] = ()
+    disabled: bool = False
+    expanded: bool = False
+    on_select: Callable[[], object] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _TreeEntry:
+    value: str
+    label: str
+    depth: int
+    parent: str
+    children: tuple[str, ...]
+    disabled: bool
+    expanded: bool
+    on_select: Callable[[], object] | None
+```
+
+- [ ] **Step 2: Add `TreeView` fields, properties, and normalization**
+
+```python
+@dataclass(init=False, slots=True)
+class TreeView:
+    nodes: Sequence[TreeNode]
+    expanded_values: Sequence[str] = ()
+    empty_text: str = "No nodes"
+    wrap: bool = True
+    indent: int = 2
+    collapsed_marker: str = "+"
+    expanded_marker: str = "-"
+    leaf_marker: str = " "
+    theme: ThemeResolver | None = None
+    focused: bool = False
+    _entries: dict[str, _TreeEntry] = field(default_factory=dict, init=False, repr=False)
+    _root_values: tuple[str, ...] = field(default=(), init=False, repr=False)
+    _expanded_values: set[str] = field(default_factory=set, init=False, repr=False)
+    _active_value: str = field(default="", init=False, repr=False)
+    _first_visible_index: int = field(default=0, init=False, repr=False)
+
+    def __init__(
+        self,
+        nodes: Sequence[TreeNode],
+        active_value: str = "",
+        expanded_values: Sequence[str] = (),
+        empty_text: str = "No nodes",
+        wrap: bool = True,
+        indent: int = 2,
+        collapsed_marker: str = "+",
+        expanded_marker: str = "-",
+        leaf_marker: str = " ",
+        theme: ThemeResolver | None = None,
+        focused: bool = False,
+    ) -> None:
+        self.nodes = tuple(nodes)
+        self.expanded_values = tuple(expanded_values)
+        self.empty_text = empty_text
+        self.wrap = wrap
+        self.indent = max(0, indent)
+        self.collapsed_marker = collapsed_marker
+        self.expanded_marker = expanded_marker
+        self.leaf_marker = leaf_marker
+        self.theme = theme
+        self.focused = focused
+        self._entries = {}
+        self._root_values = tuple(node.value for node in self.nodes)
+        for node in self.nodes:
+            self._add_node(node, depth=0, parent="")
+        self._expanded_values = self._initial_expanded_values()
+        self._active_value = self._normalize_active_value(active_value)
+        self._first_visible_index = 0
+
+    @property
+    def expanded_value_set(self) -> frozenset[str]:
+        return frozenset(self._expanded_values)
+
+    @property
+    def visible_values(self) -> tuple[str, ...]:
+        return tuple(entry.value for entry in self._visible_entries())
+
+    @property
+    def active_value(self) -> str:
+        return self._active_value
+```
+
+`TreeView` uses `init=False` so `active_value` can be an initializer argument
+while remaining a read-only property backed by `_active_value`.
+
+- [ ] **Step 3: Implement normalization helpers**
+
+```python
+    def _add_node(self, node: TreeNode, *, depth: int, parent: str) -> None:
+        if node.value in self._entries:
+            raise ValueError(f"duplicate TreeNode value: {node.value!r}")
+        children = tuple(child.value for child in node.children)
+        self._entries[node.value] = _TreeEntry(
+            value=node.value,
+            label=node.label,
+            depth=depth,
+            parent=parent,
+            children=children,
+            disabled=node.disabled,
+            expanded=node.expanded,
+            on_select=node.on_select,
+        )
+        for child in node.children:
+            self._add_node(child, depth=depth + 1, parent=node.value)
+
+    def _initial_expanded_values(self) -> set[str]:
+        expanded: set[str] = set()
+        for entry in self._entries.values():
+            if entry.expanded and entry.children:
+                expanded.add(entry.value)
+        for value in self.expanded_values:
+            entry = self._entry(value)
+            if entry.children:
+                expanded.add(value)
+        return expanded
+
+    def _entry(self, value: str) -> _TreeEntry:
+        try:
+            return self._entries[value]
+        except KeyError as exc:
+            raise ValueError(f"unknown TreeNode value: {value!r}") from exc
+
+    def _visible_entries(self) -> tuple[_TreeEntry, ...]:
+        result: list[_TreeEntry] = []
+        for value in self._root_values:
+            self._append_visible(value, result)
+        return tuple(result)
+
+    def _append_visible(self, value: str, result: list[_TreeEntry]) -> None:
+        entry = self._entries[value]
+        result.append(entry)
+        if entry.value not in self._expanded_values:
+            return
+        for child in entry.children:
+            self._append_visible(child, result)
+
+    def _enabled_visible_entries(self) -> tuple[_TreeEntry, ...]:
+        return tuple(entry for entry in self._visible_entries() if not entry.disabled)
+
+    def _normalize_active_value(self, preferred: str) -> str:
+        visible = self._visible_entries()
+        visible_enabled = {entry.value for entry in visible if not entry.disabled}
+        if preferred in visible_enabled:
+            return preferred
+        return "" if not visible_enabled else next(entry.value for entry in visible if entry.value in visible_enabled)
+```
+
+- [ ] **Step 4: Implement minimal methods and render**
+
+```python
+    def focus(self) -> None:
+        self.focused = True
+
+    def blur(self) -> None:
+        self.focused = False
+
+    def is_expanded(self, value: str) -> bool:
+        entry = self._entry(value)
+        return bool(entry.children and value in self._expanded_values)
+
+    def expand(self, value: str) -> bool:
+        entry = self._entry(value)
+        if not entry.children or value in self._expanded_values:
+            return False
+        self._expanded_values.add(value)
+        return True
+
+    def collapse(self, value: str) -> bool:
+        entry = self._entry(value)
+        if not entry.children or value not in self._expanded_values:
+            return False
+        self._expanded_values.remove(value)
+        self._repair_active_after_collapse(value)
+        return True
+
+    def toggle(self, value: str) -> bool:
+        return self.collapse(value) if self.is_expanded(value) else self.expand(value)
+
+    def handle_input(self, event: object) -> object:
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        width = autowrap_safe_width(constraints.width)
+        height = max(0, constraints.max_height)
+        if height == 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        rows = self._visible_entries()
+        if not rows:
+            empty = truncate_to_width(self.empty_text, max_width=width, ellipsis="")
+            return RenderResult.from_lines([RenderLine(style_text(empty, self.theme, "widget.tree.empty"))], constraints=constraints)
+        lines = [RenderLine(truncate_to_width(entry.label, max_width=width, ellipsis="")) for entry in rows[:height]]
+        return RenderResult.from_lines(lines, constraints=constraints)
+```
+
+Implement `_repair_active_after_collapse()` with the spec fallback in Task 4 if
+not needed for Task 1 tests.
+
+- [ ] **Step 5: Add public exports**
+
+In `src/loushang/tui/ui_parts/widgets/__init__.py`:
+
+```python
+from .tree import TreeNode as TreeNode
+from .tree import TreeView as TreeView
+```
+
+Add `"TreeNode"` and `"TreeView"` to `widgets.__all__`.
+
+In `src/loushang/tui/ui_parts/__init__.py`:
+
+```python
+from .widgets import TreeNode as TreeNode
+from .widgets import TreeView as TreeView
+```
+
+Add both names to `ui_parts.__all__`.
+
+In `src/loushang/tui/__init__.py`, add both names to the existing
+`from loushang.tui.ui_parts import (...)` block and to top-level `__all__`.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+```
+
+Expected: Task 1 tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/loushang/tui/ui_parts/widgets/tree.py src/loushang/tui/ui_parts/widgets/__init__.py src/loushang/tui/ui_parts/__init__.py src/loushang/tui/__init__.py
+git commit -m "feat(tui): add treeview skeleton"
+```
+
+---
+
+### Task 3: Add Failing Navigation, Expansion, And Activation Tests
+
+**Files:**
+- Modify: `tests/tui/test_widgets_tree.py`
+
+- [ ] **Step 1: Add navigation tests**
+
+```python
+def test_tree_view_navigation_skips_disabled_and_honors_wrap_false() -> None:
+    tree = TreeView(sample_nodes(), wrap=False)
+    tree.focus()
+
+    assert tree.active_value == "src"
+    assert tree.handle_input(InputEvent(kind="key", key="down")) is True
+    assert tree.active_value == "widgets"
+    assert tree.handle_input(InputEvent(kind="key", key="down")) is True
+    assert tree.active_value == "tests"
+    assert tree.handle_input(InputEvent(kind="key", key="down")) is False
+    assert tree.handle_input(InputEvent(kind="key", key="home")) is True
+    assert tree.active_value == "src"
+    assert tree.handle_input(InputEvent(kind="key", key="up")) is False
+
+
+def test_tree_view_empty_and_all_disabled_navigation_returns_none() -> None:
+    assert TreeView(()).handle_input(InputEvent(kind="key", key="down")) is None
+
+    disabled = TreeView((TreeNode("disabled", "Disabled", disabled=True),))
+    disabled.focus()
+    assert disabled.active_value == ""
+    assert disabled.handle_input(InputEvent(kind="key", key="down")) is None
+    assert disabled.handle_input(InputEvent(kind="key", key="enter")) is None
+```
+
+- [ ] **Step 2: Add expand/collapse keyboard tests**
+
+```python
+def test_tree_view_right_expands_then_moves_to_enabled_direct_child() -> None:
+    tree = TreeView((TreeNode("root", "root", children=(TreeNode("child", "child"),)),))
+    tree.focus()
+
+    assert tree.visible_values == ("root",)
+    assert tree.handle_input(InputEvent(kind="key", key="right")) is True
+    assert tree.expanded_value_set == frozenset({"root"})
+    assert tree.visible_values == ("root", "child")
+    assert tree.active_value == "root"
+    assert tree.handle_input(InputEvent(kind="key", key="right")) is True
+    assert tree.active_value == "child"
+
+
+def test_tree_view_right_does_not_skip_disabled_direct_children_to_grandchildren() -> None:
+    tree = TreeView(
+        (
+            TreeNode(
+                "root",
+                "root",
+                expanded=True,
+                children=(TreeNode("disabled", "disabled", disabled=True, children=(TreeNode("grand", "grand"),)),),
+            ),
+        )
+    )
+    tree.focus()
+
+    assert tree.handle_input(InputEvent(kind="key", key="right")) is False
+    assert tree.active_value == "root"
+
+
+def test_tree_view_left_collapses_or_moves_to_enabled_parent() -> None:
+    tree = TreeView(sample_nodes(), active_value="widgets")
+    tree.focus()
+
+    assert tree.handle_input(InputEvent(kind="key", key="left")) is True
+    assert tree.active_value == "src"
+    assert tree.handle_input(InputEvent(kind="key", key="left")) is True
+    assert tree.expanded_value_set == frozenset()
+    assert tree.active_value == "src"
+    assert tree.handle_input(InputEvent(kind="key", key="left")) is False
+```
+
+- [ ] **Step 3: Add programmatic state and collapse fallback tests**
+
+```python
+def test_tree_view_programmatic_expand_collapse_toggle_and_unknown_values() -> None:
+    tree = TreeView(sample_nodes())
+
+    assert tree.expand("tests") is True
+    assert tree.expand("tests") is False
+    assert tree.is_expanded("tests") is True
+    assert tree.collapse("tests") is True
+    assert tree.collapse("tests") is False
+    assert tree.toggle("tests") is True
+    assert tree.toggle("tests") is True
+    assert tree.expand("widgets") is False
+
+    with pytest.raises(ValueError):
+        tree.expand("missing")
+
+
+def test_tree_view_collapse_hidden_active_falls_back_deterministically() -> None:
+    tree = TreeView(sample_nodes(), expanded_values=("tests",), active_value="integration")
+    tree.focus()
+
+    assert tree.collapse("tests") is True
+
+    assert tree.active_value == "tests"
+
+    disabled_branch = TreeView(
+        (
+            TreeNode("before", "before"),
+            TreeNode("branch", "branch", disabled=True, expanded=True, children=(TreeNode("child", "child"),)),
+            TreeNode("after", "after"),
+        ),
+        active_value="child",
+    )
+
+    assert disabled_branch.collapse("branch") is True
+    assert disabled_branch.active_value == "before"
+```
+
+- [ ] **Step 4: Add activation tests**
+
+```python
+def test_tree_view_activation_returns_callback_or_select_intent() -> None:
+    calls: list[str] = []
+    tree = TreeView(
+        (
+            TreeNode("callback", "callback", on_select=lambda: calls.append("callback")),
+            TreeNode("plain", "plain"),
+        )
+    )
+    tree.focus()
+
+    assert tree.handle_input(InputEvent(kind="key", key="enter")) is True
+    assert calls == ["callback"]
+    assert tree.handle_input(InputEvent(kind="key", key="down")) is True
+    assert intent_tuple(tree.handle_input(InputEvent(kind="key", key="enter"))) == ("select", "plain", "")
+    assert intent_tuple(tree.handle_input(InputEvent(kind="key", key="space"))) == ("select", "plain", "")
+    assert intent_tuple(tree.handle_input(InputEvent(kind="text", text=" "))) == ("select", "plain", "")
+```
+
+- [ ] **Step 5: Run focused tests to verify failures**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+```
+
+Expected: FAIL on unimplemented navigation/input behavior.
+
+- [ ] **Step 6: Commit failing tests**
+
+```bash
+git add tests/tui/test_widgets_tree.py
+git commit -m "test(tui): cover treeview input behavior"
+```
+
+---
+
+### Task 4: Implement Navigation, Expansion, Collapse Fallback, And Activation
+
+**Files:**
+- Modify: `src/loushang/tui/ui_parts/widgets/tree.py`
+- Test: `tests/tui/test_widgets_tree.py`
+
+- [ ] **Step 1: Add active movement helpers**
+
+```python
+    def _move_active(self, delta: int) -> bool | None:
+        enabled = tuple(entry.value for entry in self._enabled_visible_entries())
+        if not enabled:
+            return None
+        if self._active_value not in enabled:
+            self._active_value = enabled[0]
+            return True
+        position = enabled.index(self._active_value)
+        next_position = position + delta
+        if self.wrap:
+            next_position %= len(enabled)
+        elif next_position < 0 or next_position >= len(enabled):
+            return False
+        next_value = enabled[next_position]
+        if next_value == self._active_value:
+            return False
+        self._active_value = next_value
+        return True
+
+    def _jump_active(self, *, first: bool) -> bool | None:
+        enabled = tuple(entry.value for entry in self._enabled_visible_entries())
+        if not enabled:
+            return None
+        target = enabled[0] if first else enabled[-1]
+        if target == self._active_value:
+            return False
+        self._active_value = target
+        return True
+```
+
+- [ ] **Step 2: Add parent/child and collapse fallback helpers**
+
+```python
+    def _active_entry(self) -> _TreeEntry | None:
+        if not self._active_value:
+            return None
+        entry = self._entries.get(self._active_value)
+        return None if entry is None or entry.disabled else entry
+
+    def _first_enabled_direct_child(self, entry: _TreeEntry) -> str:
+        for value in entry.children:
+            child = self._entries[value]
+            if not child.disabled:
+                return value
+        return ""
+
+    def _nearest_enabled_visible_parent(self, entry: _TreeEntry) -> str:
+        parent = entry.parent
+        while parent:
+            candidate = self._entries[parent]
+            if not candidate.disabled and parent in self.visible_values:
+                return parent
+            parent = candidate.parent
+        return ""
+
+    def _repair_active_after_collapse(self, collapsed_value: str) -> None:
+        visible_values = self.visible_values
+        if self._active_value in visible_values:
+            return
+        collapsed = self._entries[collapsed_value]
+        if not collapsed.disabled:
+            self._active_value = collapsed_value
+            return
+        try:
+            collapsed_index = visible_values.index(collapsed_value)
+        except ValueError:
+            collapsed_index = 0
+        visible = self._visible_entries()
+        for index in range(collapsed_index - 1, -1, -1):
+            if not visible[index].disabled:
+                self._active_value = visible[index].value
+                return
+        for index in range(collapsed_index + 1, len(visible)):
+            if not visible[index].disabled:
+                self._active_value = visible[index].value
+                return
+        self._active_value = ""
+```
+
+- [ ] **Step 3: Implement right/left and activation**
+
+```python
+    def _expand_or_move_child(self) -> bool | None:
+        entry = self._active_entry()
+        if entry is None:
+            return None
+        if not entry.children:
+            return False
+        if entry.value not in self._expanded_values:
+            self._expanded_values.add(entry.value)
+            return True
+        child = self._first_enabled_direct_child(entry)
+        if not child:
+            return False
+        if child == self._active_value:
+            return False
+        self._active_value = child
+        return True
+
+    def _collapse_or_move_parent(self) -> bool | None:
+        entry = self._active_entry()
+        if entry is None:
+            return None
+        if entry.children and entry.value in self._expanded_values:
+            return self.collapse(entry.value)
+        parent = self._nearest_enabled_visible_parent(entry)
+        if not parent:
+            return False
+        self._active_value = parent
+        return True
+
+    def _activate(self) -> object:
+        entry = self._active_entry()
+        if entry is None:
+            return None
+        if entry.on_select is not None:
+            return callback_result(entry.on_select())
+        from loushang.tui.input import InputIntent
+
+        return InputIntent(kind="select", text=entry.value)
+```
+
+Use a lazy import for `InputIntent` to avoid import cycles.
+
+- [ ] **Step 4: Implement full `handle_input()`**
+
+```python
+    def handle_input(self, event: object) -> object:
+        if getattr(event, "kind", "") == "key":
+            key = getattr(event, "key", "")
+            if key == "up":
+                return self._move_active(-1)
+            if key == "down":
+                return self._move_active(1)
+            if key == "home":
+                return self._jump_active(first=True)
+            if key == "end":
+                return self._jump_active(first=False)
+            if key == "right":
+                return self._expand_or_move_child()
+            if key == "left":
+                return self._collapse_or_move_parent()
+        if is_activation_event(event):
+            return self._activate()
+        return None
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+```
+
+Expected: all current tree tests PASS.
+
+- [ ] **Step 6: Run adjacent tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_table.py tests/tui/test_widgets_light_controls.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/loushang/tui/ui_parts/widgets/tree.py
+git commit -m "feat(tui): handle treeview input"
+```
+
+---
+
+### Task 5: Add Failing Render, Viewport, Theme, Docs Example Tests
+
+**Files:**
+- Modify: `tests/tui/test_widgets_tree.py`
+
+- [ ] **Step 1: Add render structure tests**
+
+```python
+def test_tree_view_renders_indentation_markers_focus_and_disabled_rows() -> None:
+    tree = TreeView(sample_nodes())
+    tree.focus()
+
+    assert plain_lines(tree, width=30, height=6) == (
+        "> - src",
+        "      widgets",
+        "      runtime",
+        "  + tests",
+    )
+```
+
+- [ ] **Step 2: Add width, empty, and viewport tests**
+
+```python
+def test_tree_view_respects_width_empty_and_height_viewport() -> None:
+    empty = TreeView((), empty_text="Nothing here")
+    assert plain_lines(empty, width=8, height=3) == ("Nothing",)
+
+    tree = TreeView(
+        tuple(TreeNode(str(index), f"Item {index}") for index in range(6)),
+        active_value="5",
+    )
+    tree.focus()
+
+    lines = render_lines(tree, width=8, height=3)
+
+    assert plain_lines(tree, width=8, height=3) == (
+        "    Item",
+        "    Item",
+        ">   Item",
+    )
+    assert_widths_within(lines, 8)
+```
+
+- [ ] **Step 3: Add theme token tests**
+
+```python
+def test_tree_view_applies_theme_tokens() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.tree.row": {"color": "white"},
+            "widget.tree.focus": {"bold": True, "color": "green"},
+            "widget.tree.disabled": {"dim": True},
+            "widget.tree.empty": {"color": "bright_black"},
+        }
+    )
+    tree = TreeView(sample_nodes(), theme=theme)
+    tree.focus()
+
+    raw = render_lines(tree, width=30, height=4)
+
+    assert raw[0].startswith("\x1b[1;32m> - src")
+    assert raw[1].startswith("\x1b[37m      widgets")
+    assert raw[2].startswith("\x1b[2m      runtime")
+    assert render_lines(TreeView((), theme=theme), width=10, height=1)[0].startswith("\x1b[90mNo nodes")
+```
+
+- [ ] **Step 4: Run focused tests to verify failures**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+```
+
+Expected: FAIL on render/theme behavior.
+
+- [ ] **Step 5: Commit failing tests**
+
+```bash
+git add tests/tui/test_widgets_tree.py
+git commit -m "test(tui): cover treeview rendering"
+```
+
+---
+
+### Task 6: Implement Deterministic Rendering And Viewport
+
+**Files:**
+- Modify: `src/loushang/tui/ui_parts/widgets/tree.py`
+- Test: `tests/tui/test_widgets_tree.py`
+
+- [ ] **Step 1: Implement marker, row, and viewport helpers**
+
+```python
+    def _ensure_active_visible(self, height: int) -> None:
+        visible = self._visible_entries()
+        if height <= 0 or not visible or not self._active_value:
+            return
+        index_by_value = {entry.value: index for index, entry in enumerate(visible)}
+        active_index = index_by_value.get(self._active_value)
+        if active_index is None:
+            return
+        if active_index < self._first_visible_index:
+            self._first_visible_index = active_index
+        elif active_index >= self._first_visible_index + height:
+            self._first_visible_index = active_index - height + 1
+        max_first = max(0, len(visible) - height)
+        self._first_visible_index = max(0, min(self._first_visible_index, max_first))
+
+    def _marker(self, entry: _TreeEntry) -> str:
+        if not entry.children:
+            return self.leaf_marker
+        return self.expanded_marker if entry.value in self._expanded_values else self.collapsed_marker
+
+    def _row_line(self, entry: _TreeEntry, width: int) -> str:
+        focused_row = self.focused and entry.value == self._active_value and not entry.disabled
+        prefix = "> " if focused_row else "  "
+        indent = " " * (entry.depth * self.indent)
+        text = truncate_to_width(f"{prefix}{indent}{self._marker(entry)} {entry.label}", max_width=width, ellipsis="")
+        token = "widget.tree.disabled" if entry.disabled else "widget.tree.focus" if focused_row else "widget.tree.row"
+        return style_text(text, self.theme, token)
+```
+
+- [ ] **Step 2: Replace `render()`**
+
+```python
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        width = autowrap_safe_width(constraints.width)
+        height = max(0, constraints.max_height)
+        if height == 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        visible = self._visible_entries()
+        if not visible:
+            empty = truncate_to_width(self.empty_text, max_width=width, ellipsis="")
+            return RenderResult.from_lines([RenderLine(style_text(empty, self.theme, "widget.tree.empty"))], constraints=constraints)
+        self._ensure_active_visible(height)
+        rows = visible[self._first_visible_index : self._first_visible_index + height]
+        lines = [RenderLine(self._row_line(entry, width)) for entry in rows]
+        return RenderResult.from_lines(lines, constraints=constraints)
+```
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run adjacent hardening tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_table.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_hardening.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/loushang/tui/ui_parts/widgets/tree.py
+git commit -m "feat(tui): render treeview"
+```
+
+---
+
+### Task 7: Add Docs And Runnable Example
+
+**Files:**
+- Create: `examples/tui/49_widgets_tree.py`
+- Modify: `docs/en/reference/tui-widgets.md`
+- Modify: `docs/zh-CN/reference/tui-widgets.md`
+- Test: `tests/tui/test_widgets_tree.py`
+
+- [ ] **Step 1: Add failing example import test**
+
+```python
+def test_widgets_tree_example_imports() -> None:
+    namespace = runpy.run_path("examples/tui/49_widgets_tree.py", run_name="__test__")
+
+    assert callable(namespace["build_app"])
+```
+
+- [ ] **Step 2: Run the example import test to verify failure**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py::test_widgets_tree_example_imports -q
+```
+
+Expected: FAIL because `examples/tui/49_widgets_tree.py` does not exist.
+
+- [ ] **Step 3: Create `examples/tui/49_widgets_tree.py`**
+
+```python
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from loushang.tui import (
+    FocusableMixin,
+    InputEvent,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    TreeNode,
+    TreeView,
+    Tui,
+    TuiInputResult,
+    TuiRunner,
+    truncate_to_width,
+)
+
+
+@dataclass(slots=True)
+class TreeViewApp(FocusableMixin):
+    tree: TreeView = field(
+        default_factory=lambda: TreeView(
+            (
+                TreeNode("src", "src", expanded=True, children=(TreeNode("widgets", "widgets"), TreeNode("runtime", "runtime"))),
+                TreeNode("tests", "tests", children=(TreeNode("unit", "unit"), TreeNode("integration", "integration"))),
+            )
+        )
+    )
+    message: str = "Use arrows to navigate. Enter selects. Press q to quit."
+
+    def __post_init__(self) -> None:
+        super().__init__()
+        self.tree.focus()
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        tree_result = self.tree.render(RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2)))
+        rows = [
+            *tree_result.lines,
+            RenderLine(""),
+            RenderLine(truncate_to_width(self.message, max_width=constraints.width, ellipsis="")),
+        ]
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints)
+
+    def handle_input(self, event: Any) -> object:
+        result = self.tree.handle_input(event)
+        if getattr(result, "kind", "") == "select":
+            self.message = f"Selected: {getattr(result, 'text', '')}"
+        return result
+
+
+def build_app() -> Tui:
+    tui = Tui()
+    app = TreeViewApp()
+    tui.add_child(app)
+    tui.set_focus(app)
+    return tui
+
+
+async def main() -> int:
+    tui = build_app()
+
+    async def on_input(event: InputEvent, context: Any) -> TuiInputResult:
+        if event.kind == "text" and "q" in event.text.lower():
+            return context.stop(0)
+        context.tui.handle_input(event)
+        return TuiInputResult()
+
+    return await TuiRunner(tui).run(on_input=on_input)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))
+```
+
+- [ ] **Step 4: Update English docs**
+
+In `docs/en/reference/tui-widgets.md`:
+
+- Add `P1D Tree Controls` after P1C.
+- Add `TreeNode` / `TreeView` entry.
+- Document right/left expand-collapse behavior and `select` intents.
+- Add theme tokens `widget.tree.row`, `widget.tree.focus`, `widget.tree.disabled`, `widget.tree.empty`.
+- Remove `TreeView` from planned catalog.
+- Add example link.
+
+Snippet:
+
+```python
+from loushang.tui import TreeNode, TreeView
+
+tree = TreeView(
+    (
+        TreeNode("src", "src", expanded=True, children=(TreeNode("widgets", "widgets"),)),
+        TreeNode("tests", "tests"),
+    )
+)
+tree.focus()
+```
+
+- [ ] **Step 5: Update Chinese docs**
+
+Mirror the English content in `docs/zh-CN/reference/tui-widgets.md`.
+
+- [ ] **Step 6: Run focused tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add examples/tui/49_widgets_tree.py docs/en/reference/tui-widgets.md docs/zh-CN/reference/tui-widgets.md tests/tui/test_widgets_tree.py
+git commit -m "docs(tui): document treeview widget"
+```
+
+---
+
+### Task 8: Final Verification And Cleanup
+
+**Files:**
+- Review all changed files.
+
+- [ ] **Step 1: Run focused TreeView tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run adjacent widget tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_table.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_hardening.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full TUI tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run Ruff on touched surfaces**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui tests/tui examples/tui/49_widgets_tree.py docs
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect git diff**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --check
+```
+
+Expected: no whitespace errors; diff contains only spec/plan, TreeView widget,
+exports, tests, docs, and example.
+
+- [ ] **Step 6: Commit any final fixes**
+
+If verification required small fixes:
+
+```bash
+git add <fixed-files>
+git commit -m "fix(tui): finalize treeview widget"
+```
+
+If no fixes were needed, do not create an empty commit.
+
+---
+
+## Success Criteria
+
+- `TreeNode` and `TreeView` are exported from `loushang.tui`, `loushang.tui.ui_parts`, and `loushang.tui.ui_parts.widgets`.
+- Duplicate values and unknown `expanded_values` raise `ValueError`.
+- Initial expansion ignores leaf values and preserves only expanded branches.
+- Navigation skips disabled visible nodes and keeps active row in the viewport.
+- `right` expands collapsed branches or moves to first enabled direct child only.
+- `left` collapses expanded branches or moves to nearest enabled visible parent.
+- Programmatic expand/collapse/toggle/is-expanded semantics match the spec.
+- Activation returns callbacks or `InputIntent(kind="select", text=value)`.
+- Rendering obeys width and height constraints with deterministic ASCII markers.
+- Theme tokens are deterministic and covered.
+- Docs and example import tests pass.
+- Existing TUI tests remain green.

--- a/docs/superpowers/specs/2026-06-11-tui-widgets-p1d-treeview-design.md
+++ b/docs/superpowers/specs/2026-06-11-tui-widgets-p1d-treeview-design.md
@@ -90,6 +90,18 @@ The first public API should also expose:
 - `expand(value)`, `collapse(value)`, and `toggle(value)`.
 - `is_expanded(value)`.
 
+Programmatic state methods use exact return semantics:
+
+- Unknown `value` raises `ValueError`.
+- `expand(value)` returns `True` when a branch changes from collapsed to
+  expanded, `False` when the node is already expanded or is a leaf.
+- `collapse(value)` returns `True` when a branch changes from expanded to
+  collapsed, `False` when the node is already collapsed or is a leaf.
+- `toggle(value)` returns the result of `collapse(value)` when expanded and
+  `expand(value)` when collapsed.
+- `is_expanded(value)` returns `False` for leaves and raises `ValueError` for
+  unknown values.
+
 `TreeView` normalizes `nodes` to immutable internal entries in `__post_init__`.
 Node `value` values must be unique across the tree. Duplicate values raise
 `ValueError` during construction because expansion, active row, and selection
@@ -116,10 +128,10 @@ Default keys:
 | `down` | Move to next enabled visible node. |
 | `home` | Move to first enabled visible node. |
 | `end` | Move to last enabled visible node. |
-| `right` | Expand collapsed active branch, or move to first enabled child when already expanded. |
+| `right` | Expand collapsed active branch, or move to first enabled direct child when already expanded. |
 | `left` | Collapse expanded active branch, or move to nearest enabled visible parent. |
 | `enter` / `space` | Activate active node. |
-| text event containing literal space | Activate active node. |
+| exact text event `text == " "` | Activate active node. |
 
 Movement returns:
 
@@ -136,15 +148,30 @@ Activation returns:
 `right` semantics:
 
 1. If active node has children and is collapsed, expand it and return `True`.
-2. If active node is expanded, move to the first enabled visible descendant that
-   is now immediately under that branch and return `True`.
+2. If active node is expanded, move to the first enabled direct child and
+   return `True`.
 3. If neither applies, return `False`.
+
+`right` does not skip disabled direct children to reach enabled grandchildren.
+If all direct children are disabled, it returns `False`.
 
 `left` semantics:
 
 1. If active node has children and is expanded, collapse it and return `True`.
 2. Otherwise move to the nearest enabled visible parent and return `True`.
 3. If there is no enabled visible parent, return `False`.
+
+Collapse active fallback:
+
+- Keyboard collapse and `collapse(value)` use the same fallback rules.
+- If the current active node remains visible after collapse, keep it.
+- If the collapse hides the active node, prefer the collapsed branch when it is
+  enabled.
+- If the collapsed branch is disabled, search visible enabled nodes in this
+  deterministic order: previous visible rows before the collapsed branch,
+  nearest first; then following visible rows after the collapsed branch, nearest
+  first.
+- If no enabled visible node exists, set active value to `""`.
 
 Disabled nodes:
 
@@ -189,10 +216,11 @@ Viewport behavior:
 
 - `TreeView` keeps `_first_visible_index` so the active row stays in view.
 - The visible window is based on flattened visible rows, not total node count.
-- Collapsing a branch that hides the active node moves active state to the
-  collapsed branch if that branch is enabled; otherwise to the nearest enabled
-  visible node.
-- `constraints.max_height <= 0` renders no lines.
+- Collapsing a branch that hides the active node uses the collapse active
+  fallback rules from input behavior.
+- `constraints.max_height <= 0` is handled defensively by rendering no lines,
+  although normal `RenderConstraints` construction already rejects non-positive
+  heights.
 
 ## Theme Tokens
 

--- a/docs/superpowers/specs/2026-06-11-tui-widgets-p1d-treeview-design.md
+++ b/docs/superpowers/specs/2026-06-11-tui-widgets-p1d-treeview-design.md
@@ -1,0 +1,296 @@
+# TUI Widgets P1D TreeView Design
+
+## Status
+
+Draft for spec review.
+
+## Context
+
+`loushang.tui` now has a useful first widget catalog:
+
+- P0A foundation widgets: buttons, choices, fields, forms, dialogs.
+- P0B small controls: badges, status pills, progress, key-value lists, toolbar.
+- P0C light controls: menu, tabs, spinner.
+- P1A data controls: table.
+- P1B/P1C text and dialog inputs: textarea and question dialog.
+
+The next gap is a reusable tree widget for hierarchical data. Callers can fake
+this with `Menu` or `Table`, but they must hand-roll flattening, indentation,
+expand/collapse state, active row visibility, disabled nodes, and selection
+intent wiring. `TreeView` should provide that foundation without taking on file
+system, async loading, or checkbox-tree behavior.
+
+## Goals
+
+- Add a public `TreeNode` data class and `TreeView` widget.
+- Support static nested trees with unique node values.
+- Support local focus, active-row navigation, expand/collapse, and activation.
+- Return structured `InputIntent(kind="select", text=node.value)` by default.
+- Allow per-node `on_select` callbacks to override the default return value.
+- Skip disabled nodes for active navigation and activation while still rendering
+  them.
+- Keep active rows visible inside a height-constrained viewport.
+- Render deterministic ASCII tree rows under narrow width and short height.
+- Export stable public API through `loushang.tui.ui_parts.widgets`,
+  `loushang.tui.ui_parts`, and top-level `loushang.tui`.
+- Add focused tests, docs, and a small example.
+
+## Non-Goals
+
+- Do not add lazy loading or async child providers in P1D.
+- Do not read the file system or provide a file browser widget.
+- Do not add multi-select, checkbox tree, drag/drop, search, filter, or typeahead.
+- Do not add mouse support.
+- Do not add inline rename/edit behavior.
+- Do not change `InputRouter`, `SurfaceHost`, `Menu`, `Table`, or
+  `SelectList`.
+- Do not introduce new `InputIntentKind` values; reuse existing `select`.
+
+## Public API
+
+Add `src/loushang/tui/ui_parts/widgets/tree.py`.
+
+```python
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+@dataclass(frozen=True, slots=True)
+class TreeNode:
+    value: str
+    label: str
+    children: Sequence["TreeNode"] = ()
+    disabled: bool = False
+    expanded: bool = False
+    on_select: Callable[[], object] | None = None
+
+
+@dataclass(slots=True)
+class TreeView:
+    nodes: Sequence[TreeNode]
+    active_value: str = ""
+    expanded_values: Sequence[str] = ()
+    empty_text: str = "No nodes"
+    wrap: bool = True
+    indent: int = 2
+    collapsed_marker: str = "+"
+    expanded_marker: str = "-"
+    leaf_marker: str = " "
+    theme: ThemeResolver | None = None
+    focused: bool = False
+```
+
+The first public API should also expose:
+
+- `focus()` and `blur()`.
+- `handle_input(event)`.
+- `render(constraints)`.
+- `expanded_value_set` as a read-only property returning `frozenset[str]`.
+- `visible_values` as a read-only property returning the currently visible node
+  values in render/navigation order.
+- `expand(value)`, `collapse(value)`, and `toggle(value)`.
+- `is_expanded(value)`.
+
+`TreeView` normalizes `nodes` to immutable internal entries in `__post_init__`.
+Node `value` values must be unique across the tree. Duplicate values raise
+`ValueError` during construction because expansion, active row, and selection
+state are value-keyed.
+
+Initial expansion state is the union of:
+
+- each `TreeNode(expanded=True)`;
+- `TreeView(expanded_values=...)`.
+
+Initial active state:
+
+- if `active_value` names an enabled visible node, use it;
+- otherwise choose the first enabled visible node;
+- if no enabled visible node exists, use `""`.
+
+## Input Behavior
+
+Default keys:
+
+| Input | Behavior |
+| --- | --- |
+| `up` | Move to previous enabled visible node. |
+| `down` | Move to next enabled visible node. |
+| `home` | Move to first enabled visible node. |
+| `end` | Move to last enabled visible node. |
+| `right` | Expand collapsed active branch, or move to first enabled child when already expanded. |
+| `left` | Collapse expanded active branch, or move to nearest enabled visible parent. |
+| `enter` / `space` | Activate active node. |
+| text event containing literal space | Activate active node. |
+
+Movement returns:
+
+- `True` when active or expansion state changes;
+- `False` at a non-wrapping boundary with no state change;
+- `None` when there is no enabled visible node.
+
+Activation returns:
+
+- `None` when there is no active enabled node;
+- `callback_result(node.on_select())` when `on_select` is provided;
+- otherwise `InputIntent(kind="select", text=node.value)`.
+
+`right` semantics:
+
+1. If active node has children and is collapsed, expand it and return `True`.
+2. If active node is expanded, move to the first enabled visible descendant that
+   is now immediately under that branch and return `True`.
+3. If neither applies, return `False`.
+
+`left` semantics:
+
+1. If active node has children and is expanded, collapse it and return `True`.
+2. Otherwise move to the nearest enabled visible parent and return `True`.
+3. If there is no enabled visible parent, return `False`.
+
+Disabled nodes:
+
+- are visible;
+- may be expanded initially or through `expand(value)` if a caller controls
+  state programmatically;
+- are skipped by keyboard active navigation;
+- are not activated.
+
+## Rendering
+
+`TreeView.render(constraints)` returns visible rows in preorder. Children render
+only when all ancestors are expanded.
+
+Default row shape:
+
+```text
+{focus_prefix}{indent}{marker} {label}
+```
+
+Where:
+
+- `focus_prefix` is `"> "` for the active focused row, otherwise `"  "`;
+- `indent` is `" " * (depth * indent)`;
+- `marker` is `collapsed_marker` for collapsed branches, `expanded_marker` for
+  expanded branches, and `leaf_marker` for leaves.
+
+Examples:
+
+```text
+> - src
+      widgets
+  + tests
+```
+
+Rows are truncated with `truncate_to_width(..., ellipsis="")` against
+`autowrap_safe_width(constraints.width)`.
+
+When `nodes` is empty, render one `empty_text` row with `widget.tree.empty`.
+
+Viewport behavior:
+
+- `TreeView` keeps `_first_visible_index` so the active row stays in view.
+- The visible window is based on flattened visible rows, not total node count.
+- Collapsing a branch that hides the active node moves active state to the
+  collapsed branch if that branch is enabled; otherwise to the nearest enabled
+  visible node.
+- `constraints.max_height <= 0` renders no lines.
+
+## Theme Tokens
+
+Add these initial stable tokens:
+
+| Token | Applies to |
+| --- | --- |
+| `widget.tree.row` | Enabled inactive rows. |
+| `widget.tree.focus` | Focused active row. |
+| `widget.tree.disabled` | Disabled rows. |
+| `widget.tree.empty` | Empty-state row. |
+
+P1D does not style disclosure markers separately; each row is styled as one
+line. A future slice can add marker-specific tokens if needed.
+
+## Files In Scope
+
+Production:
+
+- `src/loushang/tui/ui_parts/widgets/tree.py`
+- `src/loushang/tui/ui_parts/widgets/__init__.py`
+- `src/loushang/tui/ui_parts/__init__.py`
+- `src/loushang/tui/__init__.py`
+
+Tests:
+
+- `tests/tui/test_widgets_tree.py`
+- Adjacent widget hardening tests only if constraint/theme coverage is clearer
+  there.
+
+Docs and examples:
+
+- `docs/en/reference/tui-widgets.md`
+- `docs/zh-CN/reference/tui-widgets.md`
+- `examples/tui/49_widgets_tree.py`
+
+## Testing Strategy
+
+Use TDD for implementation:
+
+1. Add public export tests.
+2. Add construction tests for normalization, duplicate value rejection, initial
+   expanded values, and initial active fallback.
+3. Add navigation tests for up/down/home/end, wrap false boundaries, disabled
+   node skipping, and empty/all-disabled trees.
+4. Add expand/collapse tests for right/left, programmatic methods, and active
+   fallback when collapsing hides active descendants.
+5. Add activation tests for enter, key-space, text-space, callbacks, and default
+   `InputIntent(kind="select", text=value)`.
+6. Add render tests for indentation, markers, focus prefix, disabled rows,
+   empty state, width truncation, height viewport, and theme tokens.
+7. Add docs and example importability tests.
+8. Run focused tests, adjacent widget tests, full TUI tests, and Ruff.
+
+Expected verification commands:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_table.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_hardening.py -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui tests/tui examples/tui/49_widgets_tree.py docs
+```
+
+## Rollout Plan
+
+This should be one focused PR with small commits:
+
+1. Commit the design spec.
+2. Commit the implementation plan after spec review.
+3. Add failing export and construction tests.
+4. Implement `TreeNode`, `TreeView` skeleton, normalization, and public exports.
+5. Add failing navigation, expand/collapse, and activation tests.
+6. Implement input behavior and programmatic state methods.
+7. Add failing render/theme/constraint tests.
+8. Implement deterministic rendering and viewport handling.
+9. Add docs and example coverage.
+10. Run focused, adjacent, full TUI, and Ruff verification.
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Tree values are duplicated and expansion state becomes ambiguous. | Reject duplicate values during construction. |
+| Lazy loading pressure bloats P1D. | Keep P1D static; add async/lazy behavior only after real callers appear. |
+| Keyboard semantics diverge from common tree behavior. | Use standard right-expand/left-collapse behavior and cover it with tests. |
+| Collapsing branches hides active state unexpectedly. | Define fallback rules and test them. |
+| Tree rendering breaks narrow terminals. | Use existing width helpers and constraint tests. |
+| `TreeView` overlaps too much with `Menu`. | Keep `TreeView` focused on hierarchy, expansion state, and indentation. |
+
+## Success Criteria
+
+- `TreeNode` and `TreeView` are exported from public TUI modules.
+- Duplicate node values raise `ValueError`.
+- Visible flattening respects expansion state.
+- Navigation skips disabled nodes and keeps active row visible.
+- Right/left expand, collapse, and parent/child movement are deterministic.
+- Activation returns callbacks or `InputIntent(kind="select", text=value)`.
+- Rendering obeys width and height constraints with deterministic ASCII markers.
+- Theme tokens are deterministic and covered.
+- Docs and example import tests pass.
+- Existing TUI tests remain green.

--- a/docs/superpowers/specs/2026-06-11-tui-widgets-p1d-treeview-design.md
+++ b/docs/superpowers/specs/2026-06-11-tui-widgets-p1d-treeview-design.md
@@ -112,6 +112,14 @@ Initial expansion state is the union of:
 - each `TreeNode(expanded=True)`;
 - `TreeView(expanded_values=...)`.
 
+Initial expansion normalization:
+
+- unknown values in `expanded_values` raise `ValueError`;
+- leaf values in `expanded_values` are ignored;
+- `TreeNode(expanded=True)` on a leaf is ignored;
+- `expanded_value_set` contains only branch node values that are currently
+  expanded, so it stays consistent with `is_expanded(leaf) == False`.
+
 Initial active state:
 
 - if `active_value` names an enabled visible node, use it;

--- a/docs/zh-CN/reference/tui-widgets.md
+++ b/docs/zh-CN/reference/tui-widgets.md
@@ -120,6 +120,28 @@ dialog = QuestionDialog(
 dialog.focus()
 ```
 
+## P1D 树控件
+
+| 控件 | 用途 |
+| --- | --- |
+| `TreeNode` / `TreeView` | 带局部 active-row 导航和展开状态的静态层级数据。 |
+
+`TreeView` 以 preorder 展平可见节点。`right` 会展开折叠分支，或移动到第一个可用的直接子节点；
+`left` 会折叠已展开分支，或移动到最近的可用可见父节点。激活可用节点时，除非节点定义了
+`on_select`，否则返回 `InputIntent(kind="select", text=value)`。
+
+```python
+from loushang.tui import TreeNode, TreeView
+
+tree = TreeView(
+    (
+        TreeNode("src", "src", expanded=True, children=(TreeNode("widgets", "widgets"),)),
+        TreeNode("tests", "tests"),
+    )
+)
+tree.focus()
+```
+
 ## 表单
 
 ```python
@@ -216,6 +238,10 @@ Dialog 会先处理 `escape` 和 `ctrl+c`，再委派给内部字段。body 焦�
 | `widget.table.focus` | 获得焦点的激活 table 行。 |
 | `widget.table.disabled` | 禁用 table 行。 |
 | `widget.table.empty` | table 空状态文本。 |
+| `widget.tree.row` | 可用的非激活 tree 行。 |
+| `widget.tree.focus` | 获得焦点的激活 tree 行。 |
+| `widget.tree.disabled` | 禁用 tree 行。 |
+| `widget.tree.empty` | tree 空状态文本。 |
 | `widget.textArea.label` | `TextArea` 标签行。 |
 | `widget.textArea.placeholder` | `TextArea` placeholder 文本。 |
 | `widget.textArea.text` | `TextArea` 正文文本。 |
@@ -224,7 +250,7 @@ Dialog 会先处理 `escape` 和 `ctrl+c`，再委派给内部字段。body 焦�
 
 ## 计划中的控件目录
 
-`Popover`、`TreeView` 和 `Toast` 是计划中的目录项，不属于当前 widget 实现范围。
+`Popover` 和 `Toast` 是计划中的目录项，不属于当前 widget 实现范围。
 
 ## 示例
 
@@ -240,3 +266,5 @@ Dialog 会先处理 `escape` 和 `ctrl+c`，再委派给内部字段。body 焦�
   一个在小型表单中进行多行文本输入的示例。
 - [examples/tui/48_widgets_question_dialog.py](../../../examples/tui/48_widgets_question_dialog.py)：
   一个返回结构化提交与取消 intent 的多行问答对话框示例。
+- [examples/tui/49_widgets_tree.py](../../../examples/tui/49_widgets_tree.py)：
+  一个带键盘展开和选择行为的静态层级树示例。

--- a/examples/tui/49_widgets_tree.py
+++ b/examples/tui/49_widgets_tree.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from loushang.tui import (
+    FocusableMixin,
+    InputEvent,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    TreeNode,
+    TreeView,
+    Tui,
+    TuiInputResult,
+    TuiRunner,
+    truncate_to_width,
+)
+
+
+@dataclass(slots=True)
+class TreeViewApp(FocusableMixin):
+    tree: TreeView = field(default_factory=lambda: TreeView(_nodes()))
+    message: str = "Use arrows to navigate. Enter selects. Press q to quit."
+
+    def __post_init__(self) -> None:
+        super().__init__()
+        self.tree.focus()
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        tree_result = self.tree.render(
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2))
+        )
+        rows = [
+            *tree_result.lines,
+            RenderLine(""),
+            RenderLine(truncate_to_width(self.message, max_width=constraints.width, ellipsis="")),
+        ]
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints)
+
+    def handle_input(self, event: Any) -> object:
+        result = self.tree.handle_input(event)
+        if getattr(result, "kind", "") == "select":
+            self.message = f"Selected: {getattr(result, 'text', '')}"
+        return result
+
+
+def build_app() -> Tui:
+    tui = Tui()
+    app = TreeViewApp()
+    tui.add_child(app)
+    tui.set_focus(app)
+    return tui
+
+
+async def main() -> int:
+    tui = build_app()
+
+    async def on_input(event: InputEvent, context: Any) -> TuiInputResult:
+        if event.kind == "text" and "q" in event.text.lower():
+            return context.stop(0)
+        context.tui.handle_input(event)
+        return TuiInputResult()
+
+    return await TuiRunner(tui).run(on_input=on_input)
+
+
+def _nodes() -> tuple[TreeNode, ...]:
+    return (
+        TreeNode(
+            "src",
+            "src",
+            expanded=True,
+            children=(
+                TreeNode("widgets", "widgets"),
+                TreeNode("runtime", "runtime"),
+            ),
+        ),
+        TreeNode(
+            "tests",
+            "tests",
+            children=(
+                TreeNode("unit", "unit"),
+                TreeNode("integration", "integration"),
+            ),
+        ),
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/loushang/tui/__init__.py
+++ b/src/loushang/tui/__init__.py
@@ -283,6 +283,8 @@ from loushang.tui.ui_parts import (
     Toggle,
     Toolbar,
     ToolbarAction,
+    TreeNode,
+    TreeView,
     WorkingLine,
     loushang_welcome_theme,
 )
@@ -475,6 +477,8 @@ __all__ = [
     "TranscriptBuffer",
     "TranscriptView",
     "TruncatedText",
+    "TreeNode",
+    "TreeView",
     "TuiInputHandler",
     "TuiInputResult",
     "TuiRunContext",

--- a/src/loushang/tui/ui_parts/__init__.py
+++ b/src/loushang/tui/ui_parts/__init__.py
@@ -54,6 +54,8 @@ from .widgets import TextField as TextField
 from .widgets import Toggle as Toggle
 from .widgets import Toolbar as Toolbar
 from .widgets import ToolbarAction as ToolbarAction
+from .widgets import TreeNode as TreeNode
+from .widgets import TreeView as TreeView
 
 __all__ = [
     "Badge",
@@ -109,5 +111,7 @@ __all__ = [
     "Toggle",
     "Toolbar",
     "ToolbarAction",
+    "TreeNode",
+    "TreeView",
     "WorkingLine",
 ]

--- a/src/loushang/tui/ui_parts/widgets/__init__.py
+++ b/src/loushang/tui/ui_parts/widgets/__init__.py
@@ -35,6 +35,8 @@ from .tabs import Tabs as Tabs
 from .textarea import TextArea as TextArea
 from .toolbar import Toolbar as Toolbar
 from .toolbar import ToolbarAction as ToolbarAction
+from .tree import TreeNode as TreeNode
+from .tree import TreeView as TreeView
 
 __all__ = [
     "Button",
@@ -72,4 +74,6 @@ __all__ = [
     "Toggle",
     "Toolbar",
     "ToolbarAction",
+    "TreeNode",
+    "TreeView",
 ]

--- a/src/loushang/tui/ui_parts/widgets/tree.py
+++ b/src/loushang/tui/ui_parts/widgets/tree.py
@@ -6,7 +6,11 @@ from dataclasses import dataclass, field
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
 from loushang.tui.theme import ThemeResolver
-from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event, style_text
+from loushang.tui.ui_parts.widgets._utils import (
+    callback_result,
+    is_activation_event,
+    style_text,
+)
 
 __all__ = ["TreeNode", "TreeView"]
 

--- a/src/loushang/tui/ui_parts/widgets/tree.py
+++ b/src/loushang/tui/ui_parts/widgets/tree.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
+from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.widgets._utils import callback_result, is_activation_event, style_text
+
+__all__ = ["TreeNode", "TreeView"]
+
+
+@dataclass(frozen=True, slots=True)
+class TreeNode:
+    value: str
+    label: str
+    children: Sequence["TreeNode"] = ()
+    disabled: bool = False
+    expanded: bool = False
+    on_select: Callable[[], object] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _TreeEntry:
+    value: str
+    label: str
+    depth: int
+    parent: str
+    children: tuple[str, ...]
+    disabled: bool
+    expanded: bool
+    on_select: Callable[[], object] | None
+
+
+@dataclass(init=False, slots=True)
+class TreeView:
+    nodes: Sequence[TreeNode]
+    expanded_values: Sequence[str] = ()
+    empty_text: str = "No nodes"
+    wrap: bool = True
+    indent: int = 2
+    collapsed_marker: str = "+"
+    expanded_marker: str = "-"
+    leaf_marker: str = " "
+    theme: ThemeResolver | None = None
+    focused: bool = False
+    _entries: dict[str, _TreeEntry] = field(default_factory=dict, init=False, repr=False)
+    _root_values: tuple[str, ...] = field(default=(), init=False, repr=False)
+    _expanded_values: set[str] = field(default_factory=set, init=False, repr=False)
+    _active_value: str = field(default="", init=False, repr=False)
+    _first_visible_index: int = field(default=0, init=False, repr=False)
+
+    def __init__(
+        self,
+        nodes: Sequence[TreeNode],
+        active_value: str = "",
+        expanded_values: Sequence[str] = (),
+        empty_text: str = "No nodes",
+        wrap: bool = True,
+        indent: int = 2,
+        collapsed_marker: str = "+",
+        expanded_marker: str = "-",
+        leaf_marker: str = " ",
+        theme: ThemeResolver | None = None,
+        focused: bool = False,
+    ) -> None:
+        self.nodes = tuple(nodes)
+        self.expanded_values = tuple(expanded_values)
+        self.empty_text = empty_text
+        self.wrap = wrap
+        self.indent = max(0, indent)
+        self.collapsed_marker = collapsed_marker
+        self.expanded_marker = expanded_marker
+        self.leaf_marker = leaf_marker
+        self.theme = theme
+        self.focused = focused
+        self._entries = {}
+        self._root_values = tuple(node.value for node in self.nodes)
+        for node in self.nodes:
+            self._add_node(node, depth=0, parent="")
+        self._expanded_values = self._initial_expanded_values()
+        self._active_value = self._normalize_active_value(active_value)
+        self._first_visible_index = 0
+
+    @property
+    def expanded_value_set(self) -> frozenset[str]:
+        return frozenset(self._expanded_values)
+
+    @property
+    def visible_values(self) -> tuple[str, ...]:
+        return tuple(entry.value for entry in self._visible_entries())
+
+    @property
+    def active_value(self) -> str:
+        return self._active_value
+
+    def _add_node(self, node: TreeNode, *, depth: int, parent: str) -> None:
+        if node.value in self._entries:
+            raise ValueError(f"duplicate TreeNode value: {node.value!r}")
+        children = tuple(child.value for child in node.children)
+        self._entries[node.value] = _TreeEntry(
+            value=node.value,
+            label=node.label,
+            depth=depth,
+            parent=parent,
+            children=children,
+            disabled=node.disabled,
+            expanded=node.expanded,
+            on_select=node.on_select,
+        )
+        for child in node.children:
+            self._add_node(child, depth=depth + 1, parent=node.value)
+
+    def _initial_expanded_values(self) -> set[str]:
+        expanded: set[str] = set()
+        for entry in self._entries.values():
+            if entry.expanded and entry.children:
+                expanded.add(entry.value)
+        for value in self.expanded_values:
+            entry = self._entry(value)
+            if entry.children:
+                expanded.add(value)
+        return expanded
+
+    def _entry(self, value: str) -> _TreeEntry:
+        try:
+            return self._entries[value]
+        except KeyError as exc:
+            raise ValueError(f"unknown TreeNode value: {value!r}") from exc
+
+    def _visible_entries(self) -> tuple[_TreeEntry, ...]:
+        result: list[_TreeEntry] = []
+        for value in self._root_values:
+            self._append_visible(value, result)
+        return tuple(result)
+
+    def _append_visible(self, value: str, result: list[_TreeEntry]) -> None:
+        entry = self._entries[value]
+        result.append(entry)
+        if entry.value not in self._expanded_values:
+            return
+        for child in entry.children:
+            self._append_visible(child, result)
+
+    def _enabled_visible_entries(self) -> tuple[_TreeEntry, ...]:
+        return tuple(entry for entry in self._visible_entries() if not entry.disabled)
+
+    def _normalize_active_value(self, preferred: str) -> str:
+        visible = self._visible_entries()
+        visible_enabled = {entry.value for entry in visible if not entry.disabled}
+        if preferred in visible_enabled:
+            return preferred
+        return "" if not visible_enabled else next(entry.value for entry in visible if entry.value in visible_enabled)
+
+    def focus(self) -> None:
+        self.focused = True
+
+    def blur(self) -> None:
+        self.focused = False
+
+    def is_expanded(self, value: str) -> bool:
+        entry = self._entry(value)
+        return bool(entry.children and value in self._expanded_values)
+
+    def expand(self, value: str) -> bool:
+        entry = self._entry(value)
+        if not entry.children or value in self._expanded_values:
+            return False
+        self._expanded_values.add(value)
+        return True
+
+    def collapse(self, value: str) -> bool:
+        entry = self._entry(value)
+        if not entry.children or value not in self._expanded_values:
+            return False
+        self._expanded_values.remove(value)
+        self._repair_active_after_collapse(value)
+        return True
+
+    def toggle(self, value: str) -> bool:
+        return self.collapse(value) if self.is_expanded(value) else self.expand(value)
+
+    def handle_input(self, event: object) -> object:
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        width = autowrap_safe_width(constraints.width)
+        height = max(0, constraints.max_height)
+        if height == 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        rows = self._visible_entries()
+        if not rows:
+            empty = truncate_to_width(self.empty_text, max_width=width, ellipsis="")
+            return RenderResult.from_lines(
+                [RenderLine(style_text(empty, self.theme, "widget.tree.empty"))],
+                constraints=constraints,
+            )
+        lines = [RenderLine(truncate_to_width(entry.label, max_width=width, ellipsis="")) for entry in rows[:height]]
+        return RenderResult.from_lines(lines, constraints=constraints)

--- a/src/loushang/tui/ui_parts/widgets/tree.py
+++ b/src/loushang/tui/ui_parts/widgets/tree.py
@@ -294,6 +294,34 @@ class TreeView:
 
         return InputIntent(kind="select", text=entry.value)
 
+    def _ensure_active_visible(self, height: int) -> None:
+        visible = self._visible_entries()
+        if height <= 0 or not visible or not self._active_value:
+            return
+        index_by_value = {entry.value: index for index, entry in enumerate(visible)}
+        active_index = index_by_value.get(self._active_value)
+        if active_index is None:
+            return
+        if active_index < self._first_visible_index:
+            self._first_visible_index = active_index
+        elif active_index >= self._first_visible_index + height:
+            self._first_visible_index = active_index - height + 1
+        max_first = max(0, len(visible) - height)
+        self._first_visible_index = max(0, min(self._first_visible_index, max_first))
+
+    def _marker(self, entry: _TreeEntry) -> str:
+        if not entry.children:
+            return self.leaf_marker
+        return self.expanded_marker if entry.value in self._expanded_values else self.collapsed_marker
+
+    def _row_line(self, entry: _TreeEntry, width: int) -> str:
+        focused_row = self.focused and entry.value == self._active_value and not entry.disabled
+        prefix = "> " if focused_row else "  "
+        indent = " " * (entry.depth * self.indent)
+        text = truncate_to_width(f"{prefix}{indent}{self._marker(entry)} {entry.label}", max_width=width, ellipsis="")
+        token = "widget.tree.disabled" if entry.disabled else "widget.tree.focus" if focused_row else "widget.tree.row"
+        return style_text(text, self.theme, token)
+
     def handle_input(self, event: object) -> object:
         if getattr(event, "kind", "") == "key":
             key = getattr(event, "key", "")
@@ -318,12 +346,14 @@ class TreeView:
         height = max(0, constraints.max_height)
         if height == 0:
             return RenderResult.from_lines([], constraints=constraints)
-        rows = self._visible_entries()
-        if not rows:
+        visible = self._visible_entries()
+        if not visible:
             empty = truncate_to_width(self.empty_text, max_width=width, ellipsis="")
             return RenderResult.from_lines(
                 [RenderLine(style_text(empty, self.theme, "widget.tree.empty"))],
                 constraints=constraints,
             )
-        lines = [RenderLine(truncate_to_width(entry.label, max_width=width, ellipsis="")) for entry in rows[:height]]
+        self._ensure_active_visible(height)
+        rows = visible[self._first_visible_index : self._first_visible_index + height]
+        lines = [RenderLine(self._row_line(entry, width)) for entry in rows]
         return RenderResult.from_lines(lines, constraints=constraints)

--- a/src/loushang/tui/ui_parts/widgets/tree.py
+++ b/src/loushang/tui/ui_parts/widgets/tree.py
@@ -181,7 +181,136 @@ class TreeView:
     def toggle(self, value: str) -> bool:
         return self.collapse(value) if self.is_expanded(value) else self.expand(value)
 
+    def _move_active(self, delta: int) -> bool | None:
+        enabled = tuple(entry.value for entry in self._enabled_visible_entries())
+        if not enabled:
+            return None
+        if self._active_value not in enabled:
+            self._active_value = enabled[0]
+            return True
+        position = enabled.index(self._active_value)
+        next_position = position + delta
+        if self.wrap:
+            next_position %= len(enabled)
+        elif next_position < 0 or next_position >= len(enabled):
+            return False
+        next_value = enabled[next_position]
+        if next_value == self._active_value:
+            return False
+        self._active_value = next_value
+        return True
+
+    def _jump_active(self, *, first: bool) -> bool | None:
+        enabled = tuple(entry.value for entry in self._enabled_visible_entries())
+        if not enabled:
+            return None
+        target = enabled[0] if first else enabled[-1]
+        if target == self._active_value:
+            return False
+        self._active_value = target
+        return True
+
+    def _active_entry(self) -> _TreeEntry | None:
+        if not self._active_value:
+            return None
+        entry = self._entries.get(self._active_value)
+        return None if entry is None or entry.disabled else entry
+
+    def _first_enabled_direct_child(self, entry: _TreeEntry) -> str:
+        for value in entry.children:
+            child = self._entries[value]
+            if not child.disabled:
+                return value
+        return ""
+
+    def _nearest_enabled_visible_parent(self, entry: _TreeEntry) -> str:
+        parent = entry.parent
+        while parent:
+            candidate = self._entries[parent]
+            if not candidate.disabled and parent in self.visible_values:
+                return parent
+            parent = candidate.parent
+        return ""
+
+    def _repair_active_after_collapse(self, collapsed_value: str) -> None:
+        visible_values = self.visible_values
+        if self._active_value in visible_values:
+            return
+        collapsed = self._entries[collapsed_value]
+        if not collapsed.disabled:
+            self._active_value = collapsed_value
+            return
+        try:
+            collapsed_index = visible_values.index(collapsed_value)
+        except ValueError:
+            collapsed_index = 0
+        visible = self._visible_entries()
+        for index in range(collapsed_index - 1, -1, -1):
+            if not visible[index].disabled:
+                self._active_value = visible[index].value
+                return
+        for index in range(collapsed_index + 1, len(visible)):
+            if not visible[index].disabled:
+                self._active_value = visible[index].value
+                return
+        self._active_value = ""
+
+    def _expand_or_move_child(self) -> bool | None:
+        entry = self._active_entry()
+        if entry is None:
+            return None
+        if not entry.children:
+            return False
+        if entry.value not in self._expanded_values:
+            self._expanded_values.add(entry.value)
+            return True
+        child = self._first_enabled_direct_child(entry)
+        if not child:
+            return False
+        if child == self._active_value:
+            return False
+        self._active_value = child
+        return True
+
+    def _collapse_or_move_parent(self) -> bool | None:
+        entry = self._active_entry()
+        if entry is None:
+            return None
+        if entry.children and entry.value in self._expanded_values:
+            return self.collapse(entry.value)
+        parent = self._nearest_enabled_visible_parent(entry)
+        if not parent:
+            return False
+        self._active_value = parent
+        return True
+
+    def _activate(self) -> object:
+        entry = self._active_entry()
+        if entry is None:
+            return None
+        if entry.on_select is not None:
+            return callback_result(entry.on_select())
+        from loushang.tui.input import InputIntent
+
+        return InputIntent(kind="select", text=entry.value)
+
     def handle_input(self, event: object) -> object:
+        if getattr(event, "kind", "") == "key":
+            key = getattr(event, "key", "")
+            if key == "up":
+                return self._move_active(-1)
+            if key == "down":
+                return self._move_active(1)
+            if key == "home":
+                return self._jump_active(first=True)
+            if key == "end":
+                return self._jump_active(first=False)
+            if key == "right":
+                return self._expand_or_move_child()
+            if key == "left":
+                return self._collapse_or_move_parent()
+        if is_activation_event(event):
+            return self._activate()
         return None
 
     def render(self, constraints: RenderConstraints) -> RenderResult:

--- a/tests/tui/test_widgets_tree.py
+++ b/tests/tui/test_widgets_tree.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import runpy
+from typing import Any
+
+import pytest
+
+from loushang.tui import (
+    InputEvent,
+    RenderConstraints,
+    ThemeResolver,
+    TreeNode,
+    TreeView,
+    strip_control_sequences,
+    visible_width,
+)
+from loushang.tui.ui_parts import TreeNode as UiTreeNode
+from loushang.tui.ui_parts import TreeView as UiTreeView
+from loushang.tui.ui_parts.widgets import TreeNode as WidgetTreeNode
+from loushang.tui.ui_parts.widgets import TreeView as WidgetTreeView
+
+
+def render_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
+    result = part.render(RenderConstraints(width=width, max_height=height))
+    return tuple(line.text for line in result.lines)
+
+
+def plain_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
+    return tuple(strip_control_sequences(line) for line in render_lines(part, width=width, height=height))
+
+
+def assert_widths_within(lines: tuple[str, ...], width: int) -> None:
+    assert all(visible_width(line) <= width for line in lines)
+
+
+def intent_tuple(intent: object) -> tuple[str, str, str]:
+    return (getattr(intent, "kind", ""), getattr(intent, "text", ""), getattr(intent, "note", ""))
+
+
+def sample_nodes() -> tuple[TreeNode, ...]:
+    return (
+        TreeNode(
+            "src",
+            "src",
+            expanded=True,
+            children=(
+                TreeNode("widgets", "widgets"),
+                TreeNode("runtime", "runtime", disabled=True),
+            ),
+        ),
+        TreeNode(
+            "tests",
+            "tests",
+            children=(
+                TreeNode("unit", "unit"),
+                TreeNode("integration", "integration"),
+            ),
+        ),
+    )
+
+
+def test_tree_widgets_are_reexported_from_public_modules() -> None:
+    assert TreeNode is UiTreeNode
+    assert TreeNode is WidgetTreeNode
+    assert TreeView is UiTreeView
+    assert TreeView is WidgetTreeView
+    assert TreeNode("src", "src").value == "src"
+
+
+def test_tree_view_normalizes_expansion_and_active_state() -> None:
+    tree = TreeView(sample_nodes(), expanded_values=("tests", "unit"), active_value="missing")
+
+    assert tree.expanded_value_set == frozenset({"src", "tests"})
+    assert tree.is_expanded("src") is True
+    assert tree.is_expanded("widgets") is False
+    assert tree.visible_values == ("src", "widgets", "runtime", "tests", "unit", "integration")
+    assert tree.active_value == "src"
+
+
+def test_tree_view_rejects_duplicate_values_and_unknown_expanded_values() -> None:
+    with pytest.raises(ValueError):
+        TreeView((TreeNode("dup", "One"), TreeNode("dup", "Two")))
+
+    with pytest.raises(ValueError):
+        TreeView(sample_nodes(), expanded_values=("missing",))
+
+
+def test_tree_view_initial_active_falls_back_to_first_enabled_visible_node() -> None:
+    tree = TreeView(
+        (
+            TreeNode("disabled", "Disabled", disabled=True),
+            TreeNode("enabled", "Enabled"),
+        ),
+        active_value="disabled",
+    )
+
+    assert tree.active_value == "enabled"

--- a/tests/tui/test_widgets_tree.py
+++ b/tests/tui/test_widgets_tree.py
@@ -282,3 +282,9 @@ def test_tree_view_applies_theme_tokens() -> None:
     assert raw[1].startswith("\x1b[37m      widgets")
     assert raw[2].startswith("\x1b[2m      runtime")
     assert render_lines(TreeView((), theme=theme), width=10, height=1)[0].startswith("\x1b[90mNo nodes")
+
+
+def test_widgets_tree_example_imports() -> None:
+    namespace = runpy.run_path("examples/tui/49_widgets_tree.py", run_name="__test__")
+
+    assert callable(namespace["build_app"])

--- a/tests/tui/test_widgets_tree.py
+++ b/tests/tui/test_widgets_tree.py
@@ -254,14 +254,14 @@ def test_tree_view_respects_width_empty_and_height_viewport() -> None:
     )
     tree.focus()
 
-    lines = render_lines(tree, width=8, height=3)
+    lines = render_lines(tree, width=9, height=3)
 
-    assert plain_lines(tree, width=8, height=3) == (
+    assert plain_lines(tree, width=9, height=3) == (
         "    Item",
         "    Item",
         ">   Item",
     )
-    assert_widths_within(lines, 8)
+    assert_widths_within(lines, 9)
 
 
 def test_tree_view_applies_theme_tokens() -> None:

--- a/tests/tui/test_widgets_tree.py
+++ b/tests/tui/test_widgets_tree.py
@@ -230,3 +230,55 @@ def test_tree_view_activation_returns_callback_or_select_intent() -> None:
     assert intent_tuple(tree.handle_input(InputEvent(kind="key", key="enter"))) == ("select", "plain", "")
     assert intent_tuple(tree.handle_input(InputEvent(kind="key", key="space"))) == ("select", "plain", "")
     assert intent_tuple(tree.handle_input(InputEvent(kind="text", text=" "))) == ("select", "plain", "")
+
+
+def test_tree_view_renders_indentation_markers_focus_and_disabled_rows() -> None:
+    tree = TreeView(sample_nodes())
+    tree.focus()
+
+    assert plain_lines(tree, width=30, height=6) == (
+        "> - src",
+        "      widgets",
+        "      runtime",
+        "  + tests",
+    )
+
+
+def test_tree_view_respects_width_empty_and_height_viewport() -> None:
+    empty = TreeView((), empty_text="Nothing here")
+    assert plain_lines(empty, width=8, height=3) == ("Nothing",)
+
+    tree = TreeView(
+        tuple(TreeNode(str(index), f"Item {index}") for index in range(6)),
+        active_value="5",
+    )
+    tree.focus()
+
+    lines = render_lines(tree, width=8, height=3)
+
+    assert plain_lines(tree, width=8, height=3) == (
+        "    Item",
+        "    Item",
+        ">   Item",
+    )
+    assert_widths_within(lines, 8)
+
+
+def test_tree_view_applies_theme_tokens() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.tree.row": {"color": "white"},
+            "widget.tree.focus": {"bold": True, "color": "green"},
+            "widget.tree.disabled": {"dim": True},
+            "widget.tree.empty": {"color": "bright_black"},
+        }
+    )
+    tree = TreeView(sample_nodes(), theme=theme)
+    tree.focus()
+
+    raw = render_lines(tree, width=30, height=4)
+
+    assert raw[0].startswith("\x1b[1;32m> - src")
+    assert raw[1].startswith("\x1b[37m      widgets")
+    assert raw[2].startswith("\x1b[2m      runtime")
+    assert render_lines(TreeView((), theme=theme), width=10, height=1)[0].startswith("\x1b[90mNo nodes")

--- a/tests/tui/test_widgets_tree.py
+++ b/tests/tui/test_widgets_tree.py
@@ -95,3 +95,138 @@ def test_tree_view_initial_active_falls_back_to_first_enabled_visible_node() -> 
     )
 
     assert tree.active_value == "enabled"
+
+
+def test_tree_view_navigation_skips_disabled_and_honors_wrap_false() -> None:
+    tree = TreeView(sample_nodes(), wrap=False)
+    tree.focus()
+
+    assert tree.active_value == "src"
+    assert tree.handle_input(InputEvent(kind="key", key="down")) is True
+    assert tree.active_value == "widgets"
+    assert tree.handle_input(InputEvent(kind="key", key="down")) is True
+    assert tree.active_value == "tests"
+    assert tree.handle_input(InputEvent(kind="key", key="down")) is False
+    assert tree.handle_input(InputEvent(kind="key", key="home")) is True
+    assert tree.active_value == "src"
+    assert tree.handle_input(InputEvent(kind="key", key="up")) is False
+
+
+def test_tree_view_empty_and_all_disabled_navigation_returns_none() -> None:
+    assert TreeView(()).handle_input(InputEvent(kind="key", key="down")) is None
+
+    disabled = TreeView((TreeNode("disabled", "Disabled", disabled=True),))
+    disabled.focus()
+    assert disabled.active_value == ""
+    assert disabled.handle_input(InputEvent(kind="key", key="down")) is None
+    assert disabled.handle_input(InputEvent(kind="key", key="enter")) is None
+
+
+def test_tree_view_right_expands_then_moves_to_enabled_direct_child() -> None:
+    tree = TreeView((TreeNode("root", "root", children=(TreeNode("child", "child"),)),))
+    tree.focus()
+
+    assert tree.visible_values == ("root",)
+    assert tree.handle_input(InputEvent(kind="key", key="right")) is True
+    assert tree.expanded_value_set == frozenset({"root"})
+    assert tree.visible_values == ("root", "child")
+    assert tree.active_value == "root"
+    assert tree.handle_input(InputEvent(kind="key", key="right")) is True
+    assert tree.active_value == "child"
+
+
+def test_tree_view_right_does_not_skip_disabled_direct_children_to_grandchildren() -> None:
+    tree = TreeView(
+        (
+            TreeNode(
+                "root",
+                "root",
+                expanded=True,
+                children=(
+                    TreeNode(
+                        "disabled",
+                        "disabled",
+                        disabled=True,
+                        children=(TreeNode("grand", "grand"),),
+                    ),
+                ),
+            ),
+        )
+    )
+    tree.focus()
+
+    assert tree.handle_input(InputEvent(kind="key", key="right")) is False
+    assert tree.active_value == "root"
+
+
+def test_tree_view_left_collapses_or_moves_to_enabled_parent() -> None:
+    tree = TreeView(sample_nodes(), active_value="widgets")
+    tree.focus()
+
+    assert tree.handle_input(InputEvent(kind="key", key="left")) is True
+    assert tree.active_value == "src"
+    assert tree.handle_input(InputEvent(kind="key", key="left")) is True
+    assert tree.expanded_value_set == frozenset()
+    assert tree.active_value == "src"
+    assert tree.handle_input(InputEvent(kind="key", key="left")) is False
+
+
+def test_tree_view_programmatic_expand_collapse_toggle_and_unknown_values() -> None:
+    tree = TreeView(sample_nodes())
+
+    assert tree.expand("tests") is True
+    assert tree.expand("tests") is False
+    assert tree.is_expanded("tests") is True
+    assert tree.collapse("tests") is True
+    assert tree.collapse("tests") is False
+    assert tree.toggle("tests") is True
+    assert tree.toggle("tests") is True
+    assert tree.expand("widgets") is False
+
+    with pytest.raises(ValueError):
+        tree.expand("missing")
+
+
+def test_tree_view_collapse_hidden_active_falls_back_deterministically() -> None:
+    tree = TreeView(sample_nodes(), expanded_values=("tests",), active_value="integration")
+    tree.focus()
+
+    assert tree.collapse("tests") is True
+
+    assert tree.active_value == "tests"
+
+    disabled_branch = TreeView(
+        (
+            TreeNode("before", "before"),
+            TreeNode(
+                "branch",
+                "branch",
+                disabled=True,
+                expanded=True,
+                children=(TreeNode("child", "child"),),
+            ),
+            TreeNode("after", "after"),
+        ),
+        active_value="child",
+    )
+
+    assert disabled_branch.collapse("branch") is True
+    assert disabled_branch.active_value == "before"
+
+
+def test_tree_view_activation_returns_callback_or_select_intent() -> None:
+    calls: list[str] = []
+    tree = TreeView(
+        (
+            TreeNode("callback", "callback", on_select=lambda: calls.append("callback")),
+            TreeNode("plain", "plain"),
+        )
+    )
+    tree.focus()
+
+    assert tree.handle_input(InputEvent(kind="key", key="enter")) is True
+    assert calls == ["callback"]
+    assert tree.handle_input(InputEvent(kind="key", key="down")) is True
+    assert intent_tuple(tree.handle_input(InputEvent(kind="key", key="enter"))) == ("select", "plain", "")
+    assert intent_tuple(tree.handle_input(InputEvent(kind="key", key="space"))) == ("select", "plain", "")
+    assert intent_tuple(tree.handle_input(InputEvent(kind="text", text=" "))) == ("select", "plain", "")


### PR DESCRIPTION
## Summary
- Add TreeNode/TreeView for static hierarchical data with expansion, navigation, activation, viewport, and theme support.
- Export TreeView through public TUI modules and add focused widget coverage.
- Document TreeView in English/Chinese references and add runnable example.

## Test Plan
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_table.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_hardening.py -q
- [x] uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
- [x] uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui tests/tui examples/tui/49_widgets_tree.py docs