### PR TITLE
test(harness): harden approval compatibility

### DIFF
--- a/docs/internals/architecture/harness/slice-1-approval-tools-presentation-design.md
+++ b/docs/internals/architecture/harness/slice-1-approval-tools-presentation-design.md
@@ -68,6 +68,12 @@ For example, a current `policy_decision` field must become `object | None` or
 a neutral metadata mapping. Harness must not import
 `loushang.coding.policy.types.PolicyDecision`.
 
+Approval contracts should fail fast on invalid neutral values. In Slice 1,
+`ApprovalDecision` validates its disposition, and `resolve_approval` validates
+that resolvers return an `ApprovalDecision` after awaiting sync or async
+resolver output. This is contract hardening only; product policy semantics,
+approval audit payloads, and UI behavior stay outside harness.
+
 ### Coding Keeps
 
 `loushang.coding.policy` keeps coding policy and UI integration:
@@ -85,6 +91,11 @@ a neutral metadata mapping. Harness must not import
 implementation owns pending futures, presenter payload shape, and product UI
 behavior. A later slice may define a neutral approval broker if it can be
 expressed without importing UI callbacks or product payload semantics.
+
+Coding compatibility paths re-export harness-owned approval contracts where
+they were already part of the coding surface. Those shims preserve import paths;
+they do not change class ownership, add new top-level SDK exports, or move
+`InteractiveApprovalResolver` into harness.
 
 ## Tools Core Boundary
 

--- a/src/loushang/harness/approval.py
+++ b/src/loushang/harness/approval.py
@@ -25,6 +25,10 @@ class ApprovalDecision:
     disposition: Literal["allow", "deny"]
     reason: str | None = None
 
+    def __post_init__(self) -> None:
+        if self.disposition not in {"allow", "deny"}:
+            raise ValueError(f"Unsupported approval decision disposition: {self.disposition}")
+
     @classmethod
     def allow(cls) -> "ApprovalDecision":
         return cls(disposition="allow")
@@ -66,5 +70,7 @@ async def resolve_approval(
     resolved = resolver or DenyApprovalResolver()
     result = resolved.resolve(request)
     if inspect.isawaitable(result):
-        return await result
+        result = await result
+    if not isinstance(result, ApprovalDecision):
+        raise TypeError(f"ApprovalResolver returned {type(result).__name__}, expected ApprovalDecision")
     return result

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -92,6 +92,9 @@ def test_harness_slice1_symbols_are_not_top_level_exports() -> None:
         "ApprovalDecision",
         "ApprovalRequest",
         "ApprovalResolver",
+        "DenyApprovalResolver",
+        "HeadlessApprovalResolver",
+        "MaybeAwaitable",
         "ToolContribution",
         "ToolDefinition",
         "ToolPackDefinition",
@@ -101,6 +104,7 @@ def test_harness_slice1_symbols_are_not_top_level_exports() -> None:
         "ToolResolutionError",
         "ToolResolutionResult",
         "ToolResultPresentation",
+        "resolve_approval",
         "resolve_tool_contributions",
         "tool",
     }

--- a/tests/coding/test_approval_compatibility.py
+++ b/tests/coding/test_approval_compatibility.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+
+
+def test_coding_policy_reexports_harness_owned_approval_contracts() -> None:
+    import loushang.coding as coding
+    import loushang.coding.policy as coding_policy
+    import loushang.coding.policy.approval as coding_approval
+    import loushang.harness.approval as harness_approval
+
+    owner_symbols = (
+        "ApprovalDecision",
+        "ApprovalRequest",
+        "ApprovalResolver",
+        "HeadlessApprovalResolver",
+        "resolve_approval",
+    )
+    coding_top_level_symbols = owner_symbols[:-1]
+
+    for name in owner_symbols:
+        assert getattr(coding_approval, name) is getattr(harness_approval, name)
+        assert getattr(coding_policy, name) is getattr(harness_approval, name)
+
+    for name in coding_top_level_symbols:
+        assert getattr(coding, name) is getattr(harness_approval, name)
+
+    assert coding_approval.DenyApprovalResolver is harness_approval.DenyApprovalResolver
+    assert coding_policy.DenyApprovalResolver is harness_approval.DenyApprovalResolver
+
+
+def test_coding_interactive_approval_resolver_remains_product_owned() -> None:
+    import loushang.harness.approval as harness_approval
+    from loushang.coding.policy import (
+        InteractiveApprovalResolver,
+        PolicyEnforcementError,
+    )
+
+    assert not hasattr(harness_approval, "InteractiveApprovalResolver")
+    assert InteractiveApprovalResolver.__module__ == "loushang.coding.policy.approval"
+    assert PolicyEnforcementError.__module__ == "loushang.coding.policy.approval"
+
+
+def test_coding_interactive_approval_fallback_accepts_harness_resolver() -> None:
+    from loushang.coding.policy import InteractiveApprovalResolver
+    from loushang.harness.approval import (
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    resolver = InteractiveApprovalResolver(fallback=HeadlessApprovalResolver(mode="allow"))
+
+    decision = asyncio.run(
+        resolver.resolve(
+            ApprovalRequest(
+                tool_name="write",
+                arguments={"path": "approved.txt"},
+                reason="needs approval",
+            )
+        )
+    )
+
+    assert decision == ApprovalDecision.allow()
+
+
+def test_coding_resolve_approval_uses_harness_result_validation() -> None:
+    import pytest
+
+    from loushang.coding.policy import ApprovalRequest, resolve_approval
+
+    class InvalidResolver:
+        def resolve(self, request):
+            del request
+            return "allow"
+
+    with pytest.raises(TypeError, match="ApprovalResolver returned str"):
+        asyncio.run(resolve_approval(InvalidResolver(), ApprovalRequest(tool_name="write", arguments={})))

--- a/tests/harness/test_approval.py
+++ b/tests/harness/test_approval.py
@@ -10,6 +10,15 @@ def test_approval_decision_helpers_cover_allow_and_deny() -> None:
     assert ApprovalDecision.deny("blocked") == ApprovalDecision(disposition="deny", reason="blocked")
 
 
+def test_approval_decision_rejects_invalid_disposition() -> None:
+    import pytest
+
+    from loushang.harness.approval import ApprovalDecision
+
+    with pytest.raises(ValueError, match="Unsupported approval decision disposition"):
+        ApprovalDecision(disposition="prompt")  # type: ignore[arg-type]
+
+
 def test_resolve_approval_defaults_to_deny() -> None:
     from loushang.harness.approval import ApprovalRequest, resolve_approval
 
@@ -26,6 +35,25 @@ def test_resolve_approval_defaults_to_deny() -> None:
 
     assert decision.disposition == "deny"
     assert decision.reason == "needs approval"
+
+
+def test_resolve_approval_rejects_invalid_resolver_result() -> None:
+    import pytest
+
+    from loushang.harness.approval import ApprovalRequest, resolve_approval
+
+    class InvalidResolver:
+        def resolve(self, request):
+            del request
+            return object()
+
+    with pytest.raises(TypeError, match="ApprovalResolver returned object"):
+        asyncio.run(
+            resolve_approval(
+                InvalidResolver(),
+                ApprovalRequest(tool_name="write", arguments={}),
+            )
+        )
 
 
 def test_headless_approval_resolver_can_allow() -> None:


### PR DESCRIPTION
## Summary

- Harden neutral harness approval contracts by validating `ApprovalDecision.disposition` and resolver return values in `resolve_approval`.
- Add coding approval compatibility tests proving existing coding import paths re-export harness-owned approval contracts without moving coding-owned interactive resolver behavior.
- Extend import-boundary guard coverage for Slice 1 approval symbols.
- Update the Slice 1 design note to document approval contract hardening and compatibility shim boundaries.

## Boundary Notes

- Harness owns only neutral approval request/decision/resolver contracts and fail-fast validation.
- Coding still owns `InteractiveApprovalResolver`, `PolicyEnforcementError`, policy decisions, audit payloads, UI presenter payloads, and product behavior.
- No new top-level `loushang.coding` SDK exports are introduced.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/harness/test_approval.py tests/coding/test_approval_compatibility.py tests/coding/test_policy_engine.py tests/coding/test_tool_policy_integration.py tests/architecture/test_import_boundaries.py -q` - 55 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_coding_command_catalog.py tests/coding/test_session_command_controller.py tests/coding/test_screen_coding_tui_surfaces.py tests/coding/test_prompt_assembly.py -q` - 90 passed
- `uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/harness/approval.py tests/harness/test_approval.py tests/coding/test_approval_compatibility.py tests/architecture/test_import_boundaries.py` - passed
- `git diff --check` - passed
