### PR TITLE
feat(tui): add reusable status bar styling

### DIFF
--- a/docs/superpowers/plans/2026-06-14-tui-statusbar-rendering.md
+++ b/docs/superpowers/plans/2026-06-14-tui-statusbar-rendering.md
@@ -1,0 +1,734 @@
+# TUI Status Bar Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add reusable semantic styling and separator support to `StatusBar` without changing default unstyled behavior.
+
+**Architecture:** Keep the feature contained in `src/loushang/tui/ui_parts/status.py`. `StatusField` carries optional semantic metadata, while `StatusBar` owns separator joining, style-mode selection, theme fallback, and built-in default styles. Coding/product settings work is explicitly deferred to a later code-lane PR.
+
+**Tech Stack:** Python dataclasses, existing `loushang.tui.theme.ThemeResolver`, `ThemeStyle`, `apply_theme_style`, pytest, Ruff.
+
+---
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-06-14-tui-statusbar-rendering-design.md`
+- Lane split: `docs/superpowers/specs/2026-06-14-tui-statusline-settings-tab-design.md`
+- Existing implementation: `src/loushang/tui/ui_parts/status.py`
+- Existing footer tests: `tests/tui/test_footer_statusline.py`
+- Existing composer bottom-frame tests: `tests/tui/test_composer_bottom_frame.py`
+- Existing theme API: `src/loushang/tui/theme.py`
+
+## File Structure
+
+- Modify: `src/loushang/tui/ui_parts/status.py`
+  - Extend `StatusField`.
+  - Extend `StatusBar`.
+  - Add local helpers for joining, token normalization, token candidate order,
+    built-in styles, and final segment styling.
+  - Preserve `StatusField.token` in `_render_extension_statuses()`.
+- Verify: `src/loushang/tui/ui_parts/__init__.py`
+  - No source change expected because it already re-exports `StatusBar` and
+    `StatusField`.
+- Verify: `src/loushang/tui/__init__.py`
+  - No source change expected because it already re-exports `StatusBar` and
+    `StatusField`.
+- Create: `tests/tui/test_status_bar.py`
+  - Focused tests for the reusable renderer API and styling behavior.
+- Modify: `tests/tui/test_footer_statusline.py`
+  - Add a focused regression test for `_render_extension_statuses()` because
+    token preservation is otherwise not observable through the current
+    unthemed `FooterView` public API.
+
+## Implementation Notes
+
+- Do not touch `src/loushang/coding/...` in this plan.
+- Do not add Settings UI, `/statusline` behavior, persistence, or product
+  status-line field builders.
+- Keep `StatusBar.style_mode` default as `"plain"` so existing callers remain
+  unstyled.
+- Apply styling only after field selection and truncation. Field fitting must
+  use raw text and the raw separator.
+- Import theme primitives directly in `status.py`:
+
+```python
+from loushang.tui.theme import ThemeResolver, ThemeStyle, apply_theme_style
+```
+
+- Use local helpers rather than changing the global theme system.
+
+## Task 1: Compatibility, Token Field, and Custom Separator
+
+**Files:**
+- Create: `tests/tui/test_status_bar.py`
+- Modify: `src/loushang/tui/ui_parts/status.py`
+
+- [ ] **Step 1: Write failing tests for default compatibility and separator**
+
+Add `tests/tui/test_status_bar.py`:
+
+```python
+from __future__ import annotations
+
+from loushang.tui import RenderConstraints, StatusBar, StatusField, visible_width
+
+
+def rendered_text(status: StatusBar, *, width: int = 40) -> str:
+    result = status.render(RenderConstraints(width=width, max_height=1))
+    return result.lines[0].text
+
+
+def test_status_bar_default_output_is_unchanged() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100),
+            StatusField("running", priority=80),
+        ]
+    )
+
+    assert rendered_text(status, width=30) == "model | running"
+
+
+def test_status_bar_accepts_optional_field_token() -> None:
+    field = StatusField("model", priority=100, token="model")
+
+    assert field.text == "model"
+    assert field.priority == 100
+    assert field.token == "model"
+
+
+def test_status_bar_custom_separator_changes_joined_text() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100),
+            StatusField("running", priority=80),
+        ],
+        separator=" · ",
+    )
+
+    assert rendered_text(status, width=30) == "model · running"
+
+
+def test_status_bar_priority_fitting_uses_custom_separator() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100),
+            StatusField("very-long-branch-name", priority=10),
+            StatusField("running", priority=80),
+        ],
+        separator=" · ",
+    )
+
+    line = rendered_text(status, width=16)
+
+    assert line == "model · running"
+    assert visible_width(line) == 15
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py -q
+```
+
+Expected: FAIL because `StatusField` has no `token` parameter and `StatusBar`
+has no `separator` parameter.
+
+- [ ] **Step 3: Implement minimal compatibility and separator support**
+
+In `src/loushang/tui/ui_parts/status.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class StatusField:
+    text: str
+    priority: int = 0
+    token: str = ""
+
+
+@dataclass(slots=True)
+class StatusBar:
+    fields: list[StatusField] | tuple[StatusField, ...] = field(default_factory=list)
+    separator: str = " | "
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        target_width = autowrap_safe_width(constraints.width)
+        ordered = sorted(self.fields, key=lambda status_field: status_field.priority, reverse=True)
+        selected: list[StatusField] = []
+        for status_field in ordered:
+            candidate = selected + [status_field]
+            text = _join_status(candidate, separator=self.separator)
+            if visible_width(text) <= target_width:
+                selected = candidate
+        text = _join_status(selected, separator=self.separator)
+        if not text and ordered:
+            text = ordered[0].text
+        line = truncate_to_width(text, max_width=target_width)
+        return RenderResult.from_lines([RenderLine(line)], constraints=constraints)
+
+
+def _join_status(fields: list[StatusField], *, separator: str) -> str:
+    return separator.join(field.text for field in fields)
+```
+
+Update any internal calls to `_join_status(...)` to pass `separator=...`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py tests/tui/test_composer_bottom_frame.py::test_status_bar_omits_low_priority_fields_before_wrapping -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add src/loushang/tui/ui_parts/status.py tests/tui/test_status_bar.py
+git commit -m "feat(tui): add status bar separator metadata"
+```
+
+## Task 2: Plain Mode API
+
+**Files:**
+- Modify: `src/loushang/tui/ui_parts/status.py`
+- Modify: `tests/tui/test_status_bar.py`
+
+- [ ] **Step 1: Write a failing test for `plain` mode**
+
+Add the import near the top of `tests/tui/test_status_bar.py`:
+
+```python
+from loushang.tui.theme import ThemeResolver
+```
+
+Append to `tests/tui/test_status_bar.py`:
+
+```python
+
+def test_status_bar_plain_mode_ignores_theme_tokens() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "statusBar.model": {"foreground": "red"},
+            "statusBar.field": {"foreground": "green"},
+            "statusBar.separator": {"foreground": "yellow"},
+        }
+    )
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("running", priority=80, token="runtime.running"),
+        ],
+        theme=theme,
+        style_mode="plain",
+    )
+
+    assert rendered_text(status, width=30) == "model | running"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py::test_status_bar_plain_mode_ignores_theme_tokens -q
+```
+
+Expected: FAIL because `StatusBar` has no `theme` or `style_mode` parameters.
+
+- [ ] **Step 3: Implement minimal `plain` mode API**
+
+In `src/loushang/tui/ui_parts/status.py`:
+
+```python
+from loushang.tui.theme import ThemeResolver
+
+
+StatusBarStyleMode = Literal["plain", "muted", "codex-like"]
+
+
+@dataclass(slots=True)
+class StatusBar:
+    fields: list[StatusField] | tuple[StatusField, ...] = field(default_factory=list)
+    separator: str = " | "
+    style_mode: StatusBarStyleMode = "plain"
+    theme: ThemeResolver | None = None
+```
+
+Keep rendering unstyled for now when `style_mode == "plain"`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add src/loushang/tui/ui_parts/status.py tests/tui/test_status_bar.py
+git commit -m "feat(tui): add status bar plain style mode"
+```
+
+## Task 3: Styled Modes, Built-In Defaults, and Theme Overrides
+
+**Files:**
+- Modify: `src/loushang/tui/ui_parts/status.py`
+- Modify: `tests/tui/test_status_bar.py`
+- Modify: `tests/tui/test_footer_statusline.py`
+
+- [ ] **Step 1: Write failing tests for built-in styled output**
+
+Append to `tests/tui/test_status_bar.py`:
+
+```python
+def test_status_bar_codex_like_mode_applies_builtin_field_styles_without_theme() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("idle", priority=80, token="runtime.idle"),
+        ],
+        style_mode="codex-like",
+    )
+
+    line = rendered_text(status, width=30)
+
+    assert "\x1b[36mmodel\x1b[39m" in line
+    assert "\x1b[2midle\x1b[22m" in line
+
+
+def test_status_bar_codex_like_mode_styles_separator_without_theme() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("branch", priority=80, token="branch"),
+        ],
+        style_mode="codex-like",
+    )
+
+    line = rendered_text(status, width=30)
+
+    assert "\x1b[2m | \x1b[22m" in line
+
+
+def test_status_bar_muted_mode_applies_builtin_styles_without_theme() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("branch", priority=80, token="branch"),
+        ],
+        style_mode="muted",
+    )
+
+    line = rendered_text(status, width=30)
+
+    assert "\x1b[2mmodel\x1b[22m" in line
+    assert "\x1b[2m | \x1b[22m" in line
+
+
+def test_status_bar_theme_override_beats_builtin_style() -> None:
+    theme = ThemeResolver(defaults={"statusBar.codexLike.model": {"foreground": "red"}})
+    status = StatusBar(
+        [StatusField("model", priority=100, token="model")],
+        style_mode="codex-like",
+        theme=theme,
+    )
+
+    assert rendered_text(status, width=20) == "\x1b[31mmodel\x1b[39m"
+```
+
+Add imports near the top of `tests/tui/test_footer_statusline.py`:
+
+```python
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.status import _render_extension_statuses
+```
+
+Append to `tests/tui/test_footer_statusline.py`:
+
+```python
+def test_footer_view_preserves_extension_status_tokens_when_sanitizing() -> None:
+    theme = ThemeResolver(defaults={"statusBar.model": {"foreground": "red"}})
+    lines = _render_extension_statuses(
+        (
+            StatusField("bad\nmodel\ttext", priority=100, token="model"),
+        ),
+        RenderConstraints(width=40, max_height=1),
+        style_mode="codex-like",
+        theme=theme,
+    )
+
+    assert lines == ["\x1b[31mbad model text\x1b[39m"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py tests/tui/test_footer_statusline.py::test_footer_view_preserves_extension_status_tokens_when_sanitizing -q
+```
+
+Expected: FAIL because styled modes do not yet apply ANSI output and
+`_render_extension_statuses()` has no optional styling parameters yet.
+
+- [ ] **Step 3: Implement token styling helpers**
+
+In `src/loushang/tui/ui_parts/status.py`, add helpers with this shape:
+
+```python
+from loushang.tui.theme import ThemeResolver, ThemeStyle, apply_theme_style
+
+
+_MODE_TOKEN_PREFIX = {
+    "codex-like": "codexLike",
+    "muted": "muted",
+}
+
+_CODEX_LIKE_DEFAULTS: dict[str, ThemeStyle] = {
+    "model": {"foreground": "cyan"},
+    "workspace": {"foreground": "green"},
+    "branch": {"foreground": "yellow"},
+    "session": {"foreground": "bright_black"},
+    "runtime.running": {"foreground": "green"},
+    "runtime.idle": {"dim": True},
+    "queue": {"foreground": "magenta"},
+    "message": {"foreground": "bright_white"},
+    "separator": {"dim": True},
+}
+
+_MUTED_DEFAULTS: dict[str, ThemeStyle] = {
+    "field": {"dim": True},
+    "separator": {"dim": True},
+}
+```
+
+Add a style lookup that:
+
+- returns `None` immediately for `style_mode == "plain"`
+- resolves theme token candidates first
+- falls back to built-in defaults only when no theme style resolves
+- falls back to generic built-ins for unknown muted fields
+
+Implementation outline:
+
+```python
+def _style_for_status_part(
+    *,
+    theme: ThemeResolver | None,
+    style_mode: StatusBarStyleMode,
+    token: str,
+    separator: bool = False,
+) -> ThemeStyle | None:
+    if style_mode == "plain":
+        return None
+    semantic_token, exact_tokens = _normalize_status_token(token, style_mode=style_mode)
+    for candidate in _status_token_candidates(
+        semantic_token,
+        style_mode=style_mode,
+        exact_tokens=exact_tokens,
+        separator=separator,
+    ):
+        style = theme.resolve(candidate) if theme is not None else {}
+        if style:
+            return style
+    return _builtin_status_style(style_mode, semantic_token, separator=separator)
+```
+
+Render by joining already-styled segments after selection:
+
+```python
+def _render_status_segments(
+    fields: list[StatusField],
+    *,
+    separator: str,
+    style_mode: StatusBarStyleMode,
+    theme: ThemeResolver | None,
+) -> str:
+    rendered: list[str] = []
+    for index, field in enumerate(fields):
+        if index:
+            rendered.append(_style_status_text(separator, theme, style_mode, "separator", separator=True))
+        rendered.append(_style_status_text(field.text, theme, style_mode, field.token))
+    return "".join(rendered)
+```
+
+For the fallback single-field truncation path, style the truncated field text
+with the winning field's token.
+
+Update `_render_extension_statuses(...)` to preserve `token` and accept optional
+private styling parameters:
+
+```python
+def _render_extension_statuses(
+    statuses: list[StatusField] | tuple[StatusField, ...],
+    constraints: RenderConstraints,
+    *,
+    separator: str = " | ",
+    style_mode: StatusBarStyleMode = "plain",
+    theme: ThemeResolver | None = None,
+) -> list[str]:
+    sanitized = [
+        StatusField(
+            _sanitize_footer_text(status.text),
+            priority=status.priority,
+            token=status.token,
+        )
+        for status in statuses
+        if _sanitize_footer_text(status.text)
+    ]
+    ...
+    return [
+        line.text
+        for line in StatusBar(
+            sanitized,
+            separator=separator,
+            style_mode=style_mode,
+            theme=theme,
+        ).render(constraints).lines
+    ]
+```
+
+Use these optional private-helper parameters only for tests and future internal
+callers. Do not add `theme` or `style_mode` fields to `FooterView` in this
+task; that would broaden public footer behavior beyond the current slice.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py tests/tui/test_footer_statusline.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add src/loushang/tui/ui_parts/status.py tests/tui/test_status_bar.py tests/tui/test_footer_statusline.py
+git commit -m "feat(tui): style status bar semantic tokens"
+```
+
+## Task 4: Width Safety, Unknown Tokens, and Fully Qualified Tokens
+
+**Files:**
+- Modify: `src/loushang/tui/ui_parts/status.py`
+- Modify: `tests/tui/test_status_bar.py`
+- Modify: `tests/tui/test_composer_bottom_frame.py` only if existing
+  expectations need a compatible import or helper adjustment.
+
+- [ ] **Step 1: Write failing tests for fitting and token normalization**
+
+Append to `tests/tui/test_status_bar.py`:
+
+```python
+def test_status_bar_width_fitting_ignores_ansi_sequences() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("very-long-branch-name", priority=10, token="branch"),
+            StatusField("running", priority=80, token="runtime.running"),
+        ],
+        style_mode="codex-like",
+    )
+
+    line = rendered_text(status, width=16)
+
+    assert "very-long-branch-name" not in line
+    assert visible_width(line) == 15
+    assert "model" in line
+    assert "running" in line
+
+
+def test_status_bar_unknown_token_falls_back_to_generic_field_style() -> None:
+    theme = ThemeResolver(defaults={"statusBar.field": {"foreground": "blue"}})
+    status = StatusBar(
+        [StatusField("custom", priority=100, token="unknown")],
+        style_mode="codex-like",
+        theme=theme,
+    )
+
+    assert rendered_text(status, width=20) == "\x1b[34mcustom\x1b[39m"
+
+
+def test_status_bar_fully_qualified_token_behaves_like_semantic_token() -> None:
+    status = StatusBar(
+        [StatusField("model", priority=100, token="statusBar.model")],
+        style_mode="codex-like",
+    )
+
+    assert rendered_text(status, width=20) == "\x1b[36mmodel\x1b[39m"
+
+
+def test_status_bar_mode_qualified_token_resolves_exact_token_first() -> None:
+    theme = ThemeResolver(defaults={"statusBar.codexLike.model": {"foreground": "red"}})
+    status = StatusBar(
+        [StatusField("model", priority=100, token="statusBar.codexLike.model")],
+        style_mode="codex-like",
+        theme=theme,
+    )
+
+    assert rendered_text(status, width=20) == "\x1b[31mmodel\x1b[39m"
+```
+
+- [ ] **Step 2: Run tests to verify failures or current gaps**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py -q
+```
+
+Expected: FAIL for any missing token normalization or width-safety behavior.
+
+- [ ] **Step 3: Tighten normalization and fitting implementation**
+
+Update helper behavior:
+
+```python
+def _normalize_status_token(
+    token: str,
+    *,
+    style_mode: StatusBarStyleMode,
+) -> tuple[str, tuple[str, ...]]:
+    normalized = token.strip()
+    if not normalized:
+        return "field", ()
+    mode_prefix = _MODE_TOKEN_PREFIX.get(style_mode, "")
+    if mode_prefix and normalized.startswith(f"statusBar.{mode_prefix}."):
+        semantic = normalized[len(f"statusBar.{mode_prefix}.") :]
+        return semantic or "field", (normalized,)
+    if normalized.startswith("statusBar."):
+        semantic = normalized[len("statusBar.") :]
+        return semantic or "field", ()
+    return normalized, ()
+```
+
+Mode-qualified tokens apply to the active style mode. Any token in the form
+`statusBar.<mode>.<token>` for the current style mode should try the exact token
+first, then continue through the semantic `<token>` fallback chain. For example,
+`statusBar.codexLike.model` in `codex-like` mode tries
+`statusBar.codexLike.model` first, then continues as `model`.
+
+Ensure the selected field set is determined before applying
+`apply_theme_style(...)`. Never call `visible_width()` on styled candidate
+strings.
+
+- [ ] **Step 4: Run focused and existing status-bar tests**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py tests/tui/test_composer_bottom_frame.py::test_status_bar_omits_low_priority_fields_before_wrapping tests/tui/test_composer_bottom_frame.py::test_status_bar_reserves_last_column_to_avoid_terminal_autowrap -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src/loushang/tui/ui_parts/status.py tests/tui/test_status_bar.py tests/tui/test_composer_bottom_frame.py
+git commit -m "test(tui): lock status bar token fallback behavior"
+```
+
+## Task 5: Public Export and Regression Verification
+
+**Files:**
+- Modify: `tests/tui/test_status_bar.py`
+- Verify: `src/loushang/tui/__init__.py`
+- Verify: `src/loushang/tui/ui_parts/__init__.py`
+
+- [ ] **Step 1: Add public export tests if not already covered**
+
+Add these imports near the top of `tests/tui/test_status_bar.py`:
+
+```python
+from loushang.tui import StatusBar as PublicStatusBar
+from loushang.tui import StatusField as PublicStatusField
+from loushang.tui.ui_parts.status import StatusBar as ModuleStatusBar
+from loushang.tui.ui_parts.status import StatusField as ModuleStatusField
+```
+
+Append to `tests/tui/test_status_bar.py`:
+
+```python
+
+def test_status_bar_public_exports_are_updated_classes() -> None:
+    assert PublicStatusBar is ModuleStatusBar
+    assert PublicStatusField is ModuleStatusField
+    assert PublicStatusField("x", token="model").token == "model"
+```
+
+- [ ] **Step 2: Run export test**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py::test_status_bar_public_exports_are_updated_classes -q
+```
+
+Expected: PASS. If it fails, update the public export modules without changing
+their existing public names.
+
+- [ ] **Step 3: Run full TUI status regression**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_status_bar.py tests/tui/test_footer_statusline.py tests/tui/test_composer_bottom_frame.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run focused lint**
+
+Run:
+
+```bash
+uv run ruff check src/loushang/tui/ui_parts/status.py tests/tui/test_status_bar.py tests/tui/test_footer_statusline.py tests/tui/test_composer_bottom_frame.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit final verification changes**
+
+If Step 1 changed only tests:
+
+```bash
+git add tests/tui/test_status_bar.py src/loushang/tui/__init__.py src/loushang/tui/ui_parts/__init__.py
+git commit -m "test(tui): verify status bar public exports"
+```
+
+If no file changed in this task, skip the commit and record the verification
+commands in the final implementation report.
+
+## Final Handoff
+
+After all tasks pass:
+
+1. Run:
+
+```bash
+git status --short
+git log --oneline -5
+```
+
+2. Confirm no `src/loushang/coding/...` files changed.
+3. Summarize the final public API for the code lane:
+   - `StatusField(token=...)`
+   - `StatusBar(separator=...)`
+   - `StatusBar(style_mode=...)`
+   - `StatusBar(theme=...)`
+   - `plain` default compatibility
+   - `statusBar.*` token fallback behavior
+4. State that the code lane should start from `main` after the TUI PR merges
+   and should depend only on public `StatusBar` / `StatusField` APIs.

--- a/docs/superpowers/specs/2026-06-14-tui-statusbar-rendering-design.md
+++ b/docs/superpowers/specs/2026-06-14-tui-statusbar-rendering-design.md
@@ -1,0 +1,326 @@
+# TUI Status Bar Rendering Design
+
+## Status
+
+Ready for TUI-lane implementation planning.
+
+This is the TUI-lane execution spec for the reusable status-bar rendering
+foundation. It intentionally excludes the coding settings tab and other product
+integration work.
+
+## Package Scope
+
+Implement the feature in:
+
+`src/loushang/tui/ui_parts/status.py`
+
+Keep public exports through:
+
+- `src/loushang/tui/ui_parts/__init__.py`
+- `src/loushang/tui/__init__.py`
+
+No `src/loushang/coding/...` files should be changed for product behavior in
+this slice.
+
+## Current Behavior
+
+`StatusBar` currently:
+
+- accepts a sequence of `StatusField(text, priority)`
+- sorts fields by descending priority
+- keeps adding fields while the joined text fits
+- joins selected fields with `" | "`
+- falls back to the highest-priority field if no joined candidate fits
+- truncates to the available width
+- returns a single `RenderLine`
+
+This behavior is useful and should remain the default.
+
+## Goals
+
+- Add optional semantic tokens to `StatusField`.
+- Add configurable separator support to `StatusBar`.
+- Add optional status-bar styling through existing `ThemeResolver`.
+- Keep default rendering byte-for-byte compatible for unstyled callers.
+- Keep width fitting based on unstyled visible text.
+- Preserve token metadata when footer extension status fields are sanitized.
+- Provide stable public API for the later code-lane Status Line settings work.
+
+## Non-Goals
+
+- Do not add Settings UI.
+- Do not add status-line product settings models.
+- Do not change `/statusline`.
+- Do not add persistence.
+- Do not introduce a new global theme registry.
+- Do not embed ANSI sequences in `StatusField.text`.
+- Do not change transcript, composer input, or command behavior.
+
+## Public API
+
+Extend `StatusField` from:
+
+```python
+@dataclass(frozen=True, slots=True)
+class StatusField:
+    text: str
+    priority: int = 0
+```
+
+to:
+
+```python
+@dataclass(frozen=True, slots=True)
+class StatusField:
+    text: str
+    priority: int = 0
+    token: str = ""
+```
+
+Extend `StatusBar` from:
+
+```python
+@dataclass(slots=True)
+class StatusBar:
+    fields: list[StatusField] | tuple[StatusField, ...] = field(default_factory=list)
+```
+
+to:
+
+```python
+@dataclass(slots=True)
+class StatusBar:
+    fields: list[StatusField] | tuple[StatusField, ...] = field(default_factory=list)
+    separator: str = " | "
+    style_mode: Literal["plain", "muted", "codex-like"] = "plain"
+    theme: ThemeResolver | None = None
+```
+
+The default values are part of the compatibility contract.
+
+## Rendering Rules
+
+`StatusBar.render()` continues to choose fields using unstyled text:
+
+1. sanitize is not added here; callers already pass display text
+2. sort fields by descending priority
+3. build joined candidates using the configured separator
+4. choose the largest fitting priority-ordered set
+5. if no set fits, use the highest-priority field text
+6. truncate the unstyled selected text to target width
+7. apply styles after selection and truncation
+
+Because styling is applied after fitting, ANSI escape sequences must not affect
+`visible_width()`.
+
+Empty fields still render a blank single-line status result.
+
+## Separator Behavior
+
+`separator` is the exact string inserted between selected fields. The default is
+`" | "`.
+
+Examples:
+
+- `separator=" | "` renders `model | branch | idle`
+- `separator=" · "` renders `model · branch · idle`
+
+Separators are omitted when only one field is selected.
+
+When styling is enabled, separators are styled independently from fields.
+
+## Styling Modes
+
+`plain` is the compatibility mode:
+
+- no field styling
+- no separator styling
+- no `statusBar.*` token resolution
+- no default style fallback
+
+`muted` and `codex-like` are styled modes:
+
+- they resolve through the provided `ThemeResolver`
+- they apply built-in default token styles when no theme override exists
+- they must preserve readable output when `theme` is `None`
+
+The TUI lane does not define product meaning for a token. It only treats token
+strings as semantic identifiers used to build theme-token fallback chains.
+
+## Theme Token Resolution
+
+Status-bar token resolution uses existing theme primitives:
+
+- `ThemeResolver`
+- `ThemeStyle`
+- `apply_theme_style`
+
+For a field with `token="model"` and `style_mode="codex-like"`, resolve in this
+order:
+
+1. `statusBar.codexLike.model`
+2. `statusBar.model`
+3. `statusBar.codexLike.field`
+4. `statusBar.field`
+5. built-in style for `codex-like` and `model`
+6. no style
+
+For `style_mode="muted"` and `token="branch"`, resolve:
+
+1. `statusBar.muted.branch`
+2. `statusBar.branch`
+3. `statusBar.muted.field`
+4. `statusBar.field`
+5. built-in muted style
+6. no style
+
+For separators in `codex-like`, resolve:
+
+1. `statusBar.codexLike.separator`
+2. `statusBar.separator`
+3. built-in separator style
+4. no style
+
+For separators in `muted`, resolve:
+
+1. `statusBar.muted.separator`
+2. `statusBar.separator`
+3. built-in separator style
+4. no style
+
+`plain` skips this whole process.
+
+## Built-In Styled Defaults
+
+The renderer must provide small built-in defaults so `style_mode` has visible
+effect without requiring every app to define theme overrides. This is part of
+the public behavior for `muted` and `codex-like`.
+
+Required defaults:
+
+- `codex-like` model: `{"foreground": "cyan"}`
+- `codex-like` workspace: `{"foreground": "green"}`
+- `codex-like` branch: `{"foreground": "yellow"}`
+- `codex-like` session: `{"foreground": "bright_black"}`
+- `codex-like` runtime running: `{"foreground": "green"}`
+- `codex-like` runtime idle: `{"dim": True}`
+- `codex-like` queue: `{"foreground": "magenta"}`
+- `codex-like` message: `{"foreground": "bright_white"}`
+- `codex-like` separator: `{"dim": True}`
+- `muted` fields: `{"dim": True}`
+- `muted` separator: `{"dim": True}`
+
+If theme overrides are present, they take precedence over built-in defaults.
+Built-ins are only used after the relevant theme-token fallback chain resolves
+to no style.
+
+## Token Normalization
+
+The TUI API accepts token fragments without the `statusBar.` prefix:
+
+- `model`
+- `workspace`
+- `runtime.idle`
+
+If a caller passes a fully qualified token beginning with `statusBar.`, the
+renderer strips exactly that prefix before constructing the normal status-bar
+fallback chain. For example, `token="statusBar.model"` behaves the same as
+`token="model"` and never resolves `statusBar.statusBar.model`.
+
+If a caller passes a mode-qualified token such as `statusBar.codexLike.model`,
+the renderer first tries that exact token, then strips `statusBar.codexLike.`
+to the semantic fragment `model` and continues with the normal fallback chain.
+This keeps exact custom tokens usable without making code-lane callers depend
+on fully qualified tokens.
+
+The implementation may de-duplicate repeated token probes. Observable behavior
+must match the ordered fallback rules above.
+
+Unknown tokens are allowed. They fall back to generic field styles or no style.
+
+## Sanitized Extension Statuses
+
+`FooterView._render_extension_statuses()` currently rebuilds `StatusField`
+values after sanitizing text. It must preserve the new `token` field:
+
+```python
+StatusField(
+    _sanitize_footer_text(status.text),
+    priority=status.priority,
+    token=status.token,
+)
+```
+
+This keeps extension-provided status metadata intact.
+
+## Error Handling
+
+- `StatusBar.separator` may be an empty string; that is valid.
+- Invalid `style_mode` values are rejected by type checking and should not need
+  runtime normalization.
+- Unknown tokens do not raise.
+- If styling produces an empty style dict, render unstyled text.
+- If a theme style includes unsupported keys, existing `apply_theme_style`
+  behavior applies.
+
+## Tests
+
+Add or update tests in `tests/tui/test_footer_statusline.py` or a focused
+`tests/tui/test_status_bar.py`.
+
+Required coverage:
+
+- default `StatusBar([StatusField("model")])` output is unchanged
+- default separator remains `" | "`
+- custom separator changes joined text
+- priority fitting and fallback behavior remain unchanged
+- `plain` mode ignores theme tokens and built-in styles
+- tokenized fields render ANSI styling in `codex-like`
+- tokenized separators render ANSI styling in `codex-like`
+- `codex-like` renders built-in ANSI styling when `theme` is `None`
+- `muted` renders built-in ANSI styling when `theme` is `None`
+- theme overrides beat built-in styled defaults
+- `token="statusBar.model"` behaves like `token="model"`
+- `token="statusBar.codexLike.model"` resolves the exact token first, then
+  falls back through the semantic `model` chain
+- unknown tokens fall back safely
+- width fitting ignores ANSI escape sequences
+- `_render_extension_statuses()` preserves `StatusField.token`
+- public exports still expose the updated classes
+
+Regression command:
+
+```bash
+uv run pytest tests/tui/test_footer_statusline.py tests/tui/test_composer_bottom_frame.py -q
+```
+
+Focused lint:
+
+```bash
+uv run ruff check src/loushang/tui/ui_parts/status.py tests/tui/test_footer_statusline.py tests/tui/test_composer_bottom_frame.py
+```
+
+If a new focused status-bar test file is added, include it in both commands.
+
+## Code Lane Handoff
+
+The later code-lane product slice can rely on:
+
+- `StatusField(token=...)`
+- `StatusBar(separator=...)`
+- `StatusBar(style_mode="plain" | "muted" | "codex-like")`
+- `StatusBar(theme=ThemeResolver(...))`
+- `plain` default compatibility
+- styled token fallback under the `statusBar.*` namespace
+
+The code lane should build product-specific fields outside `loushang.tui`, then
+pass them into `StatusBar`. It should not import private helpers from
+`status.py`.
+
+## Acceptance Checklist
+
+- Public API remains backward-compatible.
+- Existing unstyled tests pass without expected-output churn.
+- New styling tests prove semantic tokens work.
+- The feature is fully contained in `loushang.tui.ui_parts`.
+- The TUI PR documents that product settings work is deferred to the code lane.

--- a/docs/superpowers/specs/2026-06-14-tui-statusline-settings-tab-design.md
+++ b/docs/superpowers/specs/2026-06-14-tui-statusline-settings-tab-design.md
@@ -1,0 +1,330 @@
+# TUI Status Line Lane Split Design
+
+## Status
+
+Ready for TUI-lane implementation planning. Code-lane handoff contract defined.
+
+This document is the temporary coordination spec for splitting status-line work
+between the Native TUI lane and the coding/product lane. The long-term internal
+architecture content should move to:
+
+`docs/internals/architecture/tui/native-terminal-core/ui-parts/status-line.md`
+
+after both lane slices stabilize.
+
+## Context
+
+The native coding TUI already has a bottom status line and a settings page:
+
+- `StatusBar` in `src/loushang/tui/ui_parts/status.py` renders a single line by
+  sorting `StatusField(text, priority)` values and joining selected fields with
+  `" | "`.
+- `NativeCodingTuiApp._status_bar()` builds product-specific fields for model,
+  workspace, branch, session, runtime, queue state, and transient status
+  message.
+- `CodingTuiStatusProvider` owns the current status-line visibility flag and
+  exposes a Config setting for `statusline`.
+- `SettingsPageView` renders the current `Status line true/false` row in the
+  Config tab.
+
+Those concerns are currently interleaved in the broader status-line settings
+idea. The reusable rendering enhancement belongs in the long-lived TUI lane;
+the product settings surface belongs in the code lane.
+
+## Decision
+
+Use a two-PR lane split:
+
+1. **TUI lane first.** Implement only reusable status-bar rendering support in
+   `loushang.tui.ui_parts`.
+2. **Code lane second.** After the TUI PR is merged and `main` is updated, the
+   code lane implements the product-facing Status Line settings tab using the
+   public TUI API.
+
+The code lane must not start from the TUI feature branch. It should start from
+`main` after the TUI rendering foundation is merged.
+
+## Overall User Outcome
+
+The final product goal remains:
+
+- a first-level `Status Line` settings tab
+- visible field toggles
+- separator selection
+- color style selection
+- live preview
+- compatibility with `/statusline on|off`
+
+This document does not authorize implementing those product controls in the TUI
+lane. It only defines the sequence and handoff.
+
+## TUI Lane Scope
+
+The TUI lane delivers a reusable, product-agnostic status-bar renderer:
+
+- `StatusField` accepts an optional semantic `token`.
+- `StatusBar` accepts `separator`, `style_mode`, and `theme`.
+- `plain` mode preserves current unstyled behavior.
+- Styled modes can resolve status-bar theme tokens through existing
+  `ThemeResolver`.
+- Width fitting and priority truncation continue to use unstyled text.
+- Public imports remain stable:
+  - `from loushang.tui import StatusBar, StatusField`
+  - `from loushang.tui.ui_parts import StatusBar, StatusField`
+  - `from loushang.tui.ui_parts.status import StatusBar, StatusField`
+
+The detailed TUI-lane execution spec is:
+
+`docs/superpowers/specs/2026-06-14-tui-statusbar-rendering-design.md`
+
+## TUI Lane Non-Goals
+
+The TUI lane must not implement product settings behavior:
+
+- no `Status Line` settings tab
+- no `StatusLineSettings`
+- no `StatusLinePreviewSnapshot`
+- no `status_line_fields(...)` product helper
+- no `/statusline` command changes
+- no `NativeCodingTuiApp._status_bar()` product rewrite beyond compatibility
+  adjustments required by the renderer
+- no persistence
+
+Existing coding status-line behavior should remain effectively unchanged while
+the TUI renderer defaults to `plain`.
+
+## Code Lane Scope
+
+After the TUI PR is merged, the code lane implements the product feature:
+
+- add `src/loushang/coding/ui/status_line.py`
+- define `StatusLineSettings`
+- define `StatusLinePreviewSnapshot`
+- define `status_line_fields(snapshot, settings)`
+- add first-level Settings tab order:
+  `Status, Config, Model, Status Line, Usage, Stats`
+- remove the duplicate `Status line` row from Config when the new tab exists
+- keep `/statusline on|off` compatible
+- make Settings tab and `/statusline` share the same effective enabled state
+- render the real status line and preview through the public TUI `StatusBar`
+  and `StatusField(token=...)` API
+
+The code lane must use the provider-owned status model described below. The
+real bottom status line and preview must also use the same field-builder helper
+to avoid divergent behavior.
+
+## Code Lane Status Ownership
+
+The code-lane slice should collapse status-line visibility into one effective
+owner:
+
+- `CodingTuiStatusProvider` owns the effective `StatusLineSettings`.
+- `StatusLineSettings.enabled` replaces `_visible` as the canonical enabled
+  value. `_visible` should either be removed or treated as derived
+  compatibility state inside the provider.
+- `NativeCodingTuiApp.state.statusline_visible` and future
+  `NativeCodingTuiApp.state.statusline_settings` are render mirrors, not
+  independent sources of truth.
+- `NativeSurfaceManager` is the sync boundary between provider-owned settings
+  and app-render state.
+
+Required sync rules:
+
+- `/statusline on|off` updates provider-owned settings first, then mirrors the
+  effective `StatusLineSettings` into `NativeCodingTuiApp`.
+- `/statusline` without an argument reports the provider-owned enabled value,
+  then mirrors that value into app state.
+- The Settings page reads its initial rows from the provider-owned
+  `StatusLineSettings`.
+- A Settings tab submit updates provider-owned settings, refreshes rows and
+  preview from the provider, and returns enough result data for
+  `NativeSurfaceManager` to mirror the effective settings into the app.
+- The open Settings preview must use the same app preview snapshot provider as
+  the real status line, so queue/message auto behavior reflects current app
+  state.
+
+## Code Lane Preview Snapshot
+
+The code-lane `StatusLinePreviewSnapshot` must contain every live value needed
+by both the real status line and the settings preview:
+
+```python
+@dataclass(frozen=True, slots=True)
+class StatusLinePreviewSnapshot:
+    model_label: str | None
+    cwd: str
+    branch: str | None
+    session_label: str | None
+    running: bool
+    pending_followups: int = 0
+    pending_steers: int = 0
+    status_message: str | None = None
+```
+
+`StatusSnapshot` from `CodingTuiStatusProvider` is not sufficient for preview
+by itself because queue counts and transient status messages currently live in
+`NativeCodingTuiApp.state`.
+
+## Code Lane Field Priorities
+
+`status_line_fields(...)` should keep the current priority order unless user
+review changes it:
+
+| Field | Token | Priority | Default |
+| --- | --- | ---: | --- |
+| model | `model` | 100 | enabled |
+| workspace | `workspace` | 90 | enabled |
+| branch | `branch` | 80 | enabled |
+| session | `session` | 70 | enabled |
+| runtime running | `runtime.running` | 60 | enabled when running |
+| runtime idle | `runtime.idle` | 60 | enabled when idle |
+| queue | `queue` | 50 | auto |
+| message | `message` | 40 | auto |
+
+This table is the source of truth for focused code-lane priority tests.
+
+## Code Lane Setting IDs and Value Cycles
+
+The code-lane Settings tab should use stable setting ids:
+
+- `statusline.enabled`: `true -> false -> true`
+- `statusline.field.model`: `true -> false -> true`
+- `statusline.field.workspace`: `true -> false -> true`
+- `statusline.field.branch`: `true -> false -> true`
+- `statusline.field.session`: `true -> false -> true`
+- `statusline.field.runtime`: `true -> false -> true`
+- `statusline.field.queue`: `auto -> true -> false -> auto`
+- `statusline.field.message`: `auto -> true -> false -> auto`
+- `statusline.separator`: `pipe -> dot -> pipe`
+- `statusline.style`: `codex-like -> muted -> plain -> codex-like`
+
+The UI may display `pipe` as `|` and `dot` as `.` or `·`, but the setting value
+should remain an enum-like string. The style setting maps directly to
+`StatusBar.style_mode`.
+
+## Code Lane Default Focus
+
+Adding `Status Line` as a top-level tab must not change the existing
+`/settings` default page. The settings page should continue opening with
+`Config` selected unless a future user request explicitly changes that
+interaction.
+
+## Handoff Contract
+
+The TUI PR is ready for code-lane pickup only when these contracts are true:
+
+- Old call sites keep working:
+  `StatusBar([StatusField("model", priority=100)])`.
+- With defaults, rendered text remains byte-for-byte compatible for unstyled
+  callers.
+- `StatusField.token` is optional and defaults to an empty string.
+- `StatusBar.separator` defaults to `" | "`.
+- `StatusBar.style_mode` defaults to `"plain"`.
+- `style_mode == "plain"` bypasses all `statusBar.*` token resolution.
+- Styled modes can resolve field and separator styles via `ThemeResolver`.
+- Tokenized fields do not affect field fitting because width calculation uses
+  unstyled text.
+- Helpers that clone `StatusField` values preserve `token`.
+- Public exports include the updated dataclass signatures.
+
+The code lane should depend only on those public contracts, not on private
+helpers inside `status.py`.
+
+## Code Lane API Consumption Example
+
+The code lane should be able to build status fields like this:
+
+```python
+fields = (
+    StatusField("moonshot/kimi-for-coding", priority=100, token="model"),
+    StatusField("loushang", priority=90, token="workspace"),
+    StatusField("tui", priority=80, token="branch"),
+    StatusField("idle", priority=60, token="runtime.idle"),
+)
+
+bar = StatusBar(
+    fields,
+    separator=" | ",
+    style_mode="codex-like",
+    theme=theme,
+)
+```
+
+The TUI renderer is responsible for mapping `"model"` to status-bar token
+chains such as `statusBar.codexLike.model`, `statusBar.model`, and
+`statusBar.field`. The code lane should not pre-resolve ANSI styling.
+
+## Code Lane Product Defaults
+
+The later code-lane product slice should use these defaults unless user review
+changes them:
+
+- status line enabled: `true`
+- model field: `true`
+- workspace field: `true`
+- branch field: `true`
+- session field: `true`
+- runtime field: `true`
+- queue field: `auto`
+- message field: `auto`
+- separator: pipe
+- color style: `codex-like`
+
+`Queue field = true` with no live data should render `queued=0 steer=0`.
+`Message field = true` with no live data should render `no status`.
+
+## Validation Sequence
+
+Before the TUI PR is handed off:
+
+- run TUI renderer tests for status-bar compatibility and styling
+- run existing composer bottom-frame tests that exercise `StatusBar`
+- run focused lint on modified files
+
+Before the later code-lane PR is handed off:
+
+- run focused tests for `src/loushang/coding/ui/status_line.py`
+- run coding settings-page tests
+- run native surface manager tests
+- run native playback tests for settings and `/statusline`
+- run focused lint on modified coding UI files
+
+Focused `status_line.py` tests should cover:
+
+- default `StatusLineSettings`
+- default field order and priority
+- `auto` queue/message behavior
+- forced `true` queue/message output when no data exists
+- forced `false` queue/message omission
+- separator enum mapping
+- style enum mapping to `StatusBar.style_mode`
+- real status line and preview using the same field builder
+
+Integration tests in native surface manager/app coverage should prove:
+
+- `/statusline` updates provider-owned enabled state and mirrors it into app
+  state
+- Settings tab updates provider-owned settings and mirrors effective settings
+  into app state
+- an open preview reads the app preview snapshot for queue/message data
+
+## Risk Controls
+
+- Keeping `plain` as the TUI default prevents a reusable widget change from
+  silently recoloring existing status bars.
+- Deferring product settings to code lane prevents the TUI PR from owning
+  coding app state, `/statusline`, and settings persistence questions.
+- Using public TUI exports as the handoff boundary keeps code lane insulated
+  from private renderer implementation details.
+- Merging the TUI PR before starting code-lane work avoids long-lived
+  cross-lane branch dependency.
+
+## Resolved Decisions
+
+- TUI renderer work is implemented first in the TUI lane.
+- Code/product settings work waits until the TUI renderer PR is merged into
+  `main`.
+- The TUI lane spec is
+  `2026-06-14-tui-statusbar-rendering-design.md`.
+- The long-term documentation target remains under
+  `docs/internals/architecture/tui/native-terminal-core/ui-parts/`.

--- a/src/loushang/coding/ui/playback_scenarios/surface.py
+++ b/src/loushang/coding/ui/playback_scenarios/surface.py
@@ -199,7 +199,8 @@ def _run_settings_search() -> object:
 
     result.assert_exit_code(0)
     result.assert_text_contains("Settings")
-    result.assert_text_contains("Search: zz")
+    result.assert_text_contains("Search settings...")
+    result.assert_text_contains("│ zz")
     result.assert_text_contains("No matching settings")
     result.assert_text_not_contains("Status line: off")
     result.assert_no_clear_screen()

--- a/src/loushang/tui/ui_parts/status.py
+++ b/src/loushang/tui/ui_parts/status.py
@@ -13,7 +13,6 @@ from loushang.tui.theme import ThemeResolver, ThemeStyle, apply_theme_style
 
 from .layout import RegionRenderable
 
-
 StatusBarStyleMode = Literal["plain", "muted", "codex-like"]
 
 _MODE_TOKEN_PREFIX = {

--- a/src/loushang/tui/ui_parts/status.py
+++ b/src/loushang/tui/ui_parts/status.py
@@ -217,9 +217,17 @@ def _style_for_status_part(
 
 
 def _normalize_status_token(token: str, *, style_mode: StatusBarStyleMode) -> tuple[str, tuple[str, ...]]:
-    del style_mode
     normalized = token.strip()
-    return (normalized or "field"), ()
+    if not normalized:
+        return "field", ()
+    mode_prefix = _MODE_TOKEN_PREFIX.get(style_mode, "")
+    if mode_prefix and normalized.startswith(f"statusBar.{mode_prefix}."):
+        semantic = normalized[len(f"statusBar.{mode_prefix}.") :]
+        return semantic or "field", (normalized,)
+    if normalized.startswith("statusBar."):
+        semantic = normalized[len("statusBar.") :]
+        return semantic or "field", ()
+    return normalized, ()
 
 
 def _status_token_candidates(
@@ -231,7 +239,16 @@ def _status_token_candidates(
 ) -> tuple[str, ...]:
     mode_prefix = _MODE_TOKEN_PREFIX[style_mode]
     token = "separator" if separator else semantic_token
-    candidates = [*exact_tokens, f"statusBar.{mode_prefix}.{token}", f"statusBar.{token}"]
+    if separator:
+        candidates = [*exact_tokens, f"statusBar.{mode_prefix}.{token}", f"statusBar.{token}"]
+    else:
+        candidates = [
+            *exact_tokens,
+            f"statusBar.{mode_prefix}.{token}",
+            f"statusBar.{token}",
+            f"statusBar.{mode_prefix}.field",
+            "statusBar.field",
+        ]
     return tuple(dict.fromkeys(candidates))
 
 

--- a/src/loushang/tui/ui_parts/status.py
+++ b/src/loushang/tui/ui_parts/status.py
@@ -9,12 +9,34 @@ from loushang.tui.cell_width import (
     visible_width,
 )
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
-from loushang.tui.theme import ThemeResolver
+from loushang.tui.theme import ThemeResolver, ThemeStyle, apply_theme_style
 
 from .layout import RegionRenderable
 
 
 StatusBarStyleMode = Literal["plain", "muted", "codex-like"]
+
+_MODE_TOKEN_PREFIX = {
+    "codex-like": "codexLike",
+    "muted": "muted",
+}
+
+_CODEX_LIKE_DEFAULTS: dict[str, ThemeStyle] = {
+    "model": {"foreground": "cyan"},
+    "workspace": {"foreground": "green"},
+    "branch": {"foreground": "yellow"},
+    "session": {"foreground": "bright_black"},
+    "runtime.running": {"foreground": "green"},
+    "runtime.idle": {"dim": True},
+    "queue": {"foreground": "magenta"},
+    "message": {"foreground": "bright_white"},
+    "separator": {"dim": True},
+}
+
+_MUTED_DEFAULTS: dict[str, ThemeStyle] = {
+    "field": {"dim": True},
+    "separator": {"dim": True},
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,9 +63,22 @@ class StatusBar:
             if visible_width(text) <= target_width:
                 selected = candidate
         text = _join_status(selected, separator=self.separator)
-        if not text and ordered:
-            text = ordered[0].text
-        line = truncate_to_width(text, max_width=target_width)
+        if text:
+            line = _render_status_segments(
+                selected,
+                separator=self.separator,
+                style_mode=self.style_mode,
+                theme=self.theme,
+            )
+        elif ordered:
+            line = _style_status_text(
+                truncate_to_width(ordered[0].text, max_width=target_width),
+                self.theme,
+                self.style_mode,
+                ordered[0].token,
+            )
+        else:
+            line = ""
         return RenderResult.from_lines([RenderLine(line)], constraints=constraints)
 
 
@@ -132,6 +167,87 @@ def _join_status(fields: list[StatusField], *, separator: str) -> str:
     return separator.join(field.text for field in fields)
 
 
+def _render_status_segments(
+    fields: list[StatusField],
+    *,
+    separator: str,
+    style_mode: StatusBarStyleMode,
+    theme: ThemeResolver | None,
+) -> str:
+    rendered: list[str] = []
+    for index, status_field in enumerate(fields):
+        if index:
+            rendered.append(_style_status_text(separator, theme, style_mode, "separator", separator=True))
+        rendered.append(_style_status_text(status_field.text, theme, style_mode, status_field.token))
+    return "".join(rendered)
+
+
+def _style_status_text(
+    text: str,
+    theme: ThemeResolver | None,
+    style_mode: StatusBarStyleMode,
+    token: str,
+    *,
+    separator: bool = False,
+) -> str:
+    style = _style_for_status_part(theme=theme, style_mode=style_mode, token=token, separator=separator)
+    return apply_theme_style(text, style)
+
+
+def _style_for_status_part(
+    *,
+    theme: ThemeResolver | None,
+    style_mode: StatusBarStyleMode,
+    token: str,
+    separator: bool = False,
+) -> ThemeStyle | None:
+    if style_mode == "plain":
+        return None
+    semantic_token, exact_tokens = _normalize_status_token(token, style_mode=style_mode)
+    for candidate in _status_token_candidates(
+        semantic_token,
+        style_mode=style_mode,
+        exact_tokens=exact_tokens,
+        separator=separator,
+    ):
+        style = theme.resolve(candidate) if theme is not None else {}
+        if style:
+            return style
+    return _builtin_status_style(style_mode, semantic_token, separator=separator)
+
+
+def _normalize_status_token(token: str, *, style_mode: StatusBarStyleMode) -> tuple[str, tuple[str, ...]]:
+    del style_mode
+    normalized = token.strip()
+    return (normalized or "field"), ()
+
+
+def _status_token_candidates(
+    semantic_token: str,
+    *,
+    style_mode: StatusBarStyleMode,
+    exact_tokens: tuple[str, ...],
+    separator: bool,
+) -> tuple[str, ...]:
+    mode_prefix = _MODE_TOKEN_PREFIX[style_mode]
+    token = "separator" if separator else semantic_token
+    candidates = [*exact_tokens, f"statusBar.{mode_prefix}.{token}", f"statusBar.{token}"]
+    return tuple(dict.fromkeys(candidates))
+
+
+def _builtin_status_style(
+    style_mode: StatusBarStyleMode,
+    semantic_token: str,
+    *,
+    separator: bool,
+) -> ThemeStyle | None:
+    if style_mode == "codex-like":
+        return _CODEX_LIKE_DEFAULTS.get("separator" if separator else semantic_token)
+    if style_mode == "muted":
+        return _MUTED_DEFAULTS.get("separator" if separator else "field")
+    return None
+
+
 def _footer_fields_fit(fields: list[FooterField], *, width: int, separator: str, min_gap: int) -> bool:
     left = _join_footer_fields(fields, side="left", separator=separator)
     right = _join_footer_fields(fields, side="right", separator=separator)
@@ -175,15 +291,29 @@ def _render_footer_part(part: RegionRenderable | str, constraints: RenderConstra
 def _render_extension_statuses(
     statuses: list[StatusField] | tuple[StatusField, ...],
     constraints: RenderConstraints,
+    *,
+    separator: str = " | ",
+    style_mode: StatusBarStyleMode = "plain",
+    theme: ThemeResolver | None = None,
 ) -> list[str]:
     sanitized = [
-        StatusField(_sanitize_footer_text(status.text), priority=status.priority)
+        StatusField(_sanitize_footer_text(status.text), priority=status.priority, token=status.token)
         for status in statuses
         if _sanitize_footer_text(status.text)
     ]
     if not sanitized:
         return []
-    return [line.text for line in StatusBar(sanitized).render(constraints).lines]
+    return [
+        line.text
+        for line in StatusBar(
+            sanitized,
+            separator=separator,
+            style_mode=style_mode,
+            theme=theme,
+        )
+        .render(constraints)
+        .lines
+    ]
 
 
 def _sanitize_footer_text(text: str) -> str:

--- a/src/loushang/tui/ui_parts/status.py
+++ b/src/loushang/tui/ui_parts/status.py
@@ -9,8 +9,12 @@ from loushang.tui.cell_width import (
     visible_width,
 )
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.theme import ThemeResolver
 
 from .layout import RegionRenderable
+
+
+StatusBarStyleMode = Literal["plain", "muted", "codex-like"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,6 +28,8 @@ class StatusField:
 class StatusBar:
     fields: list[StatusField] | tuple[StatusField, ...] = field(default_factory=list)
     separator: str = " | "
+    style_mode: StatusBarStyleMode = "plain"
+    theme: ThemeResolver | None = None
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         target_width = autowrap_safe_width(constraints.width)

--- a/src/loushang/tui/ui_parts/status.py
+++ b/src/loushang/tui/ui_parts/status.py
@@ -17,11 +17,13 @@ from .layout import RegionRenderable
 class StatusField:
     text: str
     priority: int = 0
+    token: str = ""
 
 
 @dataclass(slots=True)
 class StatusBar:
     fields: list[StatusField] | tuple[StatusField, ...] = field(default_factory=list)
+    separator: str = " | "
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         target_width = autowrap_safe_width(constraints.width)
@@ -29,10 +31,10 @@ class StatusBar:
         selected: list[StatusField] = []
         for status_field in ordered:
             candidate = selected + [status_field]
-            text = _join_status(candidate)
+            text = _join_status(candidate, separator=self.separator)
             if visible_width(text) <= target_width:
                 selected = candidate
-        text = _join_status(selected)
+        text = _join_status(selected, separator=self.separator)
         if not text and ordered:
             text = ordered[0].text
         line = truncate_to_width(text, max_width=target_width)
@@ -120,8 +122,8 @@ class WorkingLine:
         return RenderResult.from_lines([RenderLine(line)], constraints=constraints)
 
 
-def _join_status(fields: list[StatusField]) -> str:
-    return " | ".join(field.text for field in fields)
+def _join_status(fields: list[StatusField], *, separator: str) -> str:
+    return separator.join(field.text for field in fields)
 
 
 def _footer_fields_fit(fields: list[FooterField], *, width: int, separator: str, min_gap: int) -> bool:

--- a/tests/tui/test_footer_statusline.py
+++ b/tests/tui/test_footer_statusline.py
@@ -14,6 +14,8 @@ from loushang.tui import (
     StatusField,
     visible_width,
 )
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.status import _render_extension_statuses
 
 
 @dataclass(slots=True)
@@ -75,6 +77,20 @@ def test_footer_view_prefers_primary_line_under_height_pressure() -> None:
     )
 
     assert rendered_text(footer, width=24, height=1) == ("primary",)
+
+
+def test_footer_view_preserves_extension_status_tokens_when_sanitizing() -> None:
+    theme = ThemeResolver(defaults={"statusBar.model": {"foreground": "red"}})
+    lines = _render_extension_statuses(
+        (
+            StatusField("bad\nmodel\ttext", priority=100, token="model"),
+        ),
+        RenderConstraints(width=40, max_height=1),
+        style_mode="codex-like",
+        theme=theme,
+    )
+
+    assert lines == ["\x1b[31mbad model text\x1b[39m"]
 
 
 def test_extension_api_can_replace_custom_footer_and_dispose_it() -> None:

--- a/tests/tui/test_status_bar.py
+++ b/tests/tui/test_status_bar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from loushang.tui import RenderConstraints, StatusBar, StatusField, visible_width
+from loushang.tui.theme import ThemeResolver
 
 
 def rendered_text(status: StatusBar, *, width: int = 40) -> str:
@@ -53,3 +54,23 @@ def test_status_bar_priority_fitting_uses_custom_separator() -> None:
 
     assert line == "model · running"
     assert visible_width(line) == 15
+
+
+def test_status_bar_plain_mode_ignores_theme_tokens() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "statusBar.model": {"foreground": "red"},
+            "statusBar.field": {"foreground": "green"},
+            "statusBar.separator": {"foreground": "yellow"},
+        }
+    )
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("running", priority=80, token="runtime.running"),
+        ],
+        theme=theme,
+        style_mode="plain",
+    )
+
+    assert rendered_text(status, width=30) == "model | running"

--- a/tests/tui/test_status_bar.py
+++ b/tests/tui/test_status_bar.py
@@ -74,3 +74,58 @@ def test_status_bar_plain_mode_ignores_theme_tokens() -> None:
     )
 
     assert rendered_text(status, width=30) == "model | running"
+
+
+def test_status_bar_codex_like_mode_applies_builtin_field_styles_without_theme() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("idle", priority=80, token="runtime.idle"),
+        ],
+        style_mode="codex-like",
+    )
+
+    line = rendered_text(status, width=30)
+
+    assert "\x1b[36mmodel\x1b[39m" in line
+    assert "\x1b[2midle\x1b[22m" in line
+
+
+def test_status_bar_codex_like_mode_styles_separator_without_theme() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("branch", priority=80, token="branch"),
+        ],
+        style_mode="codex-like",
+    )
+
+    line = rendered_text(status, width=30)
+
+    assert "\x1b[2m | \x1b[22m" in line
+
+
+def test_status_bar_muted_mode_applies_builtin_styles_without_theme() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("branch", priority=80, token="branch"),
+        ],
+        style_mode="muted",
+    )
+
+    line = rendered_text(status, width=30)
+
+    assert "\x1b[2mmodel\x1b[22m" in line
+    assert "\x1b[2m | \x1b[22m" in line
+
+
+def test_status_bar_theme_override_beats_builtin_style() -> None:
+    theme = ThemeResolver(defaults={"statusBar.codexLike.model": {"foreground": "red"}})
+    status = StatusBar(
+        [StatusField("model", priority=100, token="model")],
+        style_mode="codex-like",
+        theme=theme,
+    )
+
+    assert rendered_text(status, width=20) == "\x1b[31mmodel\x1b[39m"

--- a/tests/tui/test_status_bar.py
+++ b/tests/tui/test_status_bar.py
@@ -129,3 +129,52 @@ def test_status_bar_theme_override_beats_builtin_style() -> None:
     )
 
     assert rendered_text(status, width=20) == "\x1b[31mmodel\x1b[39m"
+
+
+def test_status_bar_width_fitting_ignores_ansi_sequences() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100, token="model"),
+            StatusField("very-long-branch-name", priority=10, token="branch"),
+            StatusField("running", priority=80, token="runtime.running"),
+        ],
+        style_mode="codex-like",
+    )
+
+    line = rendered_text(status, width=16)
+
+    assert "very-long-branch-name" not in line
+    assert visible_width(line) == 15
+    assert "model" in line
+    assert "running" in line
+
+
+def test_status_bar_unknown_token_falls_back_to_generic_field_style() -> None:
+    theme = ThemeResolver(defaults={"statusBar.field": {"foreground": "blue"}})
+    status = StatusBar(
+        [StatusField("custom", priority=100, token="unknown")],
+        style_mode="codex-like",
+        theme=theme,
+    )
+
+    assert rendered_text(status, width=20) == "\x1b[34mcustom\x1b[39m"
+
+
+def test_status_bar_fully_qualified_token_behaves_like_semantic_token() -> None:
+    status = StatusBar(
+        [StatusField("model", priority=100, token="statusBar.model")],
+        style_mode="codex-like",
+    )
+
+    assert rendered_text(status, width=20) == "\x1b[36mmodel\x1b[39m"
+
+
+def test_status_bar_mode_qualified_token_resolves_exact_token_first() -> None:
+    theme = ThemeResolver(defaults={"statusBar.codexLike.model": {"foreground": "red"}})
+    status = StatusBar(
+        [StatusField("model", priority=100, token="statusBar.codexLike.model")],
+        style_mode="codex-like",
+        theme=theme,
+    )
+
+    assert rendered_text(status, width=20) == "\x1b[31mmodel\x1b[39m"

--- a/tests/tui/test_status_bar.py
+++ b/tests/tui/test_status_bar.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from loushang.tui import RenderConstraints, StatusBar, StatusField, visible_width
+from loushang.tui import StatusBar as PublicStatusBar
+from loushang.tui import StatusField as PublicStatusField
 from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.status import StatusBar as ModuleStatusBar
+from loushang.tui.ui_parts.status import StatusField as ModuleStatusField
 
 
 def rendered_text(status: StatusBar, *, width: int = 40) -> str:
@@ -178,3 +182,9 @@ def test_status_bar_mode_qualified_token_resolves_exact_token_first() -> None:
     )
 
     assert rendered_text(status, width=20) == "\x1b[31mmodel\x1b[39m"
+
+
+def test_status_bar_public_exports_are_updated_classes() -> None:
+    assert PublicStatusBar is ModuleStatusBar
+    assert PublicStatusField is ModuleStatusField
+    assert PublicStatusField("x", token="model").token == "model"

--- a/tests/tui/test_status_bar.py
+++ b/tests/tui/test_status_bar.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from loushang.tui import RenderConstraints, StatusBar, StatusField, visible_width
+
+
+def rendered_text(status: StatusBar, *, width: int = 40) -> str:
+    result = status.render(RenderConstraints(width=width, max_height=1))
+    return result.lines[0].text
+
+
+def test_status_bar_default_output_is_unchanged() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100),
+            StatusField("running", priority=80),
+        ]
+    )
+
+    assert rendered_text(status, width=30) == "model | running"
+
+
+def test_status_bar_accepts_optional_field_token() -> None:
+    field = StatusField("model", priority=100, token="model")
+
+    assert field.text == "model"
+    assert field.priority == 100
+    assert field.token == "model"
+
+
+def test_status_bar_custom_separator_changes_joined_text() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100),
+            StatusField("running", priority=80),
+        ],
+        separator=" · ",
+    )
+
+    assert rendered_text(status, width=30) == "model · running"
+
+
+def test_status_bar_priority_fitting_uses_custom_separator() -> None:
+    status = StatusBar(
+        [
+            StatusField("model", priority=100),
+            StatusField("very-long-branch-name", priority=10),
+            StatusField("running", priority=80),
+        ],
+        separator=" · ",
+    )
+
+    line = rendered_text(status, width=16)
+
+    assert line == "model · running"
+    assert visible_width(line) == 15

--- a/tests/tui/test_widgets_light_controls.py
+++ b/tests/tui/test_widgets_light_controls.py
@@ -181,12 +181,12 @@ def test_tabs_normalize_value_render_theme_and_width() -> None:
     assert tabs.value == "overview"
     assert tabs.selected_value == "overview"
     assert changes == []
-    assert plain_lines(tabs, width=60, height=1) == ("* [Overview]    [Logs 3]    [Settings]",)
+    assert plain_lines(tabs, width=60, height=1) == ("*[Overview]   [Logs 3]   [Settings]",)
 
     tabs.focus()
     raw = render_lines(tabs, width=60, height=1)[0]
-    assert raw.startswith("\x1b[1;36m> [Overview]")
-    assert "\x1b[2m  [Settings]" in raw
+    assert raw.startswith("\x1b[1;36m>[Overview]")
+    assert "\x1b[2m [Settings]" in raw
     assert_widths_within(render_lines(tabs, width=10, height=1), 10)
 
 
@@ -196,7 +196,7 @@ def test_tabs_level_tokens_fallback_to_legacy_tab_token() -> None:
 
     raw = render_lines(tabs, width=40, height=1)[0]
 
-    assert "\x1b[31m  [Two]" in raw
+    assert "\x1b[31m [Two]" in raw
 
 
 def test_tabs_navigation_changes_value_callbacks_and_activation_forms() -> None:
@@ -325,7 +325,7 @@ def test_widgets_light_controls_example_playback_snapshots() -> None:
     assert frames[0].lines[:12] == (
         "View Switcher",
         "",
-        "Views         > [Overview]    [Logs 3]    [Settings]",
+        "Views         >[Overview]   [Logs 3]   [Settings]",
         "Activity      | Syncing",
         "",
         "Actions",
@@ -336,7 +336,7 @@ def test_widgets_light_controls_example_playback_snapshots() -> None:
         "Status        Ready",
         "",
     )
-    assert "Views           [Overview]  > [Logs 3]    [Settings]" in frames[1].lines
+    assert "Views          [Overview]  >[Logs 3]   [Settings]" in frames[1].lines
     assert "              > Open  current view" in frames[2].lines
     assert "              > Refresh" in frames[3].lines
     assert "Status        Refreshed" in frames[4].lines
@@ -351,12 +351,12 @@ def test_widgets_light_controls_example_highlights_active_region() -> None:
     initial = tui.render(RenderConstraints(width=80, max_height=20))
     initial_lines = tuple(line.text for line in initial.lines)
 
-    assert "\x1b[1;36m> [Overview]" in initial_lines[2]
+    assert "\x1b[1;36m>[Overview]" in initial_lines[2]
     assert "\x1b[1;36m> Open" not in initial_lines[6]
 
     tui.handle_input(InputEvent(kind="key", key="tab"))
     actions = tui.render(RenderConstraints(width=80, max_height=20))
     action_lines = tuple(line.text for line in actions.lines)
 
-    assert "\x1b[1;36m> [Overview]" not in action_lines[2]
+    assert "\x1b[1;36m>[Overview]" not in action_lines[2]
     assert "\x1b[1;36m> Open" in action_lines[6]


### PR DESCRIPTION
## Summary

- Add reusable status-bar rendering support in `loushang.tui.ui_parts`: field tokens, custom separators, style modes, theme fallback, and built-in styled defaults.
- Preserve default `plain` behavior for existing unstyled `StatusBar` callers and keep the code-lane Status Line settings work deferred.
- Refresh stale Tabs and settings-search playback assertions so the full suite reflects the current UI output.

## Validation

- `uv run pytest tests -q`
- `uv run ruff check src/loushang/tui/ui_parts/status.py tests/tui/test_status_bar.py tests/tui/test_footer_statusline.py tests/tui/test_composer_bottom_frame.py tests/tui/test_widgets_light_controls.py src/loushang/coding/ui/playback_scenarios/surface.py`

## Code Lane Handoff

The later code-lane Status Line settings work should start from `main` after this PR merges and depend only on public `StatusBar` / `StatusField` APIs.
