### PR TITLE
fix(tui): improve terminal cell width accuracy

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -14,6 +14,7 @@ notice bundle for packaged binaries or container images.
 | `openai` | 2.30.0 | Apache-2.0 | Package metadata |
 | `pillow` | 12.2.0 | MIT-CMU | Package metadata; ships `LICENSE` with bundled component notices |
 | `pygments` | 2.20.0 | BSD-2-Clause | Package metadata; ships `LICENSE` and `AUTHORS` |
+| `wcwidth` | 0.8.2 | MIT | Package metadata; ships `LICENSE` |
 
 ## Distribution Guidance
 

--- a/examples/tui/36_width_probe.py
+++ b/examples/tui/36_width_probe.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import os
+import re
+import select
 import shutil
+import sys
+import time
 from dataclasses import dataclass
+from typing import TextIO
 
 from loushang.tui import (
     ambiguous_width,
@@ -29,6 +35,19 @@ SAMPLES = (
     Sample("Emoji", "status ✅ ⚡️ 👍🏽 👨\u200d💻"),
 )
 
+TERMINAL_SAMPLES = (
+    Sample("Keycap", "1️⃣"),
+    Sample("Keycap group", "1️⃣ 2️⃣ 3️⃣"),
+    Sample("Keycap row", "  │ 组合 │ 1️⃣ 2️⃣ 3️⃣ │"),
+    Sample("Bullet", "•"),
+    Sample("CJK", "中"),
+)
+
+_CURSOR_POSITION_RE = re.compile(rb"\x1b\[(\d+);(\d+)R")
+_CLEAR_PROBE_LINE = "\r\x1b[2K"
+_CURSOR_POSITION_REQUEST = "\x1b[6n"
+
+
 DIAGRAM = (
     "  ┌─────────────────────────────────────────────────────────┐",
     "  │  loushang-coding  (产品装配层 - CLI/TUI/Workflow)        │",
@@ -50,6 +69,11 @@ def main() -> int:
         type=int,
         default=0,
         help="Width used to show wrap_cells output; defaults to terminal columns minus 1.",
+    )
+    parser.add_argument(
+        "--measure-terminal",
+        action="store_true",
+        help="Measure real cursor advance with terminal position reports (POSIX TTY only).",
     )
     args = parser.parse_args()
 
@@ -73,20 +97,139 @@ def main() -> int:
     for line in DIAGRAM:
         print(f"{visible_width(line):>3} | {line}")
 
-    normalized = normalize_box_drawing_diagram(DIAGRAM)
     print("")
-    print("Normalized diagram lines")
-    for line in normalized:
-        print(f"{visible_width(line):>3} | {line}")
-
-    print("")
-    print("Wrapped diagram")
+    print(f"Wrapped original diagram (max {wrap_width} cells; '+' marks continuation)")
     for line in DIAGRAM:
         wrapped = wrap_cells(line, width=wrap_width)
         for index, chunk in enumerate(wrapped):
             marker = " " if index == 0 else "+"
             print(f"{marker} {visible_width(chunk):>3} | {strip_control_sequences(chunk)}")
+
+    normalized = normalize_box_drawing_diagram(DIAGRAM)
+    print("")
+    print("Normalized diagram lines (expected aligned)")
+    for line in normalized:
+        print(f"{visible_width(line):>3} | {line}")
+
+    if args.measure_terminal:
+        print("")
+        print("Real terminal cursor advance (do not type while probing)")
+        for result in _measure_terminal_widths(stdin=sys.stdin, stdout=sys.stdout):
+            print(result)
     return 0
+
+
+def _measure_terminal_widths(
+    *,
+    stdin: TextIO,
+    stdout: TextIO,
+    timeout: float = 0.5,
+    query_interval: float = 0.25,
+) -> tuple[str, ...]:
+    if os.name != "posix" or not stdin.isatty() or not stdout.isatty():
+        return ("unavailable: requires a POSIX TTY on both stdin and stdout",)
+
+    try:
+        import termios
+    except ImportError:
+        return ("unavailable: termios is unavailable",)
+
+    fd = stdin.fileno()
+    try:
+        original = termios.tcgetattr(fd)
+    except (OSError, ValueError) as error:
+        return (f"unavailable: cannot enter terminal probe mode: {error}",)
+    probe_attrs = [*original[:6], list(original[6])]
+    probe_attrs[3] &= ~(termios.ECHO | termios.ICANON)
+    probe_attrs[6][termios.VMIN] = 1
+    probe_attrs[6][termios.VTIME] = 0
+    results: list[str] = []
+    try:
+        termios.tcsetattr(fd, termios.TCSADRAIN, probe_attrs)
+        termios.tcflush(fd, termios.TCIFLUSH)
+        origin = _query_cursor_position(fd=fd, stdout=stdout, timeout=timeout)
+        if origin is None:
+            return ("unavailable: terminal did not answer a CPR cursor query",)
+
+        for sample in TERMINAL_SAMPLES:
+            time.sleep(max(0.0, query_interval))
+            termios.tcflush(fd, termios.TCIFLUSH)
+            end = _query_cursor_position(
+                fd=fd,
+                stdout=stdout,
+                sample=sample.text,
+                timeout=timeout,
+            )
+            if end is None:
+                results.append(
+                    f"PARTIAL terminal stopped answering cursor queries at {sample.label}"
+                )
+                break
+            results.append(_format_terminal_measurement(sample, origin=origin, end=end))
+            if end[0] != origin[0]:
+                break
+    except (OSError, ValueError) as error:
+        results.append(f"PARTIAL terminal query failed: {error}")
+    finally:
+        try:
+            stdout.write(_CLEAR_PROBE_LINE)
+            stdout.flush()
+            termios.tcflush(fd, termios.TCIFLUSH)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, original)
+
+    return tuple(results)
+
+
+def _query_cursor_position(
+    *,
+    fd: int,
+    stdout: TextIO,
+    timeout: float,
+    sample: str = "",
+) -> tuple[int, int] | None:
+    stdout.write(f"{_CLEAR_PROBE_LINE}{sample}{_CURSOR_POSITION_REQUEST}")
+    stdout.flush()
+    response = bytearray()
+    deadline = time.monotonic() + max(0.0, timeout)
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        readable, _, _ = select.select((fd,), (), (), remaining)
+        if not readable:
+            break
+        chunk = os.read(fd, 1024)
+        if not chunk:
+            break
+        response.extend(chunk)
+        match = _CURSOR_POSITION_RE.search(response)
+        if match is not None:
+            return int(match.group(1)), int(match.group(2))
+    return None
+
+
+def _format_terminal_measurement(
+    sample: Sample,
+    *,
+    origin: tuple[int, int],
+    end: tuple[int, int],
+) -> str:
+    model_width = visible_width(sample.text)
+    start_row, start_column = origin
+    end_row, end_column = end
+    if start_row != end_row or end_column < start_column:
+        terminal_width = "-"
+        status = "WRAPPED"
+    else:
+        measured_width = end_column - start_column
+        terminal_width = str(measured_width)
+        status = "OK" if measured_width == model_width else "MISMATCH"
+    codepoints = ",".join(f"U+{ord(char):04X}" for char in sample.text)
+    return (
+        f"{status} model={model_width} terminal={terminal_width} "
+        f"label={sample.label} cps={codepoints} text={sample.text}"
+    )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "openai>=2.30.0",
   "pillow>=12.2.0",
   "pygments>=2.19,<3",
+  "wcwidth==0.8.2",
 ]
 
 [project.scripts]

--- a/src/loushang/tui/cell_width.py
+++ b/src/loushang/tui/cell_width.py
@@ -7,12 +7,15 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Literal
 
+from wcwidth import iter_graphemes as _iter_graphemes
+from wcwidth import wcwidth as _codepoint_width
+from wcwidth import width as _terminal_width
+
 TAB_WIDTH = 3
 AMBIGUOUS_WIDTH_ENV = "LOUSHANG_TUI_AMBIGUOUS_WIDTH"
 _THAI_LAO_AM_TRANSLATION = str.maketrans({"\u0e33": "\u0e4d\u0e32", "\u0eb3": "\u0ecd\u0eb2"})
 _VISIBLE_WIDTH_CACHE_SIZE = 16_384
 _CLUSTER_WIDTH_CACHE_SIZE = 16_384
-_CHAR_WIDTH_CACHE_SIZE = 4_096
 AmbiguousWidth = Literal[1, 2]
 _AMBIGUOUS_WIDTH: AmbiguousWidth = 1
 
@@ -58,7 +61,6 @@ def set_ambiguous_width(width: AmbiguousWidth) -> None:
     _AMBIGUOUS_WIDTH = width
     _visible_width_cached.cache_clear()
     _cluster_width.cache_clear()
-    _char_width.cache_clear()
 
 
 def configure_cell_width_from_environment(env: Mapping[str, str] | None = None) -> None:
@@ -96,7 +98,23 @@ def normalize_terminal_output(text: str) -> str:
 
 
 def grapheme_clusters(text: str) -> tuple[str, ...]:
-    return tuple(_grapheme_clusters(text))
+    """Return the stable editor units used by input and cursor operations.
+
+    Display layout uses wcwidth's UAX #29 segmentation independently so this
+    width correction does not also change existing editor navigation semantics.
+    """
+
+    return tuple(_editor_grapheme_clusters(text))
+
+
+def max_display_cluster_width(text: str) -> int:
+    """Return the widest indivisible display cluster in styled text."""
+
+    visible = strip_control_sequences(text)
+    return max(
+        (_cluster_width(cluster) for cluster in _display_grapheme_clusters(visible)),
+        default=0,
+    )
 
 
 def wrap_cells(text: str, *, width: int) -> list[str]:
@@ -107,7 +125,7 @@ def wrap_cells(text: str, *, width: int) -> list[str]:
     for logical_line in strip_control_sequences(text).split("\n"):
         current = ""
         current_width = 0
-        for cluster in _grapheme_clusters(logical_line):
+        for cluster in _display_grapheme_clusters(logical_line):
             cluster_width = _cluster_width(cluster)
             if current and current_width + cluster_width > width:
                 wrapped.append(current)
@@ -285,7 +303,27 @@ def _visible_width_cached(text: str) -> int:
     plain_ascii_width = _plain_ascii_width(text)
     if plain_ascii_width is not None:
         return plain_ascii_width
-    return sum(_cluster_width(cluster) for cluster in _grapheme_clusters(strip_control_sequences(text)))
+    visible = strip_control_sequences(text)
+    if not _requires_cluster_measurement(visible):
+        return _measure_terminal_cells(visible)
+    return sum(_cluster_width(cluster) for cluster in _display_grapheme_clusters(visible))
+
+
+def _requires_cluster_measurement(text: str) -> bool:
+    # wcwidth's whole-string scanner carries state across zero-width/control
+    # characters and has special state for regional indicators and emoji skin
+    # tones.  UAX #29 may put those codepoints in separate clusters, so measuring
+    # the whole line can then disagree with wrapping and slicing.  Only use the
+    # whole-string fast path when every codepoint is independently positive and
+    # none belongs to a stateful positive-width class.
+    for char in text:
+        if (
+            _codepoint_width(char) <= 0
+            or _is_regional_indicator(char)
+            or _is_emoji_modifier(char)
+        ):
+            return True
+    return False
 
 
 def _plain_ascii_width(text: str) -> int | None:
@@ -505,17 +543,31 @@ def _break_long_ansi_token(token: str, *, width: int, tracker: _StyleTracker) ->
     return lines
 
 
-def _grapheme_clusters(text: str) -> list[str]:
+def _display_grapheme_clusters(text: str) -> list[str]:
+    return list(_iter_graphemes(text))
+
+
+def _editor_grapheme_clusters(text: str) -> list[str]:
     clusters: list[str] = []
     index = 0
     while index < len(text):
-        cluster = _next_cluster(text, index)
+        cluster = _next_editor_cluster(text, index)
         clusters.append(cluster)
         index += len(cluster)
     return clusters
 
 
 def _next_cluster(text: str, index: int) -> str:
+    char = text[index]
+    next_index = index + 1
+    if " " <= char <= "~" and (
+        next_index >= len(text) or text[next_index].isascii()
+    ):
+        return char
+    return next(_iter_graphemes(text, start=index), "")
+
+
+def _next_editor_cluster(text: str, index: int) -> str:
     cluster = text[index]
     index += 1
 
@@ -551,41 +603,38 @@ def _is_cluster_suffix(char: str) -> bool:
 
 @lru_cache(maxsize=_CLUSTER_WIDTH_CACHE_SIZE)
 def _cluster_width(cluster: str) -> int:
-    if not cluster:
-        return 0
-    if all(_char_width(char) == 0 for char in cluster):
-        return 0
-    if "\ufe0f" in cluster:
-        return 2
-    if "\u200d" in cluster:
-        return 2
-    if any(_is_emoji_width(char) or _is_regional_indicator(char) for char in cluster):
-        return 2
-    if any(_char_width(char) == 2 for char in cluster):
-        return 2
-    return sum(_char_width(char) for char in cluster)
+    return _measure_terminal_cells(cluster)
 
 
-@lru_cache(maxsize=_CHAR_WIDTH_CACHE_SIZE)
-def _char_width(char: str) -> int:
-    if char == "\t":
-        return TAB_WIDTH
-    if unicodedata.combining(char) != 0:
-        return 0
-    if char in {"\u0e4d", "\u0ecd"}:
-        return 0
-    if char == "\u200d" or "\ufe00" <= char <= "\ufe0f":
-        return 0
-    if "\U0001f3fb" <= char <= "\U0001f3ff":
-        return 0
-    if unicodedata.category(char) in {"Cc", "Cf"}:
-        return 0
-    east_asian_width = unicodedata.east_asian_width(char)
-    if east_asian_width in {"F", "W"}:
-        return 2
-    if east_asian_width == "A":
-        return _AMBIGUOUS_WIDTH
-    return 1
+def _measure_terminal_cells(text: str) -> int:
+    # Loushang expands tabs as three literal cells throughout its layout code.
+    # Keep that existing contract while delegating Unicode width to one pinned
+    # terminal model.  Control sequences are stripped before whole-line calls;
+    # ignore mode also makes isolated control characters deterministically zero.
+    expanded = text.replace("\t", " " * TAB_WIDTH)
+    measured = _terminal_width(
+        expanded,
+        control_codes="ignore",
+        ambiguous_width=_AMBIGUOUS_WIDTH,
+        term_program=False,
+    )
+    if "\ufe0e" not in expanded:
+        return measured
+
+    # VS15 requests text presentation, but many deployed terminals (and the
+    # previous Loushang/CC width models) keep an East Asian Wide base at two
+    # cells.  Preserve that conservative cursor contract without widening a
+    # narrow base such as ``A\ufe0e``.
+    without_vs15 = expanded.replace("\ufe0e", "")
+    return max(
+        measured,
+        _terminal_width(
+            without_vs15,
+            control_codes="ignore",
+            ambiguous_width=_AMBIGUOUS_WIDTH,
+            term_program=False,
+        ),
+    )
 
 
 configure_cell_width_from_environment()
@@ -595,9 +644,8 @@ def _is_regional_indicator(char: str) -> bool:
     return "\U0001f1e6" <= char <= "\U0001f1ff"
 
 
-def _is_emoji_width(char: str) -> bool:
-    codepoint = ord(char)
-    return 0x1F000 <= codepoint <= 0x1FBFF
+def _is_emoji_modifier(char: str) -> bool:
+    return "\U0001f3fb" <= char <= "\U0001f3ff"
 
 
 class _StyleTracker:

--- a/src/loushang/tui/markdown/renderer.py
+++ b/src/loushang/tui/markdown/renderer.py
@@ -12,7 +12,9 @@ from markdown_it import MarkdownIt
 from markdown_it.token import Token
 
 from loushang.tui.cell_width import (
+    ambiguous_width,
     autowrap_safe_width,
+    max_display_cluster_width,
     normalize_box_drawing_diagram,
     truncate_to_width,
     visible_width,
@@ -366,7 +368,7 @@ class MarkdownRenderer:
                 )
             )
         elif self.theme is None and self.code_highlighter is None and self.default_style is None:
-            raw_lines = list(_render_markdown_lines(self.markdown, width))
+            raw_lines = list(_render_markdown_lines(self.markdown, width, ambiguous_width()))
         else:
             cache_key = _renderer_cache_key(
                 markdown=self.markdown,
@@ -430,6 +432,7 @@ class MarkdownRenderer:
 
         context = (
             target_width,
+            ambiguous_width(),
             _theme_cache_signature(self.theme),
             _capabilities_cache_signature(self.capabilities),
             id(self.code_highlighter) if self.code_highlighter is not None else None,
@@ -553,6 +556,7 @@ def _renderer_cache_key(
     return (
         markdown,
         width,
+        ambiguous_width(),
         _theme_cache_signature(theme),
         _capabilities_cache_signature(capabilities),
         id(code_highlighter) if code_highlighter is not None else None,
@@ -590,7 +594,11 @@ def _capabilities_cache_signature(capabilities: TerminalCapabilities | None) -> 
 
 
 @lru_cache(maxsize=_MARKDOWN_LINE_CACHE_SIZE)
-def _render_markdown_lines(markdown: str, width: int) -> tuple[str, ...]:
+def _render_markdown_lines(
+    markdown: str,
+    width: int,
+    _ambiguous_width: int,
+) -> tuple[str, ...]:
     return _render_markdown_blocks(_parse_markdown_blocks(markdown), width=width)
 
 
@@ -975,6 +983,7 @@ def _render_markdown_blocks(
     if stable_block_count:
         block_cache_context = (
             width,
+            ambiguous_width(),
             _theme_cache_signature(theme),
             _capabilities_cache_signature(capabilities),
             id(code_highlighter) if code_highlighter is not None else None,
@@ -1836,13 +1845,15 @@ def _render_table(
     padded_rows = [row + [""] * (column_count - len(row)) for row in rows]
     column_widths = _table_column_widths(padded_rows, width)
     if column_widths is not None:
-        return _render_box_table(
+        boxed = _render_box_table(
             padded_rows,
             column_widths,
             table_alignments=table_alignments,
             theme=theme,
             capabilities=capabilities,
         )
+        if _box_table_lines_are_safe(boxed, width=width):
+            return boxed
 
     raw_lines: list[str] = []
     for line in lines:
@@ -1852,6 +1863,8 @@ def _render_table(
 
 def _table_column_widths(rows: list[list[str]], width: int) -> list[int] | None:
     column_count = max(len(row) for row in rows)
+    if not _box_table_glyphs_are_single_cell():
+        return None
     border_overhead = 3 * column_count + 1
     available_for_cells = width - border_overhead
     if available_for_cells < column_count:
@@ -1861,17 +1874,29 @@ def _table_column_widths(rows: list[list[str]], width: int) -> list[int] | None:
         max(visible_width(row[column]) for row in rows)
         for column in range(column_count)
     ]
+    hard_min_widths = [
+        max(1, max(max_display_cluster_width(row[column]) for row in rows))
+        for column in range(column_count)
+    ]
     min_widths = [
-        max(1, max(_longest_word_width(row[column], max_width=30) for row in rows))
+        max(
+            hard_min_widths[column],
+            max(_longest_word_width(row[column], max_width=30) for row in rows),
+        )
         for column in range(column_count)
     ]
     min_total = sum(min_widths)
     if min_total > available_for_cells:
         widths = list(min_widths)
         while sum(widths) > available_for_cells:
-            widest_index = max(range(column_count), key=lambda index: widths[index])
-            if widths[widest_index] <= 1:
-                break
+            shrinkable = [
+                index
+                for index in range(column_count)
+                if widths[index] > hard_min_widths[index]
+            ]
+            if not shrinkable:
+                return None
+            widest_index = max(shrinkable, key=lambda index: widths[index])
             widths[widest_index] -= 1
         if sum(widths) > available_for_cells:
             return None
@@ -1904,6 +1929,15 @@ def _table_column_widths(rows: list[list[str]], width: int) -> list[int] | None:
             if not grew:
                 break
     return widths
+
+
+def _box_table_glyphs_are_single_cell() -> bool:
+    return all(visible_width(glyph) == 1 for glyph in "┌─┬┐├┼┤│└┴┘")
+
+
+def _box_table_lines_are_safe(lines: list[str], *, width: int) -> bool:
+    line_widths = {visible_width(line) for line in lines}
+    return len(line_widths) == 1 and next(iter(line_widths), width + 1) <= width
 
 
 def _render_table_rows(

--- a/tests/tui/test_cell_width.py
+++ b/tests/tui/test_cell_width.py
@@ -35,6 +35,67 @@ def test_visible_width_handles_wide_combining_and_emoji_clusters() -> None:
     assert visible_width("🇺🇸") == 2
 
 
+def test_visible_width_uses_pinned_terminal_width_rules_for_complex_sequences() -> None:
+    expected_widths = {
+        "1️⃣": 2,
+        "☕︎": 2,
+        "A︎": 1,
+        "가": 2,
+        "한": 2,
+        "\U000e0100": 0,
+        "木\U000e0100": 2,
+        "กั": 1,
+        "ກັ": 1,
+        "🜀": 1,
+        "A️": 1,
+        "a\u200d👨": 3,
+        "\u200d👨": 2,
+        "ক্🙂": 3,
+        "Aᅡ्🙂": 3,
+        "中ᅡ्🙂": 4,
+        "\u200b🇺🇺": 4,
+        "🇺\n🇺": 4,
+        "👨\u200b\u200b\u200b🏽": 4,
+        "❤\u200b\u200b\u200b️": 1,
+        "A\u200b\u200b\u200bा": 1,
+        "🇸e🇺⃣্🏽າ": 6,
+    }
+
+    assert {sample: visible_width(sample) for sample in expected_widths} == expected_widths
+
+
+def test_complex_sequence_width_matches_layout_operations() -> None:
+    for sample, width in (
+        ("1️⃣", 2),
+        ("☕︎", 2),
+        ("A︎", 1),
+        ("가", 2),
+        ("กั", 1),
+        ("a\u200d👨", 3),
+        ("\u200d👨", 2),
+        ("ক্🙂", 3),
+        ("Aᅡ्🙂", 3),
+        ("中ᅡ्🙂", 4),
+        ("\u200b🇺🇺", 4),
+        ("👨\u200b\u200b\u200b🏽", 4),
+        ("🇸e🇺⃣্🏽າ", 6),
+    ):
+        assert wrap_cells(sample, width=width) == [sample]
+        assert slice_by_column(sample, start=0, length=width).text == sample
+        assert truncate_to_width(sample, max_width=width, ellipsis="") == sample
+
+    assert wrap_cells("🇺\n🇺", width=4) == ["🇺", "🇺"]
+    assert slice_by_column("🇺\n🇺", start=0, length=4).text == "🇺\n🇺"
+
+    styled_keycap = "\x1b[31m1️⃣\x1b[0m"
+    assert visible_width(styled_keycap) == 2
+    assert [strip_control_sequences(line) for line in wrap_ansi(styled_keycap, width=2)] == [
+        "1️⃣"
+    ]
+    sliced = slice_by_column(styled_keycap, start=0, length=2)
+    assert strip_control_sequences(sliced.text) == "1️⃣"
+
+
 def test_visible_width_can_treat_east_asian_ambiguous_symbols_as_wide() -> None:
     try:
         assert visible_width("┌─┐") == 3
@@ -140,12 +201,44 @@ def test_plain_ascii_width_and_truncation_use_fast_path(monkeypatch) -> None:
     def fail_unicode_path(*_args: object, **_kwargs: object) -> str:
         raise AssertionError("plain ASCII should not use Unicode cluster scanning")
 
-    monkeypatch.setattr(cell_width, "_grapheme_clusters", fail_unicode_path)
+    monkeypatch.setattr(cell_width, "_display_grapheme_clusters", fail_unicode_path)
     monkeypatch.setattr(cell_width, "_next_cluster", fail_unicode_path)
+    monkeypatch.setattr(cell_width, "_terminal_width", fail_unicode_path)
 
     assert visible_width("plain ASCII 123") == 15
     assert truncate_to_width("ab", max_width=4, pad=True) == "ab  "
     assert truncate_to_width("abcdef", max_width=4) == "a\x1b[0m...\x1b[0m"
+
+
+def test_independently_positive_unicode_uses_whole_string_fast_path(monkeypatch) -> None:
+    def fail_cluster_path(*_args: object, **_kwargs: object) -> list[str]:
+        raise AssertionError("common Unicode text should not require cluster scanning")
+
+    cell_width._visible_width_cached.cache_clear()
+    monkeypatch.setattr(cell_width, "_display_grapheme_clusters", fail_cluster_path)
+
+    assert visible_width("fast 中文 🙂") == 12
+
+
+def test_stateful_or_nonpositive_codepoints_require_cluster_measurement() -> None:
+    assert cell_width._requires_cluster_measurement("a‍👨") is True
+    assert cell_width._requires_cluster_measurement("‍👨") is True
+    assert cell_width._requires_cluster_measurement("ক্🙂") is True
+    assert cell_width._requires_cluster_measurement("Aᅡ्🙂") is True
+    assert cell_width._requires_cluster_measurement("中ᅡ्🙂") is True
+    assert cell_width._requires_cluster_measurement("\u200b🇺🇺") is True
+    assert cell_width._requires_cluster_measurement("🇺\n🇺") is True
+    assert cell_width._requires_cluster_measurement("👨\u200b\u200b\u200b🏽") is True
+    assert cell_width._requires_cluster_measurement("❤\u200b\u200b\u200b️") is True
+    assert cell_width._requires_cluster_measurement("A\u200b\u200b\u200bा") is True
+    assert cell_width._requires_cluster_measurement("🇸e🇺⃣্🏽າ") is True
+    assert cell_width._requires_cluster_measurement("1️⃣") is True
+    assert cell_width._requires_cluster_measurement("👨‍💻") is True
+    assert cell_width._requires_cluster_measurement("é") is True
+    assert cell_width._requires_cluster_measurement("🇺🇸") is True
+    assert cell_width._requires_cluster_measurement("👍🏽") is True
+
+    assert cell_width._requires_cluster_measurement("fast 中文 🙂") is False
 
 
 def test_strip_control_sequences_skips_scan_without_escape(monkeypatch) -> None:
@@ -158,19 +251,19 @@ def test_strip_control_sequences_skips_scan_without_escape(monkeypatch) -> None:
 
 
 def test_repeated_wide_character_width_uses_cache(monkeypatch) -> None:
-    cache_clear = getattr(cell_width._char_width, "cache_clear", None)
+    cache_clear = getattr(cell_width._cluster_width, "cache_clear", None)
     if callable(cache_clear):
         cache_clear()
 
     calls = 0
-    original = cell_width.unicodedata.east_asian_width
+    original = cell_width._terminal_width
 
-    def count_east_asian_width(char: str) -> str:
+    def count_terminal_width(*args: object, **kwargs: object) -> int:
         nonlocal calls
         calls += 1
-        return original(char)
+        return original(*args, **kwargs)
 
-    monkeypatch.setattr(cell_width.unicodedata, "east_asian_width", count_east_asian_width)
+    monkeypatch.setattr(cell_width, "_terminal_width", count_terminal_width)
 
     assert wrap_cells("龘龘龘", width=10) == ["龘龘龘"]
     assert wrap_cells("龘龘龘", width=10) == ["龘龘龘"]

--- a/tests/tui/test_content_theme.py
+++ b/tests/tui/test_content_theme.py
@@ -32,6 +32,7 @@ from loushang.tui import (
     hyperlink,
     is_terminal_image_line,
     render_terminal_image,
+    set_ambiguous_width,
     strip_control_sequences,
     theme_capabilities_from_runtime,
     visible_width,
@@ -925,6 +926,138 @@ def test_markdown_renderer_applies_pi_table_alignment_markers() -> None:
         "│ A    │   B    │     C │",
         "└──────┴────────┴───────┘",
     )
+
+
+def test_markdown_renderer_aligns_complex_unicode_cells_with_terminal_width() -> None:
+    renderer = MarkdownRenderer(
+        "| Key | Value |\n"
+        "| --- | --- |\n"
+        "| 1️⃣ | 中 |\n"
+        "| ☕︎ | A |\n"
+    )
+
+    lines = rendered_text(renderer, width=30, height=20)
+
+    assert lines == (
+        "┌─────┬───────┐",
+        "│ Key │ Value │",
+        "├─────┼───────┤",
+        "│ 1️⃣  │ 中    │",
+        "├─────┼───────┤",
+        "│ ☕︎  │ A     │",
+        "└─────┴───────┘",
+    )
+    assert {visible_width(line) for line in lines} == {15}
+
+
+def test_markdown_renderer_falls_back_when_wide_cells_cannot_fit_box_columns() -> None:
+    markdown = (
+        "| K | V |\n"
+        "| --- | --- |\n"
+        "| 中 | A |\n"
+        "| 文 | B |\n"
+    )
+
+    narrow = tuple(
+        strip_control_sequences(line)
+        for line in rendered_text(MarkdownRenderer(markdown), width=10)
+    )
+    roomy = rendered_text(MarkdownRenderer(markdown), width=11)
+    combining = rendered_text(
+        MarkdownRenderer("| K | V |\n| --- | --- |\n| é | A |\n"),
+        width=10,
+    )
+
+    assert not any(set(line) & set("┌─┬┐├┼┤│└┴┘") for line in narrow)
+    assert all(visible_width(line) <= 9 for line in narrow)
+    joined = "\n".join(narrow)
+    assert all(joined.count(value) == 1 for value in ("中", "文", "A", "B"))
+    assert {visible_width(line) for line in roomy} == {10}
+    assert roomy[3] == "│ 中 │ A │"
+    assert {visible_width(line) for line in combining} == {9}
+    assert combining[3] == "│ é │ A │"
+
+
+def test_markdown_renderer_falls_back_when_box_glyphs_are_ambiguous_wide() -> None:
+    markdown = "| Ambiguous policy | Value |\n| --- | --- |\n| row | Ω |\n"
+    try:
+        set_ambiguous_width(1)
+        renderer = MarkdownRenderer(markdown)
+        narrow_policy_lines = rendered_text(renderer, width=40)
+        assert any(set(line) & set("┌─┬┐├┼┤│└┴┘") for line in narrow_policy_lines)
+
+        set_ambiguous_width(2)
+
+        lines = rendered_text(renderer, width=40)
+
+        assert not any(
+            set(strip_control_sequences(line)) & set("┌─┬┐├┼┤│└┴┘")
+            for line in lines
+        )
+        assert all(visible_width(line) <= 39 for line in lines)
+        assert "Ω" in "\n".join(lines)
+    finally:
+        set_ambiguous_width(1)
+
+
+def test_markdown_renderer_cached_paths_follow_ambiguous_width_policy() -> None:
+    markdown = "| Cached | Value |\n| --- | --- |\n| row | Ω |\n"
+    shared_cache = markdown_renderer_module.MarkdownRenderCache()
+    renderers = (
+        MarkdownRenderer(
+            markdown + "\nThemed tail",
+            theme=ThemeResolver(defaults={"markdown.table.header": {"bold": True}}),
+        ),
+        MarkdownRenderer(
+            markdown + "\nShared tail",
+            render_cache=shared_cache,
+        ),
+    )
+    try:
+        set_ambiguous_width(1)
+        prewarmed = [rendered_text(renderer, width=40) for renderer in renderers]
+        assert all(
+            any("┌" in strip_control_sequences(line) for line in lines)
+            for lines in prewarmed
+        )
+
+        set_ambiguous_width(2)
+        rerendered = [rendered_text(renderer, width=40) for renderer in renderers]
+
+        assert all(
+            not any(
+                set(strip_control_sequences(line)) & set("┌─┬┐├┼┤│└┴┘")
+                for line in lines
+            )
+            for lines in rerendered
+        )
+    finally:
+        set_ambiguous_width(1)
+
+
+def test_markdown_renderer_rejects_unsafe_box_render_result(monkeypatch) -> None:
+    unsafe_results = (
+        ["┌─┐", "│ too wide │"],
+        ["x" * 40, "y" * 40],
+    )
+    for index, unsafe in enumerate(unsafe_results):
+        monkeypatch.setattr(
+            markdown_renderer_module,
+            "_render_box_table",
+            lambda *_args, unsafe=unsafe, **_kwargs: unsafe,
+        )
+        marker = f"Guard{index}"
+        renderer = MarkdownRenderer(
+            f"| {marker} | Value |\n| --- | --- |\n| row | safe |\n"
+        )
+
+        lines = tuple(
+            strip_control_sequences(line)
+            for line in rendered_text(renderer, width=40)
+        )
+
+        assert not any(set(line) & set("┌─┬┐├┼┤│└┴┘") for line in lines)
+        assert marker in "\n".join(lines)
 
 
 def test_markdown_renderer_table_stress_cases_preserve_width_and_row_dividers() -> None:

--- a/tests/tui/test_streaming_markdown.py
+++ b/tests/tui/test_streaming_markdown.py
@@ -4,6 +4,11 @@ from collections.abc import Iterable
 
 import pytest
 
+from loushang.tui import (
+    RenderConstraints,
+    set_ambiguous_width,
+    strip_control_sequences,
+)
 from loushang.tui.markdown import renderer as markdown_renderer
 
 
@@ -213,3 +218,44 @@ def test_markdown_render_cache_resets_streaming_state_for_new_key() -> None:
 
     assert cache._streaming_parse_state is not first_state
     assert blocks == markdown_renderer._parse_markdown_blocks("Alpha\n\nTail grows")
+
+
+def test_streaming_render_cache_context_follows_ambiguous_width_policy() -> None:
+    source = (
+        "| Stream | Value |\n"
+        "| --- | --- |\n"
+        "| row | Ω |\n\n"
+        "First\n\nSecond\n\nThird"
+    )
+    cache = markdown_renderer.MarkdownRenderCache()
+    renderer = markdown_renderer.MarkdownRenderer(
+        source,
+        render_cache=cache,
+        streaming_key=object(),
+    )
+    constraints = RenderConstraints(width=40, max_height=100)
+    try:
+        set_ambiguous_width(1)
+        narrow = renderer.render_streaming_segments(constraints)
+        assert narrow is not None
+        narrow_lines = [
+            strip_control_sequences(line)
+            for segment in narrow.segments
+            for line in segment.lines
+        ]
+        assert any("┌" in line for line in narrow_lines)
+        narrow_context = cache._streaming_render_context
+
+        set_ambiguous_width(2)
+        wide = renderer.render_streaming_segments(constraints)
+        assert wide is not None
+        wide_lines = [
+            strip_control_sequences(line)
+            for segment in wide.segments
+            for line in segment.lines
+        ]
+
+        assert cache._streaming_render_context != narrow_context
+        assert not any(set(line) & set("┌─┬┐├┼┤│└┴┘") for line in wide_lines)
+    finally:
+        set_ambiguous_width(1)

--- a/tests/tui/test_widgets_table.py
+++ b/tests/tui/test_widgets_table.py
@@ -88,6 +88,28 @@ def test_table_renders_header_rows_fixed_flexible_widths_and_alignment() -> None
     )
 
 
+def test_table_aligns_complex_unicode_cells_with_terminal_width() -> None:
+    table = Table(
+        [
+            TableColumn("key", "Key", width=4),
+            TableColumn("value", "Value", width=5, align="right"),
+        ],
+        [
+            TableRow("keycap", {"key": "1️⃣", "value": "中"}),
+            TableRow("text-presentation", {"key": "☕︎", "value": "A"}),
+        ],
+    )
+
+    lines = plain_lines(table, width=14, height=4)
+
+    assert lines == (
+        "  Key   Value",
+        "  1️⃣       中",
+        "  ☕︎        A",
+    )
+    assert {visible_width(line) for line in lines} == {13}
+
+
 def test_table_truncates_narrow_width_and_short_height() -> None:
     table = Table(
         [

--- a/tests/tui/test_width_probe_example.py
+++ b/tests/tui/test_width_probe_example.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import runpy
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+def test_width_probe_restores_termios_when_cleanup_output_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    namespace = runpy.run_path("examples/tui/36_width_probe.py", run_name="__test__")
+    measure_terminal_widths = namespace["_measure_terminal_widths"]
+
+    original = [1, 2, 3, 4, 5, 6, [7, 8]]
+    restored: list[list[Any]] = []
+
+    def tcgetattr(_fd: int) -> list[Any]:
+        return original
+
+    def tcsetattr(_fd: int, _when: int, attrs: list[Any]) -> None:
+        restored.append(attrs)
+
+    fake_termios = SimpleNamespace(
+        ECHO=1,
+        ICANON=2,
+        VMIN=0,
+        VTIME=1,
+        TCSADRAIN=3,
+        TCIFLUSH=4,
+        tcgetattr=tcgetattr,
+        tcsetattr=tcsetattr,
+        tcflush=lambda *_args: None,
+    )
+
+    class FakeStdin:
+        @staticmethod
+        def isatty() -> bool:
+            return True
+
+        @staticmethod
+        def fileno() -> int:
+            return 7
+
+    class FailingStdout:
+        @staticmethod
+        def isatty() -> bool:
+            return True
+
+        @staticmethod
+        def write(_text: str) -> None:
+            raise OSError("cleanup failed")
+
+        @staticmethod
+        def flush() -> None:
+            return None
+
+    monkeypatch.setitem(sys.modules, "termios", fake_termios)
+    monkeypatch.setitem(
+        measure_terminal_widths.__globals__,
+        "_query_cursor_position",
+        lambda **_kwargs: (1, 1),
+    )
+
+    with pytest.raises(OSError, match="cleanup failed"):
+        measure_terminal_widths(
+            stdin=FakeStdin(),
+            stdout=FailingStdout(),
+            query_interval=0,
+        )
+
+    assert len(restored) == 2
+    assert restored[-1] is original

--- a/uv.lock
+++ b/uv.lock
@@ -392,6 +392,7 @@ dependencies = [
     { name = "openai" },
     { name = "pillow" },
     { name = "pygments" },
+    { name = "wcwidth" },
 ]
 
 [package.optional-dependencies]
@@ -414,6 +415,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7,<8" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11,<1" },
+    { name = "wcwidth", specifier = "==0.8.2" },
 ]
 provides-extras = ["dev"]
 
@@ -900,4 +902,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]


### PR DESCRIPTION
## Summary

- replace the hand-written Unicode width heuristic with a pinned `wcwidth==0.8.2` terminal model while preserving existing editor grapheme semantics
- use whole-string measurement only for independently positive codepoints; fall back to UAX grapheme measurement for controls, zero-width state, regional indicators, and emoji modifiers
- make Markdown table sizing/cache contexts width-policy aware and fall back to raw Markdown when box rendering cannot be proven cell-safe
- add a real-terminal cursor-advance probe for CJK, box drawing, keycaps, variation selectors, and emoji sequences

## Root cause

The previous model treated broad Unicode ranges as fixed-width and used custom cluster rules. That disagreed with real terminals for sequences such as keycaps, variation selectors, decomposed text, and some combining scripts. Measuring an entire string directly is also not always additive: the terminal-width scanner can carry state across UAX grapheme boundaries. This change keeps the common positive-width path fast and conservatively uses exact cluster measurement whenever that state may matter.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q` — 1192 passed
- focused width/Markdown/probe suite — 157 passed
- `uv --cache-dir .uv-cache run --extra dev ruff check ...`
- `uv --cache-dir .uv-cache lock --check`
- `git diff --check`
- 111,150 exhaustive representative sequences plus 200,000 randomized sequences: no fast-path mismatch
- independent reviewer sweep of 346,200 sequences: no mismatch
- real terminal CPR: `1️⃣` measured as 2 cells and keycap group/row measurements matched the model

An extra full-repository run stops on the unrelated existing architecture assertion `test_legacy_agent_harness_package_has_been_removed` because `src/loushang/agent/harness` is present; the TUI suite is fully green.
