### PR TITLE
fix(ai): migrate Hunyuan catalog to TokenHub

### DIFF
--- a/examples/ai/11_provider_matrix.py
+++ b/examples/ai/11_provider_matrix.py
@@ -71,8 +71,8 @@ PROVIDER_EXAMPLES = (
     ),
     ProviderExample(
         "tencent-hunyuan",
-        "openai-completions",
-        "hunyuan-turbos-latest",
+        "openai-responses",
+        "hy3-preview",
         ("HUNYUAN_API_KEY",),
     ),
     ProviderExample(

--- a/src/loushang/ai/model/models.json
+++ b/src/loushang/ai/model/models.json
@@ -673,23 +673,23 @@
         "prefix": "Bearer "
       },
       "endpoints": {
-        "openai-completions": {
-          "displayName": "Tencent Hunyuan OpenAI-compatible",
-          "api": "openai-completions",
-          "baseUrl": "https://api.hunyuan.cloud.tencent.com/v1",
+        "openai-responses": {
+          "displayName": "Tencent Hunyuan TokenHub Responses API",
+          "api": "openai-responses",
+          "baseUrl": "https://tokenhub.tencentmaas.com/v1",
           "region": "cn",
           "preferred": true,
-          "docs": "https://cloud.tencent.com/document/product/1729/111007",
+          "docs": "https://cloud.tencent.com/document/product/1823/130079",
           "transport": {
             "kind": "http",
             "stream": "sse"
           },
           "models": {
-            "hunyuan-turbos-latest": {
-              "displayName": "Hunyuan TurboS Latest",
-              "family": "hunyuan-turbos",
+            "hy3-preview": {
+              "displayName": "Hy3 Preview",
+              "family": "hy3",
               "alias": "default-chat",
-              "lastUpdated": "2025-07-16",
+              "lastUpdated": "2026-06-18",
               "defaults": {
                 "maxOutputTokens": 4096
               },
@@ -711,21 +711,18 @@
               },
               "pricing": {
                 "currency": "CNY",
-                "input": 0.8,
-                "output": 2
+                "input": 1.2,
+                "output": 4,
+                "cacheRead": 0.4
               }
             }
           },
           "adapter": {
-            "store": false,
             "developerRole": false,
-            "streamingUsage": true,
-            "reasoningEffort": false,
-            "strictSchema": false,
-            "maxOutputTokensField": "max_tokens",
-            "toolResultName": false,
-            "assistantAfterToolResult": false,
-            "toolStream": false
+            "promptCacheKey": false,
+            "longCacheRetention": false,
+            "sessionIdHeader": false,
+            "assistantAfterToolResult": false
           }
         }
       }

--- a/tests/examples/test_ai_examples.py
+++ b/tests/examples/test_ai_examples.py
@@ -113,6 +113,7 @@ def test_provider_matrix_example_targets_curated_provider_models() -> None:
     assert examples[("moonshot", "openai-completions", "kimi-k2.6")]
     assert examples[("baidu-qianfan", "openai-completions-cn", "ernie-5.1")]
     assert examples[("stepfun", "openai-completions", "step-3.7-flash")]
+    assert examples[("tencent-hunyuan", "openai-responses", "hy3-preview")]
     assert len(examples) == 11
     assert "openrouter" not in {item.provider_id for item in module.PROVIDER_EXAMPLES}
     assert "amazon-bedrock" not in {


### PR DESCRIPTION
## Summary

- migrate Tencent Hunyuan from the retired hunyuan-turbos-latest route to TokenHub hy3-preview
- update the preferred endpoint to TokenHub openai-responses at https://tokenhub.tencentmaas.com/v1
- update the provider matrix example and test coverage for the new Hunyuan route

## Validation

- make check-ai passed
- tests/examples/test_ai_examples.py passed
- loushang.ai public API live smoke for tencent-hunyuan:openai-responses:hy3-preview returned ok
- loushang-ai complete live smoke passed for both tencent-hunyuan/hy3-preview and tencent-hunyuan:openai-responses:hy3-preview

## Notes

The coding CLI command loushang --model ... -p ... still needs the provider-registry prerequisite from PR #233 before it can be used as the final issue smoke path.