### PR TITLE
Stabilize TUI TreeView composition

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
@@ -11,7 +11,7 @@ are built from renderables but are described at the product-facing UI level.
 | Frame | BottomFrame, StatusBar, WorkingLine, PendingQueueView, WidgetSlot |
 | Input | Composer, TextInput, AutocompleteSurface |
 | Navigation | Tabs, [TabGroup, TabPage](./tabgroup-content-switcher.md), [PageScaffold](./page-scaffold.md) |
-| Lists | SelectList, [SearchableList](./searchable-list.md) |
+| Lists | SelectList, [SearchableList](./searchable-list.md), [TreeView](./tree.md) |
 | Surfaces | CommandSurface, SelectionSurface, SettingsSurface, ApprovalSurface, DialogSurface, HelpViewer, ChangelogViewer |
 | Transcript | ChatTranscript, UserPromptView, AssistantMessageView, ThinkingView, ToolExecutionView, ErrorView, WorkedDivider |
 | Content | MarkdownBlock, CodeBlock, DiffBlock, ImageBlock |

--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/tree.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/tree.md
@@ -1,0 +1,100 @@
+# TreeView
+
+`TreeView` is a reusable focused widget for hierarchical lists. It is intended
+for project explorers, settings category trees, diagnostics groups, and other
+bounded tree-shaped navigation inside page content.
+
+It owns flattening expanded nodes into visible rows, active-node repair,
+disabled-node skipping, expand/collapse behavior, viewport windowing, row
+markers, and structured activation results. Product pages still own selected
+detail panels, persistence, cross-page status messages, and global footer text.
+
+## Inputs And State
+
+- `TreeNode(value, label, children=(), disabled=False, expanded=False,
+  on_select=None)`.
+- `active_value`: initial active enabled visible node.
+- `expanded_values`: additional expanded node values.
+- `empty_text`: text shown when there are no nodes.
+- `wrap`: whether up/down navigation wraps between first and last enabled
+  visible nodes.
+- `indent`, `collapsed_marker`, `expanded_marker`, and `leaf_marker`: row
+  presentation controls.
+- `theme`: optional `ThemeResolver`.
+
+`value` must be unique across the full tree. `expanded_values` may only contain
+known nodes with children. Unknown or duplicate values fail early during
+construction.
+
+## Layout Behavior
+
+Rendering order is the visible tree slice only. TreeView does not render local
+headers, details, overflow rows, or footers.
+
+Each rendered row contains:
+
+1. a focus prefix (`> ` for the active focused row, otherwise two spaces)
+2. depth indentation
+3. a collapsed, expanded, or leaf marker
+4. the node label
+
+Rows are truncated to the available width. The viewport scrolls just enough to
+keep the active visible node in the rendered height. When focused, TreeView
+declares a cursor at column 0 on the active visible row so parent layouts can
+offset it through page chrome.
+
+## Focus And Activation
+
+TreeView handles these keys when focused:
+
+- `up` / `down`: move between enabled visible nodes.
+- `home` / `end`: jump to the first or last enabled visible node.
+- `right`: expand an expandable active node, or move to its first enabled
+  direct child when already expanded.
+- `left`: collapse an expanded active node, or move to the nearest enabled
+  visible parent.
+- `enter` / `space`: run `on_select` or return `InputIntent(kind="select",
+  text=value)`.
+
+Disabled nodes remain visible but are skipped by navigation and cannot be
+activated. Descendants of a disabled node are not automatically promoted as
+direct-child navigation targets.
+
+TreeView does not define a page-level focus escape. A wrapper page may translate
+an edge result, for example `up` on the first visible row, into `None` so
+`PageScaffold` or `TabGroup` can move focus to a header.
+
+## Theme Tokens
+
+| Token | Applies to |
+| --- | --- |
+| `widget.tree.row` | Normal enabled rows |
+| `widget.tree.focus` | Active row while TreeView has focus |
+| `widget.tree.disabled` | Disabled rows |
+| `widget.tree.empty` | Empty tree row |
+
+## Composition
+
+TreeView can live directly inside page content, inside a small page object that
+adds details next to or below the tree, or inside `PageScaffold` body content.
+Parent pages should preserve TreeView's cursor declaration when adding local
+chrome, then let `PageScaffold` offset the body cursor through header,
+separator, padding, and footer rows.
+
+Use page-level footer/status components for global commands and state. Keep
+TreeView rows limited to tree navigation and labels.
+
+## Test Obligations
+
+Changes to TreeView should cover:
+
+- duplicate and unknown value validation
+- initial expansion and active-node repair
+- disabled-node visibility and navigation skipping
+- up/down/home/end movement with and without wrapping
+- left/right expand, collapse, and parent/child movement
+- activation callback and `InputIntent` results
+- bounded viewport and cursor declaration on the active visible row
+- row width truncation and empty-state rendering
+- theme tokens preserving visible text
+- composition playback with `PageScaffold` when cursor offsets matter

--- a/examples/tui/55_widgets_tree_page_scaffold.py
+++ b/examples/tui/55_widgets_tree_page_scaffold.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from loushang.tui import (
+    CursorDeclaration,
+    FocusableMixin,
+    InputEvent,
+    PageScaffold,
+    PageScaffoldContext,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    TabItem,
+    Tabs,
+    ThemeResolver,
+    TreeNode,
+    TreeView,
+    Tui,
+    TuiInputResult,
+    TuiRunner,
+    truncate_to_width,
+)
+
+LABEL_WIDTH = 14
+
+TREE_PAGE_THEME = ThemeResolver(
+    defaults={
+        "widget.tabs.tab": {"color": "white"},
+        "widget.tabs.selected": {"bold": True, "color": "green"},
+        "widget.tabs.focus": {"bold": True, "color": "cyan"},
+        "widget.tabs.level0.selected_header_focus": {"bold": True, "color": "cyan"},
+        "widget.tabs.level0.selected_content_focus": {"bold": True, "color": "green"},
+        "widget.pageScaffold.separator": {"color": "bright_black"},
+        "widget.pageScaffold.footer": {"color": "bright_black"},
+        "widget.tree.row": {"color": "white"},
+        "widget.tree.focus": {"bold": True, "color": "cyan"},
+        "widget.tree.disabled": {"dim": True},
+        "widget.tree.empty": {"color": "bright_black"},
+    }
+)
+
+
+@dataclass(slots=True)
+class TreePage(FocusableMixin):
+    title: str
+    tree: TreeView
+    details: dict[str, tuple[str, str, str]]
+    selected_value: str = ""
+
+    def __post_init__(self) -> None:
+        FocusableMixin.__init__(self)
+
+    def focus(self) -> None:
+        self.focused = True
+        self.tree.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.tree.blur()
+
+    def handle_input(self, event: Any) -> object:
+        key = getattr(event, "key", "") if getattr(event, "kind", "") == "key" else ""
+        if key == "up" and self.tree.active_value == self._first_visible_value():
+            return None
+        result = self.tree.handle_input(event)
+        if getattr(result, "kind", "") == "select":
+            self.selected_value = getattr(result, "text", "")
+            path, _, _ = self.details.get(self.selected_value, ("", "", ""))
+            return f"Selected: {path}"
+        return result
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        tree_height = max(1, constraints.max_height - 6)
+        tree_result = self.tree.render(RenderConstraints(width=constraints.width, max_height=tree_height))
+        active_value = self.tree.active_value
+        path, kind, status = self.details.get(active_value, ("", "", ""))
+        if self.selected_value == active_value and path:
+            status = f"Selected: {path}"
+
+        rows = [
+            RenderLine(truncate_to_width(self.title, max_width=constraints.width, ellipsis="")),
+            *tree_result.lines,
+            RenderLine(""),
+            RenderLine("Details"),
+            _field("Path", path, width=constraints.width),
+            _field("Kind", kind, width=constraints.width),
+            _field("Status", status, width=constraints.width),
+        ]
+        cursor = None
+        if tree_result.cursor is not None:
+            cursor = CursorDeclaration(row=1 + tree_result.cursor.row, column=tree_result.cursor.column)
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
+
+    def _first_visible_value(self) -> str:
+        return self.tree.visible_values[0] if self.tree.visible_values else ""
+
+
+@dataclass(slots=True)
+class TreeScaffoldDemo(FocusableMixin):
+    tabs: Tabs = field(init=False)
+    pages: dict[str, TreePage] = field(init=False)
+    scaffold: PageScaffold = field(init=False)
+    status: str = "Ready"
+
+    def __post_init__(self) -> None:
+        FocusableMixin.__init__(self)
+        self.tabs = Tabs(
+            (
+                TabItem("files", "Files"),
+                TabItem("settings", "Settings"),
+            ),
+            on_change=self._select_tab,
+            theme=TREE_PAGE_THEME,
+        )
+        self.pages = {
+            "files": TreePage("Project tree", _files_tree(), _file_details()),
+            "settings": TreePage("Project tree", _settings_tree(), _settings_details()),
+        }
+        self.scaffold = PageScaffold(
+            header=self.tabs,
+            body=self.pages[self.tabs.value],
+            footer=self._footer,
+            theme=TREE_PAGE_THEME,
+            focused=True,
+            focus_region="body",
+            separator_after_header=True,
+            body_padding_top=1,
+            body_padding_bottom=1,
+        )
+        self.focus()
+
+    def focus(self) -> None:
+        self.focused = True
+        self.scaffold.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.scaffold.blur()
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        self.tabs.selected_focus = "header" if self.scaffold.focus_region == "header" else "content"
+        return self.scaffold.render(constraints)
+
+    def handle_input(self, event: Any) -> object:
+        result = self.scaffold.handle_input(event)
+        if isinstance(result, str):
+            self.status = result
+            return True
+        return True if result is not None else None
+
+    def _select_tab(self, value: str) -> bool:
+        self.scaffold.body = self.pages[value]
+        self.scaffold.focus_region = "header"
+        self.status = f"Selected: {value.title()}"
+        return True
+
+    def _footer(self, context: PageScaffoldContext) -> str:
+        if context.focus_region == "header":
+            return f"Tabs | {self.status} | Left/Right switch | Down tree | q quit"
+        return f"Tree | {self.status} | Up/Down move | Left/Right collapse/expand | Enter select | q quit"
+
+
+def build_app() -> Tui:
+    tui = Tui()
+    app = TreeScaffoldDemo()
+    tui.add_child(app)
+    tui.set_focus(app)
+    return tui
+
+
+async def main() -> int:
+    tui = build_app()
+
+    async def on_input(event: InputEvent, context: Any) -> TuiInputResult:
+        if _should_quit(event):
+            return context.stop(0)
+        context.tui.handle_input(event)
+        return TuiInputResult()
+
+    return await TuiRunner(tui).run(on_input=on_input)
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    text = f"{label:<{LABEL_WIDTH}}{value}"
+    return RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))
+
+
+def _files_tree() -> TreeView:
+    return TreeView(
+        (
+            TreeNode(
+                "src",
+                "src",
+                expanded=True,
+                children=(
+                    TreeNode("tui", "tui", children=(TreeNode("widgets", "widgets"), TreeNode("runtime", "runtime"))),
+                    TreeNode("coding", "coding"),
+                ),
+            ),
+            TreeNode("tests", "tests", children=(TreeNode("unit", "unit"), TreeNode("playback", "playback"))),
+            TreeNode("docs", "docs", children=(TreeNode("internals", "internals"),)),
+        ),
+        theme=TREE_PAGE_THEME,
+        wrap=False,
+    )
+
+
+def _settings_tree() -> TreeView:
+    return TreeView(
+        (
+            TreeNode(
+                "config",
+                "Config",
+                children=(
+                    TreeNode("model", "Model"),
+                    TreeNode("status-line", "Status line"),
+                    TreeNode("permissions", "Permissions"),
+                ),
+            ),
+            TreeNode(
+                "status",
+                "Status",
+                children=(TreeNode("session", "Session"), TreeNode("runtime", "Runtime")),
+            ),
+            TreeNode("stats", "Stats", children=(TreeNode("overview", "Overview"), TreeNode("models", "Models"))),
+        ),
+        theme=TREE_PAGE_THEME,
+        wrap=False,
+    )
+
+
+def _file_details() -> dict[str, tuple[str, str, str]]:
+    return {
+        "src": ("src", "folder", "expanded"),
+        "tui": ("src/tui", "folder", "collapsed"),
+        "widgets": ("src/tui/widgets", "folder", "leaf"),
+        "runtime": ("src/tui/runtime", "folder", "leaf"),
+        "coding": ("src/coding", "folder", "leaf"),
+        "tests": ("tests", "folder", "collapsed"),
+        "unit": ("tests/unit", "folder", "leaf"),
+        "playback": ("tests/playback", "folder", "leaf"),
+        "docs": ("docs", "folder", "collapsed"),
+        "internals": ("docs/internals", "folder", "leaf"),
+    }
+
+
+def _settings_details() -> dict[str, tuple[str, str, str]]:
+    return {
+        "config": ("Config", "tab", "collapsed"),
+        "model": ("Config / Model", "setting", "opens model tab"),
+        "status-line": ("Config / Status line", "setting", "true"),
+        "permissions": ("Config / Permissions", "setting", "default"),
+        "status": ("Status", "tab", "collapsed"),
+        "session": ("Status / Session", "setting", "active"),
+        "runtime": ("Status / Runtime", "setting", "idle"),
+        "stats": ("Stats", "tab", "collapsed"),
+        "overview": ("Stats / Overview", "view", "available"),
+        "models": ("Stats / Models", "view", "available"),
+    }
+
+
+def _should_quit(event: InputEvent) -> bool:
+    if event.kind == "text" and "q" in event.text.casefold():
+        return True
+    if event.kind == "key" and event.key in {"q", "ctrl+c"}:
+        return True
+    return False
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/loushang/tui/ui_parts/widgets/tree.py
+++ b/src/loushang/tui/ui_parts/widgets/tree.py
@@ -4,7 +4,12 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
-from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.core import (
+    CursorDeclaration,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+)
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.ui_parts.widgets._utils import (
     callback_result,
@@ -360,4 +365,10 @@ class TreeView:
         self._ensure_active_visible(height)
         rows = visible[self._first_visible_index : self._first_visible_index + height]
         lines = [RenderLine(self._row_line(entry, width)) for entry in rows]
-        return RenderResult.from_lines(lines, constraints=constraints)
+        cursor: CursorDeclaration | None = None
+        if self.focused and self._active_value:
+            for index, entry in enumerate(rows):
+                if entry.value == self._active_value and not entry.disabled:
+                    cursor = CursorDeclaration(row=index, column=0)
+                    break
+        return RenderResult.from_lines(lines, constraints=constraints, cursor=cursor)

--- a/tests/tui/test_widgets_tree.py
+++ b/tests/tui/test_widgets_tree.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from loushang.tui import (
+    CursorDeclaration,
     InputEvent,
     RenderConstraints,
     ThemeResolver,
@@ -245,6 +246,32 @@ def test_tree_view_renders_indentation_markers_focus_and_disabled_rows() -> None
     )
 
 
+def test_tree_view_declares_cursor_on_focused_active_row() -> None:
+    tree = TreeView(sample_nodes(), active_value="widgets")
+    tree.focus()
+
+    result = tree.render(RenderConstraints(width=30, max_height=6))
+
+    assert result.cursor == CursorDeclaration(row=1, column=0)
+
+
+def test_tree_view_cursor_tracks_scrolled_active_row() -> None:
+    tree = TreeView(
+        tuple(TreeNode(str(index), f"Item {index}") for index in range(6)),
+        active_value="5",
+    )
+    tree.focus()
+
+    result = tree.render(RenderConstraints(width=9, max_height=3))
+
+    assert plain_lines(tree, width=9, height=3) == (
+        "    Item",
+        "    Item",
+        ">   Item",
+    )
+    assert result.cursor == CursorDeclaration(row=2, column=0)
+
+
 def test_tree_view_respects_width_empty_and_height_viewport() -> None:
     empty = TreeView((), empty_text="Nothing here")
     assert plain_lines(empty, width=8, height=3) == ("Nothing",)
@@ -336,3 +363,52 @@ def test_widgets_tree_example_highlights_active_node() -> None:
     moved_lines = tuple(line.text for line in moved.lines)
 
     assert "\x1b[1;36m>     widgets" in moved_lines[4]
+
+
+def test_widgets_tree_page_scaffold_example_imports_and_offsets_cursor() -> None:
+    namespace = runpy.run_path("examples/tui/55_widgets_tree_page_scaffold.py", run_name="__test__")
+    app = namespace["build_app"]()
+
+    result = app.render(RenderConstraints(width=96, max_height=22))
+    lines = tuple(strip_control_sequences(line.text).rstrip() for line in result.lines)
+
+    assert lines[0].startswith("*[Files]")
+    assert "Project tree" in lines
+    assert any("Path          src" in line for line in lines)
+    assert result.cursor == CursorDeclaration(row=4, column=0)
+
+
+def test_widgets_tree_page_scaffold_example_playback_switches_focus_and_tree_tabs() -> None:
+    frames = play_example(
+        "examples/tui/55_widgets_tree_page_scaffold.py",
+        events=(
+            ("up to tabs", InputEvent(kind="key", key="up")),
+            ("right settings", InputEvent(kind="key", key="right")),
+            ("down to tree", InputEvent(kind="key", key="down")),
+            ("right expand", InputEvent(kind="key", key="right")),
+            ("down first child", InputEvent(kind="key", key="down")),
+            ("enter select", InputEvent(kind="key", key="enter")),
+        ),
+        width=96,
+        height=22,
+    )
+
+    initial = frames[0].lines
+    tabs = frames[1].lines
+    settings = frames[2].lines
+    body = frames[3].lines
+    child = frames[5].lines
+    selected = frames[6].lines
+
+    assert initial[0].startswith("*[Files]")
+    assert initial[-1].startswith("Tree |")
+    assert tabs[0].startswith(">[Files]")
+    assert tabs[-1].startswith("Tabs |")
+    assert ">[Settings]" in settings[0]
+    assert "*[Settings]" in body[0]
+    assert "Project tree" in body
+    assert any("Config" in line for line in child)
+    assert any("Selected:" in line for line in selected)
+    assert frames[0].cursor == (4, 0)
+    assert frames[1].cursor == (0, 0)
+    assert frames[3].cursor[0] > 2


### PR DESCRIPTION
## Summary

- declare TreeView cursors on the focused active visible row so parent page chrome can offset them correctly
- add a PageScaffold + TreeView composition example as `examples/tui/55_widgets_tree_page_scaffold.py`
- add TreeView cursor, viewport, and playback regression coverage
- document the TreeView UI part contract in internals docs

## Validation

- `uv run pytest tests/tui/test_widgets_tree.py tests/tui/test_widgets_page_scaffold.py -q`
- `uv run pytest tests/tui -q`
- `uv run ruff check src/loushang/tui/ui_parts/widgets/tree.py tests/tui/test_widgets_tree.py examples/tui/55_widgets_tree_page_scaffold.py`
- `git diff --check`
