### PR TITLE
[codex] Theme TUI PageScaffold chrome

### DIFF
--- a/examples/tui/53_widgets_page_scaffold.py
+++ b/examples/tui/53_widgets_page_scaffold.py
@@ -17,10 +17,18 @@ from loushang.tui import (
     SearchableListSelect,
     TabItem,
     Tabs,
+    ThemeResolver,
     Tui,
     TuiInputResult,
     TuiRunner,
     truncate_to_width,
+)
+
+PAGE_SCAFFOLD_THEME = ThemeResolver(
+    defaults={
+        "widget.pageScaffold.separator": {"color": "bright_black"},
+        "widget.pageScaffold.footer": {"color": "bright_black"},
+    }
 )
 
 
@@ -59,6 +67,7 @@ class PageScaffoldDemo(FocusableMixin):
             header=self.tabs,
             body=self.bodies[self.tabs.value],
             footer=self._footer,
+            theme=PAGE_SCAFFOLD_THEME,
             focused=True,
             focus_region="body",
             separator_after_header=True,

--- a/src/loushang/tui/ui_parts/widgets/page_scaffold.py
+++ b/src/loushang/tui/ui_parts/widgets/page_scaffold.py
@@ -12,6 +12,8 @@ from loushang.tui.core import (
     RenderResult,
 )
 from loushang.tui.keybindings import normalize_key_id
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.widgets._utils import style_text
 
 PageScaffoldFocusRegion = Literal["header", "body"]
 
@@ -31,6 +33,7 @@ class PageScaffold:
     body: object
     header: object | None = None
     footer: PageScaffoldFooter = ""
+    theme: ThemeResolver | None = None
     focused: bool = False
     focus_region: PageScaffoldFocusRegion = "body"
     separator_after_header: bool = False
@@ -109,7 +112,7 @@ class PageScaffold:
         if header_lines:
             rows.extend(header_lines[:page_height])
         if self.separator_after_header and header_lines and len(rows) < page_height:
-            rows.append(RenderLine("-" * max(1, width)))
+            rows.append(RenderLine(style_text("-" * max(1, width), self.theme, "widget.pageScaffold.separator")))
 
         remaining_after_chrome = page_height - len(rows)
         footer_reserved = 1 if self.reserve_footer and footer_text and remaining_after_chrome >= 2 else 0
@@ -161,7 +164,10 @@ class PageScaffold:
 
     def _footer_text(self, width: int) -> str:
         value = self.footer(self._context()) if callable(self.footer) else self.footer
-        return truncate_to_width(str(value), max_width=width, ellipsis="") if value else ""
+        if not value:
+            return ""
+        text = truncate_to_width(str(value), max_width=width, ellipsis="")
+        return style_text(text, self.theme, "widget.pageScaffold.footer")
 
     def _offset_cursor(
         self,

--- a/tests/tui/test_widgets_page_scaffold.py
+++ b/tests/tui/test_widgets_page_scaffold.py
@@ -10,6 +10,7 @@ from loushang.tui import (
     RenderConstraints,
     RenderLine,
     RenderResult,
+    ThemeResolver,
     strip_control_sequences,
 )
 from loushang.tui.ui_parts.widgets.page_scaffold import PageScaffold
@@ -82,6 +83,51 @@ def test_page_scaffold_renders_header_separator_body_padding_and_footer() -> Non
         "",
         "footer",
     )
+
+
+def test_page_scaffold_themes_separator_and_footer_without_changing_plain_text() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.pageScaffold.separator": {"color": "bright_black"},
+            "widget.pageScaffold.footer": {"dim": True},
+        }
+    )
+    scaffold = PageScaffold(
+        header=StaticPart(("header",)),
+        body=StaticPart(("body",)),
+        footer="footer",
+        separator_after_header=True,
+        theme=theme,
+    )
+
+    raw = render_lines(scaffold, width=12, height=5)
+
+    assert raw[1].startswith("\x1b[90m")
+    assert raw[1].endswith("\x1b[39m")
+    assert raw[-1].startswith("\x1b[2m")
+    assert raw[-1].endswith("\x1b[22m")
+    assert tuple(strip_control_sequences(line) for line in raw) == (
+        "header",
+        "------------",
+        "body",
+        "",
+        "footer",
+    )
+
+
+def test_page_scaffold_themed_footer_truncates_to_visible_width() -> None:
+    theme = ThemeResolver(defaults={"widget.pageScaffold.footer": {"color": "bright_black"}})
+    scaffold = PageScaffold(
+        body=StaticPart(("body",)),
+        footer="very long footer",
+        theme=theme,
+    )
+
+    raw = render_lines(scaffold, width=8, height=3)
+
+    assert raw[-1].startswith("\x1b[90m")
+    assert raw[-1].endswith("\x1b[39m")
+    assert strip_control_sequences(raw[-1]) == "very lon"
 
 
 def test_page_scaffold_reserves_footer_height_under_long_body_content() -> None:
@@ -320,6 +366,7 @@ def test_page_scaffold_example_imports_and_renders() -> None:
     result = app.render(RenderConstraints(width=96, max_height=20))
 
     assert result.lines
+    assert any("\x1b[" in line.text for line in result.lines)
 
 
 def test_page_scaffold_example_playback_switches_focus_and_keeps_footer() -> None:


### PR DESCRIPTION
## Summary

- Add `PageScaffold.theme` for scaffold-owned chrome only.
- Style `widget.pageScaffold.separator` and `widget.pageScaffold.footer`.
- Update example 53 to demonstrate themed scaffold separator/footer output.

## Notes

Header and body rendering remain owned by their child widgets, so Tabs and SearchableList theme behavior is unchanged.

## Validation

- `uv run pytest tests/tui -q`
- `uv run ruff check src/loushang/tui/ui_parts/widgets/page_scaffold.py tests/tui/test_widgets_page_scaffold.py examples/tui/53_widgets_page_scaffold.py`
