### PR TITLE
[codex] add config settings alias

### DIFF
--- a/src/loushang/coding/commands/catalog.py
+++ b/src/loushang/coding/commands/catalog.py
@@ -171,6 +171,13 @@ _LOCAL_COMMANDS_BY_ROUTE_VALUE: dict[str, CommandDef] = {
         description="Open settings",
         source="local",
     ),
+    "config": CommandDef(
+        id="coding.ui.config",
+        name="config",
+        kind=CommandKind.LOCAL_UI,
+        description="Open settings",
+        source="local",
+    ),
     "statusline": CommandDef(
         id="coding.ui.statusline",
         name="statusline",

--- a/src/loushang/coding/ui/intent.py
+++ b/src/loushang/coding/ui/intent.py
@@ -116,7 +116,7 @@ def parse_prompt_intent(text: str) -> CodingUiIntent | None:
         return StatusIntent()
     if stripped == "/terminal":
         return TerminalDiagnosticsIntent()
-    if stripped == "/settings":
+    if stripped in {"/settings", "/config"}:
         return SettingsIntent()
     if stripped == "/model" or stripped.startswith("/model "):
         return ModelSelectIntent(query=stripped[len("/model") :].strip())

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -438,7 +438,7 @@ class NativeSurfaceManager:
             self._open_terminal_diagnostics()
         elif command.name == "hotkeys" and isinstance(intent, HotkeysIntent):
             self._open_info("Hotkeys", format_hotkeys())
-        elif command.name == "settings" and isinstance(intent, SettingsIntent):
+        elif command.name in {"settings", "config"} and isinstance(intent, SettingsIntent):
             await self._open_settings()
         elif command.name == "statusline" and isinstance(intent, StatuslineIntent):
             message = self.status_provider.set_visible(intent.enabled)

--- a/tests/coding/test_coding_command_catalog.py
+++ b/tests/coding/test_coding_command_catalog.py
@@ -59,6 +59,7 @@ def test_coding_command_catalog_preserves_local_command_argument_rules() -> None
 
     assert catalog.lookup("/model kimi").name == "model"
     assert catalog.lookup("/commands model").name == "commands"
+    assert catalog.lookup("/config").name == "config"
     assert catalog.lookup("/status extra") is None
     assert catalog.lookup("/terminal extra") is None
 
@@ -83,3 +84,4 @@ def test_coding_command_catalog_lists_local_and_session_commands_once() -> None:
     assert by_name["deploy"].kind is CommandKind.SESSION
     assert by_name["deploy"].source == "extension"
     assert by_name["settings"].kind is CommandKind.LOCAL_UI
+    assert by_name["config"].kind is CommandKind.LOCAL_UI

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -405,6 +405,21 @@ def test_native_surface_manager_opens_settings_in_bottom_frame_with_runtime_over
     assert "  show footer" not in plain
 
 
+def test_native_surface_manager_config_alias_opens_settings() -> None:
+    app = _app()
+    manager = _manager(app, _Session())
+
+    asyncio.run(manager.handle_text("/config"))
+
+    assert isinstance(app.active_surface, NativeSurfaceView)
+    assert app.active_surface.title == "Settings"
+    plain = tuple(
+        strip_control_sequences(line.text)
+        for line in app.active_surface.render(RenderConstraints(width=100, max_height=14)).lines
+    )
+    assert any("Search settings" in line for line in plain)
+
+
 def test_native_surface_manager_settings_page_submit_keeps_surface_open() -> None:
     app = _app()
     manager = _manager(app, _Session())

--- a/tests/coding/test_ui_controller.py
+++ b/tests/coding/test_ui_controller.py
@@ -91,6 +91,7 @@ def test_parse_prompt_intent_routes_settings_command() -> None:
     from loushang.coding.ui.intent import SettingsIntent, parse_prompt_intent
 
     assert parse_prompt_intent("/settings") == SettingsIntent()
+    assert parse_prompt_intent("/config") == SettingsIntent()
 
 
 def test_parse_prompt_intent_routes_models_command() -> None:


### PR DESCRIPTION
## Summary
- Add `/config` as a local UI alias for the existing `/settings` command.
- Route `/config` through the same `SettingsIntent` and native Settings surface path.
- Cover parser, command catalog, and native surface manager behavior.

## Validation
- `uv run pytest tests/coding/test_ui_controller.py tests/coding/test_coding_command_catalog.py tests/coding/test_native_coding_tui_surfaces.py -q`
- `uv run ruff check src/loushang/coding/ui/intent.py src/loushang/coding/ui/native_surfaces.py src/loushang/coding/commands/catalog.py tests/coding/test_ui_controller.py tests/coding/test_coding_command_catalog.py tests/coding/test_native_coding_tui_surfaces.py`
