### PR TITLE
Split TUI compat models

### DIFF
--- a/src/loushang/tui/__init__.py
+++ b/src/loushang/tui/__init__.py
@@ -18,14 +18,9 @@ from loushang.tui.cell_width import (
     wrap_ansi,
     wrap_cells,
 )
-from loushang.tui.compat import (
+from loushang.tui.command_palette import (
     CommandPalette,
     CommandPaletteItem,
-    CompletionApplication,
-    CompletionItem,
-    CompletionProvider,
-    CompletionSuggestions,
-    InfoPanel,
 )
 from loushang.tui.completion import (
     CombinedCompletionProvider,
@@ -35,6 +30,12 @@ from loushang.tui.completion import (
     SlashCommand,
     SlashCommandCompletionProvider,
     get_completion_suggestions,
+)
+from loushang.tui.completion_models import (
+    CompletionApplication,
+    CompletionItem,
+    CompletionProvider,
+    CompletionSuggestions,
 )
 from loushang.tui.content import (
     CapabilityAwareCodeHighlighter,
@@ -82,6 +83,7 @@ from loushang.tui.framework import (
     surface_presentation,
 )
 from loushang.tui.fuzzy import FuzzyMatch, fuzzy_filter, fuzzy_match
+from loushang.tui.info_panel import InfoPanel
 from loushang.tui.input import (
     InputBatch,
     InputEvent,

--- a/src/loushang/tui/command_palette.py
+++ b/src/loushang/tui/command_palette.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.tui.completion_models import CompletionProvider
+
+
+@dataclass(frozen=True, slots=True)
+class CommandPaletteItem:
+    value: str
+    label: str = ""
+    description: str = ""
+    disabled: bool = False
+
+    def display_label(self) -> str:
+        return self.label or self.value
+
+
+@dataclass(frozen=True, slots=True)
+class CommandPalette:
+    items: tuple[CommandPaletteItem, ...]
+    title: str = "Commands"
+
+    @classmethod
+    def from_completion_provider(cls, provider: CompletionProvider, *, title: str = "Commands") -> CommandPalette:
+        return cls(
+            tuple(
+                CommandPaletteItem(value=item.value, label=item.display_label(), description=item.description)
+                for item in provider.items
+            ),
+            title=title,
+        )

--- a/src/loushang/tui/completion.py
+++ b/src/loushang/tui/completion.py
@@ -10,7 +10,7 @@ from fnmatch import fnmatch
 from pathlib import Path, PurePosixPath
 from typing import Any, Sequence
 
-from loushang.tui.compat import (
+from loushang.tui.completion_models import (
     CompletionApplication,
     CompletionItem,
     CompletionSuggestions,

--- a/src/loushang/tui/completion_models.py
+++ b/src/loushang/tui/completion_models.py
@@ -80,54 +80,6 @@ class CompletionProvider:
         )
 
 
-@dataclass(frozen=True, slots=True)
-class CommandPaletteItem:
-    value: str
-    label: str = ""
-    description: str = ""
-    disabled: bool = False
-
-    def display_label(self) -> str:
-        return self.label or self.value
-
-
-@dataclass(frozen=True, slots=True)
-class CommandPalette:
-    items: tuple[CommandPaletteItem, ...]
-    title: str = "Commands"
-
-    @classmethod
-    def from_completion_provider(cls, provider: CompletionProvider, *, title: str = "Commands") -> CommandPalette:
-        return cls(
-            tuple(
-                CommandPaletteItem(value=item.value, label=item.display_label(), description=item.description)
-                for item in provider.items
-            ),
-            title=title,
-        )
-
-
-@dataclass(frozen=True, slots=True)
-class InfoPanel:
-    title: str
-    text: str
-    footer: str = ""
-
-    @classmethod
-    def from_text(cls, *, title: str, text: str, footer: str = "") -> InfoPanel:
-        return cls(title=title, text=text, footer=footer)
-
-    @property
-    def lines(self) -> tuple[str, ...]:
-        return tuple(self.text.splitlines())
-
-    def plain_text(self) -> str:
-        parts = [self.title, self.text]
-        if self.footer:
-            parts.append(self.footer)
-        return "\n".join(part for part in parts if part)
-
-
 def _completion_matches(item: CompletionItem, needle: str) -> bool:
     if " " in needle:
         command, argument = needle.split(None, 1)

--- a/src/loushang/tui/info_panel.py
+++ b/src/loushang/tui/info_panel.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class InfoPanel:
+    title: str
+    text: str
+    footer: str = ""
+
+    @classmethod
+    def from_text(cls, *, title: str, text: str, footer: str = "") -> InfoPanel:
+        return cls(title=title, text=text, footer=footer)
+
+    @property
+    def lines(self) -> tuple[str, ...]:
+        return tuple(self.text.splitlines())
+
+    def plain_text(self) -> str:
+        parts = [self.title, self.text]
+        if self.footer:
+            parts.append(self.footer)
+        return "\n".join(part for part in parts if part)

--- a/src/loushang/tui/ui_parts/composer.py
+++ b/src/loushang/tui/ui_parts/composer.py
@@ -14,15 +14,15 @@ from loushang.tui.cell_width import (
     truncate_to_width,
     visible_width,
 )
-from loushang.tui.compat import (
-    CompletionApplication,
-    CompletionItem,
-    CompletionSuggestions,
-)
 from loushang.tui.completion import (
     CompletionCancellationToken,
     CompletionContext,
     get_completion_suggestions,
+)
+from loushang.tui.completion_models import (
+    CompletionApplication,
+    CompletionItem,
+    CompletionSuggestions,
 )
 from loushang.tui.composer_edit_buffer import (
     ComposerAtom as _Atom,

--- a/src/loushang/tui/ui_parts/widgets/command_palette.py
+++ b/src/loushang/tui/ui_parts/widgets/command_palette.py
@@ -8,7 +8,7 @@ from loushang.tui.cell_width import (
     truncate_to_width,
     visible_width,
 )
-from loushang.tui.compat import CommandPalette, CommandPaletteItem
+from loushang.tui.command_palette import CommandPalette, CommandPaletteItem
 from loushang.tui.core import (
     CursorDeclaration,
     RenderConstraints,

--- a/tests/tui/test_import_boundaries.py
+++ b/tests/tui/test_import_boundaries.py
@@ -26,6 +26,24 @@ def test_loushang_tui_does_not_export_legacy_settings_primitives() -> None:
         assert name not in tui.__all__
 
 
+def test_loushang_tui_public_models_are_not_owned_by_compat_module() -> None:
+    import loushang.tui as tui
+
+    expected_modules = {
+        "CompletionItem": "loushang.tui.completion_models",
+        "CompletionSuggestions": "loushang.tui.completion_models",
+        "CompletionApplication": "loushang.tui.completion_models",
+        "CompletionProvider": "loushang.tui.completion_models",
+        "CommandPaletteItem": "loushang.tui.command_palette",
+        "CommandPalette": "loushang.tui.command_palette",
+        "InfoPanel": "loushang.tui.info_panel",
+    }
+
+    assert not Path("src/loushang/tui/compat.py").exists()
+    for name, module_name in expected_modules.items():
+        assert getattr(tui, name).__module__ == module_name
+
+
 def test_import_boundary_check_does_not_replace_loaded_tui_classes() -> None:
     import loushang.coding.ui.command_list as command_list
     import loushang.coding.ui.renderer as renderer

--- a/tests/tui/test_widgets_command_palette.py
+++ b/tests/tui/test_widgets_command_palette.py
@@ -6,12 +6,13 @@ from typing import Any, get_args
 from loushang.tui import (
     CommandPalette,
     CommandPaletteItem,
+    CompletionItem,
+    CompletionProvider,
     InputEvent,
     RenderConstraints,
     strip_control_sequences,
     visible_width,
 )
-from loushang.tui.compat import CompletionItem, CompletionProvider
 from loushang.tui.input import InputIntentKind
 from loushang.tui.ui_parts.widgets.command_palette import CommandPaletteView
 from tests.tui.widget_example_playback import play_example


### PR DESCRIPTION
## Summary
- Remove the catch-all `loushang.tui.compat` module.
- Move completion data/provider primitives to `completion_models.py`, command palette data models to `command_palette.py`, and `InfoPanel` to `info_panel.py`.
- Keep the top-level `loushang.tui` exports stable while locking the new module ownership in tests.

## Validation
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/tui/test_import_boundaries.py::test_loushang_tui_public_models_are_not_owned_by_compat_module -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/tui/test_import_boundaries.py::test_loushang_tui_public_models_are_not_owned_by_compat_module tests/tui/test_widgets_command_palette.py tests/tui/test_completion_providers.py tests/tui/test_composer_bottom_frame.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/tui -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_completion.py tests/coding/test_ui_command_list.py tests/coding/test_ui_model_list.py tests/coding/test_ui_app.py tests/coding/test_ui_renderer.py tests/coding/test_native_coding_tui_input.py tests/coding/test_native_coding_tui_loop.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src tests`
- `git diff --check`