### PR TITLE
[codex] ignore key release input events

### DIFF
--- a/src/loushang/coding/ui/native_input.py
+++ b/src/loushang/coding/ui/native_input.py
@@ -72,6 +72,8 @@ class NativeInputRouter:
         self._composer_target = ComposerInputTarget(self.app.composer)
 
     def handle(self, event: InputEvent) -> NativeInputResult:
+        if event.kind == "key" and event.event_type == "release":
+            return NativeInputResult(render_requested=False)
         if self._runtime_surface_active():
             return self._route_runtime_surface(event)
         if self.app.active_surface is not None:
@@ -93,7 +95,7 @@ class NativeInputRouter:
             if event.rows:
                 self.height = event.rows
             return NativeInputResult()
-        if event.kind != "key" or event.event_type == "release":
+        if event.kind != "key":
             return NativeInputResult(render_requested=False)
 
         keybindings = self._keybindings()

--- a/tests/coding/test_native_coding_tui_playback.py
+++ b/tests/coding/test_native_coding_tui_playback.py
@@ -446,6 +446,39 @@ def test_native_tui_playback_smokes_terminal_context_model_selector_and_resize()
     assert steps[-1].diagnostics.operation_class == "resize_repaint"
 
 
+def test_native_tui_model_selector_ignores_key_release_events() -> None:
+    session = _Session(
+        models=(
+            ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
+            ModelSelection(provider="openai", model_id="gpt-5.4"),
+            ModelSelection(provider="anthropic", model_id="claude-sonnet"),
+        )
+    )
+    app = _app()
+    playback = _NativeInteractivePlayback(
+        app,
+        _manager(app, session),
+        columns=100,
+        rows=18,
+    )
+
+    steps = playback.play(
+        [
+            PlaybackEvent.input("/model\r"),
+            # Down press followed by a release event from an enhanced keyboard protocol.
+            PlaybackEvent.input("\x1b[1;1B\x1b[1;1:3B"),
+            PlaybackEvent.input("\r"),
+        ]
+    )
+
+    assert all(step.flush_succeeded for step in steps)
+    assert session.current_model == ModelSelection(provider="openai", model_id="gpt-5.4")
+    assert app.state.model_label == "openai/gpt-5.4"
+    lines = _plain_lines(steps[-1].diagnostics)
+    assert "Model set: openai/gpt-5.4" in lines[-1]
+    assert not any("claude-sonnet" in line for line in lines)
+
+
 def test_native_loop_filters_terminal_control_responses_before_routing() -> None:
     events = _input_events_for_chunk(InputReader(), "\x1b[?7uhello")
 
@@ -651,9 +684,18 @@ class _PlaybackTerminalContext:
 
 
 class _Session:
-    def __init__(self, *, cwd: Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        cwd: Path | None = None,
+        models: tuple[ModelSelection, ...] | None = None,
+    ) -> None:
         self.session_manager = SimpleNamespace(get_cwd=lambda: str(cwd)) if cwd is not None else None
         self.current_model = ModelSelection(provider="moonshot", model_id="kimi-for-coding")
+        self.models = models or (
+            ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
+            ModelSelection(provider="openai", model_id="gpt-5.4"),
+        )
 
     def list_commands(self) -> list[object]:
         return [
@@ -667,10 +709,7 @@ class _Session:
         return self.current_model
 
     def get_available_models(self) -> list[object]:
-        return [
-            ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
-            ModelSelection(provider="openai", model_id="gpt-5.4"),
-        ]
+        return list(self.models)
 
     async def set_model(self, selection: object) -> None:
         self.current_model = selection


### PR DESCRIPTION
## Summary

Fix native TUI input routing so key release events from enhanced keyboard protocols are ignored at the router boundary instead of being routed as a second actionable key press.

## Problem

Some terminals can emit both a key press and a key release for the same physical key. In the model selector, a Down press followed by a release event could be interpreted as two navigation actions, moving past the intended model selection. The fix must not be terminal-name-specific; this should be handled as a generic input event semantics issue.

## Changes

- Ignore `InputEvent(event_type="release")` for key events at `NativeInputRouter.handle()` before runtime or active surfaces receive the event.
- Add a native TUI playback regression covering model selection with a Down press followed by an enhanced keyboard release event.
- Keep the regression named around generic key release behavior rather than a specific terminal implementation.

## Validation

- `uv run pytest tests/coding/test_native_coding_tui_playback.py -q`
  - `24 passed`

## Notes

This is intentionally not keyed off `TERM`, `kitty`, or any specific escape sequence. The behavior is based on the parsed `InputEvent.event_type` contract, so other terminals that report release events follow the same path.