### PR TITLE
perf(tui): reuse stable transcript work across streaming frames

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-015-stable-tail-window-and-transcript-block-cache.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-015-stable-tail-window-and-transcript-block-cache.md
@@ -1,260 +1,178 @@
-# KD-015: Stable Tail Window And Transcript Block Cache
+# KD-015: Versioned Rendered Segments
 
-Status: Deferred. This is not the next streaming-performance change.
-
-Streaming Markdown parse reuse is a separate renderer optimization defined by
-KD-019. It does not require an active transcript window or any change to
-terminal-history projection.
+Status: Accepted for phased implementation.
 
 ## Purpose
 
-Keep input echo and timer-driven updates responsive when transcript history is
-long, without making the managed viewport jump or flash.
+Keep Working ticks, composer input, and streaming updates responsive after a
+long live session without dropping, trimming, or rewriting transcript history.
+
+This design changes only the internal representation of a rendered frame. It
+does not add a transcript window, change Markdown boundaries, or change terminal
+scrollback behavior.
 
 ## Problem
 
-The native coding TUI already renders transcript content from the tail, but the
-render loop still plans against an effectively unbounded `max_height`. In a long
-session, that makes each input edit or working-timer tick materialize thousands
-of logical transcript lines before diffing. The result is that transient updates
-scale with historical transcript size instead of visible viewport size.
+Committed transcript records already cache their rendered lines. The hot path
+still performs linear work over every cached line on each frame:
 
-The issue is not that committed transcript records are still changing. For a
-stable record, rendered lines are functionally stable as long as these inputs do
-not change:
+```text
+transcript blocks
+-> one flat list
+-> one flat RenderResult
+-> finalize every logical line
+-> compare every logical line
+-> emit a small terminal update
+```
 
-- transcript record data
-- render width
-- theme and terminal capabilities
-- transcript presentation policy such as thinking visibility
-- cwd-dependent display normalization
-- transcript window generation
+After a session has accumulated thousands of logical rows, a Working tick or a
+single input character therefore scales with historical transcript length even
+though only the bottom frame changed.
 
-That stability allows the runtime to cache historical transcript blocks and plan
-only against an active tail window.
+## Decision
 
-## Design
+The renderer represents a frame as immutable, versioned segments. The coding TUI
+uses three stable slots:
 
-The transcript source of truth remains the full display-record sequence. The
-runtime must add a second layer between transcript records and render planning:
+```text
+committed transcript | active draft | bottom frame
+```
 
-- stable transcript block cache: cached rendered lines for committed blocks
-- transcript block index: block boundaries plus cumulative logical line counts
-- active tail window: the only transcript logical lines exposed to the render
-  loop during steady-state planning
+An unchanged slot reuses the exact segment object from the last successfully
+committed frame. Layout and render planning use segment row counts without
+flattening segment contents. Only changed segments are finalized and compared
+line by line.
 
-The render loop must no longer require the screen root to materialize the full
-logical transcript on every tick. Instead, the transcript region provides a
-stable tail window composed from cached historical blocks plus transient tail
-content.
+The canonical record sequence and canonical rendered lines remain unchanged.
+Concatenating all segments must produce the exact output of the existing flat
+renderer.
 
-Transcript window generation is a monotonic invalidation token owned by the
-product-facing transcript window. It changes whenever transcript window
-membership or transcript presentation state is replaced in a way that makes
-previous stable-block cache entries unsafe to reuse as-is. Typical generation
-changes include transcript window replacement, transcript compaction replacement,
-resume-time transcript projection rebuild, or explicit transcript presentation
-policy replacement.
+## Segment Contract
 
-## Stable And Transient Content
+Each rendered segment is an immutable snapshot containing:
 
-Stable content includes:
+- occurrence identity;
+- render revision;
+- immutable rendered rows;
+- row count;
+- terminal-image metadata required by the existing planner.
 
-- user prompt records
-- committed assistant message records
-- committed tool execution records
-- committed thinking records
-- worked divider and compaction records
+A reused segment revision is valid only when all inputs affecting its rendered
+bytes remain unchanged, including source revision, width, theme, terminal
+capabilities, cwd, and transcript projection generation.
 
-Transient content includes:
+Two equal-valued record occurrences remain two occurrences in canonical output.
+Record separators are part of canonical segment composition and are emitted in
+exactly one place. Empty records do not create phantom separators.
 
-- streaming assistant draft buffers
-- active tool-progress rows if they are still mutating
-- bottom-frame content such as working line, composer, pending queue, and
-  statusline
+## Frame Contract
 
-Only transient content may re-render on every frame by default. Stable content
-must be reused from cache whenever its render key remains unchanged.
+A planned logical frame contains:
 
-## Block Boundaries
+- the ordered segment references;
+- aggregate logical row count;
+- declared cursor;
+- the revision of the committed frame on which the plan is based.
 
-The runtime must cache transcript content by stable block, not by the final
-flattened logical line array.
+The render loop may take the segment fast path only when the base revision is the
+last successfully committed revision. Terminal flush success is followed by one
+atomic render-loop commit of the frame, viewport, logical and hardware cursor,
+high-water mark, and terminal-image metadata. A failed flush leaves that state
+unchanged.
 
-A block is the smallest committed transcript unit whose rendered lines are
-expected to remain internally consistent across steady-state frames. In the
-native coding TUI, the default block boundary is one committed display record.
-If future product rendering composes multiple records into one semantic unit,
-that unit must still render and invalidate as one block.
+## Dirty Range
 
-The product adapter or transcript projection layer owns block-boundary
-definition. The runtime consumes committed blocks and must not invent new
-multi-record semantic blocks by inspecting rendered lines. The runtime may index
-and cache blocks, but block identity and grouping come from transcript
-projection, not from render-time heuristics.
+Segment identity proves only content reuse. Absolute position still matters.
 
-The active tail window must be selected in block units. It must never slice into
-the middle of a block only because a raw line budget was hit. If the window
-budget boundary falls inside a block, the runtime must include the entire block
-or exclude it entirely according to bottom-anchored window selection policy.
+- A Working tick or composer edit changes the bottom segment.
+- A streaming chunk changes the draft segment.
+- If a changed segment gains or loses rows, all later segments whose absolute
+  positions move are part of the affected suffix even when their content is
+  unchanged.
+- A clean prefix may be skipped only when its segment revisions, order, and
+  absolute starting rows are unchanged.
 
-## Tail Window Policy
+The existing append, protected-append, shrink, viewport, cursor, and terminal
+operation semantics remain authoritative. The segment path computes equivalent
+line facts without reading the stable prefix.
 
-The transcript region must expose an active tail window with these properties:
+## Terminal Images
 
-- bottom anchored: the newest committed or transient transcript content stays at
-  the bottom edge of the transcript window
-- visible-height preserving: the visible transcript rows always come from the
-  active tail window
-- guard-banded: the runtime keeps additional historical rows above the visible
-  viewport so small tail changes do not force immediate window replacement
-- block-stable: window membership changes only on block boundaries
+Terminal-image IDs and their row offsets are cached with the immutable segment.
+Image deletion and changed-range expansion preserve the existing behavior.
 
-For coding mode, the initial sizing target is:
+If a row shift can move an image and the segment path cannot prove equivalent
+delete and repaint operations, planning uses the existing full fallback.
 
-- visible transcript height driven by layout and commonly reaching about 80
-  rows, as a tunable default rather than a hard-coded invariant
-- guard band of roughly one additional visible-height above the viewport
-- active tail window of about two visible-heights, subject to tuning
+## Fallback
 
-Exact line counts are policy, not API, but the guard band must be large enough
-that ordinary input edits, streaming chunk completion, and working-line timer
-updates do not churn window membership.
+The existing complete render, finalize, diff, and terminal-plan path remains the
+correctness fallback. It is used for the first frame and whenever reuse cannot be
+proven, including relevant resize, render-context invalidation, transcript
+replacement, or visible surface composition.
 
-On extremely short terminals, the active tail window may collapse to only a few
-rows because it remains derived from current visible layout height. This is
-acceptable as long as the same bottom-anchored and block-stable rules still
-apply.
+Fallback is allowed to be linear in full history. The following steady-state
+frames are not:
 
-## Render Planning Contract
+| Frame | Allowed row work |
+| --- | --- |
+| Working tick | bottom frame |
+| Composer input | bottom frame |
+| New chunk | active draft plus shifted bottom frame |
+| No-op | none |
 
-During steady-state diff planning, the render loop must only see:
+A pathological unfinished Markdown construct may keep the active draft large.
+This phase does not invent a new Markdown boundary to split it.
 
-- active transcript tail window logical lines
-- current bottom-frame logical lines
-- active overlays
+## Implementation Boundary
 
-Historical transcript content outside the active tail window remains part of the
-product state, but not part of the render loop's steady-state logical line
-buffer.
+This phase changes only:
 
-The runtime must still retain enough metadata to:
+- immutable rendered-line segment and segmented-line containers;
+- transcript, layout, and no-surface composition preservation of segments;
+- segment-aware finalize, diff, terminal-image lookup, diagnostics, and committed
+  render-loop baseline;
+- focused equivalence and performance tests.
 
-- rebuild a larger or different tail window after resize or policy changes
-- rebuild the active window after theme or capability invalidation
-- export or inspect the full transcript outside the live render path
+It does not introduce:
 
-Window selection must avoid per-frame linear rescans over the entire transcript.
-The expected mechanism is a block index with cumulative logical line counts so
-tail-window selection is driven by indexed lookup plus a bounded walk over the
-blocks that actually enter the active window. The exact data structure is an
-implementation choice, but steady-state selection must scale with active-window
-size rather than total transcript history length.
+- active-window eviction;
+- Markdown semantic-group changes;
+- scheduler interval changes;
+- new terminal operations or product behavior.
 
-## Invalidation Rules
+## Correctness Oracle
 
-Stable block cache entries must be invalidated when any render key input changes:
+For every optimized test frame:
 
-- width change
-- theme change
-- terminal capability change
-- transcript presentation policy change such as thinking visibility
-- cwd-dependent display normalization change
-- transcript window generation reset or replacement
-- block data replacement by transcript reprojection
+```text
+flatten(segmented raw frame) == legacy raw frame
+flatten(segmented finalized frame) == legacy finalized frame
+```
 
-Steady-state transient updates such as:
+The optimized and legacy planners must also agree on changed range, viewport,
+logical and hardware cursor, terminal operations, and terminal-image deletes.
 
-- composer edits
-- working timer ticks
-- pending-queue changes
-- streaming draft chunk appends
+The focused fixtures cover duplicate equal records, empty records and
+separators, draft growth, bottom-frame cursor movement, row-count shifts, flush
+failure, and an affected suffix containing a terminal image.
 
-must not invalidate unrelated historical stable blocks.
+## Performance Acceptance
 
-Committed blocks remain immutable in place. Block data replacement means that a
-new transcript projection replaces a previously committed block at the transcript
-state level; it does not authorize mutating a committed block instance after
-commit.
+After an initial `4000 -> 1000 -> 1000 -> 10` render has successfully committed,
+reset the counters and render a Working tick, one input character, one new chunk,
+and a no-op frame.
 
-Height-only resize does not invalidate stable block cache entries by itself. It
-may change visible transcript height, guard-band sizing, and active tail window
-membership, but cached block renderings remain reusable when width and other
-render-key inputs are unchanged. Width resize invalidates stable block cache
-entries and follows the KD-007 reflow path.
+The hard requirements are:
 
-The block index must cover the full committed transcript. The stable block cache
-does not need to hold rendered lines for the full transcript indefinitely.
-Implementations may evict cached renderings outside the active window, guard
-band, or recent reuse set, as long as the index remains sufficient to rebuild
-them deterministically on demand.
+```text
+stable committed rows read           = 0
+stable committed rows materialized   = 0
+full frame flatten calls              = 0
+Working/input dirty rows              = O(bottom frame)
+chunk committed render misses         = 0
+no-op terminal operations             = 0
+```
 
-## Window Replacement And Repaint Policy
-
-When the active tail window membership stays within the current guard band, the
-runtime should continue using line-diff updates normally.
-
-When membership must change because the tail moved beyond the guard band, the
-runtime must treat that as a managed tail-window replacement, not as an ordinary
-small changed-range update. In that case:
-
-- the new active window is selected on block boundaries
-- the viewport remains bottom anchored
-- the runtime may use a managed baseline repaint of runtime-owned visible rows
-  instead of a fine-grained diff against the previous window contents
-
-This repaint is a controlled runtime repaint, not a resize clear-scrollback
-operation. It must preserve the no-flash and no-history-duplication guarantees
-already defined by the managed viewport design.
-
-The runtime must use a deterministic, testable policy for deciding between
-tail-window replacement repaint and ordinary diff. The design does not require a
-single global threshold constant, but the default policy must be anchored in
-window-membership change and guard-band exhaustion rather than ad hoc judgment.
-
-## Non-Goals
-
-This design does not require:
-
-- replaying terminal scrollback as runtime state
-- character-level incremental transcript diff
-- preserving full historical logical lines inside the steady-state render loop
-- solving width-reflow by partial reuse across resize
-
-Resize remains a separately defined repaint path.
-
-## Relationship To Existing Designs
-
-- KD-001 remains responsible for scheduling, line diffing, and terminal writes.
-  KD-015 narrows what logical lines are presented to that render loop during
-  steady state.
-- KD-004 remains responsible for managed viewport ownership, recovery repaint,
-  and scrollback policy. KD-015 adds a tail-window replacement path that uses
-  those repaint rules.
-- KD-006 remains responsible for stable versus transient transcript lifecycle.
-  KD-015 builds on that distinction to define what may be cached and what must
-  stay live.
-- KD-007 remains responsible for resize-stable reflow. KD-015 relies on KD-007
-  for width-driven cache invalidation and repaint, while allowing height-only
-  resize to resize the active tail window without invalidating stable block
-  renderings.
-- KD-008 remains responsible for visible transcript height after bottom-frame
-  layout. KD-015 uses that visible height to size the tail window and guard
-  band.
-
-## Test Obligations
-
-- steady-state composer edits do not scale render planning with total transcript
-  history size
-- working-timer ticks do not invalidate historical stable transcript blocks
-- render diagnostics or perf probes can prove that steady-state planning touches
-  only the active tail window plus bounded block-index lookup work
-- active tail window membership changes only on block boundaries
-- tail-window replacement preserves bottom anchoring and does not duplicate
-  transcript content
-- guard band prevents immediate window replacement on small transient tail
-  changes
-- width/theme/capability/cwd invalidation rebuilds cached stable blocks
-  deterministically
-- resize still uses the existing repaint path rather than stale stable-block
-  reuse
+Wall-clock time is supporting evidence. Steady-state Working and input cost must
+remain approximately constant as committed history grows.

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-015-stable-tail-window-and-transcript-block-cache.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-015-stable-tail-window-and-transcript-block-cache.md
@@ -1,5 +1,11 @@
 # KD-015: Stable Tail Window And Transcript Block Cache
 
+Status: Deferred. This is not the next streaming-performance change.
+
+Streaming Markdown parse reuse is a separate renderer optimization defined by
+KD-019. It does not require an active transcript window or any change to
+terminal-history projection.
+
 ## Purpose
 
 Keep input echo and timer-driven updates responsive when transcript history is

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-019-streaming-markdown-stable-prefix-cache.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-019-streaming-markdown-stable-prefix-cache.md
@@ -92,7 +92,7 @@ introduce:
 - terminal diff, viewport, scrollback, or terminal-protocol changes
 - fixed-size Markdown fragments
 
-KD-015 remains a separate, deferred option for bounding full transcript
+KD-015 remains a separate renderer optimization for reusing full transcript
 planning if that cost is still material after this optimization.
 
 ## Implementation Shape

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-019-streaming-markdown-stable-prefix-cache.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-019-streaming-markdown-stable-prefix-cache.md
@@ -1,0 +1,123 @@
+# KD-019: Streaming Markdown Stable Prefix Cache
+
+Status: Accepted. Implemented.
+
+## Purpose
+
+Keep Markdown streaming responsive as an assistant draft grows by parsing and
+formatting only its mutable semantic tail. Do this entirely inside the Markdown
+rendering path so terminal diff, viewport, and scrollback behavior do not
+change.
+
+## Problem
+
+`StreamingTextBuffer` receives append-only chunks, but each rendered version is
+currently joined into the full draft and passed through the full Markdown
+parser. The existing `MarkdownRenderCache` can reuse formatted stable blocks,
+but it runs after the full parse, which remains the dominant growing cost.
+
+## Decision
+
+Borrow Claude Code's stable-prefix strategy, adapted to Loushang's flat
+renderer.
+
+Each active streaming draft keeps a small parse state:
+
+- the draft buffer identity and previous source
+- a source-line offset marking the end of the stable prefix
+- parsed top-level block groups before that offset, including the source gap at
+  the stable/tail boundary
+
+For an append-only update:
+
+1. Parse only the source at or after the stable offset.
+2. Group markdown-it tokens by top-level Markdown block and rebase their local
+   line ranges to full-source line numbers.
+3. Keep the final two non-blank top-level groups at the mutable frontier: the
+   growing tail plus one group of lookbehind.
+4. Promote all earlier complete groups into the stable prefix and advance the
+   source-line offset.
+5. Combine the cached stable blocks with the newly parsed tail blocks and pass
+   one complete block sequence to the existing renderer.
+
+The renderer continues to return the same complete logical-line result it
+returns today. Stable prefix and mutable tail are internal parse concepts; they
+must not become separate transcript records or terminal regions.
+
+The boundary source gap must be preserved when the two parsed parts are
+combined. Otherwise parsing the tail independently would lose the blank block
+that the current full parser derives from the gap between adjacent token maps.
+
+## Semantic Boundary
+
+The stable boundary comes from top-level markdown-it token line ranges. It is
+never selected by a fixed line count, byte count, chunk count, or timer.
+
+The last top-level list, table, block quote, fenced code block, or paragraph
+remains mutable as one unit. A single continuously growing block therefore
+remains correct but receives little or no incremental benefit.
+
+The one-group lookbehind handles Markdown constructs that can merge backward
+at the input frontier. For example, a partial ordered-list marker is initially
+a paragraph and may join the preceding list when its punctuation arrives.
+
+Promotion is allowed only where parsing the prefix and tail separately is
+equivalent to parsing the complete source. If a construct has document-wide
+effects, such as a reference definition that can change an earlier block, the
+implementation keeps the stable offset at zero and uses the existing full
+parse path.
+
+## Reset And Completion
+
+Discard the incremental state when:
+
+- the active buffer changes
+- the source is no longer an append of the previous source
+- the parser cannot provide a safe top-level source boundary
+
+When streaming completes, use the ordinary full Markdown parse as the
+canonical result and discard the streaming parse state. Supported incremental
+cases must render identically to that canonical result.
+
+Width, theme, and terminal-capability changes continue to invalidate rendered
+line caches through their existing keys. They do not change Markdown source
+boundaries and do not require a new terminal protocol.
+
+## Scope
+
+This design changes only Markdown parse reuse for an active draft. It does not
+introduce:
+
+- an active transcript window or logical-row eviction
+- terminal diff, viewport, scrollback, or terminal-protocol changes
+- fixed-size Markdown fragments
+
+KD-015 remains a separate, deferred option for bounding full transcript
+planning if that cost is still material after this optimization.
+
+## Implementation Shape
+
+The implementation stays narrow:
+
+- add a per-draft streaming parse state beside the Markdown renderer
+- use top-level token source maps to advance the stable offset
+- reuse the existing `_MarkdownBlock` rendering and `MarkdownRenderCache`
+- connect the state only to `StreamingTextBuffer` rendering
+- fall back to the current full parse whenever safety is uncertain
+
+Claude Code's React component split is not copied. Loushang merges parsed
+blocks before rendering so existing blank-line, assistant-chrome, and terminal
+diff behavior stay unchanged.
+
+## Acceptance
+
+- Supported streaming fixtures produce exactly the same logical lines as a
+  full parse at every checked boundary.
+- Lists, tables, block quotes, and fenced code blocks are never split in the
+  middle of a top-level group.
+- Replacement and document-wide Markdown constructs safely reset or fall back.
+- In a fixed-width, fixed-cadence benchmark, the 1,000-line example with
+  20-line independent Markdown blocks reduces Markdown render CPU by at least
+  30 percent. This is benchmark evidence, not a cross-machine CI timing gate.
+- Continuous single-block input remains correct even when it cannot be made
+  faster by this strategy.

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/README.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/README.md
@@ -19,7 +19,7 @@ reference docs; they describe the invariants that tests must enforce.
 - [KD-012: Keyboard Protocol And Escape Buffering](./KD-012-keyboard-protocol-and-escape-buffering.md)
 - [KD-013: Terminal Runtime Capabilities](./KD-013-terminal-runtime-capabilities.md)
 - [KD-014: Tool Transcript Visual Styling](./KD-014-tool-transcript-visual-styling.md)
-- [KD-015: Stable Tail Window And Transcript Block Cache](./KD-015-stable-tail-window-and-transcript-block-cache.md)
+- [KD-015: Versioned Rendered Segments](./KD-015-stable-tail-window-and-transcript-block-cache.md)
 - [KD-016: Resume Overflow Recovery Regression Harness](./KD-016-resume-overflow-recovery-regression-harness.md)
 - [KD-017: Composer Selection And Selected Range](./KD-017-composer-selection-and-selected-range.md)
 - [KD-018: Transcript Reader And Copy Semantics](./KD-018-transcript-reader-and-copy-semantics.md)

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/README.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/README.md
@@ -23,3 +23,4 @@ reference docs; they describe the invariants that tests must enforce.
 - [KD-016: Resume Overflow Recovery Regression Harness](./KD-016-resume-overflow-recovery-regression-harness.md)
 - [KD-017: Composer Selection And Selected Range](./KD-017-composer-selection-and-selected-range.md)
 - [KD-018: Transcript Reader And Copy Semantics](./KD-018-transcript-reader-and-copy-semantics.md)
+- [KD-019: Streaming Markdown Stable Prefix Cache](./KD-019-streaming-markdown-stable-prefix-cache.md)

--- a/examples/tui/31_native_coding_markdown_perf.py
+++ b/examples/tui/31_native_coding_markdown_perf.py
@@ -309,6 +309,7 @@ async def run_script(
     render_interval_ms: int,
     trace_memory: bool,
     show_final: bool,
+    render_every_n_chunks: int = 0,
 ) -> int:
     if trace_memory and not tracemalloc.is_tracing():
         tracemalloc.start()
@@ -330,7 +331,8 @@ async def run_script(
     stdout.write(f"requested_markdown_lines={count}\n")
     stdout.write(f"rounds={rounds}\n")
     stdout.write(f"stream_seconds={stream_seconds:.3f}\n")
-    stdout.write(f"markdown_lines_per_block={MARKDOWN_LINES_PER_BLOCK}\n\n")
+    stdout.write(f"markdown_lines_per_block={MARKDOWN_LINES_PER_BLOCK}\n")
+    stdout.write(f"render_every_n_chunks={max(0, render_every_n_chunks)}\n\n")
 
     for round_index in range(1, rounds + 1):
         steps = await _drive_script_round(
@@ -339,6 +341,7 @@ async def run_script(
             count=count,
             stream_seconds=stream_seconds,
             render_interval_ms=render_interval_ms,
+            render_every_n_chunks=render_every_n_chunks,
         )
         stdout.write(_script_round_line(round_index, app=app, steps=steps))
 
@@ -361,6 +364,7 @@ async def _drive_script_round(
     count: int,
     stream_seconds: float,
     render_interval_ms: int,
+    render_every_n_chunks: int = 0,
 ) -> tuple[PlaybackStep, ...]:
     steps: list[PlaybackStep] = []
     app.render_stats.reset()
@@ -371,11 +375,16 @@ async def _drive_script_round(
     app.begin_assistant()
     delay = stream_seconds / max(1, count)
     render_interval = max(0, render_interval_ms) / 1000
+    render_every_n_chunks = max(0, render_every_n_chunks)
     next_render_at = perf_counter()
     for index in range(1, count + 1):
         app.append_assistant_chunk(_markdown_line(index))
         now = perf_counter()
-        if render_interval <= 0 or now >= next_render_at or index == count:
+        if render_every_n_chunks:
+            should_render = index % render_every_n_chunks == 0 or index == count
+        else:
+            should_render = render_interval <= 0 or now >= next_render_at or index == count
+        if should_render:
             steps.append(runtime.render_now())
             next_render_at = perf_counter() + render_interval
         if delay > 0:
@@ -552,6 +561,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=80,
         help="script render coalescing interval; use 0 to render every chunk",
     )
+    parser.add_argument(
+        "--script-render-every-n-chunks",
+        type=int,
+        default=0,
+        help="use a fixed chunk cadence instead of wall-clock render coalescing",
+    )
     parser.add_argument("--trace-memory", action="store_true", help="enable tracemalloc current/peak memory stats")
     parser.add_argument("--width", type=int, default=100, help="script snapshot width")
     parser.add_argument("--height", type=int, default=32, help="script snapshot height")
@@ -573,6 +588,7 @@ def main(argv: list[str] | None = None) -> int:
                 render_interval_ms=args.script_render_interval_ms,
                 trace_memory=args.trace_memory,
                 show_final=args.show_final,
+                render_every_n_chunks=args.script_render_every_n_chunks,
             )
         )
     return asyncio.run(run_interactive(stdin=sys.stdin, stdout=sys.stdout, stream_seconds=stream_seconds))

--- a/examples/tui/31_native_coding_markdown_perf.py
+++ b/examples/tui/31_native_coding_markdown_perf.py
@@ -12,8 +12,8 @@ from io import StringIO
 from time import perf_counter
 from typing import Any, TextIO
 
-from loushang.coding.ui.native_app import NativeCodingTuiApp
-from loushang.coding.ui.native_loop import run_native_coding_tui
+from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+from loushang.coding.ui.screen_loop import run_screen_coding_tui
 from loushang.tui import (
     PlaybackStep,
     ProcessTerminalPort,
@@ -27,6 +27,7 @@ from loushang.tui import (
 )
 
 DEFAULT_STREAM_SECONDS = 1.2
+MARKDOWN_LINES_PER_BLOCK = 20
 
 
 @dataclass(slots=True)
@@ -122,7 +123,7 @@ class PerfReport:
     gc_count_2: int
 
 
-class PerfNativeCodingTuiApp(NativeCodingTuiApp):
+class PerfNativeCodingTuiApp(ScreenCodingTuiApp):
     __slots__ = ("_last_render_line_chars", "_last_render_line_count", "perf_reports", "render_stats")
 
     def __init__(self, **kwargs: Any) -> None:
@@ -181,7 +182,14 @@ def _parse_count(text: str) -> int | None:
 
 
 def _markdown_line(index: int) -> str:
-    return f"- **Line {index}**: markdown `code-{index}` with 中文宽字符 and [link {index}](https://example.com/{index}).\n"
+    block_prefix = ""
+    if (index - 1) % MARKDOWN_LINES_PER_BLOCK == 0:
+        block_number = (index - 1) // MARKDOWN_LINES_PER_BLOCK + 1
+        block_prefix = ("" if index == 1 else "\n") + f"### Markdown block {block_number}\n\n"
+    return (
+        block_prefix + f"- **Line {index}**: markdown `code-{index}` with 中文宽字符 "
+        f"and [link {index}](https://example.com/{index}).\n"
+    )
 
 
 def _append_perf_stats(app: PerfNativeCodingTuiApp, *, requested_lines: int, stream_elapsed_seconds: float) -> None:
@@ -280,7 +288,7 @@ async def run_interactive(*, stdin: TextIO, stdout: TextIO, stream_seconds: floa
         session_label="manual",
     )
     app.set_status("type 1, 10, 100... /quit exits")
-    return await run_native_coding_tui(
+    return await run_screen_coding_tui(
         app=app,
         stdin=stdin,
         stdout=stdout,
@@ -321,7 +329,8 @@ async def run_script(
     stdout.write("Native coding markdown perf script\n")
     stdout.write(f"requested_markdown_lines={count}\n")
     stdout.write(f"rounds={rounds}\n")
-    stdout.write(f"stream_seconds={stream_seconds:.3f}\n\n")
+    stdout.write(f"stream_seconds={stream_seconds:.3f}\n")
+    stdout.write(f"markdown_lines_per_block={MARKDOWN_LINES_PER_BLOCK}\n\n")
 
     for round_index in range(1, rounds + 1):
         steps = await _drive_script_round(

--- a/examples/tui/33_native_coding_markdown_perf_trim_interactive.py
+++ b/examples/tui/33_native_coding_markdown_perf_trim_interactive.py
@@ -7,11 +7,11 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO, cast
 
-from loushang.coding.ui.native_loop import run_native_coding_tui
+from loushang.coding.ui.screen_loop import run_screen_coding_tui
 
 if TYPE_CHECKING:
-    from loushang.coding.ui.native_app import (
-        NativeCodingTuiApp as _PerfNativeCodingTuiAppBase,
+    from loushang.coding.ui.screen_app import (
+        ScreenCodingTuiApp as _PerfNativeCodingTuiAppBase,
     )
 
 
@@ -81,7 +81,7 @@ async def run_interactive(
     app.set_status(
         f"type 1, 10, 100... /quit exits | trim budget={active_line_budget} lines | per-turn auto trim"
     )
-    return await run_native_coding_tui(
+    return await run_screen_coding_tui(
         app=app,
         stdin=stdin,
         stdout=stdout,

--- a/src/loushang/coding/ui/screen_app.py
+++ b/src/loushang/coding/ui/screen_app.py
@@ -485,6 +485,7 @@ class _ScreenTranscriptRegion:
         rendered = self._render_record_uncached(
             AssistantMessageRecord(_streaming_buffer_render_text(buffer), stable=False),
             width=width,
+            markdown_streaming_key=buffer,
         )
         self._remember_streaming_buffer_cache(
             buffer,
@@ -515,7 +516,13 @@ class _ScreenTranscriptRegion:
         self._transient_source_buffer_version = -1
         return rendered
 
-    def _render_record_uncached(self, record: DisplayRecord, *, width: int) -> tuple[str, ...]:
+    def _render_record_uncached(
+        self,
+        record: DisplayRecord,
+        *,
+        width: int,
+        markdown_streaming_key: object | None = None,
+    ) -> tuple[str, ...]:
         display_record = _screen_coding_display_record(record, cwd=self.cwd)
         render_width = _screen_transcript_record_render_width(display_record, width=width)
         view = TranscriptView(
@@ -523,6 +530,7 @@ class _ScreenTranscriptRegion:
             theme=self.theme,
             capabilities=self.capabilities,
             markdown_cache=self._markdown_render_cache,
+            markdown_streaming_key=markdown_streaming_key,
         )
         rendered = view.render(RenderConstraints(width=render_width, max_height=1_000_000))
         return _coding_lines(
@@ -605,6 +613,7 @@ class _ScreenTranscriptRegion:
         self._transient_source_style_signature = None
         self._transient_source_buffer_id = None
         self._transient_source_buffer_version = -1
+        self._markdown_render_cache.clear_streaming()
 
     def promote_transient_cache(
         self,
@@ -622,9 +631,10 @@ class _ScreenTranscriptRegion:
             return
         if self._transient_source_width <= 0 or self._transient_source_style_signature is None:
             return
+        canonical_lines = self._render_record_uncached(record, width=self._transient_source_width)
         self._stable_line_cache[
             (record, self._transient_source_width, self._transient_source_style_signature)
-        ] = self._transient_line_cache_lines
+        ] = canonical_lines
         self._enforce_stable_cache_entry_limit()
 
     def _enforce_stable_cache_entry_limit(self) -> None:

--- a/src/loushang/coding/ui/screen_app.py
+++ b/src/loushang/coding/ui/screen_app.py
@@ -46,6 +46,7 @@ from loushang.tui import (
     loushang_welcome_theme,
     theme_capabilities_from_runtime,
 )
+from loushang.tui.core import RenderLineSegment, SegmentedRenderLines
 from loushang.tui.markdown.renderer import MarkdownRenderCache
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.transcript import (
@@ -261,6 +262,7 @@ class ScreenCodingTuiApp:
         max_records: int = 80,
     ) -> None:
         self.state.records.append(ContextCompactionRecord(summary=summary, tokens_before=tokens_before))
+        self.state.mark_records_changed()
         evicted = self.state.trim_transcript_prefix(max_records=max_records)
         if evicted:
             self._render_baseline_reset_reason = "transcript_window_trimmed:context_compaction"
@@ -288,6 +290,7 @@ class ScreenCodingTuiApp:
         visible_height = constraints.visible_height or constraints.max_height
         editor_height = self._bottom_frame_height(visible_height)
         self._transcript_region.records = self.state.records
+        self._transcript_region.records_revision = self.state.records_revision
         self._transcript_region.draft = None
         self._transcript_region.draft_buffer = self.state.assistant_draft_buffer
         self._transcript_region.cwd = self.state.cwd
@@ -405,6 +408,7 @@ class ScreenCodingTuiApp:
 @dataclass(slots=True)
 class _ScreenTranscriptRegion:
     records: list[DisplayRecord] = field(default_factory=list)
+    records_revision: int = 0
     draft: AssistantMessageRecord | None = None
     draft_buffer: StreamingTextBuffer | None = None
     cwd: str = ""
@@ -430,6 +434,15 @@ class _ScreenTranscriptRegion:
     _transient_source_buffer_version: int = field(default=-1, init=False, repr=False)
     _markdown_render_cache: MarkdownRenderCache = field(default_factory=MarkdownRenderCache, init=False, repr=False)
     _cache_generation: int = field(default=-1, init=False, repr=False)
+    _committed_segment_key: tuple[object, ...] | None = field(default=None, init=False, repr=False)
+    _committed_segment: RenderLineSegment | None = field(default=None, init=False, repr=False)
+    _committed_separator_rows: frozenset[int] = field(
+        default_factory=frozenset,
+        init=False,
+        repr=False,
+    )
+    _draft_segment_key: tuple[object, ...] | None = field(default=None, init=False, repr=False)
+    _draft_segment: RenderLineSegment | None = field(default=None, init=False, repr=False)
 
     @property
     def has_content(self) -> bool:
@@ -438,12 +451,12 @@ class _ScreenTranscriptRegion:
     def render(self, constraints: RenderConstraints) -> RenderResult:
         self._reset_cache_if_window_changed()
         style_signature = (*_screen_transcript_style_signature(self.theme, self.capabilities), self.cwd)
-        rows = self._render_tail_rows(
+        lines = self._render_tail_segments(
             max_height=constraints.max_height,
             width=constraints.width,
             style_signature=style_signature,
         )
-        return RenderResult(lines=tuple(RenderLine(line) for line in rows))
+        return RenderResult(lines=lines)
 
     def _render_record_lines(
         self,
@@ -563,31 +576,131 @@ class _ScreenTranscriptRegion:
         width: int,
         style_signature: tuple[object, ...],
     ) -> list[str]:
+        return [
+            line.text
+            for line in self._render_tail_segments(
+                max_height=max_height,
+                width=width,
+                style_signature=style_signature,
+            )
+        ]
+
+    def _render_tail_segments(
+        self,
+        *,
+        max_height: int,
+        width: int,
+        style_signature: tuple[object, ...],
+    ) -> SegmentedRenderLines:
         if max_height <= 0:
-            return []
-        newest_first_blocks: list[tuple[str, ...]] = []
-        used_rows = 0
-        for record in reversed(tuple(self._iter_records())):
+            return SegmentedRenderLines()
+
+        committed = self._render_committed_segment(width=width, style_signature=style_signature)
+        draft = self._render_draft_segment(
+            width=width,
+            style_signature=style_signature,
+            has_committed=committed is not None,
+        )
+        segments = tuple(segment for segment in (committed, draft) if segment is not None)
+        lines = SegmentedRenderLines.from_segments(segments)
+        if len(lines) <= max_height:
+            return lines
+
+        start = len(lines) - max_height
+        committed_rows = committed.line_count if committed is not None else 0
+        starts_at_draft_separator = (
+            draft is not None
+            and committed is not None
+            and start == committed_rows
+        )
+        if start in self._committed_separator_rows or starts_at_draft_separator:
+            start += 1
+        return lines[start:]
+
+    def _render_committed_segment(
+        self,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+    ) -> RenderLineSegment | None:
+        first_record_id = id(self.records[0]) if self.records else 0
+        last_record_id = id(self.records[-1]) if self.records else 0
+        key = (
+            id(self.records),
+            self.records_revision,
+            len(self.records),
+            first_record_id,
+            last_record_id,
+            self.window_generation,
+            width,
+            style_signature,
+        )
+        if key == self._committed_segment_key:
+            return self._committed_segment
+
+        rows: list[str] = []
+        separator_rows: set[int] = set()
+        for record in self.records:
             block = self._render_record_lines(record, width=width, style_signature=style_signature)
             if not block:
                 continue
-            separator_rows = 1 if newest_first_blocks else 0
-            available = max_height - used_rows - separator_rows
-            if available <= 0:
-                break
-            if len(block) > available:
-                block = block[-available:]
-            newest_first_blocks.append(block)
-            used_rows += separator_rows + len(block)
-            if used_rows >= max_height:
-                break
-
-        rows: list[str] = []
-        for block in reversed(newest_first_blocks):
             if rows:
+                separator_rows.add(len(rows))
                 rows.append("")
             rows.extend(block)
-        return rows[-max_height:]
+        segment = (
+            RenderLineSegment(
+                lines=tuple(RenderLine(row) for row in rows),
+                revision=key,
+            )
+            if rows
+            else None
+        )
+        self._committed_segment_key = key
+        self._committed_segment = segment
+        self._committed_separator_rows = frozenset(separator_rows)
+        return segment
+
+    def _render_draft_segment(
+        self,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+        has_committed: bool,
+    ) -> RenderLineSegment | None:
+        draft: DisplayRecord | StreamingTextBuffer | None = self.draft_buffer or self.draft
+        if draft is None:
+            self._draft_segment_key = None
+            self._draft_segment = None
+            return None
+        source_revision: object
+        if isinstance(draft, StreamingTextBuffer):
+            source_revision = (id(draft), draft.version)
+        else:
+            source_revision = draft
+        key = (
+            source_revision,
+            has_committed,
+            self.window_generation,
+            width,
+            style_signature,
+        )
+        if key == self._draft_segment_key:
+            return self._draft_segment
+
+        block = self._render_record_lines(draft, width=width, style_signature=style_signature)
+        rows = (("", *block) if has_committed and block else block)
+        segment = (
+            RenderLineSegment(
+                lines=tuple(RenderLine(row) for row in rows),
+                revision=key,
+            )
+            if rows
+            else None
+        )
+        self._draft_segment_key = key
+        self._draft_segment = segment
+        return segment
 
     def _iter_records(self) -> Iterable[DisplayRecord | StreamingTextBuffer]:
         yield from self.records
@@ -603,6 +716,11 @@ class _ScreenTranscriptRegion:
         self._transient_line_cache_key = None
         self._transient_line_cache_lines = None
         self._markdown_render_cache.clear()
+        self._committed_segment_key = None
+        self._committed_segment = None
+        self._committed_separator_rows = frozenset()
+        self._draft_segment_key = None
+        self._draft_segment = None
         self._cache_generation = self.window_generation
 
     def clear_transient_cache(self) -> None:
@@ -613,6 +731,8 @@ class _ScreenTranscriptRegion:
         self._transient_source_style_signature = None
         self._transient_source_buffer_id = None
         self._transient_source_buffer_version = -1
+        self._draft_segment_key = None
+        self._draft_segment = None
         self._markdown_render_cache.clear_streaming()
 
     def promote_transient_cache(

--- a/src/loushang/coding/ui/screen_events.py
+++ b/src/loushang/coding/ui/screen_events.py
@@ -108,6 +108,7 @@ class ScreenCodingEventProjector:
             text = _extract_text(message).strip()
             if text and not self.app.state.consume_pending_user_echo(text):
                 self.app.state.records.append(_user_record(text))
+                self.app.state.mark_records_changed()
             return
         if role == "assistant":
             self.app.begin_assistant()

--- a/src/loushang/coding/ui/screen_state.py
+++ b/src/loushang/coding/ui/screen_state.py
@@ -25,6 +25,7 @@ class ScreenTranscriptWindow:
 @dataclass(slots=True)
 class ScreenCodingTuiState:
     records: list[DisplayRecord] = field(default_factory=list)
+    records_revision: int = field(default=0, init=False)
     transcript_window_generation: int = 0
     evicted_prefix_record_count: int = 0
     active_started_at: float | None = None
@@ -56,6 +57,9 @@ class ScreenCodingTuiState:
     def assistant_draft_buffer(self) -> StreamingTextBuffer | None:
         return self._assistant_draft_buffer
 
+    def mark_records_changed(self) -> None:
+        self.records_revision += 1
+
     def replace_transcript_window(
         self,
         records: Iterable[DisplayRecord] | ScreenTranscriptWindow,
@@ -69,11 +73,15 @@ class ScreenCodingTuiState:
                 records=tuple(records),
                 evicted_prefix_record_count=evicted_prefix_record_count,
             )
-        self.records = list(window.records)
+        replacement = list(window.records)
+        records_changed = replacement != self.records
+        self.records = replacement
         self.evicted_prefix_record_count = max(0, window.evicted_prefix_record_count)
         self.transcript_window_generation += 1
         self._tool_record_indices.clear()
         self._pending_user_echo = None
+        if records_changed:
+            self.mark_records_changed()
 
     def trim_transcript_prefix(self, *, max_records: int) -> int:
         max_records = max(0, max_records)
@@ -81,6 +89,7 @@ class ScreenCodingTuiState:
             return 0
         evicted_count = len(self.records) - max_records
         del self.records[:evicted_count]
+        self.mark_records_changed()
         self.evicted_prefix_record_count += evicted_count
         self.transcript_window_generation += 1
         self._tool_record_indices.clear()
@@ -91,6 +100,7 @@ class ScreenCodingTuiState:
         stripped = text.strip()
         if stripped:
             self.records.append(UserPromptRecord(stripped))
+            self.mark_records_changed()
             self._pending_user_echo = stripped
         self.active_started_at = started_at
         self._assistant_draft_buffer = None
@@ -123,12 +133,14 @@ class ScreenCodingTuiState:
         self._assistant_draft_buffer = None
         if text:
             self.records.append(AssistantMessageRecord(text, stable=True))
+            self.mark_records_changed()
 
     def complete_run(self, *, elapsed_seconds: float) -> None:
         if self.assistant_draft is not None:
             self.end_assistant()
         if not self.records or not isinstance(self.records[-1], WorkedDividerRecord):
             self.records.append(WorkedDividerRecord(elapsed_seconds))
+            self.mark_records_changed()
         self.active_started_at = None
         self.status_message = None
         self._tool_record_indices.clear()
@@ -163,6 +175,7 @@ class ScreenCodingTuiState:
         if self.assistant_draft is not None:
             self.end_assistant()
         self.records.append(WorkedDividerRecord(elapsed_seconds))
+        self.mark_records_changed()
         self.interruption_message = message
         self.active_started_at = None
         self.status_message = None
@@ -172,12 +185,14 @@ class ScreenCodingTuiState:
     def add_error(self, summary: str, diagnostics: str = "") -> None:
         if summary:
             self.records.append(ErrorRecord(summary, diagnostics))
+            self.mark_records_changed()
         self._pending_user_echo = None
 
     def add_status(self, message: str) -> None:
         stripped = message.strip()
         if stripped:
             self.records.append(StatusRecord(stripped))
+            self.mark_records_changed()
         self._pending_user_echo = None
 
     def consume_pending_user_echo(self, text: str) -> bool:
@@ -195,10 +210,14 @@ class ScreenCodingTuiState:
     def upsert_tool_record(self, tool_call_id: str, record: ToolExecutionRecord) -> None:
         existing = self._tool_record_indices.get(tool_call_id)
         if existing is not None and 0 <= existing < len(self.records):
+            if self.records[existing] == record:
+                return
             self.records[existing] = record
+            self.mark_records_changed()
             return
         self._tool_record_indices[tool_call_id] = len(self.records)
         self.records.append(record)
+        self.mark_records_changed()
 
 
 __all__ = ["ScreenCodingTuiState", "ScreenTranscriptWindow"]

--- a/src/loushang/tui/core.py
+++ b/src/loushang/tui/core.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from bisect import bisect_right
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
+from typing import overload
 
 from loushang.tui.cell_width import visible_width
 
@@ -44,8 +47,209 @@ class RenderLine:
 
 
 @dataclass(frozen=True, slots=True)
-class RenderResult:
+class RenderLineSegment:
     lines: tuple[RenderLine, ...]
+    identity: object = field(default_factory=object)
+    revision: object = 0
+    cacheable: bool = True
+    _identity_key: tuple[object, int, int] = field(
+        init=False, repr=False, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lines, tuple):
+            object.__setattr__(self, "lines", tuple(self.lines))
+        try:
+            hash(self.identity)
+        except TypeError as exc:
+            raise TypeError("segment identity must be hashable") from exc
+        object.__setattr__(self, "_identity_key", (self.identity, 0, len(self.lines)))
+
+    @property
+    def identity_key(self) -> tuple[object, int, int]:
+        return self._identity_key
+
+    @property
+    def line_count(self) -> int:
+        return len(self.lines)
+
+    def iter_lines(self) -> Iterator[RenderLine]:
+        return iter(self.lines)
+
+
+@dataclass(frozen=True, slots=True)
+class RenderLineSegmentView:
+    segment: RenderLineSegment
+    start: int
+    stop: int
+    _identity_key: tuple[object, int, int] = field(
+        init=False, repr=False, compare=False
+    )
+
+    def __post_init__(self) -> None:
+        if self.start < 0:
+            raise ValueError("segment view start must be non-negative")
+        if self.stop < self.start:
+            raise ValueError("segment view stop must not precede start")
+        if self.stop > self.segment.line_count:
+            raise ValueError("segment view stop exceeds segment line count")
+        object.__setattr__(
+            self,
+            "_identity_key",
+            (self.segment.identity, self.start, self.stop),
+        )
+
+    @property
+    def identity_key(self) -> tuple[object, int, int]:
+        return self._identity_key
+
+    @property
+    def revision(self) -> object:
+        return self.segment.revision
+
+    @property
+    def cacheable(self) -> bool:
+        return self.segment.cacheable
+
+    @property
+    def line_count(self) -> int:
+        return self.stop - self.start
+
+    def iter_lines(self) -> Iterator[RenderLine]:
+        lines = self.segment.lines
+        return (lines[index] for index in range(self.start, self.stop))
+
+
+RenderLineSegmentLike = RenderLineSegment | RenderLineSegmentView
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class SegmentedRenderLines(Sequence[RenderLine]):
+    segments: tuple[RenderLineSegmentLike, ...] = ()
+    _segment_ends: tuple[int, ...] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        segments = tuple(segment for segment in self.segments if segment.line_count > 0)
+        if segments != self.segments:
+            object.__setattr__(self, "segments", segments)
+        total = 0
+        ends: list[int] = []
+        for segment in segments:
+            total += segment.line_count
+            ends.append(total)
+        object.__setattr__(self, "_segment_ends", tuple(ends))
+
+    @classmethod
+    def from_segments(
+        cls, segments: tuple[RenderLineSegmentLike, ...]
+    ) -> SegmentedRenderLines:
+        return cls(segments=segments)
+
+    @property
+    def line_count(self) -> int:
+        return len(self)
+
+    def iter_lines(self) -> Iterator[RenderLine]:
+        return iter(self)
+
+    def __len__(self) -> int:
+        return self._segment_ends[-1] if self._segment_ends else 0
+
+    def __iter__(self) -> Iterator[RenderLine]:
+        for segment in self.segments:
+            yield from segment.iter_lines()
+
+    @overload
+    def __getitem__(self, index: int) -> RenderLine: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> SegmentedRenderLines: ...
+
+    def __getitem__(self, index: int | slice) -> RenderLine | SegmentedRenderLines:
+        if isinstance(index, slice):
+            return self._slice(index)
+        normalized = index
+        if normalized < 0:
+            normalized += len(self)
+        if normalized < 0 or normalized >= len(self):
+            raise IndexError("render line index out of range")
+        segment_index = bisect_right(self._segment_ends, normalized)
+        segment_start = self._segment_ends[segment_index - 1] if segment_index else 0
+        segment = self.segments[segment_index]
+        return _segment_line_at(segment, normalized - segment_start)
+
+    def __eq__(self, other: object) -> bool:
+        if self is other:
+            return True
+        if not isinstance(other, Sequence):
+            return NotImplemented
+        if len(self) != len(other):
+            return False
+        return all(
+            current == candidate for current, candidate in zip(self, other, strict=True)
+        )
+
+    def tail(self, max_rows: int) -> SegmentedRenderLines:
+        if max_rows <= 0:
+            return SegmentedRenderLines()
+        if max_rows >= len(self):
+            return self
+        return self[len(self) - max_rows :]
+
+    def _slice(self, requested: slice) -> SegmentedRenderLines:
+        start, stop, step = requested.indices(len(self))
+        if step != 1:
+            selected = tuple(self[index] for index in range(start, stop, step))
+            if not selected:
+                return SegmentedRenderLines()
+            return SegmentedRenderLines.from_segments(
+                (RenderLineSegment(selected, cacheable=False),)
+            )
+        if start >= stop:
+            return SegmentedRenderLines()
+        if start == 0 and stop == len(self):
+            return self
+
+        selected_segments: list[RenderLineSegmentLike] = []
+        segment_start = 0
+        for segment, segment_end in zip(self.segments, self._segment_ends, strict=True):
+            if segment_end <= start:
+                segment_start = segment_end
+                continue
+            if segment_start >= stop:
+                break
+            local_start = max(0, start - segment_start)
+            local_stop = min(segment.line_count, stop - segment_start)
+            selected_segments.append(_slice_segment(segment, local_start, local_stop))
+            segment_start = segment_end
+        return SegmentedRenderLines.from_segments(tuple(selected_segments))
+
+
+def _segment_line_at(segment: RenderLineSegmentLike, index: int) -> RenderLine:
+    if isinstance(segment, RenderLineSegmentView):
+        return segment.segment.lines[segment.start + index]
+    return segment.lines[index]
+
+
+def _slice_segment(
+    segment: RenderLineSegmentLike,
+    start: int,
+    stop: int,
+) -> RenderLineSegmentLike:
+    if start == 0 and stop == segment.line_count:
+        return segment
+    if isinstance(segment, RenderLineSegmentView):
+        return RenderLineSegmentView(
+            segment.segment,
+            segment.start + start,
+            segment.start + stop,
+        )
+    return RenderLineSegmentView(segment, start, stop)
+
+
+@dataclass(frozen=True, slots=True)
+class RenderResult:
+    lines: Sequence[RenderLine]
     cursor: CursorDeclaration | None = None
 
     @classmethod
@@ -65,7 +269,7 @@ class RenderResult:
     @classmethod
     def from_lines(
         cls,
-        lines: list[RenderLine] | tuple[RenderLine, ...],
+        lines: Sequence[RenderLine],
         *,
         constraints: RenderConstraints,
         cursor: CursorDeclaration | None = None,
@@ -78,7 +282,9 @@ class RenderResult:
                 before_marker, marker, after_marker = text.partition(CURSOR_MARKER)
                 if marker and marker_cursor is not None:
                     raise ValueError("render result contains multiple cursor markers")
-                marker_cursor = CursorDeclaration(row=row, column=visible_width(before_marker))
+                marker_cursor = CursorDeclaration(
+                    row=row, column=visible_width(before_marker)
+                )
                 text = before_marker + after_marker
             rendered_lines.append(RenderLine(text))
         result = cls(lines=tuple(rendered_lines), cursor=marker_cursor)
@@ -87,7 +293,9 @@ class RenderResult:
 
     def validate(self, constraints: RenderConstraints) -> None:
         if len(self.lines) > constraints.max_height:
-            raise ValueError(f"render result exceeds max height {constraints.max_height}")
+            raise ValueError(
+                f"render result exceeds max height {constraints.max_height}"
+            )
 
         for index, line in enumerate(self.lines):
             if line.width > constraints.width:

--- a/src/loushang/tui/framework.py
+++ b/src/loushang/tui/framework.py
@@ -308,6 +308,15 @@ class SurfaceHost:
         for entry in self.entries:
             entry.last_row = None
             entry.last_column = None
+        if not any(
+            self._is_entry_visible(entry, size)
+            and (
+                surface_is_inline_presentation(entry.surface)
+                or surface_is_overlay_presentation(entry.surface)
+            )
+            for entry in self.entries
+        ):
+            return base
         lines = [line.text for line in base.lines]
         cursor = base.cursor
         for entry in self.entries:

--- a/src/loushang/tui/markdown/renderer.py
+++ b/src/loushang/tui/markdown/renderer.py
@@ -800,17 +800,19 @@ def _render_markdown_blocks(
 ) -> tuple[str, ...]:
     rendered: list[str] = []
     stable_block_count = max(0, len(blocks) - 1) if render_cache is not None else 0
+    block_cache_context: tuple[object, ...] = ()
+    if stable_block_count:
+        block_cache_context = (
+            width,
+            _theme_cache_signature(theme),
+            _capabilities_cache_signature(capabilities),
+            id(code_highlighter) if code_highlighter is not None else None,
+            _style_cache_signature(default_style),
+        )
     for index, block in enumerate(blocks):
         if render_cache is not None and index < stable_block_count:
             block_lines = render_cache.get_or_render(
-                _markdown_block_cache_key(
-                    block,
-                    width=width,
-                    theme=theme,
-                    capabilities=capabilities,
-                    code_highlighter=code_highlighter,
-                    default_style=default_style,
-                ),
+                (block, *block_cache_context),
                 lambda block=block: _render_markdown_block(
                     block,
                     width=width,
@@ -834,25 +836,6 @@ def _render_markdown_blocks(
         if _needs_pi_style_blank_after(block.kind, next_kind):
             rendered.append("")
     return tuple(rendered)
-
-
-def _markdown_block_cache_key(
-    block: _MarkdownBlock,
-    *,
-    width: int,
-    theme: ThemeResolver | None,
-    capabilities: TerminalCapabilities | None,
-    code_highlighter: CodeHighlighterLike | None,
-    default_style: ThemeStyle | None,
-) -> tuple[object, ...]:
-    return (
-        block,
-        width,
-        _theme_cache_signature(theme),
-        _capabilities_cache_signature(capabilities),
-        id(code_highlighter) if code_highlighter is not None else None,
-        _style_cache_signature(default_style),
-    )
 
 
 def _render_markdown_block(

--- a/src/loushang/tui/markdown/renderer.py
+++ b/src/loushang/tui/markdown/renderer.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import importlib
 import inspect
 import re
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Callable, Protocol, Sequence, TypeAlias, cast
+from typing import Protocol, TypeAlias, cast
 
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
@@ -57,6 +58,8 @@ from loushang.tui.theme import (
 _TABLE_SEPARATOR_RE = re.compile(r"^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$")
 _MARKDOWN_LINE_CACHE_SIZE = 2_048
 _MARKDOWN_STABLE_BLOCK_CACHE_SIZE = 4_096
+# A partial list marker can merge backward into the preceding top-level list.
+_STREAMING_MARKDOWN_FRONTIER_GROUPS = 2
 _MARKDOWN_PARSER = MarkdownIt("commonmark").enable("table").enable("strikethrough")
 _QUOTE_MARKER = "│ "
 
@@ -72,10 +75,72 @@ class CapabilityAwareCodeHighlighter(Protocol):
 CodeHighlighterLike: TypeAlias = CodeHighlighter | CapabilityAwareCodeHighlighter
 
 
+@dataclass(frozen=True, slots=True)
+class _ParsedMarkdownGroup:
+    start_line: int
+    end_line: int
+    blocks: tuple[_MarkdownBlock, ...]
+
+
+@dataclass(slots=True)
+class _StreamingMarkdownParseState:
+    _source: str = ""
+    _stable_end_line: int = 0
+    _stable_groups: list[_ParsedMarkdownGroup] = field(default_factory=list)
+    _last_blocks: tuple[_MarkdownBlock, ...] = ()
+    _initialized: bool = False
+    _full_parse_only: bool = False
+
+    def parse(self, markdown: str) -> tuple[_MarkdownBlock, ...]:
+        normalized = markdown.expandtabs(3)
+        if self._initialized and normalized == self._source:
+            return self._last_blocks
+        if self._initialized and not normalized.startswith(self._source):
+            self.reset()
+
+        self._source = normalized
+        self._initialized = True
+        if self._full_parse_only:
+            self._last_blocks = _parse_normalized_markdown_blocks(normalized)
+            return self._last_blocks
+
+        source_lines = normalized.split("\n")
+        tail_source = "\n".join(source_lines[self._stable_end_line :])
+        tail_groups, has_references = _parse_markdown_groups(
+            tail_source,
+            line_offset=self._stable_end_line,
+        )
+        if has_references:
+            self._stable_end_line = 0
+            self._stable_groups.clear()
+            self._full_parse_only = True
+            self._last_blocks = _parse_normalized_markdown_blocks(normalized)
+            return self._last_blocks
+
+        groups = (*self._stable_groups, *tail_groups)
+        promote_count = max(0, len(tail_groups) - _STREAMING_MARKDOWN_FRONTIER_GROUPS)
+        if promote_count:
+            promoted = tail_groups[:promote_count]
+            self._stable_groups.extend(promoted)
+            self._stable_end_line = promoted[-1].end_line
+        self._last_blocks = _markdown_blocks_from_groups(groups)
+        return self._last_blocks
+
+    def reset(self) -> None:
+        self._source = ""
+        self._stable_end_line = 0
+        self._stable_groups.clear()
+        self._last_blocks = ()
+        self._initialized = False
+        self._full_parse_only = False
+
+
 @dataclass(slots=True)
 class MarkdownRenderCache:
     stable_entry_limit: int = _MARKDOWN_STABLE_BLOCK_CACHE_SIZE
     _stable_blocks: dict[tuple[object, ...], tuple[str, ...]] = field(default_factory=dict, init=False, repr=False)
+    _streaming_key: object | None = field(default=None, init=False, repr=False)
+    _streaming_parse_state: _StreamingMarkdownParseState | None = field(default=None, init=False, repr=False)
 
     @property
     def stable_entry_count(self) -> int:
@@ -91,6 +156,17 @@ class MarkdownRenderCache:
 
     def clear(self) -> None:
         self._stable_blocks.clear()
+        self.clear_streaming()
+
+    def clear_streaming(self) -> None:
+        self._streaming_key = None
+        self._streaming_parse_state = None
+
+    def parse_streaming(self, markdown: str, *, key: object) -> tuple[_MarkdownBlock, ...]:
+        if self._streaming_key is not key or self._streaming_parse_state is None:
+            self._streaming_key = key
+            self._streaming_parse_state = _StreamingMarkdownParseState()
+        return self._streaming_parse_state.parse(markdown)
 
     def get_or_render(self, key: tuple[object, ...], render: Callable[[], tuple[str, ...]]) -> tuple[str, ...]:
         cached = self._stable_blocks.get(key)
@@ -141,6 +217,7 @@ class MarkdownRenderer:
     padding_y: int = 0
     default_style: ThemeStyle | None = None
     render_cache: MarkdownRenderCache | None = None
+    streaming_key: object | None = None
     _render_cache: dict[tuple[object, ...], tuple[str, ...]] = field(default_factory=dict, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -155,9 +232,14 @@ class MarkdownRenderer:
         framed = self.padding_x > 0 or self.padding_y > 0 or _has_background_style(frame_style)
         width = _markdown_frame_content_width(target_width, self.padding_x) if framed else target_width
         if self.render_cache is not None:
+            blocks = (
+                self.render_cache.parse_streaming(self.markdown, key=self.streaming_key)
+                if self.streaming_key is not None
+                else _parse_markdown_blocks(self.markdown)
+            )
             raw_lines = list(
                 _render_markdown_blocks(
-                    _parse_markdown_blocks(self.markdown),
+                    blocks,
                     width=width,
                     theme=self.theme,
                     capabilities=self.capabilities,
@@ -343,12 +425,74 @@ def _render_markdown_lines(markdown: str, width: int) -> tuple[str, ...]:
 
 def _parse_markdown_blocks(markdown: str) -> tuple[_MarkdownBlock, ...]:
     normalized = markdown.expandtabs(3)
+    return _parse_normalized_markdown_blocks(normalized)
+
+
+def _parse_normalized_markdown_blocks(normalized: str) -> tuple[_MarkdownBlock, ...]:
     blocks, _index = _parse_markdown_it_blocks(
         _MARKDOWN_PARSER.parse(normalized),
         0,
         stop_type=None,
         source_lines=normalized.split("\n"),
     )
+    return tuple(blocks)
+
+
+def _parse_markdown_groups(
+    markdown: str,
+    *,
+    line_offset: int,
+) -> tuple[tuple[_ParsedMarkdownGroup, ...], bool]:
+    environment: dict[str, object] = {}
+    tokens = _MARKDOWN_PARSER.parse(markdown, environment)
+    if environment.get("references"):
+        return (), True
+
+    source_lines = markdown.split("\n")
+    group_starts = [
+        index
+        for index, token in enumerate(tokens)
+        if token.level == 0 and token.map is not None and token.nesting >= 0
+    ]
+    groups: list[_ParsedMarkdownGroup] = []
+    for group_index, token_index in enumerate(group_starts):
+        token = tokens[token_index]
+        token_map = token.map
+        if token_map is None:
+            continue
+        next_token_index = group_starts[group_index + 1] if group_index + 1 < len(group_starts) else len(tokens)
+        group_blocks, _index = _parse_markdown_it_blocks(
+            tokens[token_index:next_token_index],
+            0,
+            stop_type=None,
+            source_lines=source_lines,
+        )
+        local_end_line = _token_end_line(token, token_map[1], source_lines)
+        groups.append(
+            _ParsedMarkdownGroup(
+                start_line=line_offset + token_map[0],
+                end_line=line_offset + (local_end_line if local_end_line is not None else token_map[1]),
+                blocks=tuple(group_blocks),
+            )
+        )
+    return tuple(groups), False
+
+
+def _markdown_blocks_from_groups(groups: Sequence[_ParsedMarkdownGroup]) -> tuple[_MarkdownBlock, ...]:
+    blocks: list[_MarkdownBlock] = []
+    previous_end_line: int | None = None
+    for group in groups:
+        if (
+            group.blocks
+            and previous_end_line is not None
+            and group.start_line > previous_end_line
+            and blocks
+            and blocks[-1].kind != "blank"
+        ):
+            blocks.append(_MarkdownBlock("blank"))
+        blocks.extend(group.blocks)
+        if group.blocks:
+            previous_end_line = group.end_line
     return tuple(blocks)
 
 

--- a/src/loushang/tui/playback.py
+++ b/src/loushang/tui/playback.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from itertools import zip_longest
@@ -22,8 +22,9 @@ PLAYBACK_ARTIFACTS_ENV = "LOUSHANG_TUI_PLAYBACK_ARTIFACTS"
 
 @dataclass(frozen=True, slots=True)
 class RenderDiagnostics:
-    current_logical_lines: tuple[str, ...]
-    previous_rendered_lines: tuple[str, ...] = ()
+    current_logical_lines: Sequence[str]
+    raw_logical_lines: Sequence[str] = ()
+    previous_rendered_lines: Sequence[str] = ()
     changed_line_range: tuple[int, int] | None = None
     operation_class: str | None = None
     append_start: int | None = None
@@ -43,6 +44,11 @@ class RenderDiagnostics:
     repaint_reason: str | None = None
     clear_scrollback_policy: str = "disabled"
     clear_scrollback_emitted: bool = False
+    reused_render_segment_count: int = 0
+    materialized_logical_line_count: int = 0
+    flattened_logical_line_count: int = 0
+    base_frame_revision: int = 0
+    frame_revision: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -125,7 +131,7 @@ class PlaybackHarness:
             frame: TerminalFrame | None = None
             try:
                 frame = self.port.flush(diagnostics.operations)
-            except Exception as exc:  # noqa: BLE001 - playback harness records terminal failures.
+            except Exception as exc:
                 flush_error = str(exc)
             else:
                 self.previous_successful_diagnostics = diagnostics

--- a/src/loushang/tui/render_loop.py
+++ b/src/loushang/tui/render_loop.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass
+from bisect import bisect_right
+from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import ClassVar, Literal, Protocol
 
 from loushang.tui.cell_width import normalize_terminal_output, visible_width
-from loushang.tui.core import CursorDeclaration, RenderConstraints, RenderResult
+from loushang.tui.core import (
+    CursorDeclaration,
+    RenderConstraints,
+    RenderLineSegmentLike,
+    RenderResult,
+    SegmentedRenderLines,
+)
 from loushang.tui.playback import RenderDiagnostics
 from loushang.tui.terminal import TerminalOperation, TerminalSize
 from loushang.tui.terminal_image import (
@@ -18,6 +25,72 @@ from loushang.tui.terminal_image import (
 
 ClearScrollbackPolicy = Literal["disabled", "resize", "explicit"]
 SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07"
+_FINALIZED_SEGMENT_CACHE_LIMIT = 512
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class _LogicalLineSegment:
+    raw_lines: tuple[str, ...]
+    finalized_lines: tuple[str, ...]
+    kitty_images: tuple[tuple[int, int, str], ...] = ()
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class _SegmentedTextLines(Sequence[str]):
+    segments: tuple[_LogicalLineSegment, ...] = ()
+    finalized: bool = True
+    _segment_ends: tuple[int, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        total = 0
+        ends: list[int] = []
+        for segment in self.segments:
+            total += len(self._segment_lines(segment))
+            ends.append(total)
+        object.__setattr__(self, "_segment_ends", tuple(ends))
+
+    def __len__(self) -> int:
+        return self._segment_ends[-1] if self._segment_ends else 0
+
+    def __iter__(self) -> Iterator[str]:
+        for segment in self.segments:
+            yield from self._segment_lines(segment)
+
+    def __getitem__(self, index: int | slice) -> str | tuple[str, ...]:
+        if isinstance(index, slice):
+            start, stop, step = index.indices(len(self))
+            return tuple(self[row] for row in range(start, stop, step))
+        normalized = index + len(self) if index < 0 else index
+        if normalized < 0 or normalized >= len(self):
+            raise IndexError("logical line index out of range")
+        segment_index = bisect_right(self._segment_ends, normalized)
+        segment_start = self._segment_ends[segment_index - 1] if segment_index else 0
+        return self._segment_lines(self.segments[segment_index])[normalized - segment_start]
+
+    def __eq__(self, other: object) -> bool:
+        if self is other:
+            return True
+        if not isinstance(other, Sequence):
+            return NotImplemented
+        if len(self) != len(other):
+            return False
+        return all(current == candidate for current, candidate in zip(self, other, strict=True))
+
+    def tail_segments(self, start: int) -> _SegmentedTextLines:
+        return _SegmentedTextLines(self.segments[start:], finalized=self.finalized)
+
+    def segment_start(self, index: int) -> int:
+        return self._segment_ends[index - 1] if index else 0
+
+    def iter_kitty_images(self) -> Iterator[tuple[int, int, str]]:
+        row_offset = 0
+        for segment in self.segments:
+            for row, image_id, delete_sequence in segment.kitty_images:
+                yield row_offset + row, image_id, delete_sequence
+            row_offset += len(self._segment_lines(segment))
+
+    def _segment_lines(self, segment: _LogicalLineSegment) -> tuple[str, ...]:
+        return segment.finalized_lines if self.finalized else segment.raw_lines
 
 
 class ScreenRoot(Protocol):
@@ -526,8 +599,8 @@ class RenderLoop:
     screen_root: ScreenRoot
     clear_scrollback_policy: ClearScrollbackPolicy = "resize"
     termux_session: bool = False
-    previous_rendered_lines: tuple[str, ...] = ()
-    previous_raw_lines: tuple[str, ...] = ()
+    previous_rendered_lines: Sequence[str] = ()
+    previous_raw_lines: Sequence[str] = ()
     previous_size: TerminalSize | None = None
     previous_viewport_top: int = 0
     hardware_cursor_row: int = 0
@@ -537,7 +610,19 @@ class RenderLoop:
     previous_cursor_column: int = 0
     _unsafe_viewport_reason: str | None = None
     _baseline_reset_reason: str | None = None
-    _planned_raw_lines: tuple[str, ...] = ()
+    _planned_raw_lines: Sequence[str] = ()
+    _finalized_segment_cache: dict[tuple[object, object], _LogicalLineSegment] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _planned_reused_segment_count: int = field(default=0, init=False, repr=False)
+    _planned_materialized_line_count: int = field(default=0, init=False, repr=False)
+    _planned_flattened_line_count: int = field(default=0, init=False, repr=False)
+    committed_frame_revision: int = field(default=0, init=False)
+    _next_frame_revision: int = field(default=0, init=False, repr=False)
+    _planned_base_frame_revision: int = field(default=0, init=False, repr=False)
+    _planned_frame_revision: int = field(default=0, init=False, repr=False)
 
     def mark_viewport_unsafe(self, reason: str) -> None:
         self._unsafe_viewport_reason = reason
@@ -546,16 +631,14 @@ class RenderLoop:
         self._baseline_reset_reason = reason
 
     def _build_plan_context(self, size: TerminalSize) -> RenderPlanContext:
+        self._planned_base_frame_revision = self.committed_frame_revision
+        self._next_frame_revision += 1
+        self._planned_frame_revision = self._next_frame_revision
         result = self.screen_root.render(
             RenderConstraints(width=size.columns, max_height=1_000_000, visible_height=size.rows)
         )
-        raw_current_lines = tuple(line.text for line in result.lines)
+        raw_current_lines, current_lines = self._logical_lines(result)
         self._planned_raw_lines = raw_current_lines
-        current_lines = _finalize_rendered_lines(
-            raw_current_lines,
-            previous_raw_lines=self.previous_raw_lines,
-            previous_finalized_lines=self.previous_rendered_lines,
-        )
         cursor = _cursor_or_line_end(result.cursor, current_lines)
         previous_lines = self.previous_rendered_lines
         previous_size = self.previous_size
@@ -603,6 +686,41 @@ class RenderLoop:
             width_changed=width_changed,
             height_changed=height_changed,
             previous_kitty_delete_sequences=previous_kitty_delete_sequences,
+        )
+
+    def _logical_lines(self, result: RenderResult) -> tuple[Sequence[str], Sequence[str]]:
+        self._planned_reused_segment_count = 0
+        self._planned_materialized_line_count = 0
+        self._planned_flattened_line_count = 0
+        if not isinstance(result.lines, SegmentedRenderLines):
+            raw_lines = tuple(line.text for line in result.lines)
+            self._planned_flattened_line_count = len(raw_lines)
+            self._planned_materialized_line_count = len(raw_lines)
+            return raw_lines, _finalize_rendered_lines(
+                raw_lines,
+                previous_raw_lines=self.previous_raw_lines,
+                previous_finalized_lines=self.previous_rendered_lines,
+            )
+
+        segments: list[_LogicalLineSegment] = []
+        for rendered_segment in result.lines.segments:
+            cache_key = _render_segment_cache_key(rendered_segment)
+            cached = self._finalized_segment_cache.get(cache_key) if cache_key is not None else None
+            if cached is not None:
+                self._planned_reused_segment_count += 1
+                segments.append(cached)
+                continue
+            logical_segment = _finalize_render_segment(rendered_segment)
+            self._planned_materialized_line_count += len(logical_segment.raw_lines)
+            segments.append(logical_segment)
+            if cache_key is not None:
+                self._finalized_segment_cache[cache_key] = logical_segment
+                while len(self._finalized_segment_cache) > _FINALIZED_SEGMENT_CACHE_LIMIT:
+                    self._finalized_segment_cache.pop(next(iter(self._finalized_segment_cache)))
+        logical_segments = tuple(segments)
+        return (
+            _SegmentedTextLines(logical_segments, finalized=False),
+            _SegmentedTextLines(logical_segments, finalized=True),
         )
 
     def _plan_runtime(self) -> RenderPlanRuntime:
@@ -667,8 +785,10 @@ class RenderLoop:
         )
 
     def commit(self, diagnostics: RenderDiagnostics, *, size: TerminalSize) -> None:
+        if diagnostics.base_frame_revision != self.committed_frame_revision:
+            raise RuntimeError("render plan base revision no longer matches the committed frame")
         self.previous_rendered_lines = diagnostics.current_logical_lines
-        self.previous_raw_lines = self._planned_raw_lines
+        self.previous_raw_lines = diagnostics.raw_logical_lines
         self.previous_size = size
         self.previous_viewport_top = diagnostics.viewport_top
         self.hardware_cursor_row = diagnostics.hardware_cursor_row
@@ -678,6 +798,7 @@ class RenderLoop:
         self.working_area_high_water_mark = max(
             self.working_area_high_water_mark, len(diagnostics.current_logical_lines)
         )
+        self.committed_frame_revision = diagnostics.frame_revision
         self._unsafe_viewport_reason = None
         self._baseline_reset_reason = None
 
@@ -750,6 +871,7 @@ class RenderLoop:
         terminal_cursor_column = logical_cursor.column if hardware_cursor_column is None else hardware_cursor_column
         return RenderDiagnostics(
             current_logical_lines=current_lines,
+            raw_logical_lines=self._planned_raw_lines,
             previous_rendered_lines=previous_lines,
             changed_line_range=changed_range,
             operation_class=operation_class,
@@ -770,10 +892,42 @@ class RenderLoop:
             repaint_reason=repaint_reason,
             clear_scrollback_policy=self.clear_scrollback_policy,
             clear_scrollback_emitted=clear_scrollback_emitted,
+            reused_render_segment_count=self._planned_reused_segment_count,
+            materialized_logical_line_count=self._planned_materialized_line_count,
+            flattened_logical_line_count=self._planned_flattened_line_count,
+            base_frame_revision=self._planned_base_frame_revision,
+            frame_revision=self._planned_frame_revision,
         )
 
 
-def _changed_line_range(previous_lines: tuple[str, ...], current_lines: tuple[str, ...]) -> tuple[int, int] | None:
+def _changed_line_range(previous_lines: Sequence[str], current_lines: Sequence[str]) -> tuple[int, int] | None:
+    if isinstance(previous_lines, _SegmentedTextLines) and isinstance(current_lines, _SegmentedTextLines):
+        common_segments = 0
+        common_limit = min(len(previous_lines.segments), len(current_lines.segments))
+        while (
+            common_segments < common_limit
+            and previous_lines.segments[common_segments] is current_lines.segments[common_segments]
+        ):
+            common_segments += 1
+        if common_segments == len(previous_lines.segments) == len(current_lines.segments):
+            return None
+        prefix_rows = previous_lines.segment_start(common_segments)
+        if prefix_rows != current_lines.segment_start(common_segments):
+            return _changed_line_range_flat(previous_lines, current_lines)
+        local = _changed_line_range_flat(
+            previous_lines.tail_segments(common_segments),
+            current_lines.tail_segments(common_segments),
+        )
+        if local is None:
+            return None
+        return prefix_rows + local[0], prefix_rows + local[1]
+    return _changed_line_range_flat(previous_lines, current_lines)
+
+
+def _changed_line_range_flat(
+    previous_lines: Sequence[str],
+    current_lines: Sequence[str],
+) -> tuple[int, int] | None:
     first_changed = -1
     last_changed = -1
     for index in range(max(len(previous_lines), len(current_lines))):
@@ -790,19 +944,33 @@ def _changed_line_range(previous_lines: tuple[str, ...], current_lines: tuple[st
 
 
 def _expand_changed_range_for_kitty_images(
-    previous_lines: tuple[str, ...],
+    previous_lines: Sequence[str],
     changed_range: tuple[int, int] | None,
 ) -> tuple[int, int] | None:
     if changed_range is None:
         return None
     first_changed, last_changed = changed_range
+    if isinstance(previous_lines, _SegmentedTextLines):
+        for row, _image_id, _delete_sequence in previous_lines.iter_kitty_images():
+            if row >= first_changed:
+                last_changed = max(last_changed, row)
+        return first_changed, last_changed
     for index in range(first_changed, len(previous_lines)):
         if extract_kitty_image_ids(previous_lines[index]):
             last_changed = max(last_changed, index)
     return first_changed, last_changed
 
 
-def _kitty_delete_sequences(lines: tuple[str, ...]) -> tuple[str, ...]:
+def _kitty_delete_sequences(lines: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(lines, _SegmentedTextLines):
+        deletes: list[str] = []
+        seen: set[int] = set()
+        for _row, image_id, delete_sequence in lines.iter_kitty_images():
+            if image_id in seen:
+                continue
+            seen.add(image_id)
+            deletes.append(delete_sequence)
+        return tuple(deletes)
     deletes: list[str] = []
     seen: set[int] = set()
     for line in lines:
@@ -818,9 +986,18 @@ def _kitty_delete_sequences(lines: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(deletes)
 
 
-def _kitty_delete_sequences_in_range(lines: tuple[str, ...], first: int, last: int) -> tuple[str, ...]:
+def _kitty_delete_sequences_in_range(lines: Sequence[str], first: int, last: int) -> tuple[str, ...]:
     if last < first or first >= len(lines):
         return ()
+    if isinstance(lines, _SegmentedTextLines):
+        deletes: list[str] = []
+        seen: set[int] = set()
+        for row, image_id, delete_sequence in lines.iter_kitty_images():
+            if row < first or row > last or image_id in seen:
+                continue
+            seen.add(image_id)
+            deletes.append(delete_sequence)
+        return tuple(deletes)
     return _kitty_delete_sequences(lines[max(0, first) : min(last + 1, len(lines))])
 
 
@@ -857,6 +1034,35 @@ def _finalize_rendered_line(line: str) -> str:
     if normalized.endswith(SEGMENT_RESET):
         return normalized
     return normalized + SEGMENT_RESET
+
+
+def _render_segment_cache_key(segment: RenderLineSegmentLike) -> tuple[object, object] | None:
+    if not segment.cacheable:
+        return None
+    key = (segment.identity_key, segment.revision)
+    try:
+        hash(key)
+    except TypeError:
+        return None
+    return key
+
+
+def _finalize_render_segment(segment: RenderLineSegmentLike) -> _LogicalLineSegment:
+    raw_lines = tuple(line.text for line in segment.iter_lines())
+    finalized_lines = tuple(_finalize_rendered_line(line) for line in raw_lines)
+    kitty_images: list[tuple[int, int, str]] = []
+    for row, line in enumerate(finalized_lines):
+        tmux_passthrough = _line_uses_tmux_passthrough(line)
+        for image_id in extract_kitty_image_ids(line):
+            delete_sequence = delete_kitty_image(image_id)
+            if tmux_passthrough:
+                delete_sequence = wrap_tmux_passthrough(delete_sequence)
+            kitty_images.append((row, image_id, delete_sequence))
+    return _LogicalLineSegment(
+        raw_lines=raw_lines,
+        finalized_lines=finalized_lines,
+        kitty_images=tuple(kitty_images),
+    )
 
 
 def _viewport_top(lines: tuple[str, ...], size: TerminalSize) -> int:
@@ -989,7 +1195,10 @@ def _protected_append_plan(
         return None
     if cursor.row < protected_start:
         return None
-    if previous_lines[:inserted_start] != current_lines[:inserted_start]:
+    if not (
+        isinstance(previous_lines, _SegmentedTextLines)
+        and isinstance(current_lines, _SegmentedTextLines)
+    ) and previous_lines[:inserted_start] != current_lines[:inserted_start]:
         return None
     return inserted_start, inserted_end, protected_start
 

--- a/src/loushang/tui/scheduler.py
+++ b/src/loushang/tui/scheduler.py
@@ -15,6 +15,7 @@ class RenderSchedulerConfig:
     min_render_interval_ms: int = 16
     max_coalescing_delay_ms: int = 50
     input_echo_deadline_ms: int = 16
+    stream_min_render_interval_ms: int = 50
 
     def __post_init__(self) -> None:
         if self.min_render_interval_ms < 0:
@@ -23,6 +24,8 @@ class RenderSchedulerConfig:
             raise ValueError("max_coalescing_delay_ms must be non-negative")
         if self.input_echo_deadline_ms < 0:
             raise ValueError("input_echo_deadline_ms must be non-negative")
+        if self.stream_min_render_interval_ms < 0:
+            raise ValueError("stream_min_render_interval_ms must be non-negative")
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,10 +48,20 @@ class RenderScheduler:
             return RenderScheduleDecision(render_now=True, delay_ms=0, coalesced=False)
 
         elapsed_ms = max(0, now_ms - self.last_rendered_at_ms)
-        if elapsed_ms >= self.config.min_render_interval_ms:
+        min_interval_ms = (
+            self.config.stream_min_render_interval_ms
+            if kind == "stream"
+            else self.config.min_render_interval_ms
+        )
+        if elapsed_ms >= min_interval_ms:
             return RenderScheduleDecision(render_now=True, delay_ms=0, coalesced=False)
 
-        delay_ms = min(self.config.min_render_interval_ms - elapsed_ms, self.config.max_coalescing_delay_ms)
+        remaining_ms = min_interval_ms - elapsed_ms
+        delay_ms = (
+            remaining_ms
+            if kind == "stream"
+            else min(remaining_ms, self.config.max_coalescing_delay_ms)
+        )
         return RenderScheduleDecision(render_now=False, delay_ms=delay_ms, coalesced=True)
 
     def request_animation_frame(self, source: AnimationFrameSource, *, now_ms: int) -> RenderScheduleDecision:

--- a/src/loushang/tui/transcript.py
+++ b/src/loushang/tui/transcript.py
@@ -200,6 +200,7 @@ class TranscriptView:
     capabilities: TerminalCapabilities | None = None
     code_highlighter: CodeHighlighterLike | None = None
     markdown_cache: MarkdownRenderCache | None = None
+    markdown_streaming_key: object | None = None
     _render_cache_key: tuple[object, ...] | None = field(
         default=None,
         init=False,
@@ -256,6 +257,7 @@ class TranscriptView:
                     capabilities=self.capabilities,
                     code_highlighter=self.code_highlighter,
                     markdown_cache=self.markdown_cache,
+                    markdown_streaming_key=self.markdown_streaming_key,
                 )
             )
 
@@ -272,6 +274,7 @@ class TranscriptView:
                 capabilities=self.capabilities,
                 code_highlighter=self.code_highlighter,
                 markdown_cache=self.markdown_cache,
+                markdown_streaming_key=None,
             )
         )
         self._record_line_cache[key] = rendered
@@ -289,6 +292,7 @@ def render_transcript_records(
     capabilities: TerminalCapabilities | None = None,
     code_highlighter: CodeHighlighterLike | None = None,
     markdown_cache: MarkdownRenderCache | None = None,
+    markdown_streaming_key: object | None = None,
 ) -> tuple[RenderLine, ...]:
     view = TranscriptView(
         records,
@@ -298,6 +302,7 @@ def render_transcript_records(
         capabilities=capabilities,
         code_highlighter=code_highlighter,
         markdown_cache=markdown_cache,
+        markdown_streaming_key=markdown_streaming_key,
     )
     rendered = view.render(RenderConstraints(width=width, max_height=max_height))
     return rendered.lines
@@ -316,6 +321,7 @@ def _render_record(
     capabilities: TerminalCapabilities | None = None,
     code_highlighter: CodeHighlighterLike | None = None,
     markdown_cache: MarkdownRenderCache | None = None,
+    markdown_streaming_key: object | None = None,
 ) -> list[str]:
     target_width = autowrap_safe_width(width)
     if isinstance(record, UserPromptRecord):
@@ -332,6 +338,7 @@ def _render_record(
                     capabilities=capabilities,
                     code_highlighter=code_highlighter,
                     markdown_cache=markdown_cache,
+                    markdown_streaming_key=markdown_streaming_key,
                 ),
                 width=target_width,
             )
@@ -464,6 +471,7 @@ def _render_markdown_content(
     capabilities: TerminalCapabilities | None,
     code_highlighter: CodeHighlighterLike | None,
     markdown_cache: MarkdownRenderCache | None = None,
+    markdown_streaming_key: object | None = None,
 ) -> tuple[str, ...]:
     rendered = MarkdownRenderer(
         text,
@@ -471,6 +479,7 @@ def _render_markdown_content(
         capabilities=capabilities,
         code_highlighter=code_highlighter,
         render_cache=markdown_cache,
+        streaming_key=markdown_streaming_key,
     ).render(_inner_constraints(width))
     return tuple(line.text for line in rendered.lines)
 

--- a/src/loushang/tui/ui_parts/layout.py
+++ b/src/loushang/tui/ui_parts/layout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
@@ -7,7 +8,10 @@ from loushang.tui.core import (
     CursorDeclaration,
     RenderConstraints,
     RenderLine,
+    RenderLineSegment,
+    RenderLineSegmentLike,
     RenderResult,
+    SegmentedRenderLines,
 )
 
 
@@ -48,16 +52,25 @@ class ScreenRegionStack:
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         regions = tuple(self.regions)
-        lines: list[str] = []
+        segments: list[RenderLineSegmentLike] = []
+        line_count = 0
         cursor: CursorDeclaration | None = None
         remaining = constraints.max_height
         for index, region in enumerate(regions):
             if remaining <= 0:
                 break
             future_required_height = _reserved_height(regions[index + 1 :])
-            before_gap = _allowed_gap(region.gap_before, remaining, future_required_height, region.reserved_height)
+            before_gap = _allowed_gap(
+                region.gap_before,
+                remaining,
+                future_required_height,
+                region.reserved_height,
+            )
             if before_gap:
-                lines.extend("" for _ in range(before_gap))
+                segments.append(
+                    _ephemeral_segment(tuple(RenderLine("") for _ in range(before_gap)))
+                )
+                line_count += before_gap
                 remaining -= before_gap
             available = remaining - future_required_height
             if available <= 0 and not region.required:
@@ -68,27 +81,40 @@ class ScreenRegionStack:
             if budget <= 0:
                 continue
             result = region.renderable.render(
-                RenderConstraints(width=constraints.width, max_height=budget, visible_height=constraints.visible_height)
+                RenderConstraints(
+                    width=constraints.width,
+                    max_height=budget,
+                    visible_height=constraints.visible_height,
+                )
             )
-            rendered = [line.text for line in result.lines]
-            if not rendered and not region.required:
+            rendered_count = len(result.lines)
+            if rendered_count == 0 and not region.required:
                 continue
             if result.cursor is not None:
                 if cursor is not None:
                     raise ValueError("screen region stack contains multiple cursors")
-                cursor = CursorDeclaration(row=len(lines) + result.cursor.row, column=result.cursor.column)
-            lines.extend(rendered)
-            remaining -= len(rendered)
+                cursor = CursorDeclaration(
+                    row=line_count + result.cursor.row, column=result.cursor.column
+                )
+            _extend_segments(segments, result.lines)
+            line_count += rendered_count
+            remaining -= rendered_count
             future_required_height = _reserved_height(regions[index + 1 :])
-            after_gap = _allowed_gap(region.gap_after, remaining, future_required_height, 0)
+            after_gap = _allowed_gap(
+                region.gap_after, remaining, future_required_height, 0
+            )
             if after_gap:
-                lines.extend("" for _ in range(after_gap))
+                segments.append(
+                    _ephemeral_segment(tuple(RenderLine("") for _ in range(after_gap)))
+                )
+                line_count += after_gap
                 remaining -= after_gap
 
+        lines = SegmentedRenderLines.from_segments(tuple(segments))
         if len(lines) > constraints.max_height:
-            lines = lines[-constraints.max_height :]
+            lines = lines.tail(constraints.max_height)
             cursor = None
-        return RenderResult(lines=tuple(RenderLine(line) for line in lines), cursor=cursor)
+        return RenderResult(lines=lines, cursor=cursor)
 
 
 @dataclass(slots=True)
@@ -98,8 +124,12 @@ class ScreenLayout:
     transcript: RegionRenderable | None = None
     pending: RegionRenderable | None = None
     status: RegionRenderable | None = None
-    widgets_above_editor: tuple[RegionRenderable, ...] | list[RegionRenderable] = field(default_factory=tuple)
-    widgets_below_editor: tuple[RegionRenderable, ...] | list[RegionRenderable] = field(default_factory=tuple)
+    widgets_above_editor: tuple[RegionRenderable, ...] | list[RegionRenderable] = field(
+        default_factory=tuple
+    )
+    widgets_below_editor: tuple[RegionRenderable, ...] | list[RegionRenderable] = field(
+        default_factory=tuple
+    )
     footer: RegionRenderable | None = None
     status_min_height: int = 1
     editor_min_height: int = 1
@@ -121,13 +151,29 @@ class ScreenLayout:
         _append_optional_region(regions, "header", self.header)
         _append_optional_region(regions, "transcript", self.transcript)
         _append_optional_region(regions, "pending", self.pending)
-        _append_optional_region(regions, "status", self.status, required=True, min_height=self.status_min_height)
+        _append_optional_region(
+            regions,
+            "status",
+            self.status,
+            required=True,
+            min_height=self.status_min_height,
+        )
         for index, widget in enumerate(self.widgets_above_editor):
             _append_optional_region(regions, f"widget_above_editor:{index}", widget)
-        regions.append(ScreenRegion("editor", self.editor, required=True, min_height=self.editor_min_height))
+        regions.append(
+            ScreenRegion(
+                "editor", self.editor, required=True, min_height=self.editor_min_height
+            )
+        )
         for index, widget in enumerate(self.widgets_below_editor):
             _append_optional_region(regions, f"widget_below_editor:{index}", widget)
-        _append_optional_region(regions, "footer", self.footer, required=True, min_height=self.footer_min_height)
+        _append_optional_region(
+            regions,
+            "footer",
+            self.footer,
+            required=True,
+            min_height=self.footer_min_height,
+        )
         return tuple(regions)
 
 
@@ -166,13 +212,31 @@ def _reserved_height(regions: tuple[ScreenRegion, ...]) -> int:
     return sum(region.reserved_height for region in regions if region.required)
 
 
-def _allowed_gap(requested: int, remaining: int, future_required_height: int, current_reserved_height: int) -> int:
+def _allowed_gap(
+    requested: int,
+    remaining: int,
+    future_required_height: int,
+    current_reserved_height: int,
+) -> int:
     if requested <= 0:
         return 0
     spare = remaining - future_required_height - current_reserved_height
     if spare <= 0:
         return 0
     return min(requested, spare)
+
+
+def _extend_segments(
+    segments: list[RenderLineSegmentLike], lines: Sequence[RenderLine]
+) -> None:
+    if isinstance(lines, SegmentedRenderLines):
+        segments.extend(lines.segments)
+        return
+    segments.append(_ephemeral_segment(tuple(lines)))
+
+
+def _ephemeral_segment(lines: tuple[RenderLine, ...]) -> RenderLineSegment:
+    return RenderLineSegment(lines=lines, cacheable=False)
 
 
 __all__ = [

--- a/tests/coding/test_screen_coding_tui_app.py
+++ b/tests/coding/test_screen_coding_tui_app.py
@@ -26,6 +26,41 @@ def _raw_lines(value: Any, *, width: int = 80, height: int = 24) -> list[str]:
     return [line.text for line in result.lines]
 
 
+def _legacy_transcript_tail_rows(
+    region: Any,
+    *,
+    max_height: int,
+    width: int,
+) -> list[str]:
+    newest_first_blocks: list[tuple[str, ...]] = []
+    used_rows = 0
+    for record in reversed(tuple(region._iter_records())):
+        block = region._render_record_lines(
+            record,
+            width=width,
+            style_signature=("legacy-oracle",),
+        )
+        if not block:
+            continue
+        separator_rows = 1 if newest_first_blocks else 0
+        available = max_height - used_rows - separator_rows
+        if available <= 0:
+            break
+        if len(block) > available:
+            block = block[-available:]
+        newest_first_blocks.append(block)
+        used_rows += separator_rows + len(block)
+        if used_rows >= max_height:
+            break
+
+    rows: list[str] = []
+    for block in reversed(newest_first_blocks):
+        if rows:
+            rows.append("")
+        rows.extend(block)
+    return rows[-max_height:]
+
+
 def test_screen_coding_tui_state_commits_turn_without_stale_working() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -802,6 +837,110 @@ def test_screen_coding_tui_streaming_draft_render_keeps_full_append_stable_lines
     assert len(app._transcript_region._transient_line_cache_lines or ()) >= 200
     assert "draft line 199" in rendered
     assert "draft line 0" in rendered
+
+
+def test_screen_transcript_segment_tail_matches_legacy_record_boundaries() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd1234",
+        now=lambda: 10.0,
+    )
+    duplicate = AssistantMessageRecord("same record")
+    app.state.records.extend(
+        (
+            duplicate,
+            AssistantMessageRecord(""),
+            duplicate,
+            UserPromptRecord("newest prompt"),
+        )
+    )
+    app.state.mark_records_changed()
+    app.render(RenderConstraints(width=80, max_height=100, visible_height=24))
+    region = app._transcript_region
+
+    full_height = len(
+        region.render(
+            RenderConstraints(width=80, max_height=100, visible_height=24)
+        ).lines
+    )
+    for max_height in range(1, full_height + 2):
+        expected = _legacy_transcript_tail_rows(
+            region,
+            max_height=max_height,
+            width=80,
+        )
+        actual = [
+            line.text
+            for line in region.render(
+                RenderConstraints(
+                    width=80,
+                    max_height=max_height,
+                    visible_height=24,
+                )
+            ).lines
+        ]
+
+        assert actual == expected
+
+
+def test_screen_app_reuses_committed_segment_for_tick_input_and_chunk() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.tui import RenderLoop, TerminalSize
+
+    now = [1.0]
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd1234",
+        now=lambda: now[0],
+    )
+    blocks = []
+    for block in range(50):
+        first_line = block * 20
+        lines = "\n".join(
+            f"- history line {index}" for index in range(first_line, first_line + 20)
+        )
+        blocks.append(f"### Block {block + 1}\n\n{lines}")
+    app.state.records.append(AssistantMessageRecord("\n\n".join(blocks)))
+    app.state.mark_records_changed()
+    app.begin_run(started_at=0.0)
+    loop = RenderLoop(app)
+    size = TerminalSize(columns=100, rows=30)
+
+    initial = loop.plan(size)
+    loop.commit(initial, size=size)
+    assert len(initial.current_logical_lines) >= 1_000
+
+    now[0] = 2.0
+    tick = loop.plan(size)
+
+    assert tick.reused_render_segment_count >= 1
+    assert tick.materialized_logical_line_count <= 20
+    assert tick.flattened_logical_line_count == 0
+    loop.commit(tick, size=size)
+
+    app.composer.set_text("x")
+    composer_input = loop.plan(size)
+
+    assert composer_input.reused_render_segment_count >= 1
+    assert composer_input.materialized_logical_line_count <= 20
+    assert composer_input.flattened_logical_line_count == 0
+    loop.commit(composer_input, size=size)
+
+    app.begin_assistant()
+    app.append_assistant_chunk("streaming tail")
+    chunk = loop.plan(size)
+
+    assert chunk.reused_render_segment_count >= 1
+    assert chunk.materialized_logical_line_count <= 30
+    assert chunk.flattened_logical_line_count == 0
+    assert "history line 999" in "\n".join(chunk.current_logical_lines)
+    assert "streaming tail" in "\n".join(chunk.current_logical_lines)
 
 
 def test_screen_coding_tui_streaming_draft_uses_markdown_visuals_for_append_chunks() -> None:

--- a/tests/coding/test_screen_coding_tui_app.py
+++ b/tests/coding/test_screen_coding_tui_app.py
@@ -705,6 +705,28 @@ def test_screen_coding_tui_promotes_streaming_draft_cache_after_assistant_commit
     assert app._transcript_region._transient_line_cache_lines is None
 
 
+def test_screen_coding_tui_uses_canonical_markdown_when_final_text_replaces_draft() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd1234",
+        now=lambda: 10.0,
+    )
+    app.start_prompt("stream", started_at=9.0)
+    app.begin_assistant()
+    app.append_assistant_chunk("Old\n\nTail")
+    _lines(app, width=100, height=1_000)
+
+    app.end_assistant("New **canonical**")
+    rendered = "\n".join(_lines(app, width=100, height=1_000))
+
+    assert "New canonical" in rendered
+    assert "Old" not in rendered
+
+
 def test_screen_coding_tui_complete_run_does_not_trim_active_transcript_line_window() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 

--- a/tests/coding/test_screen_coding_tui_perf_examples.py
+++ b/tests/coding/test_screen_coding_tui_perf_examples.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+
+from markdown_it import MarkdownIt
+
+_EXAMPLE = (
+    Path(__file__).parents[2] / "examples" / "tui" / "31_native_coding_markdown_perf.py"
+)
+
+
+def test_markdown_perf_fixture_starts_a_new_block_every_twenty_lines() -> None:
+    namespace = runpy.run_path(str(_EXAMPLE))
+    markdown_line = namespace["_markdown_line"]
+    markdown = "".join(markdown_line(index) for index in range(1, 42))
+    tokens = MarkdownIt("commonmark").parse(markdown)
+
+    assert (
+        sum(token.type == "heading_open" and token.level == 0 for token in tokens) == 3
+    )
+    assert (
+        sum(token.type == "bullet_list_open" and token.level == 0 for token in tokens)
+        == 3
+    )
+
+
+def test_markdown_perf_example_runs_against_screen_tui() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(_EXAMPLE),
+            "--script-count",
+            "4",
+            "--stream-seconds",
+            "0",
+            "--script-render-interval-ms",
+            "0",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "requested_lines=4" in completed.stdout
+    assert "markdown_lines_per_block=20" in completed.stdout

--- a/tests/coding/test_screen_coding_tui_perf_examples.py
+++ b/tests/coding/test_screen_coding_tui_perf_examples.py
@@ -38,6 +38,8 @@ def test_markdown_perf_example_runs_against_screen_tui() -> None:
             "0",
             "--script-render-interval-ms",
             "0",
+            "--script-render-every-n-chunks",
+            "2",
         ],
         check=False,
         capture_output=True,
@@ -48,3 +50,4 @@ def test_markdown_perf_example_runs_against_screen_tui() -> None:
     assert completed.returncode == 0, completed.stderr
     assert "requested_lines=4" in completed.stdout
     assert "markdown_lines_per_block=20" in completed.stdout
+    assert "render_every_n_chunks=2" in completed.stdout

--- a/tests/coding/test_screen_coding_tui_state.py
+++ b/tests/coding/test_screen_coding_tui_state.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from loushang.coding.ui.screen_state import (
+    ScreenCodingTuiState,
+    ScreenTranscriptWindow,
+)
+from loushang.tui.transcript import (
+    AssistantMessageRecord,
+    ToolExecutionRecord,
+    UserPromptRecord,
+)
+
+
+def _state() -> ScreenCodingTuiState:
+    return ScreenCodingTuiState(model_label="model", cwd="/repo", branch="main", session_label="session")
+
+
+def test_records_revision_tracks_record_appends_only_when_they_happen() -> None:
+    state = _state()
+
+    state.start_prompt("   ", started_at=0.0)
+    state.end_assistant()
+    state.add_error("")
+    state.add_status("   ")
+    assert state.records_revision == 0
+
+    state.start_prompt("prompt", started_at=0.0)
+    state.append_assistant_chunk("answer")
+    state.end_assistant()
+    state.complete_run(elapsed_seconds=1.0)
+    assert state.records_revision == 3
+
+    state.complete_run(elapsed_seconds=2.0)
+    assert state.records_revision == 3
+
+    state.add_error("failed")
+    state.add_status("ready")
+    assert state.records_revision == 5
+
+
+def test_records_revision_tracks_replace_trim_and_manual_changes() -> None:
+    state = _state()
+    records = (UserPromptRecord("one"), AssistantMessageRecord("two"))
+
+    state.replace_transcript_window(records)
+    assert state.records_revision == 1
+
+    state.replace_transcript_window(ScreenTranscriptWindow(records, evicted_prefix_record_count=4))
+    state.trim_transcript_prefix(max_records=2)
+    assert state.records_revision == 1
+
+    assert state.trim_transcript_prefix(max_records=1) == 1
+    assert state.records_revision == 2
+
+    state.records.append(UserPromptRecord("manual"))
+    state.mark_records_changed()
+    assert state.records_revision == 3
+
+
+def test_records_revision_tracks_tool_insert_and_changed_replacement() -> None:
+    state = _state()
+    running = ToolExecutionRecord(name="read", state="running", elapsed_seconds=0.1)
+    completed = ToolExecutionRecord(name="read", state="completed", elapsed_seconds=0.2)
+
+    state.upsert_tool_record("tool-1", running)
+    assert state.records_revision == 1
+
+    state.upsert_tool_record("tool-1", running)
+    assert state.records_revision == 1
+
+    state.upsert_tool_record("tool-1", completed)
+    assert state.records_revision == 2
+
+
+def test_records_revision_counts_each_append_in_compound_state_methods() -> None:
+    state = _state()
+    state.append_assistant_chunk("partial")
+
+    state.abort(message="stopped", elapsed_seconds=1.0)
+
+    assert state.records_revision == 2

--- a/tests/tui/test_content_theme.py
+++ b/tests/tui/test_content_theme.py
@@ -237,6 +237,33 @@ def test_markdown_renderer_reuses_shared_cache_for_stable_streaming_blocks() -> 
     assert highlighter.calls == [("print('stable')", "python")]
 
 
+def test_markdown_renderer_computes_shared_cache_context_once_per_render(monkeypatch) -> None:
+    calls = 0
+    original = markdown_renderer_module._theme_cache_signature
+
+    def theme_cache_signature(theme: ThemeResolver | None) -> tuple[object, ...] | None:
+        nonlocal calls
+        calls += 1
+        return original(theme)
+
+    monkeypatch.setattr(markdown_renderer_module, "_theme_cache_signature", theme_cache_signature)
+    cache = markdown_renderer_module.MarkdownRenderCache()
+    theme = ThemeResolver(defaults={"markdown.strong": {"bold": True}})
+
+    rendered_text(
+        MarkdownRenderer("Intro\n\nSecond\n\nTail", theme=theme, render_cache=cache),
+        width=40,
+    )
+    rendered_text(
+        MarkdownRenderer("Intro\n\nSecond\n\nTail grows", theme=theme, render_cache=cache),
+        width=40,
+    )
+    assert calls == 2
+
+    rendered_text(MarkdownRenderer("Tail", theme=theme, render_cache=cache), width=40)
+    assert calls == 2
+
+
 def test_markdown_renderer_does_not_reuse_shared_cache_for_unstable_tail_block() -> None:
     cache = markdown_renderer_module.MarkdownRenderCache()
     highlighter = FakeCodeHighlighter()

--- a/tests/tui/test_render_framework.py
+++ b/tests/tui/test_render_framework.py
@@ -135,6 +135,36 @@ def test_screen_root_preserves_base_cursor_when_no_surface_is_visible() -> None:
     assert result.cursor == CursorDeclaration(row=0, column=2)
 
 
+def test_surface_host_preserves_base_result_identity_without_visible_surfaces() -> None:
+    composer = FocusTarget("composer")
+    hidden_focus = FocusTarget("hidden")
+    composer.focus()
+    host = SurfaceHost(base_focus=composer)
+    handle = host.open_surface(
+        Surface(
+            renderable=TextRenderable(("hidden",), []),
+            focus_target=hidden_focus,
+            visible=lambda size: size.columns > 20,
+        )
+    )
+    handle.focus()
+    handle.entry.last_row = 3
+    handle.entry.last_column = 4
+    base = RenderResult(
+        lines=(RenderLine("base"),),
+        cursor=CursorDeclaration(row=0, column=4),
+    )
+
+    result = host.compose(base, RenderConstraints(width=20, max_height=5))
+
+    assert result is base
+    assert host._last_size == TerminalSize(columns=20, rows=5)
+    assert composer.focused is True
+    assert hidden_focus.focused is False
+    assert handle.entry.last_row is None
+    assert handle.entry.last_column is None
+
+
 def test_surface_host_captures_and_restores_focus() -> None:
     composer = FocusTarget("composer")
     dialog_focus = FocusTarget("dialog")

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import loushang.tui.render_loop as render_loop_module
 from loushang.observability import configure_debug_logging, reset_observability
 from loushang.tui import (
     CURSOR_MARKER,
@@ -23,6 +24,7 @@ from loushang.tui import (
     delete_kitty_image,
     wrap_tmux_passthrough,
 )
+from loushang.tui.core import RenderLineSegment, SegmentedRenderLines
 from loushang.tui.render_loop import DEFAULT_STRATEGY_ORDER, RenderPlanStrategyKind
 
 
@@ -32,6 +34,42 @@ class StaticRoot:
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         return RenderResult.from_lines([RenderLine(line) for line in self.lines], constraints=constraints)
+
+
+class SegmentedRoot:
+    def __init__(
+        self,
+        segments: tuple[RenderLineSegment, ...],
+        *,
+        cursor: CursorDeclaration | None = None,
+    ) -> None:
+        self.segments = segments
+        self.cursor = cursor
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        del constraints
+        return RenderResult(
+            lines=SegmentedRenderLines.from_segments(self.segments),
+            cursor=self.cursor,
+        )
+
+
+class FlatFrameRoot:
+    def __init__(
+        self,
+        lines: tuple[str, ...],
+        *,
+        cursor: CursorDeclaration | None = None,
+    ) -> None:
+        self.lines = lines
+        self.cursor = cursor
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        return RenderResult.from_lines(
+            tuple(RenderLine(line) for line in self.lines),
+            constraints=constraints,
+            cursor=self.cursor,
+        )
 
 
 class TextRoot:
@@ -54,6 +92,121 @@ class RecordingDebugSink:
 
     def write_debug_event(self, record) -> None:
         self.events.append(record)
+
+
+def _render_segment(
+    *lines: str,
+    identity: object | None = None,
+    revision: object = 0,
+) -> RenderLineSegment:
+    return RenderLineSegment(
+        tuple(RenderLine(line) for line in lines),
+        identity=identity if identity is not None else object(),
+        revision=revision,
+    )
+
+
+def test_segmented_render_skips_11748_committed_rows_on_bottom_frame_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    committed = _render_segment(
+        *(f"history {index}" for index in range(11_748)),
+        identity="committed",
+        revision=1,
+    )
+    bottom_identity = object()
+    root = SegmentedRoot(
+        (committed, _render_segment("Working (1s)", identity=bottom_identity, revision=1))
+    )
+    loop = RenderLoop(root)
+    size = TerminalSize(columns=80, rows=24)
+    first = loop.plan(size)
+    loop.commit(first, size=size)
+
+    compared_tail_sizes: list[tuple[int, int]] = []
+    original_changed_range = render_loop_module._changed_line_range_flat
+
+    def record_changed_range_sizes(
+        previous_lines: tuple[str, ...],
+        current_lines: tuple[str, ...],
+    ) -> tuple[int, int] | None:
+        compared_tail_sizes.append((len(previous_lines), len(current_lines)))
+        return original_changed_range(previous_lines, current_lines)
+
+    monkeypatch.setattr(
+        render_loop_module,
+        "_changed_line_range_flat",
+        record_changed_range_sizes,
+    )
+    root.segments = (
+        committed,
+        _render_segment("Working (2s)", identity=bottom_identity, revision=2),
+    )
+
+    tick = loop.plan(size)
+
+    assert tick.changed_line_range == (11_748, 11_748)
+    assert compared_tail_sizes == [(1, 1)]
+    assert tick.reused_render_segment_count == 1
+    assert tick.materialized_logical_line_count == 1
+    assert tick.flattened_logical_line_count == 0
+
+    loop.commit(tick, size=size)
+    compared_tail_sizes.clear()
+
+    no_op = loop.plan(size)
+
+    assert no_op.operation_class == "noop"
+    assert no_op.operations == ()
+    assert compared_tail_sizes == []
+    assert no_op.reused_render_segment_count == 2
+    assert no_op.materialized_logical_line_count == 0
+    assert no_op.flattened_logical_line_count == 0
+
+
+def test_segmented_row_shift_matches_flat_planner_and_repaints_shifted_image() -> None:
+    image_line = "\x1b_Gi=123;AAAA\x1b\\"
+    committed = _render_segment("history one", "history two", identity="history")
+    bottom = _render_segment(image_line, identity="bottom-image")
+    segmented_root = SegmentedRoot(
+        (committed, _render_segment("draft", identity="draft", revision=1), bottom),
+        cursor=CursorDeclaration(row=3, column=0),
+    )
+    flat_root = FlatFrameRoot(
+        ("history one", "history two", "draft", image_line),
+        cursor=CursorDeclaration(row=3, column=0),
+    )
+    segmented_loop = RenderLoop(segmented_root)
+    flat_loop = RenderLoop(flat_root)
+    size = TerminalSize(columns=80, rows=8)
+    segmented_first = segmented_loop.plan(size)
+    flat_first = flat_loop.plan(size)
+    segmented_loop.commit(segmented_first, size=size)
+    flat_loop.commit(flat_first, size=size)
+
+    segmented_root.segments = (
+        committed,
+        _render_segment("draft", "extra", identity="draft", revision=2),
+        bottom,
+    )
+    segmented_root.cursor = CursorDeclaration(row=4, column=0)
+    flat_root.lines = ("history one", "history two", "draft", "extra", image_line)
+    flat_root.cursor = CursorDeclaration(row=4, column=0)
+
+    segmented = segmented_loop.plan(size)
+    flat = flat_loop.plan(size)
+
+    assert tuple(segmented.current_logical_lines) == tuple(flat.current_logical_lines)
+    assert segmented.changed_line_range == flat.changed_line_range == (3, 4)
+    assert segmented.operation_class == flat.operation_class
+    assert segmented.operations == flat.operations
+    assert segmented.viewport_top == flat.viewport_top
+    assert segmented.logical_cursor_row == flat.logical_cursor_row
+    assert delete_kitty_image(123) in tuple(
+        operation.text
+        for operation in segmented.operations
+        if operation.kind == "write"
+    )
 
 
 def test_first_render_flushes_full_logical_lines_without_clearing_scrollback() -> None:
@@ -828,17 +981,32 @@ def test_failed_runtime_flush_does_not_advance_render_loop_snapshot() -> None:
     render_loop = RenderLoop(root)
     runtime = TuiRuntime(render_loop=render_loop, terminal=port)
     runtime.render_now()
+    committed_revision = render_loop.committed_frame_revision
     root.lines = ("second",)
     port.fail_next_flush(RuntimeError("write failed"))
 
     with pytest.raises(RuntimeError, match="write failed"):
         runtime.render_now()
 
+    assert render_loop.committed_frame_revision == committed_revision
     root.lines = ("third",)
     step = runtime.render_now()
 
     assert step.diagnostics.previous_rendered_lines == ("first",)
     assert step.diagnostics.changed_line_range == (0, 0)
+    assert step.diagnostics.base_frame_revision == committed_revision
+
+
+def test_render_loop_rejects_plan_from_a_stale_committed_frame() -> None:
+    loop = RenderLoop(StaticRoot(("line",)))
+    size = TerminalSize(columns=20, rows=5)
+    first = loop.plan(size)
+    stale = loop.plan(size)
+
+    loop.commit(first, size=size)
+
+    with pytest.raises(RuntimeError, match="base revision"):
+        loop.commit(stale, size=size)
 
 
 def test_process_terminal_port_writes_serialized_frame_to_output() -> None:

--- a/tests/tui/test_render_scheduler.py
+++ b/tests/tui/test_render_scheduler.py
@@ -7,26 +7,72 @@ def test_scheduler_records_pi_style_tuning_parameters() -> None:
     config = RenderSchedulerConfig()
 
     assert config.min_render_interval_ms == 16
+    assert config.stream_min_render_interval_ms == 50
     assert config.max_coalescing_delay_ms == 50
     assert config.input_echo_deadline_ms == 16
 
 
+def test_scheduler_config_preserves_existing_positional_argument_order() -> None:
+    config = RenderSchedulerConfig(10, 20, 30)
+
+    assert config.min_render_interval_ms == 10
+    assert config.max_coalescing_delay_ms == 20
+    assert config.input_echo_deadline_ms == 30
+    assert config.stream_min_render_interval_ms == 50
+
+
 def test_scheduler_coalesces_stream_ticks_but_keeps_input_immediate() -> None:
-    scheduler = RenderScheduler(RenderSchedulerConfig(min_render_interval_ms=16, max_coalescing_delay_ms=50))
+    scheduler = RenderScheduler(
+        RenderSchedulerConfig(
+            min_render_interval_ms=16,
+            stream_min_render_interval_ms=50,
+            max_coalescing_delay_ms=50,
+        )
+    )
     scheduler.mark_rendered(now_ms=100)
 
     stream_decision = scheduler.request_render("stream", now_ms=105)
     input_decision = scheduler.request_render("input", now_ms=106)
 
     assert stream_decision.render_now is False
-    assert stream_decision.delay_ms == 11
+    assert stream_decision.delay_ms == 45
     assert stream_decision.coalesced is True
     assert input_decision.render_now is True
     assert input_decision.delay_ms == 0
     assert input_decision.coalesced is False
 
 
-def test_scheduler_caps_stream_delay_at_max_coalescing_delay() -> None:
+def test_scheduler_stream_deadline_is_not_cut_short_by_general_coalescing_cap() -> None:
+    scheduler = RenderScheduler(
+        RenderSchedulerConfig(
+            min_render_interval_ms=16,
+            stream_min_render_interval_ms=80,
+            max_coalescing_delay_ms=50,
+        )
+    )
+    scheduler.mark_rendered(now_ms=100)
+
+    stream_decision = scheduler.request_render("stream", now_ms=105)
+    product_decision = scheduler.request_render("product", now_ms=105)
+
+    assert stream_decision.delay_ms == 75
+    assert product_decision.delay_ms == 11
+
+
+def test_scheduler_can_disable_stream_coalescing_explicitly() -> None:
+    scheduler = RenderScheduler(
+        RenderSchedulerConfig(stream_min_render_interval_ms=0)
+    )
+    scheduler.mark_rendered(now_ms=100)
+
+    decision = scheduler.request_render("stream", now_ms=100)
+
+    assert decision.render_now is True
+    assert decision.delay_ms == 0
+    assert decision.coalesced is False
+
+
+def test_scheduler_caps_non_stream_delay_at_max_coalescing_delay() -> None:
     scheduler = RenderScheduler(RenderSchedulerConfig(min_render_interval_ms=100, max_coalescing_delay_ms=40))
     scheduler.mark_rendered(now_ms=10)
 

--- a/tests/tui/test_render_segments.py
+++ b/tests/tui/test_render_segments.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from loushang.tui.core import (
+    CursorDeclaration,
+    RenderConstraints,
+    RenderLine,
+    RenderLineSegment,
+    RenderLineSegmentView,
+    RenderResult,
+    SegmentedRenderLines,
+)
+from loushang.tui.ui_parts.layout import ScreenRegion, ScreenRegionStack
+
+
+def _lines(*values: str) -> tuple[RenderLine, ...]:
+    return tuple(RenderLine(value) for value in values)
+
+
+def test_segmented_render_lines_support_sequence_access_and_tuple_equality() -> None:
+    first_identity = object()
+    first = RenderLineSegment(
+        _lines("one", "two"),
+        identity=first_identity,
+        revision=3,
+    )
+    second = RenderLineSegment(_lines("three", "four"), revision=4)
+    lines = SegmentedRenderLines.from_segments((first, second))
+
+    assert len(lines) == 4
+    assert lines.line_count == 4
+    assert lines[0] == RenderLine("one")
+    assert lines[-1] == RenderLine("four")
+    assert tuple(lines.iter_lines()) == _lines("one", "two", "three", "four")
+    assert lines == _lines("one", "two", "three", "four")
+    assert _lines("one", "two", "three", "four") == lines
+    assert first.identity_key == (first_identity, 0, 2)
+    assert isinstance(hash(first.identity_key), int)
+
+    with pytest.raises(IndexError, match="render line index out of range"):
+        _ = lines[4]
+
+
+def test_contiguous_slice_and_tail_preserve_segment_views() -> None:
+    first = RenderLineSegment(_lines("one", "two", "three"), revision=1)
+    second = RenderLineSegment(_lines("four", "five"), revision=2)
+    lines = SegmentedRenderLines.from_segments((first, second))
+
+    sliced = lines[1:]
+
+    assert tuple(sliced) == _lines("two", "three", "four", "five")
+    assert len(sliced.segments) == 2
+    assert isinstance(sliced.segments[0], RenderLineSegmentView)
+    assert sliced.segments[0].segment is first
+    assert sliced.segments[0].identity_key == (first.identity, 1, 3)
+    assert sliced.segments[0].revision == 1
+    assert sliced.segments[1] is second
+    assert lines.tail(4).segments == sliced.segments
+    assert lines.tail(5) is lines
+    assert lines.tail(0) == ()
+
+
+def test_nested_contiguous_slice_collapses_to_a_single_base_segment_view() -> None:
+    segment = RenderLineSegment(_lines("zero", "one", "two", "three"), revision=5)
+    lines = SegmentedRenderLines.from_segments((segment,))
+
+    nested = lines[1:][1:2]
+
+    assert tuple(nested) == _lines("two")
+    assert len(nested.segments) == 1
+    view = nested.segments[0]
+    assert isinstance(view, RenderLineSegmentView)
+    assert view.segment is segment
+    assert (view.start, view.stop) == (2, 3)
+
+
+def test_strided_slice_returns_an_uncacheable_ephemeral_segment() -> None:
+    lines = SegmentedRenderLines.from_segments(
+        (RenderLineSegment(_lines("zero", "one", "two", "three")),)
+    )
+
+    selected = lines[::-2]
+
+    assert tuple(selected) == _lines("three", "one")
+    assert len(selected.segments) == 1
+    assert selected.segments[0].cacheable is False
+
+
+def test_render_line_segment_rejects_unhashable_identity() -> None:
+    with pytest.raises(TypeError, match="segment identity must be hashable"):
+        RenderLineSegment(_lines("line"), identity=[])
+
+
+@dataclass(frozen=True, slots=True)
+class _SegmentedRenderable:
+    lines: SegmentedRenderLines
+    cursor: CursorDeclaration | None = None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        del constraints
+        return RenderResult(lines=self.lines, cursor=self.cursor)
+
+
+@dataclass(frozen=True, slots=True)
+class _PlainRenderable:
+    text: str
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        return RenderResult.from_lines(
+            (RenderLine(self.text),),
+            constraints=constraints,
+        )
+
+
+def test_screen_region_stack_preserves_segments_and_wraps_plain_results() -> None:
+    stable = RenderLineSegment(
+        _lines("history one", "history two"),
+        identity=object(),
+        revision=7,
+    )
+    transcript = _SegmentedRenderable(SegmentedRenderLines.from_segments((stable,)))
+    stack = ScreenRegionStack(
+        (
+            ScreenRegion("transcript", transcript, gap_after=1),
+            ScreenRegion(
+                "status", _PlainRenderable("status"), required=True, min_height=1
+            ),
+        )
+    )
+
+    result = stack.render(RenderConstraints(width=40, max_height=5))
+
+    assert isinstance(result.lines, SegmentedRenderLines)
+    assert tuple(result.lines) == _lines("history one", "history two", "", "status")
+    assert result.lines.segments[0] is stable
+    assert result.lines.segments[1].cacheable is False
+    assert result.lines.segments[2].cacheable is False
+
+
+def test_screen_region_stack_offsets_cursor_using_segment_lengths() -> None:
+    stable = RenderLineSegment(_lines("history one", "history two"))
+    editor_lines = SegmentedRenderLines.from_segments(
+        (RenderLineSegment(_lines("editor"), cacheable=False),)
+    )
+    stack = ScreenRegionStack(
+        (
+            ScreenRegion(
+                "transcript",
+                _SegmentedRenderable(SegmentedRenderLines.from_segments((stable,))),
+            ),
+            ScreenRegion(
+                "editor",
+                _SegmentedRenderable(
+                    editor_lines, cursor=CursorDeclaration(row=0, column=3)
+                ),
+                required=True,
+                min_height=1,
+            ),
+        )
+    )
+
+    result = stack.render(RenderConstraints(width=40, max_height=4))
+
+    assert result.cursor == CursorDeclaration(row=2, column=3)
+    assert isinstance(result.lines, SegmentedRenderLines)
+    assert result.lines.segments[0] is stable

--- a/tests/tui/test_runtime_render_coalescing.py
+++ b/tests/tui/test_runtime_render_coalescing.py
@@ -35,12 +35,21 @@ def test_runtime_coalesces_pending_stream_render_until_frame_deadline() -> None:
     pending = runtime.request_next_animation_frame()
 
     assert decision.render_now is False
-    assert decision.delay_ms == 11
+    assert decision.delay_ms == 45
     assert pending.render_now is False
-    assert pending.delay_ms == 11
+    assert pending.delay_ms == 45
     assert pending.coalesced is True
 
-    now[0] = 116
+    now[0] = 130
+    repeated = runtime.request_render("stream")
+    still_pending = runtime.request_next_animation_frame()
+
+    assert repeated.render_now is False
+    assert repeated.delay_ms == 20
+    assert still_pending.render_now is False
+    assert still_pending.delay_ms == 20
+
+    now[0] = 150
     due = runtime.request_next_animation_frame()
 
     assert due.render_now is True
@@ -59,6 +68,8 @@ def test_runtime_keeps_input_render_requests_immediate() -> None:
     runtime.render_now()
 
     now[0] = 105
+    runtime.request_render("stream")
+    now[0] = 106
     decision = runtime.request_render("input")
     pending = runtime.request_next_animation_frame()
 
@@ -66,6 +77,53 @@ def test_runtime_keeps_input_render_requests_immediate() -> None:
     assert decision.delay_ms == 0
     assert pending.render_now is True
     assert pending.delay_ms == 0
+
+
+def test_runtime_product_request_preempts_pending_stream_deadline() -> None:
+    now = [100]
+    root = StaticRoot(("one",))
+    runtime = TuiRuntime(
+        render_loop=RenderLoop(root),
+        terminal=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
+        now_ms=lambda: now[0],
+    )
+    runtime.render_now()
+
+    now[0] = 105
+    runtime.request_render("stream")
+    product = runtime.request_render("product")
+    pending = runtime.request_next_animation_frame()
+
+    assert product.render_now is False
+    assert product.delay_ms == 11
+    assert pending.render_now is False
+    assert pending.delay_ms == 11
+
+
+def test_runtime_coalesced_stream_renders_latest_root_at_deadline() -> None:
+    now = [100]
+    root = StaticRoot(("initial",))
+    runtime = TuiRuntime(
+        render_loop=RenderLoop(root),
+        terminal=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
+        now_ms=lambda: now[0],
+    )
+    runtime.render_now()
+
+    now[0] = 105
+    root.lines = ("intermediate",)
+    runtime.request_render("stream")
+    now[0] = 130
+    root.lines = ("latest",)
+    runtime.request_render("stream")
+
+    assert runtime.request_next_animation_frame().render_now is False
+
+    now[0] = 150
+    assert runtime.request_next_animation_frame().render_now is True
+    step = runtime.render_now()
+
+    assert step.diagnostics.current_logical_lines == ("latest",)
 
 
 def test_runtime_deletes_replaced_kitty_image_once() -> None:

--- a/tests/tui/test_streaming_markdown.py
+++ b/tests/tui/test_streaming_markdown.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+
+from loushang.tui.markdown import renderer as markdown_renderer
+
+
+def _assert_incremental_matches_full(
+    chunks: Iterable[str],
+) -> markdown_renderer._StreamingMarkdownParseState:
+    state = markdown_renderer._StreamingMarkdownParseState()
+    source = ""
+    for chunk in chunks:
+        source += chunk
+        incremental = state.parse(source)
+        canonical = markdown_renderer._parse_markdown_blocks(source)
+        assert incremental == canonical
+        assert markdown_renderer._render_markdown_blocks(
+            incremental,
+            width=51,
+        ) == markdown_renderer._render_markdown_blocks(
+            canonical,
+            width=51,
+        )
+    return state
+
+
+def test_streaming_markdown_parses_only_mutable_top_level_tail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parsed_sources: list[tuple[str, int]] = []
+    original = markdown_renderer._parse_markdown_groups
+
+    def parse_groups(
+        markdown: str,
+        *,
+        line_offset: int,
+    ) -> tuple[tuple[markdown_renderer._ParsedMarkdownGroup, ...], bool]:
+        parsed_sources.append((markdown, line_offset))
+        return original(markdown, line_offset=line_offset)
+
+    monkeypatch.setattr(markdown_renderer, "_parse_markdown_groups", parse_groups)
+
+    _assert_incremental_matches_full(
+        (
+            "## Block 1\n\nfirst",
+            "\n\n## Block 2",
+            "\n\nsecond **bold**",
+            " grows",
+            "\n\n## Block 3\n\nthird",
+        )
+    )
+
+    assert "Block 1" in parsed_sources[0][0]
+    assert "Block 1" not in parsed_sources[-1][0]
+    assert len(parsed_sources[-1][0]) < len(
+        "".join(
+            (
+                "## Block 1\n\nfirst",
+                "\n\n## Block 2",
+                "\n\nsecond **bold**",
+                " grows",
+                "\n\n## Block 3\n\nthird",
+            )
+        )
+    )
+    assert parsed_sources[-1][1] > 0
+
+
+def test_streaming_markdown_keeps_continuous_list_as_one_mutable_group() -> None:
+    state = _assert_incremental_matches_full(
+        (
+            "Intro\n\n- one\n",
+            "- two\n",
+        )
+    )
+
+    assert state._stable_groups == []
+
+    source = "Intro\n\n- one\n- two\n\nTail"
+    blocks = state.parse(source)
+
+    assert blocks == markdown_renderer._parse_markdown_blocks(source)
+    assert [group.blocks[0].kind for group in state._stable_groups] == ["paragraph"]
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "Intro\n\n1. one\n2. two\n\n1.",
+        "Intro\n\n1) one\n2) two\n\n1)",
+        "Intro\n\n3. one\n4. two\n\n1.",
+    ),
+)
+def test_streaming_markdown_keeps_one_group_of_lookbehind_for_ordered_list_frontier(
+    source: str,
+) -> None:
+    state = markdown_renderer._StreamingMarkdownParseState()
+    streamed = ""
+
+    for character in source:
+        streamed += character
+        assert state.parse(streamed) == markdown_renderer._parse_markdown_blocks(streamed)
+
+
+def test_streaming_markdown_keeps_growing_table_as_one_mutable_group() -> None:
+    state = _assert_incremental_matches_full(
+        (
+            "Intro\n\n| A | B |\n",
+            "|---|---|\n",
+            "| 1 | 2 |\n",
+        )
+    )
+
+    assert state._stable_groups == []
+
+    source = "Intro\n\n| A | B |\n|---|---|\n| 1 | 2 |\n\nTail"
+    blocks = state.parse(source)
+
+    assert blocks == markdown_renderer._parse_markdown_blocks(source)
+    assert [group.blocks[0].kind for group in state._stable_groups] == ["paragraph"]
+
+
+def test_streaming_markdown_keeps_fence_mutable_until_a_later_top_level_block() -> None:
+    fence = "`" * 3
+    state = _assert_incremental_matches_full(
+        (
+            f"Intro\n\n{fence}py\nx = 1\n",
+            f"{fence}\n",
+        )
+    )
+
+    assert state._stable_groups == []
+
+    source = f"Intro\n\n{fence}py\nx = 1\n{fence}\n\nTail"
+    blocks = state.parse(source)
+
+    assert blocks == markdown_renderer._parse_markdown_blocks(source)
+    assert [group.blocks[0].kind for group in state._stable_groups] == ["paragraph"]
+
+
+@pytest.mark.parametrize(
+    ("source", "kinds"),
+    (
+        ("Head\n\nTail", ["paragraph", "blank", "paragraph"]),
+        ("Head\n\n\nTail", ["paragraph", "blank", "paragraph"]),
+        ("# Head\nTail", ["heading", "paragraph"]),
+    ),
+)
+def test_streaming_markdown_preserves_boundary_source_gap(source: str, kinds: list[str]) -> None:
+    state = markdown_renderer._StreamingMarkdownParseState()
+
+    blocks = state.parse(source)
+
+    assert blocks == markdown_renderer._parse_markdown_blocks(source)
+    assert [block.kind for block in blocks] == kinds
+
+
+def test_streaming_markdown_rebases_repeated_tail_line_ranges() -> None:
+    state = markdown_renderer._StreamingMarkdownParseState()
+
+    for source, expected_starts in (
+        ("A\n\nB", []),
+        ("A\n\nB\n\nC", [0]),
+        ("A\n\nB\n\nC\n\nD", [0, 2]),
+    ):
+        assert state.parse(source) == markdown_renderer._parse_markdown_blocks(source)
+        assert [group.start_line for group in state._stable_groups] == expected_starts
+
+
+def test_streaming_markdown_falls_back_for_late_reference_definition() -> None:
+    state = markdown_renderer._StreamingMarkdownParseState()
+    source = "[go][id]\n\nMiddle\n\nTail"
+
+    assert state.parse(source) == markdown_renderer._parse_markdown_blocks(source)
+    assert state._stable_groups
+
+    source += "\n\n[id]: https://example.com"
+    blocks = state.parse(source)
+
+    assert blocks == markdown_renderer._parse_markdown_blocks(source)
+    assert state._full_parse_only is True
+    assert state._stable_end_line == 0
+    assert state._stable_groups == []
+    assert any(token.kind == "link" and token.href == "https://example.com" for token in blocks[0].inline)
+
+    source += "\n\nAfter"
+    assert state.parse(source) == markdown_renderer._parse_markdown_blocks(source)
+    assert state._stable_end_line == 0
+
+
+def test_streaming_markdown_resets_on_non_append_replacement() -> None:
+    state = markdown_renderer._StreamingMarkdownParseState()
+    state.parse("Alpha\n\nTail")
+
+    replacement = "Beta\n\nTail"
+    blocks = state.parse(replacement)
+
+    assert blocks == markdown_renderer._parse_markdown_blocks(replacement)
+    assert all("Alpha" not in block.text for block in blocks)
+
+
+def test_markdown_render_cache_resets_streaming_state_for_new_key() -> None:
+    cache = markdown_renderer.MarkdownRenderCache()
+    first_key = object()
+    second_key = object()
+    cache.parse_streaming("Alpha\n\nTail", key=first_key)
+    first_state = cache._streaming_parse_state
+
+    blocks = cache.parse_streaming("Alpha\n\nTail grows", key=second_key)
+
+    assert cache._streaming_parse_state is not first_state
+    assert blocks == markdown_renderer._parse_markdown_blocks("Alpha\n\nTail grows")


### PR DESCRIPTION
## Summary

- restore the native coding Markdown performance harness and coalesce streaming render requests at 50 ms
- cache the stable parse/render prefix of streaming Markdown
- carry immutable, versioned rendered segments from the coding transcript through layout and terminal planning
- reuse committed transcript segments for Working ticks, composer input, and new assistant chunks without flattening or scanning old logical rows
- preserve legacy flat rendering as the correctness oracle for record separators, row shifts, cursors, and Kitty images

## Root cause

Committed transcript records already cached their rendered lines, but every frame still flattened those cached blocks, finalized every logical row, and diffed the full history. A long session therefore made unrelated bottom-frame updates scale with all previously rendered rows.

This change keeps committed transcript, active draft, and bottom frame as separate versioned segments. The render loop finalizes and compares only changed segments and advances its baseline only after a successful terminal flush.

## Impact

After the initial render or an actual committed-record change, Working ticks, composer edits, and streaming chunks no longer rematerialize committed history. No transcript rows are trimmed or dropped, and Markdown grouping, terminal scrollback, and product behavior are unchanged.

Measured with the fake Markdown workload:

- `4000 -> 1000 -> 1000 -> 10`: final ten chunk frames averaged 8.18 ms, max 16.05 ms
- 13,815 logical rows: final ten chunk frames averaged 20.91 ms, max 30.36 ms
- steady-state frames materialized at most 19 rows and performed zero full-frame flattening

## Validation

- focused versioned-segment regressions: `140 passed`
- TUI and coding UI regressions: `1233 passed`
- core post-rebase regressions: `4 passed`
- Ruff on changed files: passed
- `git diff --check`: passed
- full suite: `4236 passed, 8 skipped`; five unrelated failures remain from live Moonshot authentication, an existing architecture-state assertion, sandbox `/tmp/project` permissions, and environment-dependent model selection

## Known limitation

A single active assistant draft growing toward 10,000 Markdown lines is still one mutable segment. Each new chunk can therefore rematerialize and diff the full draft, and the 4,096-entry Markdown block cache can thrash once that draft contains more blocks than the cache. Once the response is committed, subsequent smaller turns are fast. Splitting the active draft into stable rendered-prefix segments and a mutable frontier is intentionally left for a focused follow-up.
