### PR TITLE
Name plain event renderer explicitly

### DIFF
--- a/docs/internals/architecture/coding/reports/2026-06-15-plain-screen-ui-boundary-audit.md
+++ b/docs/internals/architecture/coding/reports/2026-06-15-plain-screen-ui-boundary-audit.md
@@ -1,7 +1,8 @@
 # 2026-06-15 Plain And Screen UI Boundary Audit
 
 This report records the current `loushang.coding.ui` boundary after the screen UI
-naming cleanup and the explicit plain renderer naming cleanup.
+naming cleanup, the explicit plain renderer naming cleanup, and the explicit
+plain event projection naming cleanup.
 
 ## Scope
 
@@ -44,17 +45,17 @@ plain-specific:
 | --- | --- | --- |
 | `plain_renderer.py` | Renders stable line-oriented coding output and optional transcript records. | Keep. This is the plain surface renderer. |
 | `plain_toolbar.py` | Formats compact toolbar/status text for plain output. | Keep. This is plain output presentation. |
-| `events.py` | Projects session events into `PlainCodingUiRenderer`. | Rename to `plain_events.py`; rename `CodingUiEventRenderer` to `PlainCodingEventRenderer`. |
+| `plain_events.py` | Projects session events into `PlainCodingUiRenderer`. | Keep. This is the plain event projector. |
 | `app.py` | Builds the current plain prompt-loop app around shared handlers. | Rename to `plain_app.py`; rename `CodingTuiApp` to `PlainCodingTuiApp`; rename `build_coding_tui_app` to `build_plain_coding_tui_app`. |
 
 Evidence:
 
-- `events.py` imports `PlainCodingUiRenderer` and calls only plain rendering
+- `plain_events.py` imports `PlainCodingUiRenderer` and calls only plain rendering
   methods.
 - `app.py` requires `PlainCodingUiRenderer`, wires `CodingTuiHandlers`, and is
   used by `_run_plain_tui`.
 - `prompt_command.py` directly uses `PlainCodingUiRenderer` plus
-  `CodingUiEventRenderer` to render one-shot prompt output.
+  `PlainCodingEventRenderer` to render one-shot prompt output.
 
 ### Screen-Specific
 
@@ -136,23 +137,23 @@ Future changes should preserve this direction. Product-specific settings rows,
 status text, coding session labels, queue state, prompt intents, and playback
 scenarios should stay out of `loushang.tui`.
 
-## Recommended Cleanup Sequence
+## Cleanup Sequence
 
-### 1. Rename Plain Event Projection
+### Completed: Rename Plain Event Projection
 
-Make the event projection boundary explicit:
+The event projection boundary is explicit:
 
-- `src/loushang/coding/ui/events.py` -> `plain_events.py`
-- `CodingUiEventRenderer` -> `PlainCodingEventRenderer`
-- update imports in:
+- `src/loushang/coding/ui/plain_events.py`
+- `PlainCodingEventRenderer`
+- imports updated in:
   - `mode.py`
   - `prompt_command.py`
   - `tests/coding/test_ui_plain_renderer.py`
-- add an import-boundary assertion that `loushang.coding.ui.events` is removed
+- import-boundary assertion added for removed `loushang.coding.ui.events`
 
-This is low risk because the class already requires `PlainCodingUiRenderer`.
+This was low risk because the class already required `PlainCodingUiRenderer`.
 
-### 2. Rename Plain App Assembly
+### 1. Rename Plain App Assembly
 
 Make the plain prompt-loop app assembly explicit:
 
@@ -169,7 +170,7 @@ Make the plain prompt-loop app assembly explicit:
 This makes `screen_app.py` and `plain_app.py` symmetrical without changing
 runtime behavior.
 
-### 3. Hold Shared Handlers Stable
+### 2. Hold Shared Handlers Stable
 
 Do not rename these in the same pass:
 
@@ -184,7 +185,7 @@ They should remain neutral until a later audit proves they are plain-only. A
 premature rename would make the architecture look cleaner than the actual
 ownership model and could cause screen semantics to fork unnecessarily.
 
-### 4. Avoid New Subpackages For Now
+### 3. Avoid New Subpackages For Now
 
 Do not introduce `ui/plain/` and `ui/screen/` subpackages yet. The flat module
 layout with explicit `plain_*` and `screen_*` names is currently simpler:
@@ -210,7 +211,7 @@ This audit does not recommend:
 
 ## Validation For Follow-Up PRs
 
-For the two recommended rename PRs, use targeted red/green validation:
+For the remaining recommended rename PR, use targeted red/green validation:
 
 - import-boundary test for the removed old module name
 - focused plain renderer/app tests
@@ -228,7 +229,7 @@ git diff --check
 
 ## Recommendation
 
-Proceed with the rename sequence above as two small behavior-preserving PRs.
-Keep plain as a first-class capability, keep screen as the interactive shell,
-and keep `loushang.tui` clean by letting it provide reusable terminal components
-rather than product-specific coding UI surfaces.
+Proceed with the remaining plain app assembly rename as a small
+behavior-preserving PR. Keep plain as a first-class capability, keep screen as
+the interactive shell, and keep `loushang.tui` clean by letting it provide
+reusable terminal components rather than product-specific coding UI surfaces.

--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -5,8 +5,8 @@ import time
 import traceback
 from typing import Any, Mapping, Sequence, TextIO
 
-from loushang.coding.ui.events import CodingUiEventRenderer
 from loushang.coding.ui.model import ensure_usable_session_model
+from loushang.coding.ui.plain_events import PlainCodingEventRenderer
 from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 from loushang.coding.work_shell import CodingWorkShell
 from loushang.work import EventLogBackend
@@ -39,7 +39,7 @@ async def run_prompt_command(
     """Run one product prompt and render the stable coding transcript."""
 
     renderer = PlainCodingUiRenderer(stdout=stdout, stderr=stderr)
-    event_renderer = CodingUiEventRenderer(renderer, render_user_messages=False)
+    event_renderer = PlainCodingEventRenderer(renderer, render_user_messages=False)
 
     def unsubscribe() -> None:
         return None
@@ -110,7 +110,7 @@ async def run_prompt_command(
 async def _run_turn(
     session: Any,
     renderer: PlainCodingUiRenderer,
-    event_renderer: CodingUiEventRenderer,
+    event_renderer: PlainCodingEventRenderer,
     prompt: str,
     *,
     images: list[object] | None = None,

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -11,8 +11,8 @@ from loushang.coding.observability import disable_session_debug, enable_session_
 from loushang.coding.ui.app import build_coding_tui_app
 from loushang.coding.ui.completion import coding_inline_completion_provider
 from loushang.coding.ui.controller import CodingUiController, ControllerResult
-from loushang.coding.ui.events import CodingUiEventRenderer
 from loushang.coding.ui.intent import AbortIntent, QuitIntent, parse_prompt_intent
+from loushang.coding.ui.plain_events import PlainCodingEventRenderer
 from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 from loushang.coding.ui.run_context import (
     open_coding_tui_run_context,
@@ -192,7 +192,7 @@ async def _run_plain_tui(
     run_context = None
     try:
         snapshot = await load_coding_tui_startup_snapshot(runtime=runtime, session=session)
-        event_renderer = CodingUiEventRenderer(renderer, tool_definition_resolver=_tool_definition_resolver(session))
+        event_renderer = PlainCodingEventRenderer(renderer, tool_definition_resolver=_tool_definition_resolver(session))
         run_context = open_coding_tui_run_context(
             session=session,
             snapshot=snapshot,

--- a/src/loushang/coding/ui/plain_events.py
+++ b/src/loushang/coding/ui/plain_events.py
@@ -9,7 +9,7 @@ from loushang.coding.ui.tool_blocks import ToolCallSnapshot, ToolTranscriptProje
 
 
 @dataclass
-class CodingUiEventRenderer:
+class PlainCodingEventRenderer:
     renderer: PlainCodingUiRenderer
     tool_definition_resolver: ToolDefinitionResolver | None = None
     max_tool_body_lines: int = 8
@@ -146,4 +146,4 @@ def _is_intentional_abort_error(stop_reason: object, error_message: object) -> b
     } or "aborted" in normalized
 
 
-__all__ = ["CodingUiEventRenderer"]
+__all__ = ["PlainCodingEventRenderer"]

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -39,6 +39,23 @@ else:
     assert result.returncode == 0, result.stderr
 
 
+def test_old_coding_ui_events_module_is_removed() -> None:
+    result = _run_python_import_boundary_check(
+        """
+import importlib
+
+try:
+    importlib.import_module("loushang.coding.ui.events")
+except ModuleNotFoundError:
+    pass
+else:
+    raise AssertionError("loushang.coding.ui.events should be named plain_events")
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_coding_ui_does_not_depend_on_legacy_settings_list_primitives() -> None:
     forbidden = (
         "SettingItem",

--- a/tests/coding/test_ui_plain_renderer.py
+++ b/tests/coding/test_ui_plain_renderer.py
@@ -56,11 +56,11 @@ def test_plain_renderer_prints_header_and_user_message() -> None:
 
 
 def test_event_renderer_buffers_assistant_deltas_until_final_block() -> None:
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle({"type": "message_start", "message": _assistant("")})
     event_renderer.handle(
@@ -85,11 +85,11 @@ def test_event_renderer_buffers_assistant_deltas_until_final_block() -> None:
 
 
 def test_event_renderer_renders_completed_assistant_markdown_without_raw_markers() -> None:
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle({"type": "message_start", "message": _assistant("")})
     event_renderer.handle({"type": "message_end", "message": _assistant("**Important**\n\n- first\n- second")})
@@ -121,11 +121,11 @@ def test_plain_renderer_can_render_generic_terminal_blocks() -> None:
 
 
 def test_event_renderer_prints_assistant_error_from_message_end() -> None:
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle(
         {
@@ -138,11 +138,11 @@ def test_event_renderer_prints_assistant_error_from_message_end() -> None:
 
 
 def test_event_renderer_prints_assistant_error_from_agent_end() -> None:
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle(
         {
@@ -155,11 +155,11 @@ def test_event_renderer_prints_assistant_error_from_agent_end() -> None:
 
 
 def test_event_renderer_prints_user_message_start() -> None:
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle(
         {
@@ -172,11 +172,11 @@ def test_event_renderer_prints_user_message_start() -> None:
 
 
 def test_event_renderer_aggregates_tool_lifecycle() -> None:
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
     result: AgentToolResult[dict[str, object]] = AgentToolResult(content=[TextPart(type="text", text="ok")], details={})
 
     event_renderer.handle({"type": "tool_execution_start", "tool_call_id": "tc1", "tool_name": "read", "args": {"path": "README.md"}})
@@ -189,11 +189,11 @@ def test_event_renderer_aggregates_tool_lifecycle() -> None:
 
 
 def test_event_renderer_does_not_duplicate_tool_result_message_after_tool_end() -> None:
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
     result: AgentToolResult[dict[str, object]] = AgentToolResult(content=[TextPart(type="text", text="ok")], details={})
     tool_result = ToolResultMessage(
         role="toolResult",
@@ -218,7 +218,7 @@ def test_event_renderer_renders_tool_block_with_bounded_result_preview() -> None
         ToolRenderContext,
         ToolRenderResultOptions,
     )
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     async def execute(*args, **kwargs):  # pragma: no cover - renderer-only test helper
@@ -240,7 +240,7 @@ def test_event_renderer_renders_tool_block_with_bounded_result_preview() -> None
         render_result=render_result,
     )
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(
+    event_renderer = PlainCodingEventRenderer(
         PlainCodingUiRenderer(stdout=stdout),
         tool_definition_resolver=lambda name: definition if name == "bash" else None,
         max_tool_body_lines=3,
@@ -260,11 +260,11 @@ def test_event_renderer_renders_tool_block_with_bounded_result_preview() -> None
 
 
 def test_event_renderer_includes_failed_tool_error_summary() -> None:
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
     result: AgentToolResult[dict[str, object]] = AgentToolResult(
         content=[TextPart(type="text", text='Validation failed for tool "write":\n  - path: is required')],
         details={},
@@ -308,11 +308,11 @@ def test_plain_renderer_prints_interruption_and_concise_error_without_traceback(
 
 
 def test_event_renderer_prints_retry_status() -> None:
-    from loushang.coding.ui.events import CodingUiEventRenderer
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 
     stdout = StringIO()
-    event_renderer = CodingUiEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
 
     event_renderer.handle({"type": "auto_retry_start", "attempt": 2, "max_attempts": 3, "delay_ms": 1000, "error_message": "rate limit"})
 


### PR DESCRIPTION
## Summary

- Renames the plain session event projector from `events.py` / `CodingUiEventRenderer` to `plain_events.py` / `PlainCodingEventRenderer`.
- Updates plain TUI and prompt-command imports to use the explicit plain event projector.
- Adds an import-boundary regression that the old `loushang.coding.ui.events` module is gone and updates the boundary audit report.

## Validation

- Red: `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_renderer.py tests/coding/test_ui_import_boundaries.py -q` failed before the rename with missing `plain_events` and old `events` still importable.
- Green: `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_renderer.py tests/coding/test_ui_import_boundaries.py -q` passed, 22 passed.
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_renderer.py tests/coding/test_ui_mode.py tests/coding/test_ui_import_boundaries.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_cli.py -k tui -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding tests/coding`
- `git diff --check`