### PR TITLE
Remove plain status render

### DIFF
--- a/src/loushang/coding/ui/app.py
+++ b/src/loushang/coding/ui/app.py
@@ -59,8 +59,6 @@ DisableDebug = Callable[[], None]
 class CodingTuiApp:
     lifecycle: RunLifecycle
     handlers: CodingTuiHandlers
-    status: Callable[[], str]
-    status_visible: Callable[[], bool]
     completion_provider: CompletionProvider | None = None
 
 
@@ -173,8 +171,6 @@ def build_coding_tui_app(
     return CodingTuiApp(
         lifecycle=lifecycle,
         handlers=handlers,
-        status=status_provider.render,
-        status_visible=status_provider.is_visible,
         completion_provider=completion_provider,
     )
 

--- a/src/loushang/coding/ui/status_provider.py
+++ b/src/loushang/coding/ui/status_provider.py
@@ -8,7 +8,6 @@ from loushang.coding.ui.status_line import (
     status_line_settings_from_control,
     status_line_settings_to_patch,
 )
-from loushang.coding.ui.toolbar import ToolbarSnapshot, render_toolbar
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,18 +43,6 @@ class CodingTuiStatusProvider:
         self._running = running
         self._statusline_settings = statusline_settings or StatusLineSettings()
         self._on_statusline_settings_changed = on_statusline_settings_changed
-
-    def render(self) -> str:
-        return render_toolbar(
-            ToolbarSnapshot(
-                model=self._model_label,
-                cwd=self._cwd,
-                branch=self._branch,
-                session=self._session_label(),
-                thinking=self._thinking_level(),
-                running=self._running(),
-            )
-        )
 
     def is_visible(self) -> bool:
         return self._statusline_settings.enabled

--- a/tests/coding/test_ui_app.py
+++ b/tests/coding/test_ui_app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 
 
-def test_build_coding_tui_app_wires_prompt_handler_and_status() -> None:
+def test_build_coding_tui_app_wires_prompt_handler_without_legacy_status_api() -> None:
     from loushang.coding.ui.app import build_coding_tui_app
     from loushang.tui import CompletionItem, CompletionProvider
 
@@ -66,9 +66,8 @@ def test_build_coding_tui_app_wires_prompt_handler_and_status() -> None:
     assert result is None
     assert session.prompts == ["hello"]
     assert "worked:0.0" in emitted
-    assert "model=moonshot/kimi" in app.status()
-    assert "session=session-name" in app.status()
-    assert "thinking=high" in app.status()
+    assert not hasattr(app, "status")
+    assert not hasattr(app, "status_visible")
     assert "prompt.dispatch.start" in traces
     assert enabled_debug == []
     assert app.completion_provider is completion_provider
@@ -263,7 +262,7 @@ def test_build_coding_tui_app_renders_plain_settings_summary() -> None:
 
     assert result is None
     assert emitted == ["settings:show", "status:Settings\nStatus line: true"]
-    assert app.status_visible() is True
+    assert not hasattr(app, "status_visible")
 
 
 def test_build_coding_tui_app_wires_info_panel_presenter() -> None:

--- a/tests/coding/test_ui_status_provider.py
+++ b/tests/coding/test_ui_status_provider.py
@@ -1,45 +1,6 @@
 from __future__ import annotations
 
 
-def test_status_provider_renders_toolbar_snapshot_from_session_state() -> None:
-    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-
-    provider = CodingTuiStatusProvider(
-        model_label="moonshot/kimi",
-        cwd="/repo",
-        branch="main",
-        session_label=lambda: "session-name",
-        thinking_level=lambda: "high",
-        running=lambda: True,
-    )
-
-    status = provider.render()
-
-    assert "model=moonshot/kimi" in status
-    assert "cwd=/repo" in status
-    assert "branch=main" in status
-    assert "session=session-name" in status
-    assert "thinking=high" in status
-    assert "running" in status
-
-
-def test_status_provider_omits_missing_optional_values() -> None:
-    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-
-    provider = CodingTuiStatusProvider(
-        model_label=None,
-        cwd="/repo",
-        branch=None,
-        session_label=lambda: None,
-        thinking_level=lambda: None,
-        running=lambda: False,
-    )
-
-    status = provider.render()
-
-    assert status == "cwd=/repo"
-
-
 def test_status_provider_tracks_statusline_visibility() -> None:
     from loushang.coding.ui.status_line import StatusLineSettings
     from loushang.coding.ui.status_provider import CodingTuiStatusProvider


### PR DESCRIPTION
## Summary

Remove the unused plain UI legacy status render surface left behind after the status slash commands were deleted.

- drop `CodingTuiApp.status` and `CodingTuiApp.status_visible`
- remove `CodingTuiStatusProvider.render()` and its toolbar dependency
- keep plain `/settings` summary text and Status Line settings behavior intact

## Validation

- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_app.py tests/coding/test_ui_status_provider.py tests/coding/test_ui_toolbar.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding tests/coding`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests -q`
- `git diff --check`
