### PR TITLE
test(tui): freeze render performance contract / 冻结渲染性能契约

### DIFF
--- a/.github/workflows/tui-render-contract.yml
+++ b/.github/workflows/tui-render-contract.yml
@@ -1,0 +1,25 @@
+name: TUI Render Contract
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  tui-render-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: make bootstrap
+
+      - name: TUI render contract
+        run: make test-tui-render-contract

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BINARY_NAME := loushang$(EXE_EXT)
 DIST_BINARY := dist/$(BINARY_NAME)
 AI_OFFLINE_ENV := env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_OAUTH_TOKEN -u ANTHROPIC_BASE_URL -u ARK_API_KEY -u BAIDU_QIANFAN_API_KEY -u COPILOT_GITHUB_TOKEN -u DASHSCOPE_API_KEY -u DEEPSEEK_API_KEY -u GH_TOKEN -u GITHUB_TOKEN -u HUNYUAN_API_KEY -u MINIMAX_API_KEY -u MOONSHOT_API_KEY -u OPENAI_API_KEY -u QIANFAN_API_KEY -u STEPFUN_API_KEY -u STEP_API_KEY -u ZAI_API_KEY
 
-.PHONY: bootstrap test test-ai check-ai test-tui lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools vendor-ai-openai-codex-complete example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-advanced-openai-codex-login example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip
+.PHONY: bootstrap test test-ai check-ai test-tui test-tui-render-contract lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools vendor-ai-openai-codex-complete example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-advanced-openai-codex-login example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip
 .PHONY: check-ai-catalog check-ai-examples check-ai-imports check-ai-coverage
 
 bootstrap:
@@ -48,6 +48,9 @@ check-ai-coverage:
 
 test-tui:
 	. .venv/bin/activate && python -m pytest tests/tui -q
+
+test-tui-render-contract:
+	uv --cache-dir .uv-cache run pytest tests/tui tests/coding -m tui_render_contract -q
 
 lint-ai:
 	. .venv/bin/activate && uv run ruff check src/loushang/ai tests/ai tests/providers

--- a/docs/internals/architecture/tui/native-terminal-core/README.md
+++ b/docs/internals/architecture/tui/native-terminal-core/README.md
@@ -63,6 +63,7 @@ This document set is written for three groups:
 - [Renderer Spec Inventory](./renderers/README.md)
 - [Terminal UX Reference Alignment](./reference/terminal-ux-feature-alignment.md)
 - [Testing Strategy](./testing-strategy.md)
+- [Render Performance Contract](./render-performance-contract.md)
 - [Development Slices](./development-slices.md)
 
 Later design passes may add:

--- a/docs/internals/architecture/tui/native-terminal-core/render-performance-contract.md
+++ b/docs/internals/architecture/tui/native-terminal-core/render-performance-contract.md
@@ -1,0 +1,141 @@
+# TUI Render Performance Contract
+
+## Status
+
+Frozen on 2026-07-16 against `main` commit
+`5fbf2674a82b1585bae729e93e7c63fb6ae45a5f`.
+The initial isolated contract run contains 151 passing cases.
+
+This contract is the guardrail for later TUI extraction and refactoring. The
+freeze itself changes tests, test entry points, and documentation only. It does
+not change the renderer, markdown renderer, transcript projection, or coding UI
+implementation.
+
+## Boundary
+
+The contract has two layers:
+
+- `loushang.tui` owns generic render segments, render planning, terminal
+  operations, streaming markdown rendering, transcript rendering, and cache
+  bounds.
+- Marked `loushang.coding.ui` tests are integration probes. They prove that a
+  product adapter can project a long or streaming conversation without
+  defeating the generic TUI fast paths.
+
+The integration probes do not make session lifecycle, tools, approval policy,
+or coding command semantics responsibilities of `loushang.tui`. If generic
+conversation interaction later moves to `harnesstui`, the marked probes may
+move with it, but their observable contract must not be weakened during the
+move.
+
+## Hard Frame Budgets
+
+All budgets below apply after the initial frame. Synchronized output is
+required in every case.
+
+| Scenario | Disallowed operation classes | Max operations | Max serialized bytes | Max changed visible lines |
+| --- | --- | ---: | ---: | ---: |
+| Ordinary interaction | `baseline_repaint`, `recovery_repaint` | 32 | 768 | 8 |
+| Long-transcript interaction | `baseline_repaint`, `recovery_repaint` | 12 | 2,000 | 3 |
+| Product composed interaction | `baseline_repaint`, `recovery_repaint` | 64 | 3,000 | 20 |
+| Product streaming control flow | `baseline_repaint`, `recovery_repaint` | 1,500 | 90,000 | 18 |
+
+The exact values are asserted in
+`tests/coding/test_tui_render_performance_contract.py`. Playback scenarios also
+exercise the budgets against real fake-terminal frames; the constants alone
+are not treated as sufficient evidence.
+
+## Structural Work Bounds
+
+The marked tests freeze these machine-independent properties:
+
+- Updating one bottom-frame row below 11,748 unchanged committed rows compares
+  only the one-row tails, reuses the committed segment, materializes one line,
+  and performs no full logical-line flattening. A subsequent no-op materializes
+  and flattens zero lines.
+- With at least 1,000 committed transcript lines, timer and composer updates
+  materialize at most 20 lines; a new streaming chunk materializes at most 30;
+  all three reuse committed segments and flatten zero logical lines.
+- With more than 512 stable streaming markdown segments, no-op, timer, and
+  composer updates reuse more than 512 segments, materialize at most 16 lines,
+  flatten zero lines, and do not rescan unchanged draft source. Appending one
+  block materializes fewer than 64 lines.
+- Render-segment finalization caches retain only the current committed frame.
+  Streaming markdown and themed renderer caches remain bounded by their active
+  render keys.
+- Streaming buffers do not join all chunks merely to render, and the
+  performance example summary retains only its last step instead of the full
+  run history.
+
+These are structural budgets, not implementation prescriptions. An
+implementation may change data structures or algorithms if it preserves the
+observable bounds and rendered result.
+
+## Correctness And Terminal Invariants
+
+Performance changes must also preserve the marked correctness baseline:
+
+- segmented output is identical to the fresh flat-render oracle at every
+  streaming chunk boundary, including lists, growing tables, closing fences,
+  late references, height clipping, and record boundaries;
+- stable markdown blocks are reused while the mutable block is rerendered;
+- terminal playback does not clear screen or scrollback during steady-state
+  streaming and does not introduce recovery repaints;
+- cursor anchors, protected bottom-frame append, resize repaint, active-window
+  replacement, image cleanup, and failed-flush retry semantics remain stable;
+- cache promotion or eviction never changes visible transcript content.
+
+## Explicit Exceptions
+
+The steady-state budgets intentionally skip the first frame. Dedicated tests
+continue to allow and verify these exceptional paths:
+
+- first render;
+- an explicit resize repaint under the configured scrollback policy;
+- an explicit baseline reset, such as replacing the active transcript window;
+- recovery repaint after the runtime proves that its viewport is unsafe.
+
+An exception must carry its expected operation class and reason. It must not be
+used to relax an ordinary interaction or long-transcript budget.
+
+## Timing Policy
+
+Wall-clock thresholds are not part of this hard contract. They vary with the
+host, Python build, instrumentation, and CI load. Existing millisecond probes
+remain useful smoke tests, but the merge gate is based on deterministic work
+counts, cache bounds, terminal operations, serialized bytes, changed rows, and
+rendered-output equivalence.
+
+## Running The Contract
+
+Run the isolated contract before and after every render-path refactor:
+
+```bash
+make test-tui-render-contract
+```
+
+The command selects tests marked `tui_render_contract`. Run the broader TUI and
+coding UI regression suites after the isolated contract passes. The same
+command is a required pull-request and `main` push check in
+`.github/workflows/tui-render-contract.yml`.
+
+## Change Protocol
+
+A refactor may not update contract thresholds in the same change merely to make
+the suite pass. A threshold or exception change requires a separate review
+that records:
+
+1. the scenario and before/after frame diagnostics;
+2. why the previous bound is no longer valid;
+3. why the new bound is not masking a regression;
+4. the replacement deterministic assertion, when an old assertion is removed.
+
+Moving a marked test between `loushang.tui`, `harnesstui`, and a product adapter
+is allowed only when the marker, behavior, and threshold remain intact.
+
+## Related Designs
+
+- [KD-001: Render Loop And Terminal Writer](./key-designs/KD-001-render-loop-and-terminal-writer.md)
+- [KD-010: Terminal Playback Harness](./key-designs/KD-010-terminal-playback-harness.md)
+- [KD-015: Versioned Rendered Segments](./key-designs/KD-015-stable-tail-window-and-transcript-block-cache.md)
+- [KD-019: Streaming Markdown Stable Prefix Cache](./key-designs/KD-019-streaming-markdown-stable-prefix-cache.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ testpaths = ["tests"]
 addopts = ["--import-mode=importlib"]
 markers = [
   "live: real provider verification that may require network access and credentials",
+  "tui_render_contract: deterministic TUI render correctness, structural performance, and terminal-operation contract",
   "vendor_verification: vendor or endpoint compatibility verification cases",
 ]
 

--- a/tests/coding/test_screen_coding_tui_app.py
+++ b/tests/coding/test_screen_coding_tui_app.py
@@ -601,6 +601,7 @@ def test_screen_coding_tui_requests_animation_frames_while_running() -> None:
     assert decision.delay_ms > 0
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_reuses_stable_transcript_render_cache() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -626,6 +627,7 @@ def test_screen_coding_tui_reuses_stable_transcript_render_cache() -> None:
     assert app._transcript_region._stable_line_cache == cached
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_reuses_unchanged_streaming_draft_cache() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -648,6 +650,7 @@ def test_screen_coding_tui_reuses_unchanged_streaming_draft_cache() -> None:
     assert app._transcript_region._draft_segments is first_cached
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_reuses_stable_streaming_markdown_blocks(monkeypatch) -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -684,6 +687,7 @@ def test_screen_coding_tui_reuses_stable_streaming_markdown_blocks(monkeypatch) 
     ]
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_rerenders_current_streaming_table_block(monkeypatch) -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -723,6 +727,7 @@ def test_screen_coding_tui_rerenders_current_streaming_table_block(monkeypatch) 
     assert rendered_tables == 3
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_clears_transient_draft_cache_after_assistant_commit() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -747,6 +752,7 @@ def test_screen_coding_tui_clears_transient_draft_cache_after_assistant_commit()
     assert app._transcript_region._draft_segments == ()
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_promotes_streaming_draft_cache_after_assistant_commit() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -775,6 +781,7 @@ def test_screen_coding_tui_promotes_streaming_draft_cache_after_assistant_commit
     assert app._transcript_region._transient_line_cache_lines is None
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_uses_canonical_markdown_when_final_text_replaces_draft() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -797,6 +804,7 @@ def test_screen_coding_tui_uses_canonical_markdown_when_final_text_replaces_draf
     assert "Old" not in rendered
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_complete_run_does_not_trim_active_transcript_line_window() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -824,6 +832,7 @@ def test_screen_coding_tui_complete_run_does_not_trim_active_transcript_line_win
     assert "turn 0 line 0" in rendered
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_explicit_active_window_trim_keeps_recent_tail() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -852,6 +861,7 @@ def test_screen_coding_tui_explicit_active_window_trim_keeps_recent_tail() -> No
     assert "turn 0 line 0" not in rendered
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_streaming_draft_render_keeps_full_append_stable_lines() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -877,6 +887,7 @@ def test_screen_coding_tui_streaming_draft_render_keeps_full_append_stable_lines
     assert "draft line 0" in rendered
 
 
+@pytest.mark.tui_render_contract
 def test_screen_transcript_segment_tail_matches_legacy_record_boundaries() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -925,6 +936,7 @@ def test_screen_transcript_segment_tail_matches_legacy_record_boundaries() -> No
         assert actual == expected
 
 
+@pytest.mark.tui_render_contract
 def test_screen_app_reuses_committed_segment_for_tick_input_and_chunk() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
     from loushang.tui import RenderLoop, TerminalSize
@@ -1062,6 +1074,7 @@ def test_screen_coding_tui_code_diagrams_do_not_wrap_right_border_with_default_w
     assert all(line.strip() != "│" for line in lines)
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_streaming_draft_buffers_chunks_until_materialized() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -1096,6 +1109,7 @@ def test_screen_coding_tui_streaming_draft_buffers_chunks_until_materialized() -
     assert "- Line 9: chunk" in app.state.records[-1].text
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_render_streaming_draft_without_materializing_full_text() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -1121,6 +1135,7 @@ def test_screen_coding_tui_render_streaming_draft_without_materializing_full_tex
     assert buffer.materialize_count == 0
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_stable_render_cache_has_entry_limit() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -1139,6 +1154,7 @@ def test_screen_coding_tui_stable_render_cache_has_entry_limit() -> None:
     assert len(app._transcript_region._stable_line_cache) <= 2
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_long_stream_keeps_latest_tail_visible() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -1159,6 +1175,7 @@ def test_screen_coding_tui_long_stream_keeps_latest_tail_visible() -> None:
     assert not any("line 0" in line for line in rendered)
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_many_records_render_recent_tail_not_prefix() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -1253,6 +1270,7 @@ def test_screen_coding_tui_preserves_markdown_ansi_when_replacing_assistant_pref
     assert "\x1b[1;36m### Heading" in heading
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_installs_active_transcript_window_without_rendering_evicted_prefix() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
@@ -1285,6 +1303,7 @@ def test_screen_coding_tui_installs_active_transcript_window_without_rendering_e
     assert "old prompt" not in rendered
 
 
+@pytest.mark.tui_render_contract
 def test_screen_coding_tui_runtime_consumes_transcript_window_reset_as_baseline_repaint() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
     from loushang.tui import FakeTerminalPort, RenderLoop, TerminalSize, TuiRuntime
@@ -1325,6 +1344,7 @@ def test_screen_coding_tui_runtime_consumes_transcript_window_reset_as_baseline_
     assert "summary only" in rendered
 
 
+@pytest.mark.tui_render_contract
 def test_streaming_draft_semantic_segments_match_fresh_flat_render_at_chunk_boundaries() -> None:
     from loushang.coding.ui.screen_app import (
         _ScreenTranscriptRegion,
@@ -1381,6 +1401,7 @@ def test_streaming_draft_semantic_segments_match_fresh_flat_render_at_chunk_boun
             assert actual == expected, (checkpoint, max_height)
 
 
+@pytest.mark.tui_render_contract
 @pytest.mark.parametrize(
     "chunks",
     (
@@ -1445,6 +1466,7 @@ def test_streaming_draft_fallback_shapes_match_fresh_flat_render(
         assert actual == expected, checkpoint
 
 
+@pytest.mark.tui_render_contract
 def test_streaming_draft_reuses_more_than_512_stable_segments_without_reading_source(
     monkeypatch,
 ) -> None:

--- a/tests/coding/test_screen_coding_tui_perf_examples.py
+++ b/tests/coding/test_screen_coding_tui_perf_examples.py
@@ -41,6 +41,7 @@ def test_markdown_perf_fixture_starts_a_new_block_every_twenty_lines() -> None:
     )
 
 
+@pytest.mark.tui_render_contract
 def test_markdown_perf_render_stats_do_not_iterate_render_lines(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -67,6 +68,7 @@ def test_markdown_perf_render_stats_do_not_iterate_render_lines(
     assert app.render_stats.last_line_count == 7
 
 
+@pytest.mark.tui_render_contract
 def test_markdown_perf_script_summary_retains_only_the_last_step() -> None:
     namespace = runpy.run_path(str(_EXAMPLE))
     summary_fields = {item.name for item in fields(namespace["ScriptRoundSummary"])}

--- a/tests/coding/test_screen_coding_tui_perf_probe.py
+++ b/tests/coding/test_screen_coding_tui_perf_probe.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from loushang.coding.ui.perf_probe import (
     build_synthetic_long_transcript_records,
     characterize_long_transcript_rendering,
@@ -8,6 +10,7 @@ from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 from loushang.tui import RenderLoop
 
 
+@pytest.mark.tui_render_contract
 def test_long_transcript_probe_shows_render_loop_plans_beyond_visible_height() -> None:
     records = build_synthetic_long_transcript_records(turns=180, tail_tool_output_lines=2400)
     app = ScreenCodingTuiApp(

--- a/tests/coding/test_screen_coding_tui_terminal_playback.py
+++ b/tests/coding/test_screen_coding_tui_terminal_playback.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from io import StringIO
 
+import pytest
+
 from loushang.coding.ui.perf_probe import build_synthetic_long_transcript_records
 from loushang.coding.ui.playback import ScreenTuiScenario
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
@@ -20,6 +22,8 @@ from loushang.tui import (
     strip_control_sequences,
 )
 from loushang.tui.theme import ThemeResolver
+
+pytestmark = pytest.mark.tui_render_contract
 
 
 def test_screen_coding_tui_streaming_uses_differential_updates_without_clearing_screen() -> None:

--- a/tests/coding/test_screen_tui_playback_harness.py
+++ b/tests/coding/test_screen_tui_playback_harness.py
@@ -130,6 +130,7 @@ def test_screen_tui_input_scenario_writes_coding_jsonl_for_manual_inspection(tmp
     }
 
 
+@pytest.mark.tui_render_contract
 def test_screen_tui_input_scenario_applies_tab_completion_without_screen_clear() -> None:
     result = (
         ScreenTuiInputScenario(width=80, height=12)
@@ -148,6 +149,7 @@ def test_screen_tui_input_scenario_applies_tab_completion_without_screen_clear()
     _assert_interaction_frame_budget(result, "screen-input-tab-completion")
 
 
+@pytest.mark.tui_render_contract
 def test_screen_tui_input_scenario_captures_local_command_without_prompt_echo() -> None:
     result = (
         ScreenTuiInputScenario(width=80, height=12)
@@ -168,6 +170,7 @@ def test_screen_tui_input_scenario_captures_local_command_without_prompt_echo() 
     _assert_interaction_frame_budget(result, "screen-input-local-command")
 
 
+@pytest.mark.tui_render_contract
 def test_screen_tui_input_scenario_routes_active_surface_before_composer() -> None:
     result = (
         ScreenTuiInputScenario(width=80, height=12)
@@ -187,6 +190,7 @@ def test_screen_tui_input_scenario_routes_active_surface_before_composer() -> No
     _assert_interaction_frame_budget(result, "screen-input-active-surface")
 
 
+@pytest.mark.tui_render_contract
 def test_screen_tui_input_scenario_captures_running_steer_without_screen_clear() -> None:
     result = (
         ScreenTuiInputScenario(width=80, height=12)
@@ -208,6 +212,7 @@ def test_screen_tui_input_scenario_captures_running_steer_without_screen_clear()
     _assert_interaction_frame_budget(result, "screen-input-running-steer")
 
 
+@pytest.mark.tui_render_contract
 def test_screen_tui_input_scenario_escape_abort_does_not_pop_pending_steer() -> None:
     result = (
         ScreenTuiInputScenario(width=80, height=12)
@@ -228,6 +233,7 @@ def test_screen_tui_input_scenario_escape_abort_does_not_pop_pending_steer() -> 
     _assert_interaction_frame_budget(result, "screen-input-escape-abort")
 
 
+@pytest.mark.tui_render_contract
 def test_screen_tui_input_scenario_idle_escape_pops_pending_steer() -> None:
     result = ScreenTuiInputScenario(width=80, height=12).with_pending_steers("queued").render().escape().run()
 
@@ -240,6 +246,7 @@ def test_screen_tui_input_scenario_idle_escape_pops_pending_steer() -> None:
     _assert_interaction_frame_budget(result, "screen-input-idle-escape-steer")
 
 
+@pytest.mark.tui_render_contract
 def test_screen_tui_input_scenario_echoes_input_after_long_transcript_without_repaint() -> None:
     result = (
         ScreenTuiInputScenario(width=100, height=18)

--- a/tests/coding/test_screen_tui_playback_runner.py
+++ b/tests/coding/test_screen_tui_playback_runner.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import sys
 
+import pytest
+
 from loushang.coding.ui import playback_runner
 from loushang.coding.ui.playback_fakes import SessionCommandPlaybackSession
 from loushang.coding.ui.playback_runner import (
@@ -217,6 +219,7 @@ def test_screen_tui_playback_runner_runs_tagged_command_scenarios(capsys) -> Non
     assert "PASS long-transcript-input" not in captured.out
 
 
+@pytest.mark.tui_render_contract
 def test_screen_tui_playback_runner_runs_tagged_product_scenarios(capsys) -> None:
     exit_code = run_playback_cli(["--tag", "product"])
 

--- a/tests/coding/test_tui_render_performance_contract.py
+++ b/tests/coding/test_tui_render_performance_contract.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from loushang.coding.ui.playback_scenarios.budgets import (
+    INTERACTION_FRAME_BUDGET,
+    LONG_TRANSCRIPT_FRAME_BUDGET,
+)
+from loushang.coding.ui.playback_scenarios.product import (
+    PRODUCT_COMPOSED_FRAME_BUDGET,
+    PRODUCT_STREAMING_CONTROL_FRAME_BUDGET,
+)
+from loushang.tui import PlaybackFrameBudget
+
+pytestmark = pytest.mark.tui_render_contract
+
+
+@pytest.mark.parametrize(
+    ("actual", "expected"),
+    (
+        (
+            INTERACTION_FRAME_BUDGET,
+            PlaybackFrameBudget(
+                disallowed_operation_classes=(
+                    "baseline_repaint",
+                    "recovery_repaint",
+                ),
+                max_operations=32,
+                max_serialized_output_bytes=768,
+                max_changed_visible_lines=8,
+                require_synchronized=True,
+            ),
+        ),
+        (
+            LONG_TRANSCRIPT_FRAME_BUDGET,
+            PlaybackFrameBudget(
+                disallowed_operation_classes=(
+                    "baseline_repaint",
+                    "recovery_repaint",
+                ),
+                max_operations=12,
+                max_serialized_output_bytes=2_000,
+                max_changed_visible_lines=3,
+                require_synchronized=True,
+            ),
+        ),
+        (
+            PRODUCT_COMPOSED_FRAME_BUDGET,
+            PlaybackFrameBudget(
+                disallowed_operation_classes=(
+                    "baseline_repaint",
+                    "recovery_repaint",
+                ),
+                max_operations=64,
+                max_serialized_output_bytes=3_000,
+                max_changed_visible_lines=20,
+                require_synchronized=True,
+            ),
+        ),
+        (
+            PRODUCT_STREAMING_CONTROL_FRAME_BUDGET,
+            PlaybackFrameBudget(
+                disallowed_operation_classes=(
+                    "baseline_repaint",
+                    "recovery_repaint",
+                ),
+                max_operations=1_500,
+                max_serialized_output_bytes=90_000,
+                max_changed_visible_lines=18,
+                require_synchronized=True,
+            ),
+        ),
+    ),
+    ids=(
+        "interaction",
+        "long-transcript",
+        "product-composed",
+        "product-streaming-control",
+    ),
+)
+def test_tui_playback_frame_budget_values_are_frozen(
+    actual: PlaybackFrameBudget,
+    expected: PlaybackFrameBudget,
+) -> None:
+    assert actual == expected

--- a/tests/tui/test_content_theme.py
+++ b/tests/tui/test_content_theme.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 from typing import Any
 
+import pytest
+
 import loushang.tui.markdown.renderer as markdown_renderer_module
 from loushang.tui import (
     CellDimensions,
@@ -188,6 +190,7 @@ def test_markdown_renderer_reuses_themed_instance_cache_until_theme_changes(monk
     assert calls == [29, 29]
 
 
+@pytest.mark.tui_render_contract
 def test_markdown_renderer_keeps_themed_instance_cache_bounded_to_current_render_key() -> None:
     renderer = MarkdownRenderer("one **two**", theme=ThemeResolver(defaults={"markdown.strong": {"bold": True}}))
 
@@ -197,6 +200,7 @@ def test_markdown_renderer_keeps_themed_instance_cache_bounded_to_current_render
     assert len(renderer._render_cache) == 1
 
 
+@pytest.mark.tui_render_contract
 def test_markdown_renderer_reuses_shared_cache_for_stable_streaming_blocks() -> None:
     cache = markdown_renderer_module.MarkdownRenderCache()
     highlighter = FakeCodeHighlighter()

--- a/tests/tui/test_render_framework.py
+++ b/tests/tui/test_render_framework.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+import pytest
+
 from loushang.tui import (
     ApprovalSurface,
     CommandSurface,
@@ -135,6 +137,7 @@ def test_screen_root_preserves_base_cursor_when_no_surface_is_visible() -> None:
     assert result.cursor == CursorDeclaration(row=0, column=2)
 
 
+@pytest.mark.tui_render_contract
 def test_surface_host_preserves_base_result_identity_without_visible_surfaces() -> None:
     composer = FocusTarget("composer")
     hidden_focus = FocusTarget("hidden")

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -31,6 +31,8 @@ from loushang.tui.core import (
 )
 from loushang.tui.render_loop import DEFAULT_STRATEGY_ORDER, RenderPlanStrategyKind
 
+pytestmark = pytest.mark.tui_render_contract
+
 
 class StaticRoot:
     def __init__(self, lines: tuple[str, ...]) -> None:

--- a/tests/tui/test_render_segments.py
+++ b/tests/tui/test_render_segments.py
@@ -15,6 +15,8 @@ from loushang.tui.core import (
 )
 from loushang.tui.ui_parts.layout import ScreenRegion, ScreenRegionStack
 
+pytestmark = pytest.mark.tui_render_contract
+
 
 def _lines(*values: str) -> tuple[RenderLine, ...]:
     return tuple(RenderLine(value) for value in values)

--- a/tests/tui/test_streaming_markdown.py
+++ b/tests/tui/test_streaming_markdown.py
@@ -11,6 +11,8 @@ from loushang.tui import (
 )
 from loushang.tui.markdown import renderer as markdown_renderer
 
+pytestmark = pytest.mark.tui_render_contract
+
 
 def _assert_incremental_matches_full(
     chunks: Iterable[str],

--- a/tests/tui/test_transcript_records.py
+++ b/tests/tui/test_transcript_records.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import loushang.tui.transcript as transcript_module
 from loushang.tui import (
     AssistantMessageRecord,
@@ -19,6 +21,8 @@ from loushang.tui import (
     render_transcript_records,
     strip_control_sequences,
 )
+
+pytestmark = pytest.mark.tui_render_contract
 
 
 def rendered_text(view: TranscriptView, *, width: int = 60, height: int = 20) -> tuple[str, ...]:


### PR DESCRIPTION
## English

### Summary

- Add a dedicated `tui_render_contract` pytest marker and `make test-tui-render-contract` entry point.
- Freeze deterministic frame budgets, structural work bounds, cache limits, terminal-operation invariants, and rendered-output equivalence across the generic TUI and Coding UI integration probes.
- Add a GitHub Actions gate for pull requests and pushes to `main`.
- Document the frozen baseline, allowed exceptional repaint paths, timing policy, and the change protocol for future render-path refactors.

### Why

The TUI render path was recently optimized and will be reorganized as generic conversation capabilities are separated from `coding.ui`. This contract establishes a stable, machine-independent baseline before that extraction, so later refactors cannot silently reintroduce full transcript materialization, unnecessary repaints, unbounded caches, or output regressions.

### Impact

This PR changes tests, test entry points, CI, and architecture documentation only. It does not modify `src/` production code or alter current rendering behavior. Wall-clock thresholds remain smoke signals rather than hard merge criteria; the gate relies on deterministic work counts and observable terminal behavior.

### Validation

- `make test-tui-render-contract`: **151 passed, 3319 deselected in 10.40s** (12.93s wall clock)
- `git diff --check`: passed

---

## 中文

### 变更摘要

- 新增专用的 `tui_render_contract` pytest marker 和 `make test-tui-render-contract` 入口。
- 冻结通用 TUI 与 Coding UI 集成探针的确定性帧预算、结构性工作量上限、缓存边界、终端操作不变量和渲染结果等价性。
- 新增面向 Pull Request 和 `main` 分支 push 的 GitHub Actions 门禁。
- 补充架构文档，记录冻结基线、允许的例外重绘路径、时间指标策略，以及后续渲染链重构的契约变更流程。

### 背景与目的

TUI 渲染路径刚完成性能优化，接下来还会伴随通用会话能力与 `coding.ui` 的职责拆分。此 PR 在重构前建立稳定且与机器性能无关的基线，防止后续迁移悄然重新引入全量 transcript materialization、不必要的整屏重绘、无界缓存或渲染结果回归。

### 影响范围

本 PR 仅修改测试、测试入口、CI 和架构文档，不修改 `src/` 生产代码，也不改变当前渲染行为。墙钟耗时仅作为 smoke 信号，不作为硬性合并条件；门禁以确定性的工作量计数和可观察终端行为为准。

### 验证

- `make test-tui-render-contract`：**151 passed，3319 deselected，pytest 10.40 秒**（总墙钟 12.93 秒）
- `git diff --check`：通过
