### PR TITLE
Persist model selection defaults

### DIFF
--- a/docs/superpowers/specs/2026-07-05-tui-model-selection-and-method-routing-design.md
+++ b/docs/superpowers/specs/2026-07-05-tui-model-selection-and-method-routing-design.md
@@ -1,0 +1,535 @@
+# TUI Model Selection And Method Routing Design
+
+## Status
+
+Ready for user review.
+
+## Context
+
+Issue #242 asks the native TUI to remember the last model selected through
+`/model`. The immediate user-facing problem is small: after choosing a model
+interactively, the next TUI session should start with that model when it is
+still valid.
+
+The design has to leave room for a larger direction: methodology-driven work
+may later use different models for different plan steps. A method run may use a
+planning model, a code model, a review model, a cheap summarization model, or a
+long-context model in one logical task.
+
+The current code already has useful boundaries:
+
+- `ModelSelection` identifies a model by `provider`, `model_id`, and optional
+  `endpoint_id`.
+- `SettingsManager` can persist `default_model` in session, global, or project
+  settings.
+- `/model` currently changes the active session model through
+  `session.set_model()`.
+- `MethodPlan`, `MethodStep`, `MethodProjection`, `WorkStepRun`, and
+  `WorkEvent` already carry metadata where future model routing facts can be
+  recorded.
+- `ModelRegistry` resolves `ModelSelection` against the active AI model
+  registry and current layered model resources.
+
+The key design problem is not just where to save `/model`. It is what `/model`
+means once methods can route work across multiple models.
+
+## Goals
+
+Current #242 goals:
+
+- Make `/model` persistence useful for current TUI sessions.
+- Keep manual model choice, session history, project policy, and method routing
+  as separate runtime facts.
+- Avoid writing personal model choices into project settings by default.
+- Preserve explicit user overrides.
+- Ensure startup revalidates the persisted default model against the current
+  registry and endpoint facts before using it.
+
+Future compatibility goals:
+
+- Allow future method steps to request model roles or capabilities without
+  forcing users to hard-code provider/model IDs into every method.
+- Ensure future method steps revalidate routed models against current registry,
+  auth, endpoint, policy, and environment facts.
+- Record enough routing information in work/session events for debugging,
+  replay, export, and cost analysis.
+
+## Non-Goals
+
+- Do not implement multi-model routing in the #242 slice.
+- Do not introduce automatic method selection.
+- Do not make `/model` rewrite method definitions.
+- Do not make `AgentSession.set_model()` implicitly write persisted settings.
+- Do not make project `.loushang/settings.json` a sink for interactive personal
+  preferences.
+- Do not infer provider or endpoint facts from model names when the registry is
+  ambiguous.
+- Do not add budget optimization, live benchmarking, or quality scoring in the
+  first persistence slice.
+
+## Decisions
+
+### Current Slice Decisions
+
+`/model` sets the active session model and persists the user's default model
+preference to global user settings.
+
+The persisted target is:
+
+```text
+~/.loushang/coding/settings.json
+```
+
+The persisted field is the existing structured `default_model`:
+
+```json
+{
+  "default_model": {
+    "provider": "openai",
+    "model_id": "gpt-5.5",
+    "endpoint_id": "openai-responses"
+  }
+}
+```
+
+`endpoint_id` should be preserved when the selected model came from a concrete
+endpoint. This avoids the common ambiguity where the same provider/model ID is
+available through multiple endpoints.
+
+`/model` must not write project settings by default. Project settings are team
+or repository policy; `/model` is a user's interactive preference. A future
+explicit command may save a project default, but that should be opt-in and
+visibly different from ordinary model switching.
+
+If a project already declares an explicit `default_model`, that project default
+continues to win on the next startup in that project. Ordinary `/model` still
+changes the current running session and saves the user's global preference, but
+it does not silently override a team/project default.
+
+`session.set_model()` remains a runtime operation. It should update the current
+agent/session state and append session history, but persistence should be owned
+by the TUI command path or another explicit control-plane command. This keeps
+RPC, extensions, tests, retry flows, and temporary switches from unexpectedly
+modifying user settings.
+
+Startup should treat persisted `default_model` as a candidate, not a guarantee.
+The bootstrap path must resolve it through the current `ModelRegistry`. If the
+model is missing, ambiguous, or points at an unavailable endpoint, startup
+should fall back to the existing registry fallback behavior and surface a
+recoverable diagnostic.
+
+Missing auth is not a #242 fallback trigger. Current session startup can keep a
+selected model active and surface auth guidance later through the auth bridge.
+Changing that behavior belongs with the future router/policy layer, not the
+first persistence slice.
+
+### Long-Term Decisions
+
+`/model` is not the long-term multi-model scheduler. It is the user's default
+model preference and fallback.
+
+Future method execution should route through a dedicated `ModelRouter` that
+accepts a model request context and returns a resolved model decision. The
+router should understand:
+
+- explicit CLI/session model overrides;
+- pinned session model choices;
+- method step model roles;
+- method step capability requirements;
+- project model policy;
+- user role mappings;
+- global `default_model`;
+- registry availability and auth;
+- fallback and diagnostic rules.
+
+Method steps should request model roles or capabilities, not concrete provider
+IDs by default. Examples:
+
+```json
+{
+  "model_role": "reviewer",
+  "required_capabilities": ["high_reasoning", "long_context"]
+}
+```
+
+Concrete provider/model selections remain allowed for advanced use, but they
+should be explicit and auditable because they encode environment-specific
+assumptions.
+
+The long-term meaning of `/model` is:
+
+> Prefer this model for ordinary turns and as the fallback for method steps that
+> do not request a stronger model role or capability.
+
+If users need stronger control, add explicit commands instead of overloading
+ordinary `/model`:
+
+```text
+/model gpt-5.5
+/model --pin gpt-5.5
+/model --role reviewer claude-opus-4-8
+/model --clear-role reviewer
+```
+
+Meanings:
+
+- `/model X` sets the active model and default preference.
+- `/model --pin X` forces this session to use X unless a hard policy blocks it.
+- `/model --role reviewer X` maps the reviewer role to X in user settings.
+- `/model --clear-role reviewer` removes the user role mapping.
+
+These commands are future scope. The #242 slice should not implement them, but
+the persistence model should not block them.
+
+## Model Preference And Policy Layers
+
+Use separate configuration concepts:
+
+### User Preference
+
+User preference belongs in global user settings:
+
+```json
+{
+  "default_model": {
+    "provider": "openai",
+    "model_id": "gpt-5.5",
+    "endpoint_id": "openai-responses"
+  },
+  "model_routing": {
+    "roles": {
+      "reviewer": {
+        "provider": "anthropic",
+        "model_id": "claude-opus-4-8",
+        "endpoint_id": "anthropic-messages"
+      }
+    },
+    "fallback": "default_model"
+  }
+}
+```
+
+Only `default_model` is in the current slice. `model_routing` is a reserved
+future shape.
+
+### Project Policy
+
+Project policy belongs in project settings and should be explicit. A project may
+also declare an explicit `default_model` as a team default, but ordinary
+interactive `/model` must not create or mutate that value.
+
+```json
+{
+  "default_model": {
+    "provider": "openai",
+    "model_id": "gpt-5.5",
+    "endpoint_id": "openai-responses"
+  },
+  "model_policy": {
+    "allowed_providers": ["openai", "anthropic"],
+    "allowed_roles": ["planner", "coder", "reviewer"],
+    "deny_endpoints": ["untrusted-local"]
+  }
+}
+```
+
+Project policy may constrain routing, but ordinary `/model` should not create or
+mutate this policy.
+
+### Session Runtime State
+
+Session runtime state records what actually happened:
+
+- the active model after a `/model` command;
+- model changes in session history;
+- method step routing decisions;
+- fallback reason, if the requested model was not used.
+
+This state is separate from user defaults because replay and audit need facts,
+not preferences.
+
+## Proposed Architecture
+
+### Current Slice
+
+Add an explicit persistence step to the TUI model selection path:
+
+```text
+/model selection
+  -> resolve selected choice from available model details
+  -> build a ModelSelection with provider, model_id, endpoint_id
+  -> session.set_model(selection)
+  -> settings_manager.set_default_model(selection, scope="global")
+  -> show "Model set" status
+```
+
+The persistence call should happen only after `session.set_model(selection)`
+succeeds. A model that cannot be applied should not become the saved default.
+
+Persist from the selected choice or resolved `Model`, not by reading the current
+model back from `session.get_model_selection()` after the switch. Some existing
+selection helpers expose only provider/model ID and can drop `endpoint_id`; the
+persistence path must preserve endpoint identity when the selected model came
+from an endpoint-aware model detail.
+
+All TUI model entry points should share the same persistence wrapper. Plain
+mode, screen mode typed `/model`, model selector submit, and the settings model
+page all eventually call model selection helpers today. If only one entry point
+adds persistence, #242 will be inconsistent.
+
+The persistence API can be a thin helper on the session facade or UI command
+handler, but it should not hide inside the low-level `set_model()` method.
+
+Recommended naming:
+
+```python
+remember_model_selection(selection, scope="global")
+```
+
+or:
+
+```python
+persist_model_selection(selection, scope="global")
+```
+
+The name should communicate durable settings writes, not ordinary runtime model
+switching.
+
+### Future Router
+
+Introduce a future `ModelRouter` behind a narrow interface:
+
+```python
+@dataclass(frozen=True)
+class ModelRequest:
+    reason: str
+    method_id: str | None = None
+    plan_id: str | None = None
+    step_id: str | None = None
+    role: str | None = None
+    required_capabilities: tuple[str, ...] = ()
+    preferred_model: ModelSelection | None = None
+    pinned_model: ModelSelection | None = None
+
+
+@dataclass(frozen=True)
+class ModelDecision:
+    selection: ModelSelection
+    source: str
+    requested_role: str | None = None
+    fallback_from: ModelSelection | None = None
+    diagnostics: tuple[str, ...] = ()
+```
+
+The initial implementation can be trivial:
+
+```text
+if pinned model exists and is allowed -> use pinned
+else if preferred/default model exists and is valid -> use preferred/default
+else registry fallback
+```
+
+Later implementations can add role and capability matching without changing
+method execution callers.
+
+Router capability labels are semantic routing labels, not raw `models.json`
+keys. The first router should map them onto the current catalog shape instead
+of copying catalog field names into method definitions:
+
+| Router label | Current catalog source |
+| --- | --- |
+| `reasoning` | `capabilities.reasoning` |
+| `tool_use` | `capabilities.toolUse` / `Capabilities.tool_use` |
+| `structured_output` | `capabilities.structuredOutput` / `Capabilities.structured_output` |
+| `vision` | `capabilities.input` contains `image` |
+| `long_context` | `capabilities.contextWindow` above a configured threshold |
+| `high_reasoning` | `capabilities.reasoning` plus a curated tier/family policy |
+| `cheap` | `pricing` below a configured threshold |
+
+This keeps method hints stable if the catalog keeps camelCase JSON keys while
+the runtime domain model exposes snake_case Python attributes.
+
+## Method Integration
+
+Current `MethodStep` should not grow hard dependencies on provider-specific
+models in the first slice. For future compatibility, method compilation and
+projection may carry model hints through existing maps:
+
+```json
+{
+  "constraint": {
+    "model_role": "planner",
+    "required_capabilities": ["long_context"]
+  }
+}
+```
+
+Using `constraint` is the safer near-term convention because current coding
+domain preparation forwards the source constraint into prepared-turn metadata.
+If a future router reads directly from `MethodProjection`, the hint can be
+promoted or copied into typed projection fields then.
+
+Long-term, promote this to typed fields if the convention becomes common:
+
+```python
+@dataclass(frozen=True)
+class MethodStep:
+    ...
+    model_role: str | None = None
+    model_requirements: ModelRequirements = field(default_factory=ModelRequirements)
+```
+
+Do not add typed fields until at least one method runtime path consumes the
+metadata. The near-term safe move is to preserve and project the hints.
+
+Every method step run should eventually record the selected model decision in
+`WorkStepRun.metadata` or a dedicated work event payload:
+
+```json
+{
+  "model_decision": {
+    "selection": {
+      "provider": "openai",
+      "model_id": "gpt-5.5",
+      "endpoint_id": "openai-responses"
+    },
+    "source": "role:reviewer",
+    "requested_role": "reviewer",
+    "fallback_from": null,
+    "diagnostics": []
+  }
+}
+```
+
+This is future scope, but the design should reserve the concept now.
+
+## Startup Resolution
+
+Recommended startup precedence for ordinary TUI sessions:
+
+1. Settings compose global, then project, then session patches.
+2. Bootstrap resolves the composed `default_model` candidate.
+3. `AgentSession` may restore a model from existing session history when
+   resuming.
+4. Explicit CLI model override is applied after session creation and wins for
+   the running session.
+5. Future session-level pinned model, if introduced, should win over defaults
+   but remain below explicit CLI override.
+6. Registry fallback is used when no valid default candidate exists.
+
+Project policy constrains every resolved choice above. It does not become the
+user's fallback preference, and ordinary `/model` does not rewrite it.
+
+If `default_model` is unavailable:
+
+- do not delete it automatically;
+- use the normal fallback model for this session;
+- emit a recoverable diagnostic with provider, model ID, endpoint ID, and reason;
+- let the user fix it with `/model` or model resource/auth changes.
+
+## Error Handling
+
+Persisting a model preference can fail after the runtime model switch succeeds.
+The TUI should keep the session on the selected model and show a warning such
+as:
+
+```text
+Model changed to openai:gpt-5.5, but saving the default failed: <reason>
+```
+
+Applying the runtime model can fail before persistence. In that case:
+
+- do not write settings;
+- keep the previous active model;
+- show the model resolution/auth error.
+
+Startup resolution can fail to use the saved default. In that case:
+
+- use a fallback model if one exists;
+- record a diagnostic;
+- keep the saved preference unchanged.
+
+Future method routing failures should distinguish:
+
+- policy denial;
+- missing model;
+- ambiguous model;
+- missing auth;
+- missing endpoint/environment;
+- capability mismatch;
+- no fallback available.
+
+## Testing
+
+Current slice tests:
+
+- `/model` calls runtime `set_model()` and then persists global
+  `default_model`.
+- Failed `set_model()` does not persist.
+- Persistence failure leaves runtime model changed and emits a warning.
+- `endpoint_id` round-trips through settings.
+- Startup uses saved `default_model` when valid.
+- Startup falls back with a diagnostic when saved default is missing,
+  ambiguous, or endpoint-unavailable.
+- Missing auth keeps the selected model behavior consistent with the current
+  auth bridge and surfaces auth guidance rather than silently rewriting the
+  user's saved default.
+- Project settings are not modified by ordinary `/model`.
+- Project explicit `default_model` still overrides the saved global preference
+  on startup.
+- Existing explicit CLI model override still wins.
+- Plain mode, screen mode, selector submit, and settings-page model selection
+  all use the same persistence behavior.
+
+Future router tests:
+
+- default model fallback;
+- pinned model override;
+- role mapping override;
+- method step role request;
+- capability-based fallback;
+- project policy denial;
+- diagnostic payload recorded in work events.
+
+## Rollout
+
+### Phase 1: #242 Persistence
+
+- Add explicit persistence after successful TUI `/model` selection.
+- Store structured `default_model` in global user settings.
+- Keep `set_model()` runtime-only.
+- Add focused tests around persistence and startup fallback.
+
+### Phase 2: Router Skeleton
+
+- Add `ModelRequest` and `ModelDecision` internal types.
+- Add a trivial `ModelRouter` that returns explicit override, default model, or
+  registry fallback.
+- Do not change method behavior yet.
+
+### Phase 3: Method Hints
+
+- Preserve `model_role` and `required_capabilities` hints from method step
+  projection/constraint metadata.
+- Record resolved model decisions in work metadata.
+
+### Phase 4: Multi-Model Method Routing
+
+- Add user role mappings.
+- Add project model policy.
+- Add capability matching against model registry facts.
+- Add explicit `/model --pin` and `/model --role` commands if user workflows
+  need them.
+
+## Open Questions
+
+- Should global `default_model` be a simple single preference, or should it
+  become workspace-keyed memory once users regularly work across projects with
+  different model stacks?
+- Should project settings allow an explicit project `default_model`, or only
+  model policy and role recommendations?
+- What is the minimal capability vocabulary for model routing:
+  `high_reasoning`, `long_context`, `cheap`, `vision`, `tool_use`, and
+  `structured_output` are likely enough for the first router.
+- Should role mappings live under `model_routing.roles` or a more general
+  `routing.models.roles` namespace if future non-model routing also appears?

--- a/docs/superpowers/specs/2026-07-05-tui-model-selection-and-method-routing-design.md
+++ b/docs/superpowers/specs/2026-07-05-tui-model-selection-and-method-routing-design.md
@@ -38,6 +38,8 @@ means once methods can route work across multiple models.
 Current #242 goals:
 
 - Make `/model` persistence useful for current TUI sessions.
+- Make TUI and CLI model selection entry points share the same apply-and-persist
+  behavior.
 - Keep manual model choice, session history, project policy, and method routing
   as separate runtime facts.
 - Avoid writing personal model choices into project settings by default.
@@ -60,6 +62,9 @@ Future compatibility goals:
 - Do not introduce automatic method selection.
 - Do not make `/model` rewrite method definitions.
 - Do not make `AgentSession.set_model()` implicitly write persisted settings.
+- Do not make RPC `set_model` persist user settings in the #242 slice; RPC
+  remains a runtime control path until its persistence semantics are designed
+  explicitly.
 - Do not make project `.loushang/settings.json` a sink for interactive personal
   preferences.
 - Do not infer provider or endpoint facts from model names when the registry is
@@ -72,7 +77,9 @@ Future compatibility goals:
 ### Current Slice Decisions
 
 `/model` sets the active session model and persists the user's default model
-preference to global user settings.
+preference to global user settings. CLI `--model` uses the same
+apply-and-persist behavior in the #242 slice, so a successful explicit CLI
+model selection also becomes the global default model.
 
 The persisted target is:
 
@@ -108,9 +115,9 @@ it does not silently override a team/project default.
 
 `session.set_model()` remains a runtime operation. It should update the current
 agent/session state and append session history, but persistence should be owned
-by the TUI command path or another explicit control-plane command. This keeps
-RPC, extensions, tests, retry flows, and temporary switches from unexpectedly
-modifying user settings.
+by the TUI/CLI command path or another explicit control-plane command. This
+keeps RPC, extensions, tests, retry flows, and temporary switches from
+unexpectedly modifying user settings.
 
 Startup should treat persisted `default_model` as a candidate, not a guarantee.
 The bootstrap path must resolve it through the current `ModelRegistry`. If the
@@ -252,7 +259,7 @@ not preferences.
 
 ### Current Slice
 
-Add an explicit persistence step to the TUI model selection path:
+Add an explicit persistence step to the TUI/CLI model selection path:
 
 ```text
 /model selection
@@ -263,6 +270,9 @@ Add an explicit persistence step to the TUI model selection path:
   -> show "Model set" status
 ```
 
+For CLI `--model`, the same wrapper runs after session creation and before the
+command-specific action continues.
+
 The persistence call should happen only after `session.set_model(selection)`
 succeeds. A model that cannot be applied should not become the saved default.
 
@@ -272,10 +282,11 @@ selection helpers expose only provider/model ID and can drop `endpoint_id`; the
 persistence path must preserve endpoint identity when the selected model came
 from an endpoint-aware model detail.
 
-All TUI model entry points should share the same persistence wrapper. Plain
-mode, screen mode typed `/model`, model selector submit, and the settings model
-page all eventually call model selection helpers today. If only one entry point
-adds persistence, #242 will be inconsistent.
+All TUI and CLI model entry points that represent user model selection should
+share the same persistence wrapper. Plain mode, screen mode typed `/model`,
+model selector submit, the settings model page, and CLI `--model` all
+eventually call model selection helpers today. If only one entry point adds
+persistence, #242 will be inconsistent.
 
 The persistence API can be a thin helper on the session facade or UI command
 handler, but it should not hide inside the low-level `set_model()` method.
@@ -477,9 +488,12 @@ Current slice tests:
 - Project settings are not modified by ordinary `/model`.
 - Project explicit `default_model` still overrides the saved global preference
   on startup.
-- Existing explicit CLI model override still wins.
+- Explicit CLI model selection still wins for that invocation and, in the #242
+  slice, persists the selected model as the new global default after the runtime
+  switch succeeds.
 - Plain mode, screen mode, selector submit, and settings-page model selection
   all use the same persistence behavior.
+- RPC `set_model` remains runtime-only.
 
 Future router tests:
 
@@ -496,6 +510,7 @@ Future router tests:
 ### Phase 1: #242 Persistence
 
 - Add explicit persistence after successful TUI `/model` selection.
+- Route CLI `--model` through the same successful-switch persistence helper.
 - Store structured `default_model` in global user settings.
 - Keep `set_model()` runtime-only.
 - Add focused tests around persistence and startup fallback.

--- a/docs/zh-CN/getting-started/README.md
+++ b/docs/zh-CN/getting-started/README.md
@@ -44,7 +44,7 @@ loushang --list-commands
 loushang -p "Inspect this repository and summarize what it does."
 ```
 
-需要选择具体模型路线时，可以使用 `--model` 或 provider 相关环境变量。`--model provider/model` 是短写：当该模型只匹配一个 endpoint，或 catalog 明确将其中一个匹配 endpoint 标为 preferred 时可用。如果同一个 provider/model 存在多个 endpoint 且没有唯一 preferred endpoint，CLI 会报告歧义并列出可显式选择的 `provider:endpoint:model` 候选。需要指定具体 endpoint、region、lane 或 protocol 时，使用 `--model provider:endpoint:model`。catalog key 中 `provider` 和 `model` id 不能包含 `:`，endpoint id 可以包含 `:`。项目与示例模型 catalog 可以放在 `.loushang/models/`，也可以在支持的入口显式传入。
+需要选择具体模型路线时，可以使用 `--model` 或 provider 相关环境变量。`--model provider/model` 是短写：当该模型只匹配一个 endpoint，或 catalog 明确将其中一个匹配 endpoint 标为 preferred 时可用。如果同一个 provider/model 存在多个 endpoint 且没有唯一 preferred endpoint，CLI 会报告歧义并列出可显式选择的 `provider:endpoint:model` 候选。需要指定具体 endpoint、region、lane 或 protocol 时，使用 `--model provider:endpoint:model`。模型切换成功后，CLI 会把完整选择保存为全局 `default_model`，路径是 `~/.loushang/coding/settings.json`；带 endpoint 的选择会保留 `provider`、`model_id` 和 `endpoint_id`，不会写入项目级 `.loushang/settings.json`。catalog key 中 `provider` 和 `model` id 不能包含 `:`，endpoint id 可以包含 `:`。项目与示例模型 catalog 可以放在 `.loushang/models/`，也可以在支持的入口显式传入。
 
 ## 下一步
 

--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -382,7 +382,12 @@ def create_agent_session(
     resolved_model: Model | None
     if model is None:
         default_selection = settings.default_model
-        resolved_model = services.model_registry.build_model(default_selection) if default_selection is not None else None
+        resolved_model = _resolve_default_model_candidate(
+            default_selection,
+            model_registry=services.model_registry,
+            diagnostics_service=services.diagnostics_service,
+            session_id=session_id,
+        )
     elif isinstance(model, ModelSelection):
         resolved_model = services.model_registry.build_model(model)
     else:
@@ -465,6 +470,87 @@ def create_agent_session(
     if scoped_models:
         session.setScopedModels(scoped_models)
     return session
+
+
+def _resolve_default_model_candidate(
+    selection: ModelSelection | None,
+    *,
+    model_registry: ModelRegistry,
+    diagnostics_service: DiagnosticsService,
+    session_id: str,
+) -> Model | None:
+    if selection is None:
+        return None
+    try:
+        return model_registry.build_model(selection)
+    except (KeyError, ValueError) as error:
+        _record_default_model_unavailable(
+            selection,
+            error=error,
+            model_registry=model_registry,
+            diagnostics_service=diagnostics_service,
+            session_id=session_id,
+        )
+        return None
+
+
+def _record_default_model_unavailable(
+    selection: ModelSelection,
+    *,
+    error: Exception,
+    model_registry: ModelRegistry,
+    diagnostics_service: DiagnosticsService,
+    session_id: str,
+) -> None:
+    reason = _default_model_unavailable_reason(
+        selection,
+        error=error,
+        model_registry=model_registry,
+    )
+    selection_ref = (
+        f"{selection.provider}:{selection.endpoint_id}:{selection.model_id}"
+        if selection.endpoint_id
+        else f"{selection.provider}:{selection.model_id}"
+    )
+    message = (
+        f"Default model unavailable: {selection_ref}; using startup fallback."
+    )
+    diagnostics_service.record(
+        diagnostics_service.normalize_error(
+            code="default_model_unavailable",
+            error=message,
+            phase="startup",
+            source="model",
+            level="warning",
+            session_id=session_id,
+            details={
+                "provider": selection.provider,
+                "model_id": selection.model_id,
+                "endpoint_id": selection.endpoint_id,
+                "reason": reason,
+                "error": str(error),
+            },
+        )
+    )
+
+
+def _default_model_unavailable_reason(
+    selection: ModelSelection,
+    *,
+    error: Exception,
+    model_registry: ModelRegistry,
+) -> str:
+    if selection.endpoint_id:
+        endpoint = model_registry.ai_registry.get_endpoint(
+            selection.provider,
+            selection.endpoint_id,
+        )
+        if endpoint is None:
+            return "endpoint_unavailable"
+        return "missing"
+    if isinstance(error, ValueError):
+        return "ambiguous"
+    return "missing"
 
 
 def create_agent_session_from_services(

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -6,13 +6,13 @@ import inspect
 import json
 import os
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager, nullcontext, redirect_stderr
 from dataclasses import asdict, dataclass, replace
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
 from pathlib import Path
-from typing import Any, Mapping, TextIO
+from typing import Any, TextIO
 
 from loushang.ai.model.registry import get_default_model_registry
 from loushang.ai.types import ImagePart
@@ -33,6 +33,11 @@ from loushang.coding.diagnostics import serialize_diagnostic
 from loushang.coding.domain import CodingDomainApp, CodingDomainRequest, MethodPolicy
 from loushang.coding.extensions.types import ResolvedFlag
 from loushang.coding.mode import ModeConfig, run_mode, run_print_mode, run_rpc_mode
+from loushang.coding.model_selection import (
+    apply_model_selection,
+    model_selection_ref,
+    persistence_warning_message,
+)
 from loushang.coding.observability import (
     coding_observability_context,
     coding_startup_observability_context,
@@ -359,7 +364,12 @@ async def run_cli(
             if callable(setter):
                 setter(args.session_name)
 
-        override_result = await _apply_model_and_thinking_overrides(args, session, stderr)
+        override_result = await _apply_model_and_thinking_overrides(
+            args,
+            session,
+            stderr,
+            settings_manager=settings_manager,
+        )
         if override_result is not None:
             return override_result
 
@@ -1376,11 +1386,26 @@ def _resolve_model_selection(args: CliArgs) -> ModelSelection | None:
     )
 
 
-async def _apply_model_and_thinking_overrides(args: CliArgs, session: Any, stderr: TextIO) -> int | None:
+async def _apply_model_and_thinking_overrides(
+    args: CliArgs,
+    session: Any,
+    stderr: TextIO,
+    *,
+    settings_manager: object | None = None,
+) -> int | None:
     try:
         explicit_model = _resolve_model_selection(args)
         if explicit_model is not None:
-            await session.set_model(explicit_model)
+            result = await apply_model_selection(
+                session,
+                explicit_model,
+                settings_manager=settings_manager,
+            )
+            if warning := persistence_warning_message(result):
+                stderr.write(
+                    f"Warning: Model changed to {model_selection_ref(result.selection)}, "
+                    f"but {warning}\n"
+                )
         if args.thinking is not None:
             session.set_thinking_level(args.thinking)
     except (RuntimeError, ValueError) as error:

--- a/src/loushang/coding/model_selection.py
+++ b/src/loushang/coding/model_selection.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from loushang.coding.types import ModelSelection
+
+
+@dataclass(frozen=True)
+class ModelSelectionApplyResult:
+    selection: ModelSelection
+    persisted: bool = False
+    persistence_error: Exception | None = None
+
+
+async def apply_model_selection(
+    session: Any,
+    selection: object,
+    *,
+    settings_manager: object | None = None,
+    scope: str = "global",
+) -> ModelSelectionApplyResult:
+    normalized = normalize_model_selection(selection)
+    if normalized is None:
+        raise ValueError("Model selection requires provider and model id.")
+
+    setter = getattr(session, "set_model", None)
+    if not callable(setter):
+        raise RuntimeError("Model selection is not available.")
+
+    await _maybe_await(setter(normalized))
+
+    resolved_settings_manager = (
+        settings_manager
+        if settings_manager is not None
+        else getattr(session, "settings_manager", None)
+    )
+    persist = getattr(resolved_settings_manager, "set_default_model", None)
+    if not callable(persist):
+        return ModelSelectionApplyResult(selection=normalized)
+
+    try:
+        persist(normalized, scope=scope)
+    except Exception as error:
+        return ModelSelectionApplyResult(selection=normalized, persistence_error=error)
+    return ModelSelectionApplyResult(selection=normalized, persisted=True)
+
+
+def normalize_model_selection(selection: object | None) -> ModelSelection | None:
+    if selection is None:
+        return None
+    provider = _string_attr(selection, "provider", "provider_id", "providerId")
+    model_id = _string_attr(selection, "model_id", "modelId", "id")
+    endpoint_id = _string_attr(selection, "endpoint_id", "endpoint", "endpointId")
+    if provider is None or model_id is None:
+        return None
+    return ModelSelection(provider=provider, model_id=model_id, endpoint_id=endpoint_id)
+
+
+def model_selection_ref(selection: ModelSelection) -> str:
+    if selection.endpoint_id:
+        return f"{selection.provider}:{selection.endpoint_id}:{selection.model_id}"
+    return f"{selection.provider}/{selection.model_id}"
+
+
+def persistence_warning_message(result: ModelSelectionApplyResult) -> str | None:
+    if result.persistence_error is None:
+        return None
+    message = (
+        str(result.persistence_error).strip()
+        or result.persistence_error.__class__.__name__
+    )
+    return f"saving the default failed: {message}"
+
+
+def _string_attr(value: object, *names: str) -> str | None:
+    for name in names:
+        if isinstance(value, Mapping):
+            raw_value = value.get(name)
+        else:
+            raw_value = getattr(value, name, None)
+        if isinstance(raw_value, str) and raw_value.strip():
+            return raw_value.strip()
+    return None
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+__all__ = [
+    "ModelSelectionApplyResult",
+    "apply_model_selection",
+    "model_selection_ref",
+    "normalize_model_selection",
+    "persistence_warning_message",
+]

--- a/src/loushang/coding/ui/model_list.py
+++ b/src/loushang/coding/ui/model_list.py
@@ -5,6 +5,10 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
+from loushang.coding.model_selection import (
+    apply_model_selection,
+    persistence_warning_message,
+)
 from loushang.coding.ui.model import (
     iter_available_model_selections,
     model_label_from_selection,
@@ -70,14 +74,24 @@ async def available_model_palette(session: Any, *, title: str = "Models") -> Com
     return CommandPalette.from_completion_provider(provider, title=title)
 
 
-async def select_available_model(session: Any, *, query: str = "", choose: ModelPaletteChooser | None = None) -> str:
+async def select_available_model(
+    session: Any,
+    *,
+    query: str = "",
+    choose: ModelPaletteChooser | None = None,
+    settings_manager: object | None = None,
+) -> str:
     stripped_query = query.strip()
     if not stripped_query:
         if choose is not None:
             selected = await _maybe_await(choose(await available_model_palette(session, title="Models")))
             if selected is None:
                 return "Model selection cancelled."
-            return await select_available_model(session, query=selected)
+            return await select_available_model(
+                session,
+                query=selected,
+                settings_manager=settings_manager,
+            )
         return await format_available_models(session)
 
     matches = _matching_model_choices(await available_model_choices(session), stripped_query)
@@ -101,8 +115,15 @@ async def select_available_model(session: Any, *, query: str = "", choose: Model
     setter = getattr(session, "set_model", None)
     if not callable(setter):
         return "Model selection is not available."
-    await _maybe_await(setter(choice.selection))
-    return f"Model set: {_choice_display_label(choice)}"
+    result = await apply_model_selection(
+        session,
+        choice.selection,
+        settings_manager=settings_manager,
+    )
+    message = f"Model set: {_choice_display_label(choice)}"
+    if warning := persistence_warning_message(result):
+        return f"{message}, but {warning}"
+    return message
 
 
 async def available_model_choices(session: Any) -> list[ModelChoice]:

--- a/src/loushang/coding/ui/settings_page.py
+++ b/src/loushang/coding/ui/settings_page.py
@@ -224,7 +224,11 @@ class SettingsPageView:
             self.feedback_message = message
             return SettingsApplyResult(message)
         if item_id == "model.current":
-            message = await select_available_model(self.session, query=value)
+            message = await select_available_model(
+                self.session,
+                query=value,
+                settings_manager=self.settings_manager,
+            )
             await self._refresh_model_page()
             self._refresh_status_page()
             self.feedback_message = message

--- a/tests/coding/test_bootstrap.py
+++ b/tests/coding/test_bootstrap.py
@@ -1178,6 +1178,170 @@ def test_create_agent_session_records_auth_resolution_failure_for_default_model(
     assert "LOUSHANG_TEST_DEMO_KEY" in diagnostics[0].message
 
 
+def test_create_agent_session_uses_saved_default_model_endpoint_when_valid(tmp_path) -> None:
+    from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
+    from loushang.coding.bootstrap import create_agent_session, create_services
+    from loushang.coding.session import ModelSelection
+    from loushang.coding.store import SessionManager
+
+    ai_registry = AiModelRegistry()
+    ai_registry.register_model(
+        Model(id="alpha", name="Alpha", provider="demo", endpoint="responses")
+    )
+    ai_registry.register_model(
+        Model(id="alpha", name="Alpha", provider="demo", endpoint="completions")
+    )
+    services = create_services(ai_model_registry=ai_registry)
+    saved_default = ModelSelection(
+        provider="demo",
+        endpoint_id="responses",
+        model_id="alpha",
+    )
+    services.settings_manager.set_default_model(saved_default)
+
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions",
+        cwd=str(tmp_path),
+        persist=False,
+    )
+    session = create_agent_session(session_manager=manager, services=services)
+
+    diagnostics = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "default_model_unavailable"
+    ]
+
+    assert session.agent.model.provider_id == "demo"
+    assert session.agent.model.id == "alpha"
+    assert session.agent.model.endpoint_id == "responses"
+    assert diagnostics == []
+
+
+def test_create_agent_session_falls_back_when_saved_default_model_is_missing(
+    tmp_path,
+) -> None:
+    from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
+    from loushang.coding.bootstrap import create_agent_session, create_services
+    from loushang.coding.session import ModelSelection
+    from loushang.coding.store import SessionManager
+
+    ai_registry = AiModelRegistry()
+    services = create_services(ai_model_registry=ai_registry)
+    saved_default = ModelSelection(provider="demo", model_id="missing")
+    services.settings_manager.set_default_model(saved_default)
+
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions",
+        cwd=str(tmp_path),
+        persist=False,
+    )
+    session = create_agent_session(session_manager=manager, services=services)
+
+    diagnostics = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "default_model_unavailable"
+    ]
+
+    assert session.get_model_selection() == ModelSelection(
+        provider="unknown",
+        model_id="unknown",
+    )
+    assert services.settings_manager.get_settings().default_model == saved_default
+    assert len(diagnostics) == 1
+    assert diagnostics[0].type == "warning"
+    assert diagnostics[0].source == "model"
+    assert diagnostics[0].details["provider"] == "demo"
+    assert diagnostics[0].details["model_id"] == "missing"
+    assert diagnostics[0].details["reason"] == "missing"
+
+
+def test_create_agent_session_falls_back_when_saved_default_model_is_ambiguous(
+    tmp_path,
+) -> None:
+    from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
+    from loushang.coding.bootstrap import create_agent_session, create_services
+    from loushang.coding.session import ModelSelection
+    from loushang.coding.store import SessionManager
+
+    ai_registry = AiModelRegistry()
+    ai_registry.register_model(
+        Model(id="alpha", name="Alpha", provider="demo", endpoint="responses")
+    )
+    ai_registry.register_model(
+        Model(id="alpha", name="Alpha", provider="demo", endpoint="completions")
+    )
+    services = create_services(ai_model_registry=ai_registry)
+    saved_default = ModelSelection(provider="demo", model_id="alpha")
+    services.settings_manager.set_default_model(saved_default)
+
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions",
+        cwd=str(tmp_path),
+        persist=False,
+    )
+    session = create_agent_session(session_manager=manager, services=services)
+
+    diagnostics = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "default_model_unavailable"
+    ]
+
+    assert session.get_model_selection() == ModelSelection(
+        provider="unknown",
+        model_id="unknown",
+    )
+    assert services.settings_manager.get_settings().default_model == saved_default
+    assert len(diagnostics) == 1
+    assert diagnostics[0].details["reason"] == "ambiguous"
+    assert diagnostics[0].details["endpoint_id"] is None
+
+
+def test_create_agent_session_falls_back_when_saved_default_endpoint_is_unavailable(
+    tmp_path,
+) -> None:
+    from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
+    from loushang.coding.bootstrap import create_agent_session, create_services
+    from loushang.coding.session import ModelSelection
+    from loushang.coding.store import SessionManager
+
+    ai_registry = AiModelRegistry()
+    ai_registry.register_model(
+        Model(id="alpha", name="Alpha", provider="demo", endpoint="responses")
+    )
+    services = create_services(ai_model_registry=ai_registry)
+    saved_default = ModelSelection(
+        provider="demo",
+        endpoint_id="retired",
+        model_id="alpha",
+    )
+    services.settings_manager.set_default_model(saved_default)
+
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions",
+        cwd=str(tmp_path),
+        persist=False,
+    )
+    session = create_agent_session(session_manager=manager, services=services)
+
+    diagnostics = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "default_model_unavailable"
+    ]
+
+    assert session.get_model_selection() == ModelSelection(
+        provider="unknown",
+        model_id="unknown",
+    )
+    assert services.settings_manager.get_settings().default_model == saved_default
+    assert len(diagnostics) == 1
+    assert diagnostics[0].details["reason"] == "endpoint_unavailable"
+    assert diagnostics[0].details["endpoint_id"] == "retired"
+
+
 def test_create_agent_session_uses_stored_oauth_credentials_for_auth_bridge(tmp_path, monkeypatch) -> None:
     import asyncio
 

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -2602,6 +2602,40 @@ def test_run_cli_accepts_explicit_endpoint_model_override(tmp_path) -> None:
     ]
 
 
+def test_apply_model_override_persists_global_default_with_endpoint() -> None:
+    from loushang.coding.cli.__main__ import _apply_model_and_thinking_overrides
+    from loushang.coding.types import ModelSelection
+
+    session = FakeSession("session-1")
+    settings_calls: list[tuple[ModelSelection | None, str]] = []
+    settings_manager = SimpleNamespace(
+        set_default_model=lambda selection, *, scope="session": settings_calls.append(
+            (selection, scope)
+        )
+    )
+    args = SimpleNamespace(provider=None, model="faux:responses:beta", thinking=None)
+    stderr = StringIO()
+
+    result = asyncio.run(
+        _apply_model_and_thinking_overrides(
+            args,
+            session,
+            stderr,
+            settings_manager=settings_manager,
+        )
+    )
+
+    selection = ModelSelection(
+        provider="faux",
+        endpoint_id="responses",
+        model_id="beta",
+    )
+    assert result is None
+    assert stderr.getvalue() == ""
+    assert session.set_model_calls == [selection]
+    assert settings_calls == [(selection, "global")]
+
+
 def test_run_cli_accepts_explicit_endpoint_model_override_with_colon_endpoint(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.types import ModelSelection

--- a/tests/coding/test_model_selection_persistence.py
+++ b/tests/coding/test_model_selection_persistence.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from loushang.coding.types import ModelSelection
+
+
+class _SettingsManager:
+    def __init__(self) -> None:
+        self.default_model_calls: list[tuple[ModelSelection | None, str]] = []
+
+    def set_default_model(
+        self,
+        selection: ModelSelection | None,
+        *,
+        scope: str = "session",
+    ) -> None:
+        self.default_model_calls.append((selection, scope))
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.settings_manager = _SettingsManager()
+        self.set_model_calls: list[object] = []
+
+    async def set_model(self, selection: object) -> None:
+        self.set_model_calls.append(selection)
+
+
+class _FailingSession(_Session):
+    async def set_model(self, selection: object) -> None:
+        self.set_model_calls.append(selection)
+        raise RuntimeError("model unavailable")
+
+
+class _FailingSettingsManager(_SettingsManager):
+    def set_default_model(
+        self,
+        selection: ModelSelection | None,
+        *,
+        scope: str = "session",
+    ) -> None:
+        super().set_default_model(selection, scope=scope)
+        raise OSError("disk full")
+
+
+def test_apply_model_selection_persists_global_default_after_runtime_switch() -> None:
+    from loushang.coding.model_selection import apply_model_selection
+
+    session = _Session()
+    detail = SimpleNamespace(
+        provider_id="dashscope",
+        endpoint_id="openai-responses",
+        id="qwen3.6-plus",
+    )
+
+    result = asyncio.run(apply_model_selection(session, detail))
+
+    expected = ModelSelection(
+        provider="dashscope",
+        endpoint_id="openai-responses",
+        model_id="qwen3.6-plus",
+    )
+    assert result.selection == expected
+    assert result.persistence_error is None
+    assert session.set_model_calls == [expected]
+    assert session.settings_manager.default_model_calls == [(expected, "global")]
+
+
+def test_apply_model_selection_writes_global_settings_not_project(tmp_path) -> None:
+    from loushang.coding.control import SettingsManager
+    from loushang.coding.model_selection import apply_model_selection
+
+    session = _Session()
+    global_settings_path = tmp_path / "global-settings.json"
+    project_settings_path = tmp_path / "project-settings.json"
+    session.settings_manager = SettingsManager(
+        global_settings_path=global_settings_path,
+        project_settings_path=project_settings_path,
+    )
+    selection = ModelSelection(
+        provider="openai",
+        endpoint_id="responses",
+        model_id="gpt-5.4",
+    )
+
+    result = asyncio.run(apply_model_selection(session, selection))
+
+    assert result.persisted is True
+    assert json.loads(global_settings_path.read_text(encoding="utf-8")) == {
+        "default_model": {
+            "provider": "openai",
+            "model_id": "gpt-5.4",
+            "endpoint_id": "responses",
+        }
+    }
+    assert not project_settings_path.exists()
+
+
+def test_apply_model_selection_does_not_persist_when_runtime_switch_fails() -> None:
+    from loushang.coding.model_selection import apply_model_selection
+
+    session = _FailingSession()
+
+    with pytest.raises(RuntimeError, match="model unavailable"):
+        asyncio.run(
+            apply_model_selection(
+                session,
+                ModelSelection(provider="openai", model_id="gpt-5.4"),
+            )
+        )
+
+    assert session.settings_manager.default_model_calls == []
+
+
+def test_apply_model_selection_reports_persistence_failure_after_runtime_switch() -> None:
+    from loushang.coding.model_selection import apply_model_selection
+
+    session = _Session()
+    session.settings_manager = _FailingSettingsManager()
+    selection = ModelSelection(
+        provider="openai",
+        endpoint_id="responses",
+        model_id="gpt-5.4",
+    )
+
+    result = asyncio.run(apply_model_selection(session, selection))
+
+    assert session.set_model_calls == [selection]
+    assert result.selection == selection
+    assert isinstance(result.persistence_error, OSError)
+    assert session.settings_manager.default_model_calls == [(selection, "global")]

--- a/tests/coding/test_screen_coding_tui_surfaces.py
+++ b/tests/coding/test_screen_coding_tui_surfaces.py
@@ -162,7 +162,13 @@ def test_screen_surface_model_selector_displays_endpoint_and_selects_full_identi
 
     asyncio.run(manager.handle_surface_intent(intent))
 
-    assert session.set_model_calls[-1] is responses_model
+    selection = ModelSelection(
+        provider="dashscope",
+        model_id="qwen3.6-plus",
+        endpoint_id="openai-responses",
+    )
+    assert session.set_model_calls[-1] == selection
+    assert session.default_model_calls[-1] == (selection, "global")
     assert app.active_surface is None
     assert app.state.status_message == "Model set: dashscope/qwen3.6-plus (endpoint: openai-responses)"
 
@@ -1024,6 +1030,8 @@ class _Session:
             ModelSelection(provider="openai", model_id="gpt-5.4"),
         ]
         self.set_model_calls: list[object] = []
+        self.default_model_calls: list[tuple[ModelSelection | None, str]] = []
+        self.settings_manager = self
         self.commands: list[object] = []
         self.model_details: list[Model] = []
         self.scoped_models: list[object] = []
@@ -1044,6 +1052,14 @@ class _Session:
     async def set_model(self, selection: object) -> None:
         self.set_model_calls.append(selection)
         self.current_model = selection
+
+    def set_default_model(
+        self,
+        selection: ModelSelection | None,
+        *,
+        scope: str = "session",
+    ) -> None:
+        self.default_model_calls.append((selection, scope))
 
     def list_commands(self) -> list[object]:
         return self.commands

--- a/tests/coding/test_screen_settings_page.py
+++ b/tests/coding/test_screen_settings_page.py
@@ -38,6 +38,7 @@ class _SettingsManager:
         self.image_auto_resize = True
         self.block_images = False
         self.retry_enabled = True
+        self.default_model_calls: list[tuple[ModelSelection | None, str]] = []
 
     def get_show_terminal_progress(self) -> bool:
         return self.terminal_progress
@@ -74,6 +75,14 @@ class _SettingsManager:
 
     def set_retry_enabled(self, enabled: bool) -> None:
         self.retry_enabled = enabled
+
+    def set_default_model(
+        self,
+        selection: ModelSelection | None,
+        *,
+        scope: str = "session",
+    ) -> None:
+        self.default_model_calls.append((selection, scope))
 
 
 def test_status_provider_exposes_read_only_snapshot() -> None:
@@ -331,3 +340,15 @@ def test_settings_page_model_tab_filters_and_selects_model() -> None:
     intent = page.handle_input(InputEvent(kind="key", key="enter"))
 
     assert intent == InputIntent(kind="setting", text="model.current", note="openai/gpt-5.4")
+
+
+def test_settings_page_model_apply_persists_with_page_settings_manager() -> None:
+    settings_manager = _SettingsManager()
+    page = _page(settings_manager=settings_manager)
+
+    result = asyncio.run(page.apply_setting("model.current", "openai/gpt-5.4"))
+
+    selection = ModelSelection(provider="openai", model_id="gpt-5.4")
+    assert result.message == "Model set: openai/gpt-5.4"
+    assert result.refresh_model_label is True
+    assert settings_manager.default_model_calls == [(selection, "global")]

--- a/tests/coding/test_session_selection_controller.py
+++ b/tests/coding/test_session_selection_controller.py
@@ -89,6 +89,47 @@ def test_selection_controller_sets_model_records_auth_refresh_and_model_select(t
     ]
 
 
+def test_selection_controller_records_explicit_endpoint_selection(tmp_path) -> None:
+    from loushang.coding.session.selection_controller import SelectionController
+
+    first = _model()
+    second = _model("alt-model", "alt")
+    registry = FakeModelRegistry([first, second])
+    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    controller = SelectionController(
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": first,
+                "thinking_level": "low",
+            }
+        ),
+        session_manager=manager,
+        get_model_registry=lambda: registry,
+        get_extension_runner=lambda: None,
+        refresh_extension_runtime=lambda reason: _append_async([], reason),
+        is_extension_runtime_refreshing=lambda: False,
+        record_model_auth_resolution=lambda model: None,
+    )
+
+    asyncio.run(
+        controller.set_model(
+            ModelSelection(
+                provider="alt",
+                endpoint_id="responses",
+                model_id="alt-model",
+            ),
+            emit_refresh=True,
+        )
+    )
+
+    assert manager.build_session_context().model == {
+        "provider": "alt",
+        "model_id": "alt-model",
+        "endpoint_id": "responses",
+    }
+
+
 def test_selection_controller_set_model_from_extension_respects_refresh_guard(tmp_path) -> None:
     from loushang.coding.session.selection_controller import SelectionController
 

--- a/tests/coding/test_ui_model_list.py
+++ b/tests/coding/test_ui_model_list.py
@@ -9,6 +9,8 @@ from loushang.coding.types import ModelSelection
 class _Session:
     def __init__(self) -> None:
         self.set_model_calls: list[ModelSelection] = []
+        self.default_model_calls: list[tuple[ModelSelection | None, str]] = []
+        self.settings_manager = self
         self.selection = ModelSelection(provider="moonshot", model_id="kimi-for-coding")
 
     def get_model_selection(self) -> ModelSelection:
@@ -23,6 +25,14 @@ class _Session:
     async def set_model(self, selection: ModelSelection) -> None:
         self.set_model_calls.append(selection)
         self.selection = selection
+
+    def set_default_model(
+        self,
+        selection: ModelSelection | None,
+        *,
+        scope: str = "session",
+    ) -> None:
+        self.default_model_calls.append((selection, scope))
 
 
 class _CurrentSecondSession(_Session):
@@ -223,7 +233,9 @@ def test_select_available_model_sets_unique_match() -> None:
     text = asyncio.run(select_available_model(session, query="gpt"))
 
     assert text == "Model set: openai/gpt-5.4"
-    assert session.set_model_calls == [ModelSelection(provider="openai", model_id="gpt-5.4")]
+    selection = ModelSelection(provider="openai", model_id="gpt-5.4")
+    assert session.set_model_calls == [selection]
+    assert session.default_model_calls == [(selection, "global")]
 
 
 def test_select_available_model_lists_models_when_query_is_empty() -> None:
@@ -292,10 +304,21 @@ def test_select_available_model_uses_full_identity_for_duplicate_endpoint_choice
     from loushang.coding.ui.model_list import select_available_model
 
     session = _DuplicateEndpointSession()
-    text = asyncio.run(select_available_model(session, query="dashscope:openai-responses:qwen3.6-plus"))
+    text = asyncio.run(
+        select_available_model(
+            session,
+            query="dashscope:openai-responses:qwen3.6-plus",
+        )
+    )
 
     assert text == "Model set: dashscope/qwen3.6-plus (endpoint: openai-responses)"
-    assert session.set_model_calls == [session.model_details[0]]
+    selection = ModelSelection(
+        provider="dashscope",
+        endpoint_id="openai-responses",
+        model_id="qwen3.6-plus",
+    )
+    assert session.set_model_calls == [selection]
+    assert session.default_model_calls == [(selection, "global")]
 
 
 def test_select_available_model_uses_preferred_endpoint_for_duplicate_label() -> None:
@@ -305,7 +328,13 @@ def test_select_available_model_uses_preferred_endpoint_for_duplicate_label() ->
     text = asyncio.run(select_available_model(session, query="dashscope/qwen3.6-plus"))
 
     assert text == "Model set: dashscope/qwen3.6-plus (endpoint: openai-responses)"
-    assert session.set_model_calls == [session.model_details[0]]
+    selection = ModelSelection(
+        provider="dashscope",
+        endpoint_id="openai-responses",
+        model_id="qwen3.6-plus",
+    )
+    assert session.set_model_calls == [selection]
+    assert session.default_model_calls == [(selection, "global")]
 
 
 def test_select_available_model_reports_duplicate_endpoint_label_as_ambiguous_without_preferred() -> None:


### PR DESCRIPTION
## Summary
- Add a shared TUI/CLI model selection helper that switches the runtime model first, then persists the successful selection as global default_model.
- Preserve full provider / model_id / endpoint_id identity through /model, settings-page selection, and CLI --model.
- Revalidate saved defaults on startup and fall back only for missing, ambiguous, or unavailable endpoints without rewriting user settings.

## Notes
- CLI --model persistence is intentional for #242 so TUI/CLI model selection entry points share the same behavior.
- RPC set_model remains runtime-only in this slice.

## Validation
- uv --cache-dir .uv-cache run --extra dev pytest ... -q: 57 passed
- uv --cache-dir .uv-cache run --extra dev ruff check --select I,F ...: All checks passed
- git diff --check: clean

Closes #242