### PR TITLE
Mark settings list API as legacy

### DIFF
--- a/src/loushang/coding/ui/app.py
+++ b/src/loushang/coding/ui/app.py
@@ -17,7 +17,7 @@ from loushang.coding.ui.follow_up_queue import FollowUpQueueHandler
 from loushang.coding.ui.handlers import (
     CodingTuiHandlers,
     InfoPanelPresenter,
-    SettingsListPresenter,
+    LegacySettingsListPresenter,
 )
 from loushang.coding.ui.hotkeys import format_hotkeys
 from loushang.coding.ui.lifecycle import RunLifecycle
@@ -85,7 +85,7 @@ def build_coding_tui_app(
     model_palette_chooser: ModelPaletteChooser | None = None,
     command_palette_chooser: CommandPaletteChooser | None = None,
     info_panel_presenter: InfoPanelPresenter | None = None,
-    settings_list_presenter: SettingsListPresenter | None = None,
+    legacy_settings_list_presenter: LegacySettingsListPresenter | None = None,
 ) -> CodingTuiApp:
     lifecycle = RunLifecycle()
     controller = CodingUiController(runtime=runtime, session=session, verbose=verbose)
@@ -168,10 +168,10 @@ def build_coding_tui_app(
         command_select=lambda query: select_coding_command(session, query=query, choose=command_palette_chooser),
         commands=lambda query: format_coding_commands(session, query=query),
         hotkeys=format_hotkeys,
-        settings=status_provider.settings_text,
-        settings_list=status_provider.settings_list,
-        apply_settings=status_provider.apply_settings,
-        present_settings_list=settings_list_presenter,
+        legacy_settings_text=status_provider.legacy_settings_text,
+        legacy_settings_list=status_provider.legacy_settings_list,
+        apply_legacy_settings=status_provider.apply_legacy_settings,
+        present_legacy_settings_list=legacy_settings_list_presenter,
         statusline=status_provider.set_visible,
         now=now,
         session_running=lambda: is_running(session),

--- a/src/loushang/coding/ui/handlers.py
+++ b/src/loushang/coding/ui/handlers.py
@@ -64,15 +64,15 @@ class CommandSelectFn(Protocol):
     def __call__(self, query: str) -> Awaitable[str]: ...
 
 
-class SettingsFn(Protocol):
+class LegacySettingsTextFn(Protocol):
     def __call__(self) -> str: ...
 
 
-class SettingsListFn(Protocol):
+class LegacySettingsListFn(Protocol):
     def __call__(self) -> SettingsList: ...
 
 
-class ApplySettingsFn(Protocol):
+class ApplyLegacySettingsFn(Protocol):
     def __call__(self, settings: SettingsList) -> str: ...
 
 
@@ -80,7 +80,7 @@ class InfoPanelPresenter(Protocol):
     def __call__(self, panel: InfoPanel) -> bool | Awaitable[bool]: ...
 
 
-class SettingsListPresenter(Protocol):
+class LegacySettingsListPresenter(Protocol):
     def __call__(self, settings: SettingsList) -> SettingsList | None | Awaitable[SettingsList | None]: ...
 
 
@@ -110,10 +110,10 @@ class CodingTuiHandlers:
         command_select: CommandSelectFn | None = None,
         commands: CommandsFn | None = None,
         hotkeys: Callable[[], str] = lambda: "",
-        settings: SettingsFn | None = None,
-        settings_list: SettingsListFn | None = None,
-        apply_settings: ApplySettingsFn | None = None,
-        present_settings_list: SettingsListPresenter | None = None,
+        legacy_settings_text: LegacySettingsTextFn | None = None,
+        legacy_settings_list: LegacySettingsListFn | None = None,
+        apply_legacy_settings: ApplyLegacySettingsFn | None = None,
+        present_legacy_settings_list: LegacySettingsListPresenter | None = None,
         statusline: Callable[[bool | None], str] = lambda _enabled: "",
         now: Callable[[], float],
         session_running: Callable[[], bool],
@@ -141,10 +141,10 @@ class CodingTuiHandlers:
         self._command_select = command_select or _empty_command_select
         self._commands = commands or _empty_commands
         self._hotkeys = hotkeys
-        self._settings = settings or _empty_settings
-        self._settings_list = settings_list
-        self._apply_settings = apply_settings
-        self._present_settings_list = present_settings_list
+        self._legacy_settings_text = legacy_settings_text or _empty_legacy_settings
+        self._legacy_settings_list = legacy_settings_list
+        self._apply_legacy_settings = apply_legacy_settings
+        self._present_legacy_settings_list = present_legacy_settings_list
         self._statusline = statusline
         self._now = now
         self._session_running = session_running
@@ -219,9 +219,9 @@ class CodingTuiHandlers:
             await self._show_info("Hotkeys", self._hotkeys(), label="hotkeys:show", local=True)
             return None
         if route is PromptRoute.SETTINGS:
-            if await self._show_settings_list():
+            if await self._show_legacy_settings_list():
                 return None
-            await self._emit(lambda: self._render_info("Settings", self._settings()), label="settings:show")
+            await self._emit(lambda: self._render_info("Settings", self._legacy_settings_text()), label="settings:show")
             return None
         if route is PromptRoute.STATUSLINE:
             enabled = intent.enabled if isinstance(intent, StatuslineIntent) else None
@@ -261,9 +261,9 @@ class CodingTuiHandlers:
             await self._show_info("Hotkeys", self._hotkeys(), label="hotkeys:show", local=True)
             return True
         if command_name == "settings":
-            if await self._show_settings_list():
+            if await self._show_legacy_settings_list():
                 return True
-            await self._emit(lambda: self._render_info("Settings", self._settings()), label="settings:show")
+            await self._emit(lambda: self._render_info("Settings", self._legacy_settings_text()), label="settings:show")
             return True
         if command_name == "statusline":
             enabled = intent.enabled if isinstance(intent, StatuslineIntent) else None
@@ -315,13 +315,17 @@ class CodingTuiHandlers:
             return
         self._render_info_panel(panel)
 
-    async def _show_settings_list(self) -> bool:
-        if self._settings_list is None or self._apply_settings is None or self._present_settings_list is None:
+    async def _show_legacy_settings_list(self) -> bool:
+        if (
+            self._legacy_settings_list is None
+            or self._apply_legacy_settings is None
+            or self._present_legacy_settings_list is None
+        ):
             return False
-        settings = await _resolve(self._present_settings_list(self._settings_list()))
+        settings = await _resolve(self._present_legacy_settings_list(self._legacy_settings_list()))
         if settings is None:
             return True
-        message = self._apply_settings(settings)
+        message = self._apply_legacy_settings(settings)
         await self._emit(lambda: self._render_status(message), label="settings:set")
         return True
 
@@ -342,7 +346,7 @@ async def _empty_command_select(_query: str) -> str:
     return "Command selection is not available."
 
 
-def _empty_settings() -> str:
+def _empty_legacy_settings() -> str:
     return "No settings available."
 
 

--- a/src/loushang/coding/ui/status_provider.py
+++ b/src/loushang/coding/ui/status_provider.py
@@ -117,7 +117,7 @@ class CodingTuiStatusProvider:
             return f"Status line style: {normalized}"
         return f"Unknown status line setting: {item_id}"
 
-    def settings_list(self) -> SettingsList:
+    def legacy_settings_list(self) -> SettingsList:
         return SettingsList(
             (
                 SettingItem(
@@ -128,15 +128,18 @@ class CodingTuiStatusProvider:
             )
         )
 
-    def apply_settings(self, settings: SettingsList) -> str:
+    def apply_legacy_settings(self, settings: SettingsList) -> str:
         for item in settings.items:
             if item.id == "statusline":
                 self._set_statusline_settings(replace(self._statusline_settings, enabled=item.enabled))
                 break
         return self.set_visible(None)
 
-    def settings_text(self) -> str:
-        return "".join(fragment for _style, fragment in SettingsListRenderer(title="Settings").render(self.settings_list()))
+    def legacy_settings_text(self) -> str:
+        return "".join(
+            fragment
+            for _style, fragment in SettingsListRenderer(title="Settings").render(self.legacy_settings_list())
+        )
 
     def _set_statusline_settings(self, settings: StatusLineSettings) -> None:
         self._statusline_settings = settings

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -504,7 +504,7 @@ def test_native_surface_manager_ignores_legacy_settings_surface_submit() -> None
     legacy_surface = NativeSurfaceView(
         title="Settings",
         purpose="settings",
-        content=SettingsSurface(list(manager.status_provider.settings_list().items), enable_search=True),
+        content=SettingsSurface(list(manager.status_provider.legacy_settings_list().items), enable_search=True),
         presentation="bottom-exclusive",
     )
     app.active_surface = legacy_surface

--- a/tests/coding/test_ui_app.py
+++ b/tests/coding/test_ui_app.py
@@ -213,7 +213,7 @@ def test_build_coding_tui_app_wires_command_palette_chooser() -> None:
     assert seen and seen[0].title == "Commands"
 
 
-def test_build_coding_tui_app_wires_settings_list_presenter() -> None:
+def test_build_coding_tui_app_wires_legacy_settings_list_presenter() -> None:
     from loushang.coding.ui.app import build_coding_tui_app
     from loushang.tui import SettingsList
 
@@ -263,7 +263,7 @@ def test_build_coding_tui_app_wires_settings_list_presenter() -> None:
         now=lambda: 10.0,
         enable_debug=lambda *, session, scopes: "/tmp/debug.log",
         disable_debug=lambda: None,
-        settings_list_presenter=present,
+        legacy_settings_list_presenter=present,
     )
 
     result = asyncio.run(app.handlers.handle_prompt("/settings"))

--- a/tests/coding/test_ui_handlers.py
+++ b/tests/coding/test_ui_handlers.py
@@ -466,7 +466,7 @@ def test_coding_tui_handlers_renders_settings_command() -> None:
         restore_queue=lambda _text: _async_none(),
         emit=emit,
         render_status=lambda text: statuses.append(text),
-        settings=lambda: "settings",
+        legacy_settings_text=lambda: "settings",
         now=lambda: 10.0,
         session_running=lambda: False,
         trace=lambda _name, **_data: None,
@@ -479,7 +479,7 @@ def test_coding_tui_handlers_renders_settings_command() -> None:
     assert statuses == ["settings"]
 
 
-def test_coding_tui_handlers_prefers_local_settings_list_presenter() -> None:
+def test_coding_tui_handlers_prefers_legacy_settings_list_presenter() -> None:
     from loushang.coding.ui.handlers import CodingTuiHandlers
     from loushang.coding.ui.intent import SettingsIntent
     from loushang.coding.ui.prompt_routing import PromptRoute
@@ -515,10 +515,10 @@ def test_coding_tui_handlers_prefers_local_settings_list_presenter() -> None:
         restore_queue=lambda _text: _async_none(),
         emit=emit,
         render_status=statuses.append,
-        settings=lambda: "fallback settings",
-        settings_list=lambda: SettingsList((SettingItem(id="statusline", label="Status line", enabled=True),)),
-        apply_settings=apply,
-        present_settings_list=present,
+        legacy_settings_text=lambda: "fallback settings",
+        legacy_settings_list=lambda: SettingsList((SettingItem(id="statusline", label="Status line", enabled=True),)),
+        apply_legacy_settings=apply,
+        present_legacy_settings_list=present,
         now=lambda: 10.0,
         session_running=lambda: False,
         trace=lambda _name, **_data: None,

--- a/tests/coding/test_ui_status_provider.py
+++ b/tests/coding/test_ui_status_provider.py
@@ -144,7 +144,7 @@ def test_status_provider_rejects_invalid_statusline_setting_values() -> None:
     assert saved == []
 
 
-def test_status_provider_formats_settings_summary() -> None:
+def test_status_provider_formats_legacy_settings_summary() -> None:
     from loushang.coding.ui.status_provider import CodingTuiStatusProvider
     from loushang.tui import SettingItem, SettingsList
 
@@ -157,9 +157,9 @@ def test_status_provider_formats_settings_summary() -> None:
         running=lambda: False,
     )
 
-    assert provider.settings_list() == SettingsList(
+    assert provider.legacy_settings_list() == SettingsList(
         (SettingItem(id="statusline", label="Status line", enabled=True),)
     )
-    assert provider.settings_text() == "Settings\n> [x] Status line"
+    assert provider.legacy_settings_text() == "Settings\n> [x] Status line"
     provider.set_visible(False)
-    assert provider.settings_text() == "Settings\n> [ ] Status line"
+    assert provider.legacy_settings_text() == "Settings\n> [ ] Status line"


### PR DESCRIPTION
## Summary
- Rename the non-Native settings list presenter path to legacy settings terminology.
- Rename StatusProvider settings-list helpers to legacy_* so they no longer look like the product SettingsPageView path.
- Update tests to keep the legacy path covered while clarifying that Native settings uses SettingsPageView.apply_setting.

## Validation
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_app.py tests/coding/test_ui_handlers.py tests/coding/test_ui_status_provider.py tests/coding/test_native_coding_tui_surfaces.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding/ui tests/coding/test_ui_app.py tests/coding/test_ui_handlers.py tests/coding/test_ui_status_provider.py tests/coding/test_native_coding_tui_surfaces.py
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests -q