### PR TITLE
feat(tui): add DataGrid column controls

### DIFF
--- a/docs/en/reference/tui-widgets.md
+++ b/docs/en/reference/tui-widgets.md
@@ -87,8 +87,9 @@ table.focus()
 
 `DataGrid` is the heavier data-control option. Use it when callers need cell
 focus, horizontal viewport behavior, fixed columns, pinned summary rows,
-selection, inline editing, sorting, or live row/cell mutation. `Table` remains
-the smaller row-focused control.
+selection, inline editing, sorting, live row/cell mutation, or column controls
+such as hide/show, move, and width changes. `Table` remains the smaller
+row-focused control.
 
 ```python
 from loushang.tui import DataGrid, DataGridColumn, DataGridRow, NumberFormatter

--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/data-grid.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/data-grid.md
@@ -100,6 +100,10 @@ The mutation API includes:
 - `remove_row()`
 - `add_column()`
 - `remove_column()`
+- `set_column_hidden()`
+- `toggle_column()`
+- `move_column()`
+- `set_column_width()`
 - `update_cell()`
 - `clear()`
 - `sort_by()`
@@ -107,6 +111,9 @@ The mutation API includes:
 
 Mutations repair active state and selection by key. `replace_rows()` preserves
 explicit keys when they still exist; shorthand replacement rows are new rows.
+Column controls hide and reveal columns without dropping cell data, reorder
+columns by key, and switch a column between fixed and flexible width. Hidden
+columns are skipped by rendering, navigation, editing, selection, and sorting.
 
 ## Formatters
 

--- a/docs/zh-CN/reference/tui-widgets.md
+++ b/docs/zh-CN/reference/tui-widgets.md
@@ -84,8 +84,8 @@ table.focus()
 ```
 
 `DataGrid` 是更重的 data control。需要单元格焦点、横向 viewport、固定列、
-pinned 汇总行、选择、内联编辑、排序或实时行/单元格突变时使用它；简单 active-row
-列表仍优先用 `Table`。
+pinned 汇总行、选择、内联编辑、排序、实时行/单元格突变，或隐藏/显示、移动、
+调整宽度这类列控制时使用它；简单 active-row 列表仍优先用 `Table`。
 
 ```python
 from loushang.tui import DataGrid, DataGridColumn, DataGridRow, NumberFormatter

--- a/examples/tui/59_widgets_datagrid_adapters.py
+++ b/examples/tui/59_widgets_datagrid_adapters.py
@@ -112,6 +112,10 @@ class DataGridAdapterExampleApp(FocusableMixin):
 
     def handle_input(self, event: Any) -> object:
         key = normalize_key_id(getattr(event, "key", "")) if getattr(event, "kind", "") == "key" else ""
+        if getattr(event, "kind", "") == "text" and self._handle_column_control(getattr(event, "text", "")):
+            return True
+        if key in {"[", "]", ",", "."} and self._handle_column_control(key):
+            return True
         if key == "tab":
             self._set_focus_region("sidebar" if self.focus_region == "grid" else "grid")
             return True
@@ -168,6 +172,63 @@ class DataGridAdapterExampleApp(FocusableMixin):
             self.active_scenario.grid.focus()
         else:
             self.active_scenario.grid.blur()
+
+    def _handle_column_control(self, action: str) -> bool:
+        if action == "v":
+            return self._toggle_change_percent_column()
+        if action == "[":
+            return self._adjust_price_width(-1)
+        if action == "]":
+            return self._adjust_price_width(1)
+        if action == ",":
+            return self._move_price_column(-1)
+        if action == ".":
+            return self._move_price_column(1)
+        return False
+
+    def _toggle_change_percent_column(self) -> bool:
+        grid = self.active_scenario.grid
+        column = _column_by_key(grid, "change_pct")
+        if column is None:
+            self.status = "No Change % column"
+            return True
+        grid.toggle_column("change_pct")
+        next_column = _column_by_key(grid, "change_pct")
+        state = "hidden" if next_column is not None and next_column.hidden else "visible"
+        self.status = f"Change % {state}"
+        return True
+
+    def _adjust_price_width(self, delta: int) -> bool:
+        grid = self.active_scenario.grid
+        column = _column_by_key(grid, "price")
+        if column is None:
+            self.status = "No Price column"
+            return True
+        width = column.width if column.width is not None else 9
+        grid.set_column_width("price", max(3, width + delta))
+        next_column = _column_by_key(grid, "price")
+        self.status = f"Price width {next_column.width if next_column is not None else width}"
+        return True
+
+    def _move_price_column(self, delta: int) -> bool:
+        grid = self.active_scenario.grid
+        visible = [column.key for column in grid.columns if not column.hidden]
+        if "price" not in visible:
+            self.status = "No visible Price column"
+            return True
+        position = visible.index("price")
+        next_position = max(0, min(len(visible) - 1, position + delta))
+        if next_position == position:
+            self.status = "Price column edge"
+            return True
+        target = visible[next_position]
+        moved = (
+            grid.move_column("price", before=target)
+            if next_position < position
+            else grid.move_column("price", after=target)
+        )
+        self.status = "Price column moved" if moved else "Price column unchanged"
+        return True
 
     def _sidebar_lines(self, height: int) -> list[str]:
         lines: list[str] = []
@@ -301,9 +362,16 @@ def _style(text: str, token: str) -> str:
     return apply_theme_style(text, ADAPTER_THEME.resolve(token))
 
 
+def _column_by_key(grid: DataGrid, key: str) -> DataGridColumn | None:
+    for column in grid.columns:
+        if column.key == key:
+            return column
+    return None
+
+
 def _footer(app: DataGridAdapterExampleApp) -> str:
     return truncate_to_width(
-        f"{app.active_scenario.title} | list: up/down, enter/right grid | tab panes | q quit | {app.status}",
+        f"{app.active_scenario.title} | v hide %, [/ ] width, ,/. move | tab panes | q quit | {app.status}",
         max_width=120,
         ellipsis="",
     )

--- a/src/loushang/tui/ui_parts/widgets/data_grid.py
+++ b/src/loushang/tui/ui_parts/widgets/data_grid.py
@@ -4,7 +4,7 @@ import csv
 import io
 import json
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from math import isfinite
 from typing import Literal, TextIO
@@ -1085,6 +1085,76 @@ class DataGrid:
         )
         if self._editing_cell_key is not None and self._editing_cell_key[1] == column_key:
             self.cancel_edit()
+        self._repair_state_after_data_change()
+        return True
+
+    def set_column_hidden(self, column_key: str, hidden: bool = True) -> bool:
+        column = self._column_by_key(column_key)
+        if column is None or column.hidden == hidden:
+            return False
+        if hidden and self._sort_state is not None and self._sort_state[0] == column.key:
+            self._sort_state = None
+        self._columns = tuple(replace(item, hidden=hidden) if item.key == column.key else item for item in self._columns)
+        self.columns = self._columns
+        if hidden and self._editing_cell_key is not None and self._editing_cell_key[1] == column.key:
+            self.cancel_edit()
+        self._repair_state_after_data_change()
+        return True
+
+    def toggle_column(self, column_key: str) -> bool:
+        column = self._column_by_key(column_key)
+        if column is None:
+            return False
+        return self.set_column_hidden(column.key, not column.hidden)
+
+    def move_column(
+        self,
+        column_key: str,
+        *,
+        index: int | None = None,
+        before: str | None = None,
+        after: str | None = None,
+    ) -> bool:
+        requested_targets = sum(target is not None for target in (index, before, after))
+        if requested_targets != 1:
+            return False
+        current = list(self._columns)
+        keys = [column.key for column in current]
+        if column_key not in keys:
+            return False
+        current_index = keys.index(column_key)
+        column = current.pop(current_index)
+        remaining_keys = [item.key for item in current]
+
+        if index is not None:
+            insert_at = max(0, min(index, len(current)))
+        elif before is not None:
+            if before == column_key or before not in remaining_keys:
+                return False
+            insert_at = remaining_keys.index(before)
+        else:
+            if after == column_key or after not in remaining_keys:
+                return False
+            insert_at = remaining_keys.index(str(after)) + 1
+
+        current.insert(insert_at, column)
+        next_columns = tuple(current)
+        if next_columns == self._columns:
+            return False
+        self._columns = next_columns
+        self.columns = self._columns
+        self._repair_state_after_data_change()
+        return True
+
+    def set_column_width(self, column_key: str, width: int | None) -> bool:
+        column = self._column_by_key(column_key)
+        if column is None:
+            return False
+        next_width = None if width is None else max(0, width)
+        if column.width == next_width:
+            return False
+        self._columns = tuple(replace(item, width=next_width) if item.key == column.key else item for item in self._columns)
+        self.columns = self._columns
         self._repair_state_after_data_change()
         return True
 

--- a/tests/tui/test_widgets_data_grid.py
+++ b/tests/tui/test_widgets_data_grid.py
@@ -882,6 +882,96 @@ def test_data_grid_mutation_apis_repair_state_and_selection() -> None:
     assert grid.sort_state is None
 
 
+def test_data_grid_column_visibility_controls_repair_active_state_and_selection() -> None:
+    grid = DataGrid(
+        [
+            DataGridColumn("code", "Code"),
+            DataGridColumn("qty", "Qty", editable=True, parser=int),
+            DataGridColumn("note", "Note"),
+        ],
+        [DataGridRow("line", {"code": "A1", "qty": 2, "note": "ready"})],
+        active_column_key="qty",
+        cursor_mode="cell",
+        selection_mode="multi",
+    )
+    grid.focus()
+
+    assert grid.select_cell("line", "qty") is True
+    assert grid.start_edit("line", "qty") is True
+    assert grid.set_column_hidden("qty") is True
+
+    assert tuple(column.hidden for column in grid.columns) == (False, True, False)
+    assert grid.active_column_key == "code"
+    assert grid.selected_cell_keys == frozenset()
+    assert grid.editing_cell_key is None
+    assert grid.sort_by("qty") is False
+    assert "Qty" not in "\n".join(plain_lines(grid, width=48, height=4))
+
+    assert grid.set_column_hidden("qty", False) is True
+    assert tuple(column.hidden for column in grid.columns) == (False, False, False)
+    assert grid.toggle_column("qty") is True
+    assert tuple(column.hidden for column in grid.columns) == (False, True, False)
+    assert grid.toggle_column("missing") is False
+
+
+def test_data_grid_hiding_all_columns_renders_empty_text() -> None:
+    grid = DataGrid(
+        [DataGridColumn("code", "Code"), DataGridColumn("qty", "Qty")],
+        [DataGridRow("line", {"code": "A1", "qty": 2})],
+        active_column_key="qty",
+        cursor_mode="cell",
+        empty_text="No visible columns",
+    )
+
+    assert grid.set_column_hidden("code") is True
+    assert grid.set_column_hidden("qty") is True
+
+    assert grid.active_column_key is None
+    assert plain_lines(grid, width=40, height=4) == ("No visible columns",)
+
+
+def test_data_grid_move_column_preserves_data_and_active_column_key() -> None:
+    grid = DataGrid(
+        [
+            DataGridColumn("symbol", "Symbol"),
+            DataGridColumn("price", "Price"),
+            DataGridColumn("change", "Change"),
+        ],
+        [DataGridRow("aapl", {"symbol": "AAPL", "price": 213.41, "change": 2.18})],
+        active_column_key="price",
+        cursor_mode="column",
+        fixed_columns=1,
+    )
+
+    assert grid.move_column("change", index=0) is True
+    assert tuple(column.key for column in grid.columns) == ("change", "symbol", "price")
+    assert grid.active_column_key == "price"
+    assert grid.cell_value("aapl", "price") == 213.41
+
+    assert grid.move_column("price", before="symbol") is True
+    assert tuple(column.key for column in grid.columns) == ("change", "price", "symbol")
+    assert grid.move_column("change", after="symbol") is True
+    assert tuple(column.key for column in grid.columns) == ("price", "symbol", "change")
+    assert grid.move_column("missing", index=0) is False
+    assert grid.move_column("price") is False
+
+
+def test_data_grid_set_column_width_updates_and_unsets_fixed_width() -> None:
+    grid = DataGrid(
+        [DataGridColumn("symbol", "Symbol"), DataGridColumn("price", "Price", width=9, align="right")],
+        [DataGridRow("aapl", {"symbol": "AAPL", "price": 213.41})],
+    )
+
+    assert grid.set_column_width("price", 4) is True
+    assert tuple(column.width for column in grid.columns) == (None, 4)
+    assert grid.set_column_width("price", 4) is False
+    assert grid.set_column_width("price", -2) is True
+    assert tuple(column.width for column in grid.columns) == (None, 0)
+    assert grid.set_column_width("price", None) is True
+    assert tuple(column.width for column in grid.columns) == (None, None)
+    assert grid.set_column_width("missing", 8) is False
+
+
 def test_data_grid_large_viewport_formats_only_visible_rows() -> None:
     formatted: list[int] = []
 
@@ -927,6 +1017,23 @@ def test_widgets_datagrid_adapter_example_imports() -> None:
     assert "DataGrid adapter examples" in lines[0]
     assert any("Records" in line for line in lines)
     assert any("AAPL" in line for line in lines)
+
+
+def test_widgets_datagrid_adapter_example_column_controls() -> None:
+    namespace = runpy.run_path("examples/tui/59_widgets_datagrid_adapters.py", run_name="__test__")
+
+    app = namespace["DataGridAdapterExampleApp"]()
+    grid = app.active_scenario.grid
+
+    assert app.handle_input(InputEvent(kind="text", text="v")) is True
+    assert next(column for column in grid.columns if column.key == "change_pct").hidden is True
+    assert "Change %" not in "\n".join(plain_lines(grid, width=72, height=8))
+
+    assert app.handle_input(InputEvent(kind="text", text="]")) is True
+    assert next(column for column in grid.columns if column.key == "price").width == 10
+
+    assert app.handle_input(InputEvent(kind="text", text=".")) is True
+    assert tuple(column.key for column in grid.columns) == ("symbol", "change", "price", "change_pct")
 
 
 def test_widgets_datagrid_adapter_example_playback_switches_sources() -> None:


### PR DESCRIPTION
## Summary
- add DataGrid column APIs to hide/show, move, and resize columns while preserving row data
- repair active state, editing state, selection, and sorting behavior when columns are hidden
- extend the DataGrid adapter example and docs to demonstrate column controls

## Test Plan
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/ui_parts/widgets/data_grid.py examples/tui/59_widgets_datagrid_adapters.py tests/tui/test_widgets_data_grid.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_widgets_data_grid.py tests/tui/test_widgets_reference_docs.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q