### PR TITLE
Name plain app assembly explicitly

### DIFF
--- a/docs/internals/architecture/coding/reports/2026-06-15-plain-screen-ui-boundary-audit.md
+++ b/docs/internals/architecture/coding/reports/2026-06-15-plain-screen-ui-boundary-audit.md
@@ -2,7 +2,7 @@
 
 This report records the current `loushang.coding.ui` boundary after the screen UI
 naming cleanup, the explicit plain renderer naming cleanup, and the explicit
-plain event projection naming cleanup.
+plain event projection and app assembly naming cleanups.
 
 ## Scope
 
@@ -46,13 +46,13 @@ plain-specific:
 | `plain_renderer.py` | Renders stable line-oriented coding output and optional transcript records. | Keep. This is the plain surface renderer. |
 | `plain_toolbar.py` | Formats compact toolbar/status text for plain output. | Keep. This is plain output presentation. |
 | `plain_events.py` | Projects session events into `PlainCodingUiRenderer`. | Keep. This is the plain event projector. |
-| `app.py` | Builds the current plain prompt-loop app around shared handlers. | Rename to `plain_app.py`; rename `CodingTuiApp` to `PlainCodingTuiApp`; rename `build_coding_tui_app` to `build_plain_coding_tui_app`. |
+| `plain_app.py` | Builds the current plain prompt-loop app around shared handlers. | Keep. This is the plain app assembly. |
 
 Evidence:
 
 - `plain_events.py` imports `PlainCodingUiRenderer` and calls only plain rendering
   methods.
-- `app.py` requires `PlainCodingUiRenderer`, wires `CodingTuiHandlers`, and is
+- `plain_app.py` requires `PlainCodingUiRenderer`, wires `CodingTuiHandlers`, and is
   used by `_run_plain_tui`.
 - `prompt_command.py` directly uses `PlainCodingUiRenderer` plus
   `PlainCodingEventRenderer` to render one-shot prompt output.
@@ -153,24 +153,22 @@ The event projection boundary is explicit:
 
 This was low risk because the class already required `PlainCodingUiRenderer`.
 
-### 1. Rename Plain App Assembly
+### Completed: Rename Plain App Assembly
 
-Make the plain prompt-loop app assembly explicit:
+The plain prompt-loop app assembly boundary is explicit:
 
-- `src/loushang/coding/ui/app.py` -> `plain_app.py`
-- `CodingTuiApp` -> `PlainCodingTuiApp`
-- `build_coding_tui_app` -> `build_plain_coding_tui_app`
-- update imports in:
+- `src/loushang/coding/ui/plain_app.py`
+- `PlainCodingTuiApp`
+- `build_plain_coding_tui_app`
+- imports updated in:
   - `mode.py`
-  - `tests/coding/test_ui_app.py`
-- consider renaming `tests/coding/test_ui_app.py` to
   `tests/coding/test_ui_plain_app.py`
-- add an import-boundary assertion that `loushang.coding.ui.app` is removed
+- import-boundary assertion added for removed `loushang.coding.ui.app`
 
 This makes `screen_app.py` and `plain_app.py` symmetrical without changing
 runtime behavior.
 
-### 2. Hold Shared Handlers Stable
+### 1. Hold Shared Handlers Stable
 
 Do not rename these in the same pass:
 
@@ -185,7 +183,7 @@ They should remain neutral until a later audit proves they are plain-only. A
 premature rename would make the architecture look cleaner than the actual
 ownership model and could cause screen semantics to fork unnecessarily.
 
-### 3. Avoid New Subpackages For Now
+### 2. Avoid New Subpackages For Now
 
 Do not introduce `ui/plain/` and `ui/screen/` subpackages yet. The flat module
 layout with explicit `plain_*` and `screen_*` names is currently simpler:
@@ -196,7 +194,7 @@ layout with explicit `plain_*` and `screen_*` names is currently simpler:
 - it still gives enough visual separation in file listings and tests.
 
 Revisit subpackages only if both surfaces continue to grow after the plain app
-and plain event renames.
+and plain event rename cleanups.
 
 ## Non-Goals
 
@@ -211,7 +209,7 @@ This audit does not recommend:
 
 ## Validation For Follow-Up PRs
 
-For the remaining recommended rename PR, use targeted red/green validation:
+For future rename PRs, use targeted red/green validation:
 
 - import-boundary test for the removed old module name
 - focused plain renderer/app tests
@@ -222,14 +220,14 @@ Suggested commands:
 
 ```bash
 uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_renderer.py tests/coding/test_ui_mode.py tests/coding/test_ui_import_boundaries.py -q
-uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_app.py tests/coding/test_cli.py -k tui -q
+uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_app.py tests/coding/test_cli.py -k tui -q
 uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding tests/coding
 git diff --check
 ```
 
 ## Recommendation
 
-Proceed with the remaining plain app assembly rename as a small
-behavior-preserving PR. Keep plain as a first-class capability, keep screen as
-the interactive shell, and keep `loushang.tui` clean by letting it provide
-reusable terminal components rather than product-specific coding UI surfaces.
+Treat the plain/screen naming cleanup as complete for the current flat module
+layout. Keep plain as a first-class capability, keep screen as the interactive
+shell, and keep `loushang.tui` clean by letting it provide reusable terminal
+components rather than product-specific coding UI surfaces.

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -8,10 +8,10 @@ from typing import Any, TextIO
 
 from loushang.ai.types import ImagePart
 from loushang.coding.observability import disable_session_debug, enable_session_debug
-from loushang.coding.ui.app import build_coding_tui_app
 from loushang.coding.ui.completion import coding_inline_completion_provider
 from loushang.coding.ui.controller import CodingUiController, ControllerResult
 from loushang.coding.ui.intent import AbortIntent, QuitIntent, parse_prompt_intent
+from loushang.coding.ui.plain_app import build_plain_coding_tui_app
 from loushang.coding.ui.plain_events import PlainCodingEventRenderer
 from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
 from loushang.coding.ui.run_context import (
@@ -201,7 +201,7 @@ async def _run_plain_tui(
             log_context_factory=log_context,
             trace=_trace,
         )
-        app = build_coding_tui_app(
+        app = build_plain_coding_tui_app(
             runtime=runtime,
             session=session,
             renderer=renderer,

--- a/src/loushang/coding/ui/plain_app.py
+++ b/src/loushang/coding/ui/plain_app.py
@@ -56,13 +56,13 @@ DisableDebug = Callable[[], None]
 
 
 @dataclass(frozen=True)
-class CodingTuiApp:
+class PlainCodingTuiApp:
     lifecycle: RunLifecycle
     handlers: CodingTuiHandlers
     completion_provider: CompletionProvider | None = None
 
 
-def build_coding_tui_app(
+def build_plain_coding_tui_app(
     *,
     runtime: Any,
     session: Any,
@@ -82,7 +82,7 @@ def build_coding_tui_app(
     model_palette_chooser: ModelPaletteChooser | None = None,
     command_palette_chooser: CommandPaletteChooser | None = None,
     info_panel_presenter: InfoPanelPresenter | None = None,
-) -> CodingTuiApp:
+) -> PlainCodingTuiApp:
     lifecycle = RunLifecycle()
     controller = CodingUiController(runtime=runtime, session=session, verbose=verbose)
     follow_up_queue = FollowUpQueueHandler(
@@ -168,11 +168,11 @@ def build_coding_tui_app(
         session_running=lambda: is_running(session),
         trace=trace,
     )
-    return CodingTuiApp(
+    return PlainCodingTuiApp(
         lifecycle=lifecycle,
         handlers=handlers,
         completion_provider=completion_provider,
     )
 
 
-__all__ = ["CodingTuiApp", "build_coding_tui_app"]
+__all__ = ["PlainCodingTuiApp", "build_plain_coding_tui_app"]

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -56,6 +56,23 @@ else:
     assert result.returncode == 0, result.stderr
 
 
+def test_old_coding_ui_app_module_is_removed() -> None:
+    result = _run_python_import_boundary_check(
+        """
+import importlib
+
+try:
+    importlib.import_module("loushang.coding.ui.app")
+except ModuleNotFoundError:
+    pass
+else:
+    raise AssertionError("loushang.coding.ui.app should be named plain_app")
+"""
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_coding_ui_does_not_depend_on_legacy_settings_list_primitives() -> None:
     forbidden = (
         "SettingItem",

--- a/tests/coding/test_ui_plain_app.py
+++ b/tests/coding/test_ui_plain_app.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 
 
-def test_build_coding_tui_app_wires_prompt_handler_without_legacy_status_api() -> None:
-    from loushang.coding.ui.app import build_coding_tui_app
+def test_build_plain_coding_tui_app_wires_prompt_handler_without_legacy_status_api() -> None:
+    from loushang.coding.ui.plain_app import build_plain_coding_tui_app
     from loushang.tui import CompletionItem, CompletionProvider
 
     emitted: list[str] = []
@@ -43,7 +43,7 @@ def test_build_coding_tui_app_wires_prompt_handler_without_legacy_status_api() -
         write()
 
     session = Session()
-    app = build_coding_tui_app(
+    app = build_plain_coding_tui_app(
         runtime=None,
         session=session,
         renderer=Renderer(),
@@ -73,9 +73,9 @@ def test_build_coding_tui_app_wires_prompt_handler_without_legacy_status_api() -
     assert app.completion_provider is completion_provider
 
 
-def test_build_coding_tui_app_wires_model_palette_chooser() -> None:
+def test_build_plain_coding_tui_app_wires_model_palette_chooser() -> None:
     from loushang.coding.types import ModelSelection
-    from loushang.coding.ui.app import build_coding_tui_app
+    from loushang.coding.ui.plain_app import build_plain_coding_tui_app
     from loushang.tui import CommandPalette
 
     emitted: list[str] = []
@@ -124,7 +124,7 @@ def test_build_coding_tui_app_wires_model_palette_chooser() -> None:
         return "openai/gpt-5.4"
 
     session = Session()
-    app = build_coding_tui_app(
+    app = build_plain_coding_tui_app(
         runtime=None,
         session=session,
         renderer=Renderer(),
@@ -150,10 +150,10 @@ def test_build_coding_tui_app_wires_model_palette_chooser() -> None:
     assert seen
 
 
-def test_build_coding_tui_app_wires_command_palette_chooser() -> None:
+def test_build_plain_coding_tui_app_wires_command_palette_chooser() -> None:
     from types import SimpleNamespace
 
-    from loushang.coding.ui.app import build_coding_tui_app
+    from loushang.coding.ui.plain_app import build_plain_coding_tui_app
     from loushang.tui import CommandPalette
 
     emitted: list[str] = []
@@ -187,7 +187,7 @@ def test_build_coding_tui_app_wires_command_palette_chooser() -> None:
         seen.append(palette)
         return "/demo"
 
-    app = build_coding_tui_app(
+    app = build_plain_coding_tui_app(
         runtime=None,
         session=Session(),
         renderer=Renderer(),
@@ -212,8 +212,8 @@ def test_build_coding_tui_app_wires_command_palette_chooser() -> None:
     assert seen and seen[0].title == "Commands"
 
 
-def test_build_coding_tui_app_renders_plain_settings_summary() -> None:
-    from loushang.coding.ui.app import build_coding_tui_app
+def test_build_plain_coding_tui_app_renders_plain_settings_summary() -> None:
+    from loushang.coding.ui.plain_app import build_plain_coding_tui_app
 
     emitted: list[str] = []
 
@@ -241,7 +241,7 @@ def test_build_coding_tui_app_renders_plain_settings_summary() -> None:
         emitted.append(label)
         write()
 
-    app = build_coding_tui_app(
+    app = build_plain_coding_tui_app(
         runtime=None,
         session=Session(),
         renderer=Renderer(),
@@ -265,8 +265,8 @@ def test_build_coding_tui_app_renders_plain_settings_summary() -> None:
     assert not hasattr(app, "status_visible")
 
 
-def test_build_coding_tui_app_wires_info_panel_presenter() -> None:
-    from loushang.coding.ui.app import build_coding_tui_app
+def test_build_plain_coding_tui_app_wires_info_panel_presenter() -> None:
+    from loushang.coding.ui.plain_app import build_plain_coding_tui_app
     from loushang.tui import InfoPanel
 
     emitted: list[str] = []
@@ -300,7 +300,7 @@ def test_build_coding_tui_app_wires_info_panel_presenter() -> None:
         seen.append(panel)
         return True
 
-    app = build_coding_tui_app(
+    app = build_plain_coding_tui_app(
         runtime=None,
         session=Session(),
         renderer=Renderer(),


### PR DESCRIPTION
## Summary

- Renames the plain prompt-loop app assembly from `app.py` / `CodingTuiApp` / `build_coding_tui_app` to `plain_app.py` / `PlainCodingTuiApp` / `build_plain_coding_tui_app`.
- Updates the plain TUI mode path and focused tests to use the explicit plain app boundary.
- Adds an import-boundary regression that the old `loushang.coding.ui.app` module is gone and updates the boundary audit report.

## Validation

- Red: `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_app.py tests/coding/test_ui_import_boundaries.py -q` failed before the rename with missing `plain_app` and old `app` still importable.
- Green: `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_app.py tests/coding/test_ui_import_boundaries.py -q` passed, 10 passed.
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_plain_app.py tests/coding/test_ui_mode.py tests/coding/test_ui_import_boundaries.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_cli.py -k tui -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding tests/coding`
- `git diff --check`