### PR TITLE
fix(tui): restore interactive perf example startup

### DIFF
--- a/examples/tui/33_native_coding_markdown_perf_trim_interactive.py
+++ b/examples/tui/33_native_coding_markdown_perf_trim_interactive.py
@@ -11,7 +11,7 @@ from loushang.coding.ui.screen_loop import run_screen_coding_tui
 
 if TYPE_CHECKING:
     from loushang.coding.ui.screen_app import (
-        ScreenCodingTuiApp as _PerfNativeCodingTuiAppBase,
+        ScreenCodingTuiApp as _PerfScreenCodingTuiAppBase,
     )
 
 
@@ -29,13 +29,17 @@ def _load_example(filename: str, module_name: str) -> Any:
     return module
 
 
-_perf31 = _load_example("31_native_coding_markdown_perf.py", "_native_coding_markdown_perf31_for33")
-_perf32 = _load_example("32_native_coding_markdown_perf_trim.py", "_native_coding_markdown_perf32_for33")
+_perf31 = _load_example(
+    "31_native_coding_markdown_perf.py", "_native_coding_markdown_perf31_for33"
+)
+_perf32 = _load_example(
+    "32_native_coding_markdown_perf_trim.py", "_native_coding_markdown_perf32_for33"
+)
 if not TYPE_CHECKING:
-    _PerfNativeCodingTuiAppBase = _perf31.PerfNativeCodingTuiApp
+    _PerfScreenCodingTuiAppBase = _perf31.PerfScreenCodingTuiApp
 
 
-class TrimInteractiveNativeCodingTuiApp(_PerfNativeCodingTuiAppBase):
+class TrimInteractiveScreenCodingTuiApp(_PerfScreenCodingTuiAppBase):
     __slots__ = ("trim_events",)
 
     def __init__(self, *, active_line_budget: int, **kwargs: Any) -> None:
@@ -61,7 +65,9 @@ class TrimInteractiveNativeCodingTuiApp(_PerfNativeCodingTuiAppBase):
                 f"budget={self.active_transcript_line_budget}"
             )
         else:
-            self.set_status(f"active window records={len(self.state.records)} budget={self.active_transcript_line_budget}")
+            self.set_status(
+                f"active window records={len(self.state.records)} budget={self.active_transcript_line_budget}"
+            )
 
 
 async def run_interactive(
@@ -71,7 +77,7 @@ async def run_interactive(
     stream_seconds: float,
     active_line_budget: int,
 ) -> int:
-    app = TrimInteractiveNativeCodingTuiApp(
+    app = TrimInteractiveScreenCodingTuiApp(
         model_label="fake-model",
         cwd="/repo",
         branch="markdown-perf-trim-interactive",
@@ -99,15 +105,28 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Interactive fake-model Markdown performance harness with per-turn active transcript trimming."
     )
-    parser.add_argument("--script-count", type=int, help="run scripted fake prompts instead of interactive mode")
-    parser.add_argument("--script-rounds", type=int, default=1, help="number of scripted fake prompts to run")
+    parser.add_argument(
+        "--script-count",
+        type=int,
+        help="run scripted fake prompts instead of interactive mode",
+    )
+    parser.add_argument(
+        "--script-rounds",
+        type=int,
+        default=1,
+        help="number of scripted fake prompts to run",
+    )
     parser.add_argument(
         "--active-line-budget",
         type=int,
         default=180,
         help="active transcript line budget applied after every completed turn",
     )
-    parser.add_argument("--show-final", action="store_true", help="print the final rendered snapshot in script mode")
+    parser.add_argument(
+        "--show-final",
+        action="store_true",
+        help="print the final rendered snapshot in script mode",
+    )
     parser.add_argument(
         "--stream-seconds",
         type=float,
@@ -120,7 +139,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=80,
         help="script render coalescing interval; use 0 to render every chunk",
     )
-    parser.add_argument("--trace-memory", action="store_true", help="enable tracemalloc current/peak memory stats")
+    parser.add_argument(
+        "--trace-memory",
+        action="store_true",
+        help="enable tracemalloc current/peak memory stats",
+    )
     parser.add_argument("--width", type=int, default=100, help="script snapshot width")
     parser.add_argument("--height", type=int, default=32, help="script snapshot height")
     return parser.parse_args(argv)

--- a/tests/coding/test_screen_coding_tui_perf_examples.py
+++ b/tests/coding/test_screen_coding_tui_perf_examples.py
@@ -18,6 +18,12 @@ from loushang.tui import (
 _EXAMPLE = (
     Path(__file__).parents[2] / "examples" / "tui" / "31_native_coding_markdown_perf.py"
 )
+_TRIM_INTERACTIVE_EXAMPLE = (
+    Path(__file__).parents[2]
+    / "examples"
+    / "tui"
+    / "33_native_coding_markdown_perf_trim_interactive.py"
+)
 
 
 def test_markdown_perf_fixture_starts_a_new_block_every_twenty_lines() -> None:
@@ -100,6 +106,19 @@ def test_markdown_perf_example_runs_against_screen_tui() -> None:
     assert "contains_last_line=True" in completed.stdout
     positions = [completed.stdout.index(f"Line {index}:") for index in range(1, 5)]
     assert positions == sorted(positions)
+
+
+def test_markdown_perf_trim_interactive_example_loads_screen_app() -> None:
+    completed = subprocess.run(
+        [sys.executable, str(_TRIM_INTERACTIVE_EXAMPLE), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "--active-line-budget" in completed.stdout
 
 
 class _LengthOnlyLines:


### PR DESCRIPTION
## Summary

- update the interactive trimmed Markdown performance example to use the `ScreenCodingTuiApp` naming contract
- replace the stale dynamic reference to the removed `PerfNativeCodingTuiApp` symbol
- add a user-level `--help` smoke test so dynamic example loading cannot regress silently

## Root cause

PR #262 renamed the main performance harness class to `PerfScreenCodingTuiApp`, but example 33 still loaded `PerfNativeCodingTuiApp` dynamically. As a result, even invoking the example with `--help` failed immediately with `AttributeError`.

## Scope

This PR changes only:

- `examples/tui/33_native_coding_markdown_perf_trim_interactive.py`
- `tests/coding/test_screen_coding_tui_perf_examples.py`

## Validation

- `ruff format --check` — passed
- `ruff check` — passed
- `pytest tests/coding/test_screen_coding_tui_perf_examples.py -q` — 5 passed
- `pytest tests/coding/test_ui_import_boundaries.py -q` — 6 passed
- example 33 `--help` — passed
- example 33 scripted render/trim run — passed
