### PR TITLE
Name coding plain renderer explicitly

### DIFF
--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, Sequence, TextIO
 
 from loushang.coding.ui.events import CodingUiEventRenderer
 from loushang.coding.ui.model import ensure_usable_session_model
-from loushang.coding.ui.renderer import CodingUiRenderer
+from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 from loushang.coding.work_shell import CodingWorkShell
 from loushang.work import EventLogBackend
 
@@ -38,7 +38,7 @@ async def run_prompt_command(
 ) -> int:
     """Run one product prompt and render the stable coding transcript."""
 
-    renderer = CodingUiRenderer(stdout=stdout, stderr=stderr)
+    renderer = PlainCodingUiRenderer(stdout=stdout, stderr=stderr)
     event_renderer = CodingUiEventRenderer(renderer, render_user_messages=False)
 
     def unsubscribe() -> None:
@@ -109,7 +109,7 @@ async def run_prompt_command(
 
 async def _run_turn(
     session: Any,
-    renderer: CodingUiRenderer,
+    renderer: PlainCodingUiRenderer,
     event_renderer: CodingUiEventRenderer,
     prompt: str,
     *,

--- a/src/loushang/coding/ui/app.py
+++ b/src/loushang/coding/ui/app.py
@@ -25,9 +25,9 @@ from loushang.coding.ui.model_list import (
     format_available_models,
     select_available_model,
 )
+from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 from loushang.coding.ui.prompt_dispatch import PromptDispatchHandler
 from loushang.coding.ui.prompt_result import PromptResultHandler
-from loushang.coding.ui.renderer import CodingUiRenderer
 from loushang.coding.ui.session_view import (
     is_running,
     session_error_message,
@@ -66,7 +66,7 @@ def build_coding_tui_app(
     *,
     runtime: Any,
     session: Any,
-    renderer: CodingUiRenderer,
+    renderer: PlainCodingUiRenderer,
     event_renderer: Any,
     stderr: TextIO,
     verbose: bool,

--- a/src/loushang/coding/ui/events.py
+++ b/src/loushang/coding/ui/events.py
@@ -4,13 +4,13 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from loushang.coding.tools import ToolDefinitionResolver
-from loushang.coding.ui.renderer import CodingUiRenderer, extract_text
+from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer, extract_text
 from loushang.coding.ui.tool_blocks import ToolCallSnapshot, ToolTranscriptProjector
 
 
 @dataclass
 class CodingUiEventRenderer:
-    renderer: CodingUiRenderer
+    renderer: PlainCodingUiRenderer
     tool_definition_resolver: ToolDefinitionResolver | None = None
     max_tool_body_lines: int = 8
     tool_calls: dict[str, ToolCallSnapshot] = field(default_factory=dict)

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -13,7 +13,7 @@ from loushang.coding.ui.completion import coding_inline_completion_provider
 from loushang.coding.ui.controller import CodingUiController, ControllerResult
 from loushang.coding.ui.events import CodingUiEventRenderer
 from loushang.coding.ui.intent import AbortIntent, QuitIntent, parse_prompt_intent
-from loushang.coding.ui.renderer import CodingUiRenderer
+from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 from loushang.coding.ui.run_context import (
     open_coding_tui_run_context,
     subscribe_session_events,
@@ -188,7 +188,7 @@ async def _run_plain_tui(
     stderr: TextIO,
     verbose: bool,
 ) -> int:
-    renderer = CodingUiRenderer(stdout=stdout, stderr=stderr, verbose=verbose)
+    renderer = PlainCodingUiRenderer(stdout=stdout, stderr=stderr, verbose=verbose)
     run_context = None
     try:
         snapshot = await load_coding_tui_startup_snapshot(runtime=runtime, session=session)

--- a/src/loushang/coding/ui/plain_renderer.py
+++ b/src/loushang/coding/ui/plain_renderer.py
@@ -35,7 +35,7 @@ from loushang.tui.transcript import (
 
 
 @dataclass
-class CodingUiRenderer:
+class PlainCodingUiRenderer:
     stdout: TextIO
     stderr: TextIO | None = None
     max_payload_chars: int = 1200
@@ -191,7 +191,7 @@ class CodingUiRenderer:
         view = TranscriptView(
             [record],
             verbose_errors=self.verbose,
-            # The coding renderer keeps its current plain terminal output by
+            # The plain renderer keeps its current terminal output by
             # default. The screen TUI path owns themed rendering.
             theme=self.transcript_theme or ThemeResolver(),
             capabilities=self.transcript_capabilities,
@@ -282,15 +282,15 @@ class CodingUiRenderer:
             constraints=constraints,
         )
 
-    def transcript_renderable(self) -> _CodingTranscriptRenderable | None:
+    def transcript_renderable(self) -> _PlainCodingTranscriptRenderable | None:
         if self.transcript_buffer is None:
             return None
-        return _CodingTranscriptRenderable(self)
+        return _PlainCodingTranscriptRenderable(self)
 
 
 @dataclass(frozen=True, slots=True)
-class _CodingTranscriptRenderable:
-    renderer: CodingUiRenderer
+class _PlainCodingTranscriptRenderable:
+    renderer: PlainCodingUiRenderer
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         return self.renderer.render_transcript(constraints)
@@ -342,4 +342,4 @@ def _coding_line(line: str, record: DisplayRecord) -> str:
     return line
 
 
-__all__ = ["CodingUiRenderer", "extract_text"]
+__all__ = ["PlainCodingUiRenderer", "extract_text"]

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -15,7 +15,24 @@ import sys
 importlib.import_module("loushang.coding.ui.screen_state")
 
 assert "loushang.coding.ui.mode" not in sys.modules
-assert "loushang.coding.ui.renderer" not in sys.modules
+assert "loushang.coding.ui.plain_renderer" not in sys.modules
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_old_coding_ui_renderer_module_is_removed() -> None:
+    result = _run_python_import_boundary_check(
+        """
+import importlib
+
+try:
+    importlib.import_module("loushang.coding.ui.renderer")
+except ModuleNotFoundError:
+    pass
+else:
+    raise AssertionError("loushang.coding.ui.renderer should be named plain_renderer")
 """
     )
 

--- a/tests/coding/test_ui_plain_renderer.py
+++ b/tests/coding/test_ui_plain_renderer.py
@@ -38,11 +38,11 @@ def _assistant(
     )
 
 
-def test_renderer_prints_header_and_user_message() -> None:
-    from loushang.coding.ui.renderer import CodingUiRenderer
+def test_plain_renderer_prints_header_and_user_message() -> None:
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    renderer = CodingUiRenderer(stdout=stdout)
+    renderer = PlainCodingUiRenderer(stdout=stdout)
 
     renderer.render_header(project_label="loushang", cwd="/repo", branch="main", session_label="254d6156", model_label="moonshot/kimi")
     renderer.render_user("hello")
@@ -57,10 +57,10 @@ def test_renderer_prints_header_and_user_message() -> None:
 
 def test_event_renderer_buffers_assistant_deltas_until_final_block() -> None:
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(CodingUiRenderer(stdout=stdout))
+    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle({"type": "message_start", "message": _assistant("")})
     event_renderer.handle(
@@ -86,10 +86,10 @@ def test_event_renderer_buffers_assistant_deltas_until_final_block() -> None:
 
 def test_event_renderer_renders_completed_assistant_markdown_without_raw_markers() -> None:
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(CodingUiRenderer(stdout=stdout))
+    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle({"type": "message_start", "message": _assistant("")})
     event_renderer.handle({"type": "message_end", "message": _assistant("**Important**\n\n- first\n- second")})
@@ -101,12 +101,12 @@ def test_event_renderer_renders_completed_assistant_markdown_without_raw_markers
     assert "**" not in output
 
 
-def test_renderer_can_render_generic_terminal_blocks() -> None:
-    from loushang.coding.ui.renderer import CodingUiRenderer
+def test_plain_renderer_can_render_generic_terminal_blocks() -> None:
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
     from loushang.tui.render import MarkdownBlock, RuleBlock, TextBlock
 
     stdout = StringIO()
-    renderer = CodingUiRenderer(stdout=stdout)
+    renderer = PlainCodingUiRenderer(stdout=stdout)
 
     renderer.render_terminal_blocks(
         [
@@ -122,10 +122,10 @@ def test_renderer_can_render_generic_terminal_blocks() -> None:
 
 def test_event_renderer_prints_assistant_error_from_message_end() -> None:
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(CodingUiRenderer(stdout=stdout))
+    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle(
         {
@@ -139,10 +139,10 @@ def test_event_renderer_prints_assistant_error_from_message_end() -> None:
 
 def test_event_renderer_prints_assistant_error_from_agent_end() -> None:
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(CodingUiRenderer(stdout=stdout))
+    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle(
         {
@@ -156,10 +156,10 @@ def test_event_renderer_prints_assistant_error_from_agent_end() -> None:
 
 def test_event_renderer_prints_user_message_start() -> None:
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(CodingUiRenderer(stdout=stdout))
+    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle(
         {
@@ -173,10 +173,10 @@ def test_event_renderer_prints_user_message_start() -> None:
 
 def test_event_renderer_aggregates_tool_lifecycle() -> None:
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(CodingUiRenderer(stdout=stdout))
+    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
     result: AgentToolResult[dict[str, object]] = AgentToolResult(content=[TextPart(type="text", text="ok")], details={})
 
     event_renderer.handle({"type": "tool_execution_start", "tool_call_id": "tc1", "tool_name": "read", "args": {"path": "README.md"}})
@@ -190,10 +190,10 @@ def test_event_renderer_aggregates_tool_lifecycle() -> None:
 
 def test_event_renderer_does_not_duplicate_tool_result_message_after_tool_end() -> None:
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(CodingUiRenderer(stdout=stdout))
+    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
     result: AgentToolResult[dict[str, object]] = AgentToolResult(content=[TextPart(type="text", text="ok")], details={})
     tool_result = ToolResultMessage(
         role="toolResult",
@@ -219,7 +219,7 @@ def test_event_renderer_renders_tool_block_with_bounded_result_preview() -> None
         ToolRenderResultOptions,
     )
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     async def execute(*args, **kwargs):  # pragma: no cover - renderer-only test helper
         raise AssertionError("not used")
@@ -241,7 +241,7 @@ def test_event_renderer_renders_tool_block_with_bounded_result_preview() -> None
     )
     stdout = StringIO()
     event_renderer = CodingUiEventRenderer(
-        CodingUiRenderer(stdout=stdout),
+        PlainCodingUiRenderer(stdout=stdout),
         tool_definition_resolver=lambda name: definition if name == "bash" else None,
         max_tool_body_lines=3,
     )
@@ -261,10 +261,10 @@ def test_event_renderer_renders_tool_block_with_bounded_result_preview() -> None
 
 def test_event_renderer_includes_failed_tool_error_summary() -> None:
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(CodingUiRenderer(stdout=stdout))
+    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
     result: AgentToolResult[dict[str, object]] = AgentToolResult(
         content=[TextPart(type="text", text='Validation failed for tool "write":\n  - path: is required')],
         details={},
@@ -276,25 +276,25 @@ def test_event_renderer_includes_failed_tool_error_summary() -> None:
     assert stdout.getvalue() == '• Edited write failed: Validation failed for tool "write":\n'
 
 
-def test_renderer_prints_worked_divider_to_terminal_width(monkeypatch) -> None:
-    from loushang.coding.ui import renderer as renderer_module
-    from loushang.coding.ui.renderer import CodingUiRenderer
+def test_plain_renderer_prints_worked_divider_to_terminal_width(monkeypatch) -> None:
+    from loushang.coding.ui import plain_renderer as renderer_module
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     monkeypatch.setattr(renderer_module.shutil, "get_terminal_size", lambda fallback: SimpleNamespace(columns=24))
     stdout = StringIO()
-    renderer = CodingUiRenderer(stdout=stdout)
+    renderer = PlainCodingUiRenderer(stdout=stdout)
 
     renderer.render_worked(1.25)
 
     assert stdout.getvalue() == "\n─ Worked for 1.2s ──────\n\n"
 
 
-def test_renderer_prints_interruption_and_concise_error_without_traceback() -> None:
-    from loushang.coding.ui.renderer import CodingUiRenderer
+def test_plain_renderer_prints_interruption_and_concise_error_without_traceback() -> None:
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
     stderr = StringIO()
-    renderer = CodingUiRenderer(stdout=stdout, stderr=stderr, verbose=False)
+    renderer = PlainCodingUiRenderer(stdout=stdout, stderr=stderr, verbose=False)
 
     renderer.render_interruption()
     renderer.render_error("boom")
@@ -309,22 +309,22 @@ def test_renderer_prints_interruption_and_concise_error_without_traceback() -> N
 
 def test_event_renderer_prints_retry_status() -> None:
     from loushang.coding.ui.events import CodingUiEventRenderer
-    from loushang.coding.ui.renderer import CodingUiRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(CodingUiRenderer(stdout=stdout))
+    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle({"type": "auto_retry_start", "attempt": 2, "max_attempts": 3, "delay_ms": 1000, "error_message": "rate limit"})
 
     assert stdout.getvalue() == "[retry] attempt 2/3 in 1000ms: rate limit\n"
 
 
-def test_renderer_can_project_assistant_markdown_through_transcript_view() -> None:
-    from loushang.coding.ui.renderer import CodingUiRenderer
+def test_plain_renderer_can_project_assistant_markdown_through_transcript_view() -> None:
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
     from loushang.tui.theme import ThemeResolver
 
     stdout = StringIO()
-    renderer = CodingUiRenderer(
+    renderer = PlainCodingUiRenderer(
         stdout=stdout,
         use_transcript_view=True,
         transcript_theme=ThemeResolver(defaults={"markdown.heading.level2": {"bold": True}}),
@@ -338,12 +338,12 @@ def test_renderer_can_project_assistant_markdown_through_transcript_view() -> No
     assert "##" not in output
 
 
-def test_renderer_can_project_tool_blocks_through_transcript_view() -> None:
-    from loushang.coding.ui.renderer import CodingUiRenderer
+def test_plain_renderer_can_project_tool_blocks_through_transcript_view() -> None:
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
     from loushang.coding.ui.tool_blocks import ToolTranscriptBlock
 
     stdout = StringIO()
-    renderer = CodingUiRenderer(stdout=stdout, use_transcript_view=True)
+    renderer = PlainCodingUiRenderer(stdout=stdout, use_transcript_view=True)
 
     renderer.render_tool_block(
         ToolTranscriptBlock(
@@ -359,12 +359,12 @@ def test_renderer_can_project_tool_blocks_through_transcript_view() -> None:
     assert stdout.getvalue() == "• Ran uv run pytest took 0.00s\n  $ uv run pytest\n  2 passed\n"
 
 
-def test_renderer_buffers_deltas_then_projects_final_assistant_record() -> None:
-    from loushang.coding.ui.renderer import CodingUiRenderer
+def test_plain_renderer_buffers_deltas_then_projects_final_assistant_record() -> None:
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
     from loushang.tui.theme import ThemeResolver
 
     stdout = StringIO()
-    renderer = CodingUiRenderer(
+    renderer = PlainCodingUiRenderer(
         stdout=stdout,
         use_transcript_view=True,
         transcript_theme=ThemeResolver(defaults={"markdown.heading.level2": {"bold": True}}),
@@ -380,8 +380,8 @@ def test_renderer_buffers_deltas_then_projects_final_assistant_record() -> None:
     assert "• Result" in stdout.getvalue()
 
 
-def test_renderer_collects_screen_transcript_without_stdout_writes() -> None:
-    from loushang.coding.ui.renderer import CodingUiRenderer
+def test_plain_renderer_collects_screen_transcript_without_stdout_writes() -> None:
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
     from loushang.tui import (
         RenderConstraints,
         TranscriptBuffer,
@@ -390,7 +390,7 @@ def test_renderer_collects_screen_transcript_without_stdout_writes() -> None:
 
     stdout = StringIO()
     buffer = TranscriptBuffer()
-    renderer = CodingUiRenderer(stdout=stdout, transcript_buffer=buffer)
+    renderer = PlainCodingUiRenderer(stdout=stdout, transcript_buffer=buffer)
 
     renderer.render_user("你好")
     renderer.begin_assistant()

--- a/tests/tui/test_import_boundaries.py
+++ b/tests/tui/test_import_boundaries.py
@@ -46,7 +46,7 @@ def test_loushang_tui_public_models_are_not_owned_by_compat_module() -> None:
 
 def test_import_boundary_check_does_not_replace_loaded_tui_classes() -> None:
     import loushang.coding.ui.command_list as command_list
-    import loushang.coding.ui.renderer as renderer
+    import loushang.coding.ui.plain_renderer as renderer
     from loushang.tui import CompletionItem
     from loushang.tui.render import MarkdownBlock
 


### PR DESCRIPTION
## Summary
- Rename `loushang.coding.ui.renderer` to `loushang.coding.ui.plain_renderer`.
- Rename `CodingUiRenderer` to `PlainCodingUiRenderer` and update plain-mode callers.
- Rename renderer tests and add an import-boundary check that the old module path is gone.

## Validation
- Red step: focused tests failed before source rename with missing `plain_renderer` and old `renderer` still importable.
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_renderer.py tests/coding/test_ui_import_boundaries.py tests/tui/test_import_boundaries.py -q` -> 29 passed
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_renderer.py tests/coding/test_ui_plain_toolbar.py tests/coding/test_ui_mode.py tests/coding/test_cli.py -k "tui or renderer or plain" tests/coding/test_ui_import_boundaries.py tests/tui/test_import_boundaries.py -q` -> 50 passed, 203 deselected
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding tests/coding tests/tui/test_import_boundaries.py` -> passed
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding -q` -> 2100 passed
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests -q` -> 3636 passed, 3 skipped
- `git diff --check` -> passed