### PR TITLE
[codex] add coding status line settings

### DIFF
--- a/docs/superpowers/plans/2026-06-14-code-status-line-settings.md
+++ b/docs/superpowers/plans/2026-06-14-code-status-line-settings.md
@@ -1,0 +1,140 @@
+# Code Status Line Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add provider-owned Status Line settings for the native coding TUI using the public TUI `StatusBar` API.
+
+**Architecture:** Product status-line state lives in `CodingTuiStatusProvider` as `StatusLineSettings`. `NativeCodingTuiApp.state` mirrors effective settings for rendering, while real and preview status lines share `status_line_fields(...)`.
+
+**Tech Stack:** Python 3.11 dataclasses, pytest, existing `loushang.tui` `StatusBar`, `StatusField`, `SearchableList`, and `TabGroup`.
+
+---
+
+## File Structure
+
+- Create `src/loushang/coding/ui/status_line.py`: settings dataclasses, preview snapshot, field builder, separator/style mappings, workspace label helper.
+- Modify `src/loushang/coding/ui/status_provider.py`: provider owns `StatusLineSettings`; old visibility APIs become compatibility wrappers.
+- Modify `src/loushang/coding/ui/native_state.py`: add mirrored `statusline_settings`.
+- Modify `src/loushang/coding/ui/native_app.py`: add settings mirror methods, preview snapshot, and shared builder status bar rendering.
+- Modify `src/loushang/coding/ui/settings_page.py`: add Status Line tab with rows, cycles, and live preview; remove old Config row.
+- Modify `src/loushang/coding/ui/native_surfaces.py`: mirror provider-owned settings after `/statusline` and settings submits.
+- Update focused tests under `tests/coding/`.
+
+## Task 1: Status Line Model And Builder
+
+**Files:**
+- Create: `src/loushang/coding/ui/status_line.py`
+- Test: `tests/coding/test_ui_status_line.py`
+
+- [ ] **Step 1: Write failing tests**
+  Cover default settings, priority/token order, queue/message `auto|true|false`, separator mapping, style mapping, and workspace label behavior.
+
+- [ ] **Step 2: Verify RED**
+  Run: `uv run pytest tests/coding/test_ui_status_line.py -q`
+  Expected: import failure for `loushang.coding.ui.status_line`.
+
+- [ ] **Step 3: Implement minimal module**
+  Add frozen dataclasses:
+  `StatusLineSettings`, `StatusLinePreviewSnapshot`.
+  Add `status_line_fields(snapshot, settings)`, `status_line_separator(settings)`, `status_line_style_mode(settings)`, and `cwd_label(cwd)`.
+
+- [ ] **Step 4: Verify GREEN**
+  Run: `uv run pytest tests/coding/test_ui_status_line.py -q`
+  Expected: pass.
+
+## Task 2: Provider Ownership
+
+**Files:**
+- Modify: `src/loushang/coding/ui/status_provider.py`
+- Test: `tests/coding/test_ui_status_provider.py`
+
+- [ ] **Step 1: Write failing provider tests**
+  Prove provider exposes effective `StatusLineSettings`, `set_visible()` updates `settings.enabled`, `apply_statusline_setting()` updates arbitrary Status Line rows, and legacy `settings_list()` remains compatible.
+
+- [ ] **Step 2: Verify RED**
+  Run: `uv run pytest tests/coding/test_ui_status_provider.py -q`
+  Expected: missing settings API assertions fail.
+
+- [ ] **Step 3: Implement provider settings ownership**
+  Replace canonical `_visible` with `_statusline_settings`; expose `statusline_settings()`, `apply_statusline_settings(settings)`, and `apply_statusline_setting(item_id, value)`.
+
+- [ ] **Step 4: Verify GREEN**
+  Run: `uv run pytest tests/coding/test_ui_status_provider.py -q`
+  Expected: pass.
+
+## Task 3: Native App Mirror And Shared Rendering
+
+**Files:**
+- Modify: `src/loushang/coding/ui/native_state.py`
+- Modify: `src/loushang/coding/ui/native_app.py`
+- Test: `tests/coding/test_ui_status_line.py`
+
+- [ ] **Step 1: Write failing app integration tests**
+  Prove `NativeCodingTuiApp.statusline_preview_snapshot()` includes queue/message data and `_status_bar()` uses the same `status_line_fields(...)` output as preview.
+
+- [ ] **Step 2: Verify RED**
+  Run: `uv run pytest tests/coding/test_ui_status_line.py -q`
+  Expected: missing app APIs fail.
+
+- [ ] **Step 3: Implement app mirror**
+  Add `statusline_settings` to native state, `set_statusline_settings(settings)`, `statusline_preview_snapshot()`, and update `_status_bar()` to use `StatusBar(fields, separator=..., style_mode=...)`.
+
+- [ ] **Step 4: Verify GREEN**
+  Run: `uv run pytest tests/coding/test_ui_status_line.py -q`
+  Expected: pass.
+
+## Task 4: Status Line Settings Tab
+
+**Files:**
+- Modify: `src/loushang/coding/ui/settings_page.py`
+- Test: `tests/coding/test_native_settings_page.py`
+
+- [ ] **Step 1: Write failing settings-page tests**
+  Cover tab order, Config default focus, Config no longer showing old `Status line` row, Status Line rows, search, cycles, and live preview.
+
+- [ ] **Step 2: Verify RED**
+  Run: `uv run pytest tests/coding/test_native_settings_page.py -q`
+  Expected: missing Status Line tab and old Config row assertions fail.
+
+- [ ] **Step 3: Implement Status Line tab**
+  Add a reusable settings-list page for Status Line rows, cycle values by id, refresh preview from provider settings, and render preview via `StatusBar(status_line_fields(...))`.
+
+- [ ] **Step 4: Verify GREEN**
+  Run: `uv run pytest tests/coding/test_native_settings_page.py -q`
+  Expected: pass.
+
+## Task 5: Surface Sync And Playback
+
+**Files:**
+- Modify: `src/loushang/coding/ui/native_surfaces.py`
+- Test: `tests/coding/test_native_coding_tui_surfaces.py`
+- Test: `tests/coding/test_native_coding_tui_playback.py`
+
+- [ ] **Step 1: Write failing sync/playback tests**
+  Cover settings submit mirroring provider settings into app, `/statusline on|off` compatibility, and `/settings` navigation to Status Line tab to toggle enabled/style/field.
+
+- [ ] **Step 2: Verify RED**
+  Run: `uv run pytest tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -q`
+  Expected: new sync/navigation assertions fail.
+
+- [ ] **Step 3: Implement sync boundary**
+  In `/statusline`, update provider first then call `app.set_statusline_settings(provider.statusline_settings())`. In settings submit, mirror returned effective settings into app.
+
+- [ ] **Step 4: Verify GREEN**
+  Run: `uv run pytest tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -q`
+  Expected: pass.
+
+## Task 6: Final Verification
+
+- [ ] Run `uv run pytest tests/coding/test_ui_status_line.py -q`
+- [ ] Run `uv run pytest tests/coding/test_ui_status_provider.py tests/coding/test_native_settings_page.py -q`
+- [ ] Run `uv run pytest tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -q`
+- [ ] Run `uv run pytest tests -q`
+- [ ] Run `uv run ruff check src/loushang/coding/ui tests/coding`
+- [ ] Report any failures that cannot be fixed in scope.
+
+## Out Of Scope
+
+- Do not add `/config` alias in this implementation.
+- Do not import private helpers from `loushang.tui.ui_parts.status`.
+- Do not add persistence unless a later task explicitly requests it.

--- a/src/loushang/coding/ui/native_app.py
+++ b/src/loushang/coding/ui/native_app.py
@@ -14,6 +14,13 @@ from loushang.coding.tools.output_preview import (
     prefers_tail_tool_output,
 )
 from loushang.coding.ui.native_state import NativeCodingTuiState, NativeTranscriptWindow
+from loushang.coding.ui.status_line import (
+    StatusLinePreviewSnapshot,
+    StatusLineSettings,
+    status_line_fields,
+    status_line_separator,
+    status_line_style_mode,
+)
 from loushang.coding.ui.transcript_reader import TranscriptReaderSurface
 from loushang.coding.ui.transcript_source import (
     ActiveWindowTranscriptSource,
@@ -32,7 +39,6 @@ from loushang.tui import (
     RenderResult,
     ScreenLayout,
     StatusBar,
-    StatusField,
     Surface,
     SurfaceHost,
     TerminalRuntimeCapabilities,
@@ -172,8 +178,24 @@ class NativeCodingTuiApp:
         self._request_render("product")
 
     def set_statusline_visible(self, visible: bool) -> None:
-        self.state.statusline_visible = visible
+        self.set_statusline_settings(replace(self.state.statusline_settings, enabled=visible))
+
+    def set_statusline_settings(self, settings: StatusLineSettings) -> None:
+        self.state.statusline_settings = settings
+        self.state.statusline_visible = settings.enabled
         self._request_render("product")
+
+    def statusline_preview_snapshot(self) -> StatusLinePreviewSnapshot:
+        return StatusLinePreviewSnapshot(
+            model_label=self.state.model_label,
+            cwd=self.state.cwd,
+            branch=self.state.branch,
+            session_label=self.state.session_label,
+            running=self.state.running,
+            pending_followups=len(self.state.pending_followups),
+            pending_steers=len(self.state.pending_steers),
+            status_message=self.state.status_message,
+        )
 
     def open_transcript_reader(self) -> bool:
         if self.surface_host is None:
@@ -369,24 +391,12 @@ class NativeCodingTuiApp:
         return PendingQueueView(sections=tuple(sections))
 
     def _status_bar(self) -> StatusBar:
-        status = "running" if self.state.running else "idle"
-        fields = [
-            StatusField(self.state.model_label or "model", priority=100),
-            StatusField(_cwd_label(self.state.cwd), priority=90),
-            StatusField(self.state.branch or "no-branch", priority=80),
-            StatusField(self.state.session_label or "no-session", priority=70),
-            StatusField(status, priority=60),
-        ]
-        if self.state.pending_followups or self.state.pending_steers:
-            fields.append(
-                StatusField(
-                    f"queued={len(self.state.pending_followups)} steer={len(self.state.pending_steers)}",
-                    priority=50,
-                )
-            )
-        if self.state.status_message:
-            fields.append(StatusField(self.state.status_message, priority=40))
-        return StatusBar(fields)
+        settings = self.state.statusline_settings
+        return StatusBar(
+            status_line_fields(self.statusline_preview_snapshot(), settings),
+            separator=status_line_separator(settings),
+            style_mode=status_line_style_mode(settings),
+        )
 
 
 @dataclass(slots=True)

--- a/src/loushang/coding/ui/native_state.py
+++ b/src/loushang/coding/ui/native_state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 
+from loushang.coding.ui.status_line import StatusLineSettings
 from loushang.tui.transcript import (
     AssistantMessageRecord,
     DisplayRecord,
@@ -36,6 +37,7 @@ class NativeCodingTuiState:
     branch: str | None = None
     session_label: str | None = None
     statusline_visible: bool = True
+    statusline_settings: StatusLineSettings = field(default_factory=StatusLineSettings)
     _assistant_draft_buffer: StreamingTextBuffer | None = field(default=None, init=False, repr=False)
     _tool_record_indices: dict[str, int] = field(default_factory=dict, repr=False)
     _pending_user_echo: str | None = field(default=None, init=False, repr=False)

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -441,12 +441,10 @@ class NativeSurfaceManager:
         elif command.name == "settings" and isinstance(intent, SettingsIntent):
             await self._open_settings()
         elif command.name == "statusline" and isinstance(intent, StatuslineIntent):
-            setter = self.set_statusline_visible or self.status_provider.set_visible
-            message = setter(intent.enabled)
-            if intent.enabled is not None:
-                self.app.set_statusline_visible(intent.enabled)
-            else:
-                self.app.set_statusline_visible(self.status_provider.is_visible())
+            message = self.status_provider.set_visible(intent.enabled)
+            if self.set_statusline_visible is not None:
+                message = self.set_statusline_visible(intent.enabled)
+            self.app.set_statusline_settings(self.status_provider.statusline_settings())
             self.app.set_status(message)
         return None
 
@@ -531,7 +529,9 @@ class NativeSurfaceManager:
         apply_setting = getattr(page, "apply_setting", None)
         if callable(apply_setting):
             result = await apply_setting(payload["id"], payload.get("value", ""))
-            if result.statusline_visible is not None:
+            if result.statusline_settings is not None:
+                self.app.set_statusline_settings(result.statusline_settings)
+            elif result.statusline_visible is not None:
                 self.app.set_statusline_visible(result.statusline_visible)
             if result.refresh_model_label:
                 await self._refresh_model_label()
@@ -541,7 +541,7 @@ class NativeSurfaceManager:
         updated = self.status_provider.settings_list().toggle(payload["id"])
         self.close_surface()
         message = self.status_provider.apply_settings(updated)
-        self.app.set_statusline_visible(self.status_provider.is_visible())
+        self.app.set_statusline_settings(self.status_provider.statusline_settings())
         self.app.set_status(message)
 
     async def _handle_dialog_submit(self, _payload: Any | None = None) -> None:
@@ -642,6 +642,7 @@ class NativeSurfaceManager:
             status_provider=self.status_provider,
             settings_manager=getattr(self.session, "settings_manager", None),
             session_settings=getattr(self.session, "settings_controller", None),
+            statusline_preview=self.app.statusline_preview_snapshot,
         )
         self._open_surface(
             NativeSurfaceView(

--- a/src/loushang/coding/ui/settings_page.py
+++ b/src/loushang/coding/ui/settings_page.py
@@ -10,6 +10,13 @@ from loushang.coding.ui.model_list import (
     current_model_choice_value,
     select_available_model,
 )
+from loushang.coding.ui.status_line import (
+    StatusLinePreviewSnapshot,
+    StatusLineSettings,
+    status_line_fields,
+    status_line_separator,
+    status_line_style_mode,
+)
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider, StatusSnapshot
 from loushang.tui import (
     CursorDeclaration,
@@ -21,6 +28,7 @@ from loushang.tui import (
     SearchableList,
     SearchableListItem,
     SearchableListSelect,
+    StatusBar,
     TabGroup,
     TabPage,
     ThemeResolver,
@@ -40,6 +48,7 @@ __all__ = [
 class SettingsApplyResult:
     message: str
     statusline_visible: bool | None = None
+    statusline_settings: StatusLineSettings | None = None
     refresh_model_label: bool = False
 
 
@@ -225,6 +234,83 @@ class ConfigSettingsPage:
 
 
 @dataclass(slots=True)
+class StatusLineSettingsPage:
+    statusline_settings: StatusLineSettings
+    statusline_preview: Callable[[], StatusLinePreviewSnapshot]
+    focused: bool = False
+    settings: SearchableList = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.settings = self._make_list(focused=False)
+
+    def focus(self) -> None:
+        self.focused = True
+        self.settings.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.settings.blur()
+
+    def editor_input_target(self) -> object | None:
+        return self.settings.editor_input_target()
+
+    def set_statusline_settings(self, settings: StatusLineSettings, *, preserve_active_key: str = "") -> None:
+        self.statusline_settings = settings
+        self.settings.set_items(_config_items(_statusline_rows(settings)), preserve_active_key=preserve_active_key)
+
+    def handle_input(self, event: object) -> object:
+        result = self.settings.handle_input(event)
+        if isinstance(result, SearchableListSelect):
+            return self._setting_intent(result.key)
+        if result is not None:
+            return result
+        if self.settings.focus_region == "list" and _is_space_event(event):
+            item = self.settings.active_item
+            if item is not None:
+                return self._setting_intent(item.key)
+        if _is_tab_fallback_key(event):
+            return True
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        if constraints.max_height <= 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        if constraints.max_height <= 6:
+            return self.settings.render(constraints)
+        result = self.settings.render(
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 4))
+        )
+        header = RenderLine(_settings_header(constraints.width))
+        preview = _statusline_preview_lines(
+            self.statusline_preview(),
+            self.statusline_settings,
+            width=constraints.width,
+        )
+        rows = [*result.lines[:3], RenderLine(""), header, *result.lines[3:], RenderLine(""), *preview]
+        cursor = result.cursor
+        if cursor is not None and cursor.row >= 3:
+            cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
+
+    def _make_list(self, *, focused: bool) -> SearchableList:
+        return SearchableList(
+            _config_items(_statusline_rows(self.statusline_settings)),
+            placeholder="Search status line...",
+            empty_text="No matching status line settings",
+            focused=focused,
+            search_box=True,
+            detail_column=SETTINGS_VALUE_COLUMN,
+            theme=SETTINGS_PAGE_THEME,
+        )
+
+    def _setting_intent(self, key: str) -> InputIntent | None:
+        row = _row_for_key(_statusline_rows(self.statusline_settings), key)
+        if row is None or row.disabled:
+            return None
+        return InputIntent(kind="setting", text=row.id, note=_next_statusline_value(row.id, row.value))
+
+
+@dataclass(slots=True)
 class ModelPage:
     choices: tuple[ModelChoice, ...]
     current_value: str | None = None
@@ -301,10 +387,12 @@ class SettingsPageView:
     status_page: StaticLinesPage = field(init=False)
     config_page: ConfigSettingsPage = field(init=False)
     model_page: ModelPage = field(init=False)
+    statusline_page: StatusLineSettingsPage = field(init=False)
     usage_page: StaticLinesPage = field(init=False)
     stats_page: TabGroup = field(init=False)
     tabs: TabGroup = field(init=False)
     focused: bool = field(default=False, init=False)
+    statusline_preview: Callable[[], StatusLinePreviewSnapshot] | None = None
 
     @classmethod
     async def create(
@@ -315,6 +403,7 @@ class SettingsPageView:
         usage_provider: Callable[[], object | None] | None = None,
         settings_manager: object | None = None,
         session_settings: object | None = None,
+        statusline_preview: Callable[[], StatusLinePreviewSnapshot] | None = None,
     ) -> SettingsPageView:
         del session_settings
         view = cls(
@@ -322,21 +411,23 @@ class SettingsPageView:
             status_provider=status_provider,
             settings_manager=settings_manager,
             usage_provider=usage_provider,
+            statusline_preview=statusline_preview,
         )
         await view._build()
         view.focus()
         return view
 
     async def apply_setting(self, item_id: str, value: str) -> SettingsApplyResult:
-        if item_id == "statusline":
-            enabled = _as_bool(value)
-            if enabled is None:
-                return SettingsApplyResult("Invalid status line value.")
-            settings = self.status_provider.settings_list().set_enabled("statusline", enabled)
-            message = self.status_provider.apply_settings(settings)
+        if item_id == "statusline" or item_id.startswith("statusline."):
+            message = self.status_provider.apply_statusline_setting(item_id, value)
             self._refresh_status_page()
-            self._refresh_config_rows(preserve_active_key="statusline")
-            return SettingsApplyResult(message, statusline_visible=self.status_provider.is_visible())
+            self._refresh_statusline_page(preserve_active_key=item_id)
+            settings = self.status_provider.statusline_settings()
+            return SettingsApplyResult(
+                message,
+                statusline_visible=settings.enabled,
+                statusline_settings=settings,
+            )
         config = _manager_bool_config(item_id)
         if config is not None:
             enabled = _as_bool(value)
@@ -395,6 +486,10 @@ class SettingsPageView:
         self.config_page = ConfigSettingsPage(_config_rows(self.status_provider, self.settings_manager))
         choices, current_value, error = await _load_model_choices(self.session)
         self.model_page = ModelPage(choices, current_value=current_value, error=error)
+        self.statusline_page = StatusLineSettingsPage(
+            self.status_provider.statusline_settings(),
+            self._statusline_preview_snapshot,
+        )
         self.usage_page = StaticLinesPage(_usage_lines(self.usage_provider))
         self.stats_page = TabGroup(
             (
@@ -410,6 +505,7 @@ class SettingsPageView:
                 TabPage("status", "Status", self.status_page),
                 TabPage("config", "Config", self.config_page),
                 TabPage("model", "Model", self.model_page),
+                TabPage("status-line", "Status Line", self.statusline_page),
                 TabPage("usage", "Usage", self.usage_page),
                 TabPage("stats", "Stats", self.stats_page),
             ),
@@ -422,6 +518,12 @@ class SettingsPageView:
 
     def _refresh_config_rows(self, *, preserve_active_key: str = "") -> None:
         self.config_page.set_rows(_config_rows(self.status_provider, self.settings_manager), preserve_active_key=preserve_active_key)
+
+    def _refresh_statusline_page(self, *, preserve_active_key: str = "") -> None:
+        self.statusline_page.set_statusline_settings(
+            self.status_provider.statusline_settings(),
+            preserve_active_key=preserve_active_key,
+        )
 
     async def _refresh_model_page(self) -> None:
         choices, current_value, error = await _load_model_choices(self.session)
@@ -437,11 +539,25 @@ class SettingsPageView:
         content = page.content if page is not None else None
         if isinstance(content, ConfigSettingsPage):
             return "search" if content.settings.focus_region == "search" else "settings-list"
+        if isinstance(content, StatusLineSettingsPage):
+            return "search" if content.settings.focus_region == "search" else "settings-list"
         if isinstance(content, ModelPage):
             return "search" if content.models.focus_region == "search" else "model-list"
         if isinstance(content, TabGroup):
             return "tabs" if content.header_focused else "page"
         return "page"
+
+    def _statusline_preview_snapshot(self) -> StatusLinePreviewSnapshot:
+        if self.statusline_preview is not None:
+            return self.statusline_preview()
+        snapshot = self.status_provider.snapshot()
+        return StatusLinePreviewSnapshot(
+            model_label=snapshot.model_label,
+            cwd=snapshot.cwd,
+            branch=snapshot.branch,
+            session_label=snapshot.session_label,
+            running=snapshot.running,
+        )
 
 
 async def _load_model_choices(session: Any) -> tuple[tuple[ModelChoice, ...], str | None, str]:
@@ -453,16 +569,29 @@ async def _load_model_choices(session: Any) -> tuple[tuple[ModelChoice, ...], st
     return tuple(choices), current_value, ""
 
 
-def _config_rows(status_provider: CodingTuiStatusProvider, settings_manager: object | None) -> tuple[ConfigRow, ...]:
-    rows = [
-        ConfigRow("statusline", "Status line", _bool_text(status_provider.is_visible())),
-    ]
+def _config_rows(_status_provider: CodingTuiStatusProvider, settings_manager: object | None) -> tuple[ConfigRow, ...]:
+    rows = []
     if settings_manager is not None:
         for config in _MANAGER_BOOL_CONFIGS:
             getter = getattr(settings_manager, config.getter, None)
             if callable(getter):
                 rows.append(ConfigRow(config.id, config.label, _bool_text(bool(getter()))))
     return tuple(rows)
+
+
+def _statusline_rows(settings: StatusLineSettings) -> tuple[ConfigRow, ...]:
+    return (
+        ConfigRow("statusline.enabled", "Enabled", _bool_text(settings.enabled)),
+        ConfigRow("statusline.field.model", "Model", _bool_text(settings.model)),
+        ConfigRow("statusline.field.workspace", "Workspace", _bool_text(settings.workspace)),
+        ConfigRow("statusline.field.branch", "Branch", _bool_text(settings.branch)),
+        ConfigRow("statusline.field.session", "Session", _bool_text(settings.session)),
+        ConfigRow("statusline.field.runtime", "Runtime", _bool_text(settings.runtime)),
+        ConfigRow("statusline.field.queue", "Queue", settings.queue),
+        ConfigRow("statusline.field.message", "Message", settings.message),
+        ConfigRow("statusline.separator", "Separator", settings.separator),
+        ConfigRow("statusline.style", "Style", settings.style),
+    )
 
 
 def _config_items(rows: tuple[ConfigRow, ...]) -> tuple[SearchableListItem, ...]:
@@ -543,6 +672,21 @@ def _model_usage_lines(current_value: str | None) -> tuple[str, ...]:
     )
 
 
+def _statusline_preview_lines(
+    snapshot: StatusLinePreviewSnapshot,
+    settings: StatusLineSettings,
+    *,
+    width: int,
+) -> tuple[RenderLine, ...]:
+    result = StatusBar(
+        status_line_fields(snapshot, settings),
+        separator=status_line_separator(settings),
+        style_mode=status_line_style_mode(settings),
+    ).render(RenderConstraints(width=width, max_height=1))
+    line = result.lines[0].text if result.lines else ""
+    return (RenderLine("Preview"), RenderLine(line))
+
+
 def _settings_header(width: int) -> str:
     value_column = max(8, min(SETTINGS_VALUE_COLUMN, max(8, width - 8)))
     return truncate_to_width(f"{'Setting':<{value_column}}Value", max_width=width, ellipsis="")
@@ -603,6 +747,25 @@ def _next_value(value: str) -> str:
     if current is None:
         return value
     return _bool_text(not current)
+
+
+def _next_statusline_value(item_id: str, value: str) -> str:
+    if item_id in {
+        "statusline.enabled",
+        "statusline.field.model",
+        "statusline.field.workspace",
+        "statusline.field.branch",
+        "statusline.field.session",
+        "statusline.field.runtime",
+    }:
+        return _next_value(value)
+    if item_id in {"statusline.field.queue", "statusline.field.message"}:
+        return {"auto": "true", "true": "false", "false": "auto"}.get(value, value)
+    if item_id == "statusline.separator":
+        return "dot" if value == "pipe" else "pipe"
+    if item_id == "statusline.style":
+        return {"codex-like": "muted", "muted": "plain", "plain": "codex-like"}.get(value, value)
+    return value
 
 
 def _is_space_event(event: object) -> bool:

--- a/src/loushang/coding/ui/status_line.py
+++ b/src/loushang/coding/ui/status_line.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from loushang.tui import StatusField
+
+StatusLineAutoValue = Literal["auto", "true", "false"]
+StatusLineSeparator = Literal["pipe", "dot"]
+StatusLineStyle = Literal["codex-like", "muted", "plain"]
+
+
+@dataclass(frozen=True, slots=True)
+class StatusLineSettings:
+    enabled: bool = True
+    model: bool = True
+    workspace: bool = True
+    branch: bool = True
+    session: bool = True
+    runtime: bool = True
+    queue: StatusLineAutoValue = "auto"
+    message: StatusLineAutoValue = "auto"
+    separator: StatusLineSeparator = "pipe"
+    style: StatusLineStyle = "codex-like"
+
+
+@dataclass(frozen=True, slots=True)
+class StatusLinePreviewSnapshot:
+    model_label: str | None
+    cwd: str
+    branch: str | None
+    session_label: str | None
+    running: bool
+    pending_followups: int = 0
+    pending_steers: int = 0
+    status_message: str | None = None
+
+
+def status_line_fields(
+    snapshot: StatusLinePreviewSnapshot,
+    settings: StatusLineSettings,
+) -> tuple[StatusField, ...]:
+    fields: list[StatusField] = []
+    if settings.model:
+        fields.append(StatusField(snapshot.model_label or "model", priority=100, token="model"))
+    if settings.workspace:
+        fields.append(StatusField(cwd_label(snapshot.cwd), priority=90, token="workspace"))
+    if settings.branch:
+        fields.append(StatusField(snapshot.branch or "no-branch", priority=80, token="branch"))
+    if settings.session:
+        fields.append(StatusField(snapshot.session_label or "no-session", priority=70, token="session"))
+    if settings.runtime:
+        runtime_text = "running" if snapshot.running else "idle"
+        runtime_token = "runtime.running" if snapshot.running else "runtime.idle"
+        fields.append(StatusField(runtime_text, priority=60, token=runtime_token))
+    if _show_auto_field(settings.queue, snapshot.pending_followups > 0 or snapshot.pending_steers > 0):
+        fields.append(
+            StatusField(
+                f"queued={max(0, snapshot.pending_followups)} steer={max(0, snapshot.pending_steers)}",
+                priority=50,
+                token="queue",
+            )
+        )
+    if _show_auto_field(settings.message, bool(snapshot.status_message)):
+        fields.append(StatusField(snapshot.status_message or "no status", priority=40, token="message"))
+    return tuple(fields)
+
+
+def status_line_separator(settings: StatusLineSettings) -> str:
+    if settings.separator == "dot":
+        return " · "
+    return " | "
+
+
+def status_line_style_mode(settings: StatusLineSettings) -> StatusLineStyle:
+    return settings.style if settings.style in {"codex-like", "muted", "plain"} else "codex-like"
+
+
+def cwd_label(cwd: str) -> str:
+    if not cwd:
+        return "cwd"
+    return cwd.rstrip("/").rsplit("/", 1)[-1] or cwd
+
+
+def _show_auto_field(value: StatusLineAutoValue, has_data: bool) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return has_data
+
+
+__all__ = [
+    "StatusLinePreviewSnapshot",
+    "StatusLineSettings",
+    "cwd_label",
+    "status_line_fields",
+    "status_line_separator",
+    "status_line_style_mode",
+]

--- a/src/loushang/coding/ui/status_provider.py
+++ b/src/loushang/coding/ui/status_provider.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 
+from loushang.coding.ui.status_line import StatusLineSettings
 from loushang.coding.ui.toolbar import ToolbarSnapshot, render_toolbar
 from loushang.tui import SettingItem, SettingsList, SettingsListRenderer
 
@@ -16,6 +17,7 @@ class StatusSnapshot:
     thinking_level: str | None
     running: bool
     statusline_visible: bool
+    statusline_settings: StatusLineSettings = field(default_factory=StatusLineSettings)
 
 
 class CodingTuiStatusProvider:
@@ -35,7 +37,7 @@ class CodingTuiStatusProvider:
         self._session_label = session_label
         self._thinking_level = thinking_level
         self._running = running
-        self._visible = True
+        self._statusline_settings = StatusLineSettings()
 
     def render(self) -> str:
         return render_toolbar(
@@ -50,7 +52,10 @@ class CodingTuiStatusProvider:
         )
 
     def is_visible(self) -> bool:
-        return self._visible
+        return self._statusline_settings.enabled
+
+    def statusline_settings(self) -> StatusLineSettings:
+        return self._statusline_settings
 
     def snapshot(self) -> StatusSnapshot:
         return StatusSnapshot(
@@ -60,13 +65,50 @@ class CodingTuiStatusProvider:
             session_label=self._session_label(),
             thinking_level=self._thinking_level(),
             running=self._running(),
-            statusline_visible=self._visible,
+            statusline_visible=self.is_visible(),
+            statusline_settings=self._statusline_settings,
         )
 
     def set_visible(self, visible: bool | None) -> str:
         if visible is not None:
-            self._visible = visible
-        return f"Status line: {'on' if self._visible else 'off'}"
+            self._statusline_settings = replace(self._statusline_settings, enabled=visible)
+        return f"Status line: {'on' if self.is_visible() else 'off'}"
+
+    def apply_statusline_settings(self, settings: StatusLineSettings) -> str:
+        self._statusline_settings = settings
+        return self.set_visible(None)
+
+    def apply_statusline_setting(self, item_id: str, value: str) -> str:
+        normalized = value.casefold()
+        if item_id in {"statusline", "statusline.enabled"}:
+            enabled = _as_bool(normalized)
+            if enabled is None:
+                return "Invalid status line enabled value."
+            return self.set_visible(enabled)
+        bool_field = _bool_statusline_field(item_id)
+        if bool_field is not None:
+            enabled = _as_bool(normalized)
+            if enabled is None:
+                return f"Invalid status line {bool_field.replace('_', ' ')} value."
+            self._statusline_settings = replace(self._statusline_settings, **{bool_field: enabled})
+            return f"Status line {bool_field.replace('_', ' ')}: {normalized}"
+        if item_id in {"statusline.field.queue", "statusline.field.message"}:
+            field_name = item_id.rsplit(".", 1)[-1]
+            if normalized not in {"auto", "true", "false"}:
+                return f"Invalid status line {field_name} value."
+            self._statusline_settings = replace(self._statusline_settings, **{field_name: normalized})
+            return f"Status line {field_name}: {normalized}"
+        if item_id == "statusline.separator":
+            if normalized not in {"pipe", "dot"}:
+                return "Invalid status line separator value."
+            self._statusline_settings = replace(self._statusline_settings, separator=normalized)
+            return f"Status line separator: {normalized}"
+        if item_id == "statusline.style":
+            if normalized not in {"codex-like", "muted", "plain"}:
+                return "Invalid status line style value."
+            self._statusline_settings = replace(self._statusline_settings, style=normalized)
+            return f"Status line style: {normalized}"
+        return f"Unknown status line setting: {item_id}"
 
     def settings_list(self) -> SettingsList:
         return SettingsList(
@@ -74,7 +116,7 @@ class CodingTuiStatusProvider:
                 SettingItem(
                     id="statusline",
                     label="Status line",
-                    enabled=self._visible,
+                    enabled=self.is_visible(),
                 ),
             )
         )
@@ -82,12 +124,30 @@ class CodingTuiStatusProvider:
     def apply_settings(self, settings: SettingsList) -> str:
         for item in settings.items:
             if item.id == "statusline":
-                self._visible = item.enabled
+                self._statusline_settings = replace(self._statusline_settings, enabled=item.enabled)
                 break
         return self.set_visible(None)
 
     def settings_text(self) -> str:
         return "".join(fragment for _style, fragment in SettingsListRenderer(title="Settings").render(self.settings_list()))
+
+
+def _as_bool(value: str) -> bool | None:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return None
+
+
+def _bool_statusline_field(item_id: str) -> str | None:
+    return {
+        "statusline.field.model": "model",
+        "statusline.field.workspace": "workspace",
+        "statusline.field.branch": "branch",
+        "statusline.field.session": "session",
+        "statusline.field.runtime": "runtime",
+    }.get(item_id)
 
 
 __all__ = ["CodingTuiStatusProvider", "StatusSnapshot"]

--- a/tests/coding/test_native_coding_tui_playback.py
+++ b/tests/coding/test_native_coding_tui_playback.py
@@ -368,6 +368,10 @@ def test_native_tui_playback_settings_page_toggles_statusline_and_exits() -> Non
     steps = playback.play(
         [
             PlaybackEvent.input("/settings\r"),
+            PlaybackEvent.input("\x1b[A"),
+            PlaybackEvent.input("\x1b[C"),
+            PlaybackEvent.input("\x1b[C"),
+            PlaybackEvent.input("\x1b[B"),
             PlaybackEvent.input("\r"),
             PlaybackEvent.input("\x1b"),
         ]
@@ -380,6 +384,71 @@ def test_native_tui_playback_settings_page_toggles_statusline_and_exits() -> Non
     lines = _plain_lines(steps[-1].diagnostics)
     assert "Settings" not in lines
     assert not any("moonshot/kimi-for-coding | repo | main | abcd | idle" in line for line in lines)
+    for step in steps:
+        step.assert_no_clear_scrollback()
+
+
+def test_native_tui_playback_settings_page_toggles_statusline_style() -> None:
+    session = _Session()
+    app = _app()
+    playback = _NativeInteractivePlayback(
+        app,
+        _manager(app, session),
+        columns=110,
+        rows=24,
+    )
+
+    steps = playback.play(
+        [
+            PlaybackEvent.input("/settings\r"),
+            PlaybackEvent.input("\x1b[A"),
+            PlaybackEvent.input("\x1b[C"),
+            PlaybackEvent.input("\x1b[C"),
+            PlaybackEvent.input("\x1b[B"),
+            PlaybackEvent.input("style"),
+            PlaybackEvent.input("\r"),
+        ]
+    )
+
+    assert all(step.flush_succeeded for step in steps)
+    assert app.active_surface is not None
+    assert app.state.statusline_settings.style == "muted"
+    assert app.state.status_message == "Status line style: muted"
+    lines = _plain_lines(steps[-1].diagnostics)
+    assert any("Style" in line and "muted" in line for line in lines)
+    for step in steps:
+        step.assert_no_clear_scrollback()
+
+
+def test_native_tui_playback_settings_page_toggles_statusline_field() -> None:
+    session = _Session()
+    app = _app()
+    playback = _NativeInteractivePlayback(
+        app,
+        _manager(app, session),
+        columns=110,
+        rows=24,
+    )
+
+    steps = playback.play(
+        [
+            PlaybackEvent.input("/settings\r"),
+            PlaybackEvent.input("\x1b[A"),
+            PlaybackEvent.input("\x1b[C"),
+            PlaybackEvent.input("\x1b[C"),
+            PlaybackEvent.input("\x1b[B"),
+            PlaybackEvent.input("queue"),
+            PlaybackEvent.input("\r"),
+        ]
+    )
+
+    assert all(step.flush_succeeded for step in steps)
+    assert app.active_surface is not None
+    assert app.state.statusline_settings.queue == "true"
+    assert app.state.status_message == "Status line queue: true"
+    lines = _plain_lines(steps[-1].diagnostics)
+    assert any("Queue" in line and "true" in line for line in lines)
+    assert any("queued=0 steer=0" in line for line in lines)
     for step in steps:
         step.assert_no_clear_scrollback()
 

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -398,9 +398,9 @@ def test_native_surface_manager_opens_settings_in_bottom_frame_with_runtime_over
 
     rendered = app.active_surface.render(RenderConstraints(width=100, max_height=14))
     plain = tuple(strip_control_sequences(line.text) for line in rendered.lines)
-    assert any("Status" in line and "Config" in line and "Model" in line for line in plain)
+    assert any("Status" in line and "Config" in line and "Model" in line and "Status Line" in line for line in plain)
     assert any("Search settings" in line for line in plain)
-    assert any("Status line" in line for line in plain)
+    assert not any("Status line" in line for line in plain[2:])
     assert "Enter/Space to change - Esc to close" not in plain
     assert "  show footer" not in plain
 
@@ -411,14 +411,35 @@ def test_native_surface_manager_settings_page_submit_keeps_surface_open() -> Non
 
     asyncio.run(manager.handle_text("/settings"))
     assert isinstance(app.active_surface, NativeSurfaceView)
+    _focus_statusline_tab(app.active_surface)
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
 
-    assert intent == InputIntent(kind="setting", text="statusline", note="false")
+    assert intent == InputIntent(kind="setting", text="statusline.enabled", note="false")
     asyncio.run(manager.handle_surface_intent(intent))
 
     assert isinstance(app.active_surface, NativeSurfaceView)
     assert app.state.statusline_visible is False
+    assert app.state.statusline_settings.enabled is False
+    assert manager.status_provider.statusline_settings().enabled is False
     assert app.state.status_message == "Status line: off"
+
+
+def test_native_surface_manager_settings_page_submit_mirrors_statusline_settings_into_app() -> None:
+    app = _app()
+    manager = _manager(app, _Session())
+
+    asyncio.run(manager.handle_text("/settings"))
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    _focus_statusline_tab(app.active_surface)
+    assert app.active_surface.content.handle_input(InputEvent(kind="text", text="style")) is True
+    intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
+
+    assert intent == InputIntent(kind="setting", text="statusline.style", note="muted")
+    asyncio.run(manager.handle_surface_intent(intent))
+
+    assert app.state.statusline_settings.style == "muted"
+    assert manager.status_provider.statusline_settings().style == "muted"
+    assert app.state.status_message == "Status line style: muted"
 
 
 def test_native_surface_manager_legacy_settings_surface_still_closes_on_submit() -> None:
@@ -843,8 +864,9 @@ def test_native_surface_manager_applies_settings_page_statusline_change() -> Non
     asyncio.run(manager.handle_text("/settings"))
 
     assert isinstance(app.active_surface, NativeSurfaceView)
+    _focus_statusline_tab(app.active_surface)
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
-    assert intent == InputIntent(kind="setting", text="statusline", note="false")
+    assert intent == InputIntent(kind="setting", text="statusline.enabled", note="false")
 
     asyncio.run(manager.handle_surface_intent(intent))
 
@@ -1037,6 +1059,13 @@ def _status_provider(app: NativeCodingTuiApp) -> CodingTuiStatusProvider:
         thinking_level=lambda: None,
         running=lambda: app.state.running,
     )
+
+
+def _focus_statusline_tab(view: NativeSurfaceView) -> None:
+    assert view.content.handle_input(InputEvent(kind="key", key="up")) is True
+    assert view.content.handle_input(InputEvent(kind="key", key="right")) is not None
+    assert view.content.handle_input(InputEvent(kind="key", key="right")) is not None
+    assert view.content.handle_input(InputEvent(kind="key", key="down")) is True
 
 
 def _only_overlay_view(app: NativeCodingTuiApp) -> NativeSurfaceView:

--- a/tests/coding/test_native_settings_page.py
+++ b/tests/coding/test_native_settings_page.py
@@ -4,6 +4,7 @@ import asyncio
 
 from loushang.coding.types import ModelSelection
 from loushang.coding.ui.settings_page import SettingsPageView
+from loushang.coding.ui.status_line import StatusLinePreviewSnapshot
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider
 from loushang.tui import InputEvent, InputIntent, RenderConstraints
 from loushang.tui.cell_width import strip_control_sequences
@@ -107,12 +108,30 @@ def _status_provider() -> CodingTuiStatusProvider:
     )
 
 
-def _page(settings_manager: object | None = None) -> SettingsPageView:
+def _preview_snapshot(**overrides: object) -> StatusLinePreviewSnapshot:
+    from dataclasses import replace
+
+    snapshot = StatusLinePreviewSnapshot(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        running=False,
+    )
+    return replace(snapshot, **overrides)
+
+
+def _page(
+    settings_manager: object | None = None,
+    *,
+    statusline_preview: object | None = None,
+) -> SettingsPageView:
     return asyncio.run(
         SettingsPageView.create(
             session=_Session(),
             status_provider=_status_provider(),
             settings_manager=settings_manager,
+            statusline_preview=statusline_preview,
         )
     )
 
@@ -130,10 +149,17 @@ def test_settings_page_opens_config_tab_with_search_focus() -> None:
     page = _page()
     lines = _plain(page)
 
-    assert any("Status" in line and "Config" in line and "Model" in line for line in lines)
+    assert any("Status" in line and "Config" in line and "Model" in line and "Status Line" in line for line in lines)
+    assert ">[Config]" in lines[0]
     assert any("Search settings" in line for line in lines)
-    assert any("Status line" in line for line in lines)
+    assert not any("Status line" in line for line in lines[2:])
     assert page.editor_input_target() is not None
+
+
+def test_settings_page_config_no_longer_shows_old_statusline_row() -> None:
+    page = _page(settings_manager=_SettingsManager())
+
+    assert not any("Status line" in line for line in _plain(page, width=96, height=24)[2:])
 
 
 def test_settings_page_config_uses_boxed_search_table_columns_footer_and_styles() -> None:
@@ -154,34 +180,77 @@ def test_settings_page_config_uses_boxed_search_table_columns_footer_and_styles(
 
     header = next(line for line in lines if "Setting" in line and "Value" in line)
     value_column = header.index("Value")
-    status_line = next(line for line in lines if "Status line" in line)
     terminal_line = next(line for line in lines if "Terminal progress" in line)
-    assert status_line.index("true") >= value_column
     assert terminal_line.index("false") >= value_column
 
 
 def test_settings_page_search_filters_config_rows() -> None:
-    page = _page()
+    page = _page(settings_manager=_SettingsManager())
 
-    assert page.handle_input(InputEvent(kind="text", text="status")) is True
+    assert page.handle_input(InputEvent(kind="text", text="progress")) is True
     lines = _plain(page)
 
-    assert any("Status line" in line for line in lines)
-    assert not any("Terminal progress" in line for line in lines)
+    assert any("Terminal progress" in line for line in lines)
+    assert not any("Show images" in line for line in lines)
 
 
-def test_settings_page_statusline_toggle_returns_setting_intent_and_apply_updates_rows() -> None:
+def test_settings_page_statusline_tab_rows_search_cycles_and_preview() -> None:
     page = _page()
+    page.tabs.focus_header()
+    page.handle_input(InputEvent(kind="key", key="right"))
+    page.handle_input(InputEvent(kind="key", key="right"))
     page.handle_input(InputEvent(kind="key", key="down"))
+
+    assert page.tabs.value == "status-line"
+    lines = _plain(page, width=120, height=24)
+    assert any("Search status line..." in line for line in lines)
+    for label in (
+        "Enabled",
+        "Model",
+        "Workspace",
+        "Branch",
+        "Session",
+        "Runtime",
+        "Queue",
+        "Message",
+        "Separator",
+        "Style",
+    ):
+        assert any(label in line for line in lines)
+    assert any("moonshot/kimi-for-coding" in line and "repo" in line for line in lines)
+
+    assert page.handle_input(InputEvent(kind="text", text="style")) is True
     intent = page.handle_input(InputEvent(kind="key", key="enter"))
 
-    assert intent == InputIntent(kind="setting", text="statusline", note="false")
+    assert intent == InputIntent(kind="setting", text="statusline.style", note="muted")
 
-    result = asyncio.run(page.apply_setting("statusline", "false"))
+
+def test_settings_page_statusline_apply_updates_rows_and_preview() -> None:
+    page = _page(statusline_preview=lambda: _preview_snapshot(pending_followups=1, pending_steers=2))
+    page.tabs.focus_header()
+    page.handle_input(InputEvent(kind="key", key="right"))
+    page.handle_input(InputEvent(kind="key", key="right"))
+    page.handle_input(InputEvent(kind="key", key="down"))
+
+    result = asyncio.run(page.apply_setting("statusline.separator", "dot"))
+
+    assert result.statusline_settings is not None
+    assert result.statusline_settings.separator == "dot"
+    assert result.message == "Status line separator: dot"
+    lines = _plain(page, width=120, height=24)
+    assert any("Separator" in line and "dot" in line for line in lines)
+    assert any("moonshot/kimi-for-coding · repo · main · abcd · idle · queued=1 steer=2" in line for line in lines)
+
+
+def test_settings_page_statusline_enabled_toggle_returns_visibility_result() -> None:
+    page = _page()
+
+    result = asyncio.run(page.apply_setting("statusline.enabled", "false"))
 
     assert result.statusline_visible is False
+    assert result.statusline_settings is not None
+    assert result.statusline_settings.enabled is False
     assert result.message == "Status line: off"
-    assert any("Status line" in line and "false" in line for line in _plain(page))
 
 
 def test_settings_page_terminal_progress_apply_updates_settings_manager_and_rows() -> None:
@@ -199,7 +268,6 @@ def test_settings_page_down_moves_past_terminal_progress_when_more_config_rows_a
     page = _page(settings_manager=_SettingsManager())
 
     assert page.handle_input(InputEvent(kind="key", key="down")) is True
-    assert page.handle_input(InputEvent(kind="key", key="down")) is True
     assert page.config_page.settings.active_key == "terminal.progress"
 
     assert page.handle_input(InputEvent(kind="key", key="down")) is True
@@ -214,7 +282,7 @@ def test_settings_page_q_is_search_text_but_closes_from_list_focus() -> None:
     assert search_page.handle_input(InputEvent(kind="text", text="q")) is True
     assert any("q" in line for line in _plain(search_page))
 
-    list_page = _page()
+    list_page = _page(settings_manager=_SettingsManager())
     list_page.handle_input(InputEvent(kind="key", key="down"))
 
     assert list_page.handle_input(InputEvent(kind="text", text="q")) == InputIntent(kind="surface_close")

--- a/tests/coding/test_ui_status_line.py
+++ b/tests/coding/test_ui_status_line.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from loushang.coding.ui.status_line import (
+    StatusLinePreviewSnapshot,
+    StatusLineSettings,
+    status_line_fields,
+    status_line_separator,
+    status_line_style_mode,
+)
+from loushang.tui import RenderConstraints, StatusBar
+
+
+def _snapshot(**overrides: object) -> StatusLinePreviewSnapshot:
+    base = StatusLinePreviewSnapshot(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/home/dev/workspace/loushang",
+        branch="main",
+        session_label="abcd",
+        running=False,
+    )
+    return replace(base, **overrides)
+
+
+def test_status_line_settings_defaults_match_product_defaults() -> None:
+    settings = StatusLineSettings()
+
+    assert settings.enabled is True
+    assert settings.model is True
+    assert settings.workspace is True
+    assert settings.branch is True
+    assert settings.session is True
+    assert settings.runtime is True
+    assert settings.queue == "auto"
+    assert settings.message == "auto"
+    assert settings.separator == "pipe"
+    assert settings.style == "codex-like"
+
+
+def test_status_line_fields_use_product_order_priority_and_tokens() -> None:
+    fields = status_line_fields(
+        _snapshot(running=True, pending_followups=2, pending_steers=1, status_message="Saved"),
+        StatusLineSettings(),
+    )
+
+    assert [(field.text, field.priority, field.token) for field in fields] == [
+        ("moonshot/kimi-for-coding", 100, "model"),
+        ("loushang", 90, "workspace"),
+        ("main", 80, "branch"),
+        ("abcd", 70, "session"),
+        ("running", 60, "runtime.running"),
+        ("queued=2 steer=1", 50, "queue"),
+        ("Saved", 40, "message"),
+    ]
+
+
+def test_status_line_fields_keep_current_missing_value_fallbacks() -> None:
+    fields = status_line_fields(
+        _snapshot(model_label=None, cwd="", branch=None, session_label=None),
+        StatusLineSettings(),
+    )
+
+    assert [field.text for field in fields[:5]] == ["model", "cwd", "no-branch", "no-session", "idle"]
+    assert fields[4].token == "runtime.idle"
+
+
+def test_status_line_fields_can_disable_regular_fields() -> None:
+    fields = status_line_fields(
+        _snapshot(),
+        StatusLineSettings(model=False, workspace=False, branch=False, session=False, runtime=False),
+    )
+
+    assert fields == ()
+
+
+def test_status_line_queue_auto_true_false_behavior() -> None:
+    snapshot = _snapshot()
+
+    assert [field.text for field in status_line_fields(snapshot, StatusLineSettings(queue="auto"))] == [
+        "moonshot/kimi-for-coding",
+        "loushang",
+        "main",
+        "abcd",
+        "idle",
+    ]
+    assert status_line_fields(snapshot, StatusLineSettings(queue="true"))[-1].text == "queued=0 steer=0"
+    assert all(field.token != "queue" for field in status_line_fields(snapshot, StatusLineSettings(queue="false")))
+
+
+def test_status_line_queue_auto_shows_when_data_exists() -> None:
+    fields = status_line_fields(_snapshot(pending_followups=1, pending_steers=3), StatusLineSettings(queue="auto"))
+
+    assert fields[-1].text == "queued=1 steer=3"
+    assert fields[-1].token == "queue"
+
+
+def test_status_line_message_auto_true_false_behavior() -> None:
+    snapshot = _snapshot(status_message=None)
+
+    assert all(field.token != "message" for field in status_line_fields(snapshot, StatusLineSettings(message="auto")))
+    assert status_line_fields(snapshot, StatusLineSettings(message="true"))[-1].text == "no status"
+    assert all(field.token != "message" for field in status_line_fields(snapshot, StatusLineSettings(message="false")))
+
+
+def test_status_line_message_auto_shows_when_data_exists() -> None:
+    fields = status_line_fields(_snapshot(status_message="Status line: on"), StatusLineSettings(message="auto"))
+
+    assert fields[-1].text == "Status line: on"
+    assert fields[-1].token == "message"
+
+
+def test_status_line_separator_and_style_mapping() -> None:
+    assert status_line_separator(StatusLineSettings(separator="pipe")) == " | "
+    assert status_line_separator(StatusLineSettings(separator="dot")) == " · "
+    assert status_line_style_mode(StatusLineSettings(style="codex-like")) == "codex-like"
+    assert status_line_style_mode(StatusLineSettings(style="muted")) == "muted"
+    assert status_line_style_mode(StatusLineSettings(style="plain")) == "plain"
+
+
+def test_native_app_statusline_preview_snapshot_includes_live_queue_and_message_state() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+
+    app = NativeCodingTuiApp(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+    )
+    app.queue_followup("next prompt")
+    app.queue_steer("interrupt")
+    app.set_status("Status line: on")
+
+    assert app.statusline_preview_snapshot() == StatusLinePreviewSnapshot(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        running=False,
+        pending_followups=1,
+        pending_steers=1,
+        status_message="Status line: on",
+    )
+
+
+def test_native_app_real_status_bar_uses_shared_status_line_builder() -> None:
+    from loushang.coding.ui.native_app import NativeCodingTuiApp
+
+    app = NativeCodingTuiApp(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+    )
+    settings = StatusLineSettings(queue="true", message="true", separator="dot", style="plain")
+    app.set_statusline_settings(settings)
+
+    expected = StatusBar(
+        status_line_fields(app.statusline_preview_snapshot(), settings),
+        separator=status_line_separator(settings),
+        style_mode=status_line_style_mode(settings),
+    ).render(RenderConstraints(width=100, max_height=1))
+    actual = app._status_bar().render(RenderConstraints(width=100, max_height=1))
+
+    assert actual.lines[0].text == expected.lines[0].text
+    assert actual.lines[0].text == "moonshot/kimi-for-coding · repo · main · abcd · idle · queued=0 steer=0 · no status"

--- a/tests/coding/test_ui_status_provider.py
+++ b/tests/coding/test_ui_status_provider.py
@@ -41,6 +41,7 @@ def test_status_provider_omits_missing_optional_values() -> None:
 
 
 def test_status_provider_tracks_statusline_visibility() -> None:
+    from loushang.coding.ui.status_line import StatusLineSettings
     from loushang.coding.ui.status_provider import CodingTuiStatusProvider
 
     provider = CodingTuiStatusProvider(
@@ -53,11 +54,77 @@ def test_status_provider_tracks_statusline_visibility() -> None:
     )
 
     assert provider.is_visible() is True
+    assert provider.statusline_settings() == StatusLineSettings()
     assert provider.set_visible(False) == "Status line: off"
     assert provider.is_visible() is False
+    assert provider.statusline_settings().enabled is False
     assert provider.set_visible(True) == "Status line: on"
     assert provider.is_visible() is True
+    assert provider.statusline_settings().enabled is True
     assert provider.set_visible(None) == "Status line: on"
+
+
+def test_status_provider_applies_full_statusline_settings() -> None:
+    from loushang.coding.ui.status_line import StatusLineSettings
+    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+
+    provider = CodingTuiStatusProvider(
+        model_label=None,
+        cwd="/repo",
+        branch=None,
+        session_label=lambda: None,
+        thinking_level=lambda: None,
+        running=lambda: False,
+    )
+    settings = StatusLineSettings(enabled=False, queue="true", message="false", separator="dot", style="muted")
+
+    assert provider.apply_statusline_settings(settings) == "Status line: off"
+
+    assert provider.statusline_settings() == settings
+    assert provider.is_visible() is False
+
+
+def test_status_provider_applies_individual_statusline_settings() -> None:
+    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+
+    provider = CodingTuiStatusProvider(
+        model_label=None,
+        cwd="/repo",
+        branch=None,
+        session_label=lambda: None,
+        thinking_level=lambda: None,
+        running=lambda: False,
+    )
+
+    assert provider.apply_statusline_setting("statusline.enabled", "false") == "Status line: off"
+    assert provider.apply_statusline_setting("statusline.field.queue", "true") == "Status line queue: true"
+    assert provider.apply_statusline_setting("statusline.separator", "dot") == "Status line separator: dot"
+    assert provider.apply_statusline_setting("statusline.style", "plain") == "Status line style: plain"
+
+    settings = provider.statusline_settings()
+    assert settings.enabled is False
+    assert settings.queue == "true"
+    assert settings.separator == "dot"
+    assert settings.style == "plain"
+
+
+def test_status_provider_rejects_invalid_statusline_setting_values() -> None:
+    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+
+    provider = CodingTuiStatusProvider(
+        model_label=None,
+        cwd="/repo",
+        branch=None,
+        session_label=lambda: None,
+        thinking_level=lambda: None,
+        running=lambda: False,
+    )
+
+    assert provider.apply_statusline_setting("statusline.field.queue", "maybe") == "Invalid status line queue value."
+    assert provider.apply_statusline_setting("statusline.separator", "slash") == "Invalid status line separator value."
+    assert provider.apply_statusline_setting("statusline.unknown", "true") == "Unknown status line setting: statusline.unknown"
+    assert provider.statusline_settings().queue == "auto"
+    assert provider.statusline_settings().separator == "pipe"
 
 
 def test_status_provider_formats_settings_summary() -> None:


### PR DESCRIPTION
## Summary
- Add `StatusLineSettings`, preview snapshots, and shared status-line field building for the coding UI.
- Move Status Line controls into a dedicated `/settings` tab with live preview and field/style/separator cycles.
- Make `CodingTuiStatusProvider` own effective status-line settings and mirror them into the native app for rendering and `/statusline` compatibility.

## Validation
- `uv run ruff check src/loushang/coding/ui tests/coding`
- `uv run pytest tests/coding/test_ui_status_line.py -q`
- `uv run pytest tests/coding/test_ui_status_provider.py tests/coding/test_native_settings_page.py -q`
- `uv run pytest tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -q`
- `uv run pytest tests -q`
