### PR TITLE
refactor(tui): extract inline edit buffer

### DIFF
--- a/examples/tui/58_widgets_datagrid.py
+++ b/examples/tui/58_widgets_datagrid.py
@@ -113,7 +113,8 @@ class DataGridExampleApp(FocusableMixin):
             right = grid_result.lines[index].text if index < len(grid_result.lines) else ""
             rows.append(RenderLine(_combine(left, right, width=width)))
         rows.append(RenderLine(""))
-        rows.append(RenderLine(_style(truncate_to_width(_footer(self), max_width=width, ellipsis=""), "example.dataGrid.meta")))
+        footer_token = "widget.dataGrid.error" if self.active_scenario.grid.editing_error else "example.dataGrid.meta"
+        rows.append(RenderLine(_style(truncate_to_width(_footer(self), max_width=width, ellipsis=""), footer_token)))
         cursor = None
         if self.focus_region == "grid" and grid_result.cursor is not None:
             cursor = CursorDeclaration(row=2 + grid_result.cursor.row, column=LEFT_WIDTH + 3 + grid_result.cursor.column)
@@ -209,10 +210,17 @@ class DataGridExampleApp(FocusableMixin):
         row_key = grid.active_row_key
         if row_key is None or row_key == "total":
             return False
+        preferred_column = grid.active_column_key or "code"
+        editable_rows = tuple(key for key in grid.row_keys if key != "total")
+        deleted_index = editable_rows.index(row_key) if row_key in editable_rows else 0
         if not grid.remove_row(row_key):
             return False
         _ensure_order_entry_line(grid)
         _refresh_order_total(grid)
+        next_rows = tuple(key for key in grid.row_keys if key != "total")
+        if next_rows:
+            target_index = min(deleted_index, len(next_rows) - 1)
+            grid.activate_cell(next_rows[target_index], preferred_column)
         self.status = f"Deleted {row_key}"
         return True
 
@@ -232,18 +240,23 @@ class DataGridExampleApp(FocusableMixin):
 
 
 def build_app() -> Tui:
+    tui, _app = _build_app_parts()
+    return tui
+
+
+def _build_app_parts() -> tuple[Tui, DataGridExampleApp]:
     tui = Tui()
     app = DataGridExampleApp()
     tui.add_child(app)
     tui.set_focus(app)
-    return tui
+    return tui, app
 
 
 async def main() -> int:
-    tui = build_app()
+    tui, app = _build_app_parts()
 
     async def on_input(event: InputEvent, context: Any) -> TuiInputResult:
-        if _should_quit(event):
+        if _should_quit(event, app):
             return context.stop(0)
         context.tui.handle_input(event)
         return TuiInputResult()
@@ -296,7 +309,7 @@ def _order_grid() -> DataGrid:
         (
             DataGridColumn("code", "Code", width=8, editable=True, enter_behavior="edit", edit_next_column_key="qty"),
             DataGridColumn("name", "Name", width=12),
-            DataGridColumn("qty", "Qty", width=5, align="right", editable=True, parser=int),
+            DataGridColumn("qty", "Qty", width=5, align="right", editable=True, parser=_parse_qty),
             DataGridColumn("price", "Price", width=8, align="right", formatter=NumberFormatter(precision=2)),
             DataGridColumn("total", "Total", width=9, align="right", formatter=NumberFormatter(precision=2)),
         ),
@@ -443,6 +456,13 @@ def _style(text: str, token: str) -> str:
 
 
 def _footer(app: DataGridExampleApp) -> str:
+    error = app.active_scenario.grid.editing_error
+    if error:
+        return truncate_to_width(
+            f"{app.active_scenario.title} | Error: {error} | fix value, Enter retry, Esc cancel",
+            max_width=120,
+            ellipsis="",
+        )
     return truncate_to_width(
         f"{app.active_scenario.title} | tab panes | list: up/down, enter/right grid | grid: type/e edit, enter commit, delete/ctrl+d row | q quit | {app.status}",
         max_width=120,
@@ -450,12 +470,32 @@ def _footer(app: DataGridExampleApp) -> str:
     )
 
 
-def _should_quit(event: InputEvent) -> bool:
+def _parse_qty(text: str) -> int:
+    try:
+        value = int(text)
+    except ValueError as exc:
+        raise ValueError("Qty must be a whole number") from exc
+    if value < 0:
+        raise ValueError("Qty must be 0 or greater")
+    return value
+
+
+def _should_quit(event: InputEvent, app: DataGridExampleApp | None = None) -> bool:
+    if event.kind == "text" and _is_editing_cell(app):
+        return False
     return (
         event.kind == "key"
         and event.key in {"q", "ctrl+c"}
         or event.kind == "text"
         and event.text.lower() == "q"
+    )
+
+
+def _is_editing_cell(app: DataGridExampleApp | None) -> bool:
+    return (
+        app is not None
+        and app.focus_region == "grid"
+        and app.active_scenario.grid.editing_cell_key is not None
     )
 
 

--- a/src/loushang/tui/ui_parts/widgets/_inline_edit_buffer.py
+++ b/src/loushang/tui/ui_parts/widgets/_inline_edit_buffer.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.tui.cell_width import grapheme_clusters
+
+
+@dataclass(slots=True)
+class InlineEditBuffer:
+    text: str = ""
+    cursor: int = 0
+    selected: bool = False
+
+    @classmethod
+    def from_value(cls, value: object | None) -> InlineEditBuffer:
+        text = "" if value is None else str(value)
+        return cls(text=text, cursor=_grapheme_len(text), selected=True)
+
+    def insert_text(self, text: str) -> bool:
+        inserted = list(grapheme_clusters(text))
+        if self.selected:
+            self.replace(text)
+            return True
+        if not inserted:
+            return False
+        clusters = self._clusters()
+        cursor = self._clamped_cursor()
+        clusters[cursor:cursor] = inserted
+        self.text = "".join(clusters)
+        self.cursor = cursor + len(inserted)
+        return True
+
+    def replace(self, text: str) -> None:
+        self.text = text
+        self.cursor = _grapheme_len(text)
+        self.selected = False
+
+    def delete_backward(self) -> bool:
+        if self.selected:
+            self.replace("")
+            return True
+        clusters = self._clusters()
+        cursor = self._clamped_cursor()
+        if cursor <= 0:
+            return False
+        del clusters[cursor - 1]
+        self.text = "".join(clusters)
+        self.cursor = cursor - 1
+        return True
+
+    def delete_forward(self) -> bool:
+        if self.selected:
+            self.replace("")
+            return True
+        clusters = self._clusters()
+        cursor = self._clamped_cursor()
+        if cursor >= len(clusters):
+            return False
+        del clusters[cursor]
+        self.text = "".join(clusters)
+        self.cursor = cursor
+        return True
+
+    def move_left(self) -> bool:
+        return self.move(-1)
+
+    def move_right(self) -> bool:
+        return self.move(1)
+
+    def move(self, delta: int) -> bool:
+        if self.selected:
+            self.selected = False
+            self.cursor = 0 if delta < 0 else _grapheme_len(self.text)
+            return True
+        next_cursor = max(0, min(_grapheme_len(self.text), self.cursor + delta))
+        if next_cursor == self.cursor:
+            return False
+        self.cursor = next_cursor
+        return True
+
+    def move_home(self) -> bool:
+        self.selected = False
+        if self.cursor == 0:
+            return False
+        self.cursor = 0
+        return True
+
+    def move_end(self) -> bool:
+        self.selected = False
+        end = _grapheme_len(self.text)
+        if self.cursor == end:
+            return False
+        self.cursor = end
+        return True
+
+    def text_before_cursor(self) -> str:
+        clusters = self._clusters()
+        return "".join(clusters[: self._clamped_cursor()])
+
+    def _clusters(self) -> list[str]:
+        return list(grapheme_clusters(self.text))
+
+    def _clamped_cursor(self) -> int:
+        return max(0, min(self.cursor, _grapheme_len(self.text)))
+
+
+def _grapheme_len(text: str) -> int:
+    return len(tuple(grapheme_clusters(text)))

--- a/src/loushang/tui/ui_parts/widgets/data_grid.py
+++ b/src/loushang/tui/ui_parts/widgets/data_grid.py
@@ -11,7 +11,6 @@ from typing import Literal, TextIO
 
 from loushang.tui.cell_width import (
     autowrap_safe_width,
-    grapheme_clusters,
     truncate_to_width,
     visible_width,
 )
@@ -23,6 +22,7 @@ from loushang.tui.core import (
 )
 from loushang.tui.keybindings import normalize_key_id
 from loushang.tui.theme import ThemeResolver
+from loushang.tui.ui_parts.widgets._inline_edit_buffer import InlineEditBuffer
 from loushang.tui.ui_parts.widgets._utils import callback_result, style_text
 
 DataGridAlign = Literal["left", "right", "center"]
@@ -270,9 +270,7 @@ class DataGrid:
     _next_generated_index: int = field(default=0, init=False, repr=False)
     _first_visible_row_index: int = field(default=0, init=False, repr=False)
     _editing_cell_key: DataGridCellKey | None = field(default=None, init=False, repr=False)
-    _edit_buffer: str = field(default="", init=False, repr=False)
-    _edit_cursor: int = field(default=0, init=False, repr=False)
-    _edit_buffer_selected: bool = field(default=False, init=False, repr=False)
+    _edit_buffer: InlineEditBuffer | None = field(default=None, init=False, repr=False)
 
     def __init__(
         self,
@@ -312,9 +310,7 @@ class DataGrid:
         self._next_generated_index = 0
         self._first_visible_row_index = 0
         self._editing_cell_key = None
-        self._edit_buffer = ""
-        self._edit_cursor = 0
-        self._edit_buffer_selected = False
+        self._edit_buffer = None
         self._columns = _normalize_columns(self.columns)
         self._rows = self._normalize_rows(self.rows)
         self._active_row_key = self._repair_row_key(active_row_key)
@@ -719,9 +715,7 @@ class DataGrid:
             return False
         cell = row.cells[column.key]
         self._editing_cell_key = (row.key, column.key)
-        self._edit_buffer = "" if cell.value is None else str(cell.value)
-        self._edit_cursor = len(tuple(grapheme_clusters(self._edit_buffer)))
-        self._edit_buffer_selected = True
+        self._edit_buffer = InlineEditBuffer.from_value(cell.value)
         self.editing_error = None
         return True
 
@@ -729,9 +723,7 @@ class DataGrid:
         if self._editing_cell_key is None and self.editing_error is None:
             return False
         self._editing_cell_key = None
-        self._edit_buffer = ""
-        self._edit_cursor = 0
-        self._edit_buffer_selected = False
+        self._edit_buffer = None
         self.editing_error = None
         return True
 
@@ -756,8 +748,9 @@ class DataGrid:
             self.cancel_edit()
             return None
         old_value = row.cells[column_key].value
+        edit_text = "" if self._edit_buffer is None else self._edit_buffer.text
         try:
-            new_value = column.parser(self._edit_buffer) if column.parser is not None else self._edit_buffer
+            new_value = column.parser(edit_text) if column.parser is not None else edit_text
         except Exception as exc:
             self.editing_error = str(exc) or exc.__class__.__name__
             return None
@@ -777,14 +770,13 @@ class DataGrid:
         return result
 
     def _handle_editing_input(self, event: object) -> object:
+        buffer = self._edit_buffer
+        if buffer is None:
+            return None
         kind = getattr(event, "kind", "")
         if kind in {"text", "paste"}:
             text = getattr(event, "text", "")
-            if self._edit_buffer_selected:
-                self._replace_edit_buffer(text)
-                self._edit_buffer_selected = False
-            else:
-                self._insert_edit_text(text)
+            buffer.insert_text(text)
             self.editing_error = None
             return True
         if kind != "key":
@@ -797,29 +789,21 @@ class DataGrid:
         if key in {"up", "down", "pageUp", "pageDown"}:
             return False
         if key == "left":
-            return self._move_edit_cursor(-1)
+            return buffer.move_left()
         if key == "right":
-            return self._move_edit_cursor(1)
+            return buffer.move_right()
         if key == "home":
-            return self._move_edit_cursor_to_start()
+            return buffer.move_home()
         if key == "end":
-            return self._move_edit_cursor_to_end()
+            return buffer.move_end()
         if key in {"tab", "shift+tab"}:
             return self._commit_and_move_edit(-1 if key == "shift+tab" else 1)
         if key == "backspace":
-            if self._edit_buffer_selected:
-                self._replace_edit_buffer("")
-                self._edit_buffer_selected = False
-            else:
-                self._delete_edit_backward()
+            buffer.delete_backward()
             self.editing_error = None
             return True
         if key == "delete":
-            if self._edit_buffer_selected:
-                self._replace_edit_buffer("")
-                self._edit_buffer_selected = False
-            else:
-                self._delete_edit_forward()
+            buffer.delete_forward()
             self.editing_error = None
             return True
         return None
@@ -835,67 +819,6 @@ class DataGrid:
             and self._active_column_key is not None
             and self._is_editable_cell(self._active_row_key, self._active_column_key)
         )
-
-    def _replace_edit_buffer(self, text: str) -> None:
-        self._edit_buffer = text
-        self._edit_cursor = len(tuple(grapheme_clusters(text)))
-
-    def _insert_edit_text(self, text: str) -> None:
-        clusters = list(grapheme_clusters(self._edit_buffer))
-        inserted = list(grapheme_clusters(text))
-        if not inserted:
-            return
-        cursor = max(0, min(self._edit_cursor, len(clusters)))
-        clusters[cursor:cursor] = inserted
-        self._edit_buffer = "".join(clusters)
-        self._edit_cursor = cursor + len(inserted)
-
-    def _delete_edit_backward(self) -> bool:
-        clusters = list(grapheme_clusters(self._edit_buffer))
-        if self._edit_cursor <= 0:
-            return False
-        cursor = max(0, min(self._edit_cursor, len(clusters)))
-        del clusters[cursor - 1]
-        self._edit_buffer = "".join(clusters)
-        self._edit_cursor = cursor - 1
-        return True
-
-    def _delete_edit_forward(self) -> bool:
-        clusters = list(grapheme_clusters(self._edit_buffer))
-        cursor = max(0, min(self._edit_cursor, len(clusters)))
-        if cursor >= len(clusters):
-            return False
-        del clusters[cursor]
-        self._edit_buffer = "".join(clusters)
-        self._edit_cursor = cursor
-        return True
-
-    def _move_edit_cursor(self, delta: int) -> bool:
-        if self._edit_buffer_selected:
-            self._edit_buffer_selected = False
-            self._edit_cursor = 0 if delta < 0 else len(tuple(grapheme_clusters(self._edit_buffer)))
-            return True
-        length = len(tuple(grapheme_clusters(self._edit_buffer)))
-        next_cursor = max(0, min(length, self._edit_cursor + delta))
-        if next_cursor == self._edit_cursor:
-            return False
-        self._edit_cursor = next_cursor
-        return True
-
-    def _move_edit_cursor_to_start(self) -> bool:
-        self._edit_buffer_selected = False
-        if self._edit_cursor == 0:
-            return False
-        self._edit_cursor = 0
-        return True
-
-    def _move_edit_cursor_to_end(self) -> bool:
-        self._edit_buffer_selected = False
-        end = len(tuple(grapheme_clusters(self._edit_buffer)))
-        if self._edit_cursor == end:
-            return False
-        self._edit_cursor = end
-        return True
 
     def _commit_and_move_edit(self, delta: int) -> object:
         previous = self._editing_cell_key
@@ -1474,7 +1397,8 @@ class DataGrid:
         for column, width in zip(columns, widths, strict=True):
             cell = row.cells[column.key]
             if self._editing_cell_key == (row.key, column.key):
-                formatted = _FormattedCell(_edit_cell_display_text(self._edit_buffer, width), "widget.dataGrid.editing")
+                edit_text = "" if self._edit_buffer is None else self._edit_buffer.text
+                formatted = _FormattedCell(_edit_cell_display_text(edit_text, width), "widget.dataGrid.editing")
             else:
                 formatted = _format_grid_cell(cell.value, column)
             values.append(formatted.text)
@@ -1542,15 +1466,11 @@ class DataGrid:
                 continue
             cell = row.cells[column.key]
             if self._editing_cell_key == (row.key, column.key):
-                return start + min(width, visible_width(self._edit_text_before_cursor()))
+                edit_text = "" if self._edit_buffer is None else self._edit_buffer.text_before_cursor()
+                return start + min(width, visible_width(edit_text))
             text = _format_grid_cell(cell.value, column).text
             return start + _cell_content_offset(text, width, column.align)
         return start
-
-    def _edit_text_before_cursor(self) -> str:
-        clusters = tuple(grapheme_clusters(self._edit_buffer))
-        cursor = max(0, min(self._edit_cursor, len(clusters)))
-        return "".join(clusters[:cursor])
 
 
 def _normalize_adapter_records(records: Iterable[Mapping[str, object]]) -> tuple[dict[str, object], ...]:

--- a/tests/tui/test_widgets_data_grid.py
+++ b/tests/tui/test_widgets_data_grid.py
@@ -989,6 +989,55 @@ def test_widgets_datagrid_example_routes_text_to_grid_after_entering_right_pane(
     assert not any("AAPL" in line for line in frames[-1].lines)
 
 
+def test_widgets_datagrid_example_q_text_does_not_quit_while_editing_cell() -> None:
+    namespace = runpy.run_path("examples/tui/58_widgets_datagrid.py", run_name="__test__")
+    app = namespace["DataGridExampleApp"]()
+    should_quit = namespace["_should_quit"]
+
+    assert should_quit(InputEvent(kind="text", text="q"), app) is True
+
+    app.handle_input(InputEvent(kind="key", key="down"))
+    app.handle_input(InputEvent(kind="key", key="enter"))
+    app.handle_input(InputEvent(kind="key", key="enter"))
+    assert app.active_scenario.grid.editing_cell_key == ("line-2", "code")
+
+    assert should_quit(InputEvent(kind="text", text="q"), app) is False
+    assert should_quit(InputEvent(kind="key", key="ctrl+c"), app) is True
+
+
+def test_widgets_datagrid_example_qty_error_is_visible_and_clears_after_success() -> None:
+    namespace = runpy.run_path("examples/tui/58_widgets_datagrid.py", run_name="__test__")
+    app = namespace["DataGridExampleApp"]()
+
+    app.handle_input(InputEvent(kind="key", key="down"))
+    app.handle_input(InputEvent(kind="key", key="enter"))
+    grid = app.active_scenario.grid
+
+    app.handle_input(InputEvent(kind="text", text="C300"))
+    app.handle_input(InputEvent(kind="key", key="enter"))
+    assert grid.editing_cell_key == ("line-2", "qty")
+
+    app.handle_input(InputEvent(kind="text", text="q"))
+    app.handle_input(InputEvent(kind="key", key="enter"))
+
+    lines = plain_lines(app, width=120, height=24)
+    raw_lines = render_lines(app, width=120, height=24)
+    assert grid.editing_cell_key == ("line-2", "qty")
+    assert grid.editing_error == "Qty must be a whole number"
+    assert any("Error: Qty must be a whole number" in line for line in lines)
+    assert any("\x1b[31m" in line and "Error: Qty must be a whole number" in line for line in raw_lines)
+
+    app.handle_input(InputEvent(kind="key", key="backspace"))
+    app.handle_input(InputEvent(kind="text", text="3"))
+    app.handle_input(InputEvent(kind="key", key="enter"))
+
+    lines = plain_lines(app, width=120, height=24)
+    assert grid.editing_cell_key is None
+    assert grid.editing_error is None
+    assert not any("Error:" in line for line in lines)
+    assert grid.cell_value("line-2", "qty") == 3
+
+
 def test_widgets_datagrid_example_order_entry_lookup_total_and_adds_next_line() -> None:
     namespace = runpy.run_path("examples/tui/58_widgets_datagrid.py", run_name="__test__")
     app = namespace["DataGridExampleApp"]()
@@ -1035,6 +1084,7 @@ def test_widgets_datagrid_example_deletes_order_rows_from_navigation_state() -> 
     app.handle_input(InputEvent(kind="key", key="delete"))
 
     assert grid.row_keys == ("line-1", "line-3", "total")
+    assert (grid.active_row_key, grid.active_column_key) == ("line-3", "code")
     assert grid.cell_value("total", "total") == 39.0
 
 
@@ -1071,4 +1121,21 @@ def test_widgets_datagrid_example_ctrl_d_deletes_order_rows_from_navigation_stat
     app.handle_input(InputEvent(kind="key", key="ctrl+d"))
 
     assert grid.row_keys == ("line-1", "line-3", "total")
+    assert (grid.active_row_key, grid.active_column_key) == ("line-3", "code")
+    assert grid.cell_value("total", "total") == 39.0
+
+
+def test_widgets_datagrid_example_delete_last_order_row_focuses_previous_row() -> None:
+    namespace = runpy.run_path("examples/tui/58_widgets_datagrid.py", run_name="__test__")
+    app = namespace["DataGridExampleApp"]()
+
+    app.handle_input(InputEvent(kind="key", key="down"))
+    app.handle_input(InputEvent(kind="key", key="enter"))
+    grid = app.active_scenario.grid
+    assert (grid.active_row_key, grid.active_column_key) == ("line-2", "code")
+
+    app.handle_input(InputEvent(kind="key", key="delete"))
+
+    assert grid.row_keys == ("line-1", "total")
+    assert (grid.active_row_key, grid.active_column_key) == ("line-1", "code")
     assert grid.cell_value("total", "total") == 39.0

--- a/tests/tui/test_widgets_inline_edit_buffer.py
+++ b/tests/tui/test_widgets_inline_edit_buffer.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from loushang.tui.ui_parts.widgets._inline_edit_buffer import InlineEditBuffer
+
+
+def test_inline_edit_buffer_initial_value_is_selected_and_replaced_by_text() -> None:
+    buffer = InlineEditBuffer.from_value("123")
+
+    assert buffer.text == "123"
+    assert buffer.cursor == 3
+    assert buffer.selected is True
+
+    assert buffer.insert_text("9") is True
+
+    assert buffer.text == "9"
+    assert buffer.cursor == 1
+    assert buffer.selected is False
+
+
+def test_inline_edit_buffer_moves_and_edits_by_grapheme_clusters() -> None:
+    buffer = InlineEditBuffer("a🙂c", cursor=3)
+
+    assert buffer.move_left() is True
+    assert buffer.cursor == 2
+    assert buffer.insert_text("X") is True
+    assert buffer.text == "a🙂Xc"
+    assert buffer.cursor == 3
+    assert buffer.text_before_cursor() == "a🙂X"
+
+    assert buffer.delete_backward() is True
+    assert buffer.text == "a🙂c"
+    assert buffer.cursor == 2
+
+    assert buffer.delete_forward() is True
+    assert buffer.text == "a🙂"
+    assert buffer.cursor == 2
+
+
+def test_inline_edit_buffer_selected_delete_and_backspace_clear_text() -> None:
+    backspace_buffer = InlineEditBuffer.from_value("abc")
+    delete_buffer = InlineEditBuffer.from_value("abc")
+
+    assert backspace_buffer.delete_backward() is True
+    assert backspace_buffer.text == ""
+    assert backspace_buffer.cursor == 0
+    assert backspace_buffer.selected is False
+
+    assert delete_buffer.delete_forward() is True
+    assert delete_buffer.text == ""
+    assert delete_buffer.cursor == 0
+    assert delete_buffer.selected is False
+
+
+def test_inline_edit_buffer_selected_arrow_moves_to_edge_and_clears_selection() -> None:
+    buffer = InlineEditBuffer.from_value("abc")
+
+    assert buffer.move_left() is True
+    assert buffer.cursor == 0
+    assert buffer.selected is False
+
+    buffer = InlineEditBuffer.from_value("abc")
+
+    assert buffer.move_right() is True
+    assert buffer.cursor == 3
+    assert buffer.selected is False


### PR DESCRIPTION
## Summary
- extract DataGrid inline text editing state into a private InlineEditBuffer helper
- keep DataGrid editing behavior while reducing duplicated cursor/delete logic
- polish the DataGrid order-entry example: delete keeps adjacent focus, text q does not quit while editing, and Qty validation shows a red error footer

## Notes
- InlineEditBuffer is private and not exported as public widget API
- PR title intentionally has no [codex] prefix

## Validation
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/ui_parts/widgets/_inline_edit_buffer.py src/loushang/tui/ui_parts/widgets/data_grid.py examples/tui/58_widgets_datagrid.py tests/tui/test_widgets_inline_edit_buffer.py tests/tui/test_widgets_data_grid.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_data_grid.py tests/tui/test_widgets_inline_edit_buffer.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q