### PR TITLE
[codex] Polish TUI settings page layout

### DIFF
--- a/src/loushang/coding/ui/native_app.py
+++ b/src/loushang/coding/ui/native_app.py
@@ -261,8 +261,7 @@ class NativeCodingTuiApp:
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         visible_height = constraints.visible_height or constraints.max_height
-        editor_height = 16 if self._expanded_bottom_frame() else 12
-        editor_height = max(1, min(editor_height, visible_height))
+        editor_height = self._bottom_frame_height(visible_height)
         self._transcript_region.records = self.state.records
         self._transcript_region.draft = None
         self._transcript_region.draft_buffer = self.state.assistant_draft_buffer
@@ -311,6 +310,15 @@ class NativeCodingTuiApp:
             or bool(self.state.pending_followups)
             or bool(self.state.interruption_message)
         )
+
+    def _bottom_frame_height(self, visible_height: int) -> int:
+        height = 12
+        if self._expanded_bottom_frame():
+            height = 16
+            preferred = getattr(self.active_surface, "preferred_height", None)
+            if isinstance(preferred, int) and preferred > 0:
+                height = max(height, preferred)
+        return max(1, min(height, visible_height))
 
     def _request_render(self, kind: RenderRequestKind) -> None:
         if self.render_requester is not None:

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -81,6 +81,7 @@ class NativeSurfaceView(FocusableMixin):
     footer: str = "Enter to select - Esc to close"
     subtitle: str = ""
     presentation: NativeSurfacePresentation = "bottom"
+    preferred_height: int | None = None
     _last_content_start_row: int = field(default=0, init=False, repr=False)
     _info_scroll_offset: int = field(default=0, init=False, repr=False)
     _last_info_body_height: int = field(default=0, init=False, repr=False)
@@ -649,6 +650,7 @@ class NativeSurfaceManager:
                 content=surface,
                 footer="",
                 presentation="bottom-exclusive",
+                preferred_height=24,
             )
         )
 

--- a/src/loushang/coding/ui/settings_page.py
+++ b/src/loushang/coding/ui/settings_page.py
@@ -23,6 +23,7 @@ from loushang.tui import (
     SearchableListSelect,
     TabGroup,
     TabPage,
+    ThemeResolver,
     truncate_to_width,
 )
 
@@ -49,6 +50,82 @@ class ConfigRow:
     value: str
     description: str = ""
     disabled: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class _ManagerBoolConfig:
+    id: str
+    label: str
+    getter: str
+    setter: str
+    status_label: str
+
+
+SETTINGS_VALUE_COLUMN = 42
+
+SETTINGS_PAGE_THEME = ThemeResolver(
+    defaults={
+        "widget.tabs.tab": {"color": "white"},
+        "widget.tabs.selected": {"bold": True, "color": "green"},
+        "widget.tabs.level0.selected_header_focus": {"bold": True, "color": "cyan"},
+        "widget.tabs.level0.selected_content_focus": {"bold": True, "color": "green"},
+        "widget.tabs.level1.selected_header_focus": {"bold": True, "color": "magenta"},
+        "widget.tabs.level1.selected_content_focus": {"bold": True, "color": "yellow"},
+        "widget.searchableList.search": {"color": "white"},
+        "widget.searchableList.placeholder": {"color": "bright_black"},
+        "widget.searchableList.item": {"color": "white"},
+        "widget.searchableList.focus": {"bold": True, "color": "cyan"},
+        "widget.searchableList.disabled": {"dim": True},
+        "widget.searchableList.description": {"color": "bright_black"},
+        "widget.searchableList.empty": {"color": "bright_black"},
+        "widget.searchableList.overflow": {"color": "bright_black"},
+    }
+)
+
+_MANAGER_BOOL_CONFIGS = (
+    _ManagerBoolConfig(
+        "terminal.progress",
+        "Terminal progress",
+        "get_show_terminal_progress",
+        "set_show_terminal_progress",
+        "Terminal progress",
+    ),
+    _ManagerBoolConfig(
+        "terminal.show_images",
+        "Show images",
+        "get_show_images",
+        "set_show_images",
+        "Show images",
+    ),
+    _ManagerBoolConfig(
+        "terminal.clear_on_shrink",
+        "Clear on shrink",
+        "get_clear_on_shrink",
+        "set_clear_on_shrink",
+        "Clear on shrink",
+    ),
+    _ManagerBoolConfig(
+        "images.auto_resize",
+        "Image auto-resize",
+        "get_image_auto_resize",
+        "set_image_auto_resize",
+        "Image auto-resize",
+    ),
+    _ManagerBoolConfig(
+        "images.block_images",
+        "Block images",
+        "get_block_images",
+        "set_block_images",
+        "Block images",
+    ),
+    _ManagerBoolConfig(
+        "retry.enabled",
+        "Retry",
+        "get_retry_enabled",
+        "set_retry_enabled",
+        "Retry",
+    ),
+)
 
 
 @dataclass(slots=True)
@@ -116,15 +193,15 @@ class ConfigSettingsPage:
     def render(self, constraints: RenderConstraints) -> RenderResult:
         if constraints.max_height <= 0:
             return RenderResult.from_lines([], constraints=constraints)
-        if constraints.max_height <= 2:
+        if constraints.max_height <= 4:
             return self.settings.render(constraints)
         result = self.settings.render(
             RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2))
         )
         header = RenderLine(_settings_header(constraints.width))
-        rows = [result.lines[0], RenderLine(_separator(constraints.width)), header, *result.lines[1:]]
+        rows = [*result.lines[:3], RenderLine(""), header, *result.lines[3:]]
         cursor = result.cursor
-        if cursor is not None and cursor.row > 0:
+        if cursor is not None and cursor.row >= 3:
             cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
         return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
 
@@ -134,6 +211,9 @@ class ConfigSettingsPage:
             placeholder="Search settings...",
             empty_text="No matching settings",
             focused=focused,
+            search_box=True,
+            detail_column=SETTINGS_VALUE_COLUMN,
+            theme=SETTINGS_PAGE_THEME,
         )
 
     def _setting_intent(self, key: str) -> InputIntent | None:
@@ -206,6 +286,9 @@ class ModelPage:
             placeholder="Search models...",
             empty_text="No matching models",
             focused=focused,
+            search_box=True,
+            detail_column=SETTINGS_VALUE_COLUMN,
+            theme=SETTINGS_PAGE_THEME,
         )
 
 
@@ -254,16 +337,17 @@ class SettingsPageView:
             self._refresh_status_page()
             self._refresh_config_rows(preserve_active_key="statusline")
             return SettingsApplyResult(message, statusline_visible=self.status_provider.is_visible())
-        if item_id == "terminal.progress":
+        config = _manager_bool_config(item_id)
+        if config is not None:
             enabled = _as_bool(value)
             if enabled is None:
-                return SettingsApplyResult("Invalid terminal progress value.")
-            setter = getattr(self.settings_manager, "set_show_terminal_progress", None)
+                return SettingsApplyResult(f"Invalid {config.label} value.")
+            setter = getattr(self.settings_manager, config.setter, None)
             if not callable(setter):
-                return SettingsApplyResult("Terminal progress is not available.")
+                return SettingsApplyResult(f"{config.status_label} is not available.")
             setter(enabled)
-            self._refresh_config_rows(preserve_active_key="terminal.progress")
-            return SettingsApplyResult(f"Terminal progress: {'on' if enabled else 'off'}")
+            self._refresh_config_rows(preserve_active_key=config.id)
+            return SettingsApplyResult(f"{config.status_label}: {'on' if enabled else 'off'}")
         if item_id == "model.current":
             message = await select_available_model(self.session, query=value)
             await self._refresh_model_page()
@@ -295,11 +379,13 @@ class SettingsPageView:
     def render(self, constraints: RenderConstraints) -> RenderResult:
         if constraints.max_height <= 0:
             return RenderResult.from_lines([], constraints=constraints)
-        body_height = max(1, constraints.max_height - 1)
+        body_height = max(1, constraints.max_height - 2)
         result = self.tabs.render(RenderConstraints(width=constraints.width, max_height=body_height))
         rows = _with_separator(result.lines, width=constraints.width)
         cursor = _offset_cursor_after_separator(result.cursor)
         footer = _footer_text(self._focus_context(), width=constraints.width)
+        while len(rows) < constraints.max_height - 1:
+            rows.append(RenderLine(""))
         if len(rows) < constraints.max_height:
             rows.append(RenderLine(footer))
         return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
@@ -317,6 +403,7 @@ class SettingsPageView:
             ),
             value="overview",
             level=1,
+            theme=SETTINGS_PAGE_THEME,
         )
         self.tabs = TabGroup(
             (
@@ -327,6 +414,7 @@ class SettingsPageView:
                 TabPage("stats", "Stats", self.stats_page),
             ),
             value="config",
+            theme=SETTINGS_PAGE_THEME,
         )
 
     def _refresh_status_page(self) -> None:
@@ -370,10 +458,10 @@ def _config_rows(status_provider: CodingTuiStatusProvider, settings_manager: obj
         ConfigRow("statusline", "Status line", _bool_text(status_provider.is_visible())),
     ]
     if settings_manager is not None:
-        terminal_progress = getattr(settings_manager, "get_show_terminal_progress", None)
-        if callable(terminal_progress):
-            rows.append(ConfigRow("terminal.progress", "Terminal progress", _bool_text(bool(terminal_progress()))))
-    rows.append(ConfigRow("model.current", "Current model", "Use Model tab", disabled=True))
+        for config in _MANAGER_BOOL_CONFIGS:
+            getter = getattr(settings_manager, config.getter, None)
+            if callable(getter):
+                rows.append(ConfigRow(config.id, config.label, _bool_text(bool(getter()))))
     return tuple(rows)
 
 
@@ -456,7 +544,8 @@ def _model_usage_lines(current_value: str | None) -> tuple[str, ...]:
 
 
 def _settings_header(width: int) -> str:
-    return truncate_to_width("Setting                                    Value", max_width=width, ellipsis="")
+    value_column = max(8, min(SETTINGS_VALUE_COLUMN, max(8, width - 8)))
+    return truncate_to_width(f"{'Setting':<{value_column}}Value", max_width=width, ellipsis="")
 
 
 def _separator(width: int) -> str:
@@ -479,14 +568,21 @@ def _offset_cursor_after_separator(cursor: CursorDeclaration | None) -> CursorDe
 
 def _footer_text(focus_context: str, *, width: int) -> str:
     if focus_context == "search":
-        text = "Search | type filter | Down list | Up tabs | Esc clear/close"
+        text = "Type to filter · Enter/↓ to select · ↑ to tabs · Esc to clear"
     elif focus_context in {"settings-list", "model-list"}:
-        text = "List | Up/Down move | Enter select | Space toggle | q close"
+        text = "↑/↓ to move · Enter/Space to select · ↑ on first row to search · q to close"
     elif focus_context == "tabs":
-        text = "Tabs | Left/Right switch | Down content | q close"
+        text = "←/→ to switch tabs · ↓ to enter · q to close"
     else:
-        text = "Page | Up tabs | q close"
+        text = "↑ to tabs · q to close"
     return truncate_to_width(text, max_width=width, ellipsis="")
+
+
+def _manager_bool_config(item_id: str) -> _ManagerBoolConfig | None:
+    for config in _MANAGER_BOOL_CONFIGS:
+        if config.id == item_id:
+            return config
+    return None
 
 
 def _bool_text(value: bool) -> str:

--- a/src/loushang/tui/ui_parts/widgets/searchable_list.py
+++ b/src/loushang/tui/ui_parts/widgets/searchable_list.py
@@ -51,6 +51,8 @@ class SearchableList:
     on_select: Callable[[SearchableListItem], object] | None
     theme: ThemeResolver | None
     focused: bool
+    search_box: bool
+    detail_column: int | None
 
     def __init__(
         self,
@@ -64,6 +66,8 @@ class SearchableList:
         on_select: Callable[[SearchableListItem], object] | None = None,
         theme: ThemeResolver | None = None,
         focused: bool = False,
+        search_box: bool = False,
+        detail_column: int | None = None,
     ) -> None:
         self._items = tuple(items)
         self.placeholder = placeholder
@@ -71,6 +75,8 @@ class SearchableList:
         self.on_select = on_select
         self.theme = theme
         self.focused = focused
+        self.search_box = search_box
+        self.detail_column = detail_column
         self.focus_region = focus_region if focus_region in {"search", "list"} else "search"
         self._active_index = max(0, active_index)
         self._scroll_offset = 0
@@ -170,9 +176,15 @@ class SearchableList:
         lines: list[RenderLine] = []
         cursor: CursorDeclaration | None = None
         query_line, query_cursor_column = self._query_line(target_width)
-        lines.append(query_line)
+        if self.search_box:
+            lines.extend(_boxed_query_lines(query_line.text, target_width))
+            query_cursor_row = 1
+            query_cursor_column += 2
+        else:
+            lines.append(query_line)
+            query_cursor_row = 0
         if self.focused and self.focus_region == "search":
-            cursor = CursorDeclaration(row=0, column=query_cursor_column)
+            cursor = CursorDeclaration(row=query_cursor_row, column=query_cursor_column)
 
         item_height = max(0, constraints.max_height - len(lines))
         if item_height > 0:
@@ -352,7 +364,6 @@ def _matches(item: SearchableListItem, needle: str) -> bool:
 def _item_line(view: SearchableList, index: int, item: SearchableListItem, width: int) -> str:
     is_focused_item = view.focused and view.focus_region == "list" and index == view._active_index and not item.disabled
     prefix = "> " if is_focused_item else "  "
-    label = truncate_to_width(f"{prefix}{item.label}", max_width=width, ellipsis="")
     item_token = (
         "widget.searchableList.disabled"
         if item.disabled
@@ -360,8 +371,19 @@ def _item_line(view: SearchableList, index: int, item: SearchableListItem, width
         if is_focused_item
         else "widget.searchableList.item"
     )
-    remaining = max(0, width - visible_width(label))
     detail = item.value or item.description
+    if view.detail_column is not None and detail:
+        detail_column = max(4, min(view.detail_column, max(4, width - 1)))
+        label = truncate_to_width(f"{prefix}{item.label}", max_width=detail_column, ellipsis="")
+        rendered = style_text(label, view.theme, item_token)
+        padding = " " * max(1, detail_column - visible_width(label))
+        detail_text = truncate_to_width(detail, max_width=max(0, width - detail_column), ellipsis="")
+        if detail_text:
+            rendered = f"{rendered}{padding}{style_text(detail_text, view.theme, 'widget.searchableList.description')}"
+        return truncate_to_width(rendered, max_width=width, ellipsis="")
+
+    label = truncate_to_width(f"{prefix}{item.label}", max_width=width, ellipsis="")
+    remaining = max(0, width - visible_width(label))
     rendered = style_text(label, view.theme, item_token)
     if detail and remaining >= 3:
         detail_text = truncate_to_width(detail, max_width=remaining - 2, ellipsis="")
@@ -373,10 +395,25 @@ def _item_line(view: SearchableList, index: int, item: SearchableListItem, width
 def _overflow_line(view: SearchableList, width: int) -> RenderLine | None:
     parts: list[str] = []
     if view.more_above:
-        parts.append(f"{view.more_above} more above")
+        parts.append(f"↑ {view.more_above} more above")
     if view.more_below:
-        parts.append(f"{view.more_below} more below")
+        parts.append(f"↓ {view.more_below} more below")
     if not parts:
         return None
     text = truncate_to_width(f"  {' / '.join(parts)}", max_width=width, ellipsis="")
     return RenderLine(style_text(text, view.theme, "widget.searchableList.overflow"))
+
+
+def _boxed_query_lines(text: str, width: int) -> list[RenderLine]:
+    if width <= 0:
+        return []
+    if width < 4:
+        return [RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))]
+    inner_width = max(0, width - 4)
+    visible_text = truncate_to_width(text, max_width=inner_width, ellipsis="")
+    padding = " " * max(0, inner_width - visible_width(visible_text))
+    return [
+        RenderLine("╭" + "─" * (width - 2) + "╮"),
+        RenderLine(f"│ {visible_text}{padding} │"),
+        RenderLine("╰" + "─" * (width - 2) + "╯"),
+    ]

--- a/src/loushang/tui/ui_parts/widgets/tab_group.py
+++ b/src/loushang/tui/ui_parts/widgets/tab_group.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 
-from loushang.tui.core import CursorDeclaration, RenderConstraints, RenderLine, RenderResult
+from loushang.tui.core import (
+    CursorDeclaration,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+)
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.ui_parts.widgets._utils import callback_result
 from loushang.tui.ui_parts.widgets.tabs import TabItem, Tabs
@@ -162,7 +167,7 @@ class TabGroup:
                 visible_height=constraints.visible_height,
             ),
         )
-        cursor = None
+        cursor = header.cursor
         if content.cursor is not None and len(header.lines) + content.cursor.row < constraints.max_height:
             cursor = CursorDeclaration(
                 row=len(header.lines) + content.cursor.row,

--- a/src/loushang/tui/ui_parts/widgets/tabs.py
+++ b/src/loushang/tui/ui_parts/widgets/tabs.py
@@ -4,8 +4,17 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Literal
 
-from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
-from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.cell_width import (
+    autowrap_safe_width,
+    truncate_to_width,
+    visible_width,
+)
+from loushang.tui.core import (
+    CursorDeclaration,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+)
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.ui_parts.widgets._utils import (
     callback_result,
@@ -72,9 +81,18 @@ class Tabs:
         if not self.tabs:
             return RenderResult.from_lines([], constraints=constraints)
         target_width = autowrap_safe_width(constraints.width)
-        parts = [_tab_segment(self, tab) for tab in self.tabs]
+        parts: list[str] = []
+        cursor_column: int | None = None
+        current_column = 0
+        for tab in self.tabs:
+            segment = _tab_segment(self, tab)
+            if self.focused and tab.value == self.value and not tab.disabled:
+                cursor_column = min(current_column, max(0, target_width - 1))
+            parts.append(segment)
+            current_column += visible_width(segment) + 2
         line = truncate_to_width("  ".join(parts), max_width=target_width, ellipsis="")
-        return RenderResult.from_lines([RenderLine(line)][: constraints.max_height], constraints=constraints)
+        cursor = None if cursor_column is None else CursorDeclaration(row=0, column=cursor_column)
+        return RenderResult.from_lines([RenderLine(line)][: constraints.max_height], constraints=constraints, cursor=cursor)
 
     def _enabled_indices(self) -> tuple[int, ...]:
         return tuple(index for index, tab in enumerate(self.tabs) if not tab.disabled)
@@ -142,7 +160,7 @@ class Tabs:
 def _tab_segment(tabs: Tabs, tab: TabItem) -> str:
     selected = tab.value == tabs.value and not tab.disabled
     focus_state = _selected_focus_state(tabs)
-    prefix = "> " if selected and focus_state in {"header", "content"} else "* " if selected else "  "
+    prefix = ">" if selected and focus_state in {"header", "content"} else "*" if selected else " "
     text = f"{prefix}[{tab.display_label}]"
     return style_text(text, tabs.theme, *_tab_tokens(tabs, selected=selected, disabled=tab.disabled))
 

--- a/tests/coding/test_native_coding_tui_playback.py
+++ b/tests/coding/test_native_coding_tui_playback.py
@@ -404,7 +404,7 @@ def test_native_tui_playback_settings_page_searches_when_opened_by_command() -> 
     assert all(step.flush_succeeded for step in steps)
     lines = _plain_lines(steps[-1].diagnostics)
     assert "Settings" in lines
-    assert "zz" in lines
+    assert any("zz" in line for line in lines)
     assert "No matching settings" in lines
     assert app.state.statusline_visible is True
     for step in steps:
@@ -431,10 +431,40 @@ def test_native_tui_playback_settings_page_q_is_search_text() -> None:
     assert all(step.flush_succeeded for step in steps)
     assert app.active_surface is not None
     lines = _plain_lines(steps[-1].diagnostics)
-    assert "q" in lines
+    assert any("q" in line for line in lines)
     assert "No matching settings" in lines
     for step in steps:
         step.assert_no_clear_scrollback()
+
+
+def test_native_tui_playback_settings_escape_restores_single_prompt_with_status_gap() -> None:
+    session = _Session()
+    app = _app()
+    playback = _NativeInteractivePlayback(
+        app,
+        _manager(app, session),
+        columns=100,
+        rows=18,
+    )
+
+    steps = playback.play(
+        [
+            PlaybackEvent.input("/settings\r"),
+            PlaybackEvent.input("\x1b"),
+        ]
+    )
+
+    assert all(step.flush_succeeded for step in steps)
+    assert app.active_surface is None
+    lines = _plain_lines(steps[-1].diagnostics)
+    prompt_rows = [index for index, line in enumerate(lines) if line.startswith("›")]
+    status_rows = [
+        index
+        for index, line in enumerate(lines)
+        if "moonshot/kimi-for-coding | repo | main | abcd | idle" in line
+    ]
+    assert prompt_rows == [status_rows[0] - 2]
+    assert lines[prompt_rows[0] + 1] == ""
 
 
 def test_native_tui_playback_settings_page_model_tab_is_available() -> None:
@@ -458,7 +488,7 @@ def test_native_tui_playback_settings_page_model_tab_is_available() -> None:
 
     assert all(step.flush_succeeded for step in steps)
     lines = _plain_lines(steps[-1].diagnostics)
-    assert "Search models..." in lines
+    assert any("Search models..." in line for line in lines)
     assert any("moonshot/kimi-for-coding" in line for line in lines)
     for step in steps:
         step.assert_no_clear_scrollback()

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -47,6 +47,14 @@ class _EscContent(_CursorContent):
         return None
 
 
+class _TallContent:
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        return RenderResult.from_lines(
+            [RenderLine(f"line {index}") for index in range(constraints.max_height)],
+            constraints=constraints,
+        )
+
+
 def test_native_surface_view_delegates_editor_input_target() -> None:
     content = _EditorTargetContent()
     view = NativeSurfaceView(title="Settings", purpose="settings", content=content)
@@ -69,6 +77,25 @@ def test_native_surface_view_delegates_escape_to_non_info_content_first() -> Non
         kind="consumed",
         note="child_escape",
     )
+
+
+def test_native_app_uses_active_surface_preferred_height_for_bottom_frame() -> None:
+    app = _app()
+    app.active_surface = NativeSurfaceView(
+        title="Settings",
+        purpose="settings",
+        content=_TallContent(),
+        footer="",
+        presentation="bottom-exclusive",
+        preferred_height=22,
+    )
+
+    rendered = app.render(RenderConstraints(width=80, max_height=30))
+    plain_lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
+
+    assert len(plain_lines) == 22
+    assert plain_lines[0] == "Settings"
+    assert plain_lines[-1] == "line 19"
 
 
 def test_native_surface_manager_opens_model_surface_and_selects_model() -> None:
@@ -369,7 +396,7 @@ def test_native_surface_manager_opens_settings_in_bottom_frame_with_runtime_over
     assert app.active_surface.presentation == "bottom-exclusive"
     assert app.surface_host.entries == []
 
-    rendered = app.active_surface.render(RenderConstraints(width=100, max_height=10))
+    rendered = app.active_surface.render(RenderConstraints(width=100, max_height=14))
     plain = tuple(strip_control_sequences(line.text) for line in rendered.lines)
     assert any("Status" in line and "Config" in line and "Model" in line for line in plain)
     assert any("Search settings" in line for line in plain)

--- a/tests/coding/test_native_settings_page.py
+++ b/tests/coding/test_native_settings_page.py
@@ -32,12 +32,47 @@ class _Session:
 class _SettingsManager:
     def __init__(self) -> None:
         self.terminal_progress = False
+        self.show_images = True
+        self.clear_on_shrink = False
+        self.image_auto_resize = True
+        self.block_images = False
+        self.retry_enabled = True
 
     def get_show_terminal_progress(self) -> bool:
         return self.terminal_progress
 
     def set_show_terminal_progress(self, enabled: bool) -> None:
         self.terminal_progress = enabled
+
+    def get_show_images(self) -> bool:
+        return self.show_images
+
+    def set_show_images(self, enabled: bool) -> None:
+        self.show_images = enabled
+
+    def get_clear_on_shrink(self) -> bool:
+        return self.clear_on_shrink
+
+    def set_clear_on_shrink(self, enabled: bool) -> None:
+        self.clear_on_shrink = enabled
+
+    def get_image_auto_resize(self) -> bool:
+        return self.image_auto_resize
+
+    def set_image_auto_resize(self, enabled: bool) -> None:
+        self.image_auto_resize = enabled
+
+    def get_block_images(self) -> bool:
+        return self.block_images
+
+    def set_block_images(self, enabled: bool) -> None:
+        self.block_images = enabled
+
+    def get_retry_enabled(self) -> bool:
+        return self.retry_enabled
+
+    def set_retry_enabled(self, enabled: bool) -> None:
+        self.retry_enabled = enabled
 
 
 def test_status_provider_exposes_read_only_snapshot() -> None:
@@ -87,6 +122,10 @@ def _plain(page: SettingsPageView, *, width: int = 100, height: int = 18) -> tup
     return tuple(strip_control_sequences(line.text) for line in rendered.lines)
 
 
+def _raw(page: SettingsPageView, *, width: int = 100, height: int = 18) -> tuple[str, ...]:
+    return tuple(line.text for line in page.render(RenderConstraints(width=width, max_height=height)).lines)
+
+
 def test_settings_page_opens_config_tab_with_search_focus() -> None:
     page = _page()
     lines = _plain(page)
@@ -95,6 +134,30 @@ def test_settings_page_opens_config_tab_with_search_focus() -> None:
     assert any("Search settings" in line for line in lines)
     assert any("Status line" in line for line in lines)
     assert page.editor_input_target() is not None
+
+
+def test_settings_page_config_uses_boxed_search_table_columns_footer_and_styles() -> None:
+    page = _page(settings_manager=_SettingsManager())
+    raw_lines = _raw(page, width=96, height=24)
+    lines = tuple(strip_control_sequences(line) for line in raw_lines)
+
+    assert "\x1b[" in raw_lines[0]
+    assert ">[Config]" in lines[0]
+    assert "> [Config]" not in lines[0]
+    assert any(line.startswith("╭") for line in lines)
+    search_index = next(index for index, line in enumerate(lines) if "Search settings..." in line)
+    assert lines[search_index].startswith("│ ")
+    assert "\x1b[" in raw_lines[search_index]
+    assert any(line.startswith("╰") for line in lines)
+    assert lines[-1] == "Type to filter · Enter/↓ to select · ↑ to tabs · Esc to clear"
+    assert not any("Current model" in line for line in lines)
+
+    header = next(line for line in lines if "Setting" in line and "Value" in line)
+    value_column = header.index("Value")
+    status_line = next(line for line in lines if "Status line" in line)
+    terminal_line = next(line for line in lines if "Terminal progress" in line)
+    assert status_line.index("true") >= value_column
+    assert terminal_line.index("false") >= value_column
 
 
 def test_settings_page_search_filters_config_rows() -> None:
@@ -132,6 +195,19 @@ def test_settings_page_terminal_progress_apply_updates_settings_manager_and_rows
     assert any("Terminal progress" in line and "true" in line for line in _plain(page))
 
 
+def test_settings_page_down_moves_past_terminal_progress_when_more_config_rows_are_available() -> None:
+    page = _page(settings_manager=_SettingsManager())
+
+    assert page.handle_input(InputEvent(kind="key", key="down")) is True
+    assert page.handle_input(InputEvent(kind="key", key="down")) is True
+    assert page.config_page.settings.active_key == "terminal.progress"
+
+    assert page.handle_input(InputEvent(kind="key", key="down")) is True
+
+    assert page.config_page.settings.active_key == "terminal.show_images"
+    assert any(line.startswith("> Show images") for line in _plain(page, width=96, height=24))
+
+
 def test_settings_page_q_is_search_text_but_closes_from_list_focus() -> None:
     search_page = _page()
 
@@ -151,6 +227,19 @@ def test_settings_page_search_editing_keys_do_not_switch_tabs() -> None:
     assert page.handle_input(InputEvent(kind="key", key="right")) is True
 
     assert page.tabs.value == before
+
+
+def test_settings_page_up_from_search_declares_cursor_on_selected_tab() -> None:
+    page = _page()
+
+    assert page.handle_input(InputEvent(kind="key", key="up")) is True
+    rendered = page.render(RenderConstraints(width=96, max_height=24))
+    lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
+
+    assert page.editor_input_target() is None
+    assert rendered.cursor is not None
+    assert rendered.cursor.row == 0
+    assert rendered.cursor.column == lines[0].index(">[Config]")
 
 
 def test_settings_page_model_tab_filters_and_selects_model() -> None:

--- a/tests/tui/test_widgets_tab_group.py
+++ b/tests/tui/test_widgets_tab_group.py
@@ -73,7 +73,7 @@ def test_tab_group_normalizes_value_and_renders_selected_page() -> None:
     assert group.selected_value == "overview"
     assert group.selected_page is not None
     assert plain_lines(group, width=40, height=4) == (
-        "* [Overview]    [Logs]",
+        "*[Overview]   [Logs]",
         "Overview page",
         "",
     )
@@ -86,14 +86,14 @@ def test_tab_group_fixed_content_height_pads_and_clips() -> None:
     )
 
     assert plain_lines(group, width=20, height=5) == (
-        "* [Long]",
+        "*[Long]",
         "one",
         "two",
     )
 
     short = TabGroup([TabPage("short", "Short", StaticPage(("one",)))], content_height=3)
     assert plain_lines(short, width=20, height=5) == (
-        "* [Short]",
+        "*[Short]",
         "one",
         "",
         "",
@@ -196,7 +196,7 @@ def test_tab_group_offsets_selected_content_cursor() -> None:
 def test_tab_group_renders_header_only_when_no_content_height_remains() -> None:
     group = TabGroup([TabPage("one", "One", StaticPage(("content",)))])
 
-    assert plain_lines(group, width=20, height=1) == ("* [One]",)
+    assert plain_lines(group, width=20, height=1) == ("*[One]",)
 
 
 def test_tab_group_uses_distinct_header_and_content_focus_tokens() -> None:
@@ -265,7 +265,7 @@ def test_tabgroup_searchable_list_example_playback_filters_settings() -> None:
     filtered = frames[-1].lines
 
     assert any("Workspace" in line and "Activity" in line for line in initial)
-    assert initial[0].startswith("> [Workspace]")
+    assert initial[0].startswith(">[Workspace]")
     assert any("Search" in line for line in initial)
     assert any("mode" in line.lower() for line in filtered)
     assert any("Model" in line or "mode" in line for line in filtered)
@@ -279,7 +279,7 @@ def test_tabgroup_searchable_list_example_styles_top_level_selected_tab() -> Non
 
     initial = tui.render(RenderConstraints(width=100, max_height=24)).lines[0].text
     assert "\x1b[" in initial
-    assert "> [Workspace]" in initial
+    assert ">[Workspace]" in initial
 
     for event in (
         InputEvent(kind="key", key="up"),
@@ -291,7 +291,7 @@ def test_tabgroup_searchable_list_example_styles_top_level_selected_tab() -> Non
 
     activity = tui.render(RenderConstraints(width=100, max_height=24)).lines[0].text
     assert "\x1b[" in activity
-    assert "> [Activity]" in activity
+    assert ">[Activity]" in activity
 
 
 def test_tabgroup_searchable_list_example_playback_switches_nested_tabs() -> None:
@@ -311,7 +311,7 @@ def test_tabgroup_searchable_list_example_playback_switches_nested_tabs() -> Non
 
     assert any("Overview" in line and "Models" in line for line in frames[-1].lines)
     assert any("Tokens per Day" in line or "Model usage" in line for line in frames[-1].lines)
-    assert any("Overview" in line and "> [Models]" in line for line in frames[-1].lines)
+    assert any("Overview" in line and ">[Models]" in line for line in frames[-1].lines)
 
 
 def test_tabgroup_searchable_list_example_up_to_tabs_down_returns_to_search() -> None:
@@ -325,7 +325,7 @@ def test_tabgroup_searchable_list_example_up_to_tabs_down_returns_to_search() ->
         height=24,
     )
 
-    assert frames[-1].lines[0].startswith("> [Workspace]")
+    assert frames[-1].lines[0].startswith(">[Workspace]")
     assert frames[-1].lines[2] == "Search settings..."
     assert not any(line.startswith("> Model") for line in frames[-1].lines)
     assert frames[-1].lines[-1].startswith("Search |")


### PR DESCRIPTION
## Summary

- Polish the native TUI settings page with a boxed search input, fixed footer help text, compact highlighted tab selection, and aligned Setting/Value columns.
- Remove the disabled model placeholder row from Config now that Model is a top-level tab, and add more real boolean config rows from SettingsManager.
- Add preferred bottom-surface height support so `/settings` opens taller without changing unrelated surfaces.
- Add regression coverage for tab cursor placement, settings list navigation, boxed search rendering, footer behavior, and native playback.

## Validation

- `uv run pytest tests/coding/test_native_settings_page.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -q` -> 81 passed
- `uv run pytest tests/tui/test_widgets_searchable_list.py tests/tui/test_widgets_tab_group.py -q` -> 29 passed
- `uv run ruff check src/loushang/tui/ui_parts/widgets/searchable_list.py src/loushang/tui/ui_parts/widgets/tabs.py src/loushang/tui/ui_parts/widgets/tab_group.py src/loushang/coding/ui/settings_page.py src/loushang/coding/ui/native_app.py src/loushang/coding/ui/native_surfaces.py tests/coding/test_native_settings_page.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py tests/tui/test_widgets_tab_group.py` -> All checks passed
