### PR TITLE
feat(tui): highlight sorted datagrid headers

### DIFF
--- a/examples/tui/58_widgets_datagrid.py
+++ b/examples/tui/58_widgets_datagrid.py
@@ -39,6 +39,8 @@ DATAGRID_THEME = ThemeResolver(
         "example.dataGrid.meta": {"color": "bright_black"},
         "example.dataGrid.status": {"color": "green"},
         "widget.dataGrid.header": {"color": "bright_black"},
+        "widget.dataGrid.sortHeader": {"bold": True, "color": "yellow"},
+        "widget.dataGrid.focusSortHeader": {"bold": True, "color": "bright_yellow", "underline": True},
         "widget.dataGrid.row": {"color": "white"},
         "widget.dataGrid.focusRow": {"bold": True, "color": "cyan"},
         "widget.dataGrid.focusCell": {"bold": True, "color": "cyan"},

--- a/examples/tui/59_widgets_datagrid_adapters.py
+++ b/examples/tui/59_widgets_datagrid_adapters.py
@@ -35,6 +35,8 @@ ADAPTER_THEME = ThemeResolver(
         "example.dataGrid.sidebarActive": {"bold": True, "color": "cyan"},
         "example.dataGrid.meta": {"color": "bright_black"},
         "widget.dataGrid.header": {"color": "bright_black"},
+        "widget.dataGrid.sortHeader": {"bold": True, "color": "yellow"},
+        "widget.dataGrid.focusSortHeader": {"bold": True, "color": "bright_yellow", "underline": True},
         "widget.dataGrid.row": {"color": "white"},
         "widget.dataGrid.focusRow": {"bold": True, "color": "cyan"},
         "widget.dataGrid.focusCell": {"bold": True, "color": "cyan"},

--- a/examples/tui/60_widgets_datagrid_large_dataset.py
+++ b/examples/tui/60_widgets_datagrid_large_dataset.py
@@ -42,6 +42,8 @@ DATA_GRID_THEME = ThemeResolver(
         "example.dataGrid.meta": {"color": "bright_black"},
         "example.dataGrid.error": {"color": "red"},
         "widget.dataGrid.header": {"color": "bright_black"},
+        "widget.dataGrid.sortHeader": {"bold": True, "color": "yellow"},
+        "widget.dataGrid.focusSortHeader": {"bold": True, "color": "bright_yellow", "underline": True},
         "widget.dataGrid.row": {"color": "white"},
         "widget.dataGrid.focusRow": {"bold": True, "color": "cyan"},
         "widget.dataGrid.focusCell": {"bold": True, "color": "cyan"},

--- a/examples/tui/61_widgets_datagrid_column_chooser.py
+++ b/examples/tui/61_widgets_datagrid_column_chooser.py
@@ -46,6 +46,8 @@ COLUMN_CHOOSER_THEME = ThemeResolver(
         "widget.columnChooser.hidden": {"color": "bright_black"},
         "widget.columnChooser.disabled": {"dim": True},
         "widget.dataGrid.header": {"color": "bright_black"},
+        "widget.dataGrid.sortHeader": {"bold": True, "color": "yellow"},
+        "widget.dataGrid.focusSortHeader": {"bold": True, "color": "bright_yellow", "underline": True},
         "widget.dataGrid.row": {"color": "white"},
         "widget.dataGrid.focusCell": {"bold": True, "color": "cyan"},
         "widget.dataGrid.fixedColumn": {"color": "bright_white"},

--- a/examples/tui/62_widgets_datagrid_column_chooser_overlay.py
+++ b/examples/tui/62_widgets_datagrid_column_chooser_overlay.py
@@ -49,6 +49,8 @@ COLUMN_CHOOSER_OVERLAY_THEME = ThemeResolver(
         "widget.columnChooser.hidden": {"color": "bright_black"},
         "widget.columnChooser.disabled": {"dim": True},
         "widget.dataGrid.header": {"color": "bright_black"},
+        "widget.dataGrid.sortHeader": {"bold": True, "color": "yellow"},
+        "widget.dataGrid.focusSortHeader": {"bold": True, "color": "bright_yellow", "underline": True},
         "widget.dataGrid.row": {"color": "white"},
         "widget.dataGrid.focusCell": {"bold": True, "color": "cyan"},
         "widget.dataGrid.fixedColumn": {"color": "bright_white"},

--- a/examples/tui/63_widgets_datagrid_header_menu.py
+++ b/examples/tui/63_widgets_datagrid_header_menu.py
@@ -44,6 +44,8 @@ HEADER_MENU_THEME = ThemeResolver(
         "widget.menu.description": {"color": "bright_black"},
         "widget.menu.disabled": {"dim": True},
         "widget.dataGrid.header": {"color": "bright_black"},
+        "widget.dataGrid.sortHeader": {"bold": True, "color": "yellow"},
+        "widget.dataGrid.focusSortHeader": {"bold": True, "color": "bright_yellow", "underline": True},
         "widget.dataGrid.row": {"color": "white"},
         "widget.dataGrid.focusCell": {"bold": True, "color": "cyan"},
         "widget.dataGrid.fixedColumn": {"color": "bright_white"},
@@ -105,10 +107,11 @@ class HeaderMenuOverlay(FocusableMixin):
 
     def __post_init__(self) -> None:
         FocusableMixin.__init__(self)
+        sort_state = self.app.grid.sort_state
         self.menu = Menu(
             (
-                MenuItem("sort_asc", "Sort ascending"),
-                MenuItem("sort_desc", "Sort descending"),
+                MenuItem("sort_asc", _sort_action_label("Sort ascending", sort_state, self.column_key, "asc")),
+                MenuItem("sort_desc", _sort_action_label("Sort descending", sort_state, self.column_key, "desc")),
                 MenuItem("hide", "Hide column"),
             ),
             theme=HEADER_MENU_THEME,
@@ -297,6 +300,15 @@ def _column_by_key(grid: DataGrid, key: str) -> DataGridColumn | None:
 def _column_label(grid: DataGrid, key: str) -> str:
     column = _column_by_key(grid, key)
     return key if column is None else column.header
+
+
+def _sort_action_label(
+    label: str,
+    sort_state: tuple[str, str] | None,
+    column_key: str,
+    direction: str,
+) -> str:
+    return f"* {label}" if sort_state == (column_key, direction) else label
 
 
 def _pad_visible(text: str, width: int) -> str:

--- a/src/loushang/tui/ui_parts/widgets/data_grid.py
+++ b/src/loushang/tui/ui_parts/widgets/data_grid.py
@@ -540,12 +540,19 @@ class DataGrid:
         cursor: CursorDeclaration | None = None
         if self.show_header and len(lines) < height:
             headers = tuple(self._header_text(column) for column in render_columns)
-            header_text = _grid_line(headers, render_columns, widths, target_width, label_width=label_width)
-            header_tokens = ["widget.dataGrid.header"]
+            header_tokens = tuple(self._header_theme_tokens(column) for column in render_columns)
+            header_text = _grid_line(
+                headers,
+                render_columns,
+                widths,
+                target_width,
+                label_width=label_width,
+                theme=self.theme,
+                cell_token_sets=header_tokens,
+            )
             if self.focused and self.cursor_mode == "column" and self._active_column_key in cell_starts:
-                header_tokens.append("widget.dataGrid.focusColumn")
                 cursor = CursorDeclaration(row=len(lines), column=cell_starts[str(self._active_column_key)])
-            lines.append(RenderLine(style_text(header_text, self.theme, *header_tokens)))
+            lines.append(RenderLine(header_text))
 
         top_rows = self._pinned_top_rows()
         body_rows = self._view_body_rows()
@@ -835,6 +842,17 @@ class DataGrid:
             return column.header
         marker = "^" if self._sort_state[1] == "asc" else "v"
         return f"{column.header} {marker}"
+
+    def _header_theme_tokens(self, column: DataGridColumn) -> tuple[str | None, ...]:
+        sorted_column = self._sort_state is not None and self._sort_state[0] == column.key
+        focused_column = self.focused and self.cursor_mode == "column" and self._active_column_key == column.key
+        if sorted_column and focused_column:
+            return ("widget.dataGrid.header", "widget.dataGrid.sortHeader", "widget.dataGrid.focusSortHeader")
+        if sorted_column:
+            return ("widget.dataGrid.header", "widget.dataGrid.sortHeader")
+        if focused_column:
+            return ("widget.dataGrid.header", "widget.dataGrid.focusColumn")
+        return ("widget.dataGrid.header",)
 
     def _repair_row_key(self, preferred: str | None) -> str | None:
         enabled = self._enabled_rows()

--- a/tests/tui/test_widgets_data_grid.py
+++ b/tests/tui/test_widgets_data_grid.py
@@ -771,7 +771,7 @@ def test_data_grid_theme_tokens_and_width_constraints_are_applied() -> None:
     raw = render_lines(grid, width=20, height=3)
     plain = tuple(strip_control_sequences(line).rstrip() for line in raw)
 
-    assert raw[0].startswith("\x1b[36m  Name")
+    assert raw[0].startswith("  \x1b[36mName")
     assert raw[1].startswith("\x1b[1;32m> Build")
     assert raw[2].startswith("\x1b[2m  Skip")
     assert plain == (
@@ -1165,6 +1165,26 @@ def test_data_grid_sort_header_markers_render_and_pinned_rows_stay_pinned() -> N
     assert grid.sort_by("runs", "asc") is True
     assert grid.row_keys == ("top", "d", "b", "bottom")
     assert "Runs ^" in plain_lines(grid, width=32, height=6)[0]
+
+
+def test_data_grid_sorted_header_uses_distinct_theme_token() -> None:
+    theme = ThemeResolver(
+        defaults={
+            "widget.dataGrid.header": {"color": "bright_black"},
+            "widget.dataGrid.sortHeader": {"color": "magenta", "bold": True},
+        }
+    )
+    grid = DataGrid(
+        [DataGridColumn("job", "Job", width=8), DataGridColumn("runs", "Runs", width=6, align="right")],
+        [DataGridRow("b", {"job": "Build", "runs": 12}), DataGridRow("d", {"job": "Deploy", "runs": 3})],
+        theme=theme,
+    )
+
+    assert grid.sort_by("runs", "asc") is True
+    header = render_lines(grid, width=32, height=3)[0]
+
+    assert "\x1b[90mJob" in header
+    assert "\x1b[1;35mRuns ^" in header
 
 
 def test_data_grid_replace_rows_preserves_explicit_keys_and_rekeys_shorthand_rows() -> None:
@@ -1677,6 +1697,8 @@ def test_widgets_datagrid_header_menu_example_sorts_and_hides_active_column() ->
     assert grid.focused is True
 
     assert tui.handle_input(InputEvent(kind="text", text="m")) == ()
+    sorted_menu_lines = plain_lines(tui, width=96, height=16)
+    assert any("* Sort ascending" in line for line in sorted_menu_lines)
     assert tui.handle_input(InputEvent(kind="key", key="down")) == ()
     assert tui.handle_input(InputEvent(kind="key", key="down")) == ()
     assert tui.handle_input(InputEvent(kind="key", key="enter"))[0].kind == "surface_close"


### PR DESCRIPTION
## Summary

- Apply distinct theme tokens to sorted DataGrid headers, including the focused sorted column state.
- Add sorted-header theme styling to the DataGrid examples.
- Mark the active sort action in the header menu example and cover it in tests.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q` -> `1144 passed`
- `git diff --check` -> clean