### PR TITLE
refactor(coding): use explicit ui entrypoint import

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -63,7 +63,7 @@ from loushang.coding.tools.read import (
     image_exceeds_inline_limits,
 )
 from loushang.coding.types import ModelSelection
-from loushang.coding.ui import run_coding_tui
+from loushang.coding.ui.mode import run_coding_tui
 from loushang.coding.workflow import (
     load_workflow,
     resolve_workflow_files,

--- a/src/loushang/coding/ui/__init__.py
+++ b/src/loushang/coding/ui/__init__.py
@@ -1,5 +1,1 @@
 """Terminal UI adapter for loushang coding."""
-
-from loushang.coding.ui.mode import run_coding_tui
-
-__all__ = ["run_coding_tui"]

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_importing_coding_ui_state_does_not_load_tui_mode_entrypoint() -> None:
+    result = _run_python_import_boundary_check(
+        """
+import importlib
+import sys
+
+importlib.import_module("loushang.coding.ui.native_state")
+
+assert "loushang.coding.ui.mode" not in sys.modules
+assert "loushang.coding.ui.renderer" not in sys.modules
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def _run_python_import_boundary_check(script: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    src_path = str(Path.cwd() / "src")
+    env["PYTHONPATH"] = src_path if not env.get("PYTHONPATH") else f"{src_path}{os.pathsep}{env['PYTHONPATH']}"
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path.cwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )


### PR DESCRIPTION
## Summary\n- Remove the package-entry re-export of run_coding_tui from loushang.coding.ui.\n- Update the CLI to import run_coding_tui from the canonical loushang.coding.ui.mode entrypoint.\n- Add a subprocess import-boundary test proving native_state does not load ui.mode or renderer.\n\n## 中文说明\n- 移除 loushang.coding.ui 包入口对 run_coding_tui 的重导出。\n- CLI 改为从明确的 loushang.coding.ui.mode 入口导入 TUI。\n- 增加 import 边界测试，确保导入 native_state 不会顺带加载 mode/renderer。\n\n## Validation\n- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_ui_import_boundaries.py -q -> 1 passed\n- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py tests/coding/test_ui_mode.py tests/coding/test_native_coding_tui_mode.py tests/coding/test_ui_import_boundaries.py -q -> 234 passed\n- uv --cache-dir .uv-cache run --extra dev pytest tests/tui tests/coding/test_ui_*.py -q -> 1032 passed\n- uv --cache-dir .uv-cache run ruff check src/loushang/coding/ui/__init__.py src/loushang/coding/cli/__main__.py tests/coding/test_ui_import_boundaries.py -> All checks passed\n- git diff --check -> no output