### PR TITLE
Split settings page modules

### DIFF
--- a/src/loushang/coding/ui/native_app.py
+++ b/src/loushang/coding/ui/native_app.py
@@ -185,6 +185,9 @@ class NativeCodingTuiApp:
         self.state.statusline_visible = settings.enabled
         self._request_render("product")
 
+    def request_render(self, kind: RenderRequestKind = "product") -> None:
+        self._request_render(kind)
+
     def statusline_preview_snapshot(self) -> StatusLinePreviewSnapshot:
         return StatusLinePreviewSnapshot(
             model_label=self.state.model_label,

--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -535,7 +535,7 @@ class NativeSurfaceManager:
                 self.app.set_statusline_visible(result.statusline_visible)
             if result.refresh_model_label:
                 await self._refresh_model_label()
-            self.app.set_status(result.message)
+            self.app.request_render("product")
             return
 
         updated = self.status_provider.settings_list().toggle(payload["id"])

--- a/src/loushang/coding/ui/settings_common.py
+++ b/src/loushang/coding/ui/settings_common.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.tui import SearchableListItem, ThemeResolver, truncate_to_width
+
+
+@dataclass(frozen=True, slots=True)
+class ConfigRow:
+    id: str
+    label: str
+    value: str
+    description: str = ""
+    disabled: bool = False
+
+
+SETTINGS_VALUE_COLUMN = 42
+
+SETTINGS_PAGE_THEME = ThemeResolver(
+    defaults={
+        "widget.tabs.tab": {"color": "white"},
+        "widget.tabs.selected": {"bold": True, "color": "green"},
+        "widget.tabs.level0.selected_header_focus": {"bold": True, "color": "cyan"},
+        "widget.tabs.level0.selected_content_focus": {"bold": True, "color": "green"},
+        "widget.tabs.level1.selected_header_focus": {"bold": True, "color": "magenta"},
+        "widget.tabs.level1.selected_content_focus": {"bold": True, "color": "yellow"},
+        "widget.searchableList.search": {"color": "white"},
+        "widget.searchableList.placeholder": {"color": "bright_black"},
+        "widget.searchableList.item": {"color": "white"},
+        "widget.searchableList.focus": {"bold": True, "color": "cyan"},
+        "widget.searchableList.disabled": {"dim": True},
+        "widget.searchableList.description": {"color": "bright_black"},
+        "widget.searchableList.empty": {"color": "bright_black"},
+        "widget.searchableList.overflow": {"color": "bright_black"},
+    }
+)
+
+
+def config_items(rows: tuple[ConfigRow, ...]) -> tuple[SearchableListItem, ...]:
+    return tuple(
+        SearchableListItem(row.id, row.label, row.value, row.description, disabled=row.disabled)
+        for row in rows
+    )
+
+
+def row_for_key(rows: tuple[ConfigRow, ...], key: str) -> ConfigRow | None:
+    for row in rows:
+        if row.id == key:
+            return row
+    return None
+
+
+def settings_header(width: int) -> str:
+    value_column = max(8, min(SETTINGS_VALUE_COLUMN, max(8, width - 8)))
+    return truncate_to_width(f"{'Setting':<{value_column}}Value", max_width=width, ellipsis="")
+
+
+def bool_text(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def as_bool(value: str) -> bool | None:
+    normalized = value.casefold()
+    if normalized == "true":
+        return True
+    if normalized == "false":
+        return False
+    return None
+
+
+def next_bool_value(value: str) -> str:
+    current = as_bool(value)
+    if current is None:
+        return value
+    return bool_text(not current)
+
+
+def is_space_event(event: object) -> bool:
+    return (
+        getattr(event, "kind", "") == "key"
+        and getattr(event, "key", "") == "space"
+    ) or (
+        getattr(event, "kind", "") == "text"
+        and getattr(event, "text", "") == " "
+    )
+
+
+def is_tab_fallback_key(event: object) -> bool:
+    return getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"left", "right", "home", "end"}

--- a/src/loushang/coding/ui/settings_config.py
+++ b/src/loushang/coding/ui/settings_config.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loushang.coding.ui.settings_common import (
+    SETTINGS_PAGE_THEME,
+    SETTINGS_VALUE_COLUMN,
+    ConfigRow,
+    bool_text,
+    config_items,
+    is_space_event,
+    is_tab_fallback_key,
+    next_bool_value,
+    row_for_key,
+    settings_header,
+)
+from loushang.tui import (
+    CursorDeclaration,
+    InputIntent,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    SearchableList,
+    SearchableListSelect,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ManagerBoolConfig:
+    id: str
+    label: str
+    getter: str
+    setter: str
+    status_label: str
+
+
+_MANAGER_BOOL_CONFIGS = (
+    ManagerBoolConfig(
+        "terminal.progress",
+        "Terminal progress",
+        "get_show_terminal_progress",
+        "set_show_terminal_progress",
+        "Terminal progress",
+    ),
+    ManagerBoolConfig(
+        "terminal.show_images",
+        "Show images",
+        "get_show_images",
+        "set_show_images",
+        "Show images",
+    ),
+    ManagerBoolConfig(
+        "terminal.clear_on_shrink",
+        "Clear on shrink",
+        "get_clear_on_shrink",
+        "set_clear_on_shrink",
+        "Clear on shrink",
+    ),
+    ManagerBoolConfig(
+        "images.auto_resize",
+        "Image auto-resize",
+        "get_image_auto_resize",
+        "set_image_auto_resize",
+        "Image auto-resize",
+    ),
+    ManagerBoolConfig(
+        "images.block_images",
+        "Block images",
+        "get_block_images",
+        "set_block_images",
+        "Block images",
+    ),
+    ManagerBoolConfig(
+        "retry.enabled",
+        "Retry",
+        "get_retry_enabled",
+        "set_retry_enabled",
+        "Retry",
+    ),
+)
+
+
+@dataclass(slots=True)
+class ConfigSettingsPage:
+    rows: tuple[ConfigRow, ...]
+    focused: bool = False
+    settings: SearchableList = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.settings = self._make_list(focused=False)
+
+    def focus(self) -> None:
+        self.focused = True
+        self.settings.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.settings.blur()
+
+    def editor_input_target(self) -> object | None:
+        return self.settings.editor_input_target()
+
+    def set_rows(self, rows: tuple[ConfigRow, ...], *, preserve_active_key: str = "") -> None:
+        self.rows = rows
+        self.settings.set_items(config_items(rows), preserve_active_key=preserve_active_key)
+
+    def handle_input(self, event: object) -> object:
+        result = self.settings.handle_input(event)
+        if isinstance(result, SearchableListSelect):
+            return self._setting_intent(result.key)
+        if result is not None:
+            return result
+        if self.settings.focus_region == "list" and is_space_event(event):
+            item = self.settings.active_item
+            if item is not None:
+                return self._setting_intent(item.key)
+        if is_tab_fallback_key(event):
+            return True
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        if constraints.max_height <= 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        if constraints.max_height <= 4:
+            return self.settings.render(constraints)
+        result = self.settings.render(
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2))
+        )
+        header = RenderLine(settings_header(constraints.width))
+        rows = [*result.lines[:3], RenderLine(""), header, *result.lines[3:]]
+        cursor = result.cursor
+        if cursor is not None and cursor.row >= 3:
+            cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
+
+    def _make_list(self, *, focused: bool) -> SearchableList:
+        return SearchableList(
+            config_items(self.rows),
+            placeholder="Search settings...",
+            empty_text="No matching settings",
+            focused=focused,
+            search_box=True,
+            detail_column=SETTINGS_VALUE_COLUMN,
+            theme=SETTINGS_PAGE_THEME,
+        )
+
+    def _setting_intent(self, key: str) -> InputIntent | None:
+        row = row_for_key(self.rows, key)
+        if row is None or row.disabled:
+            return None
+        value = next_bool_value(row.value)
+        return InputIntent(kind="setting", text=row.id, note=value)
+
+
+def config_rows(settings_manager: object | None) -> tuple[ConfigRow, ...]:
+    rows = []
+    if settings_manager is not None:
+        for config in _MANAGER_BOOL_CONFIGS:
+            getter = getattr(settings_manager, config.getter, None)
+            if callable(getter):
+                rows.append(ConfigRow(config.id, config.label, bool_text(bool(getter()))))
+    return tuple(rows)
+
+
+def manager_bool_config(item_id: str) -> ManagerBoolConfig | None:
+    for config in _MANAGER_BOOL_CONFIGS:
+        if config.id == item_id:
+            return config
+    return None

--- a/src/loushang/coding/ui/settings_page.py
+++ b/src/loushang/coding/ui/settings_page.py
@@ -169,6 +169,7 @@ class SettingsPageView:
     tabs: TabGroup = field(init=False)
     focused: bool = field(default=False, init=False)
     statusline_preview: Callable[[], StatusLinePreviewSnapshot] | None = None
+    feedback_message: str | None = field(default=None, init=False)
 
     @classmethod
     async def create(
@@ -199,6 +200,7 @@ class SettingsPageView:
             self._refresh_status_page()
             self._refresh_statusline_page(preserve_active_key=item_id)
             settings = self.status_provider.statusline_settings()
+            self.feedback_message = message
             return SettingsApplyResult(
                 message,
                 statusline_visible=settings.enabled,
@@ -208,19 +210,28 @@ class SettingsPageView:
         if config is not None:
             enabled = as_bool(value)
             if enabled is None:
-                return SettingsApplyResult(f"Invalid {config.label} value.")
+                message = f"Invalid {config.label} value."
+                self.feedback_message = message
+                return SettingsApplyResult(message)
             setter = getattr(self.settings_manager, config.setter, None)
             if not callable(setter):
-                return SettingsApplyResult(f"{config.status_label} is not available.")
+                message = f"{config.status_label} is not available."
+                self.feedback_message = message
+                return SettingsApplyResult(message)
             setter(enabled)
             self._refresh_config_rows(preserve_active_key=config.id)
-            return SettingsApplyResult(f"{config.status_label}: {'on' if enabled else 'off'}")
+            message = f"{config.status_label}: {'on' if enabled else 'off'}"
+            self.feedback_message = message
+            return SettingsApplyResult(message)
         if item_id == "model.current":
             message = await select_available_model(self.session, query=value)
             await self._refresh_model_page()
             self._refresh_status_page()
+            self.feedback_message = message
             return SettingsApplyResult(message, refresh_model_label=True)
-        return SettingsApplyResult(f"Unknown setting: {item_id}")
+        message = f"Unknown setting: {item_id}"
+        self.feedback_message = message
+        return SettingsApplyResult(message)
 
     def focus(self) -> None:
         self.focused = True
@@ -250,7 +261,7 @@ class SettingsPageView:
         result = self.tabs.render(RenderConstraints(width=constraints.width, max_height=body_height))
         rows = _with_separator(result.lines, width=constraints.width)
         cursor = _offset_cursor_after_separator(result.cursor)
-        footer = _footer_text(self._focus_context(), width=constraints.width)
+        footer = _footer_text(self._focus_context(), self.feedback_message, width=constraints.width)
         while len(rows) < constraints.max_height - 1:
             rows.append(RenderLine(""))
         if len(rows) < constraints.max_height:
@@ -427,7 +438,7 @@ def _offset_cursor_after_separator(cursor: CursorDeclaration | None) -> CursorDe
     return CursorDeclaration(row=cursor.row + 1, column=cursor.column)
 
 
-def _footer_text(focus_context: str, *, width: int) -> str:
+def _footer_text(focus_context: str, feedback_message: str | None = None, *, width: int) -> str:
     if focus_context == "search":
         text = "Type to filter · Enter/↓ to select · ↑ to tabs · Esc to clear"
     elif focus_context in {"settings-list", "model-list"}:
@@ -436,6 +447,8 @@ def _footer_text(focus_context: str, *, width: int) -> str:
         text = "←/→ to switch tabs · ↓ to enter · q to close"
     else:
         text = "↑ to tabs · q to close"
+    if feedback_message:
+        text = f"{feedback_message} · {text}"
     return truncate_to_width(text, max_width=width, ellipsis="")
 
 

--- a/src/loushang/coding/ui/settings_page.py
+++ b/src/loushang/coding/ui/settings_page.py
@@ -10,12 +10,24 @@ from loushang.coding.ui.model_list import (
     current_model_choice_value,
     select_available_model,
 )
+from loushang.coding.ui.settings_common import (
+    SETTINGS_PAGE_THEME,
+    SETTINGS_VALUE_COLUMN,
+    ConfigRow,
+    as_bool,
+    bool_text,
+    is_space_event,
+    is_tab_fallback_key,
+)
+from loushang.coding.ui.settings_config import (
+    ConfigSettingsPage,
+    config_rows,
+    manager_bool_config,
+)
+from loushang.coding.ui.settings_status_line import StatusLineSettingsPage
 from loushang.coding.ui.status_line import (
     StatusLinePreviewSnapshot,
     StatusLineSettings,
-    status_line_fields,
-    status_line_separator,
-    status_line_style_mode,
 )
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider, StatusSnapshot
 from loushang.tui import (
@@ -28,10 +40,8 @@ from loushang.tui import (
     SearchableList,
     SearchableListItem,
     SearchableListSelect,
-    StatusBar,
     TabGroup,
     TabPage,
-    ThemeResolver,
     truncate_to_width,
 )
 
@@ -50,91 +60,6 @@ class SettingsApplyResult:
     statusline_visible: bool | None = None
     statusline_settings: StatusLineSettings | None = None
     refresh_model_label: bool = False
-
-
-@dataclass(frozen=True, slots=True)
-class ConfigRow:
-    id: str
-    label: str
-    value: str
-    description: str = ""
-    disabled: bool = False
-
-
-@dataclass(frozen=True, slots=True)
-class _ManagerBoolConfig:
-    id: str
-    label: str
-    getter: str
-    setter: str
-    status_label: str
-
-
-SETTINGS_VALUE_COLUMN = 42
-
-SETTINGS_PAGE_THEME = ThemeResolver(
-    defaults={
-        "widget.tabs.tab": {"color": "white"},
-        "widget.tabs.selected": {"bold": True, "color": "green"},
-        "widget.tabs.level0.selected_header_focus": {"bold": True, "color": "cyan"},
-        "widget.tabs.level0.selected_content_focus": {"bold": True, "color": "green"},
-        "widget.tabs.level1.selected_header_focus": {"bold": True, "color": "magenta"},
-        "widget.tabs.level1.selected_content_focus": {"bold": True, "color": "yellow"},
-        "widget.searchableList.search": {"color": "white"},
-        "widget.searchableList.placeholder": {"color": "bright_black"},
-        "widget.searchableList.item": {"color": "white"},
-        "widget.searchableList.focus": {"bold": True, "color": "cyan"},
-        "widget.searchableList.disabled": {"dim": True},
-        "widget.searchableList.description": {"color": "bright_black"},
-        "widget.searchableList.empty": {"color": "bright_black"},
-        "widget.searchableList.overflow": {"color": "bright_black"},
-    }
-)
-
-_MANAGER_BOOL_CONFIGS = (
-    _ManagerBoolConfig(
-        "terminal.progress",
-        "Terminal progress",
-        "get_show_terminal_progress",
-        "set_show_terminal_progress",
-        "Terminal progress",
-    ),
-    _ManagerBoolConfig(
-        "terminal.show_images",
-        "Show images",
-        "get_show_images",
-        "set_show_images",
-        "Show images",
-    ),
-    _ManagerBoolConfig(
-        "terminal.clear_on_shrink",
-        "Clear on shrink",
-        "get_clear_on_shrink",
-        "set_clear_on_shrink",
-        "Clear on shrink",
-    ),
-    _ManagerBoolConfig(
-        "images.auto_resize",
-        "Image auto-resize",
-        "get_image_auto_resize",
-        "set_image_auto_resize",
-        "Image auto-resize",
-    ),
-    _ManagerBoolConfig(
-        "images.block_images",
-        "Block images",
-        "get_block_images",
-        "set_block_images",
-        "Block images",
-    ),
-    _ManagerBoolConfig(
-        "retry.enabled",
-        "Retry",
-        "get_retry_enabled",
-        "set_retry_enabled",
-        "Retry",
-    ),
-)
 
 
 @dataclass(slots=True)
@@ -159,155 +84,6 @@ class StaticLinesPage:
             for line in self.lines[: constraints.max_height]
         ]
         return RenderResult.from_lines(rows, constraints=constraints)
-
-
-@dataclass(slots=True)
-class ConfigSettingsPage:
-    rows: tuple[ConfigRow, ...]
-    focused: bool = False
-    settings: SearchableList = field(init=False)
-
-    def __post_init__(self) -> None:
-        self.settings = self._make_list(focused=False)
-
-    def focus(self) -> None:
-        self.focused = True
-        self.settings.focus()
-
-    def blur(self) -> None:
-        self.focused = False
-        self.settings.blur()
-
-    def editor_input_target(self) -> object | None:
-        return self.settings.editor_input_target()
-
-    def set_rows(self, rows: tuple[ConfigRow, ...], *, preserve_active_key: str = "") -> None:
-        self.rows = rows
-        self.settings.set_items(_config_items(rows), preserve_active_key=preserve_active_key)
-
-    def handle_input(self, event: object) -> object:
-        result = self.settings.handle_input(event)
-        if isinstance(result, SearchableListSelect):
-            return self._setting_intent(result.key)
-        if result is not None:
-            return result
-        if self.settings.focus_region == "list" and _is_space_event(event):
-            item = self.settings.active_item
-            if item is not None:
-                return self._setting_intent(item.key)
-        if _is_tab_fallback_key(event):
-            return True
-        return None
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        if constraints.max_height <= 0:
-            return RenderResult.from_lines([], constraints=constraints)
-        if constraints.max_height <= 4:
-            return self.settings.render(constraints)
-        result = self.settings.render(
-            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2))
-        )
-        header = RenderLine(_settings_header(constraints.width))
-        rows = [*result.lines[:3], RenderLine(""), header, *result.lines[3:]]
-        cursor = result.cursor
-        if cursor is not None and cursor.row >= 3:
-            cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
-        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
-
-    def _make_list(self, *, focused: bool) -> SearchableList:
-        return SearchableList(
-            _config_items(self.rows),
-            placeholder="Search settings...",
-            empty_text="No matching settings",
-            focused=focused,
-            search_box=True,
-            detail_column=SETTINGS_VALUE_COLUMN,
-            theme=SETTINGS_PAGE_THEME,
-        )
-
-    def _setting_intent(self, key: str) -> InputIntent | None:
-        row = _row_for_key(self.rows, key)
-        if row is None or row.disabled:
-            return None
-        value = _next_value(row.value)
-        return InputIntent(kind="setting", text=row.id, note=value)
-
-
-@dataclass(slots=True)
-class StatusLineSettingsPage:
-    statusline_settings: StatusLineSettings
-    statusline_preview: Callable[[], StatusLinePreviewSnapshot]
-    focused: bool = False
-    settings: SearchableList = field(init=False)
-
-    def __post_init__(self) -> None:
-        self.settings = self._make_list(focused=False)
-
-    def focus(self) -> None:
-        self.focused = True
-        self.settings.focus()
-
-    def blur(self) -> None:
-        self.focused = False
-        self.settings.blur()
-
-    def editor_input_target(self) -> object | None:
-        return self.settings.editor_input_target()
-
-    def set_statusline_settings(self, settings: StatusLineSettings, *, preserve_active_key: str = "") -> None:
-        self.statusline_settings = settings
-        self.settings.set_items(_config_items(_statusline_rows(settings)), preserve_active_key=preserve_active_key)
-
-    def handle_input(self, event: object) -> object:
-        result = self.settings.handle_input(event)
-        if isinstance(result, SearchableListSelect):
-            return self._setting_intent(result.key)
-        if result is not None:
-            return result
-        if self.settings.focus_region == "list" and _is_space_event(event):
-            item = self.settings.active_item
-            if item is not None:
-                return self._setting_intent(item.key)
-        if _is_tab_fallback_key(event):
-            return True
-        return None
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        if constraints.max_height <= 0:
-            return RenderResult.from_lines([], constraints=constraints)
-        if constraints.max_height <= 6:
-            return self.settings.render(constraints)
-        result = self.settings.render(
-            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 4))
-        )
-        header = RenderLine(_settings_header(constraints.width))
-        preview = _statusline_preview_lines(
-            self.statusline_preview(),
-            self.statusline_settings,
-            width=constraints.width,
-        )
-        rows = [*result.lines[:3], RenderLine(""), header, *result.lines[3:], RenderLine(""), *preview]
-        cursor = result.cursor
-        if cursor is not None and cursor.row >= 3:
-            cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
-        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
-
-    def _make_list(self, *, focused: bool) -> SearchableList:
-        return SearchableList(
-            _config_items(_statusline_rows(self.statusline_settings)),
-            placeholder="Search status line...",
-            empty_text="No matching status line settings",
-            focused=focused,
-            search_box=True,
-            detail_column=SETTINGS_VALUE_COLUMN,
-            theme=SETTINGS_PAGE_THEME,
-        )
-
-    def _setting_intent(self, key: str) -> InputIntent | None:
-        row = _row_for_key(_statusline_rows(self.statusline_settings), key)
-        if row is None or row.disabled:
-            return None
-        return InputIntent(kind="setting", text=row.id, note=_next_statusline_value(row.id, row.value))
 
 
 @dataclass(slots=True)
@@ -346,17 +122,17 @@ class ModelPage:
 
     def handle_input(self, event: object) -> object:
         if self.unavailable:
-            return True if _is_tab_fallback_key(event) else None
+            return True if is_tab_fallback_key(event) else None
         result = self.models.handle_input(event)
         if isinstance(result, SearchableListSelect):
             return InputIntent(kind="setting", text="model.current", note=result.key)
         if result is not None:
             return result
-        if self.models.focus_region == "list" and _is_space_event(event):
+        if self.models.focus_region == "list" and is_space_event(event):
             item = self.models.active_item
             if item is not None:
                 return InputIntent(kind="setting", text="model.current", note=item.key)
-        if _is_tab_fallback_key(event):
+        if is_tab_fallback_key(event):
             return True
         return None
 
@@ -428,9 +204,9 @@ class SettingsPageView:
                 statusline_visible=settings.enabled,
                 statusline_settings=settings,
             )
-        config = _manager_bool_config(item_id)
+        config = manager_bool_config(item_id)
         if config is not None:
-            enabled = _as_bool(value)
+            enabled = as_bool(value)
             if enabled is None:
                 return SettingsApplyResult(f"Invalid {config.label} value.")
             setter = getattr(self.settings_manager, config.setter, None)
@@ -483,7 +259,7 @@ class SettingsPageView:
 
     async def _build(self) -> None:
         self.status_page = StaticLinesPage(_status_lines(self.status_provider.snapshot()))
-        self.config_page = ConfigSettingsPage(_config_rows(self.status_provider, self.settings_manager))
+        self.config_page = ConfigSettingsPage(config_rows(self.settings_manager))
         choices, current_value, error = await _load_model_choices(self.session)
         self.model_page = ModelPage(choices, current_value=current_value, error=error)
         self.statusline_page = StatusLineSettingsPage(
@@ -517,7 +293,7 @@ class SettingsPageView:
         self.status_page.lines = _status_lines(self.status_provider.snapshot())
 
     def _refresh_config_rows(self, *, preserve_active_key: str = "") -> None:
-        self.config_page.set_rows(_config_rows(self.status_provider, self.settings_manager), preserve_active_key=preserve_active_key)
+        self.config_page.set_rows(config_rows(self.settings_manager), preserve_active_key=preserve_active_key)
 
     def _refresh_statusline_page(self, *, preserve_active_key: str = "") -> None:
         self.statusline_page.set_statusline_settings(
@@ -569,38 +345,6 @@ async def _load_model_choices(session: Any) -> tuple[tuple[ModelChoice, ...], st
     return tuple(choices), current_value, ""
 
 
-def _config_rows(_status_provider: CodingTuiStatusProvider, settings_manager: object | None) -> tuple[ConfigRow, ...]:
-    rows = []
-    if settings_manager is not None:
-        for config in _MANAGER_BOOL_CONFIGS:
-            getter = getattr(settings_manager, config.getter, None)
-            if callable(getter):
-                rows.append(ConfigRow(config.id, config.label, _bool_text(bool(getter()))))
-    return tuple(rows)
-
-
-def _statusline_rows(settings: StatusLineSettings) -> tuple[ConfigRow, ...]:
-    return (
-        ConfigRow("statusline.enabled", "Enabled", _bool_text(settings.enabled)),
-        ConfigRow("statusline.field.model", "Model", _bool_text(settings.model)),
-        ConfigRow("statusline.field.workspace", "Workspace", _bool_text(settings.workspace)),
-        ConfigRow("statusline.field.branch", "Branch", _bool_text(settings.branch)),
-        ConfigRow("statusline.field.session", "Session", _bool_text(settings.session)),
-        ConfigRow("statusline.field.runtime", "Runtime", _bool_text(settings.runtime)),
-        ConfigRow("statusline.field.queue", "Queue", settings.queue),
-        ConfigRow("statusline.field.message", "Message", settings.message),
-        ConfigRow("statusline.separator", "Separator", settings.separator),
-        ConfigRow("statusline.style", "Style", settings.style),
-    )
-
-
-def _config_items(rows: tuple[ConfigRow, ...]) -> tuple[SearchableListItem, ...]:
-    return tuple(
-        SearchableListItem(row.id, row.label, row.value, row.description, disabled=row.disabled)
-        for row in rows
-    )
-
-
 def _model_items(choices: tuple[ModelChoice, ...], *, current_value: str | None) -> tuple[SearchableListItem, ...]:
     return tuple(
         SearchableListItem(
@@ -613,13 +357,6 @@ def _model_items(choices: tuple[ModelChoice, ...], *, current_value: str | None)
     )
 
 
-def _row_for_key(rows: tuple[ConfigRow, ...], key: str) -> ConfigRow | None:
-    for row in rows:
-        if row.id == key:
-            return row
-    return None
-
-
 def _status_lines(snapshot: StatusSnapshot) -> tuple[str, ...]:
     return (
         "Status",
@@ -630,7 +367,7 @@ def _status_lines(snapshot: StatusSnapshot) -> tuple[str, ...]:
         f"Session            {snapshot.session_label or 'Unavailable'}",
         f"Thinking           {snapshot.thinking_level or 'Unavailable'}",
         f"Runtime            {'running' if snapshot.running else 'idle'}",
-        f"Status line        {_bool_text(snapshot.statusline_visible)}",
+        f"Status line        {bool_text(snapshot.statusline_visible)}",
     )
 
 
@@ -672,26 +409,6 @@ def _model_usage_lines(current_value: str | None) -> tuple[str, ...]:
     )
 
 
-def _statusline_preview_lines(
-    snapshot: StatusLinePreviewSnapshot,
-    settings: StatusLineSettings,
-    *,
-    width: int,
-) -> tuple[RenderLine, ...]:
-    result = StatusBar(
-        status_line_fields(snapshot, settings),
-        separator=status_line_separator(settings),
-        style_mode=status_line_style_mode(settings),
-    ).render(RenderConstraints(width=width, max_height=1))
-    line = result.lines[0].text if result.lines else ""
-    return (RenderLine("Preview"), RenderLine(line))
-
-
-def _settings_header(width: int) -> str:
-    value_column = max(8, min(SETTINGS_VALUE_COLUMN, max(8, width - 8)))
-    return truncate_to_width(f"{'Setting':<{value_column}}Value", max_width=width, ellipsis="")
-
-
 def _separator(width: int) -> str:
     return "-" * max(1, width)
 
@@ -722,62 +439,6 @@ def _footer_text(focus_context: str, *, width: int) -> str:
     return truncate_to_width(text, max_width=width, ellipsis="")
 
 
-def _manager_bool_config(item_id: str) -> _ManagerBoolConfig | None:
-    for config in _MANAGER_BOOL_CONFIGS:
-        if config.id == item_id:
-            return config
-    return None
-
-
-def _bool_text(value: bool) -> str:
-    return "true" if value else "false"
-
-
-def _as_bool(value: str) -> bool | None:
-    normalized = value.casefold()
-    if normalized == "true":
-        return True
-    if normalized == "false":
-        return False
-    return None
-
-
-def _next_value(value: str) -> str:
-    current = _as_bool(value)
-    if current is None:
-        return value
-    return _bool_text(not current)
-
-
-def _next_statusline_value(item_id: str, value: str) -> str:
-    if item_id in {
-        "statusline.enabled",
-        "statusline.field.model",
-        "statusline.field.workspace",
-        "statusline.field.branch",
-        "statusline.field.session",
-        "statusline.field.runtime",
-    }:
-        return _next_value(value)
-    if item_id in {"statusline.field.queue", "statusline.field.message"}:
-        return {"auto": "true", "true": "false", "false": "auto"}.get(value, value)
-    if item_id == "statusline.separator":
-        return "dot" if value == "pipe" else "pipe"
-    if item_id == "statusline.style":
-        return {"codex-like": "muted", "muted": "plain", "plain": "codex-like"}.get(value, value)
-    return value
-
-
-def _is_space_event(event: object) -> bool:
-    return (
-        getattr(event, "kind", "") == "key"
-        and getattr(event, "key", "") == "space"
-    ) or (
-        getattr(event, "kind", "") == "text"
-        and getattr(event, "text", "") == " "
-    )
-
-
 def _is_escape_event(event: object) -> bool:
     return getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"escape", "esc"}
 
@@ -790,7 +451,3 @@ def _is_q_event(event: object) -> bool:
         getattr(event, "kind", "") == "text"
         and getattr(event, "text", "").casefold() == "q"
     )
-
-
-def _is_tab_fallback_key(event: object) -> bool:
-    return getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"left", "right", "home", "end"}

--- a/src/loushang/coding/ui/settings_status_line.py
+++ b/src/loushang/coding/ui/settings_status_line.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from loushang.coding.ui.settings_common import (
+    SETTINGS_PAGE_THEME,
+    SETTINGS_VALUE_COLUMN,
+    ConfigRow,
+    bool_text,
+    config_items,
+    is_space_event,
+    is_tab_fallback_key,
+    next_bool_value,
+    row_for_key,
+    settings_header,
+)
+from loushang.coding.ui.status_line import (
+    StatusLinePreviewSnapshot,
+    StatusLineSettings,
+    status_line_fields,
+    status_line_separator,
+    status_line_style_mode,
+)
+from loushang.tui import (
+    CursorDeclaration,
+    InputIntent,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    SearchableList,
+    SearchableListSelect,
+    StatusBar,
+)
+
+
+@dataclass(slots=True)
+class StatusLineSettingsPage:
+    statusline_settings: StatusLineSettings
+    statusline_preview: Callable[[], StatusLinePreviewSnapshot]
+    focused: bool = False
+    settings: SearchableList = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.settings = self._make_list(focused=False)
+
+    def focus(self) -> None:
+        self.focused = True
+        self.settings.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.settings.blur()
+
+    def editor_input_target(self) -> object | None:
+        return self.settings.editor_input_target()
+
+    def set_statusline_settings(self, settings: StatusLineSettings, *, preserve_active_key: str = "") -> None:
+        self.statusline_settings = settings
+        self.settings.set_items(config_items(statusline_rows(settings)), preserve_active_key=preserve_active_key)
+
+    def handle_input(self, event: object) -> object:
+        result = self.settings.handle_input(event)
+        if isinstance(result, SearchableListSelect):
+            return self._setting_intent(result.key)
+        if result is not None:
+            return result
+        if self.settings.focus_region == "list" and is_space_event(event):
+            item = self.settings.active_item
+            if item is not None:
+                return self._setting_intent(item.key)
+        if is_tab_fallback_key(event):
+            return True
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        if constraints.max_height <= 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        if constraints.max_height <= 6:
+            return self.settings.render(constraints)
+        result = self.settings.render(
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 4))
+        )
+        header = RenderLine(settings_header(constraints.width))
+        preview = _statusline_preview_lines(
+            self.statusline_preview(),
+            self.statusline_settings,
+            width=constraints.width,
+        )
+        rows = [*result.lines[:3], RenderLine(""), header, *result.lines[3:], RenderLine(""), *preview]
+        cursor = result.cursor
+        if cursor is not None and cursor.row >= 3:
+            cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
+
+    def _make_list(self, *, focused: bool) -> SearchableList:
+        return SearchableList(
+            config_items(statusline_rows(self.statusline_settings)),
+            placeholder="Search status line...",
+            empty_text="No matching status line settings",
+            focused=focused,
+            search_box=True,
+            detail_column=SETTINGS_VALUE_COLUMN,
+            theme=SETTINGS_PAGE_THEME,
+        )
+
+    def _setting_intent(self, key: str) -> InputIntent | None:
+        row = row_for_key(statusline_rows(self.statusline_settings), key)
+        if row is None or row.disabled:
+            return None
+        return InputIntent(kind="setting", text=row.id, note=next_statusline_value(row.id, row.value))
+
+
+def statusline_rows(settings: StatusLineSettings) -> tuple[ConfigRow, ...]:
+    return (
+        ConfigRow("statusline.enabled", "Enabled", bool_text(settings.enabled)),
+        ConfigRow("statusline.field.model", "Model", bool_text(settings.model)),
+        ConfigRow("statusline.field.workspace", "Workspace", bool_text(settings.workspace)),
+        ConfigRow("statusline.field.branch", "Branch", bool_text(settings.branch)),
+        ConfigRow("statusline.field.session", "Session", bool_text(settings.session)),
+        ConfigRow("statusline.field.runtime", "Runtime", bool_text(settings.runtime)),
+        ConfigRow("statusline.field.queue", "Queue", settings.queue),
+        ConfigRow("statusline.field.message", "Message", settings.message),
+        ConfigRow("statusline.separator", "Separator", settings.separator),
+        ConfigRow("statusline.style", "Style", settings.style),
+    )
+
+
+def next_statusline_value(item_id: str, value: str) -> str:
+    if item_id in {
+        "statusline.enabled",
+        "statusline.field.model",
+        "statusline.field.workspace",
+        "statusline.field.branch",
+        "statusline.field.session",
+        "statusline.field.runtime",
+    }:
+        return next_bool_value(value)
+    if item_id in {"statusline.field.queue", "statusline.field.message"}:
+        return {"auto": "true", "true": "false", "false": "auto"}.get(value, value)
+    if item_id == "statusline.separator":
+        return "dot" if value == "pipe" else "pipe"
+    if item_id == "statusline.style":
+        return {"codex-like": "muted", "muted": "plain", "plain": "codex-like"}.get(value, value)
+    return value
+
+
+def _statusline_preview_lines(
+    snapshot: StatusLinePreviewSnapshot,
+    settings: StatusLineSettings,
+    *,
+    width: int,
+) -> tuple[RenderLine, ...]:
+    result = StatusBar(
+        status_line_fields(snapshot, settings),
+        separator=status_line_separator(settings),
+        style_mode=status_line_style_mode(settings),
+    ).render(RenderConstraints(width=width, max_height=1))
+    line = result.lines[0].text if result.lines else ""
+    return (RenderLine("Preview"), RenderLine(line))

--- a/tests/coding/test_native_coding_tui_playback.py
+++ b/tests/coding/test_native_coding_tui_playback.py
@@ -380,9 +380,12 @@ def test_native_tui_playback_settings_page_toggles_statusline_and_exits() -> Non
     assert all(step.flush_succeeded for step in steps)
     assert app.active_surface is None
     assert app.state.statusline_visible is False
-    assert app.state.status_message == "Status line: off"
+    assert app.state.status_message is None
+    before_close_lines = _plain_lines(steps[-2].diagnostics)
+    assert any("Status line: off" in line for line in before_close_lines)
     lines = _plain_lines(steps[-1].diagnostics)
     assert "Settings" not in lines
+    assert not any("Status line: off" in line for line in lines)
     assert not any("moonshot/kimi-for-coding | repo | main | abcd | idle" in line for line in lines)
     for step in steps:
         step.assert_no_clear_scrollback()
@@ -413,9 +416,10 @@ def test_native_tui_playback_settings_page_toggles_statusline_style() -> None:
     assert all(step.flush_succeeded for step in steps)
     assert app.active_surface is not None
     assert app.state.statusline_settings.style == "muted"
-    assert app.state.status_message == "Status line style: muted"
+    assert app.state.status_message is None
     lines = _plain_lines(steps[-1].diagnostics)
     assert any("Style" in line and "muted" in line for line in lines)
+    assert any("Status line style: muted" in line for line in lines)
     for step in steps:
         step.assert_no_clear_scrollback()
 
@@ -445,10 +449,11 @@ def test_native_tui_playback_settings_page_toggles_statusline_field() -> None:
     assert all(step.flush_succeeded for step in steps)
     assert app.active_surface is not None
     assert app.state.statusline_settings.queue == "true"
-    assert app.state.status_message == "Status line queue: true"
+    assert app.state.status_message is None
     lines = _plain_lines(steps[-1].diagnostics)
     assert any("Queue" in line and "true" in line for line in lines)
     assert any("queued=0 steer=0" in line for line in lines)
+    assert any("Status line queue: true" in line for line in lines)
     for step in steps:
         step.assert_no_clear_scrollback()
 

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -436,7 +436,9 @@ def test_native_surface_manager_settings_page_submit_keeps_surface_open() -> Non
     assert app.state.statusline_visible is False
     assert app.state.statusline_settings.enabled is False
     assert manager.status_provider.statusline_settings().enabled is False
-    assert app.state.status_message == "Status line: off"
+    assert app.state.status_message is None
+    plain = _surface_plain_lines(app.active_surface)
+    assert any("Status line: off" in line for line in plain)
 
 
 def test_native_surface_manager_settings_page_submit_mirrors_statusline_settings_into_app() -> None:
@@ -454,7 +456,9 @@ def test_native_surface_manager_settings_page_submit_mirrors_statusline_settings
 
     assert app.state.statusline_settings.style == "muted"
     assert manager.status_provider.statusline_settings().style == "muted"
-    assert app.state.status_message == "Status line style: muted"
+    assert app.state.status_message is None
+    plain = _surface_plain_lines(app.active_surface)
+    assert any("Status line style: muted" in line for line in plain)
 
 
 def test_native_surface_manager_statusline_command_persists_settings(tmp_path) -> None:
@@ -923,7 +927,8 @@ def test_native_surface_manager_applies_settings_page_statusline_change() -> Non
     asyncio.run(manager.handle_surface_intent(intent))
 
     assert isinstance(app.active_surface, NativeSurfaceView)
-    assert app.state.status_message == "Status line: off"
+    assert app.state.status_message is None
+    assert any("Status line: off" in line for line in _surface_plain_lines(app.active_surface))
     rendered = tuple(strip_control_sequences(line.text) for line in app.render(RenderConstraints(width=100, max_height=12)).lines)
     assert not any("moonshot/kimi-for-coding | repo | main | abcd | idle" in line for line in rendered)
 
@@ -1105,6 +1110,11 @@ def _manager(
         session=session,
         status_provider=_status_provider(app, settings_manager=settings_manager),
     )
+
+
+def _surface_plain_lines(surface: NativeSurfaceView, *, width: int = 100, height: int = 24) -> tuple[str, ...]:
+    rendered = surface.render(RenderConstraints(width=width, max_height=height))
+    return tuple(strip_control_sequences(line.text) for line in rendered.lines)
 
 
 def _status_provider(

--- a/tests/coding/test_native_settings_page.py
+++ b/tests/coding/test_native_settings_page.py
@@ -145,6 +145,16 @@ def _raw(page: SettingsPageView, *, width: int = 100, height: int = 18) -> tuple
     return tuple(line.text for line in page.render(RenderConstraints(width=width, max_height=height)).lines)
 
 
+def test_settings_page_tab_modules_export_page_components() -> None:
+    from loushang.coding.ui.settings_config import ConfigSettingsPage
+    from loushang.coding.ui.settings_status_line import StatusLineSettingsPage
+
+    page = _page()
+
+    assert isinstance(page.config_page, ConfigSettingsPage)
+    assert isinstance(page.statusline_page, StatusLineSettingsPage)
+
+
 def test_settings_page_opens_config_tab_with_search_focus() -> None:
     page = _page()
     lines = _plain(page)

--- a/tests/coding/test_ui_status_line.py
+++ b/tests/coding/test_ui_status_line.py
@@ -129,7 +129,7 @@ def test_native_app_statusline_preview_snapshot_includes_live_queue_and_message_
     )
     app.queue_followup("next prompt")
     app.queue_steer("interrupt")
-    app.set_status("Status line: on")
+    app.set_status("Saved")
 
     assert app.statusline_preview_snapshot() == StatusLinePreviewSnapshot(
         model_label="moonshot/kimi-for-coding",
@@ -139,7 +139,7 @@ def test_native_app_statusline_preview_snapshot_includes_live_queue_and_message_
         running=False,
         pending_followups=1,
         pending_steers=1,
-        status_message="Status line: on",
+        status_message="Saved",
     )
 
 


### PR DESCRIPTION
## Summary
- Split Settings Page shared row, theme, and input helpers into settings_common.py.
- Move Config tab and Status Line tab implementations into dedicated modules.
- Keep SettingsPageView as the top-level tab orchestration layer and add coverage that it uses the split page classes.

## Validation
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_native_settings_page.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding/ui tests/coding/test_native_settings_page.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests -q