### PR TITLE
docs(harness): close slice 1 audit

### DIFF
--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -21,6 +21,9 @@ planning, work event persistence, or AI provider behavior.
 - [Coding To Harness Migration Inventory](coding-to-harness-migration-inventory.md)
   records how the current `loushang.coding` modules should be classified before
   implementation moves code.
+- [Slice 1 Closure Status](slice-1-status.md) records the approval, tools-core,
+  contribution, and presentation substrate that has landed on `lane/harness`,
+  plus deferred runtime and product-adapter work.
 - [Harness Lane Development Workflow](development-workflow.md) defines how the
   long-lived `lane/harness` branch stays isolated from `main` until the
   migration is bootable and validated.

--- a/docs/internals/architecture/harness/coding-to-harness-migration-inventory.md
+++ b/docs/internals/architecture/harness/coding-to-harness-migration-inventory.md
@@ -51,6 +51,9 @@ code moves into `loushang.harness`.
 
 ### Slice 1: Approval, Tools Core, Presentation
 
+Status: closed on `lane/harness`; see
+[Slice 1 Closure Status](slice-1-status.md).
+
 Purpose: validate the OEM/extension contribution model without touching agent
 loop, TUI render loop, or AI provider behavior.
 

--- a/docs/internals/architecture/harness/slice-1-approval-tools-presentation-design.md
+++ b/docs/internals/architecture/harness/slice-1-approval-tools-presentation-design.md
@@ -2,11 +2,15 @@
 
 ## Status
 
-Draft for `lane/harness`.
+Implemented on `lane/harness` as the Slice 1 boundary design.
 
-This design starts Slice 1 of the harness migration. It is a boundary design,
-not an implementation plan. Source changes should wait until this design is
-accepted and an implementation plan is written.
+The closure audit and migration status are recorded in
+[Slice 1 Closure Status](slice-1-status.md). This document remains the boundary
+reference for approval, tools-core, tool-contribution, and presentation
+ownership. Follow-on slices still require separate design before migrating
+runtime context, dynamic extension registration, concrete tools, command
+semantics, prompt/resource semantics, TUI state, AI provider behavior, or agent
+loop behavior.
 
 ## Goal
 

--- a/docs/internals/architecture/harness/slice-1-status.md
+++ b/docs/internals/architecture/harness/slice-1-status.md
@@ -1,0 +1,176 @@
+# Harness Slice 1 Closure Status
+
+## Status
+
+Current status: closed on `lane/harness`.
+
+This closes Slice 1 as a harness-lane migration slice. It does not mean the
+harness migration is complete, and it does not make `lane/harness` ready to
+merge directly to `main`. The lane remains the integration branch for follow-on
+harness slices and product-adapter verification.
+
+Slice 1 delivered neutral approval, tools-core, tool-contribution, and
+presentation substrate while preserving coding behavior through compatibility
+adapters.
+
+## Closed Scope
+
+Slice 1 closed the following neutral owner modules:
+
+- `loushang.harness.approval`
+- `loushang.harness.tools.core`
+- `loushang.harness.tools.contribution`
+- `loushang.harness.presentation`
+
+The implementation was merged through focused PRs into `lane/harness`:
+
+- PR #247: Slice 1 hardening and owner-module boundaries.
+- PR #248: tool contribution resolver and coding adapter verification.
+- PR #249: approval compatibility hardening.
+- PR #250: presentation adapter verification and renderer fail-soft behavior.
+
+## Closure Audit
+
+Architecture boundaries:
+
+- Harness still has no import of `loushang.coding`, `loushang.tui`,
+  `loushang.work`, `loushang.method`, or `loushang.ai`.
+- Slice 1 symbols are not exported from top-level `loushang.harness.__all__`.
+- No new top-level `loushang.workspace`, `loushang.context`,
+  `loushang.memory`, `loushang.session`, `loushang.product`, or
+  `loushang.runtime` package was introduced.
+- Harness depends only on stable `loushang.agent` primitives where needed.
+
+Behavior preservation:
+
+- Coding default tool names and activation order remain coding-owned.
+- Built-in coding tool registration may use `harness.tools.contribution`, but
+  concrete tool creation, factory options, policy wiring, and execution remain
+  in coding.
+- Bootstrap-time extension tool registration may use resolver output, but
+  extension runner binding and concrete execution remain in coding.
+- Runtime dynamic extension registration remains coding-owned.
+- Approval risk policy, `PolicyDecision`, audit payloads, and interactive UI
+  behavior remain in coding.
+- Presentation notices, `fullOutputPath` projection, `[Full output: ...]`
+  labels, truncation wording, builtin renderer semantics, transcript layout,
+  and TUI behavior remain in coding.
+
+Compatibility shims:
+
+- Existing coding import paths continue to work for public and internal coding
+  surfaces.
+- Harness-owned approval and presentation contracts keep their harness
+  `__module__`; coding shims preserve import paths, not class identity.
+- Public SDK compatibility paths remain until an explicit deprecation or
+  long-term support decision is accepted.
+- Internal-only shims can be deleted only after in-repo imports move to focused
+  harness modules and product adapters no longer depend on the old path.
+
+## Migrated Neutral Mechanisms
+
+Approval:
+
+- `ApprovalRequest`
+- `ApprovalDecision`
+- `ApprovalResolver`
+- `DenyApprovalResolver`
+- `HeadlessApprovalResolver`
+- `resolve_approval`
+- fail-fast contract validation for invalid dispositions and invalid resolver
+  results
+
+Tools core:
+
+- neutral `ToolDefinition`
+- decorator metadata and `tool`
+- schema inference and schema override helpers
+- neutral tool registry mechanics
+- adaptation to stable `loushang.agent` tool primitives
+
+Tool contribution resolver:
+
+- `ToolContribution`
+- `ToolPackDefinition`
+- `ToolResolutionDiagnostic`
+- `ToolResolutionResult`
+- `ToolResolutionError`
+- `resolve_tool_contributions`
+- deterministic ordering, transitive pack includes, enable/disable filtering,
+  duplicate diagnostics, missing reference diagnostics, and opaque metadata
+  passthrough
+
+Presentation:
+
+- `ToolResultPresentation`
+- ANSI stripping and line-ending normalization
+- generic collapse helpers
+- `ToolRenderContext`
+- `ToolRenderResultOptions`
+- `ToolDefinitionResolver`
+- `ToolRenderRuntime` state, last-rendered, invalidation, and renderer
+  fail-soft behavior
+
+## Coding Still Owns
+
+Coding still owns product semantics and concrete runtime behavior:
+
+- concrete coding tools: `read`, `ls`, `find`, `grep`, `write`, `edit`, `bash`
+- tool factories, `ToolsOptions`, operation protocols, external tool download
+  policy, and default tool-pack activation
+- `ToolContext`, context provider injection, and product runtime fields
+- decorated plain-return normalization into AI content parts
+- provider schema projection
+- `PolicyDecision`, `PolicyEngine`, destructive command and path heuristics,
+  approval audit payloads, `PolicyEnforcementError`, and
+  `InteractiveApprovalResolver`
+- coding presentation helpers, protocol projection, artifact key conventions,
+  notices, truncation wording, builtin renderers, transcript blocks, and UI
+  rendering behavior
+- command catalog, slash semantics, prompt templates, session store, coding
+  runtime, CLI, mode adapters, package/resource/plugin semantics, and settings
+
+## Deferred Items
+
+Deferred items remain outside the Slice 1 closure.
+
+The following items are explicitly deferred beyond Slice 1:
+
+- runtime dynamic extension registration
+- concrete coding tools
+- command handlers and slash semantics
+- prompt templates and prompt/resource semantics
+- TUI controller/render loop and screen surface state
+- coding session store
+- AI provider/model/auth
+- agent loop and tool-call orchestration
+- work/method/channel implementations
+- neutral execution context and live session context binding
+- connector authorization and product skill semantics
+
+## Validation Matrix
+
+Validation matrix: the commands below are the required closure audit surface.
+
+Slice 1 closure should be validated with:
+
+- `uv --cache-dir .uv-cache run --extra dev pytest tests/architecture/test_import_boundaries.py -q`
+- `uv --cache-dir .uv-cache run --extra dev pytest tests/harness -q`
+- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_approval_compatibility.py tests/coding/test_policy_engine.py tests/coding/test_tool_policy_integration.py -q`
+- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_tool_registry.py tests/coding/test_tool_public_types.py tests/coding/test_tool_schema.py tests/coding/test_tool_wrapper.py tests/coding/test_tool_authoring.py -q`
+- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_bootstrap.py -k 'extension_tool or extension' -q`
+- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_extension_runner.py tests/coding/test_extension_api.py -q`
+- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_presentation_compatibility.py -q`
+- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_tool_policy_integration.py tests/coding/test_tool_presentation.py tests/coding/test_tool_render_runtime.py tests/coding/test_tool_builtin_renderers.py tests/coding/test_tool_transcript_blocks.py tests/coding/test_session_exports.py -q`
+- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_coding_command_catalog.py tests/coding/test_session_command_controller.py tests/coding/test_screen_coding_tui_surfaces.py tests/coding/test_prompt_assembly.py -q`
+- `uv --cache-dir .uv-cache run --extra dev ruff check <changed files>`
+- `git diff --check`
+
+## Next Slice Recommendation
+
+The next slice should start with design, not implementation.
+
+Recommended focus: neutral execution/contribution context boundaries that can
+serve coding and future products without importing product runtime state into
+harness. That design should precede any migration of runtime dynamic extension
+registration or live tool execution context.

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -150,6 +150,31 @@ def test_harness_slice1_compatibility_lifecycle_is_documented() -> None:
     assert sorted(phrase for phrase in required_phrases if phrase not in text) == []
 
 
+def test_harness_slice1_closure_status_is_documented() -> None:
+    path = Path("docs/internals/architecture/harness/slice-1-status.md")
+    assert path.exists()
+
+    text = " ".join(path.read_text(encoding="utf-8").split())
+    required_phrases = {
+        "Slice 1 Closure Status",
+        "Current status: closed on `lane/harness`",
+        "`loushang.harness.approval`",
+        "`loushang.harness.tools.core`",
+        "`loushang.harness.tools.contribution`",
+        "`loushang.harness.presentation`",
+        "Coding still owns",
+        "Compatibility shims",
+        "Deferred items",
+        "Validation matrix",
+        "runtime dynamic extension registration",
+        "concrete coding tools",
+        "TUI controller/render loop",
+        "AI provider/model/auth",
+    }
+
+    assert sorted(phrase for phrase in required_phrases if phrase not in text) == []
+
+
 def test_absolute_imports_include_child_aliases_from_package_import(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Add `docs/internals/architecture/harness/slice-1-status.md` as the Slice 1 closure audit and migration status record.
- Mark the Slice 1 design as implemented on `lane/harness` and link the closure status from the harness README and migration inventory.
- Add an architecture guard that keeps the closure status document present and checks key boundary phrases.

## Boundary Notes

- Documentation-only closure audit; no runtime behavior changes.
- Records landed Slice 1 substrate for approval, tools core, tool contribution resolver, and presentation.
- Keeps deferred items explicit: runtime dynamic extension registration, concrete coding tools, command/slash semantics, prompt/resource semantics, TUI controller/render loop, coding session store, AI provider/model/auth, agent loop, and work/method/channel implementation.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/architecture/test_import_boundaries.py -q` - 9 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/harness -q` - 31 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_approval_compatibility.py tests/coding/test_policy_engine.py tests/coding/test_tool_policy_integration.py -q` - 40 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_tool_registry.py tests/coding/test_tool_public_types.py tests/coding/test_tool_schema.py tests/coding/test_tool_wrapper.py tests/coding/test_tool_authoring.py -q` - 156 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_bootstrap.py -k 'extension_tool or extension' -q` - 13 passed, 41 deselected
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_extension_runner.py tests/coding/test_extension_api.py -q` - 74 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_presentation_compatibility.py -q` - 3 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_tool_policy_integration.py tests/coding/test_tool_presentation.py tests/coding/test_tool_render_runtime.py tests/coding/test_tool_builtin_renderers.py tests/coding/test_tool_transcript_blocks.py tests/coding/test_session_exports.py -q` - 37 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_coding_command_catalog.py tests/coding/test_session_command_controller.py tests/coding/test_screen_coding_tui_surfaces.py tests/coding/test_prompt_assembly.py -q` - 90 passed
- `uv --cache-dir .uv-cache run --extra dev ruff check tests/architecture/test_import_boundaries.py` - passed
- `git diff --check` - passed
