### PR TITLE
Scope plain toolbar

### DIFF
--- a/src/loushang/coding/ui/plain_toolbar.py
+++ b/src/loushang/coding/ui/plain_toolbar.py
@@ -7,7 +7,7 @@ from loushang.tui.text_utils import fixed_width
 
 
 @dataclass(frozen=True)
-class ToolbarSnapshot:
+class PlainToolbarSnapshot:
     model: str | None = None
     cwd: str | None = None
     branch: str | None = None
@@ -20,7 +20,7 @@ class ToolbarSnapshot:
     running: bool = False
 
 
-def render_toolbar(snapshot: ToolbarSnapshot, *, width: int | None = None) -> str:
+def render_plain_toolbar(snapshot: PlainToolbarSnapshot, *, width: int | None = None) -> str:
     parts: list[str] = []
     _append_part(parts, "model", snapshot.model)
     _append_part(parts, "cwd", snapshot.cwd)
@@ -45,4 +45,4 @@ def _append_part(parts: list[str], name: str, value: str | None) -> None:
         parts.append(f"{name}={value}")
 
 
-__all__ = ["ToolbarSnapshot", "render_toolbar"]
+__all__ = ["PlainToolbarSnapshot", "render_plain_toolbar"]

--- a/src/loushang/coding/ui/renderer.py
+++ b/src/loushang/coding/ui/renderer.py
@@ -6,8 +6,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TextIO
 
+from loushang.coding.ui.plain_toolbar import PlainToolbarSnapshot, render_plain_toolbar
 from loushang.coding.ui.tool_blocks import ToolTranscriptBlock
-from loushang.coding.ui.toolbar import ToolbarSnapshot, render_toolbar
 from loushang.coding.ui.transcript_projection import tool_block_to_record
 from loushang.tui import InfoPanel, RenderConstraints, RenderLine, RenderResult
 from loushang.tui.cell_width import strip_control_sequences
@@ -59,8 +59,8 @@ class CodingUiRenderer:
         del project_label
         self._write_line("Loushang TUI")
         self._write_line(
-            render_toolbar(
-                ToolbarSnapshot(
+            render_plain_toolbar(
+                PlainToolbarSnapshot(
                     model=model_label,
                     cwd=cwd,
                     branch=branch,

--- a/tests/coding/test_ui_plain_toolbar.py
+++ b/tests/coding/test_ui_plain_toolbar.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 
-def test_render_toolbar_omits_empty_fields() -> None:
-    from loushang.coding.ui.toolbar import ToolbarSnapshot, render_toolbar
+def test_render_plain_toolbar_omits_empty_fields() -> None:
+    from loushang.coding.ui.plain_toolbar import (
+        PlainToolbarSnapshot,
+        render_plain_toolbar,
+    )
 
-    snapshot = ToolbarSnapshot(
+    snapshot = PlainToolbarSnapshot(
         model="moonshot/kimi-for-coding",
         cwd="/repo",
         branch=None,
@@ -13,23 +16,26 @@ def test_render_toolbar_omits_empty_fields() -> None:
         running=True,
     )
 
-    assert render_toolbar(snapshot) == (
+    assert render_plain_toolbar(snapshot) == (
         "model=moonshot/kimi-for-coding | cwd=/repo | "
         "session=254d6156 | thinking=off | running"
     )
 
 
-def test_render_toolbar_can_return_single_fixed_width_line() -> None:
-    from loushang.coding.ui.toolbar import ToolbarSnapshot, render_toolbar
+def test_render_plain_toolbar_can_return_single_fixed_width_line() -> None:
+    from loushang.coding.ui.plain_toolbar import (
+        PlainToolbarSnapshot,
+        render_plain_toolbar,
+    )
 
-    snapshot = ToolbarSnapshot(
+    snapshot = PlainToolbarSnapshot(
         model="moonshot/kimi-for-coding",
         cwd="/a/very/long/repository/path",
         thinking="high",
         running=True,
     )
 
-    rendered = render_toolbar(snapshot, width=32)
+    rendered = render_plain_toolbar(snapshot, width=32)
 
     assert len(rendered) == 32
     assert rendered.startswith("model=moonshot/")


### PR DESCRIPTION
## Summary

Scope the remaining plain toolbar helper as a plain renderer implementation detail.

- rename `coding.ui.toolbar` to `coding.ui.plain_toolbar`
- rename `ToolbarSnapshot`/`render_toolbar` to `PlainToolbarSnapshot`/`render_plain_toolbar`
- update the plain renderer and tests to use the scoped names

## Validation

- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_toolbar.py tests/coding/test_ui_renderer.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding tests/coding`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests -q`
- `git diff --check`
