### PR TITLE
feat(tui): add DataGrid page navigation demo

### DIFF
--- a/docs/en/reference/tui-widgets.md
+++ b/docs/en/reference/tui-widgets.md
@@ -123,6 +123,8 @@ In `cell` mode, printable text on an editable active cell starts editing.
 During editing, left/right move inside the edit buffer; Enter commits, Escape
 cancels, and Tab commits toward the next editable cell. Edit buffers render
 left-aligned even for right-aligned display columns.
+Outside editing, `ctrl-f` and `ctrl-b` page forward and backward like
+`pageDown` and `pageUp`.
 
 ## P1B Text Controls
 

--- a/docs/internals/architecture/tui/native-terminal-core/ui-parts/data-grid.md
+++ b/docs/internals/architecture/tui/native-terminal-core/ui-parts/data-grid.md
@@ -71,6 +71,10 @@ Space is the selection input. Single selection replaces the current row/cell
 selection. Multi selection toggles rows, cells, or all enabled cells in the
 active column.
 
+`ctrl-f` and `ctrl-b` are DataGrid navigation aliases for `pageDown` and
+`pageUp` in non-editing row and cell modes. Editing cells keep the edit buffer
+focused; those shortcuts are not treated as grid paging while an edit is open.
+
 ## Editing
 
 Inline editing is intentionally text-based. `start_edit()` initializes the edit

--- a/docs/zh-CN/reference/tui-widgets.md
+++ b/docs/zh-CN/reference/tui-widgets.md
@@ -118,6 +118,7 @@ grid = DataGrid.from_csv(
 编辑中左右键只移动编辑缓冲区内的光标；Enter 提交，Escape 取消，Tab
 提交并尝试进入下一个可编辑单元格。即使列的展示态是右对齐，编辑缓冲区
 也会按左对齐渲染。
+非编辑状态下，`ctrl-f` 和 `ctrl-b` 分别等价于 `pageDown` 和 `pageUp`。
 
 ## P1B 文本控件
 

--- a/examples/tui/60_widgets_datagrid_large_dataset.py
+++ b/examples/tui/60_widgets_datagrid_large_dataset.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from math import ceil
+from typing import Any
+
+from loushang.tui import (
+    CursorDeclaration,
+    DataGrid,
+    DataGridColumn,
+    DataGridRow,
+    DeltaFormatter,
+    FocusableMixin,
+    InputEvent,
+    NumberFormatter,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    TextInput,
+    ThemeResolver,
+    Tui,
+    TuiInputResult,
+    TuiRunner,
+    apply_theme_style,
+    normalize_key_id,
+    strip_control_sequences,
+    truncate_to_width,
+    visible_width,
+)
+
+ROW_COUNT = 2_000
+DATA_GRID_THEME = ThemeResolver(
+    defaults={
+        "example.dataGrid.title": {"bold": True, "color": "cyan"},
+        "example.dataGrid.meta": {"color": "bright_black"},
+        "example.dataGrid.error": {"color": "red"},
+        "widget.dataGrid.header": {"color": "bright_black"},
+        "widget.dataGrid.row": {"color": "white"},
+        "widget.dataGrid.focusRow": {"bold": True, "color": "cyan"},
+        "widget.dataGrid.focusCell": {"bold": True, "color": "cyan"},
+        "widget.dataGrid.positive": {"color": "green"},
+        "widget.dataGrid.negative": {"color": "red"},
+        "widget.dataGrid.neutral": {"color": "bright_black"},
+    }
+)
+
+
+@dataclass(slots=True)
+class LargeDataGridExampleApp(FocusableMixin):
+    grid: DataGrid = field(default_factory=lambda: _large_grid(ROW_COUNT))
+    goto_input: TextInput = field(default_factory=lambda: TextInput(theme=DATA_GRID_THEME))
+    focus_region: str = "grid"
+    status: str = "Ready"
+    page_size: int = 1
+
+    def __post_init__(self) -> None:
+        FocusableMixin.__init__(self)
+        self.focus()
+
+    def focus(self) -> None:
+        self.focused = True
+        self._focus_grid()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.grid.blur()
+        self.goto_input.blur()
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        width = constraints.width
+        height = min(constraints.max_height, constraints.visible_height or constraints.max_height)
+        if height <= 0:
+            return RenderResult.from_lines([], constraints=constraints)
+
+        grid_height = max(1, height - 4)
+        self.page_size = max(1, grid_height - 1)
+        if self.focus_region == "grid":
+            self._sync_goto_value()
+
+        grid_result = self.grid.render(RenderConstraints(width=width, max_height=grid_height))
+        rows: list[RenderLine] = [
+            RenderLine(_style(truncate_to_width(f"Large DataGrid | {ROW_COUNT:,} rows", max_width=width, ellipsis=""), "example.dataGrid.title")),
+            RenderLine(_control_line(self, width)),
+            RenderLine(_style("-" * max(1, width), "example.dataGrid.meta")),
+        ]
+        grid_start = len(rows)
+        rows.extend(grid_result.lines[:grid_height])
+        while len(rows) < height - 1:
+            rows.append(RenderLine(""))
+        footer_token = "example.dataGrid.error" if self.status == "Invalid page" else "example.dataGrid.meta"
+        rows.append(RenderLine(_style(truncate_to_width(_footer(self), max_width=width, ellipsis=""), footer_token)))
+
+        cursor = None
+        if self.focus_region == "goto":
+            input_result = self.goto_input.render(RenderConstraints(width=_goto_field_width(self), max_height=1))
+            input_column = input_result.cursor.column if input_result.cursor else 0
+            cursor = CursorDeclaration(row=1, column=_goto_field_start(self) + input_column)
+        elif grid_result.cursor is not None:
+            cursor = CursorDeclaration(row=grid_start + grid_result.cursor.row, column=grid_result.cursor.column)
+        return RenderResult.from_lines(rows[:height], constraints=constraints, cursor=cursor)
+
+    def handle_input(self, event: Any) -> object:
+        key = normalize_key_id(getattr(event, "key", "")) if getattr(event, "kind", "") == "key" else ""
+        if self.focus_region == "goto":
+            if key == "enter":
+                return self._submit_page()
+            if key in {"escape", "down"}:
+                self._focus_grid()
+                self.status = "Ready"
+                return True
+            if key in {"tab", "shift+tab"}:
+                self._focus_grid()
+                return True
+            return self.goto_input.handle_input(event)
+
+        if key in {"tab", "ctrl+g", "ctrl-g", "ctrl_g"}:
+            self._focus_goto()
+            return True
+        if _is_page_forward(key):
+            return self._jump_pages(1)
+        if _is_page_backward(key):
+            return self._jump_pages(-1)
+
+        result = self.grid.handle_input(event)
+        if result is not None:
+            self.status = _page_status(self)
+            return True
+        return None
+
+    def _focus_grid(self) -> None:
+        self.focus_region = "grid"
+        self.goto_input.blur()
+        if self.focused:
+            self.grid.focus()
+
+    def _focus_goto(self) -> None:
+        self.focus_region = "goto"
+        self.grid.blur()
+        self.goto_input.focus()
+        self.goto_input.set_text(str(_current_page(self)))
+        self.goto_input.set_selection(0, len(self.goto_input.value))
+        self.status = "Enter page"
+
+    def _sync_goto_value(self) -> None:
+        value = str(_current_page(self))
+        if self.goto_input.value != value:
+            self.goto_input.set_text(value)
+
+    def _submit_page(self) -> bool:
+        raw_value = self.goto_input.value.strip()
+        try:
+            requested = int(raw_value)
+        except ValueError:
+            self.status = "Invalid page"
+            return True
+        self._go_to_page(requested)
+        self._focus_grid()
+        return True
+
+    def _jump_pages(self, delta: int) -> bool:
+        page = _current_page(self)
+        next_page = max(1, min(_total_pages(self), page + delta))
+        if next_page == page:
+            self.status = _page_status(self)
+            return False
+        self._go_to_page(next_page)
+        return True
+
+    def _go_to_page(self, page: int) -> None:
+        clamped_page = max(1, min(_total_pages(self), page))
+        row_index = (clamped_page - 1) * self.page_size
+        self.grid.activate_row(f"row-{row_index}")
+        self.status = f"Page {clamped_page}/{_total_pages(self)}"
+
+
+def build_app() -> Tui:
+    tui = Tui()
+    app = LargeDataGridExampleApp()
+    tui.add_child(app)
+    tui.set_focus(app)
+    return tui
+
+
+async def main() -> int:
+    tui = build_app()
+
+    async def on_input(event: InputEvent, context: Any) -> TuiInputResult:
+        if _should_quit(event):
+            return context.stop(0)
+        context.tui.handle_input(event)
+        return TuiInputResult()
+
+    return await TuiRunner(tui).run(on_input=on_input)
+
+
+def _large_grid(row_count: int) -> DataGrid:
+    return DataGrid(
+        _large_columns(),
+        tuple(_large_rows(row_count)),
+        cursor_mode="row",
+        fixed_columns=1,
+        theme=DATA_GRID_THEME,
+        wrap_rows=False,
+    )
+
+
+def _large_columns() -> tuple[DataGridColumn, ...]:
+    return (
+        DataGridColumn("id", "ID", width=6, align="right", formatter=NumberFormatter(precision=0)),
+        DataGridColumn("symbol", "Symbol", width=8),
+        DataGridColumn("sector", "Sector", width=12),
+        DataGridColumn("price", "Price", width=10, align="right", formatter=NumberFormatter(precision=2)),
+        DataGridColumn("change", "Change", width=9, align="right", formatter=DeltaFormatter(precision=2), theme_token_for_value=_delta_token),
+        DataGridColumn("volume", "Volume", width=11, align="right", formatter=NumberFormatter(precision=0, thousands=True)),
+        DataGridColumn("status", "Status", width=10),
+    )
+
+
+def _large_rows(row_count: int) -> tuple[DataGridRow, ...]:
+    sectors = ("AI", "Cloud", "Energy", "Fintech", "Health", "Industrial")
+    statuses = ("active", "watch", "review", "paused")
+    rows: list[DataGridRow] = []
+    for index in range(row_count):
+        rows.append(
+            DataGridRow(
+                f"row-{index}",
+                {
+                    "id": index + 1,
+                    "symbol": f"STK{index + 1:04d}",
+                    "sector": sectors[index % len(sectors)],
+                    "price": round(20.0 + (index % 137) * 1.17 + (index // 137) * 0.05, 2),
+                    "change": round(((index % 21) - 10) / 10, 2),
+                    "volume": 100_000 + index * 137,
+                    "status": statuses[index % len(statuses)],
+                },
+            )
+        )
+    return tuple(rows)
+
+
+def _delta_token(value: object) -> str | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number > 0:
+        return "widget.dataGrid.positive"
+    if number < 0:
+        return "widget.dataGrid.negative"
+    return "widget.dataGrid.neutral"
+
+
+def _control_line(app: LargeDataGridExampleApp, width: int) -> str:
+    input_width = _goto_field_width(app)
+    input_result = app.goto_input.render(RenderConstraints(width=input_width, max_height=1))
+    input_text = _pad_visible(input_result.lines[0].text if input_result.lines else "", input_width)
+    prefix = "> " if app.focus_region == "goto" else "  "
+    suffix = f"] / {_total_pages(app)}    Row {_active_row_number(app)}/{ROW_COUNT}    {app.status}"
+    return truncate_to_width(f"{prefix}Go to page: [{input_text}{suffix}", max_width=width, ellipsis="")
+
+
+def _footer(app: LargeDataGridExampleApp) -> str:
+    page = _current_page(app)
+    start = (page - 1) * app.page_size + 1
+    end = min(ROW_COUNT, page * app.page_size)
+    return (
+        f"Rows {start}-{end} of {ROW_COUNT} | Page {page}/{_total_pages(app)} | "
+        "PgUp/PgDn | Ctrl-B/Ctrl-F | Home/End | Tab/Ctrl-G page | q quit"
+    )
+
+
+def _goto_field_width(app: LargeDataGridExampleApp) -> int:
+    return max(4, len(str(_total_pages(app))) + 1)
+
+
+def _goto_field_start(app: LargeDataGridExampleApp) -> int:
+    prefix = "> " if app.focus_region == "goto" else "  "
+    return visible_width(f"{prefix}Go to page: [")
+
+
+def _pad_visible(text: str, width: int) -> str:
+    return f"{text}{' ' * max(0, width - visible_width(strip_control_sequences(text)))}"
+
+
+def _active_row_index(app: LargeDataGridExampleApp) -> int:
+    row_key = app.grid.active_row_key or "row-0"
+    try:
+        return max(0, min(ROW_COUNT - 1, int(row_key.rsplit("-", 1)[1])))
+    except (IndexError, ValueError):
+        return 0
+
+
+def _active_row_number(app: LargeDataGridExampleApp) -> int:
+    return _active_row_index(app) + 1
+
+
+def _current_page(app: LargeDataGridExampleApp) -> int:
+    return _active_row_index(app) // max(1, app.page_size) + 1
+
+
+def _total_pages(app: LargeDataGridExampleApp) -> int:
+    return max(1, ceil(ROW_COUNT / max(1, app.page_size)))
+
+
+def _page_status(app: LargeDataGridExampleApp) -> str:
+    return f"Page {_current_page(app)}/{_total_pages(app)}"
+
+
+def _is_page_forward(key: str) -> bool:
+    return key in {"pageDown", "ctrl+f", "ctrl-f"}
+
+
+def _is_page_backward(key: str) -> bool:
+    return key in {"pageUp", "ctrl+b", "ctrl-b"}
+
+
+def _style(text: str, token: str) -> str:
+    return apply_theme_style(text, DATA_GRID_THEME.resolve(token))
+
+
+def _should_quit(event: InputEvent) -> bool:
+    return (
+        event.kind == "key"
+        and event.key in {"q", "ctrl+c"}
+        or event.kind == "text"
+        and event.text.lower() == "q"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/loushang/tui/input.py
+++ b/src/loushang/tui/input.py
@@ -229,6 +229,7 @@ _CONTROL_KEY_MAP = {
     "\x04": "ctrl+d",
     "\x05": "ctrl+e",
     "\x06": "ctrl+f",
+    "\x07": "ctrl+g",
     "\x08": "backspace",
     "\x09": "tab",
     "\x0a": "ctrl+j",

--- a/src/loushang/tui/keybindings.py
+++ b/src/loushang/tui/keybindings.py
@@ -67,6 +67,7 @@ _ALIASES = {
     "ctrl_d": "ctrl+d",
     "ctrl_e": "ctrl+e",
     "ctrl_f": "ctrl+f",
+    "ctrl_g": "ctrl+g",
     "ctrl_j": "ctrl+j",
     "ctrl_k": "ctrl+k",
     "ctrl_o": "ctrl+o",

--- a/src/loushang/tui/ui_parts/widgets/data_grid.py
+++ b/src/loushang/tui/ui_parts/widgets/data_grid.py
@@ -429,6 +429,10 @@ class DataGrid:
         if self.cursor_mode == "none":
             return None
         key = normalize_key_id(getattr(event, "key", ""))
+        if key in {"ctrl+f", "ctrl-f"}:
+            key = "pageDown"
+        elif key in {"ctrl+b", "ctrl-b"}:
+            key = "pageUp"
         if key == "enter":
             if self._should_enter_start_edit():
                 return self.start_edit(str(self._active_row_key), str(self._active_column_key))
@@ -737,6 +741,23 @@ class DataGrid:
         self._active_row_key = row.key
         self._active_column_key = column.key
         return True
+
+    def activate_row(self, row_key: str) -> bool:
+        row = self._row_by_key(row_key)
+        if row is None or row.disabled or row.pinned is not None:
+            return False
+        was_editing = self._editing_cell_key is not None or self.editing_error is not None
+        self.cancel_edit()
+        changed = row.key != self._active_row_key
+        self._active_row_key = row.key
+        if self.cursor_mode == "cell":
+            next_column = self._nearest_enabled_column_in_row(row, self._active_column_key)
+            if next_column is None:
+                changed = self._repair_active_cell() or changed
+            else:
+                changed = next_column != self._active_column_key or changed
+                self._active_column_key = next_column
+        return changed or was_editing
 
     def commit_edit(self) -> DataGridEdit | None:
         if self._editing_cell_key is None:

--- a/tests/tui/test_input_routing.py
+++ b/tests/tui/test_input_routing.py
@@ -254,13 +254,14 @@ def test_input_reader_normalizes_arrow_escape_sequences() -> None:
 def test_input_reader_normalizes_common_editor_control_keys() -> None:
     reader = InputReader()
 
-    events = reader.feed("\x7f\x1b[3~\x01\x05\x0a\x0b\x0f\x15\x16\x17\x19\x1bu\x1br\x1by\x1b\r\x1b[13;2~\x1b[1;3A")
+    events = reader.feed("\x7f\x1b[3~\x01\x05\x07\x0a\x0b\x0f\x15\x16\x17\x19\x1bu\x1br\x1by\x1b\r\x1b[13;2~\x1b[1;3A")
 
     assert events == (
         InputEvent(kind="key", key="backspace"),
         InputEvent(kind="key", key="delete"),
         InputEvent(kind="key", key="ctrl+a"),
         InputEvent(kind="key", key="ctrl+e"),
+        InputEvent(kind="key", key="ctrl+g"),
         InputEvent(kind="key", key="ctrl+j"),
         InputEvent(kind="key", key="ctrl+k"),
         InputEvent(kind="key", key="ctrl+o"),

--- a/tests/tui/test_widgets_data_grid.py
+++ b/tests/tui/test_widgets_data_grid.py
@@ -262,6 +262,20 @@ def test_data_grid_row_navigation_wraps_when_enabled() -> None:
     assert grid.active_row_key == "build"
 
 
+def test_data_grid_row_mode_ctrl_f_and_ctrl_b_page_rows() -> None:
+    grid = DataGrid(
+        [DataGridColumn("job", "Job")],
+        [DataGridRow(f"row-{index}", {"job": f"Job {index}"}) for index in range(12)],
+        wrap_rows=False,
+    )
+
+    assert grid.active_row_key == "row-0"
+    assert grid.handle_input(InputEvent(kind="key", key="ctrl-f")) is True
+    assert grid.active_row_key == "row-5"
+    assert grid.handle_input(InputEvent(kind="key", key="ctrl-b")) is True
+    assert grid.active_row_key == "row-0"
+
+
 def test_data_grid_cell_mode_repairs_and_navigates_enabled_cells() -> None:
     grid = DataGrid(
         [
@@ -289,6 +303,22 @@ def test_data_grid_cell_mode_repairs_and_navigates_enabled_cells() -> None:
     assert (grid.active_row_key, grid.active_column_key) == ("b", "note")
     assert grid.handle_input(InputEvent(kind="key", key="home")) is True
     assert (grid.active_row_key, grid.active_column_key) == ("b", "qty")
+
+
+def test_data_grid_cell_mode_ctrl_f_and_ctrl_b_page_rows() -> None:
+    grid = DataGrid(
+        [DataGridColumn("code", "Code"), DataGridColumn("qty", "Qty")],
+        [DataGridRow(f"row-{index}", {"code": f"C{index}", "qty": index}) for index in range(12)],
+        active_column_key="qty",
+        cursor_mode="cell",
+        wrap_rows=False,
+    )
+
+    assert (grid.active_row_key, grid.active_column_key) == ("row-0", "qty")
+    assert grid.handle_input(InputEvent(kind="key", key="ctrl_f")) is True
+    assert (grid.active_row_key, grid.active_column_key) == ("row-5", "qty")
+    assert grid.handle_input(InputEvent(kind="key", key="ctrl_b")) is True
+    assert (grid.active_row_key, grid.active_column_key) == ("row-0", "qty")
 
 
 def test_data_grid_column_mode_moves_only_visible_columns() -> None:
@@ -584,6 +614,40 @@ def test_data_grid_activation_returns_callbacks_or_structured_targets() -> None:
         cursor_mode="column",
     )
     assert none_grid.handle_input(InputEvent(kind="key", key="enter")) is None
+
+
+def test_data_grid_activate_row_sets_active_row_and_repairs_cell_column() -> None:
+    row_grid = DataGrid(
+        [DataGridColumn("job", "Job")],
+        [
+            DataGridRow("summary", {"job": "Summary"}, pinned="top"),
+            DataGridRow("build", {"job": "Build"}),
+            DataGridRow("skip", {"job": "Skip"}, disabled=True),
+            DataGridRow("deploy", {"job": "Deploy"}),
+        ],
+    )
+
+    assert row_grid.activate_row("deploy") is True
+    assert row_grid.active_row_key == "deploy"
+    assert row_grid.activate_row("deploy") is False
+    assert row_grid.activate_row("summary") is False
+    assert row_grid.activate_row("skip") is False
+    assert row_grid.activate_row("missing") is False
+
+    cell_grid = DataGrid(
+        [DataGridColumn("code", "Code", editable=True), DataGridColumn("qty", "Qty")],
+        [
+            DataGridRow("a", {"code": "A", "qty": 1}),
+            DataGridRow("b", {"code": "B", "qty": DataGridCell(2, disabled=True)}),
+        ],
+        active_column_key="qty",
+        cursor_mode="cell",
+    )
+
+    assert cell_grid.start_edit("a", "code") is True
+    assert cell_grid.activate_row("b") is True
+    assert (cell_grid.active_row_key, cell_grid.active_column_key) == ("b", "code")
+    assert cell_grid.editing_cell_key is None
 
 
 def test_data_grid_single_selection_replaces_row_or_cell_targets() -> None:
@@ -1017,6 +1081,81 @@ def test_widgets_datagrid_adapter_example_imports() -> None:
     assert "DataGrid adapter examples" in lines[0]
     assert any("Records" in line for line in lines)
     assert any("AAPL" in line for line in lines)
+
+
+def test_widgets_datagrid_large_dataset_example_imports() -> None:
+    namespace = runpy.run_path("examples/tui/60_widgets_datagrid_large_dataset.py", run_name="__test__")
+
+    build_app = namespace["build_app"]
+    app = build_app()
+    result = app.render(RenderConstraints(width=100, max_height=24))
+    lines = tuple(strip_control_sequences(line.text).rstrip() for line in result.lines)
+
+    assert callable(build_app)
+    assert "Large DataGrid" in lines[0]
+    assert any("2,000 rows" in line for line in lines)
+    assert any("Go to page" in line for line in lines)
+    assert any("Rows 1-" in line for line in lines)
+
+
+def test_widgets_datagrid_large_dataset_go_to_page() -> None:
+    namespace = runpy.run_path("examples/tui/60_widgets_datagrid_large_dataset.py", run_name="__test__")
+
+    app = namespace["LargeDataGridExampleApp"]()
+    app.render(RenderConstraints(width=100, max_height=24))
+    page_size = app.page_size
+
+    assert app.handle_input(InputEvent(kind="key", key="ctrl+g")) is True
+    assert app.handle_input(InputEvent(kind="text", text="10")) is True
+    assert app.handle_input(InputEvent(kind="key", key="enter")) is True
+
+    assert app.grid.active_row_key == f"row-{(10 - 1) * page_size}"
+    assert app.focus_region == "grid"
+    assert "Page 10/" in app.status
+
+
+def test_widgets_datagrid_large_dataset_invalid_page_stays_in_input() -> None:
+    namespace = runpy.run_path("examples/tui/60_widgets_datagrid_large_dataset.py", run_name="__test__")
+
+    app = namespace["LargeDataGridExampleApp"]()
+    app.render(RenderConstraints(width=100, max_height=24))
+
+    assert app.handle_input(InputEvent(kind="key", key="ctrl+g")) is True
+    assert app.handle_input(InputEvent(kind="text", text="abc")) is True
+    assert app.handle_input(InputEvent(kind="key", key="enter")) is True
+
+    assert app.grid.active_row_key == "row-0"
+    assert app.focus_region == "goto"
+    assert app.status == "Invalid page"
+
+
+def test_widgets_datagrid_large_dataset_focus_shortcuts_and_input_width() -> None:
+    namespace = runpy.run_path("examples/tui/60_widgets_datagrid_large_dataset.py", run_name="__test__")
+
+    app = namespace["LargeDataGridExampleApp"]()
+    result = app.render(RenderConstraints(width=100, max_height=24))
+    lines = tuple(strip_control_sequences(line.text).rstrip() for line in result.lines)
+
+    assert app.handle_input(InputEvent(kind="text", text="g")) is None
+    assert app.focus_region == "grid"
+    assert "  Go to page: [1   ] / 106" in lines[1]
+    assert "g page" not in lines[-1]
+
+    assert app.handle_input(InputEvent(kind="key", key="ctrl_g")) is True
+    result = app.render(RenderConstraints(width=100, max_height=24))
+    lines = tuple(strip_control_sequences(line.text).rstrip() for line in result.lines)
+    assert app.focus_region == "goto"
+    assert lines[1].startswith("> Go to page:")
+
+    assert app.handle_input(InputEvent(kind="key", key="tab")) is True
+    assert app.focus_region == "grid"
+    assert app.handle_input(InputEvent(kind="key", key="tab")) is True
+    assert app.focus_region == "goto"
+
+    assert app.handle_input(InputEvent(kind="text", text="106")) is True
+    result = app.render(RenderConstraints(width=100, max_height=24))
+    lines = tuple(strip_control_sequences(line.text).rstrip() for line in result.lines)
+    assert "> Go to page: [106 ] / 106" in lines[1]
 
 
 def test_widgets_datagrid_adapter_example_column_controls() -> None:


### PR DESCRIPTION
## Summary
- add DataGrid ctrl-f/ctrl-b paging aliases and activate_row() for jump-style navigation
- add a 2,000-row DataGrid example with a go-to-page input, page status, and large viewport navigation
- normalize Ctrl+G input bytes so the example shortcut works in real terminals

## Test Plan
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/tui/input.py src/loushang/tui/keybindings.py src/loushang/tui/ui_parts/widgets/data_grid.py examples/tui/60_widgets_datagrid_large_dataset.py tests/tui/test_input_routing.py tests/tui/test_widgets_data_grid.py
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_input_routing.py tests/tui/test_widgets_data_grid.py tests/tui/test_widgets_reference_docs.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q

## Manual verification
- uv --cache-dir .uv-cache run --extra dev python examples/tui/60_widgets_datagrid_large_dataset.py
- Verified Tab/Ctrl-G focus the page input and 106 remains visible as [106 ] in an 80-column terminal