### PR TITLE
Stabilize TUI PageScaffold layout

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
@@ -10,7 +10,7 @@ are built from renderables but are described at the product-facing UI level.
 | Basic | [Text, TruncatedText, Spacer, Box, Rule, DynamicBorder, Loader, CancellableLoader, WorkedDivider](./basic.md) |
 | Frame | BottomFrame, StatusBar, WorkingLine, PendingQueueView, WidgetSlot |
 | Input | Composer, TextInput, AutocompleteSurface |
-| Navigation | Tabs, [TabGroup, TabPage](./tabgroup-content-switcher.md), PageScaffold |
+| Navigation | Tabs, [TabGroup, TabPage](./tabgroup-content-switcher.md), [PageScaffold](./page-scaffold.md) |
 | Lists | SelectList, [SearchableList](./tabgroup-content-switcher.md) |
 | Surfaces | CommandSurface, SelectionSurface, SettingsSurface, ApprovalSurface, DialogSurface, HelpViewer, ChangelogViewer |
 | Transcript | ChatTranscript, UserPromptView, AssistantMessageView, ThinkingView, ToolExecutionView, ErrorView, WorkedDivider |

--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/page-scaffold.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/page-scaffold.md
@@ -1,0 +1,83 @@
+# PageScaffold
+
+`PageScaffold` is a widget-level page shell for reusable TUI page content. It
+composes caller-owned header, body, and footer slots, reserves footer space,
+offsets body cursors through inserted chrome, and owns focus movement between
+header and body.
+
+It is not a product settings page, command surface, or screen-level frame.
+Concrete pages still own selected tab state, business actions, data loading,
+and product-specific intents.
+
+## Inputs And State
+
+- `body`: required renderable or focusable part.
+- `header`: optional renderable or focusable part.
+- `footer`: fixed string or callable receiving `PageScaffoldContext`.
+- `focused`: whether the scaffold exposes a cursor/editor target.
+- `focus_region`: `"header"` or `"body"`.
+- `separator_after_header`: renders a full-width rule when a header rendered.
+- `body_padding_top` / `body_padding_bottom`: best-effort blank rows inside the
+  body region.
+- `reserve_footer`: keeps one row available for footer text when possible.
+- `theme`: optional `ThemeResolver` for scaffold-owned chrome.
+
+`PageScaffoldContext` exposes `focus_region`, `header_focused`, and
+`body_focused` so footers can switch hint text without inspecting child widgets.
+
+## Layout Behavior
+
+Rendering order is:
+
+1. header slot
+2. optional separator
+3. top body padding
+4. body slot
+5. bottom body padding
+6. footer
+
+Body padding is decorative and yields when height is tight. If a body region is
+available, PageScaffold keeps at least one body row before allocating requested
+padding. Footer reservation also wins over padding when `reserve_footer=True`.
+
+Footer text is truncated to the visible width before theme styling is applied.
+Inserted separator and padding rows are full-width or blank; they do not ask
+child widgets to account for external chrome.
+
+## Focus Behavior
+
+`focus()` targets the configured `focus_region`, falling back to the other
+region when the preferred child cannot be focused.
+
+When the header is focused, `down` and `enter` move focus into the body before
+delegating to the header. When the body is focused, unhandled `up` and
+`shift+tab` move focus back to the header. Other input is delegated to the
+currently focused child.
+
+`editor_input_target()` delegates to the focused child only when the scaffold
+itself is focused.
+
+## Theme Tokens
+
+PageScaffold only themes chrome it owns:
+
+| Token | Applies to |
+| --- | --- |
+| `widget.pageScaffold.separator` | Separator inserted after the header |
+| `widget.pageScaffold.footer` | Footer text after width truncation |
+
+Header and body styling remain owned by child widgets such as `Tabs`,
+`SearchableList`, or page-specific renderables.
+
+## Test Obligations
+
+Changes to PageScaffold should cover:
+
+- header/body/footer layout and height constraints
+- footer reservation with long body content
+- body padding allocation under normal and tight heights
+- cursor offsets through separator and body padding
+- focus routing between header and body
+- footer callable context
+- theme tokens preserving visible text
+- public exports and example playback

--- a/docs/superpowers/specs/2026-06-14-tui-page-scaffold-design.md
+++ b/docs/superpowers/specs/2026-06-14-tui-page-scaffold-design.md
@@ -112,9 +112,12 @@ class PageScaffold:
     body: object
     header: object | None = None
     footer: PageScaffoldFooter = ""
+    theme: ThemeResolver | None = None
     focused: bool = False
     focus_region: Literal["header", "body"] = "body"
     separator_after_header: bool = False
+    body_padding_top: int = 0
+    body_padding_bottom: int = 0
     reserve_footer: bool = True
 ```
 
@@ -126,9 +129,17 @@ a smaller static widget.
 `footer` can be a fixed string or a callable. The callable receives
 `PageScaffoldContext` and returns a string for the current focus state.
 
-The first version does not need theme tokens. It should render plain separator
-and footer text. A later visual styling slice can add `widget.pageScaffold.*`
-tokens once the layout/focus contract is stable.
+`theme` applies only to scaffold-owned chrome. It must not style child-rendered
+header or body lines.
+
+`body_padding_top` and `body_padding_bottom` add best-effort blank rows inside
+the body region. Padding yields to at least one body row and to reserved footer
+space when height is tight.
+
+The supported scaffold theme tokens are:
+
+- `widget.pageScaffold.separator`
+- `widget.pageScaffold.footer`
 
 ## Focus Behavior
 
@@ -333,9 +344,12 @@ Add a short internals page or section explaining that:
 
 ## Open Decisions
 
-The first implementation should defer theme tokens. The class name and API
-should leave room for later styling, but adding `widget.pageScaffold.*` tokens
-before there is more than one consumer would be premature.
+Resolved: PageScaffold supports scaffold-owned chrome theme tokens for the
+separator and footer. Header and body styling remain owned by child widgets.
+
+Resolved: PageScaffold supports top and bottom body padding as a small layout
+hook. It does not yet support title bands, fixed body regions, or specialized
+search/footer widgets.
 
 The first implementation should not add specialized `SearchBox`, `PageFooter`,
 or `OverflowHint` widgets. `SearchableList` already covers boxed search and

--- a/examples/tui/53_widgets_page_scaffold.py
+++ b/examples/tui/53_widgets_page_scaffold.py
@@ -71,6 +71,8 @@ class PageScaffoldDemo(FocusableMixin):
             focused=True,
             focus_region="body",
             separator_after_header=True,
+            body_padding_top=1,
+            body_padding_bottom=1,
         )
         self.focus()
 

--- a/src/loushang/tui/ui_parts/widgets/page_scaffold.py
+++ b/src/loushang/tui/ui_parts/widgets/page_scaffold.py
@@ -37,6 +37,8 @@ class PageScaffold:
     focused: bool = False
     focus_region: PageScaffoldFocusRegion = "body"
     separator_after_header: bool = False
+    body_padding_top: int = 0
+    body_padding_bottom: int = 0
     reserve_footer: bool = True
 
     def focus(self) -> None:
@@ -116,13 +118,20 @@ class PageScaffold:
 
         remaining_after_chrome = page_height - len(rows)
         footer_reserved = 1 if self.reserve_footer and footer_text and remaining_after_chrome >= 2 else 0
-        body_budget = max(0, page_height - len(rows) - footer_reserved)
-        if body_budget <= 0 and not rows:
-            body_budget = page_height
+        body_region_budget = max(0, page_height - len(rows) - footer_reserved)
+        if body_region_budget <= 0 and not rows:
+            body_region_budget = page_height
+        top_padding, body_budget, bottom_padding = _allocate_body_region(
+            body_region_budget,
+            self.body_padding_top,
+            self.body_padding_bottom,
+        )
 
         body_start = len(rows)
         body_line_count = 0
-        if body_budget > 0 and len(rows) < page_height:
+        if body_region_budget > 0 and len(rows) < page_height:
+            rows.extend(RenderLine("") for _ in range(top_padding))
+            body_start = len(rows)
             body_result = _render_part(
                 self.body,
                 RenderConstraints(
@@ -135,6 +144,7 @@ class PageScaffold:
             body_lines = list(body_result.lines[:body_budget])
             body_line_count = len(body_lines)
             rows.extend(body_lines)
+            rows.extend(RenderLine("") for _ in range(bottom_padding))
         else:
             body_result = RenderResult.from_lines([], constraints=constraints)
 
@@ -204,6 +214,17 @@ def _render_part(
         return render(constraints)
     line_count = min(max(0, missing_render_lines), max(0, constraints.max_height))
     return RenderResult.from_lines([RenderLine("") for _ in range(line_count)], constraints=constraints)
+
+
+def _allocate_body_region(region_height: int, top_padding: int, bottom_padding: int) -> tuple[int, int, int]:
+    if region_height <= 0:
+        return 0, 0, 0
+    padding_budget = max(0, region_height - 1)
+    top_count = min(max(0, top_padding), padding_budget)
+    padding_budget -= top_count
+    bottom_count = min(max(0, bottom_padding), padding_budget)
+    body_budget = region_height - top_count - bottom_count
+    return top_count, body_budget, bottom_count
 
 
 def _has_method(part: object | None, name: str) -> bool:

--- a/tests/tui/test_widgets_page_scaffold.py
+++ b/tests/tui/test_widgets_page_scaffold.py
@@ -143,6 +143,52 @@ def test_page_scaffold_reserves_footer_height_under_long_body_content() -> None:
     assert "row 9" not in lines
 
 
+def test_page_scaffold_renders_body_padding_inside_reserved_footer_area() -> None:
+    scaffold = PageScaffold(
+        header=StaticPart(("header",)),
+        body=StaticPart(("body",)),
+        footer="footer",
+        separator_after_header=True,
+        body_padding_top=1,
+        body_padding_bottom=2,
+    )
+
+    assert plain_lines(scaffold, width=12, height=7) == (
+        "header",
+        "------------",
+        "",
+        "body",
+        "",
+        "",
+        "footer",
+    )
+
+
+def test_page_scaffold_body_padding_yields_to_body_and_footer_when_height_is_tight() -> None:
+    scaffold = PageScaffold(
+        body=StaticPart(("body",)),
+        footer="footer",
+        body_padding_top=3,
+        body_padding_bottom=3,
+    )
+
+    assert plain_lines(scaffold, width=20, height=2) == ("body", "footer")
+
+
+def test_page_scaffold_body_padding_counts_against_body_viewport_budget() -> None:
+    scaffold = PageScaffold(
+        body=StaticPart(tuple(f"row {index}" for index in range(10))),
+        footer="footer",
+        body_padding_top=1,
+        body_padding_bottom=1,
+    )
+
+    lines = plain_lines(scaffold, width=20, height=6)
+
+    assert lines == ("", "row 0", "row 1", "row 2", "", "footer")
+    assert "row 3" not in lines
+
+
 def test_page_scaffold_uses_visible_height_for_footer_padding() -> None:
     scaffold = PageScaffold(
         body=StaticPart(tuple(f"row {index}" for index in range(10))),
@@ -180,6 +226,22 @@ def test_page_scaffold_offsets_body_cursor_after_header_and_separator() -> None:
     result = scaffold.render(RenderConstraints(width=20, max_height=5))
 
     assert result.cursor == CursorDeclaration(row=2, column=2)
+
+
+def test_page_scaffold_offsets_body_cursor_after_body_top_padding() -> None:
+    scaffold = PageScaffold(
+        header=StaticPart(("header",)),
+        body=CursorPart(("body",), CursorDeclaration(row=0, column=3)),
+        footer="footer",
+        focused=True,
+        focus_region="body",
+        separator_after_header=True,
+        body_padding_top=2,
+    )
+
+    result = scaffold.render(RenderConstraints(width=20, max_height=7))
+
+    assert result.cursor == CursorDeclaration(row=4, column=3)
 
 
 def test_page_scaffold_uses_header_cursor_without_body_offset() -> None:


### PR DESCRIPTION
## Summary

- Add `body_padding_top` and `body_padding_bottom` hooks to `PageScaffold`.
- Keep body padding best-effort so it yields to body content and reserved footer space under tight heights.
- Update example 53 to demonstrate scaffold-owned body spacing.
- Add long-term internal PageScaffold docs and refresh the temporary design spec to match the current API.

## Validation

- `uv run pytest tests/tui/test_widgets_page_scaffold.py -q`
- `uv run pytest tests/tui -q`
- `uv run ruff check src/loushang/tui/ui_parts/widgets/page_scaffold.py tests/tui/test_widgets_page_scaffold.py examples/tui/53_widgets_page_scaffold.py`
