### PR TITLE
[codex] extract extension tool hook dispatcher

### DIFF
--- a/src/loushang/coding/extensions/__init__.py
+++ b/src/loushang/coding/extensions/__init__.py
@@ -9,6 +9,7 @@ from loushang.coding.extensions.contributions import (
     ExtensionSurfaceType,
     surfaces_from_loaded_extension,
 )
+from loushang.coding.extensions.hooks import HookDispatcher, HookKind
 from loushang.coding.extensions.loader import ExtensionLoader
 from loushang.coding.extensions.manifest import (
     ExtensionDependencyDeclaration,
@@ -81,6 +82,8 @@ __all__ = [
     "ExtensionInventory",
     "ExtensionSurfaceDescriptor",
     "ExtensionSurfaceType",
+    "HookDispatcher",
+    "HookKind",
     "InputEvent",
     "InputEventResult",
     "InputSource",

--- a/src/loushang/coding/extensions/hooks.py
+++ b/src/loushang/coding/extensions/hooks.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Sequence
+from dataclasses import replace
+from enum import Enum
+
+from loushang.agent.types import (
+    AfterToolCallResult,
+    AgentToolResult,
+    BeforeToolCallResult,
+)
+from loushang.ai.types import ToolCall
+from loushang.coding.extensions.types import (
+    ExtensionContext,
+    LoadedExtension,
+    ToolCallDecision,
+    ToolResultDecision,
+)
+from loushang.coding.loader import ResourceDiagnostic
+
+
+class HookKind(str, Enum):
+    OBSERVE = "observe"
+    TRANSFORM = "transform"
+    INTERCEPT = "intercept"
+    AUGMENT = "augment"
+
+
+ContextFactory = Callable[[LoadedExtension], ExtensionContext]
+RuntimeErrorHandler = Callable[[LoadedExtension, str, Exception], None]
+
+
+class HookDispatcher:
+    def __init__(
+        self,
+        extensions: Sequence[LoadedExtension],
+        *,
+        context_factory: ContextFactory,
+        diagnostics: list[ResourceDiagnostic],
+        runtime_error_handler: RuntimeErrorHandler | None = None,
+    ) -> None:
+        self._extensions = list(extensions)
+        self._context_factory = context_factory
+        self._diagnostics = diagnostics
+        self._runtime_error_handler = runtime_error_handler
+
+    async def before_tool_call(self, event, signal: object | None = None) -> BeforeToolCallResult | None:
+        del signal
+        current_event = event
+        changed = False
+        for extension in self._extensions:
+            handlers = extension.hooks.get("tool_call", [])
+            if not handlers:
+                continue
+            context = self._context_factory(extension)
+            for handler in handlers:
+                try:
+                    decision = handler(current_event, context)
+                    if inspect.isawaitable(decision):
+                        decision = await decision
+                except Exception as exc:
+                    self._record_hook_error(
+                        extension=extension,
+                        event="tool_call",
+                        code="extension_tool_call_failed",
+                        message=f"Extension hook 'tool_call' failed: {exc}",
+                        error=exc,
+                    )
+                    continue
+                if decision is None:
+                    continue
+                if not isinstance(decision, ToolCallDecision):
+                    self._diagnostics.append(
+                        ResourceDiagnostic(
+                            code="invalid_extension_tool_call_decision",
+                            message="tool_call hooks must return ToolCallDecision or None.",
+                            source_path=extension.source_path,
+                        )
+                    )
+                    continue
+                if decision.diagnostics:
+                    self._diagnostics.extend(decision.diagnostics)
+                rewritten_tool_name = decision.tool_name or current_event.tool_call.name
+                rewritten_arguments = decision.arguments if decision.arguments is not None else current_event.args
+                if rewritten_tool_name != current_event.tool_call.name or rewritten_arguments != current_event.args:
+                    changed = True
+                    current_event = replace(
+                        current_event,
+                        tool_call=ToolCall(
+                            type="toolCall",
+                            id=current_event.tool_call.id,
+                            name=rewritten_tool_name,
+                            arguments=rewritten_arguments,
+                            thought_signature=current_event.tool_call.thought_signature,
+                        ),
+                        args=rewritten_arguments,
+                    )
+                if decision.block:
+                    return BeforeToolCallResult(
+                        block=True,
+                        reason=decision.reason,
+                        tool_name=current_event.tool_call.name if changed else None,
+                        arguments=current_event.args if changed else None,
+                    )
+        if not changed:
+            return None
+        return BeforeToolCallResult(
+            tool_name=current_event.tool_call.name,
+            arguments=current_event.args,
+        )
+
+    async def after_tool_call(self, event, signal: object | None = None) -> AfterToolCallResult | None:
+        del signal
+        current_event = event
+        changed = False
+        for extension in self._extensions:
+            handlers = extension.hooks.get("tool_result", [])
+            if not handlers:
+                continue
+            context = self._context_factory(extension)
+            for handler in handlers:
+                try:
+                    decision = handler(current_event, context)
+                    if inspect.isawaitable(decision):
+                        decision = await decision
+                except Exception as exc:
+                    self._record_hook_error(
+                        extension=extension,
+                        event="tool_result",
+                        code="extension_tool_result_failed",
+                        message=f"Extension hook 'tool_result' failed: {exc}",
+                        error=exc,
+                    )
+                    continue
+                if decision is None:
+                    continue
+                if not isinstance(decision, ToolResultDecision):
+                    self._diagnostics.append(
+                        ResourceDiagnostic(
+                            code="invalid_extension_tool_result_decision",
+                            message="tool_result hooks must return ToolResultDecision or None.",
+                            source_path=extension.source_path,
+                        )
+                    )
+                    continue
+                if decision.diagnostics:
+                    self._diagnostics.extend(decision.diagnostics)
+                if decision.result is None:
+                    continue
+                if not isinstance(decision.result, AgentToolResult):
+                    self._diagnostics.append(
+                        ResourceDiagnostic(
+                            code="invalid_extension_tool_result_decision",
+                            message=(
+                                "tool_result decisions must return AgentToolResult instances when overriding results."
+                            ),
+                            source_path=extension.source_path,
+                        )
+                    )
+                    continue
+                changed = True
+                current_event = replace(current_event, result=decision.result)
+        if not changed:
+            return None
+        return AfterToolCallResult(
+            content=current_event.result.content,
+            details=current_event.result.details,
+            terminate=current_event.result.terminate,
+        )
+
+    def _record_hook_error(
+        self,
+        *,
+        extension: LoadedExtension,
+        event: str,
+        code: str,
+        message: str,
+        error: Exception,
+    ) -> None:
+        self._diagnostics.append(
+            ResourceDiagnostic(
+                code=code,
+                message=message,
+                source_path=extension.source_path,
+            )
+        )
+        if self._runtime_error_handler is not None:
+            self._runtime_error_handler(extension, event, error)
+
+
+__all__ = [
+    "HookDispatcher",
+    "HookKind",
+]

--- a/src/loushang/coding/extensions/runner.py
+++ b/src/loushang/coding/extensions/runner.py
@@ -3,18 +3,17 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import cast
 
 from loushang.agent.types import (
     AfterToolCallResult,
     AgentMessage,
-    AgentToolResult,
     BeforeToolCallResult,
 )
-from loushang.ai.types import ToolCall
 from loushang.coding.exec import ExecResult, ExecUpdateCallback
+from loushang.coding.extensions.hooks import HookDispatcher
 from loushang.coding.extensions.loader import ExtensionLoader
 from loushang.coding.extensions.types import (
     BeforeAgentStartResult,
@@ -35,8 +34,6 @@ from loushang.coding.extensions.types import (
     SessionBeforeTreeResult,
     SessionRefreshEvent,
     SourceInfo,
-    ToolCallDecision,
-    ToolResultDecision,
 )
 from loushang.coding.extensions.wrapper import wrap_registered_tool_definition
 from loushang.coding.loader import (
@@ -1714,119 +1711,21 @@ class ExtensionRunner:
         return current_messages
 
     async def before_tool_call(self, event, signal: object | None = None) -> BeforeToolCallResult | None:
-        current_event = event
-        changed = False
-        context = self._context_from_runtime(fallback_cwd=_context_from_agent_event(event).cwd)
-        for extension in self._extensions:
-            for handler in extension.hooks.get("tool_call", []):
-                try:
-                    decision = handler(current_event, context)
-                    if inspect.isawaitable(decision):
-                        decision = await decision
-                except Exception as exc:
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="extension_tool_call_failed",
-                            message=f"Extension hook 'tool_call' failed: {exc}",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    self._emit_runtime_error(extension=extension, event="tool_call", error=exc)
-                    continue
-                if decision is None:
-                    continue
-                if not isinstance(decision, ToolCallDecision):
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="invalid_extension_tool_call_decision",
-                            message="tool_call hooks must return ToolCallDecision or None.",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    continue
-                if decision.diagnostics:
-                    self._diagnostics.extend(decision.diagnostics)
-                rewritten_tool_name = decision.tool_name or current_event.tool_call.name
-                rewritten_arguments = decision.arguments if decision.arguments is not None else current_event.args
-                if rewritten_tool_name != current_event.tool_call.name or rewritten_arguments != current_event.args:
-                    changed = True
-                    current_event = replace(
-                        current_event,
-                        tool_call=ToolCall(
-                            type="toolCall",
-                            id=current_event.tool_call.id,
-                            name=rewritten_tool_name,
-                            arguments=rewritten_arguments,
-                            thought_signature=current_event.tool_call.thought_signature,
-                        ),
-                        args=rewritten_arguments,
-                    )
-                if decision.block:
-                    return BeforeToolCallResult(
-                        block=True,
-                        reason=decision.reason,
-                        tool_name=current_event.tool_call.name if changed else None,
-                        arguments=current_event.args if changed else None,
-                    )
-        if not changed:
-            return None
-        return BeforeToolCallResult(
-            tool_name=current_event.tool_call.name,
-            arguments=current_event.args,
-        )
+        return await self._tool_hook_dispatcher(_context_from_agent_event(event).cwd).before_tool_call(event, signal)
 
     async def after_tool_call(self, event, signal: object | None = None) -> AfterToolCallResult | None:
-        current_event = event
-        changed = False
-        context = self._context_from_runtime(fallback_cwd=_context_from_agent_event(event).cwd)
-        for extension in self._extensions:
-            for handler in extension.hooks.get("tool_result", []):
-                try:
-                    decision = handler(current_event, context)
-                    if inspect.isawaitable(decision):
-                        decision = await decision
-                except Exception as exc:
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="extension_tool_result_failed",
-                            message=f"Extension hook 'tool_result' failed: {exc}",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    self._emit_runtime_error(extension=extension, event="tool_result", error=exc)
-                    continue
-                if decision is None:
-                    continue
-                if not isinstance(decision, ToolResultDecision):
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="invalid_extension_tool_result_decision",
-                            message="tool_result hooks must return ToolResultDecision or None.",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    continue
-                if decision.diagnostics:
-                    self._diagnostics.extend(decision.diagnostics)
-                if decision.result is None:
-                    continue
-                if not isinstance(decision.result, AgentToolResult):
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="invalid_extension_tool_result_decision",
-                            message="tool_result decisions must return AgentToolResult instances when overriding results.",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    continue
-                changed = True
-                current_event = replace(current_event, result=decision.result)
-        if not changed:
-            return None
-        return AfterToolCallResult(
-            content=current_event.result.content,
-            details=current_event.result.details,
-            terminate=current_event.result.terminate,
+        return await self._tool_hook_dispatcher(_context_from_agent_event(event).cwd).after_tool_call(event, signal)
+
+    def _tool_hook_dispatcher(self, fallback_cwd: str) -> HookDispatcher:
+        return HookDispatcher(
+            self._extensions,
+            context_factory=lambda _extension: self._context_from_runtime(fallback_cwd=fallback_cwd),
+            diagnostics=self._diagnostics,
+            runtime_error_handler=lambda extension, event, error: self._emit_runtime_error(
+                extension=extension,
+                event=event,
+                error=error,
+            ),
         )
 
     def _apply_resource_handlers(

--- a/tests/coding/test_extension_hooks.py
+++ b/tests/coding/test_extension_hooks.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+from loushang.ai.types import AssistantMessage, TextPart, ToolCall, Usage
+
+
+def _usage() -> Usage:
+    return Usage(
+        input=0,
+        output=0,
+        cache_read=0,
+        cache_write=0,
+        total_tokens=0,
+        cost={},
+    )
+
+
+def _assistant_tool_call_message(tool_name: str = "calc", arguments: dict[str, object] | None = None) -> AssistantMessage:
+    return AssistantMessage(
+        role="assistant",
+        content=[
+            ToolCall(
+                type="toolCall",
+                id="tc_1",
+                name=tool_name,
+                arguments=arguments or {"x": 1},
+            )
+        ],
+        api="anthropic-messages",
+        provider="faux",
+        model="faux-model",
+        response_id=None,
+        usage=_usage(),
+        stop_reason="toolUse",
+        error_message=None,
+        timestamp=0.0,
+    )
+
+
+def _agent_context():
+    from loushang.agent.types import AgentContext
+
+    return AgentContext(
+        system_prompt="system",
+        messages=[],
+        tools=[],
+    )
+
+
+def test_hook_dispatcher_pipelines_tool_call_decisions() -> None:
+    from loushang.agent.types import BeforeToolCallContext
+    from loushang.coding.extensions import LoadedExtension, ToolCallDecision
+    from loushang.coding.extensions.hooks import HookDispatcher
+
+    seen: list[tuple[str, object]] = []
+
+    def _context_factory(_extension):
+        return SimpleNamespace(cwd="/tmp/project")
+
+    def _rewrite(event, ctx):
+        seen.append((event.tool_call.name, event.args))
+        assert ctx.cwd == "/tmp/project"
+        return ToolCallDecision(tool_name="calc_rewritten", arguments={"y": 2})
+
+    def _block(event, ctx):
+        del ctx
+        seen.append((event.tool_call.name, event.args))
+        return ToolCallDecision(block=True, reason="blocked by extension")
+
+    runner_diagnostics: list[object] = []
+    dispatcher = HookDispatcher(
+        [
+            LoadedExtension(name="rewrite", source_path=Path("/tmp/rewrite.py"), hooks={"tool_call": [_rewrite]}),
+            LoadedExtension(name="block", source_path=Path("/tmp/block.py"), hooks={"tool_call": [_block]}),
+        ],
+        context_factory=_context_factory,
+        diagnostics=runner_diagnostics,
+    )
+
+    message = _assistant_tool_call_message()
+    result = asyncio.run(
+        dispatcher.before_tool_call(
+            BeforeToolCallContext(
+                assistant_message=message,
+                tool_call=message.content[0],
+                args={"x": 1},
+                context=_agent_context(),
+            )
+        )
+    )
+
+    assert result is not None
+    assert result.block is True
+    assert result.reason == "blocked by extension"
+    assert result.tool_name == "calc_rewritten"
+    assert result.arguments == {"y": 2}
+    assert seen == [("calc", {"x": 1}), ("calc_rewritten", {"y": 2})]
+    assert runner_diagnostics == []
+
+
+def test_hook_dispatcher_pipelines_tool_result_decisions() -> None:
+    from loushang.agent.types import AfterToolCallContext, AgentToolResult
+    from loushang.coding.extensions import LoadedExtension, ToolResultDecision
+    from loushang.coding.extensions.hooks import HookDispatcher
+
+    seen: list[object] = []
+
+    def _rewrite_once(event, ctx):
+        del ctx
+        seen.append(event.result.details)
+        return ToolResultDecision(
+            result=AgentToolResult(content=[TextPart(type="text", text="one")], details={"step": 1})
+        )
+
+    def _rewrite_again(event, ctx):
+        del ctx
+        seen.append(event.result.details)
+        return ToolResultDecision(
+            result=AgentToolResult(content=[TextPart(type="text", text="two")], details={"step": 2}, terminate=True)
+        )
+
+    dispatcher = HookDispatcher(
+        [
+            LoadedExtension(name="one", source_path=Path("/tmp/one.py"), hooks={"tool_result": [_rewrite_once]}),
+            LoadedExtension(name="two", source_path=Path("/tmp/two.py"), hooks={"tool_result": [_rewrite_again]}),
+        ],
+        context_factory=lambda _extension: SimpleNamespace(cwd="/tmp/project"),
+        diagnostics=[],
+    )
+
+    message = _assistant_tool_call_message()
+    result = asyncio.run(
+        dispatcher.after_tool_call(
+            AfterToolCallContext(
+                assistant_message=message,
+                tool_call=message.content[0],
+                args={"x": 1},
+                result=AgentToolResult(content=[TextPart(type="text", text="zero")], details={"step": 0}),
+                is_error=False,
+                context=_agent_context(),
+            )
+        )
+    )
+
+    assert result is not None
+    assert result.content == [TextPart(type="text", text="two")]
+    assert result.details == {"step": 2}
+    assert result.terminate is True
+    assert seen == [{"step": 0}, {"step": 1}]
+
+
+def test_hook_dispatcher_records_tool_hook_errors_and_continues() -> None:
+    from loushang.agent.types import BeforeToolCallContext
+    from loushang.coding.extensions import LoadedExtension, ToolCallDecision
+    from loushang.coding.extensions.hooks import HookDispatcher
+
+    runtime_errors: list[tuple[str, str, str]] = []
+
+    def _broken(event, ctx):
+        del event, ctx
+        raise RuntimeError("boom")
+
+    def _rewrite(event, ctx):
+        del event, ctx
+        return ToolCallDecision(arguments={"ok": True})
+
+    diagnostics: list[object] = []
+    dispatcher = HookDispatcher(
+        [
+            LoadedExtension(name="broken", source_path=Path("/tmp/broken.py"), hooks={"tool_call": [_broken]}),
+            LoadedExtension(name="rewrite", source_path=Path("/tmp/rewrite.py"), hooks={"tool_call": [_rewrite]}),
+        ],
+        context_factory=lambda _extension: SimpleNamespace(cwd="/tmp/project"),
+        diagnostics=diagnostics,
+        runtime_error_handler=lambda extension, event, error: runtime_errors.append(
+            (extension.name, event, str(error))
+        ),
+    )
+
+    message = _assistant_tool_call_message()
+    result = asyncio.run(
+        dispatcher.before_tool_call(
+            BeforeToolCallContext(
+                assistant_message=message,
+                tool_call=message.content[0],
+                args={"x": 1},
+                context=_agent_context(),
+            )
+        )
+    )
+
+    assert result is not None
+    assert result.arguments == {"ok": True}
+    assert [getattr(diagnostic, "code", None) for diagnostic in diagnostics] == ["extension_tool_call_failed"]
+    assert runtime_errors == [("broken", "tool_call", "boom")]


### PR DESCRIPTION
## Summary

Extracts extension tool-call hook dispatch logic from the extension runner into a dedicated hooks module.

## Impact

This keeps `runner.py` focused on running extension tool calls while making hook dispatch behavior easier to test directly. The public extension exports now include the hook dispatcher types and helpers used by the runner.

## Validation

- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_extension_hooks.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_extension_runner.py tests/coding/test_extension_platform.py tests/coding/test_extension_loader.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding/extensions tests/coding/test_extension_hooks.py tests/coding/test_extension_runner.py tests/coding/test_extension_platform.py tests/coding/test_extension_loader.py`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests -q`