### PR TITLE
[codex] Polish TUI widget examples

### DIFF
--- a/docs/superpowers/plans/2026-06-12-tui-widget-examples-ux-polish-implementation.md
+++ b/docs/superpowers/plans/2026-06-12-tui-widget-examples-ux-polish-implementation.md
@@ -768,7 +768,7 @@ def test_widgets_question_dialog_example_playback_snapshots() -> None:
             ("enter", InputEvent(kind="key", key="enter")),
         ),
     )
-    assert "[Submit] > [Cancel]" in cancel_frames[2].lines
+    assert "[Submit]> [Cancel]" in cancel_frames[2].lines
     assert "Status        Cancelled" in cancel_frames[3].lines
 ```
 

--- a/docs/superpowers/plans/2026-06-12-tui-widget-examples-ux-polish-implementation.md
+++ b/docs/superpowers/plans/2026-06-12-tui-widget-examples-ux-polish-implementation.md
@@ -159,7 +159,6 @@ from __future__ import annotations
 
 import runpy
 from dataclasses import dataclass
-from typing import Any
 
 from loushang.tui import (
     FakeTerminalPort,
@@ -343,7 +342,7 @@ def test_widgets_light_controls_example_playback_snapshots() -> None:
         "Actions",
         "                Open  current view",
         "                Refresh",
-        "                Archive",
+        "                Archive  disabled",
         "",
         "Status        Ready",
         "",
@@ -434,7 +433,7 @@ Activity      | Syncing
 Actions
                 Open  current view
                 Refresh
-                Archive
+                Archive  disabled
 
 Status        Ready
 
@@ -443,6 +442,12 @@ Status        Ready
 
 When actions are focused, `Tabs.render()` must not show a `>` and `Menu.render()`
 must show a single focused action row.
+
+Modify `_menu_items()` so the archive item carries visible disabled context:
+
+```python
+MenuItem("archive", "Archive", description="disabled", disabled=True)
+```
 
 - [ ] **Step 6: Run light controls tests**
 
@@ -754,6 +759,17 @@ def test_widgets_question_dialog_example_playback_snapshots() -> None:
     assert "Status        Drafting" in frames[0].lines
     assert "> [Submit]  [Cancel]" in frames[2].lines
     assert "Status        Submitted: Cache warmup before deploy" in frames[3].lines
+
+    cancel_frames = play_example(
+        "examples/tui/48_widgets_question_dialog.py",
+        events=(
+            ("tab", InputEvent(kind="key", key="tab")),
+            ("right", InputEvent(kind="key", key="right")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+    assert "[Submit] > [Cancel]" in cancel_frames[2].lines
+    assert "Status        Cancelled" in cancel_frames[3].lines
 ```
 
 - [ ] **Step 2: Run focused test and verify it fails**
@@ -949,7 +965,8 @@ git commit -m "feat(tui): polish tree example"
 
 - [ ] **Step 1: Write failing playback test**
 
-Add to `tests/tui/test_widgets_toast.py`:
+Add `InputEvent` to the existing `from loushang.tui import (...)` import list,
+then add this playback test to `tests/tui/test_widgets_toast.py`:
 
 ```python
 from tests.tui.widget_example_playback import play_example

--- a/docs/superpowers/plans/2026-06-12-tui-widget-examples-ux-polish-implementation.md
+++ b/docs/superpowers/plans/2026-06-12-tui-widget-examples-ux-polish-implementation.md
@@ -1,0 +1,1176 @@
+# TUI Widget Examples UX Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish TUI widget examples `44-50` into clearer, scenario-based mini applications with deterministic playback-like tests for initial, navigation, and state-change frames.
+
+**Architecture:** Keep all behavior local to examples and tests. Add a small private playback snapshot helper in tests to drive each example through `TuiRuntime + FakeTerminalPort`; then update each example's layout and input handling to match the approved spec without introducing new public layout APIs or runtime changes.
+
+**Tech Stack:** Python 3.11+, dataclasses with slots, existing `loushang.tui` widgets, `RenderConstraints`, `TuiRuntime`, `FakeTerminalPort`, `RenderLoop`, pytest, Ruff.
+
+---
+
+## Reference Documents
+
+- Spec: `docs/superpowers/specs/2026-06-12-tui-widget-examples-ux-polish-design.md`
+- Existing example baseline:
+  - `examples/tui/43_widgets_foundation.py`
+  - `tests/tui/test_widgets_foundation.py`
+- Examples to polish:
+  - `examples/tui/44_widgets_small_controls.py`
+  - `examples/tui/45_widgets_light_controls.py`
+  - `examples/tui/46_widgets_table.py`
+  - `examples/tui/47_widgets_textarea.py`
+  - `examples/tui/48_widgets_question_dialog.py`
+  - `examples/tui/49_widgets_tree.py`
+  - `examples/tui/50_widgets_toast.py`
+- Existing widget tests:
+  - `tests/tui/test_widgets_small_controls.py`
+  - `tests/tui/test_widgets_light_controls.py`
+  - `tests/tui/test_widgets_table.py`
+  - `tests/tui/test_widgets_textarea.py`
+  - `tests/tui/test_widgets_question_dialog.py`
+  - `tests/tui/test_widgets_tree.py`
+  - `tests/tui/test_widgets_toast.py`
+
+## File Structure
+
+Create:
+
+- `tests/tui/widget_example_playback.py`
+  - Private test helper for loading examples with `runpy`, rendering with
+    `TuiRuntime + FakeTerminalPort`, sending `InputEvent` values through the
+    example `Tui`, and returning stripped visible lines plus cursor/operation
+    metadata.
+
+Modify:
+
+- `examples/tui/44_widgets_small_controls.py`
+  - Scenario: Indexing Job.
+  - Keep `Toolbar` as the only focusable region.
+- `tests/tui/test_widgets_small_controls.py`
+  - Add playback-like example snapshots for initial, toolbar navigation, and
+    activation.
+- `examples/tui/45_widgets_light_controls.py`
+  - Scenario: View Switcher.
+  - Add local two-region focus state for `views` and `actions`.
+- `tests/tui/test_widgets_light_controls.py`
+  - Add playback-like snapshots proving only one focus marker is visible.
+- `examples/tui/46_widgets_table.py`
+  - Scenario: Job Queue.
+  - Add selected row detail.
+- `tests/tui/test_widgets_table.py`
+  - Add playback-like snapshots for row navigation and activation.
+- `examples/tui/47_widgets_textarea.py`
+  - Scenario: Release Note Draft.
+  - Add title metadata and line-count status.
+- `tests/tui/test_widgets_textarea.py`
+  - Add playback-like snapshots for initial, edit, newline, and second edit.
+- `examples/tui/48_widgets_question_dialog.py`
+  - Scenario: Notes Inbox.
+  - Add Recent context and Status row.
+- `tests/tui/test_widgets_question_dialog.py`
+  - Add playback-like snapshots for typing, tabbing to actions, and submit/cancel
+    state changes.
+- `examples/tui/49_widgets_tree.py`
+  - Scenario: Project Explorer.
+  - Add details projection for active/selected node.
+- `tests/tui/test_widgets_tree.py`
+  - Add playback-like snapshots for navigation and selection/toggle.
+- `examples/tui/50_widgets_toast.py`
+  - Scenario: Deploy Console.
+  - Render toasts as notifications below stable console context.
+- `tests/tui/test_widgets_toast.py`
+  - Add playback-like snapshots for adding, dismissing, and clearing
+    notifications.
+
+Do not modify:
+
+- `src/loushang/tui/render_loop.py`
+- `src/loushang/tui/framework.py`
+- `src/loushang/tui/input.py`
+- `src/loushang/tui/runtime.py`
+- Public widget APIs, unless a test exposes a real widget bug. Example polish
+  should remain example-local.
+
+---
+
+### Task 1: Add Shared Playback Snapshot Helper
+
+**Files:**
+- Create: `tests/tui/widget_example_playback.py`
+- Test indirectly through: `tests/tui/test_widgets_small_controls.py`
+
+- [ ] **Step 1: Write a failing playback test for example 44 using the future helper**
+
+Add to `tests/tui/test_widgets_small_controls.py`:
+
+```python
+from tests.tui.widget_example_playback import ExampleFrame, play_example
+
+
+def test_widgets_small_controls_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/44_widgets_small_controls.py",
+        events=(
+            ("right", InputEvent(kind="key", key="right")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert [frame.label for frame in frames] == ["initial", "right", "enter"]
+    assert all(isinstance(frame, ExampleFrame) for frame in frames)
+    assert frames[0].lines[:11] == (
+        "Indexing Job  [beta]  (ready)",
+        "",
+        "Progress      Indexing [#####-------] 42%",
+        "",
+        "Details",
+        "Model         Kimi",
+        "Mode          safe  current",
+        "Queue         3 pending",
+        "",
+        "Actions       > [Refresh]  [Cancel]",
+        "Status        Ready",
+    )
+    assert "Actions       [Refresh]  > [Cancel]" in frames[1].lines
+    assert "Status        Cancelled" in frames[2].lines
+```
+
+The `ExampleFrame` import is intentionally referenced so the helper exposes a
+stable data shape.
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_small_controls.py::test_widgets_small_controls_example_playback_snapshots -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'tests.tui.widget_example_playback'`.
+
+- [ ] **Step 3: Create `tests/tui/widget_example_playback.py`**
+
+Implementation:
+
+```python
+from __future__ import annotations
+
+import runpy
+from dataclasses import dataclass
+from typing import Any
+
+from loushang.tui import (
+    FakeTerminalPort,
+    InputEvent,
+    RenderLoop,
+    TerminalSize,
+    TuiRuntime,
+    strip_control_sequences,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ExampleFrame:
+    label: str
+    lines: tuple[str, ...]
+    cursor: tuple[int, int]
+    operation_class: str | None
+
+
+def play_example(
+    path: str,
+    *,
+    events: tuple[tuple[str, InputEvent], ...] = (),
+    width: int = 80,
+    height: int = 20,
+) -> tuple[ExampleFrame, ...]:
+    namespace = runpy.run_path(path, run_name="__test__")
+    tui = namespace["build_app"]()
+    port = FakeTerminalPort(size=TerminalSize(columns=width, rows=height))
+    runtime = TuiRuntime(render_loop=RenderLoop(tui._screen_root), terminal=port)
+    frames = [_render_frame("initial", runtime)]
+    for label, event in events:
+        tui.handle_input(event)
+        frames.append(_render_frame(label, runtime))
+    return tuple(frames)
+
+
+def _render_frame(label: str, runtime: TuiRuntime) -> ExampleFrame:
+    step = runtime.render_now()
+    return ExampleFrame(
+        label=label,
+        lines=tuple(
+            strip_control_sequences(line).rstrip()
+            for line in step.diagnostics.current_logical_lines
+        ),
+        cursor=(
+            step.diagnostics.logical_cursor_row,
+            step.diagnostics.logical_cursor_column,
+        ),
+        operation_class=step.diagnostics.operation_class,
+    )
+```
+
+- [ ] **Step 4: Run the focused test and verify it now fails on expected screen content**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_small_controls.py::test_widgets_small_controls_example_playback_snapshots -q
+```
+
+Expected: FAIL because `44_widgets_small_controls.py` still renders
+`Small Controls` and old layout.
+
+- [ ] **Step 5: Commit the helper and failing test**
+
+```bash
+git add tests/tui/widget_example_playback.py tests/tui/test_widgets_small_controls.py
+git commit -m "test(tui): add widget example playback helper"
+```
+
+---
+
+### Task 2: Polish Example 44 - Indexing Job
+
+**Files:**
+- Modify: `examples/tui/44_widgets_small_controls.py`
+- Modify: `tests/tui/test_widgets_small_controls.py`
+
+- [ ] **Step 1: Implement example-local row helper**
+
+Add near the top of `examples/tui/44_widgets_small_controls.py`:
+
+```python
+LABEL_WIDTH = 14
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    return RenderLine(truncate_to_width(f"{label:<{LABEL_WIDTH}}{value}", max_width=width, ellipsis=""))
+```
+
+- [ ] **Step 2: Rewrite `SmallControlsApp.render()` to the spec layout**
+
+Use this shape:
+
+```python
+def render(self, constraints: RenderConstraints) -> RenderResult:
+    progress = ProgressBar(value=self.progress, total=100, label="Indexing", width=12)
+    progress_line = progress.render(RenderConstraints(width=max(1, constraints.width - LABEL_WIDTH), max_height=1)).lines[0].text
+    toolbar_line = self.toolbar.render(RenderConstraints(width=max(1, constraints.width - LABEL_WIDTH), max_height=1)).lines
+    rows = [
+        RenderLine(_header(constraints.width)),
+        RenderLine(""),
+        _field("Progress", progress_line, width=constraints.width),
+        RenderLine(""),
+        RenderLine("Details"),
+        _field("Model", "Kimi", width=constraints.width),
+        _field("Mode", "safe  current", width=constraints.width),
+        _field("Queue", "3 pending", width=constraints.width),
+        RenderLine(""),
+        _field("Actions", toolbar_line[0].text if toolbar_line else "", width=constraints.width),
+        _field("Status", self.message, width=constraints.width),
+        RenderLine(""),
+        RenderLine(truncate_to_width("[left/right] action  [enter] run  [q] quit", max_width=constraints.width, ellipsis="")),
+    ]
+    return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints)
+```
+
+Keep `_header()` rendering `Indexing Job  [beta]  (ready)`.
+
+- [ ] **Step 3: Run the focused playback test**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_small_controls.py::test_widgets_small_controls_example_playback_snapshots -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run all small controls tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_small_controls.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit example 44**
+
+```bash
+git add examples/tui/44_widgets_small_controls.py tests/tui/test_widgets_small_controls.py
+git commit -m "feat(tui): polish small controls example"
+```
+
+---
+
+### Task 3: Polish Example 45 - View Switcher
+
+**Files:**
+- Modify: `examples/tui/45_widgets_light_controls.py`
+- Modify: `tests/tui/test_widgets_light_controls.py`
+
+- [ ] **Step 1: Write failing playback test for region focus**
+
+Add to `tests/tui/test_widgets_light_controls.py`:
+
+```python
+from tests.tui.widget_example_playback import play_example
+
+
+def test_widgets_light_controls_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/45_widgets_light_controls.py",
+        events=(
+            ("right", InputEvent(kind="key", key="right")),
+            ("tab", InputEvent(kind="key", key="tab")),
+            ("down", InputEvent(kind="key", key="down")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert frames[0].lines[:12] == (
+        "View Switcher",
+        "",
+        "Views         > [Overview]    [Logs 3]    [Settings]",
+        "Activity      | Syncing",
+        "",
+        "Actions",
+        "                Open  current view",
+        "                Refresh",
+        "                Archive",
+        "",
+        "Status        Ready",
+        "",
+    )
+    assert "Views           [Overview]  > [Logs 3]    [Settings]" in frames[1].lines
+    assert "              > Open  current view" in frames[2].lines
+    assert "              > Refresh" in frames[3].lines
+    assert "Status        Refreshed" in frames[4].lines
+    assert sum(line.count(">") for line in frames[0].lines) == 1
+    assert sum(line.count(">") for line in frames[2].lines) == 1
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_light_controls.py::test_widgets_light_controls_example_playback_snapshots -q
+```
+
+Expected: FAIL because current example title/layout/focus region behavior still
+uses the old screen and double focus.
+
+- [ ] **Step 3: Add region focus state to `LightControlsApp`**
+
+Modify the dataclass:
+
+```python
+focus_region: str = "views"
+```
+
+Update `__post_init__()`:
+
+```python
+def __post_init__(self) -> None:
+    FocusableMixin.__init__(self)
+    self._sync_region_focus()
+```
+
+Add:
+
+```python
+def _sync_region_focus(self) -> None:
+    if self.focus_region == "views":
+        self.tabs.focus()
+        self.menu.blur()
+    else:
+        self.tabs.blur()
+        self.menu.focus()
+```
+
+- [ ] **Step 4: Rewrite `LightControlsApp.handle_input()`**
+
+```python
+def handle_input(self, event: Any) -> object:
+    if getattr(event, "kind", "") == "key" and getattr(event, "key", "") == "tab":
+        self.focus_region = "actions" if self.focus_region == "views" else "views"
+        self._sync_region_focus()
+        return True
+    if self.focus_region == "views":
+        if getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"left", "right"}:
+            result = self.tabs.handle_input(event)
+            if result is not None:
+                self.message = f"View: {self.tabs.value}"
+                return True
+        return None
+    result = self.menu.handle_input(event)
+    if result == "refresh":
+        self.spinner_frame += 1
+        self.message = "Refreshed"
+        return True
+    if result == "open":
+        self.message = f"Opened {self.tabs.value}"
+        return True
+    return result
+```
+
+- [ ] **Step 5: Rewrite `render()` with labeled regions**
+
+Use `LABEL_WIDTH = 14` and a `_field()` helper like Task 2. Render:
+
+```text
+View Switcher
+
+Views         > [Overview]    [Logs 3]    [Settings]
+Activity      | Syncing
+
+Actions
+                Open  current view
+                Refresh
+                Archive
+
+Status        Ready
+
+[tab] region  [left/right] view  [up/down] action  [enter] run  [q] quit
+```
+
+When actions are focused, `Tabs.render()` must not show a `>` and `Menu.render()`
+must show a single focused action row.
+
+- [ ] **Step 6: Run light controls tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_light_controls.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit example 45**
+
+```bash
+git add examples/tui/45_widgets_light_controls.py tests/tui/test_widgets_light_controls.py
+git commit -m "feat(tui): polish light controls example"
+```
+
+---
+
+### Task 4: Polish Example 46 - Job Queue
+
+**Files:**
+- Modify: `examples/tui/46_widgets_table.py`
+- Modify: `tests/tui/test_widgets_table.py`
+
+- [ ] **Step 1: Write failing playback test**
+
+Add to `tests/tui/test_widgets_table.py`:
+
+```python
+from tests.tui.widget_example_playback import play_example
+
+
+def test_widgets_table_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/46_widgets_table.py",
+        events=(
+            ("down", InputEvent(kind="key", key="down")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert frames[0].lines[:8] == (
+        "Job Queue  (3 jobs)",
+        "",
+        "  Job           Status                                                     Runs",
+        "> Build         ready                                                        12",
+        "  Deploy        blocked                                                       3",
+        "  Archive       disabled                                                      0",
+        "",
+        "Selected      Build is ready, 12 runs",
+    )
+    assert "> Deploy        blocked" in "\n".join(frames[1].lines)
+    assert "Selected      Deploy is blocked, 3 runs" in frames[2].lines
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_table.py::test_widgets_table_example_playback_snapshots -q
+```
+
+Expected: FAIL because current example title/detail layout differs.
+
+- [ ] **Step 3: Add row metadata helper to example**
+
+Add:
+
+```python
+JOB_DETAILS = {
+    "build": "Build is ready, 12 runs",
+    "deploy": "Deploy is blocked, 3 runs",
+    "archive": "Archive is disabled, 0 runs",
+}
+```
+
+Add helper:
+
+```python
+def _selected_detail(table: Table) -> str:
+    value = table.active_value
+    return JOB_DETAILS.get(value, "Select a job")
+```
+
+If `Table` does not expose `active_value`, inspect `src/loushang/tui/ui_parts/widgets/table.py`
+and use the existing public value/selection attribute. Do not add public API
+unless necessary.
+
+- [ ] **Step 4: Rewrite render and activation message**
+
+Render title `Job Queue  (3 jobs)`, table, selected detail, blank row, and
+footer:
+
+```text
+[up/down] row  [enter] select  [q] quit
+```
+
+On Enter result `deploy`, set selected detail to `Deploy is blocked, 3 runs`.
+
+- [ ] **Step 5: Run table tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_table.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit example 46**
+
+```bash
+git add examples/tui/46_widgets_table.py tests/tui/test_widgets_table.py
+git commit -m "feat(tui): polish table example"
+```
+
+---
+
+### Task 5: Polish Example 47 - Release Note Draft
+
+**Files:**
+- Modify: `examples/tui/47_widgets_textarea.py`
+- Modify: `tests/tui/test_widgets_textarea.py`
+
+- [ ] **Step 1: Write failing playback test**
+
+Add to `tests/tui/test_widgets_textarea.py`:
+
+```python
+from tests.tui.widget_example_playback import play_example
+
+
+def test_widgets_textarea_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/47_widgets_textarea.py",
+        events=(
+            ("type note", InputEvent(kind="text", text="Plan release")),
+            ("enter", InputEvent(kind="key", key="enter")),
+            ("type next", InputEvent(kind="text", text="Ship docs")),
+        ),
+    )
+
+    assert frames[0].lines[:11] == (
+        "Release Note Draft",
+        "",
+        "Title         Weekly deploy notes",
+        "",
+        "Notes",
+        "Write notes",
+        "",
+        "",
+        "",
+        "",
+        "Status        0 lines / unsaved",
+    )
+    assert "Status        1 line / unsaved" in frames[1].lines
+    assert "Status        2 lines / unsaved" in frames[3].lines
+    assert frames[0].cursor == (5, 0)
+```
+
+- [ ] **Step 2: Run focused test and verify it fails**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_textarea.py::test_widgets_textarea_example_playback_snapshots -q
+```
+
+Expected: FAIL because current example title/layout/status differ.
+
+- [ ] **Step 3: Update `TextAreaApp` fields and render**
+
+Set:
+
+```python
+notes: TextArea = field(default_factory=lambda: TextArea(placeholder="Write notes", height=5))
+message: str = ""
+```
+
+Add:
+
+```python
+def _line_count(value: str) -> int:
+    if not value:
+        return 0
+    return value.count("\n") + 1
+
+
+def _line_count_label(count: int) -> str:
+    return f"{count} line / unsaved" if count == 1 else f"{count} lines / unsaved"
+```
+
+Render:
+
+```text
+Release Note Draft
+
+Title         Weekly deploy notes
+
+Notes
+textarea rows render here
+Status        line count renders here
+
+[enter] newline  [type] edit  [q] quit
+```
+
+Cursor must be offset by the rows before the textarea. Preserve the textarea
+cursor from `body.cursor`.
+
+- [ ] **Step 4: Run textarea tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_textarea.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit example 47**
+
+```bash
+git add examples/tui/47_widgets_textarea.py tests/tui/test_widgets_textarea.py
+git commit -m "feat(tui): polish textarea example"
+```
+
+---
+
+### Task 6: Verify Slice 1 Together
+
+**Files:**
+- No new files expected.
+
+- [ ] **Step 1: Run targeted Slice 1 tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_small_controls.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_table.py tests/tui/test_widgets_textarea.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Ruff on Slice 1 files**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev ruff check tests/tui/widget_example_playback.py examples/tui/44_widgets_small_controls.py examples/tui/45_widgets_light_controls.py examples/tui/46_widgets_table.py examples/tui/47_widgets_textarea.py tests/tui/test_widgets_small_controls.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_table.py tests/tui/test_widgets_textarea.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 3: Commit any lint-only cleanup**
+
+Only if Step 2 required edits:
+
+```bash
+git add exact files that changed
+git commit -m "style(tui): clean up widget example slice one"
+```
+
+---
+
+### Task 7: Polish Example 48 - Notes Inbox
+
+**Files:**
+- Modify: `examples/tui/48_widgets_question_dialog.py`
+- Modify: `tests/tui/test_widgets_question_dialog.py`
+
+- [ ] **Step 1: Write failing playback test**
+
+Add to `tests/tui/test_widgets_question_dialog.py`:
+
+```python
+from tests.tui.widget_example_playback import play_example
+
+
+def test_widgets_question_dialog_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/48_widgets_question_dialog.py",
+        events=(
+            ("type answer", InputEvent(kind="text", text="Cache warmup before deploy")),
+            ("tab", InputEvent(kind="key", key="tab")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert frames[0].lines[:15] == (
+        "Notes Inbox",
+        "",
+        "Recent",
+        "  Cache deploy checklist",
+        "  Follow up on flaky test",
+        "",
+        "New Note",
+        "Add note",
+        "What should be remembered?",
+        "Write a multi-line answer",
+        "",
+        "",
+        "",
+        "Enter adds a line. Ctrl+Enter submits.",
+        "  [Submit]  [Cancel]",
+    )
+    assert "Status        Drafting" in frames[0].lines
+    assert "> [Submit]  [Cancel]" in frames[2].lines
+    assert "Status        Submitted: Cache warmup before deploy" in frames[3].lines
+```
+
+- [ ] **Step 2: Run focused test and verify it fails**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_question_dialog.py::test_widgets_question_dialog_example_playback_snapshots -q
+```
+
+Expected: FAIL because current example lacks inbox context and status row.
+
+- [ ] **Step 3: Update `QuestionDialogApp` state**
+
+Add fields:
+
+```python
+recent_notes: tuple[str, ...] = (
+    "Cache deploy checklist",
+    "Follow up on flaky test",
+)
+status: str = "Drafting"
+```
+
+Keep `dialog` focused in `__post_init__()`.
+
+- [ ] **Step 4: Rewrite render with inbox context**
+
+Render:
+
+```text
+Notes Inbox
+
+Recent
+  Cache deploy checklist
+  Follow up on flaky test
+
+New Note
+question dialog lines render here
+
+Status        Drafting
+
+Escape cancels. [tab] actions  [ctrl+enter] submit  [q] quit
+```
+
+Offset `body.cursor` by the rows preceding the dialog. If cursor row would be
+truncated, return `cursor=None`.
+
+- [ ] **Step 5: Update submit/cancel handling**
+
+In `handle_input()`:
+
+- for `question_submit`, append submitted text to the front of `recent_notes`
+  or otherwise include it in the visible recent list, set
+  `status = f"Submitted: {text}"`;
+- for `question_cancel`, keep recent notes unchanged and set
+  `status = "Cancelled"`;
+- return the original result.
+
+- [ ] **Step 6: Run question dialog tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_question_dialog.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit example 48**
+
+```bash
+git add examples/tui/48_widgets_question_dialog.py tests/tui/test_widgets_question_dialog.py
+git commit -m "feat(tui): polish question dialog example"
+```
+
+---
+
+### Task 8: Polish Example 49 - Project Explorer
+
+**Files:**
+- Modify: `examples/tui/49_widgets_tree.py`
+- Modify: `tests/tui/test_widgets_tree.py`
+
+- [ ] **Step 1: Write failing playback test**
+
+Add to `tests/tui/test_widgets_tree.py`:
+
+```python
+from tests.tui.widget_example_playback import play_example
+
+
+def test_widgets_tree_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/49_widgets_tree.py",
+        events=(
+            ("down", InputEvent(kind="key", key="down")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert frames[0].lines[:12] == (
+        "Project Explorer",
+        "",
+        "Tree",
+        "> - src",
+        "      widgets",
+        "      runtime",
+        "  + tests",
+        "",
+        "Details",
+        "Path          src",
+        "Kind          folder",
+        "Status        expanded",
+    )
+    assert "Path          src/widgets" in frames[1].lines
+    assert "Status        Selected: src/widgets" in frames[2].lines
+```
+
+- [ ] **Step 2: Run focused test and verify it fails**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py::test_widgets_tree_example_playback_snapshots -q
+```
+
+Expected: FAIL because current example lacks title/details layout.
+
+- [ ] **Step 3: Inspect `TreeView` public active/selected API**
+
+Run:
+
+```bash
+rg -n "active_value|selected|def handle_input|class TreeView" src/loushang/tui/ui_parts/widgets/tree.py
+```
+
+Use existing public API if available. If no public active value exists, keep a
+private value in the example by updating it from `TreeView` results and initial
+known nodes. Do not add public TreeView API for example polish.
+
+- [ ] **Step 4: Add example-local metadata**
+
+Add mappings:
+
+```python
+NODE_DETAILS = {
+    "src": ("src", "folder", "expanded"),
+    "widgets": ("src/widgets", "folder", "leaf"),
+    "runtime": ("src/runtime", "folder", "leaf"),
+    "tests": ("tests", "folder", "collapsed"),
+    "unit": ("tests/unit", "folder", "leaf"),
+    "integration": ("tests/integration", "folder", "leaf"),
+}
+```
+
+- [ ] **Step 5: Rewrite render with Tree and Details sections**
+
+Render title, Tree section, tree lines, Details section, detail rows, blank row,
+and footer:
+
+```text
+[up/down] node  [enter] select/toggle  [q] quit
+```
+
+Details should reflect the current active node if available; after selection,
+`Status` may show `Selected: selected path`.
+
+- [ ] **Step 6: Run tree tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_tree.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit example 49**
+
+```bash
+git add examples/tui/49_widgets_tree.py tests/tui/test_widgets_tree.py
+git commit -m "feat(tui): polish tree example"
+```
+
+---
+
+### Task 9: Polish Example 50 - Deploy Console Toasts
+
+**Files:**
+- Modify: `examples/tui/50_widgets_toast.py`
+- Modify: `tests/tui/test_widgets_toast.py`
+
+- [ ] **Step 1: Write failing playback test**
+
+Add to `tests/tui/test_widgets_toast.py`:
+
+```python
+from tests.tui.widget_example_playback import play_example
+
+
+def test_widgets_toast_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/50_widgets_toast.py",
+        events=(
+            ("warning", InputEvent(kind="text", text="w")),
+            ("success", InputEvent(kind="text", text="s")),
+            ("dismiss", InputEvent(kind="text", text="x")),
+            ("clear", InputEvent(kind="text", text="c")),
+        ),
+    )
+
+    assert frames[0].lines[:9] == (
+        "Deploy Console",
+        "",
+        "Pipeline      api-server",
+        "Status        waiting",
+        "Last event    none",
+        "",
+        "Notifications",
+        "[success] Changes saved",
+        "[info] Loushang: Welcome",
+    )
+    assert "Last event    warning toast added" in frames[1].lines
+    assert "[warning] Toast 1" in frames[1].lines
+    assert "Last event    success toast added" in frames[2].lines
+    assert "Last event    dismissed oldest" in frames[3].lines
+    assert "Last event    cleared notifications" in frames[4].lines
+```
+
+- [ ] **Step 2: Run focused test and verify it fails**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_toast.py::test_widgets_toast_example_playback_snapshots -q
+```
+
+Expected: FAIL because current example title/layout/last event text differs.
+
+- [ ] **Step 3: Add console state**
+
+Modify `ToastApp`:
+
+```python
+counter: int = 0
+last_event: str = "none"
+pipeline_status: str = "waiting"
+```
+
+- [ ] **Step 4: Rewrite render with console context**
+
+Render:
+
+```text
+Deploy Console
+
+Pipeline      api-server
+Status        waiting
+Last event    none
+
+Notifications
+toast notification rows render here
+
+[i] info  [s] success  [w] warning  [d] danger  [x] dismiss  [c] clear  [q] quit
+```
+
+Use `truncate_to_width()` for footer and field rows.
+
+- [ ] **Step 5: Update input handling for last event**
+
+Rules:
+
+- `i/s/w/d`: push toast, increment counter, set
+  `last_event = f"{kind} toast added"`.
+- `x`: call `dismiss_oldest()`, set `last_event = "dismissed oldest"` when
+  `True`, otherwise `"nothing to dismiss"`.
+- `c`: clear stack, set `last_event = "cleared notifications"`.
+
+- [ ] **Step 6: Run toast tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_toast.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit example 50**
+
+```bash
+git add examples/tui/50_widgets_toast.py tests/tui/test_widgets_toast.py
+git commit -m "feat(tui): polish toast example"
+```
+
+---
+
+### Task 10: Verify Slice 2 Together
+
+**Files:**
+- No new files expected.
+
+- [ ] **Step 1: Run targeted Slice 2 tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_question_dialog.py tests/tui/test_widgets_tree.py tests/tui/test_widgets_toast.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Ruff on Slice 2 files**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev ruff check examples/tui/48_widgets_question_dialog.py examples/tui/49_widgets_tree.py examples/tui/50_widgets_toast.py tests/tui/test_widgets_question_dialog.py tests/tui/test_widgets_tree.py tests/tui/test_widgets_toast.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 3: Commit any lint-only cleanup**
+
+Only if Step 2 required edits:
+
+```bash
+git add exact files that changed
+git commit -m "style(tui): clean up widget example slice two"
+```
+
+---
+
+### Task 11: Final Verification
+
+**Files:**
+- All changed files from previous tasks.
+
+- [ ] **Step 1: Run all polished example tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_small_controls.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_table.py tests/tui/test_widgets_textarea.py tests/tui/test_widgets_question_dialog.py tests/tui/test_widgets_tree.py tests/tui/test_widgets_toast.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full TUI tests**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run Ruff on all touched files**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev ruff check tests/tui/widget_example_playback.py examples/tui/44_widgets_small_controls.py examples/tui/45_widgets_light_controls.py examples/tui/46_widgets_table.py examples/tui/47_widgets_textarea.py examples/tui/48_widgets_question_dialog.py examples/tui/49_widgets_tree.py examples/tui/50_widgets_toast.py tests/tui/test_widgets_small_controls.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_table.py tests/tui/test_widgets_textarea.py tests/tui/test_widgets_question_dialog.py tests/tui/test_widgets_tree.py tests/tui/test_widgets_toast.py
+```
+
+Expected: `All checks passed!`
+
+- [ ] **Step 4: Check whitespace and git state**
+
+Run:
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+Expected:
+
+- `git diff --check` prints nothing.
+- `git status --short --branch` shows only expected branch information and no
+  unstaged/untracked files.
+
+- [ ] **Step 5: Manual playback spot-check command**
+
+Run:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev python - <<'PY'
+from tests.tui.widget_example_playback import play_example
+from loushang.tui import InputEvent
+
+for path, events in {
+    "examples/tui/44_widgets_small_controls.py": (("right", InputEvent(kind="key", key="right")),),
+    "examples/tui/45_widgets_light_controls.py": (("tab", InputEvent(kind="key", key="tab")),),
+    "examples/tui/46_widgets_table.py": (("down", InputEvent(kind="key", key="down")),),
+    "examples/tui/47_widgets_textarea.py": (("type", InputEvent(kind="text", text="Plan release")),),
+    "examples/tui/48_widgets_question_dialog.py": (("tab", InputEvent(kind="key", key="tab")),),
+    "examples/tui/49_widgets_tree.py": (("down", InputEvent(kind="key", key="down")),),
+    "examples/tui/50_widgets_toast.py": (("warning", InputEvent(kind="text", text="w")),),
+}.items():
+    frames = play_example(path, events=events)
+    print(f"\n== {path} ==")
+    for line in frames[-1].lines[:12]:
+        print(line)
+PY
+```
+
+Expected: Each printed final frame has a task-oriented title and at most one
+visible `>` focus marker in a single focus region.
+
+- [ ] **Step 6: Commit final verification note only if files changed**
+
+Do not create an empty commit. If final cleanup changed files:
+
+```bash
+git add exact files that changed
+git commit -m "test(tui): verify polished widget examples"
+```

--- a/docs/superpowers/specs/2026-06-12-tui-widget-examples-ux-polish-design.md
+++ b/docs/superpowers/specs/2026-06-12-tui-widget-examples-ux-polish-design.md
@@ -201,13 +201,25 @@ Views         > [Overview]    [Logs 3]    [Settings]
 Activity      | Syncing
 
 Actions
-              > Open      current view
+                Open      current view
                 Refresh
                 Archive   disabled
 
 Status        Ready
 
 [tab] region  [left/right] view  [up/down] action  [enter] run  [q] quit
+```
+
+After Tab to the actions region:
+
+```text
+Views           [Overview]    [Logs 3]    [Settings]
+Activity      | Syncing
+
+Actions
+              > Open      current view
+                Refresh
+                Archive   disabled
 ```
 
 Interaction:
@@ -286,6 +298,9 @@ Status        0 lines / unsaved
 
 [enter] newline  [type] edit  [q] quit
 ```
+
+`Write notes` is placeholder text, not initial textarea content. The initial
+draft has zero user-entered lines.
 
 After typing:
 

--- a/docs/superpowers/specs/2026-06-12-tui-widget-examples-ux-polish-design.md
+++ b/docs/superpowers/specs/2026-06-12-tui-widget-examples-ux-polish-design.md
@@ -54,8 +54,8 @@ applications while keeping the underlying widget APIs stable.
   - which keys affect region focus versus item navigation;
   - what happens after activation.
 - Remove confusing simultaneous focus cues, especially in `45`.
-- Use deterministic playback snapshots to verify the first screen and key
-  interaction frames for each example.
+- Use deterministic playback-like snapshots to verify the first screen and key
+  interaction frames for every polished example.
 - Keep examples public-facing and readable. They should teach usage patterns
   without requiring knowledge of internal render plumbing.
 - Keep implementation local to examples and tests unless a very small existing
@@ -329,6 +329,8 @@ Write a multi-line answer
 Enter adds a line. Ctrl+Enter submits.
   [Submit]  [Cancel]
 
+Status        Drafting
+
 Escape cancels. [tab] actions  [ctrl+enter] submit  [q] quit
 ```
 
@@ -337,8 +339,9 @@ Interaction:
 - Dialog remains focused.
 - Typing edits the answer.
 - Tab moves to dialog actions.
-- Submit updates the recent notes and status.
-- Cancel updates status without adding a note.
+- Submit adds the answer to recent notes and sets
+  `Status        Submitted: <answer>`.
+- Cancel keeps recent notes unchanged and sets `Status        Cancelled`.
 
 Implementation notes:
 
@@ -410,7 +413,10 @@ Interaction:
 - `i/s/w/d` push toast notifications and update `Last event`.
 - `x` dismisses the oldest visible dismissible toast.
 - `c` clears all notifications.
-- Status line reflects the last action.
+- `Status` reflects the deploy console state and stays stable unless the
+  example explicitly changes pipeline state in a later slice.
+- `Last event` reflects toast actions, such as `warning toast added`,
+  `dismissed oldest`, or `cleared notifications`.
 
 Implementation notes:
 
@@ -440,11 +446,19 @@ For each example:
    or `tui.handle_input(...)`.
 6. Assert a focused/navigation frame and an activation/state-change frame.
 
-At least one test should use `TuiRuntime + FakeTerminalPort` for a playback-like
-snapshot of an example with cursor or composed-screen behavior. The current
-test suite already has strong render-only coverage; this slice should add
-enough playback coverage to catch confusing focus markers such as `45`'s
+Every polished example should have a playback-like test helper using
+`TuiRuntime + FakeTerminalPort` or an equivalent direct `RenderLoop` setup. The
+helper should capture stripped `current_logical_lines`, the logical cursor, and
+the operation class for each scripted frame. Render-only assertions may still
+cover small pure-widget details, but the example UX contract is the playback
+snapshot because it catches confusing composed-screen states such as `45`'s
 simultaneous tabs/menu focus.
+
+For each example, the playback snapshot test must cover:
+
+- initial frame;
+- navigation frame;
+- activation or state-change frame.
 
 Run before completion:
 

--- a/docs/superpowers/specs/2026-06-12-tui-widget-examples-ux-polish-design.md
+++ b/docs/superpowers/specs/2026-06-12-tui-widget-examples-ux-polish-design.md
@@ -527,7 +527,7 @@ Each slice should keep tests green independently.
 - Examples `44-50` have clearer first screens with task-oriented titles.
 - Each example has exactly one obvious active focus region at a time.
 - Footer hints match actual example behavior.
-- Playback or render snapshot tests cover initial, navigation, and state-change
+- Playback-like snapshot tests cover initial, navigation, and state-change
   frames for each polished example.
 - No public API churn is introduced solely for example polish.
 - `tests/tui -q`, targeted widget tests, Ruff, and `git diff --check` pass.

--- a/docs/superpowers/specs/2026-06-12-tui-widget-examples-ux-polish-design.md
+++ b/docs/superpowers/specs/2026-06-12-tui-widget-examples-ux-polish-design.md
@@ -1,0 +1,504 @@
+# TUI Widget Examples UX Polish Design
+
+## Status
+
+Draft for spec review.
+
+## Context
+
+The widget catalog now has runnable examples for the P0/P1 controls:
+
+- `43_widgets_foundation.py`
+- `44_widgets_small_controls.py`
+- `45_widgets_light_controls.py`
+- `46_widgets_table.py`
+- `47_widgets_textarea.py`
+- `48_widgets_question_dialog.py`
+- `49_widgets_tree.py`
+- `50_widgets_toast.py`
+
+Example `43_widgets_foundation.py` was recently improved into a clearer
+two-column field layout. It now separates field-level Tab navigation from
+option-level arrow navigation. This should become the visual baseline for later
+widget examples.
+
+Playback snapshots for examples `44-50` show that the examples are functional
+but still read like control inventories instead of small real interfaces:
+
+- `44` shows progress, key-value rows, and toolbar controls, but the screen has
+  little task context.
+- `45` currently lets tabs and menu both render as focused, so users can see
+  two `>` markers at once.
+- `46` shows a table, but lacks enough surrounding context to explain what the
+  row selection means.
+- `47` renders a textarea and several blank rows, but the empty editor area has
+  weak visual boundaries.
+- `48` renders a question dialog as the whole page, so it does not demonstrate
+  how the dialog would appear in a real workflow.
+- `49` renders a tree, but has no detail pane to explain the selected node.
+- `50` renders toasts as the main page body, so it demonstrates toast rows but
+  not toast notifications in context.
+
+This slice should polish the examples into coherent, learnable mini
+applications while keeping the underlying widget APIs stable.
+
+## Goals
+
+- Redesign examples `44-50` as small realistic TUI screens rather than raw
+  widget inventories.
+- Keep example `43` as the style reference for clear field labels, focus
+  markers, and concise footer copy.
+- Make each example clearly show:
+  - what scenario it represents;
+  - which region currently has focus;
+  - which keys affect region focus versus item navigation;
+  - what happens after activation.
+- Remove confusing simultaneous focus cues, especially in `45`.
+- Use deterministic playback snapshots to verify the first screen and key
+  interaction frames for each example.
+- Keep examples public-facing and readable. They should teach usage patterns
+  without requiring knowledge of internal render plumbing.
+- Keep implementation local to examples and tests unless a very small existing
+  widget fix is required to make an example honest.
+
+## Non-Goals
+
+- Do not introduce a general layout engine.
+- Do not extract public `FieldGrid`, `ShortcutBar`, `Panel`, `SplitPane`, or
+  `ToastManager` APIs in this slice.
+- Do not change `SurfaceHost`, `RenderLoop`, `InputRouter`, or terminal runtime
+  behavior.
+- Do not redesign widget internals unless a playback test exposes a real widget
+  bug.
+- Do not add mouse interactions.
+- Do not make examples visually decorative at the expense of clarity. These are
+  technical learning examples, not marketing screens.
+- Do not change the already landed widget public API contracts except for small
+  backwards-compatible rendering options if they already exist on the branch.
+
+## Design Principles
+
+### Scenario First
+
+Each example should answer “what tool am I looking at?” in the first viewport.
+Titles should be literal and task-oriented:
+
+- `Indexing Job`
+- `View Switcher`
+- `Job Queue`
+- `Release Note Draft`
+- `Notes Inbox`
+- `Project Explorer`
+- `Deploy Console`
+
+### One Primary Interaction Model Per Example
+
+Each example should emphasize one interaction pattern:
+
+| Example | Primary pattern |
+| --- | --- |
+| `44` | Horizontal toolbar actions |
+| `45` | Region focus: tabs versus action menu |
+| `46` | Table row navigation and activation |
+| `47` | Multiline editing |
+| `48` | Modal question dialog over application context |
+| `49` | Tree navigation with detail projection |
+| `50` | Toast notifications over application context |
+
+### Region Boundaries
+
+Interactive regions should be visually separated with simple headings or
+spacing. A user should not have to infer whether two controls belong to the
+same focus scope.
+
+Use plain ASCII and existing widgets. Avoid heavy borders unless a widget
+already renders them.
+
+### Footer Copy
+
+Every example should end with one concise key hint row. Footer text should
+describe current example behavior, not every possible key in the widget system.
+
+Recommended shape:
+
+```text
+[tab] region  [up/down] item  [enter] select  [q] quit
+```
+
+When an example has only one region, omit `[tab] region`.
+
+### Playback As Design Contract
+
+Every polished example should have tests that render:
+
+- the initial screen;
+- at least one navigation frame;
+- at least one activation or state-change frame.
+
+Tests should assert stripped visible text for stable rows and, where useful,
+cursor position or focused-row output.
+
+## Example Designs
+
+### 44 Widgets Small Controls: Indexing Job
+
+Current screen:
+
+```text
+Small Controls  [beta]  (ready)
+
+Indexing [#####-------] 42%
+
+Model: Kimi
+Mode : safe  current
+Queue: 3 pending
+
+> [Refresh]  [Cancel]
+Ready
+```
+
+Proposed screen:
+
+```text
+Indexing Job  [beta]  (ready)
+
+Progress      Indexing [#####-------] 42%
+
+Details
+Model         Kimi
+Mode          safe  current
+Queue         3 pending
+
+Actions       > [Refresh]  [Cancel]
+Status        Ready
+
+[left/right] action  [enter] run  [q] quit
+```
+
+Interaction:
+
+- Left/right moves toolbar focus.
+- Enter activates the focused toolbar action.
+- Refresh increases progress and sets `Status Refreshed`.
+- Cancel sets `Status Cancelled`.
+
+Implementation notes:
+
+- Keep `Toolbar` as the only focusable region.
+- Use example-local label formatting for `Progress`, `Actions`, and `Status`.
+- Do not add a new public field-grid control in this slice.
+
+### 45 Widgets Light Controls: View Switcher
+
+Current issue: tabs and menu can both display `>` at the same time.
+
+Proposed screen:
+
+```text
+View Switcher
+
+Views         > [Overview]    [Logs 3]    [Settings]
+Activity      | Syncing
+
+Actions
+              > Open      current view
+                Refresh
+                Archive   disabled
+
+Status        Ready
+
+[tab] region  [left/right] view  [up/down] action  [enter] run  [q] quit
+```
+
+Interaction:
+
+- The app owns a two-region focus state: `views` or `actions`.
+- Tab switches between tabs and menu.
+- When `views` is active:
+  - left/right moves selected tab;
+  - up/down does not move menu;
+  - menu must not render focused.
+- When `actions` is active:
+  - up/down moves menu item;
+  - left/right does not move tabs unless the user tabs back to views;
+  - tabs must not render focused.
+- Enter on action runs the selected menu item.
+
+Implementation notes:
+
+- Do this in the example app with explicit region focus, not by adding a global
+  focus manager.
+- Call `tabs.focus()/blur()` and `menu.focus()/blur()` when region focus
+  changes.
+- `spinner_frame` can still advance on Refresh.
+
+### 46 Widgets Table: Job Queue
+
+Current screen is functional but too generic.
+
+Proposed screen:
+
+```text
+Job Queue  (3 jobs)
+
+  Job           Status                                                     Runs
+> Build         ready                                                        12
+  Deploy        blocked                                                       3
+  Archive       disabled                                                      0
+
+Selected      Build is ready, 12 runs
+
+[up/down] row  [enter] select  [q] quit
+```
+
+Interaction:
+
+- Up/down moves the active row.
+- Enter selects the active enabled row.
+- Footer and selected detail update after selection.
+
+Implementation notes:
+
+- Keep `Table` as the only focusable widget.
+- Example-local row metadata can generate the selected detail line.
+- Disabled row should remain visibly disabled according to existing table
+  behavior.
+
+### 47 Widgets TextArea: Release Note Draft
+
+Current screen has weak structure because the empty textarea appears as several
+blank rows.
+
+Proposed screen:
+
+```text
+Release Note Draft
+
+Title         Weekly deploy notes
+
+Notes
+Write notes
+
+
+
+
+Status        0 lines / unsaved
+
+[enter] newline  [type] edit  [q] quit
+```
+
+After typing:
+
+```text
+Status        2 lines / unsaved
+```
+
+Interaction:
+
+- Text input edits the textarea.
+- Enter inserts a newline.
+- Status reflects line count and unsaved state.
+
+Implementation notes:
+
+- Keep `Form([FormRow("notes", TextArea(...))])` as the focus owner.
+- Add surrounding labels and a status line.
+- The textarea itself should remain the editor; do not fork editing behavior.
+
+### 48 Widgets Question Dialog: Notes Inbox
+
+Current screen renders the dialog as the whole page. The polished example should
+show the dialog inside a workflow.
+
+Proposed initial screen:
+
+```text
+Notes Inbox
+
+Recent
+  Cache deploy checklist
+  Follow up on flaky test
+
+New Note
+Add note
+What should be remembered?
+Write a multi-line answer
+
+
+
+Enter adds a line. Ctrl+Enter submits.
+  [Submit]  [Cancel]
+
+Escape cancels. [tab] actions  [ctrl+enter] submit  [q] quit
+```
+
+Interaction:
+
+- Dialog remains focused.
+- Typing edits the answer.
+- Tab moves to dialog actions.
+- Submit updates the recent notes and status.
+- Cancel updates status without adding a note.
+
+Implementation notes:
+
+- This can remain inline rather than requiring a real overlay, because the
+  example runner is minimal. The important improvement is background context.
+- If an overlay is used, tests must still be deterministic and should assert the
+  composed visible screen.
+
+### 49 Widgets Tree: Project Explorer
+
+Current screen shows only the tree and a message.
+
+Proposed screen:
+
+```text
+Project Explorer
+
+Tree
+> - src
+      widgets
+      runtime
+  + tests
+
+Details
+Path          src
+Kind          folder
+Status        expanded
+
+[up/down] node  [enter] select/toggle  [q] quit
+```
+
+Interaction:
+
+- Up/down moves the active tree node.
+- Enter selects leaf nodes and toggles expandable nodes according to current
+  `TreeView` behavior.
+- Details pane reflects the active or selected node.
+
+Implementation notes:
+
+- Keep `TreeView` as the only focusable widget.
+- Example-local metadata can map node values to kind/status/detail lines.
+- Ensure details update on navigation, not only on explicit selection, so users
+  understand what focus currently means.
+
+### 50 Widgets Toast: Deploy Console
+
+Current screen renders `ToastStack` as the page body. The polished example
+should show toasts as notifications alongside app content.
+
+Proposed screen:
+
+```text
+Deploy Console
+
+Pipeline      api-server
+Status        waiting
+Last event    none
+
+Notifications
+[success] Changes saved
+[info] Loushang: Welcome
+
+[i] info  [s] success  [w] warning  [d] danger  [x] dismiss  [c] clear  [q] quit
+```
+
+Interaction:
+
+- `i/s/w/d` push toast notifications and update `Last event`.
+- `x` dismisses the oldest visible dismissible toast.
+- `c` clears all notifications.
+- Status line reflects the last action.
+
+Implementation notes:
+
+- Keep `ToastStack` non-focusable and app-owned.
+- Render notification rows below stable console context.
+- Do not add timers or overlays in this slice.
+
+## Testing Strategy
+
+Add or update focused tests under existing widget test files:
+
+- `test_widgets_small_controls.py`
+- `test_widgets_light_controls.py`
+- `test_widgets_table.py`
+- `test_widgets_textarea.py`
+- `test_widgets_question_dialog.py`
+- `test_widgets_tree.py`
+- `test_widgets_toast.py`
+
+For each example:
+
+1. Use `runpy.run_path(..., run_name="__test__")`.
+2. Call `build_app()`.
+3. Render with `RenderConstraints(width=80, max_height=20)`.
+4. Assert stable visible rows after `strip_control_sequences`.
+5. Drive one or more `InputEvent` interactions through `app.handle_input(...)`
+   or `tui.handle_input(...)`.
+6. Assert a focused/navigation frame and an activation/state-change frame.
+
+At least one test should use `TuiRuntime + FakeTerminalPort` for a playback-like
+snapshot of an example with cursor or composed-screen behavior. The current
+test suite already has strong render-only coverage; this slice should add
+enough playback coverage to catch confusing focus markers such as `45`'s
+simultaneous tabs/menu focus.
+
+Run before completion:
+
+```bash
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_small_controls.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_table.py tests/tui/test_widgets_textarea.py tests/tui/test_widgets_question_dialog.py tests/tui/test_widgets_tree.py tests/tui/test_widgets_toast.py -q
+uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
+uv --cache-dir .uv-cache run --extra dev ruff check examples/tui/44_widgets_small_controls.py examples/tui/45_widgets_light_controls.py examples/tui/46_widgets_table.py examples/tui/47_widgets_textarea.py examples/tui/48_widgets_question_dialog.py examples/tui/49_widgets_tree.py examples/tui/50_widgets_toast.py tests/tui/test_widgets_small_controls.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_table.py tests/tui/test_widgets_textarea.py tests/tui/test_widgets_question_dialog.py tests/tui/test_widgets_tree.py tests/tui/test_widgets_toast.py
+git diff --check
+```
+
+## Implementation Slices
+
+### Slice 1: Examples 44-47
+
+Polish:
+
+- `44_widgets_small_controls.py`
+- `45_widgets_light_controls.py`
+- `46_widgets_table.py`
+- `47_widgets_textarea.py`
+
+This slice covers toolbar, tabs/menu focus regions, table details, and textarea
+structure. It should also fix the most visible confusion: the double focus
+marker in `45`.
+
+### Slice 2: Examples 48-50
+
+Polish:
+
+- `48_widgets_question_dialog.py`
+- `49_widgets_tree.py`
+- `50_widgets_toast.py`
+
+This slice covers dialog context, tree details, and toast-as-notification
+composition.
+
+Each slice should keep tests green independently.
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Example helpers become accidental framework APIs. | Keep helpers private to examples. Extract public layout widgets only in a later spec. |
+| Tests become too brittle to spacing. | Assert stable rows and important alignment, but avoid overspecifying every blank line unless it carries meaning. |
+| `45` region focus duplicates future global focus manager work. | Keep the two-region state local to the example; do not generalize it. |
+| Polished examples hide simple widget usage. | Keep construction code readable and avoid large abstractions. |
+| Toast example implies automatic timers or overlays. | Explicitly keep `ToastStack` renderable and app-owned. |
+
+## Success Criteria
+
+- Examples `44-50` have clearer first screens with task-oriented titles.
+- Each example has exactly one obvious active focus region at a time.
+- Footer hints match actual example behavior.
+- Playback or render snapshot tests cover initial, navigation, and state-change
+  frames for each polished example.
+- No public API churn is introduced solely for example polish.
+- `tests/tui -q`, targeted widget tests, Ruff, and `git diff --check` pass.

--- a/examples/tui/43_widgets_foundation.py
+++ b/examples/tui/43_widgets_foundation.py
@@ -34,7 +34,7 @@ class WidgetsApp(FocusableMixin):
     open_confirm: Callable[[], None] | None = None
 
     def __post_init__(self) -> None:
-        super().__init__()
+        FocusableMixin.__init__(self)
         self.form.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:

--- a/examples/tui/43_widgets_foundation.py
+++ b/examples/tui/43_widgets_foundation.py
@@ -25,7 +25,17 @@ from loushang.tui import (
     Tui,
     TuiInputResult,
     TuiRunner,
+    truncate_to_width,
 )
+
+FIELD_LABEL_WIDTH = 14
+FIELD_LABELS = {
+    "name": "Name",
+    "cache": "Cache",
+    "mode": "Mode",
+    "auto": "Approval",
+    "model": "Model",
+}
 
 
 @dataclass(slots=True)
@@ -41,13 +51,16 @@ class WidgetsApp(FocusableMixin):
     def render(self, constraints: RenderConstraints) -> RenderResult:
         rows = [RenderLine("Loushang TUI Widgets"), RenderLine("")]
         form_start_row = len(rows)
-        form_result = self.form.render(RenderConstraints(width=constraints.width, max_height=max(0, constraints.max_height - 5)))
+        form_result = _render_form_grid(
+            self.form,
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 5)),
+        )
         rows.extend(form_result.lines)
         rows.extend(
             [
                 RenderLine(""),
-                RenderLine(self.message[: constraints.width]),
-                RenderLine("[tab] move  [ctrl+s] confirm  [q] quit"),
+                RenderLine(truncate_to_width(self.message, max_width=constraints.width, ellipsis="")),
+                RenderLine(truncate_to_width("[tab] field  [up/down] option  [space] toggle/select  [ctrl+s] confirm  [q] quit", max_width=constraints.width, ellipsis="")),
             ]
         )
         cursor = None
@@ -105,12 +118,37 @@ async def main() -> int:
 
 def _rows() -> list[FormRow]:
     return [
-        FormRow("name", TextField(label="Name", value="tower")),
+        FormRow("name", TextField(value="tower")),
         FormRow("cache", Checkbox("Enable cache", checked=True)),
-        FormRow("mode", RadioGroup([Choice("fast", "Fast"), Choice("safe", "Safe")], value="fast")),
+        FormRow("mode", RadioGroup([Choice("fast", "Fast"), Choice("safe", "Safe")], value="fast", orientation="horizontal")),
         FormRow("auto", Toggle("Auto approve")),
         FormRow("model", SelectList([SelectItem("Kimi"), SelectItem("Qwen")], max_visible=2)),
     ]
+
+
+def _render_form_grid(form: Form, constraints: RenderConstraints) -> RenderResult:
+    lines: list[RenderLine] = []
+    cursor: CursorDeclaration | None = None
+    control_width = max(1, constraints.width - FIELD_LABEL_WIDTH)
+    for row in form.rows:
+        if len(lines) >= constraints.max_height:
+            break
+        render = getattr(row.control, "render", None)
+        if not callable(render):
+            continue
+        start_row = len(lines)
+        result = render(RenderConstraints(width=control_width, max_height=constraints.max_height - len(lines)))
+        rendered_lines = result.lines[: constraints.max_height - len(lines)]
+        for index, line in enumerate(rendered_lines):
+            label = FIELD_LABELS.get(row.field_id, row.field_id) if index == 0 else ""
+            text = truncate_to_width(f"{label:<{FIELD_LABEL_WIDTH}}{line.text}", max_width=constraints.width, ellipsis="")
+            lines.append(RenderLine(text))
+        if getattr(row.control, "focused", False) and result.cursor is not None and result.cursor.row < len(rendered_lines):
+            cursor = CursorDeclaration(
+                row=start_row + result.cursor.row,
+                column=FIELD_LABEL_WIDTH + result.cursor.column,
+            )
+    return RenderResult.from_lines(lines, constraints=constraints, cursor=cursor)
 
 
 if __name__ == "__main__":

--- a/examples/tui/43_widgets_foundation.py
+++ b/examples/tui/43_widgets_foundation.py
@@ -9,6 +9,7 @@ from loushang.tui import (
     Checkbox,
     Choice,
     ConfirmDialog,
+    CursorDeclaration,
     FocusableMixin,
     Form,
     FormRow,
@@ -39,6 +40,7 @@ class WidgetsApp(FocusableMixin):
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         rows = [RenderLine("Loushang TUI Widgets"), RenderLine("")]
+        form_start_row = len(rows)
         form_result = self.form.render(RenderConstraints(width=constraints.width, max_height=max(0, constraints.max_height - 5)))
         rows.extend(form_result.lines)
         rows.extend(
@@ -48,7 +50,15 @@ class WidgetsApp(FocusableMixin):
                 RenderLine("[tab] move  [ctrl+s] confirm  [q] quit"),
             ]
         )
-        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=form_result.cursor)
+        cursor = None
+        if form_result.cursor is not None:
+            cursor = CursorDeclaration(
+                row=form_start_row + form_result.cursor.row,
+                column=form_result.cursor.column,
+            )
+            if cursor.row >= min(len(rows), constraints.max_height):
+                cursor = None
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
 
     def handle_input(self, event: Any) -> object:
         if not isinstance(event, InputEvent):

--- a/examples/tui/44_widgets_small_controls.py
+++ b/examples/tui/44_widgets_small_controls.py
@@ -13,6 +13,7 @@ from loushang.tui import (
     RenderLine,
     RenderResult,
     StatusPill,
+    ThemeResolver,
     Toolbar,
     ToolbarAction,
     Tui,
@@ -22,6 +23,13 @@ from loushang.tui import (
 )
 
 LABEL_WIDTH = 14
+SMALL_CONTROLS_THEME = ThemeResolver(
+    defaults={
+        "widget.toolbar.action": {"color": "white"},
+        "widget.toolbar.focus": {"bold": True, "color": "cyan"},
+        "widget.toolbar.disabled": {"dim": True},
+    }
+)
 
 
 def _field(label: str, value: str, *, width: int) -> RenderLine:
@@ -33,7 +41,7 @@ def _field(label: str, value: str, *, width: int) -> RenderLine:
 class SmallControlsApp(FocusableMixin):
     progress: int = 42
     message: str = "Ready"
-    toolbar: Toolbar = field(default_factory=lambda: Toolbar(_actions()))
+    toolbar: Toolbar = field(default_factory=lambda: Toolbar(_actions(), theme=SMALL_CONTROLS_THEME))
 
     def __post_init__(self) -> None:
         FocusableMixin.__init__(self)

--- a/examples/tui/44_widgets_small_controls.py
+++ b/examples/tui/44_widgets_small_controls.py
@@ -8,8 +8,6 @@ from loushang.tui import (
     Badge,
     FocusableMixin,
     InputEvent,
-    KeyValueItem,
-    KeyValueList,
     ProgressBar,
     RenderConstraints,
     RenderLine,
@@ -24,6 +22,14 @@ from loushang.tui import (
 )
 
 
+LABEL_WIDTH = 14
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    text = f"{label:<{LABEL_WIDTH}}{value}"
+    return RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))
+
+
 @dataclass(slots=True)
 class SmallControlsApp(FocusableMixin):
     progress: int = 42
@@ -35,24 +41,35 @@ class SmallControlsApp(FocusableMixin):
         self.toolbar.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
-        details = KeyValueList(
-            [
-                KeyValueItem("Model", "Kimi"),
-                KeyValueItem("Mode", "safe", description="current"),
-                KeyValueItem("Queue", "3 pending"),
-            ]
+        value_width = max(1, constraints.width - LABEL_WIDTH)
+        progress_result = ProgressBar(value=self.progress, total=100, label="Indexing", width=12).render(
+            RenderConstraints(width=value_width, max_height=1)
         )
+        progress_text = progress_result.lines[0].text if progress_result.lines else ""
+        toolbar_result = self.toolbar.render(
+            RenderConstraints(width=value_width, max_height=1)
+        )
+        toolbar_text = toolbar_result.lines[0].text if toolbar_result.lines else ""
         rows = [
             RenderLine(_header(constraints.width)),
             RenderLine(""),
-            *ProgressBar(value=self.progress, total=100, label="Indexing", width=12).render(
-                RenderConstraints(width=constraints.width, max_height=1)
-            ).lines,
+            _field("Progress", progress_text, width=constraints.width),
             RenderLine(""),
-            *details.render(RenderConstraints(width=constraints.width, max_height=4)).lines,
+            RenderLine("Details"),
+            _field("Model", "Kimi", width=constraints.width),
+            _field("Mode", "safe  current", width=constraints.width),
+            _field("Queue", "3 pending", width=constraints.width),
             RenderLine(""),
-            *self.toolbar.render(RenderConstraints(width=constraints.width, max_height=1)).lines,
-            RenderLine(truncate_to_width(self.message, max_width=constraints.width, ellipsis="")),
+            _field("Actions", toolbar_text, width=constraints.width),
+            _field("Status", self.message, width=constraints.width),
+            RenderLine(""),
+            RenderLine(
+                truncate_to_width(
+                    "[left/right] action  [enter] run  [q] quit",
+                    max_width=constraints.width,
+                    ellipsis="",
+                )
+            ),
         ]
         return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints)
 
@@ -92,7 +109,7 @@ def _header(width: int) -> str:
     constraints = RenderConstraints(width=max(1, width // 4), max_height=1)
     badge = Badge("beta", kind="info").render(constraints).lines[0].text
     status = StatusPill("ready", status="success").render(constraints).lines[0].text
-    return truncate_to_width(f"Small Controls  {badge}  {status}", max_width=width, ellipsis="")
+    return truncate_to_width(f"Indexing Job  {badge}  {status}", max_width=width, ellipsis="")
 
 
 def _actions() -> list[ToolbarAction]:

--- a/examples/tui/44_widgets_small_controls.py
+++ b/examples/tui/44_widgets_small_controls.py
@@ -31,7 +31,7 @@ class SmallControlsApp(FocusableMixin):
     toolbar: Toolbar = field(default_factory=lambda: Toolbar(_actions()))
 
     def __post_init__(self) -> None:
-        super().__init__()
+        FocusableMixin.__init__(self)
         self.toolbar.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:

--- a/examples/tui/44_widgets_small_controls.py
+++ b/examples/tui/44_widgets_small_controls.py
@@ -21,7 +21,6 @@ from loushang.tui import (
     truncate_to_width,
 )
 
-
 LABEL_WIDTH = 14
 
 

--- a/examples/tui/45_widgets_light_controls.py
+++ b/examples/tui/45_widgets_light_controls.py
@@ -15,6 +15,7 @@ from loushang.tui import (
     Spinner,
     TabItem,
     Tabs,
+    ThemeResolver,
     Tui,
     TuiInputResult,
     TuiRunner,
@@ -22,6 +23,15 @@ from loushang.tui import (
 )
 
 LABEL_WIDTH = 14
+LIGHT_CONTROLS_THEME = ThemeResolver(
+    defaults={
+        "widget.tabs.focus": {"bold": True, "color": "cyan"},
+        "widget.tabs.selected": {"color": "green"},
+        "widget.menu.focus": {"bold": True, "color": "cyan"},
+        "widget.menu.disabled": {"dim": True},
+        "widget.menu.description": {"color": "bright_black"},
+    }
+)
 
 
 def _field(label: str, value: str, *, width: int) -> RenderLine:
@@ -31,8 +41,8 @@ def _field(label: str, value: str, *, width: int) -> RenderLine:
 
 @dataclass(slots=True)
 class LightControlsApp(FocusableMixin):
-    tabs: Tabs = field(default_factory=lambda: Tabs(_tabs()))
-    menu: Menu = field(default_factory=lambda: Menu(_menu_items()))
+    tabs: Tabs = field(default_factory=lambda: Tabs(_tabs(), theme=LIGHT_CONTROLS_THEME))
+    menu: Menu = field(default_factory=lambda: Menu(_menu_items(), theme=LIGHT_CONTROLS_THEME))
     spinner_frame: int = 0
     message: str = "Ready"
     focus_region: str = "views"

--- a/examples/tui/45_widgets_light_controls.py
+++ b/examples/tui/45_widgets_light_controls.py
@@ -30,7 +30,7 @@ class LightControlsApp(FocusableMixin):
     message: str = "Ready"
 
     def __post_init__(self) -> None:
-        super().__init__()
+        FocusableMixin.__init__(self)
         self.tabs.focus()
         self.menu.focus()
 

--- a/examples/tui/45_widgets_light_controls.py
+++ b/examples/tui/45_widgets_light_controls.py
@@ -22,38 +22,85 @@ from loushang.tui import (
 )
 
 
+LABEL_WIDTH = 14
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    text = f"{label:<{LABEL_WIDTH}}{value}"
+    return RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))
+
+
 @dataclass(slots=True)
 class LightControlsApp(FocusableMixin):
     tabs: Tabs = field(default_factory=lambda: Tabs(_tabs()))
     menu: Menu = field(default_factory=lambda: Menu(_menu_items()))
     spinner_frame: int = 0
     message: str = "Ready"
+    focus_region: str = "views"
 
     def __post_init__(self) -> None:
         FocusableMixin.__init__(self)
-        self.tabs.focus()
+        self._sync_region_focus()
+
+    def _sync_region_focus(self) -> None:
+        if self.focus_region == "views":
+            self.tabs.focus()
+            self.menu.blur()
+            return
+        self.tabs.blur()
         self.menu.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
+        value_width = max(1, constraints.width - LABEL_WIDTH)
+        tab_result = self.tabs.render(RenderConstraints(width=value_width, max_height=1))
+        tab_text = tab_result.lines[0].text if tab_result.lines else ""
+        activity_result = Spinner(label="Syncing", frame=self.spinner_frame).render(
+            RenderConstraints(width=value_width, max_height=1)
+        )
+        activity_text = activity_result.lines[0].text if activity_result.lines else ""
+        menu_lines = self.menu.render(RenderConstraints(width=value_width, max_height=4)).lines
+        menu_indent = " " * LABEL_WIDTH
         rows = [
-            RenderLine(truncate_to_width("Light Controls", max_width=constraints.width, ellipsis="")),
+            RenderLine(truncate_to_width("View Switcher", max_width=constraints.width, ellipsis="")),
             RenderLine(""),
-            *self.tabs.render(RenderConstraints(width=constraints.width, max_height=1)).lines,
-            *Spinner(label="Syncing", frame=self.spinner_frame).render(
-                RenderConstraints(width=constraints.width, max_height=1)
-            ).lines,
+            _field("Views", tab_text, width=constraints.width),
+            _field("Activity", activity_text, width=constraints.width),
             RenderLine(""),
-            *self.menu.render(RenderConstraints(width=constraints.width, max_height=4)).lines,
-            RenderLine(truncate_to_width(self.message, max_width=constraints.width, ellipsis="")),
+            RenderLine("Actions"),
+            *(
+                RenderLine(
+                    truncate_to_width(
+                        f"{menu_indent}{line.text}",
+                        max_width=constraints.width,
+                        ellipsis="",
+                    )
+                )
+                for line in menu_lines
+            ),
+            RenderLine(""),
+            _field("Status", self.message, width=constraints.width),
+            RenderLine(""),
+            RenderLine(
+                truncate_to_width(
+                    "[tab] region  [left/right] view  [up/down] action  [enter] run  [q] quit",
+                    max_width=constraints.width,
+                    ellipsis="",
+                )
+            ),
         ]
         return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints)
 
     def handle_input(self, event: Any) -> object:
-        if getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"left", "right"}:
-            result = self.tabs.handle_input(event)
-            if result is not None:
-                self.message = f"View: {self.tabs.value}"
-                return True
+        if getattr(event, "kind", "") == "key" and getattr(event, "key", "") == "tab":
+            self.focus_region = "actions" if self.focus_region == "views" else "views"
+            self._sync_region_focus()
+            return True
+        if self.focus_region == "views":
+            if getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"left", "right"}:
+                result = self.tabs.handle_input(event)
+                if result is not None:
+                    self.message = f"View: {self.tabs.value}"
+                    return True
             return None
         result = self.menu.handle_input(event)
         if result == "refresh":
@@ -98,7 +145,7 @@ def _menu_items() -> list[MenuItem]:
     return [
         MenuItem("open", "Open", description="current view"),
         MenuItem("refresh", "Refresh"),
-        MenuItem("archive", "Archive", disabled=True),
+        MenuItem("archive", "Archive", description="disabled", disabled=True),
     ]
 
 

--- a/examples/tui/45_widgets_light_controls.py
+++ b/examples/tui/45_widgets_light_controls.py
@@ -21,7 +21,6 @@ from loushang.tui import (
     truncate_to_width,
 )
 
-
 LABEL_WIDTH = 14
 
 

--- a/examples/tui/46_widgets_table.py
+++ b/examples/tui/46_widgets_table.py
@@ -13,6 +13,7 @@ from loushang.tui import (
     Table,
     TableColumn,
     TableRow,
+    ThemeResolver,
     Tui,
     TuiInputResult,
     TuiRunner,
@@ -20,6 +21,14 @@ from loushang.tui import (
 )
 
 LABEL_WIDTH = 14
+TABLE_EXAMPLE_THEME = ThemeResolver(
+    defaults={
+        "widget.table.header": {"color": "bright_black"},
+        "widget.table.row": {"color": "white"},
+        "widget.table.focus": {"bold": True, "color": "cyan"},
+        "widget.table.disabled": {"dim": True},
+    }
+)
 
 JOB_DETAILS = {
     "build": "Build is ready, 12 runs",
@@ -39,7 +48,7 @@ def _selected_detail(table: Table) -> str:
 
 @dataclass(slots=True)
 class TableApp(FocusableMixin):
-    table: Table = field(default_factory=lambda: Table(_columns(), _rows()))
+    table: Table = field(default_factory=lambda: Table(_columns(), _rows(), theme=TABLE_EXAMPLE_THEME))
     message: str = ""
 
     def __post_init__(self) -> None:

--- a/examples/tui/46_widgets_table.py
+++ b/examples/tui/46_widgets_table.py
@@ -20,32 +20,61 @@ from loushang.tui import (
 )
 
 
+LABEL_WIDTH = 14
+
+JOB_DETAILS = {
+    "build": "Build is ready, 12 runs",
+    "deploy": "Deploy is blocked, 3 runs",
+    "archive": "Archive is disabled, 0 runs",
+}
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    text = f"{label:<{LABEL_WIDTH}}{value}"
+    return RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))
+
+
+def _selected_detail(table: Table) -> str:
+    return JOB_DETAILS.get(table.active_value, "Select a job")
+
+
 @dataclass(slots=True)
 class TableApp(FocusableMixin):
     table: Table = field(default_factory=lambda: Table(_columns(), _rows()))
-    message: str = "Select a job"
+    message: str = ""
 
     def __post_init__(self) -> None:
         FocusableMixin.__init__(self)
         self.table.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
+        detail = self.message or _selected_detail(self.table)
         rows = [
-            RenderLine(truncate_to_width("Table", max_width=constraints.width, ellipsis="")),
+            RenderLine(truncate_to_width("Job Queue  (3 jobs)", max_width=constraints.width, ellipsis="")),
             RenderLine(""),
             *self.table.render(
-                RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 4))
+                RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 6))
             ).lines,
             RenderLine(""),
-            RenderLine(truncate_to_width(self.message, max_width=constraints.width, ellipsis="")),
+            _field("Selected", detail, width=constraints.width),
+            RenderLine(""),
+            RenderLine(
+                truncate_to_width(
+                    "[up/down] row  [enter] select  [q] quit",
+                    max_width=constraints.width,
+                    ellipsis="",
+                )
+            ),
         ]
         return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints)
 
     def handle_input(self, event: Any) -> object:
         result = self.table.handle_input(event)
         if isinstance(result, str):
-            self.message = f"Selected {result}"
+            self.message = JOB_DETAILS.get(result, "Select a job")
             return True
+        if result is True and getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"up", "down"}:
+            self.message = ""
         return result
 
 

--- a/examples/tui/46_widgets_table.py
+++ b/examples/tui/46_widgets_table.py
@@ -26,7 +26,7 @@ class TableApp(FocusableMixin):
     message: str = "Select a job"
 
     def __post_init__(self) -> None:
-        super().__init__()
+        FocusableMixin.__init__(self)
         self.table.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:

--- a/examples/tui/46_widgets_table.py
+++ b/examples/tui/46_widgets_table.py
@@ -19,7 +19,6 @@ from loushang.tui import (
     truncate_to_width,
 )
 
-
 LABEL_WIDTH = 14
 
 JOB_DETAILS = {

--- a/examples/tui/47_widgets_textarea.py
+++ b/examples/tui/47_widgets_textarea.py
@@ -5,9 +5,8 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from loushang.tui import (
+    CursorDeclaration,
     FocusableMixin,
-    Form,
-    FormRow,
     InputEvent,
     RenderConstraints,
     RenderLine,
@@ -20,28 +19,63 @@ from loushang.tui import (
 )
 
 
+LABEL_WIDTH = 14
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    text = f"{label:<{LABEL_WIDTH}}{value}"
+    return RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))
+
+
+def _line_count(value: str) -> int:
+    if not value:
+        return 0
+    return value.count("\n") + 1
+
+
+def _line_count_label(count: int) -> str:
+    return f"{count} line / unsaved" if count == 1 else f"{count} lines / unsaved"
+
+
 @dataclass(slots=True)
 class TextAreaApp(FocusableMixin):
-    notes: TextArea = field(default_factory=lambda: TextArea(label="Notes", placeholder="Write notes", height=5))
-    message: str = "Enter adds a line. Press q to quit."
-    form: Form = field(init=False)
+    notes: TextArea = field(default_factory=lambda: TextArea(placeholder="Write notes", height=5))
+    message: str = ""
 
     def __post_init__(self) -> None:
         FocusableMixin.__init__(self)
-        self.form = Form([FormRow("notes", self.notes)])
-        self.form.focus()
+        self.notes.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
-        body = self.form.render(RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2)))
-        rows = [
-            *body.lines,
+        body = self.notes.render(RenderConstraints(width=constraints.width, max_height=5))
+        status = _line_count_label(_line_count(self.notes.value))
+        prefix = [
+            RenderLine(truncate_to_width("Release Note Draft", max_width=constraints.width, ellipsis="")),
             RenderLine(""),
-            RenderLine(truncate_to_width(self.message, max_width=constraints.width, ellipsis="")),
+            _field("Title", "Weekly deploy notes", width=constraints.width),
+            RenderLine(""),
+            RenderLine("Notes"),
         ]
-        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=body.cursor)
+        rows = [
+            *prefix,
+            *body.lines,
+            _field("Status", status, width=constraints.width),
+            RenderLine(""),
+            RenderLine(
+                truncate_to_width(
+                    "[enter] newline  [type] edit  [q] quit",
+                    max_width=constraints.width,
+                    ellipsis="",
+                )
+            ),
+        ]
+        cursor = None
+        if body.cursor is not None:
+            cursor = CursorDeclaration(row=body.cursor.row + len(prefix), column=body.cursor.column)
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
 
     def handle_input(self, event: Any) -> object:
-        return self.form.handle_input(event)
+        return self.notes.handle_input(event)
 
 
 def build_app() -> Tui:

--- a/examples/tui/47_widgets_textarea.py
+++ b/examples/tui/47_widgets_textarea.py
@@ -18,7 +18,6 @@ from loushang.tui import (
     truncate_to_width,
 )
 
-
 LABEL_WIDTH = 14
 
 

--- a/examples/tui/47_widgets_textarea.py
+++ b/examples/tui/47_widgets_textarea.py
@@ -12,6 +12,7 @@ from loushang.tui import (
     RenderLine,
     RenderResult,
     TextArea,
+    ThemeResolver,
     Tui,
     TuiInputResult,
     TuiRunner,
@@ -19,6 +20,12 @@ from loushang.tui import (
 )
 
 LABEL_WIDTH = 14
+TEXTAREA_EXAMPLE_THEME = ThemeResolver(
+    defaults={
+        "widget.textArea.placeholder": {"color": "bright_black"},
+        "widget.textArea.text": {"color": "white"},
+    }
+)
 
 
 def _field(label: str, value: str, *, width: int) -> RenderLine:
@@ -38,7 +45,9 @@ def _line_count_label(count: int) -> str:
 
 @dataclass(slots=True)
 class TextAreaApp(FocusableMixin):
-    notes: TextArea = field(default_factory=lambda: TextArea(placeholder="Write notes", height=5))
+    notes: TextArea = field(
+        default_factory=lambda: TextArea(placeholder="Write notes", height=5, theme=TEXTAREA_EXAMPLE_THEME)
+    )
     message: str = ""
 
     def __post_init__(self) -> None:

--- a/examples/tui/47_widgets_textarea.py
+++ b/examples/tui/47_widgets_textarea.py
@@ -27,7 +27,7 @@ class TextAreaApp(FocusableMixin):
     form: Form = field(init=False)
 
     def __post_init__(self) -> None:
-        super().__init__()
+        FocusableMixin.__init__(self)
         self.form = Form([FormRow("notes", self.notes)])
         self.form.focus()
 

--- a/examples/tui/48_widgets_question_dialog.py
+++ b/examples/tui/48_widgets_question_dialog.py
@@ -44,7 +44,7 @@ class QuestionDialogApp(FocusableMixin):
             title="Add note",
             question="What should be remembered?",
             placeholder="Write a multi-line answer",
-            help_text="Enter adds a line. Ctrl+Enter submits.",
+            help_text="Enter adds a line. Tab to Submit/Cancel.",
             required=True,
             theme=QUESTION_DIALOG_EXAMPLE_THEME,
         )
@@ -82,7 +82,7 @@ class QuestionDialogApp(FocusableMixin):
             RenderLine(""),
             RenderLine(
                 truncate_to_width(
-                    "Escape cancels. [tab] actions  [ctrl+enter] submit  [q] quit",
+                    "Escape cancels. [tab] buttons  [enter] choose  [q] quit",
                     max_width=constraints.width,
                     ellipsis="",
                 )

--- a/examples/tui/48_widgets_question_dialog.py
+++ b/examples/tui/48_widgets_question_dialog.py
@@ -32,7 +32,7 @@ class QuestionDialogApp(FocusableMixin):
     message: str = "Escape cancels. Press q to quit."
 
     def __post_init__(self) -> None:
-        super().__init__()
+        FocusableMixin.__init__(self)
         self.dialog.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:

--- a/examples/tui/48_widgets_question_dialog.py
+++ b/examples/tui/48_widgets_question_dialog.py
@@ -18,7 +18,6 @@ from loushang.tui import (
     truncate_to_width,
 )
 
-
 LABEL_WIDTH = 14
 
 

--- a/examples/tui/48_widgets_question_dialog.py
+++ b/examples/tui/48_widgets_question_dialog.py
@@ -12,6 +12,7 @@ from loushang.tui import (
     RenderConstraints,
     RenderLine,
     RenderResult,
+    ThemeResolver,
     Tui,
     TuiInputResult,
     TuiRunner,
@@ -19,6 +20,16 @@ from loushang.tui import (
 )
 
 LABEL_WIDTH = 14
+QUESTION_DIALOG_EXAMPLE_THEME = ThemeResolver(
+    defaults={
+        "widget.question.action": {"color": "white"},
+        "widget.question.focus": {"bold": True, "color": "cyan"},
+        "widget.question.text": {"color": "cyan"},
+        "widget.question.title": {"bold": True},
+        "widget.textArea.placeholder": {"color": "bright_black"},
+        "widget.textArea.text": {"color": "white"},
+    }
+)
 
 
 def _field(label: str, value: str, *, width: int) -> RenderLine:
@@ -35,6 +46,7 @@ class QuestionDialogApp(FocusableMixin):
             placeholder="Write a multi-line answer",
             help_text="Enter adds a line. Ctrl+Enter submits.",
             required=True,
+            theme=QUESTION_DIALOG_EXAMPLE_THEME,
         )
     )
     recent_notes: tuple[str, ...] = (

--- a/examples/tui/48_widgets_question_dialog.py
+++ b/examples/tui/48_widgets_question_dialog.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from loushang.tui import (
+    CursorDeclaration,
     FocusableMixin,
     InputEvent,
     QuestionDialog,
@@ -18,6 +19,14 @@ from loushang.tui import (
 )
 
 
+LABEL_WIDTH = 14
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    text = f"{label:<{LABEL_WIDTH}}{value}"
+    return RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))
+
+
 @dataclass(slots=True)
 class QuestionDialogApp(FocusableMixin):
     dialog: QuestionDialog = field(
@@ -29,29 +38,63 @@ class QuestionDialogApp(FocusableMixin):
             required=True,
         )
     )
-    message: str = "Escape cancels. Press q to quit."
+    recent_notes: tuple[str, ...] = (
+        "Cache deploy checklist",
+        "Follow up on flaky test",
+    )
+    status: str = "Drafting"
 
     def __post_init__(self) -> None:
         FocusableMixin.__init__(self)
         self.dialog.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
-        body = self.dialog.render(RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2)))
+        prefix = [
+            RenderLine(truncate_to_width("Notes Inbox", max_width=constraints.width, ellipsis="")),
+            RenderLine(""),
+            RenderLine("Recent"),
+            *(
+                RenderLine(truncate_to_width(f"  {note}", max_width=constraints.width, ellipsis=""))
+                for note in self.recent_notes[:2]
+            ),
+            RenderLine(""),
+            RenderLine("New Note"),
+        ]
+        body = self.dialog.render(
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - len(prefix) - 4))
+        )
         rows = [
+            *prefix,
             *body.lines,
             RenderLine(""),
-            RenderLine(truncate_to_width(self.message, max_width=constraints.width, ellipsis="")),
+            _field("Status", self.status, width=constraints.width),
+            RenderLine(""),
+            RenderLine(
+                truncate_to_width(
+                    "Escape cancels. [tab] actions  [ctrl+enter] submit  [q] quit",
+                    max_width=constraints.width,
+                    ellipsis="",
+                )
+            ),
         ]
-        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=body.cursor)
+        visible_rows = rows[: constraints.max_height]
+        cursor = None
+        if body.cursor is not None:
+            cursor_row = body.cursor.row + len(prefix)
+            if cursor_row < len(visible_rows):
+                cursor = CursorDeclaration(row=cursor_row, column=body.cursor.column)
+        return RenderResult.from_lines(visible_rows, constraints=constraints, cursor=cursor)
 
     def handle_input(self, event: Any) -> object:
         result = self.dialog.handle_input(event)
         intents = result if isinstance(result, tuple) else (() if result is None else (result,))
         for intent in intents:
             if getattr(intent, "kind", "") == "question_submit":
-                self.message = f"Submitted: {getattr(intent, 'text', '')}"
+                text = getattr(intent, "text", "")
+                self.recent_notes = (text, *self.recent_notes)
+                self.status = f"Submitted: {text}"
             elif getattr(intent, "kind", "") == "question_cancel":
-                self.message = "Cancelled"
+                self.status = "Cancelled"
         return result
 
 

--- a/examples/tui/49_widgets_tree.py
+++ b/examples/tui/49_widgets_tree.py
@@ -10,6 +10,7 @@ from loushang.tui import (
     RenderConstraints,
     RenderLine,
     RenderResult,
+    ThemeResolver,
     TreeNode,
     TreeView,
     Tui,
@@ -19,6 +20,13 @@ from loushang.tui import (
 )
 
 LABEL_WIDTH = 14
+TREE_EXAMPLE_THEME = ThemeResolver(
+    defaults={
+        "widget.tree.row": {"color": "white"},
+        "widget.tree.focus": {"bold": True, "color": "cyan"},
+        "widget.tree.disabled": {"dim": True},
+    }
+)
 
 NODE_DETAILS = {
     "src": ("src", "folder", "expanded"),
@@ -37,7 +45,7 @@ def _field(label: str, value: str, *, width: int) -> RenderLine:
 
 @dataclass(slots=True)
 class TreeViewApp(FocusableMixin):
-    tree: TreeView = field(default_factory=lambda: TreeView(_nodes()))
+    tree: TreeView = field(default_factory=lambda: TreeView(_nodes(), theme=TREE_EXAMPLE_THEME))
     selected_value: str = ""
 
     def __post_init__(self) -> None:

--- a/examples/tui/49_widgets_tree.py
+++ b/examples/tui/49_widgets_tree.py
@@ -18,11 +18,27 @@ from loushang.tui import (
     truncate_to_width,
 )
 
+LABEL_WIDTH = 14
+
+NODE_DETAILS = {
+    "src": ("src", "folder", "expanded"),
+    "widgets": ("src/widgets", "folder", "leaf"),
+    "runtime": ("src/runtime", "folder", "leaf"),
+    "tests": ("tests", "folder", "collapsed"),
+    "unit": ("tests/unit", "folder", "leaf"),
+    "integration": ("tests/integration", "folder", "leaf"),
+}
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    text = f"{label:<{LABEL_WIDTH}}{value}"
+    return RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))
+
 
 @dataclass(slots=True)
 class TreeViewApp(FocusableMixin):
     tree: TreeView = field(default_factory=lambda: TreeView(_nodes()))
-    message: str = "Use arrows to navigate. Enter selects. Press q to quit."
+    selected_value: str = ""
 
     def __post_init__(self) -> None:
         FocusableMixin.__init__(self)
@@ -30,19 +46,37 @@ class TreeViewApp(FocusableMixin):
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         tree_result = self.tree.render(
-            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2))
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 9))
         )
+        active_value = self.tree.active_value
+        path, kind, status = NODE_DETAILS.get(active_value, ("", "", ""))
+        if self.selected_value == active_value:
+            status = f"Selected: {path}"
         rows = [
+            RenderLine(truncate_to_width("Project Explorer", max_width=constraints.width, ellipsis="")),
+            RenderLine(""),
+            RenderLine("Tree"),
             *tree_result.lines,
             RenderLine(""),
-            RenderLine(truncate_to_width(self.message, max_width=constraints.width, ellipsis="")),
+            RenderLine("Details"),
+            _field("Path", path, width=constraints.width),
+            _field("Kind", kind, width=constraints.width),
+            _field("Status", status, width=constraints.width),
+            RenderLine(""),
+            RenderLine(
+                truncate_to_width(
+                    "[up/down] node  [enter] select/toggle  [q] quit",
+                    max_width=constraints.width,
+                    ellipsis="",
+                )
+            ),
         ]
         return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints)
 
     def handle_input(self, event: Any) -> object:
         result = self.tree.handle_input(event)
         if getattr(result, "kind", "") == "select":
-            self.message = f"Selected: {getattr(result, 'text', '')}"
+            self.selected_value = getattr(result, "text", "")
         return result
 
 

--- a/examples/tui/49_widgets_tree.py
+++ b/examples/tui/49_widgets_tree.py
@@ -25,7 +25,7 @@ class TreeViewApp(FocusableMixin):
     message: str = "Use arrows to navigate. Enter selects. Press q to quit."
 
     def __post_init__(self) -> None:
-        super().__init__()
+        FocusableMixin.__init__(self)
         self.tree.focus()
 
     def render(self, constraints: RenderConstraints) -> RenderResult:

--- a/examples/tui/50_widgets_toast.py
+++ b/examples/tui/50_widgets_toast.py
@@ -18,6 +18,13 @@ from loushang.tui import (
     truncate_to_width,
 )
 
+LABEL_WIDTH = 14
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    text = f"{label:<{LABEL_WIDTH}}{value}"
+    return RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))
+
 
 @dataclass(slots=True)
 class ToastApp(FocusableMixin):
@@ -31,6 +38,8 @@ class ToastApp(FocusableMixin):
         )
     )
     counter: int = 0
+    last_event: str = "none"
+    pipeline_status: str = "waiting"
 
     def __post_init__(self) -> None:
         FocusableMixin.__init__(self)
@@ -40,17 +49,22 @@ class ToastApp(FocusableMixin):
         toast_result = self.stack.render(
             RenderConstraints(
                 width=constraints.width,
-                max_height=max(1, constraints.max_height - 3),
+                max_height=max(1, constraints.max_height - 9),
             )
         )
         rows = [
-            RenderLine(truncate_to_width("Toast Stack", max_width=constraints.width, ellipsis="")),
+            RenderLine(truncate_to_width("Deploy Console", max_width=constraints.width, ellipsis="")),
             RenderLine(""),
+            _field("Pipeline", "api-server", width=constraints.width),
+            _field("Status", self.pipeline_status, width=constraints.width),
+            _field("Last event", self.last_event, width=constraints.width),
+            RenderLine(""),
+            RenderLine("Notifications"),
             *toast_result.lines,
             RenderLine(""),
             RenderLine(
                 truncate_to_width(
-                    "Press i/s/w/d to add, x to dismiss oldest, c to clear, q to quit.",
+                    "[i] info  [s] success  [w] warning  [d] danger  [x] dismiss  [c] clear  [q] quit",
                     max_width=constraints.width,
                     ellipsis="",
                 )
@@ -64,15 +78,19 @@ class ToastApp(FocusableMixin):
         key = getattr(event, "text", "").lower()
         if key == "c":
             self.stack.clear()
+            self.last_event = "cleared notifications"
             return True
         if key == "x":
-            return self.stack.dismiss_oldest()
+            dismissed = self.stack.dismiss_oldest()
+            self.last_event = "dismissed oldest" if dismissed else "nothing to dismiss"
+            return dismissed
         kinds = {"i": "info", "s": "success", "w": "warning", "d": "danger"}
         kind = kinds.get(key)
         if kind is None:
             return None
         self.counter += 1
         self.stack.push(f"Toast {self.counter}", kind=kind)
+        self.last_event = f"{kind} toast added"
         return True
 
 

--- a/examples/tui/50_widgets_toast.py
+++ b/examples/tui/50_widgets_toast.py
@@ -10,6 +10,7 @@ from loushang.tui import (
     RenderConstraints,
     RenderLine,
     RenderResult,
+    ThemeResolver,
     Toast,
     ToastStack,
     Tui,
@@ -19,6 +20,16 @@ from loushang.tui import (
 )
 
 LABEL_WIDTH = 14
+TOAST_EXAMPLE_THEME = ThemeResolver(
+    defaults={
+        "widget.toast.danger": {"color": "red"},
+        "widget.toast.info": {"color": "cyan"},
+        "widget.toast.message": {"color": "white"},
+        "widget.toast.success": {"color": "green"},
+        "widget.toast.title": {"bold": True},
+        "widget.toast.warning": {"color": "yellow"},
+    }
+)
 
 
 def _field(label: str, value: str, *, width: int) -> RenderLine:
@@ -35,6 +46,7 @@ class ToastApp(FocusableMixin):
                 Toast("Changes saved", kind="success", duration_ms=None),
             ),
             newest_on_top=True,
+            theme=TOAST_EXAMPLE_THEME,
         )
     )
     counter: int = 0

--- a/src/loushang/tui/framework.py
+++ b/src/loushang/tui/framework.py
@@ -83,13 +83,20 @@ class Container:
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         rendered_lines: list[RenderLine] = []
+        cursor: CursorDeclaration | None = None
         for child in self.children:
             remaining_height = constraints.max_height - len(rendered_lines)
             if remaining_height <= 0:
                 break
+            start_row = len(rendered_lines)
             child_result = child.render(RenderConstraints(width=constraints.width, max_height=remaining_height))
             rendered_lines.extend(child_result.lines)
-        return RenderResult.from_lines(rendered_lines, constraints=constraints)
+            if child_result.cursor is not None:
+                cursor = CursorDeclaration(
+                    row=start_row + child_result.cursor.row,
+                    column=child_result.cursor.column,
+                )
+        return RenderResult.from_lines(rendered_lines, constraints=constraints, cursor=cursor)
 
 
 @dataclass(slots=True)

--- a/src/loushang/tui/surfaces.py
+++ b/src/loushang/tui/surfaces.py
@@ -48,6 +48,7 @@ class SelectionSurface:
     focused: bool = False
     show_scroll_info: bool = True
     selected_style: ThemeStyle | None = None
+    show_selection_when_unfocused: bool = True
     theme: ThemeResolver | None = None
     selected_theme_token: str = "selection.selected"
     enable_search: bool = False
@@ -178,11 +179,12 @@ class SelectionSurface:
         self._last_visible_start = start
         self._last_visible_count = max(0, end - start)
 
+        show_selection = self.focused or self.show_selection_when_unfocused
         lines = [
             RenderLine(
                 _render_select_item(
                     self._filtered_items[index],
-                    selected=index == self.selected_index,
+                    selected=show_selection and index == self.selected_index,
                     width=constraints.width,
                     primary_column_width=self.primary_column_width or _select_primary_column_width(self._filtered_items),
                     min_description_width=self.min_description_width,

--- a/src/loushang/tui/ui_parts/widgets/choice.py
+++ b/src/loushang/tui/ui_parts/widgets/choice.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import Literal
 
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
@@ -91,6 +92,7 @@ class RadioGroup:
     options: list[Choice] | tuple[Choice, ...]
     value: str = ""
     on_change: Callable[[str], object] | None = None
+    orientation: Literal["vertical", "horizontal"] = "vertical"
     theme: ThemeResolver | None = None
     focused: bool = False
     _active_index: int = field(default=0, init=False, repr=False)
@@ -120,6 +122,10 @@ class RadioGroup:
         return None
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
+        if self.orientation == "horizontal":
+            return self._render_horizontal(constraints)
+        if self.orientation != "vertical":
+            raise ValueError("orientation must be 'vertical' or 'horizontal'")
         target_width = autowrap_safe_width(constraints.width)
         lines: list[RenderLine] = []
         for index, option in enumerate(self.options):
@@ -140,6 +146,26 @@ class RadioGroup:
             if len(lines) >= constraints.max_height:
                 break
         return RenderResult.from_lines(lines, constraints=constraints)
+
+    def _render_horizontal(self, constraints: RenderConstraints) -> RenderResult:
+        target_width = autowrap_safe_width(constraints.width)
+        segments: list[str] = []
+        for index, option in enumerate(self.options):
+            prefix = _focus_prefix(self.focused and index == self._active_index)
+            marker = "x" if option.value == self.value else " "
+            text = f"{prefix}({marker}) {option.label}"
+            if option.description:
+                text = f"{text}  {option.description}"
+            state_token = (
+                "widget.disabled"
+                if option.disabled
+                else "widget.focus"
+                if self.focused and index == self._active_index
+                else None
+            )
+            segments.append(style_text(text, self.theme, state_token))
+        rendered = truncate_to_width("  ".join(segments), max_width=target_width, ellipsis="")
+        return RenderResult.from_lines([RenderLine(rendered)][: constraints.max_height], constraints=constraints)
 
     def _initial_active_index(self) -> int:
         for index, option in enumerate(self.options):

--- a/src/loushang/tui/ui_parts/widgets/form.py
+++ b/src/loushang/tui/ui_parts/widgets/form.py
@@ -4,7 +4,12 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
-from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.core import (
+    CursorDeclaration,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+)
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.ui_parts.widgets._utils import style_text
 
@@ -90,17 +95,23 @@ class Form:
     def render(self, constraints: RenderConstraints) -> RenderResult:
         target_width = autowrap_safe_width(constraints.width)
         lines: list[RenderLine] = []
+        cursor: CursorDeclaration | None = None
+        active = self._active_control() if self.focused else None
         for row in self.rows:
             if len(lines) >= constraints.max_height:
                 break
             render = getattr(row.control, "render", None)
             if callable(render):
+                start_row = len(lines)
                 result = render(RenderConstraints(width=constraints.width, max_height=constraints.max_height - len(lines)))
-                lines.extend(result.lines[: constraints.max_height - len(lines)])
+                rendered_lines = result.lines[: constraints.max_height - len(lines)]
+                lines.extend(rendered_lines)
+                if row.control is active and result.cursor is not None and result.cursor.row < len(rendered_lines):
+                    cursor = CursorDeclaration(row=start_row + result.cursor.row, column=result.cursor.column)
             if row.error and len(lines) < constraints.max_height:
                 error = truncate_to_width(row.error, max_width=target_width, ellipsis="")
                 lines.append(RenderLine(style_text(error, self.theme, "widget.error")))
-        return RenderResult.from_lines(lines, constraints=constraints)
+        return RenderResult.from_lines(lines, constraints=constraints, cursor=cursor)
 
     def _active_control(self) -> object | None:
         if not self.rows:

--- a/src/loushang/tui/ui_parts/widgets/question_dialog.py
+++ b/src/loushang/tui/ui_parts/widgets/question_dialog.py
@@ -200,15 +200,15 @@ class QuestionDialog:
 
     def _action_text(self) -> str:
         if self._focus_slot != "actions":
-            submit_marker = " "
-            cancel_marker = " "
+            submit_marker = "  "
+            cancel_marker = "  "
         elif self._active_action == "submit":
-            submit_marker = ">"
-            cancel_marker = " "
+            submit_marker = "> "
+            cancel_marker = "  "
         else:
-            submit_marker = " "
-            cancel_marker = ">"
-        return f"{submit_marker} [{self.confirm_label}]{cancel_marker} [{self.cancel_label}]"
+            submit_marker = "  "
+            cancel_marker = "> "
+        return f"{submit_marker}[{self.confirm_label}]  {cancel_marker}[{self.cancel_label}]"
 
     def _action_line(self, width: int) -> RenderLine:
         token = "widget.question.focus" if self._focus_slot == "actions" else "widget.question.action"

--- a/src/loushang/tui/ui_parts/widgets/selection.py
+++ b/src/loushang/tui/ui_parts/widgets/selection.py
@@ -22,6 +22,7 @@ class SelectList:
         self._surface = SelectionSurface(
             self.items,
             max_visible=self.max_visible,
+            show_selection_when_unfocused=False,
             theme=self.theme,
         )
         if self.focused:

--- a/tests/tui/test_render_framework.py
+++ b/tests/tui/test_render_framework.py
@@ -106,6 +106,16 @@ def test_container_renders_children_in_order_and_propagates_remaining_constraint
     assert second.seen_constraints == [RenderConstraints(width=10, max_height=1)]
 
 
+def test_container_offsets_child_cursor_by_previous_children() -> None:
+    first = TextRenderable(("one", "two"), [])
+    second = CursorRenderable(("edit",), [], cursor=CursorDeclaration(row=0, column=4))
+    container = Container([first, second])
+
+    result = container.render(RenderConstraints(width=10, max_height=3))
+
+    assert result.cursor == CursorDeclaration(row=2, column=4)
+
+
 def test_screen_root_preserves_base_cursor_when_no_surface_is_visible() -> None:
     base = CursorRenderable(("› ", "", "status"), [], cursor=CursorDeclaration(row=0, column=2))
     screen_root = ScreenRoot(base=base, surface_host=SurfaceHost())

--- a/tests/tui/test_widgets_foundation.py
+++ b/tests/tui/test_widgets_foundation.py
@@ -280,4 +280,8 @@ def test_dialog_tabs_from_form_edge_to_actions_and_delegates_editor_target() -> 
 def test_widgets_foundation_example_imports() -> None:
     namespace = runpy.run_path("examples/tui/43_widgets_foundation.py", run_name="__test__")
 
-    assert "build_app" in namespace
+    build_app = namespace["build_app"]
+    assert callable(build_app)
+    app = build_app()
+    result = app.render(RenderConstraints(width=80, max_height=20))
+    assert result.lines

--- a/tests/tui/test_widgets_foundation.py
+++ b/tests/tui/test_widgets_foundation.py
@@ -119,6 +119,16 @@ def test_radio_group_moves_active_option_and_commits_selection() -> None:
     assert group.active_value == "fast"
 
 
+def test_radio_group_can_render_horizontal_options() -> None:
+    group = RadioGroup([Choice("fast", "Fast"), Choice("safe", "Safe")], value="fast", orientation="horizontal")
+    group.focus()
+
+    assert rendered_text(group, width=40, height=4) == ("> (x) Fast    ( ) Safe",)
+
+    assert group.handle_input(InputEvent(kind="key", key="down")) is True
+    assert rendered_text(group, width=40, height=4) == ("  (x) Fast  > ( ) Safe",)
+
+
 def test_text_field_delegates_editing_and_cursor_to_text_input() -> None:
     field = TextField(label="Name", value="tower", help_text="Required")
     field.focus()
@@ -310,10 +320,37 @@ def test_widgets_foundation_example_imports() -> None:
     assert result.lines
 
 
+def test_widgets_foundation_example_uses_two_column_field_layout() -> None:
+    namespace = runpy.run_path("examples/tui/43_widgets_foundation.py", run_name="__test__")
+
+    app = namespace["build_app"]()
+    result = app.render(RenderConstraints(width=80, max_height=20))
+    lines = tuple(strip_control_sequences(line.text) for line in result.lines)
+
+    assert lines[:9] == (
+        "Loushang TUI Widgets",
+        "",
+        "Name          tower",
+        "Cache           [x] Enable cache",
+        "Mode            (x) Fast    ( ) Safe",
+        "Approval        [off] Auto approve",
+        "Model           Kimi",
+        "                Qwen",
+        "",
+    )
+
+    app.handle_input(InputEvent(kind="key", key="tab"))
+    app.handle_input(InputEvent(kind="key", key="tab"))
+    result = app.render(RenderConstraints(width=80, max_height=20))
+    lines = tuple(strip_control_sequences(line.text) for line in result.lines)
+
+    assert lines[4] == "Mode          > (x) Fast    ( ) Safe"
+
+
 def test_widgets_foundation_example_offsets_name_cursor_after_header() -> None:
     namespace = runpy.run_path("examples/tui/43_widgets_foundation.py", run_name="__test__")
 
     app = namespace["build_app"]()
     result = app.render(RenderConstraints(width=80, max_height=20))
 
-    assert result.cursor == CursorDeclaration(row=3, column=len("tower"))
+    assert result.cursor == CursorDeclaration(row=2, column=len("Name          tower"))

--- a/tests/tui/test_widgets_foundation.py
+++ b/tests/tui/test_widgets_foundation.py
@@ -7,6 +7,7 @@ from loushang.tui import (
     Checkbox,
     Choice,
     ConfirmDialog,
+    CursorDeclaration,
     Dialog,
     Form,
     FormRow,
@@ -152,6 +153,16 @@ def test_text_field_inserts_printable_space_as_text() -> None:
     assert field.value == "a "
 
 
+def test_form_render_exposes_active_child_cursor() -> None:
+    form = Form([FormRow("name", TextField(label="Name", value="tower")), FormRow("enabled", Checkbox("Enabled"))])
+    form.focus()
+
+    result = form.render(RenderConstraints(width=40, max_height=8))
+
+    assert result.cursor is not None
+    assert (result.cursor.row, result.cursor.column) == (1, len("tower"))
+
+
 def test_select_list_delegates_navigation_and_selection_without_default_escape_close() -> None:
     select = SelectList([SelectItem("Kimi"), SelectItem("Qwen")], max_visible=2)
 
@@ -165,6 +176,18 @@ def test_select_list_can_emit_surface_close_for_popup_usage() -> None:
     select = SelectList([SelectItem("Kimi")], close_on_escape=True)
 
     assert intent_tuple(select.handle_input(InputEvent(kind="key", key="escape"))) == ("surface_close", "", "")
+
+
+def test_select_list_only_shows_focus_marker_when_focused() -> None:
+    select = SelectList([SelectItem("Kimi"), SelectItem("Qwen")], max_visible=2)
+
+    assert rendered_text(select, width=20, height=2) == ("  Kimi", "  Qwen")
+
+    select.focus()
+    assert rendered_text(select, width=20, height=2) == ("> Kimi", "  Qwen")
+
+    select.blur()
+    assert rendered_text(select, width=20, height=2) == ("  Kimi", "  Qwen")
 
 
 def test_form_tabs_between_focusable_rows_and_delegates_input() -> None:
@@ -285,3 +308,12 @@ def test_widgets_foundation_example_imports() -> None:
     app = build_app()
     result = app.render(RenderConstraints(width=80, max_height=20))
     assert result.lines
+
+
+def test_widgets_foundation_example_offsets_name_cursor_after_header() -> None:
+    namespace = runpy.run_path("examples/tui/43_widgets_foundation.py", run_name="__test__")
+
+    app = namespace["build_app"]()
+    result = app.render(RenderConstraints(width=80, max_height=20))
+
+    assert result.cursor == CursorDeclaration(row=3, column=len("tower"))

--- a/tests/tui/test_widgets_light_controls.py
+++ b/tests/tui/test_widgets_light_controls.py
@@ -333,3 +333,21 @@ def test_widgets_light_controls_example_playback_snapshots() -> None:
     assert "Status        Refreshed" in frames[4].lines
     assert sum(line.count(">") for line in frames[0].lines) == 1
     assert sum(line.count(">") for line in frames[2].lines) == 1
+
+
+def test_widgets_light_controls_example_highlights_active_region() -> None:
+    namespace = runpy.run_path("examples/tui/45_widgets_light_controls.py", run_name="__test__")
+    tui = namespace["build_app"]()
+
+    initial = tui.render(RenderConstraints(width=80, max_height=20))
+    initial_lines = tuple(line.text for line in initial.lines)
+
+    assert "\x1b[1;36m> [Overview]" in initial_lines[2]
+    assert "\x1b[1;36m> Open" not in initial_lines[6]
+
+    tui.handle_input(InputEvent(kind="key", key="tab"))
+    actions = tui.render(RenderConstraints(width=80, max_height=20))
+    action_lines = tuple(line.text for line in actions.lines)
+
+    assert "\x1b[1;36m> [Overview]" not in action_lines[2]
+    assert "\x1b[1;36m> Open" in action_lines[6]

--- a/tests/tui/test_widgets_light_controls.py
+++ b/tests/tui/test_widgets_light_controls.py
@@ -294,4 +294,8 @@ def test_spinner_applies_theme_tokens_without_width_growth() -> None:
 def test_widgets_light_controls_example_imports() -> None:
     namespace = runpy.run_path("examples/tui/45_widgets_light_controls.py", run_name="__test__")
 
-    assert "build_app" in namespace
+    build_app = namespace["build_app"]
+    assert callable(build_app)
+    app = build_app()
+    result = app.render(RenderConstraints(width=80, max_height=20))
+    assert result.lines

--- a/tests/tui/test_widgets_light_controls.py
+++ b/tests/tui/test_widgets_light_controls.py
@@ -25,6 +25,7 @@ from loushang.tui.ui_parts.widgets import MenuItem as WidgetMenuItem
 from loushang.tui.ui_parts.widgets import Spinner as WidgetSpinner
 from loushang.tui.ui_parts.widgets import TabItem as WidgetTabItem
 from loushang.tui.ui_parts.widgets import Tabs as WidgetTabs
+from tests.tui.widget_example_playback import play_example
 
 
 def render_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
@@ -299,3 +300,36 @@ def test_widgets_light_controls_example_imports() -> None:
     app = build_app()
     result = app.render(RenderConstraints(width=80, max_height=20))
     assert result.lines
+
+
+def test_widgets_light_controls_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/45_widgets_light_controls.py",
+        events=(
+            ("right", InputEvent(kind="key", key="right")),
+            ("tab", InputEvent(kind="key", key="tab")),
+            ("down", InputEvent(kind="key", key="down")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert frames[0].lines[:12] == (
+        "View Switcher",
+        "",
+        "Views         > [Overview]    [Logs 3]    [Settings]",
+        "Activity      | Syncing",
+        "",
+        "Actions",
+        "                Open  current view",
+        "                Refresh",
+        "                Archive  disabled",
+        "",
+        "Status        Ready",
+        "",
+    )
+    assert "Views           [Overview]  > [Logs 3]    [Settings]" in frames[1].lines
+    assert "              > Open  current view" in frames[2].lines
+    assert "              > Refresh" in frames[3].lines
+    assert "Status        Refreshed" in frames[4].lines
+    assert sum(line.count(">") for line in frames[0].lines) == 1
+    assert sum(line.count(">") for line in frames[2].lines) == 1

--- a/tests/tui/test_widgets_question_dialog.py
+++ b/tests/tui/test_widgets_question_dialog.py
@@ -364,3 +364,19 @@ def test_widgets_question_dialog_example_playback_snapshots() -> None:
     )
     assert any("[Submit]> [Cancel]" in line for line in cancel_frames[2].lines)
     assert "Status        Cancelled" in cancel_frames[3].lines
+
+
+def test_widgets_question_dialog_example_highlights_action_focus() -> None:
+    namespace = runpy.run_path("examples/tui/48_widgets_question_dialog.py", run_name="__test__")
+    tui = namespace["build_app"]()
+
+    initial = tui.render(RenderConstraints(width=80, max_height=20))
+    initial_lines = tuple(line.text for line in initial.lines)
+
+    assert "\x1b[1;36m> [Submit]" not in initial_lines[14]
+
+    tui.handle_input(InputEvent(kind="key", key="tab"))
+    actions = tui.render(RenderConstraints(width=80, max_height=20))
+    action_lines = tuple(line.text for line in actions.lines)
+
+    assert "\x1b[1;36m> [Submit]" in action_lines[14]

--- a/tests/tui/test_widgets_question_dialog.py
+++ b/tests/tui/test_widgets_question_dialog.py
@@ -210,7 +210,7 @@ def test_question_dialog_renders_title_question_body_actions_and_cursor_offset()
         "alpha",
         "beta",
         "",
-        "  [Submit]  [Cancel]",
+        "  [Submit]    [Cancel]",
     )
     assert result.cursor is not None
     assert (result.cursor.row, result.cursor.column) == (3, len("beta"))
@@ -221,10 +221,10 @@ def test_question_dialog_action_row_marks_active_action_without_layout_shift() -
     dialog.focus()
 
     assert dialog.handle_input(InputEvent(kind="key", key="tab")) is True
-    assert plain_lines(dialog, width=30, height=6)[-1] == "> [Submit]  [Cancel]"
+    assert plain_lines(dialog, width=30, height=6)[-1] == "> [Submit]    [Cancel]"
 
     assert dialog.handle_input(InputEvent(kind="key", key="right")) is True
-    assert plain_lines(dialog, width=30, height=6)[-1] == "  [Submit]> [Cancel]"
+    assert plain_lines(dialog, width=30, height=6)[-1] == "  [Submit]  > [Cancel]"
 
 
 def test_question_dialog_action_row_visible_width_stays_stable_across_focus_states() -> None:
@@ -347,11 +347,11 @@ def test_widgets_question_dialog_example_playback_snapshots() -> None:
         "",
         "",
         "",
-        "Enter adds a line. Ctrl+Enter submits.",
-        "  [Submit]  [Cancel]",
+        "Enter adds a line. Tab to Submit/Cancel.",
+        "  [Submit]    [Cancel]",
     )
     assert "Status        Drafting" in frames[0].lines
-    assert "> [Submit]  [Cancel]" in frames[2].lines
+    assert "> [Submit]    [Cancel]" in frames[2].lines
     assert "Status        Submitted: Cache warmup before deploy" in frames[3].lines
 
     cancel_frames = play_example(
@@ -362,7 +362,7 @@ def test_widgets_question_dialog_example_playback_snapshots() -> None:
             ("enter", InputEvent(kind="key", key="enter")),
         ),
     )
-    assert any("[Submit]> [Cancel]" in line for line in cancel_frames[2].lines)
+    assert any("[Submit]  > [Cancel]" in line for line in cancel_frames[2].lines)
     assert "Status        Cancelled" in cancel_frames[3].lines
 
 

--- a/tests/tui/test_widgets_question_dialog.py
+++ b/tests/tui/test_widgets_question_dialog.py
@@ -15,6 +15,7 @@ from loushang.tui import (
 )
 from loushang.tui.ui_parts import QuestionDialog as UiQuestionDialog
 from loushang.tui.ui_parts.widgets import QuestionDialog as WidgetQuestionDialog
+from tests.tui.widget_example_playback import play_example
 
 
 def render_result(part: Any, *, width: int = 40, height: int = 8):
@@ -320,3 +321,46 @@ def test_widgets_question_dialog_example_imports() -> None:
     app = build_app()
     result = app.render(RenderConstraints(width=80, max_height=20))
     assert result.lines
+
+
+def test_widgets_question_dialog_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/48_widgets_question_dialog.py",
+        events=(
+            ("type answer", InputEvent(kind="text", text="Cache warmup before deploy")),
+            ("tab", InputEvent(kind="key", key="tab")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert frames[0].lines[:15] == (
+        "Notes Inbox",
+        "",
+        "Recent",
+        "  Cache deploy checklist",
+        "  Follow up on flaky test",
+        "",
+        "New Note",
+        "Add note",
+        "What should be remembered?",
+        "Write a multi-line answer",
+        "",
+        "",
+        "",
+        "Enter adds a line. Ctrl+Enter submits.",
+        "  [Submit]  [Cancel]",
+    )
+    assert "Status        Drafting" in frames[0].lines
+    assert "> [Submit]  [Cancel]" in frames[2].lines
+    assert "Status        Submitted: Cache warmup before deploy" in frames[3].lines
+
+    cancel_frames = play_example(
+        "examples/tui/48_widgets_question_dialog.py",
+        events=(
+            ("tab", InputEvent(kind="key", key="tab")),
+            ("right", InputEvent(kind="key", key="right")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+    assert any("[Submit]> [Cancel]" in line for line in cancel_frames[2].lines)
+    assert "Status        Cancelled" in cancel_frames[3].lines

--- a/tests/tui/test_widgets_question_dialog.py
+++ b/tests/tui/test_widgets_question_dialog.py
@@ -315,4 +315,8 @@ def test_question_dialog_themes_title_question_and_action_rows() -> None:
 def test_widgets_question_dialog_example_imports() -> None:
     namespace = runpy.run_path("examples/tui/48_widgets_question_dialog.py", run_name="__test__")
 
-    assert callable(namespace["build_app"])
+    build_app = namespace["build_app"]
+    assert callable(build_app)
+    app = build_app()
+    result = app.render(RenderConstraints(width=80, max_height=20))
+    assert result.lines

--- a/tests/tui/test_widgets_small_controls.py
+++ b/tests/tui/test_widgets_small_controls.py
@@ -250,3 +250,19 @@ def test_widgets_small_controls_example_playback_snapshots() -> None:
     )
     assert "Actions       [Refresh]  > [Cancel]" in frames[1].lines
     assert "Status        Cancelled" in frames[2].lines
+
+
+def test_widgets_small_controls_example_highlights_toolbar_focus() -> None:
+    namespace = runpy.run_path("examples/tui/44_widgets_small_controls.py", run_name="__test__")
+    tui = namespace["build_app"]()
+
+    initial = tui.render(RenderConstraints(width=80, max_height=20))
+    initial_lines = tuple(line.text for line in initial.lines)
+
+    assert "\x1b[1;36m> [Refresh]" in initial_lines[9]
+
+    tui.handle_input(InputEvent(kind="key", key="right"))
+    moved = tui.render(RenderConstraints(width=80, max_height=20))
+    moved_lines = tuple(line.text for line in moved.lines)
+
+    assert "\x1b[1;36m> [Cancel]" in moved_lines[9]

--- a/tests/tui/test_widgets_small_controls.py
+++ b/tests/tui/test_widgets_small_controls.py
@@ -19,6 +19,7 @@ from loushang.tui import (
 )
 from loushang.tui.ui_parts import Badge as UiBadge
 from loushang.tui.ui_parts.widgets import Badge as WidgetBadge
+from tests.tui.widget_example_playback import ExampleFrame, play_example
 
 
 def render_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
@@ -221,3 +222,31 @@ def test_widgets_small_controls_example_imports() -> None:
     app = build_app()
     result = app.render(RenderConstraints(width=80, max_height=20))
     assert result.lines
+
+
+def test_widgets_small_controls_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/44_widgets_small_controls.py",
+        events=(
+            ("right", InputEvent(kind="key", key="right")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert [frame.label for frame in frames] == ["initial", "right", "enter"]
+    assert all(isinstance(frame, ExampleFrame) for frame in frames)
+    assert frames[0].lines[:11] == (
+        "Indexing Job  [beta]  (ready)",
+        "",
+        "Progress      Indexing [#####-------] 42%",
+        "",
+        "Details",
+        "Model         Kimi",
+        "Mode          safe  current",
+        "Queue         3 pending",
+        "",
+        "Actions       > [Refresh]  [Cancel]",
+        "Status        Ready",
+    )
+    assert "Actions       [Refresh]  > [Cancel]" in frames[1].lines
+    assert "Status        Cancelled" in frames[2].lines

--- a/tests/tui/test_widgets_small_controls.py
+++ b/tests/tui/test_widgets_small_controls.py
@@ -216,4 +216,8 @@ def test_toolbar_applies_theme_tokens_and_respects_width() -> None:
 def test_widgets_small_controls_example_imports() -> None:
     namespace = runpy.run_path("examples/tui/44_widgets_small_controls.py", run_name="__test__")
 
-    assert "build_app" in namespace
+    build_app = namespace["build_app"]
+    assert callable(build_app)
+    app = build_app()
+    result = app.render(RenderConstraints(width=80, max_height=20))
+    assert result.lines

--- a/tests/tui/test_widgets_table.py
+++ b/tests/tui/test_widgets_table.py
@@ -286,3 +286,19 @@ def test_widgets_table_example_playback_snapshots() -> None:
     )
     assert "> Deploy        blocked" in "\n".join(frames[1].lines)
     assert "Selected      Deploy is blocked, 3 runs" in frames[2].lines
+
+
+def test_widgets_table_example_highlights_active_row() -> None:
+    namespace = runpy.run_path("examples/tui/46_widgets_table.py", run_name="__test__")
+    tui = namespace["build_app"]()
+
+    initial = tui.render(RenderConstraints(width=80, max_height=20))
+    initial_lines = tuple(line.text for line in initial.lines)
+
+    assert "\x1b[1;36m> Build" in initial_lines[3]
+
+    tui.handle_input(InputEvent(kind="key", key="down"))
+    moved = tui.render(RenderConstraints(width=80, max_height=20))
+    moved_lines = tuple(line.text for line in moved.lines)
+
+    assert "\x1b[1;36m> Deploy" in moved_lines[4]

--- a/tests/tui/test_widgets_table.py
+++ b/tests/tui/test_widgets_table.py
@@ -257,4 +257,8 @@ def test_table_empty_state_uses_theme_and_width_rules() -> None:
 def test_widgets_table_example_imports() -> None:
     namespace = runpy.run_path("examples/tui/46_widgets_table.py", run_name="__test__")
 
-    assert "build_app" in namespace
+    build_app = namespace["build_app"]
+    assert callable(build_app)
+    app = build_app()
+    result = app.render(RenderConstraints(width=80, max_height=20))
+    assert result.lines

--- a/tests/tui/test_widgets_table.py
+++ b/tests/tui/test_widgets_table.py
@@ -19,6 +19,7 @@ from loushang.tui.ui_parts import TableRow as UiTableRow
 from loushang.tui.ui_parts.widgets import Table as WidgetTable
 from loushang.tui.ui_parts.widgets import TableColumn as WidgetTableColumn
 from loushang.tui.ui_parts.widgets import TableRow as WidgetTableRow
+from tests.tui.widget_example_playback import play_example
 
 
 def render_lines(part: Any, *, width: int = 60, height: int = 8) -> tuple[str, ...]:
@@ -262,3 +263,26 @@ def test_widgets_table_example_imports() -> None:
     app = build_app()
     result = app.render(RenderConstraints(width=80, max_height=20))
     assert result.lines
+
+
+def test_widgets_table_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/46_widgets_table.py",
+        events=(
+            ("down", InputEvent(kind="key", key="down")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert frames[0].lines[:8] == (
+        "Job Queue  (3 jobs)",
+        "",
+        "  Job           Status                                                     Runs",
+        "> Build         ready                                                        12",
+        "  Deploy        blocked                                                       3",
+        "  Archive       disabled                                                      0",
+        "",
+        "Selected      Build is ready, 12 runs",
+    )
+    assert "> Deploy        blocked" in "\n".join(frames[1].lines)
+    assert "Selected      Deploy is blocked, 3 runs" in frames[2].lines

--- a/tests/tui/test_widgets_textarea.py
+++ b/tests/tui/test_widgets_textarea.py
@@ -247,4 +247,8 @@ def test_text_area_dialog_delegates_active_editor_target() -> None:
 def test_widgets_textarea_example_imports() -> None:
     namespace = runpy.run_path("examples/tui/47_widgets_textarea.py", run_name="__test__")
 
-    assert callable(namespace["build_app"])
+    build_app = namespace["build_app"]
+    assert callable(build_app)
+    app = build_app()
+    result = app.render(RenderConstraints(width=80, max_height=20))
+    assert result.lines

--- a/tests/tui/test_widgets_textarea.py
+++ b/tests/tui/test_widgets_textarea.py
@@ -281,3 +281,19 @@ def test_widgets_textarea_example_playback_snapshots() -> None:
     assert "Status        1 line / unsaved" in frames[1].lines
     assert "Status        2 lines / unsaved" in frames[3].lines
     assert frames[0].cursor == (5, 0)
+
+
+def test_widgets_textarea_example_styles_placeholder_and_text() -> None:
+    namespace = runpy.run_path("examples/tui/47_widgets_textarea.py", run_name="__test__")
+    tui = namespace["build_app"]()
+
+    initial = tui.render(RenderConstraints(width=80, max_height=20))
+    initial_lines = tuple(line.text for line in initial.lines)
+
+    assert "\x1b[90mWrite notes" in initial_lines[5]
+
+    tui.handle_input(InputEvent(kind="text", text="Plan release"))
+    edited = tui.render(RenderConstraints(width=80, max_height=20))
+    edited_lines = tuple(line.text for line in edited.lines)
+
+    assert "\x1b[37mPlan release" in edited_lines[5]

--- a/tests/tui/test_widgets_textarea.py
+++ b/tests/tui/test_widgets_textarea.py
@@ -18,6 +18,7 @@ from loushang.tui import (
 )
 from loushang.tui.ui_parts import TextArea as UiTextArea
 from loushang.tui.ui_parts.widgets import TextArea as WidgetTextArea
+from tests.tui.widget_example_playback import play_example
 
 
 def render_result(part: Any, *, width: int = 40, height: int = 8):
@@ -252,3 +253,31 @@ def test_widgets_textarea_example_imports() -> None:
     app = build_app()
     result = app.render(RenderConstraints(width=80, max_height=20))
     assert result.lines
+
+
+def test_widgets_textarea_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/47_widgets_textarea.py",
+        events=(
+            ("type note", InputEvent(kind="text", text="Plan release")),
+            ("enter", InputEvent(kind="key", key="enter")),
+            ("type next", InputEvent(kind="text", text="Ship docs")),
+        ),
+    )
+
+    assert frames[0].lines[:11] == (
+        "Release Note Draft",
+        "",
+        "Title         Weekly deploy notes",
+        "",
+        "Notes",
+        "Write notes",
+        "",
+        "",
+        "",
+        "",
+        "Status        0 lines / unsaved",
+    )
+    assert "Status        1 line / unsaved" in frames[1].lines
+    assert "Status        2 lines / unsaved" in frames[3].lines
+    assert frames[0].cursor == (5, 0)

--- a/tests/tui/test_widgets_toast.py
+++ b/tests/tui/test_widgets_toast.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from loushang.tui import (
+    InputEvent,
     RenderConstraints,
     ThemeResolver,
     Toast,
@@ -20,6 +21,7 @@ from loushang.tui.ui_parts import ToastStack as UiToastStack
 from loushang.tui.ui_parts.widgets import Toast as WidgetToast
 from loushang.tui.ui_parts.widgets import ToastKind as WidgetToastKind
 from loushang.tui.ui_parts.widgets import ToastStack as WidgetToastStack
+from tests.tui.widget_example_playback import play_example
 
 
 class Clock:
@@ -154,6 +156,35 @@ def test_widgets_toast_example_imports() -> None:
     app = build_app()
     result = app.render(RenderConstraints(width=60, max_height=8))
     assert result.lines
+
+
+def test_widgets_toast_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/50_widgets_toast.py",
+        events=(
+            ("warning", InputEvent(kind="text", text="w")),
+            ("success", InputEvent(kind="text", text="s")),
+            ("dismiss", InputEvent(kind="text", text="x")),
+            ("clear", InputEvent(kind="text", text="c")),
+        ),
+    )
+
+    assert frames[0].lines[:9] == (
+        "Deploy Console",
+        "",
+        "Pipeline      api-server",
+        "Status        waiting",
+        "Last event    none",
+        "",
+        "Notifications",
+        "[success] Changes saved",
+        "[info] Loushang: Welcome",
+    )
+    assert "Last event    warning toast added" in frames[1].lines
+    assert "[warning] Toast 1" in frames[1].lines
+    assert "Last event    success toast added" in frames[2].lines
+    assert "Last event    dismissed oldest" in frames[3].lines
+    assert "Last event    cleared notifications" in frames[4].lines
 
 
 def test_toast_stack_normalizes_generated_values_and_timestamps() -> None:

--- a/tests/tui/test_widgets_toast.py
+++ b/tests/tui/test_widgets_toast.py
@@ -187,6 +187,23 @@ def test_widgets_toast_example_playback_snapshots() -> None:
     assert "Last event    cleared notifications" in frames[4].lines
 
 
+def test_widgets_toast_example_styles_notification_kinds() -> None:
+    namespace = runpy.run_path("examples/tui/50_widgets_toast.py", run_name="__test__")
+    tui = namespace["build_app"]()
+
+    initial = tui.render(RenderConstraints(width=80, max_height=20))
+    initial_lines = tuple(line.text for line in initial.lines)
+
+    assert initial_lines[7].startswith("\x1b[32m[success]")
+    assert initial_lines[8].startswith("\x1b[36m[info]")
+
+    tui.handle_input(InputEvent(kind="text", text="w"))
+    warning = tui.render(RenderConstraints(width=80, max_height=20))
+    warning_lines = tuple(line.text for line in warning.lines)
+
+    assert warning_lines[7].startswith("\x1b[33m[warning]")
+
+
 def test_toast_stack_normalizes_generated_values_and_timestamps() -> None:
     clock = Clock(100)
     stack = ToastStack(

--- a/tests/tui/test_widgets_tree.py
+++ b/tests/tui/test_widgets_tree.py
@@ -287,4 +287,8 @@ def test_tree_view_applies_theme_tokens() -> None:
 def test_widgets_tree_example_imports() -> None:
     namespace = runpy.run_path("examples/tui/49_widgets_tree.py", run_name="__test__")
 
-    assert callable(namespace["build_app"])
+    build_app = namespace["build_app"]
+    assert callable(build_app)
+    app = build_app()
+    result = app.render(RenderConstraints(width=80, max_height=20))
+    assert result.lines

--- a/tests/tui/test_widgets_tree.py
+++ b/tests/tui/test_widgets_tree.py
@@ -18,6 +18,7 @@ from loushang.tui.ui_parts import TreeNode as UiTreeNode
 from loushang.tui.ui_parts import TreeView as UiTreeView
 from loushang.tui.ui_parts.widgets import TreeNode as WidgetTreeNode
 from loushang.tui.ui_parts.widgets import TreeView as WidgetTreeView
+from tests.tui.widget_example_playback import play_example
 
 
 def render_lines(part: Any, *, width: int = 40, height: int = 8) -> tuple[str, ...]:
@@ -292,3 +293,30 @@ def test_widgets_tree_example_imports() -> None:
     app = build_app()
     result = app.render(RenderConstraints(width=80, max_height=20))
     assert result.lines
+
+
+def test_widgets_tree_example_playback_snapshots() -> None:
+    frames = play_example(
+        "examples/tui/49_widgets_tree.py",
+        events=(
+            ("down", InputEvent(kind="key", key="down")),
+            ("enter", InputEvent(kind="key", key="enter")),
+        ),
+    )
+
+    assert frames[0].lines[:12] == (
+        "Project Explorer",
+        "",
+        "Tree",
+        "> - src",
+        "      widgets",
+        "      runtime",
+        "  + tests",
+        "",
+        "Details",
+        "Path          src",
+        "Kind          folder",
+        "Status        expanded",
+    )
+    assert "Path          src/widgets" in frames[1].lines
+    assert "Status        Selected: src/widgets" in frames[2].lines

--- a/tests/tui/test_widgets_tree.py
+++ b/tests/tui/test_widgets_tree.py
@@ -320,3 +320,19 @@ def test_widgets_tree_example_playback_snapshots() -> None:
     )
     assert "Path          src/widgets" in frames[1].lines
     assert "Status        Selected: src/widgets" in frames[2].lines
+
+
+def test_widgets_tree_example_highlights_active_node() -> None:
+    namespace = runpy.run_path("examples/tui/49_widgets_tree.py", run_name="__test__")
+    tui = namespace["build_app"]()
+
+    initial = tui.render(RenderConstraints(width=80, max_height=20))
+    initial_lines = tuple(line.text for line in initial.lines)
+
+    assert "\x1b[1;36m> - src" in initial_lines[3]
+
+    tui.handle_input(InputEvent(kind="key", key="down"))
+    moved = tui.render(RenderConstraints(width=80, max_height=20))
+    moved_lines = tuple(line.text for line in moved.lines)
+
+    assert "\x1b[1;36m>     widgets" in moved_lines[4]

--- a/tests/tui/widget_example_playback.py
+++ b/tests/tui/widget_example_playback.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import runpy
+from dataclasses import dataclass
+
+from loushang.tui import (
+    FakeTerminalPort,
+    InputEvent,
+    RenderLoop,
+    TerminalSize,
+    TuiRuntime,
+    strip_control_sequences,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ExampleFrame:
+    label: str
+    lines: tuple[str, ...]
+    cursor: tuple[int, int]
+    operation_class: str | None
+
+
+def play_example(
+    path: str,
+    *,
+    events: tuple[tuple[str, InputEvent], ...] = (),
+    width: int = 80,
+    height: int = 20,
+) -> tuple[ExampleFrame, ...]:
+    namespace = runpy.run_path(path, run_name="__test__")
+    tui = namespace["build_app"]()
+    port = FakeTerminalPort(size=TerminalSize(columns=width, rows=height))
+    runtime = TuiRuntime(render_loop=RenderLoop(tui._screen_root), terminal=port)
+    frames = [_render_frame("initial", runtime)]
+    for label, event in events:
+        tui.handle_input(event)
+        frames.append(_render_frame(label, runtime))
+    return tuple(frames)
+
+
+def _render_frame(label: str, runtime: TuiRuntime) -> ExampleFrame:
+    step = runtime.render_now()
+    return ExampleFrame(
+        label=label,
+        lines=tuple(
+            strip_control_sequences(line).rstrip()
+            for line in step.diagnostics.current_logical_lines
+        ),
+        cursor=(
+            step.diagnostics.logical_cursor_row,
+            step.diagnostics.logical_cursor_column,
+        ),
+        operation_class=step.diagnostics.operation_class,
+    )


### PR DESCRIPTION
## Summary
- Add a private playback helper for TUI widget examples and snapshot tests for examples 44-50.
- Polish widget examples into clearer task-oriented mini apps.
- Preserve widget/runtime APIs while improving runpy compatibility, focus feedback, and example interaction clarity.

## Validation
- 128 passed: polished widget example tests
- 872 passed: full tests/tui
- Ruff touched files: All checks passed
- git diff --check: no output
- Manual playback spot-check across examples 44-50