### PR TITLE
test(coding): align Kimi Code provider fixtures

### DIFF
--- a/tests/coding/test_prompt_command.py
+++ b/tests/coding/test_prompt_command.py
@@ -97,7 +97,7 @@ def test_prompt_command_selects_usable_model_before_prompt() -> None:
 
     kimi = Model(
         id="kimi-for-coding",
-        provider="moonshot",
+        provider="kimi-code",
         endpoint="kimi-code-anthropic",
     )
 
@@ -147,7 +147,7 @@ def test_prompt_command_selects_usable_model_before_prompt() -> None:
 
         assert exit_code == 0
         assert session.set_model_calls == [kimi]
-        assert session.prompt_calls == [("hello", ModelSelection(provider="moonshot", model_id="kimi-for-coding"))]
+        assert session.prompt_calls == [("hello", ModelSelection(provider="kimi-code", model_id="kimi-for-coding"))]
 
     asyncio.run(scenario())
 

--- a/tests/coding/test_ui_model.py
+++ b/tests/coding/test_ui_model.py
@@ -39,13 +39,13 @@ def test_model_label_from_selection_hides_unknown_model() -> None:
 def test_model_label_from_selection_formats_provider_and_model() -> None:
     from loushang.coding.ui.model import model_label_from_selection
 
-    assert model_label_from_selection(ModelSelection(provider="moonshot", model_id="kimi-for-coding")) == "moonshot/kimi-for-coding"
+    assert model_label_from_selection(ModelSelection(provider="kimi-code", model_id="kimi-for-coding")) == "kimi-code/kimi-for-coding"
 
 
 def test_ensure_usable_session_model_keeps_existing_usable_model() -> None:
     from loushang.coding.ui.model import ensure_usable_session_model
 
-    current = ModelSelection(provider="moonshot", model_id="kimi-for-coding")
+    current = ModelSelection(provider="kimi-code", model_id="kimi-for-coding")
     session = _Session(current=current)
 
     result = asyncio.run(ensure_usable_session_model(session))
@@ -57,8 +57,8 @@ def test_ensure_usable_session_model_keeps_existing_usable_model() -> None:
 def test_ensure_usable_session_model_prefers_kimi_coding_anthropic_detail() -> None:
     from loushang.coding.ui.model import ensure_usable_session_model
 
-    preferred = Model(id="kimi-for-coding", provider="moonshot", endpoint="kimi-code-anthropic")
-    fallback = Model(id="kimi-for-coding", provider="moonshot", endpoint="openai-completions:cn:coding")
+    preferred = Model(id="kimi-for-coding", provider="kimi-code", endpoint="kimi-code-anthropic")
+    fallback = Model(id="kimi-for-coding", provider="kimi-code", endpoint="openai-completions:cn:coding")
     session = _Session(
         current=ModelSelection(provider="unknown", model_id="unknown"),
         details=[fallback, preferred],
@@ -66,14 +66,14 @@ def test_ensure_usable_session_model_prefers_kimi_coding_anthropic_detail() -> N
 
     result = asyncio.run(ensure_usable_session_model(session))
 
-    assert result == ModelSelection(provider="moonshot", model_id="kimi-for-coding")
+    assert result == ModelSelection(provider="kimi-code", model_id="kimi-for-coding")
     assert session.set_model_calls == [preferred]
 
 
 def test_ensure_usable_session_model_falls_back_to_available_selection() -> None:
     from loushang.coding.ui.model import ensure_usable_session_model
 
-    fallback = ModelSelection(provider="moonshot", model_id="kimi-for-coding")
+    fallback = ModelSelection(provider="kimi-code", model_id="kimi-for-coding")
     session = _Session(
         current=ModelSelection(provider="unknown", model_id="unknown"),
         selections=[fallback],


### PR DESCRIPTION
## Summary

- update the remaining Kimi Coding fixtures in `tests/coding/test_ui_model.py` and `tests/coding/test_prompt_command.py` from provider `moonshot` to `kimi-code`
- align the rendered model-label expectation with `kimi-code/kimi-for-coding`
- keep `PREFERRED_CODING_MODELS`, production catalog code, harness, TUI, and unrelated model behavior unchanged

## Root cause

PR #243 split Kimi Coding into the `kimi-code/kimi-code-anthropic/kimi-for-coding` provider contract and updated the production catalog/default selection. Its validation covered the AI checks, but these pre-existing coding fixtures and expectations were outside that test boundary, leaving them on the old `moonshot` contract.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_ui_model.py tests/coding/test_prompt_command.py -m "not live" -q`
  - 9 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding -m "not live" -q`
  - 2151 passed, 1 failed
- `uv --cache-dir .uv-cache run --extra dev pytest tests -m "not live" -q`
  - 4264 passed, 8 deselected, 1 failed

Both broader runs have the same pre-existing local-environment failure: `tests/coding/test_agent_session.py::test_agent_session_exposes_jsonl_and_html_export_methods` cannot create `/tmp/project/*.jsonl.lock` and raises `PermissionError: [Errno 13]`. The shared `/tmp/project` permissions are local environment state and are unrelated to this fixture-only change.
