### PR TITLE
Remove native settings fallback

### DIFF
--- a/src/loushang/coding/ui/native_surfaces.py
+++ b/src/loushang/coding/ui/native_surfaces.py
@@ -527,22 +527,16 @@ class NativeSurfaceManager:
         surface = self._current_surface()
         page = surface.content if isinstance(surface, NativeSurfaceView) else None
         apply_setting = getattr(page, "apply_setting", None)
-        if callable(apply_setting):
-            result = await apply_setting(payload["id"], payload.get("value", ""))
-            if result.statusline_settings is not None:
-                self.app.set_statusline_settings(result.statusline_settings)
-            elif result.statusline_visible is not None:
-                self.app.set_statusline_visible(result.statusline_visible)
-            if result.refresh_model_label:
-                await self._refresh_model_label()
-            self.app.request_render("product")
+        if not callable(apply_setting):
             return
-
-        updated = self.status_provider.settings_list().toggle(payload["id"])
-        self.close_surface()
-        message = self.status_provider.apply_settings(updated)
-        self.app.set_statusline_settings(self.status_provider.statusline_settings())
-        self.app.set_status(message)
+        result = await apply_setting(payload["id"], payload.get("value", ""))
+        if result.statusline_settings is not None:
+            self.app.set_statusline_settings(result.statusline_settings)
+        elif result.statusline_visible is not None:
+            self.app.set_statusline_visible(result.statusline_visible)
+        if result.refresh_model_label:
+            await self._refresh_model_label()
+        self.app.request_render("product")
 
     async def _handle_dialog_submit(self, _payload: Any | None = None) -> None:
         self.close_surface()

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -498,20 +498,22 @@ def test_native_surface_manager_settings_page_statusline_submit_persists_setting
     assert app.state.statusline_settings.style == "muted"
 
 
-def test_native_surface_manager_legacy_settings_surface_still_closes_on_submit() -> None:
+def test_native_surface_manager_ignores_legacy_settings_surface_submit() -> None:
     app = _app()
     manager = _manager(app, _Session())
-    app.active_surface = NativeSurfaceView(
+    legacy_surface = NativeSurfaceView(
         title="Settings",
         purpose="settings",
         content=SettingsSurface(list(manager.status_provider.settings_list().items), enable_search=True),
         presentation="bottom-exclusive",
     )
+    app.active_surface = legacy_surface
 
     asyncio.run(manager.handle_surface_intent(InputIntent(kind="setting", text="statusline", note="false")))
 
-    assert app.active_surface is None
-    assert app.state.statusline_visible is False
+    assert app.active_surface is legacy_surface
+    assert app.state.statusline_visible is True
+    assert app.state.status_message is None
 
 
 def test_native_surface_manager_settings_page_model_submit_uses_model_selection() -> None:


### PR DESCRIPTION
## Summary
- Remove the legacy SettingsSurface toggle fallback from NativeSurfaceManager settings submit handling.
- Keep settings submits scoped to SettingsPageView.apply_setting.
- Update coverage so legacy SettingsSurface submits are ignored instead of mutating status line state.

## Validation
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py tests/coding/test_native_settings_page.py tests/coding/test_ui_status_provider.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding/ui tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py tests/coding/test_native_settings_page.py tests/coding/test_ui_status_provider.py
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests -q