### PR TITLE
Remove coding legacy settings list wiring

### DIFF
--- a/src/loushang/coding/ui/app.py
+++ b/src/loushang/coding/ui/app.py
@@ -17,7 +17,6 @@ from loushang.coding.ui.follow_up_queue import FollowUpQueueHandler
 from loushang.coding.ui.handlers import (
     CodingTuiHandlers,
     InfoPanelPresenter,
-    LegacySettingsListPresenter,
 )
 from loushang.coding.ui.hotkeys import format_hotkeys
 from loushang.coding.ui.lifecycle import RunLifecycle
@@ -85,7 +84,6 @@ def build_coding_tui_app(
     model_palette_chooser: ModelPaletteChooser | None = None,
     command_palette_chooser: CommandPaletteChooser | None = None,
     info_panel_presenter: InfoPanelPresenter | None = None,
-    legacy_settings_list_presenter: LegacySettingsListPresenter | None = None,
 ) -> CodingTuiApp:
     lifecycle = RunLifecycle()
     controller = CodingUiController(runtime=runtime, session=session, verbose=verbose)
@@ -168,10 +166,7 @@ def build_coding_tui_app(
         command_select=lambda query: select_coding_command(session, query=query, choose=command_palette_chooser),
         commands=lambda query: format_coding_commands(session, query=query),
         hotkeys=format_hotkeys,
-        legacy_settings_text=status_provider.legacy_settings_text,
-        legacy_settings_list=status_provider.legacy_settings_list,
-        apply_legacy_settings=status_provider.apply_legacy_settings,
-        present_legacy_settings_list=legacy_settings_list_presenter,
+        settings_text=status_provider.settings_summary_text,
         statusline=status_provider.set_visible,
         now=now,
         session_running=lambda: is_running(session),

--- a/src/loushang/coding/ui/handlers.py
+++ b/src/loushang/coding/ui/handlers.py
@@ -21,7 +21,7 @@ from loushang.coding.ui.pending_queue import pending_queue_view, restore_queued_
 from loushang.coding.ui.prompt_dispatch import PromptDispatchOutcome
 from loushang.coding.ui.prompt_routing import PromptRoute, route_prompt_intent
 from loushang.runtime.commands import CommandEffect, CommandEffectKind
-from loushang.tui import InfoPanel, PendingQueueView, SettingsList
+from loushang.tui import InfoPanel, PendingQueueView
 
 
 class TraceFn(Protocol):
@@ -64,24 +64,12 @@ class CommandSelectFn(Protocol):
     def __call__(self, query: str) -> Awaitable[str]: ...
 
 
-class LegacySettingsTextFn(Protocol):
+class SettingsTextFn(Protocol):
     def __call__(self) -> str: ...
-
-
-class LegacySettingsListFn(Protocol):
-    def __call__(self) -> SettingsList: ...
-
-
-class ApplyLegacySettingsFn(Protocol):
-    def __call__(self, settings: SettingsList) -> str: ...
 
 
 class InfoPanelPresenter(Protocol):
     def __call__(self, panel: InfoPanel) -> bool | Awaitable[bool]: ...
-
-
-class LegacySettingsListPresenter(Protocol):
-    def __call__(self, settings: SettingsList) -> SettingsList | None | Awaitable[SettingsList | None]: ...
 
 
 class CodingTuiHandlers:
@@ -110,10 +98,7 @@ class CodingTuiHandlers:
         command_select: CommandSelectFn | None = None,
         commands: CommandsFn | None = None,
         hotkeys: Callable[[], str] = lambda: "",
-        legacy_settings_text: LegacySettingsTextFn | None = None,
-        legacy_settings_list: LegacySettingsListFn | None = None,
-        apply_legacy_settings: ApplyLegacySettingsFn | None = None,
-        present_legacy_settings_list: LegacySettingsListPresenter | None = None,
+        settings_text: SettingsTextFn | None = None,
         statusline: Callable[[bool | None], str] = lambda _enabled: "",
         now: Callable[[], float],
         session_running: Callable[[], bool],
@@ -141,10 +126,7 @@ class CodingTuiHandlers:
         self._command_select = command_select or _empty_command_select
         self._commands = commands or _empty_commands
         self._hotkeys = hotkeys
-        self._legacy_settings_text = legacy_settings_text or _empty_legacy_settings
-        self._legacy_settings_list = legacy_settings_list
-        self._apply_legacy_settings = apply_legacy_settings
-        self._present_legacy_settings_list = present_legacy_settings_list
+        self._settings_text = settings_text or _empty_settings
         self._statusline = statusline
         self._now = now
         self._session_running = session_running
@@ -219,9 +201,7 @@ class CodingTuiHandlers:
             await self._show_info("Hotkeys", self._hotkeys(), label="hotkeys:show", local=True)
             return None
         if route is PromptRoute.SETTINGS:
-            if await self._show_legacy_settings_list():
-                return None
-            await self._emit(lambda: self._render_info("Settings", self._legacy_settings_text()), label="settings:show")
+            await self._emit(lambda: self._render_info("Settings", self._settings_text()), label="settings:show")
             return None
         if route is PromptRoute.STATUSLINE:
             enabled = intent.enabled if isinstance(intent, StatuslineIntent) else None
@@ -261,9 +241,7 @@ class CodingTuiHandlers:
             await self._show_info("Hotkeys", self._hotkeys(), label="hotkeys:show", local=True)
             return True
         if command_name == "settings":
-            if await self._show_legacy_settings_list():
-                return True
-            await self._emit(lambda: self._render_info("Settings", self._legacy_settings_text()), label="settings:show")
+            await self._emit(lambda: self._render_info("Settings", self._settings_text()), label="settings:show")
             return True
         if command_name == "statusline":
             enabled = intent.enabled if isinstance(intent, StatuslineIntent) else None
@@ -315,21 +293,6 @@ class CodingTuiHandlers:
             return
         self._render_info_panel(panel)
 
-    async def _show_legacy_settings_list(self) -> bool:
-        if (
-            self._legacy_settings_list is None
-            or self._apply_legacy_settings is None
-            or self._present_legacy_settings_list is None
-        ):
-            return False
-        settings = await _resolve(self._present_legacy_settings_list(self._legacy_settings_list()))
-        if settings is None:
-            return True
-        message = self._apply_legacy_settings(settings)
-        await self._emit(lambda: self._render_status(message), label="settings:set")
-        return True
-
-
 async def _empty_models(_query: str) -> str:
     return "No models available."
 
@@ -346,7 +309,7 @@ async def _empty_command_select(_query: str) -> str:
     return "Command selection is not available."
 
 
-def _empty_legacy_settings() -> str:
+def _empty_settings() -> str:
     return "No settings available."
 
 

--- a/src/loushang/coding/ui/playback_scenarios/product.py
+++ b/src/loushang/coding/ui/playback_scenarios/product.py
@@ -11,8 +11,8 @@ from loushang.coding.ui.playback_suite import NativePlaybackScenarioSpec
 from loushang.tui import (
     PlaybackEvent,
     PlaybackFrameBudget,
-    SettingItem,
-    SettingsSurface,
+    SearchableList,
+    SearchableListItem,
     strip_control_sequences,
 )
 
@@ -56,12 +56,14 @@ def _run_product_composed_interaction() -> NativeTuiInputPlaybackResult:
     _assert_visible_contains(scenario, "Queued follow-up inputs")
     _assert_visible_contains(scenario, "follow one")
 
-    scenario.app.active_surface = SettingsSurface(
+    scenario.app.active_surface = SearchableList(
         (
-            SettingItem(id="memory", label="Memory", current_value="on"),
-            SettingItem(id="model", label="Model", current_value="kimi"),
+            SearchableListItem("memory", "Memory", "on"),
+            SearchableListItem("model", "Model", "kimi"),
         ),
-        enable_search=True,
+        focused=True,
+        placeholder="Search settings...",
+        detail_column=24,
     )
     scenario.playback.play(
         (
@@ -69,8 +71,8 @@ def _run_product_composed_interaction() -> NativeTuiInputPlaybackResult:
             PlaybackEvent.input("mo\x1b[Dx"),
         )
     )
-    _assert_visible_contains(scenario, "Search: mxo")
-    _assert_visible_contains(scenario, "No matching settings")
+    _assert_visible_contains(scenario, "mxo")
+    _assert_visible_contains(scenario, "No matching items")
 
     scenario.app.active_surface = None
     scenario.playback.play(
@@ -136,13 +138,15 @@ def _run_product_streaming_control_flow() -> NativeTuiInputPlaybackResult:
     _assert_visible_contains(scenario, "Messages to be submitted after next tool call")
     _assert_visible_contains(scenario, "steer before next tool")
 
-    scenario.app.active_surface = SettingsSurface(
+    scenario.app.active_surface = SearchableList(
         (
-            SettingItem(id="memory", label="Memory", current_value="on"),
-            SettingItem(id="model", label="Model", current_value="kimi"),
-            SettingItem(id="theme", label="Theme", current_value="system"),
+            SearchableListItem("memory", "Memory", "on"),
+            SearchableListItem("model", "Model", "kimi"),
+            SearchableListItem("theme", "Theme", "system"),
         ),
-        enable_search=True,
+        focused=True,
+        placeholder="Search settings...",
+        detail_column=24,
     )
     scenario.playback.play(
         (
@@ -150,7 +154,7 @@ def _run_product_streaming_control_flow() -> NativeTuiInputPlaybackResult:
             PlaybackEvent.input("mem"),
         )
     )
-    _assert_visible_contains(scenario, "Search: mem")
+    _assert_visible_contains(scenario, "mem")
     _assert_visible_contains(scenario, "Memory")
 
     scenario.app.active_surface = None

--- a/src/loushang/coding/ui/status_provider.py
+++ b/src/loushang/coding/ui/status_provider.py
@@ -9,7 +9,6 @@ from loushang.coding.ui.status_line import (
     status_line_settings_to_patch,
 )
 from loushang.coding.ui.toolbar import ToolbarSnapshot, render_toolbar
-from loushang.tui import SettingItem, SettingsList, SettingsListRenderer
 
 
 @dataclass(frozen=True, slots=True)
@@ -117,29 +116,8 @@ class CodingTuiStatusProvider:
             return f"Status line style: {normalized}"
         return f"Unknown status line setting: {item_id}"
 
-    def legacy_settings_list(self) -> SettingsList:
-        return SettingsList(
-            (
-                SettingItem(
-                    id="statusline",
-                    label="Status line",
-                    enabled=self.is_visible(),
-                ),
-            )
-        )
-
-    def apply_legacy_settings(self, settings: SettingsList) -> str:
-        for item in settings.items:
-            if item.id == "statusline":
-                self._set_statusline_settings(replace(self._statusline_settings, enabled=item.enabled))
-                break
-        return self.set_visible(None)
-
-    def legacy_settings_text(self) -> str:
-        return "".join(
-            fragment
-            for _style, fragment in SettingsListRenderer(title="Settings").render(self.legacy_settings_list())
-        )
+    def settings_summary_text(self) -> str:
+        return f"Settings\nStatus line: {'true' if self.is_visible() else 'false'}"
 
     def _set_statusline_settings(self, settings: StatusLineSettings) -> None:
         self._statusline_settings = settings

--- a/tests/coding/test_native_coding_tui_playback.py
+++ b/tests/coding/test_native_coding_tui_playback.py
@@ -31,8 +31,8 @@ from loushang.tui import (
     RenderConstraints,
     RenderDiagnostics,
     RenderLoop,
-    SettingItem,
-    SettingsSurface,
+    SearchableList,
+    SearchableListItem,
     TerminalRuntimeCapabilities,
     TerminalSize,
     TuiRuntime,
@@ -214,12 +214,14 @@ def test_native_tui_playback_escape_clears_idle_draft_without_abort() -> None:
 
 def test_native_tui_playback_edits_settings_search_with_text_input_cursor() -> None:
     app = _app()
-    app.active_surface = SettingsSurface(
+    app.active_surface = SearchableList(
         [
-            SettingItem(id="memory", label="Memory", current_value="on"),
-            SettingItem(id="model", label="Model", current_value="kimi"),
+            SearchableListItem("memory", "Memory", "on"),
+            SearchableListItem("model", "Model", "kimi"),
         ],
-        enable_search=True,
+        focused=True,
+        placeholder="Search settings...",
+        detail_column=24,
     )
     playback = NativeTuiInputPlayback(app)
 
@@ -227,8 +229,8 @@ def test_native_tui_playback_edits_settings_search_with_text_input_cursor() -> N
 
     assert all(step.flush_succeeded for step in steps)
     lines = _plain_lines(steps[-1].diagnostics)
-    assert "Search: mxo" in lines
-    assert "  No matching settings" in lines
+    assert "mxo" in lines
+    assert "No matching items" in lines
 
 
 def test_tui_playback_renders_auto_terminal_image_and_text_fallback(monkeypatch: Any) -> None:

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -17,6 +17,7 @@ from loushang.tui import (
     RenderConstraints,
     RenderLine,
     RenderResult,
+    SettingItem,
     SettingsSurface,
     SurfaceHost,
 )
@@ -504,7 +505,7 @@ def test_native_surface_manager_ignores_legacy_settings_surface_submit() -> None
     legacy_surface = NativeSurfaceView(
         title="Settings",
         purpose="settings",
-        content=SettingsSurface(list(manager.status_provider.legacy_settings_list().items), enable_search=True),
+        content=SettingsSurface((SettingItem(id="statusline", label="Status line", enabled=True),), enable_search=True),
         presentation="bottom-exclusive",
     )
     app.active_surface = legacy_surface

--- a/tests/coding/test_ui_app.py
+++ b/tests/coding/test_ui_app.py
@@ -213,12 +213,10 @@ def test_build_coding_tui_app_wires_command_palette_chooser() -> None:
     assert seen and seen[0].title == "Commands"
 
 
-def test_build_coding_tui_app_wires_legacy_settings_list_presenter() -> None:
+def test_build_coding_tui_app_renders_plain_settings_summary() -> None:
     from loushang.coding.ui.app import build_coding_tui_app
-    from loushang.tui import SettingsList
 
     emitted: list[str] = []
-    seen: list[SettingsList] = []
 
     class Session:
         session_id = "sid"
@@ -244,10 +242,6 @@ def test_build_coding_tui_app_wires_legacy_settings_list_presenter() -> None:
         emitted.append(label)
         write()
 
-    async def present(settings: SettingsList) -> SettingsList:
-        seen.append(settings)
-        return settings.set_enabled("statusline", False)
-
     app = build_coding_tui_app(
         runtime=None,
         session=Session(),
@@ -263,16 +257,13 @@ def test_build_coding_tui_app_wires_legacy_settings_list_presenter() -> None:
         now=lambda: 10.0,
         enable_debug=lambda *, session, scopes: "/tmp/debug.log",
         disable_debug=lambda: None,
-        legacy_settings_list_presenter=present,
     )
 
     result = asyncio.run(app.handlers.handle_prompt("/settings"))
 
     assert result is None
-    assert emitted == ["settings:set", "status:Status line: off"]
-    assert seen
-    assert seen[0].items[0].enabled is True
-    assert app.status_visible() is False
+    assert emitted == ["settings:show", "status:Settings\nStatus line: true"]
+    assert app.status_visible() is True
 
 
 def test_build_coding_tui_app_wires_info_panel_presenter() -> None:

--- a/tests/coding/test_ui_handlers.py
+++ b/tests/coding/test_ui_handlers.py
@@ -466,7 +466,7 @@ def test_coding_tui_handlers_renders_settings_command() -> None:
         restore_queue=lambda _text: _async_none(),
         emit=emit,
         render_status=lambda text: statuses.append(text),
-        legacy_settings_text=lambda: "settings",
+        settings_text=lambda: "settings",
         now=lambda: 10.0,
         session_running=lambda: False,
         trace=lambda _name, **_data: None,
@@ -477,60 +477,6 @@ def test_coding_tui_handlers_renders_settings_command() -> None:
     assert result is None
     assert emitted == ["settings:show"]
     assert statuses == ["settings"]
-
-
-def test_coding_tui_handlers_prefers_legacy_settings_list_presenter() -> None:
-    from loushang.coding.ui.handlers import CodingTuiHandlers
-    from loushang.coding.ui.intent import SettingsIntent
-    from loushang.coding.ui.prompt_routing import PromptRoute
-    from loushang.tui import SettingItem, SettingsList
-
-    emitted: list[str] = []
-    statuses: list[str] = []
-    presented: list[SettingsList] = []
-    applied: list[SettingsList] = []
-
-    async def emit(write, *, label: str):
-        emitted.append(label)
-        write()
-
-    async def present(settings: SettingsList) -> SettingsList:
-        presented.append(settings)
-        return settings.set_enabled("statusline", False)
-
-    def apply(settings: SettingsList) -> str:
-        applied.append(settings)
-        return "Status line: off"
-
-    handlers = CodingTuiHandlers(
-        lifecycle=_Lifecycle(),
-        parse_prompt=lambda _text: SettingsIntent(),
-        route_prompt=lambda _intent, _lifecycle: PromptRoute.SETTINGS,
-        follow_up=lambda _text, *, source: _async_none(),
-        steer=lambda _text: _async_none(),
-        debug=lambda _intent: _async_none(),
-        dispatch=lambda _intent: _async_none(),
-        result=lambda _outcome, *, prompt_started: _async_none(),
-        abort=lambda: _async_none(),
-        restore_queue=lambda _text: _async_none(),
-        emit=emit,
-        render_status=statuses.append,
-        legacy_settings_text=lambda: "fallback settings",
-        legacy_settings_list=lambda: SettingsList((SettingItem(id="statusline", label="Status line", enabled=True),)),
-        apply_legacy_settings=apply,
-        present_legacy_settings_list=present,
-        now=lambda: 10.0,
-        session_running=lambda: False,
-        trace=lambda _name, **_data: None,
-    )
-
-    result = asyncio.run(handlers.handle_prompt("/settings"))
-
-    assert result is None
-    assert emitted == ["settings:set"]
-    assert statuses == ["Status line: off"]
-    assert presented and presented[0].items[0].enabled is True
-    assert applied and applied[0].items[0].enabled is False
 
 
 def test_coding_tui_handlers_handles_statusline_command() -> None:

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -22,6 +22,24 @@ assert "loushang.coding.ui.renderer" not in sys.modules
     assert result.returncode == 0, result.stderr
 
 
+def test_coding_ui_does_not_depend_on_legacy_settings_list_primitives() -> None:
+    forbidden = (
+        "SettingItem",
+        "SettingsList",
+        "SettingsListRenderer",
+        "SettingsSurface",
+        "legacy_settings",
+    )
+    offenders: list[str] = []
+    for path in Path("src/loushang/coding/ui").rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for token in forbidden:
+            if token in text:
+                offenders.append(f"{path}:{token}")
+
+    assert offenders == []
+
+
 def _run_python_import_boundary_check(script: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     src_path = str(Path.cwd() / "src")

--- a/tests/coding/test_ui_status_provider.py
+++ b/tests/coding/test_ui_status_provider.py
@@ -144,9 +144,8 @@ def test_status_provider_rejects_invalid_statusline_setting_values() -> None:
     assert saved == []
 
 
-def test_status_provider_formats_legacy_settings_summary() -> None:
+def test_status_provider_formats_plain_settings_summary_without_legacy_tui_models() -> None:
     from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-    from loushang.tui import SettingItem, SettingsList
 
     provider = CodingTuiStatusProvider(
         model_label="moonshot/kimi",
@@ -157,9 +156,8 @@ def test_status_provider_formats_legacy_settings_summary() -> None:
         running=lambda: False,
     )
 
-    assert provider.legacy_settings_list() == SettingsList(
-        (SettingItem(id="statusline", label="Status line", enabled=True),)
-    )
-    assert provider.legacy_settings_text() == "Settings\n> [x] Status line"
+    assert provider.settings_summary_text() == "Settings\nStatus line: true"
+    assert not hasattr(provider, "legacy_settings_list")
+    assert not hasattr(provider, "legacy_settings_text")
     provider.set_visible(False)
-    assert provider.legacy_settings_text() == "Settings\n> [ ] Status line"
+    assert provider.settings_summary_text() == "Settings\nStatus line: false"


### PR DESCRIPTION
Summary
- Remove coding product wiring for legacy SettingsList presenter APIs.
- Replace provider legacy settings text/list output with a plain settings summary.
- Keep TUI legacy SettingsSurface available, but stop using it in coding product playback scenarios.
- Add an import-boundary test so coding UI cannot reintroduce legacy settings primitives.

Validation
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_status_provider.py tests/coding/test_ui_app.py tests/coding/test_ui_handlers.py tests/coding/test_ui_import_boundaries.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_coding_tui_playback.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_native_tui_playback_runner.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding/ui tests/coding
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding -q