### PR TITLE
Define TUI tab focus marker contract

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/tabgroup-content-switcher.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/tabgroup-content-switcher.md
@@ -23,6 +23,33 @@ Both widgets must respect `RenderConstraints.width` and
 `TabGroup` switches between header focus and selected content focus.
 `SearchableList` switches between search focus and list focus.
 
+## Tab Marker Contract
+
+Tabs reserve one fixed marker cell before the bracketed label:
+
+| Marker | Meaning |
+| --- | --- |
+| `>` | selected tab header has keyboard focus |
+| `*` | selected tab page is current, but header is not focused |
+| space | enabled normal tab or disabled tab |
+
+The marker is immediately adjacent to the label, so `>[Config]` and
+`*[Config]` are valid while `> [Config]` is not.
+
+## Tab Focus States
+
+`Tabs.selected_focus` maps to rendering as:
+
+| `selected_focus` | `focused` | Render state |
+| --- | --- | --- |
+| `auto` | `False` | selected unfocused |
+| `auto` | `True` | selected header focus |
+| `header` | any | selected header focus |
+| `content` | any | selected content focus |
+| `none` | any | selected unfocused |
+
+Only one `TabGroup` in a nested active focus path should render `>`.
+
 ## Events
 
 `TabGroup` value changes return a local structured tab-change object unless an
@@ -33,6 +60,33 @@ Both widgets must respect `RenderConstraints.width` and
 
 Tab theme resolution must preserve legacy `widget.tabs.tab` fallback while
 supporting level-aware selected header/content focus tokens.
+
+Normal tabs preserve legacy `widget.tabs.tab`, then apply newer and
+level-specific tokens:
+
+```text
+widget.tabs.tab
+widget.tabs.normal
+widget.tabs.nested.normal
+widget.tabs.levelN.normal
+```
+
+Selected header focus uses:
+
+```text
+widget.tabs.selected
+widget.tabs.focus
+widget.tabs.nested.selected_header_focus
+widget.tabs.levelN.selected_header_focus
+```
+
+Selected content focus uses:
+
+```text
+widget.tabs.selected
+widget.tabs.nested.selected_content_focus
+widget.tabs.levelN.selected_content_focus
+```
 
 ## Test Obligations
 

--- a/docs/superpowers/plans/2026-06-14-tui-tabs-focus-theme-contract.md
+++ b/docs/superpowers/plans/2026-06-14-tui-tabs-focus-theme-contract.md
@@ -1,0 +1,619 @@
+# TUI Tabs Focus Theme Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Tabs` and `TabGroup` render selected-page highlight and keyboard-focus highlight with a stable, tested contract.
+
+**Architecture:** Keep `Tabs` as the one-line primitive that maps selected/focus state to marker and theme tokens. Keep `TabGroup` as the focus-routing container that passes explicit `selected_focus` states into its internal `Tabs`. Update playback assertions and internals docs after the primitive and nested behavior are locked.
+
+**Tech Stack:** Python 3.11, pytest, existing `loushang.tui` render primitives, `ThemeResolver`, terminal playback helpers.
+
+---
+
+## Spec
+
+Implement against:
+
+`docs/superpowers/specs/2026-06-14-tui-tabs-focus-theme-contract-design.md`
+
+The key contract:
+
+- `>` means selected tab header has keyboard focus.
+- `*` means selected tab page is current, but the tab header does not have keyboard focus.
+- space means normal or disabled tab.
+- `widget.tabs.tab` remains in the normal-tab fallback chain.
+- level 0 and level 1 nested focus paths are covered by playback/unit tests.
+- level 2 is covered by synthetic unit tests only.
+
+## File Structure
+
+- Modify `src/loushang/tui/ui_parts/widgets/tabs.py`
+  - Owns primitive tab marker and theme-token state mapping.
+  - Add private helpers only; do not change public dataclass fields.
+
+- Modify `src/loushang/tui/ui_parts/widgets/tab_group.py`
+  - Should need little or no behavior change.
+  - Only adjust if tests reveal an incorrect focus-state handoff to internal `Tabs`.
+
+- Modify `tests/tui/test_widgets_light_controls.py`
+  - Primitive `Tabs` marker/token/fallback tests.
+
+- Modify `tests/tui/test_widgets_tab_group.py`
+  - Nested `TabGroup` focus-path and example playback assertions.
+
+- Modify `docs/internals/architecture/tui/native-terminal-core/ui-parts/tabgroup-content-switcher.md`
+  - Promote stable marker, focus, and theme-token contract to long-term docs.
+
+No `src/loushang/coding/...` product behavior should be changed in this plan.
+
+---
+
+### Task 1: Primitive Tabs Marker And Token Contract
+
+**Files:**
+- Modify: `tests/tui/test_widgets_light_controls.py`
+- Modify: `src/loushang/tui/ui_parts/widgets/tabs.py`
+
+- [ ] **Step 1: Add failing tests for selected-focus markers**
+
+Add tests near the existing `test_tabs_normalize_value_render_theme_and_width()` block:
+
+```python
+def test_tabs_selected_focus_states_use_distinct_markers_and_tokens() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.tabs.selected": {"color": "green"},
+            "widget.tabs.focus": {"bold": True},
+            "widget.tabs.level0.selected_header_focus": {"color": "cyan"},
+            "widget.tabs.level0.selected_content_focus": {"color": "yellow"},
+            "widget.tabs.tab": {"color": "white"},
+        }
+    )
+    tabs = Tabs(
+        [TabItem("config", "Config"), TabItem("model", "Model")],
+        value="config",
+        theme=theme,
+    )
+
+    assert plain_lines(tabs, width=40, height=1) == ("*[Config]   [Model]",)
+
+    tabs.focus()
+    header_raw = render_lines(tabs, width=40, height=1)[0]
+    assert strip_control_sequences(header_raw).startswith(">[Config]")
+    assert header_raw.startswith("\x1b[1;36m>[Config]")
+
+    tabs.selected_focus = "content"
+    content_raw = render_lines(tabs, width=40, height=1)[0]
+    assert strip_control_sequences(content_raw).startswith("*[Config]")
+    assert ">[Config]" not in strip_control_sequences(content_raw)
+    assert content_raw.startswith("\x1b[33m*[Config]")
+
+    tabs.selected_focus = "none"
+    assert plain_lines(tabs, width=40, height=1)[0].startswith("*[Config]")
+```
+
+- [ ] **Step 2: Add failing tests for level 2 and fallback behavior**
+
+Add:
+
+```python
+def test_tabs_level2_marker_and_token_fallbacks_are_stable() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.tabs.tab": {"color": "red"},
+            "widget.tabs.normal": {"color": "white"},
+            "widget.tabs.nested.normal": {"color": "blue"},
+            "widget.tabs.level2.normal": {"color": "magenta"},
+            "widget.tabs.selected": {"color": "green"},
+            "widget.tabs.nested.selected_content_focus": {"color": "yellow"},
+            "widget.tabs.level2.selected_header_focus": {"color": "cyan"},
+        }
+    )
+
+    content = Tabs(
+        [TabItem("one", "One"), TabItem("two", "Two")],
+        value="one",
+        level=2,
+        selected_focus="content",
+        theme=theme,
+    )
+    content_raw = render_lines(content, width=40, height=1)[0]
+    assert strip_control_sequences(content_raw).startswith("*[One]")
+    assert content_raw.startswith("\x1b[33m*[One]")
+    assert "\x1b[35m [Two]" in content_raw
+
+    header = Tabs(
+        [TabItem("one", "One"), TabItem("two", "Two")],
+        value="one",
+        level=2,
+        selected_focus="header",
+        theme=theme,
+    )
+    header_raw = render_lines(header, width=40, height=1)[0]
+    assert strip_control_sequences(header_raw).startswith(">[One]")
+    assert header_raw.startswith("\x1b[36m>[One]")
+```
+
+This locks:
+
+- selected content focus uses `*`, not `>`
+- nested content focus can use `widget.tabs.nested.selected_content_focus`
+- level 2 header focus can use `widget.tabs.level2.selected_header_focus`
+- level 2 normal tabs override legacy fallback through `widget.tabs.level2.normal`
+
+- [ ] **Step 3: Run tests and verify they fail for the current bug**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_widgets_light_controls.py -k "tabs_selected_focus or tabs_level2" -q
+```
+
+Expected: at least `test_tabs_selected_focus_states_use_distinct_markers_and_tokens` fails because current content focus renders `>[Config]`.
+
+- [ ] **Step 4: Implement the primitive render-state helper**
+
+In `src/loushang/tui/ui_parts/widgets/tabs.py`, replace the local marker decision with private helpers:
+
+```python
+TabRenderState = Literal[
+    "normal",
+    "selected_unfocused",
+    "selected_content_focus",
+    "selected_header_focus",
+    "disabled",
+]
+
+
+def _tab_render_state(tabs: Tabs, tab: TabItem) -> TabRenderState:
+    selected = tab.value == tabs.value and not tab.disabled
+    if tab.disabled:
+        return "disabled"
+    if not selected:
+        return "normal"
+    focus_state = _selected_focus_state(tabs)
+    if focus_state == "header":
+        return "selected_header_focus"
+    if focus_state == "content":
+        return "selected_content_focus"
+    return "selected_unfocused"
+
+
+def _tab_marker(state: TabRenderState) -> str:
+    if state == "selected_header_focus":
+        return ">"
+    if state in {"selected_unfocused", "selected_content_focus"}:
+        return "*"
+    return " "
+```
+
+Then update `_tab_segment()` to call these helpers and update `_tab_tokens()` to accept a render state:
+
+```python
+def _tab_segment(tabs: Tabs, tab: TabItem) -> str:
+    state = _tab_render_state(tabs, tab)
+    text = f"{_tab_marker(state)}[{tab.display_label}]"
+    return style_text(text, tabs.theme, *_tab_tokens(tabs, state=state))
+```
+
+Keep the public `TabFocusState` values unchanged.
+
+- [ ] **Step 5: Update `_tab_tokens()` to use the render state**
+
+Implement:
+
+```python
+def _tab_tokens(tabs: Tabs, *, state: TabRenderState) -> tuple[str, ...]:
+    level = max(0, tabs.level)
+    nested_prefix = "widget.tabs.nested" if level > 0 else ""
+    level_prefix = f"widget.tabs.level{level}"
+    if state == "disabled":
+        return tuple(
+            token
+            for token in (
+                "widget.tabs.disabled",
+                f"{nested_prefix}.disabled" if nested_prefix else "",
+                f"{level_prefix}.disabled",
+            )
+            if token
+        )
+    if state == "selected_header_focus":
+        return tuple(
+            token
+            for token in (
+                "widget.tabs.selected",
+                "widget.tabs.focus",
+                f"{nested_prefix}.selected_header_focus" if nested_prefix else "",
+                f"{level_prefix}.selected_header_focus",
+            )
+            if token
+        )
+    if state == "selected_content_focus":
+        return tuple(
+            token
+            for token in (
+                "widget.tabs.selected",
+                f"{nested_prefix}.selected_content_focus" if nested_prefix else "",
+                f"{level_prefix}.selected_content_focus",
+            )
+            if token
+        )
+    if state == "selected_unfocused":
+        return ("widget.tabs.selected",)
+    return tuple(
+        token
+        for token in (
+            "widget.tabs.tab",
+            "widget.tabs.normal",
+            f"{nested_prefix}.normal" if nested_prefix else "",
+            f"{level_prefix}.normal",
+        )
+        if token
+    )
+```
+
+- [ ] **Step 6: Run focused primitive tests**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_widgets_light_controls.py -k tabs -q
+```
+
+Expected: all selected `tabs` tests pass. If existing example playback snapshots fail because selected content focus now uses `*`, do not update them in this task unless they are in the same file and directly caused by the primitive contract.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/loushang/tui/ui_parts/widgets/tabs.py tests/tui/test_widgets_light_controls.py
+git commit -m "fix(tui): distinguish tab selected and focus markers"
+```
+
+---
+
+### Task 2: Nested TabGroup Focus Path Contract
+
+**Files:**
+- Modify: `tests/tui/test_widgets_tab_group.py`
+- Modify if needed: `src/loushang/tui/ui_parts/widgets/tab_group.py`
+
+- [ ] **Step 1: Add nested focus-path unit test**
+
+Add near the existing nested `TabGroup` tests:
+
+```python
+def test_nested_tab_group_markers_follow_active_focus_path() -> None:
+    nested_page = FocusablePage(("nested content",))
+    nested = TabGroup(
+        [
+            TabPage("overview", "Overview", nested_page),
+            TabPage("models", "Models", StaticPage(("models",))),
+        ],
+        level=1,
+    )
+    outer = TabGroup([TabPage("stats", "Stats", nested)], focused=True)
+
+    parent_header = plain_lines(outer, width=80, height=5)
+    assert parent_header[0].startswith(">[Stats]")
+    assert parent_header[1].startswith("*[Overview]")
+    assert sum(line.count(">") for line in parent_header) == 1
+
+    assert outer.focus_content() is True
+    child_header = plain_lines(outer, width=80, height=5)
+    assert child_header[0].startswith("*[Stats]")
+    assert child_header[1].startswith(">[Overview]")
+    assert sum(line.count(">") for line in child_header) == 1
+
+    assert outer.handle_input(InputEvent(kind="key", key="down")) is True
+    child_content = plain_lines(outer, width=80, height=5)
+    assert child_content[0].startswith("*[Stats]")
+    assert child_content[1].startswith("*[Overview]")
+    assert sum(line.count(">") for line in child_content) == 0
+
+    outer.focus_header()
+    parent_header_again = plain_lines(outer, width=80, height=5)
+    assert parent_header_again[0].startswith(">[Stats]")
+    assert parent_header_again[1].startswith("*[Overview]")
+    assert sum(line.count(">") for line in parent_header_again) == 1
+```
+
+- [ ] **Step 2: Add nested theme token test**
+
+Extend or add:
+
+```python
+def test_nested_tab_group_uses_parent_content_and_child_header_tokens() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.tabs.level0.selected_content_focus": {"color": "green"},
+            "widget.tabs.level1.selected_header_focus": {"color": "magenta"},
+            "widget.tabs.level1.selected_content_focus": {"color": "yellow"},
+        }
+    )
+    nested = TabGroup([TabPage("overview", "Overview", FocusablePage(("nested",)))], level=1, theme=theme)
+    outer = TabGroup([TabPage("stats", "Stats", nested)], focused=True, theme=theme)
+
+    assert outer.focus_content() is True
+    child_header_raw = render_lines(outer, width=80, height=5)
+    assert child_header_raw[0].startswith("\x1b[32m*[Stats]")
+    assert child_header_raw[1].startswith("\x1b[35m>[Overview]")
+
+    assert outer.handle_input(InputEvent(kind="key", key="down")) is True
+    child_content_raw = render_lines(outer, width=80, height=5)
+    assert child_content_raw[0].startswith("\x1b[32m*[Stats]")
+    assert child_content_raw[1].startswith("\x1b[33m*[Overview]")
+```
+
+- [ ] **Step 3: Run tests and verify failures are limited to the known marker contract**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_widgets_tab_group.py -k "nested_tab_group_markers or nested_tab_group_uses_parent" -q
+```
+
+Expected before Task 1 implementation: content focus may render `>`. After Task 1, these tests should pass unless `TabGroup` is passing the wrong `selected_focus` state.
+
+- [ ] **Step 4: Adjust `TabGroup` only if the tests expose a handoff bug**
+
+Expected current behavior is mostly correct:
+
+- `TabGroup._selected_focus_state()` returns `none`, `header`, or `content`.
+- `TabGroup.focus_header()` blurs child content before marking parent header focused.
+- `TabGroup.focus_content()` calls child `focus()` when the selected content is another `TabGroup`.
+
+Only change `src/loushang/tui/ui_parts/widgets/tab_group.py` if tests show these assumptions are false.
+
+- [ ] **Step 5: Run focused TabGroup tests**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_widgets_tab_group.py -k "not example" -q
+```
+
+Expected: all non-playback `TabGroup` tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/tui/test_widgets_tab_group.py src/loushang/tui/ui_parts/widgets/tab_group.py
+git commit -m "test(tui): lock nested tab focus path markers"
+```
+
+If `tab_group.py` was not modified, omit it from `git add`.
+
+---
+
+### Task 3: Playback Assertions For Searchable TabGroup Example
+
+**Files:**
+- Modify: `tests/tui/test_widgets_tab_group.py`
+- Do not modify `examples/tui/52_widgets_tabgroup_searchable_list.py` unless manual playback reveals the example itself is wrong.
+
+- [ ] **Step 1: Update initial content-focus expectations**
+
+In `test_tabgroup_searchable_list_example_playback_filters_settings()`, update the initial selected top-level tab assertion from:
+
+```python
+assert initial[0].startswith(">[Workspace]")
+```
+
+to:
+
+```python
+assert initial[0].startswith("*[Workspace]")
+```
+
+Reason: the example app starts with focus inside the selected Workspace page search area, not on the top-level header.
+
+- [ ] **Step 2: Update style-focused example test**
+
+In `test_tabgroup_searchable_list_example_styles_top_level_selected_tab()`, update the initial assertion:
+
+```python
+assert "*[Workspace]" in strip_control_sequences(initial)
+```
+
+Keep the later Activity assertion as header-focused:
+
+```python
+assert ">[Activity]" in strip_control_sequences(activity)
+```
+
+Also assert there is no marker spacing regression:
+
+```python
+assert "> [Activity]" not in strip_control_sequences(activity)
+```
+
+- [ ] **Step 3: Update search round-trip assertion**
+
+In `test_tabgroup_searchable_list_example_up_to_tabs_down_returns_to_search()`, update:
+
+```python
+assert frames[-1].lines[0].startswith("*[Workspace]")
+```
+
+Reason: after down returns to search/content, top-level header no longer has keyboard focus.
+
+- [ ] **Step 4: Strengthen nested playback assertion**
+
+In `test_tabgroup_searchable_list_example_playback_switches_nested_tabs()`, add:
+
+```python
+final = frames[-1].lines
+assert any("*[Activity]" in line for line in final)
+assert any(line.startswith(" [Overview]") and ">[Models]" in line for line in final)
+assert sum(line.count(">") for line in final) == 1
+assert not any("> [" in line for line in final)
+```
+
+If the nested tabs render on a line with no leading space, adjust only the leading-space part to match actual output. Keep the assertions that there is exactly one `>` and no `> [` spacing.
+
+- [ ] **Step 5: Run playback tests for the example**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_widgets_tab_group.py -k tabgroup_searchable_list_example -q
+```
+
+Expected: all searchable-list example playback tests pass with the new marker semantics.
+
+- [ ] **Step 6: Run the example import/render smoke**
+
+Run:
+
+```bash
+uv run python -c "import runpy; from loushang.tui import RenderConstraints; ns = runpy.run_path('examples/tui/52_widgets_tabgroup_searchable_list.py', run_name='__test__'); app = ns['build_app'](); result = app.render(RenderConstraints(width=100, max_height=24)); print(len(result.lines))"
+```
+
+Expected: command exits successfully and prints a positive line count. Do not
+launch the interactive runner for automated validation.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/tui/test_widgets_tab_group.py
+git commit -m "test(tui): refresh tabgroup playback focus markers"
+```
+
+---
+
+### Task 4: Documentation And Final Verification
+
+**Files:**
+- Modify: `docs/internals/architecture/tui/native-terminal-core/ui-parts/tabgroup-content-switcher.md`
+
+- [ ] **Step 1: Expand internals documentation**
+
+Update the document to include these sections:
+
+```markdown
+## Tab Marker Contract
+
+Tabs reserve one fixed marker cell before the bracketed label:
+
+| Marker | Meaning |
+| --- | --- |
+| `>` | selected tab header has keyboard focus |
+| `*` | selected tab page is current, but header is not focused |
+| space | enabled normal tab or disabled tab |
+
+The marker is immediately adjacent to the label, so `>[Config]` and
+`*[Config]` are valid while `> [Config]` is not.
+
+## Tab Focus States
+
+`Tabs.selected_focus` maps to rendering as:
+
+| `selected_focus` | `focused` | Render state |
+| --- | --- | --- |
+| `auto` | `False` | selected unfocused |
+| `auto` | `True` | selected header focus |
+| `header` | any | selected header focus |
+| `content` | any | selected content focus |
+| `none` | any | selected unfocused |
+
+Only one `TabGroup` in a nested active focus path should render `>`.
+
+## Tab Theme Fallbacks
+
+Normal tabs preserve legacy `widget.tabs.tab`, then apply newer and
+level-specific tokens:
+
+```text
+widget.tabs.tab
+widget.tabs.normal
+widget.tabs.nested.normal
+widget.tabs.levelN.normal
+```
+
+Selected header focus uses:
+
+```text
+widget.tabs.selected
+widget.tabs.focus
+widget.tabs.nested.selected_header_focus
+widget.tabs.levelN.selected_header_focus
+```
+
+Selected content focus uses:
+
+```text
+widget.tabs.selected
+widget.tabs.nested.selected_content_focus
+widget.tabs.levelN.selected_content_focus
+```
+```
+
+- [ ] **Step 2: Run focused TUI tests**
+
+Run:
+
+```bash
+uv run pytest tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_tab_group.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run focused lint**
+
+Run:
+
+```bash
+uv run ruff check src/loushang/tui/ui_parts/widgets/tabs.py src/loushang/tui/ui_parts/widgets/tab_group.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_tab_group.py
+```
+
+Expected: no lint failures.
+
+- [ ] **Step 4: Run broader TUI test slice**
+
+Run:
+
+```bash
+uv run pytest tests/tui -q
+```
+
+Expected: all TUI tests pass. If unrelated failures appear, capture exact failing tests and inspect whether they are caused by this marker contract.
+
+- [ ] **Step 5: Commit docs and final verification updates**
+
+```bash
+git add docs/internals/architecture/tui/native-terminal-core/ui-parts/tabgroup-content-switcher.md
+git commit -m "docs(tui): document tab focus marker contract"
+```
+
+- [ ] **Step 6: Final status check**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline -5
+```
+
+Expected: branch contains the plan/spec commits plus implementation commits; worktree is clean.
+
+---
+
+## Manual Validation Notes
+
+After automated tests pass, manually inspect the example if practical:
+
+```bash
+uv run python examples/tui/52_widgets_tabgroup_searchable_list.py
+```
+
+Expected visual behavior:
+
+- initial Workspace page shows selected content marker/highlight, not header focus marker
+- up from search moves header focus to `>[Workspace]`
+- right arrow moves `>` across top-level tabs with no `> [` spacing
+- down into Activity nested tabs changes top-level Activity to `*`
+- nested selected tab shows `>`
+- down into nested content changes nested selected tab from `>` to `*`
+- only one `>` is visible in the active tab hierarchy at a time
+
+Use `q` or `ctrl+c` to exit.

--- a/docs/superpowers/specs/2026-06-14-tui-tabs-focus-theme-contract-design.md
+++ b/docs/superpowers/specs/2026-06-14-tui-tabs-focus-theme-contract-design.md
@@ -1,0 +1,344 @@
+# TUI Tabs Focus And Theme Contract Design
+
+## Status
+
+Draft for spec review.
+
+This is a TUI-lane design for hardening the reusable `Tabs` and `TabGroup`
+visual/focus contract. It intentionally avoids product behavior in
+`src/loushang/coding/...` so the code lane can continue the real `/settings`
+status-line work without merge pressure.
+
+## Package Scope
+
+Primary implementation scope:
+
+- `src/loushang/tui/ui_parts/widgets/tabs.py`
+- `src/loushang/tui/ui_parts/widgets/tab_group.py`
+
+Primary validation scope:
+
+- `tests/tui/test_widgets_light_controls.py`
+- `tests/tui/test_widgets_tab_group.py`
+- `tests/tui/widget_example_playback.py`
+- `examples/tui/52_widgets_tabgroup_searchable_list.py`
+- `docs/internals/architecture/tui/native-terminal-core/ui-parts/tabgroup-content-switcher.md`
+
+No product settings implementation should be added in this slice.
+
+## Problem
+
+Recent settings-style TUI work exposed ambiguous tab states:
+
+- selected top-level tabs were sometimes not visually highlighted
+- `>` was used as both a selected-page marker and a focus marker
+- parent and child `TabGroup` headers could both appear focused
+- spacing around the focus marker could drift into forms like `> [Config]`
+- level-aware theme tokens were documented but only partially locked by tests
+
+The result is confusing in settings pages: a user cannot reliably tell whether
+arrow keys will switch tabs or whether focus is inside search/list/page content.
+
+## Goals
+
+- Define the exact tab visual states for selected page and header focus.
+- Make `>` mean only "keyboard focus is on this tab header".
+- Keep the selected page visible when focus is inside the page content.
+- Preserve colorless readability by keeping a selected marker for non-header
+  focus.
+- Lock level-aware theme-token fallback, including legacy `widget.tabs.tab`.
+- Verify nested `TabGroup` focus with level 0 and level 1 coverage.
+- Verify level 2 as synthetic unit-test coverage for marker and theme fallback
+  only; product examples do not need a three-level tab hierarchy.
+- Keep the rendered marker width stable so navigation does not shift layout.
+
+## Non-Goals
+
+- Do not implement the real Status Line settings tab.
+- Do not add `/config` or `/settings` command behavior.
+- Do not extract a full reusable settings page scaffold yet.
+- Do not introduce a global theme registry.
+- Do not redesign all widget theme APIs.
+- Do not require product pages to use three-level tab groups.
+
+## Vocabulary
+
+`selected page` means the tab whose content is currently displayed.
+
+`header focus` means keyboard input is currently handled by the tab header, so
+left/right/home/end operate on tabs.
+
+`content focus` means keyboard input is inside the selected page content, such
+as a search box, list, nested tab group, or static page.
+
+`selected highlight` means the current page is visually identified even when
+the tab header does not have focus.
+
+`focus highlight` means the selected tab header is currently the keyboard
+target.
+
+## State Model
+
+Each enabled tab renders in exactly one of these states:
+
+| State | Meaning | Marker | Required theme state |
+| --- | --- | --- | --- |
+| `normal` | Enabled, not selected | space | normal |
+| `selected_unfocused` | Selected, but this `TabGroup` is not focused | `*` | selected |
+| `selected_content_focus` | Selected, focus is inside this page content | `*` | selected content focus |
+| `selected_header_focus` | Selected, focus is on this tab header | `>` | selected header focus |
+| `disabled` | Disabled, visible, skipped by navigation | space | disabled |
+
+The marker is a fixed one-cell prefix immediately before the bracketed label:
+
+```text
+>[Config]
+*[Config]
+ [Config]
+```
+
+There must be no space between `>` or `*` and `[Label]`. The spacing between tab
+segments remains controlled by the existing inter-tab separator.
+
+The marker is not the only visual signal. Theme styling must provide the richer
+selected/focused distinction, while the marker keeps the state readable when
+colors are unavailable or stripped by tests.
+
+## Marker Contract
+
+`>` is reserved for `selected_header_focus`.
+
+`*` is reserved for selected states that are not header-focused:
+
+- `selected_unfocused`
+- `selected_content_focus`
+
+A selected tab must never render as plain unselected text unless a future
+explicit visual variant opts out of markers. This slice does not add that
+variant.
+
+Disabled selected tabs cannot exist after value normalization. If a requested
+value points at a disabled tab, selection normalizes to the next enabled tab or
+the first enabled tab.
+
+## Focus Matrix
+
+For a single top-level `TabGroup`:
+
+| Focus location | Selected tab marker | Selected tab token |
+| --- | --- | --- |
+| group blurred | `*` | `widget.tabs.selected` |
+| header focused | `>` | `widget.tabs.level0.selected_header_focus` fallback chain |
+| page content focused | `*` | `widget.tabs.level0.selected_content_focus` fallback chain |
+
+For nested tab groups:
+
+```text
+Focus at level 0 header:
+  level0 selected -> selected_header_focus, marker >
+  level1 selected -> selected_unfocused, marker *, never header focus
+
+Focus at level 1 header:
+  level0 selected -> selected_content_focus, marker *
+  level1 selected -> selected_header_focus, marker >
+
+Focus inside level 1 content:
+  level0 selected -> selected_content_focus, marker *
+  level1 selected -> selected_content_focus, marker *
+```
+
+Only one `TabGroup` in the active focus path may render
+`selected_header_focus` at a time.
+
+Primitive `Tabs.selected_focus` maps to render states as follows:
+
+| `selected_focus` | `focused` | Render state |
+| --- | --- | --- |
+| `auto` | `False` | `selected_unfocused` |
+| `auto` | `True` | `selected_header_focus` |
+| `header` | any | `selected_header_focus` |
+| `content` | any | `selected_content_focus` |
+| `none` | any | `selected_unfocused` |
+
+## Theme Token Contract
+
+The theme system already merges multiple token styles from left to right, with
+later tokens overriding earlier ones. The tab renderer must use that behavior
+as the fallback contract.
+
+For enabled unselected tabs at `level = N`, resolve:
+
+```text
+widget.tabs.tab
+widget.tabs.normal
+widget.tabs.nested.normal        # only when level > 0
+widget.tabs.levelN.normal
+```
+
+For `selected_unfocused`, resolve:
+
+```text
+widget.tabs.selected
+widget.tabs.nested.selected      # only when level > 0, if added later
+widget.tabs.levelN.selected      # if added later
+```
+
+This slice does not require adding `widget.tabs.nested.selected` or
+`widget.tabs.levelN.selected`. `widget.tabs.selected` remains sufficient for
+blurred selected tabs unless a later visual design needs level-specific blurred
+selection styling.
+
+For `selected_content_focus`, resolve:
+
+```text
+widget.tabs.selected
+widget.tabs.nested.selected_content_focus   # only when level > 0
+widget.tabs.levelN.selected_content_focus
+```
+
+For `selected_header_focus`, resolve:
+
+```text
+widget.tabs.selected
+widget.tabs.focus
+widget.tabs.nested.selected_header_focus    # only when level > 0
+widget.tabs.levelN.selected_header_focus
+```
+
+For disabled tabs at `level = N`, resolve:
+
+```text
+widget.tabs.disabled
+widget.tabs.nested.disabled       # only when level > 0
+widget.tabs.levelN.disabled
+```
+
+`widget.tabs.tab` is the legacy public token for normal enabled tabs and must
+remain in the fallback chain. A theme that only customizes `widget.tabs.tab`
+must still style unselected tabs.
+
+## Interaction Contract
+
+Primitive `Tabs`:
+
+- left/right/home/end move the selected enabled tab when focused
+- enter/space return the selected value
+- disabled tabs remain visible but are skipped by navigation
+- render selected state even when not focused
+- remain caller-dispatched: primitive `Tabs.handle_input()` continues to process
+  events when called directly, even if `focused=False`; containers decide when
+  to route input to a `Tabs` instance
+
+`TabGroup`:
+
+- when `focused=False`, it renders selected state but does not consume input
+- when `header_focused=True`, left/right/home/end switch tabs
+- down/enter from header attempts to focus selected page content
+- when content is focused, input is delegated to selected page content first
+- up/shift+tab from content returns to the current tab header if content does
+  not consume the event
+- switching tabs while content is focused blurs old content, changes value, and
+  focuses new content when possible
+
+Nested `TabGroup` content follows the same rules recursively.
+
+## Example Rendering
+
+Top-level header focus:
+
+```text
+ [Status]  >[Config]   [Model]   [Usage]   [Stats]
+```
+
+Top-level content focus inside the selected Config page:
+
+```text
+ [Status]  *[Config]   [Model]   [Usage]   [Stats]
+```
+
+Nested header focus inside Stats:
+
+```text
+ [Status]   [Config]   [Model]   [Usage]  *[Stats]
+>[Overview]   [Models]
+```
+
+Nested content focus inside Stats / Models:
+
+```text
+ [Status]   [Config]   [Model]   [Usage]  *[Stats]
+ [Overview]  *[Models]
+```
+
+Theme colors should make these states stronger than the plain examples show.
+
+## Testing Requirements
+
+Unit tests must cover:
+
+- primitive `Tabs` selected markers for blurred, header-focused, and
+  content-focus override states
+- `>` never appears for `selected_content_focus`
+- selected state remains visible when `TabGroup` content is focused
+- level 0 and level 1 selected header/content focus token resolution
+- synthetic level 2 marker and token fallback resolution
+- legacy `widget.tabs.tab` still styles normal tabs
+- disabled tabs are visible, styled, and skipped
+- marker spacing has no gap between marker and bracket
+- width truncation still respects visible width with ANSI styling
+
+Nested `TabGroup` tests must cover:
+
+- focus at parent header
+- focus at child header
+- focus inside child content
+- only one selected tab renders `>` across the nested active path
+- parent selected tab renders content-focus state while child has focus
+
+Playback tests must cover:
+
+- `examples/tui/52_widgets_tabgroup_searchable_list.py` initial content focus
+- up from search to top-level tabs
+- down from tabs back to search/content
+- switching to Activity and entering nested tabs
+- nested tab header focus shows `>` only on the nested selected tab
+- footer and long-list layout do not move during focus transitions
+
+## Documentation Requirements
+
+After implementation, promote the stable contract to:
+
+`docs/internals/architecture/tui/native-terminal-core/ui-parts/tabgroup-content-switcher.md`
+
+The superpowers spec may remain as historical design input, but long-term
+documentation should live under `docs/internals`.
+
+## Implementation Notes
+
+This design likely requires a small change in `tabs.py`: content-focus selected
+tabs should no longer use the same `>` marker as header-focused tabs.
+
+The public `Tabs.selected_focus` values can remain:
+
+- `auto`
+- `header`
+- `content`
+- `none`
+
+The renderer should map them to the state model above. No new public API is
+required for this slice.
+
+## Rollout
+
+1. Add focused unit tests for marker and token semantics.
+2. Adjust `Tabs` rendering to satisfy the state matrix.
+3. Add nested `TabGroup` focus-path tests.
+4. Refresh the tabgroup searchable-list playback assertions.
+5. Update internals documentation after tests pass.
+
+## Open Decision
+
+This design keeps `*` as the selected non-header marker for colorless
+readability and backward compatibility. If product UX later wants CC-like
+markerless selected tabs, that should be a separate visual variant rather than
+silently changing the base contract.

--- a/src/loushang/tui/ui_parts/widgets/tabs.py
+++ b/src/loushang/tui/ui_parts/widgets/tabs.py
@@ -23,6 +23,13 @@ from loushang.tui.ui_parts.widgets._utils import (
 )
 
 TabFocusState = Literal["auto", "header", "content", "none"]
+TabRenderState = Literal[
+    "normal",
+    "selected_unfocused",
+    "selected_content_focus",
+    "selected_header_focus",
+    "disabled",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -158,11 +165,31 @@ class Tabs:
 
 
 def _tab_segment(tabs: Tabs, tab: TabItem) -> str:
+    state = _tab_render_state(tabs, tab)
+    text = f"{_tab_marker(state)}[{tab.display_label}]"
+    return style_text(text, tabs.theme, *_tab_tokens(tabs, state=state))
+
+
+def _tab_render_state(tabs: Tabs, tab: TabItem) -> TabRenderState:
     selected = tab.value == tabs.value and not tab.disabled
+    if tab.disabled:
+        return "disabled"
+    if not selected:
+        return "normal"
     focus_state = _selected_focus_state(tabs)
-    prefix = ">" if selected and focus_state in {"header", "content"} else "*" if selected else " "
-    text = f"{prefix}[{tab.display_label}]"
-    return style_text(text, tabs.theme, *_tab_tokens(tabs, selected=selected, disabled=tab.disabled))
+    if focus_state == "header":
+        return "selected_header_focus"
+    if focus_state == "content":
+        return "selected_content_focus"
+    return "selected_unfocused"
+
+
+def _tab_marker(state: TabRenderState) -> str:
+    if state == "selected_header_focus":
+        return ">"
+    if state in {"selected_unfocused", "selected_content_focus"}:
+        return "*"
+    return " "
 
 
 def _selected_focus_state(tabs: Tabs) -> str:
@@ -171,11 +198,11 @@ def _selected_focus_state(tabs: Tabs) -> str:
     return "header" if tabs.focused else "none"
 
 
-def _tab_tokens(tabs: Tabs, *, selected: bool, disabled: bool) -> tuple[str, ...]:
+def _tab_tokens(tabs: Tabs, *, state: TabRenderState) -> tuple[str, ...]:
     level = max(0, tabs.level)
     nested_prefix = "widget.tabs.nested" if level > 0 else ""
     level_prefix = f"widget.tabs.level{level}"
-    if disabled:
+    if state == "disabled":
         return tuple(
             token
             for token in (
@@ -185,29 +212,28 @@ def _tab_tokens(tabs: Tabs, *, selected: bool, disabled: bool) -> tuple[str, ...
             )
             if token
         )
-    if selected:
-        focus_state = _selected_focus_state(tabs)
-        if focus_state == "header":
-            return tuple(
-                token
-                for token in (
-                    "widget.tabs.selected",
-                    "widget.tabs.focus",
-                    f"{nested_prefix}.selected_header_focus" if nested_prefix else "",
-                    f"{level_prefix}.selected_header_focus",
-                )
-                if token
+    if state == "selected_header_focus":
+        return tuple(
+            token
+            for token in (
+                "widget.tabs.selected",
+                "widget.tabs.focus",
+                f"{nested_prefix}.selected_header_focus" if nested_prefix else "",
+                f"{level_prefix}.selected_header_focus",
             )
-        if focus_state == "content":
-            return tuple(
-                token
-                for token in (
-                    "widget.tabs.selected",
-                    f"{nested_prefix}.selected_content_focus" if nested_prefix else "",
-                    f"{level_prefix}.selected_content_focus",
-                )
-                if token
+            if token
+        )
+    if state == "selected_content_focus":
+        return tuple(
+            token
+            for token in (
+                "widget.tabs.selected",
+                f"{nested_prefix}.selected_content_focus" if nested_prefix else "",
+                f"{level_prefix}.selected_content_focus",
             )
+            if token
+        )
+    if state == "selected_unfocused":
         return ("widget.tabs.selected",)
     return tuple(
         token

--- a/tests/coding/test_native_settings_page.py
+++ b/tests/coding/test_native_settings_page.py
@@ -150,7 +150,7 @@ def test_settings_page_opens_config_tab_with_search_focus() -> None:
     lines = _plain(page)
 
     assert any("Status" in line and "Config" in line and "Model" in line and "Status Line" in line for line in lines)
-    assert ">[Config]" in lines[0]
+    assert "*[Config]" in lines[0]
     assert any("Search settings" in line for line in lines)
     assert not any("Status line" in line for line in lines[2:])
     assert page.editor_input_target() is not None
@@ -168,7 +168,7 @@ def test_settings_page_config_uses_boxed_search_table_columns_footer_and_styles(
     lines = tuple(strip_control_sequences(line) for line in raw_lines)
 
     assert "\x1b[" in raw_lines[0]
-    assert ">[Config]" in lines[0]
+    assert "*[Config]" in lines[0]
     assert "> [Config]" not in lines[0]
     assert any(line.startswith("╭") for line in lines)
     search_index = next(index for index, line in enumerate(lines) if "Search settings..." in line)

--- a/tests/tui/test_widgets_light_controls.py
+++ b/tests/tui/test_widgets_light_controls.py
@@ -190,6 +190,76 @@ def test_tabs_normalize_value_render_theme_and_width() -> None:
     assert_widths_within(render_lines(tabs, width=10, height=1), 10)
 
 
+def test_tabs_selected_focus_states_use_distinct_markers_and_tokens() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.tabs.selected": {"color": "green"},
+            "widget.tabs.focus": {"bold": True},
+            "widget.tabs.level0.selected_header_focus": {"color": "cyan"},
+            "widget.tabs.level0.selected_content_focus": {"color": "yellow"},
+            "widget.tabs.tab": {"color": "white"},
+        }
+    )
+    tabs = Tabs(
+        [TabItem("config", "Config"), TabItem("model", "Model")],
+        value="config",
+        theme=theme,
+    )
+
+    assert plain_lines(tabs, width=40, height=1) == ("*[Config]   [Model]",)
+
+    tabs.focus()
+    header_raw = render_lines(tabs, width=40, height=1)[0]
+    assert strip_control_sequences(header_raw).startswith(">[Config]")
+    assert header_raw.startswith("\x1b[1;36m>[Config]")
+
+    tabs.selected_focus = "content"
+    content_raw = render_lines(tabs, width=40, height=1)[0]
+    assert strip_control_sequences(content_raw).startswith("*[Config]")
+    assert ">[Config]" not in strip_control_sequences(content_raw)
+    assert content_raw.startswith("\x1b[33m*[Config]")
+
+    tabs.selected_focus = "none"
+    assert plain_lines(tabs, width=40, height=1)[0].startswith("*[Config]")
+
+
+def test_tabs_level2_marker_and_token_fallbacks_are_stable() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.tabs.tab": {"color": "red"},
+            "widget.tabs.normal": {"color": "white"},
+            "widget.tabs.nested.normal": {"color": "blue"},
+            "widget.tabs.level2.normal": {"color": "magenta"},
+            "widget.tabs.selected": {"color": "green"},
+            "widget.tabs.nested.selected_content_focus": {"color": "yellow"},
+            "widget.tabs.level2.selected_header_focus": {"color": "cyan"},
+        }
+    )
+
+    content = Tabs(
+        [TabItem("one", "One"), TabItem("two", "Two")],
+        value="one",
+        level=2,
+        selected_focus="content",
+        theme=theme,
+    )
+    content_raw = render_lines(content, width=40, height=1)[0]
+    assert strip_control_sequences(content_raw).startswith("*[One]")
+    assert content_raw.startswith("\x1b[33m*[One]")
+    assert "\x1b[35m [Two]" in content_raw
+
+    header = Tabs(
+        [TabItem("one", "One"), TabItem("two", "Two")],
+        value="one",
+        level=2,
+        selected_focus="header",
+        theme=theme,
+    )
+    header_raw = render_lines(header, width=40, height=1)[0]
+    assert strip_control_sequences(header_raw).startswith(">[One]")
+    assert header_raw.startswith("\x1b[36m>[One]")
+
+
 def test_tabs_level_tokens_fallback_to_legacy_tab_token() -> None:
     theme = ThemeResolver(defaults={"widget.tabs.tab": {"color": "red"}})
     tabs = Tabs([TabItem("one", "One"), TabItem("two", "Two")], theme=theme)

--- a/tests/tui/test_widgets_tab_group.py
+++ b/tests/tui/test_widgets_tab_group.py
@@ -322,7 +322,7 @@ def test_tabgroup_searchable_list_example_playback_filters_settings() -> None:
     filtered = frames[-1].lines
 
     assert any("Workspace" in line and "Activity" in line for line in initial)
-    assert initial[0].startswith(">[Workspace]")
+    assert initial[0].startswith("*[Workspace]")
     assert any("Search" in line for line in initial)
     assert any("mode" in line.lower() for line in filtered)
     assert any("Model" in line or "mode" in line for line in filtered)
@@ -336,7 +336,7 @@ def test_tabgroup_searchable_list_example_styles_top_level_selected_tab() -> Non
 
     initial = tui.render(RenderConstraints(width=100, max_height=24)).lines[0].text
     assert "\x1b[" in initial
-    assert ">[Workspace]" in initial
+    assert "*[Workspace]" in strip_control_sequences(initial)
 
     for event in (
         InputEvent(kind="key", key="up"),
@@ -348,7 +348,8 @@ def test_tabgroup_searchable_list_example_styles_top_level_selected_tab() -> Non
 
     activity = tui.render(RenderConstraints(width=100, max_height=24)).lines[0].text
     assert "\x1b[" in activity
-    assert ">[Activity]" in activity
+    assert ">[Activity]" in strip_control_sequences(activity)
+    assert "> [Activity]" not in strip_control_sequences(activity)
 
 
 def test_tabgroup_searchable_list_example_playback_switches_nested_tabs() -> None:
@@ -369,6 +370,11 @@ def test_tabgroup_searchable_list_example_playback_switches_nested_tabs() -> Non
     assert any("Overview" in line and "Models" in line for line in frames[-1].lines)
     assert any("Tokens per Day" in line or "Model usage" in line for line in frames[-1].lines)
     assert any("Overview" in line and ">[Models]" in line for line in frames[-1].lines)
+    final = frames[-1].lines
+    assert any("*[Activity]" in line for line in final)
+    assert any(line.startswith(" [Overview]") and ">[Models]" in line for line in final)
+    assert sum(line.count(">") for line in final) == 1
+    assert not any("> [" in line for line in final)
 
 
 def test_tabgroup_searchable_list_example_up_to_tabs_down_returns_to_search() -> None:
@@ -382,7 +388,7 @@ def test_tabgroup_searchable_list_example_up_to_tabs_down_returns_to_search() ->
         height=24,
     )
 
-    assert frames[-1].lines[0].startswith(">[Workspace]")
+    assert frames[-1].lines[0].startswith("*[Workspace]")
     assert frames[-1].lines[2] == "Search settings..."
     assert not any(line.startswith("> Model") for line in frames[-1].lines)
     assert frames[-1].lines[-1].startswith("Search |")

--- a/tests/tui/test_widgets_tab_group.py
+++ b/tests/tui/test_widgets_tab_group.py
@@ -233,6 +233,63 @@ def test_nested_tab_group_keeps_parent_selected_content_focus() -> None:
     assert "Overview" in strip_control_sequences(raw[1])
 
 
+def test_nested_tab_group_markers_follow_active_focus_path() -> None:
+    nested_page = FocusablePage(("nested content",))
+    nested = TabGroup(
+        [
+            TabPage("overview", "Overview", nested_page),
+            TabPage("models", "Models", StaticPage(("models",))),
+        ],
+        level=1,
+    )
+    outer = TabGroup([TabPage("stats", "Stats", nested)], focused=True)
+
+    parent_header = plain_lines(outer, width=80, height=5)
+    assert parent_header[0].startswith(">[Stats]")
+    assert parent_header[1].startswith("*[Overview]")
+    assert sum(line.count(">") for line in parent_header) == 1
+
+    assert outer.focus_content() is True
+    child_header = plain_lines(outer, width=80, height=5)
+    assert child_header[0].startswith("*[Stats]")
+    assert child_header[1].startswith(">[Overview]")
+    assert sum(line.count(">") for line in child_header) == 1
+
+    assert outer.handle_input(InputEvent(kind="key", key="down")) is True
+    child_content = plain_lines(outer, width=80, height=5)
+    assert child_content[0].startswith("*[Stats]")
+    assert child_content[1].startswith("*[Overview]")
+    assert sum(line.count(">") for line in child_content) == 0
+
+    outer.focus_header()
+    parent_header_again = plain_lines(outer, width=80, height=5)
+    assert parent_header_again[0].startswith(">[Stats]")
+    assert parent_header_again[1].startswith("*[Overview]")
+    assert sum(line.count(">") for line in parent_header_again) == 1
+
+
+def test_nested_tab_group_uses_parent_content_and_child_header_tokens() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.tabs.level0.selected_content_focus": {"color": "green"},
+            "widget.tabs.level1.selected_header_focus": {"color": "magenta"},
+            "widget.tabs.level1.selected_content_focus": {"color": "yellow"},
+        }
+    )
+    nested = TabGroup([TabPage("overview", "Overview", FocusablePage(("nested",)))], level=1, theme=theme)
+    outer = TabGroup([TabPage("stats", "Stats", nested)], focused=True, theme=theme)
+
+    assert outer.focus_content() is True
+    child_header_raw = render_lines(outer, width=80, height=5)
+    assert child_header_raw[0].startswith("\x1b[32m*[Stats]")
+    assert child_header_raw[1].startswith("\x1b[35m>[Overview]")
+
+    assert outer.handle_input(InputEvent(kind="key", key="down")) is True
+    child_content_raw = render_lines(outer, width=80, height=5)
+    assert child_content_raw[0].startswith("\x1b[32m*[Stats]")
+    assert child_content_raw[1].startswith("\x1b[33m*[Overview]")
+
+
 def test_nested_tab_switch_does_not_change_parent_value() -> None:
     nested = TabGroup(
         [


### PR DESCRIPTION
## Summary

- Define and implement a stable TUI tab marker contract: `>` for tab-header keyboard focus, `*` for selected page/content focus, and space for normal/disabled tabs.
- Add primitive `Tabs`, nested `TabGroup`, level 2 fallback, and searchable-tab playback coverage.
- Promote the stable marker/focus/theme fallback contract into internals docs and refresh merged settings-page assertions for the new focus semantics.

## Test Plan

- `uv run pytest tests/tui/test_widgets_light_controls.py -k tabs -q`
- `uv run pytest tests/tui/test_widgets_tab_group.py -k "not example" -q`
- `uv run pytest tests/tui/test_widgets_tab_group.py -k tabgroup_searchable_list_example -q`
- `uv run python -c "import runpy; from loushang.tui import RenderConstraints; ns = runpy.run_path('examples/tui/52_widgets_tabgroup_searchable_list.py', run_name='__test__'); app = ns['build_app'](); result = app.render(RenderConstraints(width=100, max_height=24)); print(len(result.lines))"`
- `uv run pytest tests/tui tests/coding/test_native_settings_page.py tests/coding/test_native_coding_tui_playback.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_ui_status_line.py tests/coding/test_ui_status_provider.py -q`
- `uv run ruff check src/loushang/tui/ui_parts/widgets/tabs.py src/loushang/tui/ui_parts/widgets/tab_group.py tests/tui/test_widgets_light_controls.py tests/tui/test_widgets_tab_group.py tests/coding/test_native_settings_page.py`
- `uv run pytest tests -q`
