### PR TITLE
[codex] stabilize TUI settings demo focus

### DIFF
--- a/examples/tui/52_widgets_tabgroup_searchable_list.py
+++ b/examples/tui/52_widgets_tabgroup_searchable_list.py
@@ -134,7 +134,13 @@ class StaticPage:
 
 @dataclass(slots=True)
 class SettingsPanelsApp(FocusableMixin):
-    tabs: TabGroup = field(default_factory=lambda: TabGroup(_top_pages(), content_height=CONTENT_HEIGHT))
+    tabs: TabGroup = field(
+        default_factory=lambda: TabGroup(
+            _top_pages(),
+            content_height=CONTENT_HEIGHT,
+            theme=TABGROUP_SEARCH_THEME,
+        )
+    )
     status: str = "Ready"
 
     def __post_init__(self) -> None:

--- a/examples/tui/52_widgets_tabgroup_searchable_list.py
+++ b/examples/tui/52_widgets_tabgroup_searchable_list.py
@@ -29,6 +29,7 @@ SETTING_LABEL_WIDTH = 42
 TABGROUP_SEARCH_THEME = ThemeResolver(
     defaults={
         "widget.tabs.tab": {"color": "white"},
+        "widget.tabs.selected": {"bold": True, "color": "green"},
         "widget.tabs.level0.selected_header_focus": {"bold": True, "color": "cyan"},
         "widget.tabs.level0.selected_content_focus": {"bold": True, "color": "green"},
         "widget.tabs.level1.selected_header_focus": {"bold": True, "color": "magenta"},
@@ -97,10 +98,9 @@ class SettingsListPage(FocusableMixin):
             return f"Selected: {item.label}"
         next_value = "false" if boolean_value else "true"
         self.items = tuple(replace(existing, value=next_value) if existing.key == item.key else existing for existing in self.items)
-        query = self.settings.query
-        focus_region = self.settings.focus_region
-        focused = self.settings.focused
-        self.settings = self._make_settings(query=query, focus_region=focus_region, focused=focused)
+        self.settings.set_items(self.items, preserve_active_key=item.key)
+        if self.settings.focused:
+            self.settings.focus_list()
         return f"Toggled: {item.label} -> {next_value}"
 
     def _make_settings(
@@ -163,7 +163,7 @@ class SettingsPanelsApp(FocusableMixin):
         if len(rows) < constraints.max_height:
             rows.append(RenderLine(_separator(constraints.width)))
         if len(rows) < constraints.max_height:
-            rows.append(RenderLine(_footer_text(self.status, width=constraints.width)))
+            rows.append(RenderLine(_footer_text(_focus_context(self.tabs), self.status, width=constraints.width)))
         return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
 
     def handle_input(self, event: Any) -> object:
@@ -287,8 +287,27 @@ def _offset_cursor_after_top_separator(cursor: CursorDeclaration | None) -> Curs
     return CursorDeclaration(row=cursor.row + 1, column=cursor.column)
 
 
-def _footer_text(status: str, *, width: int) -> str:
-    text = f"{status} | Type to filter | Enter select/toggle | Space toggle | Esc clear | q quit"
+def _focus_context(tabs: TabGroup) -> str:
+    if tabs.header_focused:
+        return "tabs"
+    page = tabs.selected_page
+    content = page.content if page is not None else None
+    if isinstance(content, SettingsListPage):
+        return "settings" if content.settings.focus_region == "list" else "search"
+    if isinstance(content, TabGroup) and content.header_focused:
+        return "tabs"
+    return "page"
+
+
+def _footer_text(focus_context: str, status: str, *, width: int) -> str:
+    if focus_context == "search":
+        text = f"Search | {status} | type filter | Down list | Up tabs | Esc clear | q quit"
+    elif focus_context == "settings":
+        text = f"Settings | {status} | Up/Down move | Enter select | Space toggle | q quit"
+    elif focus_context == "tabs":
+        text = f"Tabs | {status} | Left/Right switch | Down content | q quit"
+    else:
+        text = f"{status} | Up tabs | q quit"
     return truncate_to_width(text, max_width=width, ellipsis="")
 
 

--- a/src/loushang/tui/ui_parts/widgets/searchable_list.py
+++ b/src/loushang/tui/ui_parts/widgets/searchable_list.py
@@ -3,8 +3,17 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 
-from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width, visible_width
-from loushang.tui.core import CursorDeclaration, RenderConstraints, RenderLine, RenderResult
+from loushang.tui.cell_width import (
+    autowrap_safe_width,
+    truncate_to_width,
+    visible_width,
+)
+from loushang.tui.core import (
+    CursorDeclaration,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+)
 from loushang.tui.keybindings import normalize_key_id
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.ui_parts.text_input import TextInput
@@ -114,6 +123,13 @@ class SearchableList:
         previous_key = self.active_key
         self._query_input.set_text(query)
         self._repair_active(previous_key=previous_key)
+
+    def set_items(self, items: Sequence[SearchableListItem], *, preserve_active_key: str = "") -> None:
+        previous_key = preserve_active_key or self.active_key
+        self._items = tuple(items)
+        self._repair_active(previous_key=previous_key)
+        if self.focus_region == "list" and self.active_item is None:
+            self.focus_search()
 
     def focus(self) -> None:
         self.focused = True

--- a/tests/tui/test_widgets_searchable_list.py
+++ b/tests/tui/test_widgets_searchable_list.py
@@ -103,3 +103,21 @@ def test_searchable_list_renders_bounded_viewport_and_overflow_counts() -> None:
     plain_lines(view, width=40, height=6)
     assert view.more_above > 0
     assert view.more_below > 0
+
+
+def test_searchable_list_can_preserve_active_key_when_items_are_replaced() -> None:
+    items = (
+        SearchableListItem("auto-compact", "Auto-compact", "false"),
+        SearchableListItem("reduce-motion", "Reduce motion", "false"),
+    )
+    view = SearchableList(items, query="compact", focus_region="list", focused=True)
+    replacement = (
+        SearchableListItem("auto-compact", "Auto-compact", "true"),
+        SearchableListItem("reduce-motion", "Reduce motion", "false"),
+    )
+
+    view.set_items(replacement, preserve_active_key="auto-compact")
+
+    assert view.focus_region == "list"
+    assert view.active_key == "auto-compact"
+    assert any(line.startswith("> Auto-compact") and "true" in line for line in plain_lines(view))

--- a/tests/tui/test_widgets_tab_group.py
+++ b/tests/tui/test_widgets_tab_group.py
@@ -273,6 +273,27 @@ def test_tabgroup_searchable_list_example_playback_filters_settings() -> None:
     assert any(set(line) == {"-"} for line in initial)
 
 
+def test_tabgroup_searchable_list_example_styles_top_level_selected_tab() -> None:
+    namespace = runpy.run_path("examples/tui/52_widgets_tabgroup_searchable_list.py", run_name="__test__")
+    tui = namespace["build_app"]()
+
+    initial = tui.render(RenderConstraints(width=100, max_height=24)).lines[0].text
+    assert "\x1b[" in initial
+    assert "> [Workspace]" in initial
+
+    for event in (
+        InputEvent(kind="key", key="up"),
+        InputEvent(kind="key", key="right"),
+        InputEvent(kind="key", key="right"),
+        InputEvent(kind="key", key="right"),
+    ):
+        tui.handle_input(event)
+
+    activity = tui.render(RenderConstraints(width=100, max_height=24)).lines[0].text
+    assert "\x1b[" in activity
+    assert "> [Activity]" in activity
+
+
 def test_tabgroup_searchable_list_example_playback_switches_nested_tabs() -> None:
     frames = play_example(
         "examples/tui/52_widgets_tabgroup_searchable_list.py",

--- a/tests/tui/test_widgets_tab_group.py
+++ b/tests/tui/test_widgets_tab_group.py
@@ -290,6 +290,24 @@ def test_tabgroup_searchable_list_example_playback_switches_nested_tabs() -> Non
 
     assert any("Overview" in line and "Models" in line for line in frames[-1].lines)
     assert any("Tokens per Day" in line or "Model usage" in line for line in frames[-1].lines)
+    assert any("Overview" in line and "> [Models]" in line for line in frames[-1].lines)
+
+
+def test_tabgroup_searchable_list_example_up_to_tabs_down_returns_to_search() -> None:
+    frames = play_example(
+        "examples/tui/52_widgets_tabgroup_searchable_list.py",
+        events=(
+            ("up to tabs", InputEvent(kind="key", key="up")),
+            ("down to search", InputEvent(kind="key", key="down")),
+        ),
+        width=100,
+        height=24,
+    )
+
+    assert frames[-1].lines[0].startswith("> [Workspace]")
+    assert frames[-1].lines[2] == "Search settings..."
+    assert not any(line.startswith("> Model") for line in frames[-1].lines)
+    assert frames[-1].lines[-1].startswith("Search |")
 
 
 def test_tabgroup_searchable_list_example_playback_scrolls_long_list_without_layout_jump() -> None:
@@ -375,8 +393,9 @@ def test_tabgroup_searchable_list_example_printable_space_toggles_setting() -> N
         height=24,
     )
 
-    assert any("Auto-compact" in line and "true" in line for line in frames[-1].lines)
+    assert any(line.startswith("> Auto-compact") and "true" in line for line in frames[-1].lines)
     assert any("Toggled: Auto-compact" in line for line in frames[-1].lines)
+    assert frames[-1].lines[-1].startswith("Settings |")
 
 
 def test_tabgroup_searchable_list_example_quit_keys_are_global() -> None:


### PR DESCRIPTION
## Summary
- Preserve the settings row focus after boolean toggles in the TabGroup/SearchableList demo.
- Add focus-aware footer text for search, settings-list, and tab-header states.
- Add `SearchableList.set_items()` so callers can update item values without rebuilding and losing active row state.

## Validation
- `uv run ruff check examples/tui/52_widgets_tabgroup_searchable_list.py src/loushang/tui/ui_parts/widgets/searchable_list.py tests/tui/test_widgets_searchable_list.py tests/tui/test_widgets_tab_group.py`
- `uv run pytest tests/tui -q`
