### PR TITLE
feat(harness): centralize control-plane runtime / 集中控制面运行时

### DIFF
--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -47,6 +47,10 @@ planning, work event persistence, or AI provider behavior.
   shared manifest, loading, registration, conflict resolution, observer/input
   dispatch, resource contribution, and tool-wrapper ownership while preserving
   product policy, session/model behavior, and UI integration.
+- [Control Plane Runtime Boundary](control-plane-runtime-boundary.md) defines
+  deterministic extension routing, neutral policy subjects and evaluator
+  composition, pending approval lifecycle, and the Product adapters that retain
+  risk defaults, result semantics, and presentation.
 - [Context Budget And Accounting Boundary](context-budget-accounting-boundary.md)
   defines deterministic compaction-budget and usage-estimate record ownership
   while keeping message estimation and compaction policy in product adapters.

--- a/docs/internals/architecture/harness/coding-to-harness-migration-inventory.md
+++ b/docs/internals/architecture/harness/coding-to-harness-migration-inventory.md
@@ -43,7 +43,7 @@ sufficient.
 | `coding.tools.file_mutation_queue` | Compatibility shim | Canonical per-path mutation coordination lives in `loushang.harness.workspace.mutation_queue`. Coding paths re-export the harness functions and registry; the Pi-style camelCase alias stays coding-owned. |
 | `coding.tools.read`, `ls`, `find`, `grep`, `write`, `edit`, `edit_diff`, `bash`, `process`, `ignore`, `external_tools` | Compatibility shim | Reusable implementations live in `loushang.harness.tools.workspace`. Coding injects product metadata, policy/approval, activation, and compatibility projections. |
 | `coding.tools.policy` | Compatibility shim | Neutral policy-enforcement plumbing accepts an injected evaluator and Harness approval resolver. Coding retains risk classification and concrete `PolicyEngine` defaults. |
-| `coding.policy` | Split candidate | Approval contracts and headless resolvers live in `loushang.harness.approval`; the neutral allow/deny/ask decision record and evaluator protocol live in `loushang.harness.policy`. Keep Coding risk rules, package trust defaults, allowlists, and interactive UI integration in Coding. |
+| `coding.policy` | Product adapter | Approval contracts, headless resolvers, pending-request broker lifecycle, immutable policy subjects, command normalization, rules, matchers, evaluator chains, and sync/async validation live in `loushang.harness.approval` and `loushang.harness.policy`. Coding keeps risk rules, package trust defaults, allowlists, default decisions and wording, interactive payload projection, and compatibility methods. |
 | `coding.exec` | Compatibility shim | `ExecRequest`, `ExecResult`, output records, backend/update protocols, and `ExecService` live in `loushang.harness.workspace.exec`. Coding keeps the public compatibility path; policy, session cwd resolution, tool projection, and extension behavior remain product-owned. |
 | `coding.diagnostics.types`, `coding.diagnostics.service` | Compatibility shim | Diagnostic vocabulary, records, queries, summaries, startup-check contracts, and the bounded in-memory engine live in `loushang.harness.diagnostics`. Coding paths re-export the same Harness-owned objects. |
 | `coding.diagnostics.serialization`, `coding.diagnostics.problem_bridge`, concrete checks | Keep product | Keep camelCase payload projection, observability mapping, check selection, emission timing, remediation, session bridges, and CLI/TUI behavior in Coding. |
@@ -60,7 +60,7 @@ sufficient.
 | `coding.session.AgentSession`, controllers, `coding.runtime.AgentSessionRuntime` | Product adapter | `AgentSession` delegates run, turn, queue, retry, compaction single-flight, resource/extension lifecycle, command dispatch ordering, tool activation accounting, and abort/idle/dispose coordination to Harness. `AgentSessionRuntime` delegates its opaque current slot, operation transaction, replacement callback order, import staging, navigation abort scope, and scheduling to `loushang.harness.runtime`; conversation tree/fork/replay/catalog mechanics live in `loushang.harness.conversation`. Coding keeps controller policy/adapters, event schema, concrete messages and command handlers, tool defaults/materialization, transcript schema/codec, replacement decisions/events, path/import policy, index fields, and storage policy. |
 | `coding.event` | Keep product | Coding session event protocol and product projection stay coding. Agent owns tool-output event projection and strict failure semantics; Coding consumes that view and retains its field names, filtering, render enrichment, and RPC/print behavior. |
 | `coding.extensions.events`, `manifest`, `loader`, `contributions`, `wrapper` | Compatibility shim | Event declarations, manifest parsing, descriptor-driven loading, contribution projection, and tool wrapping live in `loushang.harness.extensions`. Coding paths preserve imports and inject Coding API/policy/legacy-event adapters. |
-| `coding.extensions.api`, `runner`, `types`, `policy`, `hooks` | Product adapter | Neutral records, registration, conflict resolution, observer/input dispatch, resource contribution execution, binding storage/lifetimes, and generic bound/unbound runtime contexts live in Harness. Coding keeps typed model/thinking/command specialization, provider/UI callback injection, concrete permission defaults, session decisions, system-prompt/context reducers, and Agent tool-call adaptation. |
+| `coding.extensions.api`, `runner`, `types`, `policy`, `hooks` | Product adapter | Neutral records, registration, conflict resolution, stable route planning, observer/interceptor/reducer dispatch, resource contribution execution, binding storage/lifetimes, and generic bound/unbound runtime contexts live in Harness. Coding keeps typed model/thinking/command specialization, provider/UI callback injection, concrete permission defaults, Product result reducers, session decisions, and Agent tool-call adaptation. |
 | `coding.bootstrap` | Keep product | Product assembly. It may call harness engines but should not move. |
 | `coding.runtime` | Product adapter | Generic binding leases, runtime contexts, current-session transitions, serialized operation phases, uncommitted-candidate rollback, replacement callback ordering, exclusive import staging, navigation abort scopes, and coalesced scheduling live in `loushang.harness.runtime`. Coding keeps composition, cwd/session-file resolution and acceptance policy, concrete create/restore/fork/import/clone decisions, extension event projection, diagnostics codes, transcript semantics, package operations, and index content. |
 | `coding.ui` | Never harness | Product-owned TUI adapter and screen/controller state. Shared terminal primitives belong in `loushang.tui`, not harness. |
@@ -140,6 +140,18 @@ failure-contained observer and input dispatch, resource contribution execution,
 and tool wrapping. Coding keeps permission defaults, activation choices,
 product handlers, model/provider bindings, session projection, specialized
 result reducers, and UI commands.
+
+### Wave 2 Follow-On: Control Plane Runtime
+
+Status: implementation complete for integration into `lane/harness`; see
+[Control Plane Runtime Boundary](control-plane-runtime-boundary.md).
+
+Harness now owns event-scoped extension route planning, dependency ordering,
+generic observer/interceptor/reducer execution, neutral policy subjects and
+rules, evaluator chains, canonical effective-command normalization, neutral
+enforcement audit records, and pending approval lifecycle. Coding retains
+Product reducers, risk defaults and wording, interactive payload projection,
+session-event audit projection and persistence, and compatibility methods.
 
 ### Wave 3: Persistence, Context, And Workflow Mechanics
 

--- a/docs/internals/architecture/harness/control-plane-runtime-boundary.md
+++ b/docs/internals/architecture/harness/control-plane-runtime-boundary.md
@@ -1,0 +1,750 @@
+# Harness Control Plane Runtime Boundary
+
+## Status
+
+Status: implemented on `harness/control-plane-runtime`; integration pending.
+
+This boundary closes the product-neutral control path from extension
+contribution routing through policy evaluation and asynchronous approval. It
+builds on the existing extension, approval, policy, workspace-tool, and host
+contracts without creating another Agent loop or a general service locator.
+
+## Decision
+
+`loushang.harness` owns the reusable mechanisms for:
+
+- deterministic extension-handler ordering and dependency validation;
+- observer, interceptor, reducer, and first-match routing;
+- handler failure isolation and explicit chain-failure policy;
+- neutral policy subjects, rules, matching, and evaluator composition;
+- command-subject normalization used by reusable process tools;
+- pending approval request lifecycle, including presentation, resolution,
+  cancellation, timeout, fallback, and disposal;
+- product-neutral composition of extension routing, policy evaluation, and
+  approval resolution.
+
+Products and OEM adapters continue to own:
+
+- risk classification and the default allow, deny, and ask rules;
+- approval defaults, remembered grants, trust decisions, and user-facing
+  explanations;
+- concrete UI, RPC, and event payload projection;
+- product event/result schemas and the reducers that interpret them;
+- extension activation, permission defaults, and trust policy;
+- product tool selection and Agent tool materialization.
+
+The composition direction remains:
+
+```text
+product / OEM adapter
+  -> harness extension router
+  -> harness policy runtime + approval broker
+  -> harness workspace-tool enforcement adapter
+  -> stable Agent tool value primitives
+```
+
+The router, policy runtime, and approval broker are sibling mechanisms. The
+router does not import or locate policy, approval, workspace, or Product
+services. A Product composes them through narrow typed ports.
+
+Harness must not import Coding, Design, Research, PPT, Cowork, Method, Work,
+Channel, TUI, AI, provider, model, credential, or product session modules.
+
+## Motivation
+
+At design time, the ownership declarations were ahead of the implementation:
+
+- `ExtensionSurfaceDescriptor` carried `priority`, but runtime dispatch still
+  used extension insertion order and had no `before`, `after`, or `on_error`
+  contract;
+- `ExtensionDispatcher` supported observers, first-truthy dispatch, and one
+  hard-coded input reducer, while Coding still owned the generic loops for
+  context, before-agent, session decisions, and tool interceptors;
+- `loushang.harness.approval` owned approval value types and headless resolvers,
+  but Coding owned pending futures, request ids, presenter binding, and result
+  correlation;
+- `loushang.harness.policy` only defined a decision and a narrow protocol,
+  while Coding owned reusable command-wrapper normalization, tool/path matching,
+  and configurable rule mechanics;
+- the workspace policy layer defined a second evaluator protocol instead of
+  adapting to one Harness-owned policy subject and decision contract.
+
+This duplication makes extension and approval semantics product dependent and
+would force another product to copy Coding control-flow code. It also makes a
+future Product Session Host depend on a wide callback bag. The control plane is
+therefore migrated before higher-level session composition.
+
+## Goals
+
+1. A non-Coding product can route extension hooks, evaluate a tool policy,
+   suspend for approval, resume, and execute a tool without importing Coding.
+2. Existing Coding extension order, diagnostics, approval payloads, and public
+   compatibility paths remain stable unless an explicit ordering declaration
+   changes the order. Policy outcomes remain stable for commands that can be
+   completely normalized; incomplete or platform-dependent wrapper syntax now
+   fails safely to Product approval instead of being allowed implicitly.
+3. Extension handlers can declare deterministic relative ordering and failure
+   behavior without embedding Product types in Harness.
+4. Pending approval requests cannot leak when callers cancel, presenters fail,
+   requests time out, sessions dispose, or late results arrive.
+5. Product policy remains data and semantics supplied to a Harness mechanism;
+   Harness does not acquire Coding's destructive-command defaults.
+
+## Non-Goals
+
+- Moving Coding prompts, skills, tool descriptions, risk wording, or default
+  policy rules into Harness.
+- Selecting or trusting extensions on behalf of a Product.
+- Defining Method, Work, Channel, model-provider, or storage runtime behavior.
+- Persisting approval grants or providing an interactive UI.
+- Replacing the Agent before/after-tool hook contract.
+- Creating a universal Product manifest, dependency-injection container, or
+  arbitrary service registry.
+
+## Extension Routing
+
+### Route Declarations And Resolved Routes
+
+Harness separates extension-owned declarations from runtime-resolved routes
+under
+`loushang.harness.extensions.routing`:
+
+```python
+@dataclass(frozen=True)
+class RegisteredExtensionHandler:
+    local_route_id: str
+    event_name: str
+    handler: Callable[[object, object], object | Awaitable[object]]
+    priority: int = 0
+    after: tuple[str, ...] = ()
+    before: tuple[str, ...] = ()
+    on_error: Literal["skip", "fail_chain"] = "skip"
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ResolvedExtensionRoute:
+    route_id: str
+    extension: LoadedExtension
+    registration: RegisteredExtensionHandler
+    registration_index: int
+    source_info: SourceInfo[Path]
+```
+
+The resolved route retains the extension object required by the existing
+per-extension context factory, provenance diagnostics, and runtime-error
+callback. `ExtensionRoutePlan.from_extensions()` compiles registrations once
+per extension-set generation and exposes event-scoped resolved routes. Dispatch
+receives the request-local context factory; constructing a router for a new cwd
+does not rebuild the plan or repeat validation diagnostics.
+
+An explicit `local_route_id` is unique within one extension and event. The
+canonical route id is:
+
+```text
+<extension_id>/<event_name>/<local_route_id>
+```
+
+Each normalized, non-empty component is UTF-8 percent-encoded before joining.
+RFC 3986 unreserved characters remain readable; `/`, `%`, `#`, Unicode, and
+whitespace are encoded. The `#duplicate-N` suffix is therefore reserved for
+planner-generated identities and cannot collide with a declared component.
+`route:` references use the encoded canonical id exposed by the compiled plan.
+
+Ordering references use an unambiguous qualified grammar:
+
+- `route:<canonical-route-id>` targets exactly one route;
+- `extension:<extension-id>` targets all active routes from that extension for
+  the current event only.
+
+Automatic ids such as `legacy-0001` are generated from registration order for
+legacy handlers and are not a public cross-extension reference contract.
+Explicit duplicate local ids, self references, malformed references, and
+missing active references produce distinct diagnostics. A reference to an
+inactive optional extension is ignored so disabling an extension does not
+create ordering noise.
+
+`ExtensionSurfaceDescriptor` grows the same `after`, `before`, and `on_error`
+fields. These fields describe contribution order and remain optional so
+existing constructors preserve behavior. `LoadedExtension` gains a defaulted
+`handler_registrations` field. Registrations are the authoritative runtime
+source after load; `hooks` is a compatibility projection.
+
+For `LoadedExtension(hooks=...)` and legacy extension objects that do not carry
+registrations, plan compilation synthesizes registrations in extension order,
+mapping insertion order, and handler-list order. When explicit registrations
+exist, the loader derives the compatibility `hooks` projection from them;
+conflicting dual input produces a diagnostic instead of running a handler
+twice.
+
+The contribution API remains source compatible:
+
+```python
+api.on("context", handler)
+api.on(
+    "context",
+    handler,
+    route_id="redact-secrets",
+    priority=20,
+    after=("extension:base-context",),
+    on_error="fail_chain",
+)
+```
+
+The existing manifest `handler` field is not a reliable runtime route identity
+and is not used for ordering in this batch. Runtime ordering is declared by the
+registration API or by programmatic surface descriptors. A future manifest
+extension must add an explicit route id and exact API/manifest matching with
+unmatched and ambiguous diagnostics; it must not infer identity from an event
+or Python function name.
+
+### Stable Ordering
+
+Ordering is compiled per event with these precedence rules:
+
+1. active routes only;
+2. explicit `before` and `after` edges;
+3. higher numeric priority first among otherwise ready routes;
+4. original extension and handler registration order as the final tie-breaker.
+
+The planner computes strongly connected components, preserves edges between
+components, and topologically sorts the condensed graph. A ready set uses
+`(-priority, registration_index)`. Cycles produce an
+`extension_route_order_cycle` diagnostic with the affected route ids; internal
+edges of that component are dropped and its routes use priority plus
+registration order. Incoming, outgoing, and unrelated acyclic constraints
+remain valid. The router never chooses a different winner based on filesystem
+enumeration order.
+
+### Dispatch Modes
+
+`ExtensionRouter` provides four product-neutral operations over a compiled
+plan:
+
+- `observe`: invoke every route and collect non-`None` results;
+- `first`: stop at the first result accepted by an injected predicate;
+- `reduce`: let an injected reducer combine each result with opaque state;
+- `intercept`: a reduce specialization whose reducer may stop the chain.
+
+The generic reduction contract is:
+
+```python
+@dataclass(frozen=True)
+class RouteStep(Generic[S]):
+    state: S
+    stop: bool = False
+
+
+Reducer = Callable[
+    [S, object, ResolvedExtensionRoute],
+    RouteStep[S] | Awaitable[RouteStep[S]],
+]
+
+async def reduce(
+    event_name: str,
+    state: S,
+    *,
+    event_factory: Callable[[S, ResolvedExtensionRoute], object],
+    reducer: Reducer[S],
+    context_factory: Callable[[LoadedExtension], object],
+) -> RouteStep[S]: ...
+```
+
+Every route receives an event created from the latest state. A handler result
+of `None` skips the reducer. The reducer receives the resolved route so Product
+diagnostics retain source identity. Reducers may be synchronous or async;
+reducer, event-factory, and predicate errors are Product errors and propagate
+unchanged. Only handler invocation is governed by the route's `on_error`.
+`stop=True` returns immediately with the latest state. `observe` returns the
+ordered non-`None` results and `first` returns the first predicate match or
+`None`.
+
+Harness schedules handlers and contains handler failures; Product code
+validates and interprets Product-specific results. This replaces duplicated
+loops without moving `AgentMessage`, `ToolCall`, session-decision, prompt, or
+artifact types into Harness.
+
+`ExtensionDispatcher` remains as a compatibility facade over
+`ExtensionRouter`. Its existing `dispatch`, `dispatch_first_truthy`, and
+`dispatch_input` behavior remains stable.
+
+When a handler fails:
+
+- `on_error="skip"` records a provenance-bearing diagnostic, invokes the
+  runtime error callback, and continues;
+- `on_error="fail_chain"` records the same diagnostic and raises a typed
+  `ExtensionRouteError` after invoking the callback;
+- cancellation exceptions are not converted into diagnostics;
+- invalid Product results are reported by the injected Product reducer, not by
+  generic Harness routing.
+
+The runtime error callback is best-effort: callback failure cannot turn a
+`skip` route into a failed chain. For `fail_chain`, the router always raises
+`ExtensionRouteError` chained from the original handler error. The router
+catches `Exception`, not `BaseException`, so cancellation, process exit, and
+keyboard interruption retain normal propagation.
+
+`ExtensionResourceRuntime` consumes the same compiled route order for resource
+hooks but retains contribution aggregation semantics. This avoids a second
+ordering implementation while keeping resource result interpretation in the
+focused resource runtime.
+
+## Policy Runtime
+
+### Neutral Subjects
+
+Harness replaces the string-only evaluator protocol with focused standard
+subjects rather than a free-form attributes bag:
+
+```python
+@dataclass(frozen=True)
+class CommandPolicySubject:
+    command: tuple[str, ...]
+    cwd: str | None
+    direct_tokens: tuple[str, ...]
+    shell_payload: str | None = None
+    normalization_complete: bool = True
+
+
+@dataclass(frozen=True)
+class PathPolicySubject:
+    raw_path: str
+    resolved_path: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolPolicySubject:
+    tool_name: str
+    arguments: Mapping[str, object]
+    cwd: str | None = None
+    command: CommandPolicySubject | None = None
+    paths: tuple[PathPolicySubject, ...] = ()
+
+
+@dataclass(frozen=True)
+class CustomPolicySubject:
+    kind: str
+    value: object | None = None
+```
+
+`PolicySubject` is the union of these records. Product-defined kinds use
+`CustomPolicySubject`; Harness does not interpret their payloads. Constructors
+copy tool argument mappings and sequence fields into immutable JSON-like
+snapshots with string-only mapping keys; unsupported mutable or opaque leaves
+are rejected. `CustomPolicySubject.value` remains the explicit escape hatch for
+Product-owned opaque values. Workspace enforcement creates this snapshot once
+before any await and uses it for evaluation, legacy adapters, audit events,
+approval requests, and error projection. An injected `policy_subject` must
+match the explicit execution tool, arguments, cwd, paths, and comparable command
+projection or evaluation fails closed.
+
+The canonical command subject is built from the final `ExecRequest.command`,
+`stdin`, and cwd after command prefix, selected shell path, spawn-hook rewriting,
+and other execution adapters have run. Reconstructing it from raw bash
+arguments is not allowed. When a supported shell reads a script from stdin,
+that script is the shell payload; stdin supplied to a `-c` command or script
+file remains data and is not reclassified. Relative operands are anchored to
+the effective cwd (or the process cwd when execution inherits it); controlled
+path-identity checks recognize symlinks and `/proc/*/root` aliases to stdin.
+Restricted shell names and `+` invocation options share the corresponding
+shell parser. Shell entrypoints are classified by executable identity, using
+the last `PATH` value in the final execution environment for bare names. Empty
+and relative `PATH` entries are anchored to the effective execution cwd, not
+the host process cwd. Absolute, relative, and `PATH` aliases therefore use the
+parser for the shell they actually reference; a deceptive basename cannot
+select a different parser. An independently copied executable with a known
+shell basename uses that shell parser but remains incomplete because its
+physical identity is not trusted. Suspected stdin/fd aliases and unresolved
+stdin-consuming entrypoints set
+`normalization_complete=False`. Tool-name and path policy may run earlier, but
+command policy runs against the final spawn argv, cwd, environment, and stdin
+projection supplied to the backend.
+
+Before any policy or approval await, the Bash execution boundary materializes
+the final `ExecRequest`. Materialization resolves an inherited cwd to an
+absolute path and snapshots the complete environment after applying the public
+`ExecRequest.env` overrides. The override tuple remains the Product-visible
+projection used by approval and audit records; the complete
+`effective_environment` snapshot is execution-only state and may contain
+credentials. Policy normalization and the executor consume the same
+materialized request. `ExecService` also materializes requests at its boundary
+and passes that exact request to custom `ExecBackend` implementations. A custom
+backend or `BashOperations` implementation must honor the
+materialized `cwd` and `effective_environment` instead of rereading process
+state. Bash materializes unconditionally before policy or the first async tool
+update, including when no policy evaluator is configured. This binds cwd and
+environment across asynchronous evaluation, approval, presentation, and
+execution without rewriting argv semantics.
+
+Command policy is a control-plane guardrail, not a filesystem sandbox. Shell
+and wrapper normalization may inspect executable identity to project the
+current command, but Harness deliberately does not rewrite or freeze executable
+paths, `argv[0]`, shebang interpretation, executable bytes, files sourced by a
+shell, or lookup performed inside wrappers and shell payloads. Concurrent
+filesystem or executable-alias mutation is therefore outside this contract. A
+Product requiring adversarial check-to-execute isolation must combine policy
+with a sandbox or immutable execution image. Harness preserves native process
+semantics instead of claiming an incomplete executable snapshot.
+
+### Rules And Evaluation
+
+The evaluator protocol supports sync or async implementations and explicit
+abstention:
+
+```python
+class PolicyEvaluator(Protocol):
+    def evaluate(
+        self, subject: PolicySubject, /
+    ) -> MaybeAwaitable[PolicyDecision | None]: ...
+```
+
+`None` means that an evaluator does not apply; it is not an implicit allow.
+`evaluate_policy()` is the only invocation path. It awaits results, validates
+the result type and disposition, propagates cancellation, and wraps evaluator
+failures or invalid results in `PolicyEvaluationError`. Runtime failures never
+silently allow an operation. Invalid contributed evaluator shapes are rejected
+during activation.
+
+`PolicyRule` contains a stable id, matcher, and `PolicyDecision`.
+`RulePolicyEvaluator` returns the first matching rule or `None`; it has no
+hidden default. The Product or enforcement adapter supplies the final explicit
+default after the composed chain abstains. `PolicyEvaluatorChain` composes
+injected evaluators with one of these strategies:
+
+- `first_non_allow`: deny or ask stops the chain; otherwise the first explicit
+  allow is returned after all evaluators run, or `None` when all abstain;
+- `most_restrictive`: all evaluators run in resolved order; deny wins over ask,
+  ask wins over allow, and the first result at the winning level supplies the
+  stable reason and code;
+- `first_decision`: the first non-`None` decision is authoritative.
+
+Harness supplies reusable exact-name, token-sequence, shell-payload, and path
+substring matchers. Command normalization unwraps supported `env` and `sudo`
+forms, recognizes shell `-c` payloads, and matches direct argv by token rather
+than accidental substring. These are process-execution mechanics, not Coding
+policy. Platform-dependent or lossy forms such as `env -S`, unknown wrapper
+options, and `sudo` shell/login mode retain the best available projection but
+set `normalization_complete=False`. Harness exposes an incomplete-command
+matcher; the Product owns the fallback. Coding defaults unresolved command
+syntax to approval instead of allowing it silently. Wrapper operations that
+change executable lookup, including inline `PATH`, `env -u PATH`, and
+environment clearing (`env -i`, `--ignore-environment`, or lone `-`), are
+incomplete until their resulting lookup environment can be projected exactly.
+The same applies to `env --argv0`, shell-startup environment changes
+(`BASH_ENV`/`ENV`), and a `sudo` environment assignment that changes command
+projection. Explicit Bash startup files (`--rcfile`/`--init-file`) are
+incomplete; when they resolve to stdin, their payload is combined with the
+command payload. Common BusyBox/Toybox `sh`, `ash`, and `env` applet forms are
+projected without treating unrelated multicall applets as shells.
+Reusable Bash execution parses string commands through the configured shell.
+For argv commands it selects a shell parser only from executable identity or a
+known shell name; other resolved executables remain direct argv, while an
+unresolved stdin entrypoint is incomplete. Coding compatibility evaluation
+paths consume the same environment projection as the executable Harness
+boundary; they do not recompute commands against the host's unrelated `PATH`.
+
+Coding's `PolicyEngine` remains the public Product adapter. It constructs
+Harness rules from Coding configuration and supplies Coding's current default
+blocked/ask lists, decision codes, and reason strings. Existing
+`evaluate_action` and `evaluate_tool_call` methods remain compatible. These
+compatibility methods materialize their input for a point-in-time decision, but
+cannot return a replacement request to a caller. A caller that evaluates and
+then executes must materialize first and pass the same `ExecRequest` to both
+the compatibility evaluator and the backend. Coding's production Bash path
+does so; compatibility evaluation alone does not promise binding to a later
+execution of an unmaterialized request.
+
+The workspace policy layer consumes a single subject evaluator adapter defined
+beside the Harness policy runtime. A transition adapter recognizes existing
+duck-typed `evaluate_tool_call` and `evaluate_action` implementations, preserving
+their call order and results; unknown objects are rejected rather than treated
+as no policy. New implementations use only `evaluate(subject)`.
+
+The reusable workspace enforcement path owns a neutral audit vocabulary for
+policy evaluation and approval request/resolution, including final command argv
+and correlation ids. Products inject the sink and own redaction, projection into
+their session/event schemas, persistence, RPC/UI presentation, and compatibility
+field aliases. This keeps the mechanism observable without making Coding's
+event protocol a Harness contract.
+
+## Approval Broker
+
+`ApprovalBroker` is a Product-neutral `ApprovalResolver`. Each active pending
+set is confined to one event loop; after the set is empty, the same broker may
+be reused on a later loop. It owns correlation and lifecycle but not
+presentation:
+
+```python
+broker = ApprovalBroker(
+    fallback=HeadlessApprovalResolver(mode="deny"),
+    timeout_seconds=None,
+)
+broker.set_presenter(presenter)
+request = ensure_approval_action_id(request)
+decision = await broker.resolve(request)
+broker.resolve_request(action_id, ApprovalDecision.allow())
+```
+
+`ensure_approval_action_id()` returns an immutable request with a generated id
+when needed. Enforcement calls it before emitting the approval-requested audit
+event, then passes the same request to the broker so requested, resolved, and
+error records use one id. `ApprovalBroker.resolve()` also calls the helper
+idempotently, so the broker remains substitutable for any `ApprovalResolver`
+when a direct caller supplies no id. The broker atomically reserves the final id
+before calling the presenter. An action id that is pending or was already
+presented interactively by the same live broker raises
+`ApprovalRequestCollisionError`; this tombstone prevents a late result from an
+older session generation from approving a new request. Presenter absence and a
+disposed broker go directly to fallback resolution. `dispose()` clears the
+tombstones because presenter rebinding is then forbidden.
+
+`ApprovalRequest.arguments` accepts JSON-like mappings, sequences, strings,
+numbers, booleans, and null. Construction copies and freezes that tree; mutable
+or opaque leaves are rejected. `approval_request_to_dict()` is the stable
+Product projection and returns detached ordinary dictionaries and lists. It
+deliberately omits the evaluator-owned `policy_decision` object, which is not a
+wire contract.
+
+An `ApprovalPresenter` implements
+`present(request) -> MaybeAwaitable[None]`. The Product adapter converts the
+request into UI, RPC, or event payloads. Only presenter absence uses the
+fallback resolver. Presenter exceptions remove the pending request and
+propagate; they do not leave a hidden future. A synchronous presenter may
+resolve the request reentrantly because reservation happens before
+presentation. A presenter may also expose optional `dismiss(request)` lifecycle
+projection. Synchronous dismissal runs during broker cleanup; an awaitable is
+detached and its result consumed, so UI cleanup cannot delay or replace the
+authorization result. If an asynchronous presenter resists cancellation and
+finishes after broker cleanup, the broker dismisses the request again after
+that late completion so the stale presentation cannot remain visible. Product
+dismissers must therefore be idempotent and tolerate repeated cleanup for the
+same action id.
+
+Lifecycle rules are explicit:
+
+- caller cancellation removes and cancels the pending future;
+- timeout delegates to the fallback resolver while the request remains pending;
+  explicit cancellation or disposal can still win before fallback completes;
+- `cancel_request` accepts an injected `ApprovalDecision` and completes one
+  request;
+- `cancel_all` and `dispose` accept an injected decision and complete every
+  pending request deterministically;
+- `dispose` is idempotent and rejects new interactive requests through the
+  fallback resolver;
+- unknown, duplicate, or late results return `False` without mutation;
+- presenter replacement affects only requests created after replacement;
+- snapshots expose immutable request records, never futures.
+
+All externally supplied terminal `ApprovalDecision` values are revalidated,
+including already-instantiated values that may have been deserialized or
+mutated outside normal dataclass construction.
+
+Normal result, timeout, cancellation, and disposal compete through one
+complete-once primitive. Fallback resolution always uses `resolve_approval()`
+for sync/async handling and result validation; a broker rejects itself as its
+fallback. An unfinished fallback is cancelled and detached when an explicit
+decision wins. Presenter and fallback failures propagate after cleanup. The broker
+does not manufacture Product cancellation or disposal wording.
+
+Coding's `InteractiveApprovalResolver` becomes a composition facade over
+`ApprovalBroker`. It retains `set_request_presenter` and
+`handle_result`, converts request objects to the existing Coding dictionary
+payload, hides broker internals, and preserves accepted import paths and
+`__module__`. The resolver is runtime-owned and shared by tool definitions and
+successive sessions. Session disposal cancels only that generation's pending
+requests; it does not unbind the presenter. The host UI owns presenter binding
+for its lifetime and unbinds it on UI shutdown, so new/resume/fork replacement
+does not silently fall back to headless denial. `AgentSession` seals and
+cancels its approval generation before waiting for the host to become idle;
+replacement candidates remain staged and cannot change shared approval state.
+Every runtime replacement entrypoint reopens the shared resolver only in host
+activation, after the old session has been released. This ordering prevents a
+running operation waiting for approval from deadlocking session teardown while
+ensuring repeated cleanup from the old session cannot close the new one. Coding's
+Screen TUI projects
+Escape as rejection and queues concurrent approvals FIFO, ensuring that closing
+or replacing an overlay never leaves a broker future hidden. It subscribes to
+the host's post-release, pre-activation invalidation notification without
+replacing the primary fail-fast lifecycle callback. Notification failures are
+isolated after the old session is disposed, so early UI cleanup cannot make a
+rolled-back live approval invisible. The TUI clears old-generation surfaces on
+replacement and consumes broker
+dismissal for timeout or caller cancellation. Approval callback failure
+terminates the TUI path only after presenter teardown cancels all pending
+requests fail-closed.
+
+Session generation state and presenter attachment are separate. Detaching a
+presenter denies the active pending set and removes the UI binding, but the same
+active generation may later attach a presenter and reopen interactive
+resolution. Staged or closed generations cannot rebind or unbind the shared
+presenter. TUI shutdown always resolves the runtime's current session instead
+of using the session captured at initial startup.
+
+The Coding CLI passes the runtime-owned interactive resolver to runtime
+builders that declare `approval_resolver` or accept arbitrary keyword
+arguments. Injected legacy builders with the previous fixed keyword signature
+continue to receive only that signature; normal startup and help-time runtime
+discovery use the same compatibility invocation helper.
+
+## Policy And Approval Extension Contributions
+
+This batch adds executable `policy` and `approval` contribution paths, not only
+surface type strings. It does not allow an extension to bypass Product
+activation or trust checks.
+
+`ExtensionContributionAPI.register_policy()` and `register_approval()` create a
+focused `RegisteredControlContribution` containing a descriptor and a separate
+runtime value. Implementations are never hidden inside descriptor `metadata`.
+`LoadedExtension.control_contributions` carries these records and focused
+projection functions validate their evaluator or resolver protocol shape.
+
+Active policy contributions are interceptors composed by
+`PolicyEvaluatorChain` in resolved extension order. Policy contributions default
+to `on_error="fail_chain"`; `skip` must be selected explicitly for an advisory
+policy whose failure may safely abstain. Approval is an exclusive
+replacement slot: after Product/OEM activation filtering, the first resolved
+active contribution wins and additional active values produce a deterministic
+conflict diagnostic. The selected resolver may be supplied as the broker
+fallback; it is not a presenter. Product activation may select a different
+winner, but Harness never chains approval resolvers implicitly.
+`register_approval()` therefore fixes `on_error="fail_chain"` and does not expose
+a skip option. Directly constructed active approval records with skip semantics
+are rejected with an activation diagnostic. Harness wraps the selected resolver
+with its resolved route identity, validates synchronous and asynchronous
+results through `resolve_approval()`, and records a provenance-bearing
+`extension_approval_resolution_failed` diagnostic before propagating failure.
+Cancellation propagates without adding a failure diagnostic.
+
+The generic inventory indexes descriptors while the focused record carries the
+runtime value. Harness does not import Method or Channel to add their surface
+names; those owners must define their own processing paths first.
+
+Product/OEM code supplies each extension's activation decision. Harness then
+applies that decision uniformly at executable boundaries: hook and resource
+routes, policy and approval contributions, command/tool/flag/shortcut registry
+projection, message renderers, and runtime binding. Inactive extensions remain
+visible to inventory and diagnostics, but none of their capabilities are
+executable. A missing policy on a directly constructed legacy extension retains
+the compatibility meaning "already accepted by the caller."
+
+## Coding Cutover
+
+The Coding migration is completed in the same branch:
+
+| Current Coding owner | Result |
+| --- | --- |
+| `coding.extensions.hooks.HookDispatcher` | Compatibility facade using `ExtensionRouter`; Product Agent result coercion remains in Coding. |
+| Generic loops in `coding.extensions.runner.ExtensionRunner` | Replaced by router observe/reduce/first operations. Context creation and Product reducers remain in Coding. |
+| `coding.policy.approval.InteractiveApprovalResolver` | Thin payload adapter over Harness `ApprovalBroker`. |
+| Command parsing and generic matching in `coding.policy.engine` | Moved to Harness policy matchers/normalizers. |
+| `coding.policy.engine.PolicyEngine` | Product defaults and compatibility methods backed by Harness rules. |
+| Workspace tool policy protocol | Unified with Harness policy adapters; audit and Product error projection remain stable. |
+
+No compatibility module may retain a parallel routing, pending-request, command
+normalization, or rule-evaluation implementation.
+
+## Compatibility
+
+The following behavior remains stable, except that incomplete or
+platform-dependent command normalization now deliberately returns Product
+approval rather than implicit allow:
+
+- existing `api.on(event, handler)` calls;
+- existing `LoadedExtension.hooks` inspection;
+- insertion order when no ordering metadata is supplied;
+- Coding extension hook result types and validation diagnostics;
+- Coding `PolicyEngine` constructor arguments and outcomes for completely
+  normalized commands;
+- Coding approval presenter dictionaries and `handle_result` calls;
+- Coding approval payloads use the detached `approval_request_to_dict()`
+  projection rather than dataclass internals;
+- Harness approval and policy value-type identity through Coding re-exports;
+- tool-policy audit event names and detail keys;
+- top-level `loushang.harness.__all__` remains unchanged.
+
+New focused APIs are imported from `loushang.harness.extensions.routing`,
+`loushang.harness.policy`, and `loushang.harness.approval`; they are not promoted
+to the top-level Harness facade.
+
+## Delivery Plan
+
+1. Add route records, stable ordering, generic router, and compatibility
+   dispatch facade.
+2. Cut Coding observer, decision, context, before-agent, and tool hook loops over
+   to the router.
+3. Add neutral subjects, matchers, rules, evaluator chain, and workspace policy
+   adapter; rebuild Coding policy defaults on those mechanisms.
+4. Add `ApprovalBroker`; convert Coding interactive approval to a payload
+   adapter and wire session disposal.
+5. Add policy/approval extension-surface projection and a non-Coding OEM fixture
+   that exercises the complete control path.
+6. Remove duplicate implementations, update ownership documents, and add
+   architecture import guards.
+
+Each step must land with its focused tests in the same semantic branch. The
+branch is not integrated while Coding still has a second generic mechanism.
+
+## Validation Matrix
+
+### Extension Routing
+
+- stable insertion order with no metadata;
+- priority and before/after ordering;
+- missing-reference and cycle diagnostics;
+- skip and fail-chain behavior;
+- async and sync handlers;
+- cancellation propagation;
+- observer, first, reducer, and interceptor behavior;
+- Coding input, context, before-agent, session decision, and tool hooks.
+
+### Policy
+
+- exact tool matching and ordered rule precedence;
+- shell payload and direct argv normalization;
+- `env` and `sudo` wrapper handling;
+- executable identity, copied shell, wrapper-basename, relative/empty `PATH`,
+  and BusyBox/Toybox applet handling;
+- stdin script aliases use cwd-relative lexical normalization plus controlled
+  path-identity checks for symlink and proc-root aliases;
+- shell startup input through `--rcfile`, `--init-file`, `BASH_ENV`, and `ENV`;
+- incomplete and platform-specific wrapper syntax uses a Product fail-safe;
+- path raw/resolved candidate matching;
+- evaluator-chain strategies;
+- Coding default and configured outcomes;
+- workspace policy audit and enforcement compatibility.
+
+### Approval
+
+- presentation and result correlation;
+- missing presenter fallback;
+- presenter failure cleanup;
+- caller cancellation, timeout, explicit cancellation, and disposal;
+- duplicate and late results;
+- multiple concurrent requests;
+- UI Escape rejection and FIFO presentation of concurrent requests;
+- presenter continuity across runtime session replacement;
+- Coding dictionary projection compatibility.
+
+### Architecture And Integration
+
+- an independent OEM-shaped fixture registers an interceptor, contributes a
+  policy evaluator, suspends for approval, resumes, and reaches tool execution;
+- Harness import-boundary tests cover the new modules;
+- Coding compatibility identity and import tests remain green;
+- Ruff, mypy for touched packages, focused Harness/Coding tests, the complete
+  architecture suite, and the full non-live suite pass;
+- `git diff --check` reports no whitespace errors.
+
+## Exit Criteria
+
+This boundary is complete only when:
+
+1. Routing, policy matching, and pending approval lifecycle have one Harness
+   implementation each.
+2. Coding contains only Product defaults, Product result coercion, Product
+   presentation, and compatibility facades for these capabilities.
+3. A non-Coding fixture exercises the end-to-end control path without Product,
+   AI, Method, Work, Channel, or TUI imports.
+4. Existing Coding public behavior and snapshots remain compatible.
+5. The architecture documents and migration inventory describe implemented
+   ownership rather than planned ownership.

--- a/docs/internals/architecture/harness/extension-runtime-core-boundary.md
+++ b/docs/internals/architecture/harness/extension-runtime-core-boundary.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Status: implementation complete for integration into `lane/harness`.
+Status: implementation complete, including the follow-on control-plane routing
+closure, for integration into `lane/harness`.
 
 This boundary moves the product-neutral extension runtime core into
 `loushang.harness.extensions`. Coding remains a product adapter and preserves
@@ -21,8 +22,8 @@ Harness owns these mechanisms:
   attachment, and contribution projection;
 - deterministic command naming, first-wins flag/shortcut/tool resolution,
   source provenance, and duplicate diagnostics;
-- ordered failure-contained observer dispatch and sequential input
-  transformation;
+- stable dependency-aware route planning, failure-contained observer dispatch,
+  opaque-state reducers/interceptors, and sequential input transformation;
 - resource contribution execution and `promptPaths`, `skillPaths`, and
   `themePaths` normalization;
 - registered-tool execution wrapping with an injected context factory.
@@ -52,8 +53,8 @@ Coding keeps:
 - session switch/fork/compact/tree decisions and Coding event projection;
 - system-prompt augmentation, model/provider behavior, Agent tool-call result
   adaptation, compaction behavior, and UI integration;
-- the `ExtensionRunner` composition adapter that connects Harness engines to a
-  Coding session.
+- the `ExtensionRunner` composition adapter and Product reducers that connect
+  Harness routing to Coding session, prompt, context, and Agent result types.
 
 `loushang.coding.extensions.loader.ExtensionLoader` now only injects the Coding
 API factory, Coding permission policy, and legacy event names into the Harness
@@ -79,16 +80,16 @@ Extensions fall into three categories with different execution semantics:
 | Category | Behaviour | Failure strategy | Examples |
 | --- | --- | --- | --- |
 | **Contribution** | All declarations are aggregated; each runs independently | One failure produces a diagnostic; others continue | tool, command, skill, method, prompt, resource_root |
-| **Interceptor** | Handlers form a pipeline; each sees the output of the previous | Step failure is governed by `on_error` (skip / fail_chain) | hook, policy, approval |
-| **Replacement** | Only one active provider per slot; later registrations replace earlier ones | Not applicable — only one runs | model_provider, channel adapter, storage backend |
+| **Interceptor** | Handlers form a pipeline; each sees the output of the previous | Step failure is governed by `on_error` (skip / fail_chain) | hook, policy |
+| **Replacement** | Only one active provider per slot; the first active provider in resolved order wins and conflicts are diagnosed | Failure propagates to the Product-selected fallback; there is no chain to skip | approval, model_provider, channel adapter, storage backend |
 
 Harness owns the scheduling categories. Product adapters and OEMs decide
 which extensions are active in each category and inject policy for each slot.
 
 ## Extension Routing And Ordering
 
-Current extension execution uses insertion order. The descriptor already
-carries `priority` and should grow explicit ordering and error-policy fields:
+Extension execution is compiled into an event-scoped route plan. The descriptor
+and registered-handler records carry explicit ordering and error-policy fields:
 
 ```python
 @dataclass(frozen=True)
@@ -99,21 +100,27 @@ class ExtensionSurfaceDescriptor:
     source_path: Path
     active: bool = True
     priority: int = 0
-    after: tuple[str, ...] = ()       # run after these surfaces (by name or extension_id)
-    before: tuple[str, ...] = ()      # run before these surfaces
-    on_error: Literal["skip", "fail_chain"] = "skip"
     permission_requirements: tuple[str, ...] = ()
     diagnostics: tuple[ResourceDiagnostic, ...] = ()
     metadata: dict[str, object] = field(default_factory=dict)
+    # Appended to preserve the legacy positional constructor contract.
+    after: tuple[str, ...] = ()       # canonical route/extension references
+    before: tuple[str, ...] = ()
+    on_error: Literal["skip", "fail_chain"] = "skip"
 ```
 
-When `after` or `before` constraints create a cycle, harness emits a diagnostic
-and falls back to insertion order for the conflicting set.
+Routes use stable topological ordering with priority and registration order as
+tie-breakers. When `after` or `before` constraints create a cycle, Harness
+preserves edges outside the strongly connected component, emits a diagnostic,
+and uses priority plus registration order inside the conflicting component.
+Legacy `LoadedExtension.hooks` values synthesize registrations in existing
+extension and handler order.
 
 ## ExtensionSurfaceType Gaps
 
-The current `ExtensionSurfaceType` literal covers nine surfaces. Several
-surface types that OEM products need are not yet defined:
+The control-plane closure adds executable `policy` and `approval` contribution
+paths. Method and Channel surfaces remain owned by their respective layers and
+are not added as unprocessed Harness vocabulary:
 
 ```python
 ExtensionSurfaceType = Literal[
@@ -127,21 +134,23 @@ ExtensionSurfaceType = Literal[
     "ui",
     "autocomplete",
     "resource_root",
-    # proposed — each requires a harness processing path
-    "policy",          # inject a PolicyEvaluator
-    "approval",        # inject an ApprovalResolver
-    "method",          # register a method resource
-    "channel",         # register a channel adapter
+    # implemented control-plane contributions
+    "policy",          # inject a PolicyEvaluator chain member
+    "approval",        # select an ApprovalResolver replacement
 ]
 ```
 
-Each new surface type requires:
-1. a `from_surface()` factory in the corresponding Harness module that loads
-   and validates the extension's source;
-2. an injection path from `ExtensionInventory` to the Harness engine that
-   consumes it (e.g. host runtime, policy broker, channel registry);
-3. contract tests proving an OEM can ship the surface in a plugin without
-   importing product packages.
+Runtime values use focused control-contribution records rather than mutable
+descriptor metadata. Policy contributions compose in resolved route order;
+approval is an exclusive replacement slot with deterministic conflict
+diagnostics. Policy contributions fail the chain by default; advisory skip
+semantics must be explicit. The selected approval replacement validates its
+result and reports route/source diagnostics before propagating failures, while
+cancellation remains undiagnosed. Product/OEM code supplies activation and
+trust decisions before composition; Harness applies inactive filtering
+consistently across executable surfaces. See the
+[Control Plane Runtime Boundary](control-plane-runtime-boundary.md) for the
+runtime contracts and compatibility matrix.
 
 ## Failure And Ordering Contract
 

--- a/docs/internals/architecture/harness/host-turn-session-orchestration-core.md
+++ b/docs/internals/architecture/harness/host-turn-session-orchestration-core.md
@@ -72,6 +72,24 @@ Product runtime failure. Activation and after-commit failures still propagate
 after the new candidate becomes current, matching the accepted session
 transition contract.
 
+`SessionTransitionHost` also exposes post-release invalidation notifications.
+They run after the previous session is disposed and the current slot is cleared,
+but before candidate activation. Unlike the existing primary and subscribed
+before-invalidate callbacks, these notifications are non-veto observers:
+ordinary observer failures are isolated so cleanup projections cannot roll a
+transition back after the old runtime has already been released. Cancellation
+still propagates. An observer may schedule a later transition, but direct
+same-task replacement or disposal re-entry is rejected because the outer
+candidate has not yet reached activation.
+
+The release boundary is split around its irreversible step. Product
+before-release callbacks and primary/before-invalidate callbacks run while the
+old session is still current and may veto the transition. After they succeed,
+the host clears the current slot before calling the session disposer. A disposer
+failure or cancellation therefore propagates without republishing an object
+that may already be partly or fully finalized; an uncommitted candidate is
+still rolled back by `SessionOperationCoordinator`.
+
 ## Product Ownership
 
 Coding and future Product adapters retain:

--- a/docs/internals/architecture/harness/oem-extension-architecture.md
+++ b/docs/internals/architecture/harness/oem-extension-architecture.md
@@ -131,30 +131,32 @@ This categorisation is important because OEMs typically need all three:
 | Category | Execution | OEM use case |
 | --- | --- | --- |
 | **Contribution** (aggregate) | All declarations run independently; failure is isolated | Ship custom tools, commands, methods, skills |
-| **Interceptor** (pipeline) | Handlers form a pipeline; each sees previous output; failure governed by `on_error` | Ship custom hooks, policy evaluators, approval resolvers |
-| **Replacement** (exclusive) | Only one active per slot | Ship custom model providers, channel adapters, storage backends |
+| **Interceptor** (pipeline) | Handlers form a pipeline; each sees previous output; failure governed by `on_error` | Ship custom hooks and policy evaluators |
+| **Replacement** (exclusive) | Only one active per slot; failure propagates to the Product-selected fallback | Ship approval resolvers, custom model providers, channel adapters, storage backends |
 
-Current harness extension dispatch only supports contribution-type execution
-with stable insertion order. Interceptor pipelines and replacement slots
-require the ordering and routing extensions described in
-[Extension Runtime Core Boundary](extension-runtime-core-boundary.md#extension-routing-and-ordering).
+Harness extension dispatch now provides stable dependency-aware observer,
+interceptor, reducer, and first-match routing. Policy contributions use the
+interceptor chain; approval contributions use an exclusive replacement slot.
+The Product/OEM layer still supplies activation and trust decisions; Harness
+enforces them while building executable routes and registries. See the
+[Control Plane Runtime Boundary](control-plane-runtime-boundary.md).
 
 ## ExtensionSurfaceType Gaps
 
-The current nine surface types are sufficient for contribution-focused OEMs
-but insufficient for OEMs that need to inject policy, approval, methods, or
-channel adapters through an extension package.
+Policy and approval now have focused runtime contribution records and injection
+paths. Method and Channel remain outside Harness until their owning layers
+define corresponding registries.
 
 Missing surface types and the harness processing path each requires:
 
 | Surface type | What it carries | Harness processing path |
 | --- | --- | --- |
-| `policy` | A `PolicyEvaluator` implementation | Host or harness policy broker loads and injects it |
-| `approval` | An `ApprovalResolver` implementation | Harness approval broker loads and injects it |
+| `policy` | A `PolicyEvaluator` implementation | Harness validates it and composes it into the resolved evaluator chain |
+| `approval` | An `ApprovalResolver` implementation | Harness validates the exclusive replacement and supplies it to the approval broker |
 | `method` | A method resource (`METHOD.md` or `SKILL.md` path) | Method loader discovers and registers it |
 | `channel` | A channel adapter (transport + encoding) | Channel registry accepts and activates it |
 
-Each new surface type needs:
+The remaining Method and Channel surface types each need:
 1. A `from_surface()` factory in the corresponding harness module.
 2. An injection path from `ExtensionInventory` to the harness engine.
 3. Contract tests proving an OEM can ship the surface in a plugin without

--- a/docs/internals/architecture/harness/shared-capability-boundaries.md
+++ b/docs/internals/architecture/harness/shared-capability-boundaries.md
@@ -117,8 +117,10 @@ Product adapters own:
 - explanations shown to users;
 - default approval rules.
 
-The first harness migration should keep interactive resolvers outside harness
-unless a neutral broker can be expressed without importing UI callbacks.
+The neutral `ApprovalBroker` now owns correlation, pending futures, timeout,
+cancellation, fallback, and disposal without importing UI callbacks. Product
+interactive resolvers remain payload/presentation facades over that broker and
+continue to own all displayed wording and persisted grants.
 
 ## Presentation And Renderers
 

--- a/docs/internals/architecture/harness/slice-1-status.md
+++ b/docs/internals/architecture/harness/slice-1-status.md
@@ -9,6 +9,12 @@ harness migration is complete, and it does not make `lane/harness` ready to
 merge directly to `main`. The lane remains the integration branch for follow-on
 harness slices and product-adapter verification.
 
+This document is a historical closure record. The later
+[Control Plane Runtime Boundary](control-plane-runtime-boundary.md) moves
+pending approval lifecycle and neutral policy mechanisms into Harness while
+preserving Coding presentation and risk defaults; its ownership supersedes the
+"Coding Still Owns" snapshot below.
+
 Slice 1 delivered neutral approval, tools-core, tool-contribution, and
 presentation substrate while preserving coding behavior through compatibility
 adapters.
@@ -111,7 +117,7 @@ Presentation:
 - `ToolRenderRuntime` state, last-rendered, invalidation, and renderer
   fail-soft behavior
 
-## Coding Still Owns
+## Coding Still Owns At Slice 1 Closure
 
 Coding still owns product semantics and concrete runtime behavior:
 

--- a/docs/internals/architecture/harness/workspace-execution-boundary.md
+++ b/docs/internals/architecture/harness/workspace-execution-boundary.md
@@ -73,6 +73,21 @@ The request capture fields remain caller-supplied neutral configuration. Their
 current defaults are preserved for compatibility; harness does not decide which
 commands a product may run.
 
+`materialize_exec_request()` freezes inherited cwd and the complete merged
+environment before a request crosses an asynchronous policy or execution
+boundary. `ExecRequest.env` remains the caller-visible override set;
+`effective_environment` is the execution-only snapshot and must not be copied
+into approval, audit, or transcript projections. `ExecService` passes the
+materialized request to custom `ExecBackend` implementations, which must honor
+its `cwd` and `effective_environment` without rereading host process state. A
+caller that performs policy evaluation separately must materialize once and use
+the same request for evaluation and execution.
+
+Materialization deliberately preserves the requested command and native
+`argv[0]`/shebang/wrapper behavior. It does not freeze executable lookup,
+executable bytes, or arbitrary files read by a child process. It is a cwd and
+environment binding contract, not a sandbox or immutable filesystem guarantee.
+
 ## Compatibility
 
 Harness-owned classes keep their harness `__module__` and are not exported from

--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -28,6 +28,7 @@ from loushang.coding.package.source_manager import (
     PackageSourceResolver,
     package_source_scopes,
 )
+from loushang.coding.policy import InteractiveApprovalResolver
 from loushang.coding.prompt import assemble_prompt
 from loushang.coding.runtime import AgentSessionRuntime
 from loushang.coding.session import AgentSession
@@ -165,7 +166,8 @@ def create_services(
     return BootstrapServices(
         settings_manager=resolved_settings_manager,
         model_registry=model_registry,
-        auth_manager=auth_manager or AuthManager(ai_registry=model_registry.ai_registry),
+        auth_manager=auth_manager
+        or AuthManager(ai_registry=model_registry.ai_registry),
         resource_loader=resource_loader or DefaultResourceLoader(),
         diagnostics_service=DiagnosticsService(),
         exec_service=exec_service or ExecService(),
@@ -221,13 +223,19 @@ def create_agent_session_services(
             default_model,
         )
     ):
-        raise ValueError("service components cannot be overridden when services is provided")
+        raise ValueError(
+            "service components cannot be overridden when services is provided"
+        )
 
-    _apply_resource_loader_options(resolved_services.resource_loader, resource_loader_options)
+    _apply_resource_loader_options(
+        resolved_services.resource_loader, resource_loader_options
+    )
     resource_bundle = resolved_services.resource_loader.discover_resources(resolved_cwd)
     loader_diagnostics = tuple(resource_bundle.diagnostics)
     extension_runner = ExtensionRunner(resource_bundle.extensions)
-    flag_diagnostics = _apply_extension_flag_values(extension_runner, extension_flag_values)
+    flag_diagnostics = _apply_extension_flag_values(
+        extension_runner, extension_flag_values
+    )
     resource_bundle = extension_runner.discover_resources(resource_bundle)
     diagnostics = tuple(
         resolved_services.diagnostics_service.normalize_resource_diagnostic(
@@ -308,11 +316,16 @@ def create_agent_session(
     package_materializer: PackageMaterializer | None = None,
     append_system_prompt: list[str] | tuple[str, ...] | None = None,
     extension_flag_values: ExtensionFlagValues | None = None,
+    approval_resolver: InteractiveApprovalResolver | None = None,
 ) -> AgentSession:
     services = services or create_services()
     settings = services.settings_manager.get_settings()
-    resolved_package_materializer = package_materializer or _default_package_materializer(session_manager)
-    resolved_thinking = settings.thinking_level if thinking_level is None else thinking_level
+    resolved_package_materializer = (
+        package_materializer or _default_package_materializer(session_manager)
+    )
+    resolved_thinking = (
+        settings.thinking_level if thinking_level is None else thinking_level
+    )
     session_id = session_manager.get_header().id
     configuration = _activate_session_configuration(
         settings=settings,
@@ -325,10 +338,21 @@ def create_agent_session(
     extension_runner = _require_configured_extension_runner(configuration)
     cwd_bound_services_audit = configuration.cwd_bound_services_audit
     loader_system_prompt = _loader_system_prompt_override(services.resource_loader)
-    base_prompt = system_prompt if system_prompt is not None else loader_system_prompt if loader_system_prompt is not None else settings.system_prompt
-    append_fragments = [*_loader_append_system_prompt(services.resource_loader), *(append_system_prompt or ())]
+    base_prompt = (
+        system_prompt
+        if system_prompt is not None
+        else loader_system_prompt
+        if loader_system_prompt is not None
+        else settings.system_prompt
+    )
+    append_fragments = [
+        *_loader_append_system_prompt(services.resource_loader),
+        *(append_system_prompt or ()),
+    ]
     base_prompt = _append_system_prompt_fragments(base_prompt, append_fragments)
-    prompt_assembly = assemble_prompt(base_prompt=base_prompt, resource_bundle=resource_bundle)
+    prompt_assembly = assemble_prompt(
+        base_prompt=base_prompt, resource_bundle=resource_bundle
+    )
     resolved_prompt = prompt_assembly.system_prompt
     resolved_model: Model | None
     if model is None:
@@ -346,7 +370,9 @@ def create_agent_session(
 
     no_tools_mode = _normalize_no_tools(no_tools)
     resolved_tool_registry = tool_registry
-    allowed_tool_names_set = set(allowed_tool_names) if allowed_tool_names is not None else None
+    allowed_tool_names_set = (
+        set(allowed_tool_names) if allowed_tool_names is not None else None
+    )
     if no_tools_mode == "all":
         allowed_tool_names_set = set()
     if resolved_tool_registry is None and tools:
@@ -354,10 +380,12 @@ def create_agent_session(
         for tool in tools:
             resolved_tool_registry.register_tool(tool)
 
-    resource_bundle, resolved_tool_registry, extension_tool_diagnostics = _register_extension_tools(
-        extension_runner=extension_runner,
-        resource_bundle=resource_bundle,
-        tool_registry=resolved_tool_registry,
+    resource_bundle, resolved_tool_registry, extension_tool_diagnostics = (
+        _register_extension_tools(
+            extension_runner=extension_runner,
+            resource_bundle=resource_bundle,
+            tool_registry=resolved_tool_registry,
+        )
     )
     _record_resource_diagnostics(
         diagnostics_service=services.diagnostics_service,
@@ -415,9 +443,12 @@ def create_agent_session(
         session_start_event=session_start_event,
         package_materializer=resolved_package_materializer,
         exec_service=services.exec_service,
+        approval_resolver=approval_resolver,
     )
     session.cwd_bound_services_audit = cwd_bound_services_audit
-    scoped_models = _scoped_models_from_enabled_patterns(settings.enabled_models, services.model_registry)
+    scoped_models = _scoped_models_from_enabled_patterns(
+        settings.enabled_models, services.model_registry
+    )
     if scoped_models:
         session.setScopedModels(scoped_models)
     return session
@@ -706,9 +737,7 @@ def _record_default_model_unavailable(
         if selection.endpoint_id
         else f"{selection.provider}:{selection.model_id}"
     )
-    message = (
-        f"Default model unavailable: {selection_ref}; using startup fallback."
-    )
+    message = f"Default model unavailable: {selection_ref}; using startup fallback."
     diagnostics_service.record(
         diagnostics_service.normalize_error(
             code="default_model_unavailable",
@@ -764,6 +793,7 @@ def create_agent_session_from_services(
     session_start_event: SessionStartEvent | None = None,
     package_materializer: PackageMaterializer | None = None,
     append_system_prompt: list[str] | tuple[str, ...] | None = None,
+    approval_resolver: InteractiveApprovalResolver | None = None,
 ) -> CreateAgentSessionResult:
     extension_flag_values = (
         agent_services.extension_runner.get_flag_values()
@@ -787,6 +817,7 @@ def create_agent_session_from_services(
         package_materializer=package_materializer,
         append_system_prompt=append_system_prompt,
         extension_flag_values=extension_flag_values,
+        approval_resolver=approval_resolver,
     )
 
 
@@ -808,6 +839,7 @@ def create_agent_session_result(
     package_materializer: PackageMaterializer | None = None,
     append_system_prompt: list[str] | tuple[str, ...] | None = None,
     extension_flag_values: ExtensionFlagValues | None = None,
+    approval_resolver: InteractiveApprovalResolver | None = None,
 ) -> CreateAgentSessionResult:
     resolved_services = services or create_services()
     session = create_agent_session(
@@ -827,12 +859,15 @@ def create_agent_session_result(
         package_materializer=package_materializer,
         append_system_prompt=append_system_prompt,
         extension_flag_values=extension_flag_values,
+        approval_resolver=approval_resolver,
     )
     return CreateAgentSessionResult(
         session=session,
         resource_bundle=session.resource_bundle,
         diagnostics=tuple(
-            resolved_services.diagnostics_service.get_diagnostics(session_id=session.session_id)
+            resolved_services.diagnostics_service.get_diagnostics(
+                session_id=session.session_id
+            )
         ),
         cwd_bound_services_audit=session.cwd_bound_services_audit,
     )
@@ -887,7 +922,9 @@ def _apply_extension_flag_values(
     return diagnostics
 
 
-def _default_package_materializer(session_manager: SessionManager) -> PackageMaterializer:
+def _default_package_materializer(
+    session_manager: SessionManager,
+) -> PackageMaterializer:
     session_dir = session_manager.get_session_dir()
     if session_dir.name == "sessions":
         install_root = session_dir.parent / "packages"
@@ -930,8 +967,16 @@ def _loader_append_system_prompt(resource_loader: object) -> list[str]:
 
 
 def _append_system_prompt_fragments(base_prompt: str, fragments: list[str]) -> str:
-    parts = [base_prompt.strip()] if isinstance(base_prompt, str) and base_prompt.strip() else []
-    parts.extend(fragment.strip() for fragment in fragments if isinstance(fragment, str) and fragment.strip())
+    parts = (
+        [base_prompt.strip()]
+        if isinstance(base_prompt, str) and base_prompt.strip()
+        else []
+    )
+    parts.extend(
+        fragment.strip()
+        for fragment in fragments
+        if isinstance(fragment, str) and fragment.strip()
+    )
     return "\n\n".join(parts)
 
 
@@ -973,7 +1018,11 @@ def _reload_model_registry_with_project_layer(
     session_cwd: str,
     auth_manager: AuthManager | None = None,
 ) -> None:
-    project_root = resource_bundle.agents_path.parent if resource_bundle.agents_path is not None else Path(session_cwd)
+    project_root = (
+        resource_bundle.agents_path.parent
+        if resource_bundle.agents_path is not None
+        else Path(session_cwd)
+    )
     project_models_dir = project_root / ".loushang" / "models"
     if not project_models_dir.is_dir():
         return
@@ -1045,7 +1094,11 @@ def _scoped_models_from_enabled_patterns(
 
 def _split_model_thinking_pattern(pattern: str) -> tuple[str, ThinkingLevel | None]:
     name, separator, suffix = pattern.rpartition(":")
-    if separator and suffix in {"off", "minimal", "low", "medium", "high", "xhigh"} and name:
+    if (
+        separator
+        and suffix in {"off", "minimal", "low", "medium", "high", "xhigh"}
+        and name
+    ):
         return name, suffix
     return pattern, None
 
@@ -1069,7 +1122,9 @@ def _register_extension_tools(
     )
     conflict_diagnostics = _extension_tool_conflict_diagnostics(resolution)
     diagnostics: list[ResourceDiagnostic] = list(conflict_diagnostics.values())
-    for contribution in _extension_tool_registration_contributions(resolution, conflict_names=set(conflict_diagnostics)):
+    for contribution in _extension_tool_registration_contributions(
+        resolution, conflict_names=set(conflict_diagnostics)
+    ):
         resolved_tool_registry.register_tool(
             contribution.definition,
             source_info=contribution.source_info,
@@ -1109,7 +1164,9 @@ def _extension_tool_registration_contributions(
     return tuple(contributions)
 
 
-def _extension_tool_contributions(extension_runner: ExtensionRunner) -> tuple[ToolContribution, ...]:
+def _extension_tool_contributions(
+    extension_runner: ExtensionRunner,
+) -> tuple[ToolContribution, ...]:
     return tuple(
         ToolContribution(
             definition,
@@ -1123,7 +1180,9 @@ def _extension_tool_contributions(extension_runner: ExtensionRunner) -> tuple[To
     )
 
 
-def _extension_tool_conflict_diagnostics(resolution: ToolResolutionResult) -> dict[str, ResourceDiagnostic]:
+def _extension_tool_conflict_diagnostics(
+    resolution: ToolResolutionResult,
+) -> dict[str, ResourceDiagnostic]:
     conflicts: dict[str, ResourceDiagnostic] = {}
     for diagnostic in resolution.diagnostics:
         if diagnostic.code != "duplicate_tool":
@@ -1163,7 +1222,11 @@ def _replace_images_with_placeholder(message: Message) -> Message:
     filtered: list[object] = []
     for block in content:
         if getattr(block, "type", None) == "image":
-            if not (filtered and isinstance(filtered[-1], TextPart) and filtered[-1].text == placeholder.text):
+            if not (
+                filtered
+                and isinstance(filtered[-1], TextPart)
+                and filtered[-1].text == placeholder.text
+            ):
                 filtered.append(placeholder)
             continue
         filtered.append(block)
@@ -1200,13 +1263,21 @@ def _record_package_lockfile_diagnostics(
     for diagnostic in materializer.get_lockfile_diagnostics():
         diagnostics_service.capture_failure(
             code=str(diagnostic.get("code") or "package_lockfile_unreadable"),
-            error=str(diagnostic.get("message") or "Package lockfile could not be read."),
+            error=str(
+                diagnostic.get("message") or "Package lockfile could not be read."
+            ),
             phase="startup",
             source="bootstrap",
             level="warning",
             session_id=session_id,
-            source_path=Path(str(diagnostic["path"])) if isinstance(diagnostic.get("path"), str) else None,
-            details={key: value for key, value in diagnostic.items() if key not in {"code", "message", "path"}},
+            source_path=Path(str(diagnostic["path"]))
+            if isinstance(diagnostic.get("path"), str)
+            else None,
+            details={
+                key: value
+                for key, value in diagnostic.items()
+                if key not in {"code", "message", "path"}
+            },
         )
 
 
@@ -1351,6 +1422,7 @@ def create_agent_session_runtime(
     agent_factory: AgentFactory = Agent,
     persist: bool = True,
     append_system_prompt: list[str] | tuple[str, ...] | None = None,
+    approval_resolver: InteractiveApprovalResolver | None = None,
 ) -> AgentSessionRuntime:
     fixed_services = services if services is not None else create_services()
     runtime_diagnostics_service = fixed_services.diagnostics_service
@@ -1360,7 +1432,11 @@ def create_agent_session_runtime(
         *,
         session_start_event: SessionStartEvent | None = None,
     ) -> AgentSession:
-        session_services = services_factory(session_manager.get_cwd()) if services_factory is not None else fixed_services
+        session_services = (
+            services_factory(session_manager.get_cwd())
+            if services_factory is not None
+            else fixed_services
+        )
         session = create_agent_session(
             session_manager=session_manager,
             model=model,
@@ -1376,6 +1452,7 @@ def create_agent_session_runtime(
             agent_factory=agent_factory,
             session_start_event=session_start_event,
             append_system_prompt=append_system_prompt,
+            approval_resolver=approval_resolver,
         )
         if not persist:
             session.agent.session_id = None

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -110,20 +110,28 @@ def build_builtin_tool_registry(
     registry = ToolRegistry()
     tool_settings = _tool_settings_from_settings_manager(settings_manager)
     resolved_approval_resolver = (
-        approval_resolver if approval_resolver is not None else _approval_resolver_from_tool_settings(tool_settings)
+        approval_resolver
+        if approval_resolver is not None
+        else _approval_resolver_from_tool_settings(tool_settings)
     )
-    get_external_tool_policy = getattr(settings_manager, "get_external_tool_policy", None)
+    get_external_tool_policy = getattr(
+        settings_manager, "get_external_tool_policy", None
+    )
     register_builtin_tools(
         registry,
         diagnostics_service=diagnostics_service,
-        external_tool_policy=get_external_tool_policy() if callable(get_external_tool_policy) else None,
+        external_tool_policy=get_external_tool_policy()
+        if callable(get_external_tool_policy)
+        else None,
         policy_engine=_policy_engine_from_tool_settings(tool_settings),
         approval_resolver=resolved_approval_resolver,
     )
     return registry
 
 
-def _tool_settings_from_settings_manager(settings_manager: object | None) -> object | None:
+def _tool_settings_from_settings_manager(
+    settings_manager: object | None,
+) -> object | None:
     get_tool_settings = getattr(settings_manager, "get_tool_settings", None)
     if callable(get_tool_settings):
         return get_tool_settings()
@@ -133,7 +141,9 @@ def _tool_settings_from_settings_manager(settings_manager: object | None) -> obj
     return None
 
 
-def _policy_engine_from_tool_settings(tool_settings: object | None) -> PolicyEngine | None:
+def _policy_engine_from_tool_settings(
+    tool_settings: object | None,
+) -> PolicyEngine | None:
     if tool_settings is None:
         return None
     kwargs = {
@@ -141,15 +151,21 @@ def _policy_engine_from_tool_settings(tool_settings: object | None) -> PolicyEng
         "ask_tools": _tool_setting_tuple(tool_settings, "ask_tools"),
         "blocked_substrings": _tool_setting_tuple(tool_settings, "blocked_substrings"),
         "ask_substrings": _tool_setting_tuple(tool_settings, "ask_substrings"),
-        "blocked_path_substrings": _tool_setting_tuple(tool_settings, "blocked_path_substrings"),
-        "ask_path_substrings": _tool_setting_tuple(tool_settings, "ask_path_substrings"),
+        "blocked_path_substrings": _tool_setting_tuple(
+            tool_settings, "blocked_path_substrings"
+        ),
+        "ask_path_substrings": _tool_setting_tuple(
+            tool_settings, "ask_path_substrings"
+        ),
     }
     if not any(kwargs.values()):
         return None
     return PolicyEngine(**kwargs)
 
 
-def _approval_resolver_from_tool_settings(tool_settings: object | None) -> HeadlessApprovalResolver | None:
+def _approval_resolver_from_tool_settings(
+    tool_settings: object | None,
+) -> HeadlessApprovalResolver | None:
     if tool_settings is None:
         return None
     approval_mode = getattr(tool_settings, "approval_mode", None)
@@ -175,6 +191,7 @@ def default_runtime_builder(
     session_dir: Path,
     services: BootstrapServices,
     tool_registry: ToolRegistry,
+    approval_resolver: InteractiveApprovalResolver | None = None,
 ):
     if args.no_tools:
         allowed_tool_names = []
@@ -196,6 +213,48 @@ def default_runtime_builder(
         allowed_tool_names=allowed_tool_names,
         active_tool_names=active_tool_names,
         persist=not args.no_session,
+        approval_resolver=approval_resolver,
+    )
+
+
+def _invoke_runtime_builder(
+    runtime_builder,
+    *,
+    args: CliArgs,
+    cwd: Path,
+    session_dir: Path,
+    services: BootstrapServices,
+    tool_registry: ToolRegistry,
+    approval_resolver: InteractiveApprovalResolver | None | object = _MISSING,
+):
+    kwargs = {
+        "args": args,
+        "cwd": cwd,
+        "session_dir": session_dir,
+        "services": services,
+        "tool_registry": tool_registry,
+    }
+    if approval_resolver is not _MISSING and _accepts_keyword_argument(
+        runtime_builder, "approval_resolver"
+    ):
+        kwargs["approval_resolver"] = approval_resolver
+    return runtime_builder(**kwargs)
+
+
+def _accepts_keyword_argument(callback: Any, name: str) -> bool:
+    try:
+        parameters = inspect.signature(callback).parameters
+    except (TypeError, ValueError):
+        return callback is default_runtime_builder
+    parameter = parameters.get(name)
+    if parameter is not None and parameter.kind in {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    }:
+        return True
+    return any(
+        candidate.kind is inspect.Parameter.VAR_KEYWORD
+        for candidate in parameters.values()
     )
 
 
@@ -273,18 +332,26 @@ async def run_cli(
     if method_error is not None:
         stderr.write(f"Error: {method_error}.\n")
         return 2
-    work_log_inspect_result = _run_work_log_inspect(bootstrap_args, project_root, stdout, stderr)
+    work_log_inspect_result = _run_work_log_inspect(
+        bootstrap_args, project_root, stdout, stderr
+    )
     if work_log_inspect_result is not None:
         return work_log_inspect_result
 
     with _stdout_guard_context(bootstrap_args, stdout, stderr):
         resolved_services = services or build_default_services(project_root)
-        _report_settings_errors_for_resource_commands(bootstrap_args, resolved_services, stderr)
-        resource_toggle_result = _run_resource_toggles(bootstrap_args, resolved_services, stdout, stderr)
+        _report_settings_errors_for_resource_commands(
+            bootstrap_args, resolved_services, stderr
+        )
+        resource_toggle_result = _run_resource_toggles(
+            bootstrap_args, resolved_services, stdout, stderr
+        )
         if resource_toggle_result is not None:
             return resource_toggle_result
         runtime_args = _runtime_args_for_bootstrap(bootstrap_args)
-        session_dir = _resolve_session_dir(runtime_args, project_root, resolved_services)
+        session_dir = _resolve_session_dir(
+            runtime_args, project_root, resolved_services
+        )
         diag_export_result = _run_diag_export(
             bootstrap_args,
             project_root,
@@ -306,16 +373,24 @@ async def run_cli(
             return fake_workflow_result
         settings_manager = getattr(resolved_services, "settings_manager", None)
         tool_settings = _tool_settings_from_settings_manager(settings_manager)
-        configured_approval_resolver = _approval_resolver_from_tool_settings(tool_settings)
-        use_tui_approval_presenter = configured_approval_resolver is None
+        configured_approval_resolver = _approval_resolver_from_tool_settings(
+            tool_settings
+        )
+        interactive_approval_resolver: InteractiveApprovalResolver | None = None
         if configured_approval_resolver is None:
-            configured_approval_resolver = HeadlessApprovalResolver(mode="deny")
-        approval_resolver = InteractiveApprovalResolver(fallback=configured_approval_resolver)
+            interactive_approval_resolver = InteractiveApprovalResolver(
+                fallback=HeadlessApprovalResolver(mode="deny")
+            )
+            approval_resolver: ApprovalResolver = interactive_approval_resolver
+        else:
+            approval_resolver = configured_approval_resolver
         if runtime_args.no_builtin_tools:
             tool_registry = ToolRegistry()
         else:
             tool_registry = build_builtin_tool_registry(
-                diagnostics_service=getattr(resolved_services, "diagnostics_service", None),
+                diagnostics_service=getattr(
+                    resolved_services, "diagnostics_service", None
+                ),
                 settings_manager=getattr(resolved_services, "settings_manager", None),
                 approval_resolver=approval_resolver,
             )
@@ -326,30 +401,35 @@ async def run_cli(
         cwd=project_root,
     ):
         with _stdout_guard_context(bootstrap_args, stdout, stderr):
-            runtime = runtime_builder(
+            runtime = _invoke_runtime_builder(
+                runtime_builder,
                 args=runtime_args,
                 cwd=project_root,
                 session_dir=session_dir,
                 services=resolved_services,
                 tool_registry=tool_registry,
+                approval_resolver=interactive_approval_resolver,
             )
         with _stdout_guard_context(runtime_args, stdout, stderr):
-            list_sessions_result = _run_list_sessions(runtime_args, runtime, stdout, stderr)
+            list_sessions_result = _run_list_sessions(
+                runtime_args, runtime, stdout, stderr
+            )
         if list_sessions_result is not None:
             return list_sessions_result
 
         try:
             with _stdout_guard_context(bootstrap_args, stdout, stderr):
                 session = await _resolve_session(runtime_args, runtime, project_root)
-        except (FileNotFoundError, NotADirectoryError, RuntimeError, ValueError) as error:
+        except (
+            FileNotFoundError,
+            NotADirectoryError,
+            RuntimeError,
+            ValueError,
+        ) as error:
             stderr.write(f"Error: {_format_cli_error(error)}\n")
             return 1
     if session is None:
         return 2
-    if use_tui_approval_presenter:
-        approval_setter = getattr(session, "set_approval_presenter", None)
-        if callable(approval_setter):
-            approval_setter(approval_resolver.set_request_presenter)
     extension_flags = _collect_extension_flags(session)
     args, parse_error_code = _parse_args_for_cli(
         raw_argv,
@@ -391,7 +471,9 @@ async def run_cli(
         if list_skills_result is not None:
             return list_skills_result
 
-        method_visibility_result = _run_method_visibility(args, project_root, stdout, stderr)
+        method_visibility_result = _run_method_visibility(
+            args, project_root, stdout, stderr
+        )
         if method_visibility_result is not None:
             return method_visibility_result
 
@@ -399,11 +481,15 @@ async def run_cli(
         if list_plugins_result is not None:
             return list_plugins_result
 
-        list_packages_result = _run_list_packages(args, session, resolved_services, project_root, stdout, stderr)
+        list_packages_result = _run_list_packages(
+            args, session, resolved_services, project_root, stdout, stderr
+        )
         if list_packages_result is not None:
             return list_packages_result
 
-        package_lifecycle_result = await _run_package_lifecycle(args, session, resolved_services, stdout, stderr)
+        package_lifecycle_result = await _run_package_lifecycle(
+            args, session, resolved_services, stdout, stderr
+        )
         if package_lifecycle_result is not None:
             return package_lifecycle_result
 
@@ -443,7 +529,9 @@ async def run_cli(
 
             if args.mode == "rpc":
                 if args.file_args:
-                    stderr.write("Error: @file arguments are not supported in RPC mode.\n")
+                    stderr.write(
+                        "Error: @file arguments are not supported in RPC mode.\n"
+                    )
                     return 2
                 if rpc_runner is not run_rpc_mode:
                     return await rpc_runner(
@@ -454,7 +542,9 @@ async def run_cli(
                         render_tool_events=args.render_tool_events,
                     )
                 return await mode_runner(
-                    config=ModeConfig(mode="rpc", render_tool_events=args.render_tool_events),
+                    config=ModeConfig(
+                        mode="rpc", render_tool_events=args.render_tool_events
+                    ),
                     runtime=runtime,
                     session=session,
                     user_input=None,
@@ -486,7 +576,9 @@ async def run_cli(
                 stderr.write(f"Error: {_format_cli_error(error)}\n")
                 return 1
             if print_input.user_input is None:
-                stderr.write("Error: prompt is required for prompt/text/print/json modes.\n")
+                stderr.write(
+                    "Error: prompt is required for prompt/text/print/json modes.\n"
+                )
                 return 2
 
             try:
@@ -494,7 +586,9 @@ async def run_cli(
                     CodingDomainRequest(
                         user_input=print_input.user_input,
                         cwd=project_root,
-                        method_policy=_method_policy_from_args(args, settings_manager=settings_manager),
+                        method_policy=_method_policy_from_args(
+                            args, settings_manager=settings_manager
+                        ),
                     )
                 )
             except ValueError as error:
@@ -505,10 +599,18 @@ async def run_cli(
                 for turn_index, prepared_turn in enumerate(prepared_turns):
                     is_first_turn = turn_index == 0
                     is_last_turn = turn_index == len(prepared_turns) - 1
-                    planned_constraint = _prepared_turn_policy_metadata(prepared_turn, "planned_constraint")
-                    audit_policy = _prepared_turn_policy_metadata(prepared_turn, "audit_policy")
-                    plan_facts = _prepared_turn_policy_metadata(prepared_turn, "plan_facts")
-                    step_facts = _prepared_turn_policy_metadata(prepared_turn, "step_facts")
+                    planned_constraint = _prepared_turn_policy_metadata(
+                        prepared_turn, "planned_constraint"
+                    )
+                    audit_policy = _prepared_turn_policy_metadata(
+                        prepared_turn, "audit_policy"
+                    )
+                    plan_facts = _prepared_turn_policy_metadata(
+                        prepared_turn, "plan_facts"
+                    )
+                    step_facts = _prepared_turn_policy_metadata(
+                        prepared_turn, "step_facts"
+                    )
                     exit_code = await prompt_runner(
                         runtime=runtime,
                         session=session,
@@ -516,7 +618,9 @@ async def run_cli(
                         stdout=stdout,
                         stderr=stderr,
                         images=print_input.images if is_first_turn else None,
-                        follow_up_messages=print_input.follow_up_messages if is_last_turn else (),
+                        follow_up_messages=print_input.follow_up_messages
+                        if is_last_turn
+                        else (),
                         verbose=args.verbose,
                         work_event_log=work_event_log,
                         method_id=prepared_turn.method_id,
@@ -543,10 +647,18 @@ async def run_cli(
                 for turn_index, prepared_turn in enumerate(prepared_turns):
                     is_first_turn = turn_index == 0
                     is_last_turn = turn_index == len(prepared_turns) - 1
-                    planned_constraint = _prepared_turn_policy_metadata(prepared_turn, "planned_constraint")
-                    audit_policy = _prepared_turn_policy_metadata(prepared_turn, "audit_policy")
-                    plan_facts = _prepared_turn_policy_metadata(prepared_turn, "plan_facts")
-                    step_facts = _prepared_turn_policy_metadata(prepared_turn, "step_facts")
+                    planned_constraint = _prepared_turn_policy_metadata(
+                        prepared_turn, "planned_constraint"
+                    )
+                    audit_policy = _prepared_turn_policy_metadata(
+                        prepared_turn, "audit_policy"
+                    )
+                    plan_facts = _prepared_turn_policy_metadata(
+                        prepared_turn, "plan_facts"
+                    )
+                    step_facts = _prepared_turn_policy_metadata(
+                        prepared_turn, "step_facts"
+                    )
                     exit_code = await print_runner(
                         runtime=runtime,
                         session=session,
@@ -554,7 +666,9 @@ async def run_cli(
                         stdout=stdout,
                         stderr=stderr,
                         images=print_input.images if is_first_turn else None,
-                        follow_up_messages=print_input.follow_up_messages if is_last_turn else (),
+                        follow_up_messages=print_input.follow_up_messages
+                        if is_last_turn
+                        else (),
                         output_mode=output_mode,
                         render_tool_events=args.render_tool_events,
                         work_event_log=work_event_log,
@@ -580,8 +694,12 @@ async def run_cli(
             for turn_index, prepared_turn in enumerate(prepared_turns):
                 is_first_turn = turn_index == 0
                 is_last_turn = turn_index == len(prepared_turns) - 1
-                planned_constraint = _prepared_turn_policy_metadata(prepared_turn, "planned_constraint")
-                audit_policy = _prepared_turn_policy_metadata(prepared_turn, "audit_policy")
+                planned_constraint = _prepared_turn_policy_metadata(
+                    prepared_turn, "planned_constraint"
+                )
+                audit_policy = _prepared_turn_policy_metadata(
+                    prepared_turn, "audit_policy"
+                )
                 plan_facts = _prepared_turn_policy_metadata(prepared_turn, "plan_facts")
                 step_facts = _prepared_turn_policy_metadata(prepared_turn, "step_facts")
                 exit_code = await mode_runner(
@@ -593,7 +711,9 @@ async def run_cli(
                     session=session,
                     user_input=prepared_turn.prepared_prompt,
                     images=print_input.images if is_first_turn else None,
-                    follow_up_messages=print_input.follow_up_messages if is_last_turn else (),
+                    follow_up_messages=print_input.follow_up_messages
+                    if is_last_turn
+                    else (),
                     stdin=stdin,
                     stdout=stdout,
                     stderr=stderr,
@@ -629,7 +749,9 @@ async def _dispose_runtime_or_session(runtime: Any, session: Any) -> None:
         await result
 
 
-def _prepared_turn_policy_metadata(prepared_turn: Any, key: str) -> Mapping[str, object] | None:
+def _prepared_turn_policy_metadata(
+    prepared_turn: Any, key: str
+) -> Mapping[str, object] | None:
     value = prepared_turn.metadata.get(key)
     if isinstance(value, Mapping) and value:
         return dict(value)
@@ -666,8 +788,12 @@ def _apply_offline_mode(args: CliArgs) -> None:
         os.environ["LOUSHANG_OFFLINE"] = "1"
 
 
-def _configure_resource_loader_from_args(resource_loader: object, args: CliArgs) -> None:
-    _configure_resource_loader(resource_loader, _resource_loader_options_from_args(args))
+def _configure_resource_loader_from_args(
+    resource_loader: object, args: CliArgs
+) -> None:
+    _configure_resource_loader(
+        resource_loader, _resource_loader_options_from_args(args)
+    )
 
 
 def _resource_loader_options_from_args(args: CliArgs) -> dict[str, object]:
@@ -689,15 +815,21 @@ def _resource_loader_options_from_args(args: CliArgs) -> dict[str, object]:
     return options
 
 
-def _configure_resource_loader(resource_loader: object, options: dict[str, object]) -> None:
+def _configure_resource_loader(
+    resource_loader: object, options: dict[str, object]
+) -> None:
     setter = getattr(resource_loader, "set_runtime_options", None)
     if not callable(setter):
         return
     setter(**options)
 
 
-def _cwd_bound_services_factory(services: BootstrapServices, resource_loader_options: dict[str, object]):
-    project_base_dir = getattr(getattr(services, "settings_manager", None), "project_base_dir", None)
+def _cwd_bound_services_factory(
+    services: BootstrapServices, resource_loader_options: dict[str, object]
+):
+    project_base_dir = getattr(
+        getattr(services, "settings_manager", None), "project_base_dir", None
+    )
     if project_base_dir is None:
         return None
 
@@ -711,11 +843,19 @@ def _cwd_bound_services_factory(services: BootstrapServices, resource_loader_opt
 
 
 def _help_belongs_on_stderr(args: CliArgs) -> bool:
-    return bool(args.prompt is not None or args.prompt_steps is not None or args.mode in {"print", "json", "rpc"})
+    return bool(
+        args.prompt is not None
+        or args.prompt_steps is not None
+        or args.mode in {"print", "json", "rpc"}
+    )
 
 
 def _stdout_guard_enabled(args: CliArgs) -> bool:
-    if args.prompt is not None or args.prompt_steps is not None or args.mode in {"print", "json", "rpc"}:
+    if (
+        args.prompt is not None
+        or args.prompt_steps is not None
+        or args.mode in {"print", "json", "rpc"}
+    ):
         return True
     return bool(
         (args.list_sessions and args.list_sessions_format == "json")
@@ -725,7 +865,9 @@ def _stdout_guard_enabled(args: CliArgs) -> bool:
         or (args.list_skills and args.list_skills_format == "json")
         or (args.list_methods and args.list_methods_format == "json")
         or (args.show_method is not None and args.show_method_format == "json")
-        or (args.show_method_plan is not None and args.show_method_plan_format == "json")
+        or (
+            args.show_method_plan is not None and args.show_method_plan_format == "json"
+        )
         or (args.list_plugins and args.list_plugins_format == "json")
         or (args.list_packages and args.list_packages_format == "json")
         or (args.export is not None and args.export_result_format == "json")
@@ -740,7 +882,11 @@ def _stdout_guard_enabled(args: CliArgs) -> bool:
 
 @contextmanager
 def _stdout_guard_context(args: CliArgs, stdout: TextIO, stderr: TextIO):
-    with (stdout_guard(stdout=stdout, stderr=stderr) if _stdout_guard_enabled(args) else nullcontext()):
+    with (
+        stdout_guard(stdout=stdout, stderr=stderr)
+        if _stdout_guard_enabled(args)
+        else nullcontext()
+    ):
         yield
 
 
@@ -856,7 +1002,9 @@ def _method_policy_from_args(
     )
 
 
-def _method_settings_from_settings_manager(settings_manager: object | None) -> object | None:
+def _method_settings_from_settings_manager(
+    settings_manager: object | None,
+) -> object | None:
     get_method_settings = getattr(settings_manager, "get_method_settings", None)
     if callable(get_method_settings):
         return get_method_settings()
@@ -866,26 +1014,44 @@ def _method_settings_from_settings_manager(settings_manager: object | None) -> o
     return None
 
 
-def _resolve_work_event_log(raw_path: str | None, project_root: Path) -> JsonlEventLogBackend | None:
+def _resolve_work_event_log(
+    raw_path: str | None, project_root: Path
+) -> JsonlEventLogBackend | None:
     if raw_path is None:
         return None
     return JsonlEventLogBackend(_resolve_work_log_path(raw_path, project_root))
 
 
-def _run_work_log_inspect(args: CliArgs, project_root: Path, stdout: TextIO, stderr: TextIO) -> int | None:
+def _run_work_log_inspect(
+    args: CliArgs, project_root: Path, stdout: TextIO, stderr: TextIO
+) -> int | None:
     if args.work_log_inspect is None:
         return None
     try:
-        event_log = JsonlEventLogBackend(_resolve_work_log_path(args.work_log_inspect, project_root))
+        event_log = JsonlEventLogBackend(
+            _resolve_work_log_path(args.work_log_inspect, project_root)
+        )
         entries = event_log.query(run_id=args.work_log_run)
     except Exception as error:
         stderr.write(f"Error: {_format_cli_error(error)}\n")
         return 1
     if args.work_log_inspect_format == "json":
         raw_entries = entries[-_WORK_LOG_INSPECT_LIMIT:]
-        stdout.write(json.dumps([_work_log_entry_summary(entry) for entry in raw_entries], ensure_ascii=False) + "\n")
+        stdout.write(
+            json.dumps(
+                [_work_log_entry_summary(entry) for entry in raw_entries],
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
     elif args.work_log_inspect_format == "plans-json":
-        stdout.write(json.dumps([asdict(plan) for plan in project_work_plan_runs(entries)], ensure_ascii=False) + "\n")
+        stdout.write(
+            json.dumps(
+                [asdict(plan) for plan in project_work_plan_runs(entries)],
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
     elif args.work_log_inspect_format == "plans":
         _write_work_log_plan_summary(entries, stdout)
     else:
@@ -998,7 +1164,9 @@ def _write_work_log_plan_summary(entries: list[Any], stdout: TextIO) -> None:
             )
 
 
-def _work_log_plan_step_index(metadata: Mapping[str, object], fallback_index: int) -> str:
+def _work_log_plan_step_index(
+    metadata: Mapping[str, object], fallback_index: int
+) -> str:
     step_index = metadata.get("step_index")
     if isinstance(step_index, int) and not isinstance(step_index, bool):
         return str(step_index + 1)
@@ -1224,7 +1392,9 @@ def _runtime_args_for_bootstrap(args: CliArgs) -> CliArgs:
     return args
 
 
-def _report_settings_errors_for_resource_commands(args: CliArgs, services: Any, stderr: TextIO) -> None:
+def _report_settings_errors_for_resource_commands(
+    args: CliArgs, services: Any, stderr: TextIO
+) -> None:
     if not (
         args.list_plugins
         or args.list_packages
@@ -1237,11 +1407,20 @@ def _report_settings_errors_for_resource_commands(args: CliArgs, services: Any, 
     ):
         return
     settings_manager = getattr(services, "settings_manager", None)
-    context = "package command" if args.list_packages or args.list_plugins or args.add_plugin_sources or args.remove_plugin_sources else "settings command"
+    context = (
+        "package command"
+        if args.list_packages
+        or args.list_plugins
+        or args.add_plugin_sources
+        or args.remove_plugin_sources
+        else "settings command"
+    )
     _report_settings_errors(settings_manager, context=context, stderr=stderr)
 
 
-def _report_settings_errors(settings_manager: Any, *, context: str, stderr: TextIO) -> None:
+def _report_settings_errors(
+    settings_manager: Any, *, context: str, stderr: TextIO
+) -> None:
     drain_errors = getattr(settings_manager, "drain_errors", None)
     if not callable(drain_errors):
         return
@@ -1292,14 +1471,20 @@ def _run_resource_toggles(
         for source in args.add_plugin_sources:
             decision = PackageSecurityPolicy().evaluate_package_source(source)
             if decision.disposition == "deny":
-                _record_package_policy_diagnostic(services, source=source, reason=decision.reason)
+                _record_package_policy_diagnostic(
+                    services, source=source, reason=decision.reason
+                )
                 stderr.write(f"Error: {decision.reason}\n")
                 return 1
             added = settings_manager.add_plugin_source(source, scope="project")
             if added is False:
                 stderr.write(f"Error: plugin source already exists: {source}\n")
                 return 1
-            label = "remote plugin source" if is_remote_plugin_source(source) else "plugin source"
+            label = (
+                "remote plugin source"
+                if is_remote_plugin_source(source)
+                else "plugin source"
+            )
             stdout.write(f"added {label}\t{source}\n")
         for name in args.disable_plugins:
             settings_manager.disable_plugin(name, scope="project")
@@ -1313,7 +1498,9 @@ def _run_resource_toggles(
     return 0
 
 
-def _record_package_policy_diagnostic(services: Any, *, source: str, reason: str | None) -> None:
+def _record_package_policy_diagnostic(
+    services: Any, *, source: str, reason: str | None
+) -> None:
     diagnostics = getattr(services, "diagnostics_service", None)
     capture_failure = getattr(diagnostics, "capture_failure", None)
     if not callable(capture_failure):
@@ -1337,7 +1524,9 @@ async def _resolve_session(args: CliArgs, runtime: Any, project_root: Path):
     elif args.continue_ or args.resume:
         latest_session_file = _resolve_latest_session_file(runtime)
         if latest_session_file is None:
-            raise RuntimeError("No existing session found. Use --session or --resume <session> to restore a specific session.")
+            raise RuntimeError(
+                "No existing session found. Use --session or --resume <session> to restore a specific session."
+            )
         session = await runtime.restore_session(latest_session_file)
     elif args.session:
         session = await runtime.restore_session(args.session)
@@ -1375,7 +1564,9 @@ def _resolve_model_selection(args: CliArgs) -> ModelSelection | None:
         provider, rest = args.model.split(":", 1)
         endpoint_id, model_id = rest.rsplit(":", 1)
         if provider and endpoint_id and model_id:
-            return ModelSelection(provider=provider, endpoint_id=endpoint_id, model_id=model_id)
+            return ModelSelection(
+                provider=provider, endpoint_id=endpoint_id, model_id=model_id
+            )
     if args.provider is not None and args.model is not None:
         return ModelSelection(provider=args.provider, model_id=args.model)
     if args.provider is None and args.model is not None and "/" in args.model:
@@ -1432,7 +1623,13 @@ def _run_list_sessions(
         return 1
     use_index = args.session_index or args.refresh_session_index
     if args.refresh_session_index:
-        refresher = getattr(runtime, "refresh_all_session_indexes" if args.all_sessions else "refresh_session_index", None)
+        refresher = getattr(
+            runtime,
+            "refresh_all_session_indexes"
+            if args.all_sessions
+            else "refresh_session_index",
+            None,
+        )
         if not callable(refresher):
             stderr.write("Error: session index refresh is not available.\n")
             return 1
@@ -1443,24 +1640,48 @@ def _run_list_sessions(
             return 1
 
     if args.all_sessions and query is not None:
-        lister = getattr(runtime, "find_all_indexed_session_summaries" if use_index else "find_all_session_summaries", None)
+        lister = getattr(
+            runtime,
+            "find_all_indexed_session_summaries"
+            if use_index
+            else "find_all_session_summaries",
+            None,
+        )
         if callable(lister):
+
             def call_lister():
                 return lister(query)
         else:
             call_lister = None
     elif query is not None:
-        lister = getattr(runtime, "find_indexed_session_summaries" if use_index else "find_session_summaries", None)
+        lister = getattr(
+            runtime,
+            "find_indexed_session_summaries" if use_index else "find_session_summaries",
+            None,
+        )
         if callable(lister):
+
             def call_lister():
                 return lister(query)
         else:
             call_lister = None
     else:
         if args.all_sessions:
-            lister = getattr(runtime, "list_all_indexed_session_summaries" if use_index else "list_all_session_summaries", None)
+            lister = getattr(
+                runtime,
+                "list_all_indexed_session_summaries"
+                if use_index
+                else "list_all_session_summaries",
+                None,
+            )
         else:
-            lister = getattr(runtime, "list_indexed_session_summaries" if use_index else "list_session_summaries", None)
+            lister = getattr(
+                runtime,
+                "list_indexed_session_summaries"
+                if use_index
+                else "list_session_summaries",
+                None,
+            )
         if not callable(lister) and not use_index:
             lister = getattr(runtime, "list_session_summaries", None)
         if not callable(lister) and not use_index:
@@ -1480,7 +1701,9 @@ def _run_list_sessions(
         return 1
 
     normalized_sessions = [_try_normalize_session_record(record) for record in records]
-    normalized_sessions = [record for record in normalized_sessions if record is not None]
+    normalized_sessions = [
+        record for record in normalized_sessions if record is not None
+    ]
 
     if args.list_sessions_format == "json":
         stdout.write(json.dumps(normalized_sessions, ensure_ascii=False) + "\n")
@@ -1592,7 +1815,9 @@ def _normalize_session_record(record: Any) -> dict[str, object]:
         normalized = {
             "session_id": _string_attr(record, "session_id"),
             "cwd": _string_attr(record, "cwd"),
-            "session_file": _safe_string(session_file) if session_file is not None else None,
+            "session_file": _safe_string(session_file)
+            if session_file is not None
+            else None,
             "parent_session": _nullable_string_attr(record, "parent_session"),
             "leaf_id": _nullable_string_attr(record, "leaf_id"),
             "metadata": {
@@ -1605,7 +1830,9 @@ def _normalize_session_record(record: Any) -> dict[str, object]:
         normalized = {
             "session_id": _string_attr(record, "session_id"),
             "cwd": _string_attr(record, "cwd"),
-            "session_file": _safe_string(session_file) if session_file is not None else None,
+            "session_file": _safe_string(session_file)
+            if session_file is not None
+            else None,
             "parent_session": _nullable_string_attr(record, "parent_session"),
             "leaf_id": _nullable_string_attr(record, "leaf_id"),
             "metadata": {
@@ -1637,7 +1864,9 @@ def _json_safe_value(value: Any) -> object:
     if isinstance(value, Path):
         return str(value)
     if isinstance(value, dict):
-        return {_safe_string(key): _json_safe_value(item) for key, item in value.items()}
+        return {
+            _safe_string(key): _json_safe_value(item) for key, item in value.items()
+        }
     if isinstance(value, list | tuple):
         return [_json_safe_value(item) for item in value]
     if isinstance(value, str | int | float | bool) or value is None:
@@ -1740,8 +1969,12 @@ def _process_file_args(
                     continue
                 payload = resize_result.payload
                 mime_type = resize_result.mime_type
-                dimensions = resize_result.dimensions or detect_image_dimensions(mime_type, payload)
-                original_dimensions = resize_result.original_dimensions or original_dimensions
+                dimensions = resize_result.dimensions or detect_image_dimensions(
+                    mime_type, payload
+                )
+                original_dimensions = (
+                    resize_result.original_dimensions or original_dimensions
+                )
                 encoded = base64.b64encode(payload)
                 dimension_note = format_image_dimension_note(
                     original_dimensions=original_dimensions,
@@ -1775,9 +2008,16 @@ def _detect_supported_image_mime_type(path: Path, payload: bytes) -> str | None:
         return "image/jpeg"
     if suffix == ".png" and payload.startswith(b"\x89PNG\r\n\x1a\n"):
         return "image/png"
-    if suffix == ".gif" and (payload.startswith(b"GIF87a") or payload.startswith(b"GIF89a")):
+    if suffix == ".gif" and (
+        payload.startswith(b"GIF87a") or payload.startswith(b"GIF89a")
+    ):
         return "image/gif"
-    if suffix == ".webp" and len(payload) >= 12 and payload.startswith(b"RIFF") and payload[8:12] == b"WEBP":
+    if (
+        suffix == ".webp"
+        and len(payload) >= 12
+        and payload.startswith(b"RIFF")
+        and payload[8:12] == b"WEBP"
+    ):
         return "image/webp"
     return None
 
@@ -1858,9 +2098,15 @@ def _run_list_models(
         stderr.write("Error: model listing returned an invalid response.\n")
         return 1
     sorted_models = _unique_sorted_models(models)
-    normalized_models = _normalize_model_entries(sorted_models, include_metadata=include_metadata)
+    normalized_models = _normalize_model_entries(
+        sorted_models, include_metadata=include_metadata
+    )
     if query:
-        normalized_models = [entry for entry in normalized_models if _model_entry_matches_query(entry, query)]
+        normalized_models = [
+            entry
+            for entry in normalized_models
+            if _model_entry_matches_query(entry, query)
+        ]
     if args.list_models_format == "json":
         stdout.write(json.dumps(normalized_models, ensure_ascii=False) + "\n")
         return 0
@@ -1893,7 +2139,9 @@ def _unique_sorted_models(models: list[Any]) -> list[Any]:
     return [by_key[key] for key in sorted(by_key)]
 
 
-def _normalize_model_entries(models: list[Any], *, include_metadata: bool = False) -> list[dict[str, object]]:
+def _normalize_model_entries(
+    models: list[Any], *, include_metadata: bool = False
+) -> list[dict[str, object]]:
     entries: list[dict[str, object]] = []
     for selection in models:
         provider = _model_provider(selection)
@@ -1910,8 +2158,12 @@ def _normalize_model_entries(models: list[Any], *, include_metadata: bool = Fals
                 {
                     "context_window": _optional_int_attr(selection, "context_window"),
                     "max_tokens": _optional_int_attr(selection, "max_tokens"),
-                    "supports_thinking": _bool_model_attr(selection, "supports_thinking", "reasoning"),
-                    "supports_images": _bool_model_attr(selection, "supports_image_input"),
+                    "supports_thinking": _bool_model_attr(
+                        selection, "supports_thinking", "reasoning"
+                    ),
+                    "supports_images": _bool_model_attr(
+                        selection, "supports_image_input"
+                    ),
                 }
             )
         entries.append(entry)
@@ -1967,7 +2219,9 @@ def _is_subsequence(needle: str, haystack: str) -> bool:
     return all(char in haystack_iter for char in needle)
 
 
-def _write_model_metadata_table(models: list[dict[str, object]], stdout: TextIO) -> None:
+def _write_model_metadata_table(
+    models: list[dict[str, object]], stdout: TextIO
+) -> None:
     rows = [
         (
             str(model["provider"]),
@@ -1981,7 +2235,9 @@ def _write_model_metadata_table(models: list[dict[str, object]], stdout: TextIO)
     ]
     headers = ("provider", "model", "context", "max-out", "thinking", "images")
     widths = [
-        max(len(headers[index]), *(len(row[index]) for row in rows)) if rows else len(headers[index])
+        max(len(headers[index]), *(len(row[index]) for row in rows))
+        if rows
+        else len(headers[index])
         for index in range(len(headers))
     ]
     stdout.write(_format_model_table_row(headers, widths) + "\n")
@@ -1990,7 +2246,9 @@ def _write_model_metadata_table(models: list[dict[str, object]], stdout: TextIO)
 
 
 def _format_model_table_row(row: tuple[str, ...], widths: list[int]) -> str:
-    return "  ".join(value.ljust(widths[index]) for index, value in enumerate(row)).rstrip()
+    return "  ".join(
+        value.ljust(widths[index]) for index, value in enumerate(row)
+    ).rstrip()
 
 
 def _format_context_window(value: object) -> str:
@@ -2108,12 +2366,18 @@ def _run_list_skills(
     if skills is None:
         stderr.write("Error: skill loader is not available.\n")
         return 1
-    normalized = [_normalize_skill_entry(skill) for skill in skills if _normalize_skill_entry(skill) is not None]
+    normalized = [
+        _normalize_skill_entry(skill)
+        for skill in skills
+        if _normalize_skill_entry(skill) is not None
+    ]
     if args.list_skills_format == "json":
         stdout.write(json.dumps(normalized, ensure_ascii=False) + "\n")
         return 0
     for skill in normalized:
-        stdout.write(f"{skill['name']}\t{skill['source_kind']}\t{skill['path']}\t{skill['enabled']}\n")
+        stdout.write(
+            f"{skill['name']}\t{skill['source_kind']}\t{skill['path']}\t{skill['enabled']}\n"
+        )
     return 0
 
 
@@ -2149,7 +2413,9 @@ def _normalize_skill_entry(skill: Any) -> dict[str, object] | None:
         "source_scope": _safe_getattr(skill, "source_scope", "") or "",
         "source": _safe_getattr(skill, "source", "") or "",
         "source_root": _safe_string(source_root) if source_root is not None else "",
-        "disable_model_invocation": bool(_safe_getattr(skill, "disable_model_invocation", False)),
+        "disable_model_invocation": bool(
+            _safe_getattr(skill, "disable_model_invocation", False)
+        ),
         "enabled": bool(_safe_getattr(skill, "enabled", True)),
         "diagnostics": [
             normalized
@@ -2179,7 +2445,11 @@ def _run_method_visibility(
     stdout: TextIO,
     stderr: TextIO,
 ) -> int | None:
-    if not args.list_methods and args.show_method is None and args.show_method_plan is None:
+    if (
+        not args.list_methods
+        and args.show_method is None
+        and args.show_method_plan is None
+    ):
         return None
 
     try:
@@ -2206,7 +2476,9 @@ def _run_method_visibility(
             stderr.write(f"Error: method not found: {args.show_method_plan}\n")
             return 1
         try:
-            plan = MethodCompiler().compile(method, context=MethodContext(domain="coding"))
+            plan = MethodCompiler().compile(
+                method, context=MethodContext(domain="coding")
+            )
         except Exception as error:
             stderr.write(f"Error: {_format_cli_error(error)}\n")
             return 1
@@ -2233,7 +2505,10 @@ def _run_method_visibility(
 
 def _find_method(methods: list[Any], id_or_name: str) -> Any | None:
     for method in methods:
-        if _safe_getattr(method, "id", None) == id_or_name or _safe_getattr(method, "name", None) == id_or_name:
+        if (
+            _safe_getattr(method, "id", None) == id_or_name
+            or _safe_getattr(method, "name", None) == id_or_name
+        ):
             return method
     return None
 
@@ -2248,7 +2523,9 @@ def _normalize_method_entry(method: Any) -> dict[str, object]:
         "meta_role": _safe_getattr(method, "meta_role", None),
         "phase": _safe_getattr(method, "phase", None),
         "path": _safe_getattr(method, "source_path", "") or "",
-        "applicability": _normalize_method_applicability(_safe_getattr(method, "applicability", None)),
+        "applicability": _normalize_method_applicability(
+            _safe_getattr(method, "applicability", None)
+        ),
     }
 
 
@@ -2257,12 +2534,16 @@ def _normalize_method_applicability(applicability: Any) -> dict[str, object]:
         "domains": _string_list(_safe_getattr(applicability, "domains", ())),
         "task_types": _string_list(_safe_getattr(applicability, "task_types", ())),
         "contexts": _string_list(_safe_getattr(applicability, "contexts", ())),
-        "artifact_types": _string_list(_safe_getattr(applicability, "artifact_types", ())),
+        "artifact_types": _string_list(
+            _safe_getattr(applicability, "artifact_types", ())
+        ),
         "modalities": _string_list(_safe_getattr(applicability, "modalities", ())),
         "toolchains": _string_list(_safe_getattr(applicability, "toolchains", ())),
         "lifecycle": _string_list(_safe_getattr(applicability, "lifecycle", ())),
         "capabilities": _string_list(_safe_getattr(applicability, "capabilities", ())),
-        "complexity": _optional_string(_safe_getattr(applicability, "complexity", None)),
+        "complexity": _optional_string(
+            _safe_getattr(applicability, "complexity", None)
+        ),
         "risk": _optional_string(_safe_getattr(applicability, "risk", None)),
         "tags": _normalize_method_tags(_safe_getattr(applicability, "tags", {})),
     }
@@ -2279,9 +2560,14 @@ def _normalize_method_plan(method: Any, plan: Any) -> dict[str, object]:
             "activity": _safe_getattr(plan, "activity", None),
             "task": _safe_getattr(plan, "task", None),
             "metadata": _json_safe(_safe_getattr(plan, "metadata", {})),
-            "applicability": _normalize_method_applicability(_safe_getattr(plan, "applicability", None)),
+            "applicability": _normalize_method_applicability(
+                _safe_getattr(plan, "applicability", None)
+            ),
         },
-        "steps": [_normalize_method_plan_step(step) for step in _safe_getattr(plan, "steps", ())],
+        "steps": [
+            _normalize_method_plan_step(step)
+            for step in _safe_getattr(plan, "steps", ())
+        ],
     }
 
 
@@ -2294,7 +2580,9 @@ def _normalize_method_plan_step(step: Any) -> dict[str, object]:
         "projection": _json_safe(_safe_getattr(step, "projection", {})),
         "constraint": _json_safe(_safe_getattr(step, "constraint", {})),
         "audit": _json_safe(_safe_getattr(step, "audit", {})),
-        "applicability": _normalize_method_applicability(_safe_getattr(step, "applicability", None)),
+        "applicability": _normalize_method_applicability(
+            _safe_getattr(step, "applicability", None)
+        ),
     }
 
 
@@ -2342,7 +2630,9 @@ def _format_method_detail(method: Mapping[str, object]) -> str:
         value = method.get(key)
         if value:
             lines.append(f"{key}: {value}")
-    applicability_lines = _format_method_applicability_lines(method.get("applicability"))
+    applicability_lines = _format_method_applicability_lines(
+        method.get("applicability")
+    )
     if applicability_lines:
         lines.append("applicability:")
         lines.extend(applicability_lines)
@@ -2378,7 +2668,9 @@ def _format_method_plan_detail(payload: Mapping[str, object]) -> str:
                 lines.append(f"     guidance: {guidance}")
             constraint = _method_plan_step_mapping(raw_step, "constraint")
             if constraint:
-                lines.append(f"     constraint: {json.dumps(constraint, ensure_ascii=False)}")
+                lines.append(
+                    f"     constraint: {json.dumps(constraint, ensure_ascii=False)}"
+                )
             audit = _method_plan_step_mapping(raw_step, "audit")
             if audit:
                 lines.append(f"     audit: {json.dumps(audit, ensure_ascii=False)}")
@@ -2399,7 +2691,9 @@ def _method_plan_step_guidance(step: Mapping[str, object]) -> str:
     return ""
 
 
-def _method_plan_step_mapping(step: Mapping[str, object], key: str) -> Mapping[str, object]:
+def _method_plan_step_mapping(
+    step: Mapping[str, object], key: str
+) -> Mapping[str, object]:
     value = step.get(key)
     if isinstance(value, Mapping):
         return value
@@ -2467,7 +2761,9 @@ def _run_list_plugins(
         stdout.write(json.dumps(normalized, ensure_ascii=False) + "\n")
         return 0
     for plugin in normalized:
-        stdout.write(f"{plugin['name']}\t{plugin['version']}\t{plugin['path']}\t{plugin['enabled']}\n")
+        stdout.write(
+            f"{plugin['name']}\t{plugin['version']}\t{plugin['path']}\t{plugin['enabled']}\n"
+        )
     return 0
 
 
@@ -2475,7 +2771,11 @@ def _normalize_plugin_entry(plugin: Any) -> dict[str, object]:
     manifest = _safe_getattr(plugin, "manifest", None)
     source = _safe_getattr(plugin, "source", None)
     source_kind = _safe_getattr(source, "kind", "local")
-    source_value = _safe_getattr(source, "url", None) if source_kind == "remote" else _safe_getattr(source, "path", "")
+    source_value = (
+        _safe_getattr(source, "url", None)
+        if source_kind == "remote"
+        else _safe_getattr(source, "path", "")
+    )
     return {
         "name": _safe_string(_safe_getattr(manifest, "name", "")),
         "version": _safe_string(_safe_getattr(manifest, "version", "")),
@@ -2515,7 +2815,9 @@ def _run_list_packages(
                     disabled_plugins=tuple(getattr(settings, "disabled_plugins", ())),
                     cwd=project_root,
                     settings_manager=settings_manager,
-                    catalog_path=Path(args.package_catalog).expanduser().resolve() if args.package_catalog else None,
+                    catalog_path=Path(args.package_catalog).expanduser().resolve()
+                    if args.package_catalog
+                    else None,
                     materializer=getattr(session, "_package_materializer", None),
                 )
     except Exception as error:
@@ -2552,7 +2854,9 @@ def _write_package_text_list(packages: list[dict[str, object]], stdout: TextIO) 
     ordered_scopes.extend(sorted(scope for scope in scopes if scope not in scope_order))
     first_group = True
     for scope in ordered_scopes:
-        scoped_packages = [package for package in packages if str(package.get("scope", "")) == scope]
+        scoped_packages = [
+            package for package in packages if str(package.get("scope", "")) == scope
+        ]
         if not scoped_packages:
             continue
         if not first_group:
@@ -2615,17 +2919,28 @@ def _format_package_resources(package: dict[str, object]) -> str:
     return " ".join(parts)
 
 
-async def _run_package_lifecycle(args: CliArgs, session: Any, services: Any, stdout: TextIO, stderr: TextIO) -> int | None:
+async def _run_package_lifecycle(
+    args: CliArgs, session: Any, services: Any, stdout: TextIO, stderr: TextIO
+) -> int | None:
     install_operations: list[tuple[str, str, str]] = [
-        ("install_package", "install_package", source) for source in args.install_packages
+        ("install_package", "install_package", source)
+        for source in args.install_packages
     ]
     operations: list[tuple[str, str, str]] = []
     operations.extend(
-        ("materialize_package", "materialize_package", source) for source in args.materialize_packages
+        ("materialize_package", "materialize_package", source)
+        for source in args.materialize_packages
     )
-    operations.extend(("update_package", "update_package", source) for source in args.update_packages)
-    operations.extend(("remove_package", "remove_package", source) for source in args.remove_packages)
-    operations.extend(("uninstall_package", "uninstall_package", source) for source in args.uninstall_packages)
+    operations.extend(
+        ("update_package", "update_package", source) for source in args.update_packages
+    )
+    operations.extend(
+        ("remove_package", "remove_package", source) for source in args.remove_packages
+    )
+    operations.extend(
+        ("uninstall_package", "uninstall_package", source)
+        for source in args.uninstall_packages
+    )
     bulk_operations: list[tuple[str, str]] = []
     if args.check_package_updates:
         bulk_operations.append(("check_package_updates", "check_package_updates"))
@@ -2636,7 +2951,9 @@ async def _run_package_lifecycle(args: CliArgs, session: Any, services: Any, std
     for command, method_name, source in install_operations:
         decision = PackageSecurityPolicy().evaluate_package_source(source)
         if decision.disposition == "deny":
-            _record_package_policy_diagnostic(services, source=source, reason=decision.reason)
+            _record_package_policy_diagnostic(
+                services, source=source, reason=decision.reason
+            )
             stderr.write(f"Error: {decision.reason}\n")
             return 1
         method = getattr(session, method_name, None)
@@ -2653,7 +2970,10 @@ async def _run_package_lifecycle(args: CliArgs, session: Any, services: Any, std
         if failure := _package_lifecycle_failure(record):
             stderr.write(f"Error: {failure}\n")
             return 1
-        stdout.write(json.dumps({"command": command, "record": record}, ensure_ascii=False) + "\n")
+        stdout.write(
+            json.dumps({"command": command, "record": record}, ensure_ascii=False)
+            + "\n"
+        )
     for command, method_name in bulk_operations:
         method = getattr(session, method_name, None)
         if not callable(method):
@@ -2671,7 +2991,10 @@ async def _run_package_lifecycle(args: CliArgs, session: Any, services: Any, std
                 if failure := _package_lifecycle_failure(record):
                     stderr.write(f"Error: {failure}\n")
                     return 1
-        stdout.write(json.dumps({"command": command, "records": records}, ensure_ascii=False) + "\n")
+        stdout.write(
+            json.dumps({"command": command, "records": records}, ensure_ascii=False)
+            + "\n"
+        )
     for command, method_name, source in operations:
         method = getattr(session, method_name, None)
         if not callable(method):
@@ -2690,7 +3013,10 @@ async def _run_package_lifecycle(args: CliArgs, session: Any, services: Any, std
         if failure := _package_lifecycle_failure(record):
             stderr.write(f"Error: {failure}\n")
             return 1
-        stdout.write(json.dumps({"command": command, "record": record}, ensure_ascii=False) + "\n")
+        stdout.write(
+            json.dumps({"command": command, "record": record}, ensure_ascii=False)
+            + "\n"
+        )
     return 0
 
 
@@ -2700,7 +3026,11 @@ def _package_lifecycle_failure(record: object) -> str | None:
     if record.get("lifecycle") != "failed":
         return None
     message = record.get("errorMessage", record.get("error_message"))
-    return str(message) if isinstance(message, str) and message else "Package lifecycle failed."
+    return (
+        str(message)
+        if isinstance(message, str) and message
+        else "Package lifecycle failed."
+    )
 
 
 def _serialize_command_descriptor(command: object) -> dict[str, object] | None:
@@ -2755,20 +3085,26 @@ async def _collect_extension_flags_for_help(
     )
     resolved_services = services or build_default_services(project_root)
     try:
-        session_dir = _resolve_session_dir(bootstrap_args, project_root, resolved_services)
+        session_dir = _resolve_session_dir(
+            bootstrap_args, project_root, resolved_services
+        )
         if bootstrap_args.no_builtin_tools:
             tool_registry = ToolRegistry()
         else:
             tool_registry = build_builtin_tool_registry(
-                diagnostics_service=getattr(resolved_services, "diagnostics_service", None),
+                diagnostics_service=getattr(
+                    resolved_services, "diagnostics_service", None
+                ),
                 settings_manager=getattr(resolved_services, "settings_manager", None),
             )
-        runtime = runtime_builder(
+        runtime = _invoke_runtime_builder(
+            runtime_builder,
             args=bootstrap_args,
             cwd=project_root,
             session_dir=session_dir,
             services=resolved_services,
             tool_registry=tool_registry,
+            approval_resolver=None,
         )
         session = await _resolve_session(bootstrap_args, runtime, project_root)
         if session is None:
@@ -2793,8 +3129,7 @@ def _help_text(extension_flags: Mapping[str, ExtensionFlag] | None = None) -> st
                 line += f" (default={flag.default!r})"
             text += line
     return (
-        text
-        + "\n\n"
+        text + "\n\n"
         "Output formats:\n"
         "  --list-models-format text|json controls --list-models output.\n"
         "  --list-sessions-format tsv|json controls --list-sessions output; --all-sessions searches across session dirs.\n"

--- a/src/loushang/coding/extensions/hooks.py
+++ b/src/loushang/coding/extensions/hooks.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-import inspect
 from collections.abc import Callable, Sequence
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from enum import Enum
+from typing import Any, cast
 
 from loushang.agent.types import (
+    AfterToolCallContext,
     AfterToolCallResult,
     AgentToolResult,
+    BeforeToolCallContext,
     BeforeToolCallResult,
 )
 from loushang.ai.types import ToolCall
@@ -16,6 +18,12 @@ from loushang.coding.extensions.types import (
     LoadedExtension,
     ToolCallDecision,
     ToolResultDecision,
+)
+from loushang.harness.extensions.routing import (
+    ExtensionRoutePlan,
+    ExtensionRouter,
+    ResolvedExtensionRoute,
+    RouteStep,
 )
 from loushang.harness.resources.diagnostics import ResourceDiagnostic
 
@@ -31,6 +39,19 @@ ContextFactory = Callable[[LoadedExtension], ExtensionContext]
 RuntimeErrorHandler = Callable[[LoadedExtension, str, Exception], None]
 
 
+@dataclass(frozen=True)
+class _BeforeToolState:
+    event: BeforeToolCallContext
+    changed: bool = False
+    result: BeforeToolCallResult | None = None
+
+
+@dataclass(frozen=True)
+class _AfterToolState:
+    event: AfterToolCallContext
+    changed: bool = False
+
+
 class HookDispatcher:
     def __init__(
         self,
@@ -39,170 +60,169 @@ class HookDispatcher:
         context_factory: ContextFactory,
         diagnostics: list[ResourceDiagnostic],
         runtime_error_handler: RuntimeErrorHandler | None = None,
+        route_plan: ExtensionRoutePlan | None = None,
     ) -> None:
-        self._extensions = list(extensions)
         self._context_factory = context_factory
         self._diagnostics = diagnostics
-        self._runtime_error_handler = runtime_error_handler
-
-    async def before_tool_call(
-        self, event, signal: object | None = None
-    ) -> BeforeToolCallResult | None:
-        del signal
-        current_event = event
-        changed = False
-        for extension in self._extensions:
-            handlers = extension.hooks.get("tool_call", [])
-            if not handlers:
-                continue
-            context = self._context_factory(extension)
-            for handler in handlers:
-                try:
-                    decision = handler(current_event, context)
-                    if inspect.isawaitable(decision):
-                        decision = await decision
-                except Exception as exc:
-                    self._record_hook_error(
-                        extension=extension,
-                        event="tool_call",
-                        code="extension_tool_call_failed",
-                        message=f"Extension hook 'tool_call' failed: {exc}",
-                        error=exc,
-                    )
-                    continue
-                if decision is None:
-                    continue
-                if not isinstance(decision, ToolCallDecision):
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="invalid_extension_tool_call_decision",
-                            message="tool_call hooks must return ToolCallDecision or None.",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    continue
-                if decision.diagnostics:
-                    self._diagnostics.extend(decision.diagnostics)
-                rewritten_tool_name = decision.tool_name or current_event.tool_call.name
-                rewritten_arguments = (
-                    decision.arguments
-                    if decision.arguments is not None
-                    else current_event.args
-                )
-                if (
-                    rewritten_tool_name != current_event.tool_call.name
-                    or rewritten_arguments != current_event.args
-                ):
-                    changed = True
-                    current_event = replace(
-                        current_event,
-                        tool_call=ToolCall(
-                            type="toolCall",
-                            id=current_event.tool_call.id,
-                            name=rewritten_tool_name,
-                            arguments=rewritten_arguments,
-                            thought_signature=current_event.tool_call.thought_signature,
-                        ),
-                        args=rewritten_arguments,
-                    )
-                if decision.block:
-                    return BeforeToolCallResult(
-                        block=True,
-                        reason=decision.reason,
-                        tool_name=current_event.tool_call.name if changed else None,
-                        arguments=current_event.args if changed else None,
-                    )
-        if not changed:
-            return None
-        return BeforeToolCallResult(
-            tool_name=current_event.tool_call.name,
-            arguments=current_event.args,
+        plan = route_plan or ExtensionRoutePlan.from_extensions(
+            extensions, diagnostics=diagnostics
+        )
+        self._router = ExtensionRouter(
+            plan,
+            diagnostics=diagnostics,
+            runtime_error_handler=runtime_error_handler,
+            include_route_id_in_error_metadata=False,
+            include_provenance_in_error_metadata=False,
         )
 
-    async def after_tool_call(
-        self, event, signal: object | None = None
-    ) -> AfterToolCallResult | None:
+    async def before_tool_call(
+        self,
+        event: BeforeToolCallContext,
+        signal: object | None = None,
+    ) -> BeforeToolCallResult | None:
         del signal
-        current_event = event
-        changed = False
-        for extension in self._extensions:
-            handlers = extension.hooks.get("tool_result", [])
-            if not handlers:
-                continue
-            context = self._context_factory(extension)
-            for handler in handlers:
-                try:
-                    decision = handler(current_event, context)
-                    if inspect.isawaitable(decision):
-                        decision = await decision
-                except Exception as exc:
-                    self._record_hook_error(
-                        extension=extension,
-                        event="tool_result",
-                        code="extension_tool_result_failed",
-                        message=f"Extension hook 'tool_result' failed: {exc}",
-                        error=exc,
+
+        def reducer(
+            state: _BeforeToolState,
+            decision: object,
+            route: ResolvedExtensionRoute,
+        ) -> RouteStep[_BeforeToolState]:
+            if not isinstance(decision, ToolCallDecision):
+                self._diagnostics.append(
+                    ResourceDiagnostic(
+                        code="invalid_extension_tool_call_decision",
+                        message="tool_call hooks must return ToolCallDecision or None.",
+                        source_path=route.extension.source_path,
                     )
-                    continue
-                if decision is None:
-                    continue
-                if not isinstance(decision, ToolResultDecision):
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="invalid_extension_tool_result_decision",
-                            message="tool_result hooks must return ToolResultDecision or None.",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    continue
-                if decision.diagnostics:
-                    self._diagnostics.extend(decision.diagnostics)
-                if decision.result is None:
-                    continue
-                if not isinstance(decision.result, AgentToolResult):
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="invalid_extension_tool_result_decision",
-                            message=(
-                                "tool_result decisions must return AgentToolResult instances when overriding results."
-                            ),
-                            source_path=extension.source_path,
-                        )
-                    )
-                    continue
+                )
+                return RouteStep(state)
+            if decision.diagnostics:
+                self._diagnostics.extend(decision.diagnostics)
+            current_event = state.event
+            rewritten_tool_name = decision.tool_name or current_event.tool_call.name
+            rewritten_arguments = cast(
+                dict[str, Any],
+                decision.arguments
+                if decision.arguments is not None
+                else current_event.args,
+            )
+            changed = state.changed
+            if (
+                rewritten_tool_name != current_event.tool_call.name
+                or rewritten_arguments != current_event.args
+            ):
                 changed = True
                 current_event = replace(
                     current_event,
-                    result=decision.result,
-                    hook_details=decision.result.hook_details(),
+                    tool_call=ToolCall(
+                        type="toolCall",
+                        id=current_event.tool_call.id,
+                        name=rewritten_tool_name,
+                        arguments=rewritten_arguments,
+                        thought_signature=current_event.tool_call.thought_signature,
+                    ),
+                    args=rewritten_arguments,
                 )
-        if not changed:
+            result = None
+            if decision.block:
+                result = BeforeToolCallResult(
+                    block=True,
+                    reason=decision.reason,
+                    tool_name=current_event.tool_call.name if changed else None,
+                    arguments=(
+                        cast(dict[str, Any], current_event.args) if changed else None
+                    ),
+                )
+            return RouteStep(
+                _BeforeToolState(
+                    event=current_event,
+                    changed=changed,
+                    result=result,
+                ),
+                stop=result is not None,
+            )
+
+        outcome = await self._router.intercept(
+            "tool_call",
+            _BeforeToolState(event=event),
+            event_factory=lambda state, route: state.event,
+            reducer=reducer,
+            context_factory=self._context_factory,
+        )
+        state = outcome.state
+        if state.result is not None:
+            return state.result
+        if not state.changed:
             return None
-        return AfterToolCallResult(
-            content=current_event.result.content,
-            details=current_event.result.details,
-            terminate=current_event.result.terminate,
-            projector=current_event.result.projector,
+        return BeforeToolCallResult(
+            tool_name=state.event.tool_call.name,
+            arguments=cast(dict[str, Any], state.event.args),
         )
 
-    def _record_hook_error(
+    async def after_tool_call(
         self,
-        *,
-        extension: LoadedExtension,
-        event: str,
-        code: str,
-        message: str,
-        error: Exception,
-    ) -> None:
-        self._diagnostics.append(
-            ResourceDiagnostic(
-                code=code,
-                message=message,
-                source_path=extension.source_path,
+        event: AfterToolCallContext,
+        signal: object | None = None,
+    ) -> AfterToolCallResult | None:
+        del signal
+
+        def reducer(
+            state: _AfterToolState,
+            decision: object,
+            route: ResolvedExtensionRoute,
+        ) -> RouteStep[_AfterToolState]:
+            if not isinstance(decision, ToolResultDecision):
+                self._diagnostics.append(
+                    ResourceDiagnostic(
+                        code="invalid_extension_tool_result_decision",
+                        message="tool_result hooks must return ToolResultDecision or None.",
+                        source_path=route.extension.source_path,
+                    )
+                )
+                return RouteStep(state)
+            if decision.diagnostics:
+                self._diagnostics.extend(decision.diagnostics)
+            if decision.result is None:
+                return RouteStep(state)
+            if not isinstance(decision.result, AgentToolResult):
+                self._diagnostics.append(
+                    ResourceDiagnostic(
+                        code="invalid_extension_tool_result_decision",
+                        message=(
+                            "tool_result decisions must return AgentToolResult "
+                            "instances when overriding results."
+                        ),
+                        source_path=route.extension.source_path,
+                    )
+                )
+                return RouteStep(state)
+            return RouteStep(
+                _AfterToolState(
+                    event=replace(
+                        state.event,
+                        result=decision.result,
+                        hook_details=decision.result.hook_details(),
+                    ),
+                    changed=True,
+                )
             )
+
+        outcome = await self._router.reduce(
+            "tool_result",
+            _AfterToolState(event=event),
+            event_factory=lambda state, route: state.event,
+            reducer=reducer,
+            context_factory=self._context_factory,
         )
-        if self._runtime_error_handler is not None:
-            self._runtime_error_handler(extension, event, error)
+        state = outcome.state
+        if not state.changed:
+            return None
+        return AfterToolCallResult(
+            content=state.event.result.content,
+            details=state.event.result.details,
+            terminate=state.event.result.terminate,
+            projector=state.event.result.projector,
+        )
 
 
 __all__ = [

--- a/src/loushang/coding/extensions/runner.py
+++ b/src/loushang/coding/extensions/runner.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 from loushang.agent.types import (
     AfterToolCallResult,
@@ -31,6 +32,7 @@ from loushang.coding.extensions.types import (
     SessionRefreshEvent,
 )
 from loushang.harness.extensions.dispatch import ExtensionDispatcher
+from loushang.harness.extensions.manifest import ExtensionManifest
 from loushang.harness.extensions.registry import (
     resolve_extension_registry,
 )
@@ -38,6 +40,13 @@ from loushang.harness.extensions.registry import (
     source_info_from_extension as _source_info_from_extension,
 )
 from loushang.harness.extensions.resources import ExtensionResourceRuntime
+from loushang.harness.extensions.routing import (
+    ExtensionRoutePlan,
+    ExtensionRouter,
+    ResolvedExtensionRoute,
+    RouteStep,
+)
+from loushang.harness.extensions.types import extension_is_active
 from loushang.harness.extensions.wrapper import wrap_registered_tool_definition
 from loushang.harness.resources.diagnostics import ResourceDiagnostic
 from loushang.harness.resources.source import SourceInfo
@@ -107,10 +116,21 @@ class _ContextEvent:
     messages: list[AgentMessage]
 
 
+@dataclass(frozen=True)
+class _BeforeAgentStartState:
+    system_prompt: str
+    extra_messages: tuple[object, ...] = ()
+    diagnostics: tuple[ResourceDiagnostic, ...] = ()
+    system_prompt_changed: bool = False
+
+
 class ExtensionRunner:
-    def __init__(self, extensions: list[LoadedExtension | ExtensionDescriptor] | None = None) -> None:
+    def __init__(
+        self, extensions: list[LoadedExtension | ExtensionDescriptor] | None = None
+    ) -> None:
         self._diagnostics: list[ResourceDiagnostic] = []
         self._extensions: list[LoadedExtension] = []
+        self._active_extensions: list[LoadedExtension] = []
         self._tool_definitions: list[ToolDefinition] = []
         self._tool_source_info_by_name: dict[str, SourceInfo[Path]] = {}
         self._command_diagnostics: list[ResourceDiagnostic] = []
@@ -133,9 +153,36 @@ class ExtensionRunner:
             else:
                 loaded_extension = extension
             self._extensions.append(loaded_extension)
-            self._bind_extension_api(loaded_extension)
+            if extension_is_active(loaded_extension):
+                self._active_extensions.append(loaded_extension)
+                self._bind_extension_api(loaded_extension)
             self._diagnostics.extend(loaded_extension.diagnostics)
 
+        self._route_plan = ExtensionRoutePlan.from_extensions(
+            self._extensions,
+            diagnostics=self._diagnostics,
+        )
+
+        def runtime_error_handler(extension, event, error) -> None:
+            self._emit_runtime_error(
+                extension=extension,
+                event=event,
+                error=error,
+            )
+
+        self._router = ExtensionRouter(
+            self._route_plan,
+            diagnostics=self._diagnostics,
+            runtime_error_handler=runtime_error_handler,
+            include_route_id_in_error_metadata=False,
+        )
+        self._plain_diagnostic_router = ExtensionRouter(
+            self._route_plan,
+            diagnostics=self._diagnostics,
+            runtime_error_handler=runtime_error_handler,
+            include_route_id_in_error_metadata=False,
+            include_provenance_in_error_metadata=False,
+        )
         self._apply_registry_snapshot()
 
     def get_diagnostics(self) -> list[ResourceDiagnostic]:
@@ -157,12 +204,14 @@ class ExtensionRunner:
         return self._registered_commands_by_invocation_name.get(invocation_name)
 
     def _extension_by_name(self, name: str) -> LoadedExtension:
-        for extension in self._extensions:
+        for extension in self._active_extensions:
             if extension.name == name:
                 return extension
         return LoadedExtension(name=name, source_path=Path("<unknown>"))
 
-    async def get_command_argument_completions(self, invocation_name: str, prefix: str) -> list[object] | None:
+    async def get_command_argument_completions(
+        self, invocation_name: str, prefix: str
+    ) -> list[object] | None:
         command = self.get_command(invocation_name)
         if command is None or command.get_argument_completions is None:
             return None
@@ -209,7 +258,9 @@ class ExtensionRunner:
     def get_flag_values(self) -> dict[str, bool | str]:
         return dict(self._runtime_state.flag_values)
 
-    def create_command_context(self, *, fallback_cwd: str = "") -> ExtensionCommandContext:
+    def create_command_context(
+        self, *, fallback_cwd: str = ""
+    ) -> ExtensionCommandContext:
         return self._context_from_runtime(fallback_cwd=fallback_cwd)
 
     def has_handlers(self, hook_name: str) -> bool:
@@ -251,7 +302,7 @@ class ExtensionRunner:
         return self._tool_source_info_by_name.get(name)
 
     def get_message_renderer(self, custom_type: str):
-        for extension in self._extensions:
+        for extension in self._active_extensions:
             renderer = extension.message_renderers.get(custom_type)
             if renderer is not None:
                 return renderer
@@ -262,7 +313,7 @@ class ExtensionRunner:
 
     def list_message_renderers(self) -> list[dict[str, object]]:
         renderers: list[dict[str, object]] = []
-        for extension in self._extensions:
+        for extension in self._active_extensions:
             source_info = _source_info_from_extension(extension)
             for custom_type in extension.message_renderers:
                 renderers.append(
@@ -290,7 +341,9 @@ class ExtensionRunner:
                 {
                     "code": diagnostic.code,
                     "message": diagnostic.message,
-                    "sourcePath": diagnostic.source_path.as_posix() if diagnostic.source_path is not None else None,
+                    "sourcePath": diagnostic.source_path.as_posix()
+                    if diagnostic.source_path is not None
+                    else None,
                     "resourceId": diagnostic.resource_id,
                     "resourceType": diagnostic.resource_type,
                     "sourceKind": diagnostic.source_kind,
@@ -309,14 +362,18 @@ class ExtensionRunner:
     def listExtensions(self) -> list[dict[str, object]]:
         return self.list_extensions()
 
-    def discover_resources(self, bundle: ResourceBundle, *, reason: str = "refresh") -> ResourceBundle:
+    def discover_resources(
+        self, bundle: ResourceBundle, *, reason: str = "refresh"
+    ) -> ResourceBundle:
         del reason
         return self._resource_runtime().discover(
             bundle,
             context=_RunnerContext(cwd=str(bundle.cwd)),
         )
 
-    async def discover_resources_async(self, bundle: ResourceBundle, *, reason: str = "refresh") -> ResourceBundle:
+    async def discover_resources_async(
+        self, bundle: ResourceBundle, *, reason: str = "refresh"
+    ) -> ResourceBundle:
         del reason
         return await self._resource_runtime().discover_async(
             bundle,
@@ -332,7 +389,7 @@ class ExtensionRunner:
         self._bind_extension_apis()
 
     def _bind_extension_apis(self) -> None:
-        for extension in self._extensions:
+        for extension in self._active_extensions:
             self._bind_extension_api(extension)
 
     def _bind_extension_api(self, extension: LoadedExtension) -> None:
@@ -361,70 +418,99 @@ class ExtensionRunner:
         system_prompt_options: object | None = None,
         cwd: str = "",
     ) -> BeforeAgentStartResult | None:
-        context = self._context_from_runtime(fallback_cwd=cwd)
-        current_system_prompt = system_prompt or ""
-        extra_messages: list[object] = []
-        diagnostics: list[ResourceDiagnostic] = []
-        system_prompt_changed = False
+        prompt_state = [system_prompt or ""]
+        context = _BeforeAgentStartContext(
+            base=self._context_from_runtime(fallback_cwd=cwd),
+            get_system_prompt=lambda: prompt_state[0],
+        )
 
-        context = _BeforeAgentStartContext(base=context, get_system_prompt=lambda: current_system_prompt)
+        def event_factory(
+            state: _BeforeAgentStartState,
+            route: ResolvedExtensionRoute,
+        ) -> _ExtensionEvent:
+            del route
+            prompt_state[0] = state.system_prompt
+            return _ExtensionEvent(
+                type="before_agent_start",
+                prompt=prompt,
+                images=images,
+                system_prompt=state.system_prompt,
+                systemPrompt=state.system_prompt,
+                system_prompt_options=system_prompt_options,
+                systemPromptOptions=system_prompt_options,
+            )
 
-        for extension in self._extensions:
-            for handler in extension.hooks.get("before_agent_start", []):
-                event = _ExtensionEvent(
-                    type="before_agent_start",
-                    prompt=prompt,
-                    images=images,
-                    system_prompt=current_system_prompt,
-                    systemPrompt=current_system_prompt,
-                    system_prompt_options=system_prompt_options,
-                    systemPromptOptions=system_prompt_options,
+        def reducer(
+            state: _BeforeAgentStartState,
+            result: object,
+            route: ResolvedExtensionRoute,
+        ) -> RouteStep[_BeforeAgentStartState]:
+            del route
+            coerced = _coerce_before_agent_start_result(result)
+            if coerced is None:
+                return RouteStep(state)
+            next_system_prompt = coerced.system_prompt
+            if next_system_prompt is None and coerced.system_prompt_append:
+                next_system_prompt = (
+                    f"{state.system_prompt}\n\n{coerced.system_prompt_append}"
                 )
-                try:
-                    result = handler(event, context)
-                    if inspect.isawaitable(result):
-                        result = await result
-                except Exception as exc:
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="extension_before_agent_start_failed",
-                            message=f"Extension hook 'before_agent_start' failed: {exc}",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    self._emit_runtime_error(extension=extension, event="before_agent_start", error=exc)
-                    continue
-                coerced = _coerce_before_agent_start_result(result)
-                if coerced is None:
-                    continue
-                if coerced.diagnostics:
-                    diagnostics.extend(coerced.diagnostics)
-                if coerced.extra_messages:
-                    extra_messages.extend(coerced.extra_messages)
-                next_system_prompt = coerced.system_prompt
-                if next_system_prompt is None and coerced.system_prompt_append:
-                    next_system_prompt = f"{current_system_prompt}\n\n{coerced.system_prompt_append}"
-                if next_system_prompt is not None:
-                    current_system_prompt = next_system_prompt
-                    system_prompt_changed = True
+            return RouteStep(
+                _BeforeAgentStartState(
+                    system_prompt=(
+                        next_system_prompt
+                        if next_system_prompt is not None
+                        else state.system_prompt
+                    ),
+                    extra_messages=(
+                        *state.extra_messages,
+                        *coerced.extra_messages,
+                    ),
+                    diagnostics=(*state.diagnostics, *coerced.diagnostics),
+                    system_prompt_changed=(
+                        state.system_prompt_changed or next_system_prompt is not None
+                    ),
+                )
+            )
 
+        outcome = await self._plain_diagnostic_router.reduce(
+            "before_agent_start",
+            _BeforeAgentStartState(system_prompt=system_prompt or ""),
+            event_factory=event_factory,
+            reducer=reducer,
+            context_factory=lambda extension: context,
+        )
+        state = outcome.state
+        prompt_state[0] = state.system_prompt
+        diagnostics = list(state.diagnostics)
         if diagnostics:
             self._diagnostics.extend(diagnostics)
-        if not extra_messages and not system_prompt_changed and not diagnostics:
+        if (
+            not state.extra_messages
+            and not state.system_prompt_changed
+            and not diagnostics
+        ):
             return None
         return BeforeAgentStartResult(
-            system_prompt=current_system_prompt if system_prompt_changed else None,
-            extra_messages=extra_messages,
+            system_prompt=(
+                state.system_prompt if state.system_prompt_changed else None
+            ),
+            extra_messages=list(state.extra_messages),
             diagnostics=diagnostics,
         )
 
     async def emit_session_shutdown(self, session: object) -> None:
         await self._emit_session_hook("session_shutdown", session)
 
-    async def before_session_switch(self, event: object) -> SessionActionDecision | None:
-        return await self._emit_decision_hook("session_before_switch", event, fallback_cwd=getattr(event, "cwd", ""))
+    async def before_session_switch(
+        self, event: object
+    ) -> SessionActionDecision | None:
+        return await self._emit_decision_hook(
+            "session_before_switch", event, fallback_cwd=getattr(event, "cwd", "")
+        )
 
-    async def before_session_fork(self, event: object) -> SessionBeforeForkResult | None:
+    async def before_session_fork(
+        self, event: object
+    ) -> SessionBeforeForkResult | None:
         result = await self._emit_decision_hook(
             "session_before_fork",
             event,
@@ -440,7 +526,9 @@ class ExtensionRunner:
             diagnostics=result.diagnostics,
         )
 
-    async def before_session_compact(self, event: object) -> SessionBeforeCompactResult | None:
+    async def before_session_compact(
+        self, event: object
+    ) -> SessionBeforeCompactResult | None:
         result = await self._emit_decision_hook(
             "session_before_compact",
             event,
@@ -456,7 +544,9 @@ class ExtensionRunner:
             diagnostics=result.diagnostics,
         )
 
-    async def before_session_tree(self, event: object) -> SessionBeforeTreeResult | None:
+    async def before_session_tree(
+        self, event: object
+    ) -> SessionBeforeTreeResult | None:
         result = await self._emit_decision_hook(
             "session_before_tree",
             event,
@@ -483,60 +573,71 @@ class ExtensionRunner:
 
         current_messages = deepcopy(messages)
         context = self._context_from_runtime(fallback_cwd=cwd)
-        for extension in self._extensions:
-            for handler in extension.hooks.get("context", []):
-                event = _ContextEvent(messages=current_messages)
-                try:
-                    result = handler(event, context)
-                    if inspect.isawaitable(result):
-                        result = await result
-                except Exception as exc:
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="extension_context_failed",
-                            message=f"Extension hook 'context' failed: {exc}",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    self._emit_runtime_error(extension=extension, event="context", error=exc)
-                    continue
-                if result is None:
-                    continue
-                if not isinstance(result, ContextResult):
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code="invalid_extension_context_result",
-                            message="context hooks must return ContextResult or None.",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    continue
-                if result.diagnostics:
-                    self._diagnostics.extend(result.diagnostics)
-                if result.messages is not None:
-                    current_messages = result.messages
-        return current_messages
 
-    async def before_tool_call(self, event, signal: object | None = None) -> BeforeToolCallResult | None:
-        return await self._tool_hook_dispatcher(_context_from_agent_event(event).cwd).before_tool_call(event, signal)
+        def reducer(
+            state: list[AgentMessage],
+            result: object,
+            route: ResolvedExtensionRoute,
+        ) -> RouteStep[list[AgentMessage]]:
+            if not isinstance(result, ContextResult):
+                self._diagnostics.append(
+                    ResourceDiagnostic(
+                        code="invalid_extension_context_result",
+                        message="context hooks must return ContextResult or None.",
+                        source_path=route.extension.source_path,
+                    )
+                )
+                return RouteStep(state)
+            if result.diagnostics:
+                self._diagnostics.extend(result.diagnostics)
+            return RouteStep(
+                cast(list[AgentMessage], result.messages)
+                if result.messages is not None
+                else state
+            )
 
-    async def after_tool_call(self, event, signal: object | None = None) -> AfterToolCallResult | None:
-        return await self._tool_hook_dispatcher(_context_from_agent_event(event).cwd).after_tool_call(event, signal)
+        outcome = await self._plain_diagnostic_router.reduce(
+            "context",
+            current_messages,
+            event_factory=lambda state, route: _ContextEvent(messages=state),
+            reducer=reducer,
+            context_factory=lambda extension: context,
+        )
+        return outcome.state
+
+    async def before_tool_call(
+        self, event, signal: object | None = None
+    ) -> BeforeToolCallResult | None:
+        return await self._tool_hook_dispatcher(
+            _context_from_agent_event(event).cwd
+        ).before_tool_call(event, signal)
+
+    async def after_tool_call(
+        self, event, signal: object | None = None
+    ) -> AfterToolCallResult | None:
+        return await self._tool_hook_dispatcher(
+            _context_from_agent_event(event).cwd
+        ).after_tool_call(event, signal)
 
     def _tool_hook_dispatcher(self, fallback_cwd: str) -> HookDispatcher:
         return HookDispatcher(
             self._extensions,
-            context_factory=lambda _extension: self._context_from_runtime(fallback_cwd=fallback_cwd),
-            diagnostics=self._diagnostics,
-            runtime_error_handler=lambda extension, event, error: self._emit_runtime_error(
-                extension=extension,
-                event=event,
-                error=error,
+            context_factory=lambda _extension: self._context_from_runtime(
+                fallback_cwd=fallback_cwd
             ),
+            diagnostics=self._diagnostics,
+            runtime_error_handler=lambda extension, event, error: (
+                self._emit_runtime_error(
+                    extension=extension,
+                    event=event,
+                    error=error,
+                )
+            ),
+            route_plan=self._route_plan,
         )
 
     def _apply_registry_snapshot(self) -> None:
-        registry = resolve_extension_registry(self._extensions)
+        registry = resolve_extension_registry(self._active_extensions)
         self._diagnostics.extend(registry.diagnostics)
         self._flag_diagnostics.extend(registry.flag_diagnostics)
         self._shortcut_diagnostics.extend(registry.shortcut_diagnostics)
@@ -548,13 +649,19 @@ class ExtensionRunner:
             self._runtime_state.flag_values.setdefault(name, value)
         for registration in registry.tools:
             source_info = registration.source_info
+
+            def context_factory(
+                source_info: SourceInfo[Path] = source_info,
+            ) -> ExtensionContext:
+                return self._context_from_runtime(
+                    fallback_cwd=str(source_info.path.parent)
+                )
+
             self._tool_source_info_by_name[registration.definition.name] = source_info
             self._tool_definitions.append(
                 wrap_registered_tool_definition(
                     registration.definition,
-                    lambda source_info=source_info: self._context_from_runtime(
-                        fallback_cwd=str(source_info.path.parent)
-                    ),
+                    context_factory,
                 )
             )
 
@@ -566,40 +673,33 @@ class ExtensionRunner:
                 extension=extension,
             ),
             diagnostics=self._diagnostics,
-            runtime_error_handler=lambda extension, event, error: self._emit_runtime_error(
-                extension=extension,
-                event=event,
-                error=error,
+            runtime_error_handler=lambda extension, event, error: (
+                self._emit_runtime_error(
+                    extension=extension,
+                    event=event,
+                    error=error,
+                )
             ),
+            route_plan=self._route_plan,
         )
 
     def _resource_runtime(self) -> ExtensionResourceRuntime:
         return ExtensionResourceRuntime(
             self._extensions,
             diagnostics=self._diagnostics,
+            route_plan=self._route_plan,
         )
 
     async def _emit_session_hook(self, hook_name: str, session: object) -> None:
-        for extension in self._extensions:
-            context = self._context_from_runtime(
-                fallback_cwd=_context_from_session(session).cwd,
+        fallback_cwd = _context_from_session(session).cwd
+        await self._router.observe(
+            hook_name,
+            session,
+            context_factory=lambda extension: self._context_from_runtime(
+                fallback_cwd=fallback_cwd,
                 extension=extension,
-            )
-            for handler in extension.hooks.get(hook_name, []):
-                try:
-                    result = handler(session, context)
-                    if inspect.isawaitable(result):
-                        await result
-                except Exception as exc:
-                    self._diagnostics.append(
-                        _extension_hook_failure_diagnostic(
-                            extension=extension,
-                            hook_name=hook_name,
-                            exc=exc,
-                        )
-                    )
-                    self._emit_runtime_error(extension=extension, event=hook_name, error=exc)
-                    continue
+            ),
+        )
 
     async def _emit_decision_hook(
         self,
@@ -610,39 +710,36 @@ class ExtensionRunner:
         result_type: type[SessionActionDecision] = SessionActionDecision,
     ) -> SessionActionDecision | None:
         context = self._context_from_runtime(fallback_cwd=fallback_cwd)
-        latest_result: SessionActionDecision | None = None
-        for extension in self._extensions:
-            for handler in extension.hooks.get(hook_name, []):
-                try:
-                    result = handler(event, context)
-                    if inspect.isawaitable(result):
-                        result = await result
-                except Exception as exc:
-                    self._diagnostics.append(
-                        _extension_hook_failure_diagnostic(
-                            extension=extension,
-                            hook_name=hook_name,
-                            exc=exc,
-                        )
+
+        def reducer(
+            state: SessionActionDecision | None,
+            result: object,
+            route: ResolvedExtensionRoute,
+        ) -> RouteStep[SessionActionDecision | None]:
+            if not isinstance(result, result_type):
+                expected_name = result_type.__name__
+                self._diagnostics.append(
+                    ResourceDiagnostic(
+                        code=f"invalid_extension_{hook_name}_decision",
+                        message=(
+                            f"{hook_name} hooks must return {expected_name} or None."
+                        ),
+                        source_path=route.extension.source_path,
                     )
-                    self._emit_runtime_error(extension=extension, event=hook_name, error=exc)
-                    continue
-                if result is None:
-                    continue
-                if not isinstance(result, result_type):
-                    expected_name = result_type.__name__
-                    self._diagnostics.append(
-                        ResourceDiagnostic(
-                            code=f"invalid_extension_{hook_name}_decision",
-                            message=f"{hook_name} hooks must return {expected_name} or None.",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    continue
-                if result.diagnostics:
-                    self._diagnostics.extend(result.diagnostics)
-                latest_result = result
-        return latest_result
+                )
+                return RouteStep(state)
+            if result.diagnostics:
+                self._diagnostics.extend(result.diagnostics)
+            return RouteStep(result)
+
+        outcome = await self._router.reduce(
+            hook_name,
+            None,
+            event_factory=lambda state, route: event,
+            reducer=reducer,
+            context_factory=lambda extension: context,
+        )
+        return outcome.state
 
     def _context_from_runtime(
         self,
@@ -651,19 +748,31 @@ class ExtensionRunner:
         extension: LoadedExtension | None = None,
     ) -> ExtensionContext:
         if not self._runtime_state.is_bound:
-            return _RunnerContext(
-                cwd=fallback_cwd,
+            return cast(
+                ExtensionContext,
+                _RunnerContext(
+                    cwd=fallback_cwd,
+                    get_flag_value=self._runtime_state.flag_values.get,
+                    unsupported_theme_message=_UNSUPPORTED_THEME_MESSAGE,
+                ),
+            )
+        return cast(
+            ExtensionContext,
+            _BoundExtensionContext(
+                self._runtime_state.capture(),
+                (
+                    _source_info_from_extension(extension)
+                    if extension is not None
+                    else None
+                ),
                 get_flag_value=self._runtime_state.flag_values.get,
                 unsupported_theme_message=_UNSUPPORTED_THEME_MESSAGE,
-            )
-        return _BoundExtensionContext(
-            self._runtime_state.capture(),
-            _source_info_from_extension(extension) if extension is not None else None,
-            get_flag_value=self._runtime_state.flag_values.get,
-            unsupported_theme_message=_UNSUPPORTED_THEME_MESSAGE,
+            ),
         )
 
-    def _emit_runtime_error(self, *, extension: LoadedExtension, event: str, error: Exception) -> None:
+    def _emit_runtime_error(
+        self, *, extension: LoadedExtension, event: str, error: Exception
+    ) -> None:
         bindings = self._runtime_state.bindings
         callback = getattr(bindings, "on_error", None) if bindings is not None else None
         if not callable(callback):
@@ -675,6 +784,7 @@ class ExtensionRunner:
                 "error": str(error),
             }
         )
+
 
 def _context_from_session(session: object) -> _RunnerContext:
     session_manager = getattr(session, "session_manager", None)
@@ -746,12 +856,18 @@ def _coerce_before_agent_start_result(result: object) -> BeforeAgentStartResult 
         return result
     if isinstance(result, dict):
         system_prompt = result.get("systemPrompt", result.get("system_prompt"))
-        system_prompt_append = result.get("systemPromptAppend", result.get("system_prompt_append", ""))
-        extra_messages = result.get("messages", result.get("extraMessages", result.get("extra_messages", [])))
+        system_prompt_append = result.get(
+            "systemPromptAppend", result.get("system_prompt_append", "")
+        )
+        extra_messages = result.get(
+            "messages", result.get("extraMessages", result.get("extra_messages", []))
+        )
         diagnostics = result.get("diagnostics", [])
         return BeforeAgentStartResult(
             system_prompt=system_prompt if isinstance(system_prompt, str) else None,
-            system_prompt_append=system_prompt_append if isinstance(system_prompt_append, str) else "",
+            system_prompt_append=system_prompt_append
+            if isinstance(system_prompt_append, str)
+            else "",
             extra_messages=extra_messages if isinstance(extra_messages, list) else [],
             diagnostics=diagnostics if isinstance(diagnostics, list) else [],
         )
@@ -763,7 +879,7 @@ def _extension_visibility_snapshot(
     *,
     diagnostics: list[ResourceDiagnostic],
 ) -> dict[str, object]:
-    manifest = extension.manifest
+    manifest = cast(ExtensionManifest | None, extension.manifest)
     policy = extension.policy
     source_info = _source_info_from_extension(extension)
     extension_id = manifest.id if manifest is not None else extension.name
@@ -859,7 +975,9 @@ def _append_extension_diagnostic(
     key = (
         diagnostic.code,
         diagnostic.message,
-        diagnostic.source_path.as_posix() if diagnostic.source_path is not None else None,
+        diagnostic.source_path.as_posix()
+        if diagnostic.source_path is not None
+        else None,
     )
     if key not in seen:
         seen.add(key)
@@ -871,7 +989,9 @@ def _serialize_diagnostic(diagnostic: ResourceDiagnostic) -> dict[str, object]:
     return {
         "code": diagnostic.code,
         "message": diagnostic.message,
-        "sourcePath": diagnostic.source_path.as_posix() if diagnostic.source_path is not None else None,
+        "sourcePath": diagnostic.source_path.as_posix()
+        if diagnostic.source_path is not None
+        else None,
         "resourceId": diagnostic.resource_id,
         "resourceType": diagnostic.resource_type,
         "sourceKind": diagnostic.source_kind,
@@ -901,39 +1021,16 @@ def _path_text(value: object) -> str:
     return value.as_posix() if isinstance(value, Path) else str(value or "")
 
 
-def _extension_hook_failure_diagnostic(
-    *,
-    extension: LoadedExtension,
-    hook_name: str,
-    exc: BaseException,
-    code: str | None = None,
-) -> ResourceDiagnostic:
-    source_info = _source_info_from_extension(extension)
-    return ResourceDiagnostic(
-        code=code or f"extension_{hook_name}_failed",
-        message=f"Extension hook '{hook_name}' failed: {exc}",
-        source_path=extension.source_path,
-        metadata={
-            "extension_name": extension.name,
-            "hook": hook_name,
-            "source": source_info.source,
-            "scope": source_info.scope,
-            "origin": source_info.origin,
-            "base_dir": (
-                source_info.base_dir.as_posix()
-                if source_info.base_dir is not None
-                else extension.source_path.parent.as_posix()
-            ),
-        },
-    )
-
-
 def _serialize_source_info(source_info: SourceInfo[Path]) -> dict[str, object]:
     return {
         "path": source_info.path.as_posix(),
         "source": source_info.source,
         "scope": source_info.scope,
         "origin": source_info.origin,
-        "baseDir": source_info.base_dir.as_posix() if source_info.base_dir is not None else None,
-        "base_dir": source_info.base_dir.as_posix() if source_info.base_dir is not None else None,
+        "baseDir": source_info.base_dir.as_posix()
+        if source_info.base_dir is not None
+        else None,
+        "base_dir": source_info.base_dir.as_posix()
+        if source_info.base_dir is not None
+        else None,
     }

--- a/src/loushang/coding/policy/approval.py
+++ b/src/loushang/coding/policy/approval.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field, replace
-from uuid import uuid4
+from dataclasses import dataclass, field
 
 from loushang.harness.approval import (
+    ApprovalBroker,
     ApprovalDecision,
+    ApprovalPresenter,
     ApprovalRequest,
     ApprovalResolver,
     DenyApprovalResolver,
     HeadlessApprovalResolver,
     MaybeAwaitable,
+    approval_request_to_dict,
     resolve_approval,
 )
 from loushang.harness.tools.workspace.policy import PolicyEnforcementError
@@ -33,76 +34,102 @@ __all__ = [
 @dataclass
 class InteractiveApprovalResolver:
     fallback: ApprovalResolver
-    _pending_approvals: dict[str, asyncio.Future[ApprovalDecision]] = field(
-        default_factory=dict, init=False, repr=False
-    )
+    timeout_seconds: float | None = None
+    _broker: ApprovalBroker = field(init=False, repr=False)
     _request_presenter: Callable[[dict[str, object]], Awaitable[None] | None] | None = (
         field(default=None, init=False, repr=False)
     )
-    _request_counter: int = field(default=0, init=False, repr=False)
+    _request_dismisser: Callable[[str], Awaitable[None] | None] | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+    _session_open: bool = field(default=True, init=False, repr=False)
+    _session_close_reason: str = field(
+        default="Session closed before approval was resolved",
+        init=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        self._broker = ApprovalBroker(
+            fallback=self.fallback,
+            timeout_seconds=self.timeout_seconds,
+        )
 
     def set_request_presenter(
-        self, presenter: Callable[[dict[str, object]], Awaitable[None] | None] | None
+        self,
+        presenter: Callable[[dict[str, object]], Awaitable[None] | None] | None,
+        *,
+        dismisser: Callable[[str], Awaitable[None] | None] | None = None,
     ) -> None:
+        if presenter is None and dismisser is not None:
+            raise ValueError("dismisser requires a request presenter")
+        self._broker.set_presenter(
+            _CodingApprovalPresenter(presenter, dismisser)
+            if presenter is not None
+            else None
+        )
         self._request_presenter = presenter
+        self._request_dismisser = dismisser
 
     async def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
-        loop = asyncio.get_running_loop()
-        future = loop.create_future()
-        request_with_id = replace(
-            request,
-            action_id=request.action_id or self._next_action_id(),
-        )
-        self._pending_approvals[request_with_id.action_id] = future
-        presented = await self._present_request(request_with_id)
-        if not presented:
-            self._pending_approvals.pop(request_with_id.action_id, None)
-            return await _resolve(self.fallback, request_with_id)
-        try:
-            return await future
-        finally:
-            self._pending_approvals.pop(request_with_id.action_id, None)
+        if not self._session_open:
+            return ApprovalDecision.deny(self._session_close_reason)
+        return await self._broker.resolve(request)
+
+    def open_session(self) -> None:
+        self._session_open = True
 
     async def handle_result(
         self, action_id: str, *, approved: bool, reason: str | None = None
     ) -> bool:
-        future = self._pending_approvals.get(action_id)
-        if future is None:
-            return False
-        if future.done():
-            return False
-        future.set_result(
-            ApprovalDecision.allow() if approved else ApprovalDecision.deny(reason)
+        return self._broker.resolve_request(
+            action_id,
+            ApprovalDecision.allow() if approved else ApprovalDecision.deny(reason),
         )
-        return True
 
-    async def _present_request(self, request: ApprovalRequest) -> bool:
-        presenter = self._request_presenter
-        if presenter is None:
-            return False
-        payload = {
-            "action_id": request.action_id,
-            "tool_name": request.tool_name,
+    def close_session(
+        self,
+        reason: str = "Session closed before approval was resolved",
+    ) -> int:
+        self._session_open = False
+        self._session_close_reason = reason
+        return self._broker.cancel_all(ApprovalDecision.deny(reason))
+
+    def dispose(
+        self, reason: str = "Session closed before approval was resolved"
+    ) -> int:
+        decision = ApprovalDecision.deny(reason)
+        self._session_open = False
+        self._session_close_reason = reason
+        self._broker.set_presenter(None)
+        self._request_presenter = None
+        self._request_dismisser = None
+        return self._broker.dispose(decision)
+
+
+@dataclass(frozen=True)
+class _CodingApprovalPresenter(ApprovalPresenter):
+    callback: Callable[[dict[str, object]], Awaitable[None] | None]
+    dismiss_callback: Callable[[str], Awaitable[None] | None] | None = None
+
+    async def present(self, request: ApprovalRequest) -> None:
+        projection = approval_request_to_dict(request)
+        payload: dict[str, object] = {
+            "action_id": projection["action_id"],
+            "tool_name": projection["tool_name"],
             "action": request.reason or f"Approve {request.tool_name} tool call",
             "risk": request.reason or "Tool call requires approval",
-            "cwd": request.cwd,
-            "arguments": request.arguments,
-            "policy_code": request.policy_code,
+            "cwd": projection["cwd"],
+            "arguments": projection["arguments"],
+            "policy_code": projection["policy_code"],
         }
-        result = presenter(payload)
+        result = self.callback(payload)
         if inspect.isawaitable(result):
             await result
-        return True
 
-    def _next_action_id(self) -> str:
-        self._request_counter += 1
-        return f"approval-{self._request_counter:04d}-{uuid4().hex}"
-
-
-async def _resolve(
-    resolver: ApprovalResolver, request: ApprovalRequest
-) -> ApprovalDecision:
-    result = resolver.resolve(request)
-    if inspect.isawaitable(result):
-        return await result
-    return result
+    def dismiss(self, request: ApprovalRequest) -> Awaitable[None] | None:
+        if self.dismiss_callback is None or request.action_id is None:
+            return None
+        return self.dismiss_callback(request.action_id)

--- a/src/loushang/coding/policy/engine.py
+++ b/src/loushang/coding/policy/engine.py
@@ -1,14 +1,24 @@
 from __future__ import annotations
 
-import shlex
+import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from os.path import basename
-from pathlib import Path
 from typing import Any
 
-from loushang.harness.policy import PolicyDecision
-from loushang.harness.workspace.exec import ExecRequest
+from loushang.harness.policy import (
+    CommandSubstringMatcher,
+    ExactToolNameMatcher,
+    IncompleteCommandMatcher,
+    PathSubstringMatcher,
+    PolicyDecision,
+    PolicyRule,
+    PolicySubject,
+    RulePolicyEvaluator,
+    build_tool_policy_subject,
+    executable_search_path_from_env,
+    normalize_command_subject,
+)
+from loushang.harness.workspace.exec import ExecRequest, materialize_exec_request
 
 _DEFAULT_BLOCKED_SUBSTRINGS: tuple[str, ...] = (
     "rm -rf",
@@ -21,70 +31,12 @@ _DEFAULT_ASK_SUBSTRINGS: tuple[str, ...] = (
     "wget | sh",
     "wget|sh",
 )
-_SHELL_ENTRY_BASENAMES: tuple[str, ...] = (
-    "sh",
-    "bash",
-    "dash",
-    "zsh",
-    "ksh",
-)
-_LEADING_WRAPPER_BASENAMES: tuple[str, ...] = (
-    "env",
-    "sudo",
-)
-_ENV_NO_VALUE_OPTIONS: tuple[str, ...] = (
-    "-i",
-    "--ignore-environment",
-    "-0",
-    "--null",
-    "-v",
-    "--debug",
-)
-_ENV_VALUE_OPTIONS: tuple[str, ...] = (
-    "-u",
-    "--unset",
-    "-C",
-    "--chdir",
-    "-S",
-    "--split-string",
-    "-a",
-    "--argv0",
-    "-f",
-    "--file",
-    "--block-signal",
-    "--default-signal",
-    "--ignore-signal",
-)
-_SUDO_VALUE_OPTIONS: tuple[str, ...] = (
-    "-a",
-    "--auth-type",
-    "-c",
-    "--login-class",
-    "-u",
-    "--user",
-    "-g",
-    "--group",
-    "-h",
-    "--host",
-    "-p",
-    "--prompt",
-    "-r",
-    "--role",
-    "-t",
-    "--type",
-    "-C",
-    "--close-from",
-    "-D",
-    "--chdir",
-    "-R",
-    "--chroot",
-    "-T",
-    "--command-timeout",
-)
 
 
 def _normalize_substrings(
-    values: tuple[str, ...] | list[str], field_name: str, defaults: tuple[str, ...]
+    values: tuple[str, ...] | list[str],
+    field_name: str,
+    defaults: tuple[str, ...],
 ) -> tuple[str, ...]:
     if isinstance(values, str):
         raise TypeError(f"{field_name} must be a sequence of strings, not a string")
@@ -98,178 +50,101 @@ def _normalize_substrings(
     return tuple(normalized)
 
 
-def _normalize_strings(values: tuple[str, ...] | list[str], field_name: str) -> tuple[str, ...]:
+def _normalize_strings(
+    values: tuple[str, ...] | list[str],
+    field_name: str,
+) -> tuple[str, ...]:
     return _normalize_substrings(values, field_name, ())
-
-
-def _shell_payload(command: tuple[str, ...]) -> str | None:
-    if len(command) < 3:
-        return None
-
-    executable = basename(command[0])
-    if executable not in _SHELL_ENTRY_BASENAMES:
-        return None
-
-    shell_flag = command[1]
-    if "c" not in shell_flag:
-        return None
-
-    return command[2]
-
-
-def _is_env_assignment(token: str) -> bool:
-    if "=" not in token:
-        return False
-
-    name, _, _ = token.partition("=")
-    if not name:
-        return False
-    if not (name[0].isalpha() or name[0] == "_"):
-        return False
-    return all(ch.isalnum() or ch == "_" for ch in name[1:])
-
-
-def _split_env_string(value: str, remainder: tuple[str, ...]) -> tuple[str, ...]:
-    try:
-        split_tokens = tuple(shlex.split(value))
-    except ValueError:
-        return ("sh", "-lc", value, *remainder)
-    return (*split_tokens, *remainder)
-
-
-def _unwrap_env_command(command: tuple[str, ...]) -> tuple[str, ...]:
-    while command:
-        head = command[0]
-        if head == "--":
-            return command[1:]
-        if head in _ENV_NO_VALUE_OPTIONS:
-            command = command[1:]
-            continue
-        if head in ("-S", "--split-string"):
-            if len(command) < 2:
-                return ()
-            return _split_env_string(command[1], command[2:])
-        if head.startswith("--split-string="):
-            return _split_env_string(head.partition("=")[2], command[1:])
-        if head in _ENV_VALUE_OPTIONS:
-            if len(command) < 2:
-                return ()
-            command = command[2:]
-            continue
-        if any(head.startswith(f"{option}=") for option in _ENV_VALUE_OPTIONS if option.startswith("--")):
-            command = command[1:]
-            continue
-        if head.startswith("-"):
-            command = command[1:]
-            continue
-        if _is_env_assignment(head):
-            command = command[1:]
-            continue
-        break
-    return command
-
-
-def _unwrap_leading_wrappers(command: tuple[str, ...]) -> tuple[str, ...]:
-    while command and basename(command[0]) in _LEADING_WRAPPER_BASENAMES:
-        wrapper = basename(command[0])
-        command = command[1:]
-
-        if wrapper == "env":
-            command = _unwrap_env_command(command)
-        elif wrapper == "sudo":
-            while command:
-                head = command[0]
-                if not head.startswith("-"):
-                    break
-                if head in _SUDO_VALUE_OPTIONS:
-                    if len(command) < 2:
-                        return ()
-                    command = command[2:]
-                    continue
-                if any(head.startswith(f"{option}=") for option in _SUDO_VALUE_OPTIONS if option.startswith("--")):
-                    command = command[1:]
-                    continue
-                command = command[1:]
-    return command
-
-
-def _direct_command_tokens(command: tuple[str, ...]) -> tuple[str, ...]:
-    command = _unwrap_leading_wrappers(command)
-    if not command:
-        return ()
-    return (basename(command[0]), *command[1:])
-
-
-def _matches_substring(command: tuple[str, ...], substring: str) -> bool:
-    command = _unwrap_leading_wrappers(command)
-    payload = _shell_payload(command)
-    if payload is not None:
-        return substring in payload
-
-    tokens = _direct_command_tokens(command)
-    rule_tokens = tuple(part for part in substring.split() if part)
-    if not rule_tokens:
-        return False
-
-    if len(rule_tokens) == 1:
-        return rule_tokens[0] in tokens
-
-    window_size = len(rule_tokens)
-    for index in range(len(tokens) - window_size + 1):
-        if tokens[index : index + window_size] == rule_tokens:
-            return True
-    return False
 
 
 @dataclass(frozen=True)
 class PolicyEngine:
-    blocked_substrings: tuple[str, ...] = field(default_factory=lambda: _DEFAULT_BLOCKED_SUBSTRINGS)
-    ask_substrings: tuple[str, ...] = field(default_factory=lambda: _DEFAULT_ASK_SUBSTRINGS)
+    blocked_substrings: tuple[str, ...] = field(
+        default_factory=lambda: _DEFAULT_BLOCKED_SUBSTRINGS
+    )
+    ask_substrings: tuple[str, ...] = field(
+        default_factory=lambda: _DEFAULT_ASK_SUBSTRINGS
+    )
     blocked_tools: tuple[str, ...] = field(default_factory=tuple)
     ask_tools: tuple[str, ...] = field(default_factory=tuple)
     blocked_path_substrings: tuple[str, ...] = field(default_factory=tuple)
     ask_path_substrings: tuple[str, ...] = field(default_factory=tuple)
+    _evaluator: RulePolicyEvaluator = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         object.__setattr__(
             self,
             "blocked_substrings",
-            _normalize_substrings(self.blocked_substrings, "blocked_substrings", _DEFAULT_BLOCKED_SUBSTRINGS),
+            _normalize_substrings(
+                self.blocked_substrings,
+                "blocked_substrings",
+                _DEFAULT_BLOCKED_SUBSTRINGS,
+            ),
         )
         object.__setattr__(
             self,
             "ask_substrings",
-            _normalize_substrings(self.ask_substrings, "ask_substrings", _DEFAULT_ASK_SUBSTRINGS),
+            _normalize_substrings(
+                self.ask_substrings,
+                "ask_substrings",
+                _DEFAULT_ASK_SUBSTRINGS,
+            ),
         )
-        object.__setattr__(self, "blocked_tools", _normalize_strings(self.blocked_tools, "blocked_tools"))
-        object.__setattr__(self, "ask_tools", _normalize_strings(self.ask_tools, "ask_tools"))
+        object.__setattr__(
+            self,
+            "blocked_tools",
+            _normalize_strings(self.blocked_tools, "blocked_tools"),
+        )
+        object.__setattr__(
+            self,
+            "ask_tools",
+            _normalize_strings(self.ask_tools, "ask_tools"),
+        )
         object.__setattr__(
             self,
             "blocked_path_substrings",
-            _normalize_strings(self.blocked_path_substrings, "blocked_path_substrings"),
+            _normalize_strings(
+                self.blocked_path_substrings,
+                "blocked_path_substrings",
+            ),
         )
         object.__setattr__(
             self,
             "ask_path_substrings",
-            _normalize_strings(self.ask_path_substrings, "ask_path_substrings"),
+            _normalize_strings(
+                self.ask_path_substrings,
+                "ask_path_substrings",
+            ),
         )
+        object.__setattr__(self, "_evaluator", RulePolicyEvaluator(self._rules()))
 
-    def evaluate_action(self, *, tool_name: str, exec_request: ExecRequest) -> PolicyDecision:
-        for substring in self.blocked_substrings:
-            if _matches_substring(exec_request.command, substring):
-                return PolicyDecision.deny(
-                    f"Blocked destructive command substring: {substring}",
-                    code="command_blocked",
-                )
+    def evaluate(self, subject: PolicySubject, /) -> PolicyDecision:
+        return self._evaluator.evaluate(subject) or PolicyDecision.allow()
 
-        for substring in self.ask_substrings:
-            if _matches_substring(exec_request.command, substring):
-                return PolicyDecision.ask(
-                    f"Approval recommended for command substring: {substring}",
-                    code="command_requires_approval",
-                )
-
-        return PolicyDecision.allow()
+    def evaluate_action(
+        self,
+        *,
+        tool_name: str,
+        exec_request: ExecRequest,
+    ) -> PolicyDecision:
+        del tool_name
+        exec_request = materialize_exec_request(exec_request)
+        execution_environment = exec_request.effective_environment
+        assert execution_environment is not None
+        executable_search_path = executable_search_path_from_env(
+            execution_environment,
+            default=os.defpath,
+        )
+        return self.evaluate(
+            normalize_command_subject(
+                exec_request.command,
+                cwd=exec_request.cwd,
+                stdin=exec_request.stdin,
+                executable_search_path=executable_search_path,
+                environment_overrides=execution_environment,
+                environment_is_complete=True,
+            )
+        )
 
     def evaluate_tool_call(
         self,
@@ -278,48 +153,146 @@ class PolicyEngine:
         arguments: Mapping[str, Any],
         cwd: str | None = None,
     ) -> PolicyDecision:
-        if tool_name in self.blocked_tools:
-            return PolicyDecision.deny(f"Tool {tool_name} is blocked by policy", code="tool_blocked")
-        if tool_name in self.ask_tools:
-            return PolicyDecision.ask(f"Tool {tool_name} requires approval", code="tool_requires_approval")
-
+        command = None
         if tool_name == "bash":
-            command = arguments.get("command")
-            if isinstance(command, str):
+            raw_command = arguments.get("command")
+            normalized_command = None
+            if isinstance(raw_command, str):
+                normalized_command = ("/bin/sh", "-lc", raw_command)
+            elif (
+                isinstance(raw_command, (list, tuple))
+                and raw_command
+                and all(isinstance(part, str) for part in raw_command)
+            ):
+                normalized_command = tuple(raw_command)
+            if normalized_command is not None:
                 request_cwd = arguments.get("cwd")
-                exec_request = ExecRequest(
-                    command=("/bin/sh", "-lc", command),
-                    cwd=request_cwd if isinstance(request_cwd, str) else (cwd or ""),
+                policy_request = materialize_exec_request(
+                    ExecRequest(
+                        command=normalized_command,
+                        cwd=(request_cwd if isinstance(request_cwd, str) else cwd),
+                        env=_policy_environment_pairs(arguments.get("env", ())),
+                        stdin=(
+                            arguments.get("stdin")
+                            if isinstance(arguments.get("stdin"), str)
+                            else None
+                        ),
+                    )
                 )
-                return self.evaluate_action(tool_name=tool_name, exec_request=exec_request)
+                execution_environment = policy_request.effective_environment
+                assert execution_environment is not None
+                executable_search_path = executable_search_path_from_env(
+                    execution_environment,
+                    default=os.defpath,
+                )
+                command = normalize_command_subject(
+                    policy_request.command,
+                    cwd=policy_request.cwd,
+                    stdin=policy_request.stdin,
+                    executable_search_path=executable_search_path,
+                    environment_overrides=execution_environment,
+                    environment_is_complete=True,
+                )
+        return self.evaluate(
+            build_tool_policy_subject(
+                tool_name=tool_name,
+                arguments=arguments,
+                cwd=cwd,
+                command=command,
+            )
+        )
 
-        path_candidates = _path_candidates(arguments, cwd=cwd)
-        for substring in self.blocked_path_substrings:
-            if any(substring in candidate for candidate in path_candidates):
-                return PolicyDecision.deny(
+    def _rules(self) -> tuple[PolicyRule, ...]:
+        rules: list[PolicyRule] = []
+        rules.extend(
+            PolicyRule(
+                id=f"coding.tool.block.{index}",
+                matcher=ExactToolNameMatcher(tool_name),
+                decision=PolicyDecision.deny(
+                    f"Tool {tool_name} is blocked by policy",
+                    code="tool_blocked",
+                ),
+            )
+            for index, tool_name in enumerate(self.blocked_tools)
+        )
+        rules.extend(
+            PolicyRule(
+                id=f"coding.tool.ask.{index}",
+                matcher=ExactToolNameMatcher(tool_name),
+                decision=PolicyDecision.ask(
+                    f"Tool {tool_name} requires approval",
+                    code="tool_requires_approval",
+                ),
+            )
+            for index, tool_name in enumerate(self.ask_tools)
+        )
+        rules.extend(
+            PolicyRule(
+                id=f"coding.command.block.{index}",
+                matcher=CommandSubstringMatcher(substring),
+                decision=PolicyDecision.deny(
+                    f"Blocked destructive command substring: {substring}",
+                    code="command_blocked",
+                ),
+            )
+            for index, substring in enumerate(self.blocked_substrings)
+        )
+        rules.extend(
+            PolicyRule(
+                id=f"coding.command.ask.{index}",
+                matcher=CommandSubstringMatcher(substring),
+                decision=PolicyDecision.ask(
+                    f"Approval recommended for command substring: {substring}",
+                    code="command_requires_approval",
+                ),
+            )
+            for index, substring in enumerate(self.ask_substrings)
+        )
+        rules.extend(
+            PolicyRule(
+                id=f"coding.path.block.{index}",
+                matcher=PathSubstringMatcher(substring),
+                decision=PolicyDecision.deny(
                     f"Path is blocked by policy substring: {substring}",
                     code="path_blocked",
-                )
-        for substring in self.ask_path_substrings:
-            if any(substring in candidate for candidate in path_candidates):
-                return PolicyDecision.ask(
+                ),
+            )
+            for index, substring in enumerate(self.blocked_path_substrings)
+        )
+        rules.extend(
+            PolicyRule(
+                id=f"coding.path.ask.{index}",
+                matcher=PathSubstringMatcher(substring),
+                decision=PolicyDecision.ask(
                     f"Approval recommended for path substring: {substring}",
                     code="path_requires_approval",
-                )
+                ),
+            )
+            for index, substring in enumerate(self.ask_path_substrings)
+        )
+        rules.append(
+            PolicyRule(
+                id="coding.command.incomplete",
+                matcher=IncompleteCommandMatcher(),
+                decision=PolicyDecision.ask(
+                    "Command wrapper syntax requires approval",
+                    code="command_normalization_incomplete",
+                ),
+            )
+        )
+        return tuple(rules)
 
-        return PolicyDecision.allow()
 
-
-def _path_candidates(arguments: Mapping[str, Any], *, cwd: str | None) -> tuple[str, ...]:
-    raw_path = arguments.get("path", arguments.get("file_path"))
-    if not isinstance(raw_path, str) or not raw_path:
+def _policy_environment_pairs(value: object) -> tuple[tuple[str, str], ...]:
+    values = tuple(value.items()) if isinstance(value, Mapping) else value
+    if isinstance(values, str) or not isinstance(values, (list, tuple)):
         return ()
-    candidates = [raw_path]
-    try:
-        path = Path(raw_path).expanduser()
-        if not path.is_absolute() and cwd:
-            path = Path(cwd) / path
-        candidates.append(str(path.resolve()))
-    except (OSError, RuntimeError, ValueError):
-        pass
-    return tuple(dict.fromkeys(candidates))
+    pairs: list[tuple[str, str]] = []
+    for item in values:
+        if isinstance(item, str) or not isinstance(item, (list, tuple)):
+            return ()
+        pair = tuple(item)
+        if len(pair) != 2 or not all(isinstance(part, str) for part in pair):
+            return ()
+        pairs.append((pair[0], pair[1]))
+    return tuple(pairs)

--- a/src/loushang/coding/runtime/agent_session_runtime.py
+++ b/src/loushang/coding/runtime/agent_session_runtime.py
@@ -127,6 +127,7 @@ class AgentSessionRuntime:
             delay_seconds=session_index_flush_delay,
         )
         if current_session is not None:
+            self._open_session_approvals(current_session)
             self._bind_runtime_host(current_session)
 
     @property
@@ -152,6 +153,18 @@ class AgentSessionRuntime:
         self, callback: BeforeSessionInvalidateCallback | None
     ) -> None:
         self._session_host.set_before_invalidate(callback)
+
+    def subscribe_before_session_invalidate(
+        self,
+        callback: BeforeSessionInvalidateCallback,
+    ) -> Callable[[], None]:
+        return self._session_host.subscribe_before_invalidate(callback)
+
+    def subscribe_after_session_invalidate(
+        self,
+        callback: BeforeSessionInvalidateCallback,
+    ) -> Callable[[], None]:
+        return self._session_host.subscribe_after_invalidate(callback)
 
     async def create_session(
         self, *, cwd: str, parent_session: str | None = None
@@ -527,10 +540,11 @@ class AgentSessionRuntime:
         )
         await self._session_host.replace(
             session,
-            prepare=self._bind_runtime_host,
+            prepare=self._prepare_session_for_replacement,
             before_release=lambda previous: self._prepare_session_shutdown(
                 previous, shutdown_event
             ),
+            activate=self._open_session_approvals,
         )
 
     def get_current_session(self) -> AgentSession | None:
@@ -835,6 +849,7 @@ class AgentSessionRuntime:
             previous: AgentSession | None,
         ) -> None:
             session = candidate.session
+            self._open_session_approvals(session)
             starter = getattr(session, "start_extension_runtime", None)
             if callable(starter):
                 start_reason = (
@@ -857,8 +872,8 @@ class AgentSessionRuntime:
 
         return await self._session_operations.run(
             prepare,
-            prepare_session=lambda candidate, _previous: self._bind_runtime_host(
-                candidate.session
+            prepare_session=lambda candidate, _previous: (
+                self._prepare_session_for_replacement(candidate.session)
             ),
             before_release=lambda previous, candidate: self._prepare_session_shutdown(
                 previous,
@@ -967,6 +982,18 @@ class AgentSessionRuntime:
         setter = getattr(session, "set_extension_runtime_host", None)
         if callable(setter):
             setter(self)
+
+    def _prepare_session_for_replacement(self, session: AgentSession) -> None:
+        stage_session_approvals = getattr(session, "_stage_session_approvals", None)
+        if callable(stage_session_approvals):
+            stage_session_approvals()
+        self._bind_runtime_host(session)
+
+    @staticmethod
+    def _open_session_approvals(session: AgentSession) -> None:
+        open_session_approvals = getattr(session, "_open_session_approvals", None)
+        if callable(open_session_approvals):
+            open_session_approvals()
 
     def _record_session_index_flush_failure(
         self, exc: Exception, *, all_sessions: bool

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -167,8 +167,12 @@ class AgentSession:
         self.session_manager = session_manager
         self._settings_controller = SessionSettingsController(settings_manager)
         self.model_registry = model_registry
-        self.api_provider_registry = api_provider_registry or get_default_api_provider_registry()
-        self.oauth_provider_registry = oauth_provider_registry or get_default_oauth_registry()
+        self.api_provider_registry = (
+            api_provider_registry or get_default_api_provider_registry()
+        )
+        self.oauth_provider_registry = (
+            oauth_provider_registry or get_default_oauth_registry()
+        )
         self._auth_manager = auth_manager
         self._resource_loader = resource_loader
         self.resource_bundle = resource_bundle
@@ -177,8 +181,12 @@ class AgentSession:
         self.diagnostics_service = diagnostics_service
         self._package_materializer = package_materializer
         self._exec_service = exec_service or ExecService()
-        self.footer_data_provider = footer_data_provider or FooterDataProvider(self.session_manager.get_cwd())
-        self._base_prompt = base_prompt if base_prompt is not None else self.agent.system_prompt
+        self.footer_data_provider = footer_data_provider or FooterDataProvider(
+            self.session_manager.get_cwd()
+        )
+        self._base_prompt = (
+            base_prompt if base_prompt is not None else self.agent.system_prompt
+        )
         self._event_bus = SessionEventBus()
         self._host_runtime: HostRuntime[None] = HostRuntime(
             abort_driver=self.agent.abort,
@@ -188,8 +196,13 @@ class AgentSession:
         self._bind_package_progress_events()
         self._extension_ui_context: object | None = None
         self._extension_runtime_host: object | None = None
-        self._session_start_event = session_start_event or SessionStartEvent(reason="startup")
+        self._session_start_event = session_start_event or SessionStartEvent(
+            reason="startup"
+        )
         self._approval_resolver = approval_resolver
+        self._approval_session_state = (
+            "active" if approval_resolver is not None else "closed"
+        )
         self._diagnostics_bridge = SessionDiagnosticsBridge(
             diagnostics_service=self.diagnostics_service,
             session_manager=self.session_manager,
@@ -202,8 +215,12 @@ class AgentSession:
             agent=self.agent,
             session_manager=self.session_manager,
             tool_registry=self._tool_registry,
-            allowed_tool_names=set(allowed_tool_names) if allowed_tool_names is not None else None,
-            initial_active_tool_names=list(active_tool_names or [tool.name for tool in self.agent.tools]),
+            allowed_tool_names=set(allowed_tool_names)
+            if allowed_tool_names is not None
+            else None,
+            initial_active_tool_names=list(
+                active_tool_names or [tool.name for tool in self.agent.tools]
+            ),
             default_activate_new_tools=(
                 active_tool_names is None
                 if default_activate_new_tools is None
@@ -277,7 +294,9 @@ class AgentSession:
                 reload=self.reload_extension_runtime,
                 get_recent_assistant_texts=self.get_recent_assistant_texts,
                 get_last_assistant_text=self.get_last_assistant_text,
-                get_changelog=lambda args: read_changelog_for_cwd(self.session_manager.get_cwd(), args),
+                get_changelog=lambda args: read_changelog_for_cwd(
+                    self.session_manager.get_cwd(), args
+                ),
                 new_session=self._new_session_from_extension,
                 resume_session=self._switch_session_from_extension,
                 fork_session=self._fork_from_extension,
@@ -387,8 +406,12 @@ class AgentSession:
             session_manager=self.session_manager,
             get_model_registry=lambda: self.model_registry,
             get_extension_runner=lambda: self._extension_runner,
-            refresh_extension_runtime=lambda reason: self._refresh_extension_runtime(reason=reason),
-            is_extension_runtime_refreshing=lambda: self._extension_runtime_controller.is_refreshing,
+            refresh_extension_runtime=lambda reason: self._refresh_extension_runtime(
+                reason=reason
+            ),
+            is_extension_runtime_refreshing=lambda: (
+                self._extension_runtime_controller.is_refreshing
+            ),
             record_model_auth_resolution=self._record_model_auth_resolution,
         )
         self._view_controller = SessionViewController(
@@ -400,9 +423,15 @@ class AgentSession:
             get_last_diagnostics=lambda limit=50: self.get_last_diagnostics(limit),
             get_model_selection=self.get_model_selection,
             is_host_running=lambda: self._host_runtime.is_active,
-            get_compaction_reserve_tokens=lambda: self._get_compaction_settings().reserve_tokens,
-            get_compaction_compact_percent=lambda: self._get_compaction_settings().compact_percent,
-            get_compaction_keep_recent_tokens=lambda: self._get_compaction_settings().keep_recent_tokens,
+            get_compaction_reserve_tokens=lambda: (
+                self._get_compaction_settings().reserve_tokens
+            ),
+            get_compaction_compact_percent=lambda: (
+                self._get_compaction_settings().compact_percent
+            ),
+            get_compaction_keep_recent_tokens=lambda: (
+                self._get_compaction_settings().keep_recent_tokens
+            ),
         )
         self._prompt_controller = PromptController(
             agent=self.agent,
@@ -440,7 +469,10 @@ class AgentSession:
                 model_id=session_context.model["model_id"],
                 endpoint_id=session_context.model.get("endpoint_id"),
             )
-            if self.get_model_selection() != selection and self.model_registry is not None:
+            if (
+                self.get_model_selection() != selection
+                and self.model_registry is not None
+            ):
                 with suppress(KeyError, ValueError):
                     self.agent.model = self.model_registry.build_model(selection)
         if self._tool_registry is not None:
@@ -475,24 +507,33 @@ class AgentSession:
     def set_approval_presenter(
         self,
         presenter: Callable[[dict[str, object]], Awaitable[None] | None] | None,
+        *,
+        dismisser: Callable[[str], Awaitable[None] | None] | None = None,
     ) -> None:
-        if self._approval_resolver is None:
+        if self._approval_resolver is None or self._approval_session_state != "active":
             return
         if presenter is None:
+            self._approval_resolver.close_session(
+                "Approval presenter closed before approval was resolved"
+            )
             self._approval_resolver.set_request_presenter(None)
             return
-        self._approval_resolver.set_request_presenter(presenter)
+        self._approval_resolver.set_request_presenter(
+            presenter,
+            dismisser=dismisser,
+        )
+        self._approval_resolver.open_session()
 
-    async def handle_screen_approval(self, event: Mapping[str, object]) -> None:
+    async def handle_screen_approval(self, event: Mapping[str, object]) -> bool:
         if self._approval_resolver is None:
-            return
+            return False
         action_id = event.get("action_id")
         if not isinstance(action_id, str):
-            return
+            return False
         reason = event.get("reason")
         if reason is not None and not isinstance(reason, str):
             reason = None
-        await self._approval_resolver.handle_result(
+        return await self._approval_resolver.handle_result(
             action_id=action_id,
             approved=bool(event.get("approved")),
             reason=reason,
@@ -525,46 +566,72 @@ class AgentSession:
     def listExtensions(self) -> list[dict[str, object]]:
         return self.list_extensions()
 
-    async def execute_command_async(self, invocation_name: str, args: str) -> CommandExecutionResult | None:
-        return await self._command_controller.execute_command_async(invocation_name, args)
+    async def execute_command_async(
+        self, invocation_name: str, args: str
+    ) -> CommandExecutionResult | None:
+        return await self._command_controller.execute_command_async(
+            invocation_name, args
+        )
 
-    def _execute_resource_command(self, invocation_name: str, args: str) -> CommandExecutionResult | None:
+    def _execute_resource_command(
+        self, invocation_name: str, args: str
+    ) -> CommandExecutionResult | None:
         return self._command_controller.execute_resource_command(invocation_name, args)
 
     def _record_command_not_found(self, invocation_name: str, args: str) -> None:
         self._command_controller.record_command_not_found(invocation_name, args)
 
-    async def get_command_argument_completions(self, invocation_name: str, prefix: str) -> list[object] | None:
-        return await self._command_controller.get_command_argument_completions(invocation_name, prefix)
+    async def get_command_argument_completions(
+        self, invocation_name: str, prefix: str
+    ) -> list[object] | None:
+        return await self._command_controller.get_command_argument_completions(
+            invocation_name, prefix
+        )
 
-    def _record_extension_command_error(self, *, command: object, exc: BaseException) -> None:
-        self._command_controller.record_extension_command_error(command=command, exc=exc)
+    def _record_extension_command_error(
+        self, *, command: object, exc: BaseException
+    ) -> None:
+        self._command_controller.record_extension_command_error(
+            command=command, exc=exc
+        )
 
     def get_last_diagnostics(self, limit: int = 50) -> list[DiagnosticRecord]:
         return self._diagnostics_bridge.get_last_diagnostics(limit=limit)
 
-    def get_diagnostics(self, query: DiagnosticsQuery | None = None) -> list[DiagnosticRecord]:
+    def get_diagnostics(
+        self, query: DiagnosticsQuery | None = None
+    ) -> list[DiagnosticRecord]:
         return self._diagnostics_bridge.get_diagnostics(query=query)
 
-    def get_session_diagnostics(self, query: DiagnosticsQuery | None = None) -> list[DiagnosticRecord]:
+    def get_session_diagnostics(
+        self, query: DiagnosticsQuery | None = None
+    ) -> list[DiagnosticRecord]:
         return self._diagnostics_bridge.get_session_diagnostics(query=query)
 
-    def get_diagnostics_summary(self, query: DiagnosticsQuery | None = None) -> DiagnosticSummary:
+    def get_diagnostics_summary(
+        self, query: DiagnosticsQuery | None = None
+    ) -> DiagnosticSummary:
         return self._diagnostics_bridge.get_diagnostics_summary(query=query)
 
-    def get_session_diagnostics_summary(self, query: DiagnosticsQuery | None = None) -> DiagnosticSummary:
+    def get_session_diagnostics_summary(
+        self, query: DiagnosticsQuery | None = None
+    ) -> DiagnosticSummary:
         return self._diagnostics_bridge.get_session_diagnostics_summary(query=query)
 
     def get_last_error_report(self) -> ErrorReport | None:
         return self._diagnostics_bridge.get_last_error_report()
 
-    def get_packages(self, *, catalog_path: str | None = None) -> list[dict[str, object]]:
+    def get_packages(
+        self, *, catalog_path: str | None = None
+    ) -> list[dict[str, object]]:
         return self._package_controller.get_packages(catalog_path=catalog_path)
 
     async def materialize_package(self, source: str) -> dict[str, object]:
         return await self._package_controller.materialize_package(source)
 
-    async def install_package(self, source: str, *, scope: str = "project") -> dict[str, object]:
+    async def install_package(
+        self, source: str, *, scope: str = "project"
+    ) -> dict[str, object]:
         return await self._package_controller.install_package(source, scope=scope)
 
     async def update_package(self, source: str) -> dict[str, object]:
@@ -579,11 +646,15 @@ class AgentSession:
     def remove_package(self, source: str) -> dict[str, object]:
         return self._package_controller.remove_package(source)
 
-    def uninstall_package(self, source: str, *, scope: str = "project") -> dict[str, object]:
+    def uninstall_package(
+        self, source: str, *, scope: str = "project"
+    ) -> dict[str, object]:
         return self._package_controller.uninstall_package(source, scope=scope)
 
     def get_context_usage(self):
-        return serialize_context_usage_payload(self._view_controller.get_context_usage())
+        return serialize_context_usage_payload(
+            self._view_controller.get_context_usage()
+        )
 
     def get_session_stats(self) -> dict[str, object]:
         return self._view_controller.get_pi_style_stats()
@@ -870,7 +941,9 @@ class AgentSession:
     async def _cycle_scoped_model(self, direction: str) -> ModelSelection | None:
         return await self._selection_controller.cycle_scoped_model(direction)
 
-    def _model_selection_from_scoped_model(self, scoped: dict[str, object]) -> ModelSelection | None:
+    def _model_selection_from_scoped_model(
+        self, scoped: dict[str, object]
+    ) -> ModelSelection | None:
         return self._selection_controller.model_selection_from_scoped_model(scoped)
 
     def set_thinking_level(self, level: ThinkingLevel) -> None:
@@ -948,7 +1021,10 @@ class AgentSession:
 
     def set_session_name(self, name: str | None) -> None:
         self.session_manager.append_session_info(name)
-        event: AgentSessionEvent = {"type": "session_info_changed", "name": self.session_name}
+        event: AgentSessionEvent = {
+            "type": "session_info_changed",
+            "name": self.session_name,
+        }
         try:
             self._schedule_event_dispatch(event)
         except RuntimeError:
@@ -985,7 +1061,9 @@ class AgentSession:
         command: str,
         *,
         cwd: str | None = None,
-        env: list[list[str] | tuple[str, str]] | tuple[tuple[str, str], ...] | None = None,
+        env: list[list[str] | tuple[str, str]]
+        | tuple[tuple[str, str], ...]
+        | None = None,
         timeout_seconds: float | None = None,
         stdin: str | None = None,
         exclude_from_context: bool = False,
@@ -1009,7 +1087,9 @@ class AgentSession:
         on_chunk: Callable[[str], Awaitable[None] | None] | None = None,
         options: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        return await self._bash_controller.execute_pi_style(command, on_chunk=on_chunk, options=options)
+        return await self._bash_controller.execute_pi_style(
+            command, on_chunk=on_chunk, options=options
+        )
 
     def recordBashResult(
         self,
@@ -1060,13 +1140,19 @@ class AgentSession:
 
     # Internal ports shared by model and tool controllers.
 
-    async def _set_model_internal(self, model: Model | ModelSelection, *, emit_refresh: bool, source: str = "set") -> None:
-        await self._selection_controller.set_model(model, emit_refresh=emit_refresh, source=source)
+    async def _set_model_internal(
+        self, model: Model | ModelSelection, *, emit_refresh: bool, source: str = "set"
+    ) -> None:
+        await self._selection_controller.set_model(
+            model, emit_refresh=emit_refresh, source=source
+        )
 
     def _apply_active_tools(self, tool_names: list[str]) -> None:
         self._tool_controller.apply_active_tools(tool_names)
 
-    async def _set_active_tools_internal(self, tool_names: list[str], *, emit_refresh: bool) -> None:
+    async def _set_active_tools_internal(
+        self, tool_names: list[str], *, emit_refresh: bool
+    ) -> None:
         self._apply_active_tools(tool_names)
         if emit_refresh:
             await self._refresh_extension_runtime(reason="active_tools_changed")
@@ -1142,10 +1228,14 @@ class AgentSession:
         assert result is not None
         return result
 
-    async def compact_session(self, custom_instructions: str | None = None) -> CompactionResult:
+    async def compact_session(
+        self, custom_instructions: str | None = None
+    ) -> CompactionResult:
         return await self.compact(custom_instructions=custom_instructions)
 
-    async def maybe_compact_after_turn(self, assistant_message: AssistantMessage) -> CompactionResult | None:
+    async def maybe_compact_after_turn(
+        self, assistant_message: AssistantMessage
+    ) -> CompactionResult | None:
         return await self._check_auto_compaction(assistant_message)
 
     def get_compaction_status(self) -> CompactionStatus:
@@ -1181,7 +1271,9 @@ class AgentSession:
     def abort_branch_summary(self) -> None:
         self._tree_controller.abort_branch_summary()
 
-    async def dispose(self, session_shutdown_event: SessionShutdownEvent | None = None) -> None:
+    async def dispose(
+        self, session_shutdown_event: SessionShutdownEvent | None = None
+    ) -> None:
         try:
             await self.stop_resource_watcher()
             if self._extension_runner is not None:
@@ -1189,15 +1281,24 @@ class AgentSession:
                     session_shutdown_event or SessionShutdownEvent(reason="quit")
                 )
         finally:
-            await self._host_runtime.dispose()
-            self._finalize_after_session_shutdown()
+            self._close_session_approvals()
+            try:
+                await self._host_runtime.dispose()
+            finally:
+                self._finalize_after_session_shutdown()
 
     async def _dispose_after_session_shutdown(self) -> None:
-        await self._host_runtime.dispose()
-        await self.stop_resource_watcher()
-        self._finalize_after_session_shutdown()
+        self._close_session_approvals()
+        try:
+            await self._host_runtime.dispose()
+        finally:
+            try:
+                await self.stop_resource_watcher()
+            finally:
+                self._finalize_after_session_shutdown()
 
     def _finalize_after_session_shutdown(self) -> None:
+        self._close_session_approvals()
         if self._extension_runner is not None:
             self._invalidate_extension_contexts(
                 "Extension context is stale after session replacement or shutdown."
@@ -1205,6 +1306,33 @@ class AgentSession:
         self._unsubscribe_agent()
         self._event_bus.clear()
         self.footer_data_provider.dispose()
+
+    def _stage_session_approvals(self) -> None:
+        self._approval_session_state = "staged"
+
+    def _unbind_approval_presenter_host(self) -> None:
+        if self._approval_resolver is None:
+            return
+        if self._approval_session_state == "active":
+            self._approval_resolver.close_session(
+                "Approval presenter closed before approval was resolved"
+            )
+        self._approval_resolver.set_request_presenter(None)
+
+    def _open_session_approvals(self) -> None:
+        if self._approval_resolver is None:
+            return
+        self._approval_resolver.open_session()
+        self._approval_session_state = "active"
+
+    def _close_session_approvals(
+        self,
+        reason: str = "Session closed before approval was resolved",
+    ) -> None:
+        if self._approval_resolver is None or self._approval_session_state != "active":
+            return
+        self._approval_session_state = "closed"
+        self._approval_resolver.close_session(reason)
 
     # Internal ports shared by extension runtime and controllers.
 
@@ -1249,11 +1377,15 @@ class AgentSession:
         return {
             "cwd": self.session_manager.get_cwd(),
             "selected_tools": list(self.get_active_tool_names()),
-            "skills": list(self.resource_bundle.skills) if self.resource_bundle is not None else [],
+            "skills": list(self.resource_bundle.skills)
+            if self.resource_bundle is not None
+            else [],
             "context_files": [],
         }
 
-    def _resolve_active_tool_definitions(self, tool_names: list[str]) -> tuple[list[ToolDefinition], list[str]]:
+    def _resolve_active_tool_definitions(
+        self, tool_names: list[str]
+    ) -> tuple[list[ToolDefinition], list[str]]:
         return self._tool_controller.resolve_active_tool_definitions(tool_names)
 
     def _is_tool_allowed(self, name: str) -> bool:
@@ -1262,7 +1394,9 @@ class AgentSession:
     def _filter_allowed_tool_names(self, tool_names: list[str]) -> list[str]:
         return self._tool_controller.filter_allowed_tool_names(tool_names)
 
-    def _filter_allowed_tool_definitions(self, definitions: list[ToolDefinition]) -> list[ToolDefinition]:
+    def _filter_allowed_tool_definitions(
+        self, definitions: list[ToolDefinition]
+    ) -> list[ToolDefinition]:
         return self._tool_controller.filter_allowed_tool_definitions(definitions)
 
     def _tool_source_info(self, name: str) -> object | None:
@@ -1271,8 +1405,12 @@ class AgentSession:
     def _default_active_tool_names(self) -> list[str]:
         return self._tool_controller.default_active_tool_names()
 
-    def _register_extension_runtime_tool(self, tool: object, source_info: object | None = None) -> None:
-        definition = self._tool_controller.register_runtime_tool(tool, source_info=source_info)
+    def _register_extension_runtime_tool(
+        self, tool: object, source_info: object | None = None
+    ) -> None:
+        definition = self._tool_controller.register_runtime_tool(
+            tool, source_info=source_info
+        )
         if self._tool_registry is None:
             self._tool_registry = self._tool_controller.tool_registry
         if definition.name in self.get_active_tool_names():
@@ -1288,10 +1426,14 @@ class AgentSession:
         self._resource_refresh_controller.refresh_resources_for_extension_runtime()
 
     async def _refresh_resources_for_extension_runtime_async(self) -> None:
-        await self._resource_refresh_controller.refresh_resources_for_extension_runtime_async(reason="reload")
+        await self._resource_refresh_controller.refresh_resources_for_extension_runtime_async(
+            reason="reload"
+        )
 
     async def _reload_resources_from_watch(self) -> None:
-        await self._resource_refresh_controller.refresh_resources_for_extension_runtime_async(reason="watch")
+        await self._resource_refresh_controller.refresh_resources_for_extension_runtime_async(
+            reason="watch"
+        )
         if self._extension_runner is not None:
             await self._refresh_extension_runtime(reason="resource_watch")
 
@@ -1307,7 +1449,12 @@ class AgentSession:
         }
         bundle = self.resource_bundle
         if bundle is not None:
-            for descriptor in [*bundle.prompts, *bundle.skills, *bundle.extensions, *bundle.themes]:
+            for descriptor in [
+                *bundle.prompts,
+                *bundle.skills,
+                *bundle.extensions,
+                *bundle.themes,
+            ]:
                 source_root = getattr(descriptor, "source_root", None)
                 source_path = getattr(descriptor, "source_path", None)
                 if isinstance(source_root, Path):
@@ -1328,17 +1475,24 @@ class AgentSession:
     async def _prepare_configured_remote_package_records(self) -> None:
         await self._package_controller.prepare_configured_remote_package_records()
 
-    def _record_package_projection_diagnostics(self, packages: list[dict[str, object]]) -> None:
+    def _record_package_projection_diagnostics(
+        self, packages: list[dict[str, object]]
+    ) -> None:
         self._package_controller.record_package_projection_diagnostics(packages)
 
-    def _record_package_update_check_diagnostics(self, updates: list[dict[str, object]]) -> None:
+    def _record_package_update_check_diagnostics(
+        self, updates: list[dict[str, object]]
+    ) -> None:
         self._package_controller.record_package_update_check_diagnostics(updates)
 
     def _configure_package_resource_roots(self) -> None:
         self._package_controller.configure_package_resource_roots()
 
     async def _set_active_tools_from_extension(self, tool_names: list[str]) -> None:
-        await self._set_active_tools_internal(tool_names, emit_refresh=not self._extension_runtime_controller.is_refreshing)
+        await self._set_active_tools_internal(
+            tool_names,
+            emit_refresh=not self._extension_runtime_controller.is_refreshing,
+        )
 
     async def _set_model_from_extension(self, selection: ModelSelection) -> None:
         await self._selection_controller.set_model_from_extension(selection)
@@ -1348,27 +1502,39 @@ class AgentSession:
 
     # Extension API bridge.
 
-    async def sendCustomMessage(self, message: object, options: object | None = None) -> None:
+    async def sendCustomMessage(
+        self, message: object, options: object | None = None
+    ) -> None:
         await self._send_message_from_extension(message, options)
 
     async def sendMessage(self, message: object, options: object | None = None) -> None:
         await self.sendCustomMessage(message, options)
 
-    async def sendUserMessage(self, content: object, options: object | None = None) -> None:
+    async def sendUserMessage(
+        self, content: object, options: object | None = None
+    ) -> None:
         await self._send_user_message_from_extension_async(content, options)
 
-    async def _send_message_from_extension(self, message: object, options: object | None = None) -> None:
+    async def _send_message_from_extension(
+        self, message: object, options: object | None = None
+    ) -> None:
         await self._extension_message_controller.send_message(message, options)
 
     async def _send_message_from_extension_async(self, app_message) -> None:
         await self._extension_message_controller._send_message_async(app_message)
 
-    def _create_replaced_session_context(self, session: object | None) -> ReplacedSessionContext:
+    def _create_replaced_session_context(
+        self, session: object | None
+    ) -> ReplacedSessionContext:
         if not isinstance(session, AgentSession):
-            raise RuntimeError("Session replacement callback requires a valid AgentSession instance.")
+            raise RuntimeError(
+                "Session replacement callback requires a valid AgentSession instance."
+            )
         return self._extension_replacement_controller.create_context(session)
 
-    async def _send_user_message_from_extension_async(self, content: object, options: object | None = None) -> None:
+    async def _send_user_message_from_extension_async(
+        self, content: object, options: object | None = None
+    ) -> None:
         await self._extension_message_controller.send_user_message(content, options)
 
     async def _exec_command_from_extension(
@@ -1406,7 +1572,9 @@ class AgentSession:
             on_update=on_update,
         )
 
-    async def _compact_from_extension(self, custom_instructions: str | None = None) -> object | None:
+    async def _compact_from_extension(
+        self, custom_instructions: str | None = None
+    ) -> object | None:
         return await self.compact(custom_instructions)
 
     async def _reload_from_extension(self) -> None:
@@ -1415,25 +1583,39 @@ class AgentSession:
     def _invalidate_extension_contexts(self, message: str) -> None:
         self._extension_runtime_controller.invalidate_contexts(message)
 
-    async def _navigate_tree_from_extension(self, target_id: str, options: object | None = None) -> dict[str, object]:
+    async def _navigate_tree_from_extension(
+        self, target_id: str, options: object | None = None
+    ) -> dict[str, object]:
         opts = options if isinstance(options, dict) else {}
         result = await self.navigate_tree(
             target_id,
             summarize=bool(opts.get("summarize", False)),
-            custom_instructions=_optional_string(opts.get("customInstructions", opts.get("custom_instructions"))),
-            replace_instructions=bool(opts.get("replaceInstructions", opts.get("replace_instructions", False))),
+            custom_instructions=_optional_string(
+                opts.get("customInstructions", opts.get("custom_instructions"))
+            ),
+            replace_instructions=bool(
+                opts.get("replaceInstructions", opts.get("replace_instructions", False))
+            ),
             label=_optional_string(opts.get("label")),
         )
         return {"cancelled": result.cancelled}
 
-    async def _fork_from_extension(self, entry_id: str, options: object | None = None) -> dict[str, object]:
+    async def _fork_from_extension(
+        self, entry_id: str, options: object | None = None
+    ) -> dict[str, object]:
         return await self._extension_replacement_controller.fork(entry_id, options)
 
-    async def _new_session_from_extension(self, options: object | None = None) -> dict[str, object]:
+    async def _new_session_from_extension(
+        self, options: object | None = None
+    ) -> dict[str, object]:
         return await self._extension_replacement_controller.new_session(options)
 
-    async def _switch_session_from_extension(self, session_path: str, options: object | None = None) -> dict[str, object]:
-        return await self._extension_replacement_controller.switch_session(session_path, options)
+    async def _switch_session_from_extension(
+        self, session_path: str, options: object | None = None
+    ) -> dict[str, object]:
+        return await self._extension_replacement_controller.switch_session(
+            session_path, options
+        )
 
     async def _clone_from_builtin(self) -> dict[str, object]:
         runtime_host = self._extension_runtime_host
@@ -1455,7 +1637,9 @@ class AgentSession:
             return {"cancelled": current is previous}
         return {"cancelled": True}
 
-    async def _import_from_builtin(self, input_path: str, cwd_override: str | None = None) -> dict[str, object]:
+    async def _import_from_builtin(
+        self, input_path: str, cwd_override: str | None = None
+    ) -> dict[str, object]:
         runtime_host = self._extension_runtime_host
         if runtime_host is None:
             return {"cancelled": True}
@@ -1480,7 +1664,9 @@ class AgentSession:
             include_setup=include_setup,
         )
 
-    def _record_extension_runtime_diagnostic(self, diagnostic: ResourceDiagnostic) -> None:
+    def _record_extension_runtime_diagnostic(
+        self, diagnostic: ResourceDiagnostic
+    ) -> None:
         self._diagnostics_bridge.record_extension_runtime_diagnostic(diagnostic)
 
     # Run-loop hooks and event routing.
@@ -1538,7 +1724,9 @@ class AgentSession:
             "action": progress.action,
             "source": progress.source,
             "message": progress.message,
-            "target_path": str(progress.target_path) if progress.target_path is not None else None,
+            "target_path": str(progress.target_path)
+            if progress.target_path is not None
+            else None,
         }
         try:
             self._schedule_event_dispatch(event)
@@ -1578,7 +1766,9 @@ class AgentSession:
         attempt: int,
         final_error: str | None = None,
     ) -> None:
-        await self._retry_controller.finish(success=success, attempt=attempt, final_error=final_error)
+        await self._retry_controller.finish(
+            success=success, attempt=attempt, final_error=final_error
+        )
 
     def _should_prepare_retry(self, assistant_message: AssistantMessage) -> bool:
         return self._retry_controller.should_prepare_retry(assistant_message)
@@ -1586,7 +1776,9 @@ class AgentSession:
     def _is_retryable_error(self, assistant_message: AssistantMessage) -> bool:
         return self._retry_controller.is_retryable_error(assistant_message)
 
-    async def _handle_retryable_error(self, assistant_message: AssistantMessage) -> bool:
+    async def _handle_retryable_error(
+        self, assistant_message: AssistantMessage
+    ) -> bool:
         return await self._retry_controller.handle_retryable_error(assistant_message)
 
     def _apply_navigation_leaf(self, new_leaf_id: str | None) -> None:
@@ -1595,7 +1787,9 @@ class AgentSession:
         else:
             self.session_manager.branch(new_leaf_id)
 
-    async def _check_auto_compaction(self, assistant_message: AssistantMessage) -> CompactionResult | None:
+    async def _check_auto_compaction(
+        self, assistant_message: AssistantMessage
+    ) -> CompactionResult | None:
         return await self._compaction_controller.maybe_compact_after_turn(
             assistant_message,
             compact_internal_fn=self._compact_internal,
@@ -1643,34 +1837,46 @@ class AgentSession:
     def _record_model_auth_resolution(self, model: Model) -> None:
         self._auth_bridge_controller.record_model_auth_resolution(model)
 
-    def _record_model_auth_resolution_failure(self, model: Model, exc: Exception) -> None:
+    def _record_model_auth_resolution_failure(
+        self, model: Model, exc: Exception
+    ) -> None:
         self._auth_bridge_controller.record_model_auth_resolution_failure(model, exc)
 
-    def _record_assistant_response_error(self, assistant_message: AssistantMessage) -> None:
+    def _record_assistant_response_error(
+        self, assistant_message: AssistantMessage
+    ) -> None:
         self._diagnostics_bridge.record_assistant_response_error(assistant_message)
 
     def _record_tool_execution_error(self, event: AgentEvent) -> None:
         self._diagnostics_bridge.record_tool_execution_error(event)
 
-    def _preflight_user_input(self, user_input: str, *, allow_extension_commands: bool = True):
+    def _preflight_user_input(
+        self, user_input: str, *, allow_extension_commands: bool = True
+    ):
         return self._command_controller.preflight_user_input(
             user_input,
             allow_extension_commands=allow_extension_commands,
         )
 
-    async def _preflight_user_input_async(self, user_input: str, *, allow_extension_commands: bool = True):
+    async def _preflight_user_input_async(
+        self, user_input: str, *, allow_extension_commands: bool = True
+    ):
         return await self._command_controller.preflight_user_input_async(
             user_input,
             allow_extension_commands=allow_extension_commands,
         )
 
-    def _extract_extension_command_invocation(self, user_input: str) -> tuple[str, str] | None:
+    def _extract_extension_command_invocation(
+        self, user_input: str
+    ) -> tuple[str, str] | None:
         return self._command_controller.extract_extension_command_invocation(user_input)
 
     def _raise_if_queued_extension_command(self, user_input: str) -> None:
         self._command_controller.raise_if_queued_extension_command(user_input)
 
-    def _record_preflight_diagnostics(self, diagnostics: tuple[ResourceDiagnostic, ...]) -> None:
+    def _record_preflight_diagnostics(
+        self, diagnostics: tuple[ResourceDiagnostic, ...]
+    ) -> None:
         self._command_controller.record_preflight_diagnostics(diagnostics)
 
     def _sync_extension_diagnostics(self, *, phase: str) -> None:
@@ -1703,7 +1909,9 @@ async def _sleep_for_retry(delay_ms: int, signal: AbortSignal) -> None:
         raise asyncio.CancelledError
 
 
-def _normalize_extension_exec_command(command: str, args: Sequence[str]) -> tuple[str, ...]:
+def _normalize_extension_exec_command(
+    command: str, args: Sequence[str]
+) -> tuple[str, ...]:
     if not isinstance(command, str):
         raise TypeError("exec_command command must be a string")
     if not command:

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -4,6 +4,7 @@ import inspect
 import shlex
 import time
 import traceback
+from collections.abc import Callable
 from typing import Any, TextIO
 
 from loushang.ai.types import ImagePart
@@ -101,7 +102,9 @@ async def _run_screen_interactive_tui(
         tool_definition_resolver=tool_definition_resolver,
         active_window_state=app.state,
     )
-    history_records = session_history_records(session, tool_definition_resolver=tool_definition_resolver)
+    history_records = session_history_records(
+        session, tool_definition_resolver=tool_definition_resolver
+    )
     if history_records:
         app.replace_transcript_window(history_records, reason="resume")
         app.trim_active_transcript_window()
@@ -116,10 +119,11 @@ async def _run_screen_interactive_tui(
     app.composer.set_completion_provider(completion_provider)
     controller = CodingUiController(runtime=runtime, session=session, verbose=verbose)
 
-    async def _handle_approval(event: dict[str, object]) -> None:
+    async def _handle_approval(event: dict[str, object]) -> bool:
         sink = getattr(session, "handle_screen_approval", None)
         if callable(sink):
-            await _maybe_await(sink(event))
+            return bool(await _maybe_await(sink(event)))
+        return False
 
     settings_manager = getattr(session, "settings_manager", None)
     status_provider = CodingTuiStatusProvider(
@@ -130,7 +134,9 @@ async def _run_screen_interactive_tui(
         thinking_level=lambda: thinking_level(session),
         running=lambda: app.state.running or is_running(session),
         statusline_settings=statusline_settings_from_settings_manager(settings_manager),
-        on_statusline_settings_changed=statusline_settings_persistence_callback(settings_manager),
+        on_statusline_settings_changed=statusline_settings_persistence_callback(
+            settings_manager
+        ),
     )
     app.set_statusline_settings(status_provider.statusline_settings())
     surface_manager = ScreenSurfaceManager(
@@ -139,44 +145,148 @@ async def _run_screen_interactive_tui(
         status_provider=status_provider,
         on_approval=_handle_approval,
     )
-    projector = ScreenCodingEventProjector(
-        app,
-        tool_definition_resolver=_tool_definition_resolver(session),
-        read_pending_steers=_queue_reader(session, "get_steering_messages"),
-        read_pending_followups=_queue_reader(session, "get_follow_up_messages"),
-        now=time.monotonic,
+    unbind_approval_presenter = _bind_screen_approval_presenter(
+        session,
+        surface_manager,
+        session_provider=lambda: _runtime_session(runtime, session),
     )
 
-    observability_context = log_context(session_id=snapshot.session_observability_id, cwd=snapshot.cwd, mode="tui")
-    observability_context.__enter__()
+    def unbind_session_transition() -> None:
+        return None
+
     def unsubscribe() -> None:
         return None
 
     try:
-        _trace_start(snapshot, interactive=True)
-        unsubscribe = subscribe_session_events(session, projector.handle)
-        exit_code = await run_screen_coding_tui(
-            app=app,
-            stdin=stdin,
-            stdout=stdout,
-            handle_prompt=_screen_prompt_handler(app=app, controller=controller, stderr=stderr, verbose=verbose),
-            handle_local=surface_manager.handle_text,
-            handle_steer=_screen_text_handler(app=app, dispatch=controller.steer, label="Steering failed"),
-            handle_followup=_screen_text_handler(app=app, dispatch=controller.follow_up, label="Follow-up failed"),
-            handle_surface_intent=surface_manager.handle_surface_intent,
-            on_abort=_screen_abort_handler(controller),
-            should_exit=_screen_should_exit,
-            is_local_command=surface_manager.is_local_command,
-            keybindings=_session_keybindings(session),
+        unbind_session_transition = _bind_screen_session_transition(
+            runtime,
+            surface_manager,
         )
-        _write_resume_hint_for_clean_exit(session=session, stdout=stdout, exit_code=exit_code)
-        return exit_code
+        projector = ScreenCodingEventProjector(
+            app,
+            tool_definition_resolver=_tool_definition_resolver(session),
+            read_pending_steers=_queue_reader(session, "get_steering_messages"),
+            read_pending_followups=_queue_reader(session, "get_follow_up_messages"),
+            now=time.monotonic,
+        )
+        with log_context(
+            session_id=snapshot.session_observability_id,
+            cwd=snapshot.cwd,
+            mode="tui",
+        ):
+            try:
+                _trace_start(snapshot, interactive=True)
+                unsubscribe = subscribe_session_events(session, projector.handle)
+                exit_code = await run_screen_coding_tui(
+                    app=app,
+                    stdin=stdin,
+                    stdout=stdout,
+                    handle_prompt=_screen_prompt_handler(
+                        app=app,
+                        controller=controller,
+                        stderr=stderr,
+                        verbose=verbose,
+                    ),
+                    handle_local=surface_manager.handle_text,
+                    handle_steer=_screen_text_handler(
+                        app=app,
+                        dispatch=controller.steer,
+                        label="Steering failed",
+                    ),
+                    handle_followup=_screen_text_handler(
+                        app=app,
+                        dispatch=controller.follow_up,
+                        label="Follow-up failed",
+                    ),
+                    handle_surface_intent=surface_manager.handle_surface_intent,
+                    on_abort=_screen_abort_handler(controller),
+                    should_exit=_screen_should_exit,
+                    is_local_command=surface_manager.is_local_command,
+                    keybindings=_session_keybindings(session),
+                )
+                _write_resume_hint_for_clean_exit(
+                    session=session,
+                    stdout=stdout,
+                    exit_code=exit_code,
+                )
+                return exit_code
+            finally:
+                try:
+                    _trace("tui.end")
+                finally:
+                    unsubscribe()
     finally:
         try:
-            _trace("tui.end")
+            unbind_session_transition()
         finally:
-            unsubscribe()
-            observability_context.__exit__(None, None, None)
+            try:
+                surface_manager.clear_approval_surfaces()
+            finally:
+                unbind_approval_presenter()
+
+
+def _bind_screen_approval_presenter(
+    session: Any,
+    surface_manager: ScreenSurfaceManager,
+    *,
+    session_provider: Callable[[], Any] | None = None,
+) -> Callable[[], None]:
+    setter = getattr(session, "set_approval_presenter", None)
+    if not callable(setter):
+        return lambda: None
+
+    def present(payload: dict[str, object]) -> None:
+        action = payload.get("action")
+        risk = payload.get("risk")
+        action_id = payload.get("action_id")
+        surface_manager.open_approval(
+            action=action if isinstance(action, str) else "Approve tool call",
+            risk=risk if isinstance(risk, str) else "",
+            action_id=action_id if isinstance(action_id, str) else None,
+        )
+
+    setter(present, dismisser=surface_manager.dismiss_approval)
+
+    def unbind() -> None:
+        target = session_provider() if session_provider is not None else session
+        _unbind_session_approval_presenter(target)
+        if target is not session:
+            _unbind_session_approval_presenter(session)
+
+    return unbind
+
+
+def _unbind_session_approval_presenter(session: Any) -> None:
+    host_unbind = getattr(session, "_unbind_approval_presenter_host", None)
+    if callable(host_unbind):
+        host_unbind()
+        return
+    setter = getattr(session, "set_approval_presenter", None)
+    if callable(setter):
+        setter(None)
+
+
+def _runtime_session(runtime: Any, fallback: Any) -> Any:
+    getter = getattr(runtime, "get_current_session", None)
+    if callable(getter):
+        current = getter()
+        if current is not None:
+            return current
+    current = getattr(runtime, "current_session", None)
+    return current if current is not None else fallback
+
+
+def _bind_screen_session_transition(
+    runtime: Any,
+    surface_manager: ScreenSurfaceManager,
+) -> Callable[[], None]:
+    subscribe = getattr(runtime, "subscribe_after_session_invalidate", None)
+    if not callable(subscribe):
+        subscribe = getattr(runtime, "subscribe_before_session_invalidate", None)
+    if not callable(subscribe):
+        return lambda: None
+    unsubscribe = subscribe(surface_manager.clear_approval_surfaces)
+    return unsubscribe if callable(unsubscribe) else lambda: None
 
 
 async def _run_plain_tui(
@@ -191,8 +301,12 @@ async def _run_plain_tui(
     renderer = PlainCodingUiRenderer(stdout=stdout, stderr=stderr, verbose=verbose)
     run_context = None
     try:
-        snapshot = await load_coding_tui_startup_snapshot(runtime=runtime, session=session)
-        event_renderer = PlainCodingEventRenderer(renderer, tool_definition_resolver=_tool_definition_resolver(session))
+        snapshot = await load_coding_tui_startup_snapshot(
+            runtime=runtime, session=session
+        )
+        event_renderer = PlainCodingEventRenderer(
+            renderer, tool_definition_resolver=_tool_definition_resolver(session)
+        )
         run_context = open_coding_tui_run_context(
             session=session,
             snapshot=snapshot,
@@ -224,7 +338,9 @@ async def _run_plain_tui(
             session_label=snapshot.session_label,
             model_label=snapshot.model_label,
         )
-        return await run_non_interactive_prompt_loop(stdin=stdin, stdout=stdout, handle_prompt=app.handlers.handle_prompt)
+        return await run_non_interactive_prompt_loop(
+            stdin=stdin, stdout=stdout, handle_prompt=app.handlers.handle_prompt
+        )
     finally:
         if run_context is not None:
             run_context.close()
@@ -237,7 +353,9 @@ def _screen_prompt_handler(
     stderr: TextIO,
     verbose: bool,
 ):
-    async def handle(text: str, *, images: tuple[ImagePart, ...] | None = None) -> int | None:
+    async def handle(
+        text: str, *, images: tuple[ImagePart, ...] | None = None
+    ) -> int | None:
         intent = parse_prompt_intent(text)
         if intent is None:
             return None
@@ -246,7 +364,9 @@ def _screen_prompt_handler(
         if images is not None and hasattr(intent, "images"):
             intent = type(intent)(intent.text, images=images)
         result = await controller.dispatch(intent)
-        _record_controller_result(app=app, result=result, stderr=stderr, verbose=verbose)
+        _record_controller_result(
+            app=app, result=result, stderr=stderr, verbose=verbose
+        )
         return result.exit_code
 
     return handle
@@ -258,13 +378,17 @@ def _screen_text_handler(
     dispatch: Any,
     label: str,
 ):
-    async def handle(text: str, *, images: tuple[ImagePart, ...] | None = None) -> int | None:
+    async def handle(
+        text: str, *, images: tuple[ImagePart, ...] | None = None
+    ) -> int | None:
         if images is not None and _supports_keyword(dispatch, "images"):
             result = await _maybe_await(dispatch(text, images=images))
         else:
             result = await _maybe_await(dispatch(text))
         if isinstance(result, ControllerResult):
-            _record_controller_result(app=app, result=result, stderr=None, verbose=False, status_label=label)
+            _record_controller_result(
+                app=app, result=result, stderr=None, verbose=False, status_label=label
+            )
             return result.exit_code
         return result if isinstance(result, int) else None
 
@@ -302,7 +426,9 @@ def _screen_should_exit(text: str) -> bool:
     return isinstance(parse_prompt_intent(text), QuitIntent)
 
 
-def _write_resume_hint_for_clean_exit(*, session: Any, stdout: TextIO, exit_code: int) -> None:
+def _write_resume_hint_for_clean_exit(
+    *, session: Any, stdout: TextIO, exit_code: int
+) -> None:
     if exit_code != 0:
         return
     command = _resume_command_for_session(session)

--- a/src/loushang/coding/ui/screen_surfaces.py
+++ b/src/loushang/coding/ui/screen_surfaces.py
@@ -58,7 +58,9 @@ from loushang.tui import (
 )
 from loushang.tui.cell_width import truncate_to_width, wrap_cells
 
-ScreenSurfacePurpose = Literal["info", "model", "command", "settings", "dialog", "approval"]
+ScreenSurfacePurpose = Literal[
+    "info", "model", "command", "settings", "dialog", "approval"
+]
 ScreenSurfacePresentation = Literal["bottom", "bottom-exclusive"]
 SurfaceEventKind = Literal["surface_submit", "surface_close"]
 SurfaceEventSource = Literal["model", "command", "settings", "dialog", "approval"]
@@ -105,7 +107,9 @@ class ScreenSurfaceView(FocusableMixin):
             return None
         handler = getattr(self.content, "handle_input", None)
         if callable(handler):
-            intent = _screen_input_intent_or_none(handler(self._translate_content_input_event(event)))
+            intent = _screen_input_intent_or_none(
+                handler(self._translate_content_input_event(event))
+            )
             if intent is not None:
                 return intent
         if event.kind == "key" and event.key in {"escape", "esc"}:
@@ -122,7 +126,9 @@ class ScreenSurfaceView(FocusableMixin):
         reserved_footer_lines = 2 if self.footer else 0
         body_constraints = RenderConstraints(
             width=width,
-            max_height=max(1, constraints.max_height - len(lines) - reserved_footer_lines),
+            max_height=max(
+                1, constraints.max_height - len(lines) - reserved_footer_lines
+            ),
         )
         if isinstance(self.content, InfoPanel):
             body_lines: list[str] = []
@@ -132,11 +138,16 @@ class ScreenSurfaceView(FocusableMixin):
             self._last_info_body_line_count = len(body_lines)
             max_offset = self._max_info_scroll_offset()
             self._info_scroll_offset = max(0, min(self._info_scroll_offset, max_offset))
-            visible_body_lines = body_lines[self._info_scroll_offset : self._info_scroll_offset + body_constraints.max_height]
+            visible_body_lines = body_lines[
+                self._info_scroll_offset : self._info_scroll_offset
+                + body_constraints.max_height
+            ]
             body_start_row = len(lines)
             lines.extend(visible_body_lines)
             if visible_body_lines:
-                cursor = CursorDeclaration(row=body_start_row + len(visible_body_lines) - 1, column=0)
+                cursor = CursorDeclaration(
+                    row=body_start_row + len(visible_body_lines) - 1, column=0
+                )
         else:
             self._last_content_start_row = len(lines)
             result = self.content.render(body_constraints)
@@ -144,7 +155,9 @@ class ScreenSurfaceView(FocusableMixin):
             if result.cursor is not None:
                 cursor_row = self._last_content_start_row + result.cursor.row
                 if cursor_row < constraints.max_height:
-                    cursor = CursorDeclaration(row=cursor_row, column=result.cursor.column)
+                    cursor = CursorDeclaration(
+                        row=cursor_row, column=result.cursor.column
+                    )
         footer = self._footer_text()
         if footer and len(lines) < constraints.max_height:
             if len(lines) + 1 < constraints.max_height:
@@ -256,7 +269,9 @@ class ModelSelectorSurface:
         header = [RenderLine(self._scope_line()), RenderLine("")]
         body_height = constraints.max_height - len(header)
         if body_height <= 0:
-            return RenderResult.from_lines(header[: constraints.max_height], constraints=constraints)
+            return RenderResult.from_lines(
+                header[: constraints.max_height], constraints=constraints
+            )
         body = self._surface.render(
             RenderConstraints(
                 width=constraints.width,
@@ -264,8 +279,14 @@ class ModelSelectorSurface:
                 visible_height=constraints.visible_height,
             )
         )
-        cursor = replace(body.cursor, row=body.cursor.row + len(header)) if body.cursor is not None else None
-        return RenderResult.from_lines([*header, *body.lines], constraints=constraints, cursor=cursor)
+        cursor = (
+            replace(body.cursor, row=body.cursor.row + len(header))
+            if body.cursor is not None
+            else None
+        )
+        return RenderResult.from_lines(
+            [*header, *body.lines], constraints=constraints, cursor=cursor
+        )
 
     def _rebuild_surface(self) -> None:
         items = self.scoped_items if self._scope == "scoped" else self.all_items
@@ -301,7 +322,11 @@ class ModelSelectorSurface:
         return f"Scope: {all_models} | scoped"
 
     def _handle_ordinal_text(self, text: str) -> tuple[bool, InputIntent | None]:
-        if self._surface.filter_text or not text or any(digit not in "0123456789" for digit in text):
+        if (
+            self._surface.filter_text
+            or not text
+            or any(digit not in "0123456789" for digit in text)
+        ):
             self._pending_ordinal = ""
             return False, None
         consumed = False
@@ -330,9 +355,8 @@ class ModelSelectorSurface:
             return consumed, None
 
         ordinal = int(candidate)
-        if (
-            1 <= ordinal <= len(items)
-            and not self._has_longer_ordinal_match(candidate, len(items))
+        if 1 <= ordinal <= len(items) and not self._has_longer_ordinal_match(
+            candidate, len(items)
         ):
             self._pending_ordinal = ""
             return True, self._select_ordinal(ordinal)
@@ -364,7 +388,10 @@ class ModelSelectorSurface:
         if not prefix:
             return False
         ordinal = int(prefix)
-        return 1 <= ordinal <= item_count or ModelSelectorSurface._has_longer_ordinal_match(prefix, item_count)
+        return (
+            1 <= ordinal <= item_count
+            or ModelSelectorSurface._has_longer_ordinal_match(prefix, item_count)
+        )
 
     @staticmethod
     def _has_longer_ordinal_match(prefix: str, item_count: int) -> bool:
@@ -384,11 +411,15 @@ class ScreenSurfaceManager:
     app: ScreenCodingTuiApp
     session: Any
     status_provider: CodingTuiStatusProvider
-    on_approval: Callable[[dict[str, Any]], Awaitable[None]] | None = None
+    on_approval: Callable[[dict[str, Any]], Awaitable[bool | None]] | None = None
     command_catalog: ScreenCommandCatalog | None = None
-    _handlers: dict[SurfaceEventSource, Callable[[Any], Awaitable[None]]] = field(init=False, repr=False)
+    _handlers: dict[SurfaceEventSource, Callable[[Any], Awaitable[None]]] = field(
+        init=False, repr=False
+    )
     _active_overlay_view: ScreenSurfaceView | None = None
     _active_overlay_handle: SurfaceHandle | None = None
+    _approval_queue: list[ApprovalSurface] = field(default_factory=list, repr=False)
+    _approval_transitioning: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._handlers = {
@@ -399,7 +430,9 @@ class ScreenSurfaceManager:
             "approval": self._handle_approval_submit,
         }
         if self.command_catalog is None:
-            self.command_catalog = CodingCommandCatalog(session_commands=_session_commands_provider(self.session))
+            self.command_catalog = CodingCommandCatalog(
+                session_commands=_session_commands_provider(self.session)
+            )
 
     def is_local_command(self, text: str) -> bool:
         return self._lookup_local_command(text) is not None
@@ -412,7 +445,9 @@ class ScreenSurfaceManager:
         if command.name == "model" and isinstance(intent, ModelSelectIntent):
             await self._handle_model_intent(intent)
         elif command.name == "models" and isinstance(intent, ModelsIntent):
-            models_text = await format_available_models(self.session, query=intent.query)
+            models_text = await format_available_models(
+                self.session, query=intent.query
+            )
             self._open_info(
                 "Available Models",
                 _models_info_body(models_text),
@@ -429,11 +464,15 @@ class ScreenSurfaceManager:
                     command_catalog=self._list_command_catalog(),
                 ),
             )
-        elif command.name == "terminal" and isinstance(intent, TerminalDiagnosticsIntent):
+        elif command.name == "terminal" and isinstance(
+            intent, TerminalDiagnosticsIntent
+        ):
             self._open_terminal_diagnostics()
         elif command.name == "hotkeys" and isinstance(intent, HotkeysIntent):
             self._open_info("Hotkeys", format_hotkeys())
-        elif command.name in {"settings", "config"} and isinstance(intent, SettingsIntent):
+        elif command.name in {"settings", "config"} and isinstance(
+            intent, SettingsIntent
+        ):
             await self._open_settings()
         return None
 
@@ -446,7 +485,11 @@ class ScreenSurfaceManager:
         return command
 
     def _list_command_catalog(self) -> CodingCommandCatalog | None:
-        return self.command_catalog if isinstance(self.command_catalog, CodingCommandCatalog) else None
+        return (
+            self.command_catalog
+            if isinstance(self.command_catalog, CodingCommandCatalog)
+            else None
+        )
 
     async def handle_surface_intent(self, intent: InputIntent) -> int | None:
         surface = self._current_surface()
@@ -465,13 +508,21 @@ class ScreenSurfaceManager:
         await handler(event.payload)
         return None
 
-    def _normalize_surface_intent(self, intent: InputIntent, surface: ScreenSurfaceView) -> SurfaceEvent | None:
+    def _normalize_surface_intent(
+        self, intent: InputIntent, surface: ScreenSurfaceView
+    ) -> SurfaceEvent | None:
         if intent.kind in {"surface_close", "dialog_cancel"}:
+            if surface.purpose == "approval":
+                return _approval_surface_event(surface, approved=False)
             return SurfaceEvent(kind="surface_close", source=None)
         if surface.purpose == "model" and intent.kind in {"command", "select"}:
-            return SurfaceEvent(kind="surface_submit", source="model", payload=intent.text)
+            return SurfaceEvent(
+                kind="surface_submit", source="model", payload=intent.text
+            )
         if surface.purpose == "command" and intent.kind in {"command", "select"}:
-            return SurfaceEvent(kind="surface_submit", source="command", payload=intent.text)
+            return SurfaceEvent(
+                kind="surface_submit", source="command", payload=intent.text
+            )
         if surface.purpose == "settings" and intent.kind == "setting":
             return SurfaceEvent(
                 kind="surface_submit",
@@ -481,17 +532,10 @@ class ScreenSurfaceManager:
         if surface.purpose == "dialog" and intent.kind == "dialog_confirm":
             return SurfaceEvent(kind="surface_submit", source="dialog")
         if surface.purpose == "approval" and intent.kind in {"approve", "reject"}:
-            action_id = getattr(surface.content, "action_id", None)
-            action = getattr(surface.content, "action", None)
-            return SurfaceEvent(
-                kind="surface_submit",
-                source="approval",
-                payload={
-                    "action_id": action_id,
-                    "action": action,
-                    "approved": intent.kind == "approve",
-                    "raw_note": intent.note or action_id,
-                },
+            return _approval_surface_event(
+                surface,
+                approved=intent.kind == "approve",
+                note=intent.note,
             )
         return None
 
@@ -530,14 +574,24 @@ class ScreenSurfaceManager:
     async def _handle_dialog_submit(self, _payload: Any | None = None) -> None:
         self.close_surface()
 
-    async def _handle_approval_submit(self, payload: dict[str, Any] | None = None) -> None:
+    async def _handle_approval_submit(
+        self, payload: dict[str, Any] | None = None
+    ) -> None:
+        self._approval_transitioning = True
         self.close_surface()
-        if payload is not None and payload.get("approved"):
-            self.app.set_status(f"Action confirmed: {payload.get('action')}")
-        elif payload is not None:
-            self.app.set_status("Action rejected")
-        if self.on_approval is not None:
-            await self.on_approval(payload or {})
+        try:
+            accepted = True
+            if self.on_approval is not None:
+                accepted = await self.on_approval(payload or {}) is not False
+            if not accepted:
+                self.app.set_status("Approval request is no longer pending")
+            elif payload is not None and payload.get("approved"):
+                self.app.set_status(f"Action confirmed: {payload.get('action')}")
+            elif payload is not None:
+                self.app.set_status("Action rejected")
+        finally:
+            self._approval_transitioning = False
+            self._open_next_approval()
 
     def close_surface(self) -> None:
         if self._active_overlay_handle is not None:
@@ -545,6 +599,29 @@ class ScreenSurfaceManager:
         self._active_overlay_handle = None
         self._active_overlay_view = None
         self.app.active_surface = None
+
+    def clear_approval_surfaces(self) -> None:
+        self._approval_queue.clear()
+        current = self._current_surface()
+        if isinstance(current, ScreenSurfaceView) and current.purpose == "approval":
+            self.close_surface()
+
+    def dismiss_approval(self, action_id: str) -> None:
+        current = self._current_surface()
+        if (
+            isinstance(current, ScreenSurfaceView)
+            and current.purpose == "approval"
+            and getattr(current.content, "action_id", None) == action_id
+        ):
+            self.close_surface()
+            if not self._approval_transitioning:
+                self._open_next_approval()
+            return
+        self._approval_queue = [
+            approval
+            for approval in self._approval_queue
+            if approval.action_id != action_id
+        ]
 
     async def _handle_model_intent(self, intent: ModelSelectIntent) -> None:
         if intent.query.strip():
@@ -560,29 +637,53 @@ class ScreenSurfaceManager:
 
     async def _handle_command_intent(self, intent: CommandSelectIntent) -> None:
         if intent.query.strip():
-            command = intent.query if intent.query.startswith("/") else f"/{intent.query}"
+            command = (
+                intent.query if intent.query.startswith("/") else f"/{intent.query}"
+            )
             self.app.composer.set_text(command + " ")
             self.app.set_status(f"Command selected: {command}")
             return
         self._open_palette(
             "Commands",
-            await coding_command_palette(self.session, title="Commands", command_catalog=self._list_command_catalog()),
+            await coding_command_palette(
+                self.session,
+                title="Commands",
+                command_catalog=self._list_command_catalog(),
+            ),
             purpose="command",
         )
 
-    def _open_palette(self, title: str, palette: CommandPalette, *, purpose: Literal["model", "command"]) -> None:
+    def _open_palette(
+        self,
+        title: str,
+        palette: CommandPalette,
+        *,
+        purpose: Literal["model", "command"],
+    ) -> None:
         surface = CommandSurface(_palette_items(palette), max_visible=8)
-        self._open_surface(ScreenSurfaceView(title=title, purpose=purpose, content=surface))
+        self._open_surface(
+            ScreenSurfaceView(title=title, purpose=purpose, content=surface)
+        )
 
     async def _open_model_selector(self) -> None:
-        current_label = model_label_from_selection(await get_session_model_selection(self.session))
+        current_label = model_label_from_selection(
+            await get_session_model_selection(self.session)
+        )
         choices = await available_model_choices(self.session)
         current_value = await current_model_choice_value(self.session, choices=choices)
         scoped_selections = await iter_scoped_model_selections(self.session)
         descriptions = await model_detail_descriptions_by_label(self.session)
         surface = ModelSelectorSurface(
-            all_items=tuple(_model_choice_selector_items(choices, current_value=current_value)),
-            scoped_items=tuple(_model_selector_items(scoped_selections, current_label=current_label, descriptions=descriptions)),
+            all_items=tuple(
+                _model_choice_selector_items(choices, current_value=current_value)
+            ),
+            scoped_items=tuple(
+                _model_selector_items(
+                    scoped_selections,
+                    current_label=current_label,
+                    descriptions=descriptions,
+                )
+            ),
             selected_value=current_value or current_label,
             max_visible=10,
         )
@@ -616,7 +717,11 @@ class ScreenSurfaceManager:
 
     def _open_terminal_diagnostics(self) -> None:
         provider = self.app.terminal_diagnostics_provider
-        text = provider() if provider is not None else "Terminal diagnostics are not available outside an active TUI session."
+        text = (
+            provider()
+            if provider is not None
+            else "Terminal diagnostics are not available outside an active TUI session."
+        )
         self._open_info("Terminal", text)
 
     async def _open_settings(self) -> None:
@@ -638,16 +743,32 @@ class ScreenSurfaceManager:
             )
         )
 
-    def open_approval(self, *, action: str, risk: str = "", action_id: str | None = None) -> None:
+    def open_approval(
+        self, *, action: str, risk: str = "", action_id: str | None = None
+    ) -> None:
+        approval = ApprovalSurface(action=action, risk=risk, action_id=action_id)
+        current = self._current_surface()
+        if self._approval_transitioning or (
+            isinstance(current, ScreenSurfaceView) and current.purpose == "approval"
+        ):
+            self._approval_queue.append(approval)
+            return
+        self._open_approval_surface(approval)
+
+    def _open_approval_surface(self, approval: ApprovalSurface) -> None:
         self._open_surface(
             ScreenSurfaceView(
                 title="Approval",
                 purpose="approval",
-                content=ApprovalSurface(action=action, risk=risk, action_id=action_id),
+                content=approval,
                 footer="",
                 presentation="bottom-exclusive",
             )
         )
+
+    def _open_next_approval(self) -> None:
+        if self._approval_queue:
+            self._open_approval_surface(self._approval_queue.pop(0))
 
     def _open_surface(self, view: ScreenSurfaceView) -> None:
         self.close_surface()
@@ -669,22 +790,52 @@ class ScreenSurfaceManager:
         )
 
     def _current_surface(self) -> ScreenSurfaceView | Any | None:
-        return self._active_overlay_view if self._active_overlay_view is not None else self.app.active_surface
+        return (
+            self._active_overlay_view
+            if self._active_overlay_view is not None
+            else self.app.active_surface
+        )
 
     async def _refresh_model_label(self) -> None:
-        label = model_label_from_selection(await get_session_model_selection(self.session))
+        label = model_label_from_selection(
+            await get_session_model_selection(self.session)
+        )
         if label is not None:
             self.app.state.model_label = label
 
 
+def _approval_surface_event(
+    surface: ScreenSurfaceView,
+    *,
+    approved: bool,
+    note: str | None = None,
+) -> SurfaceEvent:
+    action_id = getattr(surface.content, "action_id", None)
+    action = getattr(surface.content, "action", None)
+    return SurfaceEvent(
+        kind="surface_submit",
+        source="approval",
+        payload={
+            "action_id": action_id,
+            "action": action,
+            "approved": approved,
+            "raw_note": note or action_id,
+        },
+    )
+
+
 def _palette_items(palette: CommandPalette) -> list[SelectItem]:
     return [
-        SelectItem(label=item.display_label(), value=item.value, description=item.description)
+        SelectItem(
+            label=item.display_label(), value=item.value, description=item.description
+        )
         for item in palette.items
     ]
 
 
-def _model_selector_description(label: str, *, current_label: str | None, descriptions: dict[str, str]) -> str:
+def _model_selector_description(
+    label: str, *, current_label: str | None, descriptions: dict[str, str]
+) -> str:
     if label == current_label:
         return "current"
     return descriptions.get(label, "")
@@ -713,7 +864,9 @@ def _model_selector_items(
             SelectItem(
                 label=f"{ordinal} {label}",
                 value=label,
-                description=_model_selector_description(label, current_label=current_label, descriptions=descriptions),
+                description=_model_selector_description(
+                    label, current_label=current_label, descriptions=descriptions
+                ),
             )
         )
     return items
@@ -732,13 +885,17 @@ def _model_choice_selector_items(
             SelectItem(
                 label=f"{ordinal} {choice.label}",
                 value=choice.value,
-                description=_model_choice_selector_description(choice, current_value=current_value),
+                description=_model_choice_selector_description(
+                    choice, current_value=current_value
+                ),
             )
         )
     return items
 
 
-def _model_choice_selector_description(choice: ModelChoice, *, current_value: str | None) -> str:
+def _model_choice_selector_description(
+    choice: ModelChoice, *, current_value: str | None
+) -> str:
     parts: list[str] = []
     if choice.value == current_value:
         parts.append("current")
@@ -755,7 +912,9 @@ def _model_choice_selector_description(choice: ModelChoice, *, current_value: st
     return " - ".join(parts)
 
 
-def _selected_model_item_index(items: tuple[SelectItem, ...], selected_value: str | None) -> int:
+def _selected_model_item_index(
+    items: tuple[SelectItem, ...], selected_value: str | None
+) -> int:
     if selected_value is None:
         return 0
     for index, item in enumerate(items):

--- a/src/loushang/harness/approval.py
+++ b/src/loushang/harness/approval.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 from collections.abc import Awaitable, Mapping
-from dataclasses import dataclass
-from typing import Any, Literal, Protocol, TypeVar
+from contextlib import suppress
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from typing import Any, Literal, Never, Protocol, TypeAlias, TypeVar
+from uuid import uuid4
 
 T = TypeVar("T")
-MaybeAwaitable = T | Awaitable[T]
+MaybeAwaitable: TypeAlias = T | Awaitable[T]
 
 
 @dataclass(frozen=True)
@@ -19,6 +23,21 @@ class ApprovalRequest:
     policy_decision: object | None = None
     action_id: str | None = None
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.tool_name, str) or not self.tool_name:
+            raise ValueError("ApprovalRequest tool_name must be a non-empty string")
+        _validate_optional_string(self.cwd, "ApprovalRequest cwd")
+        _validate_optional_string(self.reason, "ApprovalRequest reason")
+        _validate_optional_string(self.policy_code, "ApprovalRequest policy_code")
+        _validate_optional_string(self.action_id, "ApprovalRequest action_id")
+        if self.action_id == "":
+            raise ValueError("ApprovalRequest action_id must not be empty")
+        object.__setattr__(
+            self,
+            "arguments",
+            _freeze_mapping(self.arguments),
+        )
+
 
 @dataclass(frozen=True)
 class ApprovalDecision:
@@ -27,7 +46,10 @@ class ApprovalDecision:
 
     def __post_init__(self) -> None:
         if self.disposition not in {"allow", "deny"}:
-            raise ValueError(f"Unsupported approval decision disposition: {self.disposition}")
+            raise ValueError(
+                f"Unsupported approval decision disposition: {self.disposition}"
+            )
+        _validate_optional_string(self.reason, "ApprovalDecision reason")
 
     @classmethod
     def allow(cls) -> "ApprovalDecision":
@@ -42,10 +64,24 @@ class ApprovalResolver(Protocol):
     def resolve(self, request: ApprovalRequest) -> MaybeAwaitable[ApprovalDecision]: ...
 
 
+class ApprovalPresenter(Protocol):
+    def present(self, request: ApprovalRequest) -> MaybeAwaitable[None]: ...
+
+
+class ApprovalRequestCollisionError(RuntimeError):
+    def __init__(self, action_id: str) -> None:
+        super().__init__(
+            f"Approval action id was already presented by this broker: {action_id}"
+        )
+        self.action_id = action_id
+
+
 @dataclass(frozen=True)
 class DenyApprovalResolver:
     def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
-        return ApprovalDecision.deny(request.reason or f"Tool {request.tool_name} requires approval")
+        return ApprovalDecision.deny(
+            request.reason or f"Tool {request.tool_name} requires approval"
+        )
 
 
 @dataclass(frozen=True)
@@ -60,7 +96,11 @@ class HeadlessApprovalResolver:
     def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
         if self.mode == "allow":
             return ApprovalDecision.allow()
-        return ApprovalDecision.deny(self.reason or request.reason or f"Tool {request.tool_name} requires approval")
+        return ApprovalDecision.deny(
+            self.reason
+            or request.reason
+            or f"Tool {request.tool_name} requires approval"
+        )
 
 
 async def resolve_approval(
@@ -72,5 +112,407 @@ async def resolve_approval(
     if inspect.isawaitable(result):
         result = await result
     if not isinstance(result, ApprovalDecision):
-        raise TypeError(f"ApprovalResolver returned {type(result).__name__}, expected ApprovalDecision")
+        raise TypeError(
+            f"ApprovalResolver returned {type(result).__name__}, expected ApprovalDecision"
+        )
+    result.__post_init__()
     return result
+
+
+def approval_request_to_dict(request: ApprovalRequest) -> dict[str, object]:
+    """Project a request into mutable JSON-compatible Product data."""
+
+    if not isinstance(request, ApprovalRequest):
+        raise TypeError("request must be an ApprovalRequest")
+    return {
+        "tool_name": request.tool_name,
+        "arguments": _thaw_value(request.arguments),
+        "cwd": request.cwd,
+        "reason": request.reason,
+        "policy_code": request.policy_code,
+        "action_id": request.action_id,
+    }
+
+
+def ensure_approval_action_id(request: ApprovalRequest) -> ApprovalRequest:
+    """Return an immutable request with a correlation id."""
+
+    if request.action_id:
+        return request
+    return replace(request, action_id=f"approval-{uuid4().hex}")
+
+
+@dataclass
+class _PendingApproval:
+    request: ApprovalRequest
+    future: asyncio.Future[ApprovalDecision] = field(compare=False, repr=False)
+    accepting_presenter_results: bool = field(default=True, compare=False)
+
+
+class ApprovalBroker:
+    """Event-loop-confined lifecycle manager for interactive approvals."""
+
+    def __init__(
+        self,
+        *,
+        fallback: ApprovalResolver,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        if fallback is self:
+            raise ValueError("ApprovalBroker cannot use itself as fallback")
+        if timeout_seconds is not None and timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._fallback = fallback
+        self._timeout_seconds = timeout_seconds
+        self._presenter: ApprovalPresenter | None = None
+        self._pending: dict[str, _PendingApproval] = {}
+        self._presented_action_ids: set[str] = set()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._disposed = False
+
+    def set_presenter(self, presenter: ApprovalPresenter | None) -> None:
+        if self._disposed and presenter is not None:
+            raise RuntimeError("ApprovalBroker is disposed")
+        self._presenter = presenter
+
+    def pending_requests(self) -> tuple[ApprovalRequest, ...]:
+        return tuple(pending.request for pending in self._pending.values())
+
+    async def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+        request = ensure_approval_action_id(request)
+        action_id = request.action_id
+        assert action_id is not None
+        if action_id in self._pending:
+            raise ApprovalRequestCollisionError(action_id)
+        if self._disposed or self._presenter is None:
+            return await resolve_approval(self._fallback, request)
+        if action_id in self._presented_action_ids:
+            raise ApprovalRequestCollisionError(action_id)
+
+        loop = self._capture_loop()
+        future: asyncio.Future[ApprovalDecision] = loop.create_future()
+        pending = _PendingApproval(request=request, future=future)
+        self._presented_action_ids.add(action_id)
+        self._pending[action_id] = pending
+        presenter = self._presenter
+        assert presenter is not None
+        try:
+            waiter = self._present_and_wait(
+                presenter,
+                request,
+                future,
+            )
+            if self._timeout_seconds is None:
+                return await waiter
+            waiter_task = asyncio.create_task(waiter)
+            try:
+                done, _ = await asyncio.wait(
+                    (waiter_task,),
+                    timeout=self._timeout_seconds,
+                )
+                if waiter_task in done:
+                    return waiter_task.result()
+                pending.accepting_presenter_results = False
+                await _cancel_child_task(waiter_task)
+                if future.done():
+                    return future.result()
+                return await self._resolve_fallback_or_pending_decision(
+                    request,
+                    future,
+                )
+            finally:
+                if not waiter_task.done():
+                    await _cancel_child_task(waiter_task)
+        finally:
+            current = self._pending.get(action_id)
+            if current is pending:
+                self._pending.pop(action_id, None)
+            if not future.done():
+                future.cancel()
+            _dismiss_presented_request(presenter, request)
+
+    async def _present_and_wait(
+        self,
+        presenter: ApprovalPresenter,
+        request: ApprovalRequest,
+        future: asyncio.Future[ApprovalDecision],
+    ) -> ApprovalDecision:
+        presented = presenter.present(request)
+        if not inspect.isawaitable(presented):
+            return await asyncio.shield(future)
+
+        presentation_task = asyncio.ensure_future(presented)
+        try:
+            done, _ = await asyncio.wait(
+                (presentation_task, future),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if presentation_task in done:
+                await presentation_task
+                return await asyncio.shield(future)
+            return future.result()
+        finally:
+            if not presentation_task.done():
+                _cancel_detached_presentation(
+                    presentation_task,
+                    presenter=presenter,
+                    request=request,
+                )
+
+    async def _resolve_fallback_or_pending_decision(
+        self,
+        request: ApprovalRequest,
+        future: asyncio.Future[ApprovalDecision],
+    ) -> ApprovalDecision:
+        fallback_task = asyncio.create_task(resolve_approval(self._fallback, request))
+        try:
+            done, _ = await asyncio.wait(
+                (fallback_task, future),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if future in done:
+                if fallback_task in done:
+                    with suppress(asyncio.CancelledError, Exception):
+                        fallback_task.result()
+                return future.result()
+            return fallback_task.result()
+        finally:
+            if not fallback_task.done():
+                _cancel_detached_task(fallback_task)
+
+    def resolve_request(
+        self,
+        action_id: str,
+        decision: ApprovalDecision,
+    ) -> bool:
+        _validate_approval_decision(decision)
+        self._require_loop_if_pending()
+        pending = self._pending.get(action_id)
+        if (
+            pending is None
+            or not pending.accepting_presenter_results
+            or pending.future.done()
+        ):
+            return False
+        pending.future.set_result(decision)
+        return True
+
+    def cancel_request(
+        self,
+        action_id: str,
+        decision: ApprovalDecision,
+    ) -> bool:
+        _validate_approval_decision(decision)
+        self._require_loop_if_pending()
+        pending = self._pending.get(action_id)
+        if pending is None or pending.future.done():
+            return False
+        pending.future.set_result(decision)
+        return True
+
+    def cancel_all(self, decision: ApprovalDecision) -> int:
+        _validate_approval_decision(decision)
+        self._require_loop_if_pending()
+        completed = 0
+        for pending in tuple(self._pending.values()):
+            if pending.future.done():
+                continue
+            pending.future.set_result(decision)
+            completed += 1
+        return completed
+
+    def dispose(self, decision: ApprovalDecision) -> int:
+        _validate_approval_decision(decision)
+        if self._disposed:
+            return 0
+        self._require_loop_if_pending()
+        self._disposed = True
+        self._presenter = None
+        completed = self.cancel_all(decision)
+        self._presented_action_ids.clear()
+        return completed
+
+    def _capture_loop(self) -> asyncio.AbstractEventLoop:
+        loop = asyncio.get_running_loop()
+        if self._loop is None:
+            self._loop = loop
+        elif self._loop is not loop:
+            if self._pending:
+                raise RuntimeError("ApprovalBroker cannot be used across event loops")
+            self._loop = loop
+        return loop
+
+    def _require_loop_if_pending(self) -> None:
+        if not self._pending:
+            return
+        loop = asyncio.get_running_loop()
+        if self._loop is not loop:
+            raise RuntimeError(
+                "ApprovalBroker must be resolved on its owning event loop"
+            )
+
+
+class _FrozenDict(dict[str, Any]):
+    """Immutable dict snapshot that remains compatible with serializers."""
+
+    def _immutable(self, *args: object, **kwargs: object) -> Never:
+        del args, kwargs
+        raise TypeError("frozen mapping does not support mutation")
+
+    def __setitem__(self, key: str, value: Any) -> Never:
+        self._immutable(key, value)
+
+    def __delitem__(self, key: str) -> Never:
+        self._immutable(key)
+
+    def clear(self) -> Never:
+        self._immutable()
+
+    def pop(self, key: str, default: Any = None) -> Never:
+        self._immutable(key, default)
+
+    def popitem(self) -> Never:
+        self._immutable()
+
+    def setdefault(self, key: str, default: Any = None) -> Never:
+        self._immutable(key, default)
+
+    def update(self, *args: Any, **kwargs: Any) -> Never:
+        self._immutable(*args, **kwargs)
+
+    def __ior__(self, other: object) -> Never:
+        self._immutable(other)
+
+    def __reduce__(self) -> tuple[type[_FrozenDict], tuple[dict[str, Any]]]:
+        return type(self), (dict(self),)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> _FrozenDict:
+        copied = type(self)(
+            {deepcopy(key, memo): deepcopy(value, memo) for key, value in self.items()}
+        )
+        memo[id(self)] = copied
+        return copied
+
+
+def _freeze_mapping(values: Mapping[str, Any]) -> Mapping[str, Any]:
+    if not isinstance(values, Mapping):
+        raise TypeError("ApprovalRequest arguments must be a mapping")
+    return _FrozenDict(
+        {
+            _require_string_key(key): _freeze_value(value)
+            for key, value in values.items()
+        }
+    )
+
+
+def _freeze_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _FrozenDict(
+            {
+                _require_string_key(key): _freeze_value(item)
+                for key, item in value.items()
+            }
+        )
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_value(item) for item in value)
+    if value is None or isinstance(value, str | bool | int | float):
+        return value
+    raise TypeError(
+        "ApprovalRequest argument values must be JSON-compatible mappings, "
+        "sequences, strings, numbers, booleans, or null"
+    )
+
+
+def _thaw_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {key: _thaw_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_value(item) for item in value]
+    return value
+
+
+def _validate_optional_string(value: object, field_name: str) -> None:
+    if value is not None and not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string or None")
+
+
+def _require_string_key(key: object) -> str:
+    if not isinstance(key, str):
+        raise TypeError("ApprovalRequest argument mapping keys must be strings")
+    return key
+
+
+def _validate_approval_decision(decision: object) -> ApprovalDecision:
+    if not isinstance(decision, ApprovalDecision):
+        raise TypeError("decision must be an ApprovalDecision")
+    decision.__post_init__()
+    return decision
+
+
+def _cancel_detached_task(task: asyncio.Future[Any]) -> None:
+    task.cancel()
+    task.add_done_callback(_consume_detached_result)
+
+
+async def _cancel_child_task(task: asyncio.Future[Any]) -> None:
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        current = asyncio.current_task()
+        if current is not None and current.cancelling():
+            raise
+
+
+def _cancel_detached_presentation(
+    task: asyncio.Future[Any],
+    *,
+    presenter: ApprovalPresenter,
+    request: ApprovalRequest,
+) -> None:
+    task.cancel()
+
+    def _finish_presentation(completed: asyncio.Future[Any]) -> None:
+        _consume_detached_result(completed)
+        _dismiss_presented_request(presenter, request)
+
+    task.add_done_callback(_finish_presentation)
+
+
+def _dismiss_presented_request(
+    presenter: ApprovalPresenter,
+    request: ApprovalRequest,
+) -> None:
+    try:
+        dismiss = getattr(presenter, "dismiss", None)
+        if not callable(dismiss):
+            return
+        result = dismiss(request)
+        if inspect.isawaitable(result):
+            task = asyncio.ensure_future(result)
+            task.add_done_callback(_consume_detached_result)
+    except asyncio.CancelledError:
+        return
+    except Exception:
+        return
+
+
+def _consume_detached_result(completed: asyncio.Future[Any]) -> None:
+    with suppress(asyncio.CancelledError, Exception):
+        completed.result()
+
+
+__all__ = [
+    "ApprovalBroker",
+    "ApprovalDecision",
+    "ApprovalPresenter",
+    "ApprovalRequest",
+    "ApprovalRequestCollisionError",
+    "ApprovalResolver",
+    "DenyApprovalResolver",
+    "HeadlessApprovalResolver",
+    "MaybeAwaitable",
+    "approval_request_to_dict",
+    "ensure_approval_action_id",
+    "resolve_approval",
+]

--- a/src/loushang/harness/contributions.py
+++ b/src/loushang/harness/contributions.py
@@ -18,6 +18,8 @@ ExtensionSurfaceType = Literal[
     "ui",
     "autocomplete",
     "resource_root",
+    "policy",
+    "approval",
 ]
 
 
@@ -32,10 +34,15 @@ class ExtensionSurfaceDescriptor:
     permission_requirements: tuple[str, ...] = ()
     diagnostics: tuple[ResourceDiagnostic, ...] = ()
     metadata: dict[str, object] = field(default_factory=dict)
+    after: tuple[str, ...] = ()
+    before: tuple[str, ...] = ()
+    on_error: Literal["skip", "fail_chain"] = "skip"
 
 
 class DuplicateExtensionSurfaceKeyError(KeyError):
-    def __init__(self, surface_type: str, name: str, surfaces: list[ExtensionSurfaceDescriptor]) -> None:
+    def __init__(
+        self, surface_type: str, name: str, surfaces: list[ExtensionSurfaceDescriptor]
+    ) -> None:
         super().__init__(f"Duplicate extension surface key: {surface_type}:{name}")
         self.surface_type = surface_type
         self.contribution_type = surface_type
@@ -47,15 +54,23 @@ class DuplicateExtensionSurfaceKeyError(KeyError):
 @dataclass
 class ExtensionInventory:
     _surfaces: list[ExtensionSurfaceDescriptor] = field(default_factory=list)
-    _by_type: dict[str, list[ExtensionSurfaceDescriptor]] = field(default_factory=lambda: defaultdict(list))
-    _by_extension: dict[str, list[ExtensionSurfaceDescriptor]] = field(default_factory=lambda: defaultdict(list))
-    _by_key: dict[tuple[str, str], list[ExtensionSurfaceDescriptor]] = field(default_factory=lambda: defaultdict(list))
+    _by_type: dict[str, list[ExtensionSurfaceDescriptor]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    _by_extension: dict[str, list[ExtensionSurfaceDescriptor]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    _by_key: dict[tuple[str, str], list[ExtensionSurfaceDescriptor]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
 
     @classmethod
     def from_extensions(cls, extensions: Iterable[object]) -> ExtensionInventory:
         inventory = cls()
         for extension in extensions:
-            for surface in getattr(extension, "surfaces", getattr(extension, "contributions", ())):
+            for surface in getattr(
+                extension, "surfaces", getattr(extension, "contributions", ())
+            ):
                 inventory.add(surface)
         return inventory
 

--- a/src/loushang/harness/extensions/api.py
+++ b/src/loushang/harness/extensions/api.py
@@ -6,11 +6,14 @@ from pathlib import Path
 from typing import Literal, cast
 
 from loushang.agent.types import AgentTool, ensure_agent_tool, is_agent_tool_like
+from loushang.harness.contributions import ExtensionSurfaceDescriptor
 from loushang.harness.extensions.events import VALID_EXTENSION_EVENTS
+from loushang.harness.extensions.routing import RegisteredExtensionHandler
 from loushang.harness.extensions.types import (
     ExtensionHandler,
     LoadedExtension,
     RegisteredCommand,
+    RegisteredControlContribution,
     RegisteredFlag,
     RegisteredShortcut,
 )
@@ -36,6 +39,8 @@ class ExtensionContributionAPI:
         self._source_path = source_path
         self._entry_path = entry_path
         self._hooks: dict[str, list[object]] = {}
+        self._handler_registrations: list[RegisteredExtensionHandler] = []
+        self._control_contributions: list[RegisteredControlContribution] = []
         self._tool_definitions: list[ToolDefinition] = []
         self._commands: dict[str, RegisteredCommand] = {}
         self._flags: dict[str, RegisteredFlag] = {}
@@ -46,9 +51,39 @@ class ExtensionContributionAPI:
         self._diagnostics: list[ResourceDiagnostic] = []
         self._runtime_state: object | None = None
 
-    def on(self, event_name: str, handler: object) -> None:
+    def on(
+        self,
+        event_name: str,
+        handler: object,
+        *,
+        route_id: str | None = None,
+        priority: int = 0,
+        after: Sequence[str] = (),
+        before: Sequence[str] = (),
+        on_error: Literal["skip", "fail_chain"] = "skip",
+    ) -> None:
         if event_name not in VALID_EXTENSION_EVENTS:
             raise ValueError(f"Unsupported extension event: {event_name}")
+        if not callable(handler):
+            raise TypeError("Extension hook handler must be callable.")
+        event_registration_count = sum(
+            registration.event_name == event_name
+            for registration in self._handler_registrations
+        )
+        registration = RegisteredExtensionHandler(
+            local_route_id=(
+                f"legacy-{event_registration_count + 1:04d}"
+                if route_id is None
+                else route_id
+            ),
+            event_name=event_name,
+            handler=cast(ExtensionHandler, handler),
+            priority=priority,
+            after=_normalize_references(after),
+            before=_normalize_references(before),
+            on_error=on_error,
+        )
+        self._handler_registrations.append(registration)
         self._hooks.setdefault(event_name, []).append(handler)
 
     def register_tool(
@@ -64,6 +99,45 @@ class ExtensionContributionAPI:
         )
         self._tool_definitions.append(definition)
         self._register_runtime_tool(definition)
+
+    def register_policy(
+        self,
+        name: str,
+        evaluator: object,
+        *,
+        priority: int = 0,
+        after: Sequence[str] = (),
+        before: Sequence[str] = (),
+        on_error: Literal["skip", "fail_chain"] = "fail_chain",
+    ) -> None:
+        self._register_control_contribution(
+            "policy",
+            name,
+            evaluator,
+            priority=priority,
+            after=after,
+            before=before,
+            on_error=on_error,
+        )
+
+    def register_approval(
+        self,
+        name: str,
+        resolver: object,
+        *,
+        priority: int = 0,
+        after: Sequence[str] = (),
+        before: Sequence[str] = (),
+    ) -> None:
+        self._register_control_contribution(
+            "approval",
+            name,
+            resolver,
+            priority=priority,
+            after=after,
+            before=before,
+            on_error="fail_chain",
+        )
 
     def registerTool(
         self,
@@ -220,6 +294,8 @@ class ExtensionContributionAPI:
                 name: cast(list[ExtensionHandler], list(handlers))
                 for name, handlers in self._hooks.items()
             },
+            handler_registrations=list(self._handler_registrations),
+            control_contributions=list(self._control_contributions),
             tool_definitions=list(self._tool_definitions),
             commands=dict(self._commands),
             flags=dict(self._flags),
@@ -236,6 +312,57 @@ class ExtensionContributionAPI:
         callback = getattr(self._runtime_bindings(), "register_tool", None)
         if callable(callback):
             callback(definition, SourceInfo(path=self._entry_path or self._source_path))
+
+    def _register_control_contribution(
+        self,
+        contribution_type: Literal["policy", "approval"],
+        name: str,
+        value: object,
+        *,
+        priority: int,
+        after: Sequence[str],
+        before: Sequence[str],
+        on_error: Literal["skip", "fail_chain"],
+    ) -> None:
+        normalized_name = name.strip()
+        if not normalized_name:
+            raise ValueError("Control contribution name must not be empty.")
+        if isinstance(priority, bool) or not isinstance(priority, int):
+            raise TypeError("Control contribution priority must be an integer.")
+        normalized_after = _normalize_references(after)
+        normalized_before = _normalize_references(before)
+        if on_error not in {"skip", "fail_chain"}:
+            raise ValueError(
+                f"Unsupported control contribution error policy: {on_error}"
+            )
+        self._control_contributions.append(
+            RegisteredControlContribution(
+                descriptor=ExtensionSurfaceDescriptor(
+                    type=contribution_type,
+                    name=normalized_name,
+                    extension_id=self._name,
+                    source_path=self._entry_path or self._source_path,
+                    priority=priority,
+                    after=normalized_after,
+                    before=normalized_before,
+                    on_error=on_error,
+                    metadata={"source": "runtime"},
+                ),
+                value=value,
+            )
+        )
+
+
+def _normalize_references(references: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(references, str):
+        raise TypeError("Extension ordering references must be a sequence of strings.")
+    values = tuple(references)
+    if not all(isinstance(reference, str) for reference in values):
+        raise TypeError("Extension ordering references must be a sequence of strings.")
+    normalized = tuple(reference.strip() for reference in values)
+    if any(not reference for reference in normalized):
+        raise ValueError("Extension ordering references must not be empty.")
+    return normalized
 
 
 __all__ = ["ExtensionContributionAPI"]

--- a/src/loushang/harness/extensions/contributions.py
+++ b/src/loushang/harness/extensions/contributions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from loushang.harness.contributions import (
     ContributionDescriptor,
     ContributionRegistry,
@@ -74,15 +76,43 @@ def surfaces_from_loaded_extension(
         )
         for tool in getattr(extension, "tool_definitions", ())
     )
+    registrations = tuple(getattr(extension, "handler_registrations", ()))
+    if registrations:
+        surfaces.extend(
+            ExtensionSurfaceDescriptor(
+                type="hook",
+                name=registration.event_name,
+                extension_id=extension_id,
+                source_path=source_path,
+                priority=registration.priority,
+                after=registration.after,
+                before=registration.before,
+                on_error=registration.on_error,
+                metadata={
+                    "source": "runtime",
+                    "route_id": registration.local_route_id,
+                },
+            )
+            for registration in registrations
+        )
+    else:
+        surfaces.extend(
+            ExtensionSurfaceDescriptor(
+                type="hook",
+                name=event_name,
+                extension_id=extension_id,
+                source_path=source_path,
+                metadata={"source": "runtime"},
+            )
+            for event_name in getattr(extension, "hooks", {})
+        )
     surfaces.extend(
-        ExtensionSurfaceDescriptor(
-            type="hook",
-            name=event_name,
+        replace(
+            contribution.descriptor,
             extension_id=extension_id,
             source_path=source_path,
-            metadata={"source": "runtime"},
         )
-        for event_name in getattr(extension, "hooks", {})
+        for contribution in getattr(extension, "control_contributions", ())
     )
     return tuple(surfaces)
 

--- a/src/loushang/harness/extensions/control.py
+++ b/src/loushang/harness/extensions/control.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import cast
+
+from loushang.harness.approval import (
+    ApprovalDecision,
+    ApprovalRequest,
+    ApprovalResolver,
+    resolve_approval,
+)
+from loushang.harness.extensions.routing import (
+    ExtensionRoutePlan,
+    RegisteredExtensionHandler,
+    ResolvedExtensionRoute,
+)
+from loushang.harness.extensions.types import (
+    ExtensionPolicyDecision,
+    LoadedExtension,
+    RegisteredControlContribution,
+    extension_is_active,
+)
+from loushang.harness.policy import (
+    PolicyDecision,
+    PolicyEvaluationError,
+    PolicyEvaluator,
+    PolicySubject,
+    evaluate_policy,
+)
+from loushang.harness.resources.diagnostics import ResourceDiagnostic
+
+
+@dataclass(frozen=True)
+class ResolvedControlContributions:
+    """Executable control-plane values after activation and route resolution."""
+
+    policy_evaluators: tuple[PolicyEvaluator, ...]
+    approval_resolver: ApprovalResolver | None
+    policy_records: tuple[RegisteredControlContribution, ...]
+    approval_records: tuple[RegisteredControlContribution, ...]
+    selected_approval_record: RegisteredControlContribution | None
+
+
+@dataclass(frozen=True)
+class _ResolvedControlRecord:
+    route: ResolvedExtensionRoute
+    record: RegisteredControlContribution
+
+
+@dataclass(frozen=True)
+class _ExtensionPolicyEvaluator:
+    resolved: _ResolvedControlRecord
+    diagnostics: list[ResourceDiagnostic]
+
+    async def evaluate(self, subject: PolicySubject, /) -> PolicyDecision | None:
+        try:
+            return await evaluate_policy(
+                cast(PolicyEvaluator, self.resolved.record.value),
+                subject,
+            )
+        except PolicyEvaluationError as exc:
+            self.diagnostics.append(
+                _control_diagnostic(
+                    self.resolved.route,
+                    code="extension_policy_evaluation_failed",
+                    message=(
+                        f"Extension policy contribution "
+                        f"{self.resolved.record.descriptor.name!r} failed: {exc}"
+                    ),
+                )
+            )
+            if self.resolved.record.descriptor.on_error == "fail_chain":
+                raise
+            return None
+
+
+@dataclass(frozen=True)
+class _ExtensionApprovalResolver:
+    resolved: _ResolvedControlRecord
+    diagnostics: list[ResourceDiagnostic]
+
+    async def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+        try:
+            return await resolve_approval(
+                cast(ApprovalResolver, self.resolved.record.value),
+                request,
+            )
+        except Exception as exc:
+            self.diagnostics.append(
+                _control_diagnostic(
+                    self.resolved.route,
+                    code="extension_approval_resolution_failed",
+                    message=(
+                        f"Extension approval contribution "
+                        f"{self.resolved.record.descriptor.name!r} failed: {exc}"
+                    ),
+                )
+            )
+            raise
+
+
+def resolve_control_contributions(
+    extensions: Sequence[LoadedExtension],
+    *,
+    diagnostics: list[ResourceDiagnostic],
+) -> ResolvedControlContributions:
+    """Resolve policy chains and the exclusive approval replacement.
+
+    Policy records remain in resolved order and are wrapped so their declared
+    error policy is preserved. The first resolved approval record wins; later
+    active records are retained for inspection and reported as one conflict.
+    """
+
+    records_by_registration: dict[int, RegisteredControlContribution] = {}
+    extension_registrations: list[
+        tuple[LoadedExtension, tuple[RegisteredExtensionHandler, ...]]
+    ] = []
+    for extension in extensions:
+        registrations: list[RegisteredExtensionHandler] = []
+        inactive_registrations: list[RegisteredExtensionHandler] = []
+        extension_active = extension_is_active(extension)
+        for record in extension.control_contributions:
+            descriptor = record.descriptor
+            record_active = extension_active and descriptor.active
+            if record_active:
+                if (
+                    descriptor.type == "approval"
+                    and descriptor.on_error != "fail_chain"
+                ):
+                    diagnostics.append(
+                        _invalid_control_diagnostic(
+                            extension,
+                            record,
+                            reason=(
+                                "approval is an exclusive replacement and must "
+                                "use on_error='fail_chain'"
+                            ),
+                        )
+                    )
+                    continue
+                required_method = (
+                    "evaluate" if descriptor.type == "policy" else "resolve"
+                )
+                try:
+                    control_method = getattr(record.value, required_method, None)
+                except Exception as exc:
+                    diagnostics.append(
+                        _invalid_control_diagnostic(
+                            extension,
+                            record,
+                            required_method=required_method,
+                            reason=f"accessing {required_method} failed: {exc}",
+                        )
+                    )
+                    continue
+                if not callable(control_method):
+                    diagnostics.append(
+                        _invalid_control_diagnostic(
+                            extension,
+                            record,
+                            required_method=required_method,
+                        )
+                    )
+                    continue
+            try:
+                registration = RegisteredExtensionHandler(
+                    local_route_id=descriptor.name,
+                    event_name=descriptor.type,
+                    handler=_control_marker,
+                    priority=descriptor.priority if record_active else 0,
+                    after=descriptor.after if record_active else (),
+                    before=descriptor.before if record_active else (),
+                    on_error=descriptor.on_error if record_active else "skip",
+                )
+            except (TypeError, ValueError) as exc:
+                if record_active:
+                    diagnostics.append(
+                        _invalid_control_diagnostic(
+                            extension,
+                            record,
+                            reason=str(exc),
+                        )
+                    )
+                continue
+            if record_active:
+                records_by_registration[id(registration)] = record
+                registrations.append(registration)
+            else:
+                inactive_registrations.append(registration)
+        extension_registrations.append((extension, tuple(registrations)))
+        if extension_active and inactive_registrations:
+            inactive_extension = replace(
+                extension,
+                policy=ExtensionPolicyDecision(enabled=False),
+            )
+            extension_registrations.append(
+                (inactive_extension, tuple(inactive_registrations))
+            )
+        elif inactive_registrations:
+            extension_registrations[-1] = (
+                extension,
+                tuple(inactive_registrations),
+            )
+
+    plan = ExtensionRoutePlan.from_extension_registrations(
+        extension_registrations,
+        diagnostics=diagnostics,
+    )
+    policies = tuple(
+        _ResolvedControlRecord(
+            route=route,
+            record=records_by_registration[id(route.registration)],
+        )
+        for route in plan.routes_for("policy")
+    )
+    approvals = tuple(
+        _ResolvedControlRecord(
+            route=route,
+            record=records_by_registration[id(route.registration)],
+        )
+        for route in plan.routes_for("approval")
+    )
+
+    if len(approvals) > 1:
+        selected = approvals[0]
+        diagnostics.append(
+            _control_diagnostic(
+                selected.route,
+                code="conflicting_extension_approval_contributions",
+                message=(
+                    "Multiple active approval contributions resolved for the "
+                    f"exclusive slot; selected {selected.route.route_id!r}."
+                ),
+                metadata={
+                    "selected_route_id": selected.route.route_id,
+                    "conflicting_route_ids": tuple(
+                        resolved.route.route_id for resolved in approvals[1:]
+                    ),
+                },
+            )
+        )
+
+    selected_approval = approvals[0] if approvals else None
+    return ResolvedControlContributions(
+        policy_evaluators=tuple(
+            _ExtensionPolicyEvaluator(resolved, diagnostics) for resolved in policies
+        ),
+        approval_resolver=(
+            _ExtensionApprovalResolver(selected_approval, diagnostics)
+            if selected_approval is not None
+            else None
+        ),
+        policy_records=tuple(resolved.record for resolved in policies),
+        approval_records=tuple(resolved.record for resolved in approvals),
+        selected_approval_record=(
+            selected_approval.record if selected_approval is not None else None
+        ),
+    )
+
+
+def _control_marker(event: object, context: object) -> None:
+    del event, context
+
+
+def _invalid_control_diagnostic(
+    extension: LoadedExtension,
+    record: RegisteredControlContribution,
+    *,
+    required_method: str | None = None,
+    reason: str | None = None,
+) -> ResourceDiagnostic:
+    descriptor = record.descriptor
+    if reason is None:
+        reason = f"value must provide callable {required_method}()"
+    return ResourceDiagnostic(
+        code="invalid_extension_control_contribution",
+        message=(
+            f"Invalid extension {descriptor.type} contribution "
+            f"{descriptor.name!r}: {reason}."
+        ),
+        source_path=extension.source_path,
+        resource_id=descriptor.name,
+        resource_type="extension",
+        source_kind=extension.source_kind,
+        metadata={
+            "extension_name": extension.name,
+            "contribution_type": descriptor.type,
+            "required_method": required_method or "",
+        },
+    )
+
+
+def _control_diagnostic(
+    route: ResolvedExtensionRoute,
+    *,
+    code: str,
+    message: str,
+    metadata: dict[str, object] | None = None,
+) -> ResourceDiagnostic:
+    source_info = route.source_info
+    return ResourceDiagnostic(
+        code=code,
+        message=message,
+        source_path=route.extension.source_path,
+        resource_id=route.registration.local_route_id,
+        resource_type="extension",
+        source_kind=route.extension.source_kind,
+        metadata={
+            "extension_name": route.extension.name,
+            "route_id": route.route_id,
+            "source": source_info.source,
+            "scope": source_info.scope,
+            "origin": source_info.origin,
+            "base_dir": (
+                source_info.base_dir.as_posix()
+                if source_info.base_dir is not None
+                else route.extension.source_path.parent.as_posix()
+            ),
+            **(metadata or {}),
+        },
+    )
+
+
+__all__ = [
+    "ResolvedControlContributions",
+    "resolve_control_contributions",
+]

--- a/src/loushang/harness/extensions/dispatch.py
+++ b/src/loushang/harness/extensions/dispatch.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
-import inspect
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
+from dataclasses import dataclass
 
-from loushang.harness.extensions.registry import source_info_from_extension
+from loushang.harness.extensions.routing import (
+    ExtensionContextFactory,
+    ExtensionRoutePlan,
+    ExtensionRouter,
+    ExtensionRuntimeErrorHandler,
+    ResolvedExtensionRoute,
+    RouteStep,
+)
 from loushang.harness.extensions.types import (
     InputEvent,
     InputEventResult,
+    InputSource,
     LoadedExtension,
 )
 from loushang.harness.resources.diagnostics import ResourceDiagnostic
-
-ExtensionContextFactory = Callable[[LoadedExtension], object]
-ExtensionRuntimeErrorHandler = Callable[[LoadedExtension, str, Exception], None]
 
 
 class ExtensionDispatcher:
@@ -25,47 +30,39 @@ class ExtensionDispatcher:
         context_factory: ExtensionContextFactory,
         diagnostics: list[ResourceDiagnostic],
         runtime_error_handler: ExtensionRuntimeErrorHandler | None = None,
+        route_plan: ExtensionRoutePlan | None = None,
     ) -> None:
-        self._extensions = tuple(extensions)
         self._context_factory = context_factory
         self._diagnostics = diagnostics
-        self._runtime_error_handler = runtime_error_handler
+        plan = route_plan or ExtensionRoutePlan.from_extensions(
+            extensions, diagnostics=diagnostics
+        )
+        self._router = ExtensionRouter(
+            plan,
+            diagnostics=diagnostics,
+            runtime_error_handler=runtime_error_handler,
+            include_route_id_in_error_metadata=False,
+        )
 
     def has_handlers(self, event_name: str) -> bool:
-        return any(extension.hooks.get(event_name) for extension in self._extensions)
+        return self._router.has_handlers(event_name)
 
     async def dispatch(self, event_name: str, event: object) -> tuple[object, ...]:
-        results: list[object] = []
-        for extension in self._extensions:
-            context = self._context_factory(extension)
-            for handler in extension.hooks.get(event_name, ()):
-                try:
-                    result = handler(event, context)
-                    if inspect.isawaitable(result):
-                        result = await result
-                except Exception as exc:
-                    self._record_error(extension, event_name, exc)
-                    continue
-                if result is not None:
-                    results.append(result)
-        return tuple(results)
+        return await self._router.observe(
+            event_name,
+            event,
+            context_factory=self._context_factory,
+        )
 
     async def dispatch_first_truthy(
         self, event_name: str, event: object
     ) -> object | None:
-        for extension in self._extensions:
-            context = self._context_factory(extension)
-            for handler in extension.hooks.get(event_name, ()):
-                try:
-                    result = handler(event, context)
-                    if inspect.isawaitable(result):
-                        result = await result
-                except Exception as exc:
-                    self._record_error(extension, event_name, exc)
-                    continue
-                if result:
-                    return result
-        return None
+        return await self._router.first(
+            event_name,
+            event,
+            predicate=bool,
+            context_factory=self._context_factory,
+        )
 
     async def dispatch_input(
         self,
@@ -74,100 +71,107 @@ class ExtensionDispatcher:
         *,
         source: str = "interactive",
     ) -> InputEventResult:
-        current_text = text
-        current_images = images
-        transformed = False
-        for extension in self._extensions:
-            context = self._context_factory(extension)
-            for handler in extension.hooks.get("input", ()):
-                event = InputEvent(
-                    text=current_text,
-                    images=current_images,
-                    source=_normalize_input_source(source),
-                )
-                try:
-                    result = handler(event, context)
-                    if inspect.isawaitable(result):
-                        result = await result
-                except Exception as exc:
-                    self._record_error(extension, "input", exc)
-                    continue
-                action, result_text, result_images = _coerce_input_result(result)
-                if action in {None, "continue"}:
-                    continue
-                if action == "handled":
-                    return InputEventResult(
+        initial = _InputDispatchState(text=text, images=images)
+
+        def event_factory(
+            state: _InputDispatchState,
+            route: ResolvedExtensionRoute,
+        ) -> InputEvent:
+            del route
+            return InputEvent(
+                text=state.text,
+                images=state.images,
+                source=_normalize_input_source(source),
+            )
+
+        def reducer(
+            state: _InputDispatchState,
+            result: object,
+            route: ResolvedExtensionRoute,
+        ) -> RouteStep[_InputDispatchState]:
+            action, result_text, result_images = _coerce_input_result(result)
+            if action in {None, "continue"}:
+                return RouteStep(state)
+            if action == "handled":
+                return RouteStep(
+                    _InputDispatchState(
+                        text=state.text,
+                        images=state.images,
                         action="handled",
-                        text=current_text,
-                        images=current_images,
-                    )
-                if action == "transform":
-                    if result_text is None:
-                        self._diagnostics.append(
-                            _invalid_input_diagnostic(
-                                extension,
-                                "input transform results must include string text.",
-                            )
+                        transformed=state.transformed,
+                    ),
+                    stop=True,
+                )
+            if action == "transform":
+                if result_text is None:
+                    self._diagnostics.append(
+                        _invalid_input_diagnostic(
+                            route.extension,
+                            "input transform results must include string text.",
                         )
-                        continue
-                    current_text = result_text
-                    if result_images is not None:
-                        current_images = result_images
-                    transformed = True
-                    continue
-                self._diagnostics.append(
-                    _invalid_input_diagnostic(
-                        extension,
-                        (
-                            "input hooks must return action 'continue', 'transform', "
-                            "'handled', or None."
+                    )
+                    return RouteStep(state)
+                return RouteStep(
+                    _InputDispatchState(
+                        text=result_text,
+                        images=(
+                            result_images if result_images is not None else state.images
                         ),
+                        transformed=True,
                     )
                 )
-        if transformed or current_text != text or current_images is not images:
+            self._diagnostics.append(
+                _invalid_input_diagnostic(
+                    route.extension,
+                    (
+                        "input hooks must return action 'continue', 'transform', "
+                        "'handled', or None."
+                    ),
+                )
+            )
+            return RouteStep(state)
+
+        outcome = await self._router.intercept(
+            "input",
+            initial,
+            event_factory=event_factory,
+            reducer=reducer,
+            context_factory=self._context_factory,
+        )
+        state = outcome.state
+        if state.action == "handled":
+            return InputEventResult(
+                action="handled",
+                text=state.text,
+                images=state.images,
+            )
+        if state.transformed or state.text != text or state.images is not images:
             return InputEventResult(
                 action="transform",
-                text=current_text,
-                images=current_images,
+                text=state.text,
+                images=state.images,
             )
         return InputEventResult(
             action="continue",
-            text=current_text,
-            images=current_images,
+            text=state.text,
+            images=state.images,
         )
 
-    def _record_error(
-        self,
-        extension: LoadedExtension,
-        event_name: str,
-        error: Exception,
-    ) -> None:
-        source_info = source_info_from_extension(extension)
-        self._diagnostics.append(
-            ResourceDiagnostic(
-                code=f"extension_{event_name}_failed",
-                message=f"Extension hook '{event_name}' failed: {error}",
-                source_path=extension.source_path,
-                metadata={
-                    "extension_name": extension.name,
-                    "hook": event_name,
-                    "source": source_info.source,
-                    "scope": source_info.scope,
-                    "origin": source_info.origin,
-                    "base_dir": (
-                        source_info.base_dir.as_posix()
-                        if source_info.base_dir is not None
-                        else extension.source_path.parent.as_posix()
-                    ),
-                },
-            )
-        )
-        if self._runtime_error_handler is not None:
-            self._runtime_error_handler(extension, event_name, error)
+
+@dataclass(frozen=True)
+class _InputDispatchState:
+    text: str
+    images: list[object] | None
+    action: str = "continue"
+    transformed: bool = False
 
 
-def _normalize_input_source(source: str) -> str:
-    return source if source in {"interactive", "rpc", "extension"} else "interactive"
+def _normalize_input_source(source: str) -> InputSource:
+    if source == "rpc":
+        return "rpc"
+    if source == "extension":
+        return "extension"
+    return "interactive"
 
 
 def _coerce_input_result(

--- a/src/loushang/harness/extensions/loader.py
+++ b/src/loushang/harness/extensions/loader.py
@@ -263,10 +263,23 @@ def _finalize_loaded_extension(
     enabled: bool,
     policy_resolver: ExtensionPolicyResolver,
 ) -> LoadedExtension:
+    extension_id = manifest.id if manifest is not None else loaded.name
+    source_path = loaded.entry_path or loaded.source_path
     with_policy = replace(
         loaded,
         manifest=manifest,
         policy=policy_resolver(manifest, enabled),
+        control_contributions=[
+            replace(
+                contribution,
+                descriptor=replace(
+                    contribution.descriptor,
+                    extension_id=extension_id,
+                    source_path=source_path,
+                ),
+            )
+            for contribution in loaded.control_contributions
+        ],
     )
     return replace(
         with_policy, contributions=list(surfaces_from_loaded_extension(with_policy))

--- a/src/loushang/harness/extensions/manifest.py
+++ b/src/loushang/harness/extensions/manifest.py
@@ -159,8 +159,8 @@ def parse_extension_manifest(path: Path) -> ExtensionManifestParseResult:
         )
         return ExtensionManifestParseResult(diagnostics=diagnostics)
 
-    extension_id = _string_or_none(extension.get("id"))
-    name = _string_or_none(extension.get("name"))
+    extension_id = _identifier_or_none(extension.get("id"))
+    name = _identifier_or_none(extension.get("name"))
     if not extension_id:
         diagnostics.append(
             _diagnostic(
@@ -391,6 +391,13 @@ def _parse_dependencies(value: object) -> ExtensionDependencyDeclaration:
 
 def _string_or_none(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _identifier_or_none(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
 
 
 def _string_tuple(value: object) -> tuple[str, ...]:

--- a/src/loushang/harness/extensions/registry.py
+++ b/src/loushang/harness/extensions/registry.py
@@ -9,6 +9,7 @@ from loushang.harness.extensions.types import (
     ResolvedCommand,
     ResolvedFlag,
     ResolvedShortcut,
+    extension_is_active,
 )
 from loushang.harness.resources.diagnostics import ResourceDiagnostic
 from loushang.harness.resources.source import SourceInfo
@@ -43,10 +44,13 @@ class ExtensionRegistrySnapshot:
 def resolve_extension_registry(
     extensions: list[LoadedExtension] | tuple[LoadedExtension, ...],
 ) -> ExtensionRegistrySnapshot:
-    commands = _resolve_commands(extensions)
-    flags, flag_defaults, flag_diagnostics = _resolve_flags(extensions)
-    shortcuts, shortcut_diagnostics = _resolve_shortcuts(extensions)
-    tools, tool_diagnostics = _resolve_tools(extensions)
+    active_extensions = tuple(
+        extension for extension in extensions if extension_is_active(extension)
+    )
+    commands = _resolve_commands(active_extensions)
+    flags, flag_defaults, flag_diagnostics = _resolve_flags(active_extensions)
+    shortcuts, shortcut_diagnostics = _resolve_shortcuts(active_extensions)
+    tools, tool_diagnostics = _resolve_tools(active_extensions)
     return ExtensionRegistrySnapshot(
         commands=commands,
         flags=flags,

--- a/src/loushang/harness/extensions/resources.py
+++ b/src/loushang/harness/extensions/resources.py
@@ -5,6 +5,11 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import cast
 
+from loushang.harness.extensions.routing import (
+    ExtensionRouteError,
+    ExtensionRoutePlan,
+    ResolvedExtensionRoute,
+)
 from loushang.harness.extensions.types import (
     ExtensionResourceContribution,
     LoadedExtension,
@@ -26,17 +31,20 @@ class ExtensionResourceRuntime:
         extensions: Sequence[LoadedExtension],
         *,
         diagnostics: list[ResourceDiagnostic],
+        route_plan: ExtensionRoutePlan | None = None,
     ) -> None:
         self._extensions = tuple(extensions)
         self._diagnostics = diagnostics
+        self._route_plan = route_plan or ExtensionRoutePlan.from_extensions(
+            self._extensions, diagnostics=diagnostics
+        )
 
     def discover(self, bundle: ResourceBundle, *, context: object) -> ResourceBundle:
         merged = bundle
         diagnostics: list[ResourceDiagnostic] = []
-        for extension in self._extensions:
-            merged = self._apply_handlers(
-                extension=extension,
-                handlers=extension.hooks.get("resources_discover", ()),
+        for route in self._route_plan.routes_for("resources_discover"):
+            merged = self._apply_route(
+                route=route,
                 bundle=merged,
                 context=context,
                 diagnostics=diagnostics,
@@ -51,90 +59,87 @@ class ExtensionResourceRuntime:
     ) -> ResourceBundle:
         merged = bundle
         diagnostics: list[ResourceDiagnostic] = []
-        for extension in self._extensions:
-            merged = await self._apply_handlers_async(
-                extension=extension,
-                handlers=extension.hooks.get("resources_discover", ()),
+        for route in self._route_plan.routes_for("resources_discover"):
+            merged = await self._apply_route_async(
+                route=route,
                 bundle=merged,
                 context=context,
                 diagnostics=diagnostics,
             )
         return self._finish(merged, diagnostics)
 
-    def _apply_handlers(
+    def _apply_route(
         self,
         *,
-        extension: LoadedExtension,
-        handlers: Sequence[object],
+        route: ResolvedExtensionRoute,
         bundle: ResourceBundle,
         context: object,
         diagnostics: list[ResourceDiagnostic],
     ) -> ResourceBundle:
-        merged = bundle
-        for handler in handlers:
+        try:
             contribution = _invoke_resource_handler(
-                handler,
-                bundle=merged,
+                route.registration.handler,
+                bundle=bundle,
                 context=context,
-                extension=extension,
-                diagnostics=diagnostics,
             )
-            if inspect.isawaitable(contribution):
-                if inspect.iscoroutine(contribution):
-                    contribution.close()
-                diagnostics.append(
-                    ResourceDiagnostic(
-                        code="unsupported_async_extension_hook",
-                        message="Async extension hooks are not supported in P0/v1.",
-                        source_path=extension.source_path,
-                    )
+        except Exception as exc:
+            _record_resource_error(route, exc, diagnostics=diagnostics)
+            if route.registration.on_error == "fail_chain":
+                self._diagnostics.extend(diagnostics)
+                raise ExtensionRouteError(route, exc) from exc
+            return bundle
+        if inspect.isawaitable(contribution):
+            if inspect.iscoroutine(contribution):
+                contribution.close()
+            error = RuntimeError(
+                "Async extension hooks are not supported in synchronous discovery."
+            )
+            diagnostics.append(
+                ResourceDiagnostic(
+                    code="unsupported_async_extension_hook",
+                    message="Async extension hooks are not supported in P0/v1.",
+                    source_path=route.extension.source_path,
                 )
-                continue
-            merged = _merge_contribution(
-                merged,
-                contribution,
-                extension=extension,
-                diagnostics=diagnostics,
             )
-        return merged
+            if route.registration.on_error == "fail_chain":
+                self._diagnostics.extend(diagnostics)
+                raise ExtensionRouteError(route, error) from error
+            return bundle
+        return _merge_contribution(
+            bundle,
+            contribution,
+            extension=route.extension,
+            diagnostics=diagnostics,
+        )
 
-    async def _apply_handlers_async(
+    async def _apply_route_async(
         self,
         *,
-        extension: LoadedExtension,
-        handlers: Sequence[object],
+        route: ResolvedExtensionRoute,
         bundle: ResourceBundle,
         context: object,
         diagnostics: list[ResourceDiagnostic],
     ) -> ResourceBundle:
-        merged = bundle
-        for handler in handlers:
+        try:
             contribution = _invoke_resource_handler(
-                handler,
-                bundle=merged,
+                route.registration.handler,
+                bundle=bundle,
                 context=context,
-                extension=extension,
-                diagnostics=diagnostics,
             )
             if inspect.isawaitable(contribution):
-                try:
-                    contribution = await contribution
-                except Exception as exc:
-                    diagnostics.append(
-                        ResourceDiagnostic(
-                            code="extension_resources_discover_failed",
-                            message=f"Extension resource discovery failed: {exc}",
-                            source_path=extension.source_path,
-                        )
-                    )
-                    continue
-            merged = _merge_contribution(
-                merged,
-                contribution,
-                extension=extension,
-                diagnostics=diagnostics,
-            )
-        return merged
+                contribution = await contribution
+        except Exception as exc:
+            _record_resource_error(route, exc, diagnostics=diagnostics)
+            if route.registration.on_error == "fail_chain":
+                self._diagnostics.extend(diagnostics)
+                raise ExtensionRouteError(route, exc) from exc
+            return bundle
+        return _merge_contribution(
+            bundle,
+            contribution,
+            extension=route.extension,
+            diagnostics=diagnostics,
+        )
 
     def _finish(
         self,
@@ -152,21 +157,29 @@ def _invoke_resource_handler(
     *,
     bundle: ResourceBundle,
     context: object,
-    extension: LoadedExtension,
-    diagnostics: list[ResourceDiagnostic],
 ) -> object:
-    try:
-        callback = cast(Callable[[ResourceBundle, object], object], handler)
-        return callback(bundle, context)
-    except Exception as exc:
-        diagnostics.append(
-            ResourceDiagnostic(
-                code="extension_resources_discover_failed",
-                message=f"Extension resource discovery failed: {exc}",
-                source_path=extension.source_path,
-            )
+    callback = cast(Callable[[ResourceBundle, object], object], handler)
+    return callback(bundle, context)
+
+
+def _record_resource_error(
+    route: ResolvedExtensionRoute,
+    error: Exception,
+    *,
+    diagnostics: list[ResourceDiagnostic],
+) -> None:
+    diagnostics.append(
+        ResourceDiagnostic(
+            code="extension_resources_discover_failed",
+            message=f"Extension resource discovery failed: {error}",
+            source_path=route.extension.source_path,
+            metadata={
+                "extension_name": route.extension.name,
+                "hook": "resources_discover",
+                "route_id": route.route_id,
+            },
         )
-        return None
+    )
 
 
 def _merge_contribution(

--- a/src/loushang/harness/extensions/routing.py
+++ b/src/loushang/harness/extensions/routing.py
@@ -1,0 +1,799 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from heapq import heapify, heappop, heappush
+from pathlib import Path
+from typing import Generic, TypeVar
+from urllib.parse import quote
+
+from loushang.harness.extensions.registry import source_info_from_extension
+from loushang.harness.extensions.routing_types import (
+    RegisteredExtensionHandler,
+    RouteErrorPolicy,
+)
+from loushang.harness.extensions.types import (
+    ExtensionHandler,
+    LoadedExtension,
+    extension_is_active,
+)
+from loushang.harness.resources.diagnostics import ResourceDiagnostic
+from loushang.harness.resources.source import SourceInfo
+
+S = TypeVar("S")
+
+ExtensionContextFactory = Callable[[LoadedExtension], object]
+ExtensionRuntimeErrorHandler = Callable[[LoadedExtension, str, Exception], None]
+RouteReducer = Callable[
+    [S, object, "ResolvedExtensionRoute"],
+    "RouteStep[S] | Awaitable[RouteStep[S]]",
+]
+
+_SKIPPED = object()
+
+
+@dataclass(frozen=True)
+class ResolvedExtensionRoute:
+    route_id: str
+    extension: LoadedExtension
+    registration: RegisteredExtensionHandler
+    registration_index: int
+    source_info: SourceInfo[Path]
+
+
+@dataclass(frozen=True)
+class RouteStep(Generic[S]):
+    state: S
+    stop: bool = False
+
+
+class ExtensionRouteError(RuntimeError):
+    def __init__(
+        self,
+        route: ResolvedExtensionRoute,
+        error: Exception,
+    ) -> None:
+        super().__init__(f"Extension route {route.route_id!r} failed: {error}")
+        self.route = route
+        self.error = error
+
+
+@dataclass(frozen=True)
+class ExtensionRoutePlan:
+    _routes_by_event: Mapping[str, tuple[ResolvedExtensionRoute, ...]]
+    diagnostics: tuple[ResourceDiagnostic, ...] = ()
+
+    @classmethod
+    def from_extensions(
+        cls,
+        extensions: Sequence[LoadedExtension],
+        *,
+        diagnostics: list[ResourceDiagnostic] | None = None,
+    ) -> ExtensionRoutePlan:
+        planning_diagnostics: list[ResourceDiagnostic] = []
+        registrations = tuple(
+            (
+                extension,
+                _registrations_for_extension(
+                    extension,
+                    diagnostics=planning_diagnostics,
+                ),
+            )
+            for extension in extensions
+        )
+        return cls._compile(
+            registrations,
+            planning_diagnostics=planning_diagnostics,
+            diagnostics=diagnostics,
+        )
+
+    @classmethod
+    def from_extension_registrations(
+        cls,
+        registrations: Sequence[
+            tuple[LoadedExtension, Sequence[RegisteredExtensionHandler]]
+        ],
+        *,
+        diagnostics: list[ResourceDiagnostic] | None = None,
+    ) -> ExtensionRoutePlan:
+        """Compile explicit registrations without applying legacy synthesis."""
+
+        return cls._compile(
+            registrations,
+            planning_diagnostics=[],
+            diagnostics=diagnostics,
+        )
+
+    @classmethod
+    def _compile(
+        cls,
+        extension_registrations: Sequence[
+            tuple[LoadedExtension, Sequence[RegisteredExtensionHandler]]
+        ],
+        *,
+        planning_diagnostics: list[ResourceDiagnostic],
+        diagnostics: list[ResourceDiagnostic] | None,
+    ) -> ExtensionRoutePlan:
+        valid_extension_registrations = []
+        for extension, registrations in extension_registrations:
+            if _extension_id(extension):
+                valid_extension_registrations.append((extension, registrations))
+                continue
+            planning_diagnostics.append(
+                _planning_diagnostic(
+                    extension,
+                    code="invalid_extension_route_identity",
+                    message="Extension route identity must not be empty.",
+                )
+            )
+        extension_registrations = tuple(valid_extension_registrations)
+        declared_by_event: dict[str, list[ResolvedExtensionRoute]] = {}
+        registration_index = 0
+        used_route_ids: set[str] = set()
+        active_extension_ids = {
+            _extension_id(extension)
+            for extension, _ in extension_registrations
+            if extension_is_active(extension)
+        }
+        inactive_extension_ids = {
+            _extension_id(extension)
+            for extension, _ in extension_registrations
+            if not extension_is_active(extension)
+        } - active_extension_ids
+        inactive_route_ids = {
+            _canonical_route_id(
+                _extension_id(extension),
+                registration.event_name,
+                registration.local_route_id,
+            )
+            for extension, registrations in extension_registrations
+            if not extension_is_active(extension)
+            for registration in registrations
+        }
+
+        for extension, registrations in extension_registrations:
+            if not extension_is_active(extension):
+                continue
+            extension_id = _extension_id(extension)
+            for registration in registrations:
+                canonical_route_id = _canonical_route_id(
+                    extension_id,
+                    registration.event_name,
+                    registration.local_route_id,
+                )
+                route_id = canonical_route_id
+                if route_id in used_route_ids:
+                    duplicate_count = 2
+                    route_id = f"{canonical_route_id}#duplicate-{duplicate_count}"
+                    while route_id in used_route_ids:
+                        duplicate_count += 1
+                        route_id = f"{canonical_route_id}#duplicate-{duplicate_count}"
+                    planning_diagnostics.append(
+                        _planning_diagnostic(
+                            extension,
+                            code="duplicate_extension_route_id",
+                            message=(
+                                "Duplicate extension route id: "
+                                f"{registration.local_route_id}"
+                            ),
+                            metadata={
+                                "event": registration.event_name,
+                                "route_id": canonical_route_id,
+                                "resolved_route_id": route_id,
+                            },
+                        )
+                    )
+                used_route_ids.add(route_id)
+                route = ResolvedExtensionRoute(
+                    route_id=route_id,
+                    extension=extension,
+                    registration=registration,
+                    registration_index=registration_index,
+                    source_info=source_info_from_extension(extension),
+                )
+                declared_by_event.setdefault(registration.event_name, []).append(route)
+                registration_index += 1
+
+        ordered_by_event = {
+            event_name: _order_routes(
+                routes,
+                diagnostics=planning_diagnostics,
+                inactive_extension_ids=inactive_extension_ids,
+                inactive_route_ids=inactive_route_ids,
+            )
+            for event_name, routes in declared_by_event.items()
+        }
+        if diagnostics is not None:
+            diagnostics.extend(planning_diagnostics)
+        return cls(
+            _routes_by_event=ordered_by_event,
+            diagnostics=tuple(planning_diagnostics),
+        )
+
+    def routes_for(self, event_name: str) -> tuple[ResolvedExtensionRoute, ...]:
+        return self._routes_by_event.get(event_name, ())
+
+    def has_routes(self, event_name: str) -> bool:
+        return bool(self.routes_for(event_name))
+
+
+class ExtensionRouter:
+    """Invoke product-neutral extension routes from one compiled plan."""
+
+    def __init__(
+        self,
+        plan: ExtensionRoutePlan,
+        *,
+        diagnostics: list[ResourceDiagnostic],
+        runtime_error_handler: ExtensionRuntimeErrorHandler | None = None,
+        include_route_id_in_error_metadata: bool = True,
+        include_provenance_in_error_metadata: bool = True,
+    ) -> None:
+        self._plan = plan
+        self._diagnostics = diagnostics
+        self._runtime_error_handler = runtime_error_handler
+        self._include_route_id_in_error_metadata = include_route_id_in_error_metadata
+        self._include_provenance_in_error_metadata = (
+            include_provenance_in_error_metadata
+        )
+
+    @classmethod
+    def from_extensions(
+        cls,
+        extensions: Sequence[LoadedExtension],
+        *,
+        diagnostics: list[ResourceDiagnostic],
+        runtime_error_handler: ExtensionRuntimeErrorHandler | None = None,
+        include_route_id_in_error_metadata: bool = True,
+        include_provenance_in_error_metadata: bool = True,
+    ) -> ExtensionRouter:
+        return cls(
+            ExtensionRoutePlan.from_extensions(
+                extensions,
+                diagnostics=diagnostics,
+            ),
+            diagnostics=diagnostics,
+            runtime_error_handler=runtime_error_handler,
+            include_route_id_in_error_metadata=(include_route_id_in_error_metadata),
+            include_provenance_in_error_metadata=(include_provenance_in_error_metadata),
+        )
+
+    @property
+    def plan(self) -> ExtensionRoutePlan:
+        return self._plan
+
+    def has_handlers(self, event_name: str) -> bool:
+        return self._plan.has_routes(event_name)
+
+    async def observe(
+        self,
+        event_name: str,
+        event: object,
+        *,
+        context_factory: ExtensionContextFactory,
+    ) -> tuple[object, ...]:
+        results: list[object] = []
+        contexts: dict[int, object] = {}
+        for route in self._plan.routes_for(event_name):
+            result = await self._invoke(
+                route,
+                event,
+                context_factory=context_factory,
+                contexts=contexts,
+            )
+            if result is not _SKIPPED and result is not None:
+                results.append(result)
+        return tuple(results)
+
+    async def first(
+        self,
+        event_name: str,
+        event: object,
+        *,
+        predicate: Callable[[object], bool],
+        context_factory: ExtensionContextFactory,
+    ) -> object | None:
+        contexts: dict[int, object] = {}
+        for route in self._plan.routes_for(event_name):
+            result = await self._invoke(
+                route,
+                event,
+                context_factory=context_factory,
+                contexts=contexts,
+            )
+            if result is _SKIPPED or result is None:
+                continue
+            if predicate(result):
+                return result
+        return None
+
+    async def reduce(
+        self,
+        event_name: str,
+        state: S,
+        *,
+        event_factory: Callable[[S, ResolvedExtensionRoute], object],
+        reducer: RouteReducer[S],
+        context_factory: ExtensionContextFactory,
+    ) -> RouteStep[S]:
+        current = RouteStep(state=state)
+        contexts: dict[int, object] = {}
+        for route in self._plan.routes_for(event_name):
+            event = event_factory(current.state, route)
+            result = await self._invoke(
+                route,
+                event,
+                context_factory=context_factory,
+                contexts=contexts,
+            )
+            if result is _SKIPPED or result is None:
+                continue
+            next_step = reducer(current.state, result, route)
+            if inspect.isawaitable(next_step):
+                next_step = await next_step
+            if not isinstance(next_step, RouteStep):
+                raise TypeError("extension route reducer must return RouteStep")
+            current = next_step
+            if current.stop:
+                return current
+        return current
+
+    async def intercept(
+        self,
+        event_name: str,
+        state: S,
+        *,
+        event_factory: Callable[[S, ResolvedExtensionRoute], object],
+        reducer: RouteReducer[S],
+        context_factory: ExtensionContextFactory,
+    ) -> RouteStep[S]:
+        return await self.reduce(
+            event_name,
+            state,
+            event_factory=event_factory,
+            reducer=reducer,
+            context_factory=context_factory,
+        )
+
+    async def _invoke(
+        self,
+        route: ResolvedExtensionRoute,
+        event: object,
+        *,
+        context_factory: ExtensionContextFactory,
+        contexts: dict[int, object],
+    ) -> object:
+        extension_key = id(route.extension)
+        if extension_key not in contexts:
+            contexts[extension_key] = context_factory(route.extension)
+        try:
+            result = route.registration.handler(event, contexts[extension_key])
+            if inspect.isawaitable(result):
+                result = await result
+            return result
+        except Exception as exc:
+            self._record_error(route, exc)
+            if route.registration.on_error == "fail_chain":
+                raise ExtensionRouteError(route, exc) from exc
+            return _SKIPPED
+
+    def _record_error(
+        self,
+        route: ResolvedExtensionRoute,
+        error: Exception,
+    ) -> None:
+        event_name = route.registration.event_name
+        source_info = route.source_info
+        metadata: dict[str, object] = {}
+        if self._include_provenance_in_error_metadata:
+            metadata.update(
+                {
+                    "extension_name": route.extension.name,
+                    "hook": event_name,
+                    "source": source_info.source,
+                    "scope": source_info.scope,
+                    "origin": source_info.origin,
+                    "base_dir": (
+                        source_info.base_dir.as_posix()
+                        if source_info.base_dir is not None
+                        else route.extension.source_path.parent.as_posix()
+                    ),
+                }
+            )
+        if self._include_route_id_in_error_metadata:
+            metadata["route_id"] = route.route_id
+        self._diagnostics.append(
+            ResourceDiagnostic(
+                code=f"extension_{event_name}_failed",
+                message=f"Extension hook '{event_name}' failed: {error}",
+                source_path=route.extension.source_path,
+                metadata=metadata,
+            )
+        )
+        if self._runtime_error_handler is None:
+            return
+        with suppress(Exception):
+            self._runtime_error_handler(route.extension, event_name, error)
+
+
+def _registrations_for_extension(
+    extension: LoadedExtension,
+    *,
+    diagnostics: list[ResourceDiagnostic],
+) -> tuple[RegisteredExtensionHandler, ...]:
+    registrations = tuple(extension.handler_registrations)
+    if not registrations:
+        return tuple(
+            RegisteredExtensionHandler(
+                local_route_id=f"legacy-{handler_index:04d}",
+                event_name=event_name,
+                handler=handler,
+            )
+            for event_name, handlers in extension.hooks.items()
+            for handler_index, handler in enumerate(handlers, start=1)
+        )
+
+    projected: dict[str, list[ExtensionHandler]] = {}
+    for registration in registrations:
+        projected.setdefault(registration.event_name, []).append(registration.handler)
+    if extension.hooks and not _same_hook_projection(extension.hooks, projected):
+        diagnostics.append(
+            _planning_diagnostic(
+                extension,
+                code="conflicting_extension_hook_registrations",
+                message=(
+                    "Loaded extension hooks differ from authoritative handler "
+                    "registrations."
+                ),
+            )
+        )
+    return registrations
+
+
+def _same_hook_projection(
+    left: Mapping[str, Sequence[ExtensionHandler]],
+    right: Mapping[str, Sequence[ExtensionHandler]],
+) -> bool:
+    if tuple(left) != tuple(right):
+        return False
+    return all(
+        len(left[name]) == len(right[name])
+        and all(
+            left_handler is right_handler
+            for left_handler, right_handler in zip(left[name], right[name], strict=True)
+        )
+        for name in left
+    )
+
+
+def _order_routes(
+    routes: Sequence[ResolvedExtensionRoute],
+    *,
+    diagnostics: list[ResourceDiagnostic],
+    inactive_extension_ids: set[str],
+    inactive_route_ids: set[str],
+) -> tuple[ResolvedExtensionRoute, ...]:
+    if len(routes) < 2 and not any(
+        route.registration.after or route.registration.before for route in routes
+    ):
+        return tuple(routes)
+
+    route_by_id = {route.route_id: route for route in routes}
+    routes_by_extension: dict[str, list[ResolvedExtensionRoute]] = {}
+    for route in routes:
+        routes_by_extension.setdefault(_extension_id(route.extension), []).append(route)
+    edges: dict[str, set[str]] = {route.route_id: set() for route in routes}
+
+    for route in routes:
+        for relation, references in (
+            ("after", route.registration.after),
+            ("before", route.registration.before),
+        ):
+            for reference in references:
+                targets = _resolve_reference(
+                    route,
+                    reference,
+                    route_by_id=route_by_id,
+                    routes_by_extension=routes_by_extension,
+                    inactive_extension_ids=inactive_extension_ids,
+                    inactive_route_ids=inactive_route_ids,
+                    diagnostics=diagnostics,
+                )
+                for target in targets:
+                    if target.route_id == route.route_id:
+                        diagnostics.append(
+                            _route_diagnostic(
+                                route,
+                                code="extension_route_self_reference",
+                                message=(
+                                    f"Extension route {route.route_id!r} references itself."
+                                ),
+                                metadata={"reference": reference},
+                            )
+                        )
+                        continue
+                    source_id, target_id = (
+                        (target.route_id, route.route_id)
+                        if relation == "after"
+                        else (route.route_id, target.route_id)
+                    )
+                    edges[source_id].add(target_id)
+
+    components = _strongly_connected_components(routes, edges)
+    component_by_route = {
+        route_id: component_index
+        for component_index, component in enumerate(components)
+        for route_id in component
+    }
+    component_edges: dict[int, set[int]] = {
+        index: set() for index in range(len(components))
+    }
+    indegrees = {index: 0 for index in range(len(components))}
+    for source_id, target_ids in edges.items():
+        source_component = component_by_route[source_id]
+        for target_id in target_ids:
+            target_component = component_by_route[target_id]
+            if source_component == target_component:
+                continue
+            if target_component not in component_edges[source_component]:
+                component_edges[source_component].add(target_component)
+                indegrees[target_component] += 1
+
+    cyclic_components = sorted(
+        (
+            tuple(
+                sorted(
+                    (route_by_id[route_id] for route_id in component),
+                    key=_route_order_key,
+                )
+            )
+            for component in components
+            if len(component) > 1
+        ),
+        key=lambda cycle_routes: _route_order_key(cycle_routes[0]),
+    )
+    for cycle_routes in cyclic_components:
+        diagnostics.append(
+            _route_diagnostic(
+                cycle_routes[0],
+                code="extension_route_order_cycle",
+                message="Extension route ordering contains a dependency cycle.",
+                metadata={"route_ids": tuple(route.route_id for route in cycle_routes)},
+            )
+        )
+
+    component_routes = {
+        index: tuple(
+            sorted(
+                (route_by_id[route_id] for route_id in component),
+                key=_route_order_key,
+            )
+        )
+        for index, component in enumerate(components)
+    }
+    ready = [
+        (_route_order_key(component_routes[index][0]), index)
+        for index, indegree in indegrees.items()
+        if indegree == 0
+    ]
+    heapify(ready)
+    ordered: list[ResolvedExtensionRoute] = []
+    while ready:
+        _, component_index = heappop(ready)
+        ordered.extend(component_routes[component_index])
+        for target_index in component_edges[component_index]:
+            indegrees[target_index] -= 1
+            if indegrees[target_index] == 0:
+                heappush(
+                    ready,
+                    (
+                        _route_order_key(component_routes[target_index][0]),
+                        target_index,
+                    ),
+                )
+    return tuple(ordered)
+
+
+def _strongly_connected_components(
+    routes: Sequence[ResolvedExtensionRoute],
+    edges: Mapping[str, set[str]],
+) -> tuple[tuple[str, ...], ...]:
+    registration_indexes = {
+        route.route_id: route.registration_index for route in routes
+    }
+    route_ids = tuple(
+        route.route_id
+        for route in sorted(routes, key=lambda item: item.registration_index)
+    )
+    adjacency = {
+        route_id: tuple(sorted(edges[route_id], key=registration_indexes.__getitem__))
+        for route_id in route_ids
+    }
+    visited: set[str] = set()
+    finish_order: list[str] = []
+    for start_id in route_ids:
+        if start_id in visited:
+            continue
+        visited.add(start_id)
+        stack: list[tuple[str, int]] = [(start_id, 0)]
+        while stack:
+            route_id, target_index = stack[-1]
+            targets = adjacency[route_id]
+            if target_index >= len(targets):
+                stack.pop()
+                finish_order.append(route_id)
+                continue
+            target_id = targets[target_index]
+            stack[-1] = (route_id, target_index + 1)
+            if target_id in visited:
+                continue
+            visited.add(target_id)
+            stack.append((target_id, 0))
+
+    reverse_edges: dict[str, list[str]] = {route_id: [] for route_id in route_ids}
+    for source_id, target_ids in adjacency.items():
+        for target_id in target_ids:
+            reverse_edges[target_id].append(source_id)
+    for source_ids in reverse_edges.values():
+        source_ids.sort(key=registration_indexes.__getitem__)
+
+    components: list[tuple[str, ...]] = []
+    assigned: set[str] = set()
+    for start_id in reversed(finish_order):
+        if start_id in assigned:
+            continue
+        assigned.add(start_id)
+        component: list[str] = []
+        stack = [(start_id, 0)]
+        while stack:
+            route_id, source_index = stack[-1]
+            if source_index == 0:
+                component.append(route_id)
+            sources = reverse_edges[route_id]
+            if source_index >= len(sources):
+                stack.pop()
+                continue
+            source_id = sources[source_index]
+            stack[-1] = (route_id, source_index + 1)
+            if source_id in assigned:
+                continue
+            assigned.add(source_id)
+            stack.append((source_id, 0))
+        components.append(tuple(component))
+    return tuple(components)
+
+
+def _resolve_reference(
+    route: ResolvedExtensionRoute,
+    reference: str,
+    *,
+    route_by_id: Mapping[str, ResolvedExtensionRoute],
+    routes_by_extension: Mapping[str, Sequence[ResolvedExtensionRoute]],
+    inactive_extension_ids: set[str],
+    inactive_route_ids: set[str],
+    diagnostics: list[ResourceDiagnostic],
+) -> tuple[ResolvedExtensionRoute, ...]:
+    if reference.startswith("route:"):
+        route_id = reference.removeprefix("route:")
+        if not route_id:
+            diagnostics.append(
+                _route_diagnostic(
+                    route,
+                    code="malformed_extension_route_reference",
+                    message=f"Malformed extension route reference: {reference}",
+                    metadata={"reference": reference},
+                )
+            )
+            return ()
+        target = route_by_id.get(route_id)
+        if target is not None:
+            return (target,)
+        if route_id in inactive_route_ids:
+            return ()
+    elif reference.startswith("extension:"):
+        extension_id = reference.removeprefix("extension:")
+        if not extension_id:
+            diagnostics.append(
+                _route_diagnostic(
+                    route,
+                    code="malformed_extension_route_reference",
+                    message=f"Malformed extension route reference: {reference}",
+                    metadata={"reference": reference},
+                )
+            )
+            return ()
+        targets = tuple(routes_by_extension.get(extension_id, ()))
+        if targets:
+            return targets
+        if extension_id in inactive_extension_ids:
+            return ()
+    else:
+        diagnostics.append(
+            _route_diagnostic(
+                route,
+                code="malformed_extension_route_reference",
+                message=f"Malformed extension route reference: {reference}",
+                metadata={"reference": reference},
+            )
+        )
+        return ()
+
+    diagnostics.append(
+        _route_diagnostic(
+            route,
+            code="missing_extension_route_reference",
+            message=f"Unknown extension route reference: {reference}",
+            metadata={"reference": reference},
+        )
+    )
+    return ()
+
+
+def _route_order_key(route: ResolvedExtensionRoute) -> tuple[int, int]:
+    return (-route.registration.priority, route.registration_index)
+
+
+def _canonical_route_id(
+    extension_id: str,
+    event_name: str,
+    local_route_id: str,
+) -> str:
+    return "/".join(
+        quote(component, safe="")
+        for component in (extension_id, event_name, local_route_id)
+    )
+
+
+def _extension_id(extension: LoadedExtension) -> str:
+    manifest = extension.manifest
+    manifest_id = getattr(manifest, "id", None)
+    if isinstance(manifest_id, str):
+        return manifest_id.strip()
+    return extension.name.strip()
+
+
+def _planning_diagnostic(
+    extension: LoadedExtension,
+    *,
+    code: str,
+    message: str,
+    metadata: dict[str, object] | None = None,
+) -> ResourceDiagnostic:
+    return ResourceDiagnostic(
+        code=code,
+        message=message,
+        source_path=extension.source_path,
+        resource_type="extension",
+        metadata={"extension_name": extension.name, **(metadata or {})},
+    )
+
+
+def _route_diagnostic(
+    route: ResolvedExtensionRoute,
+    *,
+    code: str,
+    message: str,
+    metadata: dict[str, object] | None = None,
+) -> ResourceDiagnostic:
+    return _planning_diagnostic(
+        route.extension,
+        code=code,
+        message=message,
+        metadata={"route_id": route.route_id, **(metadata or {})},
+    )
+
+
+__all__ = [
+    "ExtensionContextFactory",
+    "ExtensionRouteError",
+    "ExtensionRoutePlan",
+    "ExtensionRouter",
+    "ExtensionRuntimeErrorHandler",
+    "RegisteredExtensionHandler",
+    "ResolvedExtensionRoute",
+    "RouteErrorPolicy",
+    "RouteReducer",
+    "RouteStep",
+]

--- a/src/loushang/harness/extensions/routing_types.py
+++ b/src/loushang/harness/extensions/routing_types.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Literal
+
+ExtensionHandler = Callable[[object, object], object | Awaitable[object] | None]
+RouteErrorPolicy = Literal["skip", "fail_chain"]
+
+
+@dataclass(frozen=True)
+class RegisteredExtensionHandler:
+    local_route_id: str
+    event_name: str
+    handler: ExtensionHandler
+    priority: int = 0
+    after: tuple[str, ...] = ()
+    before: tuple[str, ...] = ()
+    on_error: RouteErrorPolicy = "skip"
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        local_route_id = self.local_route_id.strip()
+        event_name = self.event_name.strip()
+        if not local_route_id:
+            raise ValueError("extension route id must not be empty")
+        if not event_name:
+            raise ValueError("extension route event name must not be empty")
+        if not callable(self.handler):
+            raise TypeError("extension route handler must be callable")
+        if isinstance(self.priority, bool) or not isinstance(self.priority, int):
+            raise TypeError("extension route priority must be an integer")
+        if self.on_error not in {"skip", "fail_chain"}:
+            raise ValueError(
+                f"unsupported extension route error policy: {self.on_error}"
+            )
+        object.__setattr__(self, "local_route_id", local_route_id)
+        object.__setattr__(self, "event_name", event_name)
+        object.__setattr__(self, "after", _normalized_references(self.after))
+        object.__setattr__(self, "before", _normalized_references(self.before))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+
+def _normalized_references(references: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(references, str):
+        raise TypeError("extension route references must be a sequence of strings")
+    values = tuple(references)
+    if not all(isinstance(reference, str) for reference in values):
+        raise TypeError("extension route references must be a sequence of strings")
+    normalized = tuple(reference.strip() for reference in values)
+    if any(not reference for reference in normalized):
+        raise ValueError("extension route references must not be empty")
+    return normalized
+
+
+__all__ = [
+    "ExtensionHandler",
+    "RegisteredExtensionHandler",
+    "RouteErrorPolicy",
+]

--- a/src/loushang/harness/extensions/types.py
+++ b/src/loushang/harness/extensions/types.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Any, Literal
 
 from loushang.harness.contributions import ExtensionSurfaceDescriptor
+from loushang.harness.extensions.routing_types import (
+    ExtensionHandler,
+    RegisteredExtensionHandler,
+)
 from loushang.harness.resources.diagnostics import ResourceDiagnostic
 from loushang.harness.resources.source import SourceInfo
 from loushang.harness.resources.types import (
@@ -19,7 +23,6 @@ from loushang.harness.resources.types import (
 )
 from loushang.harness.tools.core import ToolDefinition
 
-ExtensionHandler = Callable[[object, object], object | None]
 InputSource = Literal["interactive", "rpc", "extension"]
 
 
@@ -87,6 +90,18 @@ class ExtensionPolicyDecision:
     @property
     def active(self) -> bool:
         return self.enabled
+
+
+@dataclass(frozen=True)
+class RegisteredControlContribution:
+    descriptor: ExtensionSurfaceDescriptor
+    value: object
+
+    def __post_init__(self) -> None:
+        if self.descriptor.type not in {"policy", "approval"}:
+            raise ValueError(
+                "control contributions must use policy or approval surfaces"
+            )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -160,10 +175,31 @@ class LoadedExtension:
     manifest: object | None = None
     policy: ExtensionPolicyDecision | None = None
     contributions: list[ExtensionSurfaceDescriptor] = field(default_factory=list)
+    handler_registrations: list[RegisteredExtensionHandler] = field(
+        default_factory=list
+    )
+    control_contributions: list[RegisteredControlContribution] = field(
+        default_factory=list
+    )
+
+    def __post_init__(self) -> None:
+        if self.handler_registrations and not self.hooks:
+            projected: dict[str, list[ExtensionHandler]] = {}
+            for registration in self.handler_registrations:
+                projected.setdefault(registration.event_name, []).append(
+                    registration.handler
+                )
+            object.__setattr__(self, "hooks", projected)
 
     @property
     def surfaces(self) -> list[ExtensionSurfaceDescriptor]:
         return list(self.contributions)
+
+
+def extension_is_active(extension: LoadedExtension) -> bool:
+    """Return whether an extension may contribute executable capabilities."""
+
+    return extension.policy is None or extension.policy.active
 
 
 @dataclass(frozen=True)
@@ -189,11 +225,14 @@ __all__ = [
     "ExtensionHandler",
     "ExtensionPolicyDecision",
     "ExtensionResourceContribution",
+    "extension_is_active",
     "InputEvent",
     "InputEventResult",
     "InputSource",
     "LoadedExtension",
     "RegisteredCommand",
+    "RegisteredControlContribution",
+    "RegisteredExtensionHandler",
     "RegisteredFlag",
     "RegisteredShortcut",
     "ResolvedCommand",

--- a/src/loushang/harness/policy.py
+++ b/src/loushang/harness/policy.py
@@ -1,9 +1,189 @@
 from __future__ import annotations
 
+import inspect
+import os
+import shlex
+from collections.abc import Awaitable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from functools import lru_cache
+from os.path import abspath, basename, isabs, join, normpath, realpath, samefile
+from pathlib import Path
+from shutil import which
+from types import MappingProxyType
+from typing import Literal, Protocol, TypeAlias, TypeVar, cast
 
 PolicyDisposition = Literal["allow", "deny", "ask"]
+PolicyChainStrategy = Literal[
+    "first_non_allow",
+    "most_restrictive",
+    "first_decision",
+]
+
+T = TypeVar("T")
+MaybeAwaitable: TypeAlias = T | Awaitable[T]
+
+_SHELL_ENTRY_BASENAMES = frozenset(
+    {
+        "sh",
+        "ash",
+        "bash",
+        "dash",
+        "fish",
+        "hush",
+        "ksh",
+        "msh",
+        "rbash",
+        "rzsh",
+        "rksh",
+        "zsh",
+    }
+)
+_GENERIC_SHELL_ENTRY_BASENAMES = _SHELL_ENTRY_BASENAMES - {"fish"}
+_STANDARD_EXECUTABLE_DIRECTORIES = ("/bin", "/usr/bin", "/usr/local/bin")
+_MULTICALL_ENTRY_BASENAMES = frozenset({"busybox", "busybox.static", "toybox"})
+_MULTICALL_CONTROL_APPLETS = _SHELL_ENTRY_BASENAMES | {"env"}
+_STDIN_SCRIPT_PSEUDO_PATHS = frozenset(
+    {
+        "/dev/stdin",
+        "/dev/fd/0",
+        "/proc/self/fd/0",
+        "/proc/thread-self/fd/0",
+    }
+)
+_SHELL_VALUE_OPTIONS = frozenset(
+    {
+        "-O",
+        "+O",
+        "-o",
+        "+o",
+        "--init-file",
+        "--rcfile",
+    }
+)
+_SHELL_STARTUP_FILE_OPTIONS = frozenset({"--init-file", "--rcfile"})
+_SHELL_STARTUP_ENVIRONMENT_NAMES = frozenset({"BASH_ENV", "ENV"})
+_SHELL_SHORT_OPTIONS = frozenset("abefhkmnptuvxBCEHPTilrsDc")
+_LEADING_WRAPPER_BASENAMES = frozenset({"env", "sudo"})
+_ENV_NO_VALUE_OPTIONS = frozenset(
+    {
+        "-i",
+        "--ignore-environment",
+        "-0",
+        "--null",
+        "-v",
+        "--debug",
+        "--block-signal",
+        "--default-signal",
+        "--ignore-signal",
+    }
+)
+_ENV_VALUE_OPTIONS = frozenset(
+    {
+        "-u",
+        "--unset",
+        "-C",
+        "--chdir",
+        "-S",
+        "--split-string",
+        "-a",
+        "--argv0",
+        "-f",
+        "--file",
+    }
+)
+_ENV_SHORT_VALUE_OPTIONS = frozenset(
+    option[1]
+    for option in _ENV_VALUE_OPTIONS
+    if option.startswith("-") and not option.startswith("--") and len(option) == 2
+)
+_ENV_SHORT_NO_VALUE_OPTIONS = frozenset(
+    option[1]
+    for option in _ENV_NO_VALUE_OPTIONS
+    if option.startswith("-") and not option.startswith("--") and len(option) == 2
+)
+_ENV_LONG_NO_VALUE_OPTIONS = frozenset(
+    option for option in _ENV_NO_VALUE_OPTIONS if option.startswith("--")
+)
+_ENV_LONG_VALUE_OPTIONS = frozenset(
+    option for option in _ENV_VALUE_OPTIONS if option.startswith("--")
+)
+_ENV_LONG_OPTIONS = _ENV_LONG_NO_VALUE_OPTIONS | _ENV_LONG_VALUE_OPTIONS
+_SUDO_VALUE_OPTIONS = frozenset(
+    {
+        "-a",
+        "--auth-type",
+        "-c",
+        "--login-class",
+        "-u",
+        "--user",
+        "-g",
+        "--group",
+        "-h",
+        "--host",
+        "-p",
+        "--prompt",
+        "-r",
+        "--role",
+        "-t",
+        "--type",
+        "-C",
+        "--close-from",
+        "-D",
+        "--chdir",
+        "-R",
+        "--chroot",
+        "-T",
+        "--command-timeout",
+    }
+)
+_SUDO_SHORT_VALUE_OPTIONS = frozenset(
+    option[1]
+    for option in _SUDO_VALUE_OPTIONS
+    if option.startswith("-") and not option.startswith("--") and len(option) == 2
+)
+_SUDO_SHORT_NO_VALUE_OPTIONS = frozenset(
+    {
+        "A",
+        "b",
+        "B",
+        "E",
+        "e",
+        "H",
+        "i",
+        "K",
+        "k",
+        "l",
+        "n",
+        "P",
+        "S",
+        "s",
+        "V",
+        "v",
+    }
+)
+_SUDO_SHELL_MODE_LONG_OPTIONS = frozenset({"--login", "--shell"})
+_SUDO_NO_VALUE_LONG_OPTIONS = frozenset(
+    {
+        "--askpass",
+        "--background",
+        "--bell",
+        "--edit",
+        "--help",
+        "--list",
+        "--non-interactive",
+        "--preserve-env",
+        "--remove-timestamp",
+        "--reset-timestamp",
+        "--stdin",
+        "--validate",
+        "--version",
+        *_SUDO_SHELL_MODE_LONG_OPTIONS,
+    }
+)
+_SUDO_LONG_VALUE_OPTIONS = frozenset(
+    option for option in _SUDO_VALUE_OPTIONS if option.startswith("--")
+)
+_SUDO_LONG_OPTIONS = _SUDO_NO_VALUE_LONG_OPTIONS | _SUDO_LONG_VALUE_OPTIONS
 
 
 @dataclass(frozen=True)
@@ -13,6 +193,14 @@ class PolicyDecision:
     disposition: PolicyDisposition
     reason: str | None = None
     code: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.disposition not in {"allow", "deny", "ask"}:
+            raise ValueError(f"Unsupported policy disposition: {self.disposition}")
+        if self.reason is not None and not isinstance(self.reason, str):
+            raise TypeError("PolicyDecision reason must be a string or None")
+        if self.code is not None and not isinstance(self.code, str):
+            raise TypeError("PolicyDecision code must be a string or None")
 
     @classmethod
     def allow(cls) -> PolicyDecision:
@@ -27,5 +215,1255 @@ class PolicyDecision:
         return cls(disposition="ask", reason=reason, code=code)
 
 
+@dataclass(frozen=True)
+class CommandPolicySubject:
+    command: tuple[str, ...]
+    cwd: str | None
+    direct_tokens: tuple[str, ...]
+    shell_payload: str | None = None
+    normalization_complete: bool = True
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "command", _string_tuple(self.command, "command"))
+        object.__setattr__(
+            self,
+            "direct_tokens",
+            _string_tuple(self.direct_tokens, "direct_tokens"),
+        )
+        if not isinstance(self.normalization_complete, bool):
+            raise TypeError("normalization_complete must be a boolean")
+
+
+@dataclass(frozen=True)
+class PathPolicySubject:
+    raw_path: str
+    resolved_path: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolPolicySubject:
+    tool_name: str
+    arguments: Mapping[str, object]
+    cwd: str | None = None
+    command: CommandPolicySubject | None = None
+    paths: tuple[PathPolicySubject, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.tool_name, str) or not self.tool_name:
+            raise ValueError("tool_name must be a non-empty string")
+        object.__setattr__(self, "arguments", _freeze_mapping(self.arguments))
+        object.__setattr__(self, "paths", tuple(self.paths))
+
+
+@dataclass(frozen=True)
+class CustomPolicySubject:
+    kind: str
+    value: object | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, str) or not self.kind:
+            raise ValueError("kind must be a non-empty string")
+
+
+PolicySubject: TypeAlias = (
+    CommandPolicySubject | PathPolicySubject | ToolPolicySubject | CustomPolicySubject
+)
+
+
+class PolicyEvaluationError(RuntimeError):
+    """Raised when an injected policy evaluator violates its contract."""
+
+
 class PolicyEvaluator(Protocol):
-    def evaluate(self, subject: str, /) -> PolicyDecision: ...
+    def evaluate(
+        self,
+        subject: PolicySubject,
+        /,
+    ) -> MaybeAwaitable[PolicyDecision | None]: ...
+
+
+class PolicyMatcher(Protocol):
+    def matches(self, subject: PolicySubject, /) -> bool: ...
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    id: str
+    matcher: PolicyMatcher
+    decision: PolicyDecision
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or not self.id:
+            raise ValueError("PolicyRule id must be a non-empty string")
+        if not isinstance(self.decision, PolicyDecision):
+            raise TypeError("PolicyRule decision must be a PolicyDecision")
+
+
+@dataclass(frozen=True)
+class RulePolicyEvaluator:
+    rules: tuple[PolicyRule, ...]
+
+    def __post_init__(self) -> None:
+        normalized = tuple(self.rules)
+        ids = [rule.id for rule in normalized]
+        if len(ids) != len(set(ids)):
+            raise ValueError("PolicyRule ids must be unique within an evaluator")
+        object.__setattr__(self, "rules", normalized)
+
+    def evaluate(self, subject: PolicySubject, /) -> PolicyDecision | None:
+        for rule in self.rules:
+            matched = rule.matcher.matches(subject)
+            if not isinstance(matched, bool):
+                raise TypeError(
+                    f"Policy matcher for rule {rule.id!r} returned "
+                    f"{type(matched).__name__}, expected bool"
+                )
+            if matched:
+                return rule.decision
+        return None
+
+
+@dataclass(frozen=True)
+class PolicyEvaluatorChain:
+    evaluators: tuple[PolicyEvaluator, ...]
+    strategy: PolicyChainStrategy = "most_restrictive"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "evaluators", tuple(self.evaluators))
+        if self.strategy not in {
+            "first_non_allow",
+            "most_restrictive",
+            "first_decision",
+        }:
+            raise ValueError(f"Unsupported policy chain strategy: {self.strategy}")
+
+    async def evaluate(self, subject: PolicySubject, /) -> PolicyDecision | None:
+        if self.strategy == "first_decision":
+            for evaluator in self.evaluators:
+                decision = await evaluate_policy(evaluator, subject)
+                if decision is not None:
+                    return decision
+            return None
+
+        first_allow: PolicyDecision | None = None
+        first_ask: PolicyDecision | None = None
+        first_deny: PolicyDecision | None = None
+        for evaluator in self.evaluators:
+            decision = await evaluate_policy(evaluator, subject)
+            if decision is None:
+                continue
+            if self.strategy == "first_non_allow":
+                if decision.disposition != "allow":
+                    return decision
+                if first_allow is None:
+                    first_allow = decision
+                continue
+            if decision.disposition == "deny" and first_deny is None:
+                first_deny = decision
+            elif decision.disposition == "ask" and first_ask is None:
+                first_ask = decision
+            elif decision.disposition == "allow" and first_allow is None:
+                first_allow = decision
+
+        if self.strategy == "first_non_allow":
+            return first_allow
+        return first_deny or first_ask or first_allow
+
+
+async def evaluate_policy(
+    evaluator: PolicyEvaluator,
+    subject: PolicySubject,
+) -> PolicyDecision | None:
+    try:
+        evaluate = getattr(evaluator, "evaluate", None)
+        if not callable(evaluate):
+            raise PolicyEvaluationError(
+                f"Policy evaluator {type(evaluator).__name__} has no callable evaluate method"
+            )
+        result = evaluate(subject)
+        if inspect.isawaitable(result):
+            result = await result
+    except PolicyEvaluationError:
+        raise
+    except Exception as exc:
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(evaluator).__name__} failed: {exc}"
+        ) from exc
+    if result is not None and not isinstance(result, PolicyDecision):
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(evaluator).__name__} returned "
+            f"{type(result).__name__}, expected PolicyDecision or None"
+        )
+    if result is not None:
+        try:
+            result.__post_init__()
+        except (TypeError, ValueError) as exc:
+            raise PolicyEvaluationError(
+                f"Policy evaluator {type(evaluator).__name__} returned an invalid "
+                f"PolicyDecision: {exc}"
+            ) from exc
+    return result
+
+
+@dataclass(frozen=True)
+class ExactToolNameMatcher:
+    tool_name: str
+
+    def matches(self, subject: PolicySubject, /) -> bool:
+        return (
+            isinstance(subject, ToolPolicySubject)
+            and subject.tool_name == self.tool_name
+        )
+
+
+@dataclass(frozen=True)
+class CommandTokenSequenceMatcher:
+    tokens: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tokens", _string_tuple(self.tokens, "tokens"))
+
+    def matches(self, subject: PolicySubject, /) -> bool:
+        command = _command_subject(subject)
+        if command is None or command.shell_payload is not None or not self.tokens:
+            return False
+        return _contains_token_sequence(command.direct_tokens, self.tokens)
+
+
+@dataclass(frozen=True)
+class ShellPayloadSubstringMatcher:
+    substring: str
+
+    def matches(self, subject: PolicySubject, /) -> bool:
+        command = _command_subject(subject)
+        return (
+            command is not None
+            and command.shell_payload is not None
+            and self.substring in command.shell_payload
+        )
+
+
+@dataclass(frozen=True)
+class CommandSubstringMatcher:
+    """Match shell payload text or direct argv token sequences."""
+
+    substring: str
+
+    def matches(self, subject: PolicySubject, /) -> bool:
+        command = _command_subject(subject)
+        if command is None:
+            return False
+        if not command.normalization_complete and self.substring in " ".join(
+            command.command
+        ):
+            return True
+        if command.shell_payload is not None:
+            return self.substring in command.shell_payload
+        tokens = tuple(part for part in self.substring.split() if part)
+        return bool(tokens) and _contains_token_sequence(command.direct_tokens, tokens)
+
+
+@dataclass(frozen=True)
+class IncompleteCommandMatcher:
+    """Match commands whose platform-specific wrapper syntax is unresolved."""
+
+    def matches(self, subject: PolicySubject, /) -> bool:
+        command = _command_subject(subject)
+        return command is not None and not command.normalization_complete
+
+
+@dataclass(frozen=True)
+class PathSubstringMatcher:
+    substring: str
+
+    def matches(self, subject: PolicySubject, /) -> bool:
+        paths = (
+            subject.paths
+            if isinstance(subject, ToolPolicySubject)
+            else (subject,)
+            if isinstance(subject, PathPolicySubject)
+            else ()
+        )
+        return any(
+            self.substring in candidate
+            for path in paths
+            for candidate in (path.raw_path, path.resolved_path)
+            if candidate is not None
+        )
+
+
+def normalize_command_subject(
+    command: Sequence[str],
+    *,
+    cwd: str | None = None,
+    assume_shell: bool = False,
+    stdin: str | None = None,
+    executable_search_path: str | None = None,
+    environment_overrides: object | None = None,
+    environment_is_complete: bool = False,
+) -> CommandPolicySubject:
+    normalized = _string_tuple(command, "command")
+    unwrapped, normalization_complete = _unwrap_leading_wrappers(
+        normalized,
+        cwd=cwd,
+        executable_search_path=executable_search_path,
+    )
+    payload, shell_complete = _shell_payload(
+        unwrapped,
+        assume_shell=assume_shell,
+        cwd=cwd,
+        stdin=stdin,
+        executable_search_path=executable_search_path,
+        environment_overrides=environment_overrides,
+        environment_is_complete=environment_is_complete,
+    )
+    normalization_complete = normalization_complete and shell_complete
+    direct_tokens = () if payload is not None else _direct_command_tokens(unwrapped)
+    return CommandPolicySubject(
+        command=normalized,
+        cwd=cwd,
+        direct_tokens=direct_tokens,
+        shell_payload=payload,
+        normalization_complete=normalization_complete,
+    )
+
+
+def executable_search_path_from_env(
+    env: object,
+    *,
+    default: str | None = None,
+) -> str | None:
+    return environment_value_from_env(env, "PATH", default=default)
+
+
+def environment_value_from_env(
+    env: object,
+    name: str,
+    *,
+    default: str | None = None,
+) -> str | None:
+    if isinstance(env, Mapping):
+        value = env.get(name)
+        return value if isinstance(value, str) else default
+    if isinstance(env, str) or not isinstance(env, Sequence):
+        return default
+    for pair in reversed(tuple(env)):
+        if isinstance(pair, str) or not isinstance(pair, Sequence):
+            continue
+        values = tuple(pair)
+        if len(values) == 2 and values[0] == name and isinstance(values[1], str):
+            return values[1]
+    return default
+
+
+def build_path_policy_subjects(
+    arguments: Mapping[str, object],
+    *,
+    cwd: str | None = None,
+) -> tuple[PathPolicySubject, ...]:
+    raw_path = arguments.get("path", arguments.get("file_path"))
+    if not isinstance(raw_path, str) or not raw_path:
+        return ()
+    resolved_path: str | None = None
+    try:
+        path = Path(raw_path).expanduser()
+        if not path.is_absolute() and cwd:
+            path = Path(cwd) / path
+        resolved_path = str(path.resolve())
+    except (OSError, RuntimeError, ValueError):
+        pass
+    return (PathPolicySubject(raw_path=raw_path, resolved_path=resolved_path),)
+
+
+def build_tool_policy_subject(
+    *,
+    tool_name: str,
+    arguments: Mapping[str, object],
+    cwd: str | None = None,
+    command: CommandPolicySubject | None = None,
+    paths: tuple[PathPolicySubject, ...] | None = None,
+) -> ToolPolicySubject:
+    return ToolPolicySubject(
+        tool_name=tool_name,
+        arguments=arguments,
+        cwd=cwd,
+        command=command,
+        paths=build_path_policy_subjects(arguments, cwd=cwd)
+        if paths is None
+        else paths,
+    )
+
+
+def _command_subject(subject: PolicySubject) -> CommandPolicySubject | None:
+    if isinstance(subject, CommandPolicySubject):
+        return subject
+    if isinstance(subject, ToolPolicySubject):
+        return subject.command
+    return None
+
+
+def _contains_token_sequence(
+    values: tuple[str, ...],
+    expected: tuple[str, ...],
+) -> bool:
+    if len(expected) == 1:
+        return expected[0] in values
+    window_size = len(expected)
+    return any(
+        values[index : index + window_size] == expected
+        for index in range(len(values) - window_size + 1)
+    )
+
+
+def _shell_payload(
+    command: tuple[str, ...],
+    *,
+    assume_shell: bool = False,
+    cwd: str | None = None,
+    stdin: str | None = None,
+    executable_search_path: str | None = None,
+    environment_overrides: object | None = None,
+    environment_is_complete: bool = False,
+) -> tuple[str | None, bool]:
+    if not command:
+        return None, True
+    shell_family, executable_complete = _classify_shell_entrypoint(
+        command[0],
+        cwd=cwd,
+        executable_search_path=executable_search_path,
+    )
+    if shell_family == "fish":
+        payload, parser_complete = _fish_shell_payload(command, cwd=cwd, stdin=stdin)
+        return payload, executable_complete and parser_complete
+    if shell_family is None and not assume_shell:
+        return None, executable_complete or stdin is None
+    if shell_family is None:
+        executable_complete = True
+    payload, parser_complete = _generic_shell_payload(command, cwd=cwd, stdin=stdin)
+    if environment_overrides is not None and _shell_startup_environment_active(
+        environment_overrides,
+        environment_is_complete=environment_is_complete,
+    ):
+        parser_complete = False
+    return payload, executable_complete and parser_complete
+
+
+def _shell_startup_environment_active(
+    environment_overrides: object,
+    *,
+    environment_is_complete: bool,
+) -> bool:
+    return any(
+        environment_value_from_env(
+            environment_overrides,
+            name,
+            default=None if environment_is_complete else os.environ.get(name),
+        )
+        not in {None, ""}
+        for name in _SHELL_STARTUP_ENVIRONMENT_NAMES
+    )
+
+
+def _generic_shell_payload(
+    command: tuple[str, ...],
+    *,
+    cwd: str | None,
+    stdin: str | None,
+) -> tuple[str | None, bool]:
+    startup_payloads: list[str] = []
+    complete = True
+    stdin_mode = False
+    index = 1
+    while index < len(command):
+        token = command[index]
+        if token == "--":
+            if stdin_mode or index + 1 == len(command):
+                return _merge_shell_payloads(startup_payloads, stdin), complete
+            reads_stdin, path_complete = _classify_stdin_script_path(
+                command[index + 1],
+                cwd=cwd,
+            )
+            if reads_stdin:
+                return _merge_shell_payloads(startup_payloads, stdin), (
+                    complete and path_complete
+                )
+            return _merge_shell_payloads(startup_payloads), (complete and path_complete)
+        if token == "-":
+            return _merge_shell_payloads(startup_payloads, stdin), complete
+        if token in _SHELL_STARTUP_FILE_OPTIONS:
+            complete = False
+            if index + 1 >= len(command):
+                return _merge_shell_payloads(startup_payloads), False
+            startup_path = command[index + 1]
+            reads_stdin, path_complete = _classify_stdin_script_path(
+                startup_path,
+                cwd=cwd,
+            )
+            if reads_stdin and stdin is not None:
+                startup_payloads.append(stdin)
+            complete = complete and path_complete
+            index += 2
+            continue
+        startup_option = next(
+            (
+                option
+                for option in _SHELL_STARTUP_FILE_OPTIONS
+                if token.startswith(f"{option}=")
+            ),
+            None,
+        )
+        if startup_option is not None:
+            complete = False
+            startup_path = token.removeprefix(f"{startup_option}=")
+            reads_stdin, path_complete = _classify_stdin_script_path(
+                startup_path,
+                cwd=cwd,
+            )
+            if reads_stdin and stdin is not None:
+                startup_payloads.append(stdin)
+            complete = complete and path_complete
+            index += 1
+            continue
+        if token in _SHELL_VALUE_OPTIONS:
+            if index + 1 >= len(command):
+                return _merge_shell_payloads(startup_payloads), False
+            index += 2
+            continue
+        if any(
+            token.startswith(f"{option}=")
+            for option in _SHELL_VALUE_OPTIONS
+            if option.startswith("--")
+        ):
+            index += 1
+            continue
+        if token.startswith(("-O", "+O", "-o", "+o")) and len(token) > 2:
+            index += 1
+            continue
+        if token.startswith("--"):
+            index += 1
+            continue
+        if token.startswith(("-", "+")) and len(token) > 1:
+            options = token[1:]
+            if any(option not in _SHELL_SHORT_OPTIONS for option in options):
+                return _merge_shell_payloads(startup_payloads), False
+            if "c" in options:
+                payload_index = index + 1
+                if payload_index < len(command) and command[payload_index] == "--":
+                    payload_index += 1
+                return (
+                    _merge_shell_payloads(
+                        startup_payloads,
+                        command[payload_index]
+                        if payload_index < len(command)
+                        else None,
+                    ),
+                    complete,
+                )
+            if "s" in options:
+                stdin_mode = True
+            index += 1
+            continue
+        reads_stdin, path_complete = _classify_stdin_script_path(token, cwd=cwd)
+        if reads_stdin:
+            return _merge_shell_payloads(startup_payloads, stdin), (
+                complete and path_complete
+            )
+        return _merge_shell_payloads(
+            startup_payloads,
+            stdin if stdin_mode else None,
+        ), (complete and path_complete)
+    return _merge_shell_payloads(startup_payloads, stdin), complete
+
+
+def _merge_shell_payloads(
+    payloads: Sequence[str],
+    additional: str | None = None,
+) -> str | None:
+    values = [*payloads]
+    if additional is not None:
+        values.append(additional)
+    return "\n".join(values) if values else None
+
+
+def _classify_shell_entrypoint(
+    executable: str,
+    *,
+    cwd: str | None,
+    executable_search_path: str | None,
+) -> tuple[Literal["generic", "fish"] | None, bool]:
+    candidate = _resolve_executable_path(
+        executable,
+        cwd=cwd,
+        executable_search_path=executable_search_path,
+    )
+    if candidate is None:
+        if "/" not in executable and executable in _SHELL_ENTRY_BASENAMES:
+            return _shell_family_for_name(executable), True
+        return None, False
+
+    if _is_known_multicall_candidate(candidate):
+        entry_name = basename(executable)
+        if entry_name in _SHELL_ENTRY_BASENAMES:
+            return _shell_family_for_name(entry_name), True
+        return None, True
+
+    matching_families = {
+        family
+        for family, shell_paths in _known_shell_paths().items()
+        if any(_paths_refer_to_same_file(candidate, path) for path in shell_paths)
+    }
+    if len(matching_families) == 1:
+        family = matching_families.pop()
+        if (
+            basename(executable) in _SHELL_ENTRY_BASENAMES
+            or basename(realpath(candidate)) in _SHELL_ENTRY_BASENAMES
+        ):
+            return family, True
+        return None, False
+    if matching_families:
+        return None, False
+
+    try:
+        samefile(candidate, candidate)
+    except OSError:
+        if basename(executable) in _SHELL_ENTRY_BASENAMES:
+            return _shell_family_for_name(basename(executable)), False
+        return None, False
+    if basename(executable) in _SHELL_ENTRY_BASENAMES:
+        return _shell_family_for_name(basename(executable)), False
+    return None, True
+
+
+def _resolve_executable_path(
+    executable: str,
+    *,
+    cwd: str | None,
+    executable_search_path: str | None,
+) -> str | None:
+    if "/" in executable:
+        if isabs(executable) or cwd is None:
+            return executable
+        return join(cwd, executable)
+    search_path = executable_search_path
+    if search_path is None:
+        search_path = os.environ.get("PATH")
+    if search_path is not None:
+        base_dir = abspath(cwd or ".")
+        search_path = os.pathsep.join(
+            entry if isabs(entry) else join(base_dir, entry or ".")
+            for entry in search_path.split(os.pathsep)
+        )
+    return which(executable, path=search_path)
+
+
+def _shell_family_for_name(name: str) -> Literal["generic", "fish"]:
+    return "fish" if name == "fish" else "generic"
+
+
+@lru_cache(maxsize=1)
+def _known_shell_paths() -> dict[Literal["generic", "fish"], tuple[str, ...]]:
+    return {
+        "generic": _known_executable_paths(_GENERIC_SHELL_ENTRY_BASENAMES),
+        "fish": _known_executable_paths(frozenset({"fish"})),
+    }
+
+
+@lru_cache(maxsize=1)
+def _known_wrapper_paths() -> dict[Literal["env", "sudo"], tuple[str, ...]]:
+    return {
+        "env": _known_executable_paths(frozenset({"env"})),
+        "sudo": _known_executable_paths(frozenset({"sudo"})),
+    }
+
+
+@lru_cache(maxsize=1)
+def _known_multicall_paths() -> tuple[str, ...]:
+    return _known_executable_paths(_MULTICALL_ENTRY_BASENAMES)
+
+
+def _known_executable_paths(names: frozenset[str]) -> tuple[str, ...]:
+    paths: list[str] = []
+    for name in sorted(names):
+        for directory in _STANDARD_EXECUTABLE_DIRECTORIES:
+            path = f"{directory}/{name}"
+            if os.path.exists(path):
+                paths.append(path)
+    return tuple(dict.fromkeys(paths))
+
+
+def _paths_refer_to_same_file(first: str, second: str) -> bool:
+    try:
+        return samefile(first, second)
+    except OSError:
+        return False
+
+
+def _fish_shell_payload(
+    command: tuple[str, ...],
+    *,
+    cwd: str | None = None,
+    stdin: str | None = None,
+) -> tuple[str | None, bool]:
+    payloads: list[str] = []
+    complete = True
+    command_mode = False
+    script_operand = False
+    index = 1
+    long_value_options = frozenset({"--command", "--init-command"})
+    long_no_value_options = frozenset(
+        {
+            "--interactive",
+            "--login",
+            "--no-config",
+            "--no-execute",
+            "--private",
+        }
+    )
+    while index < len(command):
+        token = command[index]
+        if token == "--":
+            if index + 1 < len(command):
+                operand = command[index + 1]
+                reads_stdin, path_complete = _classify_stdin_script_path(
+                    operand,
+                    cwd=cwd,
+                )
+                if not command_mode and reads_stdin and stdin is not None:
+                    payloads.append(stdin)
+                    script_operand = True
+                else:
+                    script_operand = True
+                complete = complete and path_complete
+            break
+        if not command_mode and token == "-":
+            if stdin is not None:
+                payloads.append(stdin)
+            script_operand = True
+            break
+        if token.startswith("--"):
+            option_name, separator, attached_value = token.partition("=")
+            option = _resolve_long_option(
+                option_name,
+                long_value_options | long_no_value_options,
+            )
+            if option in long_value_options:
+                command_mode = command_mode or option == "--command"
+                if separator:
+                    payloads.append(attached_value)
+                    index += 1
+                elif index + 1 < len(command):
+                    payloads.append(command[index + 1])
+                    index += 2
+                else:
+                    complete = False
+                    break
+                continue
+            if option is None:
+                complete = False
+            index += 1
+            continue
+        if token.startswith("-") and len(token) > 1:
+            cluster = token[1:]
+            value_position = next(
+                (
+                    position
+                    for position, option in enumerate(cluster)
+                    if option in {"c", "C"}
+                ),
+                None,
+            )
+            if value_position is None:
+                if any(option not in {"i", "l", "N", "P"} for option in cluster):
+                    complete = False
+                index += 1
+                continue
+            command_mode = command_mode or cluster[value_position] == "c"
+            if any(
+                option not in {"i", "l", "N", "P"}
+                for option in cluster[:value_position]
+            ):
+                complete = False
+            attached_value = cluster[value_position + 1 :]
+            if attached_value:
+                payloads.append(attached_value)
+                index += 1
+            elif index + 1 < len(command):
+                payloads.append(command[index + 1])
+                index += 2
+            else:
+                complete = False
+                break
+            continue
+        reads_stdin, path_complete = _classify_stdin_script_path(token, cwd=cwd)
+        if not command_mode and reads_stdin and stdin is not None:
+            payloads.append(stdin)
+        complete = complete and path_complete
+        script_operand = True
+        break
+    if stdin is not None and not command_mode and not script_operand:
+        payloads.append(stdin)
+    return ("\n".join(payloads) if payloads else None), complete
+
+
+def _classify_stdin_script_path(
+    operand: str,
+    *,
+    cwd: str | None,
+) -> tuple[bool, bool]:
+    unresolved_candidate = (
+        operand
+        if isabs(operand)
+        else join(cwd, operand)
+        if cwd is not None
+        else operand
+    )
+    normalized = normpath(abspath(unresolved_candidate))
+    if normalized.startswith("//"):
+        normalized = "/" + normalized.lstrip("/")
+    folded = _fold_proc_root_alias(normalized)
+    if folded in _STDIN_SCRIPT_PSEUDO_PATHS:
+        return True, True
+
+    uncertain = False
+    for pseudo_path in _STDIN_SCRIPT_PSEUDO_PATHS:
+        try:
+            if samefile(unresolved_candidate, pseudo_path):
+                return True, True
+        except FileNotFoundError:
+            continue
+        except OSError:
+            uncertain = True
+    if uncertain and _looks_like_stdin_alias(normalized):
+        return False, False
+    return False, True
+
+
+def _fold_proc_root_alias(path: str) -> str:
+    prefixes = ("/proc/self/root/", "/proc/thread-self/root/")
+    folded = path
+    while True:
+        prefix = next(
+            (candidate for candidate in prefixes if folded.startswith(candidate)),
+            None,
+        )
+        if prefix is None:
+            return folded
+        folded = normpath("/" + folded[len(prefix) :].lstrip("/"))
+
+
+def _looks_like_stdin_alias(path: str) -> bool:
+    parts = tuple(part for part in path.split("/") if part)
+    if not parts:
+        return False
+    if parts[-1] == "stdin":
+        return True
+    return len(parts) >= 2 and parts[-2] == "fd" and parts[-1].lstrip("0") == ""
+
+
+def _is_env_assignment(token: str) -> bool:
+    if "=" not in token:
+        return False
+    name, _, _ = token.partition("=")
+    return (
+        bool(name)
+        and (name[0].isalpha() or name[0] == "_")
+        and all(ch.isalnum() or ch == "_" for ch in name[1:])
+    )
+
+
+def _is_env_operand(token: str) -> bool:
+    return "=" in token
+
+
+def _env_operand_changes_command_projection(token: str) -> bool:
+    name, separator, _ = token.partition("=")
+    return bool(separator) and name in {
+        "PATH",
+        *_SHELL_STARTUP_ENVIRONMENT_NAMES,
+    }
+
+
+def _split_env_string(value: str, remainder: tuple[str, ...]) -> tuple[str, ...]:
+    try:
+        split_tokens = tuple(shlex.split(value))
+    except ValueError:
+        return ("sh", "-lc", value, *remainder)
+    return (*split_tokens, *remainder)
+
+
+def _unwrap_env_short_options(
+    token: str,
+    remainder: tuple[str, ...],
+) -> tuple[tuple[str, ...], bool]:
+    complete = True
+    cluster = token[1:]
+    if not cluster:
+        return remainder, False
+    for index, option in enumerate(cluster):
+        if option == "i":
+            complete = False
+        if option not in _ENV_SHORT_VALUE_OPTIONS:
+            if option not in _ENV_SHORT_NO_VALUE_OPTIONS:
+                complete = False
+            continue
+        attached_value = cluster[index + 1 :]
+        if option == "S":
+            if attached_value:
+                return _split_env_string(attached_value, remainder), False
+            if not remainder:
+                return (), False
+            return _split_env_string(remainder[0], remainder[1:]), False
+        if option == "C":
+            complete = False
+        if option == "f":
+            complete = False
+        if option == "a":
+            complete = False
+        if option == "u" and (
+            attached_value in {"PATH", *_SHELL_STARTUP_ENVIRONMENT_NAMES}
+            or (
+                not attached_value
+                and remainder
+                and remainder[0] in {"PATH", *_SHELL_STARTUP_ENVIRONMENT_NAMES}
+            )
+        ):
+            complete = False
+        if attached_value:
+            return remainder, complete
+        if not remainder:
+            return (), complete
+        return remainder[1:], complete
+    return remainder, complete
+
+
+def _unwrap_env_command(
+    command: tuple[str, ...],
+) -> tuple[tuple[str, ...], bool]:
+    complete = True
+    while command:
+        head = command[0]
+        if head == "--":
+            command = command[1:]
+            while command and _is_env_operand(command[0]):
+                if _env_operand_changes_command_projection(command[0]):
+                    complete = False
+                command = command[1:]
+            return command, complete
+        if head in _ENV_NO_VALUE_OPTIONS:
+            if head in {"-i", "--ignore-environment"}:
+                complete = False
+            command = command[1:]
+            continue
+        if head == "-S":
+            if len(command) < 2:
+                return (), False
+            command = _split_env_string(command[1], command[2:])
+            complete = False
+            continue
+        if head.startswith("-S") and len(head) > 2:
+            command = _split_env_string(head[2:], command[1:])
+            complete = False
+            continue
+        if head in _ENV_VALUE_OPTIONS and not head.startswith("--"):
+            if head == "-C":
+                complete = False
+            if len(command) < 2:
+                return (), complete
+            if head in {"-a", "-f"} or (
+                head == "-u"
+                and command[1] in {"PATH", *_SHELL_STARTUP_ENVIRONMENT_NAMES}
+            ):
+                complete = False
+            command = command[2:]
+            continue
+        if head.startswith("--"):
+            option_name, separator, attached_value = head.partition("=")
+            option = _resolve_long_option(option_name, _ENV_LONG_OPTIONS)
+            if option == "--split-string":
+                complete = False
+                if separator:
+                    command = _split_env_string(attached_value, command[1:])
+                elif len(command) < 2:
+                    return (), False
+                else:
+                    command = _split_env_string(command[1], command[2:])
+                continue
+            if option in _ENV_LONG_VALUE_OPTIONS:
+                if option == "--chdir":
+                    complete = False
+                option_value = (
+                    attached_value
+                    if separator
+                    else (command[1] if len(command) >= 2 else None)
+                )
+                if option in {"--argv0", "--file"} or (
+                    option == "--unset"
+                    and option_value in {"PATH", *_SHELL_STARTUP_ENVIRONMENT_NAMES}
+                ):
+                    complete = False
+                if separator:
+                    command = command[1:]
+                elif len(command) < 2:
+                    return (), complete
+                else:
+                    command = command[2:]
+                continue
+            if option is None:
+                complete = False
+            command = command[1:]
+            continue
+        if head.startswith("-") and not head.startswith("--"):
+            command, option_complete = _unwrap_env_short_options(
+                head,
+                command[1:],
+            )
+            complete = complete and option_complete
+            continue
+        if _env_operand_changes_command_projection(head):
+            complete = False
+            command = command[1:]
+            continue
+        if head.startswith("-") or _is_env_operand(head):
+            command = command[1:]
+            continue
+        break
+    return command, complete
+
+
+def _unwrap_leading_wrappers(
+    command: tuple[str, ...],
+    *,
+    cwd: str | None,
+    executable_search_path: str | None,
+) -> tuple[tuple[str, ...], bool]:
+    complete = True
+    while command:
+        multicall = _unwrap_multicall_control_applet(
+            command,
+            cwd=cwd,
+            executable_search_path=executable_search_path,
+        )
+        if multicall is not None:
+            command, multicall_complete = multicall
+            complete = complete and multicall_complete
+            if command and command[0] == "env":
+                command, env_complete = _unwrap_env_command(command[1:])
+                complete = complete and env_complete
+            continue
+        wrapper, wrapper_identity_complete = _classify_leading_wrapper(
+            command[0],
+            cwd=cwd,
+            executable_search_path=executable_search_path,
+        )
+        complete = complete and wrapper_identity_complete
+        if wrapper is None:
+            break
+        command = command[1:]
+        if wrapper == "env":
+            command, wrapper_complete = _unwrap_env_command(command)
+            complete = complete and wrapper_complete
+            continue
+        command, shell_mode, wrapper_complete = _unwrap_sudo_command(command)
+        complete = complete and wrapper_complete
+        while command and _is_env_assignment(command[0]):
+            if _env_operand_changes_command_projection(command[0]):
+                complete = False
+            command = command[1:]
+        if shell_mode:
+            complete = False
+            return (
+                (("sh", "-c", shlex.join(command)) if command else ()),
+                complete,
+            )
+    return command, complete
+
+
+def _unwrap_multicall_control_applet(
+    command: tuple[str, ...],
+    *,
+    cwd: str | None,
+    executable_search_path: str | None,
+) -> tuple[tuple[str, ...], bool] | None:
+    if (
+        len(command) < 2
+        or basename(command[0]) not in _MULTICALL_ENTRY_BASENAMES
+        or command[1] not in _MULTICALL_CONTROL_APPLETS
+    ):
+        return None
+    candidate = _resolve_executable_path(
+        command[0],
+        cwd=cwd,
+        executable_search_path=executable_search_path,
+    )
+    identity_complete = bool(
+        candidate is not None
+        and basename(realpath(candidate)) in _MULTICALL_ENTRY_BASENAMES
+        and _is_known_multicall_candidate(candidate)
+    )
+    return command[1:], identity_complete
+
+
+def _classify_leading_wrapper(
+    executable: str,
+    *,
+    cwd: str | None,
+    executable_search_path: str | None,
+) -> tuple[Literal["env", "sudo"] | None, bool]:
+    candidate = _resolve_executable_path(
+        executable,
+        cwd=cwd,
+        executable_search_path=executable_search_path,
+    )
+    entry_name = basename(executable)
+    if candidate is None:
+        if "/" not in executable and entry_name in _LEADING_WRAPPER_BASENAMES:
+            return cast(Literal["env", "sudo"], entry_name), True
+        return None, entry_name not in _LEADING_WRAPPER_BASENAMES
+
+    if entry_name == "env" and _is_known_multicall_candidate(candidate):
+        return "env", True
+
+    if entry_name not in _LEADING_WRAPPER_BASENAMES:
+        resolved_name = basename(realpath(candidate))
+        return None, resolved_name not in _LEADING_WRAPPER_BASENAMES
+
+    wrapper = cast(Literal["env", "sudo"], entry_name)
+    if basename(realpath(candidate)) == entry_name and any(
+        _paths_refer_to_same_file(candidate, path)
+        for path in _known_wrapper_paths()[wrapper]
+    ):
+        return wrapper, True
+
+    shell_family, shell_complete = _classify_shell_entrypoint(
+        executable,
+        cwd=cwd,
+        executable_search_path=executable_search_path,
+    )
+    if shell_family is not None:
+        return None, shell_complete
+    return None, False
+
+
+def _is_known_multicall_candidate(candidate: str) -> bool:
+    return any(
+        _paths_refer_to_same_file(candidate, path) for path in _known_multicall_paths()
+    )
+
+
+def _unwrap_sudo_command(
+    command: tuple[str, ...],
+) -> tuple[tuple[str, ...], bool, bool]:
+    shell_mode = False
+    complete = True
+    while command:
+        head = command[0]
+        if head == "--":
+            return command[1:], shell_mode, complete
+        if not head.startswith("-"):
+            return command, shell_mode, complete
+        if head.startswith("--"):
+            option_name, separator, _ = head.partition("=")
+            option = _resolve_long_option(option_name, _SUDO_LONG_OPTIONS)
+            if option is None:
+                complete = False
+            if option in {"--chdir", "--chroot"}:
+                complete = False
+            if option in _SUDO_SHELL_MODE_LONG_OPTIONS:
+                shell_mode = True
+            if option in _SUDO_LONG_VALUE_OPTIONS and not separator:
+                if len(command) < 2:
+                    return (), shell_mode, complete
+                command = command[2:]
+            else:
+                command = command[1:]
+            continue
+        command, token_shell_mode, token_complete = _unwrap_sudo_short_options(
+            head,
+            command[1:],
+        )
+        shell_mode = shell_mode or token_shell_mode
+        complete = complete and token_complete
+    return command, shell_mode, complete
+
+
+def _unwrap_sudo_short_options(
+    token: str,
+    remainder: tuple[str, ...],
+) -> tuple[tuple[str, ...], bool, bool]:
+    shell_mode = False
+    complete = True
+    cluster = token[1:]
+    for index, option in enumerate(cluster):
+        if option in _SUDO_SHORT_VALUE_OPTIONS:
+            if option in {"D", "R"}:
+                complete = False
+            if index < len(cluster) - 1:
+                return remainder, shell_mode, complete
+            if not remainder:
+                return (), shell_mode, complete
+            return remainder[1:], shell_mode, complete
+        if option in {"i", "s"}:
+            shell_mode = True
+        elif option not in _SUDO_SHORT_NO_VALUE_OPTIONS:
+            complete = False
+    return remainder, shell_mode, complete
+
+
+def _resolve_long_option(
+    option_name: str,
+    options: frozenset[str],
+) -> str | None:
+    if option_name in options:
+        return option_name
+    matches = tuple(option for option in options if option.startswith(option_name))
+    return matches[0] if len(matches) == 1 else None
+
+
+def _direct_command_tokens(command: tuple[str, ...]) -> tuple[str, ...]:
+    if not command:
+        return ()
+    return (basename(command[0]), *command[1:])
+
+
+def _string_tuple(values: Sequence[str], field_name: str) -> tuple[str, ...]:
+    if isinstance(values, str):
+        raise TypeError(f"{field_name} must be a sequence of strings, not a string")
+    normalized = tuple(values)
+    if not all(isinstance(value, str) for value in normalized):
+        raise TypeError(f"{field_name} must be a sequence of strings")
+    return normalized
+
+
+def _freeze_mapping(values: Mapping[str, object]) -> Mapping[str, object]:
+    if not isinstance(values, Mapping):
+        raise TypeError("arguments must be a mapping")
+    return MappingProxyType(
+        {
+            _require_policy_mapping_key(key): _freeze_value(value)
+            for key, value in values.items()
+        }
+    )
+
+
+def _freeze_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {
+                _require_policy_mapping_key(key): _freeze_value(item)
+                for key, item in value.items()
+            }
+        )
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_value(item) for item in value)
+    if value is None or isinstance(value, str | bool | int | float):
+        return value
+    raise TypeError(
+        "policy argument values must be JSON-compatible mappings, sequences, "
+        "strings, numbers, booleans, or null"
+    )
+
+
+def _require_policy_mapping_key(key: object) -> str:
+    if not isinstance(key, str):
+        raise TypeError("policy argument mapping keys must be strings")
+    return key

--- a/src/loushang/harness/runtime/transition.py
+++ b/src/loushang/harness/runtime/transition.py
@@ -26,6 +26,9 @@ class SessionTransitionHost(Generic[S]):
         self._dispose = dispose
         self._rebind = rebind
         self._before_invalidate = before_invalidate
+        self._before_invalidate_observers: list[LifecycleCallback] = []
+        self._after_invalidate_observers: list[LifecycleCallback] = []
+        self._notifying_after_invalidate = False
         self._lock = asyncio.Lock()
         self._lock_owner: asyncio.Task[object] | None = None
         self._lock_depth = 0
@@ -37,10 +40,46 @@ class SessionTransitionHost(Generic[S]):
     def set_rebind(self, callback: SessionCallback[S] | None) -> None:
         self._rebind = callback
 
-    def set_before_invalidate(
-        self, callback: LifecycleCallback | None
-    ) -> None:
+    def set_before_invalidate(self, callback: LifecycleCallback | None) -> None:
         self._before_invalidate = callback
+
+    def subscribe_before_invalidate(
+        self,
+        callback: LifecycleCallback,
+    ) -> Callable[[], None]:
+        def observer() -> Awaitable[None] | None:
+            return callback()
+
+        self._before_invalidate_observers.append(observer)
+        active = True
+
+        def unsubscribe() -> None:
+            nonlocal active
+            if not active:
+                return
+            active = False
+            self._before_invalidate_observers.remove(observer)
+
+        return unsubscribe
+
+    def subscribe_after_invalidate(
+        self,
+        callback: LifecycleCallback,
+    ) -> Callable[[], None]:
+        def observer() -> Awaitable[None] | None:
+            return callback()
+
+        self._after_invalidate_observers.append(observer)
+        active = True
+
+        def unsubscribe() -> None:
+            nonlocal active
+            if not active:
+                return
+            active = False
+            self._after_invalidate_observers.remove(observer)
+
+        return unsubscribe
 
     @asynccontextmanager
     async def transition(self) -> AsyncIterator[None]:
@@ -72,14 +111,22 @@ class SessionTransitionHost(Generic[S]):
         before_release: SessionCallback[S] | None = None,
         activate: SessionCallback[S] | None = None,
     ) -> S:
+        self._reject_reentrant_after_invalidate_transition()
         async with self.transition():
             if prepare is not None:
                 await _invoke_session_callback(prepare, next_session)
 
             previous = self._current
             if previous is not None and previous is not next_session:
-                await self._release(previous, before_release=before_release)
+                await self._prepare_release(
+                    previous,
+                    before_release=before_release,
+                )
                 self._current = None
+                try:
+                    await _invoke_session_callback(self._dispose, previous)
+                finally:
+                    await self._notify_after_invalidate()
 
             self._current = next_session
             if activate is not None:
@@ -93,14 +140,19 @@ class SessionTransitionHost(Generic[S]):
         *,
         before_release: SessionCallback[S] | None = None,
     ) -> None:
+        self._reject_reentrant_after_invalidate_transition()
         async with self.transition():
             current = self._current
             if current is None:
                 return
-            await self._release(current, before_release=before_release)
+            await self._prepare_release(current, before_release=before_release)
             self._current = None
+            try:
+                await _invoke_session_callback(self._dispose, current)
+            finally:
+                await self._notify_after_invalidate()
 
-    async def _release(
+    async def _prepare_release(
         self,
         session: S,
         *,
@@ -110,12 +162,32 @@ class SessionTransitionHost(Generic[S]):
             await _invoke_session_callback(before_release, session)
         if self._before_invalidate is not None:
             await _invoke_lifecycle_callback(self._before_invalidate)
-        await _invoke_session_callback(self._dispose, session)
+        for observer in tuple(self._before_invalidate_observers):
+            await _invoke_lifecycle_callback(observer)
+
+    async def _notify_after_invalidate(self) -> None:
+        self._notifying_after_invalidate = True
+        try:
+            for observer in tuple(self._after_invalidate_observers):
+                try:
+                    await _invoke_lifecycle_callback(observer)
+                except Exception:
+                    continue
+        finally:
+            self._notifying_after_invalidate = False
+
+    def _reject_reentrant_after_invalidate_transition(self) -> None:
+        if (
+            self._notifying_after_invalidate
+            and self._lock_owner is asyncio.current_task()
+        ):
+            raise RuntimeError(
+                "Session transition cannot be re-entered from an "
+                "after-invalidate observer"
+            )
 
 
-async def _invoke_session_callback(
-    callback: SessionCallback[S], session: S
-) -> None:
+async def _invoke_session_callback(callback: SessionCallback[S], session: S) -> None:
     result = callback(session)
     if inspect.isawaitable(result):
         await result

--- a/src/loushang/harness/tools/workspace/bash.py
+++ b/src/loushang/harness/tools/workspace/bash.py
@@ -7,16 +7,27 @@ from typing import Any, NotRequired, Protocol, TypedDict
 from loushang.agent.types import AgentToolResult, TextPart
 from loushang.harness.approval import ApprovalResolver
 from loushang.harness.diagnostics.service import DiagnosticsService
+from loushang.harness.policy import (
+    build_tool_policy_subject,
+    executable_search_path_from_env,
+    normalize_command_subject,
+)
 from loushang.harness.workspace.exec import (
     ExecOutputChunk,
     ExecRequest,
     ExecResult,
     ExecService,
+    materialize_exec_request,
 )
 
 from .builtin_renderers import render_bash_call, render_bash_result
 from .context import ToolContextProvider
-from .policy import ToolPolicyEvaluator, enforce_tool_policy
+from .policy import (
+    ToolPolicyEvaluator,
+    enforce_tool_policy,
+    evaluate_legacy_policy_method,
+    get_policy_method,
+)
 from .runtime import (
     emit_tool_update,
     pi_truncation_details,
@@ -87,6 +98,8 @@ class BashToolDetails(TypedDict, total=False):
 
 
 class BashOperations(Protocol):
+    """Execute a request using its materialized cwd and environment."""
+
     async def execute(
         self,
         request: ExecRequest,
@@ -250,6 +263,7 @@ class _BashToolExecute:
             shell_path=self.shell_path,
             spawn_hook=self.spawn_hook,
         )
+        exec_request = materialize_exec_request(exec_request)
         await _enforce_bash_policy(
             self.policy_engine,
             tool_call_id=tool_call_id,
@@ -257,6 +271,7 @@ class _BashToolExecute:
             arguments=request_params,
             approval_resolver=self.approval_resolver,
             audit_sink=getattr(context, "event_sink", None),
+            assume_shell=isinstance(request_params.get("command"), str),
         )
 
         await emit_tool_update(on_update, AgentToolResult(content=[], details=None))
@@ -354,25 +369,65 @@ async def _enforce_bash_policy(
     arguments: dict[str, Any],
     approval_resolver: ApprovalResolver | None,
     audit_sink: object | None = None,
+    assume_shell: bool = False,
 ) -> None:
     if policy_engine is None:
         return
-    evaluate_tool_call = getattr(policy_engine, "evaluate_tool_call", None)
-    if callable(evaluate_tool_call):
+    evaluate = get_policy_method(policy_engine, "evaluate")
+    if callable(evaluate) or callable(
+        get_policy_method(policy_engine, "evaluate_tool_call")
+    ):
+        execution_environment = exec_request.effective_environment
+        assert execution_environment is not None
+        command_subject = normalize_command_subject(
+            exec_request.command,
+            cwd=exec_request.cwd,
+            assume_shell=assume_shell,
+            stdin=exec_request.stdin,
+            executable_search_path=executable_search_path_from_env(
+                execution_environment,
+                default=os.defpath,
+            ),
+            environment_overrides=execution_environment,
+            environment_is_complete=True,
+        )
+        effective_arguments = dict(arguments)
+        effective_arguments["command"] = (
+            command_subject.shell_payload
+            if assume_shell and command_subject.shell_payload is not None
+            else exec_request.command
+        )
+        if not assume_shell and command_subject.shell_payload is not None:
+            effective_arguments["shell_payload"] = command_subject.shell_payload
+        effective_arguments["cwd"] = exec_request.cwd
+        if exec_request.stdin is not None:
+            effective_arguments["stdin"] = exec_request.stdin
+        if exec_request.env or "env" in arguments:
+            effective_arguments["env"] = exec_request.env
+        policy_subject = build_tool_policy_subject(
+            tool_name="bash",
+            arguments=effective_arguments,
+            cwd=exec_request.cwd,
+            command=command_subject,
+        )
         await enforce_tool_policy(
             policy_engine,
             tool_name="bash",
-            arguments=arguments,
+            arguments=effective_arguments,
             cwd=exec_request.cwd,
+            policy_subject=policy_subject,
             approval_resolver=approval_resolver,
             tool_call_id=tool_call_id,
             audit_sink=audit_sink,
+            execution_environment=execution_environment,
         )
         return
-    evaluate_action = getattr(policy_engine, "evaluate_action", None)
-    if not callable(evaluate_action):
-        return
-    decision = evaluate_action(tool_name="bash", exec_request=exec_request)
+    decision = await evaluate_legacy_policy_method(
+        policy_engine,
+        "evaluate_action",
+        tool_name="bash",
+        exec_request=exec_request,
+    )
     if decision.disposition == "deny":
         raise PermissionError(decision.reason or "Command denied by policy")
     if decision.disposition == "ask":

--- a/src/loushang/harness/tools/workspace/policy.py
+++ b/src/loushang/harness/tools/workspace/policy.py
@@ -1,32 +1,45 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Mapping
-from typing import Any, Literal, Protocol
-from uuid import uuid4
+import os
+from collections.abc import Iterable, Mapping
+from typing import Any, Literal, Protocol, cast
 
 from loushang.harness.approval import (
     ApprovalDecision,
     ApprovalRequest,
     ApprovalResolver,
+    ensure_approval_action_id,
     resolve_approval,
+)
+from loushang.harness.policy import (
+    MaybeAwaitable,
+    PolicyDecision,
+    PolicyEvaluationError,
+    PolicyEvaluator,
+    ToolPolicySubject,
+    build_tool_policy_subject,
+    evaluate_policy,
+    executable_search_path_from_env,
+    normalize_command_subject,
 )
 
 
 class PolicyDecisionLike(Protocol):
-    disposition: Literal["allow", "deny", "ask"]
-    reason: str | None
-    code: str | None
+    @property
+    def disposition(self) -> Literal["allow", "deny", "ask"]: ...
+
+    @property
+    def reason(self) -> str | None: ...
+
+    @property
+    def code(self) -> str | None: ...
 
 
 class ToolPolicyEvaluator(Protocol):
-    def evaluate_tool_call(
-        self,
-        *,
-        tool_name: str,
-        arguments: Mapping[str, Any],
-        cwd: str | None = None,
-    ) -> PolicyDecisionLike: ...
+    def evaluate(
+        self, subject: ToolPolicySubject, /
+    ) -> MaybeAwaitable[PolicyDecision | None]: ...
 
 
 class PolicyEnforcementError(PermissionError):
@@ -41,16 +54,38 @@ async def enforce_tool_policy(
     tool_name: str,
     arguments: Mapping[str, Any],
     cwd: str | None = None,
+    policy_subject: ToolPolicySubject | None = None,
     approval_resolver: ApprovalResolver | None = None,
     tool_call_id: str | None = None,
     audit_sink: Any = None,
+    execution_environment: object | None = None,
 ) -> None:
     if policy_engine is None:
         return
-    evaluate_tool_call = getattr(policy_engine, "evaluate_tool_call", None)
-    if not callable(evaluate_tool_call):
-        return
-    decision = evaluate_tool_call(tool_name=tool_name, arguments=arguments, cwd=cwd)
+    execution_subject = build_tool_policy_subject(
+        tool_name=tool_name,
+        arguments=arguments,
+        cwd=cwd,
+    )
+    environment_snapshot = _snapshot_execution_environment(execution_environment)
+    _validate_execution_arguments(execution_subject)
+    if policy_subject is not None:
+        _validate_policy_subject_matches_execution(
+            policy_subject,
+            execution_subject,
+            execution_environment=environment_snapshot,
+        )
+    subject = policy_subject or execution_subject
+    tool_name = subject.tool_name
+    arguments = subject.arguments
+    cwd = subject.cwd
+    decision = await _evaluate_tool_policy(
+        policy_engine,
+        tool_name=tool_name,
+        arguments=arguments,
+        cwd=cwd,
+        subject=subject,
+    )
     await _emit_policy_audit_event(
         audit_sink,
         {
@@ -80,16 +115,18 @@ async def enforce_tool_policy(
             ),
         )
     if decision.disposition == "ask":
-        action_id = f"policy-{uuid4().hex}"
-        request = ApprovalRequest(
-            tool_name=tool_name,
-            arguments=arguments,
-            cwd=cwd,
-            reason=decision.reason,
-            policy_code=decision.code,
-            policy_decision=decision,
-            action_id=action_id,
+        request = ensure_approval_action_id(
+            ApprovalRequest(
+                tool_name=tool_name,
+                arguments=arguments,
+                cwd=cwd,
+                reason=decision.reason,
+                policy_code=decision.code,
+                policy_decision=decision,
+            )
         )
+        action_id = request.action_id
+        assert action_id is not None
         await _emit_policy_audit_event(
             audit_sink,
             {
@@ -143,6 +180,241 @@ async def enforce_tool_policy(
         )
 
 
+async def _evaluate_tool_policy(
+    policy_engine: ToolPolicyEvaluator | object,
+    *,
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    cwd: str | None,
+    subject: ToolPolicySubject,
+) -> PolicyDecision:
+    evaluate = get_policy_method(policy_engine, "evaluate")
+    if callable(evaluate):
+        decision = await evaluate_policy(
+            cast(PolicyEvaluator, policy_engine),
+            subject,
+        )
+        if decision is not None:
+            return decision
+        legacy_evaluate = get_policy_method(policy_engine, "evaluate_tool_call")
+        if not callable(legacy_evaluate):
+            return PolicyDecision.allow()
+    else:
+        legacy_evaluate = get_policy_method(policy_engine, "evaluate_tool_call")
+
+    # Compatibility evaluators keep their established call shape during the
+    # transition. When a dual-protocol adapter abstains through the new
+    # contract, its legacy result remains authoritative.
+    if callable(legacy_evaluate):
+        return await _evaluate_legacy_tool_policy(
+            policy_engine,
+            legacy_evaluate=legacy_evaluate,
+            tool_name=tool_name,
+            arguments=arguments,
+            cwd=cwd,
+        )
+
+    if not callable(evaluate):
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(policy_engine).__name__} has no supported evaluate method"
+        )
+    return PolicyDecision.allow()
+
+
+def _validate_execution_arguments(execution: ToolPolicySubject) -> None:
+    if execution.tool_name != "bash" or "cwd" not in execution.arguments:
+        return
+    argument_cwd = execution.arguments["cwd"]
+    if argument_cwd is not None and not isinstance(argument_cwd, str):
+        raise PolicyEvaluationError(
+            "Bash execution argument cwd must be a string or None"
+        )
+    if argument_cwd != execution.cwd:
+        raise PolicyEvaluationError(
+            "Bash execution argument cwd does not match the execution cwd"
+        )
+
+
+def _validate_policy_subject_matches_execution(
+    subject: ToolPolicySubject,
+    execution: ToolPolicySubject,
+    *,
+    execution_environment: tuple[tuple[str, str], ...] | None,
+) -> None:
+    mismatches = []
+    if subject.tool_name != execution.tool_name:
+        mismatches.append("tool_name")
+    if subject.arguments != execution.arguments:
+        mismatches.append("arguments")
+    if subject.cwd != execution.cwd:
+        mismatches.append("cwd")
+    if subject.paths != execution.paths:
+        mismatches.append("paths")
+    argument_command = execution.arguments.get("command")
+    if argument_command is None:
+        if subject.command is not None:
+            mismatches.append("command")
+    elif subject.command is None:
+        mismatches.append("command")
+    else:
+        stdin = execution.arguments.get("stdin")
+        normalized_stdin = stdin if isinstance(stdin, str) else None
+        normalization_environment = (
+            execution_environment
+            if execution_environment is not None
+            else execution.arguments.get("env", ())
+        )
+        executable_search_path = executable_search_path_from_env(
+            normalization_environment,
+            default=os.defpath if execution_environment is not None else None,
+        )
+        expected_command = None
+        command_matches_argument = True
+        if isinstance(argument_command, str):
+            expected_command = normalize_command_subject(
+                subject.command.command,
+                cwd=execution.cwd,
+                assume_shell=True,
+                stdin=normalized_stdin,
+                executable_search_path=executable_search_path,
+                environment_overrides=normalization_environment,
+                environment_is_complete=execution_environment is not None,
+            )
+            command_matches_argument = (
+                expected_command.shell_payload == argument_command
+            )
+        elif isinstance(argument_command, (list, tuple)) and all(
+            isinstance(part, str) for part in argument_command
+        ):
+            expected_command = normalize_command_subject(
+                tuple(argument_command),
+                cwd=execution.cwd,
+                stdin=normalized_stdin,
+                executable_search_path=executable_search_path,
+                environment_overrides=normalization_environment,
+                environment_is_complete=execution_environment is not None,
+            )
+        if subject.command != expected_command or not command_matches_argument:
+            mismatches.append("command")
+    if mismatches:
+        raise PolicyEvaluationError(
+            "Policy subject does not match execution fields: " + ", ".join(mismatches)
+        )
+
+
+def _snapshot_execution_environment(
+    environment: object | None,
+) -> tuple[tuple[str, str], ...] | None:
+    if environment is None:
+        return None
+    values = environment.items() if isinstance(environment, Mapping) else environment
+    if isinstance(values, str) or not isinstance(values, Iterable):
+        raise TypeError("execution_environment must contain 2-item string pairs")
+    snapshot: list[tuple[str, str]] = []
+    for item in values:
+        if isinstance(item, str) or not isinstance(item, (list, tuple)):
+            raise TypeError("execution_environment must contain 2-item string pairs")
+        pair = tuple(item)
+        if len(pair) != 2 or not all(isinstance(part, str) for part in pair):
+            raise TypeError("execution_environment must contain 2-item string pairs")
+        snapshot.append((pair[0], pair[1]))
+    return tuple(snapshot)
+
+
+def get_policy_method(policy_engine: object, name: str) -> object:
+    try:
+        return getattr(policy_engine, name, None)
+    except Exception as exc:
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(policy_engine).__name__} failed while "
+            f"accessing {name}: {exc}"
+        ) from exc
+
+
+async def _evaluate_legacy_tool_policy(
+    policy_engine: object,
+    *,
+    legacy_evaluate: Any,
+    tool_name: str,
+    arguments: Mapping[str, Any],
+    cwd: str | None,
+) -> PolicyDecision:
+    return await evaluate_legacy_policy_method(
+        policy_engine,
+        "evaluate_tool_call",
+        method=legacy_evaluate,
+        tool_name=tool_name,
+        arguments=arguments,
+        cwd=cwd,
+    )
+
+
+async def evaluate_legacy_policy_method(
+    policy_engine: object,
+    method_name: str,
+    *,
+    method: object | None = None,
+    **kwargs: object,
+) -> PolicyDecision:
+    resolved_method = (
+        method if method is not None else get_policy_method(policy_engine, method_name)
+    )
+    if not callable(resolved_method):
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(policy_engine).__name__} has no callable "
+            f"{method_name} method"
+        )
+    try:
+        result = resolved_method(**kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+    except PolicyEvaluationError:
+        raise
+    except Exception as exc:
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(policy_engine).__name__} failed: {exc}"
+        ) from exc
+    return _coerce_legacy_decision(result, evaluator=policy_engine)
+
+
+def _coerce_legacy_decision(
+    result: object,
+    *,
+    evaluator: object,
+) -> PolicyDecision:
+    if isinstance(result, PolicyDecision):
+        try:
+            result.__post_init__()
+        except (TypeError, ValueError) as exc:
+            raise PolicyEvaluationError(
+                f"Policy evaluator {type(evaluator).__name__} returned an invalid "
+                f"PolicyDecision: {exc}"
+            ) from exc
+        return result
+    try:
+        disposition = getattr(result, "disposition", None)
+        reason = getattr(result, "reason", None)
+        code = getattr(result, "code", None)
+    except Exception as exc:
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(evaluator).__name__} returned an invalid "
+            f"decision: {exc}"
+        ) from exc
+    if disposition not in {"allow", "deny", "ask"}:
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(evaluator).__name__} returned an invalid decision"
+        )
+    if reason is not None and not isinstance(reason, str):
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(evaluator).__name__} returned a non-string reason"
+        )
+    if code is not None and not isinstance(code, str):
+        raise PolicyEvaluationError(
+            f"Policy evaluator {type(evaluator).__name__} returned a non-string code"
+        )
+    return PolicyDecision(disposition=disposition, reason=reason, code=code)
+
+
 def _policy_error_details(
     *,
     tool_name: str,
@@ -176,6 +448,12 @@ def _policy_error_details(
         value = arguments.get(key)
         if isinstance(value, str):
             details[key] = value
+        elif (
+            key == "command"
+            and isinstance(value, (list, tuple))
+            and all(isinstance(part, str) for part in value)
+        ):
+            details[key] = tuple(value)
     return details
 
 
@@ -231,6 +509,12 @@ def _approval_audit_details(
         value = arguments.get(key)
         if isinstance(value, str):
             details[key] = value
+        elif (
+            key == "command"
+            and isinstance(value, (list, tuple))
+            and all(isinstance(part, str) for part in value)
+        ):
+            details[key] = tuple(value)
     return details
 
 

--- a/src/loushang/harness/workspace/exec/__init__.py
+++ b/src/loushang/harness/workspace/exec/__init__.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 from .service import ExecBackend, ExecService
-from .types import ExecOutputChunk, ExecRequest, ExecResult, ExecUpdateCallback
+from .types import (
+    ExecOutputChunk,
+    ExecRequest,
+    ExecResult,
+    ExecUpdateCallback,
+    materialize_exec_request,
+)
 
 __all__ = [
     "ExecBackend",
@@ -10,4 +16,5 @@ __all__ = [
     "ExecResult",
     "ExecService",
     "ExecUpdateCallback",
+    "materialize_exec_request",
 ]

--- a/src/loushang/harness/workspace/exec/service.py
+++ b/src/loushang/harness/workspace/exec/service.py
@@ -8,14 +8,22 @@ import tempfile
 from collections.abc import Awaitable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Protocol, TextIO
+from typing import Literal, Protocol, TextIO
 
 from loushang.harness.workspace.truncation import truncate_tail
 
-from .types import ExecOutputChunk, ExecRequest, ExecResult, ExecUpdateCallback
+from .types import (
+    ExecOutputChunk,
+    ExecRequest,
+    ExecResult,
+    ExecUpdateCallback,
+    materialize_exec_request,
+)
 
 
 class ExecBackend(Protocol):
+    """Execute a materialized request without rereading cwd or environment."""
+
     def __call__(
         self,
         request: ExecRequest,
@@ -36,6 +44,7 @@ class ExecService:
         signal: object | None = None,
         on_update: ExecUpdateCallback | None = None,
     ) -> ExecResult:
+        request = materialize_exec_request(request)
         if self._backend is not None:
             result = self._backend(request, signal=signal, on_update=on_update)
             if inspect.isawaitable(result):
@@ -44,8 +53,8 @@ class ExecService:
                 raise TypeError("exec backend must return ExecResult")
             return result
 
-        env = os.environ.copy()
-        env.update(dict(request.env))
+        assert request.effective_environment is not None
+        env = dict(request.effective_environment)
 
         process = await asyncio.create_subprocess_exec(
             *request.command,
@@ -74,7 +83,11 @@ class ExecService:
             rolling_max_bytes=request.rolling_max_bytes,
         )
 
-        async def _read_stream(stream_name: str, stream, sink: _StreamCapture) -> None:
+        async def _read_stream(
+            stream_name: Literal["stdout", "stderr"],
+            stream,
+            sink: _StreamCapture,
+        ) -> None:
             while True:
                 chunk = await stream.readline()
                 if not chunk:
@@ -88,8 +101,12 @@ class ExecService:
                     if inspect.isawaitable(update):
                         await update
 
-        stdout_task = asyncio.create_task(_read_stream("stdout", process.stdout, stdout_capture))
-        stderr_task = asyncio.create_task(_read_stream("stderr", process.stderr, stderr_capture))
+        stdout_task = asyncio.create_task(
+            _read_stream("stdout", process.stdout, stdout_capture)
+        )
+        stderr_task = asyncio.create_task(
+            _read_stream("stderr", process.stderr, stderr_capture)
+        )
         wait_task = asyncio.create_task(process.wait())
 
         if process.stdin is not None:
@@ -98,7 +115,9 @@ class ExecService:
             await process.stdin.drain()
             process.stdin.close()
 
-        abort_task = asyncio.create_task(_wait_for_abort(signal)) if signal is not None else None
+        abort_task = (
+            asyncio.create_task(_wait_for_abort(signal)) if signal is not None else None
+        )
         timed_out = False
         cancelled = False
 
@@ -106,7 +125,7 @@ class ExecService:
             if request.timeout_seconds is None and abort_task is None:
                 await wait_task
             else:
-                waiters = {wait_task}
+                waiters: set[asyncio.Task[int] | asyncio.Task[None]] = {wait_task}
                 if abort_task is not None:
                     waiters.add(abort_task)
                 done, pending = await asyncio.wait(
@@ -148,7 +167,9 @@ class ExecService:
             max_bytes=request.preview_max_bytes,
         )
         return ExecResult(
-            exit_code=process.returncode if process.returncode is not None else (-1 if timed_out or cancelled else 0),
+            exit_code=process.returncode
+            if process.returncode is not None
+            else (-1 if timed_out or cancelled else 0),
             stdout=stdout,
             stderr=stderr,
             timed_out=timed_out,
@@ -325,7 +346,9 @@ def _build_preview(
     preview = truncate_tail(content, max_lines=max_lines, max_bytes=max_bytes)
     if not preview.truncated or not content:
         return preview, None
-    artifact_path = _write_output_artifact(content, artifact_dir=artifact_dir, stream_name=stream_name)
+    artifact_path = _write_output_artifact(
+        content, artifact_dir=artifact_dir, stream_name=stream_name
+    )
     return preview, artifact_path
 
 
@@ -354,8 +377,12 @@ def _build_preview_from_capture(
     return replace(preview, truncated=True, truncated_by="bytes"), capture.artifact_path
 
 
-def _write_output_artifact(content: str, *, artifact_dir: str | None, stream_name: str) -> str:
-    fd, path = tempfile.mkstemp(prefix=f"loushang-exec-{stream_name}-", suffix=".log", dir=artifact_dir)
+def _write_output_artifact(
+    content: str, *, artifact_dir: str | None, stream_name: str
+) -> str:
+    fd, path = tempfile.mkstemp(
+        prefix=f"loushang-exec-{stream_name}-", suffix=".log", dir=artifact_dir
+    )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(content)

--- a/src/loushang/harness/workspace/exec/types.py
+++ b/src/loushang/harness/workspace/exec/types.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+import os
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field, replace
 from typing import Literal
 
 from loushang.harness.workspace.truncation import DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES
 
 
-def _as_tuple_of_strings(value: tuple[str, ...] | list[str], field_name: str) -> tuple[str, ...]:
+def _as_tuple_of_strings(
+    value: tuple[str, ...] | list[str], field_name: str
+) -> tuple[str, ...]:
     if isinstance(value, str):
         raise TypeError(f"{field_name} must be a sequence of strings, not a string")
     return tuple(value)
@@ -30,7 +33,9 @@ def _as_tuple_of_string_pairs(
     field_name: str,
 ) -> tuple[tuple[str, str], ...]:
     if isinstance(value, str):
-        raise TypeError(f"{field_name} must be a sequence of string pairs, not a string")
+        raise TypeError(
+            f"{field_name} must be a sequence of string pairs, not a string"
+        )
     normalized: list[tuple[str, str]] = []
     for item in value:
         if isinstance(item, str):
@@ -56,14 +61,67 @@ class ExecRequest:
     artifact_dir: str | None = None
     capture_full_output: bool = True
     rolling_max_bytes: int = 100 * 1024
+    effective_environment: tuple[tuple[str, str], ...] | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+        kw_only=True,
+    )
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "command", _as_tuple_of_strings(self.command, "command"))
+        object.__setattr__(
+            self, "command", _as_tuple_of_strings(self.command, "command")
+        )
         object.__setattr__(self, "env", _as_tuple_of_string_pairs(self.env, "env"))
+        if self.effective_environment is not None:
+            object.__setattr__(
+                self,
+                "effective_environment",
+                _as_tuple_of_string_pairs(
+                    self.effective_environment,
+                    "effective_environment",
+                ),
+            )
         if not isinstance(self.rolling_max_bytes, int):
             raise TypeError("rolling_max_bytes must be an integer")
         if self.rolling_max_bytes < 1:
             raise ValueError("rolling_max_bytes must be >= 1")
+
+
+def materialize_exec_request(
+    request: ExecRequest,
+    *,
+    environ: Mapping[str, str] | None = None,
+    cwd: str | None = None,
+) -> ExecRequest:
+    """Freeze inherited process state before policy evaluation or execution.
+
+    ``env`` remains the caller-visible override set. The complete merged
+    environment is stored separately so policy and execution can share one
+    request without projecting inherited credentials into approval records.
+    """
+
+    requested_cwd = request.cwd if request.cwd is not None else cwd
+    effective_cwd = (
+        os.path.abspath(requested_cwd)
+        if requested_cwd
+        else requested_cwd
+        if requested_cwd is not None
+        else os.getcwd()
+    )
+    if request.effective_environment is None:
+        effective_environment = dict(os.environ if environ is None else environ)
+        effective_environment.update(dict(request.env))
+        environment_snapshot = tuple(effective_environment.items())
+    else:
+        environment_snapshot = request.effective_environment
+    if request.cwd == effective_cwd and request.effective_environment is not None:
+        return request
+    return replace(
+        request,
+        cwd=effective_cwd,
+        effective_environment=environment_snapshot,
+    )
 
 
 @dataclass(frozen=True)
@@ -99,9 +157,21 @@ class ExecResult:
     stderr_total_bytes: int | None = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "stdout_chunks", _as_tuple_of_strings(self.stdout_chunks, "stdout_chunks"))
-        object.__setattr__(self, "stderr_chunks", _as_tuple_of_strings(self.stderr_chunks, "stderr_chunks"))
-        object.__setattr__(self, "output_chunks", _as_tuple_of_output_chunks(self.output_chunks, "output_chunks"))
+        object.__setattr__(
+            self,
+            "stdout_chunks",
+            _as_tuple_of_strings(self.stdout_chunks, "stdout_chunks"),
+        )
+        object.__setattr__(
+            self,
+            "stderr_chunks",
+            _as_tuple_of_strings(self.stderr_chunks, "stderr_chunks"),
+        )
+        object.__setattr__(
+            self,
+            "output_chunks",
+            _as_tuple_of_output_chunks(self.output_chunks, "output_chunks"),
+        )
 
 
 __all__ = [
@@ -109,4 +179,5 @@ __all__ = [
     "ExecRequest",
     "ExecResult",
     "ExecUpdateCallback",
+    "materialize_exec_request",
 ]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -618,8 +618,7 @@ def test_product_configuration_runtime_boundary_is_documented_and_adopted() -> N
     import loushang.harness as harness
 
     design_path = Path(
-        "docs/internals/architecture/harness/"
-        "product-configuration-runtime-boundary.md"
+        "docs/internals/architecture/harness/product-configuration-runtime-boundary.md"
     )
     assert design_path.exists()
     design_text = " ".join(design_path.read_text(encoding="utf-8").split())
@@ -675,13 +674,16 @@ def test_product_configuration_runtime_boundary_is_documented_and_adopted() -> N
         )
     assert missing == []
 
-    assert _find_forbidden_imports(
-        ImportBoundary(
-            name="harness config",
-            root=Path("src/loushang/harness/config"),
-            forbidden_prefixes=("loushang.ai", "loushang.coding"),
+    assert (
+        _find_forbidden_imports(
+            ImportBoundary(
+                name="harness config",
+                root=Path("src/loushang/harness/config"),
+                forbidden_prefixes=("loushang.ai", "loushang.coding"),
+            )
         )
-    ) == []
+        == []
+    )
 
     value_imports = _absolute_imports(Path("src/loushang/harness/config/values.py"))
     assert not any(
@@ -845,6 +847,203 @@ def test_harness_extension_runtime_core_boundary_is_documented() -> None:
     ).read_text(encoding="utf-8")
     assert "extension runtime core implementation" in inventory_text
     assert "Wave 2: Extension Runtime Core" in inventory_text
+
+
+def test_harness_control_plane_runtime_boundary_is_documented() -> None:
+    design_path = Path(
+        "docs/internals/architecture/harness/control-plane-runtime-boundary.md"
+    )
+    assert design_path.exists()
+    design_text = " ".join(design_path.read_text(encoding="utf-8").split())
+    required_phrases = {
+        "Harness Control Plane Runtime Boundary",
+        "`loushang.harness.extensions.routing`",
+        "`PolicyEvaluatorChain`",
+        "`ApprovalBroker`",
+        "Products and OEM adapters continue to own:",
+        "Harness must not import Coding, Design, Research, PPT, Cowork, Method, Work, Channel, TUI, AI",
+        "No compatibility module may retain a parallel routing, pending-request, command normalization, or rule-evaluation implementation",
+        "top-level `loushang.harness.__all__` remains unchanged",
+    }
+    assert (
+        sorted(phrase for phrase in required_phrases if phrase not in design_text) == []
+    )
+
+    design_link = "[Control Plane Runtime Boundary](control-plane-runtime-boundary.md)"
+    readme_text = Path("docs/internals/architecture/harness/README.md").read_text(
+        encoding="utf-8"
+    )
+    assert design_link in readme_text
+
+    inventory_text = Path(
+        "docs/internals/architecture/harness/coding-to-harness-migration-inventory.md"
+    ).read_text(encoding="utf-8")
+    assert design_link in inventory_text
+    assert "Wave 2 Follow-On: Control Plane Runtime" in inventory_text
+
+
+def test_harness_control_plane_symbols_are_not_top_level_exports() -> None:
+    import loushang.harness as harness
+
+    control_plane_symbols = {
+        "ApprovalBroker",
+        "ApprovalPresenter",
+        "ApprovalRequestCollisionError",
+        "CommandPolicySubject",
+        "CommandSubstringMatcher",
+        "CommandTokenSequenceMatcher",
+        "CustomPolicySubject",
+        "ExactToolNameMatcher",
+        "ExtensionContextFactory",
+        "ExtensionRouteError",
+        "ExtensionRoutePlan",
+        "ExtensionRouter",
+        "ExtensionRuntimeErrorHandler",
+        "IncompleteCommandMatcher",
+        "PathPolicySubject",
+        "PathSubstringMatcher",
+        "PolicyChainStrategy",
+        "PolicyDisposition",
+        "PolicyEvaluationError",
+        "PolicyEvaluator",
+        "PolicyEvaluatorChain",
+        "PolicyMatcher",
+        "PolicyRule",
+        "RegisteredExtensionHandler",
+        "ResolvedControlContributions",
+        "ResolvedExtensionRoute",
+        "RouteErrorPolicy",
+        "RouteReducer",
+        "RouteStep",
+        "RulePolicyEvaluator",
+        "ShellPayloadSubstringMatcher",
+        "ToolPolicySubject",
+        "build_path_policy_subjects",
+        "build_tool_policy_subject",
+        "ensure_approval_action_id",
+        "evaluate_policy",
+        "normalize_command_subject",
+        "resolve_control_contributions",
+    }
+
+    assert control_plane_symbols.isdisjoint(set(harness.__all__))
+
+
+def test_coding_control_plane_adapters_use_harness_mechanisms() -> None:
+    approval_path = Path("src/loushang/coding/policy/approval.py")
+    approval_imports = set(_absolute_imports(approval_path))
+    assert "loushang.harness.approval.ApprovalBroker" in approval_imports
+
+    approval_tree = ast.parse(
+        approval_path.read_text(encoding="utf-8"),
+        filename=approval_path.as_posix(),
+    )
+    approval_names = {
+        node.id for node in ast.walk(approval_tree) if isinstance(node, ast.Name)
+    }
+    approval_attributes = {
+        node.attr for node in ast.walk(approval_tree) if isinstance(node, ast.Attribute)
+    }
+    approval_calls = {
+        node.func.id
+        for node in ast.walk(approval_tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+    }
+    assert "ApprovalBroker" in approval_calls
+    assert not any(
+        _matches_any(imported, ("asyncio",)) for imported in approval_imports
+    )
+    assert {"Future", "create_future", "_pending"}.isdisjoint(
+        approval_names | approval_attributes
+    )
+
+    policy_path = Path("src/loushang/coding/policy/engine.py")
+    policy_imports = set(_absolute_imports(policy_path))
+    assert {
+        "loushang.harness.policy.RulePolicyEvaluator",
+        "loushang.harness.policy.normalize_command_subject",
+    }.issubset(policy_imports)
+
+    policy_tree = ast.parse(
+        policy_path.read_text(encoding="utf-8"),
+        filename=policy_path.as_posix(),
+    )
+    policy_function_names = {
+        node.name
+        for node in ast.walk(policy_tree)
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    }
+    assert {
+        "_direct_command_tokens",
+        "_split_env_string",
+        "_unwrap_env_command",
+        "_unwrap_leading_wrappers",
+    }.isdisjoint(policy_function_names)
+    assert not any(_matches_any(imported, ("shlex",)) for imported in policy_imports)
+
+    extension_paths = (
+        Path("src/loushang/coding/extensions/hooks.py"),
+        Path("src/loushang/coding/extensions/runner.py"),
+    )
+    extension_imports = {
+        imported for path in extension_paths for imported in _absolute_imports(path)
+    }
+    assert {
+        "loushang.harness.extensions.routing.ExtensionRoutePlan",
+        "loushang.harness.extensions.routing.ExtensionRouter",
+    }.issubset(extension_imports)
+
+    route_calls: set[str] = set()
+    route_function_names: set[str] = set()
+    for path in extension_paths:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=path.as_posix())
+        route_calls.update(
+            node.func.attr
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        )
+        route_function_names.update(
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+        )
+    assert {"from_extensions", "intercept", "observe", "reduce"}.issubset(route_calls)
+    assert {
+        "_order_routes",
+        "_route_order_key",
+        "_strongly_connected_components",
+        "_topological_sort",
+    }.isdisjoint(route_function_names)
+
+
+def test_harness_control_plane_modules_do_not_import_product_layers() -> None:
+    control_plane_paths = (
+        Path("src/loushang/harness/approval.py"),
+        Path("src/loushang/harness/policy.py"),
+        Path("src/loushang/harness/extensions/control.py"),
+        Path("src/loushang/harness/extensions/routing.py"),
+    )
+    assert [path.as_posix() for path in control_plane_paths if not path.exists()] == []
+
+    forbidden_prefixes = (
+        "loushang.ai",
+        "loushang.channel",
+        "loushang.coding",
+        "loushang.cowork",
+        "loushang.design",
+        "loushang.method",
+        "loushang.ppt",
+        "loushang.research",
+        "loushang.tui",
+        "loushang.work",
+    )
+    offenders = [
+        f"{path.as_posix()} imports {imported}"
+        for path in control_plane_paths
+        for imported in _absolute_imports(path)
+        if _matches_any(imported, forbidden_prefixes)
+    ]
+    assert offenders == []
 
 
 def test_coding_extension_compatibility_paths_share_harness_owners() -> None:
@@ -1594,8 +1793,7 @@ def test_product_capability_composition_core_is_documented_and_adopted() -> None
     ).read_text(encoding="utf-8")
     assert "Wave 5: Product Capability Composition" in inventory_text
     assert (
-        "product capability composition core implementation complete"
-        in inventory_text
+        "product capability composition core implementation complete" in inventory_text
     )
 
     expected_imports = {

--- a/tests/coding/test_agent_session.py
+++ b/tests/coding/test_agent_session.py
@@ -11,7 +11,10 @@ from loushang.ai.types import AssistantMessage, TextPart, ToolCall, Usage, UserM
 
 
 def _runtime_footer_lines(cwd: str) -> list[str]:
-    return [f"Current date: {date.today().isoformat()}", f"Current working directory: {cwd}"]
+    return [
+        f"Current date: {date.today().isoformat()}",
+        f"Current working directory: {cwd}",
+    ]
 
 
 def _user_message(text: str) -> UserMessage:
@@ -28,7 +31,9 @@ def test_agent_session_restores_persisted_context_on_init(tmp_path) -> None:
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     manager.append_message(
         UserMessage(
             role="user",
@@ -41,8 +46,13 @@ def test_agent_session_restores_persisted_context_on_init(tmp_path) -> None:
     session = AgentSession(agent=agent, session_manager=manager)
 
     assert PublicAgentSession is AgentSession
-    assert [getattr(message, "role", None) for message in agent.state.messages] == ["user"]
-    assert [getattr(message, "role", None) for message in session.get_session_context().messages] == ["user"]
+    assert [getattr(message, "role", None) for message in agent.state.messages] == [
+        "user"
+    ]
+    assert [
+        getattr(message, "role", None)
+        for message in session.get_session_context().messages
+    ] == ["user"]
 
 
 def _usage() -> Usage:
@@ -71,7 +81,9 @@ def _assistant_text_message(text: str) -> AssistantMessage:
     )
 
 
-def test_agent_session_composes_existing_transform_with_extension_context_without_mutating_state(tmp_path) -> None:
+def test_agent_session_composes_existing_transform_with_extension_context_without_mutating_state(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.agent import Agent
@@ -90,11 +102,15 @@ def test_agent_session_composes_existing_transform_with_extension_context_withou
 
     def _extension_context(event, ctx):
         seen.append(event.messages[-1].content[0].text)
-        return ContextResult(messages=event.messages + [_user_message("from-extension-context")])
+        return ContextResult(
+            messages=event.messages + [_user_message("from-extension-context")]
+        )
 
     project_dir = tmp_path / "project"
     project_dir.mkdir()
-    manager = SessionManager.new(session_dir=tmp_path, cwd=str(project_dir), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(project_dir), persist=False
+    )
     manager.append_message(_user_message("persisted"))
     agent = Agent(transform_context=_existing_transform)
     session = AgentSession(
@@ -111,15 +127,21 @@ def test_agent_session_composes_existing_transform_with_extension_context_withou
         ),
     )
 
-    transformed = asyncio.run(session.agent.transform_context(session.agent.state.messages, None))
+    transformed = asyncio.run(
+        session.agent.transform_context(session.agent.state.messages, None)
+    )
 
     assert [message.content[0].text for message in transformed] == [
         "persisted",
         "from-existing-transform",
         "from-extension-context",
     ]
-    assert [message.content[0].text for message in session.agent.state.messages] == ["persisted"]
-    assert [message.content[0].text for message in session.get_session_context().messages] == ["persisted"]
+    assert [message.content[0].text for message in session.agent.state.messages] == [
+        "persisted"
+    ]
+    assert [
+        message.content[0].text for message in session.get_session_context().messages
+    ] == ["persisted"]
     assert seen == ["from-existing-transform"]
 
 
@@ -133,7 +155,9 @@ def test_agent_session_binds_extension_runtime_state_context_methods(tmp_path) -
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
-    runner = ExtensionRunner([LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))])
+    runner = ExtensionRunner(
+        [LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))]
+    )
     session = AgentSession(
         agent=Agent(
             initial_state={
@@ -142,12 +166,16 @@ def test_agent_session_binds_extension_runtime_state_context_methods(tmp_path) -
                     id="tiny",
                     provider="faux",
                     endpoint="test",
-                    capabilities=Capabilities(input=("text",), context_window=10_000, max_tokens=1024),
+                    capabilities=Capabilities(
+                        input=("text",), context_window=10_000, max_tokens=1024
+                    ),
                 ),
                 "thinking_level": "off",
             }
         ),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         extension_runner=runner,
     )
 
@@ -179,21 +207,39 @@ def _model() -> Model:
     )
 
 
-def _stream_with_final_message(message: AssistantMessage) -> AssistantMessageEventStream:
+def _stream_with_final_message(
+    message: AssistantMessage,
+) -> AssistantMessageEventStream:
     stream = AssistantMessageEventStream()
 
     async def _feed() -> None:
         stream.push({"type": "start", "partial": message})
         stream.push({"type": "text_start", "content_index": 0, "partial": message})
-        stream.push({"type": "text_delta", "content_index": 0, "delta": message.content[0].text, "partial": message})
-        stream.push({"type": "text_end", "content_index": 0, "content": message.content[0].text, "partial": message})
+        stream.push(
+            {
+                "type": "text_delta",
+                "content_index": 0,
+                "delta": message.content[0].text,
+                "partial": message,
+            }
+        )
+        stream.push(
+            {
+                "type": "text_end",
+                "content_index": 0,
+                "content": message.content[0].text,
+                "partial": message,
+            }
+        )
         stream.push({"type": "done", "reason": message.stop_reason, "message": message})  # type: ignore[typeddict-item]
 
     asyncio.create_task(_feed())
     return stream
 
 
-def _stream_with_assistant_message(message: AssistantMessage) -> AssistantMessageEventStream:
+def _stream_with_assistant_message(
+    message: AssistantMessage,
+) -> AssistantMessageEventStream:
     stream = AssistantMessageEventStream()
 
     async def _feed() -> None:
@@ -216,7 +262,9 @@ def test_agent_session_prompt_persists_messages_and_forwards_events(tmp_path) ->
 
     async def scenario() -> None:
         agent = Agent(stream_fn=stream_fn)
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         session = AgentSession(agent=agent, session_manager=manager)
 
         def listener(event) -> None:
@@ -225,7 +273,10 @@ def test_agent_session_prompt_persists_messages_and_forwards_events(tmp_path) ->
         session.subscribe(listener)
         await session.prompt("hi")
 
-        assert [getattr(message, "role", None) for message in session.get_session_context().messages] == ["user", "assistant"]
+        assert [
+            getattr(message, "role", None)
+            for message in session.get_session_context().messages
+        ] == ["user", "assistant"]
         assert [entry.type for entry in manager.get_entries()] == ["message", "message"]
         assert event_types[0] == "agent_start"
         assert event_types[-1] == "agent_end"
@@ -233,7 +284,9 @@ def test_agent_session_prompt_persists_messages_and_forwards_events(tmp_path) ->
     asyncio.run(scenario())
 
 
-def test_agent_session_abort_mid_stream_cleans_run_state_and_keeps_queued_messages(tmp_path) -> None:
+def test_agent_session_abort_mid_stream_cleans_run_state_and_keeps_queued_messages(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
@@ -276,7 +329,9 @@ def test_agent_session_abort_mid_stream_cleans_run_state_and_keeps_queued_messag
     async def scenario() -> AgentSession:
         session = AgentSession(
             agent=Agent(stream_fn=stream_fn),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
         )
         session.subscribe(lambda event: event_types.append(event["type"]))
 
@@ -298,7 +353,9 @@ def test_agent_session_abort_mid_stream_cleans_run_state_and_keeps_queued_messag
     assert event_types[-1] == "agent_end"
 
 
-def test_agent_session_prompt_reports_preflight_before_stream_finishes(tmp_path) -> None:
+def test_agent_session_prompt_reports_preflight_before_stream_finishes(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
@@ -316,7 +373,9 @@ def test_agent_session_prompt_reports_preflight_before_stream_finishes(tmp_path)
         agent = Agent(stream_fn=stream_fn)
         session = AgentSession(
             agent=agent,
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
         )
 
         def _preflight(success: bool) -> None:
@@ -325,7 +384,9 @@ def test_agent_session_prompt_reports_preflight_before_stream_finishes(tmp_path)
         task = asyncio.create_task(session.prompt("hi", preflight_result=_preflight))
         while events != ["preflight:True", "stream-start"]:
             await asyncio.sleep(0)
-        assert [getattr(message, "role", None) for message in session.agent.state.messages] == ["user"]
+        assert [
+            getattr(message, "role", None) for message in session.agent.state.messages
+        ] == ["user"]
         release.set()
         await task
 
@@ -334,7 +395,9 @@ def test_agent_session_prompt_reports_preflight_before_stream_finishes(tmp_path)
     assert events == ["preflight:True", "stream-start"]
 
 
-def test_agent_session_prompt_expands_preflight_references_and_records_unresolved_diagnostics(tmp_path) -> None:
+def test_agent_session_prompt_expands_preflight_references_and_records_unresolved_diagnostics(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -357,7 +420,9 @@ def test_agent_session_prompt_expands_preflight_references_and_records_unresolve
         return _stream_with_final_message(_assistant_text_message("hello"))
 
     async def scenario() -> None:
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         diagnostics = DiagnosticsService()
         session = AgentSession(
             agent=Agent(stream_fn=stream_fn),
@@ -386,7 +451,9 @@ def test_agent_session_prompt_expands_preflight_references_and_records_unresolve
         await session.prompt("/skill:debugging inspect the failing branch")
         await session.prompt("/missing-template keep original")
 
-        unresolved = diagnostics.get_diagnostics(phase="runtime", source="session", type="warning")
+        unresolved = diagnostics.get_diagnostics(
+            phase="runtime", source="session", type="warning"
+        )
         assert [record.code for record in unresolved] == ["unresolved_prompt_reference"]
 
     asyncio.run(scenario())
@@ -402,7 +469,9 @@ def test_agent_session_prompt_expands_preflight_references_and_records_unresolve
     ]
 
 
-def test_agent_session_slash_prefix_deploy_consumes_extension_command_without_prompting_model(tmp_path) -> None:
+def test_agent_session_slash_prefix_deploy_consumes_extension_command_without_prompting_model(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -429,7 +498,9 @@ def test_agent_session_slash_prefix_deploy_consumes_extension_command_without_pr
     async def scenario() -> None:
         session = AgentSession(
             agent=Agent(stream_fn=stream_fn),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
@@ -484,7 +555,9 @@ def test_agent_session_input_hook_transforms_before_prompt_preflight(tmp_path) -
     async def scenario() -> None:
         session = AgentSession(
             agent=Agent(stream_fn=stream_fn),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             resource_bundle=ResourceBundle(
                 cwd=Path("/tmp/project"),
                 prompts=[
@@ -516,7 +589,9 @@ def test_agent_session_input_hook_transforms_before_prompt_preflight(tmp_path) -
     assert prompted_texts == ["Planning prompt\n\ntransformed"]
 
 
-def test_agent_session_input_hook_can_handle_prompt_without_model_call(tmp_path) -> None:
+def test_agent_session_input_hook_can_handle_prompt_without_model_call(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -543,7 +618,9 @@ def test_agent_session_input_hook_can_handle_prompt_without_model_call(tmp_path)
     async def scenario() -> None:
         session = AgentSession(
             agent=Agent(stream_fn=stream_fn),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
@@ -587,14 +664,18 @@ def test_agent_session_extension_command_runs_before_input_hook(tmp_path) -> Non
     async def scenario() -> None:
         session = AgentSession(
             agent=Agent(),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
                         name="demo",
                         source_path=Path("/tmp/project/extensions/demo.py"),
                         hooks={"input": [_input]},
-                        commands={"deploy": RegisteredCommand(name="deploy", handler=_command)},
+                        commands={
+                            "deploy": RegisteredCommand(name="deploy", handler=_command)
+                        },
                     )
                 ]
             ),
@@ -607,7 +688,9 @@ def test_agent_session_extension_command_runs_before_input_hook(tmp_path) -> Non
     assert calls == ["command:prod"]
 
 
-def test_agent_session_input_hook_transform_to_extension_command_is_plain_prompt(tmp_path) -> None:
+def test_agent_session_input_hook_transform_to_extension_command_is_plain_prompt(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -639,14 +722,18 @@ def test_agent_session_input_hook_transform_to_extension_command_is_plain_prompt
     async def scenario() -> None:
         session = AgentSession(
             agent=Agent(stream_fn=stream_fn),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
                         name="demo",
                         source_path=Path("/tmp/project/extensions/demo.py"),
                         hooks={"input": [_input]},
-                        commands={"deploy": RegisteredCommand(name="deploy", handler=_command)},
+                        commands={
+                            "deploy": RegisteredCommand(name="deploy", handler=_command)
+                        },
                     )
                 ]
             ),
@@ -681,7 +768,9 @@ def test_agent_session_forwards_agent_lifecycle_events_to_extensions(tmp_path) -
 
     def _turn_end(event, ctx):
         del ctx
-        seen.append((event.type, event.turn_index, event.message.role, len(event.tool_results)))
+        seen.append(
+            (event.type, event.turn_index, event.message.role, len(event.tool_results))
+        )
 
     def _agent_end(event, ctx):
         del ctx
@@ -690,7 +779,9 @@ def test_agent_session_forwards_agent_lifecycle_events_to_extensions(tmp_path) -
     async def scenario() -> None:
         session = AgentSession(
             agent=Agent(),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
@@ -722,7 +813,9 @@ def test_agent_session_forwards_agent_lifecycle_events_to_extensions(tmp_path) -
             {"type": "turn_end", "message": assistant, "tool_results": [tool_result]},
             session.agent.signal,
         )
-        await session._handle_agent_event({"type": "agent_end", "messages": [assistant]}, session.agent.signal)
+        await session._handle_agent_event(
+            {"type": "agent_end", "messages": [assistant]}, session.agent.signal
+        )
 
     asyncio.run(scenario())
 
@@ -734,7 +827,9 @@ def test_agent_session_forwards_agent_lifecycle_events_to_extensions(tmp_path) -
     ]
 
 
-def test_agent_session_forwards_message_and_tool_execution_events_to_extensions(tmp_path) -> None:
+def test_agent_session_forwards_message_and_tool_execution_events_to_extensions(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -752,12 +847,24 @@ def test_agent_session_forwards_message_and_tool_execution_events_to_extensions(
 
     def _tool_end(event, ctx):
         del ctx
-        seen.append((event.type, event.tool_call_id, event.toolCallId, event.tool_name, event.toolName, event.is_error, event.isError))
+        seen.append(
+            (
+                event.type,
+                event.tool_call_id,
+                event.toolCallId,
+                event.tool_name,
+                event.toolName,
+                event.is_error,
+                event.isError,
+            )
+        )
 
     async def scenario() -> None:
         session = AgentSession(
             agent=Agent(),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
@@ -772,9 +879,13 @@ def test_agent_session_forwards_message_and_tool_execution_events_to_extensions(
             ),
         )
         assistant = _assistant_text_message("done")
-        tool_result = AgentToolResult(content=[TextPart(type="text", text="ok")], details={})
+        tool_result = AgentToolResult(
+            content=[TextPart(type="text", text="ok")], details={}
+        )
 
-        await session._handle_agent_event({"type": "message_start", "message": assistant}, session.agent.signal)
+        await session._handle_agent_event(
+            {"type": "message_start", "message": assistant}, session.agent.signal
+        )
         await session._handle_agent_event(
             {
                 "type": "tool_execution_end",
@@ -794,7 +905,9 @@ def test_agent_session_forwards_message_and_tool_execution_events_to_extensions(
     ]
 
 
-def test_agent_session_records_tool_execution_error_diagnostic_with_correlation(tmp_path) -> None:
+def test_agent_session_records_tool_execution_error_diagnostic_with_correlation(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.agent.types import AgentToolResult
     from loushang.ai.types import TextPart
@@ -803,9 +916,13 @@ def test_agent_session_records_tool_execution_error_diagnostic_with_correlation(
     from loushang.coding.store import SessionManager
 
     async def scenario() -> DiagnosticsService:
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         diagnostics = DiagnosticsService()
-        session = AgentSession(agent=Agent(), session_manager=manager, diagnostics_service=diagnostics)
+        session = AgentSession(
+            agent=Agent(), session_manager=manager, diagnostics_service=diagnostics
+        )
 
         await session._handle_agent_event(
             {
@@ -871,8 +988,13 @@ def test_agent_session_applies_before_agent_start_result(tmp_path) -> None:
 
     async def scenario() -> None:
         session = AgentSession(
-            agent=Agent(stream_fn=stream_fn, initial_state={"system_prompt": "Base system prompt"}),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            agent=Agent(
+                stream_fn=stream_fn,
+                initial_state={"system_prompt": "Base system prompt"},
+            ),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
@@ -898,7 +1020,9 @@ def test_agent_session_applies_before_agent_start_result(tmp_path) -> None:
     assert entries[1].message.content == "extension context"
 
 
-def test_agent_session_extension_hook_ordering_spans_provider_tool_and_agent_end(tmp_path) -> None:
+def test_agent_session_extension_hook_ordering_spans_provider_tool_and_agent_end(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -987,7 +1111,9 @@ def test_agent_session_extension_hook_ordering_spans_provider_tool_and_agent_end
                     "tools": [FinishingTool()],
                 },
             ),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
@@ -1036,7 +1162,9 @@ def test_agent_session_execute_bash_uses_extension_user_bash_result(tmp_path) ->
     async def scenario() -> dict[str, object]:
         session = AgentSession(
             agent=Agent(),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
@@ -1061,7 +1189,9 @@ def test_agent_session_execute_bash_uses_extension_user_bash_result(tmp_path) ->
     assert seen == [("pwd", True, "/tmp/project")]
 
 
-def test_agent_session_execute_bash_uses_extension_user_bash_operations(tmp_path) -> None:
+def test_agent_session_execute_bash_uses_extension_user_bash_operations(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1075,7 +1205,9 @@ def test_agent_session_execute_bash_uses_extension_user_bash_operations(tmp_path
         def __init__(self) -> None:
             self.calls: list[tuple[ExecRequest, object | None]] = []
 
-        async def execute(self, request: ExecRequest, *, signal=None, on_update=None) -> ExecResult:
+        async def execute(
+            self, request: ExecRequest, *, signal=None, on_update=None
+        ) -> ExecResult:
             self.calls.append((request, signal))
             if on_update is not None:
                 await on_update(ExecOutputChunk(stream="stdout", text="streamed\n"))
@@ -1094,7 +1226,9 @@ def test_agent_session_execute_bash_uses_extension_user_bash_operations(tmp_path
         registry = register_builtin_tools(ToolRegistry())
         session = AgentSession(
             agent=Agent(),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
@@ -1123,7 +1257,9 @@ def test_agent_session_execute_bash_uses_extension_user_bash_operations(tmp_path
     assert chunks == [ExecOutputChunk(stream="stdout", text="streamed\n")]
 
 
-def test_agent_session_steer_rejects_extension_command_without_executing(tmp_path) -> None:
+def test_agent_session_steer_rejects_extension_command_without_executing(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     import pytest
@@ -1145,13 +1281,17 @@ def test_agent_session_steer_rejects_extension_command_without_executing(tmp_pat
 
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         extension_runner=ExtensionRunner(
             [
                 LoadedExtension(
                     name="deploy-ext",
                     source_path=Path("/tmp/project/extensions/deploy-ext.py"),
-                    commands={"deploy": RegisteredCommand(name="deploy", handler=_handler)},
+                    commands={
+                        "deploy": RegisteredCommand(name="deploy", handler=_handler)
+                    },
                 )
             ]
         ),
@@ -1166,7 +1306,9 @@ def test_agent_session_steer_rejects_extension_command_without_executing(tmp_pat
     assert calls == []
 
 
-def test_agent_session_follow_up_rejects_extension_command_without_executing(tmp_path) -> None:
+def test_agent_session_follow_up_rejects_extension_command_without_executing(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     import pytest
@@ -1188,13 +1330,17 @@ def test_agent_session_follow_up_rejects_extension_command_without_executing(tmp
 
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         extension_runner=ExtensionRunner(
             [
                 LoadedExtension(
                     name="deploy-ext",
                     source_path=Path("/tmp/project/extensions/deploy-ext.py"),
-                    commands={"deploy": RegisteredCommand(name="deploy", handler=_handler)},
+                    commands={
+                        "deploy": RegisteredCommand(name="deploy", handler=_handler)
+                    },
                 )
             ]
         ),
@@ -1209,7 +1355,9 @@ def test_agent_session_follow_up_rejects_extension_command_without_executing(tmp
     assert calls == []
 
 
-def test_agent_session_get_commands_aggregates_extension_prompt_and_skill_sources(tmp_path) -> None:
+def test_agent_session_get_commands_aggregates_extension_prompt_and_skill_sources(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1229,7 +1377,9 @@ def test_agent_session_get_commands_aggregates_extension_prompt_and_skill_source
     async def _handler(args: str, ctx):
         del args, ctx
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(
         agent=Agent(),
         session_manager=manager,
@@ -1278,16 +1428,31 @@ def test_agent_session_get_commands_aggregates_extension_prompt_and_skill_source
     )
 
     descriptors = session.list_commands()
-    non_builtin = [descriptor for descriptor in descriptors if descriptor.source != "builtin"]
+    non_builtin = [
+        descriptor for descriptor in descriptors if descriptor.source != "builtin"
+    ]
 
-    assert {descriptor.name for descriptor in descriptors} >= {"copy", "name", "session", "changelog"}
-    assert [descriptor.name for descriptor in non_builtin] == ["deploy", "plan", "skill:debugging"]
+    assert {descriptor.name for descriptor in descriptors} >= {
+        "copy",
+        "name",
+        "session",
+        "changelog",
+    }
+    assert [descriptor.name for descriptor in non_builtin] == [
+        "deploy",
+        "plan",
+        "skill:debugging",
+    ]
     assert [descriptor.description for descriptor in non_builtin] == [
         "Deploy the project",
         "Use a planning workflow before editing.",
         "Debug failures by tracing the narrowest failing path.",
     ]
-    assert [descriptor.source for descriptor in non_builtin] == ["extension", "prompt", "skill"]
+    assert [descriptor.source for descriptor in non_builtin] == [
+        "extension",
+        "prompt",
+        "skill",
+    ]
     assert [descriptor.source_info.path for descriptor in non_builtin] == [
         "/tmp/project/extensions/deploy-ext.py",
         "/tmp/project/prompts/plan.md",
@@ -1300,7 +1465,9 @@ def test_agent_session_get_commands_aggregates_extension_prompt_and_skill_source
     ]
 
 
-def test_agent_session_list_commands_hides_disabled_skills_but_keeps_explicit_only_skills(tmp_path) -> None:
+def test_agent_session_list_commands_hides_disabled_skills_but_keeps_explicit_only_skills(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1310,7 +1477,9 @@ def test_agent_session_list_commands_hides_disabled_skills_but_keeps_explicit_on
 
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         resource_bundle=ResourceBundle(
             cwd=Path("/tmp/project"),
             skills=[
@@ -1330,10 +1499,16 @@ def test_agent_session_list_commands_hides_disabled_skills_but_keeps_explicit_on
         ),
     )
 
-    assert [descriptor.name for descriptor in session.list_commands() if descriptor.source != "builtin"] == ["skill:deploy"]
+    assert [
+        descriptor.name
+        for descriptor in session.list_commands()
+        if descriptor.source != "builtin"
+    ] == ["skill:deploy"]
 
 
-def test_agent_session_execute_command_async_dispatches_extension_command(tmp_path) -> None:
+def test_agent_session_execute_command_async_dispatches_extension_command(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1353,7 +1528,9 @@ def test_agent_session_execute_command_async_dispatches_extension_command(tmp_pa
         calls.append((args, ctx.cwd, type(ctx).__name__))
 
     async def scenario() -> None:
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         session = AgentSession(
             agent=Agent(),
             session_manager=manager,
@@ -1383,7 +1560,9 @@ def test_agent_session_execute_command_async_dispatches_extension_command(tmp_pa
     asyncio.run(scenario())
 
 
-def test_agent_session_extension_command_context_exec_command_uses_exec_service(tmp_path) -> None:
+def test_agent_session_extension_command_context_exec_command_uses_exec_service(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1428,7 +1607,9 @@ def test_agent_session_extension_command_context_exec_command_uses_exec_service(
         seen.append((result, updates))
 
     async def scenario() -> None:
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         session = AgentSession(
             agent=Agent(),
             session_manager=manager,
@@ -1462,10 +1643,17 @@ def test_agent_session_extension_command_context_exec_command_uses_exec_service(
     assert ("LOUSHANG", "1") in request.env
     assert request.timeout_seconds == 5
     assert request.stdin == "payload"
-    assert seen == [(ExecResult(exit_code=0, stdout="ok\n"), [ExecOutputChunk(stream="stdout", text="ok\n")])]
+    assert seen == [
+        (
+            ExecResult(exit_code=0, stdout="ok\n"),
+            [ExecOutputChunk(stream="stdout", text="ok\n")],
+        )
+    ]
 
 
-def test_agent_session_execute_command_async_expands_prompt_and_skill_commands(tmp_path) -> None:
+def test_agent_session_execute_command_async_expands_prompt_and_skill_commands(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1479,7 +1667,9 @@ def test_agent_session_execute_command_async_expands_prompt_and_skill_commands(t
 
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         resource_bundle=ResourceBundle(
             cwd=Path("/tmp/project"),
             prompts=[
@@ -1499,8 +1689,12 @@ def test_agent_session_execute_command_async_expands_prompt_and_skill_commands(t
         ),
     )
 
-    prompt_result = asyncio.run(session.execute_command_async("/plan", "focus on retries"))
-    skill_result = asyncio.run(session.execute_command_async("skill:debugging", "inspect the failing branch"))
+    prompt_result = asyncio.run(
+        session.execute_command_async("/plan", "focus on retries")
+    )
+    skill_result = asyncio.run(
+        session.execute_command_async("skill:debugging", "inspect the failing branch")
+    )
 
     assert prompt_result is not None
     assert prompt_result.invocation_name == "plan"
@@ -1520,7 +1714,9 @@ def test_agent_session_execute_command_async_expands_prompt_and_skill_commands(t
     }
 
 
-def test_agent_session_execute_command_async_prefers_extension_over_prompt(tmp_path) -> None:
+def test_agent_session_execute_command_async_prefers_extension_over_prompt(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1541,7 +1737,9 @@ def test_agent_session_execute_command_async_prefers_extension_over_prompt(tmp_p
 
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         resource_bundle=ResourceBundle(
             cwd=Path("/tmp/project"),
             prompts=[
@@ -1557,7 +1755,9 @@ def test_agent_session_execute_command_async_prefers_extension_over_prompt(tmp_p
                 LoadedExtension(
                     name="deploy-ext",
                     source_path=Path("/tmp/project/extensions/deploy.py"),
-                    commands={"deploy": RegisteredCommand(name="deploy", handler=_handler)},
+                    commands={
+                        "deploy": RegisteredCommand(name="deploy", handler=_handler)
+                    },
                 )
             ]
         ),
@@ -1591,7 +1791,9 @@ def test_agent_session_returns_command_argument_completions(tmp_path) -> None:
     async def scenario() -> None:
         session = AgentSession(
             agent=Agent(),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
@@ -1609,13 +1811,17 @@ def test_agent_session_returns_command_argument_completions(tmp_path) -> None:
             ),
         )
 
-        assert await session.get_command_argument_completions("deploy", "prod") == [{"value": "prod-candidate"}]
+        assert await session.get_command_argument_completions("deploy", "prod") == [
+            {"value": "prod-candidate"}
+        ]
         assert await session.get_command_argument_completions("missing", "") is None
 
     asyncio.run(scenario())
 
 
-def test_agent_session_extension_command_context_wait_for_idle_and_reload(tmp_path) -> None:
+def test_agent_session_extension_command_context_wait_for_idle_and_reload(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1654,7 +1860,9 @@ def test_agent_session_extension_command_context_wait_for_idle_and_reload(tmp_pa
         )
         session = AgentSession(
             agent=Agent(),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=runner,
         )
 
@@ -1690,7 +1898,9 @@ def test_agent_session_extension_command_context_navigate_tree(tmp_path) -> None
         events.append((event.oldLeafId, event.newLeafId, event.summaryEntry))
 
     async def scenario() -> None:
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         manager.append_message(_user_message("first"))
         target_id = manager.append_message(_assistant_text_message("assistant"))
         manager.append_message(_user_message("second"))
@@ -1720,7 +1930,9 @@ def test_agent_session_extension_command_context_navigate_tree(tmp_path) -> None
         assert result.result is None
         assert results == [{"cancelled": False}]
         assert session.session_manager.get_leaf_id() == target_id
-        assert [message.content[0].text for message in session.agent.state.messages] == ["first", "assistant"]
+        assert [
+            message.content[0].text for message in session.agent.state.messages
+        ] == ["first", "assistant"]
         assert events == [(old_leaf_id, target_id, None)]
 
     asyncio.run(scenario())
@@ -1746,7 +1958,9 @@ def test_agent_session_execute_command_async_records_errors(tmp_path) -> None:
         raise RuntimeError("boom")
 
     async def scenario() -> None:
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         diagnostics_service = DiagnosticsService()
         session = AgentSession(
             agent=Agent(),
@@ -1788,15 +2002,21 @@ def test_agent_session_execute_command_async_records_errors(tmp_path) -> None:
     asyncio.run(scenario())
 
 
-def test_agent_session_execute_command_async_returns_none_for_unknown_command(tmp_path) -> None:
+def test_agent_session_execute_command_async_returns_none_for_unknown_command(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.diagnostics import DiagnosticsService
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     diagnostics_service = DiagnosticsService()
-    session = AgentSession(agent=Agent(), session_manager=manager, diagnostics_service=diagnostics_service)
+    session = AgentSession(
+        agent=Agent(), session_manager=manager, diagnostics_service=diagnostics_service
+    )
 
     assert asyncio.run(session.execute_command_async("missing", "args")) is None
     records = diagnostics_service.get_diagnostics(code="command_not_found")
@@ -1809,7 +2029,9 @@ def test_agent_session_execute_command_async_returns_none_for_unknown_command(tm
     }
 
 
-def test_agent_session_execute_command_async_keeps_resource_diagnostic_for_unresolved_command(tmp_path) -> None:
+def test_agent_session_execute_command_async_keeps_resource_diagnostic_for_unresolved_command(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1821,13 +2043,17 @@ def test_agent_session_execute_command_async_keeps_resource_diagnostic_for_unres
     diagnostics_service = DiagnosticsService()
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         diagnostics_service=diagnostics_service,
         resource_bundle=ResourceBundle(cwd=Path("/tmp/project")),
     )
 
     assert asyncio.run(session.execute_command_async("missing", "args")) is None
-    records = diagnostics_service.get_diagnostics(phase="runtime", source="session", type="warning")
+    records = diagnostics_service.get_diagnostics(
+        phase="runtime", source="session", type="warning"
+    )
     assert [record.code for record in records] == ["unresolved_prompt_reference"]
     assert diagnostics_service.get_diagnostics(code="command_not_found") == []
 
@@ -1847,7 +2073,9 @@ def test_agent_session_get_commands_includes_all_extension_commands(tmp_path) ->
     async def _handler(args: str, ctx):
         del args, ctx
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(
         agent=Agent(),
         session_manager=manager,
@@ -1873,7 +2101,11 @@ def test_agent_session_get_commands_includes_all_extension_commands(tmp_path) ->
         ),
     )
 
-    assert [command.name for command in session.list_commands() if command.source != "builtin"] == ["deploy", "secret"]
+    assert [
+        command.name
+        for command in session.list_commands()
+        if command.source != "builtin"
+    ] == ["deploy", "secret"]
 
 
 def test_agent_session_lists_user_messages_for_forking(tmp_path) -> None:
@@ -1882,7 +2114,9 @@ def test_agent_session_lists_user_messages_for_forking(tmp_path) -> None:
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     first_id = manager.append_message(_user_message("first"))
     manager.append_message(_assistant_text_message("assistant"))
     manager.append_message(
@@ -1916,8 +2150,15 @@ def test_agent_session_exposes_pi_style_last_assistant_text_alias(tmp_path) -> N
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
-    session = AgentSession(agent=Agent(), session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False))
-    session.agent.state.set_messages([_user_message("hello"), _assistant_text_message("answer")])
+    session = AgentSession(
+        agent=Agent(),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
+    )
+    session.agent.state.set_messages(
+        [_user_message("hello"), _assistant_text_message("answer")]
+    )
 
     assert session.get_last_assistant_text() == "answer"
     assert session.getLastAssistantText() == "answer"
@@ -1928,7 +2169,12 @@ def test_agent_session_exposes_recent_assistant_texts_newest_first(tmp_path) -> 
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
-    session = AgentSession(agent=Agent(), session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False))
+    session = AgentSession(
+        agent=Agent(),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
+    )
     session.agent.state.set_messages(
         [
             _assistant_text_message("first"),
@@ -1947,7 +2193,9 @@ def test_agent_session_exposes_pi_style_state_property_aliases(tmp_path) -> None
     from loushang.coding.store import SessionManager
 
     manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=True)
-    session = AgentSession(agent=Agent(initial_state={"model": _model()}), session_manager=manager)
+    session = AgentSession(
+        agent=Agent(initial_state={"model": _model()}), session_manager=manager
+    )
     session.set_session_name("Demo")
     session.set_thinking_level("high")
     session.set_steering_mode("all")
@@ -1983,33 +2231,44 @@ def test_agent_session_steer_then_continue_persists_follow_on_turn(tmp_path) -> 
 
     async def scenario() -> None:
         agent = Agent(stream_fn=stream_fn)
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         session = AgentSession(agent=agent, session_manager=manager)
         agent.state.messages.append(_assistant_text_message("existing"))
 
         def listener(event) -> None:
             if event["type"] == "queue_update":
-                queue_updates.append((list(event["steering"]), list(event["follow_up"])))
+                queue_updates.append(
+                    (list(event["steering"]), list(event["follow_up"]))
+                )
 
         session.subscribe(listener)
         session.steer("next step")
         await session.continue_run()
 
         assert prompts == ["next step"]
-        assert [getattr(message, "role", None) for message in session.get_session_context().messages[-2:]] == ["user", "assistant"]
+        assert [
+            getattr(message, "role", None)
+            for message in session.get_session_context().messages[-2:]
+        ] == ["user", "assistant"]
         assert queue_updates[0] == (["next step"], [])
 
     asyncio.run(scenario())
 
 
-def test_agent_session_exposes_pi_style_queue_accessors_and_clear_queue(tmp_path) -> None:
+def test_agent_session_exposes_pi_style_queue_accessors_and_clear_queue(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
     )
     events: list[tuple[list[str], list[str]]] = []
 
@@ -2030,21 +2289,29 @@ def test_agent_session_exposes_pi_style_queue_accessors_and_clear_queue(tmp_path
 
     cleared = session.clearQueue()
 
-    assert cleared == {"steering": ["steer one"], "followUp": ["follow one"], "follow_up": ["follow one"]}
+    assert cleared == {
+        "steering": ["steer one"],
+        "followUp": ["follow one"],
+        "follow_up": ["follow one"],
+    }
     assert session.pendingMessageCount == 0
     assert session.getSteeringMessages() == []
     assert session.getFollowUpMessages() == []
     assert events[-1] == ([], [])
 
 
-def test_agent_session_removes_visible_queue_when_queued_user_message_starts(tmp_path) -> None:
+def test_agent_session_removes_visible_queue_when_queued_user_message_starts(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
     )
     events: list[tuple[list[str], list[str]]] = []
 
@@ -2059,7 +2326,11 @@ def test_agent_session_removes_visible_queue_when_queued_user_message_starts(tmp
         session._handle_agent_event(
             {
                 "type": "message_start",
-                "message": UserMessage(role="user", content=[TextPart(type="text", text="queued")], timestamp=0.0),
+                "message": UserMessage(
+                    role="user",
+                    content=[TextPart(type="text", text="queued")],
+                    timestamp=0.0,
+                ),
             },
             session.agent.signal,
         )
@@ -2074,8 +2345,12 @@ def test_agent_session_follow_up_and_state_snapshot(tmp_path) -> None:
     from loushang.coding.session import AgentSession, RunState
     from loushang.coding.store import SessionManager
 
-    agent = Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"})
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    agent = Agent(
+        initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(agent=agent, session_manager=manager)
 
     session.follow_up("later")
@@ -2100,8 +2375,12 @@ def test_agent_session_set_model_and_thinking_level_persist_to_store(tmp_path) -
     from loushang.coding.session import AgentSession, ModelSelection
     from loushang.coding.store import SessionManager
 
-    agent = Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"})
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    agent = Agent(
+        initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(agent=agent, session_manager=manager)
 
     next_model = Model(
@@ -2120,10 +2399,18 @@ def test_agent_session_set_model_and_thinking_level_persist_to_store(tmp_path) -
     asyncio.run(session.set_model(next_model))
     session.set_thinking_level("high")
 
-    assert session.get_model_selection() == ModelSelection(provider="alt", model_id="alt-model")
+    assert session.get_model_selection() == ModelSelection(
+        provider="alt", model_id="alt-model"
+    )
     assert session.get_state().thinking_level == "high"
-    assert [entry.type for entry in manager.get_entries()] == ["model_change", "thinking_level_change"]
-    assert session.get_session_context().model == {"provider": "alt", "model_id": "alt-model"}
+    assert [entry.type for entry in manager.get_entries()] == [
+        "model_change",
+        "thinking_level_change",
+    ]
+    assert session.get_session_context().model == {
+        "provider": "alt",
+        "model_id": "alt-model",
+    }
 
 
 def test_agent_session_cycles_model_and_thinking_level(tmp_path) -> None:
@@ -2151,18 +2438,28 @@ def test_agent_session_cycles_model_and_thinking_level(tmp_path) -> None:
     ai_registry.register_model(second)
 
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": first, "thinking_level": "low"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={"system_prompt": "", "model": first, "thinking_level": "low"}
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         model_registry=ModelRegistry(ai_registry=ai_registry),
     )
 
-    assert asyncio.run(session.cycle_model()) == ModelSelection(provider="alt", model_id="alt-model")
-    assert session.get_model_selection() == ModelSelection(provider="alt", model_id="alt-model")
+    assert asyncio.run(session.cycle_model()) == ModelSelection(
+        provider="alt", model_id="alt-model"
+    )
+    assert session.get_model_selection() == ModelSelection(
+        provider="alt", model_id="alt-model"
+    )
     assert session.cycle_thinking_level() == "medium"
     assert session.get_state().thinking_level == "medium"
 
 
-def test_agent_session_emits_model_select_event_for_async_model_control(tmp_path) -> None:
+def test_agent_session_emits_model_select_event_for_async_model_control(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -2195,8 +2492,12 @@ def test_agent_session_emits_model_select_event_for_async_model_control(tmp_path
         seen.append((event.type, event.model.id, event.previousModel.id, event.source))
 
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": first, "thinking_level": "low"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={"system_prompt": "", "model": first, "thinking_level": "low"}
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         model_registry=ModelRegistry(ai_registry=ai_registry),
         extension_runner=ExtensionRunner(
             [
@@ -2210,7 +2511,9 @@ def test_agent_session_emits_model_select_event_for_async_model_control(tmp_path
     )
 
     asyncio.run(session.set_model(second))
-    assert asyncio.run(session.cycle_model("backward")) == ModelSelection(provider="faux", model_id="faux-model")
+    assert asyncio.run(session.cycle_model("backward")) == ModelSelection(
+        provider="faux", model_id="faux-model"
+    )
 
     assert seen == [
         ("model_select", "alt-model", "faux-model", "set"),
@@ -2242,16 +2545,26 @@ def test_agent_session_exposes_pi_style_model_and_session_mutators(tmp_path) -> 
     ai_registry.register_model(first)
     ai_registry.register_model(second)
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": first, "thinking_level": "low"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={"system_prompt": "", "model": first, "thinking_level": "low"}
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         model_registry=ModelRegistry(ai_registry=ai_registry),
     )
 
     asyncio.run(session.setModel(second))
-    assert session.get_model_selection() == ModelSelection(provider="alt", model_id="alt-model")
+    assert session.get_model_selection() == ModelSelection(
+        provider="alt", model_id="alt-model"
+    )
 
-    assert asyncio.run(session.cycleModel("backward")) == ModelSelection(provider="faux", model_id="faux-model")
-    assert session.get_model_selection() == ModelSelection(provider="faux", model_id="faux-model")
+    assert asyncio.run(session.cycleModel("backward")) == ModelSelection(
+        provider="faux", model_id="faux-model"
+    )
+    assert session.get_model_selection() == ModelSelection(
+        provider="faux", model_id="faux-model"
+    )
 
     session.setThinkingLevel("high")
     assert session.thinkingLevel == "high"
@@ -2281,8 +2594,8 @@ def test_agent_session_applies_extension_provider_registration(tmp_path) -> None
             "displayName": "Proxy Provider",
             "website": "https://proxy.example.com",
             "endpoints": {
-                    "proxy-simple": {
-                        "api": "openai-completions",
+                "proxy-simple": {
+                    "api": "openai-completions",
                     "displayName": "Proxy Endpoint",
                     "baseUrl": "https://proxy.example.com",
                     "authOverride": {
@@ -2310,8 +2623,16 @@ def test_agent_session_applies_extension_provider_registration(tmp_path) -> None
     )
 
     AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "low"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "low",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         model_registry=model_registry,
         extension_runner=ExtensionRunner([api.build_loaded_extension()]),
     )
@@ -2393,15 +2714,25 @@ def test_agent_session_rejects_pi_style_extension_provider_config(tmp_path) -> N
         ai_registry = AiModelRegistry()
         diagnostics_service = DiagnosticsService()
         AgentSession(
-            agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "low"}),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            agent=Agent(
+                initial_state={
+                    "system_prompt": "",
+                    "model": _model(),
+                    "thinking_level": "low",
+                }
+            ),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             model_registry=ModelRegistry(ai_registry=ai_registry),
             diagnostics_service=diagnostics_service,
             extension_runner=ExtensionRunner([api.build_loaded_extension()]),
         )
         return ai_registry, diagnostics_service
 
-    pi_style = ExtensionAPI(name="provider-ext", source_path=Path("/tmp/provider-ext.py"))
+    pi_style = ExtensionAPI(
+        name="provider-ext", source_path=Path("/tmp/provider-ext.py")
+    )
     pi_style.register_provider(
         "proxy",
         {
@@ -2419,7 +2750,9 @@ def test_agent_session_rejects_pi_style_extension_provider_config(tmp_path) -> N
         for record in diagnostics_service.get_diagnostics()
     )
 
-    mixed_stream = ExtensionAPI(name="provider-ext", source_path=Path("/tmp/provider-ext.py"))
+    mixed_stream = ExtensionAPI(
+        name="provider-ext", source_path=Path("/tmp/provider-ext.py")
+    )
     mixed_stream.register_provider(
         "proxy",
         {
@@ -2436,11 +2769,14 @@ def test_agent_session_rejects_pi_style_extension_provider_config(tmp_path) -> N
     ai_registry, diagnostics_service = _build_session(mixed_stream)
     assert ai_registry.get_provider("proxy") is None
     assert any(
-        record.code == "extension_runtime_bind_failed" and "must be registered through explicit API/OAuth APIs" in record.message
+        record.code == "extension_runtime_bind_failed"
+        and "must be registered through explicit API/OAuth APIs" in record.message
         for record in diagnostics_service.get_diagnostics()
     )
 
-    mixed_flat_fields = ExtensionAPI(name="provider-ext", source_path=Path("/tmp/provider-ext.py"))
+    mixed_flat_fields = ExtensionAPI(
+        name="provider-ext", source_path=Path("/tmp/provider-ext.py")
+    )
     mixed_flat_fields.register_provider(
         "proxy",
         {
@@ -2456,7 +2792,8 @@ def test_agent_session_rejects_pi_style_extension_provider_config(tmp_path) -> N
     ai_registry, diagnostics_service = _build_session(mixed_flat_fields)
     assert ai_registry.get_provider("proxy") is None
     assert any(
-        record.code == "extension_runtime_bind_failed" and "top-level baseUrl" in record.message
+        record.code == "extension_runtime_bind_failed"
+        and "top-level baseUrl" in record.message
         for record in diagnostics_service.get_diagnostics()
     )
 
@@ -2487,8 +2824,12 @@ def test_agent_session_exposes_pi_style_scoped_models_and_resources(tmp_path) ->
     ai_registry.register_model(second)
     loader = DefaultResourceLoader()
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": first, "thinking_level": "low"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={"system_prompt": "", "model": first, "thinking_level": "low"}
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         model_registry=ModelRegistry(ai_registry=ai_registry),
         resource_loader=loader,
     )
@@ -2496,12 +2837,17 @@ def test_agent_session_exposes_pi_style_scoped_models_and_resources(tmp_path) ->
     session.setScopedModels(
         [
             {"model": first, "thinkingLevel": "low"},
-            {"model": {"provider": "alt", "model_id": "alt-model"}, "thinkingLevel": "high"},
+            {
+                "model": {"provider": "alt", "model_id": "alt-model"},
+                "thinkingLevel": "high",
+            },
         ]
     )
 
     assert session.scopedModels[0]["model"] is first
-    assert asyncio.run(session.cycleModel()) == ModelSelection(provider="alt", model_id="alt-model")
+    assert asyncio.run(session.cycleModel()) == ModelSelection(
+        provider="alt", model_id="alt-model"
+    )
     assert session.thinkingLevel == "high"
     assert session.resourceLoader is loader
     assert isinstance(session.promptTemplates, list)
@@ -2513,8 +2859,16 @@ def test_agent_session_exposes_pi_style_thinking_and_context_queries(tmp_path) -
     from loushang.coding.store import SessionManager
 
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "low"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "low",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
     )
     session.session_manager.append_message(_user_message("hello"))
 
@@ -2522,8 +2876,22 @@ def test_agent_session_exposes_pi_style_thinking_and_context_queries(tmp_path) -
     assert session.supports_thinking() is True
     assert session.supportsXhighThinking() is True
     assert session.supports_xhigh_thinking() is True
-    assert session.getAvailableThinkingLevels() == ["off", "minimal", "low", "medium", "high", "xhigh"]
-    assert session.get_available_thinking_levels() == ["off", "minimal", "low", "medium", "high", "xhigh"]
+    assert session.getAvailableThinkingLevels() == [
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    ]
+    assert session.get_available_thinking_levels() == [
+        "off",
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    ]
     assert session.cycle_thinking_level() == "medium"
     assert session.get_context_usage()["messageCount"] == 1
 
@@ -2559,8 +2927,16 @@ def test_agent_session_exposes_pi_style_runtime_facades(tmp_path) -> None:
 
     settings = SettingsManager(project_settings_path=tmp_path / "settings.json")
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "low"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "low",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         settings_manager=settings,
     )
 
@@ -2574,7 +2950,9 @@ def test_agent_session_exposes_pi_style_runtime_facades(tmp_path) -> None:
     session.abort_branch_summary()
     assert session.isBashRunning is False
     assert session.hasPendingBashMessages is False
-    session.recordBashResult("echo hi", {"output": "hi\n", "exitCode": 0}, {"excludeFromContext": True})
+    session.recordBashResult(
+        "echo hi", {"output": "hi\n", "exitCode": 0}, {"excludeFromContext": True}
+    )
     assert session.get_session_context().messages[-1].role == "bashExecution"
 
 
@@ -2588,7 +2966,9 @@ def test_agent_session_persists_queue_modes_to_settings(tmp_path) -> None:
     settings = SettingsManager(global_settings_path=settings_path)
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         settings_manager=settings,
     )
 
@@ -2612,9 +2992,17 @@ def test_agent_session_binds_extensions_before_session_start(tmp_path) -> None:
         del event
         seen.append((ctx.cwd, tuple(ctx.get_active_tool_names())))
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
             [
@@ -2644,8 +3032,16 @@ def test_agent_session_extension_status_updates_footer_data_provider(tmp_path) -
         ctx.setStatus("build", None)
 
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         extension_runner=ExtensionRunner(
             [
                 LoadedExtension(
@@ -2658,10 +3054,14 @@ def test_agent_session_extension_status_updates_footer_data_provider(tmp_path) -
     )
     asyncio.run(session.start_extension_runtime())
 
-    assert session.footer_data_provider.get_extension_statuses() == {"deploy": "running"}
+    assert session.footer_data_provider.get_extension_statuses() == {
+        "deploy": "running"
+    }
 
 
-def test_agent_session_footer_data_provider_tracks_available_provider_count(tmp_path) -> None:
+def test_agent_session_footer_data_provider_tracks_available_provider_count(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -2672,9 +3072,15 @@ def test_agent_session_footer_data_provider_tracks_available_provider_count(tmp_
     from loushang.coding.store import SessionManager
 
     ai_registry = AiModelRegistry()
-    ai_registry.register_model(Model(id="alpha", provider="base-a", endpoint="anthropic-messages"))
-    ai_registry.register_model(Model(id="beta", provider="base-a", endpoint="anthropic-messages"))
-    ai_registry.register_model(Model(id="gamma", provider="base-b", endpoint="anthropic-messages"))
+    ai_registry.register_model(
+        Model(id="alpha", provider="base-a", endpoint="anthropic-messages")
+    )
+    ai_registry.register_model(
+        Model(id="beta", provider="base-a", endpoint="anthropic-messages")
+    )
+    ai_registry.register_model(
+        Model(id="gamma", provider="base-b", endpoint="anthropic-messages")
+    )
     model_registry = ModelRegistry(ai_registry=ai_registry)
     api = ExtensionAPI(name="provider-ext", source_path=Path("/tmp/provider-ext.py"))
     api.register_provider(
@@ -2690,8 +3096,16 @@ def test_agent_session_footer_data_provider_tracks_available_provider_count(tmp_
     )
 
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         model_registry=model_registry,
         extension_runner=ExtensionRunner([api.build_loaded_extension()]),
     )
@@ -2703,7 +3117,9 @@ def test_agent_session_footer_data_provider_tracks_available_provider_count(tmp_
     assert session.footer_data_provider.get_available_provider_count() == 2
 
 
-def test_agent_session_exposes_available_model_details_for_metadata_consumers(tmp_path) -> None:
+def test_agent_session_exposes_available_model_details_for_metadata_consumers(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
     from loushang.coding.control import ModelRegistry
@@ -2715,12 +3131,25 @@ def test_agent_session_exposes_available_model_details_for_metadata_consumers(tm
         id="detail-model",
         provider="detail-provider",
         endpoint="anthropic-messages",
-        capabilities=Capabilities(reasoning=True, input=("text", "image"), context_window=64000, max_tokens=2048),
+        capabilities=Capabilities(
+            reasoning=True,
+            input=("text", "image"),
+            context_window=64000,
+            max_tokens=2048,
+        ),
     )
     ai_registry.register_model(detailed)
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         model_registry=ModelRegistry(ai_registry=ai_registry),
     )
 
@@ -2740,8 +3169,16 @@ def test_agent_session_disposes_footer_data_provider(tmp_path) -> None:
     from loushang.coding.store import SessionManager
 
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
     )
     changes: list[str | None] = []
     session.footer_data_provider.on_branch_change(changes.append)
@@ -2752,6 +3189,271 @@ def test_agent_session_disposes_footer_data_provider(tmp_path) -> None:
 
     assert session.footer_data_provider.get_extension_statuses() == {}
     assert changes == []
+
+
+def test_agent_session_disposal_paths_complete_pending_approvals(tmp_path) -> None:
+    from loushang.agent import Agent
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.session import AgentSession
+    from loushang.coding.store import SessionManager
+
+    async def run(dispose_method: str) -> None:
+        presented = asyncio.Event()
+        resolver = InteractiveApprovalResolver(
+            fallback=HeadlessApprovalResolver(mode="allow")
+        )
+
+        def present_request(payload: dict[str, object]) -> None:
+            del payload
+            presented.set()
+
+        resolver.set_request_presenter(present_request)
+        session = AgentSession(
+            agent=Agent(
+                initial_state={
+                    "system_prompt": "",
+                    "model": _model(),
+                    "thinking_level": "off",
+                }
+            ),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path / dispose_method,
+                cwd="/tmp/project",
+                persist=False,
+            ),
+            approval_resolver=resolver,
+        )
+        pending = asyncio.create_task(
+            resolver.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await presented.wait()
+
+        await getattr(session, dispose_method)()
+        decision = await pending
+
+        assert decision.disposition == "deny"
+        assert decision.reason == "Session closed before approval was resolved"
+
+    asyncio.run(run("dispose"))
+    asyncio.run(run("_dispose_after_session_shutdown"))
+
+
+def test_agent_session_disposal_closes_approval_before_waiting_for_host(
+    tmp_path,
+) -> None:
+    from loushang.agent import Agent
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.session import AgentSession
+    from loushang.coding.store import SessionManager
+
+    async def run(dispose_method: str) -> None:
+        presented = asyncio.Event()
+        decisions = []
+        resolver = InteractiveApprovalResolver(
+            fallback=HeadlessApprovalResolver(mode="allow")
+        )
+        resolver.set_request_presenter(lambda payload: presented.set())
+        session = AgentSession(
+            agent=Agent(
+                initial_state={
+                    "system_prompt": "",
+                    "model": _model(),
+                    "thinking_level": "off",
+                }
+            ),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path / f"host-{dispose_method}",
+                cwd="/tmp/project",
+                persist=False,
+            ),
+            approval_resolver=resolver,
+        )
+
+        async def wait_for_approval() -> None:
+            decisions.append(
+                await resolver.resolve(ApprovalRequest(tool_name="write", arguments={}))
+            )
+
+        active_run = asyncio.create_task(session._host_runtime.run(wait_for_approval))
+        await presented.wait()
+        await asyncio.wait_for(getattr(session, dispose_method)(), timeout=0.2)
+        await active_run
+        late_decision = await resolver.resolve(
+            ApprovalRequest(tool_name="edit", arguments={})
+        )
+
+        assert decisions[0].disposition == "deny"
+        assert late_decision.disposition == "deny"
+        assert late_decision.reason == "Session closed before approval was resolved"
+
+    asyncio.run(run("dispose"))
+    asyncio.run(run("_dispose_after_session_shutdown"))
+
+
+def test_agent_session_presenter_detach_denies_pending_approvals(tmp_path) -> None:
+    from loushang.agent import Agent
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.session import AgentSession
+    from loushang.coding.store import SessionManager
+
+    async def run() -> None:
+        presented = asyncio.Event()
+        resolver = InteractiveApprovalResolver(
+            fallback=HeadlessApprovalResolver(mode="allow")
+        )
+        session = AgentSession(
+            agent=Agent(
+                initial_state={
+                    "system_prompt": "",
+                    "model": _model(),
+                    "thinking_level": "off",
+                }
+            ),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path,
+                cwd="/tmp/project",
+                persist=False,
+            ),
+            approval_resolver=resolver,
+        )
+        session.set_approval_presenter(lambda payload: presented.set())
+        pending = asyncio.create_task(
+            resolver.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await presented.wait()
+
+        session.set_approval_presenter(None)
+        decision = await pending
+
+        assert decision.disposition == "deny"
+        assert decision.reason == (
+            "Approval presenter closed before approval was resolved"
+        )
+        assert resolver._request_presenter is None
+
+    asyncio.run(run())
+
+
+def test_agent_session_presenter_rebind_reopens_active_approval_generation(
+    tmp_path,
+) -> None:
+    from loushang.agent import Agent
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.session import AgentSession
+    from loushang.coding.store import SessionManager
+
+    async def run() -> None:
+        resolver = InteractiveApprovalResolver(
+            fallback=HeadlessApprovalResolver(mode="deny")
+        )
+        session = AgentSession(
+            agent=Agent(
+                initial_state={
+                    "system_prompt": "",
+                    "model": _model(),
+                    "thinking_level": "off",
+                }
+            ),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path,
+                cwd="/tmp/project",
+                persist=False,
+            ),
+            approval_resolver=resolver,
+        )
+        session.set_approval_presenter(lambda payload: None)
+        session.set_approval_presenter(None)
+
+        presented = asyncio.Event()
+        session.set_approval_presenter(lambda payload: presented.set())
+        pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="rebound-session-approval",
+                )
+            )
+        )
+        await asyncio.wait_for(presented.wait(), timeout=0.5)
+        await session.handle_screen_approval(
+            {"action_id": "rebound-session-approval", "approved": True}
+        )
+
+        assert (await pending).disposition == "allow"
+        await session.dispose()
+
+    asyncio.run(run())
+
+
+def test_agent_session_disposal_finalizes_when_host_dispose_fails(tmp_path) -> None:
+    import pytest
+
+    from loushang.agent import Agent
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.session import AgentSession
+    from loushang.coding.store import SessionManager
+
+    class FailingHostRuntime:
+        async def dispose(self) -> None:
+            raise RuntimeError("host dispose failed")
+
+    async def run(dispose_method: str) -> None:
+        presented = asyncio.Event()
+        resolver = InteractiveApprovalResolver(
+            fallback=HeadlessApprovalResolver(mode="allow")
+        )
+        resolver.set_request_presenter(lambda payload: presented.set())
+        session = AgentSession(
+            agent=Agent(
+                initial_state={
+                    "system_prompt": "",
+                    "model": _model(),
+                    "thinking_level": "off",
+                }
+            ),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path / dispose_method,
+                cwd="/tmp/project",
+                persist=False,
+            ),
+            approval_resolver=resolver,
+        )
+        session._host_runtime = FailingHostRuntime()  # type: ignore[assignment]
+        pending = asyncio.create_task(
+            resolver.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await presented.wait()
+
+        with pytest.raises(RuntimeError, match="host dispose failed"):
+            await getattr(session, dispose_method)()
+        decision = await pending
+
+        assert decision.disposition == "deny"
+        assert decision.reason == "Session closed before approval was resolved"
+
+    asyncio.run(run("dispose"))
+    asyncio.run(run("_dispose_after_session_shutdown"))
 
 
 def test_agent_session_extension_runtime_actions_update_session_store(tmp_path) -> None:
@@ -2776,11 +3478,26 @@ def test_agent_session_extension_runtime_actions_update_session_store(tmp_path) 
         )
         ctx.setSessionName("Demo Session")
         ctx.setLabel(entry_id, "Root")
-        seen.append((ctx.getSessionName(), ctx.getActiveTools(), len(ctx.getAllTools()), ctx.listCommands()))
+        seen.append(
+            (
+                ctx.getSessionName(),
+                ctx.getActiveTools(),
+                len(ctx.getAllTools()),
+                ctx.listCommands(),
+            )
+        )
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
             [
@@ -2795,7 +3512,13 @@ def test_agent_session_extension_runtime_actions_update_session_store(tmp_path) 
     asyncio.run(session.start_extension_runtime())
 
     entries = manager.get_entries()
-    assert [entry.type for entry in entries] == ["message", "custom", "custom_message", "session_info", "label"]
+    assert [entry.type for entry in entries] == [
+        "message",
+        "custom",
+        "custom_message",
+        "session_info",
+        "label",
+    ]
     assert entries[1].custom_type == "demo_state"
     assert entries[1].data == {"enabled": True}
     assert entries[2].custom_type == "demo_notice"
@@ -2803,7 +3526,10 @@ def test_agent_session_extension_runtime_actions_update_session_store(tmp_path) 
     assert entries[2].details == {"source": "extension"}
     assert manager.get_session_record().metadata.name == "Demo Session"
     assert manager.get_label(entries[0].id) == "Root"
-    assert [getattr(message, "role", None) for message in session.get_session_context().messages] == [
+    assert [
+        getattr(message, "role", None)
+        for message in session.get_session_context().messages
+    ] == [
         "user",
         "custom",
     ]
@@ -2817,7 +3543,9 @@ def test_agent_session_extension_runtime_actions_update_session_store(tmp_path) 
     ]
 
 
-def test_agent_session_extension_send_user_message_triggers_turn_without_command_preflight(tmp_path) -> None:
+def test_agent_session_extension_send_user_message_triggers_turn_without_command_preflight(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.extensions import (
         ExtensionRunner,
@@ -2845,7 +3573,9 @@ def test_agent_session_extension_send_user_message_triggers_turn_without_command
         return "nested"
 
     async def scenario() -> None:
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         session = AgentSession(
             agent=Agent(stream_fn=stream_fn),
             session_manager=manager,
@@ -2855,8 +3585,12 @@ def test_agent_session_extension_send_user_message_triggers_turn_without_command
                         name="demo",
                         source_path=tmp_path / "demo.py",
                         commands={
-                            "emit": RegisteredCommand(name="emit", handler=_emit_command),
-                            "nested": RegisteredCommand(name="nested", handler=_nested_command),
+                            "emit": RegisteredCommand(
+                                name="emit", handler=_emit_command
+                            ),
+                            "nested": RegisteredCommand(
+                                name="nested", handler=_nested_command
+                            ),
                         },
                     )
                 ]
@@ -2872,7 +3606,10 @@ def test_agent_session_extension_send_user_message_triggers_turn_without_command
         assert result.result is None
         assert prompted_texts == ["/nested should stay text"]
         assert nested_command_calls == []
-        assert [getattr(message, "role", None) for message in session.get_session_context().messages] == [
+        assert [
+            getattr(message, "role", None)
+            for message in session.get_session_context().messages
+        ] == [
             "user",
             "assistant",
         ]
@@ -2880,7 +3617,9 @@ def test_agent_session_extension_send_user_message_triggers_turn_without_command
     asyncio.run(scenario())
 
 
-def test_agent_session_extension_send_user_message_queues_while_streaming(tmp_path) -> None:
+def test_agent_session_extension_send_user_message_queues_while_streaming(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.extensions import (
         ExtensionRunner,
@@ -2896,7 +3635,9 @@ def test_agent_session_extension_send_user_message_queues_while_streaming(tmp_pa
         await ctx.sendUserMessage("queued follow", {"deliverAs": "followUp"})
 
     async def scenario() -> None:
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         agent = Agent()
         session = AgentSession(
             agent=agent,
@@ -2906,7 +3647,11 @@ def test_agent_session_extension_send_user_message_queues_while_streaming(tmp_pa
                     LoadedExtension(
                         name="demo",
                         source_path=tmp_path / "demo.py",
-                        commands={"queue": RegisteredCommand(name="queue", handler=_queue_command)},
+                        commands={
+                            "queue": RegisteredCommand(
+                                name="queue", handler=_queue_command
+                            )
+                        },
                     )
                 ]
             ),
@@ -2923,7 +3668,9 @@ def test_agent_session_extension_send_user_message_queues_while_streaming(tmp_pa
     asyncio.run(scenario())
 
 
-def test_agent_session_send_message_next_turn_is_appended_after_user_message(tmp_path) -> None:
+def test_agent_session_send_message_next_turn_is_appended_after_user_message(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.agent import Agent
@@ -2941,10 +3688,15 @@ def test_agent_session_send_message_next_turn_is_appended_after_user_message(tmp
 
     async def _queue_next_turn(args: str, ctx):
         del args
-        await ctx.sendMessage({"customType": "queued_note", "content": "queued note"}, {"deliverAs": "nextTurn"})
+        await ctx.sendMessage(
+            {"customType": "queued_note", "content": "queued note"},
+            {"deliverAs": "nextTurn"},
+        )
 
     async def scenario() -> None:
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         session = AgentSession(
             agent=Agent(stream_fn=stream_fn),
             session_manager=manager,
@@ -2953,7 +3705,11 @@ def test_agent_session_send_message_next_turn_is_appended_after_user_message(tmp
                     LoadedExtension(
                         name="next-turn",
                         source_path=tmp_path / "demo.py",
-                        commands={"queue": RegisteredCommand(name="queue", handler=_queue_next_turn)},
+                        commands={
+                            "queue": RegisteredCommand(
+                                name="queue", handler=_queue_next_turn
+                            )
+                        },
                     )
                 ]
             ),
@@ -2964,21 +3720,33 @@ def test_agent_session_send_message_next_turn_is_appended_after_user_message(tmp
         await session.prompt("hello")
 
         assert [message.role for message in session.messages[:2]] == ["user", "custom"]
-        assert [message.custom_type for message in session.messages if getattr(message, "role", None) == "custom"] == [
-            "queued_note"
-        ]
+        assert [
+            message.custom_type
+            for message in session.messages
+            if getattr(message, "role", None) == "custom"
+        ] == ["queued_note"]
 
     asyncio.run(scenario())
 
 
-def test_agent_session_send_custom_message_public_api_persists_and_emits_events(tmp_path) -> None:
+def test_agent_session_send_custom_message_public_api_persists_and_emits_events(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
     )
     events: list[tuple[str, str]] = []
 
@@ -2999,12 +3767,16 @@ def test_agent_session_send_custom_message_public_api_persists_and_emits_events(
         )
     )
 
-    assert [entry.type for entry in session.session_manager.get_entries()] == ["custom_message"]
+    assert [entry.type for entry in session.session_manager.get_entries()] == [
+        "custom_message"
+    ]
     assert [message.role for message in session.messages] == ["custom"]
     assert events == [("message_start", "demo_notice"), ("message_end", "demo_notice")]
 
 
-def test_agent_session_send_user_message_public_api_triggers_turn_without_command_preflight(tmp_path) -> None:
+def test_agent_session_send_user_message_public_api_triggers_turn_without_command_preflight(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.extensions import (
         ExtensionRunner,
@@ -3030,13 +3802,19 @@ def test_agent_session_send_user_message_public_api_triggers_turn_without_comman
     async def scenario() -> None:
         session = AgentSession(
             agent=Agent(stream_fn=stream_fn),
-            session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+            session_manager=SessionManager.new(
+                session_dir=tmp_path, cwd="/tmp/project", persist=False
+            ),
             extension_runner=ExtensionRunner(
                 [
                     LoadedExtension(
                         name="demo",
                         source_path=tmp_path / "demo.py",
-                        commands={"nested": RegisteredCommand(name="nested", handler=_nested_command)},
+                        commands={
+                            "nested": RegisteredCommand(
+                                name="nested", handler=_nested_command
+                            )
+                        },
                     )
                 ]
             ),
@@ -3046,7 +3824,10 @@ def test_agent_session_send_user_message_public_api_triggers_turn_without_comman
 
         assert prompted_texts == ["/nested should stay text"]
         assert nested_command_calls == []
-        assert [getattr(message, "role", None) for message in session.get_session_context().messages] == [
+        assert [
+            getattr(message, "role", None)
+            for message in session.get_session_context().messages
+        ] == [
             "user",
             "assistant",
         ]
@@ -3054,7 +3835,9 @@ def test_agent_session_send_user_message_public_api_triggers_turn_without_comman
     asyncio.run(scenario())
 
 
-def test_agent_session_reload_extensions_refreshes_resources_before_session_start(tmp_path) -> None:
+def test_agent_session_reload_extensions_refreshes_resources_before_session_start(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -3095,9 +3878,17 @@ def test_agent_session_reload_extensions_refreshes_resources_before_session_star
             reload_calls.append(str(cwd))
             return ResourceBundle(cwd=Path(cwd), prompt_fragments=["reloaded prompt"])
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "base prompt", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "base prompt",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
             [
@@ -3130,7 +3921,10 @@ def test_agent_session_reload_extensions_refreshes_resources_before_session_star
     ]
     assert reload_calls == ["/tmp/project"]
     assert session.resource_bundle is not None
-    assert session.resource_bundle.prompt_fragments == ["reloaded prompt", "extension refresh prompt"]
+    assert session.resource_bundle.prompt_fragments == [
+        "reloaded prompt",
+        "extension refresh prompt",
+    ]
     assert "extension refresh prompt" in session.agent.system_prompt
 
 
@@ -3154,12 +3948,20 @@ def test_agent_session_set_active_tools_emits_session_refresh(tmp_path) -> None:
     def _session_refresh(event, ctx):
         seen.append((event.reason, tuple(ctx.get_active_tool_names())))
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     registry = ToolRegistry()
     registry.register_tool(read_file)
     registry.register_tool(grep_file)
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
             [
@@ -3205,19 +4007,30 @@ def test_agent_session_refresh_does_not_reemit_session_start(tmp_path) -> None:
         del ctx
         refresh_events.append(event.reason)
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     registry = ToolRegistry()
     registry.register_tool(read_file)
     registry.register_tool(grep_file)
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
             [
                 LoadedExtension(
                     name="demo",
                     source_path=tmp_path / "demo.py",
-                    hooks={"session_start": [_session_start], "session_refresh": [_session_refresh]},
+                    hooks={
+                        "session_start": [_session_start],
+                        "session_refresh": [_session_refresh],
+                    },
                 )
             ]
         ),
@@ -3232,7 +4045,9 @@ def test_agent_session_refresh_does_not_reemit_session_start(tmp_path) -> None:
     assert refresh_events == ["active_tools_changed"]
 
 
-def test_agent_session_set_extension_ui_context_rebinds_context_without_lifecycle_hooks(tmp_path) -> None:
+def test_agent_session_set_extension_ui_context_rebinds_context_without_lifecycle_hooks(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
     from loushang.coding.session import AgentSession
@@ -3248,18 +4063,29 @@ def test_agent_session_set_extension_ui_context_rebinds_context_without_lifecycl
     def _session_refresh(event, ctx):
         refresh_events.append((event.reason, ctx.hasUI))
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     runner = ExtensionRunner(
         [
             LoadedExtension(
                 name="demo",
                 source_path=tmp_path / "demo.py",
-                hooks={"session_start": [_session_start], "session_refresh": [_session_refresh]},
+                hooks={
+                    "session_start": [_session_start],
+                    "session_refresh": [_session_refresh],
+                },
             )
         ]
     )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=runner,
     )
@@ -3273,7 +4099,9 @@ def test_agent_session_set_extension_ui_context_rebinds_context_without_lifecycl
     assert context.hasUI is True
 
 
-def test_agent_session_dispose_invalidates_extension_contexts_after_shutdown_hooks(tmp_path) -> None:
+def test_agent_session_dispose_invalidates_extension_contexts_after_shutdown_hooks(
+    tmp_path,
+) -> None:
     import pytest
 
     from loushang.agent import Agent
@@ -3298,8 +4126,16 @@ def test_agent_session_dispose_invalidates_extension_contexts_after_shutdown_hoo
         ]
     )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         extension_runner=runner,
     )
     captured_context = runner.create_command_context(fallback_cwd="/tmp/project")
@@ -3307,11 +4143,15 @@ def test_agent_session_dispose_invalidates_extension_contexts_after_shutdown_hoo
     asyncio.run(session.dispose())
 
     assert seen == ["/tmp/project"]
-    with pytest.raises(RuntimeError, match="stale after session replacement or shutdown"):
+    with pytest.raises(
+        RuntimeError, match="stale after session replacement or shutdown"
+    ):
         captured_context.cwd
 
 
-def test_agent_session_dispose_invalidates_extension_contexts_when_shutdown_emit_fails(tmp_path) -> None:
+def test_agent_session_dispose_invalidates_extension_contexts_when_shutdown_emit_fails(
+    tmp_path,
+) -> None:
     import pytest
 
     from loushang.agent import Agent
@@ -3319,10 +4159,20 @@ def test_agent_session_dispose_invalidates_extension_contexts_when_shutdown_emit
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
-    runner = ExtensionRunner([LoadedExtension(name="demo", source_path=tmp_path / "demo.py")])
+    runner = ExtensionRunner(
+        [LoadedExtension(name="demo", source_path=tmp_path / "demo.py")]
+    )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         extension_runner=runner,
     )
     captured_context = runner.create_command_context(fallback_cwd="/tmp/project")
@@ -3335,7 +4185,9 @@ def test_agent_session_dispose_invalidates_extension_contexts_when_shutdown_emit
     with pytest.raises(RuntimeError, match="shutdown transport boom"):
         asyncio.run(session.dispose())
 
-    with pytest.raises(RuntimeError, match="stale after session replacement or shutdown"):
+    with pytest.raises(
+        RuntimeError, match="stale after session replacement or shutdown"
+    ):
         captured_context.cwd
 
 
@@ -3364,9 +4216,17 @@ def test_agent_session_set_model_emits_session_refresh(tmp_path) -> None:
     def _session_refresh(event, ctx):
         seen.append((event.reason, ctx.get_model_selection()))
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
             [
@@ -3384,7 +4244,9 @@ def test_agent_session_set_model_emits_session_refresh(tmp_path) -> None:
     assert seen == [("model_selection_changed", session.get_model_selection())]
 
 
-def test_agent_session_invalid_extension_refresh_model_change_keeps_top_level_model(tmp_path) -> None:
+def test_agent_session_invalid_extension_refresh_model_change_keeps_top_level_model(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.ai.model import Capabilities, Model
     from loushang.coding.diagnostics import DiagnosticsService
@@ -3409,10 +4271,18 @@ def test_agent_session_invalid_extension_refresh_model_change_keeps_top_level_mo
         del event
         await ctx.set_model(object())
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     diagnostics = DiagnosticsService()
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
             [
@@ -3428,7 +4298,11 @@ def test_agent_session_invalid_extension_refresh_model_change_keeps_top_level_mo
 
     asyncio.run(session.set_model(next_model))
 
-    diagnostics = [record for record in session.get_last_diagnostics() if record.code == "extension_session_refresh_failed"]
+    diagnostics = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "extension_session_refresh_failed"
+    ]
 
     assert session.agent.model is next_model
     assert session.get_model_selection() is not None
@@ -3437,10 +4311,15 @@ def test_agent_session_invalid_extension_refresh_model_change_keeps_top_level_mo
     assert len(diagnostics) == 1
     assert diagnostics[0].type == "error"
     assert session.get_last_error_report() is not None
-    assert session.get_last_error_report().primary.code == "extension_session_refresh_failed"
+    assert (
+        session.get_last_error_report().primary.code
+        == "extension_session_refresh_failed"
+    )
 
 
-def test_extension_session_refresh_actions_do_not_recursively_emit_refresh(tmp_path) -> None:
+def test_extension_session_refresh_actions_do_not_recursively_emit_refresh(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.ai.model import Capabilities, Model
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
@@ -3462,7 +4341,9 @@ def test_extension_session_refresh_actions_do_not_recursively_emit_refresh(tmp_p
         refresh_reasons.append(event.reason)
         await ctx.set_active_tools(["read_file", "grep_file"])
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     registry = ToolRegistry()
     registry.register_tool(read_file)
     registry.register_tool(grep_file)
@@ -3479,7 +4360,13 @@ def test_extension_session_refresh_actions_do_not_recursively_emit_refresh(tmp_p
         ),
     )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
             [
@@ -3516,12 +4403,20 @@ def test_agent_session_extension_can_request_resource_refresh(tmp_path) -> None:
         requested.append(ctx.cwd)
 
     loader = DefaultResourceLoader()
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(
         agent=Agent(),
         session_manager=manager,
         extension_runner=ExtensionRunner(
-            [LoadedExtension(name="demo", source_path=Path("/tmp/demo.py"), hooks={"session_start": [_before]})]
+            [
+                LoadedExtension(
+                    name="demo",
+                    source_path=Path("/tmp/demo.py"),
+                    hooks={"session_start": [_before]},
+                )
+            ]
         ),
         resource_loader=loader,
     )
@@ -3531,7 +4426,9 @@ def test_agent_session_extension_can_request_resource_refresh(tmp_path) -> None:
     assert session.resource_bundle is not None
 
 
-def test_agent_session_extension_request_resource_refresh_is_nonfatal_without_loader(tmp_path) -> None:
+def test_agent_session_extension_request_resource_refresh_is_nonfatal_without_loader(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -3546,21 +4443,40 @@ def test_agent_session_extension_request_resource_refresh_is_nonfatal_without_lo
         ctx.request_resource_refresh()
         requested.append(ctx.cwd)
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
-            [LoadedExtension(name="demo", source_path=Path("/tmp/demo.py"), hooks={"session_start": [_before]})]
+            [
+                LoadedExtension(
+                    name="demo",
+                    source_path=Path("/tmp/demo.py"),
+                    hooks={"session_start": [_before]},
+                )
+            ]
         ),
     )
     asyncio.run(session.start_extension_runtime())
 
     assert requested == ["/tmp/project"]
-    assert session.resource_bundle is None or session.resource_bundle.cwd == manager.get_cwd()
+    assert (
+        session.resource_bundle is None
+        or session.resource_bundle.cwd == manager.get_cwd()
+    )
 
 
-def test_agent_session_resource_refresh_rebuilds_prompt_and_tools_without_emitting_session_refresh(tmp_path) -> None:
+def test_agent_session_resource_refresh_rebuilds_prompt_and_tools_without_emitting_session_refresh(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -3584,14 +4500,28 @@ def test_agent_session_resource_refresh_rebuilds_prompt_and_tools_without_emitti
         def reload_resources(self, cwd):
             return ResourceBundle(cwd=Path(cwd), prompt_fragments=["reloaded prompt"])
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     registry = ToolRegistry()
     registry.register_tool(read_file)
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "base prompt", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "base prompt",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=ExtensionRunner(
-            [LoadedExtension(name="demo", source_path=Path("/tmp/demo.py"), hooks={"session_refresh": [_session_refresh]})]
+            [
+                LoadedExtension(
+                    name="demo",
+                    source_path=Path("/tmp/demo.py"),
+                    hooks={"session_refresh": [_session_refresh]},
+                )
+            ]
         ),
         resource_loader=_ReloadingLoader(),
         tool_registry=registry,
@@ -3623,12 +4553,22 @@ def test_agent_session_records_reload_failures_as_diagnostics(tmp_path) -> None:
             del cwd
             raise RuntimeError("reload boom")
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     diagnostics = DiagnosticsService()
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
-        extension_runner=ExtensionRunner([LoadedExtension(name="demo", source_path=tmp_path / "demo.py", hooks={})]),
+        extension_runner=ExtensionRunner(
+            [LoadedExtension(name="demo", source_path=tmp_path / "demo.py", hooks={})]
+        ),
         resource_loader=_BrokenReloadLoader(),
         resource_bundle=ResourceBundle(cwd=tmp_path),
         diagnostics_service=diagnostics,
@@ -3636,7 +4576,11 @@ def test_agent_session_records_reload_failures_as_diagnostics(tmp_path) -> None:
 
     asyncio.run(session.reload_extension_runtime())
 
-    records = [record for record in session.get_last_diagnostics() if record.code == "extension_resource_refresh_failed"]
+    records = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "extension_resource_refresh_failed"
+    ]
 
     assert len(records) == 1
     assert records[0].type == "error"
@@ -3688,10 +4632,18 @@ def test_agent_session_records_bind_failures_as_diagnostics(tmp_path) -> None:
             ]
         )
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     diagnostics = DiagnosticsService()
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         extension_runner=_BrokenBindRunner(
             [
@@ -3709,7 +4661,11 @@ def test_agent_session_records_bind_failures_as_diagnostics(tmp_path) -> None:
 
     asyncio.run(session.reload_extension_runtime())
 
-    records = [record for record in session.get_last_diagnostics() if record.code == "extension_runtime_bind_failed"]
+    records = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "extension_runtime_bind_failed"
+    ]
 
     assert len(records) == 1
     assert records[0].type == "error"
@@ -3731,7 +4687,13 @@ def test_agent_session_exposes_session_metadata_and_messages(tmp_path) -> None:
         )
     )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         diagnostics_service=DiagnosticsService(),
     )
@@ -3748,7 +4710,9 @@ def test_agent_session_exposes_context_usage_and_stats(tmp_path) -> None:
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     manager.append_message(
         UserMessage(
             role="user",
@@ -3761,13 +4725,25 @@ def test_agent_session_exposes_context_usage_and_stats(tmp_path) -> None:
             role="assistant",
             content=[
                 TextPart(type="text", text="reading"),
-                ToolCall(type="toolCall", id="tool-1", name="read", arguments={"path": "README.md"}),
+                ToolCall(
+                    type="toolCall",
+                    id="tool-1",
+                    name="read",
+                    arguments={"path": "README.md"},
+                ),
             ],
             api="anthropic-messages",
             provider="faux",
             model="faux-model",
             response_id=None,
-            usage=Usage(input=2, output=3, cache_read=5, cache_write=7, total_tokens=17, cost={"total": 0.25}),
+            usage=Usage(
+                input=2,
+                output=3,
+                cache_read=5,
+                cache_write=7,
+                total_tokens=17,
+                cost={"total": 0.25},
+            ),
             stop_reason="toolUse",
             error_message=None,
             timestamp=1.0,
@@ -3784,7 +4760,13 @@ def test_agent_session_exposes_context_usage_and_stats(tmp_path) -> None:
         )
     )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
     )
 
@@ -3830,8 +4812,16 @@ def test_agent_session_exposes_session_state_runtime_queue(tmp_path) -> None:
     from loushang.coding.store import SessionManager
 
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
     )
 
     session.steer("adjust current task")
@@ -3866,8 +4856,16 @@ def test_agent_session_set_session_name_emits_session_info_changed(tmp_path) -> 
     from loushang.coding.store import SessionManager
 
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
     )
     events: list[object] = []
     session.subscribe(events.append)
@@ -3886,8 +4884,16 @@ def test_agent_session_exposes_session_scoped_diagnostics(tmp_path) -> None:
 
     diagnostics = DiagnosticsService()
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         diagnostics_service=diagnostics,
     )
     diagnostics.record(
@@ -3909,10 +4915,15 @@ def test_agent_session_exposes_session_scoped_diagnostics(tmp_path) -> None:
         )
     )
 
-    assert [record.code for record in session.get_session_diagnostics()] == ["current_session_error"]
-    assert [record.code for record in session.get_session_diagnostics(DiagnosticsQuery(code="current_session_error"))] == [
+    assert [record.code for record in session.get_session_diagnostics()] == [
         "current_session_error"
     ]
+    assert [
+        record.code
+        for record in session.get_session_diagnostics(
+            DiagnosticsQuery(code="current_session_error")
+        )
+    ] == ["current_session_error"]
 
 
 def test_agent_session_get_packages_projects_materializer_state(tmp_path) -> None:
@@ -3928,7 +4939,9 @@ def test_agent_session_get_packages_projects_materializer_state(tmp_path) -> Non
     materializer.prepare_remote_source(source)
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
@@ -3956,7 +4969,9 @@ def test_agent_session_records_remote_package_manifest_diagnostics(tmp_path) -> 
 
     source = "https://packages.example.invalid/review-pack.git"
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         record.target_path.mkdir(parents=True)
         (record.target_path / "plugin.json").write_text("{not json", encoding="utf-8")
         return record.with_lifecycle("installed", target_path=record.target_path)
@@ -3967,12 +4982,16 @@ def test_agent_session_records_remote_package_manifest_diagnostics(tmp_path) -> 
     materializer = PackageMaterializer(
         install_root=tmp_path / "packages",
         backend=backend,
-        security_policy=PackageSecurityPolicy(trusted_hosts=("packages.example.invalid",)),
+        security_policy=PackageSecurityPolicy(
+            trusted_hosts=("packages.example.invalid",)
+        ),
     )
     asyncio.run(materializer.materialize_remote_source(source))
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
         diagnostics_service=diagnostics,
@@ -3985,7 +5004,9 @@ def test_agent_session_records_remote_package_manifest_diagnostics(tmp_path) -> 
     assert len(records) == 1
     assert records[0].phase == "resource_loading"
     assert records[0].source == "package"
-    assert records[0].source_path == tmp_path / "packages" / "review-pack" / "plugin.json"
+    assert (
+        records[0].source_path == tmp_path / "packages" / "review-pack" / "plugin.json"
+    )
 
 
 def test_agent_session_records_package_catalog_diagnostics(tmp_path) -> None:
@@ -4000,7 +5021,9 @@ def test_agent_session_records_package_catalog_diagnostics(tmp_path) -> None:
     diagnostics = DiagnosticsService()
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=SettingsManager(ControlConfig()),
         diagnostics_service=diagnostics,
     )
@@ -4015,7 +5038,9 @@ def test_agent_session_records_package_catalog_diagnostics(tmp_path) -> None:
     assert records[0].source_path == catalog_path
 
 
-def test_agent_session_materialize_package_returns_policy_denied_record(tmp_path) -> None:
+def test_agent_session_materialize_package_returns_policy_denied_record(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.agent import Agent
@@ -4029,7 +5054,9 @@ def test_agent_session_materialize_package_returns_policy_denied_record(tmp_path
     materializer = PackageMaterializer(install_root=tmp_path / "packages")
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
@@ -4056,7 +5083,9 @@ def test_agent_session_updates_and_removes_materialized_packages(tmp_path) -> No
     settings = SettingsManager(ControlConfig(plugin_sources=(source,)))
     versions = ["1.0.0", "2.0.0"]
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         record.target_path.mkdir(parents=True, exist_ok=True)
         (record.target_path / "plugin.json").write_text(
             json.dumps({"name": "review-pack", "version": versions.pop(0)}),
@@ -4064,10 +5093,14 @@ def test_agent_session_updates_and_removes_materialized_packages(tmp_path) -> No
         )
         return record.with_lifecycle("installed")
 
-    materializer = PackageMaterializer(install_root=tmp_path / "packages", backend=backend)
+    materializer = PackageMaterializer(
+        install_root=tmp_path / "packages", backend=backend
+    )
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
@@ -4077,7 +5110,14 @@ def test_agent_session_updates_and_removes_materialized_packages(tmp_path) -> No
 
     assert installed["lifecycle"] == "installed"
     assert updated["lifecycle"] == "installed"
-    assert json.loads((tmp_path / "packages" / "review-pack" / "plugin.json").read_text(encoding="utf-8"))["version"] == "2.0.0"
+    assert (
+        json.loads(
+            (tmp_path / "packages" / "review-pack" / "plugin.json").read_text(
+                encoding="utf-8"
+            )
+        )["version"]
+        == "2.0.0"
+    )
     removed = session.remove_package(source)
     assert removed["lifecycle"] == "remote_registered"
     assert (tmp_path / "packages" / "review-pack").exists() is False
@@ -4097,15 +5137,21 @@ def test_agent_session_installs_and_uninstalls_package_with_settings(tmp_path) -
 
     source = "https://packages.example.invalid/review-pack.git"
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         record.target_path.mkdir(parents=True, exist_ok=True)
         return record.with_lifecycle("installed")
 
     settings = SettingsManager(ControlConfig())
-    materializer = PackageMaterializer(install_root=tmp_path / "packages", backend=backend)
+    materializer = PackageMaterializer(
+        install_root=tmp_path / "packages", backend=backend
+    )
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
@@ -4119,10 +5165,17 @@ def test_agent_session_installs_and_uninstalls_package_with_settings(tmp_path) -
     assert uninstalled["lifecycle"] == "remote_registered"
     assert settings.get_package_sources() == []
     assert materializer.get_record(source) is None
-    assert json.loads((tmp_path / "package-lock.json").read_text(encoding="utf-8"))["packages"] == []
+    assert (
+        json.loads((tmp_path / "package-lock.json").read_text(encoding="utf-8"))[
+            "packages"
+        ]
+        == []
+    )
 
 
-def test_agent_session_installs_and_uninstalls_local_package_with_settings(tmp_path) -> None:
+def test_agent_session_installs_and_uninstalls_local_package_with_settings(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.agent import Agent
@@ -4137,23 +5190,31 @@ def test_agent_session_installs_and_uninstalls_local_package_with_settings(tmp_p
     materializer = PackageMaterializer(install_root=tmp_path / "packages")
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
 
-    installed = asyncio.run(session.install_package(str(local_package), scope="project"))
+    installed = asyncio.run(
+        session.install_package(str(local_package), scope="project")
+    )
 
     assert installed["lifecycle"] == "installed"
     assert installed["source"] == str(local_package)
     assert installed["targetPath"] == str(local_package.resolve())
-    assert [package.source for package in settings.get_package_sources()] == [str(local_package)]
+    assert [package.source for package in settings.get_package_sources()] == [
+        str(local_package)
+    ]
     uninstalled = session.uninstall_package(str(local_package), scope="project")
     assert uninstalled["lifecycle"] == "remote_registered"
     assert settings.get_package_sources() == []
 
 
-def test_agent_session_install_package_does_not_persist_failed_materialization(tmp_path) -> None:
+def test_agent_session_install_package_does_not_persist_failed_materialization(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.agent import Agent
@@ -4167,14 +5228,20 @@ def test_agent_session_install_package_does_not_persist_failed_materialization(t
 
     source = "https://packages.example.invalid/review-pack.git"
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         return record.with_lifecycle("failed", error_message="clone failed")
 
     settings = SettingsManager(ControlConfig())
-    materializer = PackageMaterializer(install_root=tmp_path / "packages", backend=backend)
+    materializer = PackageMaterializer(
+        install_root=tmp_path / "packages", backend=backend
+    )
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
@@ -4186,7 +5253,9 @@ def test_agent_session_install_package_does_not_persist_failed_materialization(t
     assert session.get_packages() == []
 
 
-def test_agent_session_install_package_refreshes_resources_for_current_session(tmp_path) -> None:
+def test_agent_session_install_package_refreshes_resources_for_current_session(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.agent import Agent
@@ -4201,18 +5270,28 @@ def test_agent_session_install_package_refreshes_resources_for_current_session(t
 
     source = "https://packages.example.invalid/review-pack.git"
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         (record.target_path / "prompts").mkdir(parents=True, exist_ok=True)
         (record.target_path / "skills" / "review").mkdir(parents=True, exist_ok=True)
-        (record.target_path / "prompts" / "review.md").write_text("Package review prompt", encoding="utf-8")
-        (record.target_path / "skills" / "review" / "SKILL.md").write_text("Package review skill", encoding="utf-8")
+        (record.target_path / "prompts" / "review.md").write_text(
+            "Package review prompt", encoding="utf-8"
+        )
+        (record.target_path / "skills" / "review" / "SKILL.md").write_text(
+            "Package review skill", encoding="utf-8"
+        )
         return record.with_lifecycle("installed")
 
     settings = SettingsManager(ControlConfig(system_prompt="Base"))
-    materializer = PackageMaterializer(install_root=tmp_path / "packages", backend=backend)
+    materializer = PackageMaterializer(
+        install_root=tmp_path / "packages", backend=backend
+    )
     session = AgentSession(
         agent=Agent(initial_state={"system_prompt": "Base"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         resource_loader=DefaultResourceLoader(),
         package_materializer=materializer,
@@ -4222,7 +5301,11 @@ def test_agent_session_install_package_refreshes_resources_for_current_session(t
     asyncio.run(session.install_package(source))
 
     assert "Package review prompt" in session.agent.system_prompt
-    assert [command.name for command in session.list_commands() if command.source != "builtin"] == ["review", "skill:review"]
+    assert [
+        command.name
+        for command in session.list_commands()
+        if command.source != "builtin"
+    ] == ["review", "skill:review"]
 
 
 def test_agent_session_emits_package_progress_events(tmp_path) -> None:
@@ -4239,26 +5322,35 @@ def test_agent_session_emits_package_progress_events(tmp_path) -> None:
 
     source = "https://packages.example.invalid/review-pack.git"
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         record.target_path.mkdir(parents=True, exist_ok=True)
         return record.with_lifecycle("installed")
 
     settings = SettingsManager(ControlConfig())
-    materializer = PackageMaterializer(install_root=tmp_path / "packages", backend=backend)
+    materializer = PackageMaterializer(
+        install_root=tmp_path / "packages", backend=backend
+    )
     session = AgentSession(
         agent=Agent(initial_state={"system_prompt": "Base"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
     events: list[dict[str, object]] = []
-    session.subscribe(lambda event: events.append(event) if event["type"] == "package_progress" else None)
+    session.subscribe(
+        lambda event: (
+            events.append(event) if event["type"] == "package_progress" else None
+        )
+    )
 
     asyncio.run(session.install_package(source))
 
     assert [
-        (event["progress_type"], event["action"], event["source"])
-        for event in events
+        (event["progress_type"], event["action"], event["source"]) for event in events
     ] == [
         ("start", "install", source),
         ("complete", "install", source),
@@ -4280,17 +5372,23 @@ def test_agent_session_updates_all_packages_and_checks_updates(tmp_path) -> None
     source = "https://packages.example.invalid/review-pack.git"
     calls: list[str] = []
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         calls.append(record.source)
         record.target_path.mkdir(parents=True, exist_ok=True)
         return record.with_lifecycle("installed", target_path=record.target_path)
 
-    materializer = PackageMaterializer(install_root=tmp_path / "packages", backend=backend)
+    materializer = PackageMaterializer(
+        install_root=tmp_path / "packages", backend=backend
+    )
     materializer.prepare_remote_source(source)
     settings = SettingsManager(ControlConfig(plugin_sources=(source,)))
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
@@ -4319,19 +5417,29 @@ def test_agent_session_updates_and_checks_configured_package_sources(tmp_path) -
     source = "https://packages.example.invalid/review-pack.git"
     calls: list[str] = []
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         calls.append(record.source)
         record.target_path.mkdir(parents=True, exist_ok=True)
-        return record.with_lifecycle("installed", target_path=record.target_path).with_git_state(
+        return record.with_lifecycle(
+            "installed", target_path=record.target_path
+        ).with_git_state(
             installed_commit="abc123",
             resolved_commit="abc123",
         )
 
-    settings = SettingsManager(ControlConfig(package_sources=(PackageSourceConfig(source=source),)))
-    materializer = PackageMaterializer(install_root=tmp_path / "packages", backend=backend)
+    settings = SettingsManager(
+        ControlConfig(package_sources=(PackageSourceConfig(source=source),))
+    )
+    materializer = PackageMaterializer(
+        install_root=tmp_path / "packages", backend=backend
+    )
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
@@ -4344,7 +5452,9 @@ def test_agent_session_updates_and_checks_configured_package_sources(tmp_path) -
     assert updates[0]["status"] == "check_failed"
 
 
-def test_agent_session_update_packages_dedupes_configured_sources_by_identity(tmp_path) -> None:
+def test_agent_session_update_packages_dedupes_configured_sources_by_identity(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.agent import Agent
@@ -4371,12 +5481,16 @@ def test_agent_session_update_packages_dedupes_configured_sources_by_identity(tm
     )
     calls: list[str] = []
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         calls.append(record.source)
         record.target_path.mkdir(parents=True, exist_ok=True)
         return record.with_lifecycle("installed", target_path=record.target_path)
 
-    settings = SettingsManager(global_settings_path=global_settings, project_settings_path=project_settings)
+    settings = SettingsManager(
+        global_settings_path=global_settings, project_settings_path=project_settings
+    )
     materializer = PackageMaterializer(
         install_root=tmp_path / "packages",
         backend=backend,
@@ -4384,18 +5498,24 @@ def test_agent_session_update_packages_dedupes_configured_sources_by_identity(tm
     )
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path / "project"), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path / "project"), persist=False
+        ),
         settings_manager=settings,
         package_materializer=materializer,
     )
 
     records = asyncio.run(session.update_packages())
 
-    assert [record["source"] for record in records] == ["git+https://github.com/acme/review-pack"]
+    assert [record["source"] for record in records] == [
+        "git+https://github.com/acme/review-pack"
+    ]
     assert calls == ["git+https://github.com/acme/review-pack"]
 
 
-def test_agent_session_package_projection_dedupes_pinned_versions_by_package_identity(tmp_path) -> None:
+def test_agent_session_package_projection_dedupes_pinned_versions_by_package_identity(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.control import SettingsManager
     from loushang.coding.package import PackageMaterializer
@@ -4406,23 +5526,35 @@ def test_agent_session_package_projection_dedupes_pinned_versions_by_package_ide
     project_settings = tmp_path / "project" / ".loushang" / "settings.json"
     global_settings.parent.mkdir()
     project_settings.parent.mkdir(parents=True)
-    global_settings.write_text(json.dumps({"packages": ["pypi:acme-review-pack==1.2.3"]}), encoding="utf-8")
-    project_settings.write_text(json.dumps({"packages": ["pypi:acme-review-pack==1.3.0"]}), encoding="utf-8")
+    global_settings.write_text(
+        json.dumps({"packages": ["pypi:acme-review-pack==1.2.3"]}), encoding="utf-8"
+    )
+    project_settings.write_text(
+        json.dumps({"packages": ["pypi:acme-review-pack==1.3.0"]}), encoding="utf-8"
+    )
 
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path / "project"), persist=False),
-        settings_manager=SettingsManager(global_settings_path=global_settings, project_settings_path=project_settings),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path / "project"), persist=False
+        ),
+        settings_manager=SettingsManager(
+            global_settings_path=global_settings, project_settings_path=project_settings
+        ),
         package_materializer=PackageMaterializer(install_root=tmp_path / "packages"),
     )
 
     packages = session.get_packages()
 
-    assert [package["source"] for package in packages] == ["pypi:acme-review-pack==1.3.0"]
+    assert [package["source"] for package in packages] == [
+        "pypi:acme-review-pack==1.3.0"
+    ]
     assert "versionConflict" not in packages[0]
 
 
-def test_agent_session_configures_package_roots_from_all_settings_scopes(tmp_path) -> None:
+def test_agent_session_configures_package_roots_from_all_settings_scopes(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.control import SettingsManager
     from loushang.coding.loader import DefaultResourceLoader
@@ -4438,14 +5570,22 @@ def test_agent_session_configures_package_roots_from_all_settings_scopes(tmp_pat
     project_settings.parent.mkdir(parents=True)
     global_pack.mkdir(parents=True)
     project_pack.mkdir(parents=True)
-    global_settings.write_text(json.dumps({"packages": ["packages/global-pack"]}), encoding="utf-8")
-    project_settings.write_text(json.dumps({"packages": ["packages/project-pack"]}), encoding="utf-8")
+    global_settings.write_text(
+        json.dumps({"packages": ["packages/global-pack"]}), encoding="utf-8"
+    )
+    project_settings.write_text(
+        json.dumps({"packages": ["packages/project-pack"]}), encoding="utf-8"
+    )
 
-    settings = SettingsManager(global_settings_path=global_settings, project_settings_path=project_settings)
+    settings = SettingsManager(
+        global_settings_path=global_settings, project_settings_path=project_settings
+    )
     loader = DefaultResourceLoader()
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path / "project"), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path / "project"), persist=False
+        ),
         settings_manager=settings,
         resource_loader=loader,
         package_materializer=PackageMaterializer(install_root=tmp_path / "packages"),
@@ -4459,7 +5599,9 @@ def test_agent_session_configures_package_roots_from_all_settings_scopes(tmp_pat
     )
 
 
-def test_agent_session_configures_same_relative_package_roots_from_distinct_scopes(tmp_path) -> None:
+def test_agent_session_configures_same_relative_package_roots_from_distinct_scopes(
+    tmp_path,
+) -> None:
     from loushang.agent import Agent
     from loushang.coding.control import SettingsManager
     from loushang.coding.loader import DefaultResourceLoader
@@ -4475,14 +5617,22 @@ def test_agent_session_configures_same_relative_package_roots_from_distinct_scop
     project_settings.parent.mkdir(parents=True)
     global_pack.mkdir(parents=True)
     project_pack.mkdir(parents=True)
-    global_settings.write_text(json.dumps({"packages": ["packages/shared-pack"]}), encoding="utf-8")
-    project_settings.write_text(json.dumps({"packages": ["packages/shared-pack"]}), encoding="utf-8")
+    global_settings.write_text(
+        json.dumps({"packages": ["packages/shared-pack"]}), encoding="utf-8"
+    )
+    project_settings.write_text(
+        json.dumps({"packages": ["packages/shared-pack"]}), encoding="utf-8"
+    )
 
-    settings = SettingsManager(global_settings_path=global_settings, project_settings_path=project_settings)
+    settings = SettingsManager(
+        global_settings_path=global_settings, project_settings_path=project_settings
+    )
     loader = DefaultResourceLoader()
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path / "project"), persist=False),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path / "project"), persist=False
+        ),
         settings_manager=settings,
         resource_loader=loader,
         package_materializer=PackageMaterializer(install_root=tmp_path / "packages"),
@@ -4512,20 +5662,30 @@ def test_agent_session_records_package_update_check_failures(tmp_path) -> None:
 
     source = (tmp_path / "missing.git").as_uri()
 
-    async def backend(record: PackageMaterializationRecord) -> PackageMaterializationRecord:
+    async def backend(
+        record: PackageMaterializationRecord,
+    ) -> PackageMaterializationRecord:
         record.target_path.mkdir(parents=True, exist_ok=True)
-        return record.with_lifecycle("installed", target_path=record.target_path).with_git_state(
+        return record.with_lifecycle(
+            "installed", target_path=record.target_path
+        ).with_git_state(
             installed_commit="abc123",
             resolved_commit="abc123",
         )
 
     diagnostics = DiagnosticsService()
-    materializer = PackageMaterializer(install_root=tmp_path / "packages", backend=backend)
+    materializer = PackageMaterializer(
+        install_root=tmp_path / "packages", backend=backend
+    )
     asyncio.run(materializer.materialize_remote_source(source))
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
-        settings_manager=SettingsManager(ControlConfig(package_sources=(PackageSourceConfig(source=source),))),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
+        settings_manager=SettingsManager(
+            ControlConfig(package_sources=(PackageSourceConfig(source=source),))
+        ),
         package_materializer=materializer,
         diagnostics_service=diagnostics,
     )
@@ -4551,13 +5711,21 @@ def test_agent_session_records_package_version_conflict_diagnostics(tmp_path) ->
     second = tmp_path / "plugins" / "debug-pack-b"
     first.mkdir(parents=True)
     second.mkdir(parents=True)
-    (first / "plugin.json").write_text(json.dumps({"name": "debug-pack", "version": "1.0.0"}), encoding="utf-8")
-    (second / "plugin.json").write_text(json.dumps({"name": "debug-pack", "version": "2.0.0"}), encoding="utf-8")
+    (first / "plugin.json").write_text(
+        json.dumps({"name": "debug-pack", "version": "1.0.0"}), encoding="utf-8"
+    )
+    (second / "plugin.json").write_text(
+        json.dumps({"name": "debug-pack", "version": "2.0.0"}), encoding="utf-8"
+    )
     diagnostics = DiagnosticsService()
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False),
-        settings_manager=SettingsManager(ControlConfig(plugin_sources=(str(first), str(second)))),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(tmp_path), persist=False
+        ),
+        settings_manager=SettingsManager(
+            ControlConfig(plugin_sources=(str(first), str(second)))
+        ),
         diagnostics_service=diagnostics,
     )
 
@@ -4581,7 +5749,9 @@ def test_agent_session_exposes_jsonl_and_html_export_methods(tmp_path) -> None:
 
     project_dir = tmp_path / "project"
     project_dir.mkdir()
-    manager = SessionManager.new(session_dir=tmp_path, cwd=str(project_dir), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(project_dir), persist=False
+    )
     manager.append_message(
         UserMessage(
             role="user",
@@ -4590,7 +5760,13 @@ def test_agent_session_exposes_jsonl_and_html_export_methods(tmp_path) -> None:
         )
     )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
     )
 
@@ -4629,8 +5805,16 @@ def test_agent_session_exposes_diagnostics_views(tmp_path) -> None:
         )
     )
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        ),
         diagnostics_service=diagnostics_service,
     )
 
@@ -4667,7 +5851,9 @@ def test_agent_session_set_model_records_auth_resolution_failures(tmp_path) -> N
             name="Open",
             provider="demo",
             endpoint="responses",
-            capabilities=Capabilities(reasoning=True, input=("text",), context_window=128000, max_tokens=4096),
+            capabilities=Capabilities(
+                reasoning=True, input=("text",), context_window=128000, max_tokens=4096
+            ),
         )
     )
     ai_registry.register_model(
@@ -4676,14 +5862,24 @@ def test_agent_session_set_model_records_auth_resolution_failures(tmp_path) -> N
             name="Secured",
             provider="demo",
             endpoint="responses",
-            capabilities=Capabilities(reasoning=True, input=("text",), context_window=128000, max_tokens=4096),
+            capabilities=Capabilities(
+                reasoning=True, input=("text",), context_window=128000, max_tokens=4096
+            ),
         )
     )
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     diagnostics_service = DiagnosticsService()
     session = AgentSession(
-        agent=Agent(initial_state={"system_prompt": "", "model": _model(), "thinking_level": "off"}),
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
         session_manager=manager,
         model_registry=ModelRegistry(ai_registry=ai_registry),
         auth_manager=AuthManager(ai_registry=ai_registry, env={}),
@@ -4692,9 +5888,15 @@ def test_agent_session_set_model_records_auth_resolution_failures(tmp_path) -> N
 
     asyncio.run(session.set_model(ModelSelection(provider="demo", model_id="secured")))
 
-    diagnostics = [record for record in session.get_last_diagnostics() if record.code == "model_auth_unresolved"]
+    diagnostics = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "model_auth_unresolved"
+    ]
 
-    assert session.get_model_selection() == ModelSelection(provider="demo", model_id="secured")
+    assert session.get_model_selection() == ModelSelection(
+        provider="demo", model_id="secured"
+    )
     assert len(diagnostics) == 1
     assert diagnostics[0].type == "warning"
     assert diagnostics[0].details["provider"] == "demo"
@@ -4712,7 +5914,9 @@ def test_agent_session_serializes_async_queue_updates_for_steer(tmp_path) -> Non
 
     async def scenario() -> None:
         agent = Agent(stream_fn=stream_fn)
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         session = AgentSession(agent=agent, session_manager=manager)
         agent.state.messages.append(_assistant_text_message("existing"))
 
@@ -4729,7 +5933,11 @@ def test_agent_session_serializes_async_queue_updates_for_steer(tmp_path) -> Non
         assert event_types[0] == "queue_update"
         assert event_types.count("queue_update") == 2
         assert event_types.index("agent_start") > 0
-        queue_update_indexes = [index for index, event_type in enumerate(event_types) if event_type == "queue_update"]
+        queue_update_indexes = [
+            index
+            for index, event_type in enumerate(event_types)
+            if event_type == "queue_update"
+        ]
         assert queue_update_indexes[1] < event_types.index("message_start")
 
     asyncio.run(scenario())
@@ -4747,7 +5955,9 @@ def test_agent_session_serializes_async_queue_updates_for_follow_up(tmp_path) ->
 
     async def scenario() -> None:
         agent = Agent(stream_fn=stream_fn)
-        manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+        manager = SessionManager.new(
+            session_dir=tmp_path, cwd="/tmp/project", persist=False
+        )
         session = AgentSession(agent=agent, session_manager=manager)
         agent.state.messages.append(_assistant_text_message("existing"))
 
@@ -4764,7 +5974,11 @@ def test_agent_session_serializes_async_queue_updates_for_follow_up(tmp_path) ->
         assert event_types[0] == "queue_update"
         assert event_types.count("queue_update") == 2
         assert event_types.index("agent_start") > 0
-        queue_update_indexes = [index for index, event_type in enumerate(event_types) if event_type == "queue_update"]
+        queue_update_indexes = [
+            index
+            for index, event_type in enumerate(event_types)
+            if event_type == "queue_update"
+        ]
         assert queue_update_indexes[1] < event_types.index("message_start")
 
     asyncio.run(scenario())

--- a/tests/coding/test_agent_session_runtime.py
+++ b/tests/coding/test_agent_session_runtime.py
@@ -70,12 +70,16 @@ def test_runtime_create_switch_and_list_sessions(tmp_path) -> None:
     project_a.mkdir()
     project_b.mkdir()
 
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
 
     first = asyncio.run(runtime.create_session(cwd=str(project_a)))
     first.session_manager.append_message(_user_message("first"))
 
-    second_manager = SessionManager.new(session_dir=tmp_path, cwd=str(project_b.resolve()), persist=True)
+    second_manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(project_b.resolve()), persist=True
+    )
     second_manager.append_message(_user_message("second"))
     assert second_manager.session_file is not None
 
@@ -83,8 +87,13 @@ def test_runtime_create_switch_and_list_sessions(tmp_path) -> None:
     records = runtime.list_sessions()
 
     assert runtime.get_current_session() is switched
-    assert [message.content[0].text for message in switched.get_session_context().messages] == ["second"]
-    assert [record.cwd for record in records] == [str(project_b.resolve()), str(project_a.resolve())]
+    assert [
+        message.content[0].text for message in switched.get_session_context().messages
+    ] == ["second"]
+    assert [record.cwd for record in records] == [
+        str(project_b.resolve()),
+        str(project_a.resolve()),
+    ]
 
 
 def test_runtime_clone_session_forks_current_leaf(tmp_path) -> None:
@@ -92,7 +101,9 @@ def test_runtime_clone_session_forks_current_leaf(tmp_path) -> None:
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     session = asyncio.run(runtime.create_session(cwd=str(project)))
     session.session_manager.append_message(_user_message("first"))
     session.session_manager.append_message(_assistant_message("second"))
@@ -103,7 +114,9 @@ def test_runtime_clone_session_forks_current_leaf(tmp_path) -> None:
     assert runtime.get_current_session() is cloned
     assert cloned.session_manager.session_file != session.session_manager.session_file
     assert cloned.session_manager.get_leaf_id() == leaf_id
-    assert [message.content[0].text for message in cloned.get_session_context().messages] == ["first", "second"]
+    assert [
+        message.content[0].text for message in cloned.get_session_context().messages
+    ] == ["first", "second"]
 
 
 def test_runtime_lists_session_summaries(tmp_path) -> None:
@@ -111,7 +124,9 @@ def test_runtime_lists_session_summaries(tmp_path) -> None:
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     session = asyncio.run(runtime.create_session(cwd=str(project)))
     session.set_session_name("Runtime Summary")
     asyncio.run(session.set_model(_model()))
@@ -134,17 +149,25 @@ def test_runtime_finds_session_summaries(tmp_path) -> None:
     project_b = tmp_path / "project-b"
     project_a.mkdir()
     project_b.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
 
     first = asyncio.run(runtime.create_session(cwd=str(project_a)))
     first.set_session_name("Alpha")
     first.session_manager.append_message(_user_message("alpha repository task"))
 
-    second = asyncio.run(runtime.create_session(cwd=str(project_b), parent_session=str(first.session_file)))
+    second = asyncio.run(
+        runtime.create_session(
+            cwd=str(project_b), parent_session=str(first.session_file)
+        )
+    )
     second.set_session_name("Beta")
     second.session_manager.append_message(_user_message("beta follow up"))
 
-    summaries = runtime.find_session_summaries(SessionQuery(name="bet", text="follow", limit=1))
+    summaries = runtime.find_session_summaries(
+        SessionQuery(name="bet", text="follow", limit=1)
+    )
 
     assert [summary.session_id for summary in summaries] == [second.session_id]
 
@@ -155,10 +178,14 @@ def test_runtime_renames_and_deletes_sessions_by_resolved_reference(tmp_path) ->
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     current = asyncio.run(runtime.create_session(cwd=str(project)))
 
-    other_manager = SessionManager.new(session_dir=tmp_path, cwd=str(project), persist=True)
+    other_manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(project), persist=True
+    )
     other_file = other_manager.get_session_file()
     assert other_file is not None
 
@@ -179,7 +206,9 @@ def test_runtime_delete_session_refuses_current_session(tmp_path) -> None:
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     current = asyncio.run(runtime.create_session(cwd=str(project)))
     session_file = current.session_manager.get_session_file()
     assert session_file is not None
@@ -217,7 +246,9 @@ def test_runtime_rename_session_records_failure_diagnostic(tmp_path) -> None:
     with pytest.raises(FileNotFoundError):
         runtime.rename_session("missing-session", "New Name")
 
-    records = diagnostics_service.get_diagnostics(query=DiagnosticsQuery(code="session_rename_failed"))
+    records = diagnostics_service.get_diagnostics(
+        query=DiagnosticsQuery(code="session_rename_failed")
+    )
 
     assert runtime.get_current_session() is current
     assert len(records) == 1
@@ -257,7 +288,9 @@ def test_runtime_delete_session_records_failure_diagnostic(tmp_path) -> None:
     with pytest.raises(FileNotFoundError):
         runtime.delete_session("missing-session")
 
-    records = diagnostics_service.get_diagnostics(query=DiagnosticsQuery(code="session_delete_failed"))
+    records = diagnostics_service.get_diagnostics(
+        query=DiagnosticsQuery(code="session_delete_failed")
+    )
 
     assert runtime.get_current_session() is current
     assert len(records) == 1
@@ -277,8 +310,12 @@ def test_runtime_lists_all_session_summaries_across_session_dirs(tmp_path) -> No
     project_a.mkdir()
     project_b.mkdir()
     sessions_root = tmp_path / "sessions"
-    runtime_a = create_agent_session_runtime(session_dir=sessions_root / "project-a", model=_model(), persist=True)
-    runtime_b = create_agent_session_runtime(session_dir=sessions_root / "project-b", model=_model(), persist=True)
+    runtime_a = create_agent_session_runtime(
+        session_dir=sessions_root / "project-a", model=_model(), persist=True
+    )
+    runtime_b = create_agent_session_runtime(
+        session_dir=sessions_root / "project-b", model=_model(), persist=True
+    )
 
     first = asyncio.run(runtime_a.create_session(cwd=str(project_a)))
     first.set_session_name("Alpha")
@@ -287,7 +324,10 @@ def test_runtime_lists_all_session_summaries_across_session_dirs(tmp_path) -> No
 
     summaries = runtime_a.list_all_session_summaries()
 
-    assert {summary.session_id for summary in summaries} == {first.session_id, second.session_id}
+    assert {summary.session_id for summary in summaries} == {
+        first.session_id,
+        second.session_id,
+    }
     assert {summary.name for summary in summaries} == {"Alpha", "Beta"}
 
 
@@ -300,8 +340,12 @@ def test_runtime_finds_all_session_summaries_across_session_dirs(tmp_path) -> No
     project_a.mkdir()
     project_b.mkdir()
     sessions_root = tmp_path / "sessions"
-    runtime_a = create_agent_session_runtime(session_dir=sessions_root / "project-a", model=_model(), persist=True)
-    runtime_b = create_agent_session_runtime(session_dir=sessions_root / "project-b", model=_model(), persist=True)
+    runtime_a = create_agent_session_runtime(
+        session_dir=sessions_root / "project-a", model=_model(), persist=True
+    )
+    runtime_b = create_agent_session_runtime(
+        session_dir=sessions_root / "project-b", model=_model(), persist=True
+    )
 
     asyncio.run(runtime_a.create_session(cwd=str(project_a))).set_session_name("Alpha")
     second = asyncio.run(runtime_b.create_session(cwd=str(project_b)))
@@ -322,23 +366,39 @@ def test_runtime_exposes_indexed_session_summary_facades(tmp_path) -> None:
     project_a.mkdir()
     project_b.mkdir()
     sessions_root = tmp_path / "sessions"
-    runtime_a = create_agent_session_runtime(session_dir=sessions_root / "project-a", model=_model(), persist=True)
-    runtime_b = create_agent_session_runtime(session_dir=sessions_root / "project-b", model=_model(), persist=True)
+    runtime_a = create_agent_session_runtime(
+        session_dir=sessions_root / "project-a", model=_model(), persist=True
+    )
+    runtime_b = create_agent_session_runtime(
+        session_dir=sessions_root / "project-b", model=_model(), persist=True
+    )
 
     first = asyncio.run(runtime_a.create_session(cwd=str(project_a)))
     first.session_manager.append_message(_user_message("indexed alpha"))
     second = asyncio.run(runtime_b.create_session(cwd=str(project_b)))
     second.session_manager.append_message(_user_message("indexed beta"))
 
-    assert [summary.session_id for summary in runtime_a.refresh_session_index()] == [first.session_id]
-    assert [summary.session_id for summary in runtime_a.list_indexed_session_summaries()] == [first.session_id]
-    assert [summary.session_id for summary in runtime_a.find_indexed_session_summaries(SessionQuery(text="alpha"))] == [
+    assert [summary.session_id for summary in runtime_a.refresh_session_index()] == [
         first.session_id
     ]
-    assert [summary.session_id for summary in runtime_a.refresh_all_session_indexes()] == [second.session_id, first.session_id]
-    assert [summary.session_id for summary in runtime_a.find_all_indexed_session_summaries(SessionQuery(text="beta"))] == [
-        second.session_id
-    ]
+    assert [
+        summary.session_id for summary in runtime_a.list_indexed_session_summaries()
+    ] == [first.session_id]
+    assert [
+        summary.session_id
+        for summary in runtime_a.find_indexed_session_summaries(
+            SessionQuery(text="alpha")
+        )
+    ] == [first.session_id]
+    assert [
+        summary.session_id for summary in runtime_a.refresh_all_session_indexes()
+    ] == [second.session_id, first.session_id]
+    assert [
+        summary.session_id
+        for summary in runtime_a.find_all_indexed_session_summaries(
+            SessionQuery(text="beta")
+        )
+    ] == [second.session_id]
 
 
 def test_runtime_auto_refreshes_session_index_after_replacement(tmp_path) -> None:
@@ -347,7 +407,9 @@ def test_runtime_auto_refreshes_session_index_after_replacement(tmp_path) -> Non
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     runtime.auto_refresh_session_index = True
     runtime.session_index_flush_delay = 0.01
 
@@ -360,7 +422,9 @@ def test_runtime_auto_refreshes_session_index_after_replacement(tmp_path) -> Non
     session = asyncio.run(scenario())
 
     assert SessionManager.index_file(tmp_path).exists()
-    assert [summary.session_id for summary in runtime.list_indexed_session_summaries()] == [session.session_id]
+    assert [
+        summary.session_id for summary in runtime.list_indexed_session_summaries()
+    ] == [session.session_id]
 
 
 def test_runtime_auto_refreshes_session_index_after_rename_and_delete(tmp_path) -> None:
@@ -388,18 +452,23 @@ def test_runtime_auto_refreshes_session_index_after_rename_and_delete(tmp_path) 
         runtime.rename_session(first.get_header().id, "Renamed")
         assert SessionManager.load_index(tmp_path) == []
         await runtime.drain_session_index_flush()
-        assert next(
-            summary
-            for summary in SessionManager.load_index(tmp_path)
-            if summary.session_id == first.get_header().id
-        ).name == "Renamed"
+        assert (
+            next(
+                summary
+                for summary in SessionManager.load_index(tmp_path)
+                if summary.session_id == first.get_header().id
+            ).name
+            == "Renamed"
+        )
 
         runtime.delete_session(second.get_header().id)
         await runtime.drain_session_index_flush()
 
     asyncio.run(scenario())
 
-    assert {summary.session_id for summary in SessionManager.load_index(tmp_path)} == {first.get_header().id}
+    assert {summary.session_id for summary in SessionManager.load_index(tmp_path)} == {
+        first.get_header().id
+    }
 
 
 def test_runtime_auto_index_refresh_uses_debounce_interval(tmp_path) -> None:
@@ -408,7 +477,9 @@ def test_runtime_auto_index_refresh_uses_debounce_interval(tmp_path) -> None:
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     runtime.auto_refresh_session_index = True
     runtime.session_index_refresh_interval = 60.0
 
@@ -434,7 +505,9 @@ def test_runtime_list_sessions_ignores_default_jsonl_exports(tmp_path) -> None:
 
     project_root = tmp_path / "project"
     project_root.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     session = asyncio.run(runtime.create_session(cwd=str(project_root)))
     session.session_manager.append_message(_user_message("first"))
 
@@ -452,7 +525,9 @@ def test_runtime_list_sessions_skips_invalid_session_files(tmp_path) -> None:
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     session = asyncio.run(runtime.create_session(cwd=str(project)))
     session.session_manager.append_message(_user_message("hello"))
 
@@ -492,8 +567,13 @@ def test_runtime_fork_session_switches_to_selected_branch(tmp_path) -> None:
     assert forked.session_manager.session_file is not None
     assert forked.session_manager.session_file != original_file
     assert forked.session_manager.get_header().parent_session == str(original_file)
-    assert [entry.id for entry in forked.session_manager.get_branch()] == [first_id, second_id]
-    assert [message.content[0].text for message in forked.get_session_context().messages] == ["root", "answer"]
+    assert [entry.id for entry in forked.session_manager.get_branch()] == [
+        first_id,
+        second_id,
+    ]
+    assert [
+        message.content[0].text for message in forked.get_session_context().messages
+    ] == ["root", "answer"]
     expected_context = (
         "# Project Context\n\n"
         "Project-specific instructions and guidelines:\n\n"
@@ -505,22 +585,31 @@ def test_runtime_fork_session_switches_to_selected_branch(tmp_path) -> None:
     )
 
 
-def test_runtime_fork_session_before_user_message_returns_selected_text(tmp_path) -> None:
+def test_runtime_fork_session_before_user_message_returns_selected_text(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session_runtime
 
     project_root = tmp_path / "project"
     project_root.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     session = asyncio.run(runtime.create_session(cwd=str(project_root)))
     first_id = session.session_manager.append_message(_user_message("root"))
     second_id = session.session_manager.append_message(_assistant_message("answer"))
     third_id = session.session_manager.append_message(_user_message("tail"))
 
-    forked, selected_text = asyncio.run(runtime.fork_session_with_result(third_id, position="before"))
+    forked, selected_text = asyncio.run(
+        runtime.fork_session_with_result(third_id, position="before")
+    )
 
     assert runtime.get_current_session() is forked
     assert selected_text == "tail"
-    assert [entry.id for entry in forked.session_manager.get_branch()] == [first_id, second_id]
+    assert [entry.id for entry in forked.session_manager.get_branch()] == [
+        first_id,
+        second_id,
+    ]
 
 
 def test_runtime_fork_before_requires_user_message(tmp_path) -> None:
@@ -530,7 +619,9 @@ def test_runtime_fork_before_requires_user_message(tmp_path) -> None:
 
     project_root = tmp_path / "project"
     project_root.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     session = asyncio.run(runtime.create_session(cwd=str(project_root)))
     session.session_manager.append_message(_user_message("root"))
     assistant_id = session.session_manager.append_message(_assistant_message("answer"))
@@ -544,7 +635,9 @@ def test_runtime_exposes_pi_style_lifecycle_method_aliases(tmp_path) -> None:
 
     project_root = tmp_path / "project"
     project_root.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     session = asyncio.run(runtime.create_session(cwd=str(project_root)))
     first_id = session.session_manager.append_message(_user_message("root"))
     second_id = session.session_manager.append_message(_assistant_message("answer"))
@@ -554,17 +647,29 @@ def test_runtime_exposes_pi_style_lifecycle_method_aliases(tmp_path) -> None:
 
     fork_result = asyncio.run(runtime.fork(third_id))
     forked = runtime.get_current_session()
-    assert fork_result == {"cancelled": False, "selectedText": "tail", "selected_text": "tail"}
+    assert fork_result == {
+        "cancelled": False,
+        "selectedText": "tail",
+        "selected_text": "tail",
+    }
     assert forked is not None
-    assert [entry.id for entry in forked.session_manager.get_branch()] == [first_id, second_id]
+    assert [entry.id for entry in forked.session_manager.get_branch()] == [
+        first_id,
+        second_id,
+    ]
 
     switch_result = asyncio.run(runtime.switchSession(first_session_file))
     assert switch_result == {"cancelled": False}
     assert runtime.get_current_session() is not forked
 
-    new_result = asyncio.run(runtime.newSession({"parentSession": str(first_session_file)}))
+    new_result = asyncio.run(
+        runtime.newSession({"parentSession": str(first_session_file)})
+    )
     assert new_result == {"cancelled": False}
-    assert runtime.get_current_session().session_manager.get_header().parent_session == str(first_session_file)
+    assert (
+        runtime.get_current_session().session_manager.get_header().parent_session
+        == str(first_session_file)
+    )
 
 
 def test_runtime_pi_style_new_session_runs_setup_and_with_session(tmp_path) -> None:
@@ -572,7 +677,9 @@ def test_runtime_pi_style_new_session_runs_setup_and_with_session(tmp_path) -> N
 
     project_root = tmp_path / "project"
     project_root.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     session = asyncio.run(runtime.create_session(cwd=str(project_root)))
     first_session_file = session.session_manager.session_file
     assert first_session_file is not None
@@ -583,23 +690,39 @@ def test_runtime_pi_style_new_session_runs_setup_and_with_session(tmp_path) -> N
         manager.append_message(_user_message("initialized from setup"))
 
     async def _with_session(ctx):
-        events.append(("withSession", (ctx.cwd, ctx.sessionManager is runtime.get_current_session().session_manager)))
+        events.append(
+            (
+                "withSession",
+                (
+                    ctx.cwd,
+                    ctx.sessionManager is runtime.get_current_session().session_manager,
+                ),
+            )
+        )
 
-    result = asyncio.run(runtime.newSession(
-        {
-            "parentSession": str(first_session_file),
-            "setup": _setup,
-            "withSession": _with_session,
-        }
-    ))
+    result = asyncio.run(
+        runtime.newSession(
+            {
+                "parentSession": str(first_session_file),
+                "setup": _setup,
+                "withSession": _with_session,
+            }
+        )
+    )
     created = runtime.get_current_session()
 
     assert result == {"cancelled": False}
     assert created is not None
     assert created is not session
-    assert created.session_manager.get_header().parent_session == str(first_session_file)
-    assert [message.content[0].text for message in created.get_session_context().messages] == ["initialized from setup"]
-    assert [message.content[0].text for message in created.agent.state.messages] == ["initialized from setup"]
+    assert created.session_manager.get_header().parent_session == str(
+        first_session_file
+    )
+    assert [
+        message.content[0].text for message in created.get_session_context().messages
+    ] == ["initialized from setup"]
+    assert [message.content[0].text for message in created.agent.state.messages] == [
+        "initialized from setup"
+    ]
     assert events == [
         ("setup", str(project_root.resolve())),
         ("withSession", (str(project_root.resolve()), True)),
@@ -612,12 +735,16 @@ def test_runtime_pi_style_switch_and_fork_run_with_session(tmp_path) -> None:
 
     project_root = tmp_path / "project"
     project_root.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     session = asyncio.run(runtime.create_session(cwd=str(project_root)))
     user_id = session.session_manager.append_message(_user_message("root"))
     session.session_manager.append_message(_assistant_message("answer"))
 
-    target_manager = SessionManager.new(session_dir=tmp_path, cwd=str(project_root), persist=True)
+    target_manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(project_root), persist=True
+    )
     target_manager.append_message(_user_message("target"))
     target_file = target_manager.session_file
     assert target_file is not None
@@ -625,17 +752,29 @@ def test_runtime_pi_style_switch_and_fork_run_with_session(tmp_path) -> None:
     events: list[tuple[str, object]] = []
 
     async def _switch_with_session(ctx):
-        events.append(("switch", [message.content[0].text for message in ctx.sessionManager.build_session_context().messages]))
+        events.append(
+            (
+                "switch",
+                [
+                    message.content[0].text
+                    for message in ctx.sessionManager.build_session_context().messages
+                ],
+            )
+        )
 
     async def _fork_with_session(ctx):
         events.append(("fork", [entry.id for entry in ctx.sessionManager.get_branch()]))
 
-    switch_result = asyncio.run(runtime.switchSession(target_file, {"withSession": _switch_with_session}))
+    switch_result = asyncio.run(
+        runtime.switchSession(target_file, {"withSession": _switch_with_session})
+    )
     switch_session = runtime.get_current_session()
     assert switch_session is not None
 
     asyncio.run(runtime.switchSession(session.session_manager.session_file))
-    fork_result = asyncio.run(runtime.fork(user_id, {"position": "at", "withSession": _fork_with_session}))
+    fork_result = asyncio.run(
+        runtime.fork(user_id, {"position": "at", "withSession": _fork_with_session})
+    )
 
     assert switch_result == {"cancelled": False}
     assert fork_result == {"cancelled": False}
@@ -652,7 +791,9 @@ def test_runtime_replacement_callbacks_require_async_callables(tmp_path) -> None
 
     project_root = tmp_path / "project"
     project_root.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     asyncio.run(runtime.create_session(cwd=str(project_root)))
 
     def _sync_setup(manager):
@@ -662,7 +803,9 @@ def test_runtime_replacement_callbacks_require_async_callables(tmp_path) -> None
         asyncio.run(runtime.newSession({"setup": _sync_setup}))
 
 
-def test_runtime_replacement_callback_failures_keep_replacement_and_record_diagnostics(tmp_path) -> None:
+def test_runtime_replacement_callback_failures_keep_replacement_and_record_diagnostics(
+    tmp_path,
+) -> None:
     import pytest
 
     from loushang.coding.diagnostics import DiagnosticsQuery, DiagnosticsService
@@ -691,7 +834,9 @@ def test_runtime_replacement_callback_failures_keep_replacement_and_record_diagn
     target_root = tmp_path / "target"
     project_root.mkdir()
     target_root.mkdir()
-    target_manager = SessionManager.new(session_dir=tmp_path, cwd=str(target_root), persist=True)
+    target_manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(target_root), persist=True
+    )
     target_file = target_manager.session_file
     assert target_file is not None
 
@@ -736,11 +881,15 @@ def test_runtime_import_from_jsonl_copies_and_switches_session(tmp_path) -> None
     project_root.mkdir()
     import_dir = tmp_path / "imports"
     import_dir.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path / "sessions", model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path / "sessions", model=_model(), persist=True
+    )
     original = asyncio.run(runtime.create_session(cwd=str(project_root)))
     original.session_manager.append_message(_user_message("original"))
 
-    imported_manager = SessionManager.new(session_dir=import_dir, cwd=str(project_root), persist=True)
+    imported_manager = SessionManager.new(
+        session_dir=import_dir, cwd=str(project_root), persist=True
+    )
     imported_manager.append_message(_user_message("imported"))
     imported_file = imported_manager.session_file
     assert imported_file is not None
@@ -751,12 +900,19 @@ def test_runtime_import_from_jsonl_copies_and_switches_session(tmp_path) -> None
     assert result == {"cancelled": False}
     assert current is not None
     assert current is not original
-    assert current.session_manager.session_file == (tmp_path / "sessions" / imported_file.name).resolve()
+    assert (
+        current.session_manager.session_file
+        == (tmp_path / "sessions" / imported_file.name).resolve()
+    )
     assert current.session_manager.session_file.exists()
-    assert [message.content[0].text for message in current.get_session_context().messages] == ["imported"]
+    assert [
+        message.content[0].text for message in current.get_session_context().messages
+    ] == ["imported"]
 
 
-def test_runtime_import_from_jsonl_does_not_overwrite_existing_same_name_session(tmp_path) -> None:
+def test_runtime_import_from_jsonl_does_not_overwrite_existing_same_name_session(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session_runtime
     from loushang.coding.store import SessionManager
 
@@ -765,13 +921,17 @@ def test_runtime_import_from_jsonl_does_not_overwrite_existing_same_name_session
     session_dir = tmp_path / "sessions"
     project_root.mkdir()
     import_dir.mkdir()
-    runtime = create_agent_session_runtime(session_dir=session_dir, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=session_dir, model=_model(), persist=True
+    )
     existing = asyncio.run(runtime.create_session(cwd=str(project_root)))
     existing.session_manager.append_message(_user_message("existing session"))
     existing_file = existing.session_manager.session_file
     assert existing_file is not None
 
-    imported_manager = SessionManager.new(session_dir=import_dir, cwd=str(project_root), persist=True)
+    imported_manager = SessionManager.new(
+        session_dir=import_dir, cwd=str(project_root), persist=True
+    )
     imported_manager.append_message(_user_message("imported same basename"))
     imported_file = imported_manager.session_file
     assert imported_file is not None
@@ -787,12 +947,14 @@ def test_runtime_import_from_jsonl_does_not_overwrite_existing_same_name_session
     assert current.session_manager.session_file != existing_file
     assert current.session_manager.session_file is not None
     assert current.session_manager.session_file.exists()
-    assert [message.content[0].text for message in current.session_manager.build_session_context().messages] == [
-        "imported same basename"
-    ]
-    assert [message.content[0].text for message in reloaded_existing.build_session_context().messages] == [
-        "existing session"
-    ]
+    assert [
+        message.content[0].text
+        for message in current.session_manager.build_session_context().messages
+    ] == ["imported same basename"]
+    assert [
+        message.content[0].text
+        for message in reloaded_existing.build_session_context().messages
+    ] == ["existing session"]
 
 
 def test_runtime_import_from_jsonl_retries_when_unique_destination_is_claimed_before_copy(
@@ -810,13 +972,17 @@ def test_runtime_import_from_jsonl_retries_when_unique_destination_is_claimed_be
     session_dir = tmp_path / "sessions"
     project_root.mkdir()
     import_dir.mkdir()
-    runtime = create_agent_session_runtime(session_dir=session_dir, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=session_dir, model=_model(), persist=True
+    )
     existing = asyncio.run(runtime.create_session(cwd=str(project_root)))
     existing.session_manager.append_message(_user_message("existing session"))
     existing_file = existing.session_manager.session_file
     assert existing_file is not None
 
-    imported_manager = SessionManager.new(session_dir=import_dir, cwd=str(project_root), persist=True)
+    imported_manager = SessionManager.new(
+        session_dir=import_dir, cwd=str(project_root), persist=True
+    )
     imported_manager.append_message(_user_message("imported after race"))
     imported_file = imported_manager.session_file
     assert imported_file is not None
@@ -848,9 +1014,10 @@ def test_runtime_import_from_jsonl_retries_when_unique_destination_is_claimed_be
     ]
     assert copy_attempts[0].read_text(encoding="utf-8") == "external winner\n"
     assert current.session_manager.session_file == copy_attempts[1]
-    assert [message.content[0].text for message in current.session_manager.build_session_context().messages] == [
-        "imported after race"
-    ]
+    assert [
+        message.content[0].text
+        for message in current.session_manager.build_session_context().messages
+    ] == ["imported after race"]
 
 
 def test_runtime_import_from_jsonl_race_retry_emits_before_switch_once_for_final_destination(
@@ -911,7 +1078,9 @@ def test_runtime_import_from_jsonl_race_retry_emits_before_switch_once_for_final
     existing_file = existing.session_manager.session_file
     assert existing_file is not None
 
-    imported_manager = SessionManager.new(session_dir=import_dir, cwd=str(project_root), persist=True)
+    imported_manager = SessionManager.new(
+        session_dir=import_dir, cwd=str(project_root), persist=True
+    )
     imported_manager.append_message(_user_message("imported after race"))
     imported_file = imported_manager.session_file
     assert imported_file is not None
@@ -940,7 +1109,9 @@ def test_runtime_import_from_jsonl_race_retry_emits_before_switch_once_for_final
     assert seen_targets == [str(final_destination)]
 
 
-def test_runtime_import_from_jsonl_cleans_copied_file_when_stored_cwd_is_missing(tmp_path) -> None:
+def test_runtime_import_from_jsonl_cleans_copied_file_when_stored_cwd_is_missing(
+    tmp_path,
+) -> None:
     import pytest
 
     from loushang.coding.bootstrap import create_agent_session_runtime
@@ -953,9 +1124,13 @@ def test_runtime_import_from_jsonl_cleans_copied_file_when_stored_cwd_is_missing
     session_dir = tmp_path / "sessions"
     project_root.mkdir()
     import_dir.mkdir()
-    runtime = create_agent_session_runtime(session_dir=session_dir, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=session_dir, model=_model(), persist=True
+    )
     current = asyncio.run(runtime.create_session(cwd=str(project_root)))
-    imported_manager = SessionManager.new(session_dir=import_dir, cwd=str(missing_cwd), persist=True)
+    imported_manager = SessionManager.new(
+        session_dir=import_dir, cwd=str(missing_cwd), persist=True
+    )
     imported_manager.append_message(_user_message("missing cwd import"))
     imported_file = imported_manager.session_file
     assert imported_file is not None
@@ -1005,14 +1180,18 @@ def test_runtime_import_from_jsonl_records_failure_diagnostic(tmp_path) -> None:
         diagnostics_service=diagnostics_service,
     )
     current = asyncio.run(runtime.create_session(cwd=str(project_root)))
-    imported_manager = SessionManager.new(session_dir=import_dir, cwd=str(missing_cwd), persist=True)
+    imported_manager = SessionManager.new(
+        session_dir=import_dir, cwd=str(missing_cwd), persist=True
+    )
     imported_file = imported_manager.session_file
     assert imported_file is not None
 
     with pytest.raises(MissingSessionCwdError):
         asyncio.run(runtime.importFromJsonl(str(imported_file)))
 
-    records = diagnostics_service.get_diagnostics(query=DiagnosticsQuery(code="session_import_failed"))
+    records = diagnostics_service.get_diagnostics(
+        query=DiagnosticsQuery(code="session_import_failed")
+    )
 
     assert runtime.get_current_session() is current
     assert len(records) == 1
@@ -1020,7 +1199,9 @@ def test_runtime_import_from_jsonl_records_failure_diagnostic(tmp_path) -> None:
     assert records[0].details["operation"] == "import_from_jsonl"
     assert records[0].details["input_path"] == str(imported_file)
     assert records[0].details["source_path"] == str(imported_file.resolve())
-    assert records[0].details["target_session_file"] == str((session_dir / imported_file.name).resolve())
+    assert records[0].details["target_session_file"] == str(
+        (session_dir / imported_file.name).resolve()
+    )
     assert records[0].details["cwd_override"] is None
 
 
@@ -1031,7 +1212,9 @@ def test_runtime_restore_rejects_session_when_stored_cwd_is_missing(tmp_path) ->
     from loushang.coding.store import SessionManager
 
     missing_cwd = tmp_path / "missing-project"
-    manager = SessionManager.new(session_dir=tmp_path, cwd=str(missing_cwd), persist=True)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(missing_cwd), persist=True
+    )
     session_file = manager.session_file
     assert session_file is not None
     created: list[SessionManager] = []
@@ -1040,7 +1223,9 @@ def test_runtime_restore_rejects_session_when_stored_cwd_is_missing(tmp_path) ->
         created.append(next_manager)
         return object()
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
 
     with pytest.raises(MissingSessionCwdError) as exc_info:
         asyncio.run(runtime.restore_session(session_file))
@@ -1079,7 +1264,9 @@ def test_runtime_restore_session_records_failure_diagnostic(tmp_path) -> None:
     session_dir = tmp_path / "sessions"
     project_root.mkdir()
     diagnostics_service = DiagnosticsService()
-    target_manager = SessionManager.new(session_dir=session_dir, cwd=str(missing_cwd), persist=True)
+    target_manager = SessionManager.new(
+        session_dir=session_dir, cwd=str(missing_cwd), persist=True
+    )
     target_file = target_manager.session_file
     assert target_file is not None
     runtime = AgentSessionRuntime(
@@ -1093,7 +1280,9 @@ def test_runtime_restore_session_records_failure_diagnostic(tmp_path) -> None:
     with pytest.raises(MissingSessionCwdError):
         asyncio.run(runtime.restore_session(target_file))
 
-    records = diagnostics_service.get_diagnostics(query=DiagnosticsQuery(code="session_restore_failed"))
+    records = diagnostics_service.get_diagnostics(
+        query=DiagnosticsQuery(code="session_restore_failed")
+    )
 
     assert runtime.get_current_session() is current
     assert len(records) == 1
@@ -1112,7 +1301,9 @@ def test_runtime_restore_can_fallback_when_stored_cwd_is_missing(tmp_path) -> No
     project_root = tmp_path / "project"
     missing_cwd = tmp_path / "missing-project"
     project_root.mkdir()
-    manager = SessionManager.new(session_dir=tmp_path, cwd=str(missing_cwd), persist=True)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(missing_cwd), persist=True
+    )
     manager.append_message(_user_message("hello"))
     session_file = manager.session_file
     assert session_file is not None
@@ -1135,7 +1326,9 @@ def test_runtime_restore_can_fallback_when_stored_cwd_is_missing(tmp_path) -> No
         created.append(next_manager)
         return DummySession(next_manager)
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
 
     restored = asyncio.run(
         runtime.restore_session(
@@ -1149,7 +1342,9 @@ def test_runtime_restore_can_fallback_when_stored_cwd_is_missing(tmp_path) -> No
     assert created == [restored.session_manager]
 
 
-def test_runtime_import_from_jsonl_cwd_override_bypasses_missing_stored_cwd(tmp_path) -> None:
+def test_runtime_import_from_jsonl_cwd_override_bypasses_missing_stored_cwd(
+    tmp_path,
+) -> None:
     from loushang.coding.runtime import AgentSessionRuntime
     from loushang.coding.store import SessionManager
 
@@ -1158,7 +1353,9 @@ def test_runtime_import_from_jsonl_cwd_override_bypasses_missing_stored_cwd(tmp_
     import_dir = tmp_path / "imports"
     project_root.mkdir()
     import_dir.mkdir()
-    imported_manager = SessionManager.new(session_dir=import_dir, cwd=str(missing_cwd), persist=True)
+    imported_manager = SessionManager.new(
+        session_dir=import_dir, cwd=str(missing_cwd), persist=True
+    )
     imported_manager.append_message(_user_message("imported"))
     imported_file = imported_manager.session_file
     assert imported_file is not None
@@ -1179,18 +1376,27 @@ def test_runtime_import_from_jsonl_cwd_override_bypasses_missing_stored_cwd(tmp_
         async def dispose(self) -> None:
             return None
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path / "sessions", session_factory=DummySession, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path / "sessions", session_factory=DummySession, persist=True
+    )
 
-    result = asyncio.run(runtime.importFromJsonl(str(imported_file), cwd_override=str(project_root)))
+    result = asyncio.run(
+        runtime.importFromJsonl(str(imported_file), cwd_override=str(project_root))
+    )
     current = runtime.get_current_session()
 
     assert result == {"cancelled": False}
     assert current is not None
     assert current.session_manager.get_cwd() == str(project_root.resolve())
-    assert [message.content[0].text for message in current.session_manager.build_session_context().messages] == ["imported"]
+    assert [
+        message.content[0].text
+        for message in current.session_manager.build_session_context().messages
+    ] == ["imported"]
 
 
-def test_runtime_import_from_jsonl_respects_before_switch_cancellation(tmp_path) -> None:
+def test_runtime_import_from_jsonl_respects_before_switch_cancellation(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1207,7 +1413,9 @@ def test_runtime_import_from_jsonl_respects_before_switch_cancellation(tmp_path)
     project_root.mkdir()
     import_dir = tmp_path / "imports"
     import_dir.mkdir()
-    imported_manager = SessionManager.new(session_dir=import_dir, cwd=str(project_root), persist=True)
+    imported_manager = SessionManager.new(
+        session_dir=import_dir, cwd=str(project_root), persist=True
+    )
     imported_manager.append_message(_user_message("imported"))
     imported_file = imported_manager.session_file
     assert imported_file is not None
@@ -1234,7 +1442,9 @@ def test_runtime_import_from_jsonl_respects_before_switch_cancellation(tmp_path)
             ),
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path / "sessions", session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path / "sessions", session_factory=_factory, persist=True
+    )
     current = asyncio.run(runtime.create_session(cwd=str(project_root)))
 
     result = asyncio.run(runtime.importFromJsonl(str(imported_file)))
@@ -1245,7 +1455,9 @@ def test_runtime_import_from_jsonl_respects_before_switch_cancellation(tmp_path)
     assert not (tmp_path / "sessions" / imported_file.name).exists()
 
 
-def test_runtime_import_from_jsonl_records_before_switch_failure_and_flushes_index(tmp_path) -> None:
+def test_runtime_import_from_jsonl_records_before_switch_failure_and_flushes_index(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -1262,7 +1474,9 @@ def test_runtime_import_from_jsonl_records_before_switch_failure_and_flushes_ind
     import_dir.mkdir()
     diagnostics_service = DiagnosticsService()
 
-    imported_manager = SessionManager.new(session_dir=import_dir, cwd=str(project_root), persist=True)
+    imported_manager = SessionManager.new(
+        session_dir=import_dir, cwd=str(project_root), persist=True
+    )
     imported_manager.append_message(_user_message("imported"))
     imported_file = imported_manager.session_file
     assert imported_file is not None
@@ -1310,10 +1524,18 @@ def test_runtime_import_from_jsonl_records_before_switch_failure_and_flushes_ind
     )
 
     assert current is not None
-    assert current.session_manager.session_file == (session_dir / imported_file.name).resolve()
-    assert current.session_id in {summary.session_id for summary in SessionManager.load_index(session_dir)}
+    assert (
+        current.session_manager.session_file
+        == (session_dir / imported_file.name).resolve()
+    )
+    assert current.session_id in {
+        summary.session_id for summary in SessionManager.load_index(session_dir)
+    }
     assert len(records) == 1
-    assert records[0].message == "Extension hook 'session_before_switch' failed: before switch boom"
+    assert (
+        records[0].message
+        == "Extension hook 'session_before_switch' failed: before switch boom"
+    )
 
 
 def test_runtime_pi_style_lifecycle_aliases_report_cancellation(tmp_path) -> None:
@@ -1368,7 +1590,9 @@ def test_runtime_pi_style_lifecycle_aliases_report_cancellation(tmp_path) -> Non
     entry_id = current.session_manager.append_message(_user_message("root"))
 
     assert asyncio.run(runtime.newSession()) == {"cancelled": True}
-    assert asyncio.run(runtime.fork(entry_id, {"position": "at"})) == {"cancelled": True}
+    assert asyncio.run(runtime.fork(entry_id, {"position": "at"})) == {
+        "cancelled": True
+    }
     assert runtime.get_current_session() is current
     assert current.disposed is False
 
@@ -1415,7 +1639,9 @@ def test_extension_command_context_fork_uses_runtime_host(tmp_path) -> None:
             ),
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     session = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -1430,7 +1656,10 @@ def test_extension_command_context_fork_uses_runtime_host(tmp_path) -> None:
     assert results == [{"cancelled": False}]
     assert forked is not None
     assert forked is not session
-    assert [entry.id for entry in forked.session_manager.get_branch()] == [first_id, second_id]
+    assert [entry.id for entry in forked.session_manager.get_branch()] == [
+        first_id,
+        second_id,
+    ]
 
 
 def test_extension_command_context_fork_supports_before_position(tmp_path) -> None:
@@ -1476,7 +1705,9 @@ def test_extension_command_context_fork_supports_before_position(tmp_path) -> No
             ),
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     session = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -1490,7 +1721,9 @@ def test_extension_command_context_fork_supports_before_position(tmp_path) -> No
     seen_branches.append([entry.id for entry in forked.session_manager.get_branch()])
 
     assert result.result is None
-    assert results == [{"cancelled": False, "selected_text": "tail", "selectedText": "tail"}]
+    assert results == [
+        {"cancelled": False, "selected_text": "tail", "selectedText": "tail"}
+    ]
     assert forked is not session
     assert seen_branches == [[first_id, second_id]]
 
@@ -1536,7 +1769,9 @@ def test_extension_command_context_fork_defaults_to_before_position(tmp_path) ->
             ),
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     session = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -1548,12 +1783,19 @@ def test_extension_command_context_fork_defaults_to_before_position(tmp_path) ->
     forked = runtime.get_current_session()
 
     assert result.result is None
-    assert results == [{"cancelled": False, "selected_text": "tail", "selectedText": "tail"}]
+    assert results == [
+        {"cancelled": False, "selected_text": "tail", "selectedText": "tail"}
+    ]
     assert forked is not None
-    assert [entry.id for entry in forked.session_manager.get_branch()] == [first_id, second_id]
+    assert [entry.id for entry in forked.session_manager.get_branch()] == [
+        first_id,
+        second_id,
+    ]
 
 
-def test_extension_command_context_fork_before_runs_with_session_on_new_fork(tmp_path) -> None:
+def test_extension_command_context_fork_before_runs_with_session_on_new_fork(
+    tmp_path,
+) -> None:
     import asyncio
     from pathlib import Path
 
@@ -1574,10 +1816,7 @@ def test_extension_command_context_fork_before_runs_with_session_on_new_fork(tmp
             seen.append(
                 (
                     replaced_ctx.cwd,
-                    [
-                        entry.id
-                        for entry in replaced_ctx.sessionManager.get_branch()
-                    ],
+                    [entry.id for entry in replaced_ctx.sessionManager.get_branch()],
                 )
             )
 
@@ -1605,7 +1844,9 @@ def test_extension_command_context_fork_before_runs_with_session_on_new_fork(tmp
             ),
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     session = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -1643,9 +1884,16 @@ def test_extension_command_context_new_session_uses_runtime_host(tmp_path) -> No
             manager.append_message(_user_message("initialized"))
 
         async def _with_session(replaced_ctx):
-            callback_events.append(("withSession", (replaced_ctx.cwd, replaced_ctx.sessionManager is not None)))
+            callback_events.append(
+                (
+                    "withSession",
+                    (replaced_ctx.cwd, replaced_ctx.sessionManager is not None),
+                )
+            )
 
-        await ctx.newSession({"parentSession": "parent-1", "setup": _setup, "withSession": _with_session})
+        await ctx.newSession(
+            {"parentSession": "parent-1", "setup": _setup, "withSession": _with_session}
+        )
 
     def _factory(manager: SessionManager, *, session_start_event=None) -> AgentSession:
         return AgentSession(
@@ -1669,7 +1917,9 @@ def test_extension_command_context_new_session_uses_runtime_host(tmp_path) -> No
             ),
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     session = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -1682,14 +1932,18 @@ def test_extension_command_context_new_session_uses_runtime_host(tmp_path) -> No
     assert created is not session
     assert created.session_manager.get_header().parent_session == "parent-1"
     assert created.session_manager.get_cwd() == str(project.resolve())
-    assert [message.content[0].text for message in created.get_session_context().messages] == ["initialized"]
+    assert [
+        message.content[0].text for message in created.get_session_context().messages
+    ] == ["initialized"]
     assert callback_events == [
         ("setup", str(project.resolve())),
         ("withSession", (str(project.resolve()), True)),
     ]
 
 
-def test_extension_command_new_session_with_session_gets_fresh_context_and_stales_old_context(tmp_path) -> None:
+def test_extension_command_new_session_with_session_gets_fresh_context_and_stales_old_context(
+    tmp_path,
+) -> None:
     import asyncio
     from pathlib import Path
 
@@ -1710,7 +1964,9 @@ def test_extension_command_new_session_with_session_gets_fresh_context_and_stale
         old_ctx = ctx
 
         async def _with_session(replaced_ctx):
-            events.append(("fresh", (replaced_ctx.cwd, replaced_ctx.sessionManager is not None)))
+            events.append(
+                ("fresh", (replaced_ctx.cwd, replaced_ctx.sessionManager is not None))
+            )
             try:
                 old_ctx.cwd
             except RuntimeError as exc:
@@ -1740,7 +1996,9 @@ def test_extension_command_new_session_with_session_gets_fresh_context_and_stale
             ),
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     session = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -1754,7 +2012,9 @@ def test_extension_command_new_session_with_session_gets_fresh_context_and_stale
     ]
 
 
-def test_replaced_session_context_send_message_becomes_stale_after_next_replacement(tmp_path) -> None:
+def test_replaced_session_context_send_message_becomes_stale_after_next_replacement(
+    tmp_path,
+) -> None:
     import asyncio
     from pathlib import Path
 
@@ -1777,7 +2037,9 @@ def test_replaced_session_context_send_message_becomes_stale_after_next_replacem
 
         async def _with_session(replaced_ctx):
             captured["ctx"] = replaced_ctx
-            await replaced_ctx.sendMessage({"customType": "demo", "content": "fresh", "display": True})
+            await replaced_ctx.sendMessage(
+                {"customType": "demo", "content": "fresh", "display": True}
+            )
 
         await ctx.newSession({"withSession": _with_session})
 
@@ -1803,7 +2065,9 @@ def test_replaced_session_context_send_message_becomes_stale_after_next_replacem
             ),
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     session = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -1813,12 +2077,18 @@ def test_replaced_session_context_send_message_becomes_stale_after_next_replacem
     current = runtime.get_current_session()
     assert result.result is None
     assert current is not None
-    assert [entry.custom_type for entry in current.session_manager.get_entries()] == ["demo"]
+    assert [entry.custom_type for entry in current.session_manager.get_entries()] == [
+        "demo"
+    ]
 
     asyncio.run(runtime.newSession())
 
     with pytest.raises(RuntimeError, match="stale"):
-        asyncio.run(replaced_ctx.sendMessage({"customType": "demo", "content": "stale", "display": True}))
+        asyncio.run(
+            replaced_ctx.sendMessage(
+                {"customType": "demo", "content": "stale", "display": True}
+            )
+        )
     with pytest.raises(RuntimeError, match="stale"):
         asyncio.run(replaced_ctx.sendUserMessage("stale user text"))
 
@@ -1835,8 +2105,12 @@ def test_agent_session_exposes_pi_style_replaced_session_context(tmp_path) -> No
     project.mkdir()
     session = AgentSession(
         agent=Agent(),
-        session_manager=SessionManager.new(session_dir=tmp_path, cwd=str(project), persist=True),
-        extension_runner=ExtensionRunner([LoadedExtension(name="demo", source_path=Path("/tmp/demo.py"))]),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path, cwd=str(project), persist=True
+        ),
+        extension_runner=ExtensionRunner(
+            [LoadedExtension(name="demo", source_path=Path("/tmp/demo.py"))]
+        ),
     )
 
     context = session.createReplacedSessionContext()
@@ -1864,7 +2138,12 @@ def test_extension_command_context_switch_session_uses_runtime_host(tmp_path) ->
 
     async def _switch_command(args: str, ctx):
         async def _with_session(replaced_ctx):
-            callback_events.append(("withSession", (replaced_ctx.cwd, replaced_ctx.sessionManager is not None)))
+            callback_events.append(
+                (
+                    "withSession",
+                    (replaced_ctx.cwd, replaced_ctx.sessionManager is not None),
+                )
+            )
 
         await ctx.switchSession(args, {"withSession": _with_session})
 
@@ -1892,8 +2171,12 @@ def test_extension_command_context_switch_session_uses_runtime_host(tmp_path) ->
 
     project = tmp_path / "project"
     project.mkdir()
-    first_manager = SessionManager.new(session_dir=tmp_path, cwd=str(project), persist=True)
-    second_manager = SessionManager.new(session_dir=tmp_path, cwd=str(project), persist=True)
+    first_manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(project), persist=True
+    )
+    second_manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(project), persist=True
+    )
     second_manager.append_message(_user_message("restored"))
     runtime = AgentSessionRuntime(
         session_dir=tmp_path,
@@ -1904,17 +2187,23 @@ def test_extension_command_context_switch_session_uses_runtime_host(tmp_path) ->
     session = runtime.get_current_session()
     assert session is not None
 
-    result = asyncio.run(session.execute_command_async("switch", str(second_manager.session_file)))
+    result = asyncio.run(
+        session.execute_command_async("switch", str(second_manager.session_file))
+    )
     switched = runtime.get_current_session()
 
     assert result.result is None
     assert switched is not None
     assert switched is not session
-    assert [message.content[0].text for message in switched.get_session_context().messages] == ["restored"]
+    assert [
+        message.content[0].text for message in switched.get_session_context().messages
+    ] == ["restored"]
     assert callback_events == [("withSession", (str(project.resolve()), True))]
 
 
-def test_extension_command_replacement_callbacks_require_async_callables(tmp_path) -> None:
+def test_extension_command_replacement_callbacks_require_async_callables(
+    tmp_path,
+) -> None:
     import asyncio
     from pathlib import Path
 
@@ -1950,7 +2239,9 @@ def test_extension_command_replacement_callbacks_require_async_callables(tmp_pat
                     LoadedExtension(
                         name="new-ext",
                         source_path=Path("/tmp/new-ext.py"),
-                        commands={"new": RegisteredCommand(name="new", handler=_new_command)},
+                        commands={
+                            "new": RegisteredCommand(name="new", handler=_new_command)
+                        },
                     )
                 ]
             ),
@@ -1970,7 +2261,9 @@ def test_extension_command_replacement_callbacks_require_async_callables(tmp_pat
 
     assert result is not None
     assert result.result is None
-    assert [diagnostic.code for diagnostic in diagnostics_service.get_diagnostics()] == ["extension_command_failed"]
+    assert [
+        diagnostic.code for diagnostic in diagnostics_service.get_diagnostics()
+    ] == ["extension_command_failed"]
 
 
 def test_runtime_exposes_diagnostics_snapshot(tmp_path) -> None:
@@ -2008,9 +2301,12 @@ def test_runtime_exposes_diagnostics_snapshot(tmp_path) -> None:
         "startup_warning",
         "runtime_error",
     ]
-    assert [record.code for record in runtime.get_diagnostics(DiagnosticsQuery(phase="runtime", source="session"))] == [
-        "runtime_error"
-    ]
+    assert [
+        record.code
+        for record in runtime.get_diagnostics(
+            DiagnosticsQuery(phase="runtime", source="session")
+        )
+    ] == ["runtime_error"]
     assert runtime.get_last_error_report() is not None
     assert runtime.get_last_error_report().primary.code == "runtime_error"
 
@@ -2046,11 +2342,15 @@ def test_runtime_exposes_current_session_diagnostics(tmp_path) -> None:
         )
     )
 
-    assert [record.code for record in runtime.get_session_diagnostics(DiagnosticsQuery(level="error"))] == [
-        "current_runtime_error"
-    ]
     assert [
-        record.code for record in runtime.get_session_diagnostics(DiagnosticsQuery(code="current_runtime_error"))
+        record.code
+        for record in runtime.get_session_diagnostics(DiagnosticsQuery(level="error"))
+    ] == ["current_runtime_error"]
+    assert [
+        record.code
+        for record in runtime.get_session_diagnostics(
+            DiagnosticsQuery(code="current_runtime_error")
+        )
     ] == ["current_runtime_error"]
     summary = runtime.get_session_diagnostics_summary(DiagnosticsQuery(level="error"))
     assert summary.total_count == 1
@@ -2059,7 +2359,9 @@ def test_runtime_exposes_current_session_diagnostics(tmp_path) -> None:
     assert summary.latest_error.code == "current_runtime_error"
 
 
-def test_agent_session_runtime_create_restore_and_fork_reconstruct_extension_start_hooks(tmp_path) -> None:
+def test_agent_session_runtime_create_restore_and_fork_reconstruct_extension_start_hooks(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -2086,10 +2388,12 @@ def test_agent_session_runtime_create_restore_and_fork_reconstruct_extension_sta
                         hooks={"session_start": [_session_start]},
                     )
                 ]
-                ),
-            )
+            ),
+        )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     session = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -2098,7 +2402,11 @@ def test_agent_session_runtime_create_restore_and_fork_reconstruct_extension_sta
     fork_entry_id = restored.session_manager.get_entries()[0].id
     asyncio.run(runtime.fork_session(fork_entry_id))
 
-    assert events == [str(project.resolve()), str(project.resolve()), str(project.resolve())]
+    assert events == [
+        str(project.resolve()),
+        str(project.resolve()),
+        str(project.resolve()),
+    ]
 
 
 def test_runtime_replacement_emits_shutdown_before_next_session_start(tmp_path) -> None:
@@ -2144,7 +2452,9 @@ def test_runtime_replacement_emits_shutdown_before_next_session_start(tmp_path) 
             ),
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     first = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -2157,7 +2467,11 @@ def test_runtime_replacement_emits_shutdown_before_next_session_start(tmp_path) 
     assert runtime.get_current_session() is not None
     assert events == [
         ("before_switch", None, None),
-        ("shutdown", "new", str(runtime.get_current_session().session_manager.session_file)),
+        (
+            "shutdown",
+            "new",
+            str(runtime.get_current_session().session_manager.session_file),
+        ),
         ("start", "new", str(first_session_file)),
     ]
 
@@ -2239,7 +2553,9 @@ def test_runtime_syncs_extension_lifecycle_failure_diagnostics(tmp_path) -> None
     )
 
 
-def test_runtime_new_session_reuses_current_cwd_and_disposes_previous_session(tmp_path) -> None:
+def test_runtime_new_session_reuses_current_cwd_and_disposes_previous_session(
+    tmp_path,
+) -> None:
     from loushang.coding.runtime import AgentSessionRuntime
     from loushang.coding.store import SessionManager
 
@@ -2267,7 +2583,217 @@ def test_runtime_new_session_reuses_current_cwd_and_disposes_previous_session(tm
     assert second.session_manager.get_cwd() == str(project.resolve())
     assert first.disposed is True
     assert second.disposed is False
-    assert second.session_manager.get_header().id != first.session_manager.get_header().id
+    assert (
+        second.session_manager.get_header().id != first.session_manager.get_header().id
+    )
+
+
+def test_runtime_session_replacement_keeps_shared_approval_presenter(tmp_path) -> None:
+    from loushang.coding.bootstrap import create_agent_session_runtime
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+
+    project = tmp_path / "project"
+    project.mkdir()
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+    presented: list[dict[str, object]] = []
+    presentation = asyncio.Event()
+
+    def present(payload: dict[str, object]) -> None:
+        presented.append(payload)
+        presentation.set()
+
+    resolver.set_request_presenter(present)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path / "sessions",
+        model=_model(),
+        persist=False,
+        approval_resolver=resolver,
+    )
+
+    async def run() -> None:
+        await runtime.create_session(cwd=str(project))
+        first_pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="first-session-approval",
+                )
+            )
+        )
+        await asyncio.wait_for(presentation.wait(), timeout=0.5)
+
+        second = await runtime.new_session()
+        first_decision = await first_pending
+        assert first_decision.disposition == "deny"
+        assert first_decision.reason == "Session closed before approval was resolved"
+        assert second is runtime.get_current_session()
+
+        presentation.clear()
+        second_pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="second-session-approval",
+                )
+            )
+        )
+        await asyncio.wait_for(presentation.wait(), timeout=0.5)
+        assert presented[-1]["action_id"] == "second-session-approval"
+        await second.handle_screen_approval(
+            {"action_id": "second-session-approval", "approved": True}
+        )
+        assert (await second_pending).disposition == "allow"
+        await second.dispose()
+
+    asyncio.run(run())
+    resolver.dispose()
+
+
+def test_runtime_direct_replacement_reactivates_shared_approval_presenter(
+    tmp_path,
+) -> None:
+    from loushang.coding.bootstrap import create_agent_session_runtime
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.store import SessionManager
+
+    project = tmp_path / "project"
+    project.mkdir()
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+    presented: list[dict[str, object]] = []
+    presentation = asyncio.Event()
+
+    def present(payload: dict[str, object]) -> None:
+        presented.append(payload)
+        presentation.set()
+
+    resolver.set_request_presenter(present)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path / "sessions",
+        model=_model(),
+        persist=False,
+        approval_resolver=resolver,
+    )
+
+    async def run() -> None:
+        await runtime.create_session(cwd=str(project))
+        first_pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="direct-first-approval",
+                )
+            )
+        )
+        await asyncio.wait_for(presentation.wait(), timeout=0.5)
+
+        replacement_manager = SessionManager.new(
+            session_dir=tmp_path / "sessions",
+            cwd=str(project),
+            persist=False,
+        )
+        replacement = runtime.session_factory(replacement_manager)
+        await runtime.replace_current_session(replacement)
+        assert (await first_pending).disposition == "deny"
+        assert runtime.get_current_session() is replacement
+
+        presentation.clear()
+        second_pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="direct-second-approval",
+                )
+            )
+        )
+        await asyncio.wait_for(presentation.wait(), timeout=0.5)
+        assert presented[-1]["action_id"] == "direct-second-approval"
+        await replacement.handle_screen_approval(
+            {"action_id": "direct-second-approval", "approved": True}
+        )
+        assert (await second_pending).disposition == "allow"
+        await replacement.dispose()
+
+    asyncio.run(run())
+    resolver.dispose()
+
+
+def test_runtime_injected_current_session_reopens_shared_approval_resolver(
+    tmp_path,
+) -> None:
+    from loushang.agent import Agent
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.runtime import AgentSessionRuntime
+    from loushang.coding.session import AgentSession
+    from loushang.coding.store import SessionManager
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+    presented = asyncio.Event()
+    resolver.set_request_presenter(lambda payload: presented.set())
+    resolver.close_session("previous session closed")
+    manager = SessionManager.new(
+        session_dir=tmp_path,
+        cwd=str(tmp_path),
+        persist=False,
+    )
+    session = AgentSession(
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=manager,
+        approval_resolver=resolver,
+    )
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path,
+        session_factory=lambda _manager: session,
+        persist=False,
+        current_session=session,
+    )
+
+    async def run() -> None:
+        pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="injected-current-approval",
+                )
+            )
+        )
+        await asyncio.wait_for(presented.wait(), timeout=0.5)
+        await session.handle_screen_approval(
+            {"action_id": "injected-current-approval", "approved": True}
+        )
+        assert (await pending).disposition == "allow"
+        await runtime.dispose()
+
+    asyncio.run(run())
+    resolver.dispose()
 
 
 def test_runtime_replacement_disposes_agent_session_local_resources(tmp_path) -> None:
@@ -2283,12 +2809,16 @@ def test_runtime_replacement_disposes_agent_session_local_resources(tmp_path) ->
             session_start_event=session_start_event,
         )
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=True)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=True
+    )
     project = tmp_path / "project"
     project.mkdir()
     first = asyncio.run(runtime.create_session(cwd=str(project)))
     first.footer_data_provider.set_extension_status("demo", "running")
-    first.footer_data_provider.start_git_watcher(poll_interval_seconds=0.01, debounce_seconds=0)
+    first.footer_data_provider.start_git_watcher(
+        poll_interval_seconds=0.01, debounce_seconds=0
+    )
     assert first.footer_data_provider.is_git_watcher_running()
 
     second = asyncio.run(runtime.new_session())
@@ -2299,7 +2829,9 @@ def test_runtime_replacement_disposes_agent_session_local_resources(tmp_path) ->
     assert first.footer_data_provider.is_git_watcher_running() is False
 
 
-def test_runtime_replacement_records_shutdown_emit_failure_and_keeps_replacement(tmp_path) -> None:
+def test_runtime_replacement_records_shutdown_emit_failure_and_keeps_replacement(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.agent import Agent
@@ -2339,7 +2871,9 @@ def test_runtime_replacement_records_shutdown_emit_failure_and_keeps_replacement
     first.footer_data_provider.set_extension_status("demo", "running")
 
     second = asyncio.run(runtime.new_session())
-    records = diagnostics_service.get_diagnostics(query=DiagnosticsQuery(code="session_shutdown_failed"))
+    records = diagnostics_service.get_diagnostics(
+        query=DiagnosticsQuery(code="session_shutdown_failed")
+    )
 
     assert runtime.get_current_session() is second
     assert second is not first
@@ -2348,10 +2882,14 @@ def test_runtime_replacement_records_shutdown_emit_failure_and_keeps_replacement
     assert records[0].message == "shutdown transport boom"
     assert records[0].session_id == first.session_id
     assert records[0].details["reason"] == "new"
-    assert records[0].details["target_session_file"] == str(second.session_manager.session_file)
+    assert records[0].details["target_session_file"] == str(
+        second.session_manager.session_file
+    )
 
 
-def test_runtime_new_session_factory_failure_keeps_current_session_alive(tmp_path) -> None:
+def test_runtime_new_session_factory_failure_keeps_current_session_alive(
+    tmp_path,
+) -> None:
     import pytest
 
     from loushang.coding.runtime import AgentSessionRuntime
@@ -2375,7 +2913,9 @@ def test_runtime_new_session_factory_failure_keeps_current_session_alive(tmp_pat
             raise RuntimeError("factory boom")
         return DummySession(manager)
 
-    runtime = AgentSessionRuntime(session_dir=tmp_path, session_factory=_factory, persist=False)
+    runtime = AgentSessionRuntime(
+        session_dir=tmp_path, session_factory=_factory, persist=False
+    )
     project = tmp_path / "project"
     project.mkdir()
     first = asyncio.run(runtime.create_session(cwd=str(project)))
@@ -2436,7 +2976,9 @@ def test_runtime_replacements_are_serialized(tmp_path) -> None:
     assert runtime.get_current_session() is third
 
 
-def test_runtime_dispose_records_session_index_flush_failure(tmp_path, monkeypatch) -> None:
+def test_runtime_dispose_records_session_index_flush_failure(
+    tmp_path, monkeypatch
+) -> None:
     from loushang.coding.diagnostics import DiagnosticsQuery, DiagnosticsService
     from loushang.coding.runtime import AgentSessionRuntime
     from loushang.coding.store import SessionManager
@@ -2469,12 +3011,16 @@ def test_runtime_dispose_records_session_index_flush_failure(tmp_path, monkeypat
             del cls, session_dir
             raise RuntimeError("index boom")
 
-        monkeypatch.setattr(SessionManager, "refresh_index", classmethod(_fail_refresh_index))
+        monkeypatch.setattr(
+            SessionManager, "refresh_index", classmethod(_fail_refresh_index)
+        )
         await runtime.dispose()
         return session
 
     session = asyncio.run(scenario())
-    records = diagnostics_service.get_diagnostics(query=DiagnosticsQuery(code="session_index_refresh_failed"))
+    records = diagnostics_service.get_diagnostics(
+        query=DiagnosticsQuery(code="session_index_refresh_failed")
+    )
 
     assert runtime.get_current_session() is None
     assert session.disposed is True
@@ -2488,7 +3034,9 @@ def test_runtime_exposes_current_session_and_cwd_properties(tmp_path) -> None:
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=False)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=False
+    )
 
     session = asyncio.run(runtime.create_session(cwd=str(project)))
 
@@ -2527,7 +3075,12 @@ def test_runtime_replacement_callbacks_run_before_with_session(tmp_path) -> None
         events.append(("before", first.disposed))
 
     async def _with_session(ctx):
-        events.append(("withSession", ctx.sessionManager is runtime.get_current_session().session_manager))
+        events.append(
+            (
+                "withSession",
+                ctx.sessionManager is runtime.get_current_session().session_manager,
+            )
+        )
 
     runtime.set_rebind_session(_rebind)
     runtime.set_before_session_invalidate(_before_invalidate)
@@ -2547,7 +3100,9 @@ def test_runtime_restore_session_accepts_session_id(tmp_path) -> None:
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
 
     created = asyncio.run(runtime.create_session(cwd=str(project)))
     restored = asyncio.run(runtime.restore_session(created.session_id))
@@ -2561,7 +3116,9 @@ def test_runtime_restore_session_accepts_session_id_prefix(tmp_path) -> None:
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
 
     created = asyncio.run(runtime.create_session(cwd=str(project)))
     restored = asyncio.run(runtime.restore_session(created.session_id[:8]))
@@ -2578,7 +3135,9 @@ def test_runtime_restore_session_rejects_ambiguous_session_id_prefix(tmp_path) -
 
     project = tmp_path / "project"
     project.mkdir()
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=True)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=True
+    )
     timestamp = "2026-05-01T00:00:00Z"
     for session_id in ("abcdef01", "abcdef02"):
         (tmp_path / f"{timestamp}_{session_id}.jsonl").write_text(
@@ -2600,13 +3159,17 @@ def test_runtime_restore_session_rejects_ambiguous_session_id_prefix(tmp_path) -
         asyncio.run(runtime.restore_session("abcdef"))
 
 
-def test_runtime_create_session_normalizes_cwd_and_rejects_missing_paths(tmp_path) -> None:
+def test_runtime_create_session_normalizes_cwd_and_rejects_missing_paths(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session_runtime
 
     project = tmp_path / "project"
     nested = project / "nested"
     nested.mkdir(parents=True)
-    runtime = create_agent_session_runtime(session_dir=tmp_path, model=_model(), persist=False)
+    runtime = create_agent_session_runtime(
+        session_dir=tmp_path, model=_model(), persist=False
+    )
 
     created = asyncio.run(runtime.create_session(cwd=str(nested / "..")))
 
@@ -2620,7 +3183,9 @@ def test_runtime_create_session_normalizes_cwd_and_rejects_missing_paths(tmp_pat
         raise AssertionError("create_session should reject missing cwd paths")
 
 
-def test_runtime_new_session_respects_extension_before_switch_cancellation(tmp_path) -> None:
+def test_runtime_new_session_respects_extension_before_switch_cancellation(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.coding.extensions import (
@@ -2673,7 +3238,9 @@ def test_runtime_new_session_respects_extension_before_switch_cancellation(tmp_p
     assert seen == [("new", str(project.resolve()), None)]
 
 
-def test_runtime_fork_session_respects_extension_before_fork_cancellation(tmp_path) -> None:
+def test_runtime_fork_session_respects_extension_before_fork_cancellation(
+    tmp_path,
+) -> None:
     from pathlib import Path
 
     from loushang.coding.extensions import (
@@ -2824,8 +3391,12 @@ def test_runtime_restore_session_allows_extension_non_cancel_decision(tmp_path) 
     target = tmp_path / "target"
     project.mkdir()
     target.mkdir()
-    current_manager = SessionManager.new(session_dir=tmp_path, cwd=str(project), persist=True)
-    target_manager = SessionManager.new(session_dir=tmp_path, cwd=str(target), persist=True)
+    current_manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(project), persist=True
+    )
+    target_manager = SessionManager.new(
+        session_dir=tmp_path, cwd=str(target), persist=True
+    )
     target_manager.append_message(_user_message("from target"))
 
     runtime = AgentSessionRuntime(
@@ -2843,8 +3414,12 @@ def test_runtime_restore_session_allows_extension_non_cancel_decision(tmp_path) 
     assert current.disposed is True
     assert runtime.get_current_session() is restored
     assert isinstance(restored, DummySession)
-    assert [entry.id for entry in restored.session_manager.get_entries()] == [target_manager.get_entries()[0].id]
-    assert seen == [("resume", str(project.resolve()), str(target_manager.session_file))]
+    assert [entry.id for entry in restored.session_manager.get_entries()] == [
+        target_manager.get_entries()[0].id
+    ]
+    assert seen == [
+        ("resume", str(project.resolve()), str(target_manager.session_file))
+    ]
 
 
 def test_runtime_fork_session_allows_extension_non_cancel_decision(tmp_path) -> None:

--- a/tests/coding/test_approval_compatibility.py
+++ b/tests/coding/test_approval_compatibility.py
@@ -69,6 +69,48 @@ def test_coding_interactive_approval_fallback_accepts_harness_resolver() -> None
     assert decision == ApprovalDecision.allow()
 
 
+def test_coding_interactive_approval_presents_mutable_nested_payload() -> None:
+    from loushang.coding.policy import InteractiveApprovalResolver
+    from loushang.harness.approval import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presented = asyncio.Event()
+    payloads: list[dict[str, object]] = []
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+
+    def presenter(payload: dict[str, object]) -> None:
+        payloads.append(payload)
+        presented.set()
+
+    resolver.set_request_presenter(presenter)
+
+    async def run() -> None:
+        pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="edit",
+                    arguments={"edits": [{"oldText": "before", "newText": "after"}]},
+                )
+            )
+        )
+        await presented.wait()
+        action_id = payloads[0]["action_id"]
+        assert isinstance(action_id, str)
+        assert await resolver.handle_result(action_id, approved=True)
+        await pending
+
+    asyncio.run(run())
+
+    arguments = payloads[0]["arguments"]
+    assert arguments == {"edits": [{"oldText": "before", "newText": "after"}]}
+    assert isinstance(arguments, dict)
+    assert isinstance(arguments["edits"], list)
+
+
 def test_coding_resolve_approval_uses_harness_result_validation() -> None:
     import pytest
 
@@ -85,3 +127,27 @@ def test_coding_resolve_approval_uses_harness_result_validation() -> None:
                 InvalidResolver(), ApprovalRequest(tool_name="write", arguments={})
             )
         )
+
+
+def test_coding_interactive_approval_rejects_rebind_without_retaining_callback() -> (
+    None
+):
+    import pytest
+
+    from loushang.coding.policy import (
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+    resolver.dispose()
+
+    def presenter(payload: dict[str, object]) -> None:
+        del payload
+
+    with pytest.raises(RuntimeError, match="disposed"):
+        resolver.set_request_presenter(presenter)
+
+    assert resolver._request_presenter is None

--- a/tests/coding/test_bootstrap.py
+++ b/tests/coding/test_bootstrap.py
@@ -52,7 +52,9 @@ def _assistant_message(text: str) -> AssistantMessage:
     )
 
 
-def _assistant_tool_call_message(tool_name: str = "calc", arguments: dict[str, object] | None = None) -> AssistantMessage:
+def _assistant_tool_call_message(
+    tool_name: str = "calc", arguments: dict[str, object] | None = None
+) -> AssistantMessage:
     return AssistantMessage(
         role="assistant",
         content=[
@@ -74,23 +76,60 @@ def _assistant_tool_call_message(tool_name: str = "calc", arguments: dict[str, o
     )
 
 
-def _stream_with_final_message(message: AssistantMessage) -> AssistantMessageEventStream:
+def _stream_with_final_message(
+    message: AssistantMessage,
+) -> AssistantMessageEventStream:
     stream = AssistantMessageEventStream()
     stream.push({"type": "start", "partial": message})
     if message.content and isinstance(message.content[0], TextPart):
         stream.push({"type": "text_start", "content_index": 0, "partial": message})
-        stream.push({"type": "text_delta", "content_index": 0, "delta": message.content[0].text, "partial": message})
-        stream.push({"type": "text_end", "content_index": 0, "content": message.content[0].text, "partial": message})
+        stream.push(
+            {
+                "type": "text_delta",
+                "content_index": 0,
+                "delta": message.content[0].text,
+                "partial": message,
+            }
+        )
+        stream.push(
+            {
+                "type": "text_end",
+                "content_index": 0,
+                "content": message.content[0].text,
+                "partial": message,
+            }
+        )
     elif message.content and isinstance(message.content[0], ToolCall):
         stream.push({"type": "toolcall_start", "content_index": 0, "partial": message})
-        stream.push({"type": "toolcall_delta", "content_index": 0, "delta": '{"x": 1}', "partial": message})
-        stream.push({"type": "toolcall_end", "content_index": 0, "tool_call": message.content[0], "partial": message})
+        stream.push(
+            {
+                "type": "toolcall_delta",
+                "content_index": 0,
+                "delta": '{"x": 1}',
+                "partial": message,
+            }
+        )
+        stream.push(
+            {
+                "type": "toolcall_end",
+                "content_index": 0,
+                "tool_call": message.content[0],
+                "partial": message,
+            }
+        )
     stream.push({"type": "done", "reason": message.stop_reason, "message": message})  # type: ignore[typeddict-item]
     return stream
 
 
 def _run_git(args: list[str], *, cwd) -> None:
-    subprocess.run(["git", *args], cwd=cwd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
 
 
 def _runtime_footer(cwd: str) -> str:
@@ -187,7 +226,9 @@ def test_create_agent_session_uses_manager_header_as_agent_session_id(tmp_path) 
     from loushang.coding.bootstrap import create_agent_session
     from loushang.coding.store import SessionManager
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
 
     session = create_agent_session(
         session_manager=manager,
@@ -200,6 +241,32 @@ def test_create_agent_session_uses_manager_header_as_agent_session_id(tmp_path) 
     assert session.get_model_selection().model_id == "faux-model"
 
 
+def test_create_agent_session_keeps_runtime_approval_resolver(tmp_path) -> None:
+    from loushang.coding.bootstrap import create_agent_session
+    from loushang.coding.policy import (
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.store import SessionManager
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path,
+        cwd="/tmp/project",
+        persist=False,
+    )
+
+    session = create_agent_session(
+        session_manager=manager,
+        model=_model(),
+        approval_resolver=resolver,
+    )
+
+    assert session._approval_resolver is resolver
+
+
 def test_create_agent_session_result_returns_sdk_creation_snapshot(tmp_path) -> None:
     from loushang.coding import CreateAgentSessionResult, create_agent_session_result
     from loushang.coding.bootstrap import create_services
@@ -210,9 +277,13 @@ def test_create_agent_session_result_returns_sdk_creation_snapshot(tmp_path) -> 
     missing_package_root = tmp_path / "missing-package"
     project_root.mkdir()
     services = create_services(
-        settings_manager=SettingsManager(ControlConfig(package_roots=(str(missing_package_root),)))
+        settings_manager=SettingsManager(
+            ControlConfig(package_roots=(str(missing_package_root),))
+        )
     )
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
     result = create_agent_session_result(
         session_manager=manager,
@@ -224,9 +295,11 @@ def test_create_agent_session_result_returns_sdk_creation_snapshot(tmp_path) -> 
     assert result.session.session_manager is manager
     assert result.resource_bundle is result.session.resource_bundle
     assert result.cwd_bound_services_audit is result.session.cwd_bound_services_audit
-    assert [record.code for record in result.diagnostics if record.phase == "startup" and record.type != "info"] == [
-        "package_root_unavailable"
-    ]
+    assert [
+        record.code
+        for record in result.diagnostics
+        if record.phase == "startup" and record.type != "info"
+    ] == ["package_root_unavailable"]
 
     services.diagnostics_service.capture_failure(
         code="later_warning",
@@ -237,9 +310,11 @@ def test_create_agent_session_result_returns_sdk_creation_snapshot(tmp_path) -> 
         session_id=result.session.session_id,
     )
 
-    assert [record.code for record in result.diagnostics if record.phase == "startup" and record.type != "info"] == [
-        "package_root_unavailable"
-    ]
+    assert [
+        record.code
+        for record in result.diagnostics
+        if record.phase == "startup" and record.type != "info"
+    ] == ["package_root_unavailable"]
 
 
 def test_create_agent_session_services_builds_cwd_bound_services(tmp_path) -> None:
@@ -280,7 +355,9 @@ def test_create_agent_session_from_services_uses_cwd_bound_services(tmp_path) ->
         cwd=project_root,
         global_settings_path=tmp_path / "global" / "settings.json",
     )
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
     result = create_agent_session_from_services(
         agent_services=agent_services,
@@ -293,7 +370,9 @@ def test_create_agent_session_from_services_uses_cwd_bound_services(tmp_path) ->
     assert result.session.session_manager is manager
 
 
-def test_create_agent_session_services_loads_extension_flags_and_values(tmp_path) -> None:
+def test_create_agent_session_services_loads_extension_flags_and_values(
+    tmp_path,
+) -> None:
     from loushang.coding import create_agent_session_services
 
     project_root = tmp_path / "project"
@@ -317,7 +396,10 @@ def test_create_agent_session_services_loads_extension_flags_and_values(tmp_path
     )
 
     assert agent_services.extension_runner is not None
-    assert [flag.name for flag in agent_services.extension_runner.get_flags()] == ["plan", "request-id"]
+    assert [flag.name for flag in agent_services.extension_runner.get_flags()] == [
+        "plan",
+        "request-id",
+    ]
     assert agent_services.extension_runner.get_flag_values() == {
         "plan": True,
         "request-id": "req-123",
@@ -325,7 +407,9 @@ def test_create_agent_session_services_loads_extension_flags_and_values(tmp_path
     assert agent_services.diagnostics == ()
 
 
-def test_create_agent_session_from_services_applies_extension_flag_values(tmp_path) -> None:
+def test_create_agent_session_from_services_applies_extension_flag_values(
+    tmp_path,
+) -> None:
     from loushang.coding import (
         create_agent_session_from_services,
         create_agent_session_services,
@@ -350,7 +434,9 @@ def test_create_agent_session_from_services_applies_extension_flag_values(tmp_pa
         global_settings_path=tmp_path / "global" / "settings.json",
         extension_flag_values={"plan": True, "request-id": "req-123"},
     )
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
     result = create_agent_session_from_services(
         agent_services=agent_services,
@@ -364,7 +450,9 @@ def test_create_agent_session_from_services_applies_extension_flag_values(tmp_pa
     }
 
 
-def test_create_agent_session_services_reports_extension_flag_value_errors(tmp_path) -> None:
+def test_create_agent_session_services_reports_extension_flag_value_errors(
+    tmp_path,
+) -> None:
     from loushang.coding import create_agent_session_services
 
     project_root = tmp_path / "project"
@@ -404,9 +492,13 @@ def test_audit_cwd_bound_services_reports_project_settings_mismatch(tmp_path) ->
     project_b = tmp_path / "project-b"
     project_a.mkdir()
     project_b.mkdir()
-    settings_manager = SettingsManager(project_settings_path=default_project_settings_path(project_a))
+    settings_manager = SettingsManager(
+        project_settings_path=default_project_settings_path(project_a)
+    )
     services = create_services(settings_manager=settings_manager)
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_b), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_b), persist=False
+    )
 
     audit = audit_cwd_bound_services(session_manager=manager, services=services)
 
@@ -424,7 +516,9 @@ def test_audit_cwd_bound_services_accepts_matching_resource_bundle(tmp_path) -> 
     project = tmp_path / "project"
     project.mkdir()
     services = create_services()
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project), persist=False
+    )
 
     audit = audit_cwd_bound_services(
         session_manager=manager,
@@ -436,7 +530,9 @@ def test_audit_cwd_bound_services_accepts_matching_resource_bundle(tmp_path) -> 
     assert audit.issues == []
 
 
-def test_create_agent_session_runtime_can_build_services_per_session_cwd(tmp_path) -> None:
+def test_create_agent_session_runtime_can_build_services_per_session_cwd(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.coding.bootstrap import create_agent_session_runtime, create_services
@@ -494,12 +590,17 @@ def test_create_agent_session_runtime_builds_working_default_sessions(tmp_path) 
         assert runtime.get_current_session() is session
         assert session.session_manager.get_header().id
         assert session.agent.session_id is None
-        assert [message.content[0].text for message in session.get_session_context().messages] == ["hi", "bootstrapped"]
+        assert [
+            message.content[0].text
+            for message in session.get_session_context().messages
+        ] == ["hi", "bootstrapped"]
 
     asyncio.run(scenario())
 
 
-def test_create_agent_session_injects_settings_and_agents_md_into_system_prompt(tmp_path) -> None:
+def test_create_agent_session_injects_settings_and_agents_md_into_system_prompt(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.store import SessionManager
     from loushang.coding.tools import ToolRegistry, register_builtin_tools
@@ -510,7 +611,9 @@ def test_create_agent_session_injects_settings_and_agents_md_into_system_prompt(
     (project_root / "AGENTS.md").write_text("Use repo conventions.", encoding="utf-8")
 
     services = create_services(system_prompt="Base system prompt.")
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(nested), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(nested), persist=False
+    )
     registry = ToolRegistry()
     register_builtin_tools(registry)
 
@@ -536,15 +639,22 @@ def test_create_agent_session_injects_settings_and_agents_md_into_system_prompt(
         f"{_runtime_footer(str(nested))}"
     )
     assert session.get_active_tool_names() == ["bash"]
-    assert services.resource_loader.get_resource_bundle().agents_md == "Use repo conventions."
+    assert (
+        services.resource_loader.get_resource_bundle().agents_md
+        == "Use repo conventions."
+    )
 
 
-def test_create_agent_session_applies_allowed_tool_names_to_default_active_tools(tmp_path) -> None:
+def test_create_agent_session_applies_allowed_tool_names_to_default_active_tools(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session
     from loushang.coding.store import SessionManager
     from loushang.coding.tools import ToolRegistry, register_builtin_tools
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     registry = ToolRegistry()
     register_builtin_tools(registry)
 
@@ -557,11 +667,16 @@ def test_create_agent_session_applies_allowed_tool_names_to_default_active_tools
 
     assert session.get_active_tool_names() == ["read", "grep"]
     assert [tool.name for tool in session.agent.tools] == ["read", "grep"]
-    assert [definition.name for definition in session.get_all_tools()] == ["read", "grep"]
+    assert [definition.name for definition in session.get_all_tools()] == [
+        "read",
+        "grep",
+    ]
     assert "- bash:" not in session.agent.system_prompt
 
 
-def test_create_agent_session_no_tools_builtin_keeps_dynamic_extension_tools(tmp_path) -> None:
+def test_create_agent_session_no_tools_builtin_keeps_dynamic_extension_tools(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.coding.bootstrap import create_agent_session, create_services
@@ -621,8 +736,12 @@ def test_create_agent_session_no_tools_builtin_keeps_dynamic_extension_tools(tmp
     registry = ToolRegistry()
     register_builtin_tools(registry)
     session = create_agent_session(
-        session_manager=SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False),
-        services=create_services(resource_loader=_Loader(), system_prompt="Base system prompt."),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+        ),
+        services=create_services(
+            resource_loader=_Loader(), system_prompt="Base system prompt."
+        ),
         model=_model(),
         tool_registry=registry,
         no_tools="builtin",
@@ -638,7 +757,9 @@ def test_create_agent_session_no_tools_builtin_keeps_dynamic_extension_tools(tmp
     assert "- bash:" not in session.agent.system_prompt
 
 
-def test_create_agent_session_no_tools_all_hides_dynamic_extension_tools_and_prompts_none(tmp_path) -> None:
+def test_create_agent_session_no_tools_all_hides_dynamic_extension_tools_and_prompts_none(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.coding.bootstrap import create_agent_session, create_services
@@ -698,8 +819,12 @@ def test_create_agent_session_no_tools_all_hides_dynamic_extension_tools_and_pro
     registry = ToolRegistry()
     register_builtin_tools(registry)
     session = create_agent_session(
-        session_manager=SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False),
-        services=create_services(resource_loader=_Loader(), system_prompt="Base system prompt."),
+        session_manager=SessionManager.new(
+            session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+        ),
+        services=create_services(
+            resource_loader=_Loader(), system_prompt="Base system prompt."
+        ),
         model=_model(),
         tool_registry=registry,
         no_tools="all",
@@ -737,10 +862,15 @@ def test_create_agent_session_runtime_applies_allowed_tool_names(tmp_path) -> No
 
     assert isinstance(session.session_manager, SessionManager)
     assert session.get_active_tool_names() == ["read", "grep"]
-    assert [definition.name for definition in session.get_all_tools()] == ["read", "grep"]
+    assert [definition.name for definition in session.get_all_tools()] == [
+        "read",
+        "grep",
+    ]
 
 
-def test_create_agent_session_uses_settings_package_roots_for_external_package_prompts(tmp_path) -> None:
+def test_create_agent_session_uses_settings_package_roots_for_external_package_prompts(
+    tmp_path,
+) -> None:
     import json
 
     from loushang.coding.bootstrap import create_agent_session, create_services
@@ -768,7 +898,9 @@ def test_create_agent_session_uses_settings_package_roots_for_external_package_p
     services = create_services(
         settings_manager=SettingsManager(global_settings_path=global_settings_path),
     )
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
     session = create_agent_session(
         session_manager=manager,
@@ -778,9 +910,10 @@ def test_create_agent_session_uses_settings_package_roots_for_external_package_p
 
     assert "Base system prompt." in session.agent.system_prompt
     assert "Package review rules" in session.agent.system_prompt
-    assert [descriptor.source_kind for descriptor in services.resource_loader.get_resource_bundle().prompts] == [
-        "external_package"
-    ]
+    assert [
+        descriptor.source_kind
+        for descriptor in services.resource_loader.get_resource_bundle().prompts
+    ] == ["external_package"]
     assert [
         (command.name, command.source_info.origin, command.source_info.base_dir)
         for command in session.list_commands()
@@ -799,24 +932,44 @@ def test_reload_extension_runtime_reloads_settings_resource_roots(tmp_path) -> N
     project_root.mkdir()
     (first_root / "prompts").mkdir(parents=True)
     (second_root / "prompts").mkdir(parents=True)
-    (first_root / "prompts" / "freshness.md").write_text("Old global prompt", encoding="utf-8")
-    (second_root / "prompts" / "freshness.md").write_text("Fresh global prompt", encoding="utf-8")
+    (first_root / "prompts" / "freshness.md").write_text(
+        "Old global prompt", encoding="utf-8"
+    )
+    (second_root / "prompts" / "freshness.md").write_text(
+        "Fresh global prompt", encoding="utf-8"
+    )
 
     global_settings_path = tmp_path / "global-settings.json"
     global_settings_path.write_text(
-        json.dumps({"system_prompt": "Base system prompt.", "resource_roots": [str(first_root)]}),
+        json.dumps(
+            {
+                "system_prompt": "Base system prompt.",
+                "resource_roots": [str(first_root)],
+            }
+        ),
         encoding="utf-8",
     )
 
-    services = create_services(settings_manager=SettingsManager(global_settings_path=global_settings_path))
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
-    session = create_agent_session(session_manager=manager, services=services, model=_model())
+    services = create_services(
+        settings_manager=SettingsManager(global_settings_path=global_settings_path)
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
+    session = create_agent_session(
+        session_manager=manager, services=services, model=_model()
+    )
 
     assert "Old global prompt" in session.agent.system_prompt
     assert "Fresh global prompt" not in session.agent.system_prompt
 
     global_settings_path.write_text(
-        json.dumps({"system_prompt": "Base system prompt.", "resource_roots": [str(second_root)]}),
+        json.dumps(
+            {
+                "system_prompt": "Base system prompt.",
+                "resource_roots": [str(second_root)],
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -827,7 +980,9 @@ def test_reload_extension_runtime_reloads_settings_resource_roots(tmp_path) -> N
     assert "Fresh global prompt" in session.agent.system_prompt
 
 
-def test_create_agent_session_uses_settings_package_sources_with_filters(tmp_path) -> None:
+def test_create_agent_session_uses_settings_package_sources_with_filters(
+    tmp_path,
+) -> None:
     import json
 
     from loushang.coding.bootstrap import create_agent_session, create_services
@@ -864,10 +1019,16 @@ def test_create_agent_session_uses_settings_package_sources_with_filters(tmp_pat
         encoding="utf-8",
     )
 
-    services = create_services(settings_manager=SettingsManager(global_settings_path=global_settings_path))
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    services = create_services(
+        settings_manager=SettingsManager(global_settings_path=global_settings_path)
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
-    session = create_agent_session(session_manager=manager, services=services, model=_model())
+    session = create_agent_session(
+        session_manager=manager, services=services, model=_model()
+    )
 
     bundle = services.resource_loader.get_resource_bundle()
     assert "Package review rules" in session.agent.system_prompt
@@ -876,7 +1037,9 @@ def test_create_agent_session_uses_settings_package_sources_with_filters(tmp_pat
     assert [skill.name for skill in bundle.skills] == ["review"]
 
 
-def test_create_agent_session_uses_settings_plugin_sources_for_external_package_resources(tmp_path) -> None:
+def test_create_agent_session_uses_settings_plugin_sources_for_external_package_resources(
+    tmp_path,
+) -> None:
     import json
 
     from loushang.coding.bootstrap import create_agent_session, create_services
@@ -892,7 +1055,9 @@ def test_create_agent_session_uses_settings_plugin_sources_for_external_package_
     prompts_dir.mkdir(parents=True)
     skills_dir.mkdir(parents=True)
     extensions_dir.mkdir(parents=True)
-    (plugin_root / "plugin.json").write_text(json.dumps({"name": "debug-pack"}), encoding="utf-8")
+    (plugin_root / "plugin.json").write_text(
+        json.dumps({"name": "debug-pack"}), encoding="utf-8"
+    )
     (prompts_dir / "debug.md").write_text("Plugin debug prompt", encoding="utf-8")
     (skills_dir / "SKILL.md").write_text("Plugin debug skill", encoding="utf-8")
     (extensions_dir / "deploy.py").write_text(
@@ -921,7 +1086,9 @@ def test_create_agent_session_uses_settings_plugin_sources_for_external_package_
     services = create_services(
         settings_manager=SettingsManager(project_settings_path=project_settings_path),
     )
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
     session = create_agent_session(
         session_manager=manager,
@@ -940,7 +1107,9 @@ def test_create_agent_session_uses_settings_plugin_sources_for_external_package_
     ] == [("deploy", "package", str(extensions_dir))]
 
 
-def test_create_agent_session_materializes_git_package_sources_by_default(tmp_path) -> None:
+def test_create_agent_session_materializes_git_package_sources_by_default(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.coding.bootstrap import create_agent_session
@@ -960,16 +1129,24 @@ def test_create_agent_session_materializes_git_package_sources_by_default(tmp_pa
     remote_repo = tmp_path / "review-pack.git"
     _run_git(["clone", "--bare", str(source_repo), str(remote_repo)], cwd=tmp_path)
 
-    manager = SessionManager.new(session_dir=tmp_path / ".loushang" / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / ".loushang" / "sessions",
+        cwd=str(tmp_path),
+        persist=False,
+    )
     session = create_agent_session(session_manager=manager, model=_model())
 
     record = asyncio.run(session.materialize_package(remote_repo.as_uri()))
 
     assert record["lifecycle"] == "installed"
-    assert record["targetPath"] == str(tmp_path / ".loushang" / "packages" / "review-pack")
+    assert record["targetPath"] == str(
+        tmp_path / ".loushang" / "packages" / "review-pack"
+    )
 
 
-def test_create_agent_session_auto_materializes_configured_remote_package_sources(tmp_path) -> None:
+def test_create_agent_session_auto_materializes_configured_remote_package_sources(
+    tmp_path,
+) -> None:
     import json
 
     from loushang.coding.bootstrap import create_agent_session, create_services
@@ -982,10 +1159,16 @@ def test_create_agent_session_auto_materializes_configured_remote_package_source
     source_repo.mkdir()
     (source_repo / "resources" / "prompts").mkdir(parents=True)
     (source_repo / "prompts").mkdir()
-    (source_repo / "resources" / "prompts" / "review.md").write_text("Remote package prompt", encoding="utf-8")
-    (source_repo / "prompts" / "ignored.md").write_text("Ignored root prompt", encoding="utf-8")
+    (source_repo / "resources" / "prompts" / "review.md").write_text(
+        "Remote package prompt", encoding="utf-8"
+    )
+    (source_repo / "prompts" / "ignored.md").write_text(
+        "Ignored root prompt", encoding="utf-8"
+    )
     (source_repo / "loushang-package.json").write_text(
-        json.dumps({"name": "review-pack", "version": "1.0.0", "packageRoot": "resources"}),
+        json.dumps(
+            {"name": "review-pack", "version": "1.0.0", "packageRoot": "resources"}
+        ),
         encoding="utf-8",
     )
     _run_git(["init"], cwd=source_repo)
@@ -997,11 +1180,21 @@ def test_create_agent_session_auto_materializes_configured_remote_package_source
     _run_git(["clone", "--bare", str(source_repo), str(remote_repo)], cwd=tmp_path)
 
     global_settings_path = tmp_path / "global-settings.json"
-    global_settings_path.write_text(json.dumps({"packages": [remote_repo.as_uri()]}), encoding="utf-8")
-    services = create_services(settings_manager=SettingsManager(global_settings_path=global_settings_path))
-    manager = SessionManager.new(session_dir=tmp_path / ".loushang" / "sessions", cwd=str(project_root), persist=False)
+    global_settings_path.write_text(
+        json.dumps({"packages": [remote_repo.as_uri()]}), encoding="utf-8"
+    )
+    services = create_services(
+        settings_manager=SettingsManager(global_settings_path=global_settings_path)
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path / ".loushang" / "sessions",
+        cwd=str(project_root),
+        persist=False,
+    )
 
-    session = create_agent_session(session_manager=manager, services=services, model=_model())
+    session = create_agent_session(
+        session_manager=manager, services=services, model=_model()
+    )
 
     assert "Remote package prompt" in session.agent.system_prompt
     assert "Ignored root prompt" not in session.agent.system_prompt
@@ -1020,7 +1213,9 @@ def test_create_agent_session_applies_disabled_plugin_sources(tmp_path) -> None:
     prompts_dir = plugin_root / "prompts"
     project_root.mkdir()
     prompts_dir.mkdir(parents=True)
-    (plugin_root / "plugin.json").write_text(json.dumps({"name": "debug-pack"}), encoding="utf-8")
+    (plugin_root / "plugin.json").write_text(
+        json.dumps({"name": "debug-pack"}), encoding="utf-8"
+    )
     (prompts_dir / "debug.md").write_text("Plugin debug prompt", encoding="utf-8")
 
     settings_path = tmp_path / "settings.json"
@@ -1034,8 +1229,12 @@ def test_create_agent_session_applies_disabled_plugin_sources(tmp_path) -> None:
         encoding="utf-8",
     )
 
-    services = create_services(settings_manager=SettingsManager(project_settings_path=settings_path))
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    services = create_services(
+        settings_manager=SettingsManager(project_settings_path=settings_path)
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
     session = create_agent_session(
         session_manager=manager,
@@ -1060,10 +1259,16 @@ def test_create_agent_session_marks_disabled_skills(tmp_path) -> None:
     (skill_dir / "SKILL.md").write_text("Debug skill", encoding="utf-8")
 
     settings_path = tmp_path / "settings.json"
-    settings_path.write_text(json.dumps({"disabled_skills": ["debug"]}), encoding="utf-8")
+    settings_path.write_text(
+        json.dumps({"disabled_skills": ["debug"]}), encoding="utf-8"
+    )
 
-    services = create_services(settings_manager=SettingsManager(project_settings_path=settings_path))
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    services = create_services(
+        settings_manager=SettingsManager(project_settings_path=settings_path)
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
     session = create_agent_session(
         session_manager=manager,
@@ -1081,7 +1286,9 @@ def test_create_agent_session_includes_tool_prompt_from_registry(tmp_path) -> No
     from loushang.coding.tools import ToolRegistry, register_builtin_tools
 
     services = create_services(system_prompt="Base system prompt.")
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     registry = ToolRegistry()
     register_builtin_tools(registry)
 
@@ -1097,13 +1304,17 @@ def test_create_agent_session_includes_tool_prompt_from_registry(tmp_path) -> No
     assert "bash" in session.agent.system_prompt
 
 
-def test_create_agent_session_synthesizes_definitions_from_legacy_tools(tmp_path) -> None:
+def test_create_agent_session_synthesizes_definitions_from_legacy_tools(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.store import SessionManager
     from loushang.coding.tools import ToolRegistry, register_builtin_tools
 
     services = create_services(system_prompt="Base system prompt.")
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     registry = ToolRegistry()
     register_builtin_tools(registry)
 
@@ -1114,7 +1325,15 @@ def test_create_agent_session_synthesizes_definitions_from_legacy_tools(tmp_path
         tools=registry.list_enabled_tools(),
     )
 
-    assert session.get_active_tool_names() == ["read", "ls", "find", "grep", "bash", "edit", "write"]
+    assert session.get_active_tool_names() == [
+        "read",
+        "ls",
+        "find",
+        "grep",
+        "bash",
+        "edit",
+        "write",
+    ]
     assert [definition.name for definition in session.get_all_tools()] == [
         "bash",
         "read",
@@ -1127,7 +1346,9 @@ def test_create_agent_session_synthesizes_definitions_from_legacy_tools(tmp_path
     assert "Available tools:" in session.agent.system_prompt
 
 
-def test_create_agent_session_defaults_custom_tools_active_without_defaulting_all_builtins(tmp_path) -> None:
+def test_create_agent_session_defaults_custom_tools_active_without_defaulting_all_builtins(
+    tmp_path,
+) -> None:
     from loushang.agent.types import AgentToolResult
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.store import SessionManager
@@ -1137,12 +1358,16 @@ def test_create_agent_session_defaults_custom_tools_active_without_defaulting_al
         register_builtin_tools,
     )
 
-    async def execute_custom_tool(tool_call_id: str, params: dict[str, object], signal=None, on_update=None):
+    async def execute_custom_tool(
+        tool_call_id: str, params: dict[str, object], signal=None, on_update=None
+    ):
         del tool_call_id, params, signal, on_update
         return AgentToolResult(content=[], details={})
 
     services = create_services(system_prompt="Base system prompt.")
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     registry = ToolRegistry()
     register_builtin_tools(registry)
     registry.register_tool(
@@ -1150,7 +1375,12 @@ def test_create_agent_session_defaults_custom_tools_active_without_defaulting_al
             name="custom_tool",
             label="Custom Tool",
             description="custom tool",
-            parameters={"type": "object", "properties": {}, "required": [], "additionalProperties": False},
+            parameters={
+                "type": "object",
+                "properties": {},
+                "required": [],
+                "additionalProperties": False,
+            },
             execute=execute_custom_tool,
         )
     )
@@ -1162,7 +1392,16 @@ def test_create_agent_session_defaults_custom_tools_active_without_defaulting_al
         tool_registry=registry,
     )
 
-    assert session.get_active_tool_names() == ["read", "ls", "find", "grep", "bash", "edit", "write", "custom_tool"]
+    assert session.get_active_tool_names() == [
+        "read",
+        "ls",
+        "find",
+        "grep",
+        "bash",
+        "edit",
+        "write",
+        "custom_tool",
+    ]
     assert [definition.name for definition in session.get_all_tools()] == [
         "bash",
         "read",
@@ -1177,20 +1416,29 @@ def test_create_agent_session_defaults_custom_tools_active_without_defaulting_al
     assert "- grep:" in session.agent.system_prompt
 
 
-def test_create_agent_session_marks_failing_builtin_tool_result_as_error(tmp_path) -> None:
+def test_create_agent_session_marks_failing_builtin_tool_result_as_error(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.coding import SessionManager, ToolRegistry, register_builtin_tools
     from loushang.coding.bootstrap import create_agent_session
 
     async def stream_fn(model, context, options=None):
-        if any(getattr(message, "role", None) == "toolResult" for message in context.messages):
+        if any(
+            getattr(message, "role", None) == "toolResult"
+            for message in context.messages
+        ):
             return _stream_with_final_message(_assistant_message("done"))
         return _stream_with_final_message(
-            _assistant_tool_call_message(tool_name="read", arguments={"path": "missing.txt"})
+            _assistant_tool_call_message(
+                tool_name="read", arguments={"path": "missing.txt"}
+            )
         )
 
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     registry = ToolRegistry()
     register_builtin_tools(registry)
 
@@ -1219,7 +1467,9 @@ def test_create_agent_session_marks_failing_builtin_tool_result_as_error(tmp_pat
     assert "missing.txt" in tool_results[0].content[0].text
 
 
-def test_create_agent_session_records_auth_resolution_failure_for_default_model(tmp_path) -> None:
+def test_create_agent_session_records_auth_resolution_failure_for_default_model(
+    tmp_path,
+) -> None:
     from loushang.ai.model.domain import Auth, Endpoint
     from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
     from loushang.coding.bootstrap import create_agent_session, create_services
@@ -1243,28 +1493,42 @@ def test_create_agent_session_records_auth_resolution_failure_for_default_model(
             name="Secured",
             provider="demo",
             endpoint="responses",
-            capabilities=Capabilities(reasoning=True, input=("text",), context_window=128000, max_tokens=4096),
+            capabilities=Capabilities(
+                reasoning=True, input=("text",), context_window=128000, max_tokens=4096
+            ),
         )
     )
     services = create_services(
         ai_model_registry=ai_registry,
         auth_manager=AuthManager(ai_registry=ai_registry, env={}),
     )
-    services.settings_manager.set_default_model(ModelSelection(provider="demo", model_id="secured"))
+    services.settings_manager.set_default_model(
+        ModelSelection(provider="demo", model_id="secured")
+    )
 
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     session = create_agent_session(session_manager=manager, services=services)
 
-    diagnostics = [record for record in session.get_last_diagnostics() if record.code == "model_auth_unresolved"]
+    diagnostics = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "model_auth_unresolved"
+    ]
 
-    assert session.get_model_selection() == ModelSelection(provider="demo", model_id="secured")
+    assert session.get_model_selection() == ModelSelection(
+        provider="demo", model_id="secured"
+    )
     assert len(diagnostics) == 1
     assert diagnostics[0].type == "warning"
     assert diagnostics[0].source == "model"
     assert "LOUSHANG_TEST_DEMO_KEY" in diagnostics[0].message
 
 
-def test_create_agent_session_uses_saved_default_model_endpoint_when_valid(tmp_path) -> None:
+def test_create_agent_session_uses_saved_default_model_endpoint_when_valid(
+    tmp_path,
+) -> None:
     from loushang.ai.model.registry import ModelRegistry as AiModelRegistry
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.session import ModelSelection
@@ -1428,7 +1692,9 @@ def test_create_agent_session_falls_back_when_saved_default_endpoint_is_unavaila
     assert diagnostics[0].details["endpoint_id"] == "retired"
 
 
-def test_create_agent_session_uses_stored_oauth_credentials_for_auth_bridge(tmp_path, monkeypatch) -> None:
+def test_create_agent_session_uses_stored_oauth_credentials_for_auth_bridge(
+    tmp_path, monkeypatch
+) -> None:
     import asyncio
 
     from loushang.ai.auth.types import OAuthCredentials
@@ -1455,17 +1721,25 @@ def test_create_agent_session_uses_stored_oauth_credentials_for_auth_bridge(tmp_
             name="Secured",
             provider="demo",
             endpoint="responses",
-            capabilities=Capabilities(reasoning=True, input=("text",), context_window=128000, max_tokens=4096),
+            capabilities=Capabilities(
+                reasoning=True, input=("text",), context_window=128000, max_tokens=4096
+            ),
         )
     )
 
     credential_store = {
-        "providers": {"demo": OAuthCredentials(provider="demo", access_token="oauth-token")},
+        "providers": {
+            "demo": OAuthCredentials(provider="demo", access_token="oauth-token")
+        },
         "endpoints": {},
         "models": {},
     }
-    monkeypatch.setattr("loushang.ai.auth.storage.load_credential_store", lambda: credential_store)
-    monkeypatch.setattr("loushang.ai.auth.facade.load_credential_store", lambda: credential_store)
+    monkeypatch.setattr(
+        "loushang.ai.auth.storage.load_credential_store", lambda: credential_store
+    )
+    monkeypatch.setattr(
+        "loushang.ai.auth.facade.load_credential_store", lambda: credential_store
+    )
     monkeypatch.setattr(
         "loushang.ai.auth.oauth.get_oauth_api_key",
         lambda provider, credentials: {
@@ -1478,22 +1752,32 @@ def test_create_agent_session_uses_stored_oauth_credentials_for_auth_bridge(tmp_
         ai_model_registry=ai_registry,
         auth_manager=AuthManager(ai_registry=ai_registry, env={}),
     )
-    services.settings_manager.set_default_model(ModelSelection(provider="demo", model_id="secured"))
+    services.settings_manager.set_default_model(
+        ModelSelection(provider="demo", model_id="secured")
+    )
 
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     session = create_agent_session(session_manager=manager, services=services)
 
     api_key = session.agent.get_api_key("demo")
     if inspect.isawaitable(api_key):
         api_key = asyncio.run(api_key)
 
-    diagnostics = [record for record in session.get_last_diagnostics() if record.code == "model_auth_unresolved"]
+    diagnostics = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "model_auth_unresolved"
+    ]
 
     assert api_key == "demo-oauth-key"
     assert diagnostics == []
 
 
-def test_create_agent_session_marks_failing_mutation_builtin_tool_result_as_error(tmp_path) -> None:
+def test_create_agent_session_marks_failing_mutation_builtin_tool_result_as_error(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.coding import SessionManager, ToolRegistry, register_builtin_tools
@@ -1502,16 +1786,24 @@ def test_create_agent_session_marks_failing_mutation_builtin_tool_result_as_erro
     (tmp_path / "main.py").write_text("alpha\n", encoding="utf-8")
 
     async def stream_fn(model, context, options=None):
-        if any(getattr(message, "role", None) == "toolResult" for message in context.messages):
+        if any(
+            getattr(message, "role", None) == "toolResult"
+            for message in context.messages
+        ):
             return _stream_with_final_message(_assistant_message("done"))
         return _stream_with_final_message(
             _assistant_tool_call_message(
                 tool_name="edit",
-                arguments={"path": "main.py", "edits": [{"oldText": "missing", "newText": "new"}]},
+                arguments={
+                    "path": "main.py",
+                    "edits": [{"oldText": "missing", "newText": "new"}],
+                },
             )
         )
 
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     registry = ToolRegistry()
     register_builtin_tools(registry)
 
@@ -1540,7 +1832,9 @@ def test_create_agent_session_marks_failing_mutation_builtin_tool_result_as_erro
     assert "missing" in tool_results[0].content[0].text
 
 
-def test_create_agent_session_passes_resource_loader_into_agent_session(tmp_path) -> None:
+def test_create_agent_session_passes_resource_loader_into_agent_session(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.loader import DefaultResourceLoader
     from loushang.coding.store import SessionManager
@@ -1556,7 +1850,9 @@ def test_create_agent_session_passes_resource_loader_into_agent_session(tmp_path
 
     loader = _RecordingLoader()
     services = create_services(resource_loader=loader)
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
 
     session = create_agent_session(
         session_manager=manager,
@@ -1585,18 +1881,31 @@ def test_runtime_tool_failures_still_surface_as_tool_result_errors(tmp_path) -> 
         }
         prepare_arguments = None
 
-        async def execute(self, tool_call_id: str, params: dict[str, object], signal=None, on_update=None):
+        async def execute(
+            self,
+            tool_call_id: str,
+            params: dict[str, object],
+            signal=None,
+            on_update=None,
+        ):
             del tool_call_id, params, signal, on_update
             raise RuntimeError("runtime tool exploded")
 
     async def stream_fn(model, context, options=None):
-        if any(getattr(message, "role", None) == "toolResult" for message in context.messages):
+        if any(
+            getattr(message, "role", None) == "toolResult"
+            for message in context.messages
+        ):
             return _stream_with_final_message(_assistant_message("done"))
         return _stream_with_final_message(
-            _assistant_tool_call_message(tool_name="runtime_tool", arguments={"value": 1})
+            _assistant_tool_call_message(
+                tool_name="runtime_tool", arguments={"value": 1}
+            )
         )
 
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     session = create_agent_session(
         session_manager=manager,
         model=_model(),
@@ -1619,7 +1928,11 @@ def test_runtime_tool_failures_still_surface_as_tool_result_errors(tmp_path) -> 
     assert tool_results[0].tool_name == "runtime_tool"
     assert tool_results[0].is_error is True
     assert tool_results[0].content[0].text == "runtime tool exploded"
-    diagnostics = [record for record in session.get_last_diagnostics() if record.code == "tool_execution_failed"]
+    diagnostics = [
+        record
+        for record in session.get_last_diagnostics()
+        if record.code == "tool_execution_failed"
+    ]
     assert len(diagnostics) == 1
     assert diagnostics[0].code == "tool_execution_failed"
     assert diagnostics[0].source == "tool"
@@ -1631,30 +1944,42 @@ def test_create_agent_session_wires_coding_convert_to_llm(tmp_path) -> None:
     from loushang.coding.message import BranchSummaryMessage
     from loushang.coding.store import SessionManager
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = create_agent_session(
         session_manager=manager,
         model=_model(),
     )
 
     converted = session.agent.convert_to_llm(
-        [BranchSummaryMessage(role="branchSummary", summary="done", from_id="b1", timestamp=0.0)]
+        [
+            BranchSummaryMessage(
+                role="branchSummary", summary="done", from_id="b1", timestamp=0.0
+            )
+        ]
     )
 
     assert len(converted) == 1
     assert converted[0].role == "user"
 
 
-def test_create_agent_session_convert_to_llm_blocks_images_when_configured(tmp_path) -> None:
+def test_create_agent_session_convert_to_llm_blocks_images_when_configured(
+    tmp_path,
+) -> None:
     from loushang.ai.types import ImagePart, TextPart, ToolResultMessage, UserMessage
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.control import ControlConfig, ImageSettings, SettingsManager
     from loushang.coding.store import SessionManager
 
     services = create_services(
-        settings_manager=SettingsManager(ControlConfig(images=ImageSettings(block_images=True))),
+        settings_manager=SettingsManager(
+            ControlConfig(images=ImageSettings(block_images=True))
+        ),
     )
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     session = create_agent_session(
         session_manager=manager,
         services=services,
@@ -1708,7 +2033,9 @@ def test_create_agent_session_merges_extension_resources_and_tools(tmp_path) -> 
     from loushang.coding.store import SessionManager
     from loushang.coding.tools import ToolDefinition
 
-    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+    async def _execute_tool(
+        tool_name: str, arguments: dict[str, object], context, signal
+    ):
         return {"tool_name": tool_name, "arguments": arguments}
 
     class _Extension:
@@ -1759,8 +2086,12 @@ def test_create_agent_session_merges_extension_resources_and_tools(tmp_path) -> 
             self._bundle = bundle
             return bundle
 
-    services = create_services(resource_loader=_Loader(), system_prompt="Base system prompt.")
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    services = create_services(
+        resource_loader=_Loader(), system_prompt="Base system prompt."
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
 
     session = create_agent_session(
         session_manager=manager,
@@ -1768,7 +2099,10 @@ def test_create_agent_session_merges_extension_resources_and_tools(tmp_path) -> 
         model=_model(),
     )
 
-    assert "Base system prompt.\n\nRepo rules\n\nExtension rules" in session.agent.system_prompt
+    assert (
+        "Base system prompt.\n\nRepo rules\n\nExtension rules"
+        in session.agent.system_prompt
+    )
     assert session.get_active_tool_names() == ["ext_tool"]
     assert [definition.name for definition in session.get_all_tools()] == ["ext_tool"]
     assert session.getAllTools()[0]["sourceInfo"] == {
@@ -1781,7 +2115,9 @@ def test_create_agent_session_merges_extension_resources_and_tools(tmp_path) -> 
     assert session.resource_bundle.prompt_fragments == ["Repo rules", "Extension rules"]
 
 
-def test_create_agent_session_wires_extension_tool_interception_into_agent(tmp_path) -> None:
+def test_create_agent_session_wires_extension_tool_interception_into_agent(
+    tmp_path,
+) -> None:
     import asyncio
 
     from loushang.coding.bootstrap import create_agent_session, create_services
@@ -1842,7 +2178,9 @@ def test_create_agent_session_wires_extension_tool_interception_into_agent(tmp_p
         encoding="utf-8",
     )
 
-    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+    async def _execute_tool(
+        tool_name: str, arguments: dict[str, object], context, signal
+    ):
         from loushang.agent.types import AgentToolResult
         from loushang.ai.types import TextPart
 
@@ -1867,12 +2205,19 @@ def test_create_agent_session_wires_extension_tool_interception_into_agent(tmp_p
             return bundle
 
     async def stream_fn(model, context, options=None):
-        if any(getattr(message, "role", None) == "toolResult" for message in context.messages):
+        if any(
+            getattr(message, "role", None) == "toolResult"
+            for message in context.messages
+        ):
             return _stream_with_final_message(_assistant_message("done"))
         return _stream_with_final_message(_assistant_tool_call_message())
 
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
-    services = create_services(resource_loader=_Loader(), system_prompt="Base system prompt.")
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
+    services = create_services(
+        resource_loader=_Loader(), system_prompt="Base system prompt."
+    )
     base_tool = ToolDefinition(
         name="calc",
         label="Calc",
@@ -1911,7 +2256,9 @@ def test_create_agent_session_wires_extension_tool_interception_into_agent(tmp_p
     assert tool_results[0].details == {"rewritten": True}
 
 
-def test_create_agent_session_records_nonfatal_extension_tool_conflicts(tmp_path) -> None:
+def test_create_agent_session_records_nonfatal_extension_tool_conflicts(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.loader import (
         DefaultResourceLoader,
@@ -1956,7 +2303,9 @@ def test_create_agent_session_records_nonfatal_extension_tool_conflicts(tmp_path
         encoding="utf-8",
     )
 
-    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+    async def _execute_tool(
+        tool_name: str, arguments: dict[str, object], context, signal
+    ):
         from loushang.agent.types import AgentToolResult
         from loushang.ai.types import TextPart
 
@@ -1980,8 +2329,12 @@ def test_create_agent_session_records_nonfatal_extension_tool_conflicts(tmp_path
             self._bundle = bundle
             return bundle
 
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
-    services = create_services(resource_loader=_Loader(), system_prompt="Base system prompt.")
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
+    services = create_services(
+        resource_loader=_Loader(), system_prompt="Base system prompt."
+    )
     base_tool = ToolDefinition(
         name="calc",
         label="Calc",
@@ -2012,7 +2365,9 @@ def test_extension_tool_contribution_projection_preserves_source_info(tmp_path) 
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
     from loushang.coding.tools import ToolDefinition
 
-    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+    async def _execute_tool(
+        tool_name: str, arguments: dict[str, object], context, signal
+    ):
         del tool_name, arguments, context, signal
         return {"ok": True}
 
@@ -2033,7 +2388,9 @@ def test_extension_tool_contribution_projection_preserves_source_info(tmp_path) 
 
     contributions = _extension_tool_contributions(runner)
 
-    assert [contribution.definition.name for contribution in contributions] == ["ext_review"]
+    assert [contribution.definition.name for contribution in contributions] == [
+        "ext_review"
+    ]
     assert contributions[0].enabled is True
     assert contributions[0].source_info == runner.get_tool_source_info("ext_review")
     assert contributions[0].metadata == {
@@ -2051,7 +2408,9 @@ def test_register_extension_tools_uses_harness_resolver_for_dry_run_conflicts(
     from loushang.coding.tools import ToolDefinition, ToolRegistry
     from loushang.harness.tools.contribution import resolve_tool_contributions
 
-    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+    async def _execute_tool(
+        tool_name: str, arguments: dict[str, object], context, signal
+    ):
         del tool_name, arguments, context, signal
         return {"ok": True}
 
@@ -2083,7 +2442,9 @@ def test_register_extension_tools_uses_harness_resolver_for_dry_run_conflicts(
 
     def spy_resolver(contributions, **kwargs):
         contribution_tuple = tuple(contributions)
-        calls.append(tuple(contribution.definition.name for contribution in contribution_tuple))
+        calls.append(
+            tuple(contribution.definition.name for contribution in contribution_tuple)
+        )
         return resolve_tool_contributions(contribution_tuple, **kwargs)
 
     monkeypatch.setattr(bootstrap, "resolve_tool_contributions", spy_resolver)
@@ -2097,8 +2458,12 @@ def test_register_extension_tools_uses_harness_resolver_for_dry_run_conflicts(
     assert calls == [("calc", "calc")]
     assert resolved_registry is registry
     assert [definition.name for definition in registry.list_definitions()] == ["calc"]
-    assert [diagnostic.code for diagnostic in diagnostics] == ["extension_tool_conflict"]
-    assert [diagnostic.code for diagnostic in bundle.diagnostics] == ["extension_tool_conflict"]
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "extension_tool_conflict"
+    ]
+    assert [diagnostic.code for diagnostic in bundle.diagnostics] == [
+        "extension_tool_conflict"
+    ]
 
 
 def test_register_extension_tools_registers_resolver_output_only(
@@ -2110,7 +2475,9 @@ def test_register_extension_tools_registers_resolver_output_only(
     from loushang.coding.tools import ToolDefinition, ToolRegistry
     from loushang.harness.tools.contribution import ToolResolutionResult
 
-    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+    async def _execute_tool(
+        tool_name: str, arguments: dict[str, object], context, signal
+    ):
         del tool_name, arguments, context, signal
         return {"ok": True}
 
@@ -2152,7 +2519,9 @@ def test_register_extension_tools_preserves_resolver_source_info(tmp_path) -> No
     from loushang.coding.loader import ResourceBundle
     from loushang.coding.tools import ToolDefinition, ToolRegistry
 
-    async def _execute_tool(tool_name: str, arguments: dict[str, object], context, signal):
+    async def _execute_tool(
+        tool_name: str, arguments: dict[str, object], context, signal
+    ):
         del tool_name, arguments, context, signal
         return {"ok": True}
 
@@ -2181,11 +2550,15 @@ def test_register_extension_tools_preserves_resolver_source_info(tmp_path) -> No
 
     assert diagnostics == []
     assert registry is not None
-    assert [definition.name for definition in registry.list_definitions()] == ["ext_calc"]
+    assert [definition.name for definition in registry.list_definitions()] == [
+        "ext_calc"
+    ]
     assert registry.get_source_info("ext_calc") == source_info
 
 
-def test_create_agent_session_passes_compaction_settings_to_session(tmp_path, monkeypatch) -> None:
+def test_create_agent_session_passes_compaction_settings_to_session(
+    tmp_path, monkeypatch
+) -> None:
     import asyncio
 
     from loushang.coding.bootstrap import create_agent_session, create_services
@@ -2195,14 +2568,20 @@ def test_create_agent_session_passes_compaction_settings_to_session(tmp_path, mo
 
     services = create_services()
     services.settings_manager.update_settings(
-        compaction=CompactionSettings(enabled=True, reserve_tokens=8192, keep_recent_tokens=1)
+        compaction=CompactionSettings(
+            enabled=True, reserve_tokens=8192, keep_recent_tokens=1
+        )
     )
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path, cwd="/tmp/project", persist=False
+    )
     manager.append_message(
         UserMessage(
             role="user",
-            content=[TextPart(type="text", text="older context that should be compacted")],
+            content=[
+                TextPart(type="text", text="older context that should be compacted")
+            ],
             timestamp=0.0,
         )
     )
@@ -2245,7 +2624,9 @@ def test_create_agent_session_passes_control_thinking_settings(tmp_path) -> None
     )
     manager = SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False)
 
-    session = create_agent_session(session_manager=manager, model=_model(), services=services)
+    session = create_agent_session(
+        session_manager=manager, model=_model(), services=services
+    )
 
     assert session.agent.thinking_budgets == {"low": 1024, "high": 4096}
     assert session.agent.max_retry_delay_ms == 1234
@@ -2275,15 +2656,27 @@ def test_create_agent_session_applies_enabled_models_as_scoped_models(tmp_path) 
     ai_registry.register_model(second)
     services = create_services(
         ai_model_registry=ai_registry,
-        settings_manager=SettingsManager(ControlConfig(enabled_models=("faux-model:low", "alt-model:high", "missing"))),
+        settings_manager=SettingsManager(
+            ControlConfig(
+                enabled_models=("faux-model:low", "alt-model:high", "missing")
+            )
+        ),
     )
     manager = SessionManager.new(session_dir=tmp_path, cwd=str(tmp_path), persist=False)
 
-    session = create_agent_session(session_manager=manager, model=first, services=services)
+    session = create_agent_session(
+        session_manager=manager, model=first, services=services
+    )
 
     assert session.scopedModels == [
-        {"model": {"provider": "faux", "model_id": "faux-model"}, "thinkingLevel": "low"},
-        {"model": {"provider": "alt", "model_id": "alt-model"}, "thinkingLevel": "high"},
+        {
+            "model": {"provider": "faux", "model_id": "faux-model"},
+            "thinkingLevel": "low",
+        },
+        {
+            "model": {"provider": "alt", "model_id": "alt-model"},
+            "thinkingLevel": "high",
+        },
     ]
 
 
@@ -2314,7 +2707,9 @@ def test_create_agent_session_records_resource_loading_diagnostics(tmp_path) -> 
             return bundle
 
     services = create_services(resource_loader=_Loader())
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
 
     create_agent_session(
         session_manager=manager,
@@ -2322,14 +2717,18 @@ def test_create_agent_session_records_resource_loading_diagnostics(tmp_path) -> 
         model=_model(),
     )
 
-    diagnostics = services.diagnostics_service.get_diagnostics(phase="resource_loading", source="loader")
+    diagnostics = services.diagnostics_service.get_diagnostics(
+        phase="resource_loading", source="loader"
+    )
 
     assert len(diagnostics) == 1
     assert diagnostics[0].code == "duplicate_prompt"
     assert diagnostics[0].session_id == manager.get_header().id
 
 
-def test_create_agent_session_records_startup_package_root_diagnostics(tmp_path) -> None:
+def test_create_agent_session_records_startup_package_root_diagnostics(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.control import SettingsManager
     from loushang.coding.store import SessionManager
@@ -2343,8 +2742,12 @@ def test_create_agent_session_records_startup_package_root_diagnostics(tmp_path)
         f'{{"package_roots": ["{missing_package_root}"]}}',
         encoding="utf-8",
     )
-    services = create_services(settings_manager=SettingsManager(global_settings_path=settings_path))
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    services = create_services(
+        settings_manager=SettingsManager(global_settings_path=settings_path)
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
     create_agent_session(
         session_manager=manager,
@@ -2368,11 +2771,15 @@ def test_create_agent_session_records_startup_package_root_diagnostics(tmp_path)
     }
 
 
-def test_create_agent_session_records_executable_source_identity_diagnostic(tmp_path) -> None:
+def test_create_agent_session_records_executable_source_identity_diagnostic(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.store import SessionManager
 
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     services = create_services()
 
     create_agent_session(
@@ -2406,8 +2813,12 @@ def test_create_agent_session_records_package_lockfile_diagnostics(tmp_path) -> 
 
     lockfile = tmp_path / "package-lock.json"
     lockfile.write_text("not json", encoding="utf-8")
-    materializer = PackageMaterializer(install_root=tmp_path / "packages", lockfile_path=lockfile)
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False)
+    materializer = PackageMaterializer(
+        install_root=tmp_path / "packages", lockfile_path=lockfile
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(tmp_path), persist=False
+    )
     services = create_services()
 
     create_agent_session(
@@ -2428,7 +2839,9 @@ def test_create_agent_session_records_package_lockfile_diagnostics(tmp_path) -> 
     assert diagnostics[0].source_path == lockfile
 
 
-def test_create_agent_session_records_invalid_plugin_source_and_continues(tmp_path) -> None:
+def test_create_agent_session_records_invalid_plugin_source_and_continues(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.control import SettingsManager
     from loushang.coding.store import SessionManager
@@ -2451,8 +2864,12 @@ def test_create_agent_session_records_invalid_plugin_source_and_continues(tmp_pa
         ),
         encoding="utf-8",
     )
-    services = create_services(settings_manager=SettingsManager(global_settings_path=settings_path))
-    manager = SessionManager.new(session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False)
+    services = create_services(
+        settings_manager=SettingsManager(global_settings_path=settings_path)
+    )
+    manager = SessionManager.new(
+        session_dir=tmp_path / "sessions", cwd=str(project_root), persist=False
+    )
 
     session = create_agent_session(
         session_manager=manager,
@@ -2462,7 +2879,9 @@ def test_create_agent_session_records_invalid_plugin_source_and_continues(tmp_pa
 
     diagnostics = [
         record
-        for record in services.diagnostics_service.get_diagnostics(phase="startup", source="bootstrap")
+        for record in services.diagnostics_service.get_diagnostics(
+            phase="startup", source="bootstrap"
+        )
         if record.code == "plugin_source_unresolved"
     ]
 

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -66,11 +66,19 @@ class FakeSession:
 
     def export_to_html(self, output_path: str | None = None) -> str:
         self.set_export_calls.append(output_path)
-        return output_path if output_path is not None else str(self.session_file.with_suffix(".html"))
+        return (
+            output_path
+            if output_path is not None
+            else str(self.session_file.with_suffix(".html"))
+        )
 
     def export_to_jsonl(self, output_path: str | None = None) -> str:
         self.set_jsonl_export_calls.append(output_path)
-        return output_path if output_path is not None else str(self.session_file.with_name(f"{self.session_id}-export.jsonl"))
+        return (
+            output_path
+            if output_path is not None
+            else str(self.session_file.with_name(f"{self.session_id}-export.jsonl"))
+        )
 
     def get_available_models(self):
         self.get_available_models_calls += 1
@@ -98,39 +106,85 @@ class FakeSession:
 
     async def materialize_package(self, source: str) -> dict[str, object]:
         self.materialize_package_calls.append(source)
-        return {"source": source, "name": "review-pack", "lifecycle": "installed", "targetPath": "/tmp/packages/review-pack"}
+        return {
+            "source": source,
+            "name": "review-pack",
+            "lifecycle": "installed",
+            "targetPath": "/tmp/packages/review-pack",
+        }
 
     def get_packages(self, *, catalog_path: str | None = None):
         del catalog_path
         return list(self.packages_payload)
 
-    async def install_package(self, source: str, *, scope: str = "project") -> dict[str, object]:
+    async def install_package(
+        self, source: str, *, scope: str = "project"
+    ) -> dict[str, object]:
         self.install_package_calls.append((source, scope))
-        return {"source": source, "name": "review-pack", "lifecycle": "installed", "targetPath": "/tmp/packages/review-pack"}
+        return {
+            "source": source,
+            "name": "review-pack",
+            "lifecycle": "installed",
+            "targetPath": "/tmp/packages/review-pack",
+        }
 
     async def update_package(self, source: str) -> dict[str, object]:
         self.update_package_calls.append(source)
-        return {"source": source, "name": "review-pack", "lifecycle": "installed", "targetPath": "/tmp/packages/review-pack"}
+        return {
+            "source": source,
+            "name": "review-pack",
+            "lifecycle": "installed",
+            "targetPath": "/tmp/packages/review-pack",
+        }
 
     async def update_packages(self) -> list[dict[str, object]]:
         self.update_packages_calls += 1
-        return [{"source": "all", "name": "all", "lifecycle": "installed", "targetPath": "/tmp/packages"}]
+        return [
+            {
+                "source": "all",
+                "name": "all",
+                "lifecycle": "installed",
+                "targetPath": "/tmp/packages",
+            }
+        ]
 
     async def check_package_updates(self) -> list[dict[str, object]]:
         self.check_package_updates_calls += 1
-        return [{"source": "all", "name": "review-pack", "currentCommit": "a", "availableCommit": "b", "pinned": False}]
+        return [
+            {
+                "source": "all",
+                "name": "review-pack",
+                "currentCommit": "a",
+                "availableCommit": "b",
+                "pinned": False,
+            }
+        ]
 
     def remove_package(self, source: str) -> dict[str, object]:
         self.remove_package_calls.append(source)
-        return {"source": source, "name": "review-pack", "lifecycle": "remote_registered", "targetPath": "/tmp/packages/review-pack"}
+        return {
+            "source": source,
+            "name": "review-pack",
+            "lifecycle": "remote_registered",
+            "targetPath": "/tmp/packages/review-pack",
+        }
 
-    def uninstall_package(self, source: str, *, scope: str = "project") -> dict[str, object]:
+    def uninstall_package(
+        self, source: str, *, scope: str = "project"
+    ) -> dict[str, object]:
         self.uninstall_package_calls.append((source, scope))
-        return {"source": source, "name": "review-pack", "lifecycle": "remote_registered", "targetPath": "/tmp/packages/review-pack"}
+        return {
+            "source": source,
+            "name": "review-pack",
+            "lifecycle": "remote_registered",
+            "targetPath": "/tmp/packages/review-pack",
+        }
 
 
 class FakeRuntime:
-    def __init__(self, session: FakeSession, records: list[object] | None = None) -> None:
+    def __init__(
+        self, session: FakeSession, records: list[object] | None = None
+    ) -> None:
         self._current_session = session
         self.new_session_calls: list[str] = []
         self.restore_session_calls: list[str] = []
@@ -431,7 +485,9 @@ def _fake_services(
         method=method_settings,
     )
     settings_manager = SimpleNamespace(get_settings=lambda: settings)
-    return SimpleNamespace(settings_manager=settings_manager, diagnostics_service=object())
+    return SimpleNamespace(
+        settings_manager=settings_manager, diagnostics_service=object()
+    )
 
 
 def _write_review_method(project_root: Path) -> None:
@@ -603,12 +659,16 @@ def test_parse_args_accepts_method_visibility_flags_and_subcommands() -> None:
     assert args.list_methods is True
     assert args.list_methods_format == "json"
 
-    show_args = parse_args(["method", "show", "method:task:review", "--show-method-format", "json"])
+    show_args = parse_args(
+        ["method", "show", "method:task:review", "--show-method-format", "json"]
+    )
 
     assert show_args.show_method == "method:task:review"
     assert show_args.show_method_format == "json"
 
-    plan_show_args = parse_args(["method", "plan", "show", "review", "--format", "json"])
+    plan_show_args = parse_args(
+        ["method", "plan", "show", "review", "--format", "json"]
+    )
 
     assert plan_show_args.show_method_plan == "review"
     assert plan_show_args.show_method_plan_format == "json"
@@ -841,7 +901,9 @@ def test_parse_args_rewrites_diag_export_subcommand() -> None:
     assert args.messages == ()
 
 
-def test_default_runtime_builder_maps_tools_to_allowed_and_active_tools(tmp_path) -> None:
+def test_default_runtime_builder_maps_tools_to_allowed_and_active_tools(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_services
     from loushang.coding.cli.__main__ import default_runtime_builder
     from loushang.coding.tools import ToolRegistry, register_builtin_tools
@@ -859,7 +921,10 @@ def test_default_runtime_builder_maps_tools_to_allowed_and_active_tools(tmp_path
     session = asyncio.run(runtime.create_session(cwd=str(tmp_path)))
 
     assert session.get_active_tool_names() == ["read", "grep"]
-    assert [definition.name for definition in session.get_all_tools()] == ["read", "grep"]
+    assert [definition.name for definition in session.get_all_tools()] == [
+        "read",
+        "grep",
+    ]
 
 
 def test_default_runtime_builder_maps_no_tools_to_empty_allowed_tools(tmp_path) -> None:
@@ -929,12 +994,16 @@ def test_default_runtime_builder_applies_resource_and_prompt_options(tmp_path) -
 
     session = asyncio.run(runtime.create_session(cwd=str(project_root)))
 
-    assert session.agent.system_prompt.startswith("System from file\n\nAppend from file\n\nInline append")
+    assert session.agent.system_prompt.startswith(
+        "System from file\n\nAppend from file\n\nInline append"
+    )
     assert "Project guidance" not in session.agent.system_prompt
     assert [skill.name for skill in session.resource_bundle.skills] == ["review"]
 
 
-def test_default_runtime_builder_rebuilds_project_bound_services_for_session_cwd(tmp_path) -> None:
+def test_default_runtime_builder_rebuilds_project_bound_services_for_session_cwd(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import (
         build_default_services,
         default_runtime_builder,
@@ -967,7 +1036,9 @@ def test_default_runtime_builder_rebuilds_project_bound_services_for_session_cwd
     assert "Project B guidance" in second.agent.system_prompt
 
 
-def test_cwd_bound_services_factory_uses_sdk_services_creation(tmp_path, monkeypatch) -> None:
+def test_cwd_bound_services_factory_uses_sdk_services_creation(
+    tmp_path, monkeypatch
+) -> None:
     import loushang.coding.cli.__main__ as cli_main
     from loushang.coding.bootstrap import create_services
 
@@ -987,9 +1058,16 @@ def test_cwd_bound_services_factory_uses_sdk_services_creation(tmp_path, monkeyp
         calls.append(kwargs)
         return SimpleNamespace(services=created_services)
 
-    monkeypatch.setattr(cli_main, "create_agent_session_services", fake_create_agent_session_services, raising=False)
+    monkeypatch.setattr(
+        cli_main,
+        "create_agent_session_services",
+        fake_create_agent_session_services,
+        raising=False,
+    )
 
-    factory = cli_main._cwd_bound_services_factory(base_services, resource_loader_options)
+    factory = cli_main._cwd_bound_services_factory(
+        base_services, resource_loader_options
+    )
 
     assert factory is not None
     assert factory(str(project_b)) is created_services
@@ -1001,7 +1079,9 @@ def test_cwd_bound_services_factory_uses_sdk_services_creation(tmp_path, monkeyp
     ]
 
 
-def test_run_cli_sets_offline_environment_before_building_runtime(tmp_path, monkeypatch) -> None:
+def test_run_cli_sets_offline_environment_before_building_runtime(
+    tmp_path, monkeypatch
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     monkeypatch.delenv("LOUSHANG_OFFLINE", raising=False)
@@ -1045,7 +1125,79 @@ def test_run_cli_sets_offline_environment_before_building_runtime(tmp_path, monk
     assert captured_args[0].no_skills is True
 
 
-def test_cli_builtin_tool_registry_uses_settings_external_tool_policy(monkeypatch) -> None:
+def test_run_cli_shares_interactive_approval_resolver_with_tools_and_runtime(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from loushang.coding.cli import __main__ as cli_main
+    from loushang.coding.policy import InteractiveApprovalResolver
+    from loushang.coding.tools import ToolRegistry
+
+    captured: dict[str, object] = {}
+    runtime = FakeRuntime(FakeSession("unused"))
+
+    def build_registry(**kwargs):
+        captured["tool_resolver"] = kwargs["approval_resolver"]
+        return ToolRegistry()
+
+    def runtime_builder(**kwargs):
+        captured["runtime_resolver"] = kwargs["approval_resolver"]
+        return runtime
+
+    monkeypatch.setattr(cli_main, "build_builtin_tool_registry", build_registry)
+
+    exit_code = asyncio.run(
+        cli_main.run_cli(
+            ["--list-sessions"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=runtime_builder,
+        )
+    )
+
+    assert exit_code == 0
+    assert isinstance(captured["tool_resolver"], InteractiveApprovalResolver)
+    assert captured["runtime_resolver"] is captured["tool_resolver"]
+
+
+def test_run_cli_keeps_legacy_fixed_runtime_builder_signature(tmp_path) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    captured: dict[str, object] = {}
+    runtime = FakeRuntime(FakeSession("unused"))
+
+    def runtime_builder(*, args, cwd, session_dir, services, tool_registry):
+        captured.update(
+            args=args,
+            cwd=cwd,
+            session_dir=session_dir,
+            services=services,
+            tool_registry=tool_registry,
+        )
+        return runtime
+
+    exit_code = asyncio.run(
+        run_cli(
+            ["--list-sessions"],
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=runtime_builder,
+        )
+    )
+
+    assert exit_code == 0
+    assert captured["cwd"] == tmp_path.resolve()
+
+
+def test_cli_builtin_tool_registry_uses_settings_external_tool_policy(
+    monkeypatch,
+) -> None:
     from loushang.coding.cli import __main__ as cli_main
     from loushang.coding.control import ControlConfig, SettingsManager, ToolSettings
 
@@ -1056,14 +1208,18 @@ def test_cli_builtin_tool_registry_uses_settings_external_tool_policy(monkeypatc
         return registry
 
     monkeypatch.setattr(cli_main, "register_builtin_tools", fake_register_builtin_tools)
-    manager = SettingsManager(ControlConfig(tools=ToolSettings(external_tool_policy="required")))
+    manager = SettingsManager(
+        ControlConfig(tools=ToolSettings(external_tool_policy="required"))
+    )
 
     cli_main.build_builtin_tool_registry(settings_manager=manager)
 
     assert captured["external_tool_policy"] == "required"
 
 
-def test_cli_builtin_tool_registry_binds_headless_policy_from_settings(tmp_path) -> None:
+def test_cli_builtin_tool_registry_binds_headless_policy_from_settings(
+    tmp_path,
+) -> None:
     from loushang.coding.cli import __main__ as cli_main
     from loushang.coding.control import ControlConfig, SettingsManager, ToolSettings
     from loushang.coding.tools import ToolContext
@@ -1079,10 +1235,16 @@ def test_cli_builtin_tool_registry_binds_headless_policy_from_settings(tmp_path)
             )
         )
     )
-    allow_registry = cli_main.build_builtin_tool_registry(settings_manager=allow_manager)
-    allow_tool = allow_registry.materialize_tool("write", context_provider=context_provider)
+    allow_registry = cli_main.build_builtin_tool_registry(
+        settings_manager=allow_manager
+    )
+    allow_tool = allow_registry.materialize_tool(
+        "write", context_provider=context_provider
+    )
 
-    asyncio.run(allow_tool.execute("call-allow", {"path": "allowed.txt", "content": "ok"}))
+    asyncio.run(
+        allow_tool.execute("call-allow", {"path": "allowed.txt", "content": "ok"})
+    )
 
     deny_manager = SettingsManager(
         ControlConfig(
@@ -1094,10 +1256,14 @@ def test_cli_builtin_tool_registry_binds_headless_policy_from_settings(tmp_path)
         )
     )
     deny_registry = cli_main.build_builtin_tool_registry(settings_manager=deny_manager)
-    deny_tool = deny_registry.materialize_tool("write", context_provider=context_provider)
+    deny_tool = deny_registry.materialize_tool(
+        "write", context_provider=context_provider
+    )
 
     with pytest.raises(PermissionError, match="headless policy denied"):
-        asyncio.run(deny_tool.execute("call-deny", {"path": "denied.txt", "content": "blocked"}))
+        asyncio.run(
+            deny_tool.execute("call-deny", {"path": "denied.txt", "content": "blocked"})
+        )
 
     assert (tmp_path / "allowed.txt").read_text(encoding="utf-8") == "ok"
     assert not (tmp_path / "denied.txt").exists()
@@ -1178,7 +1344,9 @@ def test_parse_args_supports_command_dispatch_flags() -> None:
     assert args.messages == ("hello",)
 
 
-def test_parse_args_maps_pi_style_package_subcommands_to_package_manager_commands() -> None:
+def test_parse_args_maps_pi_style_package_subcommands_to_package_manager_commands() -> (
+    None
+):
     from loushang.coding.cli.args import parse_args
 
     install = parse_args(["install", "plugins/debug-pack"])
@@ -1215,7 +1383,9 @@ def test_parse_args_supports_explicit_package_lifecycle_flags() -> None:
         ]
     )
 
-    assert args.materialize_packages == ("https://packages.example.invalid/review-pack.git",)
+    assert args.materialize_packages == (
+        "https://packages.example.invalid/review-pack.git",
+    )
     assert args.update_packages == ("https://packages.example.invalid/review-pack.git",)
     assert args.remove_packages == ("https://packages.example.invalid/review-pack.git",)
 
@@ -1259,7 +1429,59 @@ def test_run_cli_prints_help_and_exits_before_runtime(tmp_path) -> None:
     asyncio.run(scenario())
 
 
-@pytest.mark.parametrize("argv", (["--mode", "json", "--help"], ["--mode", "print", "--help"]))
+def test_run_cli_help_supports_builder_with_required_approval_resolver(
+    tmp_path,
+) -> None:
+    from loushang.coding.cli.__main__ import run_cli
+
+    session = FakeSession("help-session")
+    session.extension_runner = SimpleNamespace(
+        get_flags=lambda: [
+            SimpleNamespace(
+                name="review-mode",
+                type="boolean",
+                description="Require review",
+                default=False,
+            )
+        ]
+    )
+    runtime = FakeRuntime(session)
+    captured: list[object] = []
+
+    def runtime_builder(
+        *,
+        args,
+        cwd,
+        session_dir,
+        services,
+        tool_registry,
+        approval_resolver,
+    ):
+        del args, cwd, session_dir, services, tool_registry
+        captured.append(approval_resolver)
+        return runtime
+
+    stdout = StringIO()
+    exit_code = asyncio.run(
+        run_cli(
+            ["--help"],
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=_fake_services(),
+            runtime_builder=runtime_builder,
+        )
+    )
+
+    assert exit_code == 0
+    assert captured == [None]
+    assert "--review-mode [boolean]" in stdout.getvalue()
+
+
+@pytest.mark.parametrize(
+    "argv", (["--mode", "json", "--help"], ["--mode", "print", "--help"])
+)
 def test_run_cli_routes_non_interactive_help_to_stderr(argv, tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
@@ -1282,7 +1504,9 @@ def test_run_cli_routes_non_interactive_help_to_stderr(argv, tmp_path) -> None:
     asyncio.run(scenario())
 
 
-def test_run_cli_routes_non_interactive_help_startup_stdout_to_stderr(tmp_path, monkeypatch) -> None:
+def test_run_cli_routes_non_interactive_help_startup_stdout_to_stderr(
+    tmp_path, monkeypatch
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     runtime = FakeRuntime(FakeSession("session-1"))
@@ -1314,7 +1538,9 @@ def test_run_cli_routes_non_interactive_help_startup_stdout_to_stderr(tmp_path, 
     asyncio.run(scenario())
 
 
-def test_run_cli_routes_machine_readable_command_startup_stdout_to_stderr(tmp_path, monkeypatch) -> None:
+def test_run_cli_routes_machine_readable_command_startup_stdout_to_stderr(
+    tmp_path, monkeypatch
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     runtime = FakeRuntime(FakeSession("session-1"), records=[])
@@ -1345,7 +1571,9 @@ def test_run_cli_routes_machine_readable_command_startup_stdout_to_stderr(tmp_pa
     asyncio.run(scenario())
 
 
-def test_run_cli_routes_print_mode_runtime_stdout_chatter_to_stderr(tmp_path, monkeypatch) -> None:
+def test_run_cli_routes_print_mode_runtime_stdout_chatter_to_stderr(
+    tmp_path, monkeypatch
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     runtime = FakeRuntime(FakeSession("session-1"))
@@ -1381,7 +1609,9 @@ def test_run_cli_routes_print_mode_runtime_stdout_chatter_to_stderr(tmp_path, mo
     asyncio.run(scenario())
 
 
-def test_run_cli_routes_machine_readable_command_runtime_stdout_chatter_to_stderr(tmp_path, monkeypatch) -> None:
+def test_run_cli_routes_machine_readable_command_runtime_stdout_chatter_to_stderr(
+    tmp_path, monkeypatch
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     class ChatteringRuntime(FakeRuntime):
@@ -1434,7 +1664,9 @@ def test_run_cli_prints_version_and_exits_before_runtime(tmp_path) -> None:
     asyncio.run(scenario())
 
 
-def test_run_cli_prints_source_info_and_exits_before_runtime(tmp_path, monkeypatch) -> None:
+def test_run_cli_prints_source_info_and_exits_before_runtime(
+    tmp_path, monkeypatch
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     bin_dir = tmp_path / "bin"
@@ -1498,7 +1730,9 @@ def test_run_cli_prints_source_info_as_json(tmp_path, monkeypatch) -> None:
     active.write_text("#!/bin/sh\n", encoding="utf-8")
     active.chmod(0o755)
     monkeypatch.setenv("PATH", str(bin_dir))
-    monkeypatch.setattr(sys, "argv", ["loushang", "--source-info", "--source-info-format", "json"])
+    monkeypatch.setattr(
+        sys, "argv", ["loushang", "--source-info", "--source-info-format", "json"]
+    )
 
     stdout = StringIO()
     stderr = StringIO()
@@ -1674,7 +1908,9 @@ def test_run_cli_diag_export_exits_before_runtime_creation(tmp_path) -> None:
 
     session_dir = tmp_path / "sessions"
     session_dir.mkdir()
-    (session_dir / "latest.jsonl").write_text('{"type":"user","text":"hello"}\n', encoding="utf-8")
+    (session_dir / "latest.jsonl").write_text(
+        '{"type":"user","text":"hello"}\n', encoding="utf-8"
+    )
     debug_file = tmp_path / "debug.log"
     debug_file.write_text("debug line\n", encoding="utf-8")
     output = tmp_path / "diag.zip"
@@ -1850,6 +2086,7 @@ def test_run_cli_reports_export_method_not_available(tmp_path) -> None:
             runtime_builder=lambda **kwargs: runtime,
         )
         assert exit_code == 1
+
     asyncio.run(scenario())
 
     assert "jsonl export is not available." in stderr.getvalue()
@@ -2099,7 +2336,9 @@ def test_run_cli_list_sessions_supports_no_diagnostics_filter(tmp_path) -> None:
     assert stderr.getvalue() == ""
 
 
-def test_run_cli_list_sessions_supports_all_sessions_with_query_filters(tmp_path) -> None:
+def test_run_cli_list_sessions_supports_all_sessions_with_query_filters(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.store import SessionQuery
 
@@ -2172,7 +2411,14 @@ def test_run_cli_list_sessions_can_use_session_index(tmp_path) -> None:
 
     async def scenario() -> None:
         exit_code = await run_cli(
-            ["--list-sessions", "--session-index", "--session-query", "indexed", "--list-sessions-format", "json"],
+            [
+                "--list-sessions",
+                "--session-index",
+                "--session-query",
+                "indexed",
+                "--list-sessions-format",
+                "json",
+            ],
             stdin=StringIO(""),
             stdout=stdout,
             stderr=stderr,
@@ -2184,7 +2430,9 @@ def test_run_cli_list_sessions_can_use_session_index(tmp_path) -> None:
 
     asyncio.run(scenario())
 
-    assert runtime.find_indexed_session_summaries_calls == [SessionQuery(text="indexed")]
+    assert runtime.find_indexed_session_summaries_calls == [
+        SessionQuery(text="indexed")
+    ]
     assert runtime.find_session_summaries_calls == []
     assert json.loads(stdout.getvalue())[0]["session_id"] == "session-indexed"
     assert stderr.getvalue() == ""
@@ -2200,7 +2448,13 @@ def test_run_cli_list_sessions_can_refresh_all_session_indexes(tmp_path) -> None
 
     async def scenario() -> None:
         exit_code = await run_cli(
-            ["--list-sessions", "--all-sessions", "--refresh-session-index", "--session-query", "global"],
+            [
+                "--list-sessions",
+                "--all-sessions",
+                "--refresh-session-index",
+                "--session-query",
+                "global",
+            ],
             stdin=StringIO(""),
             stdout=stdout,
             stderr=stderr,
@@ -2213,7 +2467,9 @@ def test_run_cli_list_sessions_can_refresh_all_session_indexes(tmp_path) -> None
     asyncio.run(scenario())
 
     assert runtime.refresh_all_session_indexes_calls == 1
-    assert runtime.find_all_indexed_session_summaries_calls == [SessionQuery(text="global")]
+    assert runtime.find_all_indexed_session_summaries_calls == [
+        SessionQuery(text="global")
+    ]
     assert runtime.find_all_session_summaries_calls == []
     assert stderr.getvalue() == ""
 
@@ -2402,7 +2658,9 @@ def test_run_cli_reports_list_sessions_invalid_payload(tmp_path) -> None:
     assert "session listing returned an invalid response." in stderr.getvalue()
 
 
-def test_run_cli_skips_session_records_that_fail_normalization(tmp_path, monkeypatch) -> None:
+def test_run_cli_skips_session_records_that_fail_normalization(
+    tmp_path, monkeypatch
+) -> None:
     from loushang.coding.cli import __main__ as cli_main
     from loushang.coding.cli.__main__ import run_cli
 
@@ -2426,7 +2684,9 @@ def test_run_cli_skips_session_records_that_fail_normalization(tmp_path, monkeyp
             raise RuntimeError("broken record")
         return original(record)
 
-    monkeypatch.setattr(cli_main, "_normalize_session_record", _broken_normalize_session_record)
+    monkeypatch.setattr(
+        cli_main, "_normalize_session_record", _broken_normalize_session_record
+    )
 
     runtime = FakeRuntime(FakeSession("unused"), records=["broken", valid_record])
     stdout = StringIO()
@@ -2522,7 +2782,9 @@ def test_run_cli_reports_list_sessions_with_unprintable_fields(tmp_path) -> None
     assert stderr.getvalue() == ""
 
 
-def test_run_cli_dispatches_print_mode_with_restored_session_and_model_override(tmp_path) -> None:
+def test_run_cli_dispatches_print_mode_with_restored_session_and_model_override(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.types import ModelSelection
 
@@ -2560,7 +2822,9 @@ def test_run_cli_dispatches_print_mode_with_restored_session_and_model_override(
     asyncio.run(scenario())
 
     assert runtime.restore_session_calls == ["session-1"]
-    assert runtime.get_current_session().set_model_calls == [ModelSelection(provider="faux", model_id="beta")]
+    assert runtime.get_current_session().set_model_calls == [
+        ModelSelection(provider="faux", model_id="beta")
+    ]
     assert print_runner.calls[0]["user_input"] == "hello world"
     assert print_runner.calls[0]["follow_up_messages"] == ()
     assert print_runner.calls[0]["output_mode"] == "json"
@@ -2636,7 +2900,9 @@ def test_apply_model_override_persists_global_default_with_endpoint() -> None:
     assert settings_calls == [(selection, "global")]
 
 
-def test_run_cli_accepts_explicit_endpoint_model_override_with_colon_endpoint(tmp_path) -> None:
+def test_run_cli_accepts_explicit_endpoint_model_override_with_colon_endpoint(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.types import ModelSelection
 
@@ -2841,7 +3107,9 @@ def test_run_cli_dash_p_uses_method_default_from_settings(tmp_path) -> None:
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(
-                method_settings=MethodSettings(mode="explicit", selected_method="review"),
+                method_settings=MethodSettings(
+                    mode="explicit", selected_method="review"
+                ),
             ),
             runtime_builder=lambda **kwargs: runtime,
             prompt_runner=prompt_runner,
@@ -2856,7 +3124,9 @@ def test_run_cli_dash_p_uses_method_default_from_settings(tmp_path) -> None:
     assert call["prompt"].endswith("User request:\n\ncheck src/app.py")
 
 
-def test_run_cli_dash_p_method_flag_overrides_method_default_from_settings(tmp_path) -> None:
+def test_run_cli_dash_p_method_flag_overrides_method_default_from_settings(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.control import MethodSettings
 
@@ -2873,7 +3143,9 @@ def test_run_cli_dash_p_method_flag_overrides_method_default_from_settings(tmp_p
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(
-                method_settings=MethodSettings(mode="explicit", selected_method="review"),
+                method_settings=MethodSettings(
+                    mode="explicit", selected_method="review"
+                ),
             ),
             runtime_builder=lambda **kwargs: runtime,
             prompt_runner=prompt_runner,
@@ -2888,7 +3160,9 @@ def test_run_cli_dash_p_method_flag_overrides_method_default_from_settings(tmp_p
     assert "Use concise review guidance." not in call["prompt"]
 
 
-def test_run_cli_dash_p_no_method_overrides_method_default_from_settings(tmp_path) -> None:
+def test_run_cli_dash_p_no_method_overrides_method_default_from_settings(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.control import MethodSettings
 
@@ -2904,7 +3178,9 @@ def test_run_cli_dash_p_no_method_overrides_method_default_from_settings(tmp_pat
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(
-                method_settings=MethodSettings(mode="explicit", selected_method="review"),
+                method_settings=MethodSettings(
+                    mode="explicit", selected_method="review"
+                ),
             ),
             runtime_builder=lambda **kwargs: runtime,
             prompt_runner=prompt_runner,
@@ -2998,7 +3274,9 @@ def test_run_cli_dash_p_with_missing_method_reports_error(tmp_path) -> None:
 
     assert prompt_runner.calls == []
     assert "method not found: missing" in stderr.getvalue()
-    assert "Run 'loushang method list' to inspect available methods." in stderr.getvalue()
+    assert (
+        "Run 'loushang method list' to inspect available methods." in stderr.getvalue()
+    )
 
 
 def test_run_cli_dash_p_with_missing_method_default_reports_error(tmp_path) -> None:
@@ -3017,7 +3295,9 @@ def test_run_cli_dash_p_with_missing_method_default_reports_error(tmp_path) -> N
             stderr=stderr,
             cwd=tmp_path,
             services=_fake_services(
-                method_settings=MethodSettings(mode="explicit", selected_method="missing"),
+                method_settings=MethodSettings(
+                    mode="explicit", selected_method="missing"
+                ),
             ),
             runtime_builder=lambda **kwargs: runtime,
             prompt_runner=prompt_runner,
@@ -3028,10 +3308,14 @@ def test_run_cli_dash_p_with_missing_method_default_reports_error(tmp_path) -> N
 
     assert prompt_runner.calls == []
     assert "method not found: missing" in stderr.getvalue()
-    assert "Run 'loushang method list' to inspect available methods." in stderr.getvalue()
+    assert (
+        "Run 'loushang method list' to inspect available methods." in stderr.getvalue()
+    )
 
 
-def test_run_cli_dash_p_with_unsupported_method_default_mode_reports_error(tmp_path) -> None:
+def test_run_cli_dash_p_with_unsupported_method_default_mode_reports_error(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.control import MethodSettings
 
@@ -3261,7 +3545,9 @@ steps:
     assert stderr.getvalue() == ""
 
 
-def test_run_cli_fake_prompt_steps_json_mode_outputs_json_without_runtime(tmp_path) -> None:
+def test_run_cli_fake_prompt_steps_json_mode_outputs_json_without_runtime(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     workflows_dir = tmp_path / "workflows"
@@ -3421,7 +3707,9 @@ def test_run_cli_mode_print_with_fixed_method_executes_each_step(tmp_path) -> No
     assert second_call["step_facts"]["step_index"] == 1
     assert second_call["emit_plan_start"] is False
     assert second_call["emit_plan_completion"] is True
-    assert "Run focused tests or explain why they cannot run." in second_call["user_input"]
+    assert (
+        "Run focused tests or explain why they cannot run." in second_call["user_input"]
+    )
     assert second_call["user_input"].endswith("User request:\n\ncheck src/app.py")
     assert second_call["output_mode"] == "text"
 
@@ -3442,7 +3730,9 @@ def test_run_cli_mode_print_uses_method_default_from_settings(tmp_path) -> None:
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(
-                method_settings=MethodSettings(mode="explicit", selected_method="review"),
+                method_settings=MethodSettings(
+                    mode="explicit", selected_method="review"
+                ),
             ),
             runtime_builder=lambda **kwargs: runtime,
             print_runner=print_runner,
@@ -3585,7 +3875,10 @@ def test_run_cli_passes_at_image_to_initial_prompt(tmp_path) -> None:
     assert len(images) == 1
     assert images[0].mime_type == "image/png"
     assert images[0].data == base64.b64encode(image_bytes).decode("ascii")
-    assert f'<file name="{image_path.resolve()}"></file>' in print_runner.calls[0]["user_input"]
+    assert (
+        f'<file name="{image_path.resolve()}"></file>'
+        in print_runner.calls[0]["user_input"]
+    )
 
 
 def test_run_cli_resizes_large_at_image_and_adds_dimension_note(tmp_path) -> None:
@@ -3625,7 +3918,10 @@ def test_run_cli_resizes_large_at_image_and_adds_dimension_note(tmp_path) -> Non
     assert images[0].data != base64.b64encode(original_bytes).decode("ascii")
     user_input = print_runner.calls[0]["user_input"]
     assert isinstance(user_input, str)
-    assert f'<file name="{image_path.resolve()}">[Image: original 2100x10, displayed at ' in user_input
+    assert (
+        f'<file name="{image_path.resolve()}">[Image: original 2100x10, displayed at '
+        in user_input
+    )
     assert "Multiply coordinates" in user_input
 
 
@@ -3794,7 +4090,9 @@ def test_run_cli_dispatches_continue_by_restoring_latest_session(tmp_path) -> No
 
 
 @pytest.mark.parametrize("resume_flag", ["--continue", "--resume"])
-def test_run_cli_dispatches_restore_by_latest_session_for_resume_mode(tmp_path, resume_flag) -> None:
+def test_run_cli_dispatches_restore_by_latest_session_for_resume_mode(
+    tmp_path, resume_flag
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     latest = Path(tmp_path / ".loushang" / "sessions" / "latest.jsonl")
@@ -3811,7 +4109,9 @@ def test_run_cli_dispatches_restore_by_latest_session_for_resume_mode(tmp_path, 
 
     async def scenario() -> None:
         exit_code = await run_cli(
-            [resume_flag, "hello"] if resume_flag == "--continue" else [resume_flag, "--message", "hello"],
+            [resume_flag, "hello"]
+            if resume_flag == "--continue"
+            else [resume_flag, "--message", "hello"],
             stdin=StringIO(""),
             stdout=StringIO(),
             stderr=StringIO(),
@@ -3883,7 +4183,9 @@ def test_run_cli_reports_continue_without_existing_sessions(tmp_path) -> None:
 
 
 @pytest.mark.parametrize("resume_flag", ["--continue", "--resume"])
-def test_run_cli_reports_restore_errors_when_list_sessions_fails(tmp_path, resume_flag) -> None:
+def test_run_cli_reports_restore_errors_when_list_sessions_fails(
+    tmp_path, resume_flag
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     class BrokenListSessionsRuntime(FakeRuntime):
@@ -3895,7 +4197,9 @@ def test_run_cli_reports_restore_errors_when_list_sessions_fails(tmp_path, resum
 
     async def scenario() -> None:
         exit_code = await run_cli(
-            [resume_flag, "hello"] if resume_flag == "--continue" else [resume_flag, "--message", "hello"],
+            [resume_flag, "hello"]
+            if resume_flag == "--continue"
+            else [resume_flag, "--message", "hello"],
             stdin=StringIO(""),
             stdout=StringIO(),
             stderr=stderr,
@@ -3912,7 +4216,9 @@ def test_run_cli_reports_restore_errors_when_list_sessions_fails(tmp_path, resum
 
 
 @pytest.mark.parametrize("resume_flag", ["--continue", "--resume"])
-def test_run_cli_reports_restore_invalid_list_sessions_payload(tmp_path, resume_flag) -> None:
+def test_run_cli_reports_restore_invalid_list_sessions_payload(
+    tmp_path, resume_flag
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     class BrokenListSessionsRuntime(FakeRuntime):
@@ -3924,7 +4230,9 @@ def test_run_cli_reports_restore_invalid_list_sessions_payload(tmp_path, resume_
 
     async def scenario() -> None:
         exit_code = await run_cli(
-            [resume_flag, "hello"] if resume_flag == "--continue" else [resume_flag, "--message", "hello"],
+            [resume_flag, "hello"]
+            if resume_flag == "--continue"
+            else [resume_flag, "--message", "hello"],
             stdin=StringIO(""),
             stdout=StringIO(),
             stderr=stderr,
@@ -4114,7 +4422,9 @@ def test_run_cli_default_path_uses_unified_mode_runner(tmp_path) -> None:
     assert mode_runner.calls[0]["user_input"] == "hello"
 
 
-def test_run_cli_default_path_with_method_prepares_prompt_and_method_id(tmp_path) -> None:
+def test_run_cli_default_path_with_method_prepares_prompt_and_method_id(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     _write_review_method(tmp_path)
@@ -4183,11 +4493,15 @@ def test_run_cli_default_path_with_fixed_method_executes_each_step(tmp_path) -> 
     assert second_call["step_index"] == 1
     assert second_call["emit_plan_start"] is False
     assert second_call["emit_plan_completion"] is True
-    assert "Run focused tests or explain why they cannot run." in second_call["user_input"]
+    assert (
+        "Run focused tests or explain why they cannot run." in second_call["user_input"]
+    )
     assert second_call["user_input"].endswith("User request:\n\ncheck src/app.py")
 
 
-def test_run_cli_default_path_passes_work_log_backend_to_unified_mode_runner(tmp_path) -> None:
+def test_run_cli_default_path_passes_work_log_backend_to_unified_mode_runner(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.work import JsonlEventLogBackend
 
@@ -4292,7 +4606,9 @@ def test_run_cli_work_log_inspect_text_includes_method_id(tmp_path) -> None:
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
@@ -4300,8 +4616,30 @@ def test_run_cli_work_log_inspect_text_includes_method_id(tmp_path) -> None:
 
     assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
         _WORK_LOG_INSPECT_COLUMNS,
-        ["1", "SubmitCodingTurn", "run-1", "session-1", "", "method:task:review", "", "", "", ""],
-        ["2", "WorkRunStarted", "run-1", "session-1", "immediate", "method:task:review", "", "", "", ""],
+        [
+            "1",
+            "SubmitCodingTurn",
+            "run-1",
+            "session-1",
+            "",
+            "method:task:review",
+            "",
+            "",
+            "",
+            "",
+        ],
+        [
+            "2",
+            "WorkRunStarted",
+            "run-1",
+            "session-1",
+            "immediate",
+            "method:task:review",
+            "",
+            "",
+            "",
+            "",
+        ],
     ]
 
 
@@ -4332,7 +4670,9 @@ def test_run_cli_work_log_inspect_text_includes_plan_step_metadata(tmp_path) -> 
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
@@ -4355,7 +4695,9 @@ def test_run_cli_work_log_inspect_text_includes_plan_step_metadata(tmp_path) -> 
     ]
 
 
-def test_run_cli_work_log_inspect_plans_outputs_plan_summary_without_runtime(tmp_path) -> None:
+def test_run_cli_work_log_inspect_plans_outputs_plan_summary_without_runtime(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.work import JsonlEventLogBackend
 
@@ -4389,17 +4731,67 @@ def test_run_cli_work_log_inspect_plans_outputs_plan_summary_without_runtime(tmp
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
     asyncio.run(scenario())
 
     assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
-        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title", "deviation"],
-        ["plan", "", "plan:method:task:review", "completed", "", "method:task:review", "2/2", "0", "verify", "", ""],
-        ["step", "1", "inspect", "completed", "run-inspect", "method:task:review", "", "", "", "Inspect current changes", ""],
-        ["step", "2", "verify", "completed", "run-verify", "method:task:review", "", "", "", "Run focused checks", ""],
+        [
+            "type",
+            "index",
+            "id",
+            "status",
+            "run_id",
+            "method_id",
+            "completed_steps",
+            "failed_steps",
+            "current_step",
+            "title",
+            "deviation",
+        ],
+        [
+            "plan",
+            "",
+            "plan:method:task:review",
+            "completed",
+            "",
+            "method:task:review",
+            "2/2",
+            "0",
+            "verify",
+            "",
+            "",
+        ],
+        [
+            "step",
+            "1",
+            "inspect",
+            "completed",
+            "run-inspect",
+            "method:task:review",
+            "",
+            "",
+            "",
+            "Inspect current changes",
+            "",
+        ],
+        [
+            "step",
+            "2",
+            "verify",
+            "completed",
+            "run-verify",
+            "method:task:review",
+            "",
+            "",
+            "",
+            "Run focused checks",
+            "",
+        ],
     ]
 
 
@@ -4448,16 +4840,54 @@ def test_run_cli_work_log_inspect_plans_respects_run_filter(tmp_path) -> None:
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
     asyncio.run(scenario())
 
     assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
-        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title", "deviation"],
-        ["plan", "", "plan:method:task:review", "running", "", "method:task:review", "0/1", "1", "verify", "", ""],
-        ["step", "2", "verify", "failed", "run-verify", "method:task:review", "", "", "", "Run focused checks", ""],
+        [
+            "type",
+            "index",
+            "id",
+            "status",
+            "run_id",
+            "method_id",
+            "completed_steps",
+            "failed_steps",
+            "current_step",
+            "title",
+            "deviation",
+        ],
+        [
+            "plan",
+            "",
+            "plan:method:task:review",
+            "running",
+            "",
+            "method:task:review",
+            "0/1",
+            "1",
+            "verify",
+            "",
+            "",
+        ],
+        [
+            "step",
+            "2",
+            "verify",
+            "failed",
+            "run-verify",
+            "method:task:review",
+            "",
+            "",
+            "",
+            "Run focused checks",
+            "",
+        ],
     ]
 
 
@@ -4494,15 +4924,41 @@ def test_run_cli_work_log_inspect_plans_shows_step_deviation(tmp_path) -> None:
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
     asyncio.run(scenario())
 
     assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
-        ["type", "index", "id", "status", "run_id", "method_id", "completed_steps", "failed_steps", "current_step", "title", "deviation"],
-        ["plan", "", "plan:method:task:review", "running", "", "method:task:review", "1/1", "0", "inspect", "", ""],
+        [
+            "type",
+            "index",
+            "id",
+            "status",
+            "run_id",
+            "method_id",
+            "completed_steps",
+            "failed_steps",
+            "current_step",
+            "title",
+            "deviation",
+        ],
+        [
+            "plan",
+            "",
+            "plan:method:task:review",
+            "running",
+            "",
+            "method:task:review",
+            "1/1",
+            "0",
+            "inspect",
+            "",
+            "",
+        ],
         [
             "step",
             "1",
@@ -4519,7 +4975,9 @@ def test_run_cli_work_log_inspect_plans_shows_step_deviation(tmp_path) -> None:
     ]
 
 
-def test_run_cli_work_log_inspect_plans_projects_full_log_not_tail_limit(tmp_path) -> None:
+def test_run_cli_work_log_inspect_plans_projects_full_log_not_tail_limit(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.work import JsonlEventLogBackend
 
@@ -4552,15 +5010,41 @@ def test_run_cli_work_log_inspect_plans_projects_full_log_not_tail_limit(tmp_pat
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
     asyncio.run(scenario())
 
     assert [line.split("\t") for line in stdout.getvalue().splitlines()][1:] == [
-        ["plan", "", "plan:method:task:review", "completed", "", "method:task:review", "1/1", "0", "inspect", "", ""],
-        ["step", "1", "inspect", "completed", "run-inspect", "method:task:review", "", "", "", "Inspect current changes", ""],
+        [
+            "plan",
+            "",
+            "plan:method:task:review",
+            "completed",
+            "",
+            "method:task:review",
+            "1/1",
+            "0",
+            "inspect",
+            "",
+            "",
+        ],
+        [
+            "step",
+            "1",
+            "inspect",
+            "completed",
+            "run-inspect",
+            "method:task:review",
+            "",
+            "",
+            "",
+            "Inspect current changes",
+            "",
+        ],
     ]
 
 
@@ -4599,13 +5083,20 @@ def test_run_cli_work_log_inspect_plans_json_outputs_plan_projection(tmp_path) -
 
     async def scenario() -> None:
         exit_code = await run_cli(
-            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "plans-json"],
+            [
+                "--work-log-inspect",
+                str(log_path),
+                "--work-log-inspect-format",
+                "plans-json",
+            ],
             stdin=StringIO(),
             stdout=stdout,
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
@@ -4627,7 +5118,9 @@ def test_run_cli_work_log_inspect_plans_json_outputs_plan_projection(tmp_path) -
         "level": "reasoned",
         "requires_reason": True,
     }
-    assert payload[0]["steps"][0]["metadata"]["audit_policy"] == {"record": ["status", "reason"]}
+    assert payload[0]["steps"][0]["metadata"]["audit_policy"] == {
+        "record": ["status", "reason"]
+    }
     assert payload[0]["metadata"]["plan_facts"] == plan_facts
     assert payload[0]["steps"][0]["metadata"]["step_facts"] == step_facts
 
@@ -4659,13 +5152,20 @@ def test_run_cli_work_log_inspect_plans_json_includes_step_deviation(tmp_path) -
 
     async def scenario() -> None:
         exit_code = await run_cli(
-            ["--work-log-inspect", str(log_path), "--work-log-inspect-format", "plans-json"],
+            [
+                "--work-log-inspect",
+                str(log_path),
+                "--work-log-inspect-format",
+                "plans-json",
+            ],
             stdin=StringIO(),
             stdout=stdout,
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
@@ -4731,7 +5231,9 @@ def test_run_cli_work_log_inspect_outputs_json_without_runtime(tmp_path) -> None
     ]
 
 
-def test_run_cli_work_log_inspect_json_includes_method_id_when_present(tmp_path) -> None:
+def test_run_cli_work_log_inspect_json_includes_method_id_when_present(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.work import JsonlEventLogBackend
 
@@ -4754,7 +5256,9 @@ def test_run_cli_work_log_inspect_json_includes_method_id_when_present(tmp_path)
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
@@ -4790,7 +5294,9 @@ def test_run_cli_work_log_inspect_json_includes_plan_step_metadata(tmp_path) -> 
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
@@ -4804,7 +5310,9 @@ def test_run_cli_work_log_inspect_json_includes_plan_step_metadata(tmp_path) -> 
     assert summary["step_title"] == "Inspect current changes"
 
 
-def test_run_cli_work_log_inspect_json_includes_tool_approval_audit_metadata(tmp_path) -> None:
+def test_run_cli_work_log_inspect_json_includes_tool_approval_audit_metadata(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.work import JsonlEventLogBackend
 
@@ -4836,7 +5344,9 @@ def test_run_cli_work_log_inspect_json_includes_tool_approval_audit_metadata(tmp
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
@@ -4859,8 +5369,16 @@ def test_run_cli_work_log_inspect_filters_by_run(tmp_path) -> None:
 
     log_path = tmp_path / "events.jsonl"
     event_log = JsonlEventLogBackend(log_path)
-    _append_work_log_inspect_entry(event_log, sequence=1, kind="ContentDelta", run_id="run-1")
-    _append_work_log_inspect_entry(event_log, sequence=2, kind="ApprovalRequested", run_id="run-2", delivery_hint="immediate")
+    _append_work_log_inspect_entry(
+        event_log, sequence=1, kind="ContentDelta", run_id="run-1"
+    )
+    _append_work_log_inspect_entry(
+        event_log,
+        sequence=2,
+        kind="ApprovalRequested",
+        run_id="run-2",
+        delivery_hint="immediate",
+    )
     stdout = StringIO()
 
     async def scenario() -> None:
@@ -4871,7 +5389,9 @@ def test_run_cli_work_log_inspect_filters_by_run(tmp_path) -> None:
             stderr=StringIO(),
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(AssertionError("runtime should not start")),
+            runtime_builder=lambda **kwargs: (_ for _ in ()).throw(
+                AssertionError("runtime should not start")
+            ),
         )
         assert exit_code == 0
 
@@ -4879,7 +5399,18 @@ def test_run_cli_work_log_inspect_filters_by_run(tmp_path) -> None:
 
     assert [line.split("\t") for line in stdout.getvalue().splitlines()] == [
         _WORK_LOG_INSPECT_COLUMNS,
-        ["2", "ApprovalRequested", "run-2", "session-1", "immediate", "", "", "", "", ""],
+        [
+            "2",
+            "ApprovalRequested",
+            "run-2",
+            "session-1",
+            "immediate",
+            "",
+            "",
+            "",
+            "",
+            "",
+        ],
     ]
 
 
@@ -4913,9 +5444,18 @@ def test_run_cli_default_rpc_path_uses_unified_mode_runner(tmp_path) -> None:
 @pytest.mark.parametrize(
     ("argv", "message"),
     [
-        (["--tui", "--work-log", "events.jsonl"], "--work-log is not supported in TUI mode"),
-        (["--mode", "rpc", "--work-log", "events.jsonl"], "--work-log is not supported in RPC mode"),
-        (["--work-log", "events.jsonl", "--prompt-steps", "workflow.json"], "--work-log is not supported with --prompt-steps"),
+        (
+            ["--tui", "--work-log", "events.jsonl"],
+            "--work-log is not supported in TUI mode",
+        ),
+        (
+            ["--mode", "rpc", "--work-log", "events.jsonl"],
+            "--work-log is not supported in RPC mode",
+        ),
+        (
+            ["--work-log", "events.jsonl", "--prompt-steps", "workflow.json"],
+            "--work-log is not supported with --prompt-steps",
+        ),
     ],
 )
 def test_run_cli_rejects_work_log_on_unsupported_paths(tmp_path, argv, message) -> None:
@@ -4952,7 +5492,9 @@ def test_run_cli_rejects_work_log_on_unsupported_paths(tmp_path, argv, message) 
         (["--method", "review", "--tui"], TtyStringIO(""), TtyStringIO()),
     ],
 )
-def test_run_cli_rejects_method_on_unsupported_interactive_paths(tmp_path, argv, stdin, stdout) -> None:
+def test_run_cli_rejects_method_on_unsupported_interactive_paths(
+    tmp_path, argv, stdin, stdout
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     _write_review_method(tmp_path)
@@ -5057,7 +5599,9 @@ def test_run_cli_defaults_to_tui_for_interactive_bare_startup(tmp_path) -> None:
         (["--continue"], "/tmp/latest-session.jsonl"),
     ],
 )
-def test_run_cli_defaults_to_tui_for_interactive_resume_flows(tmp_path, argv, expected_restore) -> None:
+def test_run_cli_defaults_to_tui_for_interactive_resume_flows(
+    tmp_path, argv, expected_restore
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     latest_session = SimpleNamespace(session_file=Path("/tmp/latest-session.jsonl"))
@@ -5107,7 +5651,9 @@ def test_run_cli_no_tui_keeps_interactive_bare_startup_in_text_mode(tmp_path) ->
     assert "prompt is required" in stderr.getvalue()
 
 
-def test_run_cli_keeps_interactive_positional_prompt_out_of_default_tui(tmp_path) -> None:
+def test_run_cli_keeps_interactive_positional_prompt_out_of_default_tui(
+    tmp_path,
+) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     runtime = FakeRuntime(FakeSession("session-1"))
@@ -5321,9 +5867,21 @@ def test_run_cli_lists_models_and_returns_early(tmp_path) -> None:
         def get_available_models(self):
             self.get_available_models_calls += 1
             return [
-                type("ModelSelection", (), {"provider": "anthropic", "model_id": "claude-3-opus"}),
-                type("ModelSelection", (), {"provider": "google", "model_id": "gemini-2.0"}),
-                type("ModelSelection", (), {"provider": "anthropic", "model_id": "claude-3-haiku"}),
+                type(
+                    "ModelSelection",
+                    (),
+                    {"provider": "anthropic", "model_id": "claude-3-opus"},
+                ),
+                type(
+                    "ModelSelection",
+                    (),
+                    {"provider": "google", "model_id": "gemini-2.0"},
+                ),
+                type(
+                    "ModelSelection",
+                    (),
+                    {"provider": "anthropic", "model_id": "claude-3-haiku"},
+                ),
             ]
 
     runtime = FakeRuntime(ModelSession("session-1"))
@@ -5333,13 +5891,15 @@ def test_run_cli_lists_models_and_returns_early(tmp_path) -> None:
 
     async def scenario() -> None:
         exit_code = await run_cli(
-                ["--list-models", "anthropic"],
+            ["--list-models", "anthropic"],
             stdin=StringIO(""),
             stdout=stdout,
             stderr=stderr,
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: runtime_args.append(kwargs["args"]) or runtime,
+            runtime_builder=lambda **kwargs: (
+                runtime_args.append(kwargs["args"]) or runtime
+            ),
             print_runner=FakeRunner(),
         )
         assert exit_code == 0
@@ -5359,9 +5919,21 @@ def test_run_cli_lists_models_as_json(tmp_path) -> None:
         def get_available_models(self):
             self.get_available_models_calls += 1
             return [
-                type("ModelSelection", (), {"provider": "anthropic", "model_id": "claude-3-opus"}),
-                type("ModelSelection", (), {"provider": "google", "model_id": "gemini-2.0"}),
-                type("ModelSelection", (), {"provider": "anthropic", "model_id": "claude-3-haiku"}),
+                type(
+                    "ModelSelection",
+                    (),
+                    {"provider": "anthropic", "model_id": "claude-3-opus"},
+                ),
+                type(
+                    "ModelSelection",
+                    (),
+                    {"provider": "google", "model_id": "gemini-2.0"},
+                ),
+                type(
+                    "ModelSelection",
+                    (),
+                    {"provider": "anthropic", "model_id": "claude-3-haiku"},
+                ),
             ]
 
     runtime = FakeRuntime(ModelSession("session-1"))
@@ -5409,13 +5981,23 @@ def test_run_cli_lists_model_metadata_when_session_exposes_details(tmp_path) -> 
                     id="claude-3-opus",
                     provider="anthropic",
                     endpoint="anthropic-messages",
-                    capabilities=Capabilities(reasoning=True, input=("text", "image"), context_window=200000, max_tokens=8192),
+                    capabilities=Capabilities(
+                        reasoning=True,
+                        input=("text", "image"),
+                        context_window=200000,
+                        max_tokens=8192,
+                    ),
                 ),
                 Model(
                     id="gpt-5-mini",
                     provider="openai",
                     endpoint="responses",
-                    capabilities=Capabilities(reasoning=False, input=("text",), context_window=128000, max_tokens=4096),
+                    capabilities=Capabilities(
+                        reasoning=False,
+                        input=("text",),
+                        context_window=128000,
+                        max_tokens=4096,
+                    ),
                 ),
             ]
 
@@ -5455,7 +6037,12 @@ def test_run_cli_lists_model_metadata_as_json(tmp_path) -> None:
                     id="kimi-k2.5",
                     provider="moonshot",
                     endpoint="anthropic-messages",
-                    capabilities=Capabilities(reasoning=True, input=("text",), context_window=256000, max_tokens=16384),
+                    capabilities=Capabilities(
+                        reasoning=True,
+                        input=("text",),
+                        context_window=256000,
+                        max_tokens=16384,
+                    ),
                 )
             ]
 
@@ -5496,8 +6083,16 @@ def test_run_cli_lists_models_deduplicates_provider_model_pairs(tmp_path) -> Non
         def get_available_models(self):
             self.get_available_models_calls += 1
             return [
-                type("ModelSelection", (), {"provider": "moonshot", "model_id": "kimi-k2.5"}),
-                type("ModelSelection", (), {"provider": "moonshot", "model_id": "kimi-k2.5"}),
+                type(
+                    "ModelSelection",
+                    (),
+                    {"provider": "moonshot", "model_id": "kimi-k2.5"},
+                ),
+                type(
+                    "ModelSelection",
+                    (),
+                    {"provider": "moonshot", "model_id": "kimi-k2.5"},
+                ),
                 type("ModelSelection", (), {"provider": "openai", "model_id": "gpt-5"}),
             ]
 
@@ -5685,6 +6280,7 @@ def test_run_cli_list_models_query_ignores_raising_model_attributes(tmp_path) ->
             runtime_builder=lambda **kwargs: runtime,
         )
         assert exit_code == 0
+
     asyncio.run(scenario())
 
     assert stdout.getvalue() == "openai/gpt-5\n"
@@ -5772,7 +6368,9 @@ def test_run_cli_lists_commands_and_returns_early(tmp_path) -> None:
             stderr=stderr,
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: runtime_args.append(kwargs["args"]) or runtime,
+            runtime_builder=lambda **kwargs: (
+                runtime_args.append(kwargs["args"]) or runtime
+            ),
         )
         assert exit_code == 0
 
@@ -6030,14 +6628,19 @@ def test_run_cli_lists_diagnostics_as_tsv_and_returns_early(tmp_path) -> None:
             stderr=stderr,
             cwd=tmp_path,
             services=_fake_services(),
-            runtime_builder=lambda **kwargs: runtime_args.append(kwargs["args"]) or runtime,
+            runtime_builder=lambda **kwargs: (
+                runtime_args.append(kwargs["args"]) or runtime
+            ),
         )
         assert exit_code == 0
 
     asyncio.run(scenario())
 
     assert runtime_args[0].no_session is True
-    assert stdout.getvalue() == "error\truntime\tprovider\tassistant_response_error\t3\tprovider failed\n"
+    assert (
+        stdout.getvalue()
+        == "error\truntime\tprovider\tassistant_response_error\t3\tprovider failed\n"
+    )
     assert stderr.getvalue() == ""
 
 
@@ -6123,11 +6726,7 @@ def test_run_cli_lists_project_skill_provenance_as_json(tmp_path) -> None:
     skill_dir = tmp_path / "skills" / "debug"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
-        "---\n"
-        "name: debug\n"
-        "description: Debug failures.\n"
-        "---\n\n"
-        "Debug body.",
+        "---\nname: debug\ndescription: Debug failures.\n---\n\nDebug body.",
         encoding="utf-8",
     )
     loader = DefaultResourceLoader()
@@ -6211,7 +6810,9 @@ def test_run_cli_lists_methods_as_json(tmp_path) -> None:
         "Review the diff carefully.",
         encoding="utf-8",
     )
-    (tmp_path / "methods" / "METHOD.md").write_text("Future method manifest.", encoding="utf-8")
+    (tmp_path / "methods" / "METHOD.md").write_text(
+        "Future method manifest.", encoding="utf-8"
+    )
     session = FakeSession("session-1")
     runtime = FakeRuntime(session)
     stdout = StringIO()
@@ -6428,7 +7029,7 @@ def test_run_cli_shows_fixed_method_plan_as_json(tmp_path) -> None:
 
     async def scenario() -> None:
         exit_code = await run_cli(
-                ["method", "plan", "show", "review", "--format", "json"],
+            ["method", "plan", "show", "review", "--format", "json"],
             stdin=StringIO(""),
             stdout=stdout,
             stderr=stderr,
@@ -6449,15 +7050,23 @@ def test_run_cli_shows_fixed_method_plan_as_json(tmp_path) -> None:
     assert payload["plan"]["mode"] == "fixed"
     assert payload["plan"]["metadata"]["step_count"] == 2
     assert [step["id"] for step in payload["steps"]] == ["inspect", "verify"]
-    assert [step["title"] for step in payload["steps"]] == ["Inspect current changes", "Run focused checks"]
+    assert [step["title"] for step in payload["steps"]] == [
+        "Inspect current changes",
+        "Run focused checks",
+    ]
     first_projection = payload["steps"][0]["projection"]
     second_projection = payload["steps"][1]["projection"]
-    assert first_projection["step_guidance"] == "Read changed files and summarize intent."
+    assert (
+        first_projection["step_guidance"] == "Read changed files and summarize intent."
+    )
     assert first_projection["step_index"] == 0
     assert first_projection["step_count"] == 2
     assert first_projection["meta_role"] == "VALIDATOR"
     assert "Step inspect - Inspect current changes" in first_projection["content"]
-    assert second_projection["step_guidance"] == "Run focused tests or explain why they cannot run."
+    assert (
+        second_projection["step_guidance"]
+        == "Run focused tests or explain why they cannot run."
+    )
     assert second_projection["step_index"] == 1
     assert second_projection["step_count"] == 2
     assert "Step verify - Run focused checks" in second_projection["content"]
@@ -6604,7 +7213,9 @@ def test_run_cli_lists_disabled_plugins_as_tsv(tmp_path) -> None:
 
     plugin_root = tmp_path / "plugins" / "debug-pack"
     plugin_root.mkdir(parents=True)
-    (plugin_root / "plugin.json").write_text(json.dumps({"name": "debug-pack"}), encoding="utf-8")
+    (plugin_root / "plugin.json").write_text(
+        json.dumps({"name": "debug-pack"}), encoding="utf-8"
+    )
     settings_path = tmp_path / ".loushang" / "settings.json"
     settings_path.parent.mkdir()
     settings_path.write_text(
@@ -6619,7 +7230,9 @@ def test_run_cli_lists_disabled_plugins_as_tsv(tmp_path) -> None:
     runtime = FakeRuntime(FakeSession("session-1"))
     stdout = StringIO()
     stderr = StringIO()
-    services = create_services(settings_manager=SettingsManager(project_settings_path=settings_path))
+    services = create_services(
+        settings_manager=SettingsManager(project_settings_path=settings_path)
+    )
 
     async def scenario() -> None:
         exit_code = await run_cli(
@@ -6645,8 +7258,12 @@ def test_run_cli_lists_package_roots_and_plugin_packages_as_json(tmp_path) -> No
     package_root = tmp_path / "packages" / "review-pack"
     (package_root / "prompts").mkdir(parents=True)
     (package_root / "skills" / "review").mkdir(parents=True)
-    (package_root / "prompts" / "review.md").write_text("Package prompt", encoding="utf-8")
-    (package_root / "skills" / "review" / "SKILL.md").write_text("Package skill", encoding="utf-8")
+    (package_root / "prompts" / "review.md").write_text(
+        "Package prompt", encoding="utf-8"
+    )
+    (package_root / "skills" / "review" / "SKILL.md").write_text(
+        "Package skill", encoding="utf-8"
+    )
     plugin_root = tmp_path / "plugins" / "debug-pack"
     plugin_package_root = plugin_root / "resources"
     (plugin_package_root / "themes").mkdir(parents=True)
@@ -6726,10 +7343,19 @@ def test_run_cli_lists_package_scopes_from_settings_layers(tmp_path) -> None:
     project_package_root = tmp_path / "project-package"
     global_plugin_root = tmp_path / "global" / "plugin"
     project_plugin_root = tmp_path / "project-plugin"
-    for root in (global_package_root, project_package_root, global_plugin_root, project_plugin_root):
+    for root in (
+        global_package_root,
+        project_package_root,
+        global_plugin_root,
+        project_plugin_root,
+    ):
         root.mkdir(parents=True)
-    (global_plugin_root / "plugin.json").write_text(json.dumps({"name": "global-plugin"}), encoding="utf-8")
-    (project_plugin_root / "plugin.json").write_text(json.dumps({"name": "project-plugin"}), encoding="utf-8")
+    (global_plugin_root / "plugin.json").write_text(
+        json.dumps({"name": "global-plugin"}), encoding="utf-8"
+    )
+    (project_plugin_root / "plugin.json").write_text(
+        json.dumps({"name": "project-plugin"}), encoding="utf-8"
+    )
     global_settings_path = tmp_path / "global-settings.json"
     project_settings_path = tmp_path / ".loushang" / "settings.json"
     project_settings_path.parent.mkdir()
@@ -6776,7 +7402,9 @@ def test_run_cli_lists_package_scopes_from_settings_layers(tmp_path) -> None:
     asyncio.run(scenario())
 
     packages = json.loads(stdout.getvalue())
-    assert [(package["name"], package["kind"], package["scope"]) for package in packages] == [
+    assert [
+        (package["name"], package["kind"], package["scope"]) for package in packages
+    ] == [
         ("package", "package_root", "user"),
         ("project-package", "package_root", "project"),
         ("global-plugin", "plugin", "user"),
@@ -6793,7 +7421,9 @@ def test_run_cli_reports_settings_load_warnings_for_package_listing(tmp_path) ->
     project_settings_path = tmp_path / ".loushang" / "settings.json"
     project_settings_path.parent.mkdir()
     project_settings_path.write_text("{not-json", encoding="utf-8")
-    services = create_services(settings_manager=SettingsManager(project_settings_path=project_settings_path))
+    services = create_services(
+        settings_manager=SettingsManager(project_settings_path=project_settings_path)
+    )
     runtime = FakeRuntime(FakeSession("session-1"))
     stdout = StringIO()
     stderr = StringIO()
@@ -6817,7 +7447,9 @@ def test_run_cli_reports_settings_load_warnings_for_package_listing(tmp_path) ->
     assert "Expecting property name" in stderr.getvalue()
 
 
-def test_run_cli_reports_settings_load_warnings_once_for_plugin_toggles(tmp_path) -> None:
+def test_run_cli_reports_settings_load_warnings_once_for_plugin_toggles(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_services
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.control import SettingsManager
@@ -6825,7 +7457,9 @@ def test_run_cli_reports_settings_load_warnings_once_for_plugin_toggles(tmp_path
     project_settings_path = tmp_path / ".loushang" / "settings.json"
     project_settings_path.parent.mkdir()
     project_settings_path.write_text("{not-json", encoding="utf-8")
-    services = create_services(settings_manager=SettingsManager(project_settings_path=project_settings_path))
+    services = create_services(
+        settings_manager=SettingsManager(project_settings_path=project_settings_path)
+    )
     stdout = StringIO()
     stderr = StringIO()
 
@@ -6843,7 +7477,10 @@ def test_run_cli_reports_settings_load_warnings_once_for_plugin_toggles(tmp_path
 
     asyncio.run(scenario())
 
-    assert stdout.getvalue() == "added plugin source\tplugins/debug-pack\ndisabled plugin\tlegacy\n"
+    assert (
+        stdout.getvalue()
+        == "added plugin source\tplugins/debug-pack\ndisabled plugin\tlegacy\n"
+    )
     assert stderr.getvalue().count("Warning (package command, project settings):") == 1
 
 
@@ -6852,7 +7489,11 @@ def test_run_cli_remove_missing_plugin_source_returns_stable_error(tmp_path) -> 
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.control import SettingsManager
 
-    services = create_services(settings_manager=SettingsManager(project_settings_path=tmp_path / ".loushang" / "settings.json"))
+    services = create_services(
+        settings_manager=SettingsManager(
+            project_settings_path=tmp_path / ".loushang" / "settings.json"
+        )
+    )
     stdout = StringIO()
     stderr = StringIO()
 
@@ -6871,7 +7512,10 @@ def test_run_cli_remove_missing_plugin_source_returns_stable_error(tmp_path) -> 
     asyncio.run(scenario())
 
     assert stdout.getvalue() == ""
-    assert stderr.getvalue() == "Error: no matching plugin source found: plugins/missing-pack\n"
+    assert (
+        stderr.getvalue()
+        == "Error: no matching plugin source found: plugins/missing-pack\n"
+    )
 
 
 def test_run_cli_add_duplicate_plugin_source_returns_stable_error(tmp_path) -> None:
@@ -6885,7 +7529,9 @@ def test_run_cli_add_duplicate_plugin_source_returns_stable_error(tmp_path) -> N
         json.dumps({"plugin_sources": ["plugins/debug-pack"]}),
         encoding="utf-8",
     )
-    services = create_services(settings_manager=SettingsManager(project_settings_path=project_settings_path))
+    services = create_services(
+        settings_manager=SettingsManager(project_settings_path=project_settings_path)
+    )
     stdout = StringIO()
     stderr = StringIO()
 
@@ -6904,16 +7550,22 @@ def test_run_cli_add_duplicate_plugin_source_returns_stable_error(tmp_path) -> N
     asyncio.run(scenario())
 
     assert stdout.getvalue() == ""
-    assert stderr.getvalue() == "Error: plugin source already exists: plugins/debug-pack\n"
+    assert (
+        stderr.getvalue() == "Error: plugin source already exists: plugins/debug-pack\n"
+    )
 
 
-def test_run_cli_adds_https_remote_plugin_source_without_resolving_local_path(tmp_path) -> None:
+def test_run_cli_adds_https_remote_plugin_source_without_resolving_local_path(
+    tmp_path,
+) -> None:
     from loushang.coding.bootstrap import create_services
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.control import SettingsManager
 
     project_settings_path = tmp_path / ".loushang" / "settings.json"
-    services = create_services(settings_manager=SettingsManager(project_settings_path=project_settings_path))
+    services = create_services(
+        settings_manager=SettingsManager(project_settings_path=project_settings_path)
+    )
     stdout = StringIO()
     stderr = StringIO()
 
@@ -6948,7 +7600,11 @@ def test_run_cli_rejects_insecure_remote_plugin_source(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
     from loushang.coding.control import SettingsManager
 
-    services = create_services(settings_manager=SettingsManager(project_settings_path=tmp_path / ".loushang" / "settings.json"))
+    services = create_services(
+        settings_manager=SettingsManager(
+            project_settings_path=tmp_path / ".loushang" / "settings.json"
+        )
+    )
     diagnostics = services.diagnostics_service
     stdout = StringIO()
     stderr = StringIO()
@@ -7014,9 +7670,33 @@ def test_run_cli_runs_explicit_package_lifecycle_commands(tmp_path) -> None:
     assert session.update_package_calls == [source]
     assert session.remove_package_calls == [source]
     assert [json.loads(line) for line in stdout.getvalue().splitlines()] == [
-        {"command": "materialize_package", "record": {"source": source, "name": "review-pack", "lifecycle": "installed", "targetPath": "/tmp/packages/review-pack"}},
-        {"command": "update_package", "record": {"source": source, "name": "review-pack", "lifecycle": "installed", "targetPath": "/tmp/packages/review-pack"}},
-        {"command": "remove_package", "record": {"source": source, "name": "review-pack", "lifecycle": "remote_registered", "targetPath": "/tmp/packages/review-pack"}},
+        {
+            "command": "materialize_package",
+            "record": {
+                "source": source,
+                "name": "review-pack",
+                "lifecycle": "installed",
+                "targetPath": "/tmp/packages/review-pack",
+            },
+        },
+        {
+            "command": "update_package",
+            "record": {
+                "source": source,
+                "name": "review-pack",
+                "lifecycle": "installed",
+                "targetPath": "/tmp/packages/review-pack",
+            },
+        },
+        {
+            "command": "remove_package",
+            "record": {
+                "source": source,
+                "name": "review-pack",
+                "lifecycle": "remote_registered",
+                "targetPath": "/tmp/packages/review-pack",
+            },
+        },
     ]
     assert stderr.getvalue() == ""
 
@@ -7244,8 +7924,12 @@ def test_run_cli_marks_package_version_conflicts_in_json(tmp_path) -> None:
     second_plugin = tmp_path / "plugins" / "debug-pack-b"
     first_plugin.mkdir(parents=True)
     second_plugin.mkdir(parents=True)
-    (first_plugin / "plugin.json").write_text(json.dumps({"name": "debug-pack", "version": "1.0.0"}), encoding="utf-8")
-    (second_plugin / "plugin.json").write_text(json.dumps({"name": "debug-pack", "version": "2.0.0"}), encoding="utf-8")
+    (first_plugin / "plugin.json").write_text(
+        json.dumps({"name": "debug-pack", "version": "1.0.0"}), encoding="utf-8"
+    )
+    (second_plugin / "plugin.json").write_text(
+        json.dumps({"name": "debug-pack", "version": "2.0.0"}), encoding="utf-8"
+    )
     runtime = FakeRuntime(FakeSession("session-1"))
     stdout = StringIO()
     stderr = StringIO()
@@ -7257,7 +7941,9 @@ def test_run_cli_marks_package_version_conflicts_in_json(tmp_path) -> None:
             stdout=stdout,
             stderr=stderr,
             cwd=tmp_path,
-            services=_fake_services(plugin_sources=(str(first_plugin), str(second_plugin))),
+            services=_fake_services(
+                plugin_sources=(str(first_plugin), str(second_plugin))
+            ),
             runtime_builder=lambda **kwargs: runtime,
         )
         assert exit_code == 0
@@ -7296,7 +7982,13 @@ def test_run_cli_lists_offline_package_catalog_entries(tmp_path) -> None:
 
     async def scenario() -> None:
         exit_code = await run_cli(
-            ["--list-packages", "--list-packages-format", "json", "--package-catalog", str(catalog_path)],
+            [
+                "--list-packages",
+                "--list-packages-format",
+                "json",
+                "--package-catalog",
+                str(catalog_path),
+            ],
             stdin=StringIO(""),
             stdout=stdout,
             stderr=stderr,
@@ -7382,10 +8074,14 @@ def test_run_cli_lists_remote_plugin_source_lifecycle_state(tmp_path) -> None:
     project_settings_path = tmp_path / ".loushang" / "settings.json"
     project_settings_path.parent.mkdir()
     project_settings_path.write_text(
-        json.dumps({"plugin_sources": ["https://packages.example.invalid/review-pack.git"]}),
+        json.dumps(
+            {"plugin_sources": ["https://packages.example.invalid/review-pack.git"]}
+        ),
         encoding="utf-8",
     )
-    services = create_services(settings_manager=SettingsManager(project_settings_path=project_settings_path))
+    services = create_services(
+        settings_manager=SettingsManager(project_settings_path=project_settings_path)
+    )
     runtime = FakeRuntime(FakeSession("session-1"))
     stdout = StringIO()
     stderr = StringIO()
@@ -7735,7 +8431,9 @@ def test_run_cli_executes_command_and_prints_output(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     session = FakeSession("session-1")
-    session.set_execute_command_result(type("Execution", (), {"result": {"status": "ok"}})())
+    session.set_execute_command_result(
+        type("Execution", (), {"result": {"status": "ok"}})()
+    )
     runtime = FakeRuntime(session)
     stdout = StringIO()
     stderr = StringIO()
@@ -7755,7 +8453,7 @@ def test_run_cli_executes_command_and_prints_output(tmp_path) -> None:
     asyncio.run(scenario())
 
     assert session.execute_command_calls == [("deploy", "now")]
-    assert stdout.getvalue() == "{\"status\": \"ok\"}\n"
+    assert stdout.getvalue() == '{"status": "ok"}\n'
     assert stderr.getvalue() == ""
 
 
@@ -7763,7 +8461,9 @@ def test_run_cli_executes_command_with_json_result_envelope(tmp_path) -> None:
     from loushang.coding.cli.__main__ import run_cli
 
     session = FakeSession("session-1")
-    session.set_execute_command_result(type("Execution", (), {"result": {"status": "ok"}})())
+    session.set_execute_command_result(
+        type("Execution", (), {"result": {"status": "ok"}})()
+    )
     runtime = FakeRuntime(session)
     stdout = StringIO()
     stderr = StringIO()
@@ -7880,7 +8580,11 @@ def test_run_cli_prints_non_jsonifiable_command_result(tmp_path) -> None:
     asyncio.run(scenario())
 
     assert stdout.getvalue().strip().startswith("{")
-    assert "1" in stdout.getvalue() and "2" in stdout.getvalue() and "3" in stdout.getvalue()
+    assert (
+        "1" in stdout.getvalue()
+        and "2" in stdout.getvalue()
+        and "3" in stdout.getvalue()
+    )
     assert "Error" not in stderr.getvalue()
 
 
@@ -8048,7 +8752,9 @@ def test_run_cli_reports_fork_errors(tmp_path, resume_flag) -> None:
         if resume_flag == "--session":
             args = ["--session", "session-1", *args]
         else:
-            runtime.session_records = [SimpleNamespace(session_file=Path(f"/tmp/{resume_flag}-session.jsonl"))]
+            runtime.session_records = [
+                SimpleNamespace(session_file=Path(f"/tmp/{resume_flag}-session.jsonl"))
+            ]
             runtime.restore_session_calls = []
             args = [resume_flag, *args]
 

--- a/tests/coding/test_extension_platform.py
+++ b/tests/coding/test_extension_platform.py
@@ -55,6 +55,37 @@ packages = ["acme-sdk>=0.3"]
     assert result.manifest.dependencies.python.packages == ("acme-sdk>=0.3",)
 
 
+def test_extension_manifest_parser_normalizes_identifiers_and_rejects_blank_id(
+    tmp_path,
+) -> None:
+    from loushang.coding.extensions.manifest import parse_extension_manifest
+
+    manifest_path = tmp_path / "loushang-extension.toml"
+    manifest_path.write_text(
+        '[extension]\nid = "  acme.review  "\nname = "  Acme Review  "\n',
+        encoding="utf-8",
+    )
+
+    normalized = parse_extension_manifest(manifest_path)
+
+    assert normalized.manifest is not None
+    assert normalized.manifest.id == "acme.review"
+    assert normalized.manifest.name == "Acme Review"
+    assert normalized.diagnostics == []
+
+    manifest_path.write_text(
+        '[extension]\nid = "   "\nname = "Acme Review"\n',
+        encoding="utf-8",
+    )
+
+    blank = parse_extension_manifest(manifest_path)
+
+    assert blank.manifest is None
+    assert [diagnostic.code for diagnostic in blank.diagnostics] == [
+        "missing_extension_manifest_id"
+    ]
+
+
 def test_extension_manifest_rejects_removed_provider_hooks(tmp_path) -> None:
     from loushang.coding.extensions.contributions import surfaces_from_loaded_extension
     from loushang.coding.extensions.manifest import parse_extension_manifest

--- a/tests/coding/test_extension_runner.py
+++ b/tests/coding/test_extension_runner.py
@@ -20,7 +20,9 @@ def _usage() -> Usage:
     )
 
 
-def _assistant_tool_call_message(tool_name: str = "calc", arguments: dict[str, object] | None = None) -> AssistantMessage:
+def _assistant_tool_call_message(
+    tool_name: str = "calc", arguments: dict[str, object] | None = None
+) -> AssistantMessage:
     return AssistantMessage(
         role="assistant",
         content=[
@@ -69,6 +71,8 @@ def _tool(name: str):
         parameters={},
         execute=_execute_tool,
     )
+
+
 def _user_message(text: str) -> UserMessage:
     return UserMessage(
         role="user",
@@ -77,7 +81,9 @@ def _user_message(text: str) -> UserMessage:
     )
 
 
-def test_extension_runner_merges_resource_contributions_from_loaded_extensions() -> None:
+def test_extension_runner_merges_resource_contributions_from_loaded_extensions() -> (
+    None
+):
     from loushang.coding.extensions import (
         ExtensionResourceContribution,
         ExtensionRunner,
@@ -126,7 +132,9 @@ def test_extension_runner_wraps_extension_tools_with_context() -> None:
         seen["tool_call_id"] = tool_call_id
         seen["params"] = params
         seen["cwd"] = ctx.cwd
-        return AgentToolResult(content=[TextPart(type="text", text="ok")], details={"ok": True})
+        return AgentToolResult(
+            content=[TextPart(type="text", text="ok")], details={"ok": True}
+        )
 
     runner = ExtensionRunner(
         [
@@ -146,7 +154,9 @@ def test_extension_runner_wraps_extension_tools_with_context() -> None:
         ]
     )
 
-    result = asyncio.run(runner.list_tool_definitions()[0].execute("tc1", {"x": 1}, None, None))
+    result = asyncio.run(
+        runner.list_tool_definitions()[0].execute("tc1", {"x": 1}, None, None)
+    )
 
     assert result.details == {"ok": True}
     assert seen == {"tool_call_id": "tc1", "params": {"x": 1}, "cwd": "/tmp/extensions"}
@@ -164,7 +174,9 @@ def test_extension_runner_keeps_legacy_four_argument_extension_tools() -> None:
         del signal, on_update
         seen["tool_call_id"] = tool_call_id
         seen["params"] = params
-        return AgentToolResult(content=[TextPart(type="text", text="ok")], details={"ok": True})
+        return AgentToolResult(
+            content=[TextPart(type="text", text="ok")], details={"ok": True}
+        )
 
     runner = ExtensionRunner(
         [
@@ -184,7 +196,9 @@ def test_extension_runner_keeps_legacy_four_argument_extension_tools() -> None:
         ]
     )
 
-    result = asyncio.run(runner.list_tool_definitions()[0].execute("tc1", {"x": 1}, None, None))
+    result = asyncio.run(
+        runner.list_tool_definitions()[0].execute("tc1", {"x": 1}, None, None)
+    )
 
     assert result.details == {"ok": True}
     assert seen == {"tool_call_id": "tc1", "params": {"x": 1}}
@@ -202,12 +216,20 @@ def test_extension_runner_resolves_duplicate_command_names() -> None:
     object.__setattr__(
         first,
         "commands",
-        {"deploy": RegisteredCommand(name="deploy", description="first", handler=_handler)},
+        {
+            "deploy": RegisteredCommand(
+                name="deploy", description="first", handler=_handler
+            )
+        },
     )
     object.__setattr__(
         second,
         "commands",
-        {"deploy": RegisteredCommand(name="deploy", description="second", handler=_handler)},
+        {
+            "deploy": RegisteredCommand(
+                name="deploy", description="second", handler=_handler
+            )
+        },
     )
 
     runner = ExtensionRunner([first, second])
@@ -236,7 +258,11 @@ def test_extension_runner_preserves_package_command_source_info() -> None:
     object.__setattr__(
         extension,
         "commands",
-        {"deploy": RegisteredCommand(name="deploy", description="package", handler=_handler)},
+        {
+            "deploy": RegisteredCommand(
+                name="deploy", description="package", handler=_handler
+            )
+        },
     )
 
     runner = ExtensionRunner([extension])
@@ -261,17 +287,29 @@ def test_extension_runner_avoids_command_alias_collision_with_literal_name() -> 
     object.__setattr__(
         first,
         "commands",
-        {"deploy": RegisteredCommand(name="deploy", description="first", handler=_handler)},
+        {
+            "deploy": RegisteredCommand(
+                name="deploy", description="first", handler=_handler
+            )
+        },
     )
     object.__setattr__(
         second,
         "commands",
-        {"deploy": RegisteredCommand(name="deploy", description="second", handler=_handler)},
+        {
+            "deploy": RegisteredCommand(
+                name="deploy", description="second", handler=_handler
+            )
+        },
     )
     object.__setattr__(
         third,
         "commands",
-        {"deploy:1": RegisteredCommand(name="deploy:1", description="literal", handler=_handler)},
+        {
+            "deploy:1": RegisteredCommand(
+                name="deploy:1", description="literal", handler=_handler
+            )
+        },
     )
 
     runner = ExtensionRunner([first, second, third])
@@ -292,12 +330,20 @@ def test_extension_runner_shortcut_collisions_are_first_wins() -> None:
     object.__setattr__(
         first,
         "shortcuts",
-        {"ctrl+p": RegisteredShortcut(shortcut="ctrl+p", handler=lambda ctx: None, description="first")},
+        {
+            "ctrl+p": RegisteredShortcut(
+                shortcut="ctrl+p", handler=lambda ctx: None, description="first"
+            )
+        },
     )
     object.__setattr__(
         second,
         "shortcuts",
-        {"ctrl+p": RegisteredShortcut(shortcut="ctrl+p", handler=lambda ctx: None, description="second")},
+        {
+            "ctrl+p": RegisteredShortcut(
+                shortcut="ctrl+p", handler=lambda ctx: None, description="second"
+            )
+        },
     )
 
     runner = ExtensionRunner([first, second])
@@ -311,7 +357,9 @@ def test_extension_runner_shortcut_collisions_are_first_wins() -> None:
     assert shortcuts[0].extension_name == "one"
     assert shortcuts[0].source_info.path == Path("/tmp/one.py")
     assert len(diagnostics) == 1
-    assert any(diagnostic.source_path == second.source_path for diagnostic in diagnostics)
+    assert any(
+        diagnostic.source_path == second.source_path for diagnostic in diagnostics
+    )
 
 
 def test_extension_runner_flag_collisions_are_first_wins() -> None:
@@ -323,12 +371,20 @@ def test_extension_runner_flag_collisions_are_first_wins() -> None:
     object.__setattr__(
         first,
         "flags",
-        {"plan": RegisteredFlag(name="plan", type="boolean", description="first", default=False)},
+        {
+            "plan": RegisteredFlag(
+                name="plan", type="boolean", description="first", default=False
+            )
+        },
     )
     object.__setattr__(
         second,
         "flags",
-        {"plan": RegisteredFlag(name="plan", type="boolean", description="second", default=True)},
+        {
+            "plan": RegisteredFlag(
+                name="plan", type="boolean", description="second", default=True
+            )
+        },
     )
 
     runner = ExtensionRunner([first, second])
@@ -343,7 +399,9 @@ def test_extension_runner_flag_collisions_are_first_wins() -> None:
     assert flags[0].extension_name == "one"
     assert flags[0].source_info.path == Path("/tmp/one.py")
     assert len(diagnostics) == 1
-    assert any(diagnostic.source_path == second.source_path for diagnostic in diagnostics)
+    assert any(
+        diagnostic.source_path == second.source_path for diagnostic in diagnostics
+    )
 
 
 def test_extension_runner_populates_flag_defaults() -> None:
@@ -359,22 +417,36 @@ def test_extension_runner_populates_flag_defaults() -> None:
         first,
         "flags",
         {
-            "plan": RegisteredFlag(name="plan", type="boolean", description="first", default=False),
-            "request-id": RegisteredFlag(name="request-id", type="string", description="first", default="abc"),
+            "plan": RegisteredFlag(
+                name="plan", type="boolean", description="first", default=False
+            ),
+            "request-id": RegisteredFlag(
+                name="request-id", type="string", description="first", default="abc"
+            ),
         },
     )
     object.__setattr__(
         second,
         "flags",
-        {"verbose": RegisteredFlag(name="verbose", type="boolean", description="second", default=True)},
+        {
+            "verbose": RegisteredFlag(
+                name="verbose", type="boolean", description="second", default=True
+            )
+        },
     )
 
     runner = ExtensionRunner([first, second])
 
-    assert runner.get_flag_values() == {"plan": False, "request-id": "abc", "verbose": True}
+    assert runner.get_flag_values() == {
+        "plan": False,
+        "request-id": "abc",
+        "verbose": True,
+    }
 
 
-def test_extension_runner_does_not_overwrite_explicit_flag_values_with_defaults() -> None:
+def test_extension_runner_does_not_overwrite_explicit_flag_values_with_defaults() -> (
+    None
+):
     from loushang.coding.extensions import (
         ExtensionRunner,
         LoadedExtension,
@@ -385,7 +457,11 @@ def test_extension_runner_does_not_overwrite_explicit_flag_values_with_defaults(
     object.__setattr__(
         ext,
         "flags",
-        {"plan": RegisteredFlag(name="plan", type="boolean", description="plan mode", default=False)},
+        {
+            "plan": RegisteredFlag(
+                name="plan", type="boolean", description="plan mode", default=False
+            )
+        },
     )
 
     runner = ExtensionRunner([ext])
@@ -438,8 +514,12 @@ def test_extension_runner_emits_lifecycle_hooks_and_rejects_duplicate_tools() ->
 
     assert state["first"] == ["start", "refresh", "shutdown"]
     assert state["second"] == ["start"]
-    assert [definition.name for definition in runner.list_tool_definitions()] == ["ext_tool"]
-    assert [diagnostic.code for diagnostic in runner.get_diagnostics()] == ["duplicate_extension_tool"]
+    assert [definition.name for definition in runner.list_tool_definitions()] == [
+        "ext_tool"
+    ]
+    assert [diagnostic.code for diagnostic in runner.get_diagnostics()] == [
+        "duplicate_extension_tool"
+    ]
 
 
 def test_extension_runner_records_hook_failures_as_diagnostics() -> None:
@@ -462,7 +542,9 @@ def test_extension_runner_records_hook_failures_as_diagnostics() -> None:
     merged = runner.discover_resources(ResourceBundle(cwd=Path("/tmp/project")))
 
     assert merged.prompt_fragments == []
-    assert [diagnostic.code for diagnostic in merged.diagnostics] == ["extension_resources_discover_failed"]
+    assert [diagnostic.code for diagnostic in merged.diagnostics] == [
+        "extension_resources_discover_failed"
+    ]
 
 
 def test_extension_runner_closes_async_session_hook_coroutines() -> None:
@@ -530,12 +612,20 @@ def test_extension_runner_records_session_refresh_hook_failures() -> None:
             record_diagnostic=lambda diagnostic: None,
         )
     )
-    asyncio.run(runner.emit_session_refresh(SessionRefreshEvent(reason="model_selection_changed")))
+    asyncio.run(
+        runner.emit_session_refresh(
+            SessionRefreshEvent(reason="model_selection_changed")
+        )
+    )
 
-    assert any(d.code == "extension_session_refresh_failed" for d in runner.get_diagnostics())
+    assert any(
+        d.code == "extension_session_refresh_failed" for d in runner.get_diagnostics()
+    )
 
 
-def test_extension_runner_records_session_action_callback_failures_via_refresh_hook_diagnostics() -> None:
+def test_extension_runner_records_session_action_callback_failures_via_refresh_hook_diagnostics() -> (
+    None
+):
     from loushang.coding.extensions import (
         ExtensionRunner,
         ExtensionRuntimeBindings,
@@ -573,9 +663,15 @@ def test_extension_runner_records_session_action_callback_failures_via_refresh_h
             record_diagnostic=lambda diagnostic: None,
         )
     )
-    asyncio.run(runner.emit_session_refresh(SessionRefreshEvent(reason="model_selection_changed")))
+    asyncio.run(
+        runner.emit_session_refresh(
+            SessionRefreshEvent(reason="model_selection_changed")
+        )
+    )
 
-    assert any(d.code == "extension_session_refresh_failed" for d in runner.get_diagnostics())
+    assert any(
+        d.code == "extension_session_refresh_failed" for d in runner.get_diagnostics()
+    )
 
 
 def test_extension_runner_pipelines_tool_call_decisions() -> None:
@@ -704,7 +800,9 @@ def test_extension_runner_pipelines_tool_result_decisions() -> None:
     assert seen == ["original", "first rewrite"]
 
 
-def test_extension_runner_pipelines_context_results_without_mutating_input_messages() -> None:
+def test_extension_runner_pipelines_context_results_without_mutating_input_messages() -> (
+    None
+):
     import asyncio
 
     from loushang.coding.extensions import (
@@ -722,7 +820,9 @@ def test_extension_runner_pipelines_context_results_without_mutating_input_messa
 
     async def _append(event, ctx):
         seen.append(event.messages[0].content[0].text)
-        return ContextResult(messages=event.messages + [_user_message("appended later")])
+        return ContextResult(
+            messages=event.messages + [_user_message("appended later")]
+        )
 
     original_messages = [_user_message("original")]
     runner = ExtensionRunner(
@@ -773,12 +873,18 @@ def test_extension_runner_emit_input_chains_transform_results() -> None:
 
     runner = ExtensionRunner(
         [
-            LoadedExtension(name="one", source_path=Path("/tmp/one.py"), hooks={"input": [_first]}),
-            LoadedExtension(name="two", source_path=Path("/tmp/two.py"), hooks={"input": [_second]}),
+            LoadedExtension(
+                name="one", source_path=Path("/tmp/one.py"), hooks={"input": [_first]}
+            ),
+            LoadedExtension(
+                name="two", source_path=Path("/tmp/two.py"), hooks={"input": [_second]}
+            ),
         ]
     )
 
-    result = asyncio.run(runner.emit_input("start", None, source="rpc", cwd="/tmp/project"))
+    result = asyncio.run(
+        runner.emit_input("start", None, source="rpc", cwd="/tmp/project")
+    )
 
     assert result.action == "transform"
     assert result.text == "start one two"
@@ -808,12 +914,18 @@ def test_extension_runner_emit_input_stops_on_handled_result() -> None:
 
     runner = ExtensionRunner(
         [
-            LoadedExtension(name="one", source_path=Path("/tmp/one.py"), hooks={"input": [_first]}),
-            LoadedExtension(name="two", source_path=Path("/tmp/two.py"), hooks={"input": [_second]}),
+            LoadedExtension(
+                name="one", source_path=Path("/tmp/one.py"), hooks={"input": [_first]}
+            ),
+            LoadedExtension(
+                name="two", source_path=Path("/tmp/two.py"), hooks={"input": [_second]}
+            ),
         ]
     )
 
-    result = asyncio.run(runner.emit_input("start", None, source="interactive", cwd="/tmp/project"))
+    result = asyncio.run(
+        runner.emit_input("start", None, source="interactive", cwd="/tmp/project")
+    )
 
     assert result.action == "handled"
     assert seen == ["start"]
@@ -851,12 +963,16 @@ def test_extension_runner_returns_command_argument_completions() -> None:
         ]
     )
 
-    completions = asyncio.run(runner.get_command_argument_completions("deploy", "staging"))
+    completions = asyncio.run(
+        runner.get_command_argument_completions("deploy", "staging")
+    )
 
     assert completions == [{"value": "staging-prod"}]
 
 
-def test_extension_runner_records_diagnostic_for_invalid_command_argument_completions() -> None:
+def test_extension_runner_records_diagnostic_for_invalid_command_argument_completions() -> (
+    None
+):
     import asyncio
 
     from loushang.coding.extensions import (
@@ -978,6 +1094,76 @@ def test_extension_runner_get_message_renderer_uses_first_registration() -> None
     assert runner.get_message_renderer("missing") is None
 
 
+def test_extension_runner_does_not_expose_or_bind_inactive_surfaces() -> None:
+    from loushang.coding.extensions import (
+        ExtensionPolicyDecision,
+        ExtensionRunner,
+        LoadedExtension,
+        RegisteredCommand,
+        RegisteredFlag,
+        RegisteredShortcut,
+    )
+
+    class RuntimeAPI:
+        def __init__(self) -> None:
+            self.bind_calls = 0
+
+        def bind_runtime_state(self, state: object) -> None:
+            del state
+            self.bind_calls += 1
+
+    async def _command(arguments: str, context: object) -> None:
+        del arguments, context
+
+    def renderer(message: object, options: object, theme: object) -> object:
+        return message, options, theme
+
+    api = RuntimeAPI()
+    inactive = LoadedExtension(
+        name="inactive",
+        source_path=Path("/tmp/inactive.py"),
+        tool_definitions=[_tool("hidden_tool")],
+        commands={
+            "hidden": RegisteredCommand(name="hidden", handler=_command),
+        },
+        flags={
+            "hidden": RegisteredFlag(
+                name="hidden",
+                type="boolean",
+                default=True,
+            ),
+        },
+        shortcuts={
+            "ctrl+h": RegisteredShortcut(
+                shortcut="ctrl+h",
+                handler=lambda context: context,
+            ),
+        },
+        message_renderers={"hidden.card": renderer},
+        api=api,
+        policy=ExtensionPolicyDecision(enabled=False),
+    )
+
+    runner = ExtensionRunner([inactive])
+    runner.bind_runtime(
+        _runtime_bindings(
+            cwd="/tmp/project",
+            active_tool_names=[],
+            model_selection=None,
+        )
+    )
+
+    assert runner.list_tool_definitions() == []
+    assert runner.get_registered_commands() == []
+    assert runner.get_flags() == []
+    assert runner.get_shortcuts() == []
+    assert runner.get_flag_values() == {}
+    assert runner.get_message_renderer("hidden.card") is None
+    assert runner.list_message_renderers() == []
+    assert runner.list_extensions()[0]["enabled"] is False
+    assert api.bind_calls == 0
+
+
 def test_extension_runner_exposes_headless_renderer_and_diagnostic_snapshots() -> None:
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
     from loushang.coding.loader import ResourceDiagnostic
@@ -991,7 +1177,11 @@ def test_extension_runner_exposes_headless_renderer_and_diagnostic_snapshots() -
                 name="cards",
                 source_path=Path("/tmp/extensions/cards.py"),
                 message_renderers={"demo.card": _renderer},
-                diagnostics=[ResourceDiagnostic(code="demo_warning", message="demo", resource_id="demo.card")],
+                diagnostics=[
+                    ResourceDiagnostic(
+                        code="demo_warning", message="demo", resource_id="demo.card"
+                    )
+                ],
             )
         ]
     )
@@ -1006,7 +1196,9 @@ def test_extension_runner_exposes_headless_renderer_and_diagnostic_snapshots() -
     assert snapshot["diagnostics"][0]["resourceId"] == "demo.card"
 
 
-def test_extension_runner_resources_discover_accepts_pi_style_path_result(tmp_path) -> None:
+def test_extension_runner_resources_discover_accepts_pi_style_path_result(
+    tmp_path,
+) -> None:
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
     from loushang.coding.loader import ResourceBundle
 
@@ -1040,9 +1232,15 @@ def test_extension_runner_resources_discover_accepts_pi_style_path_result(tmp_pa
 
     bundle = runner.discover_resources(ResourceBundle(cwd=tmp_path))
 
-    assert [(prompt.name, prompt.text) for prompt in bundle.prompts] == [("plan", "Plan prompt")]
-    assert [(skill.name, skill.content) for skill in bundle.skills] == [("debug", "Debug skill")]
-    assert [(theme.name, theme.source_path) for theme in bundle.themes] == [("clean", theme_file)]
+    assert [(prompt.name, prompt.text) for prompt in bundle.prompts] == [
+        ("plan", "Plan prompt")
+    ]
+    assert [(skill.name, skill.content) for skill in bundle.skills] == [
+        ("debug", "Debug skill")
+    ]
+    assert [(theme.name, theme.source_path) for theme in bundle.themes] == [
+        ("clean", theme_file)
+    ]
 
 
 def test_extension_runner_resources_discover_awaits_async_path_result(tmp_path) -> None:
@@ -1073,11 +1271,15 @@ def test_extension_runner_resources_discover_awaits_async_path_result(tmp_path) 
     bundle = asyncio.run(runner.discover_resources_async(ResourceBundle(cwd=tmp_path)))
 
     assert calls == [str(tmp_path)]
-    assert [(prompt.name, prompt.text) for prompt in bundle.prompts] == [("plan", "Async plan prompt")]
+    assert [(prompt.name, prompt.text) for prompt in bundle.prompts] == [
+        ("plan", "Async plan prompt")
+    ]
     assert runner.get_diagnostics() == []
 
 
-def test_extension_runner_resources_discover_path_result_reports_missing_paths(tmp_path) -> None:
+def test_extension_runner_resources_discover_path_result_reports_missing_paths(
+    tmp_path,
+) -> None:
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
     from loushang.coding.loader import ResourceBundle
 
@@ -1152,8 +1354,12 @@ def test_extension_api_runtime_action_methods_delegate_from_command_closure() ->
     asyncio.run(command.handler("", context))
 
     assert tracker["append_entry_calls"] == [("demo_state", {"ok": True})]
-    assert tracker["send_message_calls"] == [({"customType": "notice", "content": "hello"}, None)]
-    assert tracker["send_user_message_calls"] == [("follow up", {"deliverAs": "followUp"})]
+    assert tracker["send_message_calls"] == [
+        ({"customType": "notice", "content": "hello"}, None)
+    ]
+    assert tracker["send_user_message_calls"] == [
+        ("follow up", {"deliverAs": "followUp"})
+    ]
     assert tracker["set_active_tools_calls"] == [["read", "grep"]]
     assert tracker["set_model_calls"] == [{"provider": "demo", "model_id": "next"}]
     assert tracker["thinking_before"] == "medium"
@@ -1251,7 +1457,9 @@ def _runtime_bindings(
     async def _reload() -> None:
         runtime_tracker["reload_calls"] += 1
 
-    async def _navigate_tree(target_id: str, options: object | None = None) -> dict[str, object]:
+    async def _navigate_tree(
+        target_id: str, options: object | None = None
+    ) -> dict[str, object]:
         runtime_tracker["navigate_tree_calls"].append((target_id, options))
         return {"cancelled": False}
 
@@ -1264,14 +1472,18 @@ def _runtime_bindings(
         runtime_tracker["new_session_calls"].append(options)
         return {"cancelled": False}
 
-    async def _switch_session(session_path: str, options: object | None = None) -> dict[str, object]:
+    async def _switch_session(
+        session_path: str, options: object | None = None
+    ) -> dict[str, object]:
         runtime_tracker["switch_session_calls"].append((session_path, options))
         return {"cancelled": False}
 
     async def _send_message(message: object, options: object | None = None) -> None:
         runtime_tracker["send_message_calls"].append((message, options))
 
-    async def _send_user_message(content: object, options: object | None = None) -> None:
+    async def _send_user_message(
+        content: object, options: object | None = None
+    ) -> None:
         runtime_tracker["send_user_message_calls"].append((content, options))
 
     async def _compact(custom_instructions: str | None = None) -> None:
@@ -1293,23 +1505,36 @@ def _runtime_bindings(
         get_model_selection=lambda: model_selection,
         set_active_tools=_set_active_tools,
         set_model=_set_model,
-        append_entry=lambda custom_type, data=None: runtime_tracker["append_entry_calls"].append((custom_type, data)),
+        append_entry=lambda custom_type, data=None: runtime_tracker[
+            "append_entry_calls"
+        ].append((custom_type, data)),
         send_message=_send_message,
         send_user_message=_send_user_message,
-        set_session_name=lambda name: runtime_tracker["set_session_name_calls"].append(name),
+        set_session_name=lambda name: runtime_tracker["set_session_name_calls"].append(
+            name
+        ),
         get_session_name=lambda: "Demo Session",
-        set_label=lambda entry_id, label: runtime_tracker["set_label_calls"].append((entry_id, label)),
+        set_label=lambda entry_id, label: runtime_tracker["set_label_calls"].append(
+            (entry_id, label)
+        ),
         list_commands=list_commands,
         request_resource_refresh=lambda: runtime_tracker.__setitem__(
-            "resource_refresh_requests", runtime_tracker["resource_refresh_requests"] + 1
+            "resource_refresh_requests",
+            runtime_tracker["resource_refresh_requests"] + 1,
         ),
-        shutdown=lambda: runtime_tracker.__setitem__("shutdown_calls", runtime_tracker["shutdown_calls"] + 1),
-        abort=lambda: runtime_tracker.__setitem__("abort_calls", runtime_tracker["abort_calls"] + 1),
+        shutdown=lambda: runtime_tracker.__setitem__(
+            "shutdown_calls", runtime_tracker["shutdown_calls"] + 1
+        ),
+        abort=lambda: runtime_tracker.__setitem__(
+            "abort_calls", runtime_tracker["abort_calls"] + 1
+        ),
         is_idle=is_idle,
         has_pending_messages=has_pending_messages,
         get_context_usage=get_context_usage,
         get_thinking_level=get_thinking_level,
-        set_thinking_level=lambda level: runtime_tracker["set_thinking_level_calls"].append(level),
+        set_thinking_level=lambda level: runtime_tracker[
+            "set_thinking_level_calls"
+        ].append(level),
         compact=_compact,
         get_system_prompt=get_system_prompt,
         wait_for_idle=wait_for_idle or _wait_for_idle,
@@ -1319,7 +1544,9 @@ def _runtime_bindings(
         new_session=new_session or _new_session,
         switch_session=switch_session or _switch_session,
         exec_command=exec_command,
-        record_diagnostic=lambda diagnostic: runtime_tracker["recorded_diagnostics"].append(diagnostic),
+        record_diagnostic=lambda diagnostic: runtime_tracker[
+            "recorded_diagnostics"
+        ].append(diagnostic),
         ui_context=ui_context,
         on_error=on_error,
     )
@@ -1363,10 +1590,24 @@ def test_extension_runner_reports_hook_failures_to_runtime_error_sink() -> None:
             )
         ]
     )
-    runner.bind_runtime(_runtime_bindings(cwd="/tmp/project", active_tool_names=[], model_selection=None, on_error=errors.append))
+    runner.bind_runtime(
+        _runtime_bindings(
+            cwd="/tmp/project",
+            active_tool_names=[],
+            model_selection=None,
+            on_error=errors.append,
+        )
+    )
 
-    asyncio.run(runner.emit_session_refresh(SessionRefreshEvent(reason="model_selection_changed")))
-    assert asyncio.run(runner.before_session_switch(SimpleNamespace(cwd="/tmp/project"))) is None
+    asyncio.run(
+        runner.emit_session_refresh(
+            SessionRefreshEvent(reason="model_selection_changed")
+        )
+    )
+    assert (
+        asyncio.run(runner.before_session_switch(SimpleNamespace(cwd="/tmp/project")))
+        is None
+    )
     asyncio.run(runner.emit_context([_user_message("original")], cwd="/tmp/project"))
     asyncio.run(
         runner.before_tool_call(
@@ -1385,7 +1626,9 @@ def test_extension_runner_reports_hook_failures_to_runtime_error_sink() -> None:
                 assistant_message=_assistant_tool_call_message(),
                 tool_call=_assistant_tool_call_message().content[0],
                 args={"x": 1},
-                result=AgentToolResult(content=[TextPart(type="text", text="original")], details={}),
+                result=AgentToolResult(
+                    content=[TextPart(type="text", text="original")], details={}
+                ),
                 is_error=False,
                 context=_agent_context(),
             ),
@@ -1394,11 +1637,31 @@ def test_extension_runner_reports_hook_failures_to_runtime_error_sink() -> None:
     )
 
     assert errors == [
-        {"extensionPath": "/tmp/broken.py", "event": "session_refresh", "error": "session_refresh boom"},
-        {"extensionPath": "/tmp/broken.py", "event": "session_before_switch", "error": "session_before_switch boom"},
-        {"extensionPath": "/tmp/broken.py", "event": "context", "error": "context boom"},
-        {"extensionPath": "/tmp/broken.py", "event": "tool_call", "error": "tool_call boom"},
-        {"extensionPath": "/tmp/broken.py", "event": "tool_result", "error": "tool_result boom"},
+        {
+            "extensionPath": "/tmp/broken.py",
+            "event": "session_refresh",
+            "error": "session_refresh boom",
+        },
+        {
+            "extensionPath": "/tmp/broken.py",
+            "event": "session_before_switch",
+            "error": "session_before_switch boom",
+        },
+        {
+            "extensionPath": "/tmp/broken.py",
+            "event": "context",
+            "error": "context boom",
+        },
+        {
+            "extensionPath": "/tmp/broken.py",
+            "event": "tool_call",
+            "error": "tool_call boom",
+        },
+        {
+            "extensionPath": "/tmp/broken.py",
+            "event": "tool_result",
+            "error": "tool_result boom",
+        },
     ]
 
 
@@ -1415,11 +1678,27 @@ def test_extension_runner_emits_agent_lifecycle_events() -> None:
 
     def _turn_start(event, ctx):
         del ctx
-        seen.append((event.type, event.turn_index, event.turnIndex, isinstance(event.timestamp, int)))
+        seen.append(
+            (
+                event.type,
+                event.turn_index,
+                event.turnIndex,
+                isinstance(event.timestamp, int),
+            )
+        )
 
     def _tool_start(event, ctx):
         del ctx
-        seen.append((event.type, event.tool_call_id, event.toolCallId, event.tool_name, event.toolName, event.args))
+        seen.append(
+            (
+                event.type,
+                event.tool_call_id,
+                event.toolCallId,
+                event.tool_name,
+                event.toolName,
+                event.args,
+            )
+        )
 
     runner = ExtensionRunner(
         [
@@ -1436,7 +1715,9 @@ def test_extension_runner_emits_agent_lifecycle_events() -> None:
     )
 
     asyncio.run(runner.emit_event({"type": "agent_start"}))
-    asyncio.run(runner.emit_event({"type": "turn_start", "turn_index": 2, "timestamp": 123}))
+    asyncio.run(
+        runner.emit_event({"type": "turn_start", "turn_index": 2, "timestamp": 123})
+    )
     asyncio.run(
         runner.emit_event(
             {
@@ -1455,7 +1736,9 @@ def test_extension_runner_emits_agent_lifecycle_events() -> None:
     ]
 
 
-def test_extension_runner_emits_runtime_error_for_agent_lifecycle_hook_failure() -> None:
+def test_extension_runner_emits_runtime_error_for_agent_lifecycle_hook_failure() -> (
+    None
+):
     import asyncio
 
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
@@ -1474,15 +1757,32 @@ def test_extension_runner_emits_runtime_error_for_agent_lifecycle_hook_failure()
             )
         ]
     )
-    runner.bind_runtime(_runtime_bindings(cwd="/tmp/project", active_tool_names=[], model_selection=None, on_error=errors.append))
+    runner.bind_runtime(
+        _runtime_bindings(
+            cwd="/tmp/project",
+            active_tool_names=[],
+            model_selection=None,
+            on_error=errors.append,
+        )
+    )
 
     asyncio.run(runner.emit_event({"type": "agent_start"}))
 
-    assert [diagnostic.code for diagnostic in runner.get_diagnostics()] == ["extension_agent_start_failed"]
-    assert errors == [{"extensionPath": "/tmp/broken.py", "event": "agent_start", "error": "agent start boom"}]
+    assert [diagnostic.code for diagnostic in runner.get_diagnostics()] == [
+        "extension_agent_start_failed"
+    ]
+    assert errors == [
+        {
+            "extensionPath": "/tmp/broken.py",
+            "event": "agent_start",
+            "error": "agent start boom",
+        }
+    ]
 
 
-def test_extension_runner_before_agent_start_returns_messages_and_system_prompt() -> None:
+def test_extension_runner_before_agent_start_returns_messages_and_system_prompt() -> (
+    None
+):
     import asyncio
 
     from loushang.coding.extensions import (
@@ -1492,9 +1792,18 @@ def test_extension_runner_before_agent_start_returns_messages_and_system_prompt(
     )
 
     seen: list[tuple[object, ...]] = []
+    retained_contexts: list[object] = []
 
     def _first(event, ctx):
-        seen.append((event.type, event.prompt, event.system_prompt, event.systemPrompt, ctx.getSystemPrompt()))
+        seen.append(
+            (
+                event.type,
+                event.prompt,
+                event.system_prompt,
+                event.systemPrompt,
+                ctx.getSystemPrompt(),
+            )
+        )
         return BeforeAgentStartResult(
             system_prompt="First override",
             extra_messages=[
@@ -1509,12 +1818,21 @@ def test_extension_runner_before_agent_start_returns_messages_and_system_prompt(
 
     def _second(event, ctx):
         seen.append((event.type, event.system_prompt, ctx.getSystemPrompt()))
+        retained_contexts.append(ctx)
         return {"systemPrompt": "Second override"}
 
     runner = ExtensionRunner(
         [
-            LoadedExtension(name="first", source_path=Path("/tmp/first.py"), hooks={"before_agent_start": [_first]}),
-            LoadedExtension(name="second", source_path=Path("/tmp/second.py"), hooks={"before_agent_start": [_second]}),
+            LoadedExtension(
+                name="first",
+                source_path=Path("/tmp/first.py"),
+                hooks={"before_agent_start": [_first]},
+            ),
+            LoadedExtension(
+                name="second",
+                source_path=Path("/tmp/second.py"),
+                hooks={"before_agent_start": [_second]},
+            ),
         ]
     )
 
@@ -1542,6 +1860,7 @@ def test_extension_runner_before_agent_start_returns_messages_and_system_prompt(
         ("before_agent_start", "hello", "Base prompt", "Base prompt", "Base prompt"),
         ("before_agent_start", "First override", "First override"),
     ]
+    assert retained_contexts[0].getSystemPrompt() == "Second override"
 
 
 def test_extension_runner_user_bash_returns_first_handler_result() -> None:
@@ -1561,14 +1880,27 @@ def test_extension_runner_user_bash_returns_first_handler_result() -> None:
 
     runner = ExtensionRunner(
         [
-            LoadedExtension(name="first", source_path=Path("/tmp/first.py"), hooks={"user_bash": [_first]}),
-            LoadedExtension(name="second", source_path=Path("/tmp/second.py"), hooks={"user_bash": [_second]}),
+            LoadedExtension(
+                name="first",
+                source_path=Path("/tmp/first.py"),
+                hooks={"user_bash": [_first]},
+            ),
+            LoadedExtension(
+                name="second",
+                source_path=Path("/tmp/second.py"),
+                hooks={"user_bash": [_second]},
+            ),
         ]
     )
 
     result = asyncio.run(
         runner.emit_user_bash(
-            {"type": "user_bash", "command": "pwd", "exclude_from_context": True, "cwd": "/tmp/project"},
+            {
+                "type": "user_bash",
+                "command": "pwd",
+                "exclude_from_context": True,
+                "cwd": "/tmp/project",
+            },
             cwd="/tmp/project",
         )
     )
@@ -1597,18 +1929,38 @@ def test_extension_runner_user_bash_reports_runtime_errors() -> None:
             )
         ]
     )
-    runner.bind_runtime(_runtime_bindings(cwd="/tmp/project", active_tool_names=[], model_selection=None, on_error=errors.append))
+    runner.bind_runtime(
+        _runtime_bindings(
+            cwd="/tmp/project",
+            active_tool_names=[],
+            model_selection=None,
+            on_error=errors.append,
+        )
+    )
 
     result = asyncio.run(
         runner.emit_user_bash(
-            {"type": "user_bash", "command": "pwd", "exclude_from_context": False, "cwd": "/tmp/project"},
+            {
+                "type": "user_bash",
+                "command": "pwd",
+                "exclude_from_context": False,
+                "cwd": "/tmp/project",
+            },
             cwd="/tmp/project",
         )
     )
 
     assert result is None
-    assert [diagnostic.code for diagnostic in runner.get_diagnostics()] == ["extension_user_bash_failed"]
-    assert errors == [{"extensionPath": "/tmp/broken.py", "event": "user_bash", "error": "bash hook boom"}]
+    assert [diagnostic.code for diagnostic in runner.get_diagnostics()] == [
+        "extension_user_bash_failed"
+    ]
+    assert errors == [
+        {
+            "extensionPath": "/tmp/broken.py",
+            "event": "user_bash",
+            "error": "bash hook boom",
+        }
+    ]
 
 
 def test_extension_runner_refresh_runtime_updates_context_visible_state() -> None:
@@ -1618,7 +1970,9 @@ def test_extension_runner_refresh_runtime_updates_context_visible_state() -> Non
 
     def _refresh(event, ctx):
         del event
-        seen.append((ctx.cwd, tuple(ctx.get_active_tool_names()), ctx.get_model_selection()))
+        seen.append(
+            (ctx.cwd, tuple(ctx.get_active_tool_names()), ctx.get_model_selection())
+        )
 
     runner = ExtensionRunner(
         [
@@ -1647,7 +2001,11 @@ def test_extension_runner_refresh_runtime_updates_context_visible_state() -> Non
     asyncio.run(runner.emit_session_refresh(object()))
 
     assert seen == [
-        ("/tmp/project", ("read", "grep"), {"provider": "demo", "model_id": "demo-model"})
+        (
+            "/tmp/project",
+            ("read", "grep"),
+            {"provider": "demo", "model_id": "demo-model"},
+        )
     ]
 
 
@@ -1673,7 +2031,10 @@ def test_extension_runner_bind_runtime_and_emit_session_refresh() -> None:
             LoadedExtension(
                 name="demo",
                 source_path=Path("/tmp/extensions/demo.py"),
-                hooks={"session_start": [_session_start], "session_refresh": [_session_refresh]},
+                hooks={
+                    "session_start": [_session_start],
+                    "session_refresh": [_session_refresh],
+                },
             )
         ]
     )
@@ -1693,7 +2054,9 @@ def test_extension_runner_bind_runtime_and_emit_session_refresh() -> None:
             model_selection={"provider": "demo", "model_id": "second"},
         )
     )
-    asyncio.run(runner.emit_session_refresh(SessionRefreshEvent(reason="tools_changed")))
+    asyncio.run(
+        runner.emit_session_refresh(SessionRefreshEvent(reason="tools_changed"))
+    )
 
     assert events == [("start", "/tmp/project"), ("refresh", "/tmp/project-two")]
 
@@ -1741,7 +2104,10 @@ def test_extension_runner_context_queries_are_live_after_refresh() -> None:
     original_get_active_tool_names, original_get_model_selection = held_accessors[0]
 
     assert tuple(original_context.get_active_tool_names()) == ("read", "grep")
-    assert original_context.get_model_selection() == {"provider": "demo", "model_id": "second"}
+    assert original_context.get_model_selection() == {
+        "provider": "demo",
+        "model_id": "second",
+    }
     assert tuple(original_get_active_tool_names()) == ("read", "grep")
     assert original_get_model_selection() == {"provider": "demo", "model_id": "second"}
 
@@ -1753,7 +2119,9 @@ def test_extension_runner_context_queries_are_live_after_refresh() -> None:
     ]
 
 
-def test_extension_runner_context_mutators_delegate_through_live_runtime_bindings() -> None:
+def test_extension_runner_context_mutators_delegate_through_live_runtime_bindings() -> (
+    None
+):
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
     from loushang.coding.loader import ResourceDiagnostic
 
@@ -1793,7 +2161,9 @@ def test_extension_runner_context_mutators_delegate_through_live_runtime_binding
     assert tracker["shutdown_calls"] == 1
 
 
-def test_extension_runner_context_pi_style_session_and_registry_actions_delegate() -> None:
+def test_extension_runner_context_pi_style_session_and_registry_actions_delegate() -> (
+    None
+):
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
 
     tracker: dict[str, object] = {}
@@ -1803,7 +2173,9 @@ def test_extension_runner_context_pi_style_session_and_registry_actions_delegate
         del event
         await ctx.setActiveTools(["read", "grep"])
         ctx.appendEntry("demo_state", {"enabled": True})
-        await ctx.sendMessage({"customType": "demo_message", "content": "hello"}, {"triggerTurn": False})
+        await ctx.sendMessage(
+            {"customType": "demo_message", "content": "hello"}, {"triggerTurn": False}
+        )
         await ctx.sendUserMessage("run this", {"deliverAs": "followUp"})
         ctx.setSessionName("Demo")
         ctx.setLabel("entry-1", "Bookmark")
@@ -1840,7 +2212,9 @@ def test_extension_runner_context_pi_style_session_and_registry_actions_delegate
     assert tracker["send_message_calls"] == [
         ({"customType": "demo_message", "content": "hello"}, {"triggerTurn": False})
     ]
-    assert tracker["send_user_message_calls"] == [("run this", {"deliverAs": "followUp"})]
+    assert tracker["send_user_message_calls"] == [
+        ("run this", {"deliverAs": "followUp"})
+    ]
     assert tracker["set_session_name_calls"] == ["Demo"]
     assert tracker["set_label_calls"] == [("entry-1", "Bookmark")]
     assert seen == [
@@ -1853,7 +2227,9 @@ def test_extension_runner_context_pi_style_session_and_registry_actions_delegate
     ]
 
 
-def test_extension_runner_context_runtime_state_methods_delegate_through_bindings() -> None:
+def test_extension_runner_context_runtime_state_methods_delegate_through_bindings() -> (
+    None
+):
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
 
     seen: list[tuple[object, ...]] = []
@@ -1959,16 +2335,29 @@ def test_extension_runner_context_exposes_pi_style_runtime_properties() -> None:
     )
     asyncio.run(runner.emit_session_start(object()))
 
-    assert seen == [(session_manager, session_manager, model_registry, model_registry, model_selection, signal)]
+    assert seen == [
+        (
+            session_manager,
+            session_manager,
+            model_registry,
+            model_registry,
+            model_selection,
+            signal,
+        )
+    ]
 
 
-def test_extension_runner_command_context_wait_for_idle_and_reload_delegate_through_bindings() -> None:
+def test_extension_runner_command_context_wait_for_idle_and_reload_delegate_through_bindings() -> (
+    None
+):
     import asyncio
 
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
 
     tracker: dict[str, object] = {}
-    runner = ExtensionRunner([LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))])
+    runner = ExtensionRunner(
+        [LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))]
+    )
     runner.bind_runtime(
         _runtime_bindings(
             cwd="/tmp/project",
@@ -1990,13 +2379,17 @@ def test_extension_runner_command_context_wait_for_idle_and_reload_delegate_thro
     assert tracker["reload_calls"] == 1
 
 
-def test_extension_runner_command_context_navigate_tree_delegates_through_bindings() -> None:
+def test_extension_runner_command_context_navigate_tree_delegates_through_bindings() -> (
+    None
+):
     import asyncio
 
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
 
     tracker: dict[str, object] = {}
-    runner = ExtensionRunner([LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))])
+    runner = ExtensionRunner(
+        [LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))]
+    )
     runner.bind_runtime(
         _runtime_bindings(
             cwd="/tmp/project",
@@ -2008,10 +2401,12 @@ def test_extension_runner_command_context_navigate_tree_delegates_through_bindin
 
     async def scenario() -> None:
         context = runner.create_command_context(fallback_cwd="/tmp/project")
-        assert await context.navigateTree("entry-1", {"summarize": True, "customInstructions": "brief"}) == {
+        assert await context.navigateTree(
+            "entry-1", {"summarize": True, "customInstructions": "brief"}
+        ) == {"cancelled": False}
+        assert await context.navigate_tree("entry-2", {"label": "keep"}) == {
             "cancelled": False
         }
-        assert await context.navigate_tree("entry-2", {"label": "keep"}) == {"cancelled": False}
 
     asyncio.run(scenario())
 
@@ -2027,7 +2422,9 @@ def test_extension_runner_command_context_fork_delegates_through_bindings() -> N
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
 
     tracker: dict[str, object] = {}
-    runner = ExtensionRunner([LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))])
+    runner = ExtensionRunner(
+        [LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))]
+    )
     runner.bind_runtime(
         _runtime_bindings(
             cwd="/tmp/project",
@@ -2046,13 +2443,17 @@ def test_extension_runner_command_context_fork_delegates_through_bindings() -> N
     assert tracker["fork_calls"] == ["entry-1"]
 
 
-def test_extension_runner_command_context_new_and_switch_session_delegate_through_bindings() -> None:
+def test_extension_runner_command_context_new_and_switch_session_delegate_through_bindings() -> (
+    None
+):
     import asyncio
 
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
 
     tracker: dict[str, object] = {}
-    runner = ExtensionRunner([LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))])
+    runner = ExtensionRunner(
+        [LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))]
+    )
     runner.bind_runtime(
         _runtime_bindings(
             cwd="/tmp/project",
@@ -2064,21 +2465,32 @@ def test_extension_runner_command_context_new_and_switch_session_delegate_throug
 
     async def scenario() -> None:
         context = runner.create_command_context(fallback_cwd="/tmp/project")
-        assert await context.newSession({"parentSession": "parent-1"}) == {"cancelled": False}
-        assert await context.new_session({"parent_session": "parent-2"}) == {"cancelled": False}
+        assert await context.newSession({"parentSession": "parent-1"}) == {
+            "cancelled": False
+        }
+        assert await context.new_session({"parent_session": "parent-2"}) == {
+            "cancelled": False
+        }
         assert await context.switchSession("/tmp/session.jsonl") == {"cancelled": False}
-        assert await context.switch_session("/tmp/other.jsonl", {"withSession": "ignored"}) == {"cancelled": False}
+        assert await context.switch_session(
+            "/tmp/other.jsonl", {"withSession": "ignored"}
+        ) == {"cancelled": False}
 
     asyncio.run(scenario())
 
-    assert tracker["new_session_calls"] == [{"parentSession": "parent-1"}, {"parent_session": "parent-2"}]
+    assert tracker["new_session_calls"] == [
+        {"parentSession": "parent-1"},
+        {"parent_session": "parent-2"},
+    ]
     assert tracker["switch_session_calls"] == [
         ("/tmp/session.jsonl", None),
         ("/tmp/other.jsonl", {"withSession": "ignored"}),
     ]
 
 
-def test_extension_runner_command_context_exec_command_delegates_through_bindings() -> None:
+def test_extension_runner_command_context_exec_command_delegates_through_bindings() -> (
+    None
+):
     import asyncio
 
     from loushang.coding.exec import ExecOutputChunk, ExecResult
@@ -2097,7 +2509,9 @@ def test_extension_runner_command_context_exec_command_delegates_through_binding
                 await update
         return ExecResult(exit_code=2, stderr="warn\n")
 
-    runner = ExtensionRunner([LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))])
+    runner = ExtensionRunner(
+        [LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))]
+    )
     runner.bind_runtime(
         _runtime_bindings(
             cwd="/tmp/project",
@@ -2151,7 +2565,9 @@ def test_extension_runner_command_context_exec_command_delegates_through_binding
 def test_extension_runner_invalidates_captured_runtime_contexts() -> None:
     from loushang.coding.extensions import ExtensionRunner, LoadedExtension
 
-    runner = ExtensionRunner([LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))])
+    runner = ExtensionRunner(
+        [LoadedExtension(name="demo", source_path=Path("/tmp/extensions/demo.py"))]
+    )
     runner.bind_runtime(
         _runtime_bindings(
             cwd="/tmp/project",
@@ -2276,18 +2692,26 @@ def test_extension_runner_emits_tree_and_compact_decision_hooks() -> None:
                     "session_before_compact": [_after_compact],
                     "session_before_fork": [_after_fork],
                 },
-            )
+            ),
         ]
     )
 
     tree_decision = asyncio.run(
-        runner.before_session_tree(SessionBeforeTreeEvent(target_id="entry-1", old_leaf_id="entry-2", cwd="/tmp/project"))
+        runner.before_session_tree(
+            SessionBeforeTreeEvent(
+                target_id="entry-1", old_leaf_id="entry-2", cwd="/tmp/project"
+            )
+        )
     )
     compact_decision = asyncio.run(
-        runner.before_session_compact(SessionBeforeCompactEvent(reason="manual", cwd="/tmp/project"))
+        runner.before_session_compact(
+            SessionBeforeCompactEvent(reason="manual", cwd="/tmp/project")
+        )
     )
     fork_decision = asyncio.run(
-        runner.before_session_fork(SessionBeforeForkEvent(entry_id="entry-3", cwd="/tmp/project"))
+        runner.before_session_fork(
+            SessionBeforeForkEvent(entry_id="entry-3", cwd="/tmp/project")
+        )
     )
 
     assert tree_decision == SessionBeforeTreeResult(

--- a/tests/coding/test_policy_engine.py
+++ b/tests/coding/test_policy_engine.py
@@ -5,8 +5,12 @@ def test_policy_decision_helpers_cover_allow_deny_and_ask() -> None:
     from loushang.coding.policy.types import PolicyDecision
 
     assert PolicyDecision.allow() == PolicyDecision(disposition="allow", reason=None)
-    assert PolicyDecision.deny("blocked") == PolicyDecision(disposition="deny", reason="blocked")
-    assert PolicyDecision.ask("needs approval") == PolicyDecision(disposition="ask", reason="needs approval")
+    assert PolicyDecision.deny("blocked") == PolicyDecision(
+        disposition="deny", reason="blocked"
+    )
+    assert PolicyDecision.ask("needs approval") == PolicyDecision(
+        disposition="ask", reason="needs approval"
+    )
 
 
 def test_policy_engine_denies_blocked_commands() -> None:
@@ -16,7 +20,9 @@ def test_policy_engine_denies_blocked_commands() -> None:
     engine = PolicyEngine(blocked_substrings=["rm -rf", "git reset --hard"])
     decision = engine.evaluate_action(
         tool_name="bash",
-        exec_request=ExecRequest(command=["/bin/sh", "-lc", "rm -rf /tmp/demo"], cwd="/tmp"),
+        exec_request=ExecRequest(
+            command=["/bin/sh", "-lc", "rm -rf /tmp/demo"], cwd="/tmp"
+        ),
     )
 
     assert decision.disposition == "deny"
@@ -30,7 +36,9 @@ def test_policy_engine_denies_destructive_commands_by_default() -> None:
     engine = PolicyEngine()
     decision = engine.evaluate_action(
         tool_name="bash",
-        exec_request=ExecRequest(command=["/bin/sh", "-lc", "git reset --hard HEAD~1"], cwd="/tmp"),
+        exec_request=ExecRequest(
+            command=["/bin/sh", "-lc", "git reset --hard HEAD~1"], cwd="/tmp"
+        ),
     )
 
     assert decision.disposition == "deny"
@@ -71,7 +79,9 @@ def test_policy_engine_asks_for_risky_default_heuristics() -> None:
     engine = PolicyEngine()
     decision = engine.evaluate_action(
         tool_name="bash",
-        exec_request=ExecRequest(command=["/bin/sh", "-lc", "git push origin main"], cwd="/tmp"),
+        exec_request=ExecRequest(
+            command=["/bin/sh", "-lc", "git push origin main"], cwd="/tmp"
+        ),
     )
 
     assert decision.disposition == "ask"
@@ -125,7 +135,9 @@ def test_policy_engine_asks_for_env_wrapped_shell_payload_with_option_flags() ->
     assert decision.disposition == "ask"
 
 
-def test_policy_engine_asks_for_env_wrapped_shell_payload_with_split_string_flag() -> None:
+def test_policy_engine_asks_for_env_wrapped_shell_payload_with_split_string_flag() -> (
+    None
+):
     from loushang.coding.exec import ExecRequest
     from loushang.coding.policy import PolicyEngine
 
@@ -157,7 +169,7 @@ def test_policy_engine_asks_for_env_wrapped_shell_payload_with_unset_option() ->
     assert decision.disposition == "ask"
 
 
-def test_policy_engine_allows_env_wrapped_malformed_split_string_without_crashing() -> None:
+def test_policy_engine_requires_approval_for_incomplete_env_split_string() -> None:
     from loushang.coding.exec import ExecRequest
     from loushang.coding.policy import PolicyEngine
 
@@ -170,10 +182,13 @@ def test_policy_engine_allows_env_wrapped_malformed_split_string_without_crashin
         ),
     )
 
-    assert decision.disposition == "allow"
+    assert decision.disposition == "ask"
+    assert decision.code == "command_normalization_incomplete"
 
 
-def test_policy_engine_denies_env_wrapped_malformed_split_string_with_destructive_payload() -> None:
+def test_policy_engine_denies_env_wrapped_malformed_split_string_with_destructive_payload() -> (
+    None
+):
     from loushang.coding.exec import ExecRequest
     from loushang.coding.policy import PolicyEngine
 
@@ -189,6 +204,167 @@ def test_policy_engine_denies_env_wrapped_malformed_split_string_with_destructiv
     assert decision.disposition == "deny"
 
 
+def test_policy_engine_denies_destructive_payloads_after_wrapper_options() -> None:
+    from loushang.coding.exec import ExecRequest
+    from loushang.coding.policy import PolicyEngine
+
+    commands = (
+        ["sudo", "-nu", "root", "FOO=bar", "bash", "-c", "rm -rf /tmp"],
+        ["sudo", "--use", "root", "bash", "-c", "rm -rf /tmp"],
+        ["sudo", "--chd", "/tmp", "bash", "-c", "rm -rf /tmp"],
+        ["sudo", "-s", "rm", "-rf", "/tmp"],
+        ["sudo", "--login", "rm", "-rf", "/tmp"],
+        ["env", "1FOO=bar", "bash", "-c", "rm -rf /tmp"],
+        ["env", "=bar", "bash", "-c", "rm -rf /tmp"],
+        ["env", "--", "FOO=bar", "bash", "-c", "rm -rf /tmp"],
+        ["env", "--chd", "/tmp", "bash", "-c", "rm -rf /tmp"],
+        ["env", "--uns", "FOO", "bash", "-c", "rm -rf /tmp"],
+        ["env", "-iu", "FOO", "bash", "-c", "rm -rf /tmp"],
+        ["env", "-iS", "bash -c 'rm -rf /tmp'"],
+        ["env", "-S", "-i bash -c 'rm -rf /tmp'"],
+        ["env", "-S", "FOO=bar bash -c 'rm -rf /tmp'"],
+        ["env", "--default-signal", "bash", "-c", "rm -rf /tmp"],
+        ["env", "--ignore-signal", "bash", "-c", "rm -rf /tmp"],
+        ["env", "--block-signal", "bash", "-c", "rm -rf /tmp"],
+        ["fish", "--command", "rm -rf /tmp"],
+        ["fish", "--command=rm -rf /tmp"],
+        ["fish", "-C", "printf setup", "-c", "rm -rf /tmp"],
+        ["fish", "-c", "printf safe", "-c", "rm -rf /tmp"],
+    )
+    engine = PolicyEngine()
+
+    for command in commands:
+        decision = engine.evaluate_action(
+            tool_name="bash",
+            exec_request=ExecRequest(command=command, cwd="/tmp"),
+        )
+        assert decision.disposition == "deny", command
+
+
+def test_policy_engine_denies_literal_block_in_nonportable_env_split_syntax() -> None:
+    from loushang.coding.exec import ExecRequest
+    from loushang.coding.policy import PolicyEngine
+
+    engine = PolicyEngine()
+    decision = engine.evaluate_action(
+        tool_name="bash",
+        exec_request=ExecRequest(
+            command=["env", "-S", r'bash\_-c\_"rm -rf /tmp"'],
+            cwd="/tmp",
+        ),
+    )
+
+    assert decision.disposition == "deny"
+    assert decision.code == "command_blocked"
+
+
+def test_policy_engine_requires_approval_for_dynamic_env_split_syntax() -> None:
+    from loushang.coding.exec import ExecRequest
+    from loushang.coding.policy import PolicyEngine
+
+    decision = PolicyEngine().evaluate_action(
+        tool_name="bash",
+        exec_request=ExecRequest(
+            command=["env", "-S", "${RUNNER} -c 'printf ok'"],
+            cwd="/tmp",
+        ),
+    )
+
+    assert decision.disposition == "ask"
+    assert decision.code == "command_normalization_incomplete"
+
+
+def test_policy_engine_compatibility_method_normalizes_list_commands() -> None:
+    from loushang.coding.policy import PolicyEngine
+
+    engine = PolicyEngine()
+
+    direct = engine.evaluate_tool_call(
+        tool_name="bash",
+        arguments={"command": ["rm", "-rf", "/tmp"]},
+    )
+    shell = engine.evaluate_tool_call(
+        tool_name="bash",
+        arguments={"command": ["bash", "-c", "rm -rf /tmp"]},
+    )
+    literal = engine.evaluate_tool_call(
+        tool_name="bash",
+        arguments={"command": ["python", "-c", 'print("rm -rf")']},
+    )
+
+    assert direct.disposition == "deny"
+    assert shell.disposition == "deny"
+    assert literal.disposition == "allow"
+
+
+def test_policy_engine_evaluates_shell_stdin_without_treating_data_as_script() -> None:
+    from loushang.coding.exec import ExecRequest
+    from loushang.coding.policy import PolicyEngine
+
+    engine = PolicyEngine()
+
+    destructive_script = engine.evaluate_action(
+        tool_name="bash",
+        exec_request=ExecRequest(
+            command=["bash", "-s"],
+            stdin="rm -rf /tmp/policy-stdin\n",
+        ),
+    )
+    command_data = engine.evaluate_action(
+        tool_name="bash",
+        exec_request=ExecRequest(
+            command=["bash", "-c", "cat"],
+            stdin="rm -rf /tmp/policy-data\n",
+        ),
+    )
+
+    assert destructive_script.disposition == "deny"
+    assert destructive_script.code == "command_blocked"
+    assert command_data.disposition == "allow"
+
+
+def test_policy_engine_compatibility_paths_use_last_execution_path(tmp_path) -> None:
+    from loushang.coding.exec import ExecRequest
+    from loushang.coding.policy import PolicyEngine
+
+    (tmp_path / "cat").symlink_to("/bin/bash")
+    engine = PolicyEngine()
+    dangerous_env = (("PATH", "/usr/bin"), ("PATH", str(tmp_path)))
+    safe_env = tuple(reversed(dangerous_env))
+
+    action = engine.evaluate_action(
+        tool_name="bash",
+        exec_request=ExecRequest(
+            command=("cat", "+x"),
+            cwd=str(tmp_path),
+            env=dangerous_env,
+            stdin="rm -rf /tmp/policy-stdin\n",
+        ),
+    )
+    tool_call = engine.evaluate_tool_call(
+        tool_name="bash",
+        arguments={
+            "command": ["cat", "+x"],
+            "cwd": str(tmp_path),
+            "env": dangerous_env,
+            "stdin": "rm -rf /tmp/policy-stdin\n",
+        },
+    )
+    safe_action = engine.evaluate_action(
+        tool_name="bash",
+        exec_request=ExecRequest(
+            command=("cat", "+x"),
+            cwd=str(tmp_path),
+            env=safe_env,
+            stdin="rm -rf /tmp/policy-stdin\n",
+        ),
+    )
+
+    assert action.disposition == "deny"
+    assert tool_call.disposition == "deny"
+    assert safe_action.disposition == "allow"
+
+
 def test_policy_engine_asks_for_absolute_path_git_push() -> None:
     from loushang.coding.exec import ExecRequest
     from loushang.coding.policy import PolicyEngine
@@ -196,7 +372,9 @@ def test_policy_engine_asks_for_absolute_path_git_push() -> None:
     engine = PolicyEngine()
     decision = engine.evaluate_action(
         tool_name="bash",
-        exec_request=ExecRequest(command=["/usr/bin/git", "push", "origin", "main"], cwd="/tmp"),
+        exec_request=ExecRequest(
+            command=["/usr/bin/git", "push", "origin", "main"], cwd="/tmp"
+        ),
     )
 
     assert decision.disposition == "ask"
@@ -209,7 +387,9 @@ def test_policy_engine_denies_sudo_wrapped_destructive_command() -> None:
     engine = PolicyEngine()
     decision = engine.evaluate_action(
         tool_name="bash",
-        exec_request=ExecRequest(command=["sudo", "/bin/rm", "-rf", "/tmp"], cwd="/tmp"),
+        exec_request=ExecRequest(
+            command=["sudo", "/bin/rm", "-rf", "/tmp"], cwd="/tmp"
+        ),
     )
 
     assert decision.disposition == "deny"
@@ -231,7 +411,9 @@ def test_policy_engine_denies_sudo_wrapped_destructive_command_with_options() ->
     assert decision.disposition == "deny"
 
 
-def test_policy_engine_denies_sudo_wrapped_destructive_command_with_prompt_option() -> None:
+def test_policy_engine_denies_sudo_wrapped_destructive_command_with_prompt_option() -> (
+    None
+):
     from loushang.coding.exec import ExecRequest
     from loushang.coding.policy import PolicyEngine
 
@@ -247,7 +429,9 @@ def test_policy_engine_denies_sudo_wrapped_destructive_command_with_prompt_optio
     assert decision.disposition == "deny"
 
 
-def test_policy_engine_denies_sudo_wrapped_destructive_command_with_chroot_option() -> None:
+def test_policy_engine_denies_sudo_wrapped_destructive_command_with_chroot_option() -> (
+    None
+):
     from loushang.coding.exec import ExecRequest
     from loushang.coding.policy import PolicyEngine
 
@@ -270,7 +454,9 @@ def test_policy_engine_preserves_default_ask_rules_when_customized() -> None:
     engine = PolicyEngine(ask_substrings=["curl | sh"])
     decision = engine.evaluate_action(
         tool_name="bash",
-        exec_request=ExecRequest(command=["/bin/sh", "-lc", "git push origin main"], cwd="/tmp"),
+        exec_request=ExecRequest(
+            command=["/bin/sh", "-lc", "git push origin main"], cwd="/tmp"
+        ),
     )
 
     assert decision.disposition == "ask"
@@ -292,7 +478,13 @@ def test_policy_engine_uses_shell_payload_with_trailing_args() -> None:
     ask_decision = engine.evaluate_action(
         tool_name="bash",
         exec_request=ExecRequest(
-            command=["/bin/sh", "-lc", "git push origin main", "ignored", "still-ignored"],
+            command=[
+                "/bin/sh",
+                "-lc",
+                "git push origin main",
+                "ignored",
+                "still-ignored",
+            ],
             cwd="/tmp",
         ),
     )
@@ -308,7 +500,9 @@ def test_policy_engine_ignores_literal_substrings_in_direct_argv_commands() -> N
     engine = PolicyEngine()
     decision = engine.evaluate_action(
         tool_name="python",
-        exec_request=ExecRequest(command=["python", "-c", 'print("rm -rf")'], cwd="/tmp"),
+        exec_request=ExecRequest(
+            command=["python", "-c", 'print("rm -rf")'], cwd="/tmp"
+        ),
     )
 
     assert decision.disposition == "allow"
@@ -390,3 +584,800 @@ def test_policy_engine_evaluates_resolved_path_substring_rules() -> None:
     assert decision.disposition == "deny"
     assert decision.code == "path_blocked"
     assert "/tmp/project/secrets" in (decision.reason or "")
+
+
+def test_bash_policy_evaluates_effective_command_after_prefix(tmp_path) -> None:
+    import asyncio
+
+    import pytest
+
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import create_bash_tool_definition
+
+    class UnexpectedExecService:
+        async def execute(self, request, **kwargs):
+            del request, kwargs
+            raise AssertionError("blocked effective command must not execute")
+
+    bash = create_bash_tool_definition(
+        policy_engine=PolicyEngine(),
+        exec_service=UnexpectedExecService(),
+        command_prefix="rm -rf /tmp/policy-prefix",
+    )
+
+    with pytest.raises(PermissionError, match="rm -rf"):
+        asyncio.run(
+            bash.execute(
+                "call-effective-prefix",
+                {"command": "pwd", "cwd": str(tmp_path)},
+            )
+        )
+
+
+def test_bash_policy_evaluates_configured_shell_path(tmp_path) -> None:
+    import asyncio
+
+    import pytest
+
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import create_bash_tool_definition
+
+    class UnexpectedExecService:
+        async def execute(self, request, **kwargs):
+            del request, kwargs
+            raise AssertionError("blocked configured shell command must not execute")
+
+    bash = create_bash_tool_definition(
+        policy_engine=PolicyEngine(),
+        exec_service=UnexpectedExecService(),
+        shell_path="/opt/product-shell",
+    )
+
+    with pytest.raises(PermissionError, match="rm -rf"):
+        asyncio.run(
+            bash.execute(
+                "call-configured-shell",
+                {"command": "rm -rf /tmp/policy-shell", "cwd": str(tmp_path)},
+            )
+        )
+
+
+def test_bash_policy_blocks_destructive_shell_stdin_before_execution(tmp_path) -> None:
+    import asyncio
+    from shutil import copy2
+
+    import pytest
+
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import create_bash_tool_definition
+
+    class UnexpectedExecService:
+        async def execute(self, request, **kwargs):
+            del request, kwargs
+            raise AssertionError("blocked stdin script must not execute")
+
+    bash = create_bash_tool_definition(
+        policy_engine=PolicyEngine(),
+        exec_service=UnexpectedExecService(),
+    )
+    (tmp_path / "stdin-script").symlink_to("/dev/stdin")
+    (tmp_path / "root").symlink_to("/")
+    (tmp_path / "shell-alias").symlink_to("/bin/bash")
+    (tmp_path / "fish").symlink_to("/bin/bash")
+    (tmp_path / "env").symlink_to("/bin/bash")
+    (tmp_path / "sudo").symlink_to("/bin/bash")
+    (tmp_path / "runner").symlink_to("/usr/bin/env")
+    copied_shell_dir = tmp_path / "copied-shell"
+    copied_shell_dir.mkdir()
+    copy2("/bin/bash", copied_shell_dir / "bash")
+
+    for index, (command, cwd) in enumerate(
+        (
+            (["bash", "-s"], str(tmp_path)),
+            (["bash", "-"], str(tmp_path)),
+            (["bash", "/dev/stdin"], str(tmp_path)),
+            (["bash", "/dev/fd/0"], str(tmp_path)),
+            (["bash", "/proc/self/fd/0"], str(tmp_path)),
+            (["bash", "/proc/thread-self/fd/0"], str(tmp_path)),
+            (["bash", "/proc/self/root/dev/stdin"], str(tmp_path)),
+            (["bash", "/proc/thread-self/root/dev/stdin"], str(tmp_path)),
+            (["bash", "/proc/self/root/../dev/stdin"], str(tmp_path)),
+            (["bash", "/proc/thread-self/root/../dev/stdin"], str(tmp_path)),
+            (["bash", "/proc/self/root/../../dev/stdin"], str(tmp_path)),
+            (["bash", "../dev/stdin"], "/tmp"),
+            (["bash", "../dev/fd/0"], "/tmp"),
+            (["bash", "../proc/self/fd/0"], "/tmp"),
+            (["bash", "../proc/thread-self/fd/0"], "/tmp"),
+            (["bash", "--", "../dev/stdin"], "/tmp"),
+            (["bash", "stdin-script"], str(tmp_path)),
+            (
+                [
+                    "bash",
+                    str(tmp_path / "root" / ".." / "dev" / "stdin"),
+                ],
+                str(tmp_path),
+            ),
+            (["bash", "+x"], str(tmp_path)),
+            (["sh", "+eu"], str(tmp_path)),
+            (["rbash"], str(tmp_path)),
+            (["rzsh"], str(tmp_path)),
+            (["rksh"], str(tmp_path)),
+            ([str(tmp_path / "shell-alias")], str(tmp_path)),
+            (["./shell-alias"], str(tmp_path)),
+            ([str(tmp_path / "fish"), "+x"], str(tmp_path)),
+            ([str(tmp_path / "env")], str(tmp_path)),
+            (["./sudo"], str(tmp_path)),
+            (
+                [str(tmp_path / "runner"), "bash", "-c", "rm -rf /tmp/demo"],
+                str(tmp_path),
+            ),
+            ([str(copied_shell_dir / "bash"), "+x"], str(tmp_path)),
+            (["./copied-shell/bash", "+x"], str(tmp_path)),
+            (["/bin/busybox", "sh"], str(tmp_path)),
+            (
+                ["/bin/busybox", "ash", "-c", "rm -rf /tmp/demo"],
+                str(tmp_path),
+            ),
+        )
+    ):
+        with pytest.raises(PermissionError, match="rm -rf"):
+            asyncio.run(
+                bash.execute(
+                    f"call-stdin-policy-{index}",
+                    {
+                        "command": command,
+                        "stdin": "rm -rf /tmp/policy-stdin\n",
+                        "cwd": cwd,
+                    },
+                )
+            )
+
+    path_commands = (
+        ("shell-alias", str(tmp_path)),
+        ("env", str(tmp_path)),
+        ("bash", str(copied_shell_dir)),
+    )
+    for executable, search_path in path_commands:
+        with pytest.raises(PermissionError, match="rm -rf"):
+            asyncio.run(
+                bash.execute(
+                    f"call-path-{executable}",
+                    {
+                        "command": [executable],
+                        "stdin": "rm -rf /tmp/policy-stdin\n",
+                        "cwd": str(tmp_path),
+                        "env": [("PATH", search_path)],
+                    },
+                )
+            )
+
+
+def test_bash_policy_resolves_relative_path_from_execution_cwd(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import asyncio
+
+    import pytest
+
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import create_bash_tool_definition
+
+    class UnexpectedExecService:
+        async def execute(self, request, **kwargs):
+            del request, kwargs
+            raise AssertionError("blocked relative PATH shell must not execute")
+
+    process_cwd = tmp_path / "process"
+    execution_cwd = tmp_path / "execution"
+    process_cwd.mkdir()
+    execution_cwd.mkdir()
+    (process_cwd / "cat").symlink_to("/bin/cat")
+    (execution_cwd / "cat").symlink_to("/bin/bash")
+    monkeypatch.chdir(process_cwd)
+    bash = create_bash_tool_definition(
+        policy_engine=PolicyEngine(),
+        exec_service=UnexpectedExecService(),
+    )
+
+    with pytest.raises(PermissionError, match="rm -rf"):
+        asyncio.run(
+            bash.execute(
+                "call-relative-path-shell",
+                {
+                    "command": ["cat", "+x"],
+                    "stdin": "rm -rf /tmp/policy-stdin\n",
+                    "cwd": str(execution_cwd),
+                    "env": [("PATH", ".")],
+                },
+            )
+        )
+
+
+def test_bash_policy_blocks_relative_stdin_symlink_without_explicit_cwd(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import asyncio
+
+    import pytest
+
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import create_bash_tool_definition
+
+    class UnexpectedExecService:
+        async def execute(self, request, **kwargs):
+            del request, kwargs
+            raise AssertionError("blocked stdin script must not execute")
+
+    (tmp_path / "stdin-script").symlink_to("/dev/stdin")
+    monkeypatch.chdir(tmp_path)
+    bash = create_bash_tool_definition(
+        policy_engine=PolicyEngine(),
+        exec_service=UnexpectedExecService(),
+    )
+
+    with pytest.raises(PermissionError, match="rm -rf"):
+        asyncio.run(
+            bash.execute(
+                "call-relative-stdin-policy",
+                {
+                    "command": ["bash", "stdin-script"],
+                    "stdin": "rm -rf /tmp/policy-stdin\n",
+                },
+            )
+        )
+
+
+def test_bash_policy_fails_safe_when_env_wrapper_changes_cwd(tmp_path) -> None:
+    import asyncio
+
+    import pytest
+
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import create_bash_tool_definition
+
+    class UnexpectedExecService:
+        async def execute(self, request, **kwargs):
+            del request, kwargs
+            raise AssertionError("incomplete wrapper command must not execute")
+
+    (tmp_path / "stdin-script").symlink_to("/dev/stdin")
+    bash = create_bash_tool_definition(
+        policy_engine=PolicyEngine(),
+        exec_service=UnexpectedExecService(),
+    )
+
+    with pytest.raises(PermissionError, match="requires approval"):
+        asyncio.run(
+            bash.execute(
+                "call-env-chdir-stdin-policy",
+                {
+                    "command": [
+                        "env",
+                        "-C",
+                        str(tmp_path),
+                        "bash",
+                        "stdin-script",
+                    ],
+                    "stdin": "rm -rf /tmp/policy-stdin\n",
+                    "cwd": "/",
+                },
+            )
+        )
+
+
+def test_bash_policy_fails_safe_when_env_wrapper_changes_executable_path(
+    tmp_path,
+) -> None:
+    import asyncio
+
+    import pytest
+
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import create_bash_tool_definition
+
+    class UnexpectedExecService:
+        async def execute(self, request, **kwargs):
+            del request, kwargs
+            raise AssertionError("incomplete PATH wrapper command must not execute")
+
+    (tmp_path / "cat").symlink_to("/bin/bash")
+    bash = create_bash_tool_definition(
+        policy_engine=PolicyEngine(),
+        exec_service=UnexpectedExecService(),
+    )
+
+    commands = (
+        ["env", f"PATH={tmp_path}", "cat", "+x"],
+        ["env", "--argv0=sh", "/bin/busybox"],
+    )
+    for index, command in enumerate(commands):
+        with pytest.raises(PermissionError, match="requires approval"):
+            asyncio.run(
+                bash.execute(
+                    f"call-env-mutation-stdin-policy-{index}",
+                    {
+                        "command": command,
+                        "stdin": "rm -rf /tmp/policy-stdin\n",
+                    },
+                )
+            )
+
+
+def test_bash_policy_blocks_shell_startup_stdin_before_execution(tmp_path) -> None:
+    import asyncio
+
+    import pytest
+
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import create_bash_tool_definition
+
+    class UnexpectedExecService:
+        async def execute(self, request, **kwargs):
+            del request, kwargs
+            raise AssertionError("shell startup stdin must not execute")
+
+    bash = create_bash_tool_definition(
+        policy_engine=PolicyEngine(),
+        exec_service=UnexpectedExecService(),
+    )
+    cases = (
+        {
+            "command": [
+                "bash",
+                "--rcfile",
+                "/dev/stdin",
+                "-i",
+                "-c",
+                "printf safe",
+            ],
+            "stdin": "rm -rf /tmp/policy-startup\n",
+        },
+        {
+            "command": ["env", "BASH_ENV=/dev/stdin", "bash", "-c", "printf safe"],
+            "stdin": "rm -rf /tmp/policy-startup\n",
+        },
+        {
+            "command": ["bash", "-c", "printf safe"],
+            "env": [("BASH_ENV", "/dev/stdin")],
+            "stdin": "rm -rf /tmp/policy-startup\n",
+        },
+    )
+
+    for index, arguments in enumerate(cases):
+        with pytest.raises(PermissionError):
+            asyncio.run(
+                bash.execute(
+                    f"call-shell-startup-policy-{index}",
+                    arguments,
+                )
+            )
+
+
+def test_bash_policy_keeps_direct_argv_out_of_shell_payload_matching(
+    tmp_path,
+) -> None:
+    import asyncio
+
+    from loushang.coding.exec import ExecResult
+    from loushang.coding.policy import PolicyEngine
+    from loushang.coding.tools import create_bash_tool_definition
+
+    requests = []
+
+    class CapturingExecService:
+        async def execute(self, request, **kwargs):
+            del kwargs
+            requests.append(request)
+            return ExecResult(exit_code=0, stdout="ok", stderr="")
+
+    bash = create_bash_tool_definition(
+        policy_engine=PolicyEngine(),
+        exec_service=CapturingExecService(),
+    )
+
+    asyncio.run(
+        bash.execute(
+            "call-direct-argv",
+            {
+                "command": ["python", "-c", 'print("rm -rf")'],
+                "cwd": str(tmp_path),
+            },
+        )
+    )
+
+    assert requests[0].command == ("python", "-c", 'print("rm -rf")')
+
+
+def test_bash_legacy_policy_wraps_getter_failure_and_invalid_decision(
+    tmp_path,
+) -> None:
+    import asyncio
+    from types import SimpleNamespace
+
+    import pytest
+
+    from loushang.coding.tools import create_bash_tool_definition
+    from loushang.harness.policy import PolicyEvaluationError
+
+    class UnexpectedExecService:
+        async def execute(self, request, **kwargs):
+            del request, kwargs
+            raise AssertionError("invalid policy must not execute")
+
+    class ExplosivePolicy:
+        @property
+        def evaluate(self):
+            raise RuntimeError("evaluate getter exploded")
+
+    explosive = create_bash_tool_definition(
+        policy_engine=ExplosivePolicy(),
+        exec_service=UnexpectedExecService(),
+    )
+    with pytest.raises(PolicyEvaluationError, match="getter exploded"):
+        asyncio.run(
+            explosive.execute(
+                "call-explosive-policy",
+                {"command": "pwd", "cwd": str(tmp_path)},
+            )
+        )
+
+    class InvalidLegacyPolicy:
+        def evaluate_action(self, **kwargs):
+            del kwargs
+            return SimpleNamespace(
+                disposition="allow",
+                reason=123,
+                code=object(),
+            )
+
+    invalid = create_bash_tool_definition(
+        policy_engine=InvalidLegacyPolicy(),
+        exec_service=UnexpectedExecService(),
+    )
+    with pytest.raises(PolicyEvaluationError, match="non-string reason"):
+        asyncio.run(
+            invalid.execute(
+                "call-invalid-policy",
+                {"command": "pwd", "cwd": str(tmp_path)},
+            )
+        )
+
+    from loushang.harness.policy import PolicyDecision
+
+    malformed_decision = PolicyDecision.allow()
+    object.__setattr__(malformed_decision, "disposition", "prompt")
+
+    class MalformedLegacyPolicy:
+        def evaluate_action(self, **kwargs):
+            del kwargs
+            return malformed_decision
+
+    malformed = create_bash_tool_definition(
+        policy_engine=MalformedLegacyPolicy(),
+        exec_service=UnexpectedExecService(),
+    )
+    with pytest.raises(PolicyEvaluationError, match="invalid PolicyDecision"):
+        asyncio.run(
+            malformed.execute(
+                "call-malformed-policy-decision",
+                {"command": "pwd", "cwd": str(tmp_path)},
+            )
+        )
+
+
+def test_bash_approval_and_audit_use_effective_spawned_command(tmp_path) -> None:
+    import asyncio
+
+    from loushang.coding.exec import ExecResult
+    from loushang.coding.policy import ApprovalDecision, PolicyEngine
+    from loushang.coding.tools import (
+        BashSpawnContext,
+        ToolContext,
+        create_bash_tool_definition,
+    )
+    from loushang.coding.tools.wrapper import wrap_tool_definition
+
+    approval_requests = []
+    exec_requests = []
+    events: list[dict[str, object]] = []
+    effective_cwd = tmp_path / "effective"
+    effective_cwd.mkdir()
+
+    class CapturingApprovalResolver:
+        def resolve(self, request):
+            approval_requests.append(request)
+            return ApprovalDecision.allow()
+
+    class CapturingExecService:
+        async def execute(self, request, **kwargs):
+            del kwargs
+            exec_requests.append(request)
+            return ExecResult(exit_code=0, stdout="ok", stderr="")
+
+    def rewrite_spawn(context: BashSpawnContext) -> BashSpawnContext:
+        return BashSpawnContext(
+            command=f"{context.command}\ngit push origin review",
+            cwd=str(effective_cwd),
+            env=(("LD_PRELOAD", "/tmp/injected.so"),),
+        )
+
+    async def emit_event(event: dict[str, object]) -> None:
+        events.append(event)
+
+    def provide_context(*, tool_call_id: str) -> ToolContext:
+        return ToolContext(
+            tool_call_id=tool_call_id,
+            cwd=str(tmp_path),
+            event_sink=emit_event,
+        )
+
+    bash = wrap_tool_definition(
+        create_bash_tool_definition(
+            policy_engine=PolicyEngine(),
+            approval_resolver=CapturingApprovalResolver(),
+            exec_service=CapturingExecService(),
+            command_prefix="echo prefixed",
+            spawn_hook=rewrite_spawn,
+        ),
+        context_provider=provide_context,
+    )
+
+    asyncio.run(
+        bash.execute(
+            "call-effective-approval",
+            {
+                "command": "pwd",
+                "timeout": 3,
+                "env": (("SAFE", "1"),),
+            },
+        )
+    )
+
+    effective_command = "echo prefixed\npwd\ngit push origin review"
+    assert exec_requests[0].command[2] == effective_command
+    assert exec_requests[0].cwd == str(effective_cwd)
+    assert approval_requests[0].arguments["command"] == effective_command
+    assert approval_requests[0].arguments["cwd"] == str(effective_cwd)
+    assert approval_requests[0].arguments["env"] == (
+        ("LD_PRELOAD", "/tmp/injected.so"),
+    )
+    assert approval_requests[0].arguments["timeout"] == 3
+    assert [event["type"] for event in events] == [
+        "tool_policy_evaluated",
+        "tool_approval_requested",
+        "tool_approval_resolved",
+    ]
+    assert all(event["command"] == effective_command for event in events)
+    assert all(event["cwd"] == str(effective_cwd) for event in events)
+
+
+def test_bash_approval_and_audit_preserve_direct_wrapper_argv(tmp_path) -> None:
+    import asyncio
+
+    from loushang.coding.exec import ExecResult
+    from loushang.coding.policy import ApprovalDecision, PolicyEngine
+    from loushang.coding.tools import ToolContext, create_bash_tool_definition
+    from loushang.coding.tools.wrapper import wrap_tool_definition
+
+    approval_requests = []
+    exec_requests = []
+    events: list[dict[str, object]] = []
+
+    class CapturingApprovalResolver:
+        def resolve(self, request):
+            approval_requests.append(request)
+            return ApprovalDecision.allow()
+
+    class CapturingExecService:
+        async def execute(self, request, **kwargs):
+            del kwargs
+            exec_requests.append(request)
+            return ExecResult(exit_code=0, stdout="ok", stderr="")
+
+    async def emit_event(event: dict[str, object]) -> None:
+        events.append(event)
+
+    def provide_context(*, tool_call_id: str) -> ToolContext:
+        return ToolContext(
+            tool_call_id=tool_call_id,
+            cwd=str(tmp_path),
+            event_sink=emit_event,
+        )
+
+    bash = wrap_tool_definition(
+        create_bash_tool_definition(
+            policy_engine=PolicyEngine(),
+            approval_resolver=CapturingApprovalResolver(),
+            exec_service=CapturingExecService(),
+        ),
+        context_provider=provide_context,
+    )
+    command = (
+        "env",
+        "LD_PRELOAD=/tmp/injected.so",
+        "bash",
+        "-c",
+        "git push origin review",
+    )
+
+    asyncio.run(
+        bash.execute(
+            "call-wrapper-approval",
+            {"command": list(command), "cwd": str(tmp_path)},
+        )
+    )
+
+    assert exec_requests[0].command == command
+    assert approval_requests[0].arguments["command"] == command
+    assert approval_requests[0].arguments["shell_payload"] == "git push origin review"
+    assert all(event["command"] == command for event in events)
+
+
+def test_bash_policy_and_execution_share_frozen_path_and_cwd(
+    tmp_path, monkeypatch
+) -> None:
+    import asyncio
+
+    from loushang.coding.tools import create_bash_tool_definition
+    from loushang.harness.policy import PolicyDecision
+
+    original_cwd = tmp_path / "original"
+    changed_cwd = tmp_path / "changed"
+    original_cwd.mkdir()
+    changed_cwd.mkdir()
+    (original_cwd / "cat").symlink_to("/bin/cat")
+    (changed_cwd / "cat").symlink_to("/bin/bash")
+    marker = tmp_path / "policy-race"
+    monkeypatch.chdir(original_cwd)
+    monkeypatch.setenv("PATH", ".")
+
+    class MutatingEvaluator:
+        async def evaluate(self, subject):
+            del subject
+            monkeypatch.chdir(changed_cwd)
+            monkeypatch.setenv("PATH", ".")
+            await asyncio.sleep(0)
+            return PolicyDecision.allow()
+
+    bash = create_bash_tool_definition(policy_engine=MutatingEvaluator())
+    asyncio.run(
+        bash.execute(
+            "call-frozen-execution",
+            {
+                "command": ["cat"],
+                "stdin": f"printf raced > {marker}\n",
+            },
+        )
+    )
+
+    assert not marker.exists()
+
+
+def test_bash_without_policy_freezes_path_and_cwd_before_async_update(
+    tmp_path, monkeypatch
+) -> None:
+    import asyncio
+
+    from loushang.coding.tools import create_bash_tool_definition
+
+    original_cwd = tmp_path / "original"
+    changed_cwd = tmp_path / "changed"
+    original_cwd.mkdir()
+    changed_cwd.mkdir()
+    (original_cwd / "cat").symlink_to("/bin/cat")
+    (changed_cwd / "cat").symlink_to("/bin/bash")
+    marker = tmp_path / "update-race"
+    monkeypatch.chdir(original_cwd)
+    monkeypatch.setenv("PATH", ".")
+
+    async def mutate_process_state(update) -> None:
+        del update
+        monkeypatch.chdir(changed_cwd)
+        monkeypatch.setenv("PATH", ".")
+        await asyncio.sleep(0)
+
+    bash = create_bash_tool_definition()
+    asyncio.run(
+        bash.execute(
+            "call-frozen-no-policy",
+            {
+                "command": ["cat"],
+                "stdin": f"printf raced > {marker}\n",
+            },
+            on_update=mutate_process_state,
+        )
+    )
+
+    assert not marker.exists()
+
+
+def test_bash_approval_wait_cannot_change_startup_environment_or_leak_secrets(
+    tmp_path, monkeypatch
+) -> None:
+    import asyncio
+
+    from loushang.coding.tools import ToolContext, create_bash_tool_definition
+    from loushang.coding.tools.wrapper import wrap_tool_definition
+    from loushang.harness.approval import ApprovalDecision
+    from loushang.harness.policy import PolicyDecision
+
+    marker = tmp_path / "approval-race"
+    inherited_secret = "must-not-appear-in-control-plane-projections"
+    approval_requests = []
+    events: list[dict[str, object]] = []
+    monkeypatch.delenv("BASH_ENV", raising=False)
+    monkeypatch.delenv("ENV", raising=False)
+    monkeypatch.setenv("LOUSHANG_INHERITED_SECRET", inherited_secret)
+
+    class AskingEvaluator:
+        def evaluate(self, subject):
+            del subject
+            return PolicyDecision.ask("review execution")
+
+    class MutatingApprovalResolver:
+        async def resolve(self, request):
+            approval_requests.append(request)
+            monkeypatch.setenv("BASH_ENV", "/dev/stdin")
+            await asyncio.sleep(0)
+            return ApprovalDecision.allow()
+
+    async def emit_event(event: dict[str, object]) -> None:
+        events.append(event)
+
+    def provide_context(*, tool_call_id: str) -> ToolContext:
+        return ToolContext(tool_call_id=tool_call_id, event_sink=emit_event)
+
+    bash = wrap_tool_definition(
+        create_bash_tool_definition(
+            policy_engine=AskingEvaluator(),
+            approval_resolver=MutatingApprovalResolver(),
+        ),
+        context_provider=provide_context,
+    )
+    asyncio.run(
+        bash.execute(
+            "call-frozen-approval",
+            {
+                "command": ["/bin/bash", "-c", "printf safe"],
+                "stdin": f"printf raced > {marker}\n",
+            },
+        )
+    )
+
+    assert not marker.exists()
+    assert "env" not in approval_requests[0].arguments
+    assert inherited_secret not in repr(approval_requests)
+    assert inherited_secret not in repr(events)
+
+
+def test_policy_engine_evaluate_action_uses_materialized_environment(
+    tmp_path, monkeypatch
+) -> None:
+    from loushang.coding.exec import ExecRequest
+    from loushang.coding.policy import PolicyEngine
+    from loushang.harness.workspace.exec import materialize_exec_request
+
+    original_cwd = tmp_path / "original"
+    changed_cwd = tmp_path / "changed"
+    original_cwd.mkdir()
+    changed_cwd.mkdir()
+    (original_cwd / "cat").symlink_to("/bin/cat")
+    (changed_cwd / "cat").symlink_to("/bin/bash")
+    monkeypatch.chdir(original_cwd)
+    monkeypatch.setenv("PATH", ".")
+    request = materialize_exec_request(
+        ExecRequest(
+            command=["cat"],
+            stdin="rm -rf /tmp/materialized-policy-sentinel\n",
+        )
+    )
+
+    monkeypatch.chdir(changed_cwd)
+    decision = PolicyEngine().evaluate_action(
+        tool_name="bash",
+        exec_request=request,
+    )
+
+    assert decision.disposition == "allow"

--- a/tests/coding/test_screen_coding_tui_mode.py
+++ b/tests/coding/test_screen_coding_tui_mode.py
@@ -7,6 +7,8 @@ from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from loushang.ai import (
     AssistantMessage,
     Model,
@@ -57,8 +59,16 @@ class _Session:
             get_cwd=lambda: "/repo",
             get_session_file=lambda: Path("/tmp/254d6156.jsonl"),
         )
-        self.current_model: object = ModelSelection(provider="unknown", model_id="unknown")
-        self.model_details = [Model(id="kimi-for-coding", provider="moonshot", endpoint="kimi-code-anthropic")]
+        self.current_model: object = ModelSelection(
+            provider="unknown", model_id="unknown"
+        )
+        self.model_details = [
+            Model(
+                id="kimi-for-coding",
+                provider="moonshot",
+                endpoint="kimi-code-anthropic",
+            )
+        ]
         self.prompts: list[str] = []
         self.listeners: list[Callable[[dict[str, object]], object]] = []
         self.unsubscribed = False
@@ -79,7 +89,9 @@ class _Session:
 
     async def set_model(self, selection: object) -> None:
         if isinstance(selection, Model):
-            self.current_model = ModelSelection(provider=selection.provider_id, model_id=selection.id)
+            self.current_model = ModelSelection(
+                provider=selection.provider_id, model_id=selection.id
+            )
         else:
             self.current_model = selection
 
@@ -98,18 +110,31 @@ class _Session:
         await self._emit(
             {
                 "type": "message_start",
-                "message": UserMessage(role="user", content=[TextPart(type="text", text=text)], timestamp=0.0),
+                "message": UserMessage(
+                    role="user",
+                    content=[TextPart(type="text", text=text)],
+                    timestamp=0.0,
+                ),
             }
         )
         await self._emit(
             {
                 "type": "message_update",
                 "message": SimpleNamespace(role="assistant"),
-                "assistant_message_event": {"type": "text_delta", "content_index": 0, "delta": "hello back"},
+                "assistant_message_event": {
+                    "type": "text_delta",
+                    "content_index": 0,
+                    "delta": "hello back",
+                },
             }
         )
         await self._emit(
-            {"type": "message_end", "message": SimpleNamespace(role="assistant", content=[TextPart(type="text", text="hello back")])}
+            {
+                "type": "message_end",
+                "message": SimpleNamespace(
+                    role="assistant", content=[TextPart(type="text", text="hello back")]
+                ),
+            }
         )
 
     async def _emit(self, event: dict[str, object]) -> None:
@@ -165,13 +190,17 @@ def test_run_coding_tui_interactive_uses_screen_loop(monkeypatch) -> None:
 
     screen_app = captured["app"]
     records = getattr(screen_app, "state").records
-    assistant_records = [record for record in records if isinstance(record, AssistantMessageRecord)]
+    assistant_records = [
+        record for record in records if isinstance(record, AssistantMessageRecord)
+    ]
     assert exit_code == 0
     assert session.prompts == ["hello"]
     assert assistant_records[-1].text == "hello back"
 
 
-def test_run_coding_tui_interactive_prints_resume_hint_on_clean_exit(monkeypatch) -> None:
+def test_run_coding_tui_interactive_prints_resume_hint_on_clean_exit(
+    monkeypatch,
+) -> None:
     from loushang.coding.ui import mode
 
     session = _Session()
@@ -198,13 +227,21 @@ def test_run_coding_tui_interactive_prints_resume_hint_on_clean_exit(monkeypatch
     assert "loushang --tui --resume" not in stdout.getvalue()
 
 
-def test_run_coding_tui_interactive_replays_resumed_session_history(monkeypatch) -> None:
+def test_run_coding_tui_interactive_replays_resumed_session_history(
+    monkeypatch,
+) -> None:
     from loushang.coding.ui import mode
 
     session = _Session()
-    usage = Usage(input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={})
+    usage = Usage(
+        input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={}
+    )
     session.context_messages = [
-        UserMessage(role="user", content=[TextPart(type="text", text="previous question")], timestamp=1.0),
+        UserMessage(
+            role="user",
+            content=[TextPart(type="text", text="previous question")],
+            timestamp=1.0,
+        ),
         AssistantMessage(
             role="assistant",
             content=[TextPart(type="text", text="previous answer")],
@@ -225,7 +262,12 @@ def test_run_coding_tui_interactive_replays_resumed_session_history(monkeypatch)
             is_error=False,
             timestamp=3.0,
         ),
-        CompactionSummaryMessage(role="compactionSummary", summary="older context summary", tokens_before=128, timestamp=4.0),
+        CompactionSummaryMessage(
+            role="compactionSummary",
+            summary="older context summary",
+            tokens_before=128,
+            timestamp=4.0,
+        ),
     ]
     captured: dict[str, object] = {}
 
@@ -265,20 +307,35 @@ def test_run_coding_tui_interactive_replays_resumed_session_history(monkeypatch)
     assert records[3].tokens_before == 128
 
 
-def test_run_coding_tui_interactive_bounds_resumed_long_transcript_render_window(monkeypatch) -> None:
+def test_run_coding_tui_interactive_bounds_resumed_long_transcript_render_window(
+    monkeypatch,
+) -> None:
     from loushang.coding.ui import mode
 
     session = _Session()
-    usage = Usage(input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={})
+    usage = Usage(
+        input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={}
+    )
     for turn in range(24):
         session.context_messages.append(
-            UserMessage(role="user", content=[TextPart(type="text", text=f"question {turn}")], timestamp=float(turn))
+            UserMessage(
+                role="user",
+                content=[TextPart(type="text", text=f"question {turn}")],
+                timestamp=float(turn),
+            )
         )
         line_count = 900 if turn == 23 else 40
         session.context_messages.append(
             AssistantMessage(
                 role="assistant",
-                content=[TextPart(type="text", text="\n".join(f"answer {turn} line {line}" for line in range(line_count)))],
+                content=[
+                    TextPart(
+                        type="text",
+                        text="\n".join(
+                            f"answer {turn} line {line}" for line in range(line_count)
+                        ),
+                    )
+                ],
                 api="openai",
                 provider="moonshot",
                 model="kimi",
@@ -337,19 +394,34 @@ def test_run_coding_tui_interactive_bounds_resumed_long_transcript_render_window
     }
 
 
-def test_run_coding_tui_interactive_long_transcript_input_frame_does_not_clear_screen(monkeypatch) -> None:
+def test_run_coding_tui_interactive_long_transcript_input_frame_does_not_clear_screen(
+    monkeypatch,
+) -> None:
     from loushang.coding.ui import mode
 
     session = _Session()
-    usage = Usage(input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={})
+    usage = Usage(
+        input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={}
+    )
     for turn in range(24):
         session.context_messages.append(
-            UserMessage(role="user", content=[TextPart(type="text", text=f"question {turn}")], timestamp=float(turn))
+            UserMessage(
+                role="user",
+                content=[TextPart(type="text", text=f"question {turn}")],
+                timestamp=float(turn),
+            )
         )
         session.context_messages.append(
             AssistantMessage(
                 role="assistant",
-                content=[TextPart(type="text", text="\n".join(f"answer {turn} line {line}" for line in range(80)))],
+                content=[
+                    TextPart(
+                        type="text",
+                        text="\n".join(
+                            f"answer {turn} line {line}" for line in range(80)
+                        ),
+                    )
+                ],
                 api="openai",
                 provider="moonshot",
                 model="kimi",
@@ -388,22 +460,39 @@ def test_run_coding_tui_interactive_long_transcript_input_frame_does_not_clear_s
 
     assert exit_code == 0
     assert second.operation_class == "changed_range_update"
-    assert {operation.kind for operation in second.operations}.isdisjoint({"clear_screen", "clear_scrollback"})
+    assert {operation.kind for operation in second.operations}.isdisjoint(
+        {"clear_screen", "clear_scrollback"}
+    )
 
 
-def test_run_coding_tui_interactive_long_transcript_working_timer_frame_stays_bounded(monkeypatch) -> None:
+def test_run_coding_tui_interactive_long_transcript_working_timer_frame_stays_bounded(
+    monkeypatch,
+) -> None:
     from loushang.coding.ui import mode
 
     session = _Session()
-    usage = Usage(input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={})
+    usage = Usage(
+        input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={}
+    )
     for turn in range(24):
         session.context_messages.append(
-            UserMessage(role="user", content=[TextPart(type="text", text=f"question {turn}")], timestamp=float(turn))
+            UserMessage(
+                role="user",
+                content=[TextPart(type="text", text=f"question {turn}")],
+                timestamp=float(turn),
+            )
         )
         session.context_messages.append(
             AssistantMessage(
                 role="assistant",
-                content=[TextPart(type="text", text="\n".join(f"answer {turn} line {line}" for line in range(80)))],
+                content=[
+                    TextPart(
+                        type="text",
+                        text="\n".join(
+                            f"answer {turn} line {line}" for line in range(80)
+                        ),
+                    )
+                ],
                 api="openai",
                 provider="moonshot",
                 model="kimi",
@@ -447,22 +536,39 @@ def test_run_coding_tui_interactive_long_transcript_working_timer_frame_stays_bo
     assert second.operation_class == "changed_range_update"
     assert second.changed_line_range is not None
     assert second.changed_line_range[0] >= len(second.current_logical_lines) - 8
-    assert {operation.kind for operation in second.operations}.isdisjoint({"clear_screen", "clear_scrollback"})
+    assert {operation.kind for operation in second.operations}.isdisjoint(
+        {"clear_screen", "clear_scrollback"}
+    )
 
 
-def test_run_coding_tui_interactive_traces_resumed_transcript_window_trim(monkeypatch) -> None:
+def test_run_coding_tui_interactive_traces_resumed_transcript_window_trim(
+    monkeypatch,
+) -> None:
     from loushang.coding.ui import mode
 
     session = _Session()
-    usage = Usage(input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={})
+    usage = Usage(
+        input=1, output=2, cache_read=0, cache_write=0, total_tokens=3, cost={}
+    )
     for turn in range(24):
         session.context_messages.append(
-            UserMessage(role="user", content=[TextPart(type="text", text=f"question {turn}")], timestamp=float(turn))
+            UserMessage(
+                role="user",
+                content=[TextPart(type="text", text=f"question {turn}")],
+                timestamp=float(turn),
+            )
         )
         session.context_messages.append(
             AssistantMessage(
                 role="assistant",
-                content=[TextPart(type="text", text="\n".join(f"answer {turn} line {line}" for line in range(80)))],
+                content=[
+                    TextPart(
+                        type="text",
+                        text="\n".join(
+                            f"answer {turn} line {line}" for line in range(80)
+                        ),
+                    )
+                ],
                 api="openai",
                 provider="moonshot",
                 model="kimi",
@@ -496,16 +602,25 @@ def test_run_coding_tui_interactive_traces_resumed_transcript_window_trim(monkey
     finally:
         reset_observability()
 
-    event = next(event for event in sink.events if event.scope == "tui" and event.name == "tui.resume_history")
+    event = next(
+        event
+        for event in sink.events
+        if event.scope == "tui" and event.name == "tui.resume_history"
+    )
     app = captured["app"]
     assert exit_code == 0
     assert event.data["record_count"] == 48
     assert event.data["active_record_count"] == len(getattr(app, "state").records)
-    assert event.data["evicted_record_count"] == getattr(app, "state").evicted_prefix_record_count
+    assert (
+        event.data["evicted_record_count"]
+        == getattr(app, "state").evicted_prefix_record_count
+    )
     assert event.data["trimmed"] is True
 
 
-def test_run_coding_tui_interactive_screen_loop_dispatches_steer_and_followup(monkeypatch) -> None:
+def test_run_coding_tui_interactive_screen_loop_dispatches_steer_and_followup(
+    monkeypatch,
+) -> None:
     from loushang.coding.ui import mode
 
     session = _Session()
@@ -568,6 +683,417 @@ def test_run_coding_tui_injects_on_approval_callback(monkeypatch) -> None:
     assert isinstance(captured.get("loop_kwargs"), dict)
 
 
+def test_screen_approval_presenter_resolves_ask_tools_and_clears_pending(
+    tmp_path,
+) -> None:
+    from loushang.coding.policy import (
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+        PolicyEngine,
+    )
+    from loushang.coding.tools import (
+        ToolContext,
+        ToolRegistry,
+        register_builtin_tools,
+    )
+    from loushang.coding.ui import mode
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+    presented: list[dict[str, object]] = []
+    opened = asyncio.Event()
+
+    class ApprovalSession:
+        def set_approval_presenter(self, presenter, *, dismisser=None) -> None:
+            resolver.set_request_presenter(presenter, dismisser=dismisser)
+
+        async def handle_screen_approval(self, event: dict[str, object]) -> bool:
+            action_id = event.get("action_id")
+            assert isinstance(action_id, str)
+            return await resolver.handle_result(
+                action_id,
+                approved=bool(event.get("approved")),
+            )
+
+    class ApprovalSurfaceManager:
+        def open_approval(self, **payload: object) -> None:
+            presented.append(dict(payload))
+            opened.set()
+
+        def dismiss_approval(self, action_id: str) -> None:
+            del action_id
+
+    registry = ToolRegistry()
+    register_builtin_tools(
+        registry,
+        policy_engine=PolicyEngine(ask_tools=["write"]),
+        approval_resolver=resolver,
+    )
+
+    def context_provider(*, tool_call_id: str) -> ToolContext:
+        return ToolContext(tool_call_id=tool_call_id, cwd=str(tmp_path))
+
+    write = registry.materialize_tool(
+        "write",
+        context_provider=context_provider,
+    )
+    session = ApprovalSession()
+    unbind = mode._bind_screen_approval_presenter(
+        session,
+        ApprovalSurfaceManager(),  # type: ignore[arg-type]
+    )
+
+    async def run() -> None:
+        allow_task = asyncio.create_task(
+            write.execute(
+                "write-allow",
+                {"path": "approved.txt", "content": "allowed"},
+            )
+        )
+        await opened.wait()
+        allow_action_id = presented[-1]["action_id"]
+        assert isinstance(allow_action_id, str)
+        await session.handle_screen_approval(
+            {"action_id": allow_action_id, "approved": True}
+        )
+        await allow_task
+
+        opened.clear()
+        deny_task = asyncio.create_task(
+            write.execute(
+                "write-deny",
+                {"path": "denied.txt", "content": "denied"},
+            )
+        )
+        await opened.wait()
+        deny_action_id = presented[-1]["action_id"]
+        assert isinstance(deny_action_id, str)
+        await session.handle_screen_approval(
+            {"action_id": deny_action_id, "approved": False}
+        )
+        with pytest.raises(PermissionError):
+            await deny_task
+
+    try:
+        asyncio.run(run())
+    finally:
+        unbind()
+
+    assert (tmp_path / "approved.txt").read_text(encoding="utf-8") == "allowed"
+    assert not (tmp_path / "denied.txt").exists()
+    assert resolver._broker.pending_requests() == ()
+
+
+def test_screen_approval_unbind_targets_runtime_current_session() -> None:
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.ui import mode
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="allow")
+    )
+    shown = asyncio.Event()
+
+    class ApprovalSession:
+        def __init__(self) -> None:
+            self.active = True
+
+        def set_approval_presenter(self, presenter, *, dismisser=None) -> None:
+            if presenter is None:
+                if self.active:
+                    resolver.close_session(
+                        "Approval presenter closed before approval was resolved"
+                    )
+                    self.active = False
+                resolver.set_request_presenter(None)
+                return
+
+            def present(payload: dict[str, object]) -> object:
+                shown.set()
+                return presenter(payload)
+
+            resolver.set_request_presenter(present, dismisser=dismisser)
+
+    class ApprovalSurfaceManager:
+        def open_approval(self, **payload: object) -> None:
+            del payload
+
+        def dismiss_approval(self, action_id: str) -> None:
+            del action_id
+
+    old_session = ApprovalSession()
+    new_session = ApprovalSession()
+    current_session = old_session
+    unbind = mode._bind_screen_approval_presenter(
+        old_session,
+        ApprovalSurfaceManager(),  # type: ignore[arg-type]
+        session_provider=lambda: current_session,
+    )
+    old_session.active = False
+    new_session.active = True
+    current_session = new_session
+
+    async def run() -> object:
+        pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="approval-current-session-unbind",
+                )
+            )
+        )
+        await asyncio.wait_for(shown.wait(), timeout=0.5)
+        unbind()
+        return await asyncio.wait_for(pending, timeout=0.5)
+
+    decision = asyncio.run(run())
+
+    assert getattr(decision, "disposition") == "deny"
+    assert resolver._broker.pending_requests() == ()
+    assert resolver._request_presenter is None
+
+
+def test_screen_approval_unbind_clears_host_presenter_without_current_session() -> None:
+    from loushang.coding.policy import (
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.ui import mode
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+
+    class ClosedSession:
+        def set_approval_presenter(self, presenter, *, dismisser=None) -> None:
+            if presenter is not None:
+                resolver.set_request_presenter(presenter, dismisser=dismisser)
+
+        def _unbind_approval_presenter_host(self) -> None:
+            resolver.set_request_presenter(None)
+
+    class EmptyRuntime:
+        def get_current_session(self) -> None:
+            return None
+
+    class ApprovalSurfaceManager:
+        def open_approval(self, **payload: object) -> None:
+            del payload
+
+        def dismiss_approval(self, action_id: str) -> None:
+            del action_id
+
+    session = ClosedSession()
+    unbind = mode._bind_screen_approval_presenter(
+        session,
+        ApprovalSurfaceManager(),  # type: ignore[arg-type]
+        session_provider=lambda: mode._runtime_session(EmptyRuntime(), session),
+    )
+    assert resolver._request_presenter is not None
+
+    unbind()
+
+    assert resolver._request_presenter is None
+
+
+def test_screen_approval_unbind_clears_initial_presenter_when_current_has_none() -> (
+    None
+):
+    from loushang.coding.policy import (
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.ui import mode
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+
+    class InitialSession:
+        def set_approval_presenter(self, presenter, *, dismisser=None) -> None:
+            resolver.set_request_presenter(presenter, dismisser=dismisser)
+
+        def _unbind_approval_presenter_host(self) -> None:
+            resolver.set_request_presenter(None)
+
+    class SessionWithoutApproval:
+        def set_approval_presenter(self, presenter, *, dismisser=None) -> None:
+            del presenter, dismisser
+
+    class ApprovalSurfaceManager:
+        def open_approval(self, **payload: object) -> None:
+            del payload
+
+        def dismiss_approval(self, action_id: str) -> None:
+            del action_id
+
+    initial_session = InitialSession()
+    current_session = SessionWithoutApproval()
+    unbind = mode._bind_screen_approval_presenter(
+        initial_session,
+        ApprovalSurfaceManager(),  # type: ignore[arg-type]
+        session_provider=lambda: current_session,
+    )
+    assert resolver._request_presenter is not None
+
+    unbind()
+
+    assert resolver._request_presenter is None
+
+
+def test_screen_tui_failure_detaches_presenter_and_denies_pending(
+    monkeypatch,
+) -> None:
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.ui import mode
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="allow")
+    )
+    shown = asyncio.Event()
+
+    class ApprovalSession(_Session):
+        def set_approval_presenter(self, presenter, *, dismisser=None) -> None:
+            if presenter is None:
+                resolver.close_session(
+                    "Approval presenter closed before approval was resolved"
+                )
+                resolver.set_request_presenter(None)
+                return
+
+            def present(payload: dict[str, object]) -> object:
+                shown.set()
+                return presenter(payload)
+
+            resolver.set_request_presenter(present, dismisser=dismisser)
+
+    pending: asyncio.Task[object] | None = None
+
+    async def failing_screen_loop(**kwargs: object) -> int:
+        nonlocal pending
+        del kwargs
+        pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="approval-tui-failure",
+                )
+            )
+        )
+        await shown.wait()
+        raise RuntimeError("terminal failed")
+
+    monkeypatch.setattr(mode, "run_screen_coding_tui", failing_screen_loop)
+
+    async def run() -> tuple[int, object]:
+        exit_code = await mode.run_coding_tui(
+            runtime=object(),
+            session=ApprovalSession(),
+            stdin=_TTYStringIO(),
+            stdout=_TTYStringIO(),
+            stderr=StringIO(),
+        )
+        assert pending is not None
+        return exit_code, await pending
+
+    exit_code, decision = asyncio.run(run())
+
+    assert exit_code == 1
+    assert getattr(decision, "disposition") == "deny"
+    assert resolver._broker.pending_requests() == ()
+    assert resolver._request_presenter is None
+
+
+def test_screen_tui_projector_failure_still_unbinds_presenter(
+    monkeypatch,
+) -> None:
+    from loushang.coding.policy import (
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.coding.ui import mode
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+
+    class ApprovalSession(_Session):
+        def set_approval_presenter(self, presenter, *, dismisser=None) -> None:
+            resolver.set_request_presenter(presenter, dismisser=dismisser)
+
+    class FailingProjector:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            del args, kwargs
+            raise RuntimeError("projector failed")
+
+    monkeypatch.setattr(mode, "ScreenCodingEventProjector", FailingProjector)
+
+    exit_code = asyncio.run(
+        mode.run_coding_tui(
+            runtime=object(),
+            session=ApprovalSession(),
+            stdin=_TTYStringIO(),
+            stdout=_TTYStringIO(),
+            stderr=StringIO(),
+        )
+    )
+
+    assert exit_code == 1
+    assert resolver._request_presenter is None
+    assert resolver._broker.pending_requests() == ()
+
+
+def test_screen_session_transition_binding_clears_approval_surfaces() -> None:
+    from loushang.coding.ui import mode
+
+    subscribers: list[Callable[[], None]] = []
+    primary_calls = 0
+    clears = 0
+
+    class Runtime:
+        def subscribe_before_session_invalidate(self, callback):
+            subscribers.append(callback)
+
+            def unsubscribe() -> None:
+                subscribers.remove(callback)
+
+            return unsubscribe
+
+        def invalidate(self) -> None:
+            nonlocal primary_calls
+            primary_calls += 1
+            for callback in tuple(subscribers):
+                callback()
+
+    class SurfaceManager:
+        def clear_approval_surfaces(self) -> None:
+            nonlocal clears
+            clears += 1
+
+    runtime = Runtime()
+    unbind = mode._bind_screen_session_transition(
+        runtime,
+        SurfaceManager(),  # type: ignore[arg-type]
+    )
+    runtime.invalidate()
+    unbind()
+    runtime.invalidate()
+
+    assert clears == 1
+    assert primary_calls == 2
+    assert subscribers == []
+
+
 def test_run_coding_tui_non_interactive_keeps_plain_prompt_loop(monkeypatch) -> None:
     from loushang.coding.ui import mode
 
@@ -575,7 +1101,9 @@ def test_run_coding_tui_non_interactive_keeps_plain_prompt_loop(monkeypatch) -> 
     captured: dict[str, object] = {}
 
     async def fail_screen_loop(**_kwargs):
-        raise AssertionError("non-interactive mode should not enter screen terminal loop")
+        raise AssertionError(
+            "non-interactive mode should not enter screen terminal loop"
+        )
 
     async def fake_prompt_loop(**kwargs):
         captured.update(kwargs)
@@ -610,7 +1138,11 @@ def test_screen_event_projection_skips_duplicate_user_messages(monkeypatch) -> N
         await session._emit(
             {
                 "type": "message_start",
-                "message": type("Message", (), {"role": "user", "content": [TextPart(type="text", text=text)]})(),
+                "message": type(
+                    "Message",
+                    (),
+                    {"role": "user", "content": [TextPart(type="text", text=text)]},
+                )(),
             }
         )
 

--- a/tests/coding/test_screen_coding_tui_surfaces.py
+++ b/tests/coding/test_screen_coding_tui_surfaces.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from types import SimpleNamespace
 
 from loushang.ai import Model
@@ -62,7 +63,9 @@ def test_screen_surface_view_delegates_editor_input_target() -> None:
 
 
 def test_screen_surface_view_preserves_content_cursor_with_offset() -> None:
-    view = ScreenSurfaceView(title="Settings", purpose="settings", content=_CursorContent(), footer="")
+    view = ScreenSurfaceView(
+        title="Settings", purpose="settings", content=_CursorContent(), footer=""
+    )
 
     rendered = view.render(RenderConstraints(width=40, max_height=8))
 
@@ -70,7 +73,9 @@ def test_screen_surface_view_preserves_content_cursor_with_offset() -> None:
 
 
 def test_screen_surface_view_delegates_escape_to_non_info_content_first() -> None:
-    view = ScreenSurfaceView(title="Settings", purpose="settings", content=_EscContent())
+    view = ScreenSurfaceView(
+        title="Settings", purpose="settings", content=_EscContent()
+    )
 
     assert view.handle_input(InputEvent(kind="key", key="escape")) == InputIntent(
         kind="consumed",
@@ -127,19 +132,28 @@ def test_screen_surface_manager_opens_model_surface_and_selects_model() -> None:
 
     asyncio.run(manager.handle_surface_intent(intent))
 
-    assert session.set_model_calls[-1] == ModelSelection(provider="openai", model_id="gpt-5.4")
+    assert session.set_model_calls[-1] == ModelSelection(
+        provider="openai", model_id="gpt-5.4"
+    )
     assert app.active_surface is None
     assert app.state.status_message == "Model set: openai/gpt-5.4"
     assert app.state.model_label == "openai/gpt-5.4"
 
 
-def test_screen_surface_model_selector_displays_endpoint_and_selects_full_identity() -> None:
+def test_screen_surface_model_selector_displays_endpoint_and_selects_full_identity() -> (
+    None
+):
     session = _Session()
     session.models = [
         ModelSelection(provider="dashscope", model_id="qwen3.6-plus"),
         ModelSelection(provider="dashscope", model_id="qwen3.6-plus"),
     ]
-    responses_model = Model(id="qwen3.6-plus", provider="dashscope", endpoint="openai-responses", name="Qwen 3.6 Plus")
+    responses_model = Model(
+        id="qwen3.6-plus",
+        provider="dashscope",
+        endpoint="openai-responses",
+        name="Qwen 3.6 Plus",
+    )
     completions_model = Model(
         id="qwen3.6-plus",
         provider="dashscope",
@@ -158,7 +172,9 @@ def test_screen_surface_model_selector_displays_endpoint_and_selects_full_identi
     assert "openai-responses" in plain_lines[3]
     assert "openai-completions:cn" in plain_lines[4]
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
-    assert intent == InputIntent(kind="select", text="dashscope:openai-responses:qwen3.6-plus")
+    assert intent == InputIntent(
+        kind="select", text="dashscope:openai-responses:qwen3.6-plus"
+    )
 
     asyncio.run(manager.handle_surface_intent(intent))
 
@@ -170,12 +186,20 @@ def test_screen_surface_model_selector_displays_endpoint_and_selects_full_identi
     assert session.set_model_calls[-1] == selection
     assert session.default_model_calls[-1] == (selection, "global")
     assert app.active_surface is None
-    assert app.state.status_message == "Model set: dashscope/qwen3.6-plus (endpoint: openai-responses)"
+    assert (
+        app.state.status_message
+        == "Model set: dashscope/qwen3.6-plus (endpoint: openai-responses)"
+    )
 
 
 def test_screen_surface_model_selector_marks_only_current_endpoint() -> None:
     session = _Session()
-    responses_model = Model(id="qwen3.6-plus", provider="dashscope", endpoint="openai-responses", name="Qwen 3.6 Plus")
+    responses_model = Model(
+        id="qwen3.6-plus",
+        provider="dashscope",
+        endpoint="openai-responses",
+        name="Qwen 3.6 Plus",
+    )
     completions_model = Model(
         id="qwen3.6-plus",
         provider="dashscope",
@@ -201,14 +225,29 @@ def test_screen_surface_model_selector_marks_only_current_endpoint() -> None:
     assert len(current_lines) == 1
     assert current_lines[0].startswith("> 1. dashscope/qwen3.6-plus")
     assert "endpoint: openai-completions:cn" in current_lines[0]
-    assert any("endpoint: openai-responses" in line and "current" not in line for line in model_lines)
+    assert any(
+        "endpoint: openai-responses" in line and "current" not in line
+        for line in model_lines
+    )
 
 
 def test_screen_surface_model_selector_uses_agent_model_endpoint_for_current() -> None:
     session = _Session()
-    coding_model = Model(id="kimi-for-coding", provider="moonshot", endpoint="coding", name="Kimi for Coding")
-    anthropic_model = Model(id="kimi-for-coding", provider="moonshot", endpoint="kimi-code-anthropic", name="Kimi for Coding")
-    session.current_model = ModelSelection(provider="moonshot", model_id="kimi-for-coding")
+    coding_model = Model(
+        id="kimi-for-coding",
+        provider="moonshot",
+        endpoint="coding",
+        name="Kimi for Coding",
+    )
+    anthropic_model = Model(
+        id="kimi-for-coding",
+        provider="moonshot",
+        endpoint="kimi-code-anthropic",
+        name="Kimi for Coding",
+    )
+    session.current_model = ModelSelection(
+        provider="moonshot", model_id="kimi-for-coding"
+    )
     session.agent = SimpleNamespace(model=anthropic_model)
     session.models = [
         ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
@@ -228,7 +267,9 @@ def test_screen_surface_model_selector_uses_agent_model_endpoint_for_current() -
     assert len(current_lines) == 1
     assert current_lines[0].startswith("> 1. moonshot/kimi-for-coding")
     assert "endpoint: kimi-code-anthropic" in current_lines[0]
-    assert any("endpoint: coding" in line and "current" not in line for line in model_lines)
+    assert any(
+        "endpoint: coding" in line and "current" not in line for line in model_lines
+    )
 
 
 def test_screen_surface_model_selection_error_stays_in_tui() -> None:
@@ -248,7 +289,9 @@ def test_screen_surface_model_selection_error_stays_in_tui() -> None:
     assert app.state.status_message == "Error: model switch failed"
 
 
-def test_screen_surface_manager_opens_model_surface_in_bottom_frame_with_runtime_overlay_host() -> None:
+def test_screen_surface_manager_opens_model_surface_in_bottom_frame_with_runtime_overlay_host() -> (
+    None
+):
     session = _Session()
     app = _app()
     app.surface_host = SurfaceHost()
@@ -268,11 +311,15 @@ def test_screen_surface_manager_opens_model_surface_in_bottom_frame_with_runtime
     asyncio.run(manager.handle_surface_intent(intent))
 
     assert app.active_surface is None
-    assert session.set_model_calls[-1] == ModelSelection(provider="openai", model_id="gpt-5.4")
+    assert session.set_model_calls[-1] == ModelSelection(
+        provider="openai", model_id="gpt-5.4"
+    )
     assert app.state.model_label == "openai/gpt-5.4"
 
 
-def test_screen_surface_manager_opens_non_model_surfaces_in_runtime_overlay_host() -> None:
+def test_screen_surface_manager_opens_non_model_surfaces_in_runtime_overlay_host() -> (
+    None
+):
     app = _app()
     app.surface_host = SurfaceHost()
     manager = _manager(app, _Session())
@@ -291,7 +338,9 @@ def test_screen_surface_manager_opens_non_model_surfaces_in_runtime_overlay_host
         assert app.surface_host.entries == []
 
 
-def test_screen_surface_manager_opens_models_info_in_bottom_frame_with_runtime_overlay_host() -> None:
+def test_screen_surface_manager_opens_models_info_in_bottom_frame_with_runtime_overlay_host() -> (
+    None
+):
     app = _app()
     app.surface_host = SurfaceHost()
     manager = _manager(app, _Session())
@@ -316,7 +365,10 @@ def test_screen_surface_models_info_keeps_footer_when_content_overflows() -> Non
     session = _Session()
     session.models = [
         ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
-        *(ModelSelection(provider="provider", model_id=f"model-{index:02d}") for index in range(12)),
+        *(
+            ModelSelection(provider="provider", model_id=f"model-{index:02d}")
+            for index in range(12)
+        ),
     ]
     app = _app()
     app.surface_host = SurfaceHost()
@@ -337,7 +389,10 @@ def test_screen_surface_models_info_scrolls_with_page_keys() -> None:
     session = _Session()
     session.models = [
         ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
-        *(ModelSelection(provider="provider", model_id=f"model-{index:02d}") for index in range(12)),
+        *(
+            ModelSelection(provider="provider", model_id=f"model-{index:02d}")
+            for index in range(12)
+        ),
     ]
     app = _app()
     app.surface_host = SurfaceHost()
@@ -348,12 +403,16 @@ def test_screen_surface_models_info_scrolls_with_page_keys() -> None:
     assert isinstance(app.active_surface, ScreenSurfaceView)
     before = tuple(
         strip_control_sequences(line.text)
-        for line in app.active_surface.render(RenderConstraints(width=100, max_height=8)).lines
+        for line in app.active_surface.render(
+            RenderConstraints(width=100, max_height=8)
+        ).lines
     )
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="pageDown"))
     after = tuple(
         strip_control_sequences(line.text)
-        for line in app.active_surface.render(RenderConstraints(width=100, max_height=8)).lines
+        for line in app.active_surface.render(
+            RenderConstraints(width=100, max_height=8)
+        ).lines
     )
 
     assert intent == InputIntent(kind="consumed", note="info_scroll")
@@ -367,7 +426,10 @@ def test_screen_surface_models_info_cursor_stays_on_last_visible_body_line() -> 
     session = _Session()
     session.models = [
         ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
-        *(ModelSelection(provider="provider", model_id=f"model-{index:02d}") for index in range(12)),
+        *(
+            ModelSelection(provider="provider", model_id=f"model-{index:02d}")
+            for index in range(12)
+        ),
     ]
     app = _app()
     app.surface_host = SurfaceHost()
@@ -387,7 +449,9 @@ def test_screen_surface_models_info_cursor_stays_on_last_visible_body_line() -> 
     assert after.cursor.row == 5
 
 
-def test_screen_surface_manager_opens_settings_in_bottom_frame_with_runtime_overlay_host() -> None:
+def test_screen_surface_manager_opens_settings_in_bottom_frame_with_runtime_overlay_host() -> (
+    None
+):
     app = _app()
     app.surface_host = SurfaceHost()
     manager = _manager(app, _Session())
@@ -401,7 +465,13 @@ def test_screen_surface_manager_opens_settings_in_bottom_frame_with_runtime_over
 
     rendered = app.active_surface.render(RenderConstraints(width=100, max_height=14))
     plain = tuple(strip_control_sequences(line.text) for line in rendered.lines)
-    assert any("Status" in line and "Config" in line and "Model" in line and "Status Line" in line for line in plain)
+    assert any(
+        "Status" in line
+        and "Config" in line
+        and "Model" in line
+        and "Status Line" in line
+        for line in plain
+    )
     assert any("Search settings" in line for line in plain)
     assert not any("Status line" in line for line in plain[2:])
     assert "Enter/Space to change - Esc to close" not in plain
@@ -418,7 +488,9 @@ def test_screen_surface_manager_config_alias_opens_settings() -> None:
     assert app.active_surface.title == "Settings"
     plain = tuple(
         strip_control_sequences(line.text)
-        for line in app.active_surface.render(RenderConstraints(width=100, max_height=14)).lines
+        for line in app.active_surface.render(
+            RenderConstraints(width=100, max_height=14)
+        ).lines
     )
     assert any("Search settings" in line for line in plain)
 
@@ -432,7 +504,9 @@ def test_screen_surface_manager_settings_page_submit_keeps_surface_open() -> Non
     _focus_statusline_tab(app.active_surface)
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
 
-    assert intent == InputIntent(kind="setting", text="statusline.enabled", note="false")
+    assert intent == InputIntent(
+        kind="setting", text="statusline.enabled", note="false"
+    )
     asyncio.run(manager.handle_surface_intent(intent))
 
     assert isinstance(app.active_surface, ScreenSurfaceView)
@@ -444,14 +518,19 @@ def test_screen_surface_manager_settings_page_submit_keeps_surface_open() -> Non
     assert any("Status line: off" in line for line in plain)
 
 
-def test_screen_surface_manager_settings_page_submit_mirrors_statusline_settings_into_app() -> None:
+def test_screen_surface_manager_settings_page_submit_mirrors_statusline_settings_into_app() -> (
+    None
+):
     app = _app()
     manager = _manager(app, _Session())
 
     asyncio.run(manager.handle_text("/settings"))
     assert isinstance(app.active_surface, ScreenSurfaceView)
     _focus_statusline_tab(app.active_surface)
-    assert app.active_surface.content.handle_input(InputEvent(kind="text", text="style")) is True
+    assert (
+        app.active_surface.content.handle_input(InputEvent(kind="text", text="style"))
+        is True
+    )
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
 
     assert intent == InputIntent(kind="setting", text="statusline.style", note="muted")
@@ -464,7 +543,9 @@ def test_screen_surface_manager_settings_page_submit_mirrors_statusline_settings
     assert any("Status line style: muted" in line for line in plain)
 
 
-def test_screen_surface_manager_settings_page_statusline_submit_persists_settings(tmp_path) -> None:
+def test_screen_surface_manager_settings_page_statusline_submit_persists_settings(
+    tmp_path,
+) -> None:
     from loushang.coding.control import SettingsManager
 
     settings_path = tmp_path / "settings.json"
@@ -475,7 +556,10 @@ def test_screen_surface_manager_settings_page_statusline_submit_persists_setting
     asyncio.run(manager.handle_text("/settings"))
     assert isinstance(app.active_surface, ScreenSurfaceView)
     _focus_statusline_tab(app.active_surface)
-    assert app.active_surface.content.handle_input(InputEvent(kind="text", text="style")) is True
+    assert (
+        app.active_surface.content.handle_input(InputEvent(kind="text", text="style"))
+        is True
+    )
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
     asyncio.run(manager.handle_surface_intent(intent))
 
@@ -496,27 +580,39 @@ def test_screen_surface_manager_ignores_setting_submit_without_settings_page() -
     )
     app.active_surface = generic_surface
 
-    asyncio.run(manager.handle_surface_intent(InputIntent(kind="setting", text="statusline", note="false")))
+    asyncio.run(
+        manager.handle_surface_intent(
+            InputIntent(kind="setting", text="statusline", note="false")
+        )
+    )
 
     assert app.active_surface is generic_surface
     assert app.state.statusline_visible is True
     assert app.state.status_message is None
 
 
-def test_screen_surface_manager_settings_page_model_submit_uses_model_selection() -> None:
+def test_screen_surface_manager_settings_page_model_submit_uses_model_selection() -> (
+    None
+):
     session = _Session()
     app = _app()
     manager = _manager(app, session)
 
     asyncio.run(manager.handle_text("/settings"))
-    asyncio.run(manager.handle_surface_intent(InputIntent(kind="setting", text="model.current", note="openai/gpt-5.4")))
+    asyncio.run(
+        manager.handle_surface_intent(
+            InputIntent(kind="setting", text="model.current", note="openai/gpt-5.4")
+        )
+    )
 
     assert isinstance(app.active_surface, ScreenSurfaceView)
     assert session.set_model_calls
     assert app.state.model_label == "openai/gpt-5.4"
 
 
-def test_screen_surface_manager_runtime_overlay_escape_and_close_are_idempotent() -> None:
+def test_screen_surface_manager_runtime_overlay_escape_and_close_are_idempotent() -> (
+    None
+):
     app = _app()
     app.surface_host = SurfaceHost()
     manager = _manager(app, _Session())
@@ -623,7 +719,12 @@ def test_screen_surface_model_selector_filters_by_typed_search() -> None:
 def test_screen_surface_model_selector_uses_model_detail_descriptions() -> None:
     session = _Session()
     session.model_details = [
-        Model(id="gpt-5.4", provider="openai", endpoint="responses", name="Strong model for everyday coding."),
+        Model(
+            id="gpt-5.4",
+            provider="openai",
+            endpoint="responses",
+            name="Strong model for everyday coding.",
+        ),
     ]
     app = _app()
     manager = _manager(app, session)
@@ -634,7 +735,8 @@ def test_screen_surface_model_selector_uses_model_detail_descriptions() -> None:
     rendered = app.active_surface.render(RenderConstraints(width=100, max_height=10))
     plain_lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
     assert any(
-        line.startswith("  2. openai/gpt-5.4") and line.endswith("Strong model for everyday coding.")
+        line.startswith("  2. openai/gpt-5.4")
+        and line.endswith("Strong model for everyday coding.")
         for line in plain_lines
     )
 
@@ -656,9 +758,13 @@ def test_screen_surface_model_selector_lists_current_model_first() -> None:
     assert any(line.startswith("  2. moonshot/kimi-for-coding") for line in plain_lines)
 
 
-def test_screen_surface_model_selector_number_key_selects_current_scope_ordinal() -> None:
+def test_screen_surface_model_selector_number_key_selects_current_scope_ordinal() -> (
+    None
+):
     session = _Session()
-    session.models.append(ModelSelection(provider="anthropic", model_id="claude-sonnet"))
+    session.models.append(
+        ModelSelection(provider="anthropic", model_id="claude-sonnet")
+    )
     app = _app()
     manager = _manager(app, session)
 
@@ -705,7 +811,9 @@ def test_screen_surface_model_selector_multidigit_number_selects_ordinal() -> No
     assert intent == InputIntent(kind="select", text="p/model-12")
 
 
-def test_screen_surface_model_selector_enter_confirms_pending_single_digit_ordinal() -> None:
+def test_screen_surface_model_selector_enter_confirms_pending_single_digit_ordinal() -> (
+    None
+):
     session = _Session()
     session.models = [
         ModelSelection(provider="p", model_id=f"model-{index}")
@@ -741,7 +849,9 @@ def test_screen_surface_model_selector_number_key_extends_active_search() -> Non
     assert any("openai/gpt-5.4" in line for line in plain_lines)
 
 
-def test_screen_surface_model_selector_home_end_move_selection_before_search_is_visible() -> None:
+def test_screen_surface_model_selector_home_end_move_selection_before_search_is_visible() -> (
+    None
+):
     session = _Session()
     app = _app()
     manager = _manager(app, session)
@@ -750,12 +860,18 @@ def test_screen_surface_model_selector_home_end_move_selection_before_search_is_
 
     assert isinstance(app.active_surface, ScreenSurfaceView)
     assert app.active_surface.handle_input(InputEvent(kind="key", key="end")) is None
-    assert app.active_surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(kind="select", text="openai/gpt-5.4")
+    assert app.active_surface.handle_input(
+        InputEvent(kind="key", key="enter")
+    ) == InputIntent(kind="select", text="openai/gpt-5.4")
 
 
-def test_screen_surface_model_selector_switches_between_scoped_and_all_models_with_tab() -> None:
+def test_screen_surface_model_selector_switches_between_scoped_and_all_models_with_tab() -> (
+    None
+):
     session = _Session()
-    session.models.append(ModelSelection(provider="anthropic", model_id="claude-sonnet"))
+    session.models.append(
+        ModelSelection(provider="anthropic", model_id="claude-sonnet")
+    )
     session.scoped_models = [
         {"model": ModelSelection(provider="moonshot", model_id="kimi-for-coding")},
         {"model": {"provider": "openai", "model_id": "gpt-5.4"}},
@@ -768,7 +884,9 @@ def test_screen_surface_model_selector_switches_between_scoped_and_all_models_wi
     assert isinstance(app.active_surface, ScreenSurfaceView)
     scoped_lines = tuple(
         strip_control_sequences(line.text)
-        for line in app.active_surface.render(RenderConstraints(width=100, max_height=12)).lines
+        for line in app.active_surface.render(
+            RenderConstraints(width=100, max_height=12)
+        ).lines
     )
     assert "Scope: scoped | all" in scoped_lines
     assert any("moonshot/kimi-for-coding" in line for line in scoped_lines)
@@ -778,7 +896,9 @@ def test_screen_surface_model_selector_switches_between_scoped_and_all_models_wi
     assert app.active_surface.handle_input(InputEvent(kind="key", key="tab")) is None
     all_lines = tuple(
         strip_control_sequences(line.text)
-        for line in app.active_surface.render(RenderConstraints(width=100, max_height=12)).lines
+        for line in app.active_surface.render(
+            RenderConstraints(width=100, max_height=12)
+        ).lines
     )
     assert "Scope: all | scoped" in all_lines
     assert any("anthropic/claude-sonnet" in line for line in all_lines)
@@ -806,7 +926,9 @@ def test_screen_surface_model_selector_preserves_search_when_scope_changes() -> 
     assert app.active_surface.handle_input(InputEvent(kind="key", key="tab")) is None
     all_lines = tuple(
         strip_control_sequences(line.text)
-        for line in app.active_surface.render(RenderConstraints(width=100, max_height=12)).lines
+        for line in app.active_surface.render(
+            RenderConstraints(width=100, max_height=12)
+        ).lines
     )
     assert "Search: gpt" in all_lines
     assert any("openai/gpt-5.4" in line for line in all_lines)
@@ -816,7 +938,9 @@ def test_screen_surface_model_selector_preserves_search_when_scope_changes() -> 
 
 def test_screen_surface_model_selector_switches_scope_with_left_and_right() -> None:
     session = _Session()
-    session.models.append(ModelSelection(provider="anthropic", model_id="claude-sonnet"))
+    session.models.append(
+        ModelSelection(provider="anthropic", model_id="claude-sonnet")
+    )
     session.scoped_models = [
         {"model": ModelSelection(provider="moonshot", model_id="kimi-for-coding")},
         {"model": {"provider": "openai", "model_id": "gpt-5.4"}},
@@ -830,7 +954,9 @@ def test_screen_surface_model_selector_switches_scope_with_left_and_right() -> N
     assert app.active_surface.handle_input(InputEvent(kind="key", key="right")) is None
     all_lines = tuple(
         strip_control_sequences(line.text)
-        for line in app.active_surface.render(RenderConstraints(width=100, max_height=12)).lines
+        for line in app.active_surface.render(
+            RenderConstraints(width=100, max_height=12)
+        ).lines
     )
     assert "Scope: all | scoped" in all_lines
     assert any("anthropic/claude-sonnet" in line for line in all_lines)
@@ -838,7 +964,9 @@ def test_screen_surface_model_selector_switches_scope_with_left_and_right() -> N
     assert app.active_surface.handle_input(InputEvent(kind="key", key="left")) is None
     scoped_lines = tuple(
         strip_control_sequences(line.text)
-        for line in app.active_surface.render(RenderConstraints(width=100, max_height=12)).lines
+        for line in app.active_surface.render(
+            RenderConstraints(width=100, max_height=12)
+        ).lines
     )
     assert "Scope: scoped | all" in scoped_lines
     assert not any("anthropic/claude-sonnet" in line for line in scoped_lines)
@@ -874,14 +1002,20 @@ def test_screen_surface_view_translates_mouse_row_to_selection_content() -> None
         ],
         max_visible=3,
     )
-    view = ScreenSurfaceView(title="Models", purpose="model", content=surface, footer="Enter")
+    view = ScreenSurfaceView(
+        title="Models", purpose="model", content=surface, footer="Enter"
+    )
     view.render(RenderConstraints(width=40, max_height=8))
 
-    intent = view.handle_input(InputEvent(kind="mouse", mouse_button=0, mouse_row=3, mouse_action="press"))
+    intent = view.handle_input(
+        InputEvent(kind="mouse", mouse_button=0, mouse_row=3, mouse_action="press")
+    )
 
     assert intent is None
     assert surface.selected_index == 1
-    assert view.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(kind="select", text="two")
+    assert view.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
+        kind="select", text="two"
+    )
 
 
 def test_screen_surface_manager_applies_settings_page_statusline_change() -> None:
@@ -893,15 +1027,25 @@ def test_screen_surface_manager_applies_settings_page_statusline_change() -> Non
     assert isinstance(app.active_surface, ScreenSurfaceView)
     _focus_statusline_tab(app.active_surface)
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
-    assert intent == InputIntent(kind="setting", text="statusline.enabled", note="false")
+    assert intent == InputIntent(
+        kind="setting", text="statusline.enabled", note="false"
+    )
 
     asyncio.run(manager.handle_surface_intent(intent))
 
     assert isinstance(app.active_surface, ScreenSurfaceView)
     assert app.state.status_message is None
-    assert any("Status line: off" in line for line in _surface_plain_lines(app.active_surface))
-    rendered = tuple(strip_control_sequences(line.text) for line in app.render(RenderConstraints(width=100, max_height=12)).lines)
-    assert not any("moonshot/kimi-for-coding | repo | main | abcd | idle" in line for line in rendered)
+    assert any(
+        "Status line: off" in line for line in _surface_plain_lines(app.active_surface)
+    )
+    rendered = tuple(
+        strip_control_sequences(line.text)
+        for line in app.render(RenderConstraints(width=100, max_height=12)).lines
+    )
+    assert not any(
+        "moonshot/kimi-for-coding | repo | main | abcd | idle" in line
+        for line in rendered
+    )
 
 
 def test_screen_surface_manager_command_surface_inserts_selected_command() -> None:
@@ -1009,6 +1153,221 @@ def test_screen_surface_manager_handles_approval_reject() -> None:
     ]
 
 
+def test_screen_surface_manager_escape_rejects_approval() -> None:
+    app = _app()
+    events: list[dict[str, object]] = []
+
+    async def on_approval(event: dict[str, object]) -> None:
+        events.append(event)
+
+    manager = ScreenSurfaceManager(
+        app=app,
+        session=_Session(),
+        status_provider=_status_provider(app),
+        on_approval=on_approval,
+    )
+    manager.open_approval(
+        action="delete cache",
+        action_id="clear-cache-escape",
+    )
+    surface = app.active_surface
+    assert isinstance(surface, ScreenSurfaceView)
+
+    intent = surface.handle_input(InputEvent(kind="key", key="escape"))
+    assert intent is not None
+    asyncio.run(manager.handle_surface_intent(intent))
+
+    assert app.active_surface is None
+    assert events == [
+        {
+            "action_id": "clear-cache-escape",
+            "action": "delete cache",
+            "approved": False,
+            "raw_note": "clear-cache-escape",
+        }
+    ]
+
+
+def test_screen_surface_manager_queues_concurrent_approvals() -> None:
+    app = _app()
+    events: list[dict[str, object]] = []
+
+    async def on_approval(event: dict[str, object]) -> None:
+        events.append(event)
+
+    manager = ScreenSurfaceManager(
+        app=app,
+        session=_Session(),
+        status_provider=_status_provider(app),
+        on_approval=on_approval,
+    )
+    manager.open_approval(action="first action", action_id="approval-1")
+    manager.open_approval(action="second action", action_id="approval-2")
+
+    first = app.active_surface
+    assert isinstance(first, ScreenSurfaceView)
+    assert getattr(first.content, "action_id") == "approval-1"
+    asyncio.run(manager.handle_surface_intent(InputIntent(kind="approve")))
+
+    second = app.active_surface
+    assert isinstance(second, ScreenSurfaceView)
+    assert getattr(second.content, "action_id") == "approval-2"
+    asyncio.run(manager.handle_surface_intent(InputIntent(kind="reject")))
+
+    assert app.active_surface is None
+    assert [event["action_id"] for event in events] == ["approval-1", "approval-2"]
+    assert [event["approved"] for event in events] == [True, False]
+
+
+def test_screen_surface_manager_keeps_fifo_order_during_async_resolution() -> None:
+    app = _app()
+    callback_started = asyncio.Event()
+    release_callback = asyncio.Event()
+    events: list[str] = []
+
+    async def on_approval(event: dict[str, object]) -> None:
+        action_id = event.get("action_id")
+        assert isinstance(action_id, str)
+        events.append(action_id)
+        if action_id == "approval-a":
+            callback_started.set()
+            await release_callback.wait()
+
+    manager = ScreenSurfaceManager(
+        app=app,
+        session=_Session(),
+        status_provider=_status_provider(app),
+        on_approval=on_approval,
+    )
+
+    async def run() -> None:
+        manager.open_approval(action="A", action_id="approval-a")
+        manager.open_approval(action="B", action_id="approval-b")
+        first = asyncio.create_task(
+            manager.handle_surface_intent(InputIntent(kind="approve"))
+        )
+        await callback_started.wait()
+        manager.open_approval(action="C", action_id="approval-c")
+        release_callback.set()
+        await first
+
+        current = app.active_surface
+        assert isinstance(current, ScreenSurfaceView)
+        assert getattr(current.content, "action_id") == "approval-b"
+        await manager.handle_surface_intent(InputIntent(kind="approve"))
+        current = app.active_surface
+        assert isinstance(current, ScreenSurfaceView)
+        assert getattr(current.content, "action_id") == "approval-c"
+        await manager.handle_surface_intent(InputIntent(kind="reject"))
+
+    asyncio.run(run())
+
+    assert events == ["approval-a", "approval-b", "approval-c"]
+    assert app.active_surface is None
+
+
+def test_screen_surface_manager_clears_current_and_queued_approvals() -> None:
+    app = _app()
+    manager = _manager(app, _Session())
+    manager.open_approval(action="A", action_id="approval-a")
+    manager.open_approval(action="B", action_id="approval-b")
+
+    manager.clear_approval_surfaces()
+
+    assert app.active_surface is None
+    manager.open_approval(action="C", action_id="approval-c")
+    current = app.active_surface
+    assert isinstance(current, ScreenSurfaceView)
+    assert getattr(current.content, "action_id") == "approval-c"
+
+
+def test_screen_surface_manager_dismisses_timeout_and_cancelled_requests() -> None:
+    from loushang.coding.policy import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+
+    app = _app()
+    manager = _manager(app, _Session())
+    timeout_resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny"),
+        timeout_seconds=0.001,
+    )
+    opened = asyncio.Event()
+
+    def present(payload: dict[str, object]) -> None:
+        action = payload.get("action")
+        action_id = payload.get("action_id")
+        manager.open_approval(
+            action=action if isinstance(action, str) else "Approve",
+            action_id=action_id if isinstance(action_id, str) else None,
+        )
+        opened.set()
+
+    timeout_resolver.set_request_presenter(
+        present,
+        dismisser=manager.dismiss_approval,
+    )
+    cancel_resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+    cancel_resolver.set_request_presenter(
+        present,
+        dismisser=manager.dismiss_approval,
+    )
+
+    async def run() -> None:
+        timeout_decision = await timeout_resolver.resolve(
+            ApprovalRequest(
+                tool_name="write",
+                arguments={},
+                action_id="approval-timeout-ui",
+            )
+        )
+        assert timeout_decision.disposition == "deny"
+        assert app.active_surface is None
+
+        opened.clear()
+        cancelled = asyncio.create_task(
+            cancel_resolver.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="approval-cancel-ui",
+                )
+            )
+        )
+        await opened.wait()
+        assert app.active_surface is not None
+        cancelled.cancel()
+        with suppress(asyncio.CancelledError):
+            await cancelled
+        assert app.active_surface is None
+
+    asyncio.run(run())
+
+
+def test_screen_surface_manager_does_not_confirm_stale_approval_result() -> None:
+    app = _app()
+
+    async def reject_stale(event: dict[str, object]) -> bool:
+        del event
+        return False
+
+    manager = ScreenSurfaceManager(
+        app=app,
+        session=_Session(),
+        status_provider=_status_provider(app),
+        on_approval=reject_stale,
+    )
+    manager.open_approval(action="stale action", action_id="approval-stale")
+
+    asyncio.run(manager.handle_surface_intent(InputIntent(kind="approve")))
+
+    assert app.state.status_message == "Approval request is no longer pending"
+
+
 def test_screen_surface_manager_ignores_unmapped_surface_intent() -> None:
     app = _app()
     manager = _manager(app, _Session())
@@ -1024,7 +1383,9 @@ def test_screen_surface_manager_ignores_unmapped_surface_intent() -> None:
 
 class _Session:
     def __init__(self) -> None:
-        self.current_model: object = ModelSelection(provider="moonshot", model_id="kimi-for-coding")
+        self.current_model: object = ModelSelection(
+            provider="moonshot", model_id="kimi-for-coding"
+        )
         self.models = [
             ModelSelection(provider="moonshot", model_id="kimi-for-coding"),
             ModelSelection(provider="openai", model_id="gpt-5.4"),
@@ -1093,7 +1454,9 @@ def _manager(
     )
 
 
-def _surface_plain_lines(surface: ScreenSurfaceView, *, width: int = 100, height: int = 24) -> tuple[str, ...]:
+def _surface_plain_lines(
+    surface: ScreenSurfaceView, *, width: int = 100, height: int = 24
+) -> tuple[str, ...]:
     rendered = surface.render(RenderConstraints(width=width, max_height=height))
     return tuple(strip_control_sequences(line.text) for line in rendered.lines)
 
@@ -1111,7 +1474,9 @@ def _status_provider(
     statusline_settings = None
     on_statusline_settings_changed = None
     if settings_manager is not None:
-        statusline_settings = status_line_settings_from_control(settings_manager.get_statusline_settings())
+        statusline_settings = status_line_settings_from_control(
+            settings_manager.get_statusline_settings()
+        )
 
         def on_statusline_settings_changed(settings) -> None:
             settings_manager.set_statusline_settings(

--- a/tests/coding/test_sdk_surface.py
+++ b/tests/coding/test_sdk_surface.py
@@ -106,6 +106,7 @@ def test_coding_top_level_exposes_sdk_surface_snapshot() -> None:
         "agent_factory",
         "persist",
         "append_system_prompt",
+        "approval_resolver",
     )
     assert snapshot.to_dict()["missing_exports"] == []
 
@@ -140,7 +141,9 @@ def test_coding_sdk_surface_compatibility_report_flags_contract_drift() -> None:
             "actual": tuple(inspect.signature(coding.create_agent_session).parameters),
         }
     }
-    assert report.to_dict()["signature_mismatches"]["create_agent_session"]["expected"] == [
+    assert report.to_dict()["signature_mismatches"]["create_agent_session"][
+        "expected"
+    ] == [
         "session_manager",
         "wrong",
     ]
@@ -159,7 +162,9 @@ def test_coding_top_level_sdk_entry_signatures_are_stable() -> None:
         "thinking_level",
         "system_prompt",
     )
-    assert tuple(inspect.signature(coding.create_agent_session_services).parameters) == (
+    assert tuple(
+        inspect.signature(coding.create_agent_session_services).parameters
+    ) == (
         "cwd",
         "services",
         "ai_model_registry",
@@ -192,11 +197,14 @@ def test_coding_top_level_sdk_entry_signatures_are_stable() -> None:
         "package_materializer",
         "append_system_prompt",
         "extension_flag_values",
+        "approval_resolver",
     )
-    assert tuple(inspect.signature(coding.create_agent_session_result).parameters) == tuple(
-        inspect.signature(coding.create_agent_session).parameters
-    )
-    assert tuple(inspect.signature(coding.create_agent_session_from_services).parameters) == (
+    assert tuple(
+        inspect.signature(coding.create_agent_session_result).parameters
+    ) == tuple(inspect.signature(coding.create_agent_session).parameters)
+    assert tuple(
+        inspect.signature(coding.create_agent_session_from_services).parameters
+    ) == (
         "agent_services",
         "session_manager",
         "model",
@@ -212,6 +220,7 @@ def test_coding_top_level_sdk_entry_signatures_are_stable() -> None:
         "session_start_event",
         "package_materializer",
         "append_system_prompt",
+        "approval_resolver",
     )
     assert tuple(inspect.signature(coding.create_agent_session_runtime).parameters) == (
         "session_dir",
@@ -229,10 +238,13 @@ def test_coding_top_level_sdk_entry_signatures_are_stable() -> None:
         "agent_factory",
         "persist",
         "append_system_prompt",
+        "approval_resolver",
     )
 
 
-def test_coding_top_level_sdk_smoke_covers_session_runtime_tools_and_diagnostics(tmp_path) -> None:
+def test_coding_top_level_sdk_smoke_covers_session_runtime_tools_and_diagnostics(
+    tmp_path,
+) -> None:
     import loushang.coding as coding
 
     project_root = tmp_path / "project"
@@ -278,9 +290,14 @@ def test_coding_top_level_sdk_smoke_covers_session_runtime_tools_and_diagnostics
 
     read_only_defs = coding.create_read_only_tool_definitions()
     all_defs = coding.create_all_tool_definitions()
-    assert {"read", "grep", "ls", "find"}.issubset({definition.name for definition in read_only_defs})
+    assert {"read", "grep", "ls", "find"}.issubset(
+        {definition.name for definition in read_only_defs}
+    )
     assert {"read", "bash", "edit", "write"}.issubset(set(all_defs))
-    assert all(isinstance(definition, coding.ToolDefinition) for definition in all_defs.values())
+    assert all(
+        isinstance(definition, coding.ToolDefinition)
+        for definition in all_defs.values()
+    )
 
     runtime = coding.create_agent_session_runtime(
         session_dir=tmp_path / "runtime-sessions",
@@ -305,10 +322,19 @@ def test_coding_top_level_sdk_smoke_covers_session_runtime_tools_and_diagnostics
     import_result = asyncio.run(runtime.importFromJsonl(str(imported_file)))
     imported = runtime.get_current_session()
 
-    assert forked.session_manager.get_header().parent_session == str(created.session_manager.session_file)
+    assert forked.session_manager.get_header().parent_session == str(
+        created.session_manager.session_file
+    )
     assert import_result == {"cancelled": False}
     assert imported is not None
-    assert [message.content[0].text for message in imported.get_session_context().messages] == ["imported"]
+    assert [
+        message.content[0].text for message in imported.get_session_context().messages
+    ] == ["imported"]
     assert runtime.get_packages() == []
-    assert runtime.get_diagnostics_summary(coding.DiagnosticsQuery(level="error")).total_count == 0
+    assert (
+        runtime.get_diagnostics_summary(
+            coding.DiagnosticsQuery(level="error")
+        ).total_count
+        == 0
+    )
     assert runtime.get_diagnostics(coding.DiagnosticsQuery(source="session")) == []

--- a/tests/harness/extensions/test_control.py
+++ b/tests/harness/extensions/test_control.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from loushang.harness.approval import ApprovalDecision, ApprovalRequest
+from loushang.harness.extensions.api import ExtensionContributionAPI
+from loushang.harness.extensions.contributions import surfaces_from_loaded_extension
+from loushang.harness.extensions.control import resolve_control_contributions
+from loushang.harness.extensions.manifest import ExtensionManifest
+from loushang.harness.extensions.types import ExtensionPolicyDecision
+from loushang.harness.policy import (
+    CustomPolicySubject,
+    PolicyDecision,
+    PolicyEvaluationError,
+)
+
+
+class _Evaluator:
+    def __init__(
+        self,
+        decision: PolicyDecision | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self.decision = decision
+        self.error = error
+
+    def evaluate(self, subject):
+        del subject
+        if self.error is not None:
+            raise self.error
+        return self.decision
+
+
+class _Resolver:
+    def __init__(self, decision: ApprovalDecision) -> None:
+        self.decision = decision
+
+    def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+        del request
+        return self.decision
+
+
+def _api(name: str) -> ExtensionContributionAPI:
+    return ExtensionContributionAPI(
+        name=name,
+        source_path=Path(f"/tmp/{name}"),
+        entry_path=Path(f"/tmp/{name}/extension.py"),
+    )
+
+
+def test_control_api_keeps_runtime_values_out_of_surface_metadata() -> None:
+    evaluator = _Evaluator(PolicyDecision.allow())
+    resolver = _Resolver(ApprovalDecision.allow())
+    api = _api("runtime-name")
+
+    api.register_policy(
+        " guard ",
+        evaluator,
+        priority=20,
+        after=(" extension:base ",),
+        on_error="fail_chain",
+    )
+    api.register_approval("interactive", resolver)
+
+    extension = api.build_loaded_extension()
+    policy, approval = extension.control_contributions
+    assert policy.descriptor.name == "guard"
+    assert policy.descriptor.after == ("extension:base",)
+    assert policy.descriptor.on_error == "fail_chain"
+    assert policy.value is evaluator
+    assert approval.value is resolver
+    assert approval.descriptor.on_error == "fail_chain"
+    assert "value" not in policy.descriptor.metadata
+
+    projected = surfaces_from_loaded_extension(
+        replace(
+            extension,
+            manifest=ExtensionManifest(id="manifest-id", name="Manifest"),
+        )
+    )
+    controls = [
+        surface for surface in projected if surface.type in {"policy", "approval"}
+    ]
+    assert [(surface.type, surface.name) for surface in controls] == [
+        ("policy", "guard"),
+        ("approval", "interactive"),
+    ]
+    assert {surface.extension_id for surface in controls} == {"manifest-id"}
+
+
+def test_policy_control_contributions_fail_chain_by_default() -> None:
+    api = _api("secure-default")
+    api.register_policy("guard", _Evaluator(PolicyDecision.allow()))
+
+    record = api.build_loaded_extension().control_contributions[0]
+
+    assert record.descriptor.on_error == "fail_chain"
+
+
+def test_control_api_rejects_invalid_ordering_metadata() -> None:
+    api = _api("invalid")
+
+    with pytest.raises(TypeError, match="priority"):
+        api.register_policy("guard", _Evaluator(), priority=True)
+    with pytest.raises(TypeError, match="sequence of strings"):
+        api.register_policy("guard", _Evaluator(), after="extension:base")
+    with pytest.raises(ValueError, match="error policy"):
+        api.register_policy(
+            "guard",
+            _Evaluator(),
+            on_error="unknown",  # type: ignore[arg-type]
+        )
+    with pytest.raises(TypeError):
+        api.register_approval(  # type: ignore[call-arg]
+            "interactive",
+            _Resolver(ApprovalDecision.allow()),
+            on_error="skip",
+        )
+
+
+def test_control_resolver_rejects_skip_semantics_for_exclusive_approval() -> None:
+    api = _api("invalid-approval-semantics")
+    api.register_approval("interactive", _Resolver(ApprovalDecision.allow()))
+    extension = api.build_loaded_extension()
+    record = extension.control_contributions[0]
+    extension = replace(
+        extension,
+        control_contributions=[
+            replace(
+                record,
+                descriptor=replace(record.descriptor, on_error="skip"),
+            )
+        ],
+    )
+    diagnostics = []
+
+    resolved = resolve_control_contributions([extension], diagnostics=diagnostics)
+
+    assert resolved.approval_resolver is None
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "invalid_extension_control_contribution"
+    ]
+    assert "exclusive replacement" in diagnostics[0].message
+
+
+def test_control_resolver_isolates_shape_property_failures() -> None:
+    class ExplosiveEvaluator:
+        @property
+        def evaluate(self):
+            raise RuntimeError("shape inspection failed")
+
+    api = _api("broken-shape")
+    api.register_policy("guard", ExplosiveEvaluator())
+    diagnostics = []
+
+    resolved = resolve_control_contributions(
+        [api.build_loaded_extension()],
+        diagnostics=diagnostics,
+    )
+
+    assert resolved.policy_evaluators == ()
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "invalid_extension_control_contribution"
+    ]
+    assert "shape inspection failed" in diagnostics[0].message
+
+
+def test_resolver_returns_all_policies_in_resolved_order() -> None:
+    base_api = _api("base")
+    base_evaluator = _Evaluator(PolicyDecision.allow())
+    base_api.register_policy("base", base_evaluator)
+    tail_api = _api("tail")
+    tail_evaluator = _Evaluator(PolicyDecision.ask("review"))
+    tail_api.register_policy(
+        "tail",
+        tail_evaluator,
+        priority=100,
+        after=("route:base/policy/base",),
+    )
+    diagnostics = []
+
+    resolved = resolve_control_contributions(
+        [tail_api.build_loaded_extension(), base_api.build_loaded_extension()],
+        diagnostics=diagnostics,
+    )
+
+    assert [record.descriptor.name for record in resolved.policy_records] == [
+        "base",
+        "tail",
+    ]
+    assert len(resolved.policy_evaluators) == 2
+    assert resolved.approval_resolver is None
+    assert diagnostics == []
+
+
+def test_policy_wrapper_honors_skip_and_fail_chain() -> None:
+    skip_api = _api("skip")
+    skip_api.register_policy(
+        "broken",
+        _Evaluator(error=RuntimeError("skip failure")),
+        on_error="skip",
+    )
+    fail_api = _api("fail")
+    fail_api.register_policy(
+        "broken",
+        _Evaluator(error=RuntimeError("fail failure")),
+        on_error="fail_chain",
+    )
+    diagnostics = []
+    skip = resolve_control_contributions(
+        [skip_api.build_loaded_extension()],
+        diagnostics=diagnostics,
+    )
+
+    decision = asyncio.run(
+        skip.policy_evaluators[0].evaluate(CustomPolicySubject(kind="tool"))
+    )
+
+    assert decision is None
+    assert diagnostics[0].code == "extension_policy_evaluation_failed"
+    assert diagnostics[0].metadata["route_id"] == "skip/policy/broken"
+
+    fail = resolve_control_contributions(
+        [fail_api.build_loaded_extension()],
+        diagnostics=diagnostics,
+    )
+    with pytest.raises(PolicyEvaluationError, match="fail failure"):
+        asyncio.run(
+            fail.policy_evaluators[0].evaluate(CustomPolicySubject(kind="tool"))
+        )
+    assert [item.code for item in diagnostics] == [
+        "extension_policy_evaluation_failed",
+        "extension_policy_evaluation_failed",
+    ]
+
+
+def test_approval_uses_first_resolved_valid_active_record_and_reports_conflict() -> (
+    None
+):
+    low_api = _api("low")
+    low_resolver = _Resolver(ApprovalDecision.deny("low"))
+    low_api.register_approval("low", low_resolver)
+    high_api = _api("high")
+    high_resolver = _Resolver(ApprovalDecision.allow())
+    high_api.register_approval("high", high_resolver, priority=10)
+    invalid_api = _api("invalid")
+    invalid_api.register_approval("invalid", object(), priority=100)
+    diagnostics = []
+
+    resolved = resolve_control_contributions(
+        [
+            low_api.build_loaded_extension(),
+            invalid_api.build_loaded_extension(),
+            high_api.build_loaded_extension(),
+        ],
+        diagnostics=diagnostics,
+    )
+
+    assert resolved.approval_resolver is not None
+    assert (
+        asyncio.run(
+            resolved.approval_resolver.resolve(
+                ApprovalRequest(tool_name="write", arguments={})
+            )
+        )
+        == ApprovalDecision.allow()
+    )
+    assert resolved.selected_approval_record is resolved.approval_records[0]
+    assert [record.descriptor.name for record in resolved.approval_records] == [
+        "high",
+        "low",
+    ]
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "invalid_extension_control_contribution",
+        "conflicting_extension_approval_contributions",
+    ]
+    conflict = diagnostics[1]
+    assert conflict.metadata["selected_route_id"] == "high/approval/high"
+    assert conflict.metadata["conflicting_route_ids"] == ("low/approval/low",)
+
+
+def test_approval_conflict_survives_duplicate_extension_and_contribution_ids() -> None:
+    first_api = _api("duplicate")
+    first_resolver = _Resolver(ApprovalDecision.allow())
+    first_api.register_approval("interactive", first_resolver)
+    second_api = _api("duplicate")
+    second_resolver = _Resolver(ApprovalDecision.deny("second"))
+    second_api.register_approval("interactive", second_resolver)
+    diagnostics = []
+
+    resolved = resolve_control_contributions(
+        [first_api.build_loaded_extension(), second_api.build_loaded_extension()],
+        diagnostics=diagnostics,
+    )
+
+    assert resolved.approval_resolver is not None
+    assert (
+        asyncio.run(
+            resolved.approval_resolver.resolve(
+                ApprovalRequest(tool_name="write", arguments={})
+            )
+        )
+        == ApprovalDecision.allow()
+    )
+    assert len(resolved.approval_records) == 2
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "duplicate_extension_route_id",
+        "conflicting_extension_approval_contributions",
+    ]
+    assert diagnostics[1].metadata["conflicting_route_ids"] == (
+        "duplicate/approval/interactive#duplicate-2",
+    )
+
+
+@pytest.mark.parametrize("failure_kind", ["sync", "async", "invalid"])
+def test_approval_wrapper_reports_extension_failures_and_propagates(
+    failure_kind: str,
+) -> None:
+    class FailingResolver:
+        def resolve(self, request: ApprovalRequest):
+            del request
+            if failure_kind == "sync":
+                raise RuntimeError("sync approval failed")
+            if failure_kind == "invalid":
+                return object()
+
+            async def fail():
+                raise LookupError("async approval failed")
+
+            return fail()
+
+    api = _api(f"approval-{failure_kind}")
+    api.register_approval("interactive", FailingResolver())
+    diagnostics = []
+    resolved = resolve_control_contributions(
+        [api.build_loaded_extension()],
+        diagnostics=diagnostics,
+    )
+    assert resolved.approval_resolver is not None
+
+    expected_error = {
+        "sync": RuntimeError,
+        "async": LookupError,
+        "invalid": TypeError,
+    }[failure_kind]
+    with pytest.raises(expected_error):
+        asyncio.run(
+            resolved.approval_resolver.resolve(
+                ApprovalRequest(tool_name="write", arguments={})
+            )
+        )
+
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "extension_approval_resolution_failed"
+    ]
+    assert diagnostics[0].metadata["route_id"] == (
+        f"approval-{failure_kind}/approval/interactive"
+    )
+
+
+def test_approval_wrapper_does_not_diagnose_cancellation() -> None:
+    class CancelledResolver:
+        async def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+            del request
+            raise asyncio.CancelledError
+
+    api = _api("cancelled-approval")
+    api.register_approval("interactive", CancelledResolver())
+    diagnostics = []
+    resolved = resolve_control_contributions(
+        [api.build_loaded_extension()],
+        diagnostics=diagnostics,
+    )
+    assert resolved.approval_resolver is not None
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            resolved.approval_resolver.resolve(
+                ApprovalRequest(tool_name="write", arguments={})
+            )
+        )
+
+    assert diagnostics == []
+
+
+def test_inactive_control_routes_are_known_without_inspecting_runtime_values() -> None:
+    class ExplosiveEvaluator:
+        @property
+        def evaluate(self):
+            raise AssertionError("inactive contribution must not be inspected")
+
+    optional_api = _api("optional")
+    optional_api.register_policy("guard", ExplosiveEvaluator())
+    optional = replace(
+        optional_api.build_loaded_extension(),
+        policy=ExtensionPolicyDecision(enabled=False),
+    )
+
+    partial_api = _api("partial")
+    partial_api.register_policy("disabled", ExplosiveEvaluator())
+    partial = partial_api.build_loaded_extension()
+    partial_record = partial.control_contributions[0]
+    partial = replace(
+        partial,
+        control_contributions=[
+            replace(
+                partial_record,
+                descriptor=replace(partial_record.descriptor, active=False),
+            )
+        ],
+    )
+
+    active_api = _api("active")
+    active_evaluator = _Evaluator(PolicyDecision.allow())
+    active_api.register_policy(
+        "active",
+        active_evaluator,
+        after=(
+            "route:optional/policy/guard",
+            "route:partial/policy/disabled",
+        ),
+    )
+    diagnostics = []
+
+    resolved = resolve_control_contributions(
+        [optional, partial, active_api.build_loaded_extension()],
+        diagnostics=diagnostics,
+    )
+
+    assert [record.value for record in resolved.policy_records] == [active_evaluator]
+    assert diagnostics == []

--- a/tests/harness/extensions/test_routing.py
+++ b/tests/harness/extensions/test_routing.py
@@ -1,0 +1,763 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import get_type_hints
+
+import pytest
+
+from loushang.harness.extensions.api import ExtensionContributionAPI
+from loushang.harness.extensions.contributions import surfaces_from_loaded_extension
+from loushang.harness.extensions.dispatch import ExtensionDispatcher
+from loushang.harness.extensions.manifest import ExtensionManifest
+from loushang.harness.extensions.resources import ExtensionResourceRuntime
+from loushang.harness.extensions.routing import (
+    ExtensionRouteError,
+    ExtensionRoutePlan,
+    ExtensionRouter,
+    RegisteredExtensionHandler,
+    RouteStep,
+)
+from loushang.harness.extensions.types import ExtensionPolicyDecision, LoadedExtension
+from loushang.harness.resources.types import ResourceBundle
+
+
+def _registration(
+    route_id: str,
+    handler,
+    *,
+    event: str = "context",
+    priority: int = 0,
+    after: tuple[str, ...] = (),
+    before: tuple[str, ...] = (),
+    on_error: str = "skip",
+) -> RegisteredExtensionHandler:
+    return RegisteredExtensionHandler(
+        local_route_id=route_id,
+        event_name=event,
+        handler=handler,
+        priority=priority,
+        after=after,
+        before=before,
+        on_error=on_error,  # type: ignore[arg-type]
+    )
+
+
+def _extension(
+    name: str,
+    *registrations: RegisteredExtensionHandler,
+) -> LoadedExtension:
+    return LoadedExtension(
+        name=name,
+        source_path=Path(f"/tmp/{name}.py"),
+        handler_registrations=list(registrations),
+    )
+
+
+def _noop(event, context) -> None:
+    del event, context
+
+
+def test_contribution_api_records_ordering_metadata_and_preserves_hooks() -> None:
+    handler = _noop
+    api = ExtensionContributionAPI(name="shared", source_path=Path("/tmp/shared.py"))
+
+    api.on(
+        "context",
+        handler,
+        route_id="redact",
+        priority=20,
+        after=("extension:base",),
+        before=("route:shared/context/final",),
+        on_error="fail_chain",
+    )
+
+    extension = api.build_loaded_extension()
+    registration = extension.handler_registrations[0]
+    assert extension.hooks == {"context": [handler]}
+    assert registration.local_route_id == "redact"
+    assert registration.priority == 20
+    assert registration.after == ("extension:base",)
+    assert registration.before == ("route:shared/context/final",)
+    assert registration.on_error == "fail_chain"
+
+
+def test_loaded_extension_route_registration_type_is_runtime_reflectable() -> None:
+    hints = get_type_hints(LoadedExtension)
+
+    assert hints["handler_registrations"] == list[RegisteredExtensionHandler]
+
+
+def test_contribution_api_rejects_string_ordering_references() -> None:
+    api = ExtensionContributionAPI(name="shared", source_path=Path("/tmp/shared.py"))
+
+    with pytest.raises(TypeError, match="sequence of strings"):
+        api.on("context", _noop, after="extension:base")
+    with pytest.raises(TypeError, match="sequence of strings"):
+        api.on("context", _noop, before="extension:tail")
+
+
+def test_contribution_api_rejects_explicit_empty_route_id() -> None:
+    api = ExtensionContributionAPI(name="shared", source_path=Path("/tmp/shared.py"))
+
+    with pytest.raises(ValueError, match="route id must not be empty"):
+        api.on("context", _noop, route_id="")
+
+
+def test_registration_only_extension_projects_hooks_and_surface_metadata() -> None:
+    registration = _registration(
+        "redact",
+        _noop,
+        priority=20,
+        after=("extension:base",),
+        on_error="fail_chain",
+    )
+    extension = _extension("shared", registration)
+
+    surfaces = surfaces_from_loaded_extension(extension)
+
+    assert extension.hooks == {"context": [_noop]}
+    assert len(surfaces) == 1
+    surface = surfaces[0]
+    assert (surface.type, surface.name) == ("hook", "context")
+    assert surface.priority == 20
+    assert surface.after == ("extension:base",)
+    assert surface.on_error == "fail_chain"
+    assert surface.metadata["route_id"] == "redact"
+
+
+def test_plan_synthesizes_legacy_handlers_in_stable_two_dimensional_order() -> None:
+    calls: list[str] = []
+
+    def handler(name: str):
+        def run(event, context):
+            del event, context
+            calls.append(name)
+            return name
+
+        return run
+
+    first = LoadedExtension(
+        name="first",
+        source_path=Path("/tmp/first.py"),
+        hooks={"context": [handler("first-1"), handler("first-2")]},
+    )
+    second = LoadedExtension(
+        name="second",
+        source_path=Path("/tmp/second.py"),
+        hooks={"context": [handler("second-1")]},
+    )
+    diagnostics = []
+    plan = ExtensionRoutePlan.from_extensions([first, second], diagnostics=diagnostics)
+    router = ExtensionRouter(plan, diagnostics=diagnostics)
+    context_calls: list[str] = []
+
+    results = asyncio.run(
+        router.observe(
+            "context",
+            object(),
+            context_factory=lambda extension: (
+                context_calls.append(extension.name) or object()
+            ),
+        )
+    )
+
+    assert results == ("first-1", "first-2", "second-1")
+    assert calls == ["first-1", "first-2", "second-1"]
+    assert context_calls == ["first", "second"]
+    assert [route.route_id for route in plan.routes_for("context")] == [
+        "first/context/legacy-0001",
+        "first/context/legacy-0002",
+        "second/context/legacy-0001",
+    ]
+    assert diagnostics == []
+
+
+def test_plan_orders_constraints_before_priority_and_uses_priority_for_ready_routes() -> (
+    None
+):
+    base = _extension("base", _registration("base", _noop))
+    high = _extension("high", _registration("high", _noop, priority=20))
+    tail = _extension(
+        "tail",
+        _registration(
+            "tail",
+            _noop,
+            priority=100,
+            after=("extension:base",),
+        ),
+    )
+
+    plan = ExtensionRoutePlan.from_extensions([base, tail, high])
+
+    assert [route.extension.name for route in plan.routes_for("context")] == [
+        "high",
+        "base",
+        "tail",
+    ]
+
+
+def test_explicit_registration_plan_does_not_synthesize_legacy_hooks() -> None:
+    legacy = LoadedExtension(
+        name="legacy",
+        source_path=Path("/tmp/legacy.py"),
+        hooks={"context": [_noop]},
+    )
+    high = _registration("high", _noop, event="policy", priority=10)
+    low = _registration("low", _noop, event="policy")
+
+    plan = ExtensionRoutePlan.from_extension_registrations(
+        [
+            (
+                legacy,
+                (
+                    low,
+                    high,
+                ),
+            )
+        ]
+    )
+
+    assert plan.routes_for("context") == ()
+    assert [
+        route.registration.local_route_id for route in plan.routes_for("policy")
+    ] == [
+        "high",
+        "low",
+    ]
+
+
+def test_plan_preserves_external_edges_while_falling_back_inside_cycle() -> None:
+    before = _extension(
+        "before",
+        _registration(
+            "before",
+            _noop,
+            before=("route:a/context/a",),
+        ),
+    )
+    a = _extension(
+        "a",
+        _registration(
+            "a",
+            _noop,
+            priority=1,
+            after=("route:b/context/b",),
+        ),
+    )
+    b = _extension(
+        "b",
+        _registration(
+            "b",
+            _noop,
+            priority=9,
+            after=("route:a/context/a",),
+        ),
+    )
+    after = _extension(
+        "after",
+        _registration(
+            "after",
+            _noop,
+            after=("route:b/context/b",),
+        ),
+    )
+    diagnostics = []
+
+    plan = ExtensionRoutePlan.from_extensions(
+        [a, after, before, b],
+        diagnostics=diagnostics,
+    )
+
+    assert [route.extension.name for route in plan.routes_for("context")] == [
+        "before",
+        "b",
+        "a",
+        "after",
+    ]
+    cycle = [
+        diagnostic
+        for diagnostic in diagnostics
+        if diagnostic.code == "extension_route_order_cycle"
+    ]
+    assert len(cycle) == 1
+    assert cycle[0].metadata["route_ids"] == (
+        "b/context/b",
+        "a/context/a",
+    )
+
+
+def test_plan_reports_malformed_missing_self_and_duplicate_route_ids() -> None:
+    extension = _extension(
+        "shared",
+        _registration(
+            "same",
+            _noop,
+            after=(
+                "bad-reference",
+                "route:missing/context/route",
+                "route:shared/context/same",
+            ),
+        ),
+        _registration("same", _noop),
+    )
+    diagnostics = []
+
+    plan = ExtensionRoutePlan.from_extensions([extension], diagnostics=diagnostics)
+
+    assert len(plan.routes_for("context")) == 2
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "duplicate_extension_route_id",
+        "malformed_extension_route_reference",
+        "missing_extension_route_reference",
+        "extension_route_self_reference",
+    ]
+
+
+def test_plan_preserves_routes_when_active_extensions_share_an_id() -> None:
+    calls: list[str] = []
+
+    def handler(name: str):
+        def run(event, context) -> None:
+            del event, context
+            calls.append(name)
+
+        return run
+
+    first = _extension("duplicate", _registration("shared", handler("first")))
+    second = _extension("duplicate", _registration("shared", handler("second")))
+    diagnostics = []
+    plan = ExtensionRoutePlan.from_extensions(
+        [first, second],
+        diagnostics=diagnostics,
+    )
+    router = ExtensionRouter(plan, diagnostics=diagnostics)
+
+    asyncio.run(
+        router.observe(
+            "context",
+            object(),
+            context_factory=lambda extension: extension.name,
+        )
+    )
+
+    assert calls == ["first", "second"]
+    assert [route.route_id for route in plan.routes_for("context")] == [
+        "duplicate/context/shared",
+        "duplicate/context/shared#duplicate-2",
+    ]
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "duplicate_extension_route_id"
+    ]
+
+
+def test_route_ids_encode_components_and_reserve_duplicate_suffixes() -> None:
+    first = LoadedExtension(
+        name="first",
+        source_path=Path("/tmp/first.py"),
+        manifest=ExtensionManifest(id="a", name="First"),
+        handler_registrations=[
+            _registration("same", _noop),
+            _registration("same", _noop),
+            _registration(
+                "dependent",
+                _noop,
+                after=("route:a/context/same%23duplicate-2",),
+            ),
+            _registration("same#duplicate-2", _noop),
+            _registration("x/context/百分比%y", _noop),
+        ],
+    )
+    second = LoadedExtension(
+        name="second",
+        source_path=Path("/tmp/second.py"),
+        manifest=ExtensionManifest(id="a/context/x", name="Second"),
+        handler_registrations=[_registration("y", _noop)],
+    )
+    diagnostics = []
+
+    plan = ExtensionRoutePlan.from_extensions(
+        [first, second],
+        diagnostics=diagnostics,
+    )
+
+    assert [route.route_id for route in plan.routes_for("context")] == [
+        "a/context/same",
+        "a/context/same#duplicate-2",
+        "a/context/same%23duplicate-2",
+        "a/context/dependent",
+        "a/context/x%2Fcontext%2F%E7%99%BE%E5%88%86%E6%AF%94%25y",
+        "a%2Fcontext%2Fx/context/y",
+    ]
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "duplicate_extension_route_id"
+    ]
+
+
+def test_route_planning_handles_dependency_chains_beyond_recursion_limit() -> None:
+    route_count = 1200
+    registrations = [
+        _registration(
+            f"route-{index}",
+            _noop,
+            before=(f"route:large/context/route-{index + 1}",)
+            if index + 1 < route_count
+            else (),
+        )
+        for index in range(route_count)
+    ]
+
+    plan = ExtensionRoutePlan.from_extensions([_extension("large", *registrations)])
+
+    routes = plan.routes_for("context")
+    assert len(routes) == route_count
+    assert routes[0].route_id == "large/context/route-0"
+    assert routes[-1].route_id == f"large/context/route-{route_count - 1}"
+
+
+def test_route_planning_handles_wide_independent_route_sets() -> None:
+    route_count = 3000
+    registrations = [
+        _registration(f"route-{index}", _noop) for index in range(route_count)
+    ]
+
+    plan = ExtensionRoutePlan.from_extensions([_extension("wide", *registrations)])
+
+    routes = plan.routes_for("context")
+    assert len(routes) == route_count
+    assert routes[0].route_id == "wide/context/route-0"
+    assert routes[-1].route_id == f"wide/context/route-{route_count - 1}"
+
+
+def test_plan_normalizes_and_rejects_empty_extension_route_identities() -> None:
+    normalized = _extension(
+        " normalized ",
+        _registration("route", _noop),
+    )
+    dependent = _extension(
+        "dependent",
+        _registration(
+            "route",
+            _noop,
+            after=("extension:normalized",),
+        ),
+    )
+    empty = _extension("   ", _registration("route", _noop))
+    diagnostics = []
+
+    plan = ExtensionRoutePlan.from_extensions(
+        [dependent, empty, normalized],
+        diagnostics=diagnostics,
+    )
+
+    assert [route.route_id for route in plan.routes_for("context")] == [
+        "normalized/context/route",
+        "dependent/context/route",
+    ]
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "invalid_extension_route_identity"
+    ]
+
+
+def test_cycle_diagnostics_follow_stable_route_order() -> None:
+    root = _extension(
+        "root",
+        _registration(
+            "root",
+            _noop,
+            before=(
+                "route:a/context/one",
+                "route:b/context/one",
+            ),
+        ),
+    )
+    a = _extension(
+        "a",
+        _registration("one", _noop, after=("route:a/context/two",)),
+        _registration("two", _noop, after=("route:a/context/one",)),
+    )
+    b = _extension(
+        "b",
+        _registration("one", _noop, after=("route:b/context/two",)),
+        _registration("two", _noop, after=("route:b/context/one",)),
+    )
+    diagnostics = []
+
+    ExtensionRoutePlan.from_extensions(
+        [root, a, b],
+        diagnostics=diagnostics,
+    )
+
+    assert [
+        diagnostic.metadata["route_ids"]
+        for diagnostic in diagnostics
+        if diagnostic.code == "extension_route_order_cycle"
+    ] == [
+        ("a/context/one", "a/context/two"),
+        ("b/context/one", "b/context/two"),
+    ]
+
+
+def test_plan_skips_inactive_extensions_and_their_ordering_references() -> None:
+    calls: list[str] = []
+
+    def inactive_handler(event, context) -> None:
+        del event, context
+        calls.append("inactive")
+
+    inactive = LoadedExtension(
+        name="optional",
+        source_path=Path("/tmp/optional.py"),
+        handler_registrations=[_registration("inactive", inactive_handler)],
+        policy=ExtensionPolicyDecision(enabled=False),
+    )
+    active = _extension(
+        "active",
+        _registration(
+            "active",
+            _noop,
+            after=(
+                "extension:optional",
+                "route:optional/context/inactive",
+            ),
+        ),
+    )
+    diagnostics = []
+    plan = ExtensionRoutePlan.from_extensions(
+        [inactive, active],
+        diagnostics=diagnostics,
+    )
+    router = ExtensionRouter(plan, diagnostics=diagnostics)
+
+    asyncio.run(
+        router.observe(
+            "context",
+            object(),
+            context_factory=lambda extension: extension.name,
+        )
+    )
+
+    assert [route.extension.name for route in plan.routes_for("context")] == ["active"]
+    assert calls == []
+    assert diagnostics == []
+
+
+def test_router_reduce_passes_latest_state_and_can_stop_chain() -> None:
+    seen: list[tuple[str, int]] = []
+
+    def add_one(event, context):
+        del context
+        seen.append(("one", event))
+        return 1
+
+    async def add_two(event, context):
+        del context
+        seen.append(("two", event))
+        return 2
+
+    def never(event, context):
+        del event, context
+        raise AssertionError("stopped route must not run")
+
+    extension = _extension(
+        "math",
+        _registration("one", add_one),
+        _registration("two", add_two),
+        _registration("never", never),
+    )
+    diagnostics = []
+    router = ExtensionRouter.from_extensions(
+        [extension],
+        diagnostics=diagnostics,
+    )
+
+    async def reducer(state, result, route):
+        next_state = state + result
+        return RouteStep(next_state, stop=route.registration.local_route_id == "two")
+
+    outcome = asyncio.run(
+        router.intercept(
+            "context",
+            0,
+            event_factory=lambda state, route: state,
+            reducer=reducer,
+            context_factory=lambda extension: extension.name,
+        )
+    )
+
+    assert outcome == RouteStep(3, stop=True)
+    assert seen == [("one", 0), ("two", 1)]
+    assert diagnostics == []
+
+
+def test_router_skip_isolates_handler_and_runtime_callback_failures() -> None:
+    calls: list[str] = []
+
+    def broken(event, context):
+        del event, context
+        raise RuntimeError("handler failed")
+
+    def succeeding(event, context):
+        del event, context
+        calls.append("succeeding")
+        return "ok"
+
+    extension = _extension(
+        "shared",
+        _registration("broken", broken),
+        _registration("succeeding", succeeding),
+    )
+    diagnostics = []
+    router = ExtensionRouter.from_extensions(
+        [extension],
+        diagnostics=diagnostics,
+        runtime_error_handler=lambda extension, event, error: (_ for _ in ()).throw(
+            RuntimeError("callback failed")
+        ),
+    )
+
+    results = asyncio.run(
+        router.observe(
+            "context",
+            object(),
+            context_factory=lambda extension: extension.name,
+        )
+    )
+
+    assert results == ("ok",)
+    assert calls == ["succeeding"]
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "extension_context_failed"
+    ]
+    assert diagnostics[0].metadata["route_id"] == "shared/context/broken"
+
+
+def test_router_fail_chain_raises_typed_route_error() -> None:
+    def broken(event, context):
+        del event, context
+        raise ValueError("stop")
+
+    extension = _extension(
+        "shared",
+        _registration("broken", broken, on_error="fail_chain"),
+    )
+    diagnostics = []
+    router = ExtensionRouter.from_extensions([extension], diagnostics=diagnostics)
+
+    with pytest.raises(ExtensionRouteError) as raised:
+        asyncio.run(
+            router.observe(
+                "context",
+                object(),
+                context_factory=lambda extension: extension.name,
+            )
+        )
+
+    assert raised.value.route.route_id == "shared/context/broken"
+    assert isinstance(raised.value.__cause__, ValueError)
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "extension_context_failed"
+    ]
+
+
+def test_router_propagates_cancellation_without_diagnostic() -> None:
+    async def cancelled(event, context):
+        del event, context
+        raise asyncio.CancelledError
+
+    extension = _extension("shared", _registration("cancel", cancelled))
+    diagnostics = []
+    router = ExtensionRouter.from_extensions([extension], diagnostics=diagnostics)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            router.observe(
+                "context",
+                object(),
+                context_factory=lambda extension: extension.name,
+            )
+        )
+
+    assert diagnostics == []
+
+
+def test_dispatcher_can_reuse_plan_without_repeating_validation_diagnostics() -> None:
+    extension = _extension(
+        "shared",
+        _registration("route", _noop, after=("route:missing/context/route",)),
+    )
+    diagnostics = []
+    plan = ExtensionRoutePlan.from_extensions([extension], diagnostics=diagnostics)
+
+    first = ExtensionDispatcher(
+        [extension],
+        route_plan=plan,
+        context_factory=lambda extension: extension.name,
+        diagnostics=diagnostics,
+    )
+    second = ExtensionDispatcher(
+        [extension],
+        route_plan=plan,
+        context_factory=lambda extension: extension.name,
+        diagnostics=diagnostics,
+    )
+    asyncio.run(first.dispatch("context", object()))
+    asyncio.run(second.dispatch("context", object()))
+
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "missing_extension_route_reference"
+    ]
+
+
+def test_resource_runtime_reuses_route_order_and_honors_fail_chain() -> None:
+    calls: list[str] = []
+
+    def first(bundle, context):
+        del context
+        calls.append("first")
+        return None
+
+    def broken(bundle, context):
+        del bundle, context
+        calls.append("broken")
+        raise RuntimeError("resource failure")
+
+    first_extension = _extension(
+        "first",
+        _registration(
+            "first",
+            first,
+            event="resources_discover",
+            priority=20,
+        ),
+    )
+    broken_extension = _extension(
+        "broken",
+        _registration(
+            "broken",
+            broken,
+            event="resources_discover",
+            on_error="fail_chain",
+        ),
+    )
+    diagnostics = []
+    plan = ExtensionRoutePlan.from_extensions(
+        [broken_extension, first_extension],
+        diagnostics=diagnostics,
+    )
+    runtime = ExtensionResourceRuntime(
+        [broken_extension, first_extension],
+        diagnostics=diagnostics,
+        route_plan=plan,
+    )
+
+    with pytest.raises(ExtensionRouteError):
+        runtime.discover(
+            ResourceBundle(cwd=Path("/tmp")),
+            context=object(),
+        )
+
+    assert calls == ["first", "broken"]
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "extension_resources_discover_failed"
+    ]

--- a/tests/harness/extensions/test_runtime.py
+++ b/tests/harness/extensions/test_runtime.py
@@ -9,9 +9,11 @@ from loushang.harness.extensions.loader import ExtensionLoader
 from loushang.harness.extensions.registry import resolve_extension_registry
 from loushang.harness.extensions.resources import ExtensionResourceRuntime
 from loushang.harness.extensions.types import (
+    ExtensionPolicyDecision,
     LoadedExtension,
     RegisteredCommand,
     RegisteredFlag,
+    RegisteredShortcut,
 )
 from loushang.harness.resources.types import ExtensionDescriptor, ResourceBundle
 from loushang.harness.tools.core import ToolDefinition
@@ -35,6 +37,45 @@ def test_contribution_api_builds_product_neutral_extension() -> None:
     assert list(extension.hooks) == ["agent_start"]
     assert list(extension.commands) == ["inspect"]
     assert extension.flags["verbose"].default is False
+
+
+def test_loaded_extension_preserves_legacy_positional_field_order() -> None:
+    async def execute(
+        tool_call_id: str,
+        arguments: dict[str, object],
+        signal: object | None,
+        on_update: object | None,
+    ) -> object:
+        del tool_call_id, arguments, signal, on_update
+        return object()
+
+    tool = ToolDefinition(
+        name="lookup",
+        label="Lookup",
+        description="Lookup",
+        parameters={},
+        execute=execute,  # type: ignore[arg-type]
+    )
+
+    def hook(event: object, context: object) -> None:
+        del event, context
+
+    extension = LoadedExtension(
+        "legacy",
+        Path("/tmp/legacy.py"),
+        None,
+        "filesystem",
+        "project_local",
+        "project",
+        None,
+        {"context": [hook]},
+        [tool],
+    )
+
+    assert extension.hooks == {"context": [hook]}
+    assert extension.tool_definitions == [tool]
+    assert extension.handler_registrations == []
+    assert extension.control_contributions == []
 
 
 def test_loader_executes_register_api_without_coding_runtime(tmp_path: Path) -> None:
@@ -153,6 +194,58 @@ def test_registry_resolves_contributions_and_preserves_first_wins() -> None:
         "duplicate_extension_tool",
         "duplicate_extension_flag",
     ]
+
+
+def test_registry_excludes_every_surface_from_inactive_extensions() -> None:
+    async def command_handler(arguments: str, context: object) -> None:
+        del arguments, context
+
+    async def execute(
+        tool_call_id: str,
+        arguments: dict[str, object],
+        signal: object | None,
+        on_update: object | None,
+    ) -> object:
+        del tool_call_id, arguments, signal, on_update
+        return object()
+
+    inactive = LoadedExtension(
+        name="inactive",
+        source_path=Path("/tmp/inactive.py"),
+        commands={"deploy": RegisteredCommand(name="deploy", handler=command_handler)},
+        flags={
+            "verbose": RegisteredFlag(
+                name="verbose",
+                type="boolean",
+                default=True,
+            )
+        },
+        shortcuts={
+            "ctrl+d": RegisteredShortcut(
+                shortcut="ctrl+d",
+                handler=lambda context: context,
+            )
+        },
+        tool_definitions=[
+            ToolDefinition(
+                name="deploy",
+                label="Deploy",
+                description="Deploy",
+                parameters={},
+                execute=execute,  # type: ignore[arg-type]
+            )
+        ],
+        policy=ExtensionPolicyDecision(enabled=False),
+    )
+
+    registry = resolve_extension_registry([inactive])
+
+    assert registry.commands == ()
+    assert registry.flags == ()
+    assert registry.shortcuts == ()
+    assert registry.tools == ()
+    assert registry.flag_defaults == {}
+    assert registry.diagnostics == ()
 
 
 def test_dispatcher_preserves_order_and_contains_failures() -> None:

--- a/tests/harness/runtime/test_transition.py
+++ b/tests/harness/runtime/test_transition.py
@@ -44,6 +44,103 @@ def test_transition_host_orders_release_activation_and_rebind() -> None:
     assert host.current == "second"
 
 
+def test_transition_host_before_invalidate_subscription_preserves_primary_callback() -> (
+    None
+):
+    events: list[str] = []
+    host = SessionTransitionHost(
+        "first",
+        dispose=lambda session: events.append(f"dispose:{session}"),
+        before_invalidate=lambda: events.append("primary"),
+    )
+    unsubscribe = host.subscribe_before_invalidate(lambda: events.append("observer"))
+
+    asyncio.run(host.replace("second"))
+    unsubscribe()
+    asyncio.run(host.replace("third"))
+
+    assert events == [
+        "primary",
+        "observer",
+        "dispose:first",
+        "primary",
+        "dispose:second",
+    ]
+
+
+def test_transition_host_subscription_unsubscribe_has_token_identity() -> None:
+    events: list[str] = []
+    host = SessionTransitionHost(
+        "first",
+        dispose=lambda session: events.append(f"dispose:{session}"),
+    )
+
+    def observer() -> None:
+        events.append("observer")
+
+    unsubscribe_first = host.subscribe_before_invalidate(observer)
+    host.subscribe_before_invalidate(observer)
+    unsubscribe_first()
+    unsubscribe_first()
+
+    asyncio.run(host.replace("second"))
+
+    assert events == ["observer", "dispose:first"]
+
+
+def test_transition_host_after_invalidate_observers_are_post_release_and_isolated() -> (
+    None
+):
+    events: list[str] = []
+    host = SessionTransitionHost(
+        "first", dispose=lambda session: events.append(f"dispose:{session}")
+    )
+    host.subscribe_after_invalidate(lambda: events.append("after:first"))
+
+    def fail_observer() -> None:
+        events.append("after:failed")
+        raise RuntimeError("observer failed")
+
+    host.subscribe_after_invalidate(fail_observer)
+    host.subscribe_after_invalidate(lambda: events.append("after:last"))
+
+    asyncio.run(
+        host.replace(
+            "second",
+            activate=lambda session: events.append(f"activate:{session}"),
+        )
+    )
+
+    assert events == [
+        "dispose:first",
+        "after:first",
+        "after:failed",
+        "after:last",
+        "activate:second",
+    ]
+    assert host.current == "second"
+
+
+def test_transition_host_rejects_replacement_reentry_from_after_observer() -> None:
+    errors: list[str] = []
+    host = SessionTransitionHost("first", dispose=lambda session: None)
+
+    async def reenter() -> None:
+        try:
+            await host.replace("nested")
+        except RuntimeError as error:
+            errors.append(str(error))
+
+    host.subscribe_after_invalidate(reenter)
+
+    asyncio.run(host.replace("second"))
+
+    assert host.current == "second"
+    assert errors == [
+        "Session transition cannot be re-entered from an after-invalidate observer"
+    ]
+
+
 def test_transition_host_preserves_current_when_prepare_fails() -> None:
     async def dispose(session: str) -> None:
         del session
@@ -58,6 +155,22 @@ def test_transition_host_preserves_current_when_prepare_fails() -> None:
         asyncio.run(host.replace("second", prepare=fail_prepare))
 
     assert host.current == "first"
+
+
+def test_transition_host_does_not_publish_session_after_dispose_failure() -> None:
+    disposed: list[str] = []
+
+    async def fail_dispose(session: str) -> None:
+        disposed.append(session)
+        raise RuntimeError("dispose failed")
+
+    host = SessionTransitionHost("first", dispose=fail_dispose)
+
+    with pytest.raises(RuntimeError, match="dispose failed"):
+        asyncio.run(host.replace("second"))
+
+    assert disposed == ["first"]
+    assert host.current is None
 
 
 def test_transition_host_serializes_concurrent_replacements() -> None:
@@ -78,7 +191,7 @@ def test_transition_host_serializes_concurrent_replacements() -> None:
         await dispose_started.wait()
         third_task = asyncio.create_task(host.replace("third"))
         await asyncio.sleep(0)
-        assert host.current == "first"
+        assert host.current is None
         dispose_release.set()
         return await asyncio.gather(second_task, third_task)
 

--- a/tests/harness/test_approval.py
+++ b/tests/harness/test_approval.py
@@ -6,8 +6,12 @@ import asyncio
 def test_approval_decision_helpers_cover_allow_and_deny() -> None:
     from loushang.harness.approval import ApprovalDecision
 
-    assert ApprovalDecision.allow() == ApprovalDecision(disposition="allow", reason=None)
-    assert ApprovalDecision.deny("blocked") == ApprovalDecision(disposition="deny", reason="blocked")
+    assert ApprovalDecision.allow() == ApprovalDecision(
+        disposition="allow", reason=None
+    )
+    assert ApprovalDecision.deny("blocked") == ApprovalDecision(
+        disposition="deny", reason="blocked"
+    )
 
 
 def test_approval_decision_rejects_invalid_disposition() -> None:
@@ -17,6 +21,9 @@ def test_approval_decision_rejects_invalid_disposition() -> None:
 
     with pytest.raises(ValueError, match="Unsupported approval decision disposition"):
         ApprovalDecision(disposition="prompt")  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="reason"):
+        ApprovalDecision(disposition="deny", reason=object())  # type: ignore[arg-type]
 
 
 def test_resolve_approval_defaults_to_deny() -> None:
@@ -86,3 +93,1104 @@ def test_approval_request_accepts_opaque_policy_context() -> None:
     )
 
     assert request.policy_decision is policy_decision
+
+
+def test_approval_request_snapshots_arguments() -> None:
+    import pytest
+
+    from loushang.harness.approval import ApprovalRequest
+
+    edits = [{"oldText": "before", "newText": "after"}]
+    arguments = {"path": "before.txt", "edits": edits}
+    request = ApprovalRequest(tool_name="write", arguments=arguments)
+    arguments["path"] = "after.txt"
+    edits[0]["newText"] = "changed"
+
+    assert request.arguments["path"] == "before.txt"
+    assert request.arguments["edits"][0]["newText"] == "after"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        request.arguments["edits"][0]["newText"] = "forbidden"  # type: ignore[index]
+
+
+def test_approval_request_rejects_invalid_fields_and_mutable_leaf_values() -> None:
+    import pytest
+
+    from loushang.harness.approval import ApprovalRequest
+
+    with pytest.raises(ValueError, match="tool_name"):
+        ApprovalRequest(tool_name="", arguments={})
+    with pytest.raises(TypeError, match="cwd"):
+        ApprovalRequest(tool_name="write", arguments={}, cwd=object())  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="action_id"):
+        ApprovalRequest(tool_name="write", arguments={}, action_id="")
+    with pytest.raises(TypeError, match="JSON-compatible"):
+        ApprovalRequest(
+            tool_name="write",
+            arguments={"payload": bytearray(b"mutable")},
+        )
+    with pytest.raises(TypeError, match="mapping keys must be strings"):
+        ApprovalRequest(
+            tool_name="write",
+            arguments={"nested": {1: "numeric", "1": "string"}},
+        )
+
+
+def test_approval_request_snapshot_supports_standard_serializers() -> None:
+    import json
+    import pickle
+    from copy import deepcopy
+    from dataclasses import asdict
+
+    from loushang.harness.approval import ApprovalRequest
+
+    request = ApprovalRequest(
+        tool_name="write",
+        arguments={"path": "notes.txt", "options": {"lines": [1, 2]}},
+        action_id="approval-serializable",
+    )
+
+    copied = deepcopy(request)
+    restored = pickle.loads(pickle.dumps(request))
+    projected = asdict(request)
+
+    assert copied == request
+    assert restored == request
+    assert projected["arguments"] == request.arguments
+    assert json.loads(json.dumps(projected))["arguments"]["path"] == "notes.txt"
+
+
+def test_approval_request_public_projection_is_mutable_and_detached() -> None:
+    from loushang.harness.approval import (
+        ApprovalRequest,
+        approval_request_to_dict,
+    )
+
+    request = ApprovalRequest(
+        tool_name="edit",
+        arguments={"edits": [{"oldText": "before", "newText": "after"}]},
+    )
+
+    projected = approval_request_to_dict(request)
+    arguments = projected["arguments"]
+    assert isinstance(arguments, dict)
+    edits = arguments["edits"]
+    assert isinstance(edits, list)
+    edits[0]["newText"] = "projected mutation"
+
+    assert request.arguments["edits"][0]["newText"] == "after"  # type: ignore[index]
+
+
+def test_resolve_approval_revalidates_mutated_decision_fields() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalDecision,
+        ApprovalRequest,
+        resolve_approval,
+    )
+
+    malformed = ApprovalDecision.allow()
+    object.__setattr__(malformed, "reason", object())
+
+    class Resolver:
+        def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+            del request
+            return malformed
+
+    with pytest.raises(TypeError, match="reason"):
+        asyncio.run(
+            resolve_approval(
+                Resolver(),
+                ApprovalRequest(tool_name="write", arguments={}),
+            )
+        )
+
+
+def test_approval_broker_revalidates_all_terminal_decisions() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        HeadlessApprovalResolver,
+    )
+
+    malformed = ApprovalDecision.allow()
+    object.__setattr__(malformed, "reason", object())
+
+    operations = (
+        lambda broker: broker.resolve_request("missing", malformed),
+        lambda broker: broker.cancel_request("missing", malformed),
+        lambda broker: broker.cancel_all(malformed),
+        lambda broker: broker.dispose(malformed),
+    )
+    for operation in operations:
+        broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+        with pytest.raises(TypeError, match="reason"):
+            operation(broker)
+
+
+def test_ensure_approval_action_id_is_idempotent() -> None:
+    from loushang.harness.approval import (
+        ApprovalRequest,
+        ensure_approval_action_id,
+    )
+
+    request = ApprovalRequest(tool_name="write", arguments={})
+    prepared = ensure_approval_action_id(request)
+
+    assert prepared.action_id is not None
+    assert ensure_approval_action_id(prepared) is prepared
+
+
+def test_approval_broker_presents_and_correlates_result() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    class Presenter:
+        def __init__(self, broker: ApprovalBroker) -> None:
+            self.broker = broker
+            self.requests: list[ApprovalRequest] = []
+
+        def present(self, request: ApprovalRequest) -> None:
+            self.requests.append(request)
+            assert request.action_id is not None
+            assert self.broker.resolve_request(
+                request.action_id, ApprovalDecision.allow()
+            )
+
+    async def run() -> tuple[ApprovalDecision, tuple[ApprovalRequest, ...]]:
+        broker = ApprovalBroker(
+            fallback=HeadlessApprovalResolver(mode="deny"),
+        )
+        presenter = Presenter(broker)
+        broker.set_presenter(presenter)
+        decision = await broker.resolve(
+            ApprovalRequest(tool_name="write", arguments={"path": "x"})
+        )
+        return decision, tuple(presenter.requests)
+
+    decision, requests = asyncio.run(run())
+
+    assert decision == ApprovalDecision.allow()
+    assert len(requests) == 1
+
+
+def test_approval_broker_rejects_duplicate_pending_action_id() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalRequest,
+        ApprovalRequestCollisionError,
+        HeadlessApprovalResolver,
+    )
+
+    presented = asyncio.Event()
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+            presented.set()
+
+    async def run() -> None:
+        broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+        broker.set_presenter(Presenter())
+        request = ApprovalRequest(
+            tool_name="write",
+            arguments={},
+            action_id="approval-shared",
+        )
+        first = asyncio.create_task(broker.resolve(request))
+        await presented.wait()
+        with pytest.raises(ApprovalRequestCollisionError):
+            await broker.resolve(request)
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+        assert broker.pending_requests() == ()
+
+    asyncio.run(run())
+
+
+def test_approval_broker_rejects_pending_collision_after_presenter_unbind() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        ApprovalRequestCollisionError,
+        HeadlessApprovalResolver,
+    )
+
+    presented = asyncio.Event()
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+            presented.set()
+
+    async def run() -> None:
+        broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="allow"))
+        broker.set_presenter(Presenter())
+        request = ApprovalRequest(
+            tool_name="write",
+            arguments={},
+            action_id="approval-shared",
+        )
+        first = asyncio.create_task(broker.resolve(request))
+        await presented.wait()
+        broker.set_presenter(None)
+
+        with pytest.raises(ApprovalRequestCollisionError):
+            await broker.resolve(request)
+
+        assert (
+            await broker.resolve(
+                ApprovalRequest(
+                    tool_name="read",
+                    arguments={},
+                    action_id="approval-distinct",
+                )
+            )
+            == ApprovalDecision.allow()
+        )
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+    asyncio.run(run())
+
+
+def test_approval_broker_rejects_reuse_after_cancellation_and_late_result() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        ApprovalRequestCollisionError,
+        HeadlessApprovalResolver,
+    )
+
+    presented = asyncio.Event()
+
+    class Presenter:
+        def present(self, request: ApprovalRequest) -> None:
+            del request
+            presented.set()
+
+    async def run() -> None:
+        broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+        broker.set_presenter(Presenter())
+        request = ApprovalRequest(
+            tool_name="write",
+            arguments={},
+            action_id="approval-reused",
+        )
+        first = asyncio.create_task(broker.resolve(request))
+        await presented.wait()
+        assert broker.cancel_all(ApprovalDecision.deny("session replaced")) == 1
+        assert await first == ApprovalDecision.deny("session replaced")
+
+        with pytest.raises(ApprovalRequestCollisionError):
+            await broker.resolve(request)
+        assert not broker.resolve_request(
+            "approval-reused",
+            ApprovalDecision.allow(),
+        )
+        assert broker.pending_requests() == ()
+        assert broker.dispose(ApprovalDecision.deny("disposed")) == 0
+        assert (await broker.resolve(request)).disposition == "deny"
+
+    asyncio.run(run())
+
+
+def test_approval_broker_cleans_up_presenter_failure_and_caller_cancellation() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    class BrokenPresenter:
+        def present(self, request: ApprovalRequest) -> None:
+            del request
+            raise RuntimeError("presentation failed")
+
+    async def run() -> None:
+        broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+        broker.set_presenter(BrokenPresenter())
+        with pytest.raises(RuntimeError, match="presentation failed"):
+            await broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        assert broker.pending_requests() == ()
+
+        presented = asyncio.Event()
+        dismissed: list[str | None] = []
+
+        class WaitingPresenter:
+            async def present(self, request: ApprovalRequest) -> None:
+                del request
+                presented.set()
+
+            def dismiss(self, request: ApprovalRequest) -> None:
+                dismissed.append(request.action_id)
+
+        broker.set_presenter(WaitingPresenter())
+        task = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="edit", arguments={}))
+        )
+        await presented.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert broker.pending_requests() == ()
+        assert len(dismissed) == 1
+
+    asyncio.run(run())
+
+
+def test_approval_broker_timeout_uses_validated_fallback() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+    )
+
+    dismissed: list[str | None] = []
+
+    class Presenter:
+        def present(self, request: ApprovalRequest) -> None:
+            del request
+
+        def dismiss(self, request: ApprovalRequest) -> None:
+            dismissed.append(request.action_id)
+
+    class AsyncFallback:
+        async def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+            del request
+            return ApprovalDecision.allow()
+
+    async def run() -> tuple[ApprovalDecision, tuple[ApprovalRequest, ...]]:
+        broker = ApprovalBroker(
+            fallback=AsyncFallback(),
+            timeout_seconds=0.001,
+        )
+        broker.set_presenter(Presenter())
+        decision = await broker.resolve(
+            ApprovalRequest(
+                tool_name="write",
+                arguments={},
+                action_id="approval-timeout-dismiss",
+            )
+        )
+        return decision, broker.pending_requests()
+
+    decision, pending = asyncio.run(run())
+
+    assert decision == ApprovalDecision.allow()
+    assert pending == ()
+    assert dismissed == ["approval-timeout-dismiss"]
+
+
+def test_approval_broker_timeout_preserves_caller_cancellation_from_presenter() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    resolution: asyncio.Task[object] | None = None
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+            try:
+                await asyncio.Event().wait()
+            finally:
+                assert resolution is not None
+                resolution.cancel()
+
+    async def run() -> None:
+        nonlocal resolution
+        broker = ApprovalBroker(
+            fallback=HeadlessApprovalResolver(mode="allow"),
+            timeout_seconds=0.001,
+        )
+        broker.set_presenter(Presenter())
+        resolution = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await resolution
+        assert broker.pending_requests() == ()
+
+    asyncio.run(run())
+
+
+def test_approval_broker_does_not_wait_for_async_dismissal() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    dismiss_started = asyncio.Event()
+    dismiss_release = asyncio.Event()
+
+    class Presenter:
+        def __init__(self, broker: ApprovalBroker) -> None:
+            self.broker = broker
+
+        def present(self, request: ApprovalRequest) -> None:
+            assert request.action_id is not None
+            assert self.broker.resolve_request(
+                request.action_id,
+                ApprovalDecision.allow(),
+            )
+
+        async def dismiss(self, request: ApprovalRequest) -> None:
+            del request
+            dismiss_started.set()
+            try:
+                await dismiss_release.wait()
+            except asyncio.CancelledError:
+                await dismiss_release.wait()
+
+    async def run() -> None:
+        broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+        broker.set_presenter(Presenter(broker))
+        resolved = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await dismiss_started.wait()
+        try:
+            assert resolved.done()
+            assert await resolved == ApprovalDecision.allow()
+        finally:
+            dismiss_release.set()
+            await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+
+def test_approval_broker_ignores_sync_dismissal_cancellation() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    class Presenter:
+        def __init__(self, broker: ApprovalBroker) -> None:
+            self.broker = broker
+
+        def present(self, request: ApprovalRequest) -> None:
+            assert request.action_id is not None
+            assert self.broker.resolve_request(
+                request.action_id,
+                ApprovalDecision.allow(),
+            )
+
+        def dismiss(self, request: ApprovalRequest) -> None:
+            del request
+            raise asyncio.CancelledError
+
+    async def run() -> ApprovalDecision:
+        broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+        broker.set_presenter(Presenter(broker))
+        return await broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+
+    assert asyncio.run(run()) == ApprovalDecision.allow()
+
+
+def test_approval_broker_timeout_after_async_presenter_uses_fallback() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+
+    async def run() -> tuple[ApprovalDecision, tuple[ApprovalRequest, ...]]:
+        broker = ApprovalBroker(
+            fallback=HeadlessApprovalResolver(mode="allow"),
+            timeout_seconds=0.001,
+        )
+        broker.set_presenter(Presenter())
+        decision = await broker.resolve(
+            ApprovalRequest(tool_name="write", arguments={})
+        )
+        return decision, broker.pending_requests()
+
+    decision, pending = asyncio.run(run())
+
+    assert decision == ApprovalDecision.allow()
+    assert pending == ()
+
+
+def test_approval_broker_dispose_overrides_blocked_timeout_fallback() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+    )
+
+    fallback_started = asyncio.Event()
+    fallback_cancelled = asyncio.Event()
+    release_fallback = asyncio.Event()
+
+    class Presenter:
+        def present(self, request: ApprovalRequest) -> None:
+            del request
+
+    class BlockingFallback:
+        async def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+            del request
+            fallback_started.set()
+            try:
+                await release_fallback.wait()
+            except asyncio.CancelledError:
+                fallback_cancelled.set()
+                await release_fallback.wait()
+            return ApprovalDecision.allow()
+
+    async def run() -> tuple[ApprovalDecision, int]:
+        broker = ApprovalBroker(
+            fallback=BlockingFallback(),
+            timeout_seconds=0.001,
+        )
+        broker.set_presenter(Presenter())
+        resolution = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await fallback_started.wait()
+        pending_requests = broker.pending_requests()
+        assert len(pending_requests) == 1
+        action_id = pending_requests[0].action_id
+        assert action_id is not None
+        assert not broker.resolve_request(action_id, ApprovalDecision.allow())
+        completed = broker.dispose(ApprovalDecision.deny("session closed"))
+        try:
+            decision = await asyncio.wait_for(resolution, timeout=0.2)
+            assert broker.pending_requests() == ()
+            await fallback_cancelled.wait()
+            return decision, completed
+        finally:
+            release_fallback.set()
+            await asyncio.sleep(0)
+
+    decision, completed = asyncio.run(run())
+
+    assert decision == ApprovalDecision.deny("session closed")
+    assert completed == 1
+
+
+def test_approval_broker_rejects_late_ui_result_after_timeout() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+    )
+
+    fallback_started = asyncio.Event()
+    release_fallback = asyncio.Event()
+
+    class Presenter:
+        def present(self, request: ApprovalRequest) -> None:
+            del request
+
+    class BlockingFallback:
+        async def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+            del request
+            fallback_started.set()
+            await release_fallback.wait()
+            return ApprovalDecision.deny("fallback denied")
+
+    async def run() -> ApprovalDecision:
+        broker = ApprovalBroker(
+            fallback=BlockingFallback(),
+            timeout_seconds=0.001,
+        )
+        broker.set_presenter(Presenter())
+        resolution = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await fallback_started.wait()
+        request = broker.pending_requests()[0]
+        assert request.action_id is not None
+        assert not broker.resolve_request(
+            request.action_id,
+            ApprovalDecision.allow(),
+        )
+        release_fallback.set()
+        return await resolution
+
+    assert asyncio.run(run()) == ApprovalDecision.deny("fallback denied")
+
+
+def test_approval_broker_propagates_presenter_timeout_error() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+            raise TimeoutError("presenter internal timeout")
+
+    async def run() -> None:
+        broker = ApprovalBroker(
+            fallback=HeadlessApprovalResolver(mode="allow"),
+            timeout_seconds=1,
+        )
+        broker.set_presenter(Presenter())
+        with pytest.raises(TimeoutError, match="presenter internal timeout"):
+            await broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        assert broker.pending_requests() == ()
+
+    asyncio.run(run())
+
+
+def test_approval_broker_timeout_does_not_wait_for_cancel_resistant_presenter() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presentation_cancelled = asyncio.Event()
+    release_presenter = asyncio.Event()
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                presentation_cancelled.set()
+                await release_presenter.wait()
+
+    async def run() -> ApprovalDecision:
+        broker = ApprovalBroker(
+            fallback=HeadlessApprovalResolver(mode="allow"),
+            timeout_seconds=0.001,
+        )
+        broker.set_presenter(Presenter())
+        resolution = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await presentation_cancelled.wait()
+        await asyncio.sleep(0.01)
+        try:
+            assert resolution.done()
+            return await resolution
+        finally:
+            release_presenter.set()
+            await asyncio.sleep(0)
+
+    assert asyncio.run(run()) == ApprovalDecision.allow()
+
+
+def test_approval_broker_redismisses_cancel_resistant_late_presentation() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presentation_cancelled = asyncio.Event()
+    release_presenter = asyncio.Event()
+    events: list[str] = []
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                presentation_cancelled.set()
+                await release_presenter.wait()
+                events.append("presented-after-cancel")
+
+        def dismiss(self, request: ApprovalRequest) -> None:
+            del request
+            events.append("dismissed")
+
+    async def run() -> ApprovalDecision:
+        broker = ApprovalBroker(
+            fallback=HeadlessApprovalResolver(mode="allow"),
+            timeout_seconds=0.001,
+        )
+        broker.set_presenter(Presenter())
+        decision = await broker.resolve(
+            ApprovalRequest(tool_name="write", arguments={})
+        )
+        await presentation_cancelled.wait()
+        assert events == ["dismissed"]
+        release_presenter.set()
+        for _ in range(10):
+            if events == [
+                "dismissed",
+                "presented-after-cancel",
+                "dismissed",
+            ]:
+                break
+            await asyncio.sleep(0)
+        return decision
+
+    assert asyncio.run(run()) == ApprovalDecision.allow()
+    assert events == ["dismissed", "presented-after-cancel", "dismissed"]
+
+
+def test_approval_broker_redismisses_late_presentation_that_reraises_cancel() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presentation_cancelled = asyncio.Event()
+    release_presenter = asyncio.Event()
+    events: list[str] = []
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                presentation_cancelled.set()
+                await release_presenter.wait()
+                events.append("presented-after-cancel")
+                raise
+
+        def dismiss(self, request: ApprovalRequest) -> None:
+            del request
+            events.append("dismissed")
+
+    async def run() -> None:
+        broker = ApprovalBroker(
+            fallback=HeadlessApprovalResolver(mode="allow"),
+            timeout_seconds=0.001,
+        )
+        broker.set_presenter(Presenter())
+        await broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        await presentation_cancelled.wait()
+        assert events == ["dismissed"]
+        release_presenter.set()
+        for _ in range(10):
+            if events == [
+                "dismissed",
+                "presented-after-cancel",
+                "dismissed",
+            ]:
+                break
+            await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+    assert events == ["dismissed", "presented-after-cancel", "dismissed"]
+
+
+def test_approval_broker_dispose_completes_pending_and_uses_fallback_afterward() -> (
+    None
+):
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presented = asyncio.Event()
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+            presented.set()
+
+    async def run() -> tuple[ApprovalDecision, ApprovalDecision, int, int]:
+        broker = ApprovalBroker(
+            fallback=HeadlessApprovalResolver(mode="allow"),
+        )
+        broker.set_presenter(Presenter())
+        pending = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await presented.wait()
+        completed = broker.dispose(ApprovalDecision.deny("session closed"))
+        duplicate_dispose = broker.dispose(ApprovalDecision.deny("ignored"))
+        first = await pending
+        after = await broker.resolve(ApprovalRequest(tool_name="read", arguments={}))
+        return first, after, completed, duplicate_dispose
+
+    first, after, completed, duplicate_dispose = asyncio.run(run())
+
+    assert first == ApprovalDecision.deny("session closed")
+    assert after == ApprovalDecision.allow()
+    assert completed == 1
+    assert duplicate_dispose == 0
+
+
+def test_approval_broker_dispose_interrupts_pending_async_presentation() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presenting = asyncio.Event()
+    presentation_cancelled = asyncio.Event()
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            del request
+            presenting.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                presentation_cancelled.set()
+
+    async def run() -> ApprovalDecision:
+        broker = ApprovalBroker(
+            fallback=HeadlessApprovalResolver(mode="allow"),
+        )
+        broker.set_presenter(Presenter())
+        pending = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await presenting.wait()
+        assert broker.dispose(ApprovalDecision.deny("session closed")) == 1
+        decision = await pending
+        await presentation_cancelled.wait()
+        return decision
+
+    assert asyncio.run(run()) == ApprovalDecision.deny("session closed")
+
+
+def test_approval_broker_resolves_concurrent_requests_independently() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presented = asyncio.Event()
+    requests: list[ApprovalRequest] = []
+
+    class Presenter:
+        def present(self, request: ApprovalRequest) -> None:
+            requests.append(request)
+            if len(requests) == 2:
+                presented.set()
+
+    async def run() -> tuple[ApprovalDecision, ApprovalDecision]:
+        broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+        broker.set_presenter(Presenter())
+        first = asyncio.create_task(
+            broker.resolve(
+                ApprovalRequest(
+                    tool_name="write",
+                    arguments={},
+                    action_id="approval-first",
+                )
+            )
+        )
+        second = asyncio.create_task(
+            broker.resolve(
+                ApprovalRequest(
+                    tool_name="publish",
+                    arguments={},
+                    action_id="approval-second",
+                )
+            )
+        )
+        await presented.wait()
+
+        assert broker.cancel_request(
+            "approval-first", ApprovalDecision.deny("cancelled")
+        )
+        assert not second.done()
+        assert broker.resolve_request("approval-second", ApprovalDecision.allow())
+        decisions = await asyncio.gather(first, second)
+        assert broker.pending_requests() == ()
+        return decisions[0], decisions[1]
+
+    first, second = asyncio.run(run())
+
+    assert first == ApprovalDecision.deny("cancelled")
+    assert second == ApprovalDecision.allow()
+
+
+def test_approval_broker_can_be_reused_across_sequential_event_loops() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+
+    class Presenter:
+        def present(self, request: ApprovalRequest) -> None:
+            assert request.action_id is not None
+            assert broker.resolve_request(request.action_id, ApprovalDecision.allow())
+
+    broker.set_presenter(Presenter())
+
+    async def resolve(tool_name: str) -> ApprovalDecision:
+        return await broker.resolve(ApprovalRequest(tool_name=tool_name, arguments={}))
+
+    assert asyncio.run(resolve("write")) == ApprovalDecision.allow()
+    assert asyncio.run(resolve("publish")) == ApprovalDecision.allow()
+
+
+def test_approval_broker_wrong_loop_dispose_does_not_poison_owner_cleanup() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    class Presenter:
+        def present(self, request: ApprovalRequest) -> None:
+            del request
+
+    broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="allow"))
+    broker.set_presenter(Presenter())
+    owner_loop = asyncio.new_event_loop()
+
+    async def start_request() -> asyncio.Task[ApprovalDecision]:
+        task = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await asyncio.sleep(0)
+        return task
+
+    pending = owner_loop.run_until_complete(start_request())
+
+    async def dispose_on_wrong_loop() -> None:
+        broker.dispose(ApprovalDecision.deny("wrong loop"))
+
+    with pytest.raises(RuntimeError, match="owning event loop"):
+        asyncio.run(dispose_on_wrong_loop())
+
+    async def dispose_on_owner_loop() -> ApprovalDecision:
+        assert broker.dispose(ApprovalDecision.deny("owner cleanup")) == 1
+        return await pending
+
+    try:
+        decision = owner_loop.run_until_complete(dispose_on_owner_loop())
+    finally:
+        if not pending.done():
+            pending.cancel()
+            owner_loop.run_until_complete(
+                asyncio.gather(pending, return_exceptions=True)
+            )
+        owner_loop.close()
+
+    assert decision == ApprovalDecision.deny("owner cleanup")
+
+
+def test_approval_broker_invalid_dispose_decision_does_not_poison_cleanup() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presented = asyncio.Event()
+
+    class Presenter:
+        def present(self, request: ApprovalRequest) -> None:
+            del request
+            presented.set()
+
+    async def run() -> ApprovalDecision:
+        broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="allow"))
+        broker.set_presenter(Presenter())
+        pending = asyncio.create_task(
+            broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+        )
+        await presented.wait()
+        with pytest.raises(TypeError, match="ApprovalDecision"):
+            broker.dispose(object())  # type: ignore[arg-type]
+        assert broker.dispose(ApprovalDecision.deny("valid cleanup")) == 1
+        return await pending
+
+    assert asyncio.run(run()) == ApprovalDecision.deny("valid cleanup")
+
+
+def test_approval_broker_unknown_and_late_results_do_not_mutate_state() -> None:
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        HeadlessApprovalResolver,
+    )
+
+    broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+
+    assert not broker.resolve_request("missing", ApprovalDecision.allow())
+    assert not broker.cancel_request("missing", ApprovalDecision.deny("late"))
+
+
+def test_approval_broker_rejects_presenter_rebind_after_disposal() -> None:
+    import pytest
+
+    from loushang.harness.approval import (
+        ApprovalBroker,
+        ApprovalDecision,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presented = False
+
+    class Presenter:
+        def present(self, request: ApprovalRequest) -> None:
+            nonlocal presented
+            del request
+            presented = True
+
+    broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+    assert broker.dispose(ApprovalDecision.deny("closed")) == 0
+    broker.set_presenter(None)
+    with pytest.raises(RuntimeError, match="disposed"):
+        broker.set_presenter(Presenter())
+
+    decision = asyncio.run(
+        broker.resolve(ApprovalRequest(tool_name="write", arguments={}))
+    )
+    assert decision.disposition == "deny"
+    assert not presented

--- a/tests/harness/test_contributions.py
+++ b/tests/harness/test_contributions.py
@@ -30,7 +30,9 @@ def test_contribution_descriptor_preserves_values() -> None:
     from loushang.harness.resources.diagnostics import ResourceDiagnostic
 
     source_path = Path("/tmp/extensions/review/extension.py")
-    diagnostic = ResourceDiagnostic(code="inactive_surface", message="Surface is inactive.")
+    diagnostic = ResourceDiagnostic(
+        code="inactive_surface", message="Surface is inactive."
+    )
     descriptor = ContributionDescriptor(
         type="command",
         name="review",
@@ -49,6 +51,32 @@ def test_contribution_descriptor_preserves_values() -> None:
     assert descriptor.metadata == {"source": "manifest"}
     with pytest.raises(FrozenInstanceError):
         descriptor.name = "changed"  # type: ignore[misc]
+
+
+def test_contribution_descriptor_preserves_legacy_positional_field_order() -> None:
+    from loushang.harness.contributions import ExtensionSurfaceDescriptor
+    from loushang.harness.resources.diagnostics import ResourceDiagnostic
+
+    source_path = Path("/tmp/legacy.py")
+    diagnostic = ResourceDiagnostic(code="legacy", message="legacy")
+    descriptor = ExtensionSurfaceDescriptor(
+        "tool",
+        "lookup",
+        "legacy.extension",
+        source_path,
+        False,
+        7,
+        ("filesystem",),
+        (diagnostic,),
+        {"source": "legacy"},
+    )
+
+    assert descriptor.permission_requirements == ("filesystem",)
+    assert descriptor.diagnostics == (diagnostic,)
+    assert descriptor.metadata == {"source": "legacy"}
+    assert descriptor.after == ()
+    assert descriptor.before == ()
+    assert descriptor.on_error == "skip"
 
 
 def test_contribution_registry_preserves_order_and_indexes() -> None:
@@ -77,7 +105,10 @@ def test_contribution_registry_preserves_order_and_indexes() -> None:
     )
 
     registry = ContributionRegistry.from_extensions(
-        [SimpleNamespace(contributions=[tool, command]), SimpleNamespace(surfaces=[other])]
+        [
+            SimpleNamespace(contributions=[tool, command]),
+            SimpleNamespace(surfaces=[other]),
+        ]
     )
 
     assert registry.all() == [tool, command, other]

--- a/tests/harness/test_control_plane_runtime.py
+++ b/tests/harness/test_control_plane_runtime.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TypedDict, cast
+
+from loushang.harness.approval import (
+    ApprovalBroker,
+    ApprovalDecision,
+    ApprovalRequest,
+    HeadlessApprovalResolver,
+)
+from loushang.harness.extensions.api import ExtensionContributionAPI
+from loushang.harness.extensions.control import resolve_control_contributions
+from loushang.harness.extensions.routing import (
+    ExtensionRoutePlan,
+    ExtensionRouter,
+    ResolvedExtensionRoute,
+    RouteStep,
+)
+from loushang.harness.policy import (
+    PolicyDecision,
+    PolicyEvaluatorChain,
+    ToolPolicySubject,
+)
+from loushang.harness.resources.diagnostics import ResourceDiagnostic
+from loushang.harness.tools.workspace.policy import enforce_tool_policy
+
+
+class _ToolState(TypedDict):
+    tool_name: str
+    arguments: dict[str, object]
+
+
+def test_product_neutral_control_plane_rewrites_approves_and_executes() -> None:
+    presented = asyncio.Event()
+    approval_requests: list[ApprovalRequest] = []
+    audit_events: list[dict[str, object]] = []
+    executed: list[_ToolState] = []
+
+    class Presenter:
+        async def present(self, request: ApprovalRequest) -> None:
+            approval_requests.append(request)
+            presented.set()
+
+    class PublishPolicy:
+        def evaluate(self, subject):
+            assert isinstance(subject, ToolPolicySubject)
+            assert subject.arguments["normalized"] is True
+            return PolicyDecision.ask(
+                "Publishing requires review",
+                code="publish_requires_review",
+            )
+
+    broker = ApprovalBroker(fallback=HeadlessApprovalResolver(mode="deny"))
+    broker.set_presenter(Presenter())
+    api = ExtensionContributionAPI(
+        name="publication-controls",
+        source_path=Path("/opt/product/extensions/publication-controls.py"),
+    )
+
+    def normalize_tool_call(event: _ToolState, context: object) -> _ToolState:
+        del context
+        return {
+            "tool_name": event["tool_name"],
+            "arguments": {**event["arguments"], "normalized": True},
+        }
+
+    api.on("tool_call", normalize_tool_call, route_id="normalize")
+    api.register_policy("publish-review", PublishPolicy())
+    api.register_approval("interactive", broker)
+    extension = api.build_loaded_extension()
+
+    async def run() -> None:
+        diagnostics: list[ResourceDiagnostic] = []
+        plan = ExtensionRoutePlan.from_extensions(
+            [extension],
+            diagnostics=diagnostics,
+        )
+        router = ExtensionRouter(plan, diagnostics=diagnostics)
+        initial: _ToolState = {
+            "tool_name": "publish",
+            "arguments": {"artifact": "quarterly-review.pptx"},
+        }
+
+        def reduce_tool_call(
+            state: _ToolState,
+            result: object,
+            route: ResolvedExtensionRoute,
+        ) -> RouteStep[_ToolState]:
+            del state, route
+            return RouteStep(cast(_ToolState, result))
+
+        routed = await router.intercept(
+            "tool_call",
+            initial,
+            event_factory=lambda state, route: state,
+            reducer=reduce_tool_call,
+            context_factory=lambda loaded: {"extension": loaded.name},
+        )
+        controls = resolve_control_contributions(
+            [extension],
+            diagnostics=diagnostics,
+        )
+        assert controls.selected_approval_record is controls.approval_records[0]
+
+        state = routed.state
+        policy = PolicyEvaluatorChain(
+            controls.policy_evaluators,
+            strategy="most_restrictive",
+        )
+        enforcement = asyncio.create_task(
+            enforce_tool_policy(
+                policy,
+                tool_name=state["tool_name"],
+                arguments=state["arguments"],
+                approval_resolver=controls.approval_resolver,
+                tool_call_id="publish-1",
+                audit_sink=audit_events.append,
+            )
+        )
+
+        await presented.wait()
+        assert not enforcement.done()
+        action_id = approval_requests[0].action_id
+        assert action_id is not None
+        assert broker.resolve_request(action_id, ApprovalDecision.allow())
+        await enforcement
+
+        executed.append(state)
+        assert diagnostics == []
+
+    asyncio.run(run())
+
+    assert executed == [
+        {
+            "tool_name": "publish",
+            "arguments": {
+                "artifact": "quarterly-review.pptx",
+                "normalized": True,
+            },
+        }
+    ]
+    assert [event["type"] for event in audit_events] == [
+        "tool_policy_evaluated",
+        "tool_approval_requested",
+        "tool_approval_resolved",
+    ]
+    assert audit_events[1]["action_id"] == audit_events[2]["action_id"]

--- a/tests/harness/test_policy.py
+++ b/tests/harness/test_policy.py
@@ -1,0 +1,1254 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+
+def test_policy_decision_rejects_invalid_disposition() -> None:
+    from loushang.harness.policy import PolicyDecision
+
+    with pytest.raises(ValueError, match="Unsupported policy disposition"):
+        PolicyDecision(disposition="ignore")  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="reason"):
+        PolicyDecision(disposition="deny", reason=object())  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="code"):
+        PolicyDecision(disposition="deny", code=object())  # type: ignore[arg-type]
+
+
+def test_tool_policy_subject_takes_an_immutable_nested_snapshot() -> None:
+    from loushang.harness.policy import build_tool_policy_subject
+
+    edits = [{"oldText": "before", "newText": "after"}]
+    arguments = {"path": "notes.txt", "edits": edits}
+
+    subject = build_tool_policy_subject(
+        tool_name="edit",
+        arguments=arguments,
+        cwd="/tmp/project",
+    )
+    arguments["path"] = "changed.txt"
+    edits[0]["newText"] = "changed"
+
+    assert subject.arguments["path"] == "notes.txt"
+    assert subject.arguments["edits"][0]["newText"] == "after"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        subject.arguments["path"] = "forbidden"  # type: ignore[index]
+
+
+def test_tool_policy_subject_rejects_non_json_argument_trees() -> None:
+    from loushang.harness.policy import build_tool_policy_subject
+
+    with pytest.raises(TypeError, match="mapping keys must be strings"):
+        build_tool_policy_subject(
+            tool_name="write",
+            arguments={"nested": {1: "numeric", "1": "string"}},
+        )
+    with pytest.raises(TypeError, match="JSON-compatible"):
+        build_tool_policy_subject(
+            tool_name="write",
+            arguments={"payload": bytearray(b"mutable")},
+        )
+
+
+@pytest.mark.parametrize(
+    ("command", "payload", "tokens"),
+    [
+        (("/bin/sh", "-lc", "git push origin main"), "git push origin main", ()),
+        (
+            ("/usr/bin/git", "push", "origin", "main"),
+            None,
+            ("git", "push", "origin", "main"),
+        ),
+        (("env", "FOO=1", "bash", "-lc", "git push"), "git push", ()),
+        (("env", "1FOO=1", "bash", "-lc", "git push"), "git push", ()),
+        (("env", "=1", "bash", "-lc", "git push"), "git push", ()),
+        (("env", "--", "FOO=1", "bash", "-lc", "git push"), "git push", ()),
+        (("env", "--chd", "/tmp", "bash", "-c", "git push"), "git push", ()),
+        (("env", "--uns", "FOO", "bash", "-c", "git push"), "git push", ()),
+        (("env", "-Sbash -c 'git push'"), "git push", ()),
+        (("env", "-iu", "FOO", "bash", "-c", "git push"), "git push", ()),
+        (("env", "-iC", "/tmp", "bash", "-c", "git push"), "git push", ()),
+        (("env", "-iS", "bash -c 'git push'"), "git push", ()),
+        (("env", "-iSbash -c 'git push'"), "git push", ()),
+        (("env", "-S", "-i bash -c 'git push'"), "git push", ()),
+        (("env", "-S", "FOO=bar bash -c 'git push'"), "git push", ()),
+        (("env", "--default-signal", "bash", "-c", "git push"), "git push", ()),
+        (("env", "--ignore-signal", "bash", "-c", "git push"), "git push", ()),
+        (("env", "--block-signal", "bash", "-c", "git push"), "git push", ()),
+        (("sudo", "-u", "root", "/bin/rm", "-rf", "/tmp"), None, ("rm", "-rf", "/tmp")),
+        (("sudo", "-nu", "root", "bash", "-c", "rm -rf /tmp"), "rm -rf /tmp", ()),
+        (("sudo", "--use", "root", "bash", "-c", "rm -rf /tmp"), "rm -rf /tmp", ()),
+        (("sudo", "--chd", "/tmp", "bash", "-c", "rm -rf /tmp"), "rm -rf /tmp", ()),
+        (("sudo", "FOO=bar", "bash", "-c", "rm -rf /tmp"), "rm -rf /tmp", ()),
+        (
+            ("sudo", "-nu", "root", "FOO=bar", "bash", "-c", "rm -rf /tmp"),
+            "rm -rf /tmp",
+            (),
+        ),
+        (("sudo", "-s", "rm", "-rf", "/tmp"), "rm -rf /tmp", ()),
+        (("sudo", "--login", "rm", "-rf", "/tmp"), "rm -rf /tmp", ()),
+        (("ash", "-c", "git push"), "git push", ()),
+        (("fish", "-c", "git push"), "git push", ()),
+        (("fish", "--command", "git push"), "git push", ()),
+        (("fish", "--command=git push"), "git push", ()),
+        (
+            ("fish", "-C", "printf setup", "-c", "git push"),
+            "printf setup\ngit push",
+            (),
+        ),
+        (
+            ("fish", "-c", "printf safe", "-c", "git push"),
+            "printf safe\ngit push",
+            (),
+        ),
+        (("sh", "-c", "--", "printf shell"), "printf shell", ()),
+        (("bash", "--noprofile", "-c", "printf bash"), "printf bash", ()),
+        (("bash", "-O", "extglob", "-c", "printf extglob"), "printf extglob", ()),
+    ],
+)
+def test_command_normalization_exposes_shell_payload_or_direct_tokens(
+    command: tuple[str, ...],
+    payload: str | None,
+    tokens: tuple[str, ...],
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(command, cwd="/tmp")
+
+    assert subject.command == command
+    assert subject.shell_payload == payload
+    assert subject.direct_tokens == tokens
+
+
+def test_command_normalization_preserves_malformed_env_split_string_as_payload() -> (
+    None
+):
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(("env", "-S", "'"))
+
+    assert subject.shell_payload == "'"
+    assert subject.normalization_complete is False
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ("env", "-S", "bash -c 'printf ok'"),
+        ("env", "-S", r'bash\_-c\_"rm -rf /tmp"'),
+        ("env", "-S", "${RUNNER} -c 'rm -rf /tmp'"),
+        ("env", "--platform-specific", "bash", "-c", "printf ok"),
+        ("sudo", "--platform-specific", "bash", "-c", "printf ok"),
+        ("env", "-C", "/tmp", "bash", "stdin-script"),
+        ("env", "--chdir=/tmp", "bash", "stdin-script"),
+        ("sudo", "-D", "/tmp", "bash", "stdin-script"),
+        ("sudo", "--chroot=/tmp", "bash", "stdin-script"),
+        ("sudo", "-s", "printf", "ok"),
+        ("env", "PATH=/tmp", "cat", "+x"),
+        ("env", "--", "PATH=/tmp", "cat", "+x"),
+        ("env", "-u", "PATH", "cat", "+x"),
+        ("env", "-uPATH", "cat", "+x"),
+        ("env", "--unset=PATH", "cat", "+x"),
+        ("env", "-i", "cat", "+x"),
+        ("env", "--ignore-environment", "cat", "+x"),
+        ("env", "-", "cat", "+x"),
+        ("env", "-a", "sh", "busybox"),
+        ("env", "-ash", "busybox"),
+        ("env", "--argv0", "sh", "busybox"),
+        ("env", "--argv0=sh", "busybox"),
+        ("env", "BASH_ENV=/dev/stdin", "bash", "-c", "printf safe"),
+        ("env", "ENV=/dev/stdin", "sh", "-c", "printf safe"),
+        ("env", "-u", "BASH_ENV", "bash", "-c", "printf safe"),
+        ("env", "--unset=ENV", "sh", "-c", "printf safe"),
+        ("sudo", "PATH=/tmp", "cat", "+x"),
+    ],
+)
+def test_command_normalization_marks_platform_specific_wrappers_incomplete(
+    command: tuple[str, ...],
+) -> None:
+    from loushang.harness.policy import (
+        IncompleteCommandMatcher,
+        normalize_command_subject,
+    )
+
+    subject = normalize_command_subject(command)
+
+    assert subject.normalization_complete is False
+    assert IncompleteCommandMatcher().matches(subject)
+
+
+def test_command_normalization_can_trust_an_injected_shell_entrypoint() -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(
+        ("/opt/product-shell", "-lc", "rm -rf /tmp"),
+        assume_shell=True,
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp"
+    assert subject.normalization_complete is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ("bash",),
+        ("bash", "-s"),
+        ("bash", "-s", "argument"),
+        ("bash", "-"),
+        ("bash", "/dev/stdin"),
+        ("bash", "/dev/fd/0"),
+        ("bash", "/proc/self/fd/0"),
+        ("rbash",),
+        ("rzsh",),
+        ("rksh",),
+        ("env", "SAFE=1", "sh"),
+        ("fish",),
+        ("fish", "-"),
+        ("fish", "-C", "printf setup"),
+    ],
+)
+def test_command_normalization_exposes_shell_stdin_payload(
+    command: tuple[str, ...],
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(command, stdin="rm -rf /tmp/demo")
+
+    assert subject.shell_payload is not None
+    assert "rm -rf /tmp/demo" in subject.shell_payload
+    assert subject.direct_tokens == ()
+
+
+@pytest.mark.parametrize(
+    ("command", "cwd"),
+    [
+        (("bash", "stdin"), "/dev"),
+        (("bash", "fd/0"), "/dev"),
+        (("bash", "dev/./stdin"), "/"),
+        (("bash", "../dev/stdin"), "/tmp"),
+        (("bash", "//dev/stdin"), "/tmp"),
+        (("bash", "--", "../dev/fd/0"), "/tmp"),
+        (("bash", "../proc/thread-self/fd/0"), "/tmp"),
+        (("bash", "/proc/self/root/dev/stdin"), "/tmp"),
+        (("bash", "/proc/thread-self/root/dev/stdin"), "/tmp"),
+        (("bash", "/proc/self/root/../dev/stdin"), "/tmp"),
+        (("bash", "/proc/thread-self/root/../dev/stdin"), "/tmp"),
+        (("bash", "/proc/self/root/../../dev/stdin"), "/tmp"),
+        (("fish", "stdin"), "/dev"),
+        (("fish", "--", "../proc/self/fd/0"), "/tmp"),
+    ],
+)
+def test_command_normalization_exposes_lexically_equivalent_stdin_paths(
+    command: tuple[str, ...],
+    cwd: str,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(
+        command,
+        cwd=cwd,
+        stdin="rm -rf /tmp/demo",
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp/demo"
+    assert subject.direct_tokens == ()
+
+
+def test_command_normalization_detects_symlink_to_stdin(
+    tmp_path,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    (tmp_path / "stdin-script").symlink_to("/dev/stdin")
+
+    subject = normalize_command_subject(
+        ("bash", "stdin-script"),
+        cwd=str(tmp_path),
+        stdin="rm -rf /tmp/demo",
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp/demo"
+    assert subject.normalization_complete is True
+
+
+def test_command_normalization_detects_relative_stdin_symlink_without_cwd(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    (tmp_path / "stdin-script").symlink_to("/dev/stdin")
+    monkeypatch.chdir(tmp_path)
+
+    subject = normalize_command_subject(
+        ("bash", "stdin-script"),
+        stdin="rm -rf /tmp/demo",
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp/demo"
+    assert subject.normalization_complete is True
+
+
+def test_command_normalization_preserves_symlink_component_before_parent(
+    tmp_path,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    (tmp_path / "root").symlink_to("/")
+    operand = str(tmp_path / "root" / ".." / "dev" / "stdin")
+
+    subject = normalize_command_subject(
+        ("bash", operand),
+        stdin="rm -rf /tmp/demo",
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp/demo"
+    assert subject.normalization_complete is True
+
+
+def test_command_normalization_uses_shell_executable_identity_for_aliases(
+    tmp_path,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    shell_alias = tmp_path / "shell-alias"
+    shell_alias.symlink_to("/bin/bash")
+    commands = (
+        ((str(shell_alias),), {}),
+        (("./shell-alias",), {"cwd": str(tmp_path)}),
+        (("shell-alias",), {"executable_search_path": str(tmp_path)}),
+    )
+
+    for command, options in commands:
+        subject = normalize_command_subject(
+            command,
+            stdin="rm -rf /tmp/demo",
+            **options,
+        )
+
+        assert subject.shell_payload == "rm -rf /tmp/demo"
+        assert subject.normalization_complete is True
+
+
+def test_command_normalization_uses_identity_over_deceptive_shell_basename(
+    tmp_path,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    deceptive_fish = tmp_path / "fish"
+    deceptive_fish.symlink_to("/bin/bash")
+
+    subject = normalize_command_subject(
+        (str(deceptive_fish), "+x"),
+        stdin="rm -rf /tmp/demo",
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp/demo"
+    assert subject.normalization_complete is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ("bash", "--rcfile", "/dev/stdin", "-i", "-c", "printf safe"),
+        (
+            "bash",
+            "-i",
+            "--init-file=/proc/self/fd/0",
+            "-c",
+            "printf safe",
+        ),
+    ],
+)
+def test_command_normalization_exposes_shell_startup_file_stdin(
+    command: tuple[str, ...],
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(
+        command,
+        stdin="rm -rf /tmp/startup",
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp/startup\nprintf safe"
+    assert subject.normalization_complete is False
+
+
+def test_command_normalization_exposes_relative_startup_file_stdin_alias(
+    tmp_path,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    (tmp_path / "bashrc").symlink_to("/dev/stdin")
+    subject = normalize_command_subject(
+        ("bash", "--rcfile", "bashrc", "-i", "-c", "printf safe"),
+        cwd=str(tmp_path),
+        stdin="rm -rf /tmp/startup",
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp/startup\nprintf safe"
+    assert subject.normalization_complete is False
+
+
+def test_command_normalization_marks_shell_startup_environment_incomplete() -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(
+        ("bash", "-c", "printf safe"),
+        stdin="rm -rf /tmp/startup",
+        environment_overrides=(("BASH_ENV", "/dev/stdin"),),
+    )
+
+    assert subject.shell_payload == "printf safe"
+    assert subject.normalization_complete is False
+
+
+@pytest.mark.parametrize("wrapper_name", ["env", "sudo"])
+def test_command_normalization_does_not_unwrap_shells_with_wrapper_basenames(
+    tmp_path,
+    wrapper_name: str,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    deceptive_wrapper = tmp_path / wrapper_name
+    deceptive_wrapper.symlink_to("/bin/bash")
+    commands = (
+        ((str(deceptive_wrapper),), {}),
+        ((f"./{wrapper_name}",), {"cwd": str(tmp_path)}),
+        ((wrapper_name,), {"executable_search_path": str(tmp_path)}),
+    )
+
+    for command, options in commands:
+        subject = normalize_command_subject(
+            command,
+            stdin="rm -rf /tmp/demo",
+            **options,
+        )
+
+        assert subject.shell_payload == "rm -rf /tmp/demo"
+        assert subject.normalization_complete is True
+
+
+def test_command_normalization_marks_wrapper_with_arbitrary_basename_incomplete(
+    tmp_path,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    wrapper_alias = tmp_path / "runner"
+    wrapper_alias.symlink_to("/usr/bin/env")
+
+    subject = normalize_command_subject(
+        (str(wrapper_alias), "bash", "-c", "rm -rf /tmp/demo"),
+    )
+
+    assert subject.shell_payload is None
+    assert subject.normalization_complete is False
+
+
+def test_command_normalization_fails_safe_for_independent_shell_copies(
+    tmp_path,
+) -> None:
+    from shutil import copy2
+
+    from loushang.harness.policy import normalize_command_subject
+
+    copied_shell = tmp_path / "bash"
+    copy2("/bin/bash", copied_shell)
+    commands = (
+        ((str(copied_shell), "+x"), {}),
+        (("./bash", "+x"), {"cwd": str(tmp_path)}),
+        (
+            ("bash", "+x"),
+            {"executable_search_path": str(tmp_path)},
+        ),
+    )
+
+    for command, options in commands:
+        subject = normalize_command_subject(
+            command,
+            stdin="rm -rf /tmp/demo",
+            **options,
+        )
+
+        assert subject.shell_payload == "rm -rf /tmp/demo"
+        assert subject.normalization_complete is False
+
+
+@pytest.mark.parametrize(
+    ("search_path", "relative_directory"),
+    [
+        (".", "."),
+        ("bin", "bin"),
+        (f"{os.pathsep}/definitely/missing", "."),
+        (f"/definitely/missing{os.pathsep}", "."),
+    ],
+)
+def test_command_normalization_resolves_relative_path_entries_from_execution_cwd(
+    tmp_path,
+    monkeypatch,
+    search_path: str,
+    relative_directory: str,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    process_cwd = tmp_path / "process"
+    execution_cwd = tmp_path / "execution"
+    process_bin = process_cwd / relative_directory
+    execution_bin = execution_cwd / relative_directory
+    process_bin.mkdir(parents=True)
+    execution_bin.mkdir(parents=True)
+    (process_bin / "cat").symlink_to("/bin/cat")
+    (execution_bin / "cat").symlink_to("/bin/bash")
+    monkeypatch.chdir(process_cwd)
+
+    subject = normalize_command_subject(
+        ("cat", "+x"),
+        cwd=str(execution_cwd),
+        stdin="rm -rf /tmp/demo",
+        executable_search_path=search_path,
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp/demo"
+    assert subject.normalization_complete is True
+
+
+def test_command_normalization_marks_unresolvable_stdin_entrypoint_incomplete(
+    tmp_path,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(
+        (str(tmp_path / "missing-shell"),),
+        stdin="rm -rf /tmp/demo",
+    )
+
+    assert subject.shell_payload is None
+    assert subject.normalization_complete is False
+
+
+@pytest.mark.parametrize(
+    ("command", "stdin", "expected_payload"),
+    [
+        (("/bin/busybox", "sh"), "rm -rf /tmp/demo", "rm -rf /tmp/demo"),
+        (("busybox", "ash", "-c", "rm -rf /tmp/demo"), None, "rm -rf /tmp/demo"),
+        (
+            ("busybox", "env", "bash", "-c", "rm -rf /tmp/demo"),
+            None,
+            "rm -rf /tmp/demo",
+        ),
+        (("toybox", "sh", "-c", "rm -rf /tmp/demo"), None, "rm -rf /tmp/demo"),
+    ],
+)
+def test_command_normalization_exposes_multicall_shell_applets(
+    command: tuple[str, ...],
+    stdin: str | None,
+    expected_payload: str,
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(command, stdin=stdin)
+
+    assert subject.shell_payload == expected_payload
+    assert subject.direct_tokens == ()
+
+
+def test_command_normalization_classifies_busybox_inode_by_invocation_name(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import loushang.harness.policy as policy_module
+    from loushang.harness.policy import normalize_command_subject
+
+    multicall = tmp_path / "busybox"
+    multicall.write_text("test executable", encoding="utf-8")
+    multicall.chmod(0o755)
+    cat_applet = tmp_path / "cat"
+    env_applet = tmp_path / "env"
+    sh_applet = tmp_path / "sh"
+    cat_applet.symlink_to(multicall)
+    env_applet.symlink_to(multicall)
+    sh_applet.symlink_to(multicall)
+    monkeypatch.setattr(
+        policy_module,
+        "_known_multicall_paths",
+        lambda: (str(multicall),),
+    )
+
+    cat_subject = normalize_command_subject(
+        (str(cat_applet),),
+        stdin="ordinary data",
+    )
+    env_subject = normalize_command_subject(
+        (str(env_applet), str(sh_applet), "-c", "printf safe"),
+    )
+
+    assert cat_subject.shell_payload is None
+    assert cat_subject.direct_tokens == ("cat",)
+    assert cat_subject.normalization_complete is True
+    assert env_subject.shell_payload == "printf safe"
+    assert env_subject.normalization_complete is True
+
+
+@pytest.mark.parametrize("command", [("bash", "+x"), ("sh", "+eu")])
+def test_command_normalization_exposes_stdin_after_plus_options(
+    command: tuple[str, ...],
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(
+        command,
+        stdin="rm -rf /tmp/demo",
+    )
+
+    assert subject.shell_payload == "rm -rf /tmp/demo"
+    assert subject.normalization_complete is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        ("bash", "-c", "cat"),
+        ("bash", "/tmp/script.sh"),
+        ("bash", "--", "-"),
+        ("python", "-c", "print('ok')"),
+    ],
+)
+def test_command_normalization_keeps_non_script_stdin_out_of_shell_payload(
+    command: tuple[str, ...],
+) -> None:
+    from loushang.harness.policy import normalize_command_subject
+
+    subject = normalize_command_subject(command, stdin="rm -rf /tmp/data")
+
+    assert subject.shell_payload != "rm -rf /tmp/data"
+
+
+def test_incomplete_command_matching_scans_raw_argv_conservatively() -> None:
+    from loushang.harness.policy import (
+        CommandSubstringMatcher,
+        normalize_command_subject,
+    )
+
+    subject = normalize_command_subject(
+        ("env", "-S", r'bash\_-c\_"rm -rf /tmp"'),
+    )
+
+    assert subject.normalization_complete is False
+    assert CommandSubstringMatcher("rm -rf").matches(subject)
+
+
+def test_rule_evaluator_returns_first_match_and_abstains_without_one() -> None:
+    from loushang.harness.policy import (
+        ExactToolNameMatcher,
+        PolicyDecision,
+        PolicyRule,
+        RulePolicyEvaluator,
+        build_tool_policy_subject,
+    )
+
+    evaluator = RulePolicyEvaluator(
+        (
+            PolicyRule(
+                id="deny-write",
+                matcher=ExactToolNameMatcher("write"),
+                decision=PolicyDecision.deny("write disabled"),
+            ),
+            PolicyRule(
+                id="ask-write",
+                matcher=ExactToolNameMatcher("write"),
+                decision=PolicyDecision.ask("confirm write"),
+            ),
+        )
+    )
+
+    write = build_tool_policy_subject(tool_name="write", arguments={})
+    read = build_tool_policy_subject(tool_name="read", arguments={})
+
+    assert evaluator.evaluate(write) == PolicyDecision.deny("write disabled")
+    assert evaluator.evaluate(read) is None
+
+
+def test_rule_evaluator_rejects_duplicate_rule_ids() -> None:
+    from loushang.harness.policy import (
+        ExactToolNameMatcher,
+        PolicyDecision,
+        PolicyRule,
+        RulePolicyEvaluator,
+    )
+
+    rules = tuple(
+        PolicyRule(
+            id="same",
+            matcher=ExactToolNameMatcher(name),
+            decision=PolicyDecision.allow(),
+        )
+        for name in ("read", "write")
+    )
+
+    with pytest.raises(ValueError, match="ids must be unique"):
+        RulePolicyEvaluator(rules)
+
+
+def test_command_and_path_matchers_use_normalized_subjects(tmp_path) -> None:
+    from loushang.harness.policy import (
+        CommandSubstringMatcher,
+        PathSubstringMatcher,
+        build_tool_policy_subject,
+        normalize_command_subject,
+    )
+
+    command = normalize_command_subject(("/usr/bin/git", "push", "origin", "main"))
+    bash = build_tool_policy_subject(
+        tool_name="bash",
+        arguments={"command": "git push origin main"},
+        command=command,
+    )
+    read = build_tool_policy_subject(
+        tool_name="read",
+        arguments={"path": "secrets/token.txt"},
+        cwd=str(tmp_path),
+    )
+
+    assert CommandSubstringMatcher("git push").matches(bash)
+    assert PathSubstringMatcher(str(tmp_path / "secrets")).matches(read)
+
+
+def test_direct_command_matching_does_not_scan_unrelated_argument_text() -> None:
+    from loushang.harness.policy import (
+        CommandSubstringMatcher,
+        normalize_command_subject,
+    )
+
+    subject = normalize_command_subject(("python", "-c", 'print("rm -rf")'))
+
+    assert not CommandSubstringMatcher("rm -rf").matches(subject)
+
+
+def test_policy_evaluator_chain_most_restrictive_runs_all_in_stable_order() -> None:
+    from loushang.harness.policy import (
+        CustomPolicySubject,
+        PolicyDecision,
+        PolicyEvaluatorChain,
+        evaluate_policy,
+    )
+
+    calls: list[str] = []
+
+    class Evaluator:
+        def __init__(self, name: str, decision: PolicyDecision | None) -> None:
+            self.name = name
+            self.decision = decision
+
+        async def evaluate(self, subject):
+            del subject
+            calls.append(self.name)
+            return self.decision
+
+    chain = PolicyEvaluatorChain(
+        (
+            Evaluator("allow", PolicyDecision.allow()),
+            Evaluator("first-deny", PolicyDecision.deny("first", code="one")),
+            Evaluator("second-deny", PolicyDecision.deny("second", code="two")),
+        ),
+        strategy="most_restrictive",
+    )
+
+    decision = asyncio.run(evaluate_policy(chain, CustomPolicySubject("demo")))
+
+    assert calls == ["allow", "first-deny", "second-deny"]
+    assert decision == PolicyDecision.deny("first", code="one")
+
+
+def test_policy_evaluator_chain_strategies_preserve_abstention() -> None:
+    from loushang.harness.policy import (
+        CustomPolicySubject,
+        PolicyDecision,
+        PolicyEvaluatorChain,
+        evaluate_policy,
+    )
+
+    class ConstantEvaluator:
+        def __init__(self, decision: PolicyDecision | None) -> None:
+            self.decision = decision
+
+        def evaluate(self, subject):
+            del subject
+            return self.decision
+
+    subject = CustomPolicySubject("demo")
+    abstaining = PolicyEvaluatorChain(
+        (ConstantEvaluator(None), ConstantEvaluator(None)),
+        strategy="first_non_allow",
+    )
+    first = PolicyEvaluatorChain(
+        (
+            ConstantEvaluator(None),
+            ConstantEvaluator(PolicyDecision.allow()),
+            ConstantEvaluator(PolicyDecision.deny("later")),
+        ),
+        strategy="first_decision",
+    )
+
+    assert asyncio.run(evaluate_policy(abstaining, subject)) is None
+    assert asyncio.run(evaluate_policy(first, subject)) == PolicyDecision.allow()
+
+
+def test_policy_evaluator_wraps_evaluate_property_failures() -> None:
+    from loushang.harness.policy import (
+        CustomPolicySubject,
+        PolicyEvaluationError,
+        evaluate_policy,
+    )
+
+    class ExplosiveEvaluator:
+        @property
+        def evaluate(self):
+            raise RuntimeError("shape exploded")
+
+    with pytest.raises(PolicyEvaluationError, match="shape exploded"):
+        asyncio.run(
+            evaluate_policy(ExplosiveEvaluator(), CustomPolicySubject("test"))  # type: ignore[arg-type]
+        )
+
+
+def test_workspace_policy_wraps_protocol_and_decision_property_failures() -> None:
+    from loushang.harness.policy import PolicyDecision, PolicyEvaluationError
+    from loushang.harness.tools.workspace.policy import enforce_tool_policy
+
+    class ExplosiveProtocol:
+        @property
+        def evaluate(self):
+            raise RuntimeError("protocol exploded")
+
+    with pytest.raises(PolicyEvaluationError, match="protocol exploded"):
+        asyncio.run(
+            enforce_tool_policy(
+                ExplosiveProtocol(),
+                tool_name="read",
+                arguments={},
+            )
+        )
+
+    class ExplosiveDecision:
+        @property
+        def disposition(self):
+            raise RuntimeError("decision exploded")
+
+    class LegacyEvaluator:
+        def evaluate_tool_call(self, **kwargs):
+            del kwargs
+            return ExplosiveDecision()
+
+    with pytest.raises(PolicyEvaluationError, match="decision exploded"):
+        asyncio.run(
+            enforce_tool_policy(
+                LegacyEvaluator(),
+                tool_name="read",
+                arguments={},
+            )
+        )
+
+    class ExplicitNewEvaluator:
+        def evaluate(self, subject):
+            del subject
+            return PolicyDecision.allow()
+
+        @property
+        def evaluate_tool_call(self):
+            raise AssertionError("legacy getter must not be inspected")
+
+    asyncio.run(
+        enforce_tool_policy(
+            ExplicitNewEvaluator(),
+            tool_name="read",
+            arguments={},
+        )
+    )
+
+
+def test_evaluate_policy_wraps_failures_and_invalid_results() -> None:
+    from loushang.harness.policy import (
+        CustomPolicySubject,
+        PolicyDecision,
+        PolicyEvaluationError,
+        evaluate_policy,
+    )
+
+    class FailingEvaluator:
+        def evaluate(self, subject):
+            del subject
+            raise RuntimeError("broken")
+
+    class InvalidEvaluator:
+        def evaluate(self, subject):
+            del subject
+            return "allow"
+
+    malformed = PolicyDecision.allow()
+    object.__setattr__(malformed, "code", object())
+
+    class MalformedDecisionEvaluator:
+        def evaluate(self, subject):
+            del subject
+            return malformed
+
+    with pytest.raises(PolicyEvaluationError, match="broken"):
+        asyncio.run(evaluate_policy(FailingEvaluator(), CustomPolicySubject("demo")))
+    with pytest.raises(PolicyEvaluationError, match="expected PolicyDecision or None"):
+        asyncio.run(evaluate_policy(InvalidEvaluator(), CustomPolicySubject("demo")))
+    with pytest.raises(PolicyEvaluationError, match="invalid PolicyDecision"):
+        asyncio.run(
+            evaluate_policy(
+                MalformedDecisionEvaluator(),
+                CustomPolicySubject("demo"),
+            )
+        )
+
+
+def test_evaluate_policy_propagates_cancellation() -> None:
+    from loushang.harness.policy import CustomPolicySubject, evaluate_policy
+
+    class CancelledEvaluator:
+        async def evaluate(self, subject):
+            del subject
+            raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(evaluate_policy(CancelledEvaluator(), CustomPolicySubject("demo")))
+
+
+def test_workspace_policy_adapter_accepts_async_subject_evaluator() -> None:
+    from loushang.harness.policy import PolicyDecision, ToolPolicySubject
+    from loushang.harness.tools.workspace.policy import (
+        PolicyEnforcementError,
+        enforce_tool_policy,
+    )
+
+    seen: list[ToolPolicySubject] = []
+
+    class DenyWrites:
+        async def evaluate(self, subject):
+            assert isinstance(subject, ToolPolicySubject)
+            seen.append(subject)
+            return PolicyDecision.deny("writes disabled", code="disabled")
+
+    with pytest.raises(PolicyEnforcementError, match="writes disabled"):
+        asyncio.run(
+            enforce_tool_policy(
+                DenyWrites(),
+                tool_name="write",
+                arguments={"path": "notes.txt", "content": "text"},
+                cwd="/tmp/project",
+            )
+        )
+
+    assert seen[0].tool_name == "write"
+    assert seen[0].paths[0].resolved_path == "/tmp/project/notes.txt"
+
+
+def test_workspace_policy_uses_one_snapshot_across_async_evaluation() -> None:
+    from loushang.harness.approval import ApprovalDecision, ApprovalRequest
+    from loushang.harness.policy import PolicyDecision, ToolPolicySubject
+    from loushang.harness.tools.workspace.policy import (
+        PolicyEnforcementError,
+        enforce_tool_policy,
+    )
+
+    evaluation_started = asyncio.Event()
+    release_evaluation = asyncio.Event()
+    subjects: list[ToolPolicySubject] = []
+    requests: list[ApprovalRequest] = []
+    audit_events: list[dict[str, object]] = []
+
+    class BlockingEvaluator:
+        async def evaluate(self, subject: ToolPolicySubject) -> PolicyDecision:
+            subjects.append(subject)
+            evaluation_started.set()
+            await release_evaluation.wait()
+            return PolicyDecision.ask("review")
+
+    class DenyingResolver:
+        def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+            requests.append(request)
+            return ApprovalDecision.deny("denied")
+
+    arguments = {
+        "path": "before.txt",
+        "nested": {"value": "before"},
+    }
+
+    async def run() -> PolicyEnforcementError:
+        enforced = asyncio.create_task(
+            enforce_tool_policy(
+                BlockingEvaluator(),
+                tool_name="write",
+                arguments=arguments,
+                cwd="/tmp/project",
+                approval_resolver=DenyingResolver(),
+                audit_sink=audit_events.append,
+            )
+        )
+        await evaluation_started.wait()
+        arguments["path"] = "after.txt"
+        arguments["nested"]["value"] = "after"  # type: ignore[index]
+        release_evaluation.set()
+        with pytest.raises(PolicyEnforcementError) as caught:
+            await enforced
+        return caught.value
+
+    error = asyncio.run(run())
+
+    assert subjects[0].arguments["path"] == "before.txt"
+    assert subjects[0].arguments["nested"]["value"] == "before"  # type: ignore[index]
+    assert requests[0].arguments["path"] == "before.txt"
+    assert requests[0].arguments["nested"]["value"] == "before"  # type: ignore[index]
+    assert error.tool_result_details["path"] == "before.txt"
+    assert {event["path"] for event in audit_events if "path" in event} == {
+        "before.txt"
+    }
+
+
+def test_workspace_policy_adapter_rejects_unknown_evaluator() -> None:
+    from loushang.harness.policy import PolicyEvaluationError
+    from loushang.harness.tools.workspace.policy import enforce_tool_policy
+
+    with pytest.raises(PolicyEvaluationError, match="no supported evaluate method"):
+        asyncio.run(
+            enforce_tool_policy(
+                object(),
+                tool_name="read",
+                arguments={"path": "notes.txt"},
+            )
+        )
+
+
+def test_workspace_policy_rejects_subject_execution_mismatch() -> None:
+    from loushang.harness.policy import (
+        CommandPolicySubject,
+        PolicyEvaluationError,
+        ToolPolicySubject,
+        build_tool_policy_subject,
+    )
+    from loushang.harness.tools.workspace.policy import enforce_tool_policy
+
+    class UnexpectedEvaluator:
+        def evaluate(self, subject):
+            del subject
+            raise AssertionError("mismatched subject must not be evaluated")
+
+    benign = build_tool_policy_subject(
+        tool_name="read",
+        arguments={},
+        cwd="/tmp/project",
+    )
+    with pytest.raises(PolicyEvaluationError, match="tool_name, arguments, paths"):
+        asyncio.run(
+            enforce_tool_policy(
+                UnexpectedEvaluator(),
+                tool_name="write",
+                arguments={"path": "danger.txt", "content": "danger"},
+                cwd="/tmp/project",
+                policy_subject=benign,
+            )
+        )
+
+    command_arguments = {"command": ["git", "push"]}
+    forged = ToolPolicySubject(
+        tool_name="bash",
+        arguments=command_arguments,
+        cwd="/tmp/project",
+        command=CommandPolicySubject(
+            command=("git", "push"),
+            cwd="/tmp/project",
+            direct_tokens=(),
+        ),
+    )
+    with pytest.raises(PolicyEvaluationError, match="command"):
+        asyncio.run(
+            enforce_tool_policy(
+                UnexpectedEvaluator(),
+                tool_name="bash",
+                arguments=command_arguments,
+                cwd="/tmp/project",
+                policy_subject=forged,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("actual_command", "forged_command"),
+    [
+        ("rm -rf /tmp/danger", "printf safe"),
+        ("printf safe", "rm -rf /tmp/danger"),
+    ],
+)
+def test_workspace_policy_binds_string_subject_payload_to_execution_argument(
+    actual_command: str,
+    forged_command: str,
+) -> None:
+    from loushang.harness.policy import (
+        PolicyEvaluationError,
+        build_tool_policy_subject,
+        normalize_command_subject,
+    )
+    from loushang.harness.tools.workspace.policy import enforce_tool_policy
+
+    class UnexpectedEvaluator:
+        def evaluate(self, subject):
+            del subject
+            raise AssertionError("forged string subject must not be evaluated")
+
+    arguments = {"command": actual_command}
+    forged = build_tool_policy_subject(
+        tool_name="bash",
+        arguments=arguments,
+        cwd="/tmp/project",
+        command=normalize_command_subject(
+            ("/bin/bash", "-lc", forged_command),
+            cwd="/tmp/project",
+            assume_shell=True,
+        ),
+    )
+
+    with pytest.raises(PolicyEvaluationError, match="command"):
+        asyncio.run(
+            enforce_tool_policy(
+                UnexpectedEvaluator(),
+                tool_name="bash",
+                arguments=arguments,
+                cwd="/tmp/project",
+                policy_subject=forged,
+            )
+        )
+
+
+def test_workspace_policy_rejects_bash_argument_cwd_mismatch() -> None:
+    from loushang.harness.policy import (
+        PolicyEvaluationError,
+        build_tool_policy_subject,
+        normalize_command_subject,
+    )
+    from loushang.harness.tools.workspace.policy import enforce_tool_policy
+
+    class UnexpectedEvaluator:
+        def evaluate(self, subject):
+            del subject
+            raise AssertionError("cwd-mismatched subject must not be evaluated")
+
+    arguments = {
+        "command": ["bash", "stdin"],
+        "cwd": "/dev",
+        "stdin": "rm -rf /tmp/danger",
+    }
+    subject = build_tool_policy_subject(
+        tool_name="bash",
+        arguments=arguments,
+        cwd="/tmp",
+        command=normalize_command_subject(
+            ("bash", "stdin"),
+            cwd="/tmp",
+            stdin="rm -rf /tmp/danger",
+        ),
+    )
+
+    with pytest.raises(PolicyEvaluationError, match="cwd"):
+        asyncio.run(
+            enforce_tool_policy(
+                UnexpectedEvaluator(),
+                tool_name="bash",
+                arguments=arguments,
+                cwd="/tmp",
+                policy_subject=subject,
+            )
+        )
+
+
+def test_dual_protocol_policy_falls_back_to_legacy_when_new_contract_abstains() -> None:
+    from loushang.harness.policy import PolicyDecision
+    from loushang.harness.tools.workspace.policy import (
+        PolicyEnforcementError,
+        enforce_tool_policy,
+    )
+
+    class TransitionalEvaluator:
+        def evaluate(self, subject):
+            del subject
+            return None
+
+        def evaluate_tool_call(self, *, tool_name, arguments, cwd=None):
+            del arguments, cwd
+            return PolicyDecision.deny(f"legacy denied {tool_name}")
+
+    with pytest.raises(PolicyEnforcementError, match="legacy denied write"):
+        asyncio.run(
+            enforce_tool_policy(
+                TransitionalEvaluator(),
+                tool_name="write",
+                arguments={"path": "notes.txt", "content": "text"},
+            )
+        )
+
+
+def test_legacy_tool_policy_revalidates_policy_decision_instances() -> None:
+    from loushang.harness.policy import PolicyDecision, PolicyEvaluationError
+    from loushang.harness.tools.workspace.policy import enforce_tool_policy
+
+    malformed = PolicyDecision.allow()
+    object.__setattr__(malformed, "disposition", "prompt")
+
+    class MalformedLegacyEvaluator:
+        def evaluate_tool_call(self, *, tool_name, arguments, cwd=None):
+            del tool_name, arguments, cwd
+            return malformed
+
+    with pytest.raises(PolicyEvaluationError, match="invalid PolicyDecision"):
+        asyncio.run(
+            enforce_tool_policy(
+                MalformedLegacyEvaluator(),
+                tool_name="write",
+                arguments={"path": "notes.txt", "content": "text"},
+            )
+        )
+
+
+def test_dual_protocol_policy_uses_explicit_new_decision_before_legacy() -> None:
+    from loushang.harness.policy import PolicyDecision
+    from loushang.harness.tools.workspace.policy import enforce_tool_policy
+
+    class TransitionalEvaluator:
+        def evaluate(self, subject):
+            del subject
+            return PolicyDecision.allow()
+
+        def evaluate_tool_call(self, *, tool_name, arguments, cwd=None):
+            del tool_name, arguments, cwd
+            raise AssertionError("explicit new decision must be authoritative")
+
+    asyncio.run(
+        enforce_tool_policy(
+            TransitionalEvaluator(),
+            tool_name="write",
+            arguments={"path": "notes.txt", "content": "text"},
+        )
+    )
+
+
+def test_new_only_workspace_policy_uses_product_default_after_abstention() -> None:
+    from loushang.harness.tools.workspace.policy import enforce_tool_policy
+
+    class AbstainingEvaluator:
+        def evaluate(self, subject):
+            del subject
+            return None
+
+    asyncio.run(
+        enforce_tool_policy(
+            AbstainingEvaluator(),
+            tool_name="write",
+            arguments={"path": "notes.txt", "content": "text"},
+        )
+    )

--- a/tests/harness/workspace/test_exec.py
+++ b/tests/harness/workspace/test_exec.py
@@ -11,6 +11,7 @@ from loushang.harness.workspace.exec import (
     ExecRequest,
     ExecResult,
     ExecService,
+    materialize_exec_request,
 )
 
 
@@ -34,7 +35,50 @@ def test_exec_records_normalize_sequences_and_validate_rolling_limit() -> None:
         ExecRequest(command=["true"], rolling_max_bytes=0)
 
 
-def test_exec_service_delegates_to_custom_backend_and_streams_updates(tmp_path: Path) -> None:
+def test_exec_request_materialization_preserves_abi_and_freezes_process_state(
+    tmp_path: Path,
+) -> None:
+    request = ExecRequest(
+        ("printf", "ok"),
+        None,
+        (("B", "override"),),
+        5,
+    )
+    inherited = {"A": "one", "B": "base"}
+
+    materialized = materialize_exec_request(
+        request,
+        environ=inherited,
+        cwd=str(tmp_path),
+    )
+    inherited["A"] = "changed"
+
+    assert request.timeout_seconds == 5
+    assert request.env == (("B", "override"),)
+    assert request.effective_environment is None
+    assert materialized.cwd == str(tmp_path)
+    assert materialized.env == (("B", "override"),)
+    assert dict(materialized.effective_environment or ()) == {
+        "A": "one",
+        "B": "override",
+    }
+    assert (
+        materialize_exec_request(materialized, environ={"A": "later"}) is materialized
+    )
+
+
+def test_exec_request_materialization_preserves_explicit_empty_cwd() -> None:
+    materialized = materialize_exec_request(
+        ExecRequest(command=("true",), cwd=""),
+        environ={},
+    )
+
+    assert materialized.cwd == ""
+
+
+def test_exec_service_delegates_to_custom_backend_and_streams_updates(
+    tmp_path: Path,
+) -> None:
     seen: list[tuple[tuple[str, ...], str | None, object | None]] = []
     updates: list[ExecOutputChunk] = []
 
@@ -59,10 +103,50 @@ def test_exec_service_delegates_to_custom_backend_and_streams_updates(tmp_path: 
         )
 
         assert result.stdout == "remote\n"
-        assert seen == [(('deploy',), str(tmp_path), signal)]
+        assert seen == [(("deploy",), str(tmp_path), signal)]
 
     asyncio.run(scenario())
     assert updates == [ExecOutputChunk(stream="stdout", text="remote\n")]
+
+
+def test_exec_service_custom_backend_receives_one_frozen_process_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[ExecRequest] = []
+    original_cwd = tmp_path / "original"
+    changed_cwd = tmp_path / "changed"
+    original_cwd.mkdir()
+    changed_cwd.mkdir()
+    monkeypatch.chdir(original_cwd)
+    monkeypatch.setenv("HARNESS_EXEC_SNAPSHOT", "original")
+
+    async def backend(request, **kwargs):
+        del kwargs
+        captured.append(request)
+        monkeypatch.chdir(changed_cwd)
+        monkeypatch.setenv("HARNESS_EXEC_SNAPSHOT", "changed")
+        await asyncio.sleep(0)
+        return ExecResult(exit_code=0)
+
+    asyncio.run(
+        ExecService(backend=backend).execute(
+            ExecRequest(
+                command=["remote"],
+                env=(("HARNESS_EXEC_OVERRIDE", "caller"),),
+            )
+        )
+    )
+
+    request = captured[0]
+    assert request.cwd == str(original_cwd)
+    assert request.env == (("HARNESS_EXEC_OVERRIDE", "caller"),)
+    assert (
+        dict(request.effective_environment or ())["HARNESS_EXEC_SNAPSHOT"] == "original"
+    )
+    assert (
+        dict(request.effective_environment or ())["HARNESS_EXEC_OVERRIDE"] == "caller"
+    )
 
 
 def test_exec_service_rejects_invalid_backend_result() -> None:
@@ -77,7 +161,9 @@ def test_exec_service_rejects_invalid_backend_result() -> None:
     asyncio.run(scenario())
 
 
-def test_exec_service_runs_subprocess_and_preserves_interleaved_chunks(tmp_path: Path) -> None:
+def test_exec_service_runs_subprocess_and_preserves_interleaved_chunks(
+    tmp_path: Path,
+) -> None:
     updates: list[tuple[str, str]] = []
 
     async def scenario() -> None:
@@ -121,11 +207,18 @@ def test_exec_service_runs_subprocess_and_preserves_interleaved_chunks(tmp_path:
     ]
 
 
-def test_exec_service_builds_tail_preview_and_full_output_artifact(tmp_path: Path) -> None:
+def test_exec_service_builds_tail_preview_and_full_output_artifact(
+    tmp_path: Path,
+) -> None:
     async def scenario() -> None:
         result = await ExecService().execute(
             ExecRequest(
-                command=["/usr/bin/env", "python3", "-c", "print('a'); print('b'); print('c'); print('d')"],
+                command=[
+                    "/usr/bin/env",
+                    "python3",
+                    "-c",
+                    "print('a'); print('b'); print('c'); print('d')",
+                ],
                 cwd=str(tmp_path),
                 preview_max_lines=2,
                 preview_max_bytes=1024,
@@ -137,7 +230,10 @@ def test_exec_service_builds_tail_preview_and_full_output_artifact(tmp_path: Pat
         assert result.stdout_truncated is True
         assert result.stdout_truncated_by == "lines"
         assert result.stdout_artifact_path is not None
-        assert Path(result.stdout_artifact_path).read_text(encoding="utf-8") == "a\nb\nc\nd\n"
+        assert (
+            Path(result.stdout_artifact_path).read_text(encoding="utf-8")
+            == "a\nb\nc\nd\n"
+        )
 
     asyncio.run(scenario())
 
@@ -167,7 +263,9 @@ def test_exec_service_rolls_capture_without_losing_artifact(tmp_path: Path) -> N
         assert len(result.stdout.encode("utf-8")) <= 512
         assert result.stdout_preview == "line-0398\nline-0399\n"
         assert result.stdout_artifact_path is not None
-        assert Path(result.stdout_artifact_path).read_text(encoding="utf-8") == full_output
+        assert (
+            Path(result.stdout_artifact_path).read_text(encoding="utf-8") == full_output
+        )
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## English

### Summary

This PR centralizes the product-neutral control-plane runtime in `loushang.harness`. Coding retains product adapters, CLI/TUI presentation, and product defaults, while Harness owns reusable mechanisms for Coding, Design, Research, PPT, Cowork, and OEM products.

Key changes:

- establish generic policy evaluation, approval brokering, and immutable decision projections in Harness;
- add deterministic extension routing, control planning, dependency ordering, and cycle diagnostics;
- close the Host turn/session transition contract around release, replacement, observers, and disposal;
- materialize execution cwd and the complete environment before policy evaluation, approval, and the first asynchronous status update;
- reduce Coding policy, extension runner, AgentSession, CLI, and TUI code to product adapters over the Harness core;
- document the control-plane boundary and extend migration inventory and architectural import-boundary enforcement.

See [Control Plane Runtime Boundary](docs/internals/architecture/harness/control-plane-runtime-boundary.md) for the detailed design.

### Motivation and impact

Approval, policy, extension control, and session lifecycle mechanisms were previously distributed through Coding. Reusing them in another product required adopting or duplicating Coding-specific implementation. This change makes the mechanism/policy boundary explicit: Harness supplies deterministic, concurrency-safe, product-neutral control-plane behavior, while Coding continues to own UI, commands, defaults, and compatibility entry points.

Existing Coding behavior and entry points remain compatible. Route identity, dependency ordering, cycle diagnostics, approval cleanup, and session replacement semantics are covered by focused regression and stress tests.

### Validation

- Full non-live suite: `5091 passed, 8 deselected`
- Complete focused suite: `989 passed`
- Control-plane priority suite: `560 passed`
- Harness suite: `524 passed`
- Scoped Ruff check and Ruff format check for 51 changed Python files: passed
- Focused mypy across 11 core modules: passed
- `git diff --check`: passed

---

## 中文

### 概要

本 PR 将产品无关的控制面运行时集中到 `loushang.harness`，使 Coding 保留产品适配、CLI/TUI 展示和产品默认策略，而 Harness 负责可供 Coding、Design、Research、PPT、Cowork 及 OEM 产品复用的机制。

主要变更：

- 在 Harness 中建立通用 policy、approval broker 与不可变决策投影；
- 建立确定性的扩展路由、控制计划、依赖排序和循环诊断；
- 收口 Host turn/session transition 的释放、替换、observer 与 dispose 语义；
- 在 policy、approval 和首个异步状态更新前固化执行请求的 cwd 与完整环境；
- 将 Coding policy、extension runner、AgentSession、CLI/TUI 改为 Harness 核心之上的产品适配层；
- 补充控制面边界设计、迁移清单和架构 import-boundary 约束。

设计说明见 [Control Plane Runtime Boundary](docs/internals/architecture/harness/control-plane-runtime-boundary.md)。

### 动机与影响

此前审批、策略、扩展控制及会话生命周期的关键机制分散在 Coding 中，其他产品若要复用这些能力，需要复制 Coding 的产品实现。本次迁移明确了机制与产品策略之间的边界：Harness 提供确定性、并发安全且与产品无关的控制面；Coding 继续拥有 UI、命令、产品默认值和兼容入口。

现有 Coding 行为和入口保持兼容。新增路由 ID、依赖顺序、循环诊断、审批清理和 session replacement 行为均有针对性的回归与压力测试。

### 验证

- 全量非 live 测试：`5091 passed, 8 deselected`
- 完整聚焦测试集：`989 passed`
- 控制面优先测试集：`560 passed`
- Harness 测试集：`524 passed`
- 变更范围 Ruff check、51 个 Python 文件的 Ruff format check：通过
- 聚焦 mypy（11 个核心模块）：通过
- `git diff --check`：通过
