### PR TITLE
feat(harness): resolve tool contributions

### DIFF
--- a/docs/internals/architecture/drafts/README.md
+++ b/docs/internals/architecture/drafts/README.md
@@ -31,3 +31,4 @@ Current live references:
 - [P3 Fixed MethodPlan Flow Research](p3-fixed-methodplan-flow-research.md)
 - [Method Deviation And Evolution](method-deviation-and-evolution.md)
 - [Methodology System Reference Survey](loushang-methodology-system-reference-survey.md)
+- [WorkBuddy Lessons For Loushang](workbuddy-lessons-for-loushang.md)

--- a/docs/internals/architecture/drafts/workbuddy-lessons-for-loushang.md
+++ b/docs/internals/architecture/drafts/workbuddy-lessons-for-loushang.md
@@ -1,0 +1,241 @@
+# WorkBuddy 对 Loushang 的启示
+
+## 状态
+
+Draft / reference note.
+
+本文档沉淀对 WorkBuddy 产品形态、架构图和公开文档的观察，用作
+`loushang.harness`、`loushang.method`、`loushang.work` 后续设计输入。
+
+本文档不是已接受架构决策。若本文档与当前代码、测试、ARD 或 live
+architecture note 冲突，以 live source 为准。
+
+## 参考来源
+
+- WorkBuddy 专家和专家团架构图：用户提供的头条图片直链。
+- WorkBuddy 专家设计拆解图：用户提供的头条图片直链。
+- WorkBuddy 专家团工作方式图：用户提供的头条图片直链。
+- WorkBuddy 新建任务栏：
+  https://www.codebuddy.cn/docs/workbuddy/From-Beginner-to-Expert-Guide/Function-Description/Task-Bar
+- WorkBuddy 权限模式：
+  https://www.codebuddy.cn/docs/workbuddy/From-Beginner-to-Expert-Guide/Function-Description/Permission-Modes
+- WorkBuddy 技能：
+  https://www.codebuddy.cn/docs/workbuddy/From-Beginner-to-Expert-Guide/Function-Description/Skills-Market
+- WorkBuddy 连接器：
+  https://www.codebuddy.cn/docs/workbuddy/From-Beginner-to-Expert-Guide/Function-Description/Connector
+- WorkBuddy 评论文章：
+  https://baijiahao.baidu.com/s?id=1869854506123667076&wfr=spider&for=pc
+- OpenClaw GitHub：
+  https://github.com/openclaw/openclaw
+
+## 核心判断
+
+WorkBuddy 的价值不在于发明新的底层 Agent 原语，而在于把 Agent 的不确定执行
+包装成用户可理解、可管理、可复用的任务产品。
+
+它面向用户暴露的是：
+
+- 新建任务栏
+- Ask / Plan / Craft 工作模式
+- 专家
+- 专家团
+- 技能
+- 连接器
+- 权限模式
+- 项目、任务、工作区和产物
+
+它隐藏的是：
+
+- prompt 结构
+- context 装配
+- tool schema 和工具调用
+- 多 Agent 调度
+- 工作流状态
+- 权限判断和高风险操作 gate
+
+这对 Loushang 的启示是：底座要提供可靠机制，产品适配层要把机制包装成稳定
+交付入口。
+
+## 与 Loushang 的分层映射
+
+| WorkBuddy 概念 | Loushang 对应层 | 备注 |
+| --- | --- | --- |
+| 新建任务栏 | product adapter / prepared turn assembly | UI 和默认值不进 harness |
+| Ask / Plan / Craft | product mode + method projection + approval policy | 模式语义由产品解释 |
+| 专家 | `loushang.method` | role、workflow、deliverables、success criteria |
+| 专家团 | product orchestration / future cowork layer | 运行事实落到 `work` |
+| 技能 | `harness.tools.contribution` + product skill adapter | harness 只做中立贡献和解析 |
+| 连接器 | product connector adapter + neutral tool contracts | 授权、账号、票据不进 harness |
+| 权限模式 | `harness.approval` + product policy | harness 不拥有风险策略 |
+| 任务状态和历史 | `loushang.work` | run、event、projection、artifact refs |
+| 最终交付 | `work.ArtifactRef` + `harness.presentation` + product renderer | 交付模板属于产品或 method |
+| 项目共享配置 | product store / future collaboration product | 指令、专家、技能、连接器、资料库自动注入 |
+
+## 对 Harness 的启示
+
+Harness 应继续保持 product-neutral substrate，而不是变成 WorkBuddy 产品概念的
+集合。
+
+适合进入 harness 的机制：
+
+- prepared run / prepared turn contract
+- tool definition、tool registry、tool contribution resolver
+- neutral diagnostics
+- approval request / decision / resolver
+- neutral presentation records
+- opaque metadata passthrough
+
+不应进入 harness 的产品概念：
+
+- ExpertDefinition
+- ExpertSquad
+- TaskBar
+- Project
+- workspace store
+- connector authorization
+- model defaults
+- Ask / Plan / Craft 默认行为
+- prompt templates
+- role / workflow / deliverable semantics
+- agent team scheduling policy
+
+对当前 Slice 1b 的直接结论：`harness.tools.contribution` 是正确方向，但它应只
+解决 tool contribution、pack、include、enable/disable、deterministic
+resolution 和 diagnostics，不应解释专家、任务、工作流或交付模板。
+
+## 对 Method 的启示
+
+WorkBuddy 的“专家”本质是稳定交付模板，而不是自由聊天 persona。
+
+`loushang.method` 可以吸收这种设计思想，把 method 视为结构化 work contract：
+
+- role：谁在执行这种任务
+- workflow：按什么步骤推进
+- constraints：哪些边界不能越过
+- expected artifacts：应该产出什么
+- acceptance expectations：怎样算完成
+- guidance：执行过程中的方法论和注意事项
+- gates：哪些步骤需要确认、审阅或降级
+
+Method 不应负责执行工具，也不应记录实际产物。它定义 expected artifacts；
+`work` 记录 actual artifact refs。
+
+## 对 Work 的启示
+
+WorkBuddy 的任务列表、任务状态、工作区、结果查看和最终交付说明：真实产品需要
+可观察、可恢复、可审计的运行事实层。
+
+`loushang.work` 应重点承载：
+
+- `WorkRun`
+- `WorkEvent`
+- run status projection
+- step / plan lifecycle projection
+- actual artifact refs
+- replay / inspect 所需事件日志
+- failure、pending、approval、completed 等状态事实
+
+Work 不应成为 orchestration engine。它记录“发生了什么”，不决定“应该怎样协作”。
+
+## 对 Product Adapter 的启示
+
+WorkBuddy 的新建任务栏可以被理解为一个产品级 `Prepared Task Capsule`：
+
+```text
+mode
+model
+workspace
+tool packs / skills
+connectors
+approval mode
+context sources
+project defaults
+task prompt
+```
+
+在 Loushang 中，这类 capsule 应由产品适配层组装，再调用 harness、method、work
+等底层能力。
+
+对未来 coding / design / research / ppt / cowork 产品线，推荐方向是：
+
+- 提供用户可理解的 task preset 或 expert-like 入口。
+- 按任务启用能力，避免全局注入所有 skills/tools。
+- 将工作目录、权限模式、模型选择、上下文来源显式化。
+- 把计划、执行、产物和失败状态投影成稳定的 inspect surface。
+- 让 product adapter 拥有默认值和 UI 行为。
+
+## Loushang 是否支持完成 WorkBuddy
+
+架构上支持。
+
+当前 Loushang 已经具备或正在建设 WorkBuddy 类产品所需的关键底座：
+
+- `loushang.harness`：prepared run、approval、tools core、presentation 等中立机制。
+- `loushang.method`：结构化工作契约、method resource、compile、projection。
+- `loushang.work`：运行事实、事件日志、projection、artifact reference 方向。
+- `loushang.coding`：产品适配层示例，负责默认工具、策略、session、UI 集成。
+- `loushang.tui`：通用终端 UI primitives。
+- `loushang.ai`：provider/model/auth 边界。
+
+Loushang 与 WorkBuddy 的差异在于：WorkBuddy 已经是完整产品体验；Loushang 当前
+更像可构建多个 WorkBuddy 类产品的分层 substrate。
+
+## Loushang 能否超越 WorkBuddy
+
+有可能，但前提是继续保持边界纪律。
+
+潜在优势：
+
+- `harness`、`method`、`work`、`ai`、`tui`、product adapter 边界更明确。
+- `method` 可把专家方法论建模为结构化 contract，而不是只靠 prompt blob。
+- `work` 可提供可回放、可审计、可检查的 runtime fact layer。
+- harness 可服务 coding、design、research、ppt、cowork 和 OEM 产品，不绑定单一产品形态。
+- import-boundary tests 和 slice migration 让长期演进更可控。
+
+当前短板：
+
+- 还没有 WorkBuddy 那样完整的新建任务栏、项目、专家、专家团产品入口。
+- connector 授权、项目资产、团队协作、自动化调度仍不是完整产品能力。
+- 多 Agent 主理人调度和任务派发还没有成为稳定公共层。
+- deliverable-first 的产品体验还需要 method/work/presentation/product adapter 一起补齐。
+
+结论：现在不能说功能已经超越 WorkBuddy；但架构潜力更大，尤其适合做多产品线、
+可审计、可扩展的 Agent operating substrate。
+
+## WorkBuddy 是否开源
+
+截至本文档编写时，未找到 WorkBuddy 核心产品的官方开源仓库或开源许可证。
+公开资料显示它是 CodeBuddy / 腾讯云代码助手体系下的产品。
+
+需要区分：
+
+- WorkBuddy 核心产品：未见官方开源。
+- WorkBuddy Skill 生态：支持上传本地技能包、查找和创建技能，也提到兼容
+  OpenClaw 社区技能导入；这是扩展生态开放，不等于核心开源。
+- OpenClaw：开源项目，GitHub 仓库公开且标注 MIT License。WorkBuddy 与
+  OpenClaw 生态或功能形态相关，不代表 WorkBuddy 本身开源。
+
+## 对近期 Harness 工作的建议
+
+近期仍应推进 Slice 1b：tool contribution resolver。
+
+推荐落点：
+
+- 新增 `loushang.harness.tools.contribution`。
+- 定义 neutral `ToolContribution`、`ToolPackDefinition`、resolver result 和 diagnostics。
+- 支持 deterministic ordering、pack includes、enable/disable、duplicate 和 missing diagnostics。
+- 允许 opaque metadata 透传，但 harness 不解释领域语义。
+- coding 通过 adapter 调用 resolver，保持现有行为不变。
+
+明确不做：
+
+- 不迁移 concrete coding tools。
+- 不实现 expert / squad / workflow / task bar。
+- 不引入 workspace、context、memory、session 等新顶层包。
+- 不把 product defaults、prompt templates、model defaults、connector auth 放进 harness。
+
+一条可复用原则：
+
+> Method defines stable work contracts; Work records runtime facts and
+> deliverables; Harness provides neutral execution and contribution mechanisms;
+> product adapters package them into expert-like user experiences.

--- a/docs/internals/architecture/harness/slice-1-approval-tools-presentation-design.md
+++ b/docs/internals/architecture/harness/slice-1-approval-tools-presentation-design.md
@@ -41,6 +41,7 @@ Slice 1 introduces or fills these focused modules:
 
 - `loushang.harness.approval`
 - `loushang.harness.tools.core`
+- `loushang.harness.tools.contribution`
 - `loushang.harness.presentation`
 
 No new top-level packages such as `loushang.workspace`, `loushang.context`,
@@ -89,8 +90,8 @@ expressed without importing UI callbacks or product payload semantics.
 
 ### Harness Owns
 
-`loushang.harness.tools.core` owns neutral tool definition, contribution, schema,
-registry, and agent-adaptation mechanics:
+`loushang.harness.tools.core` owns neutral tool definition, schema, registry,
+and agent-adaptation mechanics:
 
 - `ToolDefinition`
 - `ToolRenderCall`
@@ -144,6 +145,49 @@ secondary parameter schema as opaque metadata if needed for compatibility, but
 the current behavior where runtime agent tools expose
 `provider_parameters or parameters` stays in the coding wrapper until a neutral
 provider-adaptation contract exists.
+
+### Tool Contribution Resolver
+
+`loushang.harness.tools.contribution` owns neutral tool contribution and
+tool-pack resolution mechanics:
+
+- `ToolContribution`
+- `ToolPackDefinition`
+- `ToolResolutionDiagnostic`
+- `ToolResolutionResult`
+- `ToolResolutionError`
+- `resolve_tool_contributions`
+
+The resolver supports deterministic ordering, transitive pack includes,
+enable/disable filtering, duplicate tool or pack diagnostics, and missing
+reference diagnostics. It preserves opaque `source_info` and metadata for
+product adapters, but does not interpret task, expert, workflow, prompt,
+connector, model, or UI semantics.
+
+Coding remains responsible for concrete built-in tool registration, default
+pack activation, user-facing labels, product-specific aliases, external tool
+installation policy, and any migration from current coding registry paths.
+
+Slice 1b may add a coding adapter verification path where
+`loushang.coding.tools.ToolRegistry` projects its current registry state into
+neutral `ToolContribution` records and calls the harness resolver. This path is
+read-only: it must not change registration order, enable/disable state,
+materialized runtime tools, built-in tool defaults, or prompt assembly.
+
+Coding default tool-pack registration may also call the harness resolver after
+coding has created product-owned `ToolContribution` and `ToolPackDefinition`
+records. The pack names, built-in tool names, legacy order, factory options,
+policy wiring, and default activation remain coding-owned; harness only resolves
+the supplied neutral records.
+
+Bootstrap-time coding extension tools may use the same resolver path. Coding
+adapters project extension tool metadata into neutral `ToolContribution`
+records, preserve opaque `source_info` for diagnostics, and register only the
+extension contributions returned by the resolver. Concrete execution still
+stays in coding through the existing extension runner and tool wrapper. Runtime
+dynamic registration through extension callbacks remains coding-owned in Slice
+1b; migrating that path requires a separate execution-context boundary because
+it touches live session state and product runtime behavior.
 
 ## Presentation Boundary
 
@@ -242,7 +286,7 @@ Compatibility lifecycle:
 template to copy.
 
 Its tool registry demonstrates a contribution-record shape that is relevant to
-`harness.tools.core`: tool name, schema, handler, toolset membership,
+`harness.tools.contribution`: tool name, schema, handler, toolset membership,
 availability metadata, dynamic schema override hooks, registry snapshots, and a
 generation counter. Slice 1 may borrow those mechanism concepts, but not the
 Hermes implementation style. Hermes uses import-time singleton registration,
@@ -251,8 +295,8 @@ and JSON-string dispatch; those are product/runtime choices and remain outside
 harness.
 
 Hermes toolsets also validate that pack/include resolution is a shared
-mechanism, while defaults remain product-owned. Harness may define neutral
-tool-pack contribution and include resolution in or near `harness.tools.core`.
+mechanism, while defaults remain product-owned. Harness defines neutral
+tool-pack contribution and include resolution in `harness.tools.contribution`.
 Coding still decides the default tool set, activation order, disabled platform
 bundles, aliases, and user-facing names.
 
@@ -317,8 +361,16 @@ Focused tests:
 Create `loushang.harness.tools.core` for neutral tool definition, schema,
 decorator metadata, registry mechanics, and agent-tool adaptation.
 
+Create `loushang.harness.tools.contribution` for neutral contribution records,
+tool-pack definitions, pack include resolution, enable/disable filtering, and
+resolution diagnostics.
+
 Keep decorated plain-return normalization, coding `ToolContext`, concrete tools,
 tool factories, default tool packs, and public Pi-style aliases in coding.
+Built-in coding tool registration and bootstrap-time extension tool
+registration may use `harness.tools.contribution` as a neutral resolver, but
+the supplied contributions, default pack choices, conflict policy, runner
+binding, and concrete execution remain coding-owned.
 
 Focused tests:
 
@@ -330,6 +382,7 @@ Focused tests:
 - `tests/coding/test_prompt_assembly.py`
 - extension tests that import `ToolDefinition`
 - new harness tools-core tests
+- new harness tool contribution tests
 - `tests/architecture/test_import_boundaries.py`
 
 ### Step 4: Coding Compatibility Adapters

--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -43,6 +43,11 @@ from loushang.coding.source_info import executable_source_identity
 from loushang.coding.store import SessionManager
 from loushang.coding.tools import ToolRegistry
 from loushang.coding.types import ModelSelection
+from loushang.harness.tools.contribution import (
+    ToolContribution,
+    ToolResolutionResult,
+    resolve_tool_contributions,
+)
 
 AgentFactory = Callable[..., Agent]
 ServicesFactory = Callable[[str], "BootstrapServices"]
@@ -874,34 +879,87 @@ def _register_extension_tools(
     extension_tools = extension_runner.list_tool_definitions()
     if not extension_tools:
         return resource_bundle, tool_registry, []
-
     resolved_tool_registry = tool_registry
     if resolved_tool_registry is None:
         resolved_tool_registry = ToolRegistry()
 
-    diagnostics: list[ResourceDiagnostic] = []
-    existing_names = {
-        definition.name
-        for definition in resolved_tool_registry.list_definitions()
-    }
-    for definition in extension_tools:
-        if definition.name in existing_names:
-            diagnostics.append(
-                ResourceDiagnostic(
-                    code="extension_tool_conflict",
-                    message=f"Extension tool '{definition.name}' conflicts with an existing registry tool.",
-                )
-            )
-            continue
+    resolution = _resolve_extension_tool_contributions(
+        extension_runner=extension_runner,
+        tool_registry=resolved_tool_registry,
+    )
+    conflict_diagnostics = _extension_tool_conflict_diagnostics(resolution)
+    diagnostics: list[ResourceDiagnostic] = list(conflict_diagnostics.values())
+    for contribution in _extension_tool_registration_contributions(resolution, conflict_names=set(conflict_diagnostics)):
         resolved_tool_registry.register_tool(
-            definition,
-            source_info=extension_runner.get_tool_source_info(definition.name),
+            contribution.definition,
+            source_info=contribution.source_info,
         )
-        existing_names.add(definition.name)
 
     if diagnostics:
         resource_bundle = resource_bundle.merge(diagnostics=diagnostics)
     return resource_bundle, resolved_tool_registry, diagnostics
+
+
+def _resolve_extension_tool_contributions(
+    *,
+    extension_runner: ExtensionRunner,
+    tool_registry: ToolRegistry,
+) -> ToolResolutionResult:
+    return resolve_tool_contributions(
+        (
+            *tool_registry.list_contributions(),
+            *_extension_tool_contributions(extension_runner),
+        ),
+        fail_on_errors=False,
+    )
+
+
+def _extension_tool_registration_contributions(
+    resolution: ToolResolutionResult,
+    *,
+    conflict_names: set[str],
+) -> tuple[ToolContribution, ...]:
+    contributions: list[ToolContribution] = []
+    for contribution in resolution.contributions:
+        if not _is_extension_tool_contribution(contribution):
+            continue
+        if contribution.definition.name in conflict_names:
+            continue
+        contributions.append(contribution)
+    return tuple(contributions)
+
+
+def _extension_tool_contributions(extension_runner: ExtensionRunner) -> tuple[ToolContribution, ...]:
+    return tuple(
+        ToolContribution(
+            definition,
+            source_info=extension_runner.get_tool_source_info(definition.name),
+            metadata={
+                "kind": "extension_tool",
+                "extension_tool": definition.name,
+            },
+        )
+        for definition in extension_runner.list_tool_definitions()
+    )
+
+
+def _extension_tool_conflict_diagnostics(resolution: ToolResolutionResult) -> dict[str, ResourceDiagnostic]:
+    conflicts: dict[str, ResourceDiagnostic] = {}
+    for diagnostic in resolution.diagnostics:
+        if diagnostic.code != "duplicate_tool":
+            continue
+        name = diagnostic.details.get("name")
+        if not isinstance(name, str):
+            continue
+        conflicts[name] = ResourceDiagnostic(
+            code="extension_tool_conflict",
+            message=f"Extension tool '{name}' conflicts with an existing registry tool.",
+        )
+    return conflicts
+
+
+def _is_extension_tool_contribution(contribution: ToolContribution) -> bool:
+    return contribution.metadata.get("kind") == "extension_tool"
 
 
 def _convert_to_llm_with_block_images(settings_manager: SettingsManager):

--- a/src/loushang/coding/tools/builtins.py
+++ b/src/loushang/coding/tools/builtins.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from loushang.coding.diagnostics import DiagnosticsService
 from loushang.coding.exec import ExecService
 from loushang.coding.policy import ApprovalResolver, PolicyEngine
+from loushang.harness.tools.contribution import (
+    ToolContribution,
+    ToolPackDefinition,
+    resolve_tool_contributions,
+)
 
 from .external_tools import (
     ExternalToolDownloader,
@@ -14,6 +19,7 @@ from .operations import ToolOperations
 from .registry import ToolRegistry
 
 BUILTIN_TOOL_NAMES = ("bash", "read", "ls", "find", "grep", "write", "edit")
+BUILTIN_TOOL_PACK = ToolPackDefinition(name="coding.builtin", tools=BUILTIN_TOOL_NAMES)
 
 
 def register_builtin_tools(
@@ -42,6 +48,15 @@ def register_builtin_tools(
         allow_external_tool_downloads=allow_external_tool_downloads,
         require_external_tools=require_external_tools,
     )
-    for tool_name in BUILTIN_TOOL_NAMES:
-        registry.register_tool(create_tool_definition(tool_name, options=options))
+    contributions = tuple(
+        ToolContribution(create_tool_definition(tool_name, options=options))
+        for tool_name in BUILTIN_TOOL_NAMES
+    )
+    result = resolve_tool_contributions(
+        contributions,
+        packs=(BUILTIN_TOOL_PACK,),
+        include_packs=(BUILTIN_TOOL_PACK.name,),
+    )
+    for definition in result.definitions:
+        registry.register_tool(definition)
     return registry

--- a/src/loushang/coding/tools/registry.py
+++ b/src/loushang/coding/tools/registry.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from typing import Any
 
 from loushang.agent.types import AgentTool, is_agent_tool_like
+from loushang.harness.tools.contribution import (
+    ToolContribution,
+    ToolPackDefinition,
+    ToolResolutionResult,
+    resolve_tool_contributions,
+)
 from loushang.harness.tools.core import ToolRegistry as HarnessToolRegistry
 
 from .authoring import DecoratedTool
@@ -46,6 +52,33 @@ class ToolRegistry(HarnessToolRegistry):
             wrap_tool_definition(definition, context_provider=context_provider)
             for definition in definitions
         ]
+
+    def list_contributions(self) -> tuple[ToolContribution, ...]:
+        enabled_names = {definition.name for definition in self.list_enabled_definitions()}
+        return tuple(
+            ToolContribution(
+                definition,
+                enabled=definition.name in enabled_names,
+                source_info=self.get_source_info(definition.name),
+            )
+            for definition in self.list_definitions()
+        )
+
+    def resolve_contributions(
+        self,
+        *,
+        packs: tuple[ToolPackDefinition, ...] | list[ToolPackDefinition] = (),
+        include_packs: tuple[str, ...] | list[str] = (),
+        disabled_tools: tuple[str, ...] | list[str] = (),
+        fail_on_errors: bool = True,
+    ) -> ToolResolutionResult:
+        return resolve_tool_contributions(
+            self.list_contributions(),
+            packs=packs,
+            include_packs=include_packs,
+            disabled_tools=disabled_tools,
+            fail_on_errors=fail_on_errors,
+        )
 
 
 __all__ = [

--- a/src/loushang/harness/tools/contribution.py
+++ b/src/loushang/harness/tools/contribution.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Literal
+
+from loushang.harness.tools.core import ToolDefinition
+
+DiagnosticSeverity = Literal["error", "warning"]
+
+
+@dataclass(frozen=True)
+class ToolContribution:
+    definition: ToolDefinition
+    enabled: bool = True
+    source_info: object | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.definition, ToolDefinition):
+            raise TypeError("definition must be a ToolDefinition")
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+
+@dataclass(frozen=True)
+class ToolPackDefinition:
+    name: str
+    tools: tuple[str, ...] | list[str] = ()
+    includes: tuple[str, ...] | list[str] = ()
+    enabled: bool = True
+    source_info: object | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError("name must be a non-empty string")
+        object.__setattr__(self, "tools", _tuple_of_strings(self.tools, "tools"))
+        object.__setattr__(self, "includes", _tuple_of_strings(self.includes, "includes"))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+
+@dataclass(frozen=True)
+class ToolResolutionDiagnostic:
+    code: str
+    message: str
+    severity: DiagnosticSeverity = "error"
+    details: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.severity not in {"error", "warning"}:
+            raise ValueError("severity must be 'error' or 'warning'")
+        object.__setattr__(self, "details", dict(self.details))
+
+
+@dataclass(frozen=True)
+class ToolResolutionResult:
+    contributions: tuple[ToolContribution, ...]
+    definitions: tuple[ToolDefinition, ...]
+    diagnostics: tuple[ToolResolutionDiagnostic, ...] = ()
+
+    @property
+    def has_errors(self) -> bool:
+        return any(diagnostic.severity == "error" for diagnostic in self.diagnostics)
+
+
+class ToolResolutionError(ValueError):
+    def __init__(self, diagnostics: Iterable[ToolResolutionDiagnostic]) -> None:
+        self.diagnostics = tuple(diagnostics)
+        message = "; ".join(diagnostic.message for diagnostic in self.diagnostics)
+        super().__init__(message or "tool contribution resolution failed")
+
+
+def resolve_tool_contributions(
+    contributions: Iterable[ToolContribution],
+    *,
+    packs: Iterable[ToolPackDefinition] = (),
+    include_packs: Iterable[str] = (),
+    disabled_tools: Iterable[str] = (),
+    fail_on_errors: bool = True,
+) -> ToolResolutionResult:
+    contribution_list = tuple(contributions)
+    pack_list = tuple(packs)
+    disabled_tool_names = set(disabled_tools)
+    diagnostics: list[ToolResolutionDiagnostic] = []
+
+    contributions_by_name = _first_contributions_by_name(contribution_list, diagnostics)
+    packs_by_name = _first_packs_by_name(pack_list, diagnostics)
+
+    selected_names: list[str] = []
+    requested_packs = tuple(include_packs)
+    if requested_packs:
+        for pack_name in requested_packs:
+            _expand_pack(
+                pack_name,
+                packs_by_name=packs_by_name,
+                selected_names=selected_names,
+                diagnostics=diagnostics,
+            )
+    else:
+        for contribution in contribution_list:
+            _append_unique(selected_names, contribution.definition.name)
+
+    selected_contributions: list[ToolContribution] = []
+    for name in selected_names:
+        contribution = contributions_by_name.get(name)
+        if contribution is None:
+            diagnostics.append(
+                _diagnostic(
+                    "missing_tool",
+                    f"Tool {name!r} was referenced but no contribution was registered.",
+                    name=name,
+                )
+            )
+            continue
+        if not contribution.enabled or name in disabled_tool_names:
+            continue
+        selected_contributions.append(contribution)
+
+    result = ToolResolutionResult(
+        contributions=tuple(selected_contributions),
+        definitions=tuple(contribution.definition for contribution in selected_contributions),
+        diagnostics=tuple(diagnostics),
+    )
+    if fail_on_errors and result.has_errors:
+        raise ToolResolutionError(result.diagnostics)
+    return result
+
+
+def _tuple_of_strings(value: tuple[str, ...] | list[str], field_name: str) -> tuple[str, ...]:
+    if isinstance(value, str):
+        raise TypeError(f"{field_name} must be a sequence of strings, not a string")
+    normalized: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item:
+            raise ValueError(f"{field_name} must contain non-empty strings")
+        normalized.append(item)
+    return tuple(normalized)
+
+
+def _first_contributions_by_name(
+    contributions: tuple[ToolContribution, ...],
+    diagnostics: list[ToolResolutionDiagnostic],
+) -> dict[str, ToolContribution]:
+    grouped: dict[str, list[ToolContribution]] = {}
+    for contribution in contributions:
+        grouped.setdefault(contribution.definition.name, []).append(contribution)
+
+    resolved: dict[str, ToolContribution] = {}
+    for name, matches in grouped.items():
+        resolved[name] = matches[0]
+        if len(matches) > 1:
+            diagnostics.append(
+                _diagnostic(
+                    "duplicate_tool",
+                    f"Tool {name!r} was contributed more than once.",
+                    name=name,
+                    sources=[match.source_info for match in matches],
+                )
+            )
+    return resolved
+
+
+def _first_packs_by_name(
+    packs: tuple[ToolPackDefinition, ...],
+    diagnostics: list[ToolResolutionDiagnostic],
+) -> dict[str, ToolPackDefinition]:
+    grouped: dict[str, list[ToolPackDefinition]] = {}
+    for pack in packs:
+        grouped.setdefault(pack.name, []).append(pack)
+
+    resolved: dict[str, ToolPackDefinition] = {}
+    for name, matches in grouped.items():
+        resolved[name] = matches[0]
+        if len(matches) > 1:
+            diagnostics.append(
+                _diagnostic(
+                    "duplicate_pack",
+                    f"Tool pack {name!r} was contributed more than once.",
+                    name=name,
+                    sources=[match.source_info for match in matches],
+                )
+            )
+    return resolved
+
+
+def _expand_pack(
+    name: str,
+    *,
+    packs_by_name: Mapping[str, ToolPackDefinition],
+    selected_names: list[str],
+    diagnostics: list[ToolResolutionDiagnostic],
+    stack: tuple[str, ...] = (),
+) -> None:
+    pack = packs_by_name.get(name)
+    if pack is None:
+        diagnostics.append(
+            _diagnostic(
+                "missing_pack",
+                f"Tool pack {name!r} was referenced but no pack was registered.",
+                name=name,
+            )
+        )
+        return
+    if name in stack:
+        diagnostics.append(
+            _diagnostic(
+                "cyclic_pack_include",
+                f"Tool pack {name!r} is part of a cyclic include chain.",
+                name=name,
+                chain=[*stack, name],
+            )
+        )
+        return
+    if not pack.enabled:
+        return
+
+    next_stack = (*stack, name)
+    for include_name in pack.includes:
+        _expand_pack(
+            include_name,
+            packs_by_name=packs_by_name,
+            selected_names=selected_names,
+            diagnostics=diagnostics,
+            stack=next_stack,
+        )
+    for tool_name in pack.tools:
+        _append_unique(selected_names, tool_name)
+
+
+def _append_unique(values: list[str], value: str) -> None:
+    if value not in values:
+        values.append(value)
+
+
+def _diagnostic(
+    code: str,
+    message: str,
+    *,
+    name: str,
+    sources: list[object | None] | None = None,
+    chain: list[str] | None = None,
+) -> ToolResolutionDiagnostic:
+    details: dict[str, object] = {"name": name}
+    if sources is not None:
+        details["sources"] = sources
+    if chain is not None:
+        details["chain"] = chain
+    return ToolResolutionDiagnostic(code=code, message=message, details=details)
+
+
+__all__ = [
+    "DiagnosticSeverity",
+    "ToolContribution",
+    "ToolPackDefinition",
+    "ToolResolutionDiagnostic",
+    "ToolResolutionError",
+    "ToolResolutionResult",
+    "resolve_tool_contributions",
+]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -92,10 +92,16 @@ def test_harness_slice1_symbols_are_not_top_level_exports() -> None:
         "ApprovalDecision",
         "ApprovalRequest",
         "ApprovalResolver",
+        "ToolContribution",
         "ToolDefinition",
+        "ToolPackDefinition",
         "ToolRegistry",
         "ToolRenderRuntime",
+        "ToolResolutionDiagnostic",
+        "ToolResolutionError",
+        "ToolResolutionResult",
         "ToolResultPresentation",
+        "resolve_tool_contributions",
         "tool",
     }
 

--- a/tests/coding/test_bootstrap.py
+++ b/tests/coding/test_bootstrap.py
@@ -1921,6 +1921,184 @@ def test_create_agent_session_records_nonfatal_extension_tool_conflicts(tmp_path
     assert any(record.code == "extension_tool_conflict" for record in diagnostics)
 
 
+def test_extension_tool_contribution_projection_preserves_source_info(tmp_path) -> None:
+    from loushang.coding.bootstrap import _extension_tool_contributions
+    from loushang.coding.extensions import ExtensionRunner, LoadedExtension
+    from loushang.coding.tools import ToolDefinition
+
+    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+        del tool_name, arguments, context, signal
+        return {"ok": True}
+
+    tool = ToolDefinition(
+        name="ext_review",
+        label="Review",
+        description="Extension review tool",
+        parameters={"type": "object", "properties": {}, "required": []},
+        execute=_execute_tool,
+    )
+    extension = LoadedExtension(
+        name="review-pack",
+        source_path=tmp_path / "extensions" / "review",
+        entry_path=tmp_path / "extensions" / "review" / "extension.py",
+        tool_definitions=[tool],
+    )
+    runner = ExtensionRunner([extension])
+
+    contributions = _extension_tool_contributions(runner)
+
+    assert [contribution.definition.name for contribution in contributions] == ["ext_review"]
+    assert contributions[0].enabled is True
+    assert contributions[0].source_info == runner.get_tool_source_info("ext_review")
+    assert contributions[0].metadata == {
+        "kind": "extension_tool",
+        "extension_tool": "ext_review",
+    }
+
+
+def test_register_extension_tools_uses_harness_resolver_for_dry_run_conflicts(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import loushang.coding.bootstrap as bootstrap
+    from loushang.coding.loader import ResourceBundle
+    from loushang.coding.tools import ToolDefinition, ToolRegistry
+    from loushang.harness.tools.contribution import resolve_tool_contributions
+
+    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+        del tool_name, arguments, context, signal
+        return {"ok": True}
+
+    base_tool = ToolDefinition(
+        name="calc",
+        label="Calc",
+        description="Base calc",
+        parameters={"type": "object", "properties": {}, "required": []},
+        execute=_execute_tool,
+    )
+    extension_tool = ToolDefinition(
+        name="calc",
+        label="Extension Calc",
+        description="Extension calc",
+        parameters={"type": "object", "properties": {}, "required": []},
+        execute=_execute_tool,
+    )
+    registry = ToolRegistry()
+    registry.register_tool(base_tool, source_info={"source": "base"})
+
+    class ExtensionRunner:
+        def list_tool_definitions(self):
+            return [extension_tool]
+
+        def get_tool_source_info(self, name: str):
+            return {"source": "extension", "name": name}
+
+    calls: list[tuple[str, ...]] = []
+
+    def spy_resolver(contributions, **kwargs):
+        contribution_tuple = tuple(contributions)
+        calls.append(tuple(contribution.definition.name for contribution in contribution_tuple))
+        return resolve_tool_contributions(contribution_tuple, **kwargs)
+
+    monkeypatch.setattr(bootstrap, "resolve_tool_contributions", spy_resolver)
+
+    bundle, resolved_registry, diagnostics = bootstrap._register_extension_tools(
+        extension_runner=ExtensionRunner(),
+        resource_bundle=ResourceBundle(cwd=tmp_path),
+        tool_registry=registry,
+    )
+
+    assert calls == [("calc", "calc")]
+    assert resolved_registry is registry
+    assert [definition.name for definition in registry.list_definitions()] == ["calc"]
+    assert [diagnostic.code for diagnostic in diagnostics] == ["extension_tool_conflict"]
+    assert [diagnostic.code for diagnostic in bundle.diagnostics] == ["extension_tool_conflict"]
+
+
+def test_register_extension_tools_registers_resolver_output_only(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import loushang.coding.bootstrap as bootstrap
+    from loushang.coding.loader import ResourceBundle
+    from loushang.coding.tools import ToolDefinition, ToolRegistry
+    from loushang.harness.tools.contribution import ToolResolutionResult
+
+    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+        del tool_name, arguments, context, signal
+        return {"ok": True}
+
+    extension_tool = ToolDefinition(
+        name="ext_calc",
+        label="Extension Calc",
+        description="Extension calc",
+        parameters={"type": "object", "properties": {}, "required": []},
+        execute=_execute_tool,
+    )
+    registry = ToolRegistry()
+
+    class ExtensionRunner:
+        def list_tool_definitions(self):
+            return [extension_tool]
+
+        def get_tool_source_info(self, name: str):
+            return {"source": "extension", "name": name}
+
+    def empty_resolver(contributions, **kwargs):
+        del contributions, kwargs
+        return ToolResolutionResult(contributions=(), definitions=())
+
+    monkeypatch.setattr(bootstrap, "resolve_tool_contributions", empty_resolver)
+
+    _bundle, resolved_registry, diagnostics = bootstrap._register_extension_tools(
+        extension_runner=ExtensionRunner(),
+        resource_bundle=ResourceBundle(cwd=tmp_path),
+        tool_registry=registry,
+    )
+
+    assert diagnostics == []
+    assert resolved_registry is registry
+    assert registry.list_definitions() == []
+
+
+def test_register_extension_tools_preserves_resolver_source_info(tmp_path) -> None:
+    import loushang.coding.bootstrap as bootstrap
+    from loushang.coding.loader import ResourceBundle
+    from loushang.coding.tools import ToolDefinition, ToolRegistry
+
+    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+        del tool_name, arguments, context, signal
+        return {"ok": True}
+
+    extension_tool = ToolDefinition(
+        name="ext_calc",
+        label="Extension Calc",
+        description="Extension calc",
+        parameters={"type": "object", "properties": {}, "required": []},
+        execute=_execute_tool,
+    )
+    source_info = {"source": "extension", "path": str(tmp_path / "extension.py")}
+
+    class ExtensionRunner:
+        def list_tool_definitions(self):
+            return [extension_tool]
+
+        def get_tool_source_info(self, name: str):
+            del name
+            return source_info
+
+    _bundle, registry, diagnostics = bootstrap._register_extension_tools(
+        extension_runner=ExtensionRunner(),
+        resource_bundle=ResourceBundle(cwd=tmp_path),
+        tool_registry=ToolRegistry(),
+    )
+
+    assert diagnostics == []
+    assert registry is not None
+    assert [definition.name for definition in registry.list_definitions()] == ["ext_calc"]
+    assert registry.get_source_info("ext_calc") == source_info
+
+
 def test_create_agent_session_passes_compaction_settings_to_session(tmp_path, monkeypatch) -> None:
     import asyncio
 

--- a/tests/coding/test_tool_registry.py
+++ b/tests/coding/test_tool_registry.py
@@ -76,6 +76,33 @@ def test_tool_registry_exposes_builtin_tool_family() -> None:
     assert registry.get_definition("bash").label == "Bash"
 
 
+def test_registry_resolves_harness_contributions_without_mutating_state() -> None:
+    from loushang.coding.tools import ToolRegistry, register_builtin_tools
+    from loushang.harness.tools.contribution import ToolPackDefinition
+
+    registry = ToolRegistry()
+    register_builtin_tools(registry)
+    registry.disable_tool("bash")
+
+    result = registry.resolve_contributions(
+        packs=(
+            ToolPackDefinition(name="read_only", tools=("read", "ls", "find", "grep", "bash")),
+        ),
+        include_packs=("read_only",),
+    )
+
+    assert [definition.name for definition in result.definitions] == ["read", "ls", "find", "grep"]
+    assert result.diagnostics == ()
+    assert [definition.name for definition in registry.list_enabled_definitions()] == [
+        "read",
+        "ls",
+        "find",
+        "grep",
+        "write",
+        "edit",
+    ]
+
+
 def test_tool_factory_surface_exposes_pi_style_tool_groups() -> None:
     from loushang.coding.tools import (
         ALL_TOOL_NAMES,
@@ -555,6 +582,51 @@ def test_register_builtin_tools_reuses_factory_but_keeps_legacy_order() -> None:
     registry = ToolRegistry()
     register_builtin_tools(registry)
 
+    assert [definition.name for definition in registry.list_definitions()] == [
+        "bash",
+        "read",
+        "ls",
+        "find",
+        "grep",
+        "write",
+        "edit",
+    ]
+
+
+def test_register_builtin_tools_uses_harness_pack_resolver(monkeypatch) -> None:
+    import loushang.coding.tools.builtins as builtins
+    from loushang.coding.tools import ToolRegistry
+
+    calls: list[dict[str, object]] = []
+    real_resolver = builtins.resolve_tool_contributions
+
+    def spy_resolver(contributions, **kwargs):
+        calls.append(
+            {
+                "contributions": tuple(contributions),
+                "packs": tuple(kwargs.get("packs", ())),
+                "include_packs": tuple(kwargs.get("include_packs", ())),
+            }
+        )
+        return real_resolver(calls[-1]["contributions"], **kwargs)
+
+    monkeypatch.setattr(builtins, "resolve_tool_contributions", spy_resolver)
+
+    registry = ToolRegistry()
+    builtins.register_builtin_tools(registry)
+
+    assert len(calls) == 1
+    assert [contribution.definition.name for contribution in calls[0]["contributions"]] == [
+        "bash",
+        "read",
+        "ls",
+        "find",
+        "grep",
+        "write",
+        "edit",
+    ]
+    assert [pack.name for pack in calls[0]["packs"]] == ["coding.builtin"]
+    assert calls[0]["include_packs"] == ("coding.builtin",)
     assert [definition.name for definition in registry.list_definitions()] == [
         "bash",
         "read",

--- a/tests/harness/tools/test_contribution.py
+++ b/tests/harness/tools/test_contribution.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_resolver_returns_all_enabled_contributions_in_registration_order() -> None:
+    from loushang.harness.tools.contribution import (
+        ToolContribution,
+        resolve_tool_contributions,
+    )
+
+    read = _tool_definition("read")
+    write = _tool_definition("write")
+    disabled = _tool_definition("disabled")
+
+    result = resolve_tool_contributions(
+        (
+            ToolContribution(read, source_info={"source": "builtins"}),
+            ToolContribution(write),
+            ToolContribution(disabled, enabled=False),
+        )
+    )
+
+    assert [definition.name for definition in result.definitions] == ["read", "write"]
+    assert [contribution.definition.name for contribution in result.contributions] == ["read", "write"]
+    assert result.contributions[0].source_info == {"source": "builtins"}
+    assert result.diagnostics == ()
+    assert result.has_errors is False
+
+
+def test_resolver_expands_pack_includes_transitively_before_pack_tools() -> None:
+    from loushang.harness.tools.contribution import (
+        ToolContribution,
+        ToolPackDefinition,
+        resolve_tool_contributions,
+    )
+
+    result = resolve_tool_contributions(
+        (
+            ToolContribution(_tool_definition("read")),
+            ToolContribution(_tool_definition("ls")),
+            ToolContribution(_tool_definition("write")),
+            ToolContribution(_tool_definition("grep")),
+        ),
+        packs=(
+            ToolPackDefinition(name="base", tools=("read", "ls")),
+            ToolPackDefinition(name="edit", includes=("base",), tools=("write", "grep", "read")),
+        ),
+        include_packs=("edit",),
+    )
+
+    assert [definition.name for definition in result.definitions] == ["read", "ls", "write", "grep"]
+    assert result.diagnostics == ()
+
+
+def test_resolver_filters_requested_disabled_tool_names() -> None:
+    from loushang.harness.tools.contribution import (
+        ToolContribution,
+        ToolPackDefinition,
+        resolve_tool_contributions,
+    )
+
+    result = resolve_tool_contributions(
+        (
+            ToolContribution(_tool_definition("read")),
+            ToolContribution(_tool_definition("write")),
+            ToolContribution(_tool_definition("bash"), enabled=False),
+        ),
+        packs=(ToolPackDefinition(name="default", tools=("read", "write", "bash")),),
+        include_packs=("default",),
+        disabled_tools=("write",),
+    )
+
+    assert [definition.name for definition in result.definitions] == ["read"]
+    assert result.diagnostics == ()
+
+
+def test_resolver_reports_duplicate_tools_and_packs() -> None:
+    from loushang.harness.tools.contribution import (
+        ToolContribution,
+        ToolPackDefinition,
+        resolve_tool_contributions,
+    )
+
+    result = resolve_tool_contributions(
+        (
+            ToolContribution(_tool_definition("read"), source_info={"source": "a"}),
+            ToolContribution(_tool_definition("read"), source_info={"source": "b"}),
+        ),
+        packs=(
+            ToolPackDefinition(name="default", tools=("read",), source_info={"source": "a"}),
+            ToolPackDefinition(name="default", tools=("read",), source_info={"source": "b"}),
+        ),
+        fail_on_errors=False,
+    )
+
+    assert [diagnostic.code for diagnostic in result.diagnostics] == [
+        "duplicate_tool",
+        "duplicate_pack",
+    ]
+    assert result.diagnostics[0].details["name"] == "read"
+    assert result.diagnostics[0].details["sources"] == [{"source": "a"}, {"source": "b"}]
+    assert result.diagnostics[1].details["name"] == "default"
+    assert result.has_errors is True
+
+
+def test_resolver_raises_for_missing_references_by_default() -> None:
+    from loushang.harness.tools.contribution import (
+        ToolContribution,
+        ToolPackDefinition,
+        ToolResolutionError,
+        resolve_tool_contributions,
+    )
+
+    with pytest.raises(ToolResolutionError) as exc_info:
+        resolve_tool_contributions(
+            (ToolContribution(_tool_definition("read")),),
+            packs=(ToolPackDefinition(name="broken", includes=("missing-pack",), tools=("missing-tool",)),),
+            include_packs=("broken",),
+        )
+
+    assert [diagnostic.code for diagnostic in exc_info.value.diagnostics] == [
+        "missing_pack",
+        "missing_tool",
+    ]
+    assert [diagnostic.details["name"] for diagnostic in exc_info.value.diagnostics] == [
+        "missing-pack",
+        "missing-tool",
+    ]
+
+
+def _tool_definition(name: str):
+    from loushang.agent.types import AgentToolResult
+    from loushang.harness.tools.core import ToolDefinition
+
+    async def execute(tool_call_id, params, signal=None, on_update=None):
+        del tool_call_id, params, signal, on_update
+        return AgentToolResult(content=[], details={})
+
+    return ToolDefinition(
+        name=name,
+        label=name.title(),
+        description=name,
+        parameters={"type": "object", "properties": {}, "required": []},
+        execute=execute,
+    )


### PR DESCRIPTION
## Summary

- Add `loushang.harness.tools.contribution` for neutral tool contributions, tool-pack definitions, deterministic resolution, diagnostics, and metadata/source passthrough.
- Add coding adapter paths so `ToolRegistry` can project current state into harness contributions and resolve packs without mutating registry state.
- Route coding built-in tool registration and bootstrap-time extension tool registration through resolver output while keeping concrete execution, defaults, conflict policy, and runtime dynamic extension registration in coding.
- Capture WorkBuddy lessons as a draft architecture reference.

## Boundary Notes

- Harness owns neutral resolver mechanics only.
- Coding still owns concrete tools, default pack choices, runner binding, session/runtime behavior, prompt semantics, UI behavior, and extension execution.
- Runtime dynamic extension tool registration through callbacks is intentionally unchanged for a later execution-context boundary.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/harness tests/architecture/test_import_boundaries.py tests/coding/test_tool_registry.py tests/coding/test_tool_policy_integration.py -q` - 167 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_bootstrap.py -k 'extension_tool or extension' tests/coding/test_extension_runner.py tests/coding/test_extension_api.py tests/coding/test_coding_command_catalog.py tests/coding/test_session_command_controller.py tests/coding/test_screen_coding_tui_surfaces.py tests/coding/test_prompt_assembly.py -q` - 94 passed, 124 deselected
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_coding_command_catalog.py tests/coding/test_session_command_controller.py tests/coding/test_screen_coding_tui_surfaces.py tests/coding/test_prompt_assembly.py -q` - 90 passed
- `uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/bootstrap.py src/loushang/coding/tools/builtins.py src/loushang/coding/tools/registry.py src/loushang/harness/tools/contribution.py tests/coding/test_bootstrap.py tests/coding/test_tool_registry.py tests/harness/tools/test_contribution.py tests/architecture/test_import_boundaries.py` - passed
- `git diff --check` - passed
