### PR TITLE
docs(harness): design slice 2 execution context

### DIFF
--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -24,6 +24,9 @@ planning, work event persistence, or AI provider behavior.
 - [Slice 1 Closure Status](slice-1-status.md) records the approval, tools-core,
   contribution, and presentation substrate that has landed on `lane/harness`,
   plus deferred runtime and product-adapter work.
+- [Slice 2 Execution Context Design](slice-2-execution-context-design.md)
+  drafts the neutral execution/context and runtime contribution boundaries for
+  follow-on work after Slice 1.
 - [Harness Lane Development Workflow](development-workflow.md) defines how the
   long-lived `lane/harness` branch stays isolated from `main` until the
   migration is bootable and validated.

--- a/docs/internals/architecture/harness/coding-to-harness-migration-inventory.md
+++ b/docs/internals/architecture/harness/coding-to-harness-migration-inventory.md
@@ -71,12 +71,26 @@ Keep in coding:
 - command handlers;
 - session controllers.
 
-### Slice 2: Workspace Exec
+### Slice 2: Execution Context And Runtime Contributions
+
+Status: design draft; see
+[Slice 2 Execution Context Design](slice-2-execution-context-design.md).
+
+Purpose: define the neutral live execution/context and runtime contribution
+boundary before migrating dynamic extension registration or live tool execution
+context.
+
+Move only neutral contribution/context descriptors after the design is accepted.
+Keep `ToolContext`, `ExtensionRuntimeBindings`, `ToolController`, active-tool
+policy, prompt rebuilds, session mutation, and concrete execution in coding.
+
+### Later Slice: Workspace Exec
 
 Purpose: separate process/file operation mechanics from coding policy.
 
-Move only neutral request/result/protocol shapes. Keep command allow/deny policy,
-workspace root selection, and product explanation text in coding.
+Move only neutral request/result/protocol shapes after the execution/context
+boundary is proven. Keep command allow/deny policy, workspace root selection,
+and product explanation text in coding.
 
 ### Slice 3: Resources And Source Metadata
 

--- a/docs/internals/architecture/harness/slice-1-status.md
+++ b/docs/internals/architecture/harness/slice-1-status.md
@@ -170,7 +170,9 @@ Slice 1 closure should be validated with:
 
 The next slice should start with design, not implementation.
 
-Recommended focus: neutral execution/contribution context boundaries that can
-serve coding and future products without importing product runtime state into
-harness. That design should precede any migration of runtime dynamic extension
+Recommended focus:
+[Slice 2 Execution Context Design](slice-2-execution-context-design.md),
+covering neutral execution/contribution context boundaries that can serve
+coding and future products without importing product runtime state into harness.
+That design should precede any migration of runtime dynamic extension
 registration or live tool execution context.

--- a/docs/internals/architecture/harness/slice-2-execution-context-design.md
+++ b/docs/internals/architecture/harness/slice-2-execution-context-design.md
@@ -1,0 +1,209 @@
+# Harness Slice 2 Execution Context Design
+
+## Status
+
+Status: design draft for `lane/harness`.
+
+This document defines the Slice 2 boundary design for neutral execution context
+and runtime contribution registration. No runtime behavior changes are part of
+this design slice. Implementation must wait for design approval and a separate
+implementation plan.
+
+## Goal
+
+Slice 2 should define a neutral execution context shape that lets product
+adapters expose live runtime capabilities to tools and extensions without
+moving product runtime state into `loushang.harness`.
+
+The immediate pressure comes from runtime dynamic extension registration:
+
+```text
+ExtensionAPI._register_runtime_tool
+-> ExtensionRuntimeBindings.register_tool
+-> AgentSession._register_extension_runtime_tool
+-> ToolController.register_runtime_tool
+```
+
+That path currently touches coding session state, active tool activation,
+source information, prompt rebuild, runtime bindings, and extension execution.
+Harness can define the neutral mechanism for describing runtime contributions,
+but product execution adapter code must still own product behavior.
+
+## Non-Goals
+
+Slice 2 does not migrate:
+
+- concrete coding tools
+- command handlers or slash semantics
+- prompt templates or prompt/resource semantics
+- TUI controller/render loop or screen surface state
+- coding session store
+- AI provider/model/auth
+- agent loop or tool-call orchestration
+- work/method/channel implementations
+- extension provider/model/session APIs
+- connector authorization or product skill semantics
+
+## Proposed Boundary
+
+Harness should introduce a neutral execution context boundary only if it remains
+product-agnostic.
+
+Candidate harness-owned concepts:
+
+- neutral execution context records carrying opaque ids, cwd, cancellation
+  signal, metadata, and optional event sink
+- neutral contribution registration requests for tools, renderers, or later
+  capability kinds
+- resolver integration through `harness.tools.contribution`
+- source and diagnostic passthrough as opaque values
+- product callback protocols that are typed by capability, not by coding
+  session concepts
+
+Product-owned concepts:
+
+- product execution adapter
+- active tool activation policy
+- prompt rebuild behavior
+- session state mutation
+- extension runner lifecycle
+- concrete execution, file, process, and model APIs
+- UI diagnostics, status, footer data, and message append behavior
+- coding-specific `ToolContext` and runtime binding fields
+
+Product-owned behavior remains product-owned. Harness must not interpret
+whether a runtime contribution should become active, how prompts are rebuilt,
+or how a session records diagnostics.
+
+## Current Coding Mapping
+
+`loushang.coding.tools.context.ToolContext` is a product context. It currently
+contains:
+
+- `tool_call_id`
+- `cwd`
+- diagnostics service
+- signal
+- model
+- event sink
+
+Only a subset is neutral. A future harness context may carry `tool_call_id`,
+`cwd`, `signal`, and opaque metadata. The diagnostics service, model object,
+and event payload semantics stay adapter-owned unless a separate neutral
+diagnostics or model-reference contract is accepted.
+
+`ExtensionRuntimeBindings.register_tool` is a product runtime callback. It
+currently accepts a tool object and source info, then delegates into the live
+session. Harness should not own this callback directly. Instead, coding can
+adapt the callback into a neutral contribution registration request and then
+apply product policy to resolver output.
+
+`ToolController.register_runtime_tool` is coding-owned because it mutates live
+registry state, checks allowed tool names, activates tools, and rebuilds prompt
+and tool views. Harness may provide resolver mechanics, but this method remains
+the product execution adapter for coding.
+
+## Runtime Dynamic Extension Registration
+
+Runtime dynamic extension registration should become a two-step product adapter
+flow:
+
+1. Project the extension tool into a neutral contribution.
+2. Resolve contributions with existing registry state through
+   `harness.tools.contribution`.
+3. Let coding decide whether to register, reject, diagnose, activate, or defer
+   the contribution.
+4. Let coding update active tools and prompt views.
+
+This keeps startup-time and runtime extension registration aligned without
+moving concrete execution into harness.
+
+The first implementation slice should be adapter verification only:
+
+- project runtime extension tools to `ToolContribution`
+- include source info and metadata as opaque values
+- call the resolver with existing registry contributions
+- preserve existing conflict behavior and active-tool behavior
+- keep `ToolController.register_runtime_tool` as the mutation point
+
+No concrete tool execution should move in this slice.
+
+## Proposed Modules
+
+If implementation proceeds, use focused modules under existing harness package
+boundaries:
+
+- `loushang.harness.execution.context`
+- `loushang.harness.execution.contribution`
+
+Do not add new top-level packages such as `loushang.workspace`,
+`loushang.context`, `loushang.memory`, `loushang.session`, `loushang.product`,
+or `loushang.runtime`.
+
+Do not export Slice 2 types from top-level `loushang.harness.__all__` unless a
+separate public API decision accepts that surface.
+
+## Error And Diagnostic Boundary
+
+Harness diagnostics should stay neutral:
+
+- duplicate contribution
+- missing reference
+- unsupported contribution kind
+- invalid neutral request shape
+
+Coding diagnostics stay product-owned:
+
+- extension tool conflict messages
+- startup/resource loading phases
+- session ids
+- UI status
+- prompt rebuild or active-tool policy explanations
+
+Harness may carry `source_info` and metadata but must not interpret extension
+manifest semantics or product resource policy.
+
+## Validation Strategy
+
+Implementation slices that follow this design should validate:
+
+- `tests/architecture/test_import_boundaries.py`
+- new harness execution/context tests
+- coding runtime extension registration focused tests
+- `tests/coding/test_extension_runner.py`
+- `tests/coding/test_extension_api.py`
+- `tests/coding/test_bootstrap.py -k 'extension_tool or extension'`
+- `tests/coding/test_tool_registry.py`
+- command catalog and session command controller tests if active tool behavior
+  is touched
+- screen/surface tests if prompt/tool view state is touched
+- `uv --cache-dir .uv-cache run --extra dev ruff check <changed files>`
+- `git diff --check`
+
+The architecture import-boundary test must continue proving that harness does
+not import `loushang.coding`, `loushang.tui`, `loushang.work`,
+`loushang.method`, or `loushang.ai`.
+
+## Deferred Implementation Items
+
+Deferred implementation items include:
+
+- defining final names and exact dataclass/protocol shapes
+- deciding whether neutral context is needed before runtime contribution
+  adapter verification
+- deciding whether runtime registration supports only tools first or a generic
+  contribution-kind envelope
+- deciding compatibility shim lifetime for any execution context aliases
+- deciding how source diagnostics map from neutral resolver diagnostics to
+  coding resource diagnostics
+
+## Recommended First Implementation Slice
+
+Start with runtime extension tool registration adapter verification.
+
+The first code slice should not introduce broad context APIs. It should only
+extract the common contribution projection/resolution path for runtime extension
+tools, prove behavior is unchanged, and document what remains product-owned.
+
+That keeps Slice 2 incremental and avoids prematurely designing a generic
+runtime substrate before a second product adapter needs it.

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -175,6 +175,30 @@ def test_harness_slice1_closure_status_is_documented() -> None:
     assert sorted(phrase for phrase in required_phrases if phrase not in text) == []
 
 
+def test_harness_slice2_execution_context_design_is_documented() -> None:
+    path = Path("docs/internals/architecture/harness/slice-2-execution-context-design.md")
+    assert path.exists()
+
+    text = " ".join(path.read_text(encoding="utf-8").split())
+    required_phrases = {
+        "Slice 2 Execution Context Design",
+        "Status: design draft for `lane/harness`",
+        "neutral execution context",
+        "product execution adapter",
+        "runtime dynamic extension registration",
+        "`loushang.coding.tools.context.ToolContext`",
+        "`ExtensionRuntimeBindings.register_tool`",
+        "`ToolController.register_runtime_tool`",
+        "`harness.tools.contribution`",
+        "Product-owned behavior remains product-owned",
+        "No runtime behavior changes are part of this design slice",
+        "Deferred implementation items",
+        "not import `loushang.coding`",
+    }
+
+    assert sorted(phrase for phrase in required_phrases if phrase not in text) == []
+
+
 def test_absolute_imports_include_child_aliases_from_package_import(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add the Slice 2 execution/context and runtime contribution boundary design.
- Align the harness README, Slice 1 closure status, and migration inventory with the new Slice 2 focus.
- Add an architecture guard requiring the Slice 2 design document to stay present and boundary-focused.

## Validation
- uv --cache-dir .uv-cache run --extra dev pytest tests/architecture/test_import_boundaries.py -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/harness -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_extension_runner.py tests/coding/test_extension_api.py tests/coding/test_bootstrap.py -k 'extension_tool or extension' -q
- uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_tool_registry.py -q
- uv --cache-dir .uv-cache run --extra dev ruff check tests/architecture/test_import_boundaries.py
- git diff --cached --check