### PR TITLE
refactor(harness): move command vocabulary from runtime

### DIFF
--- a/docs/internals/architecture/README.md
+++ b/docs/internals/architecture/README.md
@@ -16,7 +16,8 @@ Read in this order for current implementation decisions:
 1. [Architecture Overview](architecture-overview.md)
 2. [Subsystems](subsystem.md)
 3. Accepted ARDs under subsystem directories, especially
-   [agent harness boundaries](agent/ARD-001-agent-harness-and-product-adapters.md) and
+   [agent harness boundaries](agent/ARD-001-agent-harness-and-product-adapters.md),
+   [harness product adapter substrate](agent/ARD-002-harness-product-adapter-substrate.md), and
    [coding](coding/ARD-001-coding-product-boundaries.md)
 4. Component interfaces and core data object notes for the subsystem being edited
 5. Draft/history/reference material only when extra rationale is needed

--- a/docs/internals/architecture/agent/ARD-001-agent-harness-and-product-adapters.md
+++ b/docs/internals/architecture/agent/ARD-001-agent-harness-and-product-adapters.md
@@ -4,6 +4,15 @@
 
 Accepted
 
+## Reading Note
+
+This ARD records the initial agent/harness split and the thin prepared-run
+facade. [ARD-002: Harness Product Adapter Substrate](ARD-002-harness-product-adapter-substrate.md)
+extends the target scope of `loushang.harness` to product-neutral host,
+adapter, command, lifecycle, and diagnostics contracts. ARD-001 remains
+authoritative for the low-level `agent` boundary and for the rule that harness
+must not depend on product packages.
+
 ## Context
 
 `loushang.agent` already provides the stable low-level agent runtime surface:

--- a/docs/internals/architecture/agent/ARD-002-harness-product-adapter-substrate.md
+++ b/docs/internals/architecture/agent/ARD-002-harness-product-adapter-substrate.md
@@ -1,0 +1,257 @@
+# ARD-002: Harness Product Adapter Substrate
+
+## Status
+
+Accepted
+
+## Context
+
+[ARD-001](ARD-001-agent-harness-and-product-adapters.md) established
+`loushang.harness` as the thin prepared-run contract between product adapters
+and the low-level `loushang.agent` loop:
+
+```text
+AgentRunSpec
+AgentRunResult
+run_agent(spec)
+```
+
+That boundary is still useful, but it is too narrow for the next product
+direction. `loushang.coding` now contains reusable host mechanics that future
+product lines such as `design`, `research`, `ppt`, and `cowork` will also need:
+
+- product adapter preparation and result handoff
+- command and command-effect descriptions
+- run/session lifecycle coordination
+- abort, idle, queue, and steering contracts
+- generic diagnostics and status reporting
+- product-neutral hooks for model/run options
+
+Keeping those mechanics in `loushang.coding` would make later product lines
+depend on coding semantics. Retaining `loushang.runtime` or creating a new
+`loushang.product` package would add another abstraction layer before the
+existing `harness` boundary is fully used.
+
+The architecture should therefore extend `loushang.harness` instead of
+introducing a parallel top-level runtime or product substrate.
+
+## Decision
+
+### 1. Extend `loushang.harness` beyond the thin run facade
+
+`loushang.harness` is the cross-product product-adapter substrate.
+
+The existing prepared-run API remains valid and should stay small. Future
+modules inside `loushang.harness` may add product-neutral contracts around that
+run API, such as:
+
+```text
+loushang.harness.run          # AgentRunSpec, AgentRunResult, run_agent
+loushang.harness.adapter      # ProductAdapter / PreparedTurn / AdapterResult protocols
+loushang.harness.host         # host/session/run coordination protocols
+loushang.harness.commands     # CommandDef / CommandEffect primitives
+loushang.harness.lifecycle    # abort, idle, dispose, queue/steer contracts
+loushang.harness.diagnostics  # generic diagnostic/status records
+```
+
+These names are target ownership markers, not a requirement to create every
+module at once.
+
+### 2. Do not retain top-level `runtime` or introduce top-level `product`
+
+No new `loushang.product` package should be created for this substrate.
+
+The existing `loushang.runtime.commands` path is an obsolete temporary location,
+not a compatibility surface to preserve. When implementation work begins, its
+product-neutral command/effect types should move under `loushang.harness`, and
+the `loushang.runtime` package should be deleted rather than kept as a re-export
+shim.
+
+### 3. Keep harness product-neutral
+
+`loushang.harness` may define protocols, value objects, and coordination
+contracts that product adapters implement or consume.
+
+It must not own concrete product behavior:
+
+- coding tools
+- slash commands and command handlers
+- AGENTS.md or prompt assembly
+- coding session JSONL schema
+- extension, package, or plugin policy
+- product UI adapters
+- TUI layout, render loop, input handling, or screen state
+- method planning
+- work projection or work event persistence
+- AI provider registry, auth, endpoint availability, or default-model storage
+- concrete artifacts for coding, design, research, ppt, cowork, or other products
+
+The TUI package remains a pure terminal UI library. Product-specific TUI wiring
+belongs in the product adapter, not in `loushang.tui` or `loushang.harness`.
+
+### 4. Preserve the low-level agent boundary
+
+`loushang.agent` remains the owner of low-level agent primitives, the stateful
+`Agent` facade, and the agent loop.
+
+`loushang.harness` may use stable agent primitives and the existing loop. It
+should not re-export the stateful `Agent` facade as a product host and should
+not implement a second agent loop.
+
+### 5. Keep work and method separate from harness
+
+`loushang.work` and `loushang.method` remain separate cross-product layers.
+
+Product adapters may compose:
+
+```text
+product adapter -> loushang.harness
+product adapter -> loushang.work
+product adapter -> loushang.method   # optional, for structured work
+```
+
+`loushang.harness` should not import `loushang.work` or `loushang.method` just
+to expose product host contracts. If a harness protocol needs to carry a work
+run id, method id, or artifact id, it should use opaque identifiers or
+protocol-shaped metadata instead of depending on those packages.
+
+### 6. Define migration pressure by second use, not by extraction alone
+
+Code should move from `loushang.coding` into `loushang.harness` only when it is
+product-neutral and likely to be used by at least one non-coding product line.
+
+Good candidates:
+
+- command/effect value types
+- product adapter protocol shapes
+- run host lifecycle contracts
+- generic abort/idle/dispose state contracts
+- generic diagnostic records
+
+Poor candidates:
+
+- concrete coding tools
+- coding command catalog and handlers
+- coding prompt/resource loading policy
+- coding settings and model persistence behavior
+- coding transcript and session persistence
+- coding TUI controller state
+
+## Dependency Rules
+
+Target dependency direction:
+
+```text
+loushang.agent
+  -> loushang.ai
+
+loushang.harness
+  -> loushang.agent
+
+product adapters
+  -> loushang.harness
+  -> loushang.work
+  -> loushang.method   # optional
+  -> loushang.ai       # only for product-level helper calls
+
+product TUI adapters
+  -> loushang.tui
+```
+
+Forbidden directions:
+
+```text
+loushang.agent -> loushang.harness
+loushang.harness -> loushang.ai
+loushang.harness -> product packages, such as loushang.coding / loushang.design / loushang.research / loushang.ppt / loushang.cowork
+loushang.harness -> loushang.tui
+loushang.harness -> loushang.work / loushang.method
+product adapter -> peer product adapter, unless through an explicit protocol
+```
+
+Architecture import-boundary tests should continue to enforce the product-free
+harness boundary while allowing `loushang.harness` to grow internally.
+
+## Current Decisions
+
+- `loushang.harness` is the place for cross-product host and adapter contracts.
+- `loushang.runtime` should be removed as part of the command/effect migration.
+- No `loushang.product` package is introduced.
+- `loushang.tui` remains a pure terminal UI library.
+- Coding remains the first product adapter and the main migration source, but
+  coding-specific behavior stays in `loushang.coding`.
+- Model defaults, auth behavior, provider/model registry resolution, and
+  endpoint availability stay outside harness. Harness can carry selected model
+  options as run inputs, but it does not decide or persist them.
+
+## Phased Direction
+
+### Phase 0: Document and inventory
+
+Record the target boundary in this ARD and update subsystem documentation so
+new work does not treat `loushang.runtime` or a future `loushang.product` as a
+valid target.
+
+### Phase 1: Command/effect substrate
+
+Move product-neutral `CommandDef`, `CommandEffect`, and related enums from the
+obsolete `loushang.runtime.commands` path into `loushang.harness.commands`.
+Update internal imports to the new path and delete
+`src/loushang/runtime/__init__.py` plus `src/loushang/runtime/commands.py`.
+Do not keep `loushang.runtime` as a compatibility shim.
+
+### Phase 2: Host and adapter contracts
+
+Introduce minimal product-neutral protocols only when implementation work needs
+them. These protocols should describe handoff points, not concrete product
+state:
+
+- preparing a turn
+- running a prepared turn
+- emitting adapter results
+- aborting or waiting for idle
+- disposing a host
+- reporting generic diagnostics
+
+### Phase 3: Coding migration slices
+
+Move only the shared substrate out of coding. Each slice should have focused
+tests that prove coding behavior is unchanged and import-boundary tests that
+prove harness remains product-free.
+
+### Phase 4: Second product validation
+
+When `design`, `research`, `ppt`, or `cowork` begins implementation, validate
+the harness contracts against that second product. If a contract only serves
+coding, move it back or keep it coding-local.
+
+## Consequences
+
+### Positive
+
+- Future product lines can share host mechanics without importing coding.
+- The existing `harness` boundary becomes more useful instead of creating a new
+  top-level abstraction layer.
+- `agent`, `work`, `method`, `tui`, and product packages keep clear ownership.
+- The migration can proceed in small slices with import-boundary tests.
+
+### Negative
+
+- `harness` is no longer only a thin run facade, so documentation and module
+  names must make the internal split clear.
+- Removing `loushang.runtime` is a breaking cleanup for any stale importers.
+- Some duplication may remain in coding until a second product validates the
+  shared contract.
+
+## Relationship To ARD-001
+
+ARD-001 remains authoritative for the original agent/harness split:
+
+- `loushang.agent` owns the low-level agent runtime.
+- `loushang.harness` depends on `loushang.agent`, never the reverse.
+- product packages depend on harness, not the reverse.
+- harness does not own product semantics.
+
+This ARD extends ARD-001 by defining the next-stage scope of
+`loushang.harness` as a product-adapter substrate, not only the initial
+`AgentRunSpec` / `AgentRunResult` / `run_agent()` facade.

--- a/docs/internals/architecture/agent/README.md
+++ b/docs/internals/architecture/agent/README.md
@@ -41,14 +41,22 @@ primitives, and the agent loop.
 
 `loushang.harness` owns the prepared-run contract shared by product adapters:
 `AgentRunSpec`, `AgentRunResult`, and `run_agent()`. These are the single
-prepared-run contract, not a second `HarnessRunSpec` layer. `loushang.harness`
-depends on `loushang.agent`; `loushang.agent` must not depend on
-`loushang.harness`.
+prepared-run contract, not a second `HarnessRunSpec` layer.
+
+The next-stage harness target is broader than the initial facade:
+`loushang.harness` is the product-neutral substrate for host, adapter,
+command/effect, lifecycle, and diagnostics contracts used by coding and future
+product lines. It still must not own concrete product semantics, TUI state,
+method planning, work projection, provider auth, or model default persistence.
+
+`loushang.harness` depends on `loushang.agent`; `loushang.agent` must not
+depend on `loushang.harness`.
 
 The former `src/loushang/agent/harness` / `loushang.agent.harness`
 compatibility path has been removed. Code should import from `loushang.harness`.
 
 See [ARD-001: Agent Harness and Product Adapter Boundaries](ARD-001-agent-harness-and-product-adapters.md).
+See also [ARD-002: Harness Product Adapter Substrate](ARD-002-harness-product-adapter-substrate.md).
 The current module ownership inventory is
 [Agent Harness Module Ownership Inventory](agent-harness-module-ownership-inventory.md).
 

--- a/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
+++ b/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
@@ -4,9 +4,14 @@
 
 Ownership inventory for
 [ARD-001: Agent Harness and Product Adapter Boundaries](ARD-001-agent-harness-and-product-adapters.md).
+Updated direction:
+[ARD-002: Harness Product Adapter Substrate](ARD-002-harness-product-adapter-substrate.md).
 
 This document records module ownership for the prepared agent run contract. It is
 intentionally an inventory, not an implementation plan.
+It remains accurate for the current thin facade; future host/adapter substrate
+migration should update this inventory or add a follow-up inventory before code
+moves.
 
 ## Scope
 

--- a/docs/internals/architecture/architecture-overview.md
+++ b/docs/internals/architecture/architecture-overview.md
@@ -21,10 +21,10 @@
 - `loushang.agent`
 - `loushang.channel`
 - `loushang.coding`
+- `loushang.harness`
 - `loushang.method`
 - `loushang.tui`
 - `loushang.work`
-- `loushang.runtime`
 - `loushang.observability`
 - `loushang.ontology`
 
@@ -44,14 +44,18 @@ loushang/
       agent/
       channel/
       coding/
+      harness/
       method/
       tui/
       work/
-      runtime/
       observability/
       ontology/
   tests/
 ```
+
+`loushang.runtime` 不再作为保留子系统。若某个 worktree 在 command/effect
+迁移完成前仍存在该路径，它只是待删除的旧临时路径；相关类型迁到
+`loushang.harness.commands` 后应删除。
 
 ## Subsystem Documentation
 
@@ -60,6 +64,8 @@ loushang/
 跨层架构判断准则请参见 [Loushang Architecture Principles](./loushang-architecture-principles.md)。
 文档分层与阅读规则请参见 [Loushang Documentation Model](./loushang-documentation-model.md)。
 `loushang-tui` 子系统文档请参见 [Loushang-TUI Architecture](./tui/README.md)。
+`loushang-harness` 的产品适配器 substrate 方向请参见
+[ARD-002: Harness Product Adapter Substrate](./agent/ARD-002-harness-product-adapter-substrate.md)。
 
 ## Architecture Stack
 

--- a/docs/internals/architecture/subsystem.md
+++ b/docs/internals/architecture/subsystem.md
@@ -19,12 +19,18 @@
 
 当前已落地的支撑/实验性包包括：
 
-- `loushang.runtime`
 - `loushang.observability`
 - `loushang.ontology`
 
+`loushang.runtime` 不再作为子系统保留。若某个 worktree 中仍存在
+`src/loushang/runtime`，它只是待删除的旧 command/effect 临时路径；迁移目标是
+`loushang.harness.commands`，不保留 runtime shim。跨产品 host / adapter /
+command substrate 的目标归属是 `loushang.harness`，见
+[ARD-002: Harness Product Adapter Substrate](./agent/ARD-002-harness-product-adapter-substrate.md)。
+
 目标产品线概念包括：
 
+- `loushang.design`
 - `loushang.research`
 - `loushang.ppt`
 - `loushang.cowork`
@@ -76,12 +82,14 @@ agent 运行内核。
 - prepared agent run contract
 - UI 渲染
 - 跨边界 transport
-- coding / research / ppt / cowork 产品语义
+- coding / design / research / ppt / cowork 产品语义
 - work / method 投影语义
 
 ### loushang-harness
 
-跨产品的 prepared agent run contract。
+跨产品的 product-adapter substrate。当前已落地的核心是 prepared agent run
+contract，后续 product-neutral host / adapter / command / lifecycle /
+diagnostics 合同也归属这里。
 
 负责：
 
@@ -89,13 +97,19 @@ agent 运行内核。
 - `AgentRunResult`
 - `run_agent()`
 - headless agent run 编排
+- product-neutral adapter / prepared-turn / adapter-result contracts
+- product-neutral host lifecycle contracts
+- command/effect value objects
+- generic diagnostics / status records
 
 不负责：
 
 - `Agent` 生命周期
 - low-level agent loop ownership
-- coding / research / ppt / cowork 产品语义
+- coding / design / research / ppt / cowork 产品语义
 - work / method 投影语义
+- provider auth / model default persistence
+- TUI render loop、layout、input 或 screen state
 
 `loushang.harness` 位于 low-level agent loop 之上，依赖 `loushang.agent` 并
 复用现有 loop，不另写第二套 loop。`loushang.agent` 不依赖
@@ -103,7 +117,9 @@ agent 运行内核。
 prepared-run contract，不引入第二套 `HarnessRunSpec`。原
 `src/loushang/agent/harness` / `loushang.agent.harness` compatibility path 已删除；
 新代码应从 `loushang.harness` import。详见
-[Agent Harness and Product Adapter Boundaries](./agent/ARD-001-agent-harness-and-product-adapters.md)。
+[Agent Harness and Product Adapter Boundaries](./agent/ARD-001-agent-harness-and-product-adapters.md)
+和
+[Harness Product Adapter Substrate](./agent/ARD-002-harness-product-adapter-substrate.md)。
 
 ### loushang-channel (target)
 
@@ -126,7 +142,7 @@ prepared-run contract，不引入第二套 `HarnessRunSpec`。原
 - agent 内核状态机
 - 本地 UI 组件实现
 - 方法层调度
-- coding / research / ppt / cowork 产品内部 session
+- coding / design / research / ppt / cowork 产品内部 session
 - 产品 adapter 注册之外的业务执行
 
 `channel` 面向多客户端和多 UI：TUI、WebUI、AppUI、SDK host、RPC client
@@ -207,16 +223,16 @@ workflows 中使用 `method`，但轻量 turn 可以直接使用 `loushang.harne
 - method resource 编译
 - TUI 呈现
 - 外部 transport
-- coding / research / ppt / cowork 产品语义
+- coding / design / research / ppt / cowork 产品语义
 
-`work` 是 coding、research、ppt、cowork 等产品线共享的工作事实与投影抽象。
+`work` 是 coding、design、research、ppt、cowork 等产品线共享的工作事实与投影抽象。
 它不依赖这些产品线，也不依赖 `method`。
 
 Artifact 分层规则：
 
 - `method` 定义 expected artifact，即结构化工作“应该产出什么”
 - `work` 记录 actual artifact reference，即“实际产出了什么、在哪里、状态如何”
-- `coding` / `research` / `ppt` / `cowork` 定义具体 artifact 类型、内容、
+- `coding` / `design` / `research` / `ppt` / `cowork` 定义具体 artifact 类型、内容、
   加载、渲染、校验和物化逻辑
 
 因此 `work` 层优先引入 `ArtifactRef`，而不是抽象 `Artifact` ABC。若未来需要
@@ -273,14 +289,14 @@ loushang.ai
 
 loushang.agent
   <- loushang.harness
-  <- loushang.coding / loushang.research / loushang.ppt / loushang.cowork
+  <- loushang.coding / loushang.design / loushang.research / loushang.ppt / loushang.cowork
 ```
 
 跨产品工作抽象链路为：
 
 ```text
 loushang.work
-  <- loushang.coding / loushang.research / loushang.ppt / loushang.cowork
+  <- loushang.coding / loushang.design / loushang.research / loushang.ppt / loushang.cowork
 
 loushang.work
   <- loushang.method
@@ -297,14 +313,15 @@ external host/client -> loushang.channel -> loushang.work -> domain app
 
 - `ai` 提供模型接入能力
 - `agent` 提供运行语义
-- `harness` 提供跨产品 prepared-run contract
+- `harness` 提供跨产品 prepared-run contract 以及 product-neutral host /
+  adapter / command substrate
 - `channel` 提供目标边界通信，当前未作为源码包落地
 - `tui` 提供通用终端交互原语
 - `method` 提供可选的方法组织与 plan/projection
 - `work` 提供运行、事件、日志与 projection
 - `coding` 提供 coding 产品装配，并通过 `loushang.coding.ui` 调用
   `loushang.tui`
-- `research`、`ppt`、`cowork` 是目标产品线概念，和 `coding` 并列，而不是
+- `design`、`research`、`ppt`、`cowork` 是目标产品线概念，和 `coding` 并列，而不是
   `work` 或 `agent` 的子层
 
 ## Future Dependency Map
@@ -342,6 +359,7 @@ Product packages are peers:
 
 ```text
 coding
+design
 research
 ppt
 cowork

--- a/src/loushang/coding/commands/catalog.py
+++ b/src/loushang/coding/commands/catalog.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable
 from typing import Any
 
 from loushang.coding.commands.slash import split_slash_command
-from loushang.runtime.commands import (
+from loushang.harness.commands import (
     CommandDef,
     CommandEffect,
     CommandEffectKind,

--- a/src/loushang/coding/ui/controller.py
+++ b/src/loushang/coding/ui/controller.py
@@ -16,8 +16,8 @@ from loushang.coding.ui.intent import (
     PromptIntent,
     QuitIntent,
 )
+from loushang.harness.commands import CommandEffectKind
 from loushang.observability import get_log
-from loushang.runtime.commands import CommandEffectKind
 
 log = get_log(__name__).bind(component="CodingUiController")
 
@@ -70,7 +70,7 @@ class CodingUiController:
                 error_message="Request cancelled.",
                 traceback_text=traceback.format_exc() if self.verbose else None,
             )
-        except Exception as error:  # noqa: BLE001
+        except Exception as error:
             log.problem(
                 "coding_ui_dispatch_failed",
                 source="agent",
@@ -94,7 +94,7 @@ class CodingUiController:
                 return ControllerResult(error_message="Steering is unavailable for this session.")
             await _call_text_method(method, text, images=images)
             return ControllerResult()
-        except Exception as error:  # noqa: BLE001
+        except Exception as error:
             log.problem(
                 "coding_ui_steer_failed",
                 source="agent",
@@ -116,7 +116,7 @@ class CodingUiController:
                 return ControllerResult(error_message="Follow-up is unavailable for this session.")
             await _call_text_method(method, text, images=images)
             return ControllerResult()
-        except Exception as error:  # noqa: BLE001
+        except Exception as error:
             log.problem(
                 "coding_ui_follow_up_failed",
                 source="agent",

--- a/src/loushang/coding/ui/handlers.py
+++ b/src/loushang/coding/ui/handlers.py
@@ -19,7 +19,7 @@ from loushang.coding.ui.lifecycle import RunLifecycle
 from loushang.coding.ui.pending_queue import pending_queue_view, restore_queued_messages
 from loushang.coding.ui.prompt_dispatch import PromptDispatchOutcome
 from loushang.coding.ui.prompt_routing import PromptRoute, route_prompt_intent
-from loushang.runtime.commands import CommandEffect, CommandEffectKind
+from loushang.harness.commands import CommandEffect, CommandEffectKind
 from loushang.tui import InfoPanel, PendingQueueView
 
 

--- a/src/loushang/coding/ui/screen_surfaces.py
+++ b/src/loushang/coding/ui/screen_surfaces.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, replace
-from typing import Any, Awaitable, Literal, Protocol
+from typing import Any, Literal, Protocol
 
 from loushang.coding.commands.catalog import CodingCommandCatalog
 from loushang.coding.ui.command_list import (
@@ -37,7 +37,7 @@ from loushang.coding.ui.model_list import (
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 from loushang.coding.ui.settings_page import SettingsPageView
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-from loushang.runtime.commands import CommandDef, CommandKind
+from loushang.harness.commands import CommandDef, CommandKind
 from loushang.tui import (
     ApprovalSurface,
     CommandPalette,

--- a/src/loushang/harness/commands.py
+++ b/src/loushang/harness/commands.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Mapping
 
 
 class CommandKind(Enum):

--- a/src/loushang/runtime/__init__.py
+++ b/src/loushang/runtime/__init__.py
@@ -1,8 +1,0 @@
-from loushang.runtime.commands import (
-    CommandDef,
-    CommandEffect,
-    CommandEffectKind,
-    CommandKind,
-)
-
-__all__ = ["CommandDef", "CommandEffect", "CommandEffectKind", "CommandKind"]

--- a/tests/coding/test_coding_command_catalog.py
+++ b/tests/coding/test_coding_command_catalog.py
@@ -7,7 +7,7 @@ def test_coding_command_catalog_classifies_local_and_session_commands() -> None:
     from loushang.coding.commands.catalog import CodingCommandCatalog
     from loushang.coding.ui.intent import PromptIntent, SettingsIntent
     from loushang.coding.ui.prompt_routing import PromptRoute
-    from loushang.runtime.commands import CommandEffectKind, CommandKind
+    from loushang.harness.commands import CommandEffectKind, CommandKind
 
     catalog = CodingCommandCatalog(
         session_commands=lambda: [
@@ -49,7 +49,7 @@ def test_coding_command_catalog_leaves_plain_prompts_and_queue_routes_unowned() 
 
 def test_coding_command_catalog_preserves_local_command_argument_rules() -> None:
     from loushang.coding.commands.catalog import CodingCommandCatalog
-    from loushang.runtime.commands import CommandKind
+    from loushang.harness.commands import CommandKind
 
     catalog = CodingCommandCatalog(session_commands=lambda: [])
 
@@ -65,7 +65,7 @@ def test_coding_command_catalog_preserves_local_command_argument_rules() -> None
 
 def test_coding_command_catalog_lists_local_and_session_commands_once() -> None:
     from loushang.coding.commands.catalog import CodingCommandCatalog
-    from loushang.runtime.commands import CommandKind
+    from loushang.harness.commands import CommandKind
 
     catalog = CodingCommandCatalog(
         session_commands=lambda: [

--- a/tests/coding/test_screen_coding_tui_surfaces.py
+++ b/tests/coding/test_screen_coding_tui_surfaces.py
@@ -563,7 +563,7 @@ def test_screen_surface_manager_opens_terminal_diagnostics_surface() -> None:
 
 
 def test_screen_surface_manager_routes_local_commands_through_command_catalog() -> None:
-    from loushang.runtime.commands import CommandDef, CommandKind
+    from loushang.harness.commands import CommandDef, CommandKind
 
     class Catalog:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- include the harness product adapter substrate ARD docs commit from the control lane
- move command/effect value types from `loushang.runtime.commands` to `loushang.harness.commands`
- delete `src/loushang/runtime` with no compatibility shim
- update internal coding imports and focused tests to use `loushang.harness.commands`

## Scope
- does not change command catalog behavior, command handlers, slash command semantics, or TUI controller/surface state
- does not add command types to `loushang.harness.__init__` top-level exports

## Validation
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_coding_command_catalog.py tests/coding/test_screen_coding_tui_surfaces.py tests/coding/test_ui_handlers.py tests/coding/test_ui_controller.py tests/architecture/test_import_boundaries.py -q`
- `uv --cache-dir /tmp/uv-cache run --extra dev ruff check src/loushang/harness/commands.py src/loushang/coding/commands/catalog.py src/loushang/coding/ui/screen_surfaces.py src/loushang/coding/ui/handlers.py src/loushang/coding/ui/controller.py tests/coding/test_coding_command_catalog.py tests/coding/test_screen_coding_tui_surfaces.py`
- `rg -n "loushang\.runtime|runtime\.commands" src tests` returned no matches
- `test ! -d src/loushang/runtime`
- `git diff --check main...HEAD`