### PR TITLE
Stabilize TUI Table composition

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
@@ -11,7 +11,7 @@ are built from renderables but are described at the product-facing UI level.
 | Frame | BottomFrame, StatusBar, WorkingLine, PendingQueueView, WidgetSlot |
 | Input | Composer, TextInput, AutocompleteSurface |
 | Navigation | Tabs, [TabGroup, TabPage](./tabgroup-content-switcher.md), [PageScaffold](./page-scaffold.md) |
-| Lists | SelectList, [SearchableList](./searchable-list.md), [TreeView](./tree.md) |
+| Lists | SelectList, [SearchableList](./searchable-list.md), [Table](./table.md), [TreeView](./tree.md) |
 | Surfaces | CommandSurface, SelectionSurface, SettingsSurface, ApprovalSurface, DialogSurface, HelpViewer, ChangelogViewer |
 | Transcript | ChatTranscript, UserPromptView, AssistantMessageView, ThinkingView, ToolExecutionView, ErrorView, WorkedDivider |
 | Content | MarkdownBlock, CodeBlock, DiffBlock, ImageBlock |

--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/table.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/table.md
@@ -1,0 +1,97 @@
+# Table
+
+`Table` is a reusable focused widget for row-oriented tabular data. It is
+intended for compact queues, status lists, run summaries, and other bounded
+tables where the active unit is a row.
+
+It owns row normalization, column width allocation, row focus, disabled-row
+skipping, activation, viewport windowing, alignment, and row/header styling.
+Product pages still own selected detail panels, data loading, sorting policy,
+mutation, and global footer/status text.
+
+Table is not a full DataGrid. It does not own cell focus, horizontal scrolling,
+column resizing, inline editing, multi-select, pinned columns, or sortable
+headers. Those behaviors should be designed as a separate DataGrid contract.
+
+## Inputs And State
+
+- `TableColumn(key, header, width=None, min_width=1, align="left")`.
+- `TableRow(value, cells, disabled=False, on_select=None)`.
+- `rows`: `TableRow`, mapping rows, or sequence rows.
+- `active_index`: initial active row index.
+- `show_header`: whether to render the header row.
+- `empty_text`: text shown when there are no rows.
+- `wrap`: whether up/down navigation wraps between first and last enabled rows.
+- `theme`: optional `ThemeResolver`.
+
+Mapping rows resolve cells by column key. Sequence rows resolve cells by column
+position. Non-`TableRow` inputs derive their row value from the first non-empty
+cell, falling back to the row index.
+
+## Layout Behavior
+
+Rendering order is:
+
+1. optional header row
+2. visible body row viewport, or one empty row when there are columns but no
+   rows
+
+The left focus prefix consumes up to two columns. Remaining width is allocated
+to visible columns. Fixed-width columns keep their requested width when
+possible; flexible columns share remaining space. If the table is still too
+wide, columns shrink from right to left until the rendered line fits.
+
+Rows and cells are truncated to the available width. Right-aligned columns pad
+on the left. When focused, Table declares a cursor at column 0 on the active
+visible body row so parent layouts can offset it through page chrome.
+
+## Focus And Activation
+
+Table handles these keys when focused:
+
+- `up` / `down`: move between enabled rows.
+- `home` / `end`: jump to the first or last enabled row.
+- `enter` / `space`: run `on_select` or return the row value.
+
+Disabled rows remain visible but are skipped by navigation and cannot be
+activated.
+
+Table does not define a page-level focus escape. A wrapper page may translate
+an edge result, for example `up` on the first enabled row, into `None` so
+`PageScaffold` or `TabGroup` can move focus to a header.
+
+## Theme Tokens
+
+| Token | Applies to |
+| --- | --- |
+| `widget.table.header` | Optional header row |
+| `widget.table.row` | Normal enabled body rows |
+| `widget.table.focus` | Active body row while Table has focus |
+| `widget.table.disabled` | Disabled body rows |
+| `widget.table.empty` | Empty table row |
+
+## Composition
+
+Table can live directly inside page content, inside a page object that adds a
+detail panel below or beside the table, or inside `PageScaffold` body content.
+Parent pages should preserve Table's cursor declaration when adding local
+chrome, then let `PageScaffold` offset the body cursor through header,
+separator, padding, and footer rows.
+
+Use page-level footer/status components for global commands and state. Keep
+Table rows limited to tabular navigation and row labels.
+
+## Test Obligations
+
+Changes to Table should cover:
+
+- mapping, sequence, and `TableRow` normalization
+- fixed/flexible column width allocation and right-to-left shrinking
+- left/right alignment and width truncation
+- disabled-row visibility and navigation skipping
+- up/down/home/end movement with and without wrapping
+- activation callback and row-value results
+- bounded viewport and cursor declaration on the active visible body row
+- header-hidden and empty-state rendering
+- theme tokens preserving visible text
+- composition playback with `PageScaffold` when cursor offsets matter

--- a/examples/tui/56_widgets_table_page_scaffold.py
+++ b/examples/tui/56_widgets_table_page_scaffold.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from loushang.tui import (
+    CursorDeclaration,
+    FocusableMixin,
+    InputEvent,
+    PageScaffold,
+    PageScaffoldContext,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    TabItem,
+    Table,
+    TableColumn,
+    TableRow,
+    Tabs,
+    ThemeResolver,
+    Tui,
+    TuiInputResult,
+    TuiRunner,
+    truncate_to_width,
+)
+
+LABEL_WIDTH = 14
+
+TABLE_PAGE_THEME = ThemeResolver(
+    defaults={
+        "widget.tabs.tab": {"color": "white"},
+        "widget.tabs.selected": {"bold": True, "color": "green"},
+        "widget.tabs.focus": {"bold": True, "color": "cyan"},
+        "widget.tabs.level0.selected_header_focus": {"bold": True, "color": "cyan"},
+        "widget.tabs.level0.selected_content_focus": {"bold": True, "color": "green"},
+        "widget.pageScaffold.separator": {"color": "bright_black"},
+        "widget.pageScaffold.footer": {"color": "bright_black"},
+        "widget.table.header": {"color": "bright_black"},
+        "widget.table.row": {"color": "white"},
+        "widget.table.focus": {"bold": True, "color": "cyan"},
+        "widget.table.disabled": {"dim": True},
+        "widget.table.empty": {"color": "bright_black"},
+    }
+)
+
+
+@dataclass(slots=True)
+class TablePage(FocusableMixin):
+    title: str
+    table: Table
+    details: dict[str, str]
+    first_value: str
+    selected_value: str = ""
+
+    def __post_init__(self) -> None:
+        FocusableMixin.__init__(self)
+
+    def focus(self) -> None:
+        self.focused = True
+        self.table.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.table.blur()
+
+    def handle_input(self, event: Any) -> object:
+        key = getattr(event, "key", "") if getattr(event, "kind", "") == "key" else ""
+        if key == "up" and self.table.active_value == self.first_value:
+            return None
+        result = self.table.handle_input(event)
+        if isinstance(result, str):
+            self.selected_value = result
+            return f"Selected: {self.details.get(result, result)}"
+        return result
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        table_height = max(1, constraints.max_height - 5)
+        table_result = self.table.render(RenderConstraints(width=constraints.width, max_height=table_height))
+        active_value = self.table.active_value
+        detail = self.details.get(self.selected_value or active_value, "Select a row")
+        rows = [
+            RenderLine(truncate_to_width(self.title, max_width=constraints.width, ellipsis="")),
+            *table_result.lines,
+            RenderLine(""),
+            RenderLine("Details"),
+            _field("Selected", detail, width=constraints.width),
+        ]
+        cursor = None
+        if table_result.cursor is not None:
+            cursor = CursorDeclaration(row=1 + table_result.cursor.row, column=table_result.cursor.column)
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
+
+
+@dataclass(slots=True)
+class TableScaffoldDemo(FocusableMixin):
+    tabs: Tabs = field(init=False)
+    pages: dict[str, TablePage] = field(init=False)
+    scaffold: PageScaffold = field(init=False)
+    status: str = "Ready"
+
+    def __post_init__(self) -> None:
+        FocusableMixin.__init__(self)
+        self.tabs = Tabs(
+            (
+                TabItem("jobs", "Jobs"),
+                TabItem("runs", "Runs"),
+            ),
+            on_change=self._select_tab,
+            theme=TABLE_PAGE_THEME,
+        )
+        self.pages = {
+            "jobs": TablePage("Job table", _jobs_table(), _job_details(), first_value="build"),
+            "runs": TablePage("Run table", _runs_table(), _run_details(), first_value="plan"),
+        }
+        self.scaffold = PageScaffold(
+            header=self.tabs,
+            body=self.pages[self.tabs.value],
+            footer=self._footer,
+            theme=TABLE_PAGE_THEME,
+            focused=True,
+            focus_region="body",
+            separator_after_header=True,
+            body_padding_top=1,
+            body_padding_bottom=1,
+        )
+        self.focus()
+
+    def focus(self) -> None:
+        self.focused = True
+        self.scaffold.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.scaffold.blur()
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        self.tabs.selected_focus = "header" if self.scaffold.focus_region == "header" else "content"
+        return self.scaffold.render(constraints)
+
+    def handle_input(self, event: Any) -> object:
+        result = self.scaffold.handle_input(event)
+        if isinstance(result, str):
+            self.status = result
+            return True
+        return True if result is not None else None
+
+    def _select_tab(self, value: str) -> bool:
+        self.scaffold.body = self.pages[value]
+        self.scaffold.focus_region = "header"
+        self.status = f"Selected: {value.title()}"
+        return True
+
+    def _footer(self, context: PageScaffoldContext) -> str:
+        if context.focus_region == "header":
+            return f"Tabs | {self.status} | Left/Right switch | Down table | q quit"
+        return f"Table | {self.status} | Up/Down row | Enter select | Up tabs | q quit"
+
+
+def build_app() -> Tui:
+    tui = Tui()
+    app = TableScaffoldDemo()
+    tui.add_child(app)
+    tui.set_focus(app)
+    return tui
+
+
+async def main() -> int:
+    tui = build_app()
+
+    async def on_input(event: InputEvent, context: Any) -> TuiInputResult:
+        if _should_quit(event):
+            return context.stop(0)
+        context.tui.handle_input(event)
+        return TuiInputResult()
+
+    return await TuiRunner(tui).run(on_input=on_input)
+
+
+def _field(label: str, value: str, *, width: int) -> RenderLine:
+    text = f"{label:<{LABEL_WIDTH}}{value}"
+    return RenderLine(truncate_to_width(text, max_width=width, ellipsis=""))
+
+
+def _jobs_table() -> Table:
+    return Table(
+        (
+            TableColumn("job", "Job", width=12),
+            TableColumn("status", "Status"),
+            TableColumn("runs", "Runs", width=5, align="right"),
+        ),
+        (
+            TableRow("build", {"job": "Build", "status": "ready", "runs": 12}),
+            TableRow("deploy", {"job": "Deploy", "status": "blocked", "runs": 3}),
+            TableRow("archive", {"job": "Archive", "status": "disabled", "runs": 0}, disabled=True),
+        ),
+        theme=TABLE_PAGE_THEME,
+        wrap=False,
+    )
+
+
+def _runs_table() -> Table:
+    return Table(
+        (
+            TableColumn("run", "Run", width=12),
+            TableColumn("duration", "Duration", width=10, align="right"),
+            TableColumn("result", "Result"),
+        ),
+        (
+            TableRow("plan", {"run": "plan", "duration": "00:08", "result": "queued"}),
+            TableRow("deploy", {"run": "deploy", "duration": "01:42", "result": "completed"}),
+            TableRow("verify", {"run": "verify", "duration": "00:31", "result": "passed"}),
+        ),
+        theme=TABLE_PAGE_THEME,
+        wrap=False,
+    )
+
+
+def _job_details() -> dict[str, str]:
+    return {
+        "build": "Build is ready, 12 runs",
+        "deploy": "Deploy is blocked, 3 runs",
+        "archive": "Archive is disabled, 0 runs",
+    }
+
+
+def _run_details() -> dict[str, str]:
+    return {
+        "plan": "plan queued",
+        "deploy": "deploy completed",
+        "verify": "verify passed",
+    }
+
+
+def _should_quit(event: InputEvent) -> bool:
+    if event.kind == "text" and "q" in event.text.casefold():
+        return True
+    if event.kind == "key" and event.key in {"q", "ctrl+c"}:
+        return True
+    return False
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/examples/tui/56_widgets_table_page_scaffold.py
+++ b/examples/tui/56_widgets_table_page_scaffold.py
@@ -193,6 +193,7 @@ def _jobs_table() -> Table:
             TableRow("build", {"job": "Build", "status": "ready", "runs": 12}),
             TableRow("deploy", {"job": "Deploy", "status": "blocked", "runs": 3}),
             TableRow("archive", {"job": "Archive", "status": "disabled", "runs": 0}, disabled=True),
+            TableRow("release", {"job": "Release", "status": "ready", "runs": 7}),
         ),
         theme=TABLE_PAGE_THEME,
         wrap=False,
@@ -221,6 +222,7 @@ def _job_details() -> dict[str, str]:
         "build": "Build is ready, 12 runs",
         "deploy": "Deploy is blocked, 3 runs",
         "archive": "Archive is disabled, 0 runs",
+        "release": "Release is ready, 7 runs",
     }
 
 

--- a/src/loushang/tui/ui_parts/widgets/table.py
+++ b/src/loushang/tui/ui_parts/widgets/table.py
@@ -9,7 +9,12 @@ from loushang.tui.cell_width import (
     truncate_to_width,
     visible_width,
 )
-from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
+from loushang.tui.core import (
+    CursorDeclaration,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+)
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.ui_parts.widgets._utils import (
     callback_result,
@@ -116,15 +121,19 @@ class Table:
             lines.append(RenderLine(_table_header_line(self, widths, prefix_width, target_width)))
 
         body_height = max(0, height - len(lines))
+        cursor: CursorDeclaration | None = None
+        body_start = len(lines)
         if self._rows:
             self._ensure_active_visible(body_height)
             indexed_rows = tuple(enumerate(self._rows))
             visible_rows = indexed_rows[self._first_visible_index : self._first_visible_index + body_height]
-            for index, row in visible_rows:
+            for offset, (index, row) in enumerate(visible_rows):
+                if self.focused and index == self._active_index and not row.disabled:
+                    cursor = CursorDeclaration(row=body_start + offset, column=0)
                 lines.append(RenderLine(_table_body_line(self, index, row, widths, prefix_width, target_width)))
         elif len(lines) < height:
             lines.append(RenderLine(_table_empty_line(self, widths, prefix_width, target_width)))
-        return RenderResult.from_lines(lines[:height], constraints=constraints)
+        return RenderResult.from_lines(lines[:height], constraints=constraints, cursor=cursor)
 
     def _enabled_indices(self) -> tuple[int, ...]:
         return tuple(index for index, row in enumerate(self._rows) if not row.disabled)

--- a/tests/tui/test_widgets_table.py
+++ b/tests/tui/test_widgets_table.py
@@ -4,6 +4,7 @@ import runpy
 from typing import Any
 
 from loushang.tui import (
+    CursorDeclaration,
     InputEvent,
     RenderConstraints,
     Table,
@@ -143,6 +144,40 @@ def test_table_can_hide_header() -> None:
     )
 
     assert plain_lines(table, width=12, height=2) == ("  One",)
+
+
+def test_table_declares_cursor_on_focused_active_body_row() -> None:
+    table = Table(
+        [TableColumn("name", "Name")],
+        [
+            TableRow("one", {"name": "One"}),
+            TableRow("two", {"name": "Two"}),
+        ],
+        active_index=1,
+    )
+    table.focus()
+
+    result = table.render(RenderConstraints(width=20, max_height=4))
+
+    assert result.cursor == CursorDeclaration(row=2, column=0)
+
+
+def test_table_cursor_tracks_scrolled_active_body_row() -> None:
+    table = Table(
+        [TableColumn("name", "Name")],
+        [TableRow(str(index), {"name": f"Item {index}"}) for index in range(6)],
+        active_index=5,
+    )
+    table.focus()
+
+    result = table.render(RenderConstraints(width=20, max_height=3))
+
+    assert plain_lines(table, width=20, height=3) == (
+        "  Name",
+        "  Item 4",
+        "> Item 5",
+    )
+    assert result.cursor == CursorDeclaration(row=2, column=0)
 
 
 def test_table_navigation_activation_callbacks_and_space_forms() -> None:
@@ -302,3 +337,51 @@ def test_widgets_table_example_highlights_active_row() -> None:
     moved_lines = tuple(line.text for line in moved.lines)
 
     assert "\x1b[1;36m> Deploy" in moved_lines[4]
+
+
+def test_widgets_table_page_scaffold_example_imports_and_offsets_cursor() -> None:
+    namespace = runpy.run_path("examples/tui/56_widgets_table_page_scaffold.py", run_name="__test__")
+    app = namespace["build_app"]()
+
+    result = app.render(RenderConstraints(width=96, max_height=22))
+    lines = tuple(strip_control_sequences(line.text).rstrip() for line in result.lines)
+
+    assert lines[0].startswith("*[Jobs]")
+    assert "Job table" in lines
+    assert any("Selected      Build is ready" in line for line in lines)
+    assert result.cursor == CursorDeclaration(row=5, column=0)
+
+
+def test_widgets_table_page_scaffold_example_playback_switches_focus_and_tabs() -> None:
+    frames = play_example(
+        "examples/tui/56_widgets_table_page_scaffold.py",
+        events=(
+            ("up to tabs", InputEvent(kind="key", key="up")),
+            ("right runs", InputEvent(kind="key", key="right")),
+            ("down to table", InputEvent(kind="key", key="down")),
+            ("down row", InputEvent(kind="key", key="down")),
+            ("enter select", InputEvent(kind="key", key="enter")),
+        ),
+        width=96,
+        height=22,
+    )
+
+    initial = frames[0].lines
+    tabs = frames[1].lines
+    runs = frames[2].lines
+    body = frames[3].lines
+    moved = frames[4].lines
+    selected = frames[5].lines
+
+    assert initial[0].startswith("*[Jobs]")
+    assert initial[-1].startswith("Table |")
+    assert tabs[0].startswith(">[Jobs]")
+    assert tabs[-1].startswith("Tabs |")
+    assert ">[Runs]" in runs[0]
+    assert "*[Runs]" in body[0]
+    assert "Run table" in body
+    assert "> deploy" in "\n".join(moved)
+    assert any("Selected:" in line for line in selected)
+    assert frames[0].cursor == (5, 0)
+    assert frames[1].cursor == (0, 0)
+    assert frames[3].cursor[0] > 3

--- a/tests/tui/test_widgets_table.py
+++ b/tests/tui/test_widgets_table.py
@@ -352,6 +352,28 @@ def test_widgets_table_page_scaffold_example_imports_and_offsets_cursor() -> Non
     assert result.cursor == CursorDeclaration(row=5, column=0)
 
 
+def test_widgets_table_page_scaffold_example_jobs_show_disabled_skip_target() -> None:
+    frames = play_example(
+        "examples/tui/56_widgets_table_page_scaffold.py",
+        events=(
+            ("down deploy", InputEvent(kind="key", key="down")),
+            ("down release", InputEvent(kind="key", key="down")),
+            ("enter select", InputEvent(kind="key", key="enter")),
+        ),
+        width=96,
+        height=22,
+    )
+
+    deploy = frames[1].lines
+    release = frames[2].lines
+    selected = frames[3].lines
+
+    assert "> Deploy" in "\n".join(deploy)
+    assert "  Archive" in "\n".join(release)
+    assert "> Release" in "\n".join(release)
+    assert any("Selected: Release is ready" in line for line in selected)
+
+
 def test_widgets_table_page_scaffold_example_playback_switches_focus_and_tabs() -> None:
     frames = play_example(
         "examples/tui/56_widgets_table_page_scaffold.py",


### PR DESCRIPTION
## Summary

- declare Table cursors on the focused active visible body row so parent page chrome can offset them correctly
- add a PageScaffold + Table composition example as `examples/tui/56_widgets_table_page_scaffold.py`
- add Table cursor, viewport, and playback regression coverage
- document the Table UI part contract and clarify that full DataGrid behavior is separate

## Validation

- `uv run pytest tests/tui/test_widgets_table.py tests/tui/test_widgets_page_scaffold.py -q`
- `uv run pytest tests/tui -q`
- `uv run ruff check src/loushang/tui/ui_parts/widgets/table.py tests/tui/test_widgets_table.py examples/tui/56_widgets_table_page_scaffold.py`
- `git diff --cached --check`
