### PR TITLE
Remove TUI legacy settings primitives

### DIFF
--- a/docs/en/reference/tui-widgets.md
+++ b/docs/en/reference/tui-widgets.md
@@ -225,16 +225,12 @@ selected page changes without a callback.
 `SearchableList` owns query text, filtered items, active row, viewport offset,
 and structured selection. It does not edit settings or write configuration.
 
-## Settings Pages And Legacy Compatibility
+## Settings Pages
 
 Build new settings pages by composing `PageScaffold`, `Tabs` or `TabGroup`,
 `SearchableList`, and focused controls such as `Toggle`, `RadioGroup`, and
 `SelectList`. Product adapters should own setting ids, value cycling,
 persistence, and side effects.
-
-`SettingsSurface`, `SettingItem`, `SettingsList`, and `SettingsListRenderer`
-remain public for legacy compatibility with older settings-list callers. They
-are not the recommended path for new page-level settings UI.
 
 ## Forms
 

--- a/docs/internals/architecture/tui/native-terminal-core/development-slices.md
+++ b/docs/internals/architecture/tui/native-terminal-core/development-slices.md
@@ -124,7 +124,6 @@ Deliver:
 - AutocompleteSurface
 - CommandSurface
 - SelectionSurface
-- SettingsSurface
 - ApprovalSurface
 - DialogSurface
 

--- a/docs/internals/architecture/tui/native-terminal-core/functional-requirements/surfaces-overlays.md
+++ b/docs/internals/architecture/tui/native-terminal-core/functional-requirements/surfaces-overlays.md
@@ -39,7 +39,7 @@ the highlighted command, Tab to apply without submitting, and Esc to close.
 
 Related: SC-SO-001, KD-011
 
-## FR-SO-004: Settings Surface
+## FR-SO-004: Settings Page Surface
 
 Settings UI must be represented as a surface or surface group hosted by the
 runtime. It must not start a nested terminal application.

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-005-surface-host-and-overlays.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-005-surface-host-and-overlays.md
@@ -61,7 +61,7 @@ and terminal writer boundaries.
 - autocomplete surface
 - command surface
 - selection surface
-- settings surface
+- settings page hosted as a product surface
 - approval surface
 - dialog surface
 - help and changelog viewer surfaces

--- a/docs/internals/architecture/tui/native-terminal-core/scenarios.md
+++ b/docs/internals/architecture/tui/native-terminal-core/scenarios.md
@@ -138,10 +138,10 @@ And closing the surface restores composer focus
 And Enter executes the highlighted slash command
 And Tab applies the highlighted command without submitting.
 
-## SC-SO-002: Settings Surface
+## SC-SO-002: Settings Page Surface
 
 Given a settings command is selected
-When the settings surface opens
+When the product settings page opens as a surface
 Then it captures focus
 And user changes are returned as intents or callbacks
 And Esc closes the surface without submitting prompt text.

--- a/docs/internals/architecture/tui/native-terminal-core/traceability-matrix.md
+++ b/docs/internals/architecture/tui/native-terminal-core/traceability-matrix.md
@@ -30,13 +30,13 @@ Detailed UI part specs may add finer-grained rows later.
 | FR-SO-001 | Surface host | SC-SO-001, SC-SO-002 | KD-005 | SurfaceHost, Overlay, Focusable | test_surface_host.py | Slice 7 |
 | FR-SO-002 | Autocomplete surface | SC-SO-001 | KD-005, KD-011 | AutocompleteSurface, Composer | test_autocomplete_surface.py | Slice 7 |
 | FR-SO-003 | Command surface | SC-SO-001 | KD-005, KD-011 | CommandSurface, SelectionSurface | test_command_surface.py | Slice 7 |
-| FR-SO-004 | Settings surface | SC-SO-002 | KD-005 | SettingsSurface, SettingsList | test_settings_surface.py | Slice 7 |
+| FR-SO-004 | Settings page surface | SC-SO-002 | KD-005 | SurfaceHost, PageScaffold, SearchableList | test_widgets_settings_page_assembly.py | Slice 7 |
 | FR-SO-005 | Dialog surface | SC-SO-002 | KD-005 | DialogSurface | test_dialog_surface.py | Slice 7 |
 | FR-SO-006 | Surface Esc handling | SC-CI-003, SC-SO-002 | KD-002, KD-003, KD-005 | SurfaceHost, TuiRuntime | test_input_priority.py | Slice 7 |
 | FR-SO-007 | Selection surface | SC-SO-001, SC-SO-002, SC-SO-004 | KD-005, KD-011 | SelectionSurface, SelectList | test_selection_surface.py | Slice 7 |
 | FR-SO-008 | Approval surface | SC-SO-002, SC-CI-003 | KD-005 | ApprovalSurface, ApprovalPrompt | test_approval_surface.py | Slice 7 |
 | FR-SO-009 | Surface stacking | SC-SO-005 | KD-005 | SurfaceHost, OverlayStack | test_surface_stacking.py | Slice 7 |
-| FR-SO-010 | Constrained surface scrolling | SC-SO-005 | KD-005, KD-008 | SurfaceHost, SelectionSurface, SettingsSurface | test_constrained_surface_scrolling.py | Slice 7 |
+| FR-SO-010 | Constrained surface scrolling | SC-SO-005 | KD-005, KD-008 | SurfaceHost, SelectionSurface | test_constrained_surface_scrolling.py | Slice 7 |
 | FR-CR-001 | Markdown rendering | SC-CR-001 | KD-006 | MarkdownRenderer, CellWidth | test_markdown_rendering.py | Slice 9 |
 | FR-CR-002 | Code blocks | SC-CR-001 | KD-006, KD-009 | CodeBlock, CodeRenderer | test_code_block_rendering.py | Slice 9 |
 | FR-CR-003 | Diff blocks | SC-CR-001 | KD-006, KD-009 | DiffBlock, DiffRenderer | test_diff_block_rendering.py | Slice 9 |

--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/README.md
@@ -12,7 +12,7 @@ are built from renderables but are described at the product-facing UI level.
 | Input | Composer, TextInput, AutocompleteSurface |
 | Navigation | Tabs, [TabGroup, TabPage](./tabgroup-content-switcher.md), [PageScaffold](./page-scaffold.md) |
 | Lists | SelectList, [SearchableList](./searchable-list.md), [Table](./table.md), [TreeView](./tree.md) |
-| Surfaces | CommandSurface, SelectionSurface, SettingsSurface (legacy compatibility), ApprovalSurface, DialogSurface, HelpViewer, ChangelogViewer |
+| Surfaces | CommandSurface, SelectionSurface, ApprovalSurface, DialogSurface, HelpViewer, ChangelogViewer |
 | Transcript | ChatTranscript, UserPromptView, AssistantMessageView, ThinkingView, ToolExecutionView, ErrorView, WorkedDivider |
 | Content | MarkdownBlock, CodeBlock, DiffBlock, ImageBlock |
 

--- a/docs/internals/experimental/methodology/decision-oriented-review-requirements.md
+++ b/docs/internals/experimental/methodology/decision-oriented-review-requirements.md
@@ -186,7 +186,7 @@ decision: >
   SearchableList extracts existing searchable-list behavior into a reusable
   page-content widget.
 rationale:
-  - Avoid duplicating SelectionSurface, SettingsSurface, and CommandPaletteView behavior.
+  - Avoid duplicating SelectionSurface, SearchableList, and CommandPaletteView behavior.
   - Make long-list behavior embeddable in tab pages.
 alternatives:
   - Reuse SelectionSurface directly.
@@ -248,7 +248,7 @@ status: changes_requested
 summary: Existing searchable-list behavior already exists and should be cited.
 patch_needed: true
 ledger_update:
-  note: Mention SelectionSurface, SettingsSurface, and CommandPaletteView.
+  note: Mention SelectionSurface, SearchableList, and CommandPaletteView.
 ```
 
 The main thread should ingest the delta, update the ledger, and patch the spec

--- a/docs/zh-CN/reference/tui-widgets.md
+++ b/docs/zh-CN/reference/tui-widgets.md
@@ -213,15 +213,11 @@ view.focus()
 `SearchableList` 拥有查询文本、过滤结果、active 行、viewport offset 和结构化选择结果。
 它不编辑设置，也不写入配置。
 
-## 设置页与 Legacy Compatibility
+## 设置页
 
 新的设置页应组合 `PageScaffold`、`Tabs` 或 `TabGroup`、`SearchableList`，
 以及 `Toggle`、`RadioGroup`、`SelectList` 等可聚焦控件。产品 adapter 应拥有
 setting id、value cycle、持久化和副作用。
-
-`SettingsSurface`、`SettingItem`、`SettingsList` 和 `SettingsListRenderer`
-仍作为 legacy compatibility public API 保留，用于兼容旧 settings-list 调用方。
-它们不是新 page-level settings UI 的推荐路径。
 
 ## 表单
 

--- a/src/loushang/coding/ui/playback_scenarios/product.py
+++ b/src/loushang/coding/ui/playback_scenarios/product.py
@@ -231,7 +231,7 @@ PRODUCT_SCENARIOS = (
     ),
     NativePlaybackScenarioSpec(
         name="product-streaming-control-flow",
-        description="Exercise long streaming transcript controls with follow-up, steer, settings surface, resize, and abort.",
+        description="Exercise long streaming transcript controls with follow-up, steer, settings page, resize, and abort.",
         run=_run_product_streaming_control_flow,
         tags=(
             "product",

--- a/src/loushang/coding/ui/playback_scenarios/surface.py
+++ b/src/loushang/coding/ui/playback_scenarios/surface.py
@@ -419,7 +419,7 @@ SURFACE_SCENARIOS = (
     ),
     NativePlaybackScenarioSpec(
         name="settings-search",
-        description="Search the settings surface opened through the native command path.",
+        description="Search the settings page opened through the native command path.",
         run=_run_settings_search,
     ),
     NativePlaybackScenarioSpec(

--- a/src/loushang/tui/__init__.py
+++ b/src/loushang/tui/__init__.py
@@ -26,9 +26,6 @@ from loushang.tui.compat import (
     CompletionProvider,
     CompletionSuggestions,
     InfoPanel,
-    SettingItem,
-    SettingsList,
-    SettingsListRenderer,
 )
 from loushang.tui.completion import (
     CombinedCompletionProvider,
@@ -142,7 +139,6 @@ from loushang.tui.surfaces import (
     DialogSurface,
     SelectionSurface,
     SelectItem,
-    SettingsSurface,
 )
 from loushang.tui.terminal import (
     FakeCellStyle,
@@ -440,10 +436,6 @@ __all__ = [
     "SelectionRange",
     "SelectionController",
     "SelectionSurface",
-    "SettingsSurface",
-    "SettingItem",
-    "SettingsList",
-    "SettingsListRenderer",
     "SlashCommand",
     "SlashCommandCompletionProvider",
     "Spinner",

--- a/src/loushang/tui/compat.py
+++ b/src/loushang/tui/compat.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass, replace
-from typing import Any
+from dataclasses import dataclass
 
 
 @dataclass(frozen=True, slots=True)
@@ -128,63 +126,6 @@ class InfoPanel:
         if self.footer:
             parts.append(self.footer)
         return "\n".join(part for part in parts if part)
-
-
-@dataclass(frozen=True, slots=True)
-class SettingItem:
-    """Legacy compatibility data model for old settings-list flows.
-
-    New settings pages should compose PageScaffold with SearchableList and
-    product-owned setting adapters instead of depending on this model.
-    """
-
-    id: str
-    label: str
-    enabled: bool = False
-    description: str = ""
-    current_value: str = ""
-    values: tuple[str, ...] = ()
-    submenu: Callable[[str, Callable[[str | None], None]], Any] | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class SettingsList:
-    """Legacy compatibility container for old settings-list flows.
-
-    New settings pages should compose PageScaffold with SearchableList and
-    product-owned setting adapters instead of depending on this container.
-    """
-
-    items: tuple[SettingItem, ...]
-
-    def set_enabled(self, item_id: str, enabled: bool) -> SettingsList:
-        return SettingsList(tuple(replace(item, enabled=enabled) if item.id == item_id else item for item in self.items))
-
-    def toggle(self, item_id: str) -> SettingsList:
-        for item in self.items:
-            if item.id == item_id:
-                return self.set_enabled(item_id, not item.enabled)
-        return self
-
-
-@dataclass(frozen=True, slots=True)
-class SettingsListRenderer:
-    """Legacy compatibility text renderer for SettingsList.
-
-    New settings pages should compose PageScaffold with SearchableList and
-    product-owned setting adapters instead of depending on this renderer.
-    """
-
-    title: str = "Settings"
-
-    def render(self, settings: SettingsList) -> tuple[tuple[str, str], ...]:
-        lines = [self.title]
-        for index, item in enumerate(settings.items):
-            prefix = ">" if index == 0 else " "
-            check = "[x]" if item.enabled else "[ ]"
-            suffix = f" - {item.description}" if item.description else ""
-            lines.append(f"{prefix} {check} {item.label}{suffix}")
-        return tuple(("", line + ("\n" if index < len(lines) - 1 else "")) for index, line in enumerate(lines))
 
 
 def _completion_matches(item: CompletionItem, needle: str) -> bool:

--- a/src/loushang/tui/surfaces.py
+++ b/src/loushang/tui/surfaces.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field, replace
-from typing import Any, Literal
+from dataclasses import dataclass, field
+from typing import Literal
 
 from loushang.tui.cell_width import (
     autowrap_safe_width,
     truncate_to_width,
     visible_width,
-    wrap_cells,
 )
-from loushang.tui.compat import SettingItem
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
 from loushang.tui.fuzzy import fuzzy_match
 from loushang.tui.input import InputEvent, InputIntent, InputIntentKind
@@ -303,243 +301,6 @@ class CommandSurface(SelectionSurface):
             self.set_filter(query)
 
 
-class SettingsSurface(SelectionSurface):
-    """Legacy compatibility surface for old settings-list workflows.
-
-    New settings pages should compose PageScaffold with SearchableList and
-    product-owned setting adapters instead of depending on this surface.
-    """
-
-    def __init__(
-        self,
-        items: list[SelectItem | SettingItem] | tuple[SelectItem | SettingItem, ...],
-        *,
-        max_visible: int = 8,
-        enable_search: bool = False,
-    ) -> None:
-        self._settings_items = [item for item in items if isinstance(item, SettingItem)]
-        self._search_enabled = enable_search
-        self._search_input = TextInput(prompt="Search: ") if enable_search else None
-        self._submenu_component: Any | None = None
-        self._submenu_item_id: str | None = None
-        self._submenu_item_index: int | None = None
-        self._pending_submenu_intent: InputIntent | None = None
-        if self._settings_items and len(self._settings_items) == len(items):
-            super().__init__(items=[], max_visible=max_visible, select_kind="setting")
-            self._filtered_items = []
-            return
-        super().__init__(items=[item for item in items if isinstance(item, SelectItem)], max_visible=max_visible, select_kind="setting")
-
-    def set_filter(self, query: str) -> None:
-        if self._settings_items:
-            if self._search_input is not None:
-                self._search_input.set_text(query)
-            self.selected_index = 0
-            return
-        super().set_filter(query)
-
-    def handle_input(self, event: InputEvent) -> InputIntent | bool | None:
-        if self._submenu_component is not None:
-            return self._handle_submenu_input(event)
-        if not self._settings_items:
-            return super().handle_input(event)
-        if event.kind == "text" and event.text == " " and not self._search_enabled:
-            return self._activate_setting()
-        if event.kind == "text" and self._search_enabled:
-            if self._search_input is not None:
-                self._search_input.insert_text(event.text)
-            self.selected_index = 0
-            return True
-        if event.kind != "key":
-            return None
-        if self._search_enabled and _handle_text_input_key(self._search_input, event.key):
-            self.selected_index = 0
-            return True
-        if event.key == "up":
-            self._move_settings(-1)
-            return True
-        if event.key == "down":
-            self._move_settings(1)
-            return True
-        if event.key == "pageUp":
-            self._move_settings(-max(1, self.max_visible))
-            return True
-        if event.key == "pageDown":
-            self._move_settings(max(1, self.max_visible))
-            return True
-        if event.key in {"enter", "space"} or event.text == " ":
-            return self._activate_setting() or True
-        if event.key in {"esc", "escape"}:
-            return InputIntent(kind="surface_close")
-        return None
-
-    def selected_setting(self) -> SettingItem | None:
-        items = self._display_settings()
-        if not items:
-            return None
-        return items[self.selected_index]
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        if self._submenu_component is not None:
-            render = getattr(self._submenu_component, "render", None)
-            if callable(render):
-                return render(constraints)
-        if not self._settings_items:
-            return self._render_legacy_select_settings(constraints)
-        target_width = autowrap_safe_width(constraints.width)
-        rendered: list[str] = []
-        cursor = None
-        if self._search_enabled:
-            search_input = self._search_input or TextInput(prompt="Search: ")
-            search_result = search_input.render(
-                RenderConstraints(
-                    width=target_width,
-                    max_height=1,
-                    visible_height=constraints.visible_height,
-                )
-            )
-            rendered.extend(line.text for line in search_result.lines)
-            cursor = search_result.cursor
-            rendered.append("")
-        display_items = self._display_settings()
-        if not display_items:
-            rendered.append(truncate_to_width("  No matching settings", max_width=target_width, ellipsis=""))
-            return RenderResult.from_lines(
-                [RenderLine(line) for line in rendered[: constraints.max_height]],
-                constraints=constraints,
-                cursor=cursor,
-            )
-        self.selected_index = _clamp_setting_index(self.selected_index, display_items)
-        item_budget = max(1, min(self.max_visible, constraints.max_height - len(rendered)))
-        start = _scroll_start(self.selected_index, len(display_items), item_budget)
-        end = min(start + item_budget, len(display_items))
-        label_width = _settings_label_width(self._settings_items)
-        for index in range(start, end):
-            item = display_items[index]
-            rendered.append(_render_setting_item(item, selected=index == self.selected_index, label_width=label_width, width=target_width))
-        if start > 0 or end < len(display_items):
-            rendered.append(truncate_to_width(f"  ({self.selected_index + 1}/{len(display_items)})", max_width=target_width, ellipsis=""))
-        selected = display_items[self.selected_index]
-        if selected.description and len(rendered) + 2 <= constraints.max_height:
-            rendered.append("")
-            description_budget = max(0, constraints.max_height - len(rendered))
-            rendered.extend(_wrap_setting_description(selected.description, width=target_width)[:description_budget])
-        if len(rendered) + 2 <= constraints.max_height:
-            rendered.append("")
-            rendered.append(truncate_to_width("  Enter/Space to change - Esc to cancel", max_width=target_width, ellipsis=""))
-        return RenderResult.from_lines(
-            [RenderLine(line) for line in rendered[: constraints.max_height]],
-            constraints=constraints,
-            cursor=cursor,
-        )
-
-    def _render_legacy_select_settings(self, constraints: RenderConstraints) -> RenderResult:
-        if not self._filtered_items:
-            line = truncate_to_width(self.empty_text, max_width=autowrap_safe_width(constraints.width))
-            return RenderResult.from_lines([RenderLine(line)], constraints=constraints)
-        visible_budget = max(1, min(self.max_visible, constraints.max_height))
-        start = _scroll_start(self.selected_index, len(self._filtered_items), visible_budget)
-        end = min(start + visible_budget, len(self._filtered_items))
-        lines = [
-            RenderLine(
-                _render_legacy_settings_item(
-                    self._filtered_items[index],
-                    selected=index == self.selected_index,
-                    width=constraints.width,
-                )
-            )
-            for index in range(start, end)
-        ]
-        return RenderResult.from_lines(lines, constraints=constraints)
-
-    def _display_settings(self) -> list[SettingItem]:
-        search_query = self._search_input.value if self._search_input is not None else ""
-        if not self._search_enabled or not search_query:
-            return list(self._settings_items)
-        query = search_query.lower()
-        return [item for item in self._settings_items if _setting_item_matches_search(item, query)]
-
-    def _move_settings(self, delta: int) -> None:
-        items = self._display_settings()
-        if not items:
-            return
-        self.selected_index = (self.selected_index + delta) % len(items)
-
-    def _activate_setting(self) -> InputIntent | None:
-        selected = self.selected_setting()
-        if selected is None:
-            return None
-        if selected.submenu is not None:
-            self._submenu_item_id = selected.id
-            self._submenu_item_index = self.selected_index
-            self._pending_submenu_intent = None
-            self._submenu_component = selected.submenu(selected.current_value, self._complete_submenu_from_callback)
-            return None
-        if selected.values:
-            try:
-                current_index = selected.values.index(selected.current_value)
-            except ValueError:
-                current_index = -1
-            new_value = selected.values[(current_index + 1) % len(selected.values)]
-            self._settings_items = [
-                replace(item, current_value=new_value) if item.id == selected.id else item
-                for item in self._settings_items
-            ]
-            return InputIntent(kind="setting", text=selected.id, note=new_value)
-        if selected.current_value:
-            return InputIntent(kind="setting", text=selected.id, note=selected.current_value)
-        return InputIntent(kind="setting", text=selected.id, note="true" if selected.enabled else "false")
-
-    def _handle_submenu_input(self, event: InputEvent) -> InputIntent | bool | None:
-        component = self._submenu_component
-        handle_input = getattr(component, "handle_input", None)
-        result = handle_input(event) if callable(handle_input) else None
-        pending = self._consume_pending_submenu_intent()
-        if pending is not None:
-            return pending
-        intents = _normalize_submenu_result(result)
-        for intent in intents:
-            if intent.kind in {"select", "complete", "setting"}:
-                selected_value = intent.note or intent.text
-                return self._complete_submenu(selected_value)
-            if intent.kind in {"surface_close", "dialog_cancel"}:
-                self._close_submenu()
-                return True
-        if result is True:
-            return True
-        return result if isinstance(result, InputIntent) else None
-
-    def _complete_submenu_from_callback(self, selected_value: str | None = None) -> None:
-        if selected_value is None:
-            self._close_submenu()
-            return
-        self._pending_submenu_intent = self._complete_submenu(selected_value)
-
-    def _consume_pending_submenu_intent(self) -> InputIntent | None:
-        intent = self._pending_submenu_intent
-        self._pending_submenu_intent = None
-        return intent
-
-    def _complete_submenu(self, selected_value: str) -> InputIntent | None:
-        item_id = self._submenu_item_id
-        if item_id is None:
-            self._close_submenu()
-            return None
-        self._settings_items = [
-            replace(item, current_value=selected_value) if item.id == item_id else item
-            for item in self._settings_items
-        ]
-        self._close_submenu()
-        return InputIntent(kind="setting", text=item_id, note=selected_value)
-
-    def _close_submenu(self) -> None:
-        self._submenu_component = None
-        if self._submenu_item_index is not None:
-            self.selected_index = self._submenu_item_index
-        self._submenu_item_id = None
-        self._submenu_item_index = None
-
-
 @dataclass(slots=True)
 class ApprovalSurface:
     action: str
@@ -670,16 +431,6 @@ def _select_item_matches_filter(item: SelectItem, query: str, *, mode: Literal["
     return any(haystack.startswith(query) for haystack in haystacks[:2])
 
 
-def _setting_item_matches_search(item: SettingItem, query: str) -> bool:
-    haystacks = (
-        item.label.lower(),
-        item.id.lower(),
-        item.description.lower(),
-        item.current_value.lower(),
-    )
-    return _fuzzy_matches_any(query, haystacks)
-
-
 def _fuzzy_matches_any(query: str, haystacks: tuple[str, ...]) -> bool:
     tokens = tuple(token for token in query.split() if token)
     if not tokens:
@@ -690,74 +441,16 @@ def _fuzzy_matches_any(query: str, haystacks: tuple[str, ...]) -> bool:
     )
 
 
-def _wrap_setting_description(description: str, *, width: int) -> list[str]:
-    body_width = max(1, width - 2)
-    wrapped: list[str] = []
-    for logical_line in description.splitlines():
-        words = logical_line.split()
-        if not words:
-            wrapped.append("  ")
-            continue
-        current = ""
-        for word in words:
-            if visible_width(word) > body_width:
-                if current:
-                    wrapped.append(f"  {current}")
-                    current = ""
-                wrapped.extend(f"  {chunk}" for chunk in wrap_cells(word, width=body_width))
-                continue
-            candidate = word if not current else f"{current} {word}"
-            if visible_width(candidate) <= body_width:
-                current = candidate
-                continue
-            wrapped.append(f"  {current}")
-            current = word
-        if current:
-            wrapped.append(f"  {current}")
-    return wrapped or ["  "]
-
-
-def _render_setting_item(item: SettingItem, *, selected: bool, label_width: int, width: int) -> str:
-    prefix = "> " if selected else "  "
-    label = item.label + (" " * max(0, label_width - visible_width(item.label)))
-    value = item.current_value or ("on" if item.enabled else "off")
-    line = truncate_to_width(f"{prefix}{label}  {value}", max_width=width, ellipsis="")
-    return _style_selected_line(line, selected=selected, selected_style=DEFAULT_SELECTED_STYLE)
-
-
-def _render_legacy_settings_item(item: SelectItem, *, selected: bool, width: int) -> str:
-    prefix = "> " if selected else "  "
-    suffix = f"  {_normalize_single_line(item.description)}" if item.description else ""
-    line = truncate_to_width(f"{prefix}{item.label}{suffix}", max_width=autowrap_safe_width(width))
-    return _style_selected_line(line, selected=selected, selected_style=DEFAULT_SELECTED_STYLE)
-
-
 def _style_selected_line(line: str, *, selected: bool, selected_style: ThemeStyle | None) -> str:
     if not selected or selected_style is None:
         return line
     return apply_theme_style(line, selected_style)
 
 
-def _settings_label_width(items: list[SettingItem]) -> int:
-    if not items:
-        return 1
-    return min(30, max(visible_width(item.label) for item in items))
-
-
 def _handle_text_input_key(text_input: TextInput | None, key: str) -> bool:
     if text_input is None:
         return False
     return text_input.handle_editing_key(key)
-
-
-def _normalize_submenu_result(result: Any) -> tuple[InputIntent, ...]:
-    if result is None:
-        return ()
-    if isinstance(result, InputIntent):
-        return (result,)
-    if isinstance(result, tuple) and all(isinstance(item, InputIntent) for item in result):
-        return result
-    return ()
 
 
 def _scroll_start(selected_index: int, total: int, item_budget: int) -> int:
@@ -768,12 +461,6 @@ def _scroll_start(selected_index: int, total: int, item_budget: int) -> int:
 
 
 def _clamp_index(index: int, items: list[SelectItem]) -> int:
-    if not items:
-        return 0
-    return max(0, min(index, len(items) - 1))
-
-
-def _clamp_setting_index(index: int, items: list[SettingItem]) -> int:
     if not items:
         return 0
     return max(0, min(index, len(items) - 1))

--- a/tests/coding/test_native_coding_tui_surfaces.py
+++ b/tests/coding/test_native_coding_tui_surfaces.py
@@ -17,8 +17,6 @@ from loushang.tui import (
     RenderConstraints,
     RenderLine,
     RenderResult,
-    SettingItem,
-    SettingsSurface,
     SurfaceHost,
 )
 from loushang.tui.cell_width import strip_control_sequences
@@ -499,20 +497,20 @@ def test_native_surface_manager_settings_page_statusline_submit_persists_setting
     assert app.state.statusline_settings.style == "muted"
 
 
-def test_native_surface_manager_ignores_legacy_settings_surface_submit() -> None:
+def test_native_surface_manager_ignores_setting_submit_without_settings_page() -> None:
     app = _app()
     manager = _manager(app, _Session())
-    legacy_surface = NativeSurfaceView(
+    generic_surface = NativeSurfaceView(
         title="Settings",
         purpose="settings",
-        content=SettingsSurface((SettingItem(id="statusline", label="Status line", enabled=True),), enable_search=True),
+        content=_CursorContent(),
         presentation="bottom-exclusive",
     )
-    app.active_surface = legacy_surface
+    app.active_surface = generic_surface
 
     asyncio.run(manager.handle_surface_intent(InputIntent(kind="setting", text="statusline", note="false")))
 
-    assert app.active_surface is legacy_surface
+    assert app.active_surface is generic_surface
     assert app.state.statusline_visible is True
     assert app.state.status_message is None
 

--- a/tests/tui/test_import_boundaries.py
+++ b/tests/tui/test_import_boundaries.py
@@ -11,6 +11,21 @@ def test_import_loushang_tui_does_not_import_legacy_rendering_libraries() -> Non
     _assert_loushang_tui_import_boundary_in_subprocess()
 
 
+def test_loushang_tui_does_not_export_legacy_settings_primitives() -> None:
+    import loushang.tui as tui
+
+    removed_names = (
+        "SettingItem",
+        "SettingsList",
+        "SettingsListRenderer",
+        "SettingsSurface",
+    )
+
+    for name in removed_names:
+        assert not hasattr(tui, name)
+        assert name not in tui.__all__
+
+
 def test_import_boundary_check_does_not_replace_loaded_tui_classes() -> None:
     import loushang.coding.ui.command_list as command_list
     import loushang.coding.ui.renderer as renderer

--- a/tests/tui/test_render_framework.py
+++ b/tests/tui/test_render_framework.py
@@ -19,8 +19,6 @@ from loushang.tui import (
     RenderResult,
     ScreenRoot,
     SelectItem,
-    SettingItem,
-    SettingsSurface,
     Surface,
     SurfaceHost,
     TerminalSize,
@@ -288,8 +286,13 @@ def test_surface_host_can_close_on_call_site_intent_policy() -> None:
     host.open_surface(Surface(renderable=command, focus_target=command))
     command_intents = host.route_input(InputEvent(kind="key", key="enter"), close_on_intents=("command",))
 
-    settings = SettingsSurface([SettingItem(id="statusline", label="Status line", enabled=True)])
-    host.open_surface(Surface(renderable=settings, focus_target=settings))
+    settings_target = ReturningFocusTarget(InputIntent(kind="setting", text="statusline", note="true"))
+    host.open_surface(
+        Surface(
+            renderable=TextRenderable(("statusline",), []),
+            focus_target=settings_target,
+        )
+    )
     setting_intents = host.route_input(InputEvent(kind="key", key="enter"), close_on_intents=("setting",))
 
     approval = ApprovalSurface(action="Run command")

--- a/tests/tui/test_surfaces.py
+++ b/tests/tui/test_surfaces.py
@@ -12,10 +12,6 @@ from loushang.tui import (
     RenderConstraints,
     SelectionSurface,
     SelectItem,
-    SettingItem,
-    SettingsList,
-    SettingsListRenderer,
-    SettingsSurface,
     ThemeResolver,
     strip_control_sequences,
 )
@@ -24,13 +20,6 @@ from loushang.tui import (
 def rendered_text(surface: Any, *, width: int = 30, height: int = 5) -> tuple[str, ...]:
     result = surface.render(RenderConstraints(width=width, max_height=height))
     return tuple(line.text for line in result.lines)
-
-
-def test_settings_primitives_are_marked_legacy_compatibility() -> None:
-    for primitive in (SettingItem, SettingsList, SettingsListRenderer, SettingsSurface):
-        assert "legacy compatibility" in (primitive.__doc__ or "").casefold()
-        assert "PageScaffold" in (primitive.__doc__ or "")
-        assert "SearchableList" in (primitive.__doc__ or "")
 
 
 def test_selection_surface_wraps_navigation_and_scrolls_selected_item_visible() -> None:
@@ -335,181 +324,6 @@ def test_command_surface_searches_from_typed_text() -> None:
         "> /status",
     )
     assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(kind="command", text="/status")
-
-
-def test_settings_surface_renders_description_and_returns_setting_intent() -> None:
-    surface = SettingsSurface([SelectItem("Theme", value="theme", description="Change color theme")])
-
-    assert tuple(strip_control_sequences(line) for line in rendered_text(surface, width=50, height=3)) == ("> Theme  Change color theme",)
-    assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(kind="setting", text="theme")
-
-
-def test_settings_surface_cycles_values_and_reports_new_value() -> None:
-    surface = SettingsSurface(
-        [
-            SettingItem(
-                id="theme",
-                label="Theme",
-                current_value="dark",
-                values=("dark", "light"),
-                description="Terminal color theme",
-            )
-        ],
-        max_visible=5,
-    )
-
-    assert tuple(strip_control_sequences(line) for line in rendered_text(surface, width=44, height=6)) == (
-        "> Theme  dark",
-        "",
-        "  Terminal color theme",
-        "",
-        "  Enter/Space to change - Esc to cancel",
-    )
-
-    assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
-        kind="setting",
-        text="theme",
-        note="light",
-    )
-    assert strip_control_sequences(rendered_text(surface, width=44, height=3)[0]) == "> Theme  light"
-    assert surface.handle_input(InputEvent(kind="text", text=" ")) == InputIntent(
-        kind="setting",
-        text="theme",
-        note="dark",
-    )
-
-
-def test_settings_surface_wraps_selected_description() -> None:
-    surface = SettingsSurface(
-        [
-            SettingItem(
-                id="theme",
-                label="Theme",
-                current_value="dark",
-                description="Controls how terminal color themes are rendered in compact layouts",
-            )
-        ],
-        max_visible=5,
-    )
-
-    assert tuple(strip_control_sequences(line) for line in rendered_text(surface, width=28, height=5)) == (
-        "> Theme  dark",
-        "",
-        "  Controls how terminal",
-        "  color themes are rendered",
-        "  in compact layouts",
-    )
-
-
-def test_settings_surface_can_delegate_value_selection_to_submenu() -> None:
-    def submenu(_current: str, _done: Any) -> SelectionSurface:
-        return SelectionSurface([SelectItem("GPT", value="gpt")])
-
-    surface = SettingsSurface(
-        [
-            SettingItem(
-                id="model",
-                label="Model",
-                current_value="kimi",
-                submenu=submenu,
-            )
-        ],
-    )
-
-    assert surface.handle_input(InputEvent(kind="key", key="enter")) is True
-    assert tuple(strip_control_sequences(line) for line in rendered_text(surface, width=20, height=3)) == ("> GPT",)
-    assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
-        kind="setting",
-        text="model",
-        note="gpt",
-    )
-    assert surface.selected_setting() == SettingItem(
-        id="model",
-        label="Model",
-        current_value="gpt",
-        submenu=submenu,
-    )
-
-
-def test_settings_surface_search_filters_with_text_and_backspace() -> None:
-    surface = SettingsSurface(
-        [
-            SettingItem(id="theme", label="Theme", current_value="dark"),
-            SettingItem(id="model", label="Model", current_value="kimi"),
-        ],
-        enable_search=True,
-    )
-
-    surface.handle_input(InputEvent(kind="text", text="mo"))
-
-    assert tuple(strip_control_sequences(line) for line in rendered_text(surface, width=36, height=5)[:3]) == (
-        "Search: mo",
-        "",
-        "> Model  kimi",
-    )
-
-    surface.handle_input(InputEvent(kind="key", key="backspace"))
-
-    assert tuple(strip_control_sequences(line) for line in rendered_text(surface, width=36, height=5)[:3]) == (
-        "Search: m",
-        "",
-        "> Theme  dark",
-    )
-
-
-def test_settings_surface_consumed_paths_return_true_without_intents() -> None:
-    surface = SettingsSurface(
-        [
-            SettingItem(id="theme", label="Theme", current_value="dark"),
-            SettingItem(id="model", label="Model", current_value="kimi"),
-        ],
-        enable_search=True,
-    )
-
-    assert surface.handle_input(InputEvent(kind="text", text="mo")) is True
-    assert surface.handle_input(InputEvent(kind="key", key="backspace")) is True
-    assert surface.handle_input(InputEvent(kind="key", key="down")) is True
-
-
-def test_settings_surface_search_uses_fuzzy_matching() -> None:
-    surface = SettingsSurface(
-        [
-            SettingItem(id="model", label="Model Selection", current_value="gpt-5"),
-            SettingItem(id="theme", label="Theme", current_value="dark"),
-        ],
-        enable_search=True,
-    )
-
-    surface.handle_input(InputEvent(kind="text", text="ms"))
-
-    assert tuple(strip_control_sequences(line) for line in rendered_text(surface, width=40, height=5)[:3]) == (
-        "Search: ms",
-        "",
-        "> Model Selection  gpt-5",
-    )
-
-
-def test_settings_surface_search_uses_text_input_cursor_editing() -> None:
-    surface = SettingsSurface(
-        [
-            SettingItem(id="memory", label="Memory", current_value="on"),
-            SettingItem(id="model", label="Model", current_value="kimi"),
-        ],
-        enable_search=True,
-    )
-
-    surface.handle_input(InputEvent(kind="text", text="mo"))
-    surface.handle_input(InputEvent(kind="key", key="left"))
-    surface.handle_input(InputEvent(kind="text", text="x"))
-    result = surface.render(RenderConstraints(width=36, max_height=5))
-
-    assert tuple(line.text for line in result.lines)[:3] == (
-        "Search: mxo",
-        "",
-        "  No matching settings",
-    )
-    assert result.cursor is not None
-    assert (result.cursor.row, result.cursor.column) == (0, len("Search: mx"))
 
 
 def test_approval_surface_returns_explicit_approval_or_rejection() -> None:

--- a/tests/tui/test_widgets_reference_docs.py
+++ b/tests/tui/test_widgets_reference_docs.py
@@ -3,15 +3,21 @@ from __future__ import annotations
 from pathlib import Path
 
 
-def test_widget_reference_marks_settings_surface_as_legacy_compatibility() -> None:
+def test_widget_reference_recommends_composed_settings_pages_without_legacy_primitives() -> None:
+    removed_names = (
+        "SettingsSurface",
+        "SettingItem",
+        "SettingsList",
+        "SettingsListRenderer",
+    )
+
     for path in (
         Path("docs/en/reference/tui-widgets.md"),
         Path("docs/zh-CN/reference/tui-widgets.md"),
     ):
         text = path.read_text(encoding="utf-8")
 
-        assert "SettingsSurface" in text
-        assert "legacy compatibility" in text.casefold()
         assert "PageScaffold" in text
         assert "SearchableList" in text
-        assert "SettingsList" in text
+        for name in removed_names:
+            assert name not in text


### PR DESCRIPTION
## Summary
- Remove the legacy TUI settings primitives from the public API: SettingItem, SettingsList, SettingsListRenderer, and SettingsSurface.
- Keep settings UI on the composed path: PageScaffold, tabs, SearchableList, and product-owned adapters.
- Update tests and current docs to lock the removed exports and avoid pointing new code at settings-specific TUI primitives.

## Validation
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/tui/test_import_boundaries.py::test_loushang_tui_does_not_export_legacy_settings_primitives tests/tui/test_widgets_reference_docs.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/tui/test_surfaces.py tests/tui/test_render_framework.py tests/tui/test_import_boundaries.py tests/tui/test_widgets_reference_docs.py tests/coding/test_ui_import_boundaries.py tests/coding/test_native_coding_tui_surfaces.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/tui -q
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_import_boundaries.py tests/coding/test_native_coding_tui_surfaces.py tests/coding/test_native_settings_page.py tests/coding/test_native_coding_tui_playback.py -q
- uv --cache-dir /tmp/uv-cache run --extra dev pytest tests -q
- uv --cache-dir /tmp/uv-cache run --extra dev ruff check src tests