### PR TITLE
fix(ai): unblock provider smoke and offline auth

### DIFF
--- a/examples/ai/advanced/inspect_endpoint_contract.py
+++ b/examples/ai/advanced/inspect_endpoint_contract.py
@@ -12,6 +12,7 @@ import re
 from typing import Any
 
 from loushang.ai.model import Endpoint, load_builtin_model_registry
+from loushang.ai.options import CallOptions
 from loushang.ai.provider import resolve_request_for_model
 
 DEFAULT_PROVIDER = "moonshot"
@@ -45,6 +46,7 @@ def inspect_endpoint_contract(
             raise KeyError((provider_id, endpoint_id, model_id))
         resolved = resolve_request_for_model(
             model,
+            options=CallOptions(api_key="example-offline-api-key"),
             registry=registry,
             env=_offline_template_env(endpoint),
         )

--- a/src/loushang/agent/agent.py
+++ b/src/loushang/agent/agent.py
@@ -60,7 +60,7 @@ def _get_default_agent_api_registry() -> ApiProviderRegistry:
 async def _stream_with_registry(model, context, options=None):
     """Wrapper for stream that includes the default registry."""
     return await stream(
-        model, context, options, registry=_get_default_agent_api_registry()
+        model, context, options, provider_registry=_get_default_agent_api_registry()
     )
 
 

--- a/src/loushang/ai/auth/support.py
+++ b/src/loushang/ai/auth/support.py
@@ -184,12 +184,17 @@ def _resolve_stored_oauth_auth_view(
     model_id: str | None = None,
 ) -> AuthView | None:
     from loushang.ai.auth.storage import (
+        CredentialStoreError,
         find_scoped_credential,
         load_credential_store,
     )
 
+    try:
+        store = load_credential_store()
+    except CredentialStoreError:
+        return None
     credential = find_scoped_credential(
-        load_credential_store(),
+        store,
         provider,
         endpoint_id=endpoint_id,
         model_id=model_id,
@@ -208,6 +213,7 @@ def resolve_auth_for_model(
     provider = model.provider_id
     auth_input = normalize_auth_input(options)
     auth_config = getattr(model, "auth", None)
+    auth_kind = _auth_value(auth_config, "kind", None)
 
     if isinstance(auth_input.oauth_credentials, dict):
         oauth_view = _resolve_oauth_auth_view(provider, auth_input.oauth_credentials)
@@ -223,6 +229,9 @@ def resolve_auth_for_model(
     if oauth_view is not None:
         return oauth_view
 
+    if auth_config is None or auth_kind == "none":
+        return AuthView()
+
     oauth_view = _resolve_stored_oauth_auth_view(
         provider,
         endpoint_id=getattr(model, "endpoint_id", None),
@@ -231,8 +240,6 @@ def resolve_auth_for_model(
     if oauth_view is not None:
         return oauth_view
 
-    if auth_config is None:
-        return AuthView()
     return resolve_auth_material(config=auth_config, env=env)
 
 

--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -1037,7 +1037,7 @@ def create_agent_session_runtime(
         session_start_event: SessionStartEvent | None = None,
     ) -> AgentSession:
         session_services = services_factory(session_manager.get_cwd()) if services_factory is not None else fixed_services
-        return create_agent_session(
+        session = create_agent_session(
             session_manager=session_manager,
             model=model,
             stream_fn=stream_fn,
@@ -1053,6 +1053,9 @@ def create_agent_session_runtime(
             session_start_event=session_start_event,
             append_system_prompt=append_system_prompt,
         )
+        if not persist:
+            session.agent.session_id = None
+        return session
 
     return AgentSessionRuntime(
         session_dir=Path(session_dir),

--- a/src/loushang/coding/control/auth_manager.py
+++ b/src/loushang/coding/control/auth_manager.py
@@ -73,6 +73,7 @@ class AuthManager:
             if oauth_credentials is not None:
                 oauth_api_key = self._resolve_oauth_api_key(
                     model.provider_id,
+                    oauth_credentials,
                     endpoint_id=model.endpoint_id,
                     model_id=model.id,
                 )
@@ -133,6 +134,7 @@ class AuthManager:
     def _resolve_oauth_api_key(
         self,
         provider: str,
+        credentials: OAuthCredentials,
         *,
         endpoint_id: str | None,
         model_id: str | None,
@@ -142,8 +144,10 @@ class AuthManager:
 
             result = resolve_oauth_api_key(
                 provider,
+                credentials={provider: credentials},
                 endpoint_id=endpoint_id,
                 model_id=model_id,
+                persist_refresh=False,
             )
         except Exception:
             return None

--- a/tests/agent/test_agent_runtime.py
+++ b/tests/agent/test_agent_runtime.py
@@ -474,8 +474,9 @@ def test_default_agent_stream_preserves_canonical_options(
 
     captured_options: list[object] = []
 
-    async def stream_fn(model, context, options=None, *, registry=None):
-        del model, context, registry
+    async def stream_fn(model, context, options=None, *, provider_registry=None):
+        del model, context
+        assert provider_registry is not None
         captured_options.append(options)
         return _stream_with_final_message(_assistant_text_message("hello"))
 

--- a/tests/coding/test_bootstrap.py
+++ b/tests/coding/test_bootstrap.py
@@ -406,7 +406,8 @@ def test_create_agent_session_runtime_builds_working_default_sessions(tmp_path) 
         await session.prompt("hi")
 
         assert runtime.get_current_session() is session
-        assert session.agent.session_id == session.session_manager.get_header().id
+        assert session.session_manager.get_header().id
+        assert session.agent.session_id is None
         assert [message.content[0].text for message in session.get_session_context().messages] == ["hi", "bootstrapped"]
 
     asyncio.run(scenario())


### PR DESCRIPTION
## Summary

- pass the agent runtime provider registry through the public loushang.ai stream API using the supported keyword
- keep no-session coding runtime runs transient instead of accidentally persisting a session id
- stabilize OAuth-backed auth resolution so offline examples and stored credentials do not touch the real credential store unnecessarily

## Validation

- targeted agent/bootstrap/auth tests passed
- tests/examples/test_ai_examples.py passed
- make check-ai passed
- DeepSeek no-session provider smoke returned ok

## Notes

This is the prerequisite for running coding CLI provider smoke commands such as loushang --model ... -p ... against provider catalog branches.