### PR TITLE
Mark TUI settings primitives as legacy

### DIFF
--- a/docs/en/reference/tui-widgets.md
+++ b/docs/en/reference/tui-widgets.md
@@ -225,6 +225,17 @@ selected page changes without a callback.
 `SearchableList` owns query text, filtered items, active row, viewport offset,
 and structured selection. It does not edit settings or write configuration.
 
+## Settings Pages And Legacy Compatibility
+
+Build new settings pages by composing `PageScaffold`, `Tabs` or `TabGroup`,
+`SearchableList`, and focused controls such as `Toggle`, `RadioGroup`, and
+`SelectList`. Product adapters should own setting ids, value cycling,
+persistence, and side effects.
+
+`SettingsSurface`, `SettingItem`, `SettingsList`, and `SettingsListRenderer`
+remain public for legacy compatibility with older settings-list callers. They
+are not the recommended path for new page-level settings UI.
+
 ## Forms
 
 ```python

--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
@@ -12,7 +12,7 @@ are built from renderables but are described at the product-facing UI level.
 | Input | Composer, TextInput, AutocompleteSurface |
 | Navigation | Tabs, [TabGroup, TabPage](./tabgroup-content-switcher.md), [PageScaffold](./page-scaffold.md) |
 | Lists | SelectList, [SearchableList](./searchable-list.md), [Table](./table.md), [TreeView](./tree.md) |
-| Surfaces | CommandSurface, SelectionSurface, SettingsSurface, ApprovalSurface, DialogSurface, HelpViewer, ChangelogViewer |
+| Surfaces | CommandSurface, SelectionSurface, SettingsSurface (legacy compatibility), ApprovalSurface, DialogSurface, HelpViewer, ChangelogViewer |
 | Transcript | ChatTranscript, UserPromptView, AssistantMessageView, ThinkingView, ToolExecutionView, ErrorView, WorkedDivider |
 | Content | MarkdownBlock, CodeBlock, DiffBlock, ImageBlock |
 

--- a/docs/zh-CN/reference/tui-widgets.md
+++ b/docs/zh-CN/reference/tui-widgets.md
@@ -213,6 +213,16 @@ view.focus()
 `SearchableList` 拥有查询文本、过滤结果、active 行、viewport offset 和结构化选择结果。
 它不编辑设置，也不写入配置。
 
+## 设置页与 Legacy Compatibility
+
+新的设置页应组合 `PageScaffold`、`Tabs` 或 `TabGroup`、`SearchableList`，
+以及 `Toggle`、`RadioGroup`、`SelectList` 等可聚焦控件。产品 adapter 应拥有
+setting id、value cycle、持久化和副作用。
+
+`SettingsSurface`、`SettingItem`、`SettingsList` 和 `SettingsListRenderer`
+仍作为 legacy compatibility public API 保留，用于兼容旧 settings-list 调用方。
+它们不是新 page-level settings UI 的推荐路径。
+
 ## 表单
 
 ```python

--- a/src/loushang/tui/compat.py
+++ b/src/loushang/tui/compat.py
@@ -132,6 +132,12 @@ class InfoPanel:
 
 @dataclass(frozen=True, slots=True)
 class SettingItem:
+    """Legacy compatibility data model for old settings-list flows.
+
+    New settings pages should compose PageScaffold with SearchableList and
+    product-owned setting adapters instead of depending on this model.
+    """
+
     id: str
     label: str
     enabled: bool = False
@@ -143,6 +149,12 @@ class SettingItem:
 
 @dataclass(frozen=True, slots=True)
 class SettingsList:
+    """Legacy compatibility container for old settings-list flows.
+
+    New settings pages should compose PageScaffold with SearchableList and
+    product-owned setting adapters instead of depending on this container.
+    """
+
     items: tuple[SettingItem, ...]
 
     def set_enabled(self, item_id: str, enabled: bool) -> SettingsList:
@@ -157,6 +169,12 @@ class SettingsList:
 
 @dataclass(frozen=True, slots=True)
 class SettingsListRenderer:
+    """Legacy compatibility text renderer for SettingsList.
+
+    New settings pages should compose PageScaffold with SearchableList and
+    product-owned setting adapters instead of depending on this renderer.
+    """
+
     title: str = "Settings"
 
     def render(self, settings: SettingsList) -> tuple[tuple[str, str], ...]:

--- a/src/loushang/tui/surfaces.py
+++ b/src/loushang/tui/surfaces.py
@@ -304,6 +304,12 @@ class CommandSurface(SelectionSurface):
 
 
 class SettingsSurface(SelectionSurface):
+    """Legacy compatibility surface for old settings-list workflows.
+
+    New settings pages should compose PageScaffold with SearchableList and
+    product-owned setting adapters instead of depending on this surface.
+    """
+
     def __init__(
         self,
         items: list[SelectItem | SettingItem] | tuple[SelectItem | SettingItem, ...],

--- a/tests/tui/test_surfaces.py
+++ b/tests/tui/test_surfaces.py
@@ -13,6 +13,8 @@ from loushang.tui import (
     SelectionSurface,
     SelectItem,
     SettingItem,
+    SettingsList,
+    SettingsListRenderer,
     SettingsSurface,
     ThemeResolver,
     strip_control_sequences,
@@ -22,6 +24,13 @@ from loushang.tui import (
 def rendered_text(surface: Any, *, width: int = 30, height: int = 5) -> tuple[str, ...]:
     result = surface.render(RenderConstraints(width=width, max_height=height))
     return tuple(line.text for line in result.lines)
+
+
+def test_settings_primitives_are_marked_legacy_compatibility() -> None:
+    for primitive in (SettingItem, SettingsList, SettingsListRenderer, SettingsSurface):
+        assert "legacy compatibility" in (primitive.__doc__ or "").casefold()
+        assert "PageScaffold" in (primitive.__doc__ or "")
+        assert "SearchableList" in (primitive.__doc__ or "")
 
 
 def test_selection_surface_wraps_navigation_and_scrolls_selected_item_visible() -> None:

--- a/tests/tui/test_widgets_reference_docs.py
+++ b/tests/tui/test_widgets_reference_docs.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_widget_reference_marks_settings_surface_as_legacy_compatibility() -> None:
+    for path in (
+        Path("docs/en/reference/tui-widgets.md"),
+        Path("docs/zh-CN/reference/tui-widgets.md"),
+    ):
+        text = path.read_text(encoding="utf-8")
+
+        assert "SettingsSurface" in text
+        assert "legacy compatibility" in text.casefold()
+        assert "PageScaffold" in text
+        assert "SearchableList" in text
+        assert "SettingsList" in text


### PR DESCRIPTION
## Summary
- Mark `SettingItem`, `SettingsList`, `SettingsListRenderer`, and `SettingsSurface` as legacy compatibility primitives.
- Update EN/ZH TUI widget reference docs to recommend composing new settings pages from `PageScaffold`, tabs, `SearchableList`, and product-owned adapters.
- Add tests that lock the public docstrings and reference docs so the legacy guidance does not drift.

## Validation
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/tui -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/tui tests/tui`
