### PR TITLE
perf(tui): reuse stable streaming draft segments

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-019-streaming-markdown-stable-prefix-cache.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-019-streaming-markdown-stable-prefix-cache.md
@@ -5,9 +5,9 @@ Status: Accepted. Implemented.
 ## Purpose
 
 Keep Markdown streaming responsive as an assistant draft grows by parsing and
-formatting only its mutable semantic tail. Do this entirely inside the Markdown
-rendering path so terminal diff, viewport, and scrollback behavior do not
-change.
+formatting only its mutable semantic tail, while reusing already rendered
+semantic groups as immutable line segments. Terminal output, viewport, and
+scrollback behavior do not change.
 
 ## Problem
 
@@ -37,16 +37,17 @@ For an append-only update:
    growing tail plus one group of lookbehind.
 4. Promote all earlier complete groups into the stable prefix and advance the
    source-line offset.
-5. Combine the cached stable blocks with the newly parsed tail blocks and pass
-   one complete block sequence to the existing renderer.
+5. Render each promoted group once as an immutable line segment, and render the
+   remaining groups as one versioned mutable frontier segment.
 
-The renderer continues to return the same complete logical-line result it
-returns today. Stable prefix and mutable tail are internal parse concepts; they
-must not become separate transcript records or terminal regions.
+Stable groups and the frontier are internal render segments, not separate
+transcript records or terminal regions. Concatenating their rows must equal the
+ordinary complete Markdown render exactly.
 
-The boundary source gap must be preserved when the two parsed parts are
-combined. Otherwise parsing the tail independently would lose the blank block
-that the current full parser derives from the gap between adjacent token maps.
+Each group owns its left boundary: either the source-gap blank before it or the
+Pi-style blank implied by the previous and current block kinds. It never owns a
+trailing blank that depends on future input. This makes a promoted group safe
+to freeze without duplicating or dropping boundary rows.
 
 ## Semantic Boundary
 
@@ -75,9 +76,10 @@ Discard the incremental state when:
 - the source is no longer an append of the previous source
 - the parser cannot provide a safe top-level source boundary
 
-When streaming completes, use the ordinary full Markdown parse as the
-canonical result and discard the streaming parse state. Supported incremental
-cases must render identically to that canonical result.
+When streaming completes with the same buffer identity, version, and text as
+the last rendered frame, flatten the proven-equivalent rendered segments once
+into the stable record cache. Replaced or not-yet-rendered final text uses the
+ordinary full Markdown path. Then discard the streaming state.
 
 Width, theme, and terminal-capability changes continue to invalidate rendered
 line caches through their existing keys. They do not change Markdown source
@@ -85,15 +87,16 @@ boundaries and do not require a new terminal protocol.
 
 ## Scope
 
-This design changes only Markdown parse reuse for an active draft. It does not
-introduce:
+This design changes Markdown parse and rendered-line reuse for an active draft.
+It does not introduce:
 
 - an active transcript window or logical-row eviction
 - terminal diff, viewport, scrollback, or terminal-protocol changes
-- fixed-size Markdown fragments
+- fixed-size Markdown fragments or artificial line boundaries
 
-KD-015 remains a separate renderer optimization for reusing full transcript
-planning if that cost is still material after this optimization.
+The resulting group segments use KD-015's existing finalize and diff reuse.
+That cache retains every cacheable segment in the latest frame and no segments
+from older frames, so its memory remains bounded by the current rendered frame.
 
 ## Implementation Shape
 
@@ -101,13 +104,14 @@ The implementation stays narrow:
 
 - add a per-draft streaming parse state beside the Markdown renderer
 - use top-level token source maps to advance the stable offset
-- reuse the existing `_MarkdownBlock` rendering and `MarkdownRenderCache`
+- reuse the existing `_MarkdownBlock` rendering and semantic group boundaries
+- expose immutable stable rendered segments plus one mutable frontier segment
 - connect the state only to `StreamingTextBuffer` rendering
 - fall back to the current full parse whenever safety is uncertain
 
-Claude Code's React component split is not copied. Loushang merges parsed
-blocks before rendering so existing blank-line, assistant-chrome, and terminal
-diff behavior stay unchanged.
+Claude Code's React component split is not copied. Loushang keeps its existing
+assistant chrome and terminal planner, with exact flat rendering as the
+correctness oracle.
 
 ## Acceptance
 
@@ -121,3 +125,9 @@ diff behavior stay unchanged.
   30 percent. This is benchmark evidence, not a cross-machine CI timing gate.
 - Continuous single-block input remains correct even when it cannot be made
   faster by this strategy.
+- Working ticks and composer input do not read or materialize stable draft
+  rows. A new chunk materializes the mutable frontier and newly promoted
+  groups, not the complete draft.
+- The 10,000-line, 20-lines-per-block fixture remains exact after the number of
+  semantic groups exceeds both the Markdown block-cache capacity and 512
+  rendered segments.

--- a/src/loushang/coding/ui/screen_app.py
+++ b/src/loushang/coding/ui/screen_app.py
@@ -61,6 +61,8 @@ from loushang.tui.transcript import (
     TranscriptView,
     UserPromptRecord,
     WorkedDividerRecord,
+    _prefix_streaming_assistant_segment,
+    _render_streaming_assistant_markdown_segments,
 )
 
 ACTIVE_RENDER_INTERVAL_MS = 80
@@ -441,8 +443,30 @@ class _ScreenTranscriptRegion:
         init=False,
         repr=False,
     )
-    _draft_segment_key: tuple[object, ...] | None = field(default=None, init=False, repr=False)
-    _draft_segment: RenderLineSegment | None = field(default=None, init=False, repr=False)
+    _draft_segments_key: tuple[object, ...] | None = field(default=None, init=False, repr=False)
+    _draft_segments: tuple[RenderLineSegment, ...] = field(default=(), init=False, repr=False)
+    _draft_stream_context: tuple[object, ...] | None = field(default=None, init=False, repr=False)
+    _draft_stable_segment_cache: dict[tuple[object, ...], RenderLineSegment] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _draft_separator_identity: object = field(default_factory=object, init=False, repr=False)
+    _draft_separator_segment: RenderLineSegment | None = field(default=None, init=False, repr=False)
+    _draft_has_leading_separator: bool = field(default=False, init=False, repr=False)
+    _segmented_transient_content_segments: tuple[RenderLineSegment, ...] = field(
+        default=(),
+        init=False,
+        repr=False,
+    )
+    _segmented_transient_buffer_id: int | None = field(default=None, init=False, repr=False)
+    _segmented_transient_buffer_version: int = field(default=-1, init=False, repr=False)
+    _segmented_transient_width: int = field(default=0, init=False, repr=False)
+    _segmented_transient_style_signature: tuple[object, ...] | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
 
     @property
     def has_content(self) -> bool:
@@ -596,12 +620,15 @@ class _ScreenTranscriptRegion:
             return SegmentedRenderLines()
 
         committed = self._render_committed_segment(width=width, style_signature=style_signature)
-        draft = self._render_draft_segment(
+        draft_segments = self._render_draft_segments(
             width=width,
             style_signature=style_signature,
             has_committed=committed is not None,
         )
-        segments = tuple(segment for segment in (committed, draft) if segment is not None)
+        segments = (
+            *((committed,) if committed is not None else ()),
+            *draft_segments,
+        )
         lines = SegmentedRenderLines.from_segments(segments)
         if len(lines) <= max_height:
             return lines
@@ -609,8 +636,9 @@ class _ScreenTranscriptRegion:
         start = len(lines) - max_height
         committed_rows = committed.line_count if committed is not None else 0
         starts_at_draft_separator = (
-            draft is not None
-            and committed is not None
+            committed is not None
+            and bool(draft_segments)
+            and self._draft_has_leading_separator
             and start == committed_rows
         )
         if start in self._committed_separator_rows or starts_at_draft_separator:
@@ -661,18 +689,17 @@ class _ScreenTranscriptRegion:
         self._committed_separator_rows = frozenset(separator_rows)
         return segment
 
-    def _render_draft_segment(
+    def _render_draft_segments(
         self,
         *,
         width: int,
         style_signature: tuple[object, ...],
         has_committed: bool,
-    ) -> RenderLineSegment | None:
+    ) -> tuple[RenderLineSegment, ...]:
         draft: DisplayRecord | StreamingTextBuffer | None = self.draft_buffer or self.draft
         if draft is None:
-            self._draft_segment_key = None
-            self._draft_segment = None
-            return None
+            self._clear_draft_segment_cache()
+            return ()
         source_revision: object
         if isinstance(draft, StreamingTextBuffer):
             source_revision = (id(draft), draft.version)
@@ -685,8 +712,20 @@ class _ScreenTranscriptRegion:
             width,
             style_signature,
         )
-        if key == self._draft_segment_key:
-            return self._draft_segment
+        if key == self._draft_segments_key:
+            return self._draft_segments
+
+        if isinstance(draft, StreamingTextBuffer):
+            segmented = self._render_streaming_draft_segments(
+                draft,
+                width=width,
+                style_signature=style_signature,
+                has_committed=has_committed,
+            )
+            if segmented is not None:
+                self._draft_segments_key = key
+                self._draft_segments = segmented
+                return segmented
 
         block = self._render_record_lines(draft, width=width, style_signature=style_signature)
         rows = (("", *block) if has_committed and block else block)
@@ -698,9 +737,122 @@ class _ScreenTranscriptRegion:
             if rows
             else None
         )
-        self._draft_segment_key = key
-        self._draft_segment = segment
-        return segment
+        segments = (segment,) if segment is not None else ()
+        self._draft_segments_key = key
+        self._draft_segments = segments
+        self._draft_has_leading_separator = bool(has_committed and block)
+        self._segmented_transient_content_segments = ()
+        self._segmented_transient_buffer_id = None
+        self._segmented_transient_buffer_version = -1
+        return segments
+
+    def _render_streaming_draft_segments(
+        self,
+        buffer: StreamingTextBuffer,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+        has_committed: bool,
+    ) -> tuple[RenderLineSegment, ...] | None:
+        stream_context = (
+            id(buffer),
+            self.window_generation,
+            width,
+            style_signature,
+        )
+        if stream_context != self._draft_stream_context:
+            self._draft_stream_context = stream_context
+            self._draft_stable_segment_cache.clear()
+            self._draft_separator_segment = None
+
+        source = _streaming_buffer_render_text(buffer)
+        rendered = _render_streaming_assistant_markdown_segments(
+            source,
+            width=width,
+            theme=self.theme,
+            capabilities=self.capabilities,
+            code_highlighter=None,
+            markdown_cache=self._markdown_render_cache,
+            markdown_streaming_key=buffer,
+        )
+        if rendered is None:
+            self._draft_stable_segment_cache.clear()
+            self._draft_separator_segment = None
+            self._segmented_transient_content_segments = ()
+            self._segmented_transient_buffer_id = None
+            self._segmented_transient_buffer_version = -1
+            return None
+
+        content_segments: list[RenderLineSegment] = []
+        first_prefix_available = True
+        display_record = AssistantMessageRecord(source, stable=False)
+        for markdown_segment in rendered.segments:
+            has_nonblank = markdown_segment.has_nonblank
+            use_first_prefix = first_prefix_available and has_nonblank
+            if has_nonblank:
+                first_prefix_available = False
+            cache_key = (
+                markdown_segment.identity,
+                markdown_segment.revision,
+                use_first_prefix,
+            )
+            segment = (
+                self._draft_stable_segment_cache.get(cache_key)
+                if markdown_segment.stable
+                else None
+            )
+            if segment is None:
+                prefixed = _prefix_streaming_assistant_segment(
+                    markdown_segment.lines,
+                    width=width,
+                    use_first_prefix=use_first_prefix,
+                )
+                coding_lines = _coding_lines(
+                    prefixed,
+                    display_record,
+                    theme=self.theme,
+                    capabilities=self.capabilities,
+                )
+                segment = RenderLineSegment(
+                    lines=tuple(RenderLine(line) for line in coding_lines),
+                    identity=("streaming-markdown", markdown_segment.identity),
+                    revision=(markdown_segment.revision, use_first_prefix),
+                )
+                if markdown_segment.stable:
+                    self._draft_stable_segment_cache[cache_key] = segment
+            content_segments.append(segment)
+
+        content = tuple(content_segments)
+        segments: tuple[RenderLineSegment, ...] = content
+        if has_committed and content:
+            if self._draft_separator_segment is None:
+                self._draft_separator_segment = RenderLineSegment(
+                    lines=(RenderLine(""),),
+                    identity=self._draft_separator_identity,
+                    revision=stream_context,
+                )
+            segments = (self._draft_separator_segment, *content)
+        self._draft_has_leading_separator = bool(has_committed and content)
+
+        self._segmented_transient_content_segments = content
+        self._segmented_transient_buffer_id = id(buffer)
+        self._segmented_transient_buffer_version = buffer.version
+        self._segmented_transient_width = width
+        self._segmented_transient_style_signature = style_signature
+        return segments
+
+    def _clear_draft_segment_cache(self) -> None:
+        self._draft_segments_key = None
+        self._draft_segments = ()
+        self._draft_stream_context = None
+        self._draft_stable_segment_cache.clear()
+        self._draft_separator_segment = None
+        self._draft_has_leading_separator = False
+        self._segmented_transient_content_segments = ()
+        self._segmented_transient_buffer_id = None
+        self._segmented_transient_buffer_version = -1
+        self._segmented_transient_width = 0
+        self._segmented_transient_style_signature = None
 
     def _iter_records(self) -> Iterable[DisplayRecord | StreamingTextBuffer]:
         yield from self.records
@@ -719,8 +871,7 @@ class _ScreenTranscriptRegion:
         self._committed_segment_key = None
         self._committed_segment = None
         self._committed_separator_rows = frozenset()
-        self._draft_segment_key = None
-        self._draft_segment = None
+        self._clear_draft_segment_cache()
         self._cache_generation = self.window_generation
 
     def clear_transient_cache(self) -> None:
@@ -731,8 +882,7 @@ class _ScreenTranscriptRegion:
         self._transient_source_style_signature = None
         self._transient_source_buffer_id = None
         self._transient_source_buffer_version = -1
-        self._draft_segment_key = None
-        self._draft_segment = None
+        self._clear_draft_segment_cache()
         self._markdown_render_cache.clear_streaming()
 
     def promote_transient_cache(
@@ -741,6 +891,32 @@ class _ScreenTranscriptRegion:
         *,
         source_buffer: StreamingTextBuffer | None = None,
     ) -> None:
+        if source_buffer is not None and self._segmented_transient_content_segments:
+            if self._segmented_transient_buffer_id != id(source_buffer):
+                return
+            if self._segmented_transient_buffer_version != source_buffer.version:
+                return
+            if record.text != source_buffer.text:
+                return
+            if (
+                self._segmented_transient_width <= 0
+                or self._segmented_transient_style_signature is None
+            ):
+                return
+            canonical_lines = tuple(
+                line.text
+                for segment in self._segmented_transient_content_segments
+                for line in segment.lines
+            )
+            self._stable_line_cache[
+                (
+                    record,
+                    self._segmented_transient_width,
+                    self._segmented_transient_style_signature,
+                )
+            ] = canonical_lines
+            self._enforce_stable_cache_entry_limit()
+            return
         if self._transient_line_cache_lines is None:
             return
         if source_buffer is None and record.text != self._transient_source_text:

--- a/src/loushang/tui/markdown/renderer.py
+++ b/src/loushang/tui/markdown/renderer.py
@@ -80,6 +80,53 @@ class _ParsedMarkdownGroup:
     start_line: int
     end_line: int
     blocks: tuple[_MarkdownBlock, ...]
+    # Value equality is not enough for a streaming cache: two equal-looking
+    # top-level groups may occur at different places in the same document.  A
+    # group gets a fresh occurrence identity when it is parsed and keeps that
+    # identity after it is promoted into the stable prefix.
+    occurrence_id: object = field(default_factory=object, compare=False, repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class _StreamingMarkdownPartition:
+    """The append-only parse result without flattening the stable prefix."""
+
+    stable_groups: Sequence[_ParsedMarkdownGroup]
+    frontier_groups: tuple[_ParsedMarkdownGroup, ...]
+    generation: object
+    revision: int
+    full_blocks: tuple[_MarkdownBlock, ...] | None = None
+
+    @property
+    def segmented_safe(self) -> bool:
+        return self.full_blocks is None
+
+
+@dataclass(frozen=True, slots=True)
+class MarkdownRenderedSegment:
+    """A rendered semantic-group segment from an active Markdown stream."""
+
+    lines: tuple[str, ...]
+    identity: object
+    revision: object
+    stable: bool
+    _has_nonblank: bool = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        try:
+            hash(self.identity)
+        except TypeError as exc:
+            raise TypeError("Markdown segment identity must be hashable") from exc
+        object.__setattr__(self, "_has_nonblank", any(line != "" for line in self.lines))
+
+    @property
+    def has_nonblank(self) -> bool:
+        return self._has_nonblank
+
+
+@dataclass(frozen=True, slots=True)
+class MarkdownSegmentedRenderResult:
+    segments: tuple[MarkdownRenderedSegment, ...]
 
 
 @dataclass(slots=True)
@@ -88,21 +135,50 @@ class _StreamingMarkdownParseState:
     _stable_end_line: int = 0
     _stable_groups: list[_ParsedMarkdownGroup] = field(default_factory=list)
     _last_blocks: tuple[_MarkdownBlock, ...] = ()
+    _last_blocks_revision: int = -1
+    _last_partition: _StreamingMarkdownPartition | None = None
+    _generation: object = field(default_factory=object)
+    _revision: int = 0
     _initialized: bool = False
     _full_parse_only: bool = False
 
     def parse(self, markdown: str) -> tuple[_MarkdownBlock, ...]:
+        partition = self.update(markdown)
+        if self._last_blocks_revision == partition.revision:
+            return self._last_blocks
+        if partition.full_blocks is not None:
+            self._last_blocks = partition.full_blocks
+        else:
+            self._last_blocks = _markdown_blocks_from_groups(
+                (*partition.stable_groups, *partition.frontier_groups)
+            )
+        self._last_blocks_revision = partition.revision
+        return self._last_blocks
+
+    def update(self, markdown: str) -> _StreamingMarkdownPartition:
+        """Update the streaming partition without flattening stable groups."""
+
         normalized = markdown.expandtabs(3)
         if self._initialized and normalized == self._source:
-            return self._last_blocks
+            assert self._last_partition is not None
+            return self._last_partition
         if self._initialized and not normalized.startswith(self._source):
             self.reset()
 
         self._source = normalized
         self._initialized = True
+        self._revision += 1
         if self._full_parse_only:
-            self._last_blocks = _parse_normalized_markdown_blocks(normalized)
-            return self._last_blocks
+            partition = _StreamingMarkdownPartition(
+                stable_groups=self._stable_groups,
+                frontier_groups=(),
+                generation=self._generation,
+                revision=self._revision,
+                full_blocks=_parse_normalized_markdown_blocks(normalized),
+            )
+            self._last_partition = partition
+            self._last_blocks_revision = -1
+            return partition
 
         source_lines = normalized.split("\n")
         tail_source = "\n".join(source_lines[self._stable_end_line :])
@@ -114,23 +190,42 @@ class _StreamingMarkdownParseState:
             self._stable_end_line = 0
             self._stable_groups.clear()
             self._full_parse_only = True
-            self._last_blocks = _parse_normalized_markdown_blocks(normalized)
-            return self._last_blocks
+            partition = _StreamingMarkdownPartition(
+                stable_groups=self._stable_groups,
+                frontier_groups=(),
+                generation=self._generation,
+                revision=self._revision,
+                full_blocks=_parse_normalized_markdown_blocks(normalized),
+            )
+            self._last_partition = partition
+            self._last_blocks_revision = -1
+            return partition
 
-        groups = (*self._stable_groups, *tail_groups)
         promote_count = max(0, len(tail_groups) - _STREAMING_MARKDOWN_FRONTIER_GROUPS)
         if promote_count:
             promoted = tail_groups[:promote_count]
             self._stable_groups.extend(promoted)
             self._stable_end_line = promoted[-1].end_line
-        self._last_blocks = _markdown_blocks_from_groups(groups)
-        return self._last_blocks
+        frontier_groups = tail_groups[promote_count:]
+        partition = _StreamingMarkdownPartition(
+            stable_groups=self._stable_groups,
+            frontier_groups=frontier_groups,
+            generation=self._generation,
+            revision=self._revision,
+        )
+        self._last_partition = partition
+        self._last_blocks_revision = -1
+        return partition
 
     def reset(self) -> None:
         self._source = ""
         self._stable_end_line = 0
         self._stable_groups.clear()
         self._last_blocks = ()
+        self._last_blocks_revision = -1
+        self._last_partition = None
+        self._generation = object()
+        self._revision = 0
         self._initialized = False
         self._full_parse_only = False
 
@@ -141,6 +236,10 @@ class MarkdownRenderCache:
     _stable_blocks: dict[tuple[object, ...], tuple[str, ...]] = field(default_factory=dict, init=False, repr=False)
     _streaming_key: object | None = field(default=None, init=False, repr=False)
     _streaming_parse_state: _StreamingMarkdownParseState | None = field(default=None, init=False, repr=False)
+    _streaming_render_context: tuple[object, ...] | None = field(default=None, init=False, repr=False)
+    _streaming_render_generation: object | None = field(default=None, init=False, repr=False)
+    _streaming_rendered_stable: list[MarkdownRenderedSegment] = field(default_factory=list, init=False, repr=False)
+    _streaming_rendered_frontier: MarkdownRenderedSegment | None = field(default=None, init=False, repr=False)
 
     @property
     def stable_entry_count(self) -> int:
@@ -161,12 +260,30 @@ class MarkdownRenderCache:
     def clear_streaming(self) -> None:
         self._streaming_key = None
         self._streaming_parse_state = None
+        self._clear_streaming_rendered_segments()
 
     def parse_streaming(self, markdown: str, *, key: object) -> tuple[_MarkdownBlock, ...]:
-        if self._streaming_key is not key or self._streaming_parse_state is None:
-            self._streaming_key = key
-            self._streaming_parse_state = _StreamingMarkdownParseState()
+        self._ensure_streaming_state(key)
+        assert self._streaming_parse_state is not None
         return self._streaming_parse_state.parse(markdown)
+
+    def update_streaming(self, markdown: str, *, key: object) -> _StreamingMarkdownPartition:
+        self._ensure_streaming_state(key)
+        assert self._streaming_parse_state is not None
+        return self._streaming_parse_state.update(markdown)
+
+    def _ensure_streaming_state(self, key: object) -> None:
+        if self._streaming_key is key and self._streaming_parse_state is not None:
+            return
+        self._streaming_key = key
+        self._streaming_parse_state = _StreamingMarkdownParseState()
+        self._clear_streaming_rendered_segments()
+
+    def _clear_streaming_rendered_segments(self) -> None:
+        self._streaming_render_context = None
+        self._streaming_render_generation = None
+        self._streaming_rendered_stable.clear()
+        self._streaming_rendered_frontier = None
 
     def get_or_render(self, key: tuple[object, ...], render: Callable[[], tuple[str, ...]]) -> tuple[str, ...]:
         cached = self._stable_blocks.get(key)
@@ -281,6 +398,60 @@ class MarkdownRenderer:
                 frame_style=frame_style,
             )
         return _result(raw_lines, constraints)
+
+    def render_streaming_segments(
+        self,
+        constraints: RenderConstraints,
+    ) -> MarkdownSegmentedRenderResult | None:
+        """Render an append-only stream as stable groups plus one frontier.
+
+        Framing is intentionally excluded because padding and a background are
+        whole-result operations.  Reference definitions also require a full
+        parse, so callers should use :meth:`render` when this method returns
+        ``None``.
+        """
+
+        if self.render_cache is None or self.streaming_key is None:
+            return None
+
+        target_width = autowrap_safe_width(constraints.width)
+        frame_style = _resolve_style(self.theme, "markdown.background", self.capabilities)
+        framed = self.padding_x > 0 or self.padding_y > 0 or _has_background_style(frame_style)
+        if framed:
+            return None
+
+        partition = self.render_cache.update_streaming(
+            self.markdown,
+            key=self.streaming_key,
+        )
+        if not partition.segmented_safe:
+            self.render_cache._clear_streaming_rendered_segments()
+            return None
+
+        context = (
+            target_width,
+            _theme_cache_signature(self.theme),
+            _capabilities_cache_signature(self.capabilities),
+            id(self.code_highlighter) if self.code_highlighter is not None else None,
+            _style_cache_signature(self.default_style),
+        )
+        segments = _render_streaming_markdown_partition(
+            partition,
+            constraints=constraints,
+            width=target_width,
+            context=context,
+            theme=self.theme,
+            capabilities=self.capabilities,
+            code_highlighter=self.code_highlighter,
+            default_style=self.default_style,
+            render_cache=self.render_cache,
+        )
+        return MarkdownSegmentedRenderResult(
+            segments=_limit_markdown_rendered_segments(
+                segments,
+                max_height=constraints.max_height,
+            )
+        )
 
     def invalidate(self) -> None:
         self._render_cache.clear()
@@ -836,6 +1007,171 @@ def _render_markdown_blocks(
         if _needs_pi_style_blank_after(block.kind, next_kind):
             rendered.append("")
     return tuple(rendered)
+
+
+def _render_streaming_markdown_partition(
+    partition: _StreamingMarkdownPartition,
+    *,
+    constraints: RenderConstraints,
+    width: int,
+    context: tuple[object, ...],
+    theme: ThemeResolver | None,
+    capabilities: TerminalCapabilities | None,
+    code_highlighter: CodeHighlighterLike | None,
+    default_style: ThemeStyle | None,
+    render_cache: MarkdownRenderCache,
+) -> tuple[MarkdownRenderedSegment, ...]:
+    if (
+        render_cache._streaming_render_context != context
+        or render_cache._streaming_render_generation is not partition.generation
+    ):
+        render_cache._streaming_render_context = context
+        render_cache._streaming_render_generation = partition.generation
+        render_cache._streaming_rendered_stable.clear()
+        render_cache._streaming_rendered_frontier = None
+
+    stable_groups = partition.stable_groups
+    rendered_stable = render_cache._streaming_rendered_stable
+
+    # A generation is append-only.  Therefore the already-rendered prefix is
+    # trusted and only newly promoted groups are visited here.
+    for index in range(len(rendered_stable), len(stable_groups)):
+        group = stable_groups[index]
+        previous = stable_groups[index - 1] if index else None
+        lines = _render_streaming_markdown_group_run(
+            (group,),
+            previous_group=previous,
+            constraints=constraints,
+            width=width,
+            theme=theme,
+            capabilities=capabilities,
+            code_highlighter=code_highlighter,
+            default_style=default_style,
+            render_cache=render_cache,
+        )
+        segment = MarkdownRenderedSegment(
+            lines=lines,
+            identity=(
+                "markdown-stable-group",
+                partition.generation,
+                group.occurrence_id,
+                context,
+            ),
+            revision=0,
+            stable=True,
+        )
+        rendered_stable.append(segment)
+
+    frontier_identity = (
+        "markdown-frontier",
+        partition.generation,
+        context,
+    )
+    frontier = render_cache._streaming_rendered_frontier
+    if (
+        frontier is None
+        or frontier.identity != frontier_identity
+        or frontier.revision != partition.revision
+    ):
+        previous = stable_groups[-1] if stable_groups else None
+        frontier = MarkdownRenderedSegment(
+            lines=_render_streaming_markdown_group_run(
+                partition.frontier_groups,
+                previous_group=previous,
+                constraints=constraints,
+                width=width,
+                theme=theme,
+                capabilities=capabilities,
+                code_highlighter=code_highlighter,
+                default_style=default_style,
+                render_cache=render_cache,
+            ),
+            identity=frontier_identity,
+            revision=partition.revision,
+            stable=False,
+        )
+        render_cache._streaming_rendered_frontier = frontier
+
+    segments = tuple(rendered_stable)
+    if frontier.lines:
+        segments = (*segments, frontier)
+    return segments
+
+
+def _render_streaming_markdown_group_run(
+    groups: Sequence[_ParsedMarkdownGroup],
+    *,
+    previous_group: _ParsedMarkdownGroup | None,
+    constraints: RenderConstraints,
+    width: int,
+    theme: ThemeResolver | None,
+    capabilities: TerminalCapabilities | None,
+    code_highlighter: CodeHighlighterLike | None,
+    default_style: ThemeStyle | None,
+    render_cache: MarkdownRenderCache,
+) -> tuple[str, ...]:
+    run_blocks: list[_MarkdownBlock] = []
+    previous = previous_group if previous_group is not None and previous_group.blocks else None
+    for group in groups:
+        if not group.blocks:
+            continue
+        if previous is not None:
+            source_gap = group.start_line > previous.end_line
+            previous_kind = previous.blocks[-1].kind
+            current_kind = group.blocks[0].kind
+            if source_gap or _needs_pi_style_blank_after(previous_kind, current_kind):
+                run_blocks.append(_MarkdownBlock("blank"))
+        run_blocks.extend(group.blocks)
+        previous = group
+    if not run_blocks:
+        return ()
+
+    raw_lines = _render_markdown_blocks(
+        tuple(run_blocks),
+        width=width,
+        theme=theme,
+        capabilities=capabilities,
+        code_highlighter=code_highlighter,
+        default_style=default_style,
+        render_cache=render_cache,
+    )
+
+    # Block rendering has already wrapped to the target width.  The ordinary
+    # result finalizer is still used so rstrip/image handling stays identical;
+    # the document-wide height cap is applied after descriptors are joined.
+    unbounded_constraints = RenderConstraints(
+        width=constraints.width,
+        max_height=2_147_483_647,
+        visible_height=constraints.visible_height,
+    )
+    rendered = _result(list(raw_lines), unbounded_constraints)
+    return tuple(line.text for line in rendered.lines)
+
+
+def _limit_markdown_rendered_segments(
+    segments: tuple[MarkdownRenderedSegment, ...],
+    *,
+    max_height: int,
+) -> tuple[MarkdownRenderedSegment, ...]:
+    remaining = max_height
+    limited: list[MarkdownRenderedSegment] = []
+    for segment in segments:
+        if remaining <= 0:
+            break
+        if len(segment.lines) <= remaining:
+            limited.append(segment)
+            remaining -= len(segment.lines)
+            continue
+        limited.append(
+            MarkdownRenderedSegment(
+                lines=segment.lines[:remaining],
+                identity=("markdown-height-slice", segment.identity, remaining),
+                revision=segment.revision,
+                stable=segment.stable,
+            )
+        )
+        remaining = 0
+    return tuple(limited)
 
 
 def _render_markdown_block(

--- a/src/loushang/tui/render_loop.py
+++ b/src/loushang/tui/render_loop.py
@@ -25,7 +25,6 @@ from loushang.tui.terminal_image import (
 
 ClearScrollbackPolicy = Literal["disabled", "resize", "explicit"]
 SEGMENT_RESET = "\x1b[0m\x1b]8;;\x07"
-_FINALIZED_SEGMENT_CACHE_LIMIT = 512
 
 
 @dataclass(frozen=True, slots=True, eq=False)
@@ -722,8 +721,6 @@ class RenderLoop:
             segments.append(logical_segment)
             if cache_key is not None:
                 current_segment_cache[cache_key] = logical_segment
-                while len(current_segment_cache) > _FINALIZED_SEGMENT_CACHE_LIMIT:
-                    current_segment_cache.pop(next(iter(current_segment_cache)))
         logical_segments = tuple(segments)
         raw_lines = _SegmentedTextLines(logical_segments, finalized=False)
         finalized_lines = _SegmentedTextLines(logical_segments, finalized=True)

--- a/src/loushang/tui/transcript.py
+++ b/src/loushang/tui/transcript.py
@@ -17,6 +17,7 @@ from loushang.tui.markdown.renderer import (
     DiffBlock,
     MarkdownRenderCache,
     MarkdownRenderer,
+    MarkdownSegmentedRenderResult,
 )
 from loushang.tui.theme import TerminalCapabilities, ThemeResolver
 
@@ -482,6 +483,48 @@ def _render_markdown_content(
         streaming_key=markdown_streaming_key,
     ).render(_inner_constraints(width))
     return tuple(line.text for line in rendered.lines)
+
+
+def _render_streaming_assistant_markdown_segments(
+    text: str,
+    *,
+    width: int,
+    theme: ThemeResolver | None,
+    capabilities: TerminalCapabilities | None,
+    code_highlighter: CodeHighlighterLike | None,
+    markdown_cache: MarkdownRenderCache,
+    markdown_streaming_key: object,
+) -> MarkdownSegmentedRenderResult | None:
+    if theme is None:
+        return None
+    target_width = autowrap_safe_width(width)
+    return MarkdownRenderer(
+        text,
+        theme=theme,
+        capabilities=capabilities,
+        code_highlighter=code_highlighter,
+        render_cache=markdown_cache,
+        streaming_key=markdown_streaming_key,
+    ).render_streaming_segments(
+        _inner_constraints(target_width - visible_width("* "))
+    )
+
+
+def _prefix_streaming_assistant_segment(
+    lines: tuple[str, ...],
+    *,
+    width: int,
+    use_first_prefix: bool,
+) -> tuple[str, ...]:
+    target_width = autowrap_safe_width(width)
+    return tuple(
+        _prefixed_rendered_lines(
+            "* " if use_first_prefix else "  ",
+            "  ",
+            lines,
+            width=target_width,
+        )
+    )
 
 
 def _inner_constraints(width: int) -> RenderConstraints:

--- a/tests/coding/test_screen_coding_tui_app.py
+++ b/tests/coding/test_screen_coding_tui_app.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 import loushang.tui.markdown.renderer as markdown_renderer_module
 from loushang.tui import RenderConstraints, strip_control_sequences
 from loushang.tui.transcript import (
@@ -24,6 +26,34 @@ def _lines(value: Any, *, width: int = 80, height: int = 24) -> list[str]:
 def _raw_lines(value: Any, *, width: int = 80, height: int = 24) -> list[str]:
     result = value.render(RenderConstraints(width=width, max_height=height, visible_height=height))
     return [line.text for line in result.lines]
+
+
+def _fresh_flat_streaming_oracle_lines(
+    source: str,
+    *,
+    records: tuple[DisplayRecord, ...] = (),
+    theme: Any,
+    width: int,
+    max_height: int,
+) -> tuple[str, ...]:
+    """Render a draft without the streaming segmented cache."""
+
+    from loushang.coding.ui.screen_app import _ScreenTranscriptRegion
+
+    region = _ScreenTranscriptRegion(
+        records=list(records),
+        records_revision=1 if records else 0,
+        draft=AssistantMessageRecord(source, stable=False),
+        theme=theme,
+    )
+    rendered = region.render(
+        RenderConstraints(
+            width=width,
+            max_height=max_height,
+            visible_height=min(max_height, 24),
+        )
+    )
+    return tuple(line.text for line in rendered.lines)
 
 
 def _legacy_transcript_tail_rows(
@@ -611,11 +641,11 @@ def test_screen_coding_tui_reuses_unchanged_streaming_draft_cache() -> None:
     app.append_assistant_chunk("draft **markdown** response")
 
     _lines(app)
-    first_cached = app._transcript_region._transient_line_cache_lines
+    first_cached = app._transcript_region._draft_segments
     _lines(app)
 
-    assert first_cached is not None
-    assert app._transcript_region._transient_line_cache_lines is first_cached
+    assert first_cached
+    assert app._transcript_region._draft_segments is first_cached
 
 
 def test_screen_coding_tui_reuses_stable_streaming_markdown_blocks(monkeypatch) -> None:
@@ -708,12 +738,13 @@ def test_screen_coding_tui_clears_transient_draft_cache_after_assistant_commit()
     app.append_assistant_chunk("draft **markdown** response")
 
     _lines(app)
-    assert app._transcript_region._transient_line_cache_lines is not None
+    assert app._transcript_region._draft_segments
 
     app.end_assistant()
 
     assert app._transcript_region._transient_line_cache_key is None
     assert app._transcript_region._transient_line_cache_lines is None
+    assert app._transcript_region._draft_segments == ()
 
 
 def test_screen_coding_tui_promotes_streaming_draft_cache_after_assistant_commit() -> None:
@@ -731,8 +762,12 @@ def test_screen_coding_tui_promotes_streaming_draft_cache_after_assistant_commit
     app.append_assistant_chunk("\n".join(f"- **Line {line}**: `code-{line}`" for line in range(100)))
 
     _lines(app, width=100, height=1_000)
-    transient_lines = app._transcript_region._transient_line_cache_lines
-    assert transient_lines is not None
+    transient_lines = tuple(
+        line.text
+        for segment in app._transcript_region._segmented_transient_content_segments
+        for line in segment.lines
+    )
+    assert transient_lines
 
     app.end_assistant()
 
@@ -834,7 +869,10 @@ def test_screen_coding_tui_streaming_draft_render_keeps_full_append_stable_lines
     rendered_lines = _lines(app, width=100, height=1_000)
     rendered = "\n".join(rendered_lines)
 
-    assert len(app._transcript_region._transient_line_cache_lines or ()) >= 200
+    assert sum(
+        segment.line_count
+        for segment in app._transcript_region._segmented_transient_content_segments
+    ) >= 200
     assert "draft line 199" in rendered
     assert "draft line 0" in rendered
 
@@ -1285,3 +1323,205 @@ def test_screen_coding_tui_runtime_consumes_transcript_window_reset_as_baseline_
     rendered = "\n".join(step.diagnostics.current_logical_lines)
     assert "old prompt" not in rendered
     assert "summary only" in rendered
+
+
+def test_streaming_draft_semantic_segments_match_fresh_flat_render_at_chunk_boundaries() -> None:
+    from loushang.coding.ui.screen_app import (
+        _ScreenTranscriptRegion,
+        _terminal_transcript_theme,
+    )
+    from loushang.tui.transcript import StreamingTextBuffer
+
+    theme = _terminal_transcript_theme()
+    records: tuple[DisplayRecord, ...] = (UserPromptRecord("committed prompt"),)
+    buffer = StreamingTextBuffer()
+    region = _ScreenTranscriptRegion(
+        records=list(records),
+        records_revision=1,
+        draft_buffer=buffer,
+        theme=theme,
+    )
+    chunks = (
+        "#",
+        "## Markdown block 1\n",
+        "\n",
+        "- alpha\n- beta\n",
+        "\n### Markdown block 2\n\n",
+        "-",
+        " gamma\n- delta\n\n",
+        "### Markdown block 3\n\n- epsilon\n",
+        "- zeta\n\n### Markdown block 4",
+        "\n\n- eta\n- theta\n",
+        "\n\n### Markdown block 5\n\n- iota\n- kappa",
+    )
+    source = ""
+
+    for checkpoint, chunk in enumerate(chunks, start=1):
+        buffer.append(chunk)
+        source += chunk
+        for max_height in (1_000_000, 1, 7, 24):
+            actual = tuple(
+                line.text
+                for line in region.render(
+                    RenderConstraints(
+                        width=88,
+                        max_height=max_height,
+                        visible_height=min(max_height, 24),
+                    )
+                ).lines
+            )
+            expected = _fresh_flat_streaming_oracle_lines(
+                source,
+                records=records,
+                theme=theme,
+                width=88,
+                max_height=max_height,
+            )
+
+            assert actual == expected, (checkpoint, max_height)
+
+
+@pytest.mark.parametrize(
+    "chunks",
+    (
+        (
+            "- list item 1\n",
+            "- list item 2\n",
+            "- list item 3 with **bold**\n",
+            "- list item 4 with [link](https://example.com)\n",
+        ),
+        (
+            "| Name | Value |\n",
+            "| --- | --- |\n",
+            "| alpha | short |\n",
+            "| beta | this later cell is deliberately much wider than the earlier cells |\n",
+        ),
+        (
+            "```python\n",
+            "print('first')\n",
+            "print('second')\n",
+            "```\n",
+            "\nParagraph after the closed fence.\n",
+        ),
+        (
+            "See the [documentation][docs].\n\n",
+            "A paragraph parsed before the definition.\n\n",
+            "### A heading before the late definition\n\n",
+            "[docs]: https://example.com/docs\n",
+        ),
+    ),
+    ids=("continuous-list", "growing-table", "closing-fence", "late-reference"),
+)
+def test_streaming_draft_fallback_shapes_match_fresh_flat_render(
+    chunks: tuple[str, ...],
+) -> None:
+    from loushang.coding.ui.screen_app import (
+        _ScreenTranscriptRegion,
+        _terminal_transcript_theme,
+    )
+    from loushang.tui.transcript import StreamingTextBuffer
+
+    theme = _terminal_transcript_theme()
+    buffer = StreamingTextBuffer()
+    region = _ScreenTranscriptRegion(draft_buffer=buffer, theme=theme)
+    source = ""
+
+    for checkpoint, chunk in enumerate(chunks, start=1):
+        buffer.append(chunk)
+        source += chunk
+        actual = tuple(
+            line.text
+            for line in region.render(
+                RenderConstraints(width=72, max_height=1_000_000, visible_height=24)
+            ).lines
+        )
+        expected = _fresh_flat_streaming_oracle_lines(
+            source,
+            theme=theme,
+            width=72,
+            max_height=1_000_000,
+        )
+
+        assert actual == expected, checkpoint
+
+
+def test_streaming_draft_reuses_more_than_512_stable_segments_without_reading_source(
+    monkeypatch,
+) -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.tui import RenderLoop, TerminalSize
+    from loushang.tui.transcript import StreamingTextBuffer
+
+    now = [1.0]
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd1234",
+        now=lambda: now[0],
+    )
+    app.begin_run(started_at=0.0)
+    app.begin_assistant()
+    source = "\n\n".join(
+        f"Independent paragraph {index} with `code-{index}`."
+        for index in range(600)
+    )
+    app.append_assistant_chunk(source)
+
+    loop = RenderLoop(app)
+    size = TerminalSize(columns=100, rows=30)
+    initial = loop.plan(size)
+    loop.commit(initial, size=size)
+    assert len(initial.current_logical_lines) > 1_000
+
+    buffer = app.state.assistant_draft_buffer
+    assert isinstance(buffer, StreamingTextBuffer)
+
+    def fail_if_old_source_is_read(_buffer: StreamingTextBuffer) -> tuple[str, ...]:
+        raise AssertionError("unchanged draft source was scanned")
+
+    with monkeypatch.context() as source_guard:
+        source_guard.setattr(StreamingTextBuffer, "logical_lines", fail_if_old_source_is_read)
+
+        no_op = loop.plan(size)
+        assert no_op.reused_render_segment_count > 512
+        assert no_op.materialized_logical_line_count <= 16
+        assert no_op.flattened_logical_line_count == 0
+        loop.commit(no_op, size=size)
+
+        now[0] = 2.0
+        tick = loop.plan(size)
+        assert tick.reused_render_segment_count > 512
+        assert tick.materialized_logical_line_count <= 16
+        assert tick.flattened_logical_line_count == 0
+        loop.commit(tick, size=size)
+
+        app.composer.set_text("x")
+        composer_input = loop.plan(size)
+        assert composer_input.reused_render_segment_count > 512
+        assert composer_input.materialized_logical_line_count <= 16
+        assert composer_input.flattened_logical_line_count == 0
+        loop.commit(composer_input, size=size)
+
+    appended = "\n\nIndependent paragraph 600 with `code-600`."
+    source += appended
+    app.append_assistant_chunk(appended)
+    chunk = loop.plan(size)
+
+    assert chunk.reused_render_segment_count > 512
+    assert 0 < chunk.materialized_logical_line_count < 64
+    assert chunk.flattened_logical_line_count == 0
+
+    optimized_transcript = tuple(
+        line.text
+        for line in app._transcript_region.render(
+            RenderConstraints(width=100, max_height=1_000_000, visible_height=30)
+        ).lines
+    )
+    expected_transcript = _fresh_flat_streaming_oracle_lines(
+        source,
+        theme=app.transcript_theme,
+        width=100,
+        max_height=1_000_000,
+    )
+    assert optimized_transcript == expected_transcript

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -211,6 +211,42 @@ def test_segment_cache_retains_only_the_latest_segmented_frame() -> None:
     }
 
 
+def test_segment_cache_retains_every_segment_in_the_latest_frame() -> None:
+    stable = tuple(
+        _render_segment(
+            f"stable group {index}",
+            identity=("stable-group", index),
+            revision=1,
+        )
+        for index in range(600)
+    )
+    frontier_identity = object()
+    root = SegmentedRoot(
+        (*stable, _render_segment("frontier one", identity=frontier_identity, revision=1))
+    )
+    loop = RenderLoop(root)
+    size = TerminalSize(columns=80, rows=24)
+    first = loop.plan(size)
+    loop.commit(first, size=size)
+
+    assert len(loop._finalized_segment_cache) == 601
+
+    root.segments = (
+        *stable,
+        _render_segment("frontier two", identity=frontier_identity, revision=2),
+    )
+    changed = loop.plan(size)
+
+    assert changed.reused_render_segment_count == 600
+    assert changed.materialized_logical_line_count == 1
+    loop.commit(changed, size=size)
+
+    no_op = loop.plan(size)
+
+    assert no_op.reused_render_segment_count == 601
+    assert no_op.materialized_logical_line_count == 0
+
+
 def test_segment_cache_replacement_is_atomic_when_finalization_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- expose the append-only Markdown partition without flattening all stable blocks
- render promoted top-level semantic groups once as immutable rendered segments
- keep the final two semantic groups in one versioned mutable frontier segment
- preserve assistant prefixes and Markdown boundary blanks with exact flat-render equivalence
- retain every cacheable segment in the latest frame so drafts with more than 512 semantic groups do not re-finalize their prefix
- reuse the rendered draft on completion when buffer identity, version, and text still match

## Root cause

The existing streaming parser only reparsed the mutable tail, but every frame still walked and copied the complete block sequence and rebuilt one full draft segment.

At roughly 4,100 input lines, the 4,096-entry Markdown block cache also entered FIFO churn: the number of blocks actually rendered in one frame jumped from about 106 to 4,306. A production-style baseline measured a 29.4s plan, including 19.6s in Markdown rendering, while only about 120 terminal rows had changed.

## Design

The active draft is now represented as:

```text
immutable rendered semantic-group segments
+ one mutable frontier segment
```

Segment boundaries come only from the existing markdown-it top-level groups. Each group owns its left boundary blank and never owns a trailing blank that depends on future input. Continuous lists, growing tables, unfinished fences, late references, framed Markdown, and other cases that cannot prove safe reuse continue through the complete-render fallback.

The RenderLoop cache still retains only the latest complete frame, but no longer evicts current-frame entries after 512 segments. Its space remains proportional to the current rendered frame rather than historical revisions.

## Performance evidence

Using the 20-lines-per-Markdown-block fixture, rendering every 100 input lines:

| Checkpoint | Plan time | Draft segments | Reused segments | Materialized rows |
| ---: | ---: | ---: | ---: | ---: |
| 1,000 | 222ms | 100 | 90 | 144 |
| 4,000 | 277ms | 400 | 390 | 144 |
| 10,000 | 270ms | 1,000 | 990 | 144 |

The 4,096 block-cache capacity is reached after 5,000 lines without recreating the previous performance cliff. The 100-frame 10,000-line run spent 25.2s total in planning, averaging 252ms per sampled frame.

These timings are supporting evidence rather than CI thresholds.

## Correctness and validation

- fresh full flat-render raw ANSI oracle at every 1,000-line checkpoint from 1,000 through 10,000 lines
- exact oracle coverage at every chunk boundary for headings/lists, source gaps, growing tables, unfinished/closed fences, late references, committed/draft separators, and heights `1`, `7`, `24`, and full
- more than 512 stable segments with Working tick and composer input guarded against reading `StreamingTextBuffer.logical_lines()`
- `uv --cache-dir .uv-cache run --extra dev pytest tests/tui tests/coding/test_screen_coding_tui_app.py -q` — 1,230 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_cli.py -k tui -q` — 16 passed
- focused post-review suite — 118 passed
- Ruff and `git diff --check` passed

The full repository run completed with 4,247 passed and 8 skipped. Its four failures are outside this diff: an ignored stale `agent/harness/__pycache__` directory, local `/tmp/project` write permissions, and two existing tests that still construct the old `moonshot` provider after the catalog moved Kimi Code to `kimi-code`.

## Remaining boundary

A new chunk still materializes and checks the complete source string (`logical_lines`/join/expandtabs/prefix check). This PR removes rebuilding, copying, and finalizing the old rendered prefix; source-level append-only materialization can be profiled and addressed separately.
