### PR TITLE
fix(ai): treat session id as optional provider hint

### DIFF
--- a/docs/en/sdk/README.md
+++ b/docs/en/sdk/README.md
@@ -36,6 +36,17 @@ Use subpackages only when you need an advanced boundary:
 - `loushang.ai.advanced.registry` for provider registry wiring.
 - `loushang.ai.contrib.openai_codex` for the optional OpenAI Codex integration.
 
+### Session Hints And Prompt Caching
+
+`CallOptions.session_id` is a best-effort session hint. Adapters that support
+prompt cache keys or session/affinity headers may map it to provider-specific
+request fields. Adapters that do not support those mechanisms ignore it instead
+of failing the request.
+
+Use `cache_retention="long"` only with endpoints that advertise long cache
+retention support. Long retention remains a hard capability request and may fail
+fast when the selected adapter does not support it.
+
 ## Models And Catalog
 
 The built-in catalog is `models.json`. It intentionally contains a small

--- a/src/loushang/ai/api/streaming.py
+++ b/src/loushang/ai/api/streaming.py
@@ -88,7 +88,7 @@ def _adapter_supports_long_cache_retention(adapter_config: object) -> bool:
     return True
 
 
-def _adapter_supports_session_id(adapter_config: object) -> bool:
+def _adapter_consumes_session_hint(adapter_config: object) -> bool:
     if isinstance(adapter_config, OpenAICompletionsConfig):
         return (
             adapter_config.prompt_cache_key or adapter_config.session_affinity_headers
@@ -102,6 +102,27 @@ def _adapter_supports_session_id(adapter_config: object) -> bool:
     if isinstance(adapter_config, AnthropicMessagesConfig):
         return adapter_config.session_affinity_headers
     return True
+
+
+def _normalize_session_hint_for_adapter(
+    options: CallOptions | None,
+    adapter_config: object,
+) -> CallOptions | None:
+    """Return call options safe for the resolved adapter."""
+    if options is None:
+        return None
+
+    session_id = getattr(options, "session_id", None)
+    if not isinstance(session_id, str) or not session_id:
+        return options
+
+    if getattr(options, "cache_retention", None) == "none":
+        return replace(options, session_id=None)
+
+    if _adapter_consumes_session_hint(adapter_config):
+        return options
+
+    return replace(options, session_id=None)
 
 
 def _validate_explicit_adapter_config(model, resolved, options) -> None:
@@ -118,21 +139,6 @@ def _validate_explicit_adapter_config(model, resolved, options) -> None:
             endpoint=getattr(resolved, "endpoint", None),
             model=getattr(model, "id", None),
             details={"capability": "cache_long_retention"},
-        )
-
-    session_id = getattr(options, "session_id", None)
-    if (
-        isinstance(session_id, str)
-        and session_id
-        and cache_retention != "none"
-        and not _adapter_supports_session_id(adapter_config)
-    ):
-        raise UnsupportedCapabilityError(
-            f"Model {model.id!r} does not support session id",
-            provider=getattr(resolved, "provider", None),
-            endpoint=getattr(resolved, "endpoint", None),
-            model=getattr(model, "id", None),
-            details={"capability": "session_id"},
         )
 
 
@@ -276,6 +282,10 @@ async def _start_stream(
 ):
     options = _validate_call_options(options)
     resolved = resolve_request_for_model(model, options=options)
+    options = _normalize_session_hint_for_adapter(
+        options,
+        getattr(resolved, "adapter_config", None),
+    )
     normalization_result = normalize_context_result(
         context,
         model=_normalization_model(model, resolved),

--- a/src/loushang/ai/providers/openai_completions.py
+++ b/src/loushang/ai/providers/openai_completions.py
@@ -709,22 +709,6 @@ def _validate_cache_session_options(
             model=getattr(model, "id", None),
             details={"capability": "cache_long_retention"},
         )
-    if (
-        cache_retention != "none"
-        and isinstance(session_id, str)
-        and session_id
-        and not (
-            adapter_config.prompt_cache_key or adapter_config.session_affinity_headers
-        )
-    ):
-        raise UnsupportedCapabilityError(
-            f"Model {getattr(model, 'id', '<unknown>')!r} does not support session id",
-            source=getattr(resolved, "api", None),
-            provider=getattr(resolved, "provider", None),
-            endpoint=getattr(resolved, "endpoint", None),
-            model=getattr(model, "id", None),
-            details={"capability": "session_id"},
-        )
 
 
 def _apply_reasoning_params(

--- a/src/loushang/ai/providers/openai_responses.py
+++ b/src/loushang/ai/providers/openai_responses.py
@@ -75,24 +75,6 @@ def _validate_cache_session_options(
             model=getattr(model, "id", None),
             details={"capability": "cache_long_retention"},
         )
-    if (
-        (cache_retention or "short") != "none"
-        and isinstance(session_id, str)
-        and session_id
-        and not (
-            adapter_config.prompt_cache_key
-            or adapter_config.session_id_header
-            or adapter_config.session_affinity_headers
-        )
-    ):
-        raise UnsupportedCapabilityError(
-            f"Model {getattr(model, 'id', '<unknown>')!r} does not support session id",
-            source=getattr(resolved, "api", None),
-            provider=getattr(resolved, "provider", None),
-            endpoint=getattr(resolved, "endpoint", None),
-            model=getattr(model, "id", None),
-            details={"capability": "session_id"},
-        )
 
 
 class OpenAIResponsesProvider:
@@ -172,15 +154,25 @@ class OpenAIResponsesProvider:
             cache_retention=cache_retention,
             session_id=session_id,
         )
-        if (
+        should_apply_session_headers = (
             (cache_retention or "short") != "none"
             and isinstance(session_id, str)
             and session_id
-        ):
+            and (
+                adapter_config.session_id_header
+                or adapter_config.session_affinity_headers
+            )
+        )
+        if should_apply_session_headers:
             apply_session_headers(
                 default_headers,
                 session_id,
                 include_session_id=adapter_config.session_id_header,
+                include_client_request_id=(
+                    adapter_config.session_id_header
+                    or adapter_config.session_affinity_headers
+                ),
+                include_affinity=adapter_config.session_affinity_headers,
             )
 
         client = self._client or AsyncOpenAI(  # type: ignore[call-arg]

--- a/tests/ai/test_api_streaming.py
+++ b/tests/ai/test_api_streaming.py
@@ -1391,7 +1391,9 @@ def test_stream_public_path_uses_openai_responses_typed_request(
         "session-responses"
     )
     assert "prompt_cache_retention" not in _FakeAsyncOpenAI.last_create_kwargs
-    assert "session_id" not in _FakeAsyncOpenAI.last_init_kwargs["default_headers"]
+    headers = _FakeAsyncOpenAI.last_init_kwargs.get("default_headers") or {}
+    assert "session_id" not in headers
+    assert "x-client-request-id" not in headers
 
 
 def test_stream_public_path_rejects_unsupported_long_cache_retention(
@@ -1440,10 +1442,12 @@ def test_stream_public_path_rejects_unsupported_long_cache_retention(
         asyncio.run(_run())
 
 
-def test_stream_public_path_rejects_unsupported_session_id(
+def test_stream_public_path_ignores_unsupported_session_id_hint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     registry = ApiProviderRegistry()
+    provider = _Provider(api="openai-completions")
+    registry.register_api_provider(provider)
     model = SimpleNamespace(
         id="gpt-test",
         provider_id="custom",
@@ -1473,15 +1477,18 @@ def test_stream_public_path_rejects_unsupported_session_id(
     )
 
     async def _run() -> None:
-        await stream(
+        event_stream = await stream(
             model,
             {"messages": [UserMessage(role="user", content="hello", timestamp=0.0)]},
             CallOptions(session_id="session-public"),
             provider_registry=registry,
         )
+        await event_stream.result()
 
-    with pytest.raises(UnsupportedCapabilityError, match="session id"):
-        asyncio.run(_run())
+    asyncio.run(_run())
+
+    assert isinstance(provider.options, CallOptions)
+    assert provider.options.session_id is None
 
 
 def test_stream_public_path_uses_adapter_protocol_override_for_cache_validation(

--- a/tests/providers/test_openai_completions_provider.py
+++ b/tests/providers/test_openai_completions_provider.py
@@ -119,6 +119,15 @@ def _adapter_config_from_compat(
     return OpenAICompletionsConfig.from_raw(raw)
 
 
+def _assert_no_session_hint_fields() -> None:
+    assert "prompt_cache_key" not in _FakeAsyncOpenAI.last_create_kwargs
+    assert "prompt_cache_retention" not in _FakeAsyncOpenAI.last_create_kwargs
+    headers = _FakeAsyncOpenAI.last_init_kwargs.get("default_headers") or {}
+    assert "session_id" not in headers
+    assert "x-client-request-id" not in headers
+    assert "x-session-affinity" not in headers
+
+
 def test_openai_completions_payload_maps_user_image_assistant_toolcall_and_tool_result_mixed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1050,26 +1059,26 @@ def test_openai_completions_supplied_request_typed_adapter_overrides_stale_optio
         capabilities=Capabilities(input=("text",), max_tokens=4096),
     )
 
-    with pytest.raises(UnsupportedCapabilityError, match="session id"):
-        asyncio.run(
-            _collect_parts(
-                _invoke_raw_parts(
-                    provider,
-                    _Model(),
-                    {
-                        "messages": [
-                            UserMessage(role="user", content="hello", timestamp=0.0)
-                        ]
-                    },
-                    CallOptions(
-                        cache_retention="short",
-                        session_id="session-stale",
-                    ),
-                    request=request,
-                )
+    asyncio.run(
+        _collect_parts(
+            _invoke_raw_parts(
+                provider,
+                _Model(),
+                {
+                    "messages": [
+                        UserMessage(role="user", content="hello", timestamp=0.0)
+                    ]
+                },
+                CallOptions(
+                    cache_retention="short",
+                    session_id="session-stale",
+                ),
+                request=request,
             )
         )
-    assert _FakeAsyncOpenAI.last_create_kwargs == {}
+    )
+
+    _assert_no_session_hint_fields()
 
 
 def test_openai_completions_supplied_request_typed_dialect_overrides_stale_options(
@@ -1194,7 +1203,44 @@ def test_openai_completions_explicit_prompt_cache_key_reaches_sdk_payload(
     assert _FakeAsyncOpenAI.last_create_kwargs["prompt_cache_retention"] == "24h"
 
 
-def test_openai_completions_official_url_requires_prompt_cache_support_flag(
+def test_openai_completions_rejects_unsupported_long_cache_retention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_openai_module(monkeypatch)
+    _patch_resolved_request(
+        monkeypatch,
+        compat={
+            SUPPORTS_LONG_CACHE_RETENTION: False,
+            SUPPORTS_PROMPT_CACHE_KEY: True,
+        },
+        reasoning_effort=None,
+    )
+    provider = OpenAICompletionsProvider()
+
+    with pytest.raises(UnsupportedCapabilityError, match="long cache retention"):
+        asyncio.run(
+            _collect_parts(
+                _invoke_raw_parts(
+                    provider,
+                    _Model(),
+                    {
+                        "messages": [
+                            UserMessage(role="user", content="hello", timestamp=0.0)
+                        ]
+                    },
+                    CallOptions(
+                        api_key="test-key",
+                        cache_retention="long",
+                        session_id="session-long",
+                    ),
+                )
+            )
+        )
+
+    assert _FakeAsyncOpenAI.last_create_kwargs == {}
+
+
+def test_openai_completions_official_url_ignores_unsupported_session_hint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _fake_openai_module(monkeypatch)
@@ -1219,26 +1265,27 @@ def test_openai_completions_official_url_requires_prompt_cache_support_flag(
     model = registry.get_model("custom-openai", "openai-completions", "gpt-test")
     provider = OpenAICompletionsProvider()
 
-    with pytest.raises(UnsupportedCapabilityError, match="session id"):
-        asyncio.run(
-            _collect_parts(
-                _invoke_raw_parts(
-                    provider,
-                    model,
-                    {
-                        "messages": [
-                            UserMessage(role="user", content="hello", timestamp=0.0)
-                        ]
-                    },
-                    CallOptions(
-                        api_key="test-key",
-                        cache_retention="long",
-                        session_id="session-official",
-                    ),
-                )
+    asyncio.run(
+        _collect_parts(
+            _invoke_raw_parts(
+                provider,
+                model,
+                {
+                    "messages": [
+                        UserMessage(role="user", content="hello", timestamp=0.0)
+                    ]
+                },
+                CallOptions(
+                    api_key="test-key",
+                    cache_retention="long",
+                    session_id="session-official",
+                ),
             )
         )
-    assert _FakeAsyncOpenAI.last_create_kwargs == {}
+    )
+
+    assert _FakeAsyncOpenAI.last_init_kwargs["base_url"] == "https://api.openai.com/v1"
+    _assert_no_session_hint_fields()
 
 
 def test_openai_completions_typed_prompt_cache_key_unsupported_disables_payload(
@@ -1267,26 +1314,27 @@ def test_openai_completions_typed_prompt_cache_key_unsupported_disables_payload(
     model = registry.get_model("custom-openai", "openai-completions", "gpt-test")
     provider = OpenAICompletionsProvider()
 
-    with pytest.raises(UnsupportedCapabilityError, match="session id"):
-        asyncio.run(
-            _collect_parts(
-                _invoke_raw_parts(
-                    provider,
-                    model,
-                    {
-                        "messages": [
-                            UserMessage(role="user", content="hello", timestamp=0.0)
-                        ]
-                    },
-                    CallOptions(
-                        api_key="test-key",
-                        cache_retention="long",
-                        session_id="session-official",
-                    ),
-                )
+    asyncio.run(
+        _collect_parts(
+            _invoke_raw_parts(
+                provider,
+                model,
+                {
+                    "messages": [
+                        UserMessage(role="user", content="hello", timestamp=0.0)
+                    ]
+                },
+                CallOptions(
+                    api_key="test-key",
+                    cache_retention="long",
+                    session_id="session-official",
+                ),
             )
         )
-    assert _FakeAsyncOpenAI.last_create_kwargs == {}
+    )
+
+    assert _FakeAsyncOpenAI.last_init_kwargs["base_url"] == "https://api.openai.com/v1"
+    _assert_no_session_hint_fields()
 
 
 def test_openai_completions_prompt_cache_key_defaults_off_for_short_sessions(
@@ -1296,26 +1344,26 @@ def test_openai_completions_prompt_cache_key_defaults_off_for_short_sessions(
     _patch_resolved_request(monkeypatch, compat={}, reasoning_effort=None)
     provider = OpenAICompletionsProvider()
 
-    with pytest.raises(UnsupportedCapabilityError, match="session id"):
-        asyncio.run(
-            _collect_parts(
-                _invoke_raw_parts(
-                    provider,
-                    _Model(),
-                    {
-                        "messages": [
-                            UserMessage(role="user", content="hello", timestamp=0.0)
-                        ]
-                    },
-                    CallOptions(
-                        api_key="test-key",
-                        cache_retention="short",
-                        session_id="session-short",
-                    ),
-                )
+    asyncio.run(
+        _collect_parts(
+            _invoke_raw_parts(
+                provider,
+                _Model(),
+                {
+                    "messages": [
+                        UserMessage(role="user", content="hello", timestamp=0.0)
+                    ]
+                },
+                CallOptions(
+                    api_key="test-key",
+                    cache_retention="short",
+                    session_id="session-short",
+                ),
             )
         )
-    assert _FakeAsyncOpenAI.last_create_kwargs == {}
+    )
+
+    _assert_no_session_hint_fields()
 
 
 def test_openai_completions_prompt_cache_key_can_be_disabled(
@@ -1329,26 +1377,26 @@ def test_openai_completions_prompt_cache_key_can_be_disabled(
     )
     provider = OpenAICompletionsProvider()
 
-    with pytest.raises(UnsupportedCapabilityError, match="session id"):
-        asyncio.run(
-            _collect_parts(
-                _invoke_raw_parts(
-                    provider,
-                    _Model(),
-                    {
-                        "messages": [
-                            UserMessage(role="user", content="hello", timestamp=0.0)
-                        ]
-                    },
-                    CallOptions(
-                        api_key="test-key",
-                        cache_retention="short",
-                        session_id="session-short",
-                    ),
-                )
+    asyncio.run(
+        _collect_parts(
+            _invoke_raw_parts(
+                provider,
+                _Model(),
+                {
+                    "messages": [
+                        UserMessage(role="user", content="hello", timestamp=0.0)
+                    ]
+                },
+                CallOptions(
+                    api_key="test-key",
+                    cache_retention="short",
+                    session_id="session-short",
+                ),
             )
         )
-    assert _FakeAsyncOpenAI.last_create_kwargs == {}
+    )
+
+    _assert_no_session_hint_fields()
 
 
 def test_openai_completions_prompt_cache_key_disables_long_retention_params(
@@ -1365,26 +1413,26 @@ def test_openai_completions_prompt_cache_key_disables_long_retention_params(
     )
     provider = OpenAICompletionsProvider()
 
-    with pytest.raises(UnsupportedCapabilityError, match="session id"):
-        asyncio.run(
-            _collect_parts(
-                _invoke_raw_parts(
-                    provider,
-                    _Model(),
-                    {
-                        "messages": [
-                            UserMessage(role="user", content="hello", timestamp=0.0)
-                        ]
-                    },
-                    CallOptions(
-                        api_key="test-key",
-                        cache_retention="long",
-                        session_id="session-long",
-                    ),
-                )
+    asyncio.run(
+        _collect_parts(
+            _invoke_raw_parts(
+                provider,
+                _Model(),
+                {
+                    "messages": [
+                        UserMessage(role="user", content="hello", timestamp=0.0)
+                    ]
+                },
+                CallOptions(
+                    api_key="test-key",
+                    cache_retention="long",
+                    session_id="session-long",
+                ),
             )
         )
-    assert _FakeAsyncOpenAI.last_create_kwargs == {}
+    )
+
+    _assert_no_session_hint_fields()
 
 
 def test_openai_completions_explicit_zai_thinking_format(

--- a/tests/providers/test_openai_responses_provider.py
+++ b/tests/providers/test_openai_responses_provider.py
@@ -97,6 +97,15 @@ async def _stream(provider, model, context, options=None, request=None):
     )
 
 
+def _assert_no_session_hint_fields() -> None:
+    assert "prompt_cache_key" not in _FakeAsyncOpenAI.last_create_kwargs
+    assert "prompt_cache_retention" not in _FakeAsyncOpenAI.last_create_kwargs
+    headers = _FakeAsyncOpenAI.last_init_kwargs.get("default_headers") or {}
+    assert "session_id" not in headers
+    assert "x-client-request-id" not in headers
+    assert "x-session-affinity" not in headers
+
+
 def test_openai_responses_payload_maps_formal_context_and_tools(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -452,11 +461,50 @@ def test_openai_responses_supplied_request_adapter_config_projects_to_payload(
     ]
     assert _FakeAsyncOpenAI.last_create_kwargs["prompt_cache_key"] == "session-options"
     assert "prompt_cache_retention" not in _FakeAsyncOpenAI.last_create_kwargs
-    assert "session_id" not in _FakeAsyncOpenAI.last_init_kwargs["default_headers"]
-    assert (
-        _FakeAsyncOpenAI.last_init_kwargs["default_headers"]["x-client-request-id"]
-        == "session-options"
+    headers = _FakeAsyncOpenAI.last_init_kwargs.get("default_headers") or {}
+    assert "session_id" not in headers
+    assert "x-client-request-id" not in headers
+
+
+def test_openai_responses_ignores_unsupported_session_id_hint_without_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_openai_module(monkeypatch)
+    provider = OpenAIResponsesProvider()
+    request = ProviderRequest(
+        provider="openai",
+        endpoint="openai-responses",
+        api="openai-responses",
+        base_url="https://api.openai.test/v1",
+        headers={"Authorization": "Bearer test-key"},
+        adapter_config=OpenAIResponsesConfig(
+            prompt_cache_key=False,
+            session_id_header=False,
+            session_affinity_headers=False,
+        ),
+        capabilities=Capabilities(input=("text",), reasoning=True),
+        max_tokens=128,
     )
+
+    asyncio.run(
+        _collect_parts(
+            _invoke_raw_parts(
+                provider,
+                _Model(reasoning=True),
+                Context(
+                    system_prompt=None,
+                    messages=[UserMessage(role="user", content="hello", timestamp=0)],
+                ),
+                CallOptions(
+                    cache_retention="short",
+                    session_id="session-direct",
+                ),
+                request,
+            )
+        )
+    )
+
+    _assert_no_session_hint_fields()
 
 
 def test_openai_responses_rejects_unsupported_long_cache_retention(
@@ -549,7 +597,9 @@ def test_openai_responses_supplied_request_typed_adapter_overrides_stale_options
     ]
     assert _FakeAsyncOpenAI.last_create_kwargs["prompt_cache_key"] == "session-typed"
     assert "prompt_cache_retention" not in _FakeAsyncOpenAI.last_create_kwargs
-    assert "session_id" not in _FakeAsyncOpenAI.last_init_kwargs["default_headers"]
+    headers = _FakeAsyncOpenAI.last_init_kwargs.get("default_headers") or {}
+    assert "session_id" not in headers
+    assert "x-client-request-id" not in headers
 
 
 def test_openai_responses_uses_upstream_model_id(


### PR DESCRIPTION
## Summary

- Treat `CallOptions.session_id` as a best-effort provider hint instead of a hard provider capability request.
- Drop unsupported session hints after adapter resolution before building the provider request.
- Keep `cache_retention="long"` as a hard capability request.
- Prevent OpenAI Responses adapters without session/affinity header support from leaking `x-client-request-id`.
- Update provider/public-path tests and SDK docs for the new contract.

## Root Cause

Coding sessions always pass a local `session_id` into `loushang.ai`. The AI layer previously treated that value as a required provider capability, so ordinary chat adapters that did not support prompt-cache keys or session headers could fail locally before the provider call.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/ai/test_api_streaming.py tests/providers/test_openai_completions_provider.py tests/providers/test_openai_responses_provider.py -q`
- `UV_CACHE_DIR=/tmp/uv-cache make check-ai`
