### PR TITLE
fix(ai): split Kimi Code catalog provider

### DIFF
--- a/src/loushang/ai/contrib/moonshot/quota.py
+++ b/src/loushang/ai/contrib/moonshot/quota.py
@@ -80,7 +80,10 @@ class _HttpxPlatformQuotaTransport:
 def endpoint_quota_query_for_model(model: Model) -> EndpointQuotaQuery | None:
     provider = model.provider_id
     endpoint = model.endpoint_id
-    if provider == "moonshot" and endpoint in {"coding", "kimi-code-anthropic"}:
+    if provider in {"kimi-code", "moonshot"} and endpoint in {
+        "coding",
+        "kimi-code-anthropic",
+    }:
         return EndpointQuotaQuery(
             provider=provider,
             endpoint=endpoint,

--- a/src/loushang/ai/model/models.json
+++ b/src/loushang/ai/model/models.json
@@ -490,7 +490,19 @@
             "assistantReasoningContent": false,
             "reasoningFormat": "moonshot"
           }
-        },
+        }
+      }
+    },
+    "kimi-code": {
+      "displayName": "Kimi Code",
+      "website": "https://www.kimi.com/code",
+      "auth": {
+        "kind": "apiKey",
+        "apiKeyEnv": "KIMI_CODE_API_KEY",
+        "header": "Authorization",
+        "prefix": "Bearer "
+      },
+      "endpoints": {
         "kimi-code-anthropic": {
           "displayName": "Kimi Code Anthropic Messages",
           "api": "anthropic-messages",

--- a/src/loushang/coding/ui/model.py
+++ b/src/loushang/coding/ui/model.py
@@ -18,7 +18,7 @@ class PreferredModel:
 
 
 PREFERRED_CODING_MODELS = (
-    PreferredModel("moonshot", "kimi-code-anthropic", "kimi-for-coding"),
+    PreferredModel("kimi-code", "kimi-code-anthropic", "kimi-for-coding"),
 )
 
 

--- a/tests/ai/test_curated_catalog.py
+++ b/tests/ai/test_curated_catalog.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from loushang.ai.auth.support import merge_auth_config
 from loushang.ai.model import (
     AnthropicMessagesConfig,
     ModelRegistry,
@@ -36,6 +37,7 @@ def test_curated_catalog_loads_runtime_models_json() -> None:
         "baidu-qianfan",
         "dashscope",
         "deepseek",
+        "kimi-code",
         "minimax",
         "moonshot",
         "openai",
@@ -98,6 +100,23 @@ def test_minimax_anthropic_catalog_uses_sdk_base_url_and_short_cache() -> None:
     assert endpoint.base_url == "https://api.minimax.io/anthropic"
     assert isinstance(endpoint.adapter, AnthropicMessagesConfig)
     assert endpoint.adapter.long_cache_retention is False
+
+
+def test_kimi_code_catalog_uses_its_own_api_key_not_moonshot_platform_key() -> None:
+    registry = _load_curated_registry()
+    provider = registry.get_provider("kimi-code")
+    endpoint = registry.get_endpoint("kimi-code", "kimi-code-anthropic")
+    model = registry.get_model("kimi-code", "kimi-code-anthropic", "kimi-for-coding")
+
+    assert provider is not None
+    assert endpoint is not None
+    merged_auth = merge_auth_config(provider.auth, endpoint.auth, model.auth)
+
+    assert merged_auth.kind == "apiKey"
+    assert merged_auth.api_key_env == "KIMI_CODE_API_KEY"
+    assert merged_auth.header == "Authorization"
+    assert merged_auth.prefix == "Bearer "
+    assert endpoint.base_url == "https://api.kimi.com/coding"
 
 
 def test_curated_openai_style_custom_base_urls_declare_adapter() -> None:

--- a/tests/ai/test_model_catalog.py
+++ b/tests/ai/test_model_catalog.py
@@ -7,6 +7,7 @@ CURATED_PROVIDER_IDS = [
     "baidu-qianfan",
     "dashscope",
     "deepseek",
+    "kimi-code",
     "minimax",
     "moonshot",
     "openai",

--- a/tests/ai/test_provider_resolution.py
+++ b/tests/ai/test_provider_resolution.py
@@ -50,7 +50,7 @@ def test_builtin_openai_style_model_resolves_adapter_config() -> None:
 
     assert resolved.provider == "moonshot"
     assert resolved.endpoint == "openai-completions"
-    assert resolved.base_url == "https://api.moonshot.ai/v1"
+    assert resolved.base_url == "https://api.moonshot.cn/v1"
     assert isinstance(resolved.adapter_config, OpenAICompletionsConfig)
     assert resolved.adapter_config.developer_role is False
     assert resolved.adapter_config.reasoning_format == "moonshot"


### PR DESCRIPTION
## Summary

- Split Kimi Code into its own catalog provider instead of modeling it under Moonshot Platform.
- Configure `kimi-code:kimi-code-anthropic:kimi-for-coding` to use `KIMI_CODE_API_KEY`.
- Keep Moonshot Platform models on `MOONSHOT_API_KEY` and `https://api.moonshot.cn/v1`.
- Update the TUI preferred coding model and catalog tests for the new provider id.

## Why

Kimi Code and Kimi/Moonshot Platform are different product surfaces. Kimi Code can be used through its own API key for subscription-based coding access, while Moonshot Platform remains the pay-as-you-go API platform.

Keeping them under one `moonshot` provider caused `kimi-for-coding` to inherit `MOONSHOT_API_KEY`, which mixes those auth domains.

## Validation

- `make check-ai`
