### PR TITLE
test(coding): isolate session export paths

### DIFF
--- a/tests/coding/test_agent_session.py
+++ b/tests/coding/test_agent_session.py
@@ -4577,7 +4577,10 @@ def test_agent_session_exposes_jsonl_and_html_export_methods(tmp_path) -> None:
     from loushang.coding.session import AgentSession
     from loushang.coding.store import SessionManager
 
-    manager = SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    manager = SessionManager.new(session_dir=tmp_path, cwd=str(project_dir), persist=False)
     manager.append_message(
         UserMessage(
             role="user",


### PR DESCRIPTION
## Summary

- create a per-test project directory under pytest's `tmp_path`
- point the session export test's `cwd` at that isolated directory instead of the shared `/tmp/project` path
- leave production JSONL and HTML export behavior unchanged

## Root cause

`test_agent_session_exposes_jsonl_and_html_export_methods` used a hard-coded `/tmp/project` cwd. Session export writes lock and output files beneath the session cwd, so the test depended on host-specific ownership and permissions for a shared absolute path. Using a directory owned by the test restores pytest isolation.

## Impact

The export contract remains unchanged, while the test no longer fails when `/tmp/project` is not writable in the local or CI environment.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_agent_session.py::test_agent_session_exposes_jsonl_and_html_export_methods -q`
  - 1 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_agent_session.py -m "not live" -q`
  - 105 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding -m "not live" -q`
  - 2152 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests -m "not live" -q`
  - 4265 passed, 8 deselected
