### PR TITLE
refactor(work): stop re-exporting coding shell

### DIFF
--- a/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
+++ b/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
@@ -58,7 +58,8 @@ loushang.coding -> loushang.method
 Current transitional compatibility exports:
 
 ```text
-loushang.work.CodingWorkShell remains as a compatibility export for the coding-owned implementation.
+loushang.work.coding.CodingWorkShell remains as an explicit compatibility module for the coding-owned implementation.
+loushang.work no longer re-exports CodingWorkShell from the package root.
 ```
 
 These couplings do not block P2 harness work because `agent.harness` must not

--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -27,7 +27,6 @@ from loushang.work.types import (
 __all__ = [
     "ArtifactRef",
     "ArtifactStatus",
-    "CodingWorkShell",
     "DeliveryHint",
     "EventLogBackend",
     "EventLogEntry",
@@ -46,11 +45,3 @@ __all__ = [
     "project_agent_event_to_work_events",
     "project_work_plan_runs",
 ]
-
-
-def __getattr__(name: str) -> object:
-    if name == "CodingWorkShell":
-        from loushang.coding.work_shell import CodingWorkShell
-
-        return CodingWorkShell
-    raise AttributeError(f"module 'loushang.work' has no attribute {name!r}")

--- a/tests/coding/test_work_shell.py
+++ b/tests/coding/test_work_shell.py
@@ -33,7 +33,8 @@ class FakePromptSession:
 
 
 def test_coding_work_shell_wraps_prompt_and_logs_operation_run_and_projected_events() -> None:
-    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import InMemoryEventLogBackend
 
     async def scenario() -> None:
         event_log = InMemoryEventLogBackend()
@@ -91,7 +92,8 @@ def test_coding_work_shell_wraps_prompt_and_logs_operation_run_and_projected_eve
 
 
 def test_coding_work_shell_logs_tool_policy_and_approval_audit_events() -> None:
-    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import InMemoryEventLogBackend
 
     async def scenario() -> None:
         event_log = InMemoryEventLogBackend()
@@ -164,7 +166,8 @@ def test_coding_work_shell_logs_tool_policy_and_approval_audit_events() -> None:
 
 def test_coding_work_shell_jsonl_log_can_replay_persisted_turn(tmp_path) -> None:
     from loushang.ai.types import AssistantMessage, TextPart, Usage
-    from loushang.work import CodingWorkShell, JsonlEventLogBackend
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import JsonlEventLogBackend
 
     usage = Usage(input=0, output=0, cache_read=0, cache_write=0, total_tokens=0, cost={})
     assistant = AssistantMessage(
@@ -221,7 +224,8 @@ def test_coding_work_shell_jsonl_log_can_replay_persisted_turn(tmp_path) -> None
 
 
 def test_coding_work_shell_records_method_id_as_metadata_only() -> None:
-    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import InMemoryEventLogBackend
 
     async def scenario() -> None:
         event_log = InMemoryEventLogBackend()
@@ -252,7 +256,8 @@ def test_coding_work_shell_records_method_id_as_metadata_only() -> None:
 
 
 def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
-    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import InMemoryEventLogBackend
 
     async def scenario() -> None:
         event_log = InMemoryEventLogBackend()
@@ -344,7 +349,8 @@ def test_coding_work_shell_records_plan_and_step_lifecycle_events() -> None:
 
 
 def test_coding_work_shell_can_suppress_plan_boundaries_for_middle_step() -> None:
-    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import InMemoryEventLogBackend
 
     async def scenario() -> None:
         event_log = InMemoryEventLogBackend()
@@ -383,7 +389,8 @@ def test_coding_work_shell_can_suppress_plan_boundaries_for_middle_step() -> Non
 
 
 def test_coding_work_shell_records_plan_failure_even_when_plan_boundaries_are_suppressed() -> None:
-    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import InMemoryEventLogBackend
 
     async def scenario() -> None:
         event_log = InMemoryEventLogBackend()
@@ -427,7 +434,8 @@ def test_coding_work_shell_records_plan_failure_even_when_plan_boundaries_are_su
 
 
 def test_coding_work_shell_records_step_and_plan_failures_before_run_failure() -> None:
-    from loushang.work import CodingWorkShell, InMemoryEventLogBackend
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import InMemoryEventLogBackend
 
     async def scenario() -> None:
         event_log = InMemoryEventLogBackend()

--- a/tests/coding/test_work_shell_adapter.py
+++ b/tests/coding/test_work_shell_adapter.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 
-def test_coding_work_shell_adapter_exposes_coding_owned_entrypoint() -> None:
+def test_work_coding_compat_module_exposes_coding_owned_entrypoint() -> None:
     from loushang.coding.work_shell import CodingWorkShell
-    from loushang.work import CodingWorkShell as CompatCodingWorkShell
+    from loushang.work.coding import CodingWorkShell as CompatCodingWorkShell
 
     assert CodingWorkShell is CompatCodingWorkShell
     assert CodingWorkShell.__module__ == "loushang.coding.work_shell"

--- a/tests/work/test_public_api.py
+++ b/tests/work/test_public_api.py
@@ -7,7 +7,6 @@ def test_work_public_api_exposes_current_work_surface_without_multi_agent_types(
     assert set(work.__all__) == {
         "ArtifactRef",
         "ArtifactStatus",
-        "CodingWorkShell",
         "DeliveryHint",
         "EventLogBackend",
         "EventLogEntry",
@@ -30,4 +29,5 @@ def test_work_public_api_exposes_current_work_surface_without_multi_agent_types(
     assert not hasattr(work, "AgentLane")
     assert not hasattr(work, "TaskLedger")
     assert not hasattr(work, "CollaborationBus")
+    assert not hasattr(work, "CodingWorkShell")
     assert not hasattr(work, "PromptSession")


### PR DESCRIPTION
## Summary\n- Stop re-exporting the coding-owned CodingWorkShell from the loushang.work package root.\n- Keep the explicit loushang.work.coding compatibility module for existing adapter imports.\n- Move CodingWorkShell behavior tests under tests/coding and update architecture notes for the dependency boundary.\n\n## 中文说明\n- loushang.work 根包不再暴露 coding 拥有的 CodingWorkShell。\n- 保留显式兼容模块 loushang.work.coding，避免一次性删除旧适配入口。\n- 将 CodingWorkShell 行为测试移到 tests/coding，并同步架构边界说明。\n\n## Validation\n- RED: uv --cache-dir .uv-cache run --extra dev pytest tests/work/test_public_api.py tests/coding/test_work_shell_adapter.py tests/coding/test_work_shell.py -q -> failed because loushang.work.__all__ still contained CodingWorkShell\n- uv --cache-dir .uv-cache run --extra dev pytest tests/work tests/coding/test_work_shell.py tests/coding/test_work_shell_adapter.py -q -> 33 passed\n- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_prompt_command.py tests/coding/test_print_mode.py tests/coding/test_work_shell.py tests/coding/test_work_shell_adapter.py -q -> 49 passed\n- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -q -> 219 passed\n- uv --cache-dir .uv-cache run ruff check src/loushang/work/__init__.py src/loushang/work/coding.py tests/work/test_public_api.py tests/coding/test_work_shell.py tests/coding/test_work_shell_adapter.py -> All checks passed\n- git diff --check -> no output\n- rg old root CodingWorkShell imports outside archived docs -> no matches