### PR TITLE
test(harness): harden slice 1 boundaries

### DIFF
--- a/docs/internals/architecture/harness/slice-1-approval-tools-presentation-design.md
+++ b/docs/internals/architecture/harness/slice-1-approval-tools-presentation-design.md
@@ -222,6 +222,20 @@ public SDK surface decision is explicit. They can be deleted only when:
 Top-level `loushang.coding` and `loushang.coding.tools` exports remain stable
 through Slice 1.
 
+Compatibility lifecycle:
+
+- internal-only shims should be deleted once all in-repo imports have moved to
+  the focused harness owner module and no product adapter still needs the old
+  submodule path;
+- public SDK compatibility paths stay until a documented deprecation or
+  long-term support decision is accepted for each path;
+- Pi-style wrapper aliases stay in `loushang.coding.tools.wrapper` and must not
+  be introduced as module-level aliases in neutral harness modules;
+- harness-owned classes keep their harness `__module__`; coding compatibility
+  shims preserve import paths, not class module identity;
+- compatibility tests should cover both retained public paths and deleted
+  neutral-surface aliases before any shim removal.
+
 ## External Reference: Hermes Agent
 
 `~/workspace/hermes-agent` is useful as a boundary validation sample, not as a

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import importlib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -82,6 +83,54 @@ def test_core_runtime_packages_do_not_import_product_layers() -> None:
 
 def test_legacy_agent_harness_package_has_been_removed() -> None:
     assert not Path("src/loushang/agent/harness").exists()
+
+
+def test_harness_slice1_symbols_are_not_top_level_exports() -> None:
+    import loushang.harness as harness
+
+    slice1_symbols = {
+        "ApprovalDecision",
+        "ApprovalRequest",
+        "ApprovalResolver",
+        "ToolDefinition",
+        "ToolRegistry",
+        "ToolRenderRuntime",
+        "ToolResultPresentation",
+        "tool",
+    }
+
+    assert slice1_symbols.isdisjoint(set(harness.__all__))
+
+
+def test_harness_tools_core_does_not_expose_pi_style_module_aliases() -> None:
+    module = importlib.import_module("loushang.harness.tools.core")
+
+    pi_style_aliases = {
+        "createToolDefinitionFromAgentTool",
+        "wrapToolDefinition",
+        "wrapToolDefinitions",
+    }
+
+    assert [name for name in sorted(pi_style_aliases) if hasattr(module, name)] == []
+
+
+def test_harness_slice1_compatibility_lifecycle_is_documented() -> None:
+    text = " ".join(
+        Path("docs/internals/architecture/harness/slice-1-approval-tools-presentation-design.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    required_phrases = {
+        "`__module__`",
+        "harness-owned classes keep their harness `__module__`",
+        "coding compatibility shims preserve import paths, not class module identity",
+        "Pi-style wrapper aliases stay in `loushang.coding.tools.wrapper`",
+        "internal-only shims",
+        "public SDK compatibility paths",
+    }
+
+    assert sorted(phrase for phrase in required_phrases if phrase not in text) == []
 
 
 def test_absolute_imports_include_child_aliases_from_package_import(


### PR DESCRIPTION
## Summary

Harden the harness Slice 1 boundary after the initial approval/tools.core/presentation extraction.

Changes:
- Add architecture tests that keep Slice 1 symbols out of top-level `loushang.harness.__all__`.
- Add architecture coverage preventing Pi-style wrapper aliases from leaking into `loushang.harness.tools.core`.
- Document compatibility shim lifecycle, public SDK compatibility paths, and the `__module__` decision for harness-owned classes.

## Validation

- `uv --cache-dir .uv-cache run pytest tests/architecture/test_import_boundaries.py tests/harness/test_approval.py tests/harness/test_presentation.py tests/harness/tools/test_core.py tests/coding/test_tool_authoring.py tests/coding/test_tool_wrapper.py tests/coding/test_tool_public_types.py -q` -> 50 passed
- `uv --cache-dir .uv-cache run ruff check tests/architecture/test_import_boundaries.py` -> passed
- `git diff --check` -> clean

Base: `lane/harness`
Head: `harness/slice-1-hardening`