### PR TITLE
Clarify screen and plain TUI entrypoints

### DIFF
--- a/docs/en/user-guide/README.md
+++ b/docs/en/user-guide/README.md
@@ -10,6 +10,18 @@ The user guide explains the product surfaces that are currently relevant for `lo
 
 Use `loushang --tui` to start the terminal UI product surface when you want an interactive coding session. The installed `loushang-tui` command is a convenience entry point for the same TUI mode.
 
+TUI mode has two runtime surfaces. With TTY stdin/stdout, `loushang --tui` and
+`loushang-tui` open the screen surface. With piped or redirected stdio under
+`--tui`, the same mode uses the plain prompt loop, which is useful for smoke
+tests:
+
+```bash
+printf "hi\n/quit\n" | loushang --tui
+```
+
+There is no separate UI selector flag for plain output. Use `--tui` and let
+terminal interactivity choose the surface.
+
 Useful starting commands:
 
 ```bash
@@ -18,6 +30,7 @@ loushang --list-models
 loushang --list-commands
 loushang --list-sessions
 loushang --tui
+loushang-tui
 loushang -p "Summarize the current project."
 ```
 

--- a/docs/internals/testing/screen-tui-playback.md
+++ b/docs/internals/testing/screen-tui-playback.md
@@ -42,6 +42,22 @@ result to the `AssertionError` as `playback_result`. The scenario runner will
 write the normal error file plus the JSONL trace and final screen artifact, so
 reviewers can inspect the last frames without rerunning the scenario locally.
 
+## Manual entrypoint smoke
+
+Use these commands to separate product entrypoint problems from playback harness
+regressions:
+
+```bash
+loushang --tui
+loushang-tui
+printf "hi\n/quit\n" | loushang --tui
+```
+
+The first two commands should open the screen surface in an interactive terminal.
+The piped command runs through the same TUI mode but falls back to the plain prompt loop
+because stdin is not interactive. Do not use a separate UI selector flag for this
+smoke path.
+
 Useful direct smoke commands:
 
 ```bash

--- a/docs/zh-CN/user-guide/README.md
+++ b/docs/zh-CN/user-guide/README.md
@@ -10,6 +10,16 @@
 
 需要交互式 coding session 时，可以使用 `loushang --tui` 启动终端 UI 产品面。已安装的 `loushang-tui` 命令是同一 TUI 模式的便捷入口。
 
+TUI 模式当前有两个运行面。在 stdin/stdout 都是 TTY 时，`loushang --tui` 和
+`loushang-tui` 会打开 screen 交互面。在 `--tui` 下使用管道或重定向 stdio 时，同一模式会使用
+plain prompt loop，适合做快速 smoke test：
+
+```bash
+printf "hi\n/quit\n" | loushang --tui
+```
+
+plain 输出没有单独的 UI selector flag。继续使用 `--tui`，由终端交互性决定具体运行面。
+
 常用起始命令：
 
 ```bash
@@ -18,6 +28,7 @@ loushang --list-models
 loushang --list-commands
 loushang --list-sessions
 loushang --tui
+loushang-tui
 loushang -p "Summarize the current project."
 ```
 

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -8,6 +8,35 @@ def test_testing_docs_use_screen_tui_playback_name() -> None:
     assert not Path("docs/internals/testing/native-tui-playback.md").exists()
 
 
+def test_public_user_guides_document_coding_tui_entrypoints() -> None:
+    english = Path("docs/en/user-guide/README.md").read_text(encoding="utf-8")
+    chinese = Path("docs/zh-CN/user-guide/README.md").read_text(encoding="utf-8")
+
+    for text in (english, chinese):
+        assert "`loushang --tui`" in text
+        assert "`loushang-tui`" in text
+        assert 'printf "hi\\n/quit\\n" | loushang --tui' in text
+        assert "`--ui plain`" not in text
+
+    assert "screen surface" in english
+    assert "plain prompt loop" in english
+    assert "screen 交互面" in chinese
+    assert "plain prompt loop" in chinese
+
+
+def test_screen_tui_playback_docs_document_manual_entrypoint_smoke() -> None:
+    text = Path("docs/internals/testing/screen-tui-playback.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Manual entrypoint smoke" in text
+    assert "loushang --tui" in text
+    assert "loushang-tui" in text
+    assert 'printf "hi\\n/quit\\n" | loushang --tui' in text
+    assert "plain prompt loop" in text
+    assert "`--ui plain`" not in text
+
+
 def test_testing_strategy_documents_composer_selection_manual_smoke() -> None:
     text = Path(
         "docs/internals/architecture/tui/native-terminal-core/testing-strategy.md"


### PR DESCRIPTION
## Summary
- Document that `loushang --tui` and `loushang-tui` open the screen surface in interactive terminals.
- Document that piped `--tui` runs the plain prompt loop for smoke tests.
- Add doc regression tests for the public guides and screen playback testing notes.

## Validation
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/tui/test_tui_testing_strategy_docs.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/coding/test_cli.py -k "tui_entrypoint or tui_flag or no_tui_flag or conflicting_tui_flags" -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check tests/tui/test_tui_testing_strategy_docs.py`
- `git diff --check`