### PR TITLE
perf(tui): bound finalized segment cache to current frame

### DIFF
--- a/src/loushang/tui/render_loop.py
+++ b/src/loushang/tui/render_loop.py
@@ -702,26 +702,33 @@ class RenderLoop:
                 previous_finalized_lines=self.previous_rendered_lines,
             )
 
+        # Retain only segments from the latest complete segmented materialization.
+        # Building off to the side keeps the previous cache intact if finalization fails.
+        previous_segment_cache = self._finalized_segment_cache
+        current_segment_cache: dict[tuple[object, object], _LogicalLineSegment] = {}
         segments: list[_LogicalLineSegment] = []
         for rendered_segment in result.lines.segments:
             cache_key = _render_segment_cache_key(rendered_segment)
-            cached = self._finalized_segment_cache.get(cache_key) if cache_key is not None else None
-            if cached is not None:
+            logical_segment = (
+                current_segment_cache.get(cache_key) if cache_key is not None else None
+            )
+            if logical_segment is None and cache_key is not None:
+                logical_segment = previous_segment_cache.get(cache_key)
+            if logical_segment is not None:
                 self._planned_reused_segment_count += 1
-                segments.append(cached)
-                continue
-            logical_segment = _finalize_render_segment(rendered_segment)
-            self._planned_materialized_line_count += len(logical_segment.raw_lines)
+            else:
+                logical_segment = _finalize_render_segment(rendered_segment)
+                self._planned_materialized_line_count += len(logical_segment.raw_lines)
             segments.append(logical_segment)
             if cache_key is not None:
-                self._finalized_segment_cache[cache_key] = logical_segment
-                while len(self._finalized_segment_cache) > _FINALIZED_SEGMENT_CACHE_LIMIT:
-                    self._finalized_segment_cache.pop(next(iter(self._finalized_segment_cache)))
+                current_segment_cache[cache_key] = logical_segment
+                while len(current_segment_cache) > _FINALIZED_SEGMENT_CACHE_LIMIT:
+                    current_segment_cache.pop(next(iter(current_segment_cache)))
         logical_segments = tuple(segments)
-        return (
-            _SegmentedTextLines(logical_segments, finalized=False),
-            _SegmentedTextLines(logical_segments, finalized=True),
-        )
+        raw_lines = _SegmentedTextLines(logical_segments, finalized=False)
+        finalized_lines = _SegmentedTextLines(logical_segments, finalized=True)
+        self._finalized_segment_cache = current_segment_cache
+        return raw_lines, finalized_lines
 
     def _plan_runtime(self) -> RenderPlanRuntime:
         return RenderPlanRuntime(

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -24,7 +24,11 @@ from loushang.tui import (
     delete_kitty_image,
     wrap_tmux_passthrough,
 )
-from loushang.tui.core import RenderLineSegment, SegmentedRenderLines
+from loushang.tui.core import (
+    RenderLineSegment,
+    RenderLineSegmentLike,
+    SegmentedRenderLines,
+)
 from loushang.tui.render_loop import DEFAULT_STRATEGY_ORDER, RenderPlanStrategyKind
 
 
@@ -39,7 +43,7 @@ class StaticRoot:
 class SegmentedRoot:
     def __init__(
         self,
-        segments: tuple[RenderLineSegment, ...],
+        segments: tuple[RenderLineSegmentLike, ...],
         *,
         cursor: CursorDeclaration | None = None,
     ) -> None:
@@ -162,6 +166,162 @@ def test_segmented_render_skips_11748_committed_rows_on_bottom_frame_update(
     assert no_op.reused_render_segment_count == 2
     assert no_op.materialized_logical_line_count == 0
     assert no_op.flattened_logical_line_count == 0
+
+
+def test_segment_cache_retains_only_the_latest_segmented_frame() -> None:
+    committed = _render_segment("history", identity="committed", revision=1)
+    root = SegmentedRoot((committed,))
+    loop = RenderLoop(root)
+    size = TerminalSize(columns=80, rows=24)
+    latest_draft: RenderLineSegment | None = None
+
+    for revision in range(600):
+        draft_line_count = revision // 100 + 1
+        latest_draft = _render_segment(
+            *(f"draft revision {revision} line {line}" for line in range(draft_line_count)),
+            revision=revision,
+        )
+        root.segments = (committed, latest_draft)
+        frame = loop.plan(size)
+        loop.commit(frame, size=size)
+
+        assert len(loop._finalized_segment_cache) == 2
+        assert sum(
+            len(segment.raw_lines)
+            for segment in loop._finalized_segment_cache.values()
+        ) == draft_line_count + 1
+
+    assert latest_draft is not None
+    assert set(loop._finalized_segment_cache) == {
+        (committed.identity_key, committed.revision),
+        (latest_draft.identity_key, latest_draft.revision),
+    }
+
+    no_op = loop.plan(size)
+
+    assert no_op.reused_render_segment_count == 2
+    assert no_op.materialized_logical_line_count == 0
+
+    root.segments = (committed,)
+    completed = loop.plan(size)
+
+    assert tuple(completed.current_logical_lines) == ("history",)
+    assert set(loop._finalized_segment_cache) == {
+        (committed.identity_key, committed.revision)
+    }
+
+
+def test_segment_cache_replacement_is_atomic_when_finalization_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = SegmentedRoot((_render_segment("old", revision=1),))
+    loop = RenderLoop(root)
+    size = TerminalSize(columns=80, rows=24)
+    loop.plan(size)
+    previous_cache = loop._finalized_segment_cache
+    previous_cache_items = tuple(previous_cache.items())
+    root.segments = (
+        _render_segment("new one", revision=2),
+        _render_segment("new two", revision=2),
+    )
+    original_finalize = render_loop_module._finalize_render_segment
+    finalize_calls = 0
+
+    def fail_second_segment(segment: RenderLineSegmentLike):
+        nonlocal finalize_calls
+        finalize_calls += 1
+        if finalize_calls == 2:
+            raise RuntimeError("finalization failed")
+        return original_finalize(segment)
+
+    monkeypatch.setattr(
+        render_loop_module,
+        "_finalize_render_segment",
+        fail_second_segment,
+    )
+
+    with pytest.raises(RuntimeError, match="finalization failed"):
+        loop.plan(size)
+
+    assert loop._finalized_segment_cache is previous_cache
+    assert tuple(loop._finalized_segment_cache.items()) == previous_cache_items
+
+
+def test_segment_cache_sweeps_changed_views_without_changing_flat_output() -> None:
+    base = _render_segment(
+        "zero",
+        "one",
+        "two",
+        "three",
+        identity="shared",
+        revision=1,
+    )
+    first_view = SegmentedRenderLines.from_segments((base,))[0:2]
+    second_view = SegmentedRenderLines.from_segments((base,))[1:3]
+    root = SegmentedRoot(first_view.segments)
+    flat_root = FlatFrameRoot(("zero", "one"))
+    loop = RenderLoop(root)
+    flat_loop = RenderLoop(flat_root)
+    size = TerminalSize(columns=80, rows=24)
+    first = loop.plan(size)
+    flat_first = flat_loop.plan(size)
+    loop.commit(first, size=size)
+    flat_loop.commit(flat_first, size=size)
+    first_key = (
+        first_view.segments[0].identity_key,
+        first_view.segments[0].revision,
+    )
+
+    root.segments = second_view.segments
+    flat_root.lines = ("one", "two")
+    changed = loop.plan(size)
+    flat_changed = flat_loop.plan(size)
+    second_key = (
+        second_view.segments[0].identity_key,
+        second_view.segments[0].revision,
+    )
+
+    assert tuple(changed.current_logical_lines) == tuple(flat_changed.current_logical_lines)
+    assert changed.changed_line_range == flat_changed.changed_line_range
+    assert changed.operation_class == flat_changed.operation_class
+    assert changed.operations == flat_changed.operations
+    assert first_key not in loop._finalized_segment_cache
+    assert set(loop._finalized_segment_cache) == {second_key}
+    loop.commit(changed, size=size)
+
+    no_op = loop.plan(size)
+
+    assert no_op.reused_render_segment_count == 1
+    assert no_op.materialized_logical_line_count == 0
+
+
+def test_failed_segmented_flush_reuses_cache_without_advancing_baseline() -> None:
+    identity = object()
+    root = SegmentedRoot(
+        (_render_segment("first", identity=identity, revision=1),)
+    )
+    port = FakeTerminalPort(size=TerminalSize(columns=20, rows=5))
+    loop = RenderLoop(root)
+    runtime = TuiRuntime(render_loop=loop, terminal=port)
+    runtime.render_now()
+    committed_revision = loop.committed_frame_revision
+    root.segments = (
+        _render_segment("second", identity=identity, revision=2),
+    )
+    port.fail_next_flush(RuntimeError("write failed"))
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        runtime.render_now()
+
+    assert loop.committed_frame_revision == committed_revision
+
+    retried = runtime.render_now()
+
+    assert retried.diagnostics.reused_render_segment_count == 1
+    assert retried.diagnostics.materialized_logical_line_count == 0
+    assert tuple(retried.diagnostics.previous_rendered_lines) == ("first",)
+    assert tuple(retried.diagnostics.current_logical_lines) == ("second",)
+    assert retried.diagnostics.base_frame_revision == committed_revision
 
 
 def test_segmented_row_shift_matches_flat_planner_and_repaints_shifted_image() -> None:


### PR DESCRIPTION
## Summary

- retain finalized render segments only from the latest complete segmented materialization
- preserve the existing exact segment cache key and terminal baseline semantics
- add focused regressions for cache lifecycle, atomic replacement, segment views, and failed flush retries

## Root cause

Each growing assistant draft produced a new exact segment cache key. The render loop kept historical finalized draft snapshots until the global 512-entry limit, retaining many obsolete raw/finalized line tuples and increasing allocator pressure during long streams.

## Implementation

The render loop now reads reusable entries from the previous segmented cache while building a frame-local cache on the side. After every segment has finalized successfully, it atomically installs the new cache. Entries absent from the latest segmented materialization are no longer retained.

The change does not alter Markdown grouping, segment identity/revision keys, terminal diff operations, scheduling intervals, or explicit GC behavior.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q` — 1179 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_screen_coding_tui_app.py -q` — 44 passed
- focused render-segment and perf-example regressions — 9 passed
- Ruff and `git diff --check` passed
- two independent implementation reviews returned GO with no blockers

A focused 10,000-line cache probe retained 2 entries / 10,001 cached rows instead of 101 entries / 505,001 cached rows.

## Manual validation

- streamed 10,000-line responses multiple times
- accumulated committed transcript exceeded 20,000 lines
- subsequent 1,000/100/10-line responses remained responsive

## Known limitation

A single 10,000-line active draft can still slow down while streaming because each changed draft revision still materializes the complete current draft. That O(n) active-draft work is intentionally left for a separate follow-up.
