### PR TITLE
Fix Kimi coding endpoint and screen provider errors

### DIFF
--- a/src/loushang/ai/model/models.json
+++ b/src/loushang/ai/model/models.json
@@ -490,6 +490,56 @@
             "assistantReasoningContent": false,
             "reasoningFormat": "moonshot"
           }
+        },
+        "kimi-code-anthropic": {
+          "displayName": "Kimi Code Anthropic Messages",
+          "api": "anthropic-messages",
+          "baseUrl": "https://api.kimi.com/coding",
+          "baseUrlEnv": "MOONSHOT_ANTHROPIC_MESSAGES_URL",
+          "region": "cn",
+          "lane": "coding",
+          "preferred": true,
+          "docs": "https://www.kimi.com/code/docs/en/",
+          "models": {
+            "kimi-for-coding": {
+              "displayName": "Kimi for Coding",
+              "family": "kimi-coding",
+              "alias": "default-coding",
+              "knowledge": "2025-01",
+              "releaseDate": "2026-01",
+              "lastUpdated": "2026-01",
+              "defaults": {
+                "maxOutputTokens": 32768
+              },
+              "capabilities": {
+                "contextWindow": 262144,
+                "maxTokens": 32768,
+                "input": [
+                  "text"
+                ],
+                "output": [
+                  "text"
+                ],
+                "reasoning": true,
+                "stream": true,
+                "toolUse": true,
+                "structuredOutput": true,
+                "attachment": false,
+                "temperature": true
+              },
+              "pricing": {
+                "currency": "CNY",
+                "input": 0,
+                "output": 0,
+                "cacheRead": 0,
+                "cacheWrite": 0
+              }
+            }
+          },
+          "adapter": {
+            "sessionAffinityHeaders": true,
+            "longCacheRetention": false
+          }
         }
       }
     },

--- a/src/loushang/coding/ui/model.py
+++ b/src/loushang/coding/ui/model.py
@@ -19,7 +19,6 @@ class PreferredModel:
 
 PREFERRED_CODING_MODELS = (
     PreferredModel("moonshot", "kimi-code-anthropic", "kimi-for-coding"),
-    PreferredModel("moonshot", "openai-completions:cn:coding", "kimi-for-coding"),
 )
 
 

--- a/src/loushang/coding/ui/screen_events.py
+++ b/src/loushang/coding/ui/screen_events.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from loushang.coding.ui.event_policy import is_cancelled_error_message
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 from loushang.coding.ui.tool_blocks import (
     ToolCallSnapshot,
@@ -29,6 +30,7 @@ class ScreenCodingEventProjector:
     _tool_projector: ToolTranscriptProjector = field(init=False, repr=False)
     _tool_calls: dict[str, ToolCallSnapshot] = field(default_factory=dict, init=False, repr=False)
     _tool_started_at: dict[str, float] = field(default_factory=dict, init=False, repr=False)
+    _rendered_assistant_error_ids: set[int] = field(default_factory=set, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._tool_projector = ToolTranscriptProjector(
@@ -52,6 +54,9 @@ class ScreenCodingEventProjector:
             return
         if event_type == "message_end":
             self._handle_message_end(event)
+            return
+        if event_type == "agent_end":
+            self._handle_agent_end(event)
             return
         if event_type == "tool_execution_start":
             self._handle_tool_start(event)
@@ -125,11 +130,33 @@ class ScreenCodingEventProjector:
         role = getattr(message, "role", None)
         if role == "assistant":
             text = _extract_text(message)
-            stop_reason = getattr(message, "stop_reason", None)
-            error_message = getattr(message, "error_message", None)
             self.app.end_assistant(text)
-            if stop_reason in {"error", "aborted"} and isinstance(error_message, str) and error_message:
-                self.app.add_error(error_message)
+            self._render_assistant_error(message)
+
+    def _handle_agent_end(self, event: dict[str, Any]) -> None:
+        messages = event.get("messages")
+        if not isinstance(messages, list):
+            return
+        for message in reversed(messages):
+            if getattr(message, "role", None) == "assistant":
+                self._render_assistant_error(message)
+                return
+
+    def _render_assistant_error(self, message: object) -> bool:
+        error_message = getattr(message, "error_message", None)
+        stop_reason = getattr(message, "stop_reason", None)
+        if not isinstance(error_message, str) or not error_message:
+            return False
+        if stop_reason not in {"error", "aborted"}:
+            return False
+        if stop_reason == "aborted" and is_cancelled_error_message(error_message):
+            return True
+        message_id = id(message)
+        if message_id in self._rendered_assistant_error_ids:
+            return True
+        self._rendered_assistant_error_ids.add(message_id)
+        self.app.add_error(error_message)
+        return True
 
     def _handle_tool_start(self, event: dict[str, Any]) -> None:
         tool_call_id = _tool_call_id(event)

--- a/tests/coding/test_screen_coding_tui_events.py
+++ b/tests/coding/test_screen_coding_tui_events.py
@@ -7,6 +7,7 @@ from loushang.ai import TextPart, UserMessage
 from loushang.tui.transcript import (
     AssistantMessageRecord,
     ContextCompactionRecord,
+    ErrorRecord,
     ToolExecutionRecord,
     UserPromptRecord,
 )
@@ -46,6 +47,23 @@ def test_screen_event_projector_streams_assistant_to_draft_then_commits_once() -
     assert [record for record in app.state.records if isinstance(record, AssistantMessageRecord)] == [
         AssistantMessageRecord("你好，世界")
     ]
+
+
+def test_screen_event_projector_renders_assistant_error_from_agent_end() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_events import ScreenCodingEventProjector
+
+    app = ScreenCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 1.0)
+    projector = ScreenCodingEventProjector(app)
+
+    projector.handle(
+        {
+            "type": "agent_end",
+            "messages": [_assistant(stop_reason="error", error_message="provider failure")],
+        }
+    )
+
+    assert app.state.records == [ErrorRecord("provider failure")]
 
 
 def test_screen_event_projector_renders_user_message_and_skips_optimistic_echo() -> None:


### PR DESCRIPTION
## Summary
- add the Moonshot Kimi coding Anthropic endpoint and keep kimi-for-coding scoped to that endpoint
- prefer moonshot/kimi-code-anthropic/kimi-for-coding for coding UI startup
- surface assistant provider errors from agent_end in the screen TUI, matching plain-mode behavior

## Root Cause
The TUI lane had kimi-for-coding wired through the regular Moonshot OpenAI-compatible endpoint, which does not advertise session-id support for coding sessions. Screen mode also missed some provider errors that were only present on agent_end messages.

## Validation
- uv --cache-dir .uv-cache run --extra dev pytest tests/ai/test_curated_catalog.py tests/coding/test_ui_model.py tests/coding/test_ui_startup.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/ai/test_curated_catalog.py tests/coding/test_ui_model.py tests/coding/test_ui_startup.py tests/coding/test_screen_coding_tui_events.py tests/coding/test_screen_coding_tui_loop.py -q
- uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/ui/model.py
- git diff --check