### PR TITLE
[codex] Refactor import boundaries and extension surfaces / 收敛 import 边界与 extension surfaces

### DIFF
--- a/docs/en/user-guide/README.md
+++ b/docs/en/user-guide/README.md
@@ -56,7 +56,7 @@ loushang --no-tools -p "Explain the repository from context only."
 
 Extensions are Python files that can register lifecycle hooks, tools, dynamic resources, commands, and flags. Start with the runnable extension examples in [examples/coding/extensions](../../../examples/coding/extensions/).
 
-An extension may include an adjacent `loushang-extension.toml` manifest to declare identity, permission level, dependencies, and expected contributions. Use `/extensions` to inspect loaded extensions, contribution summaries, and diagnostics; use `/extensions <id>` for one extension. `/tools` includes source information for extension-provided tools when available.
+An extension may include an adjacent `loushang-extension.toml` manifest to declare identity, permission level, dependencies, and expected runtime surfaces. Use `/extensions` to inspect loaded extensions, surface summaries, and diagnostics; use `/extensions <id>` for one extension. `/tools` includes source information for extension-provided tools when available.
 
 ## Packages And Plugins
 

--- a/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
+++ b/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
@@ -236,3 +236,5 @@ These names are intentionally excluded from `loushang.agent.harness`:
 4. Completed: route `Agent` prompt and continuation execution through `agent.harness` while preserving the stateful lifecycle.
 5. Completed: isolate method resource loading from `loushang.coding.loader`.
 6. Completed: move `CodingWorkShell` implementation ownership to `loushang.coding.work_shell`.
+7. Completed: add architecture import boundary tests for agent, harness, work, method, and channel.
+8. Completed: remove remaining package-level compatibility shims from `loushang.coding.cli` and `loushang.coding.types`.

--- a/docs/internals/plans/2026-06-08-loushang-coding-extension-platform-integration-plan.md
+++ b/docs/internals/plans/2026-06-08-loushang-coding-extension-platform-integration-plan.md
@@ -26,7 +26,7 @@ contract.
   - `src/loushang/coding/commands`
   - `src/loushang/coding/tools`
   - `src/loushang/tui/extensions.py`
-- Record the contribution matrix:
+- Record the extension surface matrix:
   - current support
   - target support
   - owner subsystem
@@ -35,7 +35,7 @@ contract.
 - Record final decisions for:
   - manifest format
   - permission model
-  - contribution conflicts
+  - surface conflicts
   - hook classes
   - UI bridge boundary
   - dependency scope
@@ -52,18 +52,18 @@ contract.
 - New manifest parser.
 - New UI.
 
-## P1: Manifest, Policy, And Contribution Registry Skeleton
+## P1: Manifest, Policy, And Extension Inventory Projection
 
 ### Objective
 
-Add structured extension metadata and contribution projection without changing
+Add structured extension metadata and inventory projection without changing
 user-visible runtime behavior.
 
 ### Implementation
 
 - Add an internal extension manifest model for `loushang-extension.toml`.
 - Add parser diagnostics for invalid TOML, unknown required fields, unsupported
-  contribution sections, and invalid permission levels.
+  surface declaration sections, and invalid permission levels.
 - Parse and store dependency declarations, but do not install or resolve them in
   P1.
 - Reserve internal dependency resolution state for future isolated import paths;
@@ -73,19 +73,21 @@ user-visible runtime behavior.
   - permission level
   - internal capabilities
   - managed-hooks-only decision
-- Add `ContributionRegistry` or equivalent projection with contribution
-  descriptors for commands, tools, prompts, skills, hooks, models/providers,
-  UI, autocomplete, and resource roots.
-- Wire the loader to produce contribution descriptors in addition to existing
-  loaded extension data.
+- Add `ExtensionInventory`, `ExtensionSurfaceSnapshot`, or an equivalent
+  inventory-only projection with descriptors for commands, tools, prompts,
+  skills, hooks, models/providers, UI, autocomplete, and resource roots.
+- If the interim code keeps the `ContributionRegistry` name, document and test it
+  as read-only inventory rather than an activation or arbitration layer.
+- Wire the loader to produce surface descriptors in addition to existing loaded
+  extension data.
 - Keep existing `register(api)` runtime compatibility.
 
 ### Tests
 
 - Manifest parser accepts minimal valid TOML.
 - Invalid manifest produces extension diagnostics, not an uncaught exception.
-- Policy-disabled extension remains visible but contributes no active entries.
-- Registry records source info and inactive reasons.
+- Policy-disabled extension remains visible but exposes no runtime surfaces.
+- Inventory records source info and inactive reasons.
 
 ### Not In Scope
 
@@ -97,23 +99,25 @@ user-visible runtime behavior.
 
 ### Objective
 
-Route the main user-facing contribution types through the registry.
+Keep main user-facing surfaces on their owning resolvers while projecting their
+state into the extension inventory.
 
 ### Implementation
 
-- Mount extension commands through the command catalog using contribution
-  metadata and source diagnostics.
+- Mount extension commands through the command resolver using source metadata and
+  diagnostics from the extension runtime.
 - Mount extension tools only after policy evaluation, conflict resolution, and
-  denied-tool filtering.
-- Preserve existing prompt and skill resource loader precedence; add registry
-  diagnostics that explain collisions and inactive resources.
+  denied-tool filtering in the tool surface.
+- Preserve existing prompt and skill resource loader precedence; project loader
+  diagnostics into the inventory so collisions and inactive resources remain
+  explainable.
 - Add `/extensions` as the first management surface.
   - Register it as a built-in core management command, not as an
     extension-contributed command.
   - Route its output through the existing command plane and diagnostics
     projection.
-  - It should list active tools, commands, hooks, prompts, skills, permissions,
-    conflicts, and load warnings.
+  - It should list exposed tools, commands, hooks, prompts, skills,
+    permissions, conflicts, and load warnings.
   - It should not install, update, or remove extensions in this phase.
 
 ### Tests
@@ -122,7 +126,7 @@ Route the main user-facing contribution types through the registry.
   exists.
 - Denied tool does not appear in model-visible tool list.
 - Duplicate command names are visible with disambiguation diagnostics.
-- `/extensions` prints active tools and inactive reasons without the
+- `/extensions` prints exposed tools and inactive reasons without the
   `? thinking:` transcript artifact.
 
 ### Not In Scope
@@ -183,7 +187,7 @@ Expose extension UI integration through controlled bridge APIs.
 
 - Extend the existing TUI extension host into an `ExtensionUiBridge`-style
   runtime surface.
-- Allow extension contributions for:
+- Allow controlled extension UI surfaces for:
   - status
   - footer/header
   - surfaces/modals
@@ -194,7 +198,7 @@ Expose extension UI integration through controlled bridge APIs.
   - message renderers
 - Route keyboard and command palette integration through an action registry.
 - Keep raw screen/layout/key access private to the TUI implementation.
-- Surface UI contribution diagnostics in `/extensions`.
+- Surface UI diagnostics in `/extensions`.
 
 ### Tests
 
@@ -238,7 +242,7 @@ Add dependency semantics with conservative installation boundaries.
   global environment.
 - Missing binary produces a non-fatal diagnostic.
 - Unsupported system capability produces diagnostic-only status.
-- Dependency failures disable dependent contributions without hiding the whole
+- Dependency failures disable dependent surfaces without hiding the whole
   extension.
 
 ### Not In Scope
@@ -275,13 +279,13 @@ Each implementation PR should include:
 
 Each phase should keep a narrow rollback path:
 
-- P1 can disable the new manifest and contribution projection while leaving
+- P1 can disable the new manifest and inventory projection while leaving
   existing `register(api)` loading active.
 - P2 can hide `/extensions` and fall back to current command/tool/resource
   registration paths.
 - P3 must keep compatibility wrappers around existing hook event names until
   all call sites are routed through the dispatcher and tested.
-- P4 can disable UI bridge contributions while preserving non-UI extension
+- P4 can disable UI bridge surfaces while preserving non-UI extension
   runtime behavior.
 - P5 can disable dependency resolution and leave dependency declarations as
   diagnostics-only metadata.
@@ -294,7 +298,7 @@ extension author APIs during rollback.
 Implementation PRs should include lightweight performance checks or explicit
 review evidence for hot paths:
 
-- contribution lookup is indexed by contribution type and id
+- inventory lookup is indexed by surface type and id
 - tool exposure is recomputed on extension/tool state changes, not per render
   frame
 - hook dispatch has deterministic ordering and timeout behavior for blocking
@@ -307,7 +311,7 @@ review evidence for hot paths:
 
 The platform integration work is complete when:
 
-- `/extensions` can explain enabled extensions, inactive contributions,
+- `/extensions` can explain enabled extensions, inactive or rejected surfaces,
   permissions, conflicts, dependencies, and hook declarations.
 - Extension tools are filtered before model exposure.
 - Hook semantics are centrally declared and dispatched.

--- a/docs/internals/specs/2026-05-16-loushang-coding-resource-extensibility-p0-design.md
+++ b/docs/internals/specs/2026-05-16-loushang-coding-resource-extensibility-p0-design.md
@@ -335,7 +335,7 @@ Stabilize configuration slices before the corresponding heavy behaviors land.
 
 ### Current Problem
 
-Today [ControlConfig](/home/dev/workspace/loushang/src/loushang/coding/types.py:12) only carries:
+Today [ControlConfig](/home/dev/workspace/loushang/src/loushang/coding/control/types.py:88) only carries:
 
 - `default_model`
 - `thinking_level`

--- a/docs/internals/specs/2026-06-08-loushang-coding-extension-platform-integration-design.md
+++ b/docs/internals/specs/2026-06-08-loushang-coding-extension-platform-integration-design.md
@@ -10,7 +10,7 @@ The platform should make extensions a first-class product surface across:
 - commands
 - tools
 - prompts and skills
-- model/provider contributions
+- model/provider runtime surfaces
 - runtime hooks
 - TUI UI and autocomplete
 - plugin/package distribution
@@ -36,9 +36,10 @@ capabilities in one phase.
 
 The current gap is not whether extensions can run. The gap is that extension
 capabilities are still registered and surfaced through several separate paths.
-Authors and users need a unified mental model, and the runtime needs a single
-place to project extension contributions, conflicts, permissions, and
-diagnostics.
+Authors and users need a unified mental model, and management surfaces need a
+single read model for extension surfaces, conflicts, permissions, and
+diagnostics. Runtime activation remains owned by each surface-specific
+controller or dispatcher.
 
 ## Relationship To Existing Designs
 
@@ -55,8 +56,9 @@ supersede them.
   prompts, skills, themes, and resource roots.
 
 This design adds the missing platform layer above those documents: a manifest,
-policy, contribution registry, diagnostics projection, and staged integration
-plan that tie the existing subsystems together.
+policy, extension inventory projection, diagnostics projection, and staged
+integration plan that tie the existing subsystems together without replacing
+surface-specific runtime owners.
 
 ## Boundary Decisions
 
@@ -96,7 +98,7 @@ It owns:
 
 - author-facing registration APIs
 - runtime hooks
-- command/tool/UI/model/prompt/skill contributions
+- command/tool/UI/model/prompt/skill runtime surfaces
 - extension diagnostics
 - extension policy and permissions
 
@@ -175,7 +177,7 @@ Use a hybrid permission model:
   `session_mutation`, `ui_mutation`, `tool_mutation`
 
 The level is what users and management UI should display. The capabilities are
-what loader, registry, and runtime enforcement should use.
+what loader, inventory projection, and runtime enforcement should use.
 
 Recommended default mapping:
 
@@ -185,9 +187,10 @@ Recommended default mapping:
 - `powerful`: `standard` plus exec, network, session mutation, tool mutation, or
   provider/model mutation
 
-Policy should be evaluated before contributions become active. A denied
+Policy should be evaluated before runtime surfaces are exposed. A denied
 extension should remain visible in diagnostics and management surfaces, but its
-runtime contributions should not be exposed.
+tools, commands, hooks, provider registrations, resources, and UI surfaces
+should be filtered by their owning runtime controllers or dispatchers.
 
 Add a policy switch equivalent in meaning to:
 
@@ -205,17 +208,17 @@ For this policy:
 - managed hooks are hook declarations loaded from enabled extensions delivered
   by accepted plugin/package sources or managed configuration
 - unmanaged hooks are local project, user, or session hook definitions that are
-  not tied to a loaded extension contribution
+  not tied to a loaded extension declaration
 
-## Contribution Registry
+## Extension Inventory Projection
 
-Introduce a `ContributionRegistry` as the central projection of extension
-capabilities.
+Introduce an `ExtensionInventory` or equivalent read model as the central
+projection of extension runtime surfaces.
 
-It should store normalized contributions with:
+It should store normalized surface records with:
 
-- contribution id
-- contribution type
+- surface id
+- surface type
 - extension id
 - source info
 - scope
@@ -224,12 +227,26 @@ It should store normalized contributions with:
 - conflict policy
 - diagnostics
 
-The registry should not execute extension code. It is a projection and
-arbitration layer between extension loading and product/runtime surfaces.
+The inventory must not execute extension code, activate runtime behavior, or
+arbitrate winners directly. It is a management and diagnostics projection over
+decisions made by the owning runtime surfaces:
 
-### Contribution Types
+- tools remain owned by the tool registry and extension runner
+- commands remain owned by the command resolver
+- prompts, skills, themes, and resource roots remain owned by the resource
+  loader and resource refresh pipeline
+- hooks remain owned by the hook dispatcher
+- model/providers remain owned by provider-specific controllers
+- UI and autocomplete remain owned by the TUI bridge and action/autocomplete
+  registries
 
-Initial contribution types:
+If an interim implementation keeps the `ContributionRegistry` name for
+compatibility, its contract is still inventory-only. It must not become the
+activation path for tools, commands, hooks, resources, providers, or UI.
+
+### Surface Record Types
+
+Initial surface record types:
 
 - command
 - tool
@@ -241,9 +258,9 @@ Initial contribution types:
 - autocomplete
 - resource_root
 
-### Conflict Policy
+### Conflict Visibility
 
-Use contribution-type-specific policies:
+Use surface-specific policies in the owning resolver or dispatcher:
 
 - commands: allow duplicate display names; disambiguate in UI and diagnostics;
   allow user-configured default winner later
@@ -255,9 +272,10 @@ Use contribution-type-specific policies:
   targets
 - model/provider entries: require explicit override for duplicate ids
 
-Never drop an entire extension solely because one contribution conflicts. Drop
-or disable the conflicting contribution and keep the rest of the extension
-visible.
+The inventory records the resulting winner, rejection, inactive reason, or
+diagnostic. Never drop an entire extension solely because one surface conflicts.
+The owning resolver may reject or disable the conflicting surface while the rest
+of the extension remains visible.
 
 ## Tools
 
@@ -267,11 +285,12 @@ the model.
 The required order is:
 
 1. load extension
-2. normalize tool contribution
+2. collect runtime tool registrations and manifest tool declarations
 3. evaluate extension policy and permission capabilities
-4. resolve tool conflicts
+4. resolve tool conflicts in the tool surface
 5. filter denied tools
-6. expose active tools to the model/tool registry
+6. expose allowed tools to the model/tool registry
+7. project the resulting tool state into the extension inventory
 
 Call-time permission checks remain necessary, but they are not sufficient. A
 tool denied by policy should not appear in the model-visible tool list.
@@ -372,8 +391,8 @@ manifest.
 Extension platform plumbing sits near hot paths, so implementation phases should
 keep these constraints visible:
 
-- contribution lookup should use indexed maps rather than repeated linear scans
-  over all extensions
+- inventory lookup should use indexed maps rather than repeated linear scans over
+  all extensions
 - model-visible tool filtering should be computed when extension/tool state
   changes, not on every token or render event
 - hook dispatch should run with deterministic ordering and explicit timeouts for
@@ -395,8 +414,8 @@ Minimum visible fields:
 - source
 - enabled/disabled state
 - permission level
-- active contributions
-- inactive contributions with reasons
+- exposed runtime surfaces
+- inactive or rejected surfaces with reasons
 - conflicts
 - dependency diagnostics
 - hook declarations

--- a/examples/coding/extensions/README.md
+++ b/examples/coding/extensions/README.md
@@ -9,7 +9,7 @@ These examples demonstrate the current `loushang-coding` `ExtensionAPI v1` surfa
 ### Examples
 
 - `01_lifecycle.py`: `session_start`, `before_agent_start`, `session_shutdown`
-- `02_dynamic_resources.py`: `resources_discover` with prompt and skill contributions
+- `02_dynamic_resources.py`: `resources_discover` with prompt and skill resource additions
 - `03_custom_tool.py`: `@tool` and tool execution through a session
 - `04_tool_guard.py`: `tool_call` and `tool_result` interception
 - `05_manifest_visibility.py`: `loushang-extension.toml`, `/extensions`, and extension tool source visibility

--- a/src/loushang/coding/cli/__init__.py
+++ b/src/loushang/coding/cli/__init__.py
@@ -1,13 +1,3 @@
-from typing import Any
-
 from loushang.coding.cli.args import CliArgs, parse_args
 
-__all__ = ["CliArgs", "main", "parse_args", "run_cli"]
-
-
-def __getattr__(name: str) -> Any:
-    if name in {"main", "run_cli"}:
-        from loushang.coding.cli import __main__
-
-        return getattr(__main__, name)
-    raise AttributeError(name)
+__all__ = ["CliArgs", "parse_args"]

--- a/src/loushang/coding/extensions/__init__.py
+++ b/src/loushang/coding/extensions/__init__.py
@@ -2,6 +2,12 @@ from loushang.coding.extensions.api import ExtensionAPI
 from loushang.coding.extensions.contributions import (
     ContributionDescriptor,
     ContributionRegistry,
+    DuplicateContributionKeyError,
+    DuplicateExtensionSurfaceKeyError,
+    ExtensionInventory,
+    ExtensionSurfaceDescriptor,
+    ExtensionSurfaceType,
+    surfaces_from_loaded_extension,
 )
 from loushang.coding.extensions.loader import ExtensionLoader
 from loushang.coding.extensions.manifest import (
@@ -57,6 +63,8 @@ __all__ = [
     "ContextResult",
     "ContributionDescriptor",
     "ContributionRegistry",
+    "DuplicateContributionKeyError",
+    "DuplicateExtensionSurfaceKeyError",
     "ExtensionAPI",
     "ExtensionContext",
     "ExtensionCommandContext",
@@ -70,6 +78,9 @@ __all__ = [
     "ExtensionPolicyDecision",
     "ExtensionResourceContribution",
     "ExtensionRuntimeBindings",
+    "ExtensionInventory",
+    "ExtensionSurfaceDescriptor",
+    "ExtensionSurfaceType",
     "InputEvent",
     "InputEventResult",
     "InputSource",
@@ -93,6 +104,7 @@ __all__ = [
     "SessionRefreshEvent",
     "SessionShutdownEvent",
     "SessionStartEvent",
+    "surfaces_from_loaded_extension",
     "ToolCallDecision",
     "ToolResultDecision",
     "VALID_EXTENSION_EVENTS",

--- a/src/loushang/coding/extensions/contributions.py
+++ b/src/loushang/coding/extensions/contributions.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from loushang.coding.loader import ResourceDiagnostic
 
-ContributionType = Literal[
+ExtensionSurfaceType = Literal[
     "command",
     "tool",
     "prompt",
@@ -22,8 +22,8 @@ ContributionType = Literal[
 
 
 @dataclass(frozen=True)
-class ContributionDescriptor:
-    type: ContributionType
+class ExtensionSurfaceDescriptor:
+    type: ExtensionSurfaceType
     name: str
     extension_id: str
     source_path: Path
@@ -34,63 +34,65 @@ class ContributionDescriptor:
     metadata: dict[str, object] = field(default_factory=dict)
 
 
-class DuplicateContributionKeyError(KeyError):
-    def __init__(self, contribution_type: str, name: str, contributions: list[ContributionDescriptor]) -> None:
-        super().__init__(f"Duplicate contribution key: {contribution_type}:{name}")
-        self.contribution_type = contribution_type
+class DuplicateExtensionSurfaceKeyError(KeyError):
+    def __init__(self, surface_type: str, name: str, surfaces: list[ExtensionSurfaceDescriptor]) -> None:
+        super().__init__(f"Duplicate extension surface key: {surface_type}:{name}")
+        self.surface_type = surface_type
+        self.contribution_type = surface_type
         self.name = name
-        self.contributions = list(contributions)
+        self.surfaces = list(surfaces)
+        self.contributions = list(surfaces)
 
 
 @dataclass
-class ContributionRegistry:
-    _contributions: list[ContributionDescriptor] = field(default_factory=list)
-    _by_type: dict[str, list[ContributionDescriptor]] = field(default_factory=lambda: defaultdict(list))
-    _by_extension: dict[str, list[ContributionDescriptor]] = field(default_factory=lambda: defaultdict(list))
-    _by_key: dict[tuple[str, str], list[ContributionDescriptor]] = field(default_factory=lambda: defaultdict(list))
+class ExtensionInventory:
+    _surfaces: list[ExtensionSurfaceDescriptor] = field(default_factory=list)
+    _by_type: dict[str, list[ExtensionSurfaceDescriptor]] = field(default_factory=lambda: defaultdict(list))
+    _by_extension: dict[str, list[ExtensionSurfaceDescriptor]] = field(default_factory=lambda: defaultdict(list))
+    _by_key: dict[tuple[str, str], list[ExtensionSurfaceDescriptor]] = field(default_factory=lambda: defaultdict(list))
 
     @classmethod
-    def from_extensions(cls, extensions: Iterable[object]) -> "ContributionRegistry":
-        registry = cls()
+    def from_extensions(cls, extensions: Iterable[object]) -> "ExtensionInventory":
+        inventory = cls()
         for extension in extensions:
-            for contribution in getattr(extension, "contributions", ()):
-                registry.add(contribution)
-        return registry
+            for surface in getattr(extension, "surfaces", getattr(extension, "contributions", ())):
+                inventory.add(surface)
+        return inventory
 
-    def add(self, contribution: ContributionDescriptor) -> None:
-        self._contributions.append(contribution)
-        self._by_type[contribution.type].append(contribution)
-        self._by_extension[contribution.extension_id].append(contribution)
-        self._by_key[(contribution.type, contribution.name)].append(contribution)
+    def add(self, surface: ExtensionSurfaceDescriptor) -> None:
+        self._surfaces.append(surface)
+        self._by_type[surface.type].append(surface)
+        self._by_extension[surface.extension_id].append(surface)
+        self._by_key[(surface.type, surface.name)].append(surface)
 
-    def all(self) -> list[ContributionDescriptor]:
-        return list(self._contributions)
+    def all(self) -> list[ExtensionSurfaceDescriptor]:
+        return list(self._surfaces)
 
-    def by_type(self, contribution_type: str) -> list[ContributionDescriptor]:
-        return list(self._by_type.get(contribution_type, ()))
+    def by_type(self, surface_type: str) -> list[ExtensionSurfaceDescriptor]:
+        return list(self._by_type.get(surface_type, ()))
 
-    def by_extension(self, extension_id: str) -> list[ContributionDescriptor]:
+    def by_extension(self, extension_id: str) -> list[ExtensionSurfaceDescriptor]:
         return list(self._by_extension.get(extension_id, ()))
 
-    def by_key(self, contribution_type: str, name: str) -> list[ContributionDescriptor]:
-        return list(self._by_key.get((contribution_type, name), ()))
+    def by_key(self, surface_type: str, name: str) -> list[ExtensionSurfaceDescriptor]:
+        return list(self._by_key.get((surface_type, name), ()))
 
-    def get(self, contribution_type: str, name: str) -> ContributionDescriptor:
-        contributions = self._by_key[(contribution_type, name)]
-        if len(contributions) > 1:
-            raise DuplicateContributionKeyError(contribution_type, name, contributions)
-        return contributions[0]
+    def get(self, surface_type: str, name: str) -> ExtensionSurfaceDescriptor:
+        surfaces = self._by_key[(surface_type, name)]
+        if len(surfaces) > 1:
+            raise DuplicateExtensionSurfaceKeyError(surface_type, name, surfaces)
+        return surfaces[0]
 
 
-def contributions_from_loaded_extension(extension: object) -> tuple[ContributionDescriptor, ...]:
+def surfaces_from_loaded_extension(extension: object) -> tuple[ExtensionSurfaceDescriptor, ...]:
     extension_id = _extension_id(extension)
     source_path = getattr(extension, "entry_path", None) or getattr(extension, "source_path")
-    contributions: list[ContributionDescriptor] = []
+    surfaces: list[ExtensionSurfaceDescriptor] = []
 
     manifest = getattr(extension, "manifest", None)
     if manifest is not None:
-        contributions.extend(
-            ContributionDescriptor(
+        surfaces.extend(
+            ExtensionSurfaceDescriptor(
                 type="command",
                 name=command.name,
                 extension_id=extension_id,
@@ -99,8 +101,8 @@ def contributions_from_loaded_extension(extension: object) -> tuple[Contribution
             )
             for command in manifest.commands
         )
-        contributions.extend(
-            ContributionDescriptor(
+        surfaces.extend(
+            ExtensionSurfaceDescriptor(
                 type="tool",
                 name=tool.name,
                 extension_id=extension_id,
@@ -109,8 +111,8 @@ def contributions_from_loaded_extension(extension: object) -> tuple[Contribution
             )
             for tool in manifest.tools
         )
-        contributions.extend(
-            ContributionDescriptor(
+        surfaces.extend(
+            ExtensionSurfaceDescriptor(
                 type="hook",
                 name=hook.event,
                 extension_id=extension_id,
@@ -120,8 +122,8 @@ def contributions_from_loaded_extension(extension: object) -> tuple[Contribution
             for hook in manifest.hooks
         )
 
-    contributions.extend(
-        ContributionDescriptor(
+    surfaces.extend(
+        ExtensionSurfaceDescriptor(
             type="command",
             name=name,
             extension_id=extension_id,
@@ -130,8 +132,8 @@ def contributions_from_loaded_extension(extension: object) -> tuple[Contribution
         )
         for name in getattr(extension, "commands", {})
     )
-    contributions.extend(
-        ContributionDescriptor(
+    surfaces.extend(
+        ExtensionSurfaceDescriptor(
             type="tool",
             name=tool.name,
             extension_id=extension_id,
@@ -140,8 +142,8 @@ def contributions_from_loaded_extension(extension: object) -> tuple[Contribution
         )
         for tool in getattr(extension, "tool_definitions", ())
     )
-    contributions.extend(
-        ContributionDescriptor(
+    surfaces.extend(
+        ExtensionSurfaceDescriptor(
             type="hook",
             name=event_name,
             extension_id=extension_id,
@@ -150,7 +152,7 @@ def contributions_from_loaded_extension(extension: object) -> tuple[Contribution
         )
         for event_name in getattr(extension, "hooks", {})
     )
-    return tuple(contributions)
+    return tuple(surfaces)
 
 
 def _extension_id(extension: object) -> str:
@@ -158,3 +160,10 @@ def _extension_id(extension: object) -> str:
     if manifest is not None:
         return manifest.id
     return str(getattr(extension, "name"))
+
+
+ContributionType = ExtensionSurfaceType
+ContributionDescriptor = ExtensionSurfaceDescriptor
+DuplicateContributionKeyError = DuplicateExtensionSurfaceKeyError
+ContributionRegistry = ExtensionInventory
+contributions_from_loaded_extension = surfaces_from_loaded_extension

--- a/src/loushang/coding/extensions/loader.py
+++ b/src/loushang/coding/extensions/loader.py
@@ -9,7 +9,7 @@ from dataclasses import replace
 from pathlib import Path
 
 from loushang.coding.extensions.api import ExtensionAPI
-from loushang.coding.extensions.contributions import contributions_from_loaded_extension
+from loushang.coding.extensions.contributions import surfaces_from_loaded_extension
 from loushang.coding.extensions.manifest import parse_extension_manifest
 from loushang.coding.extensions.policy import policy_from_manifest
 from loushang.coding.extensions.types import LoadedExtension
@@ -213,7 +213,7 @@ def _finalize_loaded_extension(
         manifest=manifest,
         policy=policy_from_manifest(manifest, enabled=enabled),
     )
-    return replace(with_policy, contributions=list(contributions_from_loaded_extension(with_policy)))
+    return replace(with_policy, contributions=list(surfaces_from_loaded_extension(with_policy)))
 
 
 def _load_descriptor_manifest(descriptor: ExtensionDescriptor):

--- a/src/loushang/coding/extensions/runner.py
+++ b/src/loushang/coding/extensions/runner.py
@@ -2291,6 +2291,7 @@ def _extension_visibility_snapshot(
     extension_id = manifest.id if manifest is not None else extension.name
     extension_name = manifest.name if manifest is not None else extension.name
     manifest_path = _extension_manifest_path(extension)
+    surfaces = [_serialize_surface(surface) for surface in extension.surfaces]
     return {
         "id": extension_id,
         "name": extension_name,
@@ -2314,10 +2315,8 @@ def _extension_visibility_snapshot(
             if manifest is not None
             else ()
         ),
-        "contributions": [
-            _serialize_contribution(contribution)
-            for contribution in extension.contributions
-        ],
+        "surfaces": surfaces,
+        "contributions": list(surfaces),
         "diagnostics": [
             _serialize_diagnostic(diagnostic)
             for diagnostic in _extension_visibility_diagnostics(
@@ -2329,19 +2328,19 @@ def _extension_visibility_snapshot(
     }
 
 
-def _serialize_contribution(contribution: object) -> dict[str, object]:
-    metadata = getattr(contribution, "metadata", {})
+def _serialize_surface(surface: object) -> dict[str, object]:
+    metadata = getattr(surface, "metadata", {})
     source = metadata.get("source") if isinstance(metadata, dict) else None
     return {
-        "type": str(getattr(contribution, "type", "")),
-        "name": str(getattr(contribution, "name", "")),
-        "active": bool(getattr(contribution, "active", True)),
-        "priority": int(getattr(contribution, "priority", 0)),
+        "type": str(getattr(surface, "type", "")),
+        "name": str(getattr(surface, "name", "")),
+        "active": bool(getattr(surface, "active", True)),
+        "priority": int(getattr(surface, "priority", 0)),
         "source": source if isinstance(source, str) else "",
-        "sourcePath": _path_text(getattr(contribution, "source_path", None)),
+        "sourcePath": _path_text(getattr(surface, "source_path", None)),
         "diagnostics": [
             _serialize_diagnostic(diagnostic)
-            for diagnostic in getattr(contribution, "diagnostics", ())
+            for diagnostic in getattr(surface, "diagnostics", ())
             if isinstance(diagnostic, ResourceDiagnostic)
         ],
     }

--- a/src/loushang/coding/extensions/types.py
+++ b/src/loushang/coding/extensions/types.py
@@ -10,7 +10,7 @@ from loushang.agent import AgentMessage, ThinkingLevel
 from loushang.coding.commands import SessionCommandDescriptor
 from loushang.coding.compaction import BranchSummaryResult, CompactionResult
 from loushang.coding.exec import ExecResult, ExecUpdateCallback
-from loushang.coding.extensions.contributions import ContributionDescriptor
+from loushang.coding.extensions.contributions import ExtensionSurfaceDescriptor
 from loushang.coding.extensions.manifest import ExtensionManifest
 from loushang.coding.extensions.policy import ExtensionPolicyDecision
 from loushang.coding.loader import (
@@ -775,7 +775,11 @@ class LoadedExtension:
     api: object | None = None
     manifest: ExtensionManifest | None = None
     policy: ExtensionPolicyDecision | None = None
-    contributions: list[ContributionDescriptor] = field(default_factory=list)
+    contributions: list[ExtensionSurfaceDescriptor] = field(default_factory=list)
+
+    @property
+    def surfaces(self) -> list[ExtensionSurfaceDescriptor]:
+        return list(self.contributions)
 
 
 @dataclass(frozen=True)

--- a/src/loushang/coding/session/builtin_commands.py
+++ b/src/loushang/coding/session/builtin_commands.py
@@ -503,10 +503,10 @@ def _extensions_summary_message(extensions: list[dict[str, object]]) -> str:
 
 
 def _extension_summary(extension: Mapping[str, object]) -> str:
-    contribution_count = len(_list_field(extension, "contributions"))
+    surface_count = len(_surface_records(extension))
     diagnostic_count = len(_list_field(extension, "diagnostics"))
     details = [_string_mapping_field(extension, "permissionLevel", default="safe")]
-    details.append(f"{contribution_count} {_pluralize('contribution', contribution_count)}")
+    details.append(f"{surface_count} {_pluralize('surface', surface_count)}")
     if diagnostic_count:
         details.append(f"{diagnostic_count} {_pluralize('diagnostic', diagnostic_count)}")
     return f"{_extension_id(extension)} ({', '.join(details)})"
@@ -528,9 +528,9 @@ def _extension_list_display_lines(extension: Mapping[str, object]) -> list[str]:
     source_path = _string_mapping_field(extension, "sourcePath")
     if source_path:
         lines.append(f"  Source: {source_path}")
-    contributions = _list_field(extension, "contributions")
-    if contributions:
-        lines.append(f"  Contributions: {_contributions_summary(contributions)}")
+    surfaces = _surface_records(extension)
+    if surfaces:
+        lines.append(f"  Surfaces: {_surfaces_summary(surfaces)}")
     diagnostics = _list_field(extension, "diagnostics")
     if diagnostics:
         lines.append(f"  Diagnostics: {len(diagnostics)}")
@@ -557,35 +557,42 @@ def _extension_detail_display(extension: Mapping[str, object]) -> str:
     manifest_path = _string_mapping_field(extension, "manifestPath")
     if manifest_path:
         lines.append(f"Manifest: {manifest_path}")
-    lines.extend(_contributions_detail_lines(_list_field(extension, "contributions")))
+    lines.extend(_surfaces_detail_lines(_surface_records(extension)))
     lines.extend(_diagnostic_detail_lines(_list_field(extension, "diagnostics")))
     return "\n".join(lines)
 
 
-def _contributions_summary(contributions: list[object]) -> str:
+def _surface_records(extension: Mapping[str, object]) -> list[object]:
+    surfaces = _list_field(extension, "surfaces")
+    if surfaces:
+        return surfaces
+    return _list_field(extension, "contributions")
+
+
+def _surfaces_summary(surfaces: list[object]) -> str:
     parts: list[str] = []
-    for contribution in contributions:
-        if not isinstance(contribution, Mapping):
+    for surface in surfaces:
+        if not isinstance(surface, Mapping):
             continue
-        contribution_type = _string_mapping_field(contribution, "type", default="contribution")
-        name = _string_mapping_field(contribution, "name")
+        surface_type = _string_mapping_field(surface, "type", default="surface")
+        name = _string_mapping_field(surface, "name")
         if name:
-            parts.append(f"{contribution_type} {name}")
+            parts.append(f"{surface_type} {name}")
     return ", ".join(parts) if parts else "(none)"
 
 
-def _contributions_detail_lines(contributions: list[object]) -> list[str]:
-    if not contributions:
-        return ["Contributions:", "- (none)"]
-    lines = ["Contributions:"]
-    for contribution in contributions:
-        if not isinstance(contribution, Mapping):
+def _surfaces_detail_lines(surfaces: list[object]) -> list[str]:
+    if not surfaces:
+        return ["Surfaces:", "- (none)"]
+    lines = ["Surfaces:"]
+    for surface in surfaces:
+        if not isinstance(surface, Mapping):
             continue
-        contribution_type = _string_mapping_field(contribution, "type", default="contribution")
-        name = _string_mapping_field(contribution, "name", default="(unnamed)")
-        source = _string_mapping_field(contribution, "source")
+        surface_type = _string_mapping_field(surface, "type", default="surface")
+        name = _string_mapping_field(surface, "name", default="(unnamed)")
+        source = _string_mapping_field(surface, "source")
         suffix = f" ({source})" if source else ""
-        lines.append(f"- {contribution_type} {name}{suffix}")
+        lines.append(f"- {surface_type} {name}{suffix}")
     return lines
 
 

--- a/src/loushang/coding/types.py
+++ b/src/loushang/coding/types.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from loushang.coding.control.types import ControlConfig
 
 
 @dataclass(frozen=True)
@@ -14,12 +10,4 @@ class ModelSelection:
     endpoint_id: str | None = None
 
 
-def __getattr__(name: str):
-    if name == "ControlConfig":
-        from loushang.coding.control.types import ControlConfig
-
-        return ControlConfig
-    raise AttributeError(name)
-
-
-__all__ = ["ControlConfig", "ModelSelection"]
+__all__ = ["ModelSelection"]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ImportBoundary:
+    name: str
+    root: Path
+    forbidden_prefixes: tuple[str, ...]
+    allowed_paths: frozenset[str] = frozenset()
+
+
+def test_core_runtime_packages_do_not_import_product_layers() -> None:
+    boundaries = (
+        ImportBoundary(
+            name="agent",
+            root=Path("src/loushang/agent"),
+            forbidden_prefixes=(
+                "loushang.coding",
+                "loushang.method",
+                "loushang.tui",
+                "loushang.work",
+            ),
+        ),
+        ImportBoundary(
+            name="agent.harness",
+            root=Path("src/loushang/agent/harness"),
+            forbidden_prefixes=(
+                "loushang.coding",
+                "loushang.method",
+                "loushang.tui",
+                "loushang.work",
+            ),
+        ),
+        ImportBoundary(
+            name="work",
+            root=Path("src/loushang/work"),
+            forbidden_prefixes=(
+                "loushang.agent",
+                "loushang.coding",
+                "loushang.method",
+                "loushang.tui",
+            ),
+            allowed_paths=frozenset({"src/loushang/work/coding.py"}),
+        ),
+        ImportBoundary(
+            name="method",
+            root=Path("src/loushang/method"),
+            forbidden_prefixes=(
+                "loushang.coding",
+                "loushang.tui",
+            ),
+        ),
+        ImportBoundary(
+            name="channel",
+            root=Path("src/loushang/channel"),
+            forbidden_prefixes=(
+                "loushang.agent",
+                "loushang.coding",
+                "loushang.method",
+                "loushang.tui",
+            ),
+        ),
+    )
+
+    offenders: list[str] = []
+    for boundary in boundaries:
+        offenders.extend(_find_forbidden_imports(boundary))
+
+    assert offenders == []
+
+
+def _find_forbidden_imports(boundary: ImportBoundary) -> list[str]:
+    offenders: list[str] = []
+    for path in sorted(boundary.root.rglob("*.py")):
+        relative_path = path.as_posix()
+        if relative_path in boundary.allowed_paths:
+            continue
+        for imported in _absolute_imports(path):
+            if _matches_any(imported, boundary.forbidden_prefixes):
+                offenders.append(f"{boundary.name}: {relative_path} imports {imported}")
+    return offenders
+
+
+def _absolute_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=path.as_posix())
+    imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module is not None:
+            imports.append(node.module)
+    return imports
+
+
+def _matches_any(imported: str, prefixes: tuple[str, ...]) -> bool:
+    return any(imported == prefix or imported.startswith(f"{prefix}.") for prefix in prefixes)

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -1584,11 +1584,13 @@ def test_main_uses_process_argv_when_argv_is_omitted(monkeypatch) -> None:
     assert "prompt is required" not in stderr.getvalue()
 
 
-def test_cli_package_lazily_exports_main_and_run_cli() -> None:
+def test_cli_package_exports_args_without_entrypoint_shims() -> None:
     from loushang.coding import cli
 
-    assert cli.main
-    assert cli.run_cli
+    assert set(cli.__all__) == {"CliArgs", "parse_args"}
+    assert cli.parse_args
+    assert not hasattr(cli, "main")
+    assert not hasattr(cli, "run_cli")
 
 
 def test_loushang_tui_entrypoint_forces_tui(monkeypatch) -> None:

--- a/tests/coding/test_extension_platform.py
+++ b/tests/coding/test_extension_platform.py
@@ -80,7 +80,7 @@ level = "root"
     assert result.diagnostics[0].resource_type == "extension"
 
 
-def test_extension_manifest_parser_keeps_manifest_for_partial_contribution_errors(tmp_path) -> None:
+def test_extension_manifest_parser_keeps_manifest_for_partial_surface_declaration_errors(tmp_path) -> None:
     from loushang.coding.extensions.manifest import parse_extension_manifest
 
     manifest_path = tmp_path / "loushang-extension.toml"
@@ -111,7 +111,7 @@ name = "valid_tool"
     ]
 
 
-def test_extension_loader_attaches_manifest_policy_and_contributions(tmp_path) -> None:
+def test_extension_loader_attaches_manifest_policy_and_surface_snapshot(tmp_path) -> None:
     from loushang.coding.extensions.loader import ExtensionLoader
     from loushang.coding.loader import ExtensionDescriptor
 
@@ -186,13 +186,14 @@ kind = "augment"
     assert extension.policy is not None
     assert extension.policy.permission_level == "standard"
     assert extension.policy.capabilities == ("filesystem",)
-    assert sorted((contribution.type, contribution.name) for contribution in extension.contributions) == [
+    assert sorted((surface.type, surface.name) for surface in extension.surfaces) == [
         ("command", "acme-review"),
         ("hook", "before_agent_start"),
         ("hook", "session_start"),
         ("tool", "manifest_lookup"),
         ("tool", "runtime_lookup"),
     ]
+    assert extension.contributions == extension.surfaces
     assert loader.get_diagnostics() == []
 
 
@@ -200,11 +201,11 @@ def test_extension_runner_lists_extension_visibility_snapshot() -> None:
     from pathlib import Path
 
     from loushang.coding.extensions import (
-        ContributionDescriptor,
         ExtensionManifest,
         ExtensionPermissionDeclaration,
         ExtensionPolicyDecision,
         ExtensionRunner,
+        ExtensionSurfaceDescriptor,
         LoadedExtension,
     )
     from loushang.coding.loader import ResourceDiagnostic
@@ -222,14 +223,14 @@ def test_extension_runner_lists_extension_visibility_snapshot() -> None:
         manifest=manifest,
         policy=ExtensionPolicyDecision(permission_level="standard", capabilities=("filesystem",)),
         contributions=[
-            ContributionDescriptor(
+            ExtensionSurfaceDescriptor(
                 type="command",
                 name="acme-review",
                 extension_id="acme.review",
                 source_path=Path("/tmp/project/extensions/review/extension.py"),
                 metadata={"source": "manifest"},
             ),
-            ContributionDescriptor(
+            ExtensionSurfaceDescriptor(
                 type="tool",
                 name="review_lookup",
                 extension_id="acme.review",
@@ -260,6 +261,26 @@ def test_extension_runner_lists_extension_visibility_snapshot() -> None:
             "enabled": True,
             "permissionLevel": "standard",
             "capabilities": ["filesystem"],
+            "surfaces": [
+                {
+                    "type": "command",
+                    "name": "acme-review",
+                    "active": True,
+                    "priority": 0,
+                    "source": "manifest",
+                    "sourcePath": "/tmp/project/extensions/review/extension.py",
+                    "diagnostics": [],
+                },
+                {
+                    "type": "tool",
+                    "name": "review_lookup",
+                    "active": True,
+                    "priority": 0,
+                    "source": "runtime",
+                    "sourcePath": "/tmp/project/extensions/review/extension.py",
+                    "diagnostics": [],
+                },
+            ],
             "contributions": [
                 {
                     "type": "command",
@@ -295,12 +316,12 @@ def test_extension_runner_lists_extension_visibility_snapshot() -> None:
     ]
 
 
-def test_contribution_registry_indexes_loaded_extension_contributions(tmp_path) -> None:
+def test_extension_inventory_indexes_loaded_extension_surfaces(tmp_path) -> None:
     from pathlib import Path
 
     from loushang.coding.extensions.contributions import (
-        ContributionDescriptor,
-        ContributionRegistry,
+        ExtensionInventory,
+        ExtensionSurfaceDescriptor,
     )
     from loushang.coding.extensions.types import LoadedExtension
 
@@ -308,13 +329,13 @@ def test_contribution_registry_indexes_loaded_extension_contributions(tmp_path) 
         name="review",
         source_path=Path("/tmp/review/extension.py"),
         contributions=[
-            ContributionDescriptor(
+            ExtensionSurfaceDescriptor(
                 type="tool",
                 name="lookup",
                 extension_id="review",
                 source_path=Path("/tmp/review/extension.py"),
             ),
-            ContributionDescriptor(
+            ExtensionSurfaceDescriptor(
                 type="command",
                 name="review",
                 extension_id="review",
@@ -323,47 +344,47 @@ def test_contribution_registry_indexes_loaded_extension_contributions(tmp_path) 
         ],
     )
 
-    registry = ContributionRegistry.from_extensions([extension])
+    inventory = ExtensionInventory.from_extensions([extension])
 
-    assert [contribution.name for contribution in registry.by_type("tool")] == ["lookup"]
-    assert [contribution.name for contribution in registry.by_extension("review")] == [
+    assert [surface.name for surface in inventory.by_type("tool")] == ["lookup"]
+    assert [surface.name for surface in inventory.by_extension("review")] == [
         "lookup",
         "review",
     ]
-    assert registry.get("tool", "lookup").extension_id == "review"
+    assert inventory.get("tool", "lookup").extension_id == "review"
 
 
-def test_contribution_registry_does_not_silently_overwrite_duplicate_keys() -> None:
+def test_extension_inventory_does_not_silently_overwrite_duplicate_keys() -> None:
     from pathlib import Path
 
     import pytest
 
     from loushang.coding.extensions.contributions import (
-        ContributionDescriptor,
-        ContributionRegistry,
-        DuplicateContributionKeyError,
+        DuplicateExtensionSurfaceKeyError,
+        ExtensionInventory,
+        ExtensionSurfaceDescriptor,
     )
 
-    first = ContributionDescriptor(
+    first = ExtensionSurfaceDescriptor(
         type="command",
         name="review",
         extension_id="one",
         source_path=Path("/tmp/one.py"),
     )
-    second = ContributionDescriptor(
+    second = ExtensionSurfaceDescriptor(
         type="command",
         name="review",
         extension_id="two",
         source_path=Path("/tmp/two.py"),
     )
 
-    registry = ContributionRegistry()
-    registry.add(first)
-    registry.add(second)
+    inventory = ExtensionInventory()
+    inventory.add(first)
+    inventory.add(second)
 
-    assert [contribution.extension_id for contribution in registry.by_key("command", "review")] == [
+    assert [surface.extension_id for surface in inventory.by_key("command", "review")] == [
         "one",
         "two",
     ]
-    with pytest.raises(DuplicateContributionKeyError):
-        registry.get("command", "review")
+    with pytest.raises(DuplicateExtensionSurfaceKeyError):
+        inventory.get("command", "review")

--- a/tests/coding/test_session_command_controller.py
+++ b/tests/coding/test_session_command_controller.py
@@ -373,7 +373,7 @@ def test_command_controller_executes_builtin_extensions_list_and_detail(tmp_path
             "sourcePath": "/tmp/project/extensions/review/extension.py",
             "permissionLevel": "standard",
             "capabilities": ["filesystem"],
-            "contributions": [
+            "surfaces": [
                 {"type": "command", "name": "acme-review", "active": True, "source": "manifest"},
                 {"type": "tool", "name": "review_lookup", "active": True, "source": "runtime"},
             ],
@@ -403,12 +403,12 @@ def test_command_controller_executes_builtin_extensions_list_and_detail(tmp_path
         "command": "extensions",
         "status": "ok",
         "extensions": extensions,
-        "message": "Extensions: acme.review (standard, 2 contributions, 1 diagnostic)",
+        "message": "Extensions: acme.review (standard, 2 surfaces, 1 diagnostic)",
         "display": (
             "Extensions:\n"
             "- acme.review - Acme Review [standard]\n"
             "  Source: /tmp/project/extensions/review/extension.py\n"
-            "  Contributions: command acme-review, tool review_lookup\n"
+            "  Surfaces: command acme-review, tool review_lookup\n"
             "  Diagnostics: 1"
         ),
     }
@@ -427,7 +427,7 @@ def test_command_controller_executes_builtin_extensions_list_and_detail(tmp_path
             "Permission: standard\n"
             "Capabilities: filesystem\n"
             "Source: /tmp/project/extensions/review/extension.py\n"
-            "Contributions:\n"
+            "Surfaces:\n"
             "- command acme-review (manifest)\n"
             "- tool review_lookup (runtime)\n"
             "Diagnostics:\n"

--- a/tests/coding/test_types.py
+++ b/tests/coding/test_types.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+def test_coding_types_exports_model_selection_without_control_config_shim() -> None:
+    import loushang.coding.types as coding_types
+
+    assert coding_types.__all__ == ["ModelSelection"]
+    assert coding_types.ModelSelection(provider="faux", model_id="alpha").endpoint_id is None
+    assert not hasattr(coding_types, "ControlConfig")

--- a/tests/coding/test_ui_controller.py
+++ b/tests/coding/test_ui_controller.py
@@ -218,8 +218,8 @@ def test_controller_prefers_session_command_display_text_for_status() -> None:
                     "source": "builtin",
                     "command": invocation_name,
                     "status": "ok",
-                    "message": "Extensions: acme.review (standard, 2 contributions)",
-                    "display": "Extensions:\n- acme.review - Acme Review [standard]\n  Contributions: command acme-review, tool review_lookup",
+                    "message": "Extensions: acme.review (standard, 2 surfaces)",
+                    "display": "Extensions:\n- acme.review - Acme Review [standard]\n  Surfaces: command acme-review, tool review_lookup",
                 },
             )
 
@@ -231,7 +231,7 @@ def test_controller_prefers_session_command_display_text_for_status() -> None:
     assert result.status_message == (
         "Extensions:\n"
         "- acme.review - Acme Review [standard]\n"
-        "  Contributions: command acme-review, tool review_lookup"
+        "  Surfaces: command acme-review, tool review_lookup"
     )
 
 


### PR DESCRIPTION
## English

### Summary
- Add a static architecture import-boundary test for agent, agent.harness, work, method, and channel.
- Remove package-level compatibility shims from `loushang.coding.cli` and `loushang.coding.types`.
- Update docs to record the completed boundary guard and the canonical `ControlConfig` location.
- Rename the extension management projection from contribution-centric terminology to surface/inventory terminology.
- Add `ExtensionSurfaceDescriptor`, `ExtensionInventory`, `DuplicateExtensionSurfaceKeyError`, and `surfaces_from_loaded_extension` as primary API names.
- Keep the previous `Contribution*` names and `contributions` JSON field as compatibility aliases.
- Update `/extensions` output to show `Surfaces` while still accepting legacy `contributions` snapshots.

### Rationale
The branch tightens import boundaries and also clarifies the extension platform model. Extension runtime activation remains owned by surface-specific controllers and dispatchers; the inventory is a read-only management and diagnostics projection, not an activation or arbitration layer.

### Validation
Existing branch validation:
- `uv --cache-dir .uv-cache run --extra dev pytest tests/architecture/test_import_boundaries.py tests/coding/test_cli.py::test_cli_package_exports_args_without_entrypoint_shims tests/coding/test_types.py -q` -> 3 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/architecture tests/agent tests/work tests/method tests/channel tests/coding/test_cli.py tests/coding/test_types.py tests/coding/test_control_services.py -q` -> 368 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli/__init__.py src/loushang/coding/types.py tests/architecture/test_import_boundaries.py tests/coding/test_cli.py tests/coding/test_types.py` -> All checks passed

Latest extension surface validation:
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_extension_api.py tests/coding/test_extension_loader.py tests/coding/test_extension_platform.py tests/coding/test_extension_runner.py tests/coding/test_session_extension_runtime_bindings.py tests/coding/test_session_extension_runtime_controller.py tests/coding/test_session_extension_hooks.py tests/coding/test_session_extension_message_controller.py tests/coding/test_session_extension_provider_controller.py tests/coding/test_session_extension_replacement_controller.py tests/coding/test_session_extension_event_sink.py tests/coding/test_cli_extension_flags.py tests/coding/test_session_command_controller.py tests/coding/test_ui_controller.py -q` -> 167 passed
- `uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/extensions/contributions.py src/loushang/coding/extensions/loader.py src/loushang/coding/extensions/types.py src/loushang/coding/extensions/__init__.py src/loushang/coding/extensions/runner.py src/loushang/coding/session/builtin_commands.py tests/coding/test_extension_platform.py tests/coding/test_session_command_controller.py tests/coding/test_ui_controller.py` -> All checks passed

## 中文

### 概要
- 增加架构级 import 边界测试，覆盖 agent、agent.harness、work、method、channel 的依赖方向。
- 移除 `loushang.coding.cli` 和 `loushang.coding.types` 的包级兼容 shim。
- 更新文档，记录边界守卫已落地，并修正 `ControlConfig` 的真实位置。
- 将 extension 管理投影从 contribution 语义收敛为 surface/inventory 语义。
- 新增 `ExtensionSurfaceDescriptor`、`ExtensionInventory`、`DuplicateExtensionSurfaceKeyError` 和 `surfaces_from_loaded_extension` 作为主命名。
- 保留旧的 `Contribution*` 命名和 `contributions` JSON 字段作为兼容别名。
- `/extensions` 展示改为 `Surfaces`，同时继续兼容旧的 `contributions` 快照输入。

### 背景
这个分支同时收紧 import 边界，并澄清 extension 平台模型。extension runtime 仍由各 surface 自己的 controller/dispatcher 激活；inventory 只是只读管理和诊断投影，不成为统一执行、激活或仲裁层。

### 验证
分支已有验证：
- `uv --cache-dir .uv-cache run --extra dev pytest tests/architecture/test_import_boundaries.py tests/coding/test_cli.py::test_cli_package_exports_args_without_entrypoint_shims tests/coding/test_types.py -q` -> 3 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/architecture tests/agent tests/work tests/method tests/channel tests/coding/test_cli.py tests/coding/test_types.py tests/coding/test_control_services.py -q` -> 368 passed
- `uv --cache-dir .uv-cache run ruff check src/loushang/coding/cli/__init__.py src/loushang/coding/types.py tests/architecture/test_import_boundaries.py tests/coding/test_cli.py tests/coding/test_types.py` -> All checks passed

本次 extension surface 验证：
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_extension_api.py tests/coding/test_extension_loader.py tests/coding/test_extension_platform.py tests/coding/test_extension_runner.py tests/coding/test_session_extension_runtime_bindings.py tests/coding/test_session_extension_runtime_controller.py tests/coding/test_session_extension_hooks.py tests/coding/test_session_extension_message_controller.py tests/coding/test_session_extension_provider_controller.py tests/coding/test_session_extension_replacement_controller.py tests/coding/test_session_extension_event_sink.py tests/coding/test_cli_extension_flags.py tests/coding/test_session_command_controller.py tests/coding/test_ui_controller.py -q` -> 167 passed
- `uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/extensions/contributions.py src/loushang/coding/extensions/loader.py src/loushang/coding/extensions/types.py src/loushang/coding/extensions/__init__.py src/loushang/coding/extensions/runner.py src/loushang/coding/session/builtin_commands.py tests/coding/test_extension_platform.py tests/coding/test_session_command_controller.py tests/coding/test_ui_controller.py` -> All checks passed