### PR TITLE
feat(tui): add DataGrid data adapters

### DIFF
--- a/docs/en/reference/tui-widgets.md
+++ b/docs/en/reference/tui-widgets.md
@@ -104,6 +104,20 @@ grid = DataGrid(
 grid.focus()
 ```
 
+For common data sources, `DataGrid` also has explicit adapter constructors.
+`from_records()` accepts mapping records and infers columns from first-seen key
+order. `from_json()` accepts JSON text, a top-level record list, or an object
+with a `records` list. `from_csv()` reads a header row with the standard
+library CSV parser and keeps CSV cell values as strings.
+
+```python
+grid = DataGrid.from_csv(
+    "symbol,price\nAAPL,196.45\nMSFT,421.10\n",
+    row_key_field="symbol",
+    cursor_mode="cell",
+)
+```
+
 In `cell` mode, printable text on an editable active cell starts editing.
 During editing, left/right move inside the edit buffer; Enter commits, Escape
 cancels, and Tab commits toward the next editable cell. Edit buffers render
@@ -429,3 +443,19 @@ implementation.
   inline toast stack with queue, dismissal, and clear actions.
 - [examples/tui/51_widgets_command_palette.py](../../../examples/tui/51_widgets_command_palette.py):
   searchable command palette with filtering, navigation, selection, and cancel.
+- [examples/tui/52_widgets_tabgroup_searchable_list.py](../../../examples/tui/52_widgets_tabgroup_searchable_list.py):
+  tabbed settings-style pages with searchable long lists.
+- [examples/tui/53_widgets_page_scaffold.py](../../../examples/tui/53_widgets_page_scaffold.py):
+  reusable page chrome with header, body, footer, and focus routing.
+- [examples/tui/54_widgets_settings_page_assembly.py](../../../examples/tui/54_widgets_settings_page_assembly.py):
+  settings page assembly using page, tabs, and searchable list widgets.
+- [examples/tui/55_widgets_tree_page_scaffold.py](../../../examples/tui/55_widgets_tree_page_scaffold.py):
+  tree view inside a reusable page scaffold.
+- [examples/tui/56_widgets_table_page_scaffold.py](../../../examples/tui/56_widgets_table_page_scaffold.py):
+  table view inside a reusable page scaffold.
+- [examples/tui/57_widgets_directory_tree.py](../../../examples/tui/57_widgets_directory_tree.py):
+  directory tree rendering and navigation.
+- [examples/tui/58_widgets_datagrid.py](../../../examples/tui/58_widgets_datagrid.py):
+  interactive DataGrid scenarios with editing, sorting, fixed columns, and mutation.
+- [examples/tui/59_widgets_datagrid_adapters.py](../../../examples/tui/59_widgets_datagrid_adapters.py):
+  DataGrid construction from records, JSON, and CSV sources.

--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/data-grid.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/data-grid.md
@@ -28,6 +28,20 @@ Rows can be explicit `DataGridRow` objects or shorthand mapping/list/tuple rows.
 Shorthand rows receive generated `row-<n>` keys; durable refresh state should
 use explicit keys.
 
+Convenience adapters are available when callers already have common data
+shapes:
+
+- `DataGrid.from_records(records, columns=None, row_key_field=None, **grid_options)`
+- `DataGrid.from_json(data, records_key="records", columns=None, row_key_field=None, **grid_options)`
+- `DataGrid.from_csv(data, columns=None, row_key_field=None, dialect="excel", csv_options=None, **grid_options)`
+
+`from_records()` accepts mapping records and infers columns from first-seen key
+order when columns are not supplied. `from_json()` accepts a JSON text payload,
+a top-level record list, or an object containing a `records` list. `from_csv()`
+uses `csv.DictReader`, expects a header row, and keeps cell values as strings.
+The adapters are thin constructor helpers; they do not infer numeric types,
+formatters, validators, or editing rules.
+
 ## Rendering
 
 Rendering owns:
@@ -104,8 +118,9 @@ Built-in formatters are display-only:
 - `DeltaFormatter`
 - `CompactNumberFormatter`
 
-They do not mutate state. CSV/JSON/DataFrame input adapters should remain a
-separate future adapter layer instead of implicit constructor guessing.
+They do not mutate state. Records, JSON, and CSV input adapters are explicit
+classmethods instead of implicit constructor guessing. DataFrame support remains
+future work and should not add a pandas dependency to the base TUI package.
 
 ## Theme Tokens
 

--- a/docs/zh-CN/reference/tui-widgets.md
+++ b/docs/zh-CN/reference/tui-widgets.md
@@ -101,6 +101,19 @@ grid = DataGrid(
 grid.focus()
 ```
 
+对于常见数据源，`DataGrid` 也提供显式 adapter 构造入口。
+`from_records()` 接受 mapping records，并按首次出现的 key 顺序推断列。
+`from_json()` 接受 JSON 文本、顶层 record list，或包含 `records` list 的对象。
+`from_csv()` 使用标准库 CSV parser 读取 header row，CSV 单元格值保持为字符串。
+
+```python
+grid = DataGrid.from_csv(
+    "symbol,price\nAAPL,196.45\nMSFT,421.10\n",
+    row_key_field="symbol",
+    cursor_mode="cell",
+)
+```
+
 在 `cell` 模式下，可编辑 active cell 上的可打印输入会直接进入编辑。
 编辑中左右键只移动编辑缓冲区内的光标；Enter 提交，Escape 取消，Tab
 提交并尝试进入下一个可编辑单元格。即使列的展示态是右对齐，编辑缓冲区
@@ -411,3 +424,19 @@ Dialog 会先处理 `escape` 和 `ctrl+c`，再委派给内部字段。body 焦�
   一个带队列、关闭和清空动作的内联 toast stack 示例。
 - [examples/tui/51_widgets_command_palette.py](../../../examples/tui/51_widgets_command_palette.py)：
   一个带过滤、导航、选择和取消行为的可搜索命令面板示例。
+- [examples/tui/52_widgets_tabgroup_searchable_list.py](../../../examples/tui/52_widgets_tabgroup_searchable_list.py)：
+  带 tab 和可搜索长列表的 settings 风格页面示例。
+- [examples/tui/53_widgets_page_scaffold.py](../../../examples/tui/53_widgets_page_scaffold.py)：
+  带 header、body、footer 和焦点路由的可复用页面脚手架示例。
+- [examples/tui/54_widgets_settings_page_assembly.py](../../../examples/tui/54_widgets_settings_page_assembly.py)：
+  使用 page、tabs 和 searchable list 组合 settings 页面。
+- [examples/tui/55_widgets_tree_page_scaffold.py](../../../examples/tui/55_widgets_tree_page_scaffold.py)：
+  将 tree view 放入可复用页面脚手架的示例。
+- [examples/tui/56_widgets_table_page_scaffold.py](../../../examples/tui/56_widgets_table_page_scaffold.py)：
+  将 table view 放入可复用页面脚手架的示例。
+- [examples/tui/57_widgets_directory_tree.py](../../../examples/tui/57_widgets_directory_tree.py)：
+  directory tree 渲染和导航示例。
+- [examples/tui/58_widgets_datagrid.py](../../../examples/tui/58_widgets_datagrid.py)：
+  展示编辑、排序、固定列和突变能力的交互式 DataGrid 示例。
+- [examples/tui/59_widgets_datagrid_adapters.py](../../../examples/tui/59_widgets_datagrid_adapters.py)：
+  从 records、JSON 和 CSV 数据源构造 DataGrid 的示例。

--- a/examples/tui/59_widgets_datagrid_adapters.py
+++ b/examples/tui/59_widgets_datagrid_adapters.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from loushang.tui import (
+    CursorDeclaration,
+    DataGrid,
+    DataGridColumn,
+    DeltaFormatter,
+    FocusableMixin,
+    InputEvent,
+    NumberFormatter,
+    PercentFormatter,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    ThemeResolver,
+    Tui,
+    TuiInputResult,
+    TuiRunner,
+    apply_theme_style,
+    normalize_key_id,
+    truncate_to_width,
+    visible_width,
+)
+
+LEFT_WIDTH = 22
+
+ADAPTER_THEME = ThemeResolver(
+    defaults={
+        "example.dataGrid.title": {"bold": True, "color": "cyan"},
+        "example.dataGrid.sidebar": {"color": "white"},
+        "example.dataGrid.sidebarActive": {"bold": True, "color": "cyan"},
+        "example.dataGrid.meta": {"color": "bright_black"},
+        "widget.dataGrid.header": {"color": "bright_black"},
+        "widget.dataGrid.row": {"color": "white"},
+        "widget.dataGrid.focusRow": {"bold": True, "color": "cyan"},
+        "widget.dataGrid.focusCell": {"bold": True, "color": "cyan"},
+        "widget.dataGrid.disabled": {"dim": True},
+        "widget.dataGrid.empty": {"color": "bright_black"},
+        "widget.dataGrid.positive": {"color": "green"},
+        "widget.dataGrid.negative": {"color": "red"},
+        "widget.dataGrid.neutral": {"color": "bright_black"},
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterScenario:
+    key: str
+    title: str
+    grid: DataGrid
+
+
+@dataclass(slots=True)
+class DataGridAdapterExampleApp(FocusableMixin):
+    scenarios: tuple[AdapterScenario, ...] = field(default_factory=tuple)
+    active_index: int = 0
+    focus_region: str = "sidebar"
+    status: str = "Records adapter"
+
+    def __post_init__(self) -> None:
+        FocusableMixin.__init__(self)
+        self.scenarios = (
+            AdapterScenario("1", "Records", _records_grid()),
+            AdapterScenario("2", "JSON", _json_grid()),
+            AdapterScenario("3", "CSV", _csv_grid()),
+        )
+        self.focus()
+
+    @property
+    def active_scenario(self) -> AdapterScenario:
+        return self.scenarios[self.active_index]
+
+    def focus(self) -> None:
+        self.focused = True
+        self._sync_grid_focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.active_scenario.grid.blur()
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        width = constraints.width
+        height = min(constraints.max_height, constraints.visible_height or constraints.max_height)
+        if height <= 0:
+            return RenderResult.from_lines([], constraints=constraints)
+
+        right_width = max(1, width - LEFT_WIDTH - 3)
+        body_height = max(1, height - 4)
+        grid_result = self.active_scenario.grid.render(RenderConstraints(width=right_width, max_height=body_height))
+        left_lines = self._sidebar_lines(body_height)
+        rows = [
+            RenderLine(_style(truncate_to_width("DataGrid adapter examples", max_width=width, ellipsis=""), "example.dataGrid.title")),
+            RenderLine(""),
+        ]
+        for index in range(body_height):
+            left = left_lines[index] if index < len(left_lines) else ""
+            right = grid_result.lines[index].text if index < len(grid_result.lines) else ""
+            rows.append(RenderLine(_combine(left, right, width=width)))
+        rows.append(RenderLine(""))
+        rows.append(RenderLine(_style(truncate_to_width(_footer(self), max_width=width, ellipsis=""), "example.dataGrid.meta")))
+
+        cursor = None
+        if self.focus_region == "grid" and grid_result.cursor is not None:
+            cursor = CursorDeclaration(row=2 + grid_result.cursor.row, column=LEFT_WIDTH + 3 + grid_result.cursor.column)
+        elif self.focus_region == "sidebar":
+            cursor = CursorDeclaration(row=2 + self.active_index, column=0)
+        return RenderResult.from_lines(rows[:height], constraints=constraints, cursor=cursor)
+
+    def handle_input(self, event: Any) -> object:
+        key = normalize_key_id(getattr(event, "key", "")) if getattr(event, "kind", "") == "key" else ""
+        if key == "tab":
+            self._set_focus_region("sidebar" if self.focus_region == "grid" else "grid")
+            return True
+        if self.focus_region == "sidebar":
+            return self._handle_sidebar_input(event, key)
+        if key == "escape":
+            self._set_focus_region("sidebar")
+            return True
+        return self.active_scenario.grid.handle_input(event)
+
+    def _handle_sidebar_input(self, event: Any, key: str) -> object:
+        if key == "up":
+            return self._move_sidebar(-1)
+        if key == "down":
+            return self._move_sidebar(1)
+        if key in {"enter", "right"}:
+            self._set_focus_region("grid")
+            return True
+        if getattr(event, "kind", "") == "text":
+            text = getattr(event, "text", "")
+            if text in {scenario.key for scenario in self.scenarios}:
+                self._select_scenario(text)
+                return True
+        return None
+
+    def _move_sidebar(self, delta: int) -> bool:
+        next_index = max(0, min(len(self.scenarios) - 1, self.active_index + delta))
+        if next_index == self.active_index:
+            return False
+        self.active_scenario.grid.blur()
+        self.active_index = next_index
+        self._sync_grid_focus()
+        self.status = f"{self.active_scenario.title} adapter"
+        return True
+
+    def _select_scenario(self, key: str) -> None:
+        for index, scenario in enumerate(self.scenarios):
+            if scenario.key == key:
+                self.active_scenario.grid.blur()
+                self.active_index = index
+                self._sync_grid_focus()
+                self.status = f"{scenario.title} adapter"
+                return
+
+    def _set_focus_region(self, region: str) -> None:
+        if region == self.focus_region:
+            return
+        self.focus_region = region
+        self._sync_grid_focus()
+        self.status = "Adapter list" if region == "sidebar" else self.active_scenario.title
+
+    def _sync_grid_focus(self) -> None:
+        if self.focused and self.focus_region == "grid":
+            self.active_scenario.grid.focus()
+        else:
+            self.active_scenario.grid.blur()
+
+    def _sidebar_lines(self, height: int) -> list[str]:
+        lines: list[str] = []
+        for index, scenario in enumerate(self.scenarios):
+            if index == self.active_index:
+                prefix = "> " if self.focus_region == "sidebar" else "* "
+            else:
+                prefix = "  "
+            text = truncate_to_width(f"{prefix}{scenario.key} {scenario.title}", max_width=LEFT_WIDTH, ellipsis="")
+            token = "example.dataGrid.sidebarActive" if index == self.active_index else "example.dataGrid.sidebar"
+            lines.append(_style(text, token))
+        while len(lines) < height:
+            lines.append("")
+        return lines
+
+
+def build_app() -> Tui:
+    tui = Tui()
+    app = DataGridAdapterExampleApp()
+    tui.add_child(app)
+    tui.set_focus(app)
+    return tui
+
+
+async def main() -> int:
+    tui = build_app()
+
+    async def on_input(event: InputEvent, context: Any) -> TuiInputResult:
+        if _should_quit(event):
+            return context.stop(0)
+        context.tui.handle_input(event)
+        return TuiInputResult()
+
+    return await TuiRunner(tui).run(on_input=on_input)
+
+
+def _records_grid() -> DataGrid:
+    return DataGrid.from_records(
+        (
+            {"symbol": "AAPL", "price": 213.41, "change": 2.18, "change_pct": 0.0103},
+            {"symbol": "MSFT", "price": 491.72, "change": -1.64, "change_pct": -0.0033},
+            {"symbol": "NVDA", "price": 142.83, "change": 0.0, "change_pct": 0.0},
+        ),
+        columns=_market_columns(),
+        row_key_field="symbol",
+        cursor_mode="cell",
+        fixed_columns=1,
+        theme=ADAPTER_THEME,
+        wrap_rows=False,
+    )
+
+
+def _json_grid() -> DataGrid:
+    return DataGrid.from_json(
+        {
+            "records": [
+                {"job": "Build", "status": "ready", "runs": 12},
+                {"job": "Deploy", "status": "blocked", "runs": 3},
+                {"job": "Archive", "status": "disabled", "runs": 0},
+            ]
+        },
+        columns=(
+            DataGridColumn("job", "Job", width=12),
+            DataGridColumn("status", "Status", width=12),
+            DataGridColumn("runs", "Runs", width=6, align="right"),
+        ),
+        row_key_field="job",
+        cursor_mode="row",
+        theme=ADAPTER_THEME,
+        wrap_rows=False,
+    )
+
+
+def _csv_grid() -> DataGrid:
+    return DataGrid.from_csv(
+        "symbol,price,change,change_pct\n"
+        "AAPL,213.41,2.18,0.0103\n"
+        "MSFT,491.72,-1.64,-0.0033\n"
+        "NVDA,142.83,0.0,0.0\n",
+        columns=_market_columns(),
+        row_key_field="symbol",
+        cursor_mode="cell",
+        fixed_columns=1,
+        theme=ADAPTER_THEME,
+        wrap_rows=False,
+    )
+
+
+def _market_columns() -> tuple[DataGridColumn, ...]:
+    return (
+        DataGridColumn("symbol", "Symbol", width=7),
+        DataGridColumn("price", "Price", width=9, align="right", formatter=NumberFormatter(precision=2)),
+        DataGridColumn(
+            "change",
+            "Change",
+            width=8,
+            align="right",
+            formatter=DeltaFormatter(precision=2),
+            theme_token_for_value=_delta_token,
+        ),
+        DataGridColumn(
+            "change_pct",
+            "Change %",
+            width=9,
+            align="right",
+            formatter=PercentFormatter(precision=2, sign=True),
+            theme_token_for_value=_delta_token,
+        ),
+    )
+
+
+def _delta_token(value: object) -> str | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number > 0:
+        return "widget.dataGrid.positive"
+    if number < 0:
+        return "widget.dataGrid.negative"
+    return "widget.dataGrid.neutral"
+
+
+def _combine(left: str, right: str, *, width: int) -> str:
+    left_text = truncate_to_width(left, max_width=LEFT_WIDTH, ellipsis="")
+    padding = " " * max(0, LEFT_WIDTH - visible_width(left_text))
+    return truncate_to_width(f"{left_text}{padding} | {right}", max_width=width, ellipsis="")
+
+
+def _style(text: str, token: str) -> str:
+    return apply_theme_style(text, ADAPTER_THEME.resolve(token))
+
+
+def _footer(app: DataGridAdapterExampleApp) -> str:
+    return truncate_to_width(
+        f"{app.active_scenario.title} | list: up/down, enter/right grid | tab panes | q quit | {app.status}",
+        max_width=120,
+        ellipsis="",
+    )
+
+
+def _should_quit(event: InputEvent) -> bool:
+    return (
+        event.kind == "key"
+        and event.key in {"q", "ctrl+c"}
+        or event.kind == "text"
+        and event.text.lower() == "q"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/loushang/tui/ui_parts/widgets/data_grid.py
+++ b/src/loushang/tui/ui_parts/widgets/data_grid.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, Sequence
+import csv
+import io
+import json
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from math import isfinite
-from typing import Literal
+from typing import Literal, TextIO
 
 from loushang.tui.cell_width import (
     autowrap_safe_width,
@@ -318,6 +321,53 @@ class DataGrid:
         self._active_column_key = self._repair_column_key(active_column_key)
         if self.cursor_mode == "cell":
             self._repair_active_cell()
+
+    @classmethod
+    def from_records(
+        cls,
+        records: Iterable[Mapping[str, object]],
+        *,
+        columns: Sequence[DataGridColumn] | None = None,
+        row_key_field: str | None = None,
+        **grid_options: object,
+    ) -> DataGrid:
+        normalized_records = _normalize_adapter_records(records)
+        grid_columns = tuple(columns) if columns is not None else _columns_from_records(normalized_records)
+        rows = _rows_from_records(normalized_records, row_key_field=row_key_field)
+        return cls(grid_columns, rows, **grid_options)
+
+    @classmethod
+    def from_json(
+        cls,
+        data: str | bytes | bytearray | Sequence[Mapping[str, object]] | Mapping[str, object],
+        *,
+        records_key: str = "records",
+        columns: Sequence[DataGridColumn] | None = None,
+        row_key_field: str | None = None,
+        **grid_options: object,
+    ) -> DataGrid:
+        payload = _json_payload(data)
+        records = _records_from_json_payload(payload, records_key=records_key)
+        return cls.from_records(records, columns=columns, row_key_field=row_key_field, **grid_options)
+
+    @classmethod
+    def from_csv(
+        cls,
+        data: str | TextIO,
+        *,
+        columns: Sequence[DataGridColumn] | None = None,
+        row_key_field: str | None = None,
+        dialect: str = "excel",
+        csv_options: Mapping[str, object] | None = None,
+        **grid_options: object,
+    ) -> DataGrid:
+        records, header_columns = _records_from_csv(data, dialect=dialect, csv_options=csv_options)
+        return cls.from_records(
+            records,
+            columns=columns if columns is not None else header_columns,
+            row_key_field=row_key_field,
+            **grid_options,
+        )
 
     @property
     def row_keys(self) -> tuple[str, ...]:
@@ -1501,6 +1551,111 @@ class DataGrid:
         clusters = tuple(grapheme_clusters(self._edit_buffer))
         cursor = max(0, min(self._edit_cursor, len(clusters)))
         return "".join(clusters[:cursor])
+
+
+def _normalize_adapter_records(records: Iterable[Mapping[str, object]]) -> tuple[dict[str, object], ...]:
+    if isinstance(records, (str, bytes)):
+        raise TypeError("DataGrid records must contain mappings")
+    normalized: list[dict[str, object]] = []
+    for record in records:
+        if not isinstance(record, Mapping):
+            raise TypeError("DataGrid records must contain mappings")
+        normalized.append(_string_key_record(record))
+    return tuple(normalized)
+
+
+def _string_key_record(record: Mapping[object, object]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in record.items():
+        text_key = str(key)
+        if text_key in result:
+            raise ValueError(f"duplicate record key after string conversion: {text_key!r}")
+        result[text_key] = value
+    return result
+
+
+def _columns_from_records(records: Sequence[Mapping[str, object]]) -> tuple[DataGridColumn, ...]:
+    keys: list[str] = []
+    seen: set[str] = set()
+    for record in records:
+        for key in record:
+            if key in seen:
+                continue
+            seen.add(key)
+            keys.append(key)
+    return tuple(_column_from_key(key) for key in keys)
+
+
+def _column_from_key(key: str) -> DataGridColumn:
+    return DataGridColumn(key, _header_from_key(key))
+
+
+def _header_from_key(key: str) -> str:
+    words = str(key).replace("_", " ").replace("-", " ").split()
+    return " ".join(word[:1].upper() + word[1:] for word in words) if words else str(key)
+
+
+def _rows_from_records(
+    records: Sequence[Mapping[str, object]],
+    *,
+    row_key_field: str | None,
+) -> tuple[DataGridRow | Mapping[str, object], ...]:
+    if row_key_field is None:
+        return tuple(records)
+    rows: list[DataGridRow] = []
+    key_field = str(row_key_field)
+    for index, record in enumerate(records):
+        if key_field not in record:
+            raise ValueError(f"row_key_field {key_field!r} is missing from record {index}")
+        rows.append(DataGridRow(str(record[key_field]), record))
+    return tuple(rows)
+
+
+def _json_payload(
+    data: str | bytes | bytearray | Sequence[Mapping[str, object]] | Mapping[str, object],
+) -> object:
+    if isinstance(data, (str, bytes, bytearray)):
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSON data: {exc.msg}") from exc
+    return data
+
+
+def _records_from_json_payload(payload: object, *, records_key: str) -> Sequence[Mapping[str, object]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, Mapping):
+        if records_key not in payload:
+            raise ValueError(f"JSON object must contain a {records_key!r} records key")
+        records = payload[records_key]
+        if not isinstance(records, list):
+            raise TypeError(f"JSON {records_key!r} value must be a list of records")
+        return records
+    raise TypeError("JSON data must be a list of records or an object containing records")
+
+
+def _records_from_csv(
+    data: str | TextIO,
+    *,
+    dialect: str,
+    csv_options: Mapping[str, object] | None,
+) -> tuple[tuple[Mapping[str, object], ...], tuple[DataGridColumn, ...]]:
+    stream = io.StringIO(data) if isinstance(data, str) else data
+    if not hasattr(stream, "read"):
+        raise TypeError("CSV data must be a string or text stream")
+    reader = csv.DictReader(stream, dialect=dialect, **dict(csv_options or {}))
+    if not reader.fieldnames:
+        raise ValueError("CSV input must include a header row")
+    fieldnames = tuple(str(field) for field in reader.fieldnames)
+    if any(not field for field in fieldnames):
+        raise ValueError("CSV header names must be non-empty")
+    records: list[Mapping[str, object]] = []
+    for row in reader:
+        if None in row:
+            raise ValueError("CSV row has more fields than the header")
+        records.append({str(key): "" if value is None else value for key, value in row.items()})
+    return tuple(records), tuple(_column_from_key(field) for field in fieldnames)
 
 
 def _normalize_columns(columns: Sequence[DataGridColumn]) -> tuple[DataGridColumn, ...]:

--- a/tests/tui/test_widgets_data_grid.py
+++ b/tests/tui/test_widgets_data_grid.py
@@ -94,6 +94,97 @@ def test_data_grid_normalizes_mapping_list_tuple_rows_and_cell_metadata() -> Non
     assert "Hidden" not in "\n".join(lines)
 
 
+def test_data_grid_from_records_infers_columns_and_preserves_first_seen_order() -> None:
+    grid = DataGrid.from_records(
+        [
+            {"symbol": "AAPL", "price": 196.45},
+            {"price": 421.10, "symbol": "MSFT", "change_pct": 0.014},
+        ],
+        cursor_mode="cell",
+    )
+
+    assert tuple(column.key for column in grid.columns) == ("symbol", "price", "change_pct")
+    assert tuple(column.header for column in grid.columns) == ("Symbol", "Price", "Change Pct")
+    assert grid.row_keys == ("row-0", "row-1")
+    assert grid.active_row_key == "row-0"
+    assert grid.active_column_key == "symbol"
+    assert grid.cell_value("row-0", "change_pct") == ""
+    assert grid.cell_value("row-1", "change_pct") == 0.014
+
+
+def test_data_grid_from_records_uses_explicit_columns_and_row_key_field() -> None:
+    grid = DataGrid.from_records(
+        [
+            {"id": "aapl", "symbol": "AAPL", "price": 196.45, "ignored": True},
+            {"id": "msft", "symbol": "MSFT", "price": 421.10, "ignored": True},
+        ],
+        columns=[
+            DataGridColumn("symbol", "Ticker"),
+            DataGridColumn("price", "Last", align="right", formatter=NumberFormatter(precision=2)),
+        ],
+        row_key_field="id",
+    )
+
+    assert tuple(column.header for column in grid.columns) == ("Ticker", "Last")
+    assert grid.row_keys == ("aapl", "msft")
+    assert grid.cell_value("aapl", "symbol") == "AAPL"
+    assert grid.cell_value("aapl", "price") == 196.45
+    assert grid.cell_value("aapl", "ignored") is None
+
+
+def test_data_grid_from_json_accepts_top_level_records_and_record_wrappers() -> None:
+    top_level = DataGrid.from_json('[{"job": "Build", "runs": 12}]')
+    wrapped = DataGrid.from_json({"records": [{"job": "Deploy", "runs": 3}]})
+
+    assert tuple(column.key for column in top_level.columns) == ("job", "runs")
+    assert top_level.cell_value("row-0", "job") == "Build"
+    assert wrapped.cell_value("row-0", "job") == "Deploy"
+    assert wrapped.cell_value("row-0", "runs") == 3
+
+
+def test_data_grid_from_csv_reads_headers_and_rows() -> None:
+    grid = DataGrid.from_csv(
+        "symbol,price,change_pct\nAAPL,196.45,0.014\nMSFT,421.10,-0.003\n",
+        row_key_field="symbol",
+    )
+
+    assert tuple(column.key for column in grid.columns) == ("symbol", "price", "change_pct")
+    assert grid.row_keys == ("AAPL", "MSFT")
+    assert grid.cell_value("AAPL", "price") == "196.45"
+    assert grid.cell_value("MSFT", "change_pct") == "-0.003"
+
+
+def test_data_grid_from_csv_accepts_csv_options_and_grid_options() -> None:
+    grid = DataGrid.from_csv(
+        "symbol;price\nAAPL;196.45\n",
+        csv_options={"delimiter": ";"},
+        cursor_mode="cell",
+        show_header=False,
+    )
+
+    assert tuple(column.key for column in grid.columns) == ("symbol", "price")
+    assert grid.cell_value("row-0", "price") == "196.45"
+    assert grid.cursor_mode == "cell"
+    assert grid.show_header is False
+
+
+def test_data_grid_adapters_reject_unsupported_shapes() -> None:
+    with pytest.raises(TypeError, match="records must contain mappings"):
+        DataGrid.from_records([{"job": "Build"}, ["Deploy"]])  # type: ignore[list-item]
+
+    with pytest.raises(ValueError, match="row_key_field"):
+        DataGrid.from_records([{"job": "Build"}], row_key_field="id")
+
+    with pytest.raises(ValueError, match="JSON"):
+        DataGrid.from_json("{")
+
+    with pytest.raises(ValueError, match="records"):
+        DataGrid.from_json({"items": [{"job": "Build"}]})
+
+    with pytest.raises(ValueError, match="header"):
+        DataGrid.from_csv("")
+
+
 def test_data_grid_applies_custom_formatter_results_to_rendered_text() -> None:
     def status_formatter(value: object) -> DataGridFormatResult:
         return DataGridFormatResult(text=f"[{value}]", theme_token="example.status")
@@ -822,6 +913,39 @@ def test_widgets_datagrid_example_imports() -> None:
     assert "DataGrid examples" in lines[0]
     assert any("Market watchlist" in line for line in lines)
     assert any("AAPL" in line for line in lines)
+
+
+def test_widgets_datagrid_adapter_example_imports() -> None:
+    namespace = runpy.run_path("examples/tui/59_widgets_datagrid_adapters.py", run_name="__test__")
+
+    build_app = namespace["build_app"]
+    app = build_app()
+    result = app.render(RenderConstraints(width=96, max_height=20))
+    lines = tuple(strip_control_sequences(line.text).rstrip() for line in result.lines)
+
+    assert callable(build_app)
+    assert "DataGrid adapter examples" in lines[0]
+    assert any("Records" in line for line in lines)
+    assert any("AAPL" in line for line in lines)
+
+
+def test_widgets_datagrid_adapter_example_playback_switches_sources() -> None:
+    frames = play_example(
+        "examples/tui/59_widgets_datagrid_adapters.py",
+        events=(
+            ("json", InputEvent(kind="key", key="down")),
+            ("csv", InputEvent(kind="key", key="down")),
+        ),
+        width=104,
+        height=20,
+    )
+
+    assert any("Records" in line for line in frames[0].lines)
+    assert any("AAPL" in line for line in frames[0].lines)
+    assert any("JSON" in line for line in frames[1].lines)
+    assert any("Deploy" in line for line in frames[1].lines)
+    assert any("CSV" in line for line in frames[2].lines)
+    assert any("MSFT" in line for line in frames[2].lines)
 
 
 def test_widgets_datagrid_example_playback_switches_scenarios() -> None:


### PR DESCRIPTION
## Summary
- add DataGrid.from_records, DataGrid.from_json, and DataGrid.from_csv constructor helpers
- document adapter behavior and keep DataFrame/pandas support as future work without a base dependency
- add a DataGrid adapter example that switches between records, JSON, and CSV sources

## Notes
- adapters are explicit classmethods; the DataGrid constructor still expects columns and rows
- CSV uses csv.DictReader and keeps CSV cell values as strings
- PR title intentionally has no [codex] prefix

## Validation
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/ui_parts/widgets/data_grid.py examples/tui/59_widgets_datagrid_adapters.py tests/tui/test_widgets_data_grid.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_data_grid.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_reference_docs.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q