### PR TITLE
[codex] Add real tabbed settings page

### DIFF
--- a/docs/superpowers/plans/2026-06-13-tui-real-settings-page-integration-implementation.md
+++ b/docs/superpowers/plans/2026-06-13-tui-real-settings-page-integration-implementation.md
@@ -1,0 +1,947 @@
+# TUI Real Settings Page Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the real native TUI `/settings` path with a tabbed `Status / Config / Model / Usage / Stats` control-center page backed by `TabGroup` and `SearchableList`, while preserving legacy surfaces and `/model`.
+
+**Architecture:** Add a focused product view in `src/loushang/coding/ui/settings_page.py` that composes existing generic widgets. `NativeSurfaceManager` remains the lifecycle owner; it opens the page, delegates new-page setting/model side effects to `SettingsPageView.apply_setting()`, and preserves legacy `SettingsSurface` close-on-submit behavior. `NativeSurfaceView` gets compatible input/cursor delegation so active bottom surfaces can host searchable page content correctly.
+
+**Tech Stack:** Python 3.11 dataclasses, existing `loushang.tui` render/input primitives, `TabGroup`, `SearchableList`, `pytest`, native TUI playback harness.
+
+---
+
+## File Structure
+
+- Create `src/loushang/coding/ui/settings_page.py`
+  - Product-level settings/control-center page.
+  - Owns page composition, adapters, `apply_setting()`, focus-aware input, and rendering.
+  - Does not replace generic widgets or legacy `SettingsSurface`.
+- Modify `src/loushang/coding/ui/native_surfaces.py`
+  - Add `NativeSurfaceView.editor_input_target()`.
+  - Preserve non-`InfoPanel` content cursors.
+  - Let non-info hosted content consume Esc before host close fallback.
+  - Open settings asynchronously and delegate new-page submit handling.
+- Modify `src/loushang/coding/ui/status_provider.py`
+  - Add a small read-only status snapshot method/dataclass instead of parsing rendered toolbar text.
+- Add `tests/coding/test_native_settings_page.py`
+  - Focused unit tests for `SettingsPageView`, page adapters, keyboard routing, and apply behavior.
+- Modify `tests/coding/test_native_coding_tui_surfaces.py`
+  - Manager/host integration tests and existing `/settings` expectations.
+- Modify `tests/coding/test_native_coding_tui_playback.py`
+  - Playback expectations for the real `/settings` path.
+- Optional after implementation stabilizes: update durable internal docs under `docs/internals/architecture/tui/native-terminal-core/`.
+
+---
+
+### Task 1: Fix NativeSurfaceView Host Delegation
+
+**Files:**
+- Modify: `src/loushang/coding/ui/native_surfaces.py`
+- Test: `tests/coding/test_native_coding_tui_surfaces.py`
+
+- [ ] **Step 1: Add failing tests for host editor target, cursor offset, and Esc delegation**
+
+Append focused tests near other `NativeSurfaceView` tests:
+
+```python
+class _CursorContent:
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        return RenderResult.from_lines(
+            [RenderLine("query")],
+            constraints=constraints,
+            cursor=CursorDeclaration(row=0, column=3),
+        )
+
+
+class _EditorTargetContent(_CursorContent):
+    def __init__(self) -> None:
+        self.target = object()
+
+    def editor_input_target(self) -> object:
+        return self.target
+
+
+class _EscContent(_CursorContent):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def handle_input(self, event: InputEvent) -> InputIntent | bool | None:
+        self.calls += 1
+        if event.kind == "key" and event.key in {"esc", "escape"}:
+            return InputIntent(kind="consumed", note="child_escape")
+        return None
+
+
+def test_native_surface_view_delegates_editor_input_target() -> None:
+    content = _EditorTargetContent()
+    view = NativeSurfaceView(title="Settings", purpose="settings", content=content)
+
+    assert view.editor_input_target() is content.target
+
+
+def test_native_surface_view_preserves_content_cursor_with_offset() -> None:
+    view = NativeSurfaceView(title="Settings", purpose="settings", content=_CursorContent(), footer="")
+
+    rendered = view.render(RenderConstraints(width=40, max_height=8))
+
+    assert rendered.cursor == CursorDeclaration(row=2, column=3)
+
+
+def test_native_surface_view_delegates_escape_to_non_info_content_first() -> None:
+    content = _EscContent()
+    view = NativeSurfaceView(title="Settings", purpose="settings", content=content)
+
+    assert view.handle_input(InputEvent(kind="key", key="escape")) == InputIntent(
+        kind="consumed",
+        note="child_escape",
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_coding_tui_surfaces.py -q
+```
+
+Expected: new tests fail because `NativeSurfaceView` has no `editor_input_target()`, drops non-info cursors, and closes before content can consume Esc.
+
+- [ ] **Step 3: Implement host delegation**
+
+In `NativeSurfaceView`:
+
+```python
+def editor_input_target(self) -> object | None:
+    target = getattr(self.content, "editor_input_target", None)
+    return target() if callable(target) else None
+```
+
+Change `handle_input()` so info surfaces keep current behavior, but non-info surfaces delegate first:
+
+```python
+def handle_input(self, event: InputEvent) -> InputIntent | None:
+    if self.purpose == "info":
+        if event.kind == "key" and event.key in {"enter", "space", "escape", "esc"}:
+            return InputIntent(kind="surface_close")
+        if event.kind == "key":
+            return self._handle_info_scroll_input(event.key)
+        return None
+
+    handler = getattr(self.content, "handle_input", None)
+    if callable(handler):
+        intent = _native_input_intent_or_none(handler(self._translate_content_input_event(event)))
+        if intent is not None:
+            return intent
+    if event.kind == "key" and event.key in {"escape", "esc"}:
+        return InputIntent(kind="surface_close")
+    return None
+```
+
+When rendering non-info content, offset its cursor:
+
+```python
+else:
+    self._last_content_start_row = len(lines)
+    result = self.content.render(body_constraints)
+    lines.extend(line.text for line in result.lines)
+    if result.cursor is not None:
+        cursor_row = self._last_content_start_row + result.cursor.row
+        if cursor_row < constraints.max_height:
+            cursor = CursorDeclaration(row=cursor_row, column=result.cursor.column)
+```
+
+- [ ] **Step 4: Run host tests**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_coding_tui_surfaces.py -q
+```
+
+Expected: tests pass or unrelated existing tests reveal assumptions that need local updates.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/loushang/coding/ui/native_surfaces.py tests/coding/test_native_coding_tui_surfaces.py
+git commit -m "fix(tui): delegate native surface content input hooks"
+```
+
+---
+
+### Task 2: Add Status Snapshot API
+
+**Files:**
+- Modify: `src/loushang/coding/ui/status_provider.py`
+- Test: `tests/coding/test_native_settings_page.py`
+
+- [ ] **Step 1: Write failing status snapshot test**
+
+Create `tests/coding/test_native_settings_page.py` with:
+
+```python
+from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+
+
+def test_status_provider_exposes_read_only_snapshot() -> None:
+    provider = CodingTuiStatusProvider(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label=lambda: "abcd",
+        thinking_level=lambda: "medium",
+        running=lambda: False,
+    )
+
+    snapshot = provider.snapshot()
+
+    assert snapshot.model_label == "moonshot/kimi-for-coding"
+    assert snapshot.cwd == "/repo"
+    assert snapshot.branch == "main"
+    assert snapshot.session_label == "abcd"
+    assert snapshot.thinking_level == "medium"
+    assert snapshot.running is False
+    assert snapshot.statusline_visible is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_settings_page.py::test_status_provider_exposes_read_only_snapshot -q
+```
+
+Expected: fail because `snapshot()` does not exist.
+
+- [ ] **Step 3: Implement `StatusSnapshot`**
+
+In `src/loushang/coding/ui/status_provider.py`:
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class StatusSnapshot:
+    model_label: str | None
+    cwd: str
+    branch: str | None
+    session_label: str | None
+    thinking_level: str | None
+    running: bool
+    statusline_visible: bool
+```
+
+Add:
+
+```python
+def snapshot(self) -> StatusSnapshot:
+    return StatusSnapshot(
+        model_label=self._model_label,
+        cwd=self._cwd,
+        branch=self._branch,
+        session_label=self._session_label(),
+        thinking_level=self._thinking_level(),
+        running=self._running(),
+        statusline_visible=self._visible,
+    )
+```
+
+Export `StatusSnapshot` in `__all__`.
+
+- [ ] **Step 4: Run test**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_settings_page.py::test_status_provider_exposes_read_only_snapshot -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/loushang/coding/ui/status_provider.py tests/coding/test_native_settings_page.py
+git commit -m "feat(tui): expose coding status snapshot"
+```
+
+---
+
+### Task 3: Implement SettingsPageView Core
+
+**Files:**
+- Create: `src/loushang/coding/ui/settings_page.py`
+- Test: `tests/coding/test_native_settings_page.py`
+
+- [ ] **Step 1: Add failing page render and focus tests**
+
+Add tests:
+
+```python
+import asyncio
+
+from loushang.coding.types import ModelSelection
+from loushang.coding.ui.settings_page import SettingsPageView
+from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+from loushang.tui import InputEvent, InputIntent, RenderConstraints, strip_control_sequences
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.current_model = ModelSelection(provider="moonshot", model_id="kimi-for-coding")
+        self.models = (
+            ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
+            ModelSelection(provider="openai", model_id="gpt-5.4"),
+        )
+        self.set_model_calls = []
+
+    def get_model_selection(self) -> object:
+        return self.current_model
+
+    def get_available_models(self) -> list[object]:
+        return list(self.models)
+
+    async def set_model(self, selection: object) -> None:
+        self.set_model_calls.append(selection)
+        self.current_model = selection
+
+
+def _status_provider() -> CodingTuiStatusProvider:
+    return CodingTuiStatusProvider(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label=lambda: "abcd",
+        thinking_level=lambda: None,
+        running=lambda: False,
+    )
+
+
+def _page() -> SettingsPageView:
+    return asyncio.run(SettingsPageView.create(session=_Session(), status_provider=_status_provider()))
+
+
+def _plain(page: SettingsPageView, *, width: int = 100, height: int = 18) -> tuple[str, ...]:
+    rendered = page.render(RenderConstraints(width=width, max_height=height))
+    return tuple(strip_control_sequences(line.text) for line in rendered.lines)
+
+
+def test_settings_page_opens_config_tab_with_search_focus() -> None:
+    page = _page()
+    lines = _plain(page)
+
+    assert any("Status" in line and "Config" in line and "Model" in line for line in lines)
+    assert any("Search settings" in line for line in lines)
+    assert any("Status line" in line for line in lines)
+    assert page.editor_input_target() is not None
+
+
+def test_settings_page_search_filters_config_rows() -> None:
+    page = _page()
+
+    assert page.handle_input(InputEvent(kind="text", text="status")) is True
+    lines = _plain(page)
+
+    assert any("Status line" in line for line in lines)
+    assert not any("Terminal progress" in line for line in lines)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_settings_page.py -q
+```
+
+Expected: fail because `settings_page.py` does not exist.
+
+- [ ] **Step 3: Add data objects and simple render pages**
+
+Create `src/loushang/coding/ui/settings_page.py` with:
+
+```python
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from loushang.coding.ui.model_list import ModelChoice, available_model_choices, current_model_choice_value, select_available_model
+from loushang.coding.ui.status_provider import CodingTuiStatusProvider, StatusSnapshot
+from loushang.tui import (
+    CursorDeclaration,
+    FocusableMixin,
+    InputEvent,
+    InputIntent,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    SearchableList,
+    SearchableListItem,
+    SearchableListSelect,
+    TabGroup,
+    TabPage,
+    truncate_to_width,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsApplyResult:
+    message: str
+    statusline_visible: bool | None = None
+    refresh_model_label: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigRow:
+    id: str
+    label: str
+    value: str
+    description: str = ""
+    disabled: bool = False
+```
+
+Implement small helpers:
+
+```python
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _as_bool(value: str) -> bool | None:
+    normalized = value.casefold()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    return None
+```
+
+Implement `StaticLinesPage(FocusableMixin)`:
+
+- stores tuple lines;
+- `focus()`/`blur()` update focus;
+- `handle_input()` consumes left/right/home/end while focused;
+- `render()` truncates lines.
+
+Implement `SettingsPageView` with:
+
+- `create(session, status_provider, usage_provider=None, settings_manager=None, session_settings=None)`;
+- top-level tabs with selected value `"config"`;
+- `focus()` calls `tabs.focus_content()`;
+- `editor_input_target()` delegates to tabs;
+- `render()` uses `tabs.render()`, adds a separator and focus-aware footer;
+- `handle_input()` delegates to tabs first, then close fallback;
+- `apply_setting()` initially supports `"statusline"` and `"model.current"`.
+
+Keep initial implementation minimal: Status/Usage/Stats can render static lines from available snapshots or unavailable text.
+
+- [ ] **Step 4: Add ConfigSettingsPage**
+
+Implement `ConfigSettingsPage(FocusableMixin)`:
+
+- takes `rows: tuple[ConfigRow, ...]`;
+- owns `SearchableList`;
+- `focus()` focuses list search;
+- `handle_input()`:
+  - delegates to `SearchableList`;
+  - returns `InputIntent(kind="setting", text=row.id, note=next_value)` for enter/space activation;
+  - consumes unhandled left/right/home/end while focused;
+- `set_rows(rows, preserve_active_key="")` refreshes list items.
+
+Initial row builder should include:
+
+```python
+def _config_rows(status_provider: CodingTuiStatusProvider, settings_manager: object | None) -> tuple[ConfigRow, ...]:
+    rows = [
+        ConfigRow("statusline", "Status line", _bool_text(status_provider.is_visible())),
+    ]
+    if settings_manager is not None:
+        getter = getattr(settings_manager, "get_show_terminal_progress", None)
+        if callable(getter):
+            rows.append(ConfigRow("terminal.progress", "Terminal progress", _bool_text(bool(getter()))))
+    rows.append(ConfigRow("model.current", "Current model", "Use Model tab", disabled=True))
+    return tuple(rows)
+```
+
+- [ ] **Step 5: Add ModelPage**
+
+Implement `ModelPage(FocusableMixin)`:
+
+- takes model choices and current value;
+- owns `SearchableList`;
+- renders `Search models...`;
+- activation returns `InputIntent(kind="setting", text="model.current", note=item.key)`;
+- unavailable state uses `StaticLinesPage` behavior.
+
+Use `SearchableListItem(choice.value, choice.label, status, choice.description)`.
+
+- [ ] **Step 6: Add apply behavior**
+
+In `SettingsPageView.apply_setting()`:
+
+```python
+if item_id == "statusline":
+    enabled = _as_bool(value)
+    if enabled is None:
+        return SettingsApplyResult("Invalid status line value.")
+    settings = self.status_provider.settings_list().set_enabled("statusline", enabled)
+    message = self.status_provider.apply_settings(settings)
+    self._refresh_config_rows(preserve_active_key="statusline")
+    return SettingsApplyResult(message, statusline_visible=self.status_provider.is_visible())
+
+if item_id == "model.current":
+    message = await select_available_model(self.session, query=value)
+    await self._refresh_model_page()
+    return SettingsApplyResult(message, refresh_model_label=True)
+```
+
+Unknown ids return `SettingsApplyResult(f"Unknown setting: {item_id}")`.
+
+- [ ] **Step 7: Run page tests**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_settings_page.py -q
+```
+
+Expected: tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/loushang/coding/ui/settings_page.py tests/coding/test_native_settings_page.py
+git commit -m "feat(tui): add tabbed settings page view"
+```
+
+---
+
+### Task 4: Add SettingsPageView Interaction Tests
+
+**Files:**
+- Modify: `tests/coding/test_native_settings_page.py`
+- Modify: `src/loushang/coding/ui/settings_page.py`
+
+- [ ] **Step 1: Add failing interaction tests**
+
+Add tests:
+
+```python
+def test_settings_page_statusline_toggle_returns_setting_intent_and_apply_updates_rows() -> None:
+    page = _page()
+    page.handle_input(InputEvent(kind="key", key="down"))
+    intent = page.handle_input(InputEvent(kind="key", key="enter"))
+
+    assert intent == InputIntent(kind="setting", text="statusline", note="false")
+
+    result = asyncio.run(page.apply_setting("statusline", "false"))
+
+    assert result.statusline_visible is False
+    assert result.message == "Status line: off"
+    assert any("Status line" in line and "false" in line for line in _plain(page))
+
+
+def test_settings_page_q_is_search_text_but_closes_from_list_focus() -> None:
+    page = _page()
+
+    assert page.handle_input(InputEvent(kind="text", text="q")) is True
+    assert any("q" in line for line in _plain(page))
+
+    page.handle_input(InputEvent(kind="key", key="down"))
+    assert page.handle_input(InputEvent(kind="text", text="q")) == InputIntent(kind="surface_close")
+
+
+def test_settings_page_search_editing_keys_do_not_switch_tabs() -> None:
+    page = _page()
+
+    before = page.tabs.value
+    assert page.handle_input(InputEvent(kind="key", key="right")) is True
+
+    assert page.tabs.value == before
+
+
+def test_settings_page_model_tab_filters_and_selects_model() -> None:
+    page = _page()
+    page.tabs.focus_header()
+    page.handle_input(InputEvent(kind="key", key="right"))
+    page.handle_input(InputEvent(kind="key", key="right"))
+    page.handle_input(InputEvent(kind="key", key="down"))
+
+    assert page.tabs.value == "model"
+    assert page.handle_input(InputEvent(kind="text", text="gpt")) is True
+    intent = page.handle_input(InputEvent(kind="key", key="enter"))
+
+    assert intent == InputIntent(kind="setting", text="model.current", note="openai/gpt-5.4")
+```
+
+- [ ] **Step 2: Run tests to verify failures**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_settings_page.py -q
+```
+
+Expected: interaction gaps fail if routing/apply is incomplete.
+
+- [ ] **Step 3: Fix interaction routing**
+
+In `SettingsPageView.handle_input()`:
+
+- delegate to `self.tabs.handle_input(event)` first;
+- if result is `SearchableListSelect`, convert by selected page type;
+- if result is not `None`, return result;
+- close on Esc/Escape;
+- close on text/key `q` only if `_focus_context()` is `"tabs"`, `"page"`, or `"settings-list"`, not `"search"`.
+
+In `ConfigSettingsPage` and `ModelPage`, make activation explicit for list/search enter and list-space. Do not intercept text `" "` while search is focused.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_settings_page.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/loushang/coding/ui/settings_page.py tests/coding/test_native_settings_page.py
+git commit -m "test(tui): cover settings page keyboard behavior"
+```
+
+---
+
+### Task 5: Integrate SettingsPageView Into NativeSurfaceManager
+
+**Files:**
+- Modify: `src/loushang/coding/ui/native_surfaces.py`
+- Modify: `tests/coding/test_native_coding_tui_surfaces.py`
+
+- [ ] **Step 1: Add failing manager tests**
+
+Update `test_native_surface_manager_opens_settings_in_bottom_frame_with_runtime_overlay_host()` to expect the new tabbed page:
+
+```python
+rendered = app.active_surface.render(RenderConstraints(width=100, max_height=12))
+plain = tuple(strip_control_sequences(line.text) for line in rendered.lines)
+assert any("Status" in line and "Config" in line and "Model" in line for line in plain)
+assert any("Search settings" in line for line in plain)
+assert any("Status line" in line for line in plain)
+```
+
+Add tests:
+
+```python
+def test_native_surface_manager_settings_page_submit_keeps_surface_open() -> None:
+    app = _app()
+    manager = _manager(app, _Session())
+
+    asyncio.run(manager.handle_text("/settings"))
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
+
+    assert intent == InputIntent(kind="setting", text="statusline", note="false")
+    asyncio.run(manager.handle_surface_intent(intent))
+
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    assert app.state.statusline_visible is False
+    assert app.state.status_message == "Status line: off"
+
+
+def test_native_surface_manager_legacy_settings_surface_still_closes_on_submit() -> None:
+    app = _app()
+    manager = _manager(app, _Session())
+    app.active_surface = NativeSurfaceView(
+        title="Settings",
+        purpose="settings",
+        content=SettingsSurface(list(manager.status_provider.settings_list().items), enable_search=True),
+        presentation="bottom-exclusive",
+    )
+
+    asyncio.run(manager.handle_surface_intent(InputIntent(kind="setting", text="statusline", note="false")))
+
+    assert app.active_surface is None
+    assert app.state.statusline_visible is False
+```
+
+Add model submit test:
+
+```python
+def test_native_surface_manager_settings_page_model_submit_uses_model_selection() -> None:
+    session = _Session()
+    app = _app()
+    manager = _manager(app, session)
+
+    asyncio.run(manager.handle_text("/settings"))
+    asyncio.run(manager.handle_surface_intent(InputIntent(kind="setting", text="model.current", note="openai/gpt-5.4")))
+
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    assert session.set_model_calls
+    assert app.state.model_label == "openai/gpt-5.4"
+```
+
+- [ ] **Step 2: Run targeted tests to verify failures**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_coding_tui_surfaces.py -q
+```
+
+Expected: settings opener and submit routing tests fail.
+
+- [ ] **Step 3: Make `_open_settings()` async and await it**
+
+In imports:
+
+```python
+from loushang.coding.ui.settings_page import SettingsPageView
+```
+
+Change:
+
+```python
+elif command.name == "settings" and isinstance(intent, SettingsIntent):
+    await self._open_settings()
+```
+
+Change `_open_settings`:
+
+```python
+async def _open_settings(self) -> None:
+    surface = await SettingsPageView.create(
+        session=self.session,
+        status_provider=self.status_provider,
+        settings_manager=getattr(self.session, "settings_manager", None),
+        session_settings=getattr(self.session, "settings_controller", None),
+    )
+    self._open_surface(
+        NativeSurfaceView(
+            title="Settings",
+            purpose="settings",
+            content=surface,
+            footer="",
+            presentation="bottom-exclusive",
+        )
+    )
+```
+
+- [ ] **Step 4: Delegate new-page submit handling**
+
+Update `_handle_settings_submit()`:
+
+```python
+async def _handle_settings_submit(self, payload: dict[str, str]) -> None:
+    surface = self._current_surface()
+    page = surface.content if isinstance(surface, NativeSurfaceView) else None
+    apply_setting = getattr(page, "apply_setting", None)
+    if callable(apply_setting):
+        result = await apply_setting(payload["id"], payload.get("value", ""))
+        if getattr(result, "statusline_visible", None) is not None:
+            self.app.set_statusline_visible(result.statusline_visible)
+        if getattr(result, "refresh_model_label", False):
+            await self._refresh_model_label()
+        self.app.set_status(result.message)
+        return
+
+    updated = self.status_provider.settings_list().toggle(payload["id"])
+    self.close_surface()
+    message = self.status_provider.apply_settings(updated)
+    self.app.set_statusline_visible(self.status_provider.is_visible())
+    self.app.set_status(message)
+```
+
+- [ ] **Step 5: Run manager tests**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_coding_tui_surfaces.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/loushang/coding/ui/native_surfaces.py tests/coding/test_native_coding_tui_surfaces.py
+git commit -m "feat(tui): open real tabbed settings page"
+```
+
+---
+
+### Task 6: Update Native Playback Coverage
+
+**Files:**
+- Modify: `tests/coding/test_native_coding_tui_playback.py`
+
+- [ ] **Step 1: Update existing `/settings` playback tests**
+
+Change `test_native_tui_playback_settings_surface_toggles_statusline()` expectations:
+
+```python
+steps = playback.play(
+    [
+        PlaybackEvent.input("/settings\r"),
+        PlaybackEvent.input("\r"),
+        PlaybackEvent.input("\x1b"),
+    ]
+)
+
+assert app.active_surface is None
+assert app.state.statusline_visible is False
+assert app.state.status_message == "Status line: off"
+```
+
+Update visible text assertions to expect the tabbed page during intermediate frames and absence after Esc.
+
+Change search test expectations from legacy `Search: zz` to the new query row. Assert:
+
+```python
+assert any("Search settings" in line and "zz" in line for line in lines)
+assert any("No matching settings" in line for line in lines)
+```
+
+- [ ] **Step 2: Add playback tests for q and Model tab**
+
+Add:
+
+```python
+def test_native_tui_playback_settings_q_is_search_text_then_list_close_key() -> None:
+    session = _Session()
+    app = _app()
+    playback = _NativeInteractivePlayback(app, _manager(app, session), columns=100, rows=18)
+
+    steps = playback.play(
+        [
+            PlaybackEvent.input("/settings\r"),
+            PlaybackEvent.input("q"),
+        ]
+    )
+
+    assert app.active_surface is not None
+    assert any("q" in line for line in _plain_lines(steps[-1].diagnostics))
+
+
+def test_native_tui_playback_settings_model_tab_is_available() -> None:
+    session = _Session()
+    app = _app()
+    playback = _NativeInteractivePlayback(app, _manager(app, session), columns=100, rows=18)
+
+    steps = playback.play(
+        [
+            PlaybackEvent.input("/settings\r"),
+            PlaybackEvent.input("\x1b[A"),  # search -> top tabs
+            PlaybackEvent.input("\x1b[C"),
+            PlaybackEvent.input("\x1b[C"),
+            PlaybackEvent.input("\x1b[B"),  # content
+        ]
+    )
+
+    lines = _plain_lines(steps[-1].diagnostics)
+    assert any("Search models" in line for line in lines)
+    assert any("moonshot/kimi-for-coding" in line for line in lines)
+```
+
+Adjust exact key sequences if playback translation differs; keep intent assertions stable.
+
+- [ ] **Step 3: Run playback tests**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_coding_tui_playback.py -k settings -q
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/coding/test_native_coding_tui_playback.py
+git commit -m "test(tui): update settings page playback"
+```
+
+---
+
+### Task 7: Final Focused Verification And Cleanup
+
+**Files:**
+- Modify only if tests reveal small issues:
+  - `src/loushang/coding/ui/settings_page.py`
+  - `src/loushang/coding/ui/native_surfaces.py`
+  - `tests/coding/test_native_settings_page.py`
+  - `tests/coding/test_native_coding_tui_surfaces.py`
+  - `tests/coding/test_native_coding_tui_playback.py`
+
+- [ ] **Step 1: Run focused test suite**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_settings_page.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -k "settings or model_selector or native_surface_view" -q
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run widget regressions**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_widgets_tab_group.py tests/tui/test_widgets_searchable_list.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run lint on touched files**
+
+Run:
+
+```bash
+uv run ruff check src/loushang/coding/ui/settings_page.py src/loushang/coding/ui/native_surfaces.py src/loushang/coding/ui/status_provider.py tests/coding/test_native_settings_page.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Manual smoke**
+
+Run:
+
+```bash
+uv run pytest tests/coding/test_native_coding_tui_playback.py -k settings -q
+```
+
+Expected: pass. This is the automated playback equivalent of manual `/settings` smoke for this slice.
+
+- [ ] **Step 5: Commit any final cleanup**
+
+If Step 1-4 required fixes:
+
+```bash
+git add <changed-files>
+git commit -m "fix(tui): polish settings page integration"
+```
+
+If no fixes were needed, skip this commit.
+
+---
+
+## Implementation Notes
+
+- Do not add a new `InputIntentKind` for model selection.
+- Do not delete `SettingsSurface`; legacy tests must still pass.
+- Do not close the new `SettingsPageView` after Config or Model selection.
+- Do not parse toolbar render text for Status page data.
+- Do not compute Usage by broad session introspection. Use an explicit provider or render unavailable.
+- Keep `/model` behavior intact. Existing model selector tests should continue to pass.
+- Keep changes local to the coding product surface and host compatibility hooks; do not refactor generic widgets unless a test proves a widget bug.

--- a/docs/superpowers/specs/2026-06-13-tui-real-settings-page-integration-design.md
+++ b/docs/superpowers/specs/2026-06-13-tui-real-settings-page-integration-design.md
@@ -110,6 +110,12 @@ These are host-level compatibility fixes, not `SettingsPageView`-specific
 shortcuts. Existing surfaces should keep their current visual behavior unless
 they already return a cursor.
 
+Bottom-exclusive active surfaces still route input through
+`NativeSurfaceView.handle_input()` and the hosted content's `handle_input()`.
+`SettingsPageView.handle_input()` must therefore delegate text, paste, and
+editing keys to the focused page content directly. `editor_input_target()` is a
+host compatibility and cursor-editing hook, not the only path for search input.
+
 The initial page structure:
 
 ```text
@@ -149,8 +155,11 @@ Responsibilities:
 - Hide the hardware cursor unless the selected content declares a real text
   input cursor.
 - Translate Config page selection results into `InputIntent(kind="setting")`.
-- Treat `q`, Esc, and Escape as close keys by returning
-  `InputIntent(kind="surface_close")`.
+- Delegate close keys to the focused child first. If the child does not consume
+  the key, Esc/Escape close the page. Search fields may consume Esc to clear a
+  non-empty query, matching `SearchableList`.
+- Treat `q` as close only when focus is on tab headers, static pages, or list
+  rows. Search/text-input focus must accept printable `q` as query text.
 - Keep the surface open after Config changes and Model selections so users can
   make multiple changes in one visit.
 - Expose `apply_setting(id, value)` as the single owner for new-page Config and
@@ -165,9 +174,10 @@ The view should use the same focus rules proven by
 - Up from the first Config list item returns to search.
 - Left/right move only the focused tab header.
 - Nested Stats tabs use their own level-1 focus and colors.
-- Interactive page wrappers consume left/right/home/end while their search or
-  list content is focused, so the current `TabGroup` fallback tab navigation
-  cannot switch top-level pages from inside an editing/list region.
+- Interactive page wrappers delegate to the focused child first. Only if the
+  child does not handle left/right/home/end should the wrapper consume the key
+  to prevent parent `TabGroup` fallback navigation. Search fields must keep
+  normal cursor movement and home/end editing behavior.
 
 ### ConfigSettingsPage
 
@@ -389,7 +399,10 @@ Add native playback tests for the real `/settings` command:
 - left/right on focused tabs switches top-level pages;
 - Model appears as a top-level tab and shows the current model;
 - Stats page exposes `Overview / Model Usage` nested tabs;
-- `q` or Esc exits the page.
+- `q` exits from tabs/static/list focus but is inserted while search is
+  focused;
+- Esc closes when the focused child does not consume it, while search can use
+  Esc to clear a non-empty query.
 
 Add manager/host tests:
 
@@ -404,6 +417,11 @@ Add manager/host tests:
 - `NativeSurfaceView.editor_input_target()` delegates to hosted content.
 - `NativeSurfaceView.render()` offsets and preserves non-`InfoPanel` content
   cursors.
+- `SettingsPageView.handle_input()` routes text/paste/editing keys through the
+  selected page content even when hosted as a bottom-exclusive active surface.
+- `q` close behavior is focus-region aware.
+- left/right/home/end work inside search fields and do not switch parent tabs
+  when interactive content focus does not handle them.
 - No new `InputIntentKind` is added for model selection.
 - The standalone `/model` command and `ModelSelectorSurface` behavior remain
   covered by existing tests or a focused regression.

--- a/docs/superpowers/specs/2026-06-13-tui-real-settings-page-integration-design.md
+++ b/docs/superpowers/specs/2026-06-13-tui-real-settings-page-integration-design.md
@@ -31,6 +31,8 @@ surface without replacing every settings and stats data source in one change.
 ## Goals
 
 - Upgrade the real `/settings` native TUI path to a tabbed control-center page.
+- Keep the existing `/model` command and `ModelSelectorSurface` behavior
+  unchanged, except for optional shared helper reuse.
 - Use `TabGroup` for the top-level `Status / Config / Model / Usage / Stats`
   sections.
 - Use `SearchableList` for the Config page, including long-list viewport
@@ -62,6 +64,7 @@ surface without replacing every settings and stats data source in one change.
   set.
 - Do not rewrite model registry, provider configuration, or model metadata
   management in this slice.
+- Do not remove or degrade the standalone `/model` selector path.
 
 ## Proposed Architecture
 
@@ -78,13 +81,34 @@ widgets into the coding product page:
   changes;
 - returns `InputIntent(kind="setting", text="model.current", note=<choice>)`
   when the Model page selects a model;
+- exposes `async apply_setting(id, value)` so `NativeSurfaceManager` can
+  delegate new-page setting/model side effects back to the page instead of
+  duplicating adapter routing;
 - returns `InputIntent(kind="surface_close")` for close keys;
 - exposes an `editor_input_target()` so text input reaches the focused
   `SearchableList` search box.
 
-`NativeSurfaceManager._open_settings()` should instantiate this view and keep
-using `NativeSurfaceView(purpose="settings")`. That preserves the existing
-surface lifecycle and `_normalize_surface_intent()` handling.
+`NativeSurfaceManager._open_settings()` should become async and be awaited from
+`handle_text()`, matching the existing async command handling used by model
+selection. It should instantiate this view and keep using
+`NativeSurfaceView(purpose="settings")`. That preserves the existing surface
+lifecycle and `_normalize_surface_intent()` handling.
+
+`SettingsPageView` should be created through an async builder or equivalent
+factory that loads a model-choice snapshot from existing async model helpers. If
+model choices cannot be loaded, the Model page renders an unavailable state and
+the standalone `/model` command remains the fallback.
+
+`NativeSurfaceView` needs two compatible delegation changes for this integration:
+
+- `editor_input_target()` delegates to hosted content when content exposes that
+  method.
+- `render()` offsets and returns non-`InfoPanel` content cursors, rather than
+  dropping them.
+
+These are host-level compatibility fixes, not `SettingsPageView`-specific
+shortcuts. Existing surfaces should keep their current visual behavior unless
+they already return a cursor.
 
 The initial page structure:
 
@@ -96,7 +120,7 @@ Config page:
   Setting                                    Value
   Status line                                true
   Auto compaction                            true
-  Provider retry                             true
+  Auto retry                                 true
   Terminal progress                          false
   ...
 
@@ -125,8 +149,12 @@ Responsibilities:
 - Hide the hardware cursor unless the selected content declares a real text
   input cursor.
 - Translate Config page selection results into `InputIntent(kind="setting")`.
-- Avoid closing the surface after a boolean toggle unless future user testing
-  shows close-on-change is preferred.
+- Treat `q`, Esc, and Escape as close keys by returning
+  `InputIntent(kind="surface_close")`.
+- Keep the surface open after Config changes and Model selections so users can
+  make multiple changes in one visit.
+- Expose `apply_setting(id, value)` as the single owner for new-page Config and
+  Model side effects.
 
 The view should use the same focus rules proven by
 `examples/tui/52_widgets_tabgroup_searchable_list.py`:
@@ -137,6 +165,9 @@ The view should use the same focus rules proven by
 - Up from the first Config list item returns to search.
 - Left/right move only the focused tab header.
 - Nested Stats tabs use their own level-1 focus and colors.
+- Interactive page wrappers consume left/right/home/end while their search or
+  list content is focused, so the current `TabGroup` fallback tab navigation
+  cannot switch top-level pages from inside an editing/list region.
 
 ### ConfigSettingsPage
 
@@ -161,8 +192,8 @@ existing getters/setters:
 - status line visibility, through `CodingTuiStatusProvider`;
 - auto compaction, through `SessionSettingsController` if available;
 - auto retry, through `SessionSettingsController` if available;
-- terminal progress, through `SettingsManager.get_terminal_settings()` and
-  `update_settings()`;
+- terminal progress, through `SettingsManager.get_show_terminal_progress()` and
+  `set_show_terminal_progress()`;
 - theme, read-only or cycle-through only if the existing accepted values are
   explicit.
 
@@ -197,11 +228,13 @@ keep `/model` as the fallback path.
 ### StatusPage
 
 The Status page should be read-only in the first slice. It should show compact
-runtime facts that already exist:
+runtime facts from a small explicit snapshot API, not by parsing rendered
+toolbar text or reaching into private provider fields.
+
+Add or inject a read-only status snapshot with:
 
 - current model label;
-- current cwd and branch from the status provider snapshot inputs when
-  available;
+- current cwd and branch;
 - session label;
 - thinking level;
 - running/idle state;
@@ -213,8 +246,9 @@ guessing.
 ### UsagePage
 
 The Usage page should be read-only in the first slice. It should render current
-context usage using `current_context_usage()` or the same snapshot data already
-available to session status logic.
+context usage only through an explicit optional usage snapshot/provider.
+`current_context_usage()` requires messages, branch entries, and model inputs;
+the page should not discover those by broad session introspection.
 
 Minimum useful rows:
 
@@ -224,8 +258,8 @@ Minimum useful rows:
 - compaction threshold if available;
 - source, such as estimated or assistant usage.
 
-If usage cannot be computed from the current session object, render
-`Usage data unavailable` and keep the page navigable.
+If the usage provider is absent or cannot compute a snapshot from explicit
+inputs, render `Usage data unavailable` and keep the page navigable.
 
 ### StatsPage
 
@@ -243,13 +277,17 @@ session totals and explicitly state that historical stats are unavailable.
 
 Opening `/settings`:
 
-1. `NativeSurfaceManager.handle_text("/settings")` calls `_open_settings()`.
-2. `_open_settings()` builds `SettingsPageView` with:
+1. `NativeSurfaceManager.handle_text("/settings")` awaits `_open_settings()`.
+2. `_open_settings()` loads the model-choice snapshot with existing async model
+   helpers. Failures become a Model page unavailable state.
+3. `_open_settings()` builds `SettingsPageView` with:
    - `CodingTuiStatusProvider`;
    - the current session;
-   - a model-choice snapshot when it can be loaded without blocking render;
+   - the model-choice snapshot or unavailable state;
+   - a read-only status snapshot provider;
+   - an optional usage snapshot provider;
    - optional `SessionSettingsController` or `SettingsManager` accessors.
-3. `NativeSurfaceView` hosts the page with `purpose="settings"`.
+4. `NativeSurfaceView` hosts the page with `purpose="settings"`.
 
 Changing a setting:
 
@@ -259,26 +297,35 @@ Changing a setting:
 3. The page returns `InputIntent(kind="setting", text=row.id, note=new_value)`.
 4. `NativeSurfaceManager._normalize_surface_intent()` keeps producing a
    settings submit event.
-5. `_handle_settings_submit()` routes the payload to the relevant adapter, or
-   to model selection when `id == "model.current"`.
-6. The surface remains open, the row value refreshes, and the app status line
-   shows a concise result.
-
-The current manager closes the settings surface after submit. The integration
-should adjust this for the new page only: Config toggles should keep the page
-open so users can change multiple settings. Legacy `SettingsSurface` behavior
-can remain close-on-submit.
+5. `_handle_settings_submit()` checks the current surface content.
+6. If the content is `SettingsPageView`, the manager calls
+   `await page.apply_setting(id, value)`, keeps the surface open, refreshes
+   app status/statusline/model label from the result, and does not duplicate
+   adapter logic.
+7. If the content is legacy `SettingsSurface`, the manager preserves existing
+   close-on-submit behavior.
 
 Changing the model:
 
 1. `ModelPage` activates the current enabled model row.
 2. The page returns `InputIntent(kind="setting", text="model.current",
    note=<choice>)`.
-3. `NativeSurfaceManager._handle_settings_submit()` routes that payload to
-   `select_available_model()`, matching the existing `/model` selector
-   behavior.
-4. The page remains open, the current model marker refreshes, and the app
+3. `NativeSurfaceManager._handle_settings_submit()` delegates to
+   `SettingsPageView.apply_setting("model.current", choice)`.
+4. The page method calls `select_available_model()`, matching the existing
+   `/model` selector behavior.
+5. The page remains open, the current model marker refreshes, and the app
    status/model label updates.
+
+`SettingsPageView.apply_setting()` should return a small result object or
+equivalent tuple containing:
+
+- user-facing status message;
+- optional status line visibility;
+- whether the app model label should be refreshed;
+- whether the page rows were refreshed successfully.
+
+Adapter write failures return a recoverable message and keep the page open.
 
 ## Visual And Focus States
 
@@ -326,7 +373,11 @@ Add unit tests for the new product page content:
 - selecting an enabled model emits the expected model action;
 - read-only/disabled rows are visible but skipped by navigation;
 - Stats renders nested level-1 tabs;
-- tiny render heights do not crash.
+- tiny render heights do not crash;
+- `SettingsPageView.apply_setting()` keeps the page open, refreshes rows, and
+  returns a status result for successful Config changes.
+- `SettingsPageView.apply_setting("model.current", value)` calls the model
+  selection path without requiring a new `InputIntentKind`.
 
 Add native playback tests for the real `/settings` command:
 
@@ -339,6 +390,23 @@ Add native playback tests for the real `/settings` command:
 - Model appears as a top-level tab and shows the current model;
 - Stats page exposes `Overview / Model Usage` nested tabs;
 - `q` or Esc exits the page.
+
+Add manager/host tests:
+
+- `_open_settings()` is async and `handle_text("/settings")` awaits it.
+- `_normalize_surface_intent()` still maps
+  `InputIntent(kind="setting", text="model.current", note=value)` through the
+  settings submit path.
+- `_handle_settings_submit()` delegates to `SettingsPageView.apply_setting()`
+  and keeps the surface open for the new page.
+- `_handle_settings_submit()` preserves legacy `SettingsSurface`
+  close-on-submit behavior.
+- `NativeSurfaceView.editor_input_target()` delegates to hosted content.
+- `NativeSurfaceView.render()` offsets and preserves non-`InfoPanel` content
+  cursors.
+- No new `InputIntentKind` is added for model selection.
+- The standalone `/model` command and `ModelSelectorSurface` behavior remain
+  covered by existing tests or a focused regression.
 
 Keep existing `SettingsSurface` tests. Add one explicit test proving the legacy
 surface remains importable and still renders searchable settings.
@@ -360,11 +428,7 @@ the slice.
 
 ## Open Decisions
 
-1. Whether Config toggles should keep the page open for all settings or only
-   for the new `SettingsPageView`.
-2. Which `SettingsManager` fields are safe enough to expose as writable in the
+1. Which `SettingsManager` fields are safe enough to expose as writable in the
    first implementation plan.
-3. Whether Model selection inside `/settings` should close the page after
-   success or keep the page open like Config toggles.
-4. Whether `/settings` should be renamed in UI copy to `Config` while keeping
+2. Whether `/settings` should be renamed in UI copy to `Config` while keeping
    the slash command unchanged.

--- a/docs/superpowers/specs/2026-06-13-tui-real-settings-page-integration-design.md
+++ b/docs/superpowers/specs/2026-06-13-tui-real-settings-page-integration-design.md
@@ -1,0 +1,370 @@
+# TUI Real Settings Page Integration Design
+
+## Status
+
+Ready for user review.
+
+## Context
+
+`TabGroup` and `SearchableList` now provide the widget foundation for
+settings-style pages:
+
+- top-level and nested tab headers;
+- persistent selected page content;
+- search input plus filtered long-list viewport;
+- focus transitions between tabs, search, and list content;
+- level-aware tab theme states;
+- structured selection results.
+
+The current product `/settings` path still opens `SettingsSurface` through
+`NativeSurfaceManager._open_settings()`. That path is useful but narrow:
+
+- `SettingsSurface` is an overlay/surface, not ordinary tab page content.
+- `CodingTuiStatusProvider.settings_list()` currently exposes only
+  `Status line`.
+- Submitted settings are handled by toggling a `SettingsList` item and applying
+  it back to the status provider.
+
+The next step is to connect the new widget capabilities to a real product
+surface without replacing every settings and stats data source in one change.
+
+## Goals
+
+- Upgrade the real `/settings` native TUI path to a tabbed control-center page.
+- Use `TabGroup` for the top-level `Status / Config / Model / Usage / Stats`
+  sections.
+- Use `SearchableList` for the Config page, including long-list viewport
+  support.
+- Use a nested `TabGroup(level=1)` under Stats for `Overview / Model Usage`.
+- Preserve the existing `/settings` command and native surface intent flow.
+- Keep the legacy `SettingsSurface` available for compatibility and tests.
+- Reuse existing `SettingItem` / `SettingsList` where they are sufficient.
+- Add a small adapter layer for product settings rows instead of inventing a
+  second settings schema.
+- Connect only low-risk real settings in the first integration slice.
+- Render Usage and Stats from available real session/context data where
+  possible, with explicit unavailable states where data does not exist.
+- Add playback coverage for the real `/settings` path.
+
+## Non-Goals
+
+- Do not delete `SettingsSurface`.
+- Do not expose every `SettingsManager` field as a writable UI setting in the
+  first slice.
+- Do not add long-term historical usage storage.
+- Do not fake contribution heatmaps, token history, or model-usage percentages
+  when the real data source is absent.
+- Do not make the first slice depend on mouse support.
+- Do not add a new global focus manager.
+- Do not change the public contracts of `TabGroup` or `SearchableList` unless a
+  real integration bug proves the contract insufficient.
+- Do not copy another product's exact visual styling, colors, labels, or field
+  set.
+- Do not rewrite model registry, provider configuration, or model metadata
+  management in this slice.
+
+## Proposed Architecture
+
+Add a product-level native surface content object, tentatively named
+`SettingsPageView`, under `src/loushang/coding/ui/`.
+
+`SettingsPageView` is not a new generic widget. It composes existing generic
+widgets into the coding product page:
+
+- owns the top-level `TabGroup`;
+- owns page-specific adapters;
+- delegates render and input to selected page content;
+- returns `InputIntent(kind="setting", text=<id>, note=<value>)` when a setting
+  changes;
+- returns `InputIntent(kind="setting", text="model.current", note=<choice>)`
+  when the Model page selects a model;
+- returns `InputIntent(kind="surface_close")` for close keys;
+- exposes an `editor_input_target()` so text input reaches the focused
+  `SearchableList` search box.
+
+`NativeSurfaceManager._open_settings()` should instantiate this view and keep
+using `NativeSurfaceView(purpose="settings")`. That preserves the existing
+surface lifecycle and `_normalize_surface_intent()` handling.
+
+The initial page structure:
+
+```text
+Status   Config   Model   Usage   Stats
+
+Config page:
+  Search settings...
+  Setting                                    Value
+  Status line                                true
+  Auto compaction                            true
+  Provider retry                             true
+  Terminal progress                          false
+  ...
+
+Model page:
+  Search models...
+  Model                                      Status
+  kimi-for-coding                            current
+  kimi-k2.5
+  Haiku 4.5
+
+Stats page:
+  Overview   Model Usage
+  <read-only usage summary>
+```
+
+## Components
+
+### SettingsPageView
+
+Responsibilities:
+
+- Build the top-level `TabGroup`.
+- Keep focus stable across tab switches.
+- Render a simple separator between tab headers and page content.
+- Render a focus-aware footer.
+- Hide the hardware cursor unless the selected content declares a real text
+  input cursor.
+- Translate Config page selection results into `InputIntent(kind="setting")`.
+- Avoid closing the surface after a boolean toggle unless future user testing
+  shows close-on-change is preferred.
+
+The view should use the same focus rules proven by
+`examples/tui/52_widgets_tabgroup_searchable_list.py`:
+
+- Down from top-level tab header enters the selected page.
+- Up from Config search returns to top-level tabs.
+- Down from Config search enters the list.
+- Up from the first Config list item returns to search.
+- Left/right move only the focused tab header.
+- Nested Stats tabs use their own level-1 focus and colors.
+
+### ConfigSettingsPage
+
+Responsibilities:
+
+- Own one `SearchableList`.
+- Render a header row and a separator above list rows.
+- Support long lists through the existing `SearchableList` viewport.
+- Keep active row stable when a value changes.
+- Return structured setting-change events.
+
+Config rows should be produced from adapters:
+
+- `StatusSettingsAdapter` wraps `CodingTuiStatusProvider.settings_list()` for
+  the existing `Status line` setting.
+- `ControlSettingsAdapter` exposes a small allowlist of low-risk
+  `SettingsManager` fields.
+
+The first allowlist should prefer simple booleans and enum-like values with
+existing getters/setters:
+
+- status line visibility, through `CodingTuiStatusProvider`;
+- auto compaction, through `SessionSettingsController` if available;
+- auto retry, through `SessionSettingsController` if available;
+- terminal progress, through `SettingsManager.get_terminal_settings()` and
+  `update_settings()`;
+- theme, read-only or cycle-through only if the existing accepted values are
+  explicit.
+
+Rows without a safe write path must be read-only or disabled. Disabled rows stay
+visible in filtering but are skipped by navigation, matching
+`SearchableList`.
+
+### ModelPage
+
+The Model page should become a first-level tab because model selection is a
+primary coding workflow, not a secondary Config row.
+
+Responsibilities:
+
+- Show the current model clearly in the first viewport.
+- Reuse the same data sources as the existing `/model` selector:
+  `available_model_choices()`, `current_model_choice_value()`,
+  `iter_scoped_model_selections()`, and model detail descriptions where
+  available.
+- Render model choices through `SearchableList` so search, long-list scrolling,
+  active-row repair, and disabled-row behavior match Config.
+- Selecting an enabled model should return
+  `InputIntent(kind="setting", text="model.current", note=<choice>)` so the
+  existing settings surface event path can route it without adding a new
+  `InputIntentKind`.
+- Keep the settings page open after selection and refresh the status/model
+  label.
+
+If model choices cannot be loaded, render a read-only unavailable state and
+keep `/model` as the fallback path.
+
+### StatusPage
+
+The Status page should be read-only in the first slice. It should show compact
+runtime facts that already exist:
+
+- current model label;
+- current cwd and branch from the status provider snapshot inputs when
+  available;
+- session label;
+- thinking level;
+- running/idle state;
+- status line visibility.
+
+If a value is unavailable, render a short `Unavailable` value instead of
+guessing.
+
+### UsagePage
+
+The Usage page should be read-only in the first slice. It should render current
+context usage using `current_context_usage()` or the same snapshot data already
+available to session status logic.
+
+Minimum useful rows:
+
+- current context tokens;
+- context window;
+- percent used;
+- compaction threshold if available;
+- source, such as estimated or assistant usage.
+
+If usage cannot be computed from the current session object, render
+`Usage data unavailable` and keep the page navigable.
+
+### StatsPage
+
+Stats should use a nested `TabGroup(level=1)`:
+
+- `Overview`: compact read-only session/context summary.
+- `Model Usage`: model-related usage summary, clearly distinct from the
+  top-level Model selection page.
+
+The first slice should not render fake historical charts. If the repository
+does not yet have durable usage aggregation, Overview can render current
+session totals and explicitly state that historical stats are unavailable.
+
+## Data Flow
+
+Opening `/settings`:
+
+1. `NativeSurfaceManager.handle_text("/settings")` calls `_open_settings()`.
+2. `_open_settings()` builds `SettingsPageView` with:
+   - `CodingTuiStatusProvider`;
+   - the current session;
+   - a model-choice snapshot when it can be loaded without blocking render;
+   - optional `SessionSettingsController` or `SettingsManager` accessors.
+3. `NativeSurfaceView` hosts the page with `purpose="settings"`.
+
+Changing a setting:
+
+1. `ConfigSettingsPage` activates the current enabled row.
+2. Boolean rows toggle in place. Enum rows cycle only when the allowed values
+   are explicit.
+3. The page returns `InputIntent(kind="setting", text=row.id, note=new_value)`.
+4. `NativeSurfaceManager._normalize_surface_intent()` keeps producing a
+   settings submit event.
+5. `_handle_settings_submit()` routes the payload to the relevant adapter, or
+   to model selection when `id == "model.current"`.
+6. The surface remains open, the row value refreshes, and the app status line
+   shows a concise result.
+
+The current manager closes the settings surface after submit. The integration
+should adjust this for the new page only: Config toggles should keep the page
+open so users can change multiple settings. Legacy `SettingsSurface` behavior
+can remain close-on-submit.
+
+Changing the model:
+
+1. `ModelPage` activates the current enabled model row.
+2. The page returns `InputIntent(kind="setting", text="model.current",
+   note=<choice>)`.
+3. `NativeSurfaceManager._handle_settings_submit()` routes that payload to
+   `select_available_model()`, matching the existing `/model` selector
+   behavior.
+4. The page remains open, the current model marker refreshes, and the app
+   status/model label updates.
+
+## Visual And Focus States
+
+The real page should use semantic theme tokens rather than hardcoded product
+colors:
+
+- unselected tab;
+- selected tab with focus inside page content;
+- selected tab with focus on the tab header;
+- level-1 selected tab with content focus;
+- level-1 selected tab with header focus;
+- search box focus;
+- active Config row;
+- disabled Config row;
+- overflow hint.
+
+The level-aware resolver must keep the existing `widget.tabs.tab` fallback for
+normal tab styling, preserving theme compatibility.
+
+The first selected top-level tab must visibly appear selected even when there
+is no left arrow or preceding tab. Focus markers and selected styling should
+not disagree.
+
+## Error Handling
+
+- Adapter write failures should keep the settings page open and set a status
+  message with the recoverable error text.
+- Unknown row ids should be ignored with a recoverable status message.
+- Missing `SettingsManager` or session usage data should degrade to read-only
+  or unavailable rows.
+- A failed value refresh should not clear the user's search query.
+- The page must not crash when the terminal height is too small; it should clip
+  body rows and keep footer rendering best-effort.
+
+## Testing
+
+Add unit tests for the new product page content:
+
+- builds top-level `Status / Config / Model / Usage / Stats` pages;
+- Config search filters rows;
+- long Config lists scroll;
+- Up/Down transitions between tabs, search, and list;
+- toggling a boolean row updates the value and preserves active row;
+- Model search filters model rows;
+- selecting an enabled model emits the expected model action;
+- read-only/disabled rows are visible but skipped by navigation;
+- Stats renders nested level-1 tabs;
+- tiny render heights do not crash.
+
+Add native playback tests for the real `/settings` command:
+
+- `/settings` opens the tabbed page instead of the legacy single settings list;
+- typing filters Config rows;
+- Up from search moves focus to top-level tabs without a stale cursor artifact;
+- Down from search enters the list;
+- Space or Enter toggles a boolean setting and keeps the page open;
+- left/right on focused tabs switches top-level pages;
+- Model appears as a top-level tab and shows the current model;
+- Stats page exposes `Overview / Model Usage` nested tabs;
+- `q` or Esc exits the page.
+
+Keep existing `SettingsSurface` tests. Add one explicit test proving the legacy
+surface remains importable and still renders searchable settings.
+
+## Migration Plan
+
+1. Land this spec as the temporary execution record.
+2. Write an implementation plan from this spec.
+3. Add `SettingsPageView` and adapters behind the existing `/settings` path.
+4. Add focused tests and playback scenarios.
+5. Update durable internal architecture docs after the implementation settles.
+
+Long-term documentation should live under:
+
+`docs/internals/architecture/tui/native-terminal-core/`
+
+This spec stays under `docs/superpowers/specs/` as the development record for
+the slice.
+
+## Open Decisions
+
+1. Whether Config toggles should keep the page open for all settings or only
+   for the new `SettingsPageView`.
+2. Which `SettingsManager` fields are safe enough to expose as writable in the
+   first implementation plan.
+3. Whether Model selection inside `/settings` should close the page after
+   success or keep the page open like Config toggles.
+4. Whether `/settings` should be renamed in UI copy to `Config` while keeping
+   the slash command unchanged.

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -37,6 +37,7 @@ from loushang.coding.ui.model_list import (
     select_available_model,
 )
 from loushang.coding.ui.native_app import NativeCodingTuiApp
+from loushang.coding.ui.settings_page import SettingsPageView
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider
 from loushang.runtime.commands import CommandDef, CommandKind
 from loushang.tui import (
@@ -438,7 +439,7 @@ class NativeSurfaceManager:
         elif command.name == "hotkeys" and isinstance(intent, HotkeysIntent):
             self._open_info("Hotkeys", format_hotkeys())
         elif command.name == "settings" and isinstance(intent, SettingsIntent):
-            self._open_settings()
+            await self._open_settings()
         elif command.name == "statusline" and isinstance(intent, StatuslineIntent):
             setter = self.set_statusline_visible or self.status_provider.set_visible
             message = setter(intent.enabled)
@@ -525,6 +526,18 @@ class NativeSurfaceManager:
         self.close_surface()
 
     async def _handle_settings_submit(self, payload: dict[str, str]) -> None:
+        surface = self._current_surface()
+        page = surface.content if isinstance(surface, NativeSurfaceView) else None
+        apply_setting = getattr(page, "apply_setting", None)
+        if callable(apply_setting):
+            result = await apply_setting(payload["id"], payload.get("value", ""))
+            if result.statusline_visible is not None:
+                self.app.set_statusline_visible(result.statusline_visible)
+            if result.refresh_model_label:
+                await self._refresh_model_label()
+            self.app.set_status(result.message)
+            return
+
         updated = self.status_provider.settings_list().toggle(payload["id"])
         self.close_surface()
         message = self.status_provider.apply_settings(updated)
@@ -623,8 +636,13 @@ class NativeSurfaceManager:
         text = provider() if provider is not None else "Terminal diagnostics are not available outside an active TUI session."
         self._open_info("Terminal", text)
 
-    def _open_settings(self) -> None:
-        surface = SettingsSurface(list(self.status_provider.settings_list().items), max_visible=8, enable_search=True)
+    async def _open_settings(self) -> None:
+        surface = await SettingsPageView.create(
+            session=self.session,
+            status_provider=self.status_provider,
+            settings_manager=getattr(self.session, "settings_manager", None),
+            session_settings=getattr(self.session, "settings_controller", None),
+        )
         self._open_surface(
             NativeSurfaceView(
                 title="Settings",

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -93,18 +93,24 @@ class NativeSurfaceView(FocusableMixin):
     def exclusive_bottom(self) -> bool:
         return self.presentation == "bottom-exclusive"
 
+    def editor_input_target(self) -> object | None:
+        target = getattr(self.content, "editor_input_target", None)
+        return target() if callable(target) else None
+
     def handle_input(self, event: InputEvent) -> InputIntent | None:
-        if event.kind == "key" and event.key in {"escape", "esc"}:
-            return InputIntent(kind="surface_close")
         if self.purpose == "info":
-            if event.kind == "key" and event.key in {"enter", "space"}:
+            if event.kind == "key" and event.key in {"enter", "space", "escape", "esc"}:
                 return InputIntent(kind="surface_close")
             if event.kind == "key":
                 return self._handle_info_scroll_input(event.key)
             return None
         handler = getattr(self.content, "handle_input", None)
         if callable(handler):
-            return _native_input_intent_or_none(handler(self._translate_content_input_event(event)))
+            intent = _native_input_intent_or_none(handler(self._translate_content_input_event(event)))
+            if intent is not None:
+                return intent
+        if event.kind == "key" and event.key in {"escape", "esc"}:
+            return InputIntent(kind="surface_close")
         return None
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
@@ -136,6 +142,10 @@ class NativeSurfaceView(FocusableMixin):
             self._last_content_start_row = len(lines)
             result = self.content.render(body_constraints)
             lines.extend(line.text for line in result.lines)
+            if result.cursor is not None:
+                cursor_row = self._last_content_start_row + result.cursor.row
+                if cursor_row < constraints.max_height:
+                    cursor = CursorDeclaration(row=cursor_row, column=result.cursor.column)
         footer = self._footer_text()
         if footer and len(lines) < constraints.max_height:
             if len(lines) + 1 < constraints.max_height:

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -59,7 +59,6 @@ from loushang.tui import (
     apply_theme_style,
 )
 from loushang.tui.cell_width import truncate_to_width, wrap_cells
-from loushang.tui.surfaces import SettingsSurface
 
 NativeSurfacePurpose = Literal["info", "model", "command", "settings", "dialog", "approval"]
 NativeSurfacePresentation = Literal["bottom", "bottom-exclusive"]

--- a/src/loushang/coding/ui/settings_page.py
+++ b/src/loushang/coding/ui/settings_page.py
@@ -1,0 +1,527 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from loushang.coding.ui.model_list import (
+    ModelChoice,
+    available_model_choices,
+    current_model_choice_value,
+    select_available_model,
+)
+from loushang.coding.ui.status_provider import CodingTuiStatusProvider, StatusSnapshot
+from loushang.tui import (
+    CursorDeclaration,
+    InputEvent,
+    InputIntent,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    SearchableList,
+    SearchableListItem,
+    SearchableListSelect,
+    TabGroup,
+    TabPage,
+    truncate_to_width,
+)
+
+__all__ = [
+    "ConfigRow",
+    "ConfigSettingsPage",
+    "ModelPage",
+    "SettingsApplyResult",
+    "SettingsPageView",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class SettingsApplyResult:
+    message: str
+    statusline_visible: bool | None = None
+    refresh_model_label: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigRow:
+    id: str
+    label: str
+    value: str
+    description: str = ""
+    disabled: bool = False
+
+
+@dataclass(slots=True)
+class StaticLinesPage:
+    lines: tuple[str, ...]
+    focused: bool = False
+
+    def focus(self) -> None:
+        self.focused = True
+
+    def blur(self) -> None:
+        self.focused = False
+
+    def handle_input(self, event: object) -> object:
+        if getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"left", "right", "home", "end"}:
+            return True
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        rows = [
+            RenderLine(truncate_to_width(line, max_width=constraints.width, ellipsis=""))
+            for line in self.lines[: constraints.max_height]
+        ]
+        return RenderResult.from_lines(rows, constraints=constraints)
+
+
+@dataclass(slots=True)
+class ConfigSettingsPage:
+    rows: tuple[ConfigRow, ...]
+    focused: bool = False
+    settings: SearchableList = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.settings = self._make_list(focused=False)
+
+    def focus(self) -> None:
+        self.focused = True
+        self.settings.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.settings.blur()
+
+    def editor_input_target(self) -> object | None:
+        return self.settings.editor_input_target()
+
+    def set_rows(self, rows: tuple[ConfigRow, ...], *, preserve_active_key: str = "") -> None:
+        self.rows = rows
+        self.settings.set_items(_config_items(rows), preserve_active_key=preserve_active_key)
+
+    def handle_input(self, event: object) -> object:
+        result = self.settings.handle_input(event)
+        if isinstance(result, SearchableListSelect):
+            return self._setting_intent(result.key)
+        if result is not None:
+            return result
+        if self.settings.focus_region == "list" and _is_space_event(event):
+            item = self.settings.active_item
+            if item is not None:
+                return self._setting_intent(item.key)
+        if _is_tab_fallback_key(event):
+            return True
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        if constraints.max_height <= 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        if constraints.max_height <= 2:
+            return self.settings.render(constraints)
+        result = self.settings.render(
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2))
+        )
+        header = RenderLine(_settings_header(constraints.width))
+        rows = [result.lines[0], RenderLine(_separator(constraints.width)), header, *result.lines[1:]]
+        cursor = result.cursor
+        if cursor is not None and cursor.row > 0:
+            cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
+
+    def _make_list(self, *, focused: bool) -> SearchableList:
+        return SearchableList(
+            _config_items(self.rows),
+            placeholder="Search settings...",
+            empty_text="No matching settings",
+            focused=focused,
+        )
+
+    def _setting_intent(self, key: str) -> InputIntent | None:
+        row = _row_for_key(self.rows, key)
+        if row is None or row.disabled:
+            return None
+        value = _next_value(row.value)
+        return InputIntent(kind="setting", text=row.id, note=value)
+
+
+@dataclass(slots=True)
+class ModelPage:
+    choices: tuple[ModelChoice, ...]
+    current_value: str | None = None
+    error: str = ""
+    focused: bool = False
+    models: SearchableList = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.models = self._make_list(focused=False)
+
+    @property
+    def unavailable(self) -> bool:
+        return bool(self.error) or not self.choices
+
+    def focus(self) -> None:
+        self.focused = True
+        self.models.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.models.blur()
+
+    def editor_input_target(self) -> object | None:
+        if self.unavailable:
+            return None
+        return self.models.editor_input_target()
+
+    def set_choices(self, choices: tuple[ModelChoice, ...], *, current_value: str | None, error: str = "") -> None:
+        self.choices = choices
+        self.current_value = current_value
+        self.error = error
+        self.models.set_items(_model_items(choices, current_value=current_value), preserve_active_key=current_value or "")
+
+    def handle_input(self, event: object) -> object:
+        if self.unavailable:
+            return True if _is_tab_fallback_key(event) else None
+        result = self.models.handle_input(event)
+        if isinstance(result, SearchableListSelect):
+            return InputIntent(kind="setting", text="model.current", note=result.key)
+        if result is not None:
+            return result
+        if self.models.focus_region == "list" and _is_space_event(event):
+            item = self.models.active_item
+            if item is not None:
+                return InputIntent(kind="setting", text="model.current", note=item.key)
+        if _is_tab_fallback_key(event):
+            return True
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        if self.unavailable:
+            lines = ("Model selection unavailable", self.error or "No models available.")
+            return StaticLinesPage(lines).render(constraints)
+        return self.models.render(constraints)
+
+    def _make_list(self, *, focused: bool) -> SearchableList:
+        return SearchableList(
+            _model_items(self.choices, current_value=self.current_value),
+            placeholder="Search models...",
+            empty_text="No matching models",
+            focused=focused,
+        )
+
+
+@dataclass(slots=True)
+class SettingsPageView:
+    session: Any
+    status_provider: CodingTuiStatusProvider
+    settings_manager: object | None = None
+    usage_provider: Callable[[], object | None] | None = None
+    status_page: StaticLinesPage = field(init=False)
+    config_page: ConfigSettingsPage = field(init=False)
+    model_page: ModelPage = field(init=False)
+    usage_page: StaticLinesPage = field(init=False)
+    stats_page: TabGroup = field(init=False)
+    tabs: TabGroup = field(init=False)
+    focused: bool = field(default=False, init=False)
+
+    @classmethod
+    async def create(
+        cls,
+        *,
+        session: Any,
+        status_provider: CodingTuiStatusProvider,
+        usage_provider: Callable[[], object | None] | None = None,
+        settings_manager: object | None = None,
+        session_settings: object | None = None,
+    ) -> SettingsPageView:
+        del session_settings
+        view = cls(
+            session=session,
+            status_provider=status_provider,
+            settings_manager=settings_manager,
+            usage_provider=usage_provider,
+        )
+        await view._build()
+        view.focus()
+        return view
+
+    async def apply_setting(self, item_id: str, value: str) -> SettingsApplyResult:
+        if item_id == "statusline":
+            enabled = _as_bool(value)
+            if enabled is None:
+                return SettingsApplyResult("Invalid status line value.")
+            settings = self.status_provider.settings_list().set_enabled("statusline", enabled)
+            message = self.status_provider.apply_settings(settings)
+            self._refresh_status_page()
+            self._refresh_config_rows(preserve_active_key="statusline")
+            return SettingsApplyResult(message, statusline_visible=self.status_provider.is_visible())
+        if item_id == "model.current":
+            message = await select_available_model(self.session, query=value)
+            await self._refresh_model_page()
+            self._refresh_status_page()
+            return SettingsApplyResult(message, refresh_model_label=True)
+        return SettingsApplyResult(f"Unknown setting: {item_id}")
+
+    def focus(self) -> None:
+        self.focused = True
+        self.tabs.focus_content()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.tabs.blur()
+
+    def editor_input_target(self) -> object | None:
+        return self.tabs.editor_input_target()
+
+    def handle_input(self, event: InputEvent) -> object:
+        result = self.tabs.handle_input(event)
+        if result is not None:
+            return result
+        if _is_escape_event(event):
+            return InputIntent(kind="surface_close")
+        if _is_q_event(event) and self._focus_context() in {"tabs", "page", "settings-list", "model-list"}:
+            return InputIntent(kind="surface_close")
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        if constraints.max_height <= 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        body_height = max(1, constraints.max_height - 1)
+        result = self.tabs.render(RenderConstraints(width=constraints.width, max_height=body_height))
+        rows = _with_separator(result.lines, width=constraints.width)
+        cursor = _offset_cursor_after_separator(result.cursor)
+        footer = _footer_text(self._focus_context(), width=constraints.width)
+        if len(rows) < constraints.max_height:
+            rows.append(RenderLine(footer))
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
+
+    async def _build(self) -> None:
+        self.status_page = StaticLinesPage(_status_lines(self.status_provider.snapshot()))
+        self.config_page = ConfigSettingsPage(_config_rows(self.status_provider, self.settings_manager))
+        choices, current_value, error = await _load_model_choices(self.session)
+        self.model_page = ModelPage(choices, current_value=current_value, error=error)
+        self.usage_page = StaticLinesPage(_usage_lines(self.usage_provider))
+        self.stats_page = TabGroup(
+            (
+                TabPage("overview", "Overview", StaticLinesPage(_stats_overview_lines(self.status_provider.snapshot()))),
+                TabPage("model-usage", "Model Usage", StaticLinesPage(_model_usage_lines(current_value))),
+            ),
+            value="overview",
+            level=1,
+        )
+        self.tabs = TabGroup(
+            (
+                TabPage("status", "Status", self.status_page),
+                TabPage("config", "Config", self.config_page),
+                TabPage("model", "Model", self.model_page),
+                TabPage("usage", "Usage", self.usage_page),
+                TabPage("stats", "Stats", self.stats_page),
+            ),
+            value="config",
+        )
+
+    def _refresh_status_page(self) -> None:
+        self.status_page.lines = _status_lines(self.status_provider.snapshot())
+
+    def _refresh_config_rows(self, *, preserve_active_key: str = "") -> None:
+        self.config_page.set_rows(_config_rows(self.status_provider, self.settings_manager), preserve_active_key=preserve_active_key)
+
+    async def _refresh_model_page(self) -> None:
+        choices, current_value, error = await _load_model_choices(self.session)
+        self.model_page.set_choices(choices, current_value=current_value, error=error)
+        selected = self.stats_page.selected_page
+        if selected is not None and isinstance(selected.content, StaticLinesPage):
+            selected.content.lines = _model_usage_lines(current_value)
+
+    def _focus_context(self) -> str:
+        if self.tabs.header_focused:
+            return "tabs"
+        page = self.tabs.selected_page
+        content = page.content if page is not None else None
+        if isinstance(content, ConfigSettingsPage):
+            return "search" if content.settings.focus_region == "search" else "settings-list"
+        if isinstance(content, ModelPage):
+            return "search" if content.models.focus_region == "search" else "model-list"
+        if isinstance(content, TabGroup):
+            return "tabs" if content.header_focused else "page"
+        return "page"
+
+
+async def _load_model_choices(session: Any) -> tuple[tuple[ModelChoice, ...], str | None, str]:
+    try:
+        choices = await available_model_choices(session)
+        current_value = await current_model_choice_value(session, choices=choices)
+    except Exception as error:
+        return (), None, str(error)
+    return tuple(choices), current_value, ""
+
+
+def _config_rows(status_provider: CodingTuiStatusProvider, settings_manager: object | None) -> tuple[ConfigRow, ...]:
+    rows = [
+        ConfigRow("statusline", "Status line", _bool_text(status_provider.is_visible())),
+    ]
+    if settings_manager is not None:
+        terminal_progress = getattr(settings_manager, "get_show_terminal_progress", None)
+        if callable(terminal_progress):
+            rows.append(ConfigRow("terminal.progress", "Terminal progress", _bool_text(bool(terminal_progress()))))
+    rows.append(ConfigRow("model.current", "Current model", "Use Model tab", disabled=True))
+    return tuple(rows)
+
+
+def _config_items(rows: tuple[ConfigRow, ...]) -> tuple[SearchableListItem, ...]:
+    return tuple(
+        SearchableListItem(row.id, row.label, row.value, row.description, disabled=row.disabled)
+        for row in rows
+    )
+
+
+def _model_items(choices: tuple[ModelChoice, ...], *, current_value: str | None) -> tuple[SearchableListItem, ...]:
+    return tuple(
+        SearchableListItem(
+            choice.value,
+            choice.label,
+            "current" if choice.value == current_value else "",
+            choice.description,
+        )
+        for choice in choices
+    )
+
+
+def _row_for_key(rows: tuple[ConfigRow, ...], key: str) -> ConfigRow | None:
+    for row in rows:
+        if row.id == key:
+            return row
+    return None
+
+
+def _status_lines(snapshot: StatusSnapshot) -> tuple[str, ...]:
+    return (
+        "Status",
+        "",
+        f"Model              {snapshot.model_label or 'Unavailable'}",
+        f"Workspace          {snapshot.cwd}",
+        f"Branch             {snapshot.branch or 'Unavailable'}",
+        f"Session            {snapshot.session_label or 'Unavailable'}",
+        f"Thinking           {snapshot.thinking_level or 'Unavailable'}",
+        f"Runtime            {'running' if snapshot.running else 'idle'}",
+        f"Status line        {_bool_text(snapshot.statusline_visible)}",
+    )
+
+
+def _usage_lines(provider: Callable[[], object | None] | None) -> tuple[str, ...]:
+    if provider is None:
+        return ("Usage", "", "Usage data unavailable")
+    try:
+        snapshot = provider()
+    except Exception:
+        snapshot = None
+    if snapshot is None:
+        return ("Usage", "", "Usage data unavailable")
+    return (
+        "Usage",
+        "",
+        f"Current context    {getattr(snapshot, 'tokens', 'Unavailable')}",
+        f"Context window     {getattr(snapshot, 'context_window', 'Unavailable')}",
+        f"Percent used       {getattr(snapshot, 'percent', 'Unavailable')}",
+        f"Source             {getattr(snapshot, 'source', 'Unavailable')}",
+    )
+
+
+def _stats_overview_lines(snapshot: StatusSnapshot) -> tuple[str, ...]:
+    return (
+        "Session Overview",
+        "",
+        f"Session            {snapshot.session_label or 'Unavailable'}",
+        f"Runtime            {'running' if snapshot.running else 'idle'}",
+        "Historical stats   Unavailable",
+    )
+
+
+def _model_usage_lines(current_value: str | None) -> tuple[str, ...]:
+    return (
+        "Model Usage",
+        "",
+        f"Current model      {current_value or 'Unavailable'}",
+        "Historical usage   Unavailable",
+    )
+
+
+def _settings_header(width: int) -> str:
+    return truncate_to_width("Setting                                    Value", max_width=width, ellipsis="")
+
+
+def _separator(width: int) -> str:
+    return "-" * max(1, width)
+
+
+def _with_separator(lines: tuple[RenderLine, ...], *, width: int) -> list[RenderLine]:
+    if not lines:
+        return []
+    return [lines[0], RenderLine(_separator(width)), *lines[1:]]
+
+
+def _offset_cursor_after_separator(cursor: CursorDeclaration | None) -> CursorDeclaration | None:
+    if cursor is None:
+        return None
+    if cursor.row == 0:
+        return cursor
+    return CursorDeclaration(row=cursor.row + 1, column=cursor.column)
+
+
+def _footer_text(focus_context: str, *, width: int) -> str:
+    if focus_context == "search":
+        text = "Search | type filter | Down list | Up tabs | Esc clear/close"
+    elif focus_context in {"settings-list", "model-list"}:
+        text = "List | Up/Down move | Enter select | Space toggle | q close"
+    elif focus_context == "tabs":
+        text = "Tabs | Left/Right switch | Down content | q close"
+    else:
+        text = "Page | Up tabs | q close"
+    return truncate_to_width(text, max_width=width, ellipsis="")
+
+
+def _bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _as_bool(value: str) -> bool | None:
+    normalized = value.casefold()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    return None
+
+
+def _next_value(value: str) -> str:
+    current = _as_bool(value)
+    if current is None:
+        return value
+    return _bool_text(not current)
+
+
+def _is_space_event(event: object) -> bool:
+    return (
+        getattr(event, "kind", "") == "key"
+        and getattr(event, "key", "") == "space"
+    ) or (
+        getattr(event, "kind", "") == "text"
+        and getattr(event, "text", "") == " "
+    )
+
+
+def _is_escape_event(event: object) -> bool:
+    return getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"escape", "esc"}
+
+
+def _is_q_event(event: object) -> bool:
+    return (
+        getattr(event, "kind", "") == "key"
+        and getattr(event, "key", "").casefold() == "q"
+    ) or (
+        getattr(event, "kind", "") == "text"
+        and getattr(event, "text", "").casefold() == "q"
+    )
+
+
+def _is_tab_fallback_key(event: object) -> bool:
+    return getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"left", "right", "home", "end"}

--- a/src/loushang/coding/ui/settings_page.py
+++ b/src/loushang/coding/ui/settings_page.py
@@ -254,6 +254,16 @@ class SettingsPageView:
             self._refresh_status_page()
             self._refresh_config_rows(preserve_active_key="statusline")
             return SettingsApplyResult(message, statusline_visible=self.status_provider.is_visible())
+        if item_id == "terminal.progress":
+            enabled = _as_bool(value)
+            if enabled is None:
+                return SettingsApplyResult("Invalid terminal progress value.")
+            setter = getattr(self.settings_manager, "set_show_terminal_progress", None)
+            if not callable(setter):
+                return SettingsApplyResult("Terminal progress is not available.")
+            setter(enabled)
+            self._refresh_config_rows(preserve_active_key="terminal.progress")
+            return SettingsApplyResult(f"Terminal progress: {'on' if enabled else 'off'}")
         if item_id == "model.current":
             message = await select_available_model(self.session, query=value)
             await self._refresh_model_page()

--- a/src/loushang/coding/ui/status_provider.py
+++ b/src/loushang/coding/ui/status_provider.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from loushang.coding.ui.toolbar import ToolbarSnapshot, render_toolbar
 from loushang.tui import SettingItem, SettingsList, SettingsListRenderer
+
+
+@dataclass(frozen=True, slots=True)
+class StatusSnapshot:
+    model_label: str | None
+    cwd: str
+    branch: str | None
+    session_label: str | None
+    thinking_level: str | None
+    running: bool
+    statusline_visible: bool
 
 
 class CodingTuiStatusProvider:
@@ -40,6 +52,17 @@ class CodingTuiStatusProvider:
     def is_visible(self) -> bool:
         return self._visible
 
+    def snapshot(self) -> StatusSnapshot:
+        return StatusSnapshot(
+            model_label=self._model_label,
+            cwd=self._cwd,
+            branch=self._branch,
+            session_label=self._session_label(),
+            thinking_level=self._thinking_level(),
+            running=self._running(),
+            statusline_visible=self._visible,
+        )
+
     def set_visible(self, visible: bool | None) -> str:
         if visible is not None:
             self._visible = visible
@@ -67,4 +90,4 @@ class CodingTuiStatusProvider:
         return "".join(fragment for _style, fragment in SettingsListRenderer(title="Settings").render(self.settings_list()))
 
 
-__all__ = ["CodingTuiStatusProvider"]
+__all__ = ["CodingTuiStatusProvider", "StatusSnapshot"]

--- a/tests/coding/test_native_coding_tui_playback.py
+++ b/tests/coding/test_native_coding_tui_playback.py
@@ -355,7 +355,7 @@ def test_native_tui_playback_command_surface_filters_and_selects_command() -> No
         step.assert_no_clear_scrollback()
 
 
-def test_native_tui_playback_settings_surface_toggles_statusline() -> None:
+def test_native_tui_playback_settings_page_toggles_statusline_and_exits() -> None:
     session = _Session()
     app = _app()
     playback = _NativeInteractivePlayback(
@@ -369,6 +369,7 @@ def test_native_tui_playback_settings_surface_toggles_statusline() -> None:
         [
             PlaybackEvent.input("/settings\r"),
             PlaybackEvent.input("\r"),
+            PlaybackEvent.input("\x1b"),
         ]
     )
 
@@ -383,7 +384,7 @@ def test_native_tui_playback_settings_surface_toggles_statusline() -> None:
         step.assert_no_clear_scrollback()
 
 
-def test_native_tui_playback_settings_surface_searches_when_opened_by_command() -> None:
+def test_native_tui_playback_settings_page_searches_when_opened_by_command() -> None:
     session = _Session()
     app = _app()
     playback = _NativeInteractivePlayback(
@@ -403,9 +404,62 @@ def test_native_tui_playback_settings_surface_searches_when_opened_by_command() 
     assert all(step.flush_succeeded for step in steps)
     lines = _plain_lines(steps[-1].diagnostics)
     assert "Settings" in lines
-    assert "Search: zz" in lines
-    assert "  No matching settings" in lines
+    assert "zz" in lines
+    assert "No matching settings" in lines
     assert app.state.statusline_visible is True
+    for step in steps:
+        step.assert_no_clear_scrollback()
+
+
+def test_native_tui_playback_settings_page_q_is_search_text() -> None:
+    session = _Session()
+    app = _app()
+    playback = _NativeInteractivePlayback(
+        app,
+        _manager(app, session),
+        columns=100,
+        rows=18,
+    )
+
+    steps = playback.play(
+        [
+            PlaybackEvent.input("/settings\r"),
+            PlaybackEvent.input("q"),
+        ]
+    )
+
+    assert all(step.flush_succeeded for step in steps)
+    assert app.active_surface is not None
+    lines = _plain_lines(steps[-1].diagnostics)
+    assert "q" in lines
+    assert "No matching settings" in lines
+    for step in steps:
+        step.assert_no_clear_scrollback()
+
+
+def test_native_tui_playback_settings_page_model_tab_is_available() -> None:
+    session = _Session()
+    app = _app()
+    playback = _NativeInteractivePlayback(
+        app,
+        _manager(app, session),
+        columns=100,
+        rows=18,
+    )
+
+    steps = playback.play(
+        [
+            PlaybackEvent.input("/settings\r"),
+            PlaybackEvent.input("\x1b[A"),
+            PlaybackEvent.input("\x1b[C"),
+            PlaybackEvent.input("\x1b[B"),
+        ]
+    )
+
+    assert all(step.flush_succeeded for step in steps)
+    lines = _plain_lines(steps[-1].diagnostics)
+    assert "Search models..." in lines
+    assert any("moonshot/kimi-for-coding" in line for line in lines)
     for step in steps:
         step.assert_no_clear_scrollback()
 

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -17,6 +17,7 @@ from loushang.tui import (
     RenderConstraints,
     RenderLine,
     RenderResult,
+    SettingsSurface,
     SurfaceHost,
 )
 from loushang.tui.cell_width import strip_control_sequences
@@ -370,9 +371,56 @@ def test_native_surface_manager_opens_settings_in_bottom_frame_with_runtime_over
 
     rendered = app.active_surface.render(RenderConstraints(width=100, max_height=10))
     plain = tuple(strip_control_sequences(line.text) for line in rendered.lines)
-    assert plain.count("  Enter/Space to change - Esc to cancel") == 1
+    assert any("Status" in line and "Config" in line and "Model" in line for line in plain)
+    assert any("Search settings" in line for line in plain)
+    assert any("Status line" in line for line in plain)
     assert "Enter/Space to change - Esc to close" not in plain
     assert "  show footer" not in plain
+
+
+def test_native_surface_manager_settings_page_submit_keeps_surface_open() -> None:
+    app = _app()
+    manager = _manager(app, _Session())
+
+    asyncio.run(manager.handle_text("/settings"))
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
+
+    assert intent == InputIntent(kind="setting", text="statusline", note="false")
+    asyncio.run(manager.handle_surface_intent(intent))
+
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    assert app.state.statusline_visible is False
+    assert app.state.status_message == "Status line: off"
+
+
+def test_native_surface_manager_legacy_settings_surface_still_closes_on_submit() -> None:
+    app = _app()
+    manager = _manager(app, _Session())
+    app.active_surface = NativeSurfaceView(
+        title="Settings",
+        purpose="settings",
+        content=SettingsSurface(list(manager.status_provider.settings_list().items), enable_search=True),
+        presentation="bottom-exclusive",
+    )
+
+    asyncio.run(manager.handle_surface_intent(InputIntent(kind="setting", text="statusline", note="false")))
+
+    assert app.active_surface is None
+    assert app.state.statusline_visible is False
+
+
+def test_native_surface_manager_settings_page_model_submit_uses_model_selection() -> None:
+    session = _Session()
+    app = _app()
+    manager = _manager(app, session)
+
+    asyncio.run(manager.handle_text("/settings"))
+    asyncio.run(manager.handle_surface_intent(InputIntent(kind="setting", text="model.current", note="openai/gpt-5.4")))
+
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    assert session.set_model_calls
+    assert app.state.model_label == "openai/gpt-5.4"
 
 
 def test_native_surface_manager_runtime_overlay_escape_and_close_are_idempotent() -> None:
@@ -761,7 +809,7 @@ def test_native_surface_manager_opens_status_info_and_closes_with_escape() -> No
     assert app.active_surface is None
 
 
-def test_native_surface_manager_applies_settings_surface() -> None:
+def test_native_surface_manager_applies_settings_page_statusline_change() -> None:
     app = _app()
     manager = _manager(app, _Session())
 
@@ -769,11 +817,11 @@ def test_native_surface_manager_applies_settings_surface() -> None:
 
     assert isinstance(app.active_surface, NativeSurfaceView)
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
-    assert intent == InputIntent(kind="setting", text="statusline", note="true")
+    assert intent == InputIntent(kind="setting", text="statusline", note="false")
 
     asyncio.run(manager.handle_surface_intent(intent))
 
-    assert app.active_surface is None
+    assert isinstance(app.active_surface, NativeSurfaceView)
     assert app.state.status_message == "Status line: off"
     rendered = tuple(strip_control_sequences(line.text) for line in app.render(RenderConstraints(width=100, max_height=12)).lines)
     assert not any("moonshot/kimi-for-coding | repo | main | abcd | idle" in line for line in rendered)

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -10,13 +10,64 @@ from loushang.coding.ui.native_surfaces import NativeSurfaceManager, NativeSurfa
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider
 from loushang.tui import (
     ApprovalSurface,
+    CursorDeclaration,
     DialogSurface,
     InputEvent,
     InputIntent,
     RenderConstraints,
+    RenderLine,
+    RenderResult,
     SurfaceHost,
 )
 from loushang.tui.cell_width import strip_control_sequences
+
+
+class _CursorContent:
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        return RenderResult.from_lines(
+            [RenderLine("query")],
+            constraints=constraints,
+            cursor=CursorDeclaration(row=0, column=3),
+        )
+
+
+class _EditorTargetContent(_CursorContent):
+    def __init__(self) -> None:
+        self.target = object()
+
+    def editor_input_target(self) -> object:
+        return self.target
+
+
+class _EscContent(_CursorContent):
+    def handle_input(self, event: InputEvent) -> InputIntent | bool | None:
+        if event.kind == "key" and event.key in {"esc", "escape"}:
+            return InputIntent(kind="consumed", note="child_escape")
+        return None
+
+
+def test_native_surface_view_delegates_editor_input_target() -> None:
+    content = _EditorTargetContent()
+    view = NativeSurfaceView(title="Settings", purpose="settings", content=content)
+
+    assert view.editor_input_target() is content.target
+
+
+def test_native_surface_view_preserves_content_cursor_with_offset() -> None:
+    view = NativeSurfaceView(title="Settings", purpose="settings", content=_CursorContent(), footer="")
+
+    rendered = view.render(RenderConstraints(width=40, max_height=8))
+
+    assert rendered.cursor == CursorDeclaration(row=2, column=3)
+
+
+def test_native_surface_view_delegates_escape_to_non_info_content_first() -> None:
+    view = NativeSurfaceView(title="Settings", purpose="settings", content=_EscContent())
+
+    assert view.handle_input(InputEvent(kind="key", key="escape")) == InputIntent(
+        kind="consumed",
+        note="child_escape",
+    )
 
 
 def test_native_surface_manager_opens_model_surface_and_selects_model() -> None:

--- a/tests/coding/test_native_settings_page.py
+++ b/tests/coding/test_native_settings_page.py
@@ -1,6 +1,32 @@
 from __future__ import annotations
 
+import asyncio
+
+from loushang.coding.types import ModelSelection
+from loushang.coding.ui.settings_page import SettingsPageView
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+from loushang.tui import InputEvent, RenderConstraints
+from loushang.tui.cell_width import strip_control_sequences
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.current_model = ModelSelection(provider="moonshot", model_id="kimi-for-coding")
+        self.models = (
+            ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
+            ModelSelection(provider="openai", model_id="gpt-5.4"),
+        )
+        self.set_model_calls: list[object] = []
+
+    def get_model_selection(self) -> object:
+        return self.current_model
+
+    def get_available_models(self) -> list[object]:
+        return list(self.models)
+
+    async def set_model(self, selection: object) -> None:
+        self.set_model_calls.append(selection)
+        self.current_model = selection
 
 
 def test_status_provider_exposes_read_only_snapshot() -> None:
@@ -22,3 +48,43 @@ def test_status_provider_exposes_read_only_snapshot() -> None:
     assert snapshot.thinking_level == "medium"
     assert snapshot.running is False
     assert snapshot.statusline_visible is True
+
+
+def _status_provider() -> CodingTuiStatusProvider:
+    return CodingTuiStatusProvider(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label=lambda: "abcd",
+        thinking_level=lambda: None,
+        running=lambda: False,
+    )
+
+
+def _page() -> SettingsPageView:
+    return asyncio.run(SettingsPageView.create(session=_Session(), status_provider=_status_provider()))
+
+
+def _plain(page: SettingsPageView, *, width: int = 100, height: int = 18) -> tuple[str, ...]:
+    rendered = page.render(RenderConstraints(width=width, max_height=height))
+    return tuple(strip_control_sequences(line.text) for line in rendered.lines)
+
+
+def test_settings_page_opens_config_tab_with_search_focus() -> None:
+    page = _page()
+    lines = _plain(page)
+
+    assert any("Status" in line and "Config" in line and "Model" in line for line in lines)
+    assert any("Search settings" in line for line in lines)
+    assert any("Status line" in line for line in lines)
+    assert page.editor_input_target() is not None
+
+
+def test_settings_page_search_filters_config_rows() -> None:
+    page = _page()
+
+    assert page.handle_input(InputEvent(kind="text", text="status")) is True
+    lines = _plain(page)
+
+    assert any("Status line" in line for line in lines)
+    assert not any("Terminal progress" in line for line in lines)

--- a/tests/coding/test_native_settings_page.py
+++ b/tests/coding/test_native_settings_page.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+
+
+def test_status_provider_exposes_read_only_snapshot() -> None:
+    provider = CodingTuiStatusProvider(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label=lambda: "abcd",
+        thinking_level=lambda: "medium",
+        running=lambda: False,
+    )
+
+    snapshot = provider.snapshot()
+
+    assert snapshot.model_label == "moonshot/kimi-for-coding"
+    assert snapshot.cwd == "/repo"
+    assert snapshot.branch == "main"
+    assert snapshot.session_label == "abcd"
+    assert snapshot.thinking_level == "medium"
+    assert snapshot.running is False
+    assert snapshot.statusline_visible is True

--- a/tests/coding/test_native_settings_page.py
+++ b/tests/coding/test_native_settings_page.py
@@ -5,7 +5,7 @@ import asyncio
 from loushang.coding.types import ModelSelection
 from loushang.coding.ui.settings_page import SettingsPageView
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-from loushang.tui import InputEvent, RenderConstraints
+from loushang.tui import InputEvent, InputIntent, RenderConstraints
 from loushang.tui.cell_width import strip_control_sequences
 
 
@@ -27,6 +27,17 @@ class _Session:
     async def set_model(self, selection: object) -> None:
         self.set_model_calls.append(selection)
         self.current_model = selection
+
+
+class _SettingsManager:
+    def __init__(self) -> None:
+        self.terminal_progress = False
+
+    def get_show_terminal_progress(self) -> bool:
+        return self.terminal_progress
+
+    def set_show_terminal_progress(self, enabled: bool) -> None:
+        self.terminal_progress = enabled
 
 
 def test_status_provider_exposes_read_only_snapshot() -> None:
@@ -61,8 +72,14 @@ def _status_provider() -> CodingTuiStatusProvider:
     )
 
 
-def _page() -> SettingsPageView:
-    return asyncio.run(SettingsPageView.create(session=_Session(), status_provider=_status_provider()))
+def _page(settings_manager: object | None = None) -> SettingsPageView:
+    return asyncio.run(
+        SettingsPageView.create(
+            session=_Session(),
+            status_provider=_status_provider(),
+            settings_manager=settings_manager,
+        )
+    )
 
 
 def _plain(page: SettingsPageView, *, width: int = 100, height: int = 18) -> tuple[str, ...]:
@@ -88,3 +105,62 @@ def test_settings_page_search_filters_config_rows() -> None:
 
     assert any("Status line" in line for line in lines)
     assert not any("Terminal progress" in line for line in lines)
+
+
+def test_settings_page_statusline_toggle_returns_setting_intent_and_apply_updates_rows() -> None:
+    page = _page()
+    page.handle_input(InputEvent(kind="key", key="down"))
+    intent = page.handle_input(InputEvent(kind="key", key="enter"))
+
+    assert intent == InputIntent(kind="setting", text="statusline", note="false")
+
+    result = asyncio.run(page.apply_setting("statusline", "false"))
+
+    assert result.statusline_visible is False
+    assert result.message == "Status line: off"
+    assert any("Status line" in line and "false" in line for line in _plain(page))
+
+
+def test_settings_page_terminal_progress_apply_updates_settings_manager_and_rows() -> None:
+    settings_manager = _SettingsManager()
+    page = _page(settings_manager=settings_manager)
+
+    result = asyncio.run(page.apply_setting("terminal.progress", "true"))
+
+    assert settings_manager.terminal_progress is True
+    assert result.message == "Terminal progress: on"
+    assert any("Terminal progress" in line and "true" in line for line in _plain(page))
+
+
+def test_settings_page_q_is_search_text_but_closes_from_list_focus() -> None:
+    search_page = _page()
+
+    assert search_page.handle_input(InputEvent(kind="text", text="q")) is True
+    assert any("q" in line for line in _plain(search_page))
+
+    list_page = _page()
+    list_page.handle_input(InputEvent(kind="key", key="down"))
+
+    assert list_page.handle_input(InputEvent(kind="text", text="q")) == InputIntent(kind="surface_close")
+
+
+def test_settings_page_search_editing_keys_do_not_switch_tabs() -> None:
+    page = _page()
+
+    before = page.tabs.value
+    assert page.handle_input(InputEvent(kind="key", key="right")) is True
+
+    assert page.tabs.value == before
+
+
+def test_settings_page_model_tab_filters_and_selects_model() -> None:
+    page = _page()
+    page.tabs.focus_header()
+    page.handle_input(InputEvent(kind="key", key="right"))
+    page.handle_input(InputEvent(kind="key", key="down"))
+
+    assert page.tabs.value == "model"
+    assert page.handle_input(InputEvent(kind="text", text="gpt")) is True
+    intent = page.handle_input(InputEvent(kind="key", key="enter"))
+
+    assert intent == InputIntent(kind="setting", text="model.current", note="openai/gpt-5.4")


### PR DESCRIPTION
## Summary

- Add a real tabbed settings page for the native TUI with Status, Config, Model, Usage, and Stats top-level tabs.
- Promote model selection to a first-level tab while reusing the existing model-choice plumbing.
- Route settings-page keyboard/input behavior through the native surface content hooks so focus, Escape, tab navigation, config toggles, and model selection behave consistently.
- Add focused tests and playback coverage for the settings page behavior.

## Validation

- `uv run pytest tests/coding/test_native_settings_page.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -q`
- `uv run pytest tests/tui/test_widgets_tab_group.py tests/tui/test_widgets_searchable_list.py -q`
- `uv run ruff check src/loushang/coding/ui/settings_page.py src/loushang/coding/ui/native_surfaces.py src/loushang/coding/ui/status_provider.py tests/coding/test_native_settings_page.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py`
