### PR TITLE
fix(ai): use Moonshot China API endpoint

### DIFF
--- a/src/loushang/ai/model/models.json
+++ b/src/loushang/ai/model/models.json
@@ -412,7 +412,7 @@
         "openai-completions": {
           "displayName": "Moonshot OpenAI-compatible Chat Completions",
           "api": "openai-completions",
-          "baseUrl": "https://api.moonshot.ai/v1",
+          "baseUrl": "https://api.moonshot.cn/v1",
           "preferred": true,
           "docs": "https://platform.kimi.ai/docs/api-reference",
           "models": {


### PR DESCRIPTION
  ## Summary

  Update the built-in Moonshot OpenAI-compatible endpoint from `https://api.moonshot.ai/v1` to `https://api.moonshot.cn/v1`.

  ## Why

  `MOONSHOT_API_KEY` authenticates successfully against `https://api.moonshot.cn/v1/models`, including `kimi-k2.6`, but the built-in catalog routed requests to `https://api.moonshot.ai/v1`, which returns `401
  Invalid Authentication`.

  ## Validation

  - Confirmed local registry resolves `moonshot:openai-completions:kimi-k2.6` to `https://api.moonshot.cn/v1` on the feature branch.
  - Manual curl verification: `.cn` succeeds, `.ai` returns 401.
  - `make check-ai` was attempted but could not run because `ruff` is missing from the active environment.