### PR TITLE
refactor(harnesstui): extract tool and status foundations / 提取工具与状态基础层

### DIFF
--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -19,6 +19,9 @@ This layer owns reusable Harness-oriented terminal interaction, including:
 
 - adapting neutral conversation snapshots and actions to TUI records and
   surfaces;
+- neutral tool-result views, transcript blocks, and deterministic presentation
+  projection;
+- shared Harness status profiles that product shells can populate and present;
 - reusable conversation reading, pending/working presentation, and input
   coordination;
 - UI-side approval presentation and decision routing after the neutral Harness
@@ -49,3 +52,32 @@ The stable imports introduced by this slice are the explicit module paths
 `loushang.harnesstui.conversation.reader` and
 `loushang.harnesstui.conversation.source`. The conversation package does not
 yet expose a broader convenience API.
+
+## Tool Transcript and Status Profile
+
+This migration slice adds two reusable presentation capabilities without
+moving product event interpretation into this package.
+
+`loushang.harnesstui.conversation.tool_transcript` owns the neutral tool-result
+view and the display contracts used to project tool activity into conversation
+records. Its inputs describe presentation-ready facts rather than Agent or
+provider objects. Deterministic transcript status, block construction, and
+record projection belong here because they are reusable across Harness-backed
+terminal products.
+
+`loushang.coding.ui` remains responsible for adapting raw `AgentToolResult`
+instances and runtime events into that neutral view. It also retains product
+policy: which events are visible, product-specific labels and commands,
+redaction, and any decision that requires Coding runtime state. This keeps the
+dependency pointing from Coding into Harnesstui and prevents Agent event types
+from becoming presentation contracts.
+
+`loushang.harnesstui.status.line` owns a shared Harness status profile and its
+product-neutral presentation rules. A product shell supplies the profile's
+values and decides when those values change. This capability is not the generic
+`loushang.tui` status-bar mechanism: TUI continues to own the widget, layout,
+styling primitives, invalidation, and frame rendering. Harnesstui must not
+reach into those mechanics or introduce a second status-bar runtime.
+
+These explicit module paths are the stable imports for this slice. The package
+initializers do not need to provide convenience re-exports.

--- a/docs/internals/architecture/tui/README.md
+++ b/docs/internals/architecture/tui/README.md
@@ -35,3 +35,8 @@ Target source entrypoints remain:
 Harness conversation contracts into reusable TUI interaction. Product adapters
 such as `loushang.coding.ui` provide Coding-specific state, event projection,
 commands, policy, and runtime assembly.
+
+For status presentation, `loushang.tui` owns the generic status-bar widget and
+its layout, styling, invalidation, and rendering mechanics. A shared Harness
+status profile belongs to `loushang.harnesstui`; products populate that profile
+and retain their own status policy.

--- a/src/loushang/coding/ui/screen_app.py
+++ b/src/loushang/coding/ui/screen_app.py
@@ -8,13 +8,6 @@ from dataclasses import dataclass, field, replace
 from typing import Any
 
 from loushang.coding.ui.screen_state import ScreenCodingTuiState, ScreenTranscriptWindow
-from loushang.coding.ui.status_line import (
-    StatusLinePreviewSnapshot,
-    StatusLineSettings,
-    status_line_fields,
-    status_line_separator,
-    status_line_style_mode,
-)
 from loushang.coding.ui.transcript_source import ActiveWindowTranscriptSource
 from loushang.coding.ui.transcript_style import apply_coding_transcript_style
 from loushang.harness.tools.workspace.output_preview import (
@@ -25,6 +18,13 @@ from loushang.harness.tools.workspace.output_preview import (
 )
 from loushang.harnesstui.conversation.reader import TranscriptReaderSurface
 from loushang.harnesstui.conversation.source import TranscriptSource
+from loushang.harnesstui.status.line import (
+    StatusLinePreviewSnapshot,
+    StatusLineSettings,
+    status_line_fields,
+    status_line_separator,
+    status_line_style_mode,
+)
 from loushang.tui import (
     BottomFrame,
     Composer,

--- a/src/loushang/coding/ui/screen_state.py
+++ b/src/loushang/coding/ui/screen_state.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 
-from loushang.coding.ui.status_line import StatusLineSettings
+from loushang.harnesstui.status.line import StatusLineSettings
 from loushang.tui.transcript import (
     AssistantMessageRecord,
     DisplayRecord,

--- a/src/loushang/coding/ui/settings_page.py
+++ b/src/loushang/coding/ui/settings_page.py
@@ -25,11 +25,11 @@ from loushang.coding.ui.settings_config import (
     manager_bool_config,
 )
 from loushang.coding.ui.settings_status_line import StatusLineSettingsPage
-from loushang.coding.ui.status_line import (
+from loushang.coding.ui.status_provider import CodingTuiStatusProvider, StatusSnapshot
+from loushang.harnesstui.status.line import (
     StatusLinePreviewSnapshot,
     StatusLineSettings,
 )
-from loushang.coding.ui.status_provider import CodingTuiStatusProvider, StatusSnapshot
 from loushang.tui import (
     CursorDeclaration,
     InputEvent,

--- a/src/loushang/coding/ui/settings_status_line.py
+++ b/src/loushang/coding/ui/settings_status_line.py
@@ -15,7 +15,7 @@ from loushang.coding.ui.settings_common import (
     row_for_key,
     settings_header,
 )
-from loushang.coding.ui.status_line import (
+from loushang.harnesstui.status.line import (
     StatusLinePreviewSnapshot,
     StatusLineSettings,
     status_line_fields,

--- a/src/loushang/coding/ui/status_line.py
+++ b/src/loushang/coding/ui/status_line.py
@@ -1,136 +1,26 @@
-from __future__ import annotations
+"""Compatibility imports for the shared status-line model and projection."""
 
-from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import Literal, cast
-
-from loushang.tui import StatusField
-
-StatusLineAutoValue = Literal["auto", "true", "false"]
-StatusLineSeparator = Literal["pipe", "dot"]
-StatusLineStyle = Literal["codex-like", "muted", "plain"]
-
-
-@dataclass(frozen=True, slots=True)
-class StatusLineSettings:
-    enabled: bool = True
-    model: bool = True
-    workspace: bool = True
-    branch: bool = True
-    session: bool = True
-    runtime: bool = True
-    queue: StatusLineAutoValue = "auto"
-    message: StatusLineAutoValue = "auto"
-    separator: StatusLineSeparator = "pipe"
-    style: StatusLineStyle = "codex-like"
-
-
-@dataclass(frozen=True, slots=True)
-class StatusLinePreviewSnapshot:
-    model_label: str | None
-    cwd: str
-    branch: str | None
-    session_label: str | None
-    running: bool
-    pending_followups: int = 0
-    pending_steers: int = 0
-    status_message: str | None = None
-
-
-def status_line_fields(
-    snapshot: StatusLinePreviewSnapshot,
-    settings: StatusLineSettings,
-) -> tuple[StatusField, ...]:
-    fields: list[StatusField] = []
-    if settings.model:
-        fields.append(StatusField(snapshot.model_label or "model", priority=100, token="model"))
-    if settings.workspace:
-        fields.append(StatusField(cwd_label(snapshot.cwd), priority=90, token="workspace"))
-    if settings.branch:
-        fields.append(StatusField(snapshot.branch or "no-branch", priority=80, token="branch"))
-    if settings.session:
-        fields.append(StatusField(snapshot.session_label or "no-session", priority=70, token="session"))
-    if settings.runtime:
-        runtime_text = "running" if snapshot.running else "idle"
-        runtime_token = "runtime.running" if snapshot.running else "runtime.idle"
-        fields.append(StatusField(runtime_text, priority=60, token=runtime_token))
-    if _show_auto_field(settings.queue, snapshot.pending_followups > 0 or snapshot.pending_steers > 0):
-        fields.append(
-            StatusField(
-                f"queued={max(0, snapshot.pending_followups)} steer={max(0, snapshot.pending_steers)}",
-                priority=50,
-                token="queue",
-            )
-        )
-    if _show_auto_field(settings.message, bool(snapshot.status_message)):
-        fields.append(StatusField(snapshot.status_message or "no status", priority=40, token="message"))
-    return tuple(fields)
-
-
-def status_line_separator(settings: StatusLineSettings) -> str:
-    if settings.separator == "dot":
-        return " · "
-    return " | "
-
-
-def status_line_style_mode(settings: StatusLineSettings) -> StatusLineStyle:
-    return settings.style if settings.style in {"codex-like", "muted", "plain"} else "codex-like"
-
-
-def status_line_settings_from_control(settings: object | None) -> StatusLineSettings:
-    if settings is None:
-        return StatusLineSettings()
-    if isinstance(settings, StatusLineSettings):
-        return settings
-    defaults = StatusLineSettings()
-    return StatusLineSettings(
-        enabled=bool(_setting_value(settings, "enabled", defaults.enabled)),
-        model=bool(_setting_value(settings, "model", defaults.model)),
-        workspace=bool(_setting_value(settings, "workspace", defaults.workspace)),
-        branch=bool(_setting_value(settings, "branch", defaults.branch)),
-        session=bool(_setting_value(settings, "session", defaults.session)),
-        runtime=bool(_setting_value(settings, "runtime", defaults.runtime)),
-        queue=cast(StatusLineAutoValue, _setting_value(settings, "queue", defaults.queue)),
-        message=cast(StatusLineAutoValue, _setting_value(settings, "message", defaults.message)),
-        separator=cast(StatusLineSeparator, _setting_value(settings, "separator", defaults.separator)),
-        style=cast(StatusLineStyle, _setting_value(settings, "style", defaults.style)),
-    )
-
-
-def status_line_settings_to_patch(settings: StatusLineSettings) -> dict[str, object]:
-    return {
-        "enabled": settings.enabled,
-        "model": settings.model,
-        "workspace": settings.workspace,
-        "branch": settings.branch,
-        "session": settings.session,
-        "runtime": settings.runtime,
-        "queue": settings.queue,
-        "message": settings.message,
-        "separator": settings.separator,
-        "style": settings.style,
-    }
-
-
-def cwd_label(cwd: str) -> str:
-    if not cwd:
-        return "cwd"
-    return cwd.rstrip("/").rsplit("/", 1)[-1] or cwd
-
-
-def _setting_value(settings: object, key: str, default: object) -> object:
-    if isinstance(settings, Mapping):
-        return settings.get(key, default)
-    return getattr(settings, key, default)
-
-
-def _show_auto_field(value: StatusLineAutoValue, has_data: bool) -> bool:
-    if value == "true":
-        return True
-    if value == "false":
-        return False
-    return has_data
-
+from loushang.harnesstui.status.line import StatusLineAutoValue as StatusLineAutoValue
+from loushang.harnesstui.status.line import (
+    StatusLinePreviewSnapshot as StatusLinePreviewSnapshot,
+)
+from loushang.harnesstui.status.line import StatusLineSeparator as StatusLineSeparator
+from loushang.harnesstui.status.line import StatusLineSettings as StatusLineSettings
+from loushang.harnesstui.status.line import StatusLineStyle as StatusLineStyle
+from loushang.harnesstui.status.line import cwd_label as cwd_label
+from loushang.harnesstui.status.line import status_line_fields as status_line_fields
+from loushang.harnesstui.status.line import (
+    status_line_separator as status_line_separator,
+)
+from loushang.harnesstui.status.line import (
+    status_line_settings_from_control as status_line_settings_from_control,
+)
+from loushang.harnesstui.status.line import (
+    status_line_settings_to_patch as status_line_settings_to_patch,
+)
+from loushang.harnesstui.status.line import (
+    status_line_style_mode as status_line_style_mode,
+)
 
 __all__ = [
     "StatusLinePreviewSnapshot",

--- a/src/loushang/coding/ui/status_provider.py
+++ b/src/loushang/coding/ui/status_provider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 
-from loushang.coding.ui.status_line import (
+from loushang.harnesstui.status.line import (
     StatusLineSettings,
     status_line_settings_from_control,
     status_line_settings_to_patch,

--- a/src/loushang/coding/ui/tool_blocks.py
+++ b/src/loushang/coding/ui/tool_blocks.py
@@ -1,90 +1,81 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import Any, Literal
+from dataclasses import dataclass, field
+from typing import Any
 
 from loushang.agent.types import AgentToolResult
-from loushang.harness.presentation import (
-    ToolDefinitionResolver,
-    ToolRenderRuntime,
-)
-from loushang.harness.tools.workspace.output_preview import (
-    collapse_tool_output_preview,
-    drop_tool_timing_tail_line,
-    prefers_tail_tool_output,
-)
+from loushang.harness.presentation import ToolDefinitionResolver, ToolRenderRuntime
 from loushang.harness.tools.workspace.presentation import (
     render_tool_result_presentation,
 )
-from loushang.tui.render import diff_stat
-
-ToolTranscriptStatus = Literal[
-    "running", "ok", "error", "cancelled", "timed_out", "terminate"
-]
-
-
-@dataclass(frozen=True)
-class ToolCallSnapshot:
-    tool_name: str
-    args: object | None = None
-    rendered_call_text: str | None = None
-
-
-@dataclass(frozen=True)
-class ToolTranscriptBlock:
-    tool_call_id: str
-    tool_name: str
-    status: ToolTranscriptStatus
-    verb: str
-    title: str
-    detail: str | None = None
-    body: str | None = None
+from loushang.harnesstui.conversation.tool_transcript import (
+    ToolCallSnapshot,
+    ToolCallView,
+    ToolResultView,
+    ToolTranscriptBlock,
+    ToolTranscriptStatus,
+)
+from loushang.harnesstui.conversation.tool_transcript import (
+    ToolTranscriptProjector as NeutralToolTranscriptProjector,
+)
 
 
 @dataclass
 class ToolTranscriptProjector:
+    """Adapt Coding tool events to the neutral transcript projector."""
+
     tool_definition_resolver: ToolDefinitionResolver | None = None
     render_runtime: ToolRenderRuntime | None = None
     max_body_lines: int = 8
+    _projector: NeutralToolTranscriptProjector = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         if self.render_runtime is None:
             self.render_runtime = ToolRenderRuntime()
+        self._projector = NeutralToolTranscriptProjector(
+            verb_resolver=_verb,
+            body_visibility=_should_show_body,
+            command_resolver=_command_for_transcript,
+            max_body_lines=self.max_body_lines,
+        )
 
     def remember_call(self, event: Mapping[str, Any]) -> ToolCallSnapshot:
-        tool_name = _tool_name(event)
-        rendered = self._render_event_text(event, expanded=False)
-        return ToolCallSnapshot(
-            tool_name=tool_name, args=event.get("args"), rendered_call_text=rendered
+        return self._projector.remember_call(
+            ToolCallView(
+                tool_call_id=_tool_call_id(event),
+                tool_name=_tool_name(event),
+                args=event.get("args"),
+                rendered_text=self._render_event_text(event, expanded=False),
+            )
         )
 
     def project_result(
-        self, event: Mapping[str, Any], snapshot: ToolCallSnapshot | None = None
+        self,
+        event: Mapping[str, Any],
+        snapshot: ToolCallSnapshot | None = None,
     ) -> ToolTranscriptBlock:
-        tool_call_id = _tool_call_id(event)
+        result = _event_result(event)
+        status = _result_status(event, result=result)
         tool_name = snapshot.tool_name if snapshot is not None else _tool_name(event)
-        args = snapshot.args if snapshot is not None else event.get("args")
-        status = _result_status(event)
-        rendered_call = snapshot.rendered_call_text if snapshot is not None else None
-        title = _title(tool_name, args, rendered_call)
-        detail = _detail(event, tool_name=tool_name, status=status)
-        rendered_result = self._render_event_text(event, expanded=False)
-        body = _body(
-            tool_name,
-            event,
-            status=status,
-            rendered_result=rendered_result,
-            max_lines=self.max_body_lines,
-        )
-        return ToolTranscriptBlock(
-            tool_call_id=tool_call_id,
-            tool_name=tool_name,
-            status=status,
-            verb=_verb(tool_name, args),
-            title=title,
-            detail=detail,
-            body=body,
+        result_text = ""
+        if _should_show_body(tool_name, status):
+            result_text = _fallback_result_text(
+                result,
+                max_lines=self.max_body_lines,
+            )
+        return self._projector.project_result(
+            ToolResultView(
+                tool_call_id=_tool_call_id(event),
+                tool_name=_tool_name(event),
+                status=status,
+                args=event.get("args"),
+                result_text=result_text,
+                rendered_text=self._render_event_text(event, expanded=False),
+                details=_transcript_result_details(result),
+                error_summary=_tool_error_summary(result),
+            ),
+            snapshot,
         )
 
     def project_tool_result_message(self, message: object) -> ToolTranscriptBlock:
@@ -104,7 +95,10 @@ class ToolTranscriptProjector:
         return self.project_result(event)
 
     def _render_event_text(
-        self, event: Mapping[str, Any], *, expanded: bool
+        self,
+        event: Mapping[str, Any],
+        *,
+        expanded: bool,
     ) -> str | None:
         if self.tool_definition_resolver is None or self.render_runtime is None:
             return None
@@ -117,6 +111,12 @@ class ToolTranscriptProjector:
         except Exception:
             return None
         return _rendered_text(rendered)
+
+
+def _event_result(event: Mapping[str, Any]) -> object:
+    if event.get("type") == "tool_execution_update":
+        return event.get("partial_result")
+    return event.get("result")
 
 
 def _tool_call_id(event: Mapping[str, Any]) -> str:
@@ -144,24 +144,22 @@ def _rendered_text(rendered: object) -> str | None:
     return None
 
 
-def _title(tool_name: str, args: object | None, rendered_call: str | None) -> str:
-    if rendered_call:
-        first_line = rendered_call.splitlines()[0].strip()
-        if first_line.startswith("$ "):
-            return f"{tool_name} {first_line[2:].strip()}"
-        if first_line:
-            return first_line
-    detail = _arg_detail(args)
-    return f"{tool_name} {detail}" if detail else tool_name
-
-
-def _arg_detail(args: object | None) -> str | None:
-    if isinstance(args, Mapping):
-        for key in ("path", "file_path", "pattern", "query", "command"):
-            value = args.get(key)
-            if isinstance(value, str) and value:
-                return value
-    return None
+def _result_status(
+    event: Mapping[str, Any],
+    *,
+    result: object,
+) -> ToolTranscriptStatus:
+    details = _transcript_result_details(result)
+    if details:
+        if details.get("timed_out") is True or details.get("timedOut") is True:
+            return "timed_out"
+        if details.get("cancelled") is True or details.get("canceled") is True:
+            return "cancelled"
+    if bool(event.get("is_error", False)):
+        return "error"
+    if isinstance(result, AgentToolResult) and result.terminate:
+        return "terminate"
+    return "ok"
 
 
 def _verb(tool_name: str, args: object | None) -> str:
@@ -190,120 +188,16 @@ def _command_from_args(args: object | None) -> str:
     return ""
 
 
-def _result_status(event: Mapping[str, Any]) -> ToolTranscriptStatus:
-    result = (
-        event.get("partial_result")
-        if event.get("type") == "tool_execution_update"
-        else event.get("result")
-    )
-    details = _transcript_result_details(result)
-    if details:
-        if details.get("timed_out") is True or details.get("timedOut") is True:
-            return "timed_out"
-        if details.get("cancelled") is True or details.get("canceled") is True:
-            return "cancelled"
-    if bool(event.get("is_error", False)):
-        return "error"
-    if isinstance(result, AgentToolResult) and result.terminate:
-        return "terminate"
-    return "ok"
-
-
-def _detail(
-    event: Mapping[str, Any], *, tool_name: str, status: ToolTranscriptStatus
+def _command_for_transcript(
+    tool_name: str, args: object | None, title: str
 ) -> str | None:
-    if status == "ok":
-        return _ok_detail(event, tool_name=tool_name)
-    if status == "error":
-        reason = _tool_error_summary(event.get("result"))
-        return f"failed: {reason}" if reason else "failed"
-    if status == "timed_out":
-        return "timed out"
-    if status == "cancelled":
-        return "cancelled"
-    if status == "terminate":
-        return "terminated"
-    return None
+    return title if _verb(tool_name, args) in {"Ran", "Tested"} else None
 
 
-def _ok_detail(event: Mapping[str, Any], *, tool_name: str) -> str | None:
-    result = (
-        event.get("partial_result")
-        if event.get("type") == "tool_execution_update"
-        else event.get("result")
-    )
-    details = _transcript_result_details(result)
-    if not details:
-        return None
-    normalized = tool_name.lower()
-    if any(part in normalized for part in ("edit", "patch")):
-        return diff_stat(details.get("diff"))
-    if "write" in normalized:
-        return _write_stat(details)
-    return None
-
-
-def _write_stat(details: Mapping[str, Any]) -> str | None:
-    parts: list[str] = []
-    operation = details.get("operation")
-    if isinstance(operation, str) and operation:
-        parts.append(_write_operation_label(operation))
-    bytes_written = details.get("bytes_written", details.get("bytesWritten"))
-    formatted_size = _format_byte_count(bytes_written)
-    if formatted_size:
-        parts.append(formatted_size)
-    return ", ".join(parts) if parts else None
-
-
-def _write_operation_label(operation: str) -> str:
-    normalized = operation.lower()
-    if normalized == "create":
-        return "created"
-    if normalized == "overwrite":
-        return "overwrote"
-    return normalized.replace("_", " ")
-
-
-def _format_byte_count(value: object) -> str | None:
-    if not isinstance(value, int) or value < 0:
-        return None
-    if value < 1024:
-        return f"{value} B"
-    units = ("KiB", "MiB", "GiB")
-    amount = float(value)
-    for unit in units:
-        amount /= 1024
-        if amount < 1024:
-            return f"{amount:.1f} {unit}"
-    return f"{amount:.1f} TiB"
-
-
-def _body(
+def _should_show_body(
     tool_name: str,
-    event: Mapping[str, Any],
-    *,
     status: ToolTranscriptStatus,
-    rendered_result: str | None,
-    max_lines: int,
-) -> str | None:
-    if max_lines < 1:
-        return None
-    if not _should_show_body(tool_name, status):
-        return None
-    text = rendered_result or _fallback_result_text(event, max_lines=max_lines)
-    if not text:
-        return None
-    text = drop_tool_timing_tail_line(text.strip())
-    if not text:
-        return None
-    return collapse_tool_output_preview(
-        text,
-        max_lines=max_lines,
-        tail=prefers_tail_tool_output(tool_name),
-    )
-
-
-def _should_show_body(tool_name: str, status: ToolTranscriptStatus) -> bool:
+) -> bool:
     if status != "ok":
         return False
     normalized = tool_name.lower()
@@ -325,12 +219,7 @@ def _should_show_body(tool_name: str, status: ToolTranscriptStatus) -> bool:
     )
 
 
-def _fallback_result_text(event: Mapping[str, Any], *, max_lines: int) -> str:
-    result = (
-        event.get("partial_result")
-        if event.get("type") == "tool_execution_update"
-        else event.get("result")
-    )
+def _fallback_result_text(result: object, *, max_lines: int) -> str:
     if not isinstance(result, AgentToolResult):
         return ""
     return render_tool_result_presentation(

--- a/src/loushang/coding/ui/transcript_projection.py
+++ b/src/loushang/coding/ui/transcript_projection.py
@@ -1,53 +1,24 @@
-from __future__ import annotations
+"""Coding compatibility adapter for shared tool transcript projection."""
 
-import re
+from dataclasses import replace
 
-from loushang.coding.ui.tool_blocks import ToolTranscriptBlock
-from loushang.tui.transcript import ToolExecutionRecord, ToolOutputKind, ToolState
-
-_EXIT_CODE_RE = re.compile(r"\bexit code\s+(\d+)\b", re.IGNORECASE)
-
-
-def tool_block_to_record(block: ToolTranscriptBlock, *, elapsed_seconds: float = 0.0) -> ToolExecutionRecord:
-    output = block.body or ""
-    detail = block.detail or ""
-    return ToolExecutionRecord(
-        name=block.title or block.tool_name,
-        state=_tool_state(block.status),
-        elapsed_seconds=elapsed_seconds,
-        output=output,
-        output_kind=_output_kind(output),
-        command=block.title if block.verb in {"Ran", "Tested"} else "",
-        stderr=detail if block.status in {"error", "timed_out", "cancelled"} else "",
-        exit_code=_exit_code(detail),
-        show_stats=_output_kind(output) == "diff",
-    )
+from loushang.harnesstui.conversation.tool_transcript import (
+    ToolTranscriptBlock,
+)
+from loushang.harnesstui.conversation.tool_transcript import (
+    tool_block_to_record as project_neutral_tool_block,
+)
+from loushang.tui.transcript import ToolExecutionRecord
 
 
-def _tool_state(status: str) -> ToolState:
-    if status == "ok":
-        return "completed"
-    if status in {"cancelled"}:
-        return "cancelled"
-    if status in {"error", "timed_out"}:
-        return "failed"
-    if status == "terminate":
-        return "completed"
-    return "running"
+def tool_block_to_record(
+    block: ToolTranscriptBlock, *, elapsed_seconds: float = 0.0
+) -> ToolExecutionRecord:
+    """Preserve Coding's legacy command-label policy at the product edge."""
 
-
-def _output_kind(output: str) -> ToolOutputKind:
-    stripped = output.lstrip()
-    if stripped.startswith("diff --git") or stripped.startswith(("@@", "--- ", "+++ ")):
-        return "diff"
-    return "text"
-
-
-def _exit_code(detail: str) -> int | None:
-    match = _EXIT_CODE_RE.search(detail)
-    if match is None:
-        return None
-    return int(match.group(1))
+    if block.command is None and block.verb in {"Ran", "Tested"}:
+        block = replace(block, command=block.title)
+    return project_neutral_tool_block(block, elapsed_seconds=elapsed_seconds)
 
 
 __all__ = ["tool_block_to_record"]

--- a/src/loushang/harnesstui/conversation/tool_transcript.py
+++ b/src/loushang/harnesstui/conversation/tool_transcript.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from loushang.harness.tools.workspace.output_preview import (
+    collapse_tool_output_preview,
+    drop_tool_timing_tail_line,
+    prefers_tail_tool_output,
+)
+from loushang.tui.render import diff_stat
+from loushang.tui.transcript import ToolExecutionRecord, ToolOutputKind, ToolState
+
+ToolTranscriptStatus = Literal[
+    "running", "ok", "error", "cancelled", "timed_out", "terminate"
+]
+ToolVerbResolver = Callable[[str, object | None], str]
+ToolBodyVisibility = Callable[[str, ToolTranscriptStatus], bool]
+ToolCommandResolver = Callable[[str, object | None, str], str | None]
+
+_EXIT_CODE_RE = re.compile(r"\bexit code\s+(\d+)\b", re.IGNORECASE)
+
+
+def _default_verb(tool_name: str, args: object | None) -> str:
+    del args
+    return f"Used {tool_name}"
+
+
+def _hide_body(tool_name: str, status: ToolTranscriptStatus) -> bool:
+    del tool_name, status
+    return False
+
+
+def _hide_command(tool_name: str, args: object | None, title: str) -> str | None:
+    del tool_name, args, title
+    return None
+
+
+@dataclass(frozen=True)
+class ToolCallView:
+    """Product-neutral input for one tool call shown in a conversation."""
+
+    tool_call_id: str
+    tool_name: str
+    args: object | None = None
+    rendered_text: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolResultView:
+    """Product-neutral input for one tool result shown in a conversation."""
+
+    tool_call_id: str
+    tool_name: str
+    status: ToolTranscriptStatus
+    args: object | None = None
+    result_text: str = ""
+    rendered_text: str | None = None
+    details: Mapping[str, Any] = field(default_factory=dict)
+    error_summary: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolCallSnapshot:
+    tool_name: str
+    args: object | None = None
+    rendered_call_text: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolTranscriptBlock:
+    tool_call_id: str
+    tool_name: str
+    status: ToolTranscriptStatus
+    verb: str
+    title: str
+    detail: str | None = None
+    body: str | None = None
+    command: str | None = None
+
+
+@dataclass
+class ToolTranscriptProjector:
+    """Project neutral tool call/result views into reusable transcript blocks."""
+
+    verb_resolver: ToolVerbResolver = _default_verb
+    body_visibility: ToolBodyVisibility = _hide_body
+    command_resolver: ToolCommandResolver = _hide_command
+    max_body_lines: int = 8
+
+    def remember_call(self, view: ToolCallView) -> ToolCallSnapshot:
+        return ToolCallSnapshot(
+            tool_name=view.tool_name,
+            args=view.args,
+            rendered_call_text=view.rendered_text,
+        )
+
+    def project_result(
+        self,
+        view: ToolResultView,
+        snapshot: ToolCallSnapshot | None = None,
+    ) -> ToolTranscriptBlock:
+        tool_name = snapshot.tool_name if snapshot is not None else view.tool_name
+        args = snapshot.args if snapshot is not None else view.args
+        rendered_call = snapshot.rendered_call_text if snapshot is not None else None
+        title = _title(tool_name, args, rendered_call)
+        return ToolTranscriptBlock(
+            tool_call_id=view.tool_call_id,
+            tool_name=tool_name,
+            status=view.status,
+            verb=self.verb_resolver(tool_name, args),
+            title=title,
+            detail=_detail(view, tool_name=tool_name),
+            body=_body(
+                tool_name,
+                view,
+                visible=self.body_visibility(tool_name, view.status),
+                max_lines=self.max_body_lines,
+            ),
+            command=self.command_resolver(tool_name, args, title),
+        )
+
+
+def tool_block_to_record(
+    block: ToolTranscriptBlock, *, elapsed_seconds: float = 0.0
+) -> ToolExecutionRecord:
+    output = block.body or ""
+    detail = block.detail or ""
+    output_kind = _output_kind(output)
+    return ToolExecutionRecord(
+        name=block.title or block.tool_name,
+        state=_tool_state(block.status),
+        elapsed_seconds=elapsed_seconds,
+        output=output,
+        output_kind=output_kind,
+        command=block.command or "",
+        stderr=(detail if block.status in {"error", "timed_out", "cancelled"} else ""),
+        exit_code=_exit_code(detail),
+        show_stats=output_kind == "diff",
+    )
+
+
+def _title(tool_name: str, args: object | None, rendered_call: str | None) -> str:
+    if rendered_call:
+        first_line = rendered_call.splitlines()[0].strip()
+        if first_line.startswith("$ "):
+            return f"{tool_name} {first_line[2:].strip()}"
+        if first_line:
+            return first_line
+    detail = _arg_detail(args)
+    return f"{tool_name} {detail}" if detail else tool_name
+
+
+def _arg_detail(args: object | None) -> str | None:
+    if isinstance(args, Mapping):
+        for key in ("path", "file_path", "pattern", "query", "command"):
+            value = args.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def _detail(view: ToolResultView, *, tool_name: str) -> str | None:
+    if view.status == "ok":
+        return _ok_detail(view.details, tool_name=tool_name)
+    if view.status == "error":
+        return f"failed: {view.error_summary}" if view.error_summary else "failed"
+    if view.status == "timed_out":
+        return "timed out"
+    if view.status == "cancelled":
+        return "cancelled"
+    if view.status == "terminate":
+        return "terminated"
+    return None
+
+
+def _ok_detail(details: Mapping[str, Any], *, tool_name: str) -> str | None:
+    if not details:
+        return None
+    normalized = tool_name.lower()
+    if any(part in normalized for part in ("edit", "patch")):
+        return diff_stat(details.get("diff"))
+    if "write" in normalized:
+        return _write_stat(details)
+    return None
+
+
+def _write_stat(details: Mapping[str, Any]) -> str | None:
+    parts: list[str] = []
+    operation = details.get("operation")
+    if isinstance(operation, str) and operation:
+        parts.append(_write_operation_label(operation))
+    bytes_written = details.get("bytes_written", details.get("bytesWritten"))
+    formatted_size = _format_byte_count(bytes_written)
+    if formatted_size:
+        parts.append(formatted_size)
+    return ", ".join(parts) if parts else None
+
+
+def _write_operation_label(operation: str) -> str:
+    normalized = operation.lower()
+    if normalized == "create":
+        return "created"
+    if normalized == "overwrite":
+        return "overwrote"
+    return normalized.replace("_", " ")
+
+
+def _format_byte_count(value: object) -> str | None:
+    if not isinstance(value, int) or value < 0:
+        return None
+    if value < 1024:
+        return f"{value} B"
+    units = ("KiB", "MiB", "GiB")
+    amount = float(value)
+    for unit in units:
+        amount /= 1024
+        if amount < 1024:
+            return f"{amount:.1f} {unit}"
+    return f"{amount:.1f} TiB"
+
+
+def _body(
+    tool_name: str,
+    view: ToolResultView,
+    *,
+    visible: bool,
+    max_lines: int,
+) -> str | None:
+    if max_lines < 1 or not visible:
+        return None
+    text = view.rendered_text or view.result_text
+    if not text:
+        return None
+    text = drop_tool_timing_tail_line(text.strip())
+    if not text:
+        return None
+    return collapse_tool_output_preview(
+        text,
+        max_lines=max_lines,
+        tail=prefers_tail_tool_output(tool_name),
+    )
+
+
+def _tool_state(status: ToolTranscriptStatus) -> ToolState:
+    if status == "ok":
+        return "completed"
+    if status == "cancelled":
+        return "cancelled"
+    if status in {"error", "timed_out"}:
+        return "failed"
+    if status == "terminate":
+        return "completed"
+    return "running"
+
+
+def _output_kind(output: str) -> ToolOutputKind:
+    stripped = output.lstrip()
+    if stripped.startswith("diff --git") or stripped.startswith(("@@", "--- ", "+++ ")):
+        return "diff"
+    return "text"
+
+
+def _exit_code(detail: str) -> int | None:
+    match = _EXIT_CODE_RE.search(detail)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+__all__ = [
+    "ToolBodyVisibility",
+    "ToolCommandResolver",
+    "ToolCallSnapshot",
+    "ToolCallView",
+    "ToolResultView",
+    "ToolTranscriptBlock",
+    "ToolTranscriptProjector",
+    "ToolTranscriptStatus",
+    "ToolVerbResolver",
+    "tool_block_to_record",
+]

--- a/src/loushang/harnesstui/status/__init__.py
+++ b/src/loushang/harnesstui/status/__init__.py
@@ -1,0 +1,1 @@
+"""Shared terminal status interaction."""

--- a/src/loushang/harnesstui/status/line.py
+++ b/src/loushang/harnesstui/status/line.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from loushang.tui import StatusField
+
+StatusLineAutoValue = Literal["auto", "true", "false"]
+StatusLineSeparator = Literal["pipe", "dot"]
+StatusLineStyle = Literal["codex-like", "muted", "plain"]
+
+
+@dataclass(frozen=True, slots=True)
+class StatusLineSettings:
+    enabled: bool = True
+    model: bool = True
+    workspace: bool = True
+    branch: bool = True
+    session: bool = True
+    runtime: bool = True
+    queue: StatusLineAutoValue = "auto"
+    message: StatusLineAutoValue = "auto"
+    separator: StatusLineSeparator = "pipe"
+    style: StatusLineStyle = "codex-like"
+
+
+@dataclass(frozen=True, slots=True)
+class StatusLinePreviewSnapshot:
+    model_label: str | None
+    cwd: str
+    branch: str | None
+    session_label: str | None
+    running: bool
+    pending_followups: int = 0
+    pending_steers: int = 0
+    status_message: str | None = None
+
+
+def status_line_fields(
+    snapshot: StatusLinePreviewSnapshot,
+    settings: StatusLineSettings,
+) -> tuple[StatusField, ...]:
+    fields: list[StatusField] = []
+    if settings.model:
+        fields.append(StatusField(snapshot.model_label or "model", priority=100, token="model"))
+    if settings.workspace:
+        fields.append(StatusField(cwd_label(snapshot.cwd), priority=90, token="workspace"))
+    if settings.branch:
+        fields.append(StatusField(snapshot.branch or "no-branch", priority=80, token="branch"))
+    if settings.session:
+        fields.append(StatusField(snapshot.session_label or "no-session", priority=70, token="session"))
+    if settings.runtime:
+        runtime_text = "running" if snapshot.running else "idle"
+        runtime_token = "runtime.running" if snapshot.running else "runtime.idle"
+        fields.append(StatusField(runtime_text, priority=60, token=runtime_token))
+    if _show_auto_field(settings.queue, snapshot.pending_followups > 0 or snapshot.pending_steers > 0):
+        fields.append(
+            StatusField(
+                f"queued={max(0, snapshot.pending_followups)} steer={max(0, snapshot.pending_steers)}",
+                priority=50,
+                token="queue",
+            )
+        )
+    if _show_auto_field(settings.message, bool(snapshot.status_message)):
+        fields.append(StatusField(snapshot.status_message or "no status", priority=40, token="message"))
+    return tuple(fields)
+
+
+def status_line_separator(settings: StatusLineSettings) -> str:
+    if settings.separator == "dot":
+        return " · "
+    return " | "
+
+
+def status_line_style_mode(settings: StatusLineSettings) -> StatusLineStyle:
+    return settings.style if settings.style in {"codex-like", "muted", "plain"} else "codex-like"
+
+
+def status_line_settings_from_control(settings: object | None) -> StatusLineSettings:
+    if settings is None:
+        return StatusLineSettings()
+    if isinstance(settings, StatusLineSettings):
+        return settings
+    defaults = StatusLineSettings()
+    return StatusLineSettings(
+        enabled=bool(_setting_value(settings, "enabled", defaults.enabled)),
+        model=bool(_setting_value(settings, "model", defaults.model)),
+        workspace=bool(_setting_value(settings, "workspace", defaults.workspace)),
+        branch=bool(_setting_value(settings, "branch", defaults.branch)),
+        session=bool(_setting_value(settings, "session", defaults.session)),
+        runtime=bool(_setting_value(settings, "runtime", defaults.runtime)),
+        queue=cast(StatusLineAutoValue, _setting_value(settings, "queue", defaults.queue)),
+        message=cast(StatusLineAutoValue, _setting_value(settings, "message", defaults.message)),
+        separator=cast(StatusLineSeparator, _setting_value(settings, "separator", defaults.separator)),
+        style=cast(StatusLineStyle, _setting_value(settings, "style", defaults.style)),
+    )
+
+
+def status_line_settings_to_patch(settings: StatusLineSettings) -> dict[str, object]:
+    return {
+        "enabled": settings.enabled,
+        "model": settings.model,
+        "workspace": settings.workspace,
+        "branch": settings.branch,
+        "session": settings.session,
+        "runtime": settings.runtime,
+        "queue": settings.queue,
+        "message": settings.message,
+        "separator": settings.separator,
+        "style": settings.style,
+    }
+
+
+def cwd_label(cwd: str) -> str:
+    if not cwd:
+        return "cwd"
+    return cwd.rstrip("/").rsplit("/", 1)[-1] or cwd
+
+
+def _setting_value(settings: object, key: str, default: object) -> object:
+    if isinstance(settings, Mapping):
+        return settings.get(key, default)
+    return getattr(settings, key, default)
+
+
+def _show_auto_field(value: StatusLineAutoValue, has_data: bool) -> bool:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return has_data
+
+
+__all__ = [
+    "StatusLinePreviewSnapshot",
+    "StatusLineSettings",
+    "cwd_label",
+    "status_line_fields",
+    "status_line_settings_from_control",
+    "status_line_settings_to_patch",
+    "status_line_separator",
+    "status_line_style_mode",
+]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -159,15 +159,26 @@ def test_tui_and_harness_do_not_import_harnesstui() -> None:
     assert offenders == []
 
 
-def test_harnesstui_reader_slice_boundary_is_documented() -> None:
+def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     path = Path("docs/internals/architecture/harnesstui/README.md")
     text = path.read_text(encoding="utf-8")
 
     assert "`loushang.coding.ui` -> `loushang.harnesstui`" in text
-    assert "`loushang.tui`" in text
-    assert "`loushang.harness`" in text
-    assert "session lifecycle" in text
-    assert "render hot path" in text
+    assert "`loushang.harnesstui.conversation.reader`" in text
+    assert "`loushang.harnesstui.conversation.source`" in text
+    assert "`loushang.harnesstui.conversation.tool_transcript`" in text
+    assert "`loushang.harnesstui.status.line`" in text
+
+
+def test_harnesstui_tool_and_status_entrypoints_exist() -> None:
+    paths = (
+        Path("src/loushang/harnesstui/conversation/tool_transcript.py"),
+        Path("src/loushang/harnesstui/status/line.py"),
+    )
+
+    missing = [path.as_posix() for path in paths if not path.is_file()]
+
+    assert missing == []
 
 
 def test_importing_channel_types_does_not_eagerly_load_agent_or_ai() -> None:

--- a/tests/coding/test_ui_status_line.py
+++ b/tests/coding/test_ui_status_line.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import replace
-
-from loushang.coding.ui.status_line import (
+from loushang.coding.ui import status_line as coding_status_line
+from loushang.harnesstui.status import line as shared_status_line
+from loushang.harnesstui.status.line import (
     StatusLinePreviewSnapshot,
     StatusLineSettings,
     status_line_fields,
@@ -12,110 +12,10 @@ from loushang.coding.ui.status_line import (
 from loushang.tui import RenderConstraints, StatusBar
 
 
-def _snapshot(**overrides: object) -> StatusLinePreviewSnapshot:
-    base = StatusLinePreviewSnapshot(
-        model_label="moonshot/kimi-for-coding",
-        cwd="/home/dev/workspace/loushang",
-        branch="main",
-        session_label="abcd",
-        running=False,
-    )
-    return replace(base, **overrides)
-
-
-def test_status_line_settings_defaults_match_product_defaults() -> None:
-    settings = StatusLineSettings()
-
-    assert settings.enabled is True
-    assert settings.model is True
-    assert settings.workspace is True
-    assert settings.branch is True
-    assert settings.session is True
-    assert settings.runtime is True
-    assert settings.queue == "auto"
-    assert settings.message == "auto"
-    assert settings.separator == "pipe"
-    assert settings.style == "codex-like"
-
-
-def test_status_line_fields_use_product_order_priority_and_tokens() -> None:
-    fields = status_line_fields(
-        _snapshot(running=True, pending_followups=2, pending_steers=1, status_message="Saved"),
-        StatusLineSettings(),
-    )
-
-    assert [(field.text, field.priority, field.token) for field in fields] == [
-        ("moonshot/kimi-for-coding", 100, "model"),
-        ("loushang", 90, "workspace"),
-        ("main", 80, "branch"),
-        ("abcd", 70, "session"),
-        ("running", 60, "runtime.running"),
-        ("queued=2 steer=1", 50, "queue"),
-        ("Saved", 40, "message"),
-    ]
-
-
-def test_status_line_fields_keep_current_missing_value_fallbacks() -> None:
-    fields = status_line_fields(
-        _snapshot(model_label=None, cwd="", branch=None, session_label=None),
-        StatusLineSettings(),
-    )
-
-    assert [field.text for field in fields[:5]] == ["model", "cwd", "no-branch", "no-session", "idle"]
-    assert fields[4].token == "runtime.idle"
-
-
-def test_status_line_fields_can_disable_regular_fields() -> None:
-    fields = status_line_fields(
-        _snapshot(),
-        StatusLineSettings(model=False, workspace=False, branch=False, session=False, runtime=False),
-    )
-
-    assert fields == ()
-
-
-def test_status_line_queue_auto_true_false_behavior() -> None:
-    snapshot = _snapshot()
-
-    assert [field.text for field in status_line_fields(snapshot, StatusLineSettings(queue="auto"))] == [
-        "moonshot/kimi-for-coding",
-        "loushang",
-        "main",
-        "abcd",
-        "idle",
-    ]
-    assert status_line_fields(snapshot, StatusLineSettings(queue="true"))[-1].text == "queued=0 steer=0"
-    assert all(field.token != "queue" for field in status_line_fields(snapshot, StatusLineSettings(queue="false")))
-
-
-def test_status_line_queue_auto_shows_when_data_exists() -> None:
-    fields = status_line_fields(_snapshot(pending_followups=1, pending_steers=3), StatusLineSettings(queue="auto"))
-
-    assert fields[-1].text == "queued=1 steer=3"
-    assert fields[-1].token == "queue"
-
-
-def test_status_line_message_auto_true_false_behavior() -> None:
-    snapshot = _snapshot(status_message=None)
-
-    assert all(field.token != "message" for field in status_line_fields(snapshot, StatusLineSettings(message="auto")))
-    assert status_line_fields(snapshot, StatusLineSettings(message="true"))[-1].text == "no status"
-    assert all(field.token != "message" for field in status_line_fields(snapshot, StatusLineSettings(message="false")))
-
-
-def test_status_line_message_auto_shows_when_data_exists() -> None:
-    fields = status_line_fields(_snapshot(status_message="Status line: on"), StatusLineSettings(message="auto"))
-
-    assert fields[-1].text == "Status line: on"
-    assert fields[-1].token == "message"
-
-
-def test_status_line_separator_and_style_mapping() -> None:
-    assert status_line_separator(StatusLineSettings(separator="pipe")) == " | "
-    assert status_line_separator(StatusLineSettings(separator="dot")) == " · "
-    assert status_line_style_mode(StatusLineSettings(style="codex-like")) == "codex-like"
-    assert status_line_style_mode(StatusLineSettings(style="muted")) == "muted"
-    assert status_line_style_mode(StatusLineSettings(style="plain")) == "plain"
+def test_coding_status_line_compatibility_aliases_are_identical() -> None:
+    assert coding_status_line.__all__ == shared_status_line.__all__
+    for name in shared_status_line.__all__:
+        assert getattr(coding_status_line, name) is getattr(shared_status_line, name)
 
 
 def test_screen_app_statusline_preview_snapshot_includes_live_queue_and_message_state() -> None:

--- a/tests/coding/test_ui_transcript_projection.py
+++ b/tests/coding/test_ui_transcript_projection.py
@@ -1,67 +1,34 @@
 from __future__ import annotations
 
-from loushang.coding.ui.tool_blocks import ToolTranscriptBlock
-from loushang.tui.transcript import ToolExecutionRecord
 
+def test_coding_tool_transcript_projection_preserves_compatibility_aliases() -> None:
+    from loushang.coding.ui.tool_blocks import (
+        ToolCallSnapshot as CodingToolCallSnapshot,
+    )
+    from loushang.coding.ui.tool_blocks import (
+        ToolTranscriptBlock as CodingToolTranscriptBlock,
+    )
+    from loushang.coding.ui.tool_blocks import (
+        ToolTranscriptStatus as CodingToolTranscriptStatus,
+    )
+    from loushang.coding.ui.transcript_projection import (
+        tool_block_to_record as coding_tool_block_to_record,
+    )
+    from loushang.harnesstui.conversation.tool_transcript import (
+        ToolCallSnapshot,
+        ToolTranscriptBlock,
+        ToolTranscriptStatus,
+    )
 
-def test_tool_block_projects_to_generic_tool_execution_record() -> None:
-    from loushang.coding.ui.transcript_projection import tool_block_to_record
+    assert CodingToolCallSnapshot is ToolCallSnapshot
+    assert CodingToolTranscriptBlock is ToolTranscriptBlock
+    assert CodingToolTranscriptStatus is ToolTranscriptStatus
 
-    block = ToolTranscriptBlock(
+    legacy_block = CodingToolTranscriptBlock(
         tool_call_id="tc1",
         tool_name="bash",
         status="ok",
         verb="Ran",
-        title="uv run pytest tests/tui -q",
-        detail=None,
-        body="passed\n2 passed",
+        title="pytest -q",
     )
-
-    record = tool_block_to_record(block, elapsed_seconds=1.25)
-
-    assert record == ToolExecutionRecord(
-        name="uv run pytest tests/tui -q",
-        state="completed",
-        elapsed_seconds=1.25,
-        output="passed\n2 passed",
-        command="uv run pytest tests/tui -q",
-    )
-
-
-def test_tool_block_projects_failure_detail_to_stderr_and_exit_code() -> None:
-    from loushang.coding.ui.transcript_projection import tool_block_to_record
-
-    block = ToolTranscriptBlock(
-        tool_call_id="tc1",
-        tool_name="bash",
-        status="error",
-        verb="Ran",
-        title="pytest",
-        detail="failed: exit code 2",
-        body="",
-    )
-
-    record = tool_block_to_record(block, elapsed_seconds=0.5)
-
-    assert record.state == "failed"
-    assert record.stderr == "failed: exit code 2"
-    assert record.exit_code == 2
-
-
-def test_tool_block_infers_diff_output_kind() -> None:
-    from loushang.coding.ui.transcript_projection import tool_block_to_record
-
-    block = ToolTranscriptBlock(
-        tool_call_id="tc1",
-        tool_name="apply_patch",
-        status="ok",
-        verb="Edited",
-        title="src/app.py",
-        body="diff --git a/src/app.py b/src/app.py\n@@\n-old\n+new",
-    )
-
-    record = tool_block_to_record(block)
-
-    assert record.output_kind == "diff"
-    assert record.show_stats is True
-
+    assert coding_tool_block_to_record(legacy_block).command == "pytest -q"

--- a/tests/harnesstui/conversation/test_tool_transcript.py
+++ b/tests/harnesstui/conversation/test_tool_transcript.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from loushang.harnesstui.conversation.tool_transcript import (
+    ToolCallView,
+    ToolResultView,
+    ToolTranscriptBlock,
+    ToolTranscriptProjector,
+    tool_block_to_record,
+)
+from loushang.tui.transcript import ToolExecutionRecord
+
+
+def test_neutral_projector_combines_call_snapshot_and_result_view() -> None:
+    projector = ToolTranscriptProjector(
+        verb_resolver=lambda tool_name, args: "Tested",
+        body_visibility=lambda tool_name, status: status == "ok",
+        command_resolver=lambda tool_name, args, title: title,
+        max_body_lines=3,
+    )
+    snapshot = projector.remember_call(
+        ToolCallView(
+            tool_call_id="tc1",
+            tool_name="bash",
+            args={"command": "pytest tests/tui -q"},
+            rendered_text="$ pytest tests/tui -q",
+        )
+    )
+
+    block = projector.project_result(
+        ToolResultView(
+            tool_call_id="tc1",
+            tool_name="ignored-after-snapshot",
+            status="ok",
+            result_text="one\ntwo\nthree\nfour",
+        ),
+        snapshot,
+    )
+
+    assert block == ToolTranscriptBlock(
+        tool_call_id="tc1",
+        tool_name="bash",
+        status="ok",
+        verb="Tested",
+        title="bash pytest tests/tui -q",
+        body="... (1 earlier lines)\ntwo\nthree\nfour",
+        command="bash pytest tests/tui -q",
+    )
+
+
+def test_neutral_projector_defaults_do_not_assume_product_policy() -> None:
+    projector = ToolTranscriptProjector()
+
+    block = projector.project_result(
+        ToolResultView(
+            tool_call_id="tc1",
+            tool_name="custom",
+            status="ok",
+            args={"path": "src/app.py"},
+            result_text="not shown without a body policy",
+        )
+    )
+
+    assert block.verb == "Used custom"
+    assert block.title == "custom src/app.py"
+    assert block.body is None
+
+
+@pytest.mark.parametrize(
+    ("status", "error_summary", "detail"),
+    [
+        ("running", None, None),
+        ("error", "exit code 2", "failed: exit code 2"),
+        ("cancelled", None, "cancelled"),
+        ("timed_out", None, "timed out"),
+        ("terminate", None, "terminated"),
+    ],
+)
+def test_neutral_result_status_projects_generic_detail(
+    status: str,
+    error_summary: str | None,
+    detail: str | None,
+) -> None:
+    projector = ToolTranscriptProjector()
+
+    block = projector.project_result(
+        ToolResultView(
+            tool_call_id="tc1",
+            tool_name="tool",
+            status=status,  # type: ignore[arg-type]
+            error_summary=error_summary,
+        )
+    )
+
+    assert block.detail == detail
+
+
+def test_neutral_result_details_project_edit_and_write_stats() -> None:
+    projector = ToolTranscriptProjector()
+
+    edit = projector.project_result(
+        ToolResultView(
+            tool_call_id="edit-1",
+            tool_name="apply_patch",
+            status="ok",
+            details={"diff": "--- a/app.py\n+++ b/app.py\n@@\n-old\n+new"},
+        )
+    )
+    write = projector.project_result(
+        ToolResultView(
+            tool_call_id="write-1",
+            tool_name="write",
+            status="ok",
+            details={"operation": "overwrite", "bytesWritten": 2048},
+        )
+    )
+
+    assert edit.detail == "+1 -1"
+    assert write.detail == "overwrote, 2.0 KiB"
+
+
+def test_tool_result_view_is_immutable() -> None:
+    view = ToolResultView(tool_call_id="tc1", tool_name="tool", status="ok")
+
+    with pytest.raises(FrozenInstanceError):
+        view.status = "error"  # type: ignore[misc]
+
+
+def test_tool_block_projects_to_generic_tool_execution_record() -> None:
+    block = ToolTranscriptBlock(
+        tool_call_id="tc1",
+        tool_name="bash",
+        status="ok",
+        verb="Ran",
+        title="uv run pytest tests/tui -q",
+        detail=None,
+        body="passed\n2 passed",
+        command="uv run pytest tests/tui -q",
+    )
+
+    record = tool_block_to_record(block, elapsed_seconds=1.25)
+
+    assert record == ToolExecutionRecord(
+        name="uv run pytest tests/tui -q",
+        state="completed",
+        elapsed_seconds=1.25,
+        output="passed\n2 passed",
+        command="uv run pytest tests/tui -q",
+    )
+
+
+def test_tool_block_projects_failure_detail_to_stderr_and_exit_code() -> None:
+    block = ToolTranscriptBlock(
+        tool_call_id="tc1",
+        tool_name="bash",
+        status="error",
+        verb="Ran",
+        title="pytest",
+        detail="failed: exit code 2",
+        body="",
+    )
+
+    record = tool_block_to_record(block, elapsed_seconds=0.5)
+
+    assert record.state == "failed"
+    assert record.stderr == "failed: exit code 2"
+    assert record.exit_code == 2
+
+
+def test_neutral_record_projection_does_not_infer_command_from_product_verb() -> None:
+    block = ToolTranscriptBlock(
+        tool_call_id="tc1",
+        tool_name="custom",
+        status="ok",
+        verb="Ran",
+        title="product label",
+    )
+
+    assert tool_block_to_record(block).command == ""
+
+
+def test_tool_block_infers_diff_output_kind() -> None:
+    block = ToolTranscriptBlock(
+        tool_call_id="tc1",
+        tool_name="apply_patch",
+        status="ok",
+        verb="Edited",
+        title="src/app.py",
+        body="diff --git a/src/app.py b/src/app.py\n@@\n-old\n+new",
+    )
+
+    record = tool_block_to_record(block)
+
+    assert record.output_kind == "diff"
+    assert record.show_stats is True

--- a/tests/harnesstui/status/test_line.py
+++ b/tests/harnesstui/status/test_line.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from loushang.harnesstui.status.line import (
+    StatusLinePreviewSnapshot,
+    StatusLineSettings,
+    status_line_fields,
+    status_line_separator,
+    status_line_style_mode,
+)
+
+
+def _snapshot(**overrides: object) -> StatusLinePreviewSnapshot:
+    base = StatusLinePreviewSnapshot(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/home/dev/workspace/loushang",
+        branch="main",
+        session_label="abcd",
+        running=False,
+    )
+    return replace(base, **overrides)
+
+
+def test_status_line_settings_defaults_match_product_defaults() -> None:
+    settings = StatusLineSettings()
+
+    assert settings.enabled is True
+    assert settings.model is True
+    assert settings.workspace is True
+    assert settings.branch is True
+    assert settings.session is True
+    assert settings.runtime is True
+    assert settings.queue == "auto"
+    assert settings.message == "auto"
+    assert settings.separator == "pipe"
+    assert settings.style == "codex-like"
+
+
+def test_status_line_fields_use_product_order_priority_and_tokens() -> None:
+    fields = status_line_fields(
+        _snapshot(running=True, pending_followups=2, pending_steers=1, status_message="Saved"),
+        StatusLineSettings(),
+    )
+
+    assert [(field.text, field.priority, field.token) for field in fields] == [
+        ("moonshot/kimi-for-coding", 100, "model"),
+        ("loushang", 90, "workspace"),
+        ("main", 80, "branch"),
+        ("abcd", 70, "session"),
+        ("running", 60, "runtime.running"),
+        ("queued=2 steer=1", 50, "queue"),
+        ("Saved", 40, "message"),
+    ]
+
+
+def test_status_line_fields_keep_current_missing_value_fallbacks() -> None:
+    fields = status_line_fields(
+        _snapshot(model_label=None, cwd="", branch=None, session_label=None),
+        StatusLineSettings(),
+    )
+
+    assert [field.text for field in fields[:5]] == ["model", "cwd", "no-branch", "no-session", "idle"]
+    assert fields[4].token == "runtime.idle"
+
+
+def test_status_line_fields_can_disable_regular_fields() -> None:
+    fields = status_line_fields(
+        _snapshot(),
+        StatusLineSettings(model=False, workspace=False, branch=False, session=False, runtime=False),
+    )
+
+    assert fields == ()
+
+
+def test_status_line_queue_auto_true_false_behavior() -> None:
+    snapshot = _snapshot()
+
+    assert [field.text for field in status_line_fields(snapshot, StatusLineSettings(queue="auto"))] == [
+        "moonshot/kimi-for-coding",
+        "loushang",
+        "main",
+        "abcd",
+        "idle",
+    ]
+    assert status_line_fields(snapshot, StatusLineSettings(queue="true"))[-1].text == "queued=0 steer=0"
+    assert all(field.token != "queue" for field in status_line_fields(snapshot, StatusLineSettings(queue="false")))
+
+
+def test_status_line_queue_auto_shows_when_data_exists() -> None:
+    fields = status_line_fields(_snapshot(pending_followups=1, pending_steers=3), StatusLineSettings(queue="auto"))
+
+    assert fields[-1].text == "queued=1 steer=3"
+    assert fields[-1].token == "queue"
+
+
+def test_status_line_message_auto_true_false_behavior() -> None:
+    snapshot = _snapshot(status_message=None)
+
+    assert all(field.token != "message" for field in status_line_fields(snapshot, StatusLineSettings(message="auto")))
+    assert status_line_fields(snapshot, StatusLineSettings(message="true"))[-1].text == "no status"
+    assert all(field.token != "message" for field in status_line_fields(snapshot, StatusLineSettings(message="false")))
+
+
+def test_status_line_message_auto_shows_when_data_exists() -> None:
+    fields = status_line_fields(_snapshot(status_message="Status line: on"), StatusLineSettings(message="auto"))
+
+    assert fields[-1].text == "Status line: on"
+    assert fields[-1].token == "message"
+
+
+def test_status_line_separator_and_style_mapping() -> None:
+    assert status_line_separator(StatusLineSettings(separator="pipe")) == " | "
+    assert status_line_separator(StatusLineSettings(separator="dot")) == " · "
+    assert status_line_style_mode(StatusLineSettings(style="codex-like")) == "codex-like"
+    assert status_line_style_mode(StatusLineSettings(style="muted")) == "muted"
+    assert status_line_style_mode(StatusLineSettings(style="plain")) == "plain"


### PR DESCRIPTION
## English

### Summary

- Add a product-neutral `ToolCallView` / `ToolResultView` contract and reusable tool transcript projection under `loushang.harnesstui`.
- Move shared tool transcript blocks, status mapping, output previews, and TUI record projection into `harnesstui.conversation.tool_transcript`.
- Keep raw `AgentToolResult`, Harness renderer adaptation, and Coding verb/body/command policy in `loushang.coding.ui`.
- Move the shared Harness status-line profile and deterministic field projection into `harnesstui.status.line`.
- Preserve the previous Coding import paths and behavior through compatibility adapters and identity aliases.

### Boundaries and impact

- Harnesstui does not import Coding, Agent, or AI product/model layers.
- Harness production code is unchanged.
- The neutral tool projector is event-driven and does not enter the per-frame render path.
- Status-line implementation is moved without logic, copy, ordering, or algorithm changes; only its owner/import path changes.
- Coding's two tool projection files shrink from 426 to 286 lines; the status-line compatibility module shrinks from 144 to 34 lines.

### Validation

- Tool/Conversation focused tests: `81 passed`
- Status/Surface focused tests: `84 passed`
- Screen App/Input/Mode focused tests: `98 passed`
- Architecture import boundaries: `65 passed`
- Frozen TUI render contract: `151 passed, 3294 deselected`
- Ruff and `git diff --check`: passed

## 中文

### 变更内容

- 在 `loushang.harnesstui` 中新增产品无关的 `ToolCallView` / `ToolResultView` 契约与可复用工具 transcript 投影。
- 将共享的 Tool Transcript Block、状态映射、输出预览和 TUI Record 投影迁入 `harnesstui.conversation.tool_transcript`。
- 原始 `AgentToolResult`、Harness renderer 适配以及 Coding 的 verb/body/command 策略继续保留在 `loushang.coding.ui`。
- 将共享 Harness 状态栏 profile 与确定性的字段投影迁入 `harnesstui.status.line`。
- 通过兼容 adapter 和对象身份一致的 alias 保留原 Coding 导入路径与行为。

### 边界与影响

- Harnesstui 不依赖 Coding、Agent 或 AI 产品/模型层。
- Harness 生产代码零改动。
- 中性 Tool Projector 只在事件发生时执行，不进入逐帧渲染路径。
- Status Line 实现保持逻辑、文案、排序和算法不变，只改变 owner/import 路径。
- Coding 的两个 Tool 投影文件从 426 行降至 286 行；Status Line 兼容模块从 144 行降至 34 行。

### 验证

- Tool/Conversation 定向测试：`81 passed`
- Status/Surface 定向测试：`84 passed`
- Screen App/Input/Mode 定向测试：`98 passed`
- 架构导入边界：`65 passed`
- 冻结的 TUI 渲染契约：`151 passed, 3294 deselected`
- Ruff 与 `git diff --check`：通过
