### PR TITLE
Guard screen UI naming boundaries

### DIFF
--- a/docs/internals/architecture/coding/ARD-006-tui-method-integration-constraints.md
+++ b/docs/internals/architecture/coding/ARD-006-tui-method-integration-constraints.md
@@ -144,7 +144,7 @@ for step in prepared_turns:
 # 但 TUI 的 running/abort/queue 状态与 method step 没有衔接
 ```
 
-原因：`NativeCodingEventProjector` 和 `CodingUiController` 假设一次交互运行对应一个 `session.prompt()` 生命周期。虽然 non-interactive CLI 已能按 step 调用多次 prompt 并写入 work log，但 TUI 的 running flag、active_task、pending queue、composer state、surface overlay 还没有与 plan/step attempt 生命周期对齐；直接遍历 `prepared_turns` 会让 abort/steer/retry 行为不可预测。
+原因：`ScreenCodingEventProjector` 和 `CodingUiController` 假设一次交互运行对应一个 `session.prompt()` 生命周期。虽然 non-interactive CLI 已能按 step 调用多次 prompt 并写入 work log，但 TUI 的 running flag、active_task、pending queue、composer state、surface overlay 还没有与 plan/step attempt 生命周期对齐；直接遍历 `prepared_turns` 会让 abort/steer/retry 行为不可预测。
 
 #### 禁止 D：通过 CLI 参数绕过互斥
 
@@ -189,11 +189,11 @@ def _method_runtime_error(args: CliArgs, *, effective_tui: bool) -> str | None:
 
 ## Rationale
 
-1. **TUI 当前假设单 prompt 生命周期**：`NativeCodingEventProjector`、`CodingUiController`、`NativeCodingTuiState` 都围绕一次 `session.prompt()` 设计。method 的多步骤 `prepared_turns` 打破这个假设。
+1. **TUI 当前假设单 prompt 生命周期**：`ScreenCodingEventProjector`、`CodingUiController`、`ScreenCodingTuiState` 都围绕一次 `session.prompt()` 设计。method 的多步骤 `prepared_turns` 打破这个假设。
 
-2. **Method 在 non-interactive path 已有窄 run protocol，但 TUI 尚未接入**：`CodingDomainApp.prepare_turns()` 可返回带 `method_id`、`plan_id`、`step_id`、step policy metadata 的 prepared turns；CLI 通过 work shell 逐步执行并记录 lifecycle。TUI 目前仍只能看到用户 prompt 与 session/native events，不能可靠呈现 plan/step attempt 边界。
+2. **Method 在 non-interactive path 已有窄 run protocol，但 TUI 尚未接入**：`CodingDomainApp.prepare_turns()` 可返回带 `method_id`、`plan_id`、`step_id`、step policy metadata 的 prepared turns；CLI 通过 work shell 逐步执行并记录 lifecycle。TUI 目前仍只能看到用户 prompt 与 session/screen events，不能可靠呈现 plan/step attempt 边界。
 
-3. **WorkEvent / WorkPlanRun projection 是 method UI 的正确中介层**：TUI 的 method status layer 不应直接消费 `MethodPlan` 或裸 `prepared_turns`，而应消费 `WorkEvent` / `WorkPlanRun` projection。底层 transcript/tool rendering 可在迁移期继续使用 native/session events，直到 channel/work 边界进一步稳定。
+3. **WorkEvent / WorkPlanRun projection 是 method UI 的正确中介层**：TUI 的 method status layer 不应直接消费 `MethodPlan` 或裸 `prepared_turns`，而应消费 `WorkEvent` / `WorkPlanRun` projection。底层 transcript/tool rendering 可在迁移期继续使用 screen/session events，直到 channel/work 边界进一步稳定。
 
 4. **禁止过渡方案比允许更关键**：每步重启 TUI、伪方法化、直接消费 prepared_turns 等方案看似能快速 demo，但会制造深层债务。用户一旦形成"TUI 支持 method"的预期，后续修正成本极高。
 
@@ -222,9 +222,9 @@ def _method_runtime_error(args: CliArgs, *, effective_tui: bool) -> str | None:
 ## Impacted Code
 
 - `src/loushang/coding/cli/__main__.py`（互斥检查保留）
-- `src/loushang/coding/ui/native_events.py`（未来需与 method status projection 明确边界）
+- `src/loushang/coding/ui/screen_events.py`（未来需与 method status projection 明确边界）
 - `src/loushang/coding/ui/controller.py`（未来需支持 step-level 干预）
-- `src/loushang/coding/ui/native_app.py`（未来需支持 method step 状态显示）
+- `src/loushang/coding/ui/screen_app.py`（未来需支持 method step 状态显示）
 - `src/loushang/coding/domain/app.py`（未来需暴露 method step 运行时状态）
 - `src/loushang/work/types.py`（需保持 WorkStep/WorkPlan lifecycle 与 deviation metadata schema 稳定）
 

--- a/docs/internals/architecture/coding/loushang-coding-key-mode-sequences.md
+++ b/docs/internals/architecture/coding/loushang-coding-key-mode-sequences.md
@@ -311,7 +311,7 @@ sequenceDiagram
   - `channel` 有长期价值
   - 但不是 `rpc mode` 的前置实现条件
 
-## 4. Native TUI / `interactive mode`
+## 4. Screen TUI / `interactive mode`
 
 ### Intent
 
@@ -327,7 +327,7 @@ sequenceDiagram
   autonumber
   participant User as Terminal User
   participant CLI as CLI / tui runner
-  participant App as NativeCodingApp
+  participant App as ScreenCodingApp
   participant Controller as CodingUiController
   participant Runtime as AgentSessionRuntime
   participant Session as AgentSession
@@ -336,7 +336,7 @@ sequenceDiagram
   User->>CLI: loushang --tui / interactive resume
   CLI->>Runtime: create / restore / switch session
   Runtime-->>CLI: Session
-  CLI->>App: create native coding app
+  CLI->>App: create screen coding app
   App->>TUI: render transcript / composer / surfaces
   User->>TUI: key input / paste / surface action
   TUI-->>App: InputEvent / intent

--- a/docs/internals/testing/screen-tui-playback.md
+++ b/docs/internals/testing/screen-tui-playback.md
@@ -1,6 +1,7 @@
-# Native TUI Playback Regression Tests
+# Screen TUI Playback Regression Tests
 
-Use `tests/coding/native_tui_playback.py` when a native TUI change can affect terminal behavior, not just pure component rendering.
+Use the `tests/coding/test_screen_tui_playback_*` tests when a screen TUI
+change can affect terminal behavior, not just pure component rendering.
 
 Good candidates include:
 
@@ -16,7 +17,9 @@ Good candidates include:
 - streaming product control flows that combine long transcripts, live assistant
   draft, follow-up queueing, steering, resize, surfaces, and abort
 
-Prefer focused component tests for pure rendering functions. Use the playback harness when the test needs a `NativeCodingTuiApp`, `TuiRuntime`, and `FakeTerminalPort` together.
+Prefer focused component tests for pure rendering functions. Use the playback
+harness when the test needs a `ScreenCodingTuiApp`, `TuiRuntime`, and
+`FakeTerminalPort` together.
 
 Useful assertions:
 

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -91,6 +91,45 @@ def test_coding_ui_does_not_depend_on_legacy_settings_list_primitives() -> None:
     assert offenders == []
 
 
+def test_active_coding_ui_surfaces_do_not_use_legacy_native_product_names() -> None:
+    forbidden = (
+        "NativeCoding",
+        "NativeSurface",
+        "NativeInput",
+        "src/loushang/coding/ui/native_",
+        "tests/coding/test_native_coding_tui",
+        "native_app",
+        "native_events",
+        "native_input",
+        "native_loop",
+        "native_state",
+        "native_surfaces",
+        "native_tui",
+        "test_native_tui",
+    )
+    offenders: list[str] = []
+    roots = (
+        Path("src/loushang/coding/ui"),
+        Path("tests/coding"),
+        Path("docs/internals/architecture/coding"),
+        Path("docs/internals/testing"),
+    )
+    for root in roots:
+        for path in root.rglob("*"):
+            if not path.is_file() or path.suffix not in {".py", ".md"}:
+                continue
+            if path.resolve() == Path(__file__).resolve():
+                continue
+            if "archive" in path.parts or "history" in path.parts:
+                continue
+            text = path.read_text(encoding="utf-8")
+            for token in forbidden:
+                if token in text:
+                    offenders.append(f"{path}:{token}")
+
+    assert offenders == []
+
+
 def _run_python_import_boundary_check(script: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     src_path = str(Path.cwd() / "src")

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 
+def test_testing_docs_use_screen_tui_playback_name() -> None:
+    assert Path("docs/internals/testing/screen-tui-playback.md").exists()
+    assert not Path("docs/internals/testing/native-tui-playback.md").exists()
+
+
 def test_testing_strategy_documents_composer_selection_manual_smoke() -> None:
     text = Path(
         "docs/internals/architecture/tui/native-terminal-core/testing-strategy.md"
@@ -22,7 +27,7 @@ def test_testing_strategy_documents_product_composed_playback() -> None:
     strategy = Path(
         "docs/internals/architecture/tui/native-terminal-core/testing-strategy.md"
     ).read_text(encoding="utf-8")
-    playback = Path("docs/internals/testing/native-tui-playback.md").read_text(
+    playback = Path("docs/internals/testing/screen-tui-playback.md").read_text(
         encoding="utf-8"
     )
 
@@ -39,7 +44,7 @@ def test_testing_strategy_documents_streaming_control_and_live_smoke() -> None:
     strategy = Path(
         "docs/internals/architecture/tui/native-terminal-core/testing-strategy.md"
     ).read_text(encoding="utf-8")
-    playback = Path("docs/internals/testing/native-tui-playback.md").read_text(
+    playback = Path("docs/internals/testing/screen-tui-playback.md").read_text(
         encoding="utf-8"
     )
 


### PR DESCRIPTION
## Summary

- Adds a boundary regression that active coding UI code, tests, and current internal docs do not use legacy `NativeCoding*` or `native_*` product UI names.
- Updates active coding architecture/testing docs to use the current `screen_*` product naming.
- Renames the active playback testing doc from `native-tui-playback.md` to `screen-tui-playback.md` and updates doc tests.

## Validation

- Red: `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_import_boundaries.py -q` failed on active docs that still referenced legacy native product names.
- Red: `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/tui/test_tui_testing_strategy_docs.py -q` failed before the playback doc rename.
- Green: `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_ui_import_boundaries.py tests/tui/test_tui_testing_strategy_docs.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/coding tests/coding tests/tui/test_tui_testing_strategy_docs.py`
- `git diff --check`