### PR TITLE
refactor(harnesstui): share conversation event projection / 共享会话事件投影

### DIFF
--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -19,6 +19,8 @@ This layer owns reusable Harness-oriented terminal interaction, including:
 
 - adapting neutral conversation snapshots and actions to TUI records and
   surfaces;
+- coordinating product-neutral conversation projection state such as tool
+  timing and duplicate-result suppression;
 - neutral tool-result views, transcript blocks, and deterministic presentation
   projection;
 - shared Harness status profiles that product shells can populate and present;
@@ -81,3 +83,43 @@ reach into those mechanics or introduce a second status-bar runtime.
 
 These explicit module paths are the stable imports for this slice. The package
 initializers do not need to provide convenience re-exports.
+
+## Conversation Event Projection
+
+`loushang.harnesstui.conversation.projection` owns the reusable state machine
+that projects neutral conversation facts into a `ConversationProjectionTarget`.
+It coordinates run starts, queue snapshots, assistant streaming, tool-call
+snapshots and elapsed time, duplicate tool results, and duplicate assistant
+errors. Its inputs are strings, timestamps, neutral tool views, and other
+presentation-ready values; raw Agent/Coding event dictionaries and AI message
+objects are not part of this contract.
+
+Product adapters keep ownership of raw event interpretation. In Coding,
+`loushang.coding.ui.conversation_event_adapter` reads product event shapes,
+extracts message and compaction values, applies Coding cancellation policy,
+and converts tool events through the Coding tool adapter before invoking the
+neutral projector. Plain and Screen implementations remain product targets:
+they decide how a projected fact mutates their renderer or screen app and keep
+their product-specific status copy.
+
+Surface-interest checks happen in the Coding adapter before queue reads, text
+joins, or tool rendering. This preserves Plain and Screen's distinct event
+interests and prevents ignored or duplicate events from mutating the product
+tool-render runtime. The neutral projector exposes only cheap state probes and
+a tool-finish context for this purpose; Coding event dictionaries still never
+cross the package boundary. Tool elapsed time brackets result adaptation and
+neutral projection, while each target keeps its prior cleanup behavior if
+projection fails.
+
+Assistant text deltas form a strict pass-through hot path. The Coding adapter
+must call `ConversationProjector.assistant_delta` directly, and that method
+must call the target directly without constructing an intermediate event,
+action list, tuple, mapping, generator, or concatenated buffer. Render caching,
+segmentation, invalidation, frame composition, and terminal writes remain in
+`loushang.tui` and the product renderer; this projection layer does not replace
+or bypass the frozen TUI render-performance contract. A marked Coding adapter
+test exercises the complete adapter-to-projector-to-target delta path, so the
+existing `make test-tui-render-contract` gate covers this new boundary.
+
+The explicit module path above is the stable import for this capability. The
+package initializer does not provide a convenience re-export.

--- a/src/loushang/coding/ui/conversation_event_adapter.py
+++ b/src/loushang/coding/ui/conversation_event_adapter.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from loushang.coding.ui.event_policy import is_cancelled_error_message
+from loushang.coding.ui.tool_blocks import ToolTranscriptProjector
+from loushang.harnesstui.conversation.projection import ConversationProjector
+
+QueueReader = Callable[[], tuple[str, ...] | list[str]]
+
+
+@dataclass(slots=True)
+class CodingConversationEventAdapter:
+    """Translate raw Coding events into product-neutral conversation facts."""
+
+    projector: ConversationProjector
+    tool_projector: ToolTranscriptProjector
+    read_pending_steers: QueueReader = tuple
+    read_pending_followups: QueueReader = tuple
+    recover_tool_updates: bool = True
+    project_tool_result_messages: bool = True
+    require_assistant_message_for_delta: bool = True
+    project_run_starts: bool = True
+    project_queue_updates: bool = True
+    project_user_messages: bool = True
+    project_assistant_error_text: bool = True
+    project_compaction_details: bool = True
+
+    def handle(self, event: dict[str, Any]) -> None:
+        event_type = event.get("type")
+        if event_type == "agent_start":
+            if self.project_run_starts:
+                self.projector.run_started()
+            return
+        if event_type == "queue_update":
+            if self.project_queue_updates:
+                self.projector.queues_updated(
+                    steers=tuple(self.read_pending_steers()),
+                    followups=tuple(self.read_pending_followups()),
+                )
+            return
+        if event_type == "message_start":
+            self._handle_message_start(event)
+            return
+        if event_type == "message_update":
+            self._handle_message_update(event)
+            return
+        if event_type == "message_end":
+            self._handle_message_end(event)
+            return
+        if event_type == "agent_end":
+            self._handle_agent_end(event)
+            return
+        if event_type == "tool_execution_start":
+            self.projector.tool_started(self.tool_projector.call_view(event))
+            return
+        if event_type == "tool_execution_update":
+            self._handle_tool_update(event)
+            return
+        if event_type == "tool_execution_end":
+            tool_call_id = self.tool_projector.call_id(event)
+            context = self.projector.begin_tool_finish(tool_call_id)
+            self.projector.tool_finished(
+                self.tool_projector.result_view(event, snapshot=context.snapshot),
+                context=context,
+            )
+            return
+        if event_type == "auto_retry_start":
+            self.projector.retry_started(
+                attempt=event.get("attempt"),
+                max_attempts=event.get("max_attempts"),
+                delay_ms=event.get("delay_ms"),
+                error_message=event.get("error_message"),
+            )
+            return
+        if event_type == "compaction_start":
+            self.projector.compaction_started(reason=event.get("reason"))
+            return
+        if event_type == "compaction_end":
+            self._handle_compaction_end(event)
+
+    def _handle_message_start(self, event: dict[str, Any]) -> None:
+        message = event.get("message")
+        role = getattr(message, "role", None)
+        if role == "user":
+            if self.project_user_messages:
+                self.projector.user_message(_extract_text(message))
+        elif role == "assistant":
+            self.projector.assistant_started()
+
+    def _handle_message_update(self, event: dict[str, Any]) -> None:
+        message = event.get("message")
+        if (
+            self.require_assistant_message_for_delta
+            and getattr(message, "role", None) != "assistant"
+        ):
+            return
+        assistant_event = event.get("assistant_message_event")
+        if not isinstance(assistant_event, dict):
+            return
+        if assistant_event.get("type") != "text_delta":
+            return
+        delta = assistant_event.get("delta")
+        if isinstance(delta, str):
+            self.projector.assistant_delta(delta)
+
+    def _handle_message_end(self, event: dict[str, Any]) -> None:
+        message = event.get("message")
+        role = getattr(message, "role", None)
+        if role == "assistant":
+            error_message, show_error = _assistant_error(message)
+            final_text = (
+                ""
+                if error_message is not None
+                and not self.project_assistant_error_text
+                else _extract_text(message)
+            )
+            self.projector.assistant_finished(
+                final_text,
+                error_message=error_message,
+                show_error=show_error,
+                error_id=id(message),
+            )
+            return
+        if role == "toolResult" and self.project_tool_result_messages:
+            tool_call_id = self.tool_projector.message_id(message)
+            if tool_call_id and self.projector.has_rendered_tool_result(tool_call_id):
+                return
+            self.projector.tool_result_message(
+                self.tool_projector.tool_result_message_view(message),
+                deduplicate=bool(tool_call_id),
+            )
+
+    def _handle_tool_update(self, event: dict[str, Any]) -> None:
+        if not self.recover_tool_updates:
+            return
+        tool_call_id = self.tool_projector.call_id(event)
+        if self.projector.has_active_tool_call(tool_call_id):
+            return
+        self.projector.tool_updated(self.tool_projector.call_view(event))
+
+    def _handle_compaction_end(self, event: dict[str, Any]) -> None:
+        raw_error = event.get("error_message")
+        if raw_error:
+            self.projector.compaction_finished(
+                error_message=(
+                    raw_error if isinstance(raw_error, str) else str(raw_error)
+                ),
+                summary="",
+                tokens_before=None,
+            )
+            return
+        if not self.project_compaction_details:
+            self.projector.compaction_finished(
+                error_message=None,
+                summary="",
+                tokens_before=None,
+            )
+            return
+        self.projector.compaction_finished(
+            error_message=None,
+            summary=_compaction_summary(event),
+            tokens_before=_compaction_tokens_before(event),
+        )
+
+    def _handle_agent_end(self, event: dict[str, Any]) -> None:
+        messages = event.get("messages")
+        if not isinstance(messages, list):
+            return
+        for message in reversed(messages):
+            if getattr(message, "role", None) != "assistant":
+                continue
+            error_message, show_error = _assistant_error(message)
+            if error_message is not None:
+                self.projector.assistant_error(
+                    error_message,
+                    show_error=show_error,
+                    error_id=id(message),
+                )
+            return
+
+
+def _assistant_error(message: object) -> tuple[str | None, bool]:
+    error_message = getattr(message, "error_message", None)
+    stop_reason = getattr(message, "stop_reason", None)
+    if not isinstance(error_message, str) or not error_message:
+        return None, False
+    if stop_reason not in {"error", "aborted"}:
+        return None, False
+    show_error = not (
+        stop_reason == "aborted" and is_cancelled_error_message(error_message)
+    )
+    return error_message, show_error
+
+
+def _extract_text(value: object) -> str:
+    content = getattr(value, "content", value)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            text = getattr(part, "text", None)
+            if isinstance(text, str):
+                parts.append(text)
+        return "".join(parts)
+    return ""
+
+
+def _compaction_summary(event: dict[str, Any]) -> str:
+    result = event.get("result")
+    if not isinstance(result, dict):
+        return ""
+    summary = result.get("summary")
+    return summary.strip() if isinstance(summary, str) else ""
+
+
+def _compaction_tokens_before(event: dict[str, Any]) -> int | None:
+    result = event.get("result")
+    if not isinstance(result, dict):
+        return None
+    tokens_before = result.get("tokens_before")
+    return tokens_before if isinstance(tokens_before, int) else None
+
+
+__all__ = ["CodingConversationEventAdapter", "QueueReader"]

--- a/src/loushang/coding/ui/plain_events.py
+++ b/src/loushang/coding/ui/plain_events.py
@@ -1,149 +1,214 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
-from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer, extract_text
-from loushang.coding.ui.tool_blocks import ToolCallSnapshot, ToolTranscriptProjector
+from loushang.coding.ui.conversation_event_adapter import (
+    CodingConversationEventAdapter,
+)
+from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
+from loushang.coding.ui.tool_blocks import ToolTranscriptProjector
 from loushang.harness.presentation import ToolDefinitionResolver
+from loushang.harnesstui.conversation.projection import ConversationProjector
+from loushang.harnesstui.conversation.tool_transcript import (
+    ToolCallSnapshot,
+    ToolTranscriptBlock,
+)
 
 
-@dataclass
+@dataclass(init=False)
 class PlainCodingEventRenderer:
+    """Coding raw-event facade for the plain conversation target."""
+
     renderer: PlainCodingUiRenderer
     tool_definition_resolver: ToolDefinitionResolver | None = None
     max_tool_body_lines: int = 8
-    tool_calls: dict[str, ToolCallSnapshot] = field(default_factory=dict)
-    rendered_tool_results: set[str] = field(default_factory=set)
-    rendered_assistant_errors: set[int] = field(default_factory=set)
-    last_error_message: str | None = None
     render_user_messages: bool = True
     _tool_projector: ToolTranscriptProjector = field(init=False, repr=False)
+    _projection: ConversationProjector = field(init=False, repr=False)
+    _adapter: CodingConversationEventAdapter = field(init=False, repr=False)
 
-    def __post_init__(self) -> None:
+    def __init__(
+        self,
+        renderer: PlainCodingUiRenderer,
+        tool_definition_resolver: ToolDefinitionResolver | None = None,
+        max_tool_body_lines: int = 8,
+        tool_calls: dict[str, ToolCallSnapshot] | None = None,
+        rendered_tool_results: set[str] | None = None,
+        rendered_assistant_errors: set[int] | None = None,
+        last_error_message: str | None = None,
+        render_user_messages: bool = True,
+    ) -> None:
+        self.renderer = renderer
+        self.tool_definition_resolver = tool_definition_resolver
+        self.max_tool_body_lines = max_tool_body_lines
+        self.render_user_messages = render_user_messages
         self._tool_projector = ToolTranscriptProjector(
-            tool_definition_resolver=self.tool_definition_resolver,
-            max_body_lines=self.max_tool_body_lines,
+            tool_definition_resolver=tool_definition_resolver,
+            max_body_lines=max_tool_body_lines,
+        )
+        self._projection = ConversationProjector(
+            target=_PlainProjectionTarget(
+                renderer=renderer,
+                render_user_messages=render_user_messages,
+            ),
+            tool_projector=self._tool_projector.neutral_projector,
+            measure_tool_elapsed=False,
+            tool_finish_cleanup="before_projection",
+            tool_calls=tool_calls if tool_calls is not None else {},
+            rendered_tool_results=(
+                rendered_tool_results
+                if rendered_tool_results is not None
+                else set()
+            ),
+            rendered_assistant_errors=cast(
+                set[int | str],
+                rendered_assistant_errors
+                if rendered_assistant_errors is not None
+                else set(),
+            ),
+            last_error_message=last_error_message,
+        )
+        self._adapter = CodingConversationEventAdapter(
+            self._projection,
+            self._tool_projector,
+            recover_tool_updates=False,
+            project_tool_result_messages=True,
+            require_assistant_message_for_delta=False,
+            project_run_starts=False,
+            project_queue_updates=False,
+            project_user_messages=render_user_messages,
+            project_assistant_error_text=False,
+            project_compaction_details=False,
         )
 
+    @property
+    def tool_calls(self) -> dict[str, ToolCallSnapshot]:
+        return self._projection.tool_calls
+
+    @tool_calls.setter
+    def tool_calls(self, value: dict[str, ToolCallSnapshot]) -> None:
+        self._projection.tool_calls = value
+
+    @property
+    def rendered_tool_results(self) -> set[str]:
+        return self._projection.rendered_tool_results
+
+    @rendered_tool_results.setter
+    def rendered_tool_results(self, value: set[str]) -> None:
+        self._projection.rendered_tool_results = value
+
+    @property
+    def rendered_assistant_errors(self) -> set[int]:
+        return cast(set[int], self._projection.rendered_assistant_errors)
+
+    @rendered_assistant_errors.setter
+    def rendered_assistant_errors(self, value: set[int]) -> None:
+        self._projection.rendered_assistant_errors = cast(set[int | str], value)
+
+    @property
+    def last_error_message(self) -> str | None:
+        return self._projection.last_error_message
+
+    @last_error_message.setter
+    def last_error_message(self, value: str | None) -> None:
+        self._projection.last_error_message = value
+
     def handle(self, event: dict[str, Any]) -> None:
-        event_type = event.get("type")
-        if event_type == "message_start":
-            self._handle_message_start(event)
-            return
-        if event_type == "message_update":
-            self._handle_message_update(event)
-            return
-        if event_type == "message_end":
-            self._handle_message_end(event)
-            return
-        if event_type == "tool_execution_start":
-            tool_call_id = str(event.get("tool_call_id") or event.get("tool_name") or "tool")
-            self.tool_calls[tool_call_id] = self._tool_projector.remember_call(event)
-            return
-        if event_type == "tool_execution_update":
-            return
-        if event_type == "tool_execution_end":
-            self._handle_tool_end(event)
-            return
-        if event_type == "agent_end":
-            self._handle_agent_end(event)
-            return
-        if event_type == "auto_retry_start":
-            self.renderer.render_status(
-                "[retry] attempt "
-                f"{event.get('attempt')}/{event.get('max_attempts')} "
-                f"in {event.get('delay_ms')}ms: {event.get('error_message')}"
-            )
-            return
-        if event_type == "compaction_start":
-            self.renderer.render_status(f"[compact] start: {event.get('reason')}")
-            return
-        if event_type == "compaction_end":
-            if event.get("error_message"):
-                self.renderer.render_status(f"[compact] error: {event.get('error_message')}")
-            else:
-                self.renderer.render_status("[compact] done")
-            return
+        self._adapter.handle(event)
 
-    def _handle_message_start(self, event: dict[str, Any]) -> None:
-        message = event.get("message")
-        role = getattr(message, "role", None)
-        if role == "user" and self.render_user_messages:
-            self.renderer.render_user(extract_text(message))
-        elif role == "assistant":
-            self.renderer.begin_assistant()
 
-    def _handle_message_update(self, event: dict[str, Any]) -> None:
-        assistant_event = event.get("assistant_message_event")
-        if not isinstance(assistant_event, dict):
+@dataclass(slots=True)
+class _PlainProjectionTarget:
+    renderer: PlainCodingUiRenderer
+    render_user_messages: bool
+
+    def run_started(self, *, start_time: Callable[[], float]) -> None:
+        del start_time
+
+    def queues_updated(
+        self,
+        *,
+        steers: tuple[str, ...],
+        followups: tuple[str, ...],
+    ) -> None:
+        del steers, followups
+
+    def user_message(self, text: str) -> None:
+        if self.render_user_messages:
+            self.renderer.render_user(text)
+
+    def assistant_started(self) -> None:
+        self.renderer.begin_assistant()
+
+    def assistant_delta(self, delta: str) -> None:
+        self.renderer.write_assistant_delta(delta)
+
+    def assistant_finished(
+        self,
+        final_text: str,
+        *,
+        error_message: str | None,
+        show_error: bool,
+    ) -> None:
+        # Plain output must not commit an errored (including intentionally aborted)
+        # assistant draft. The next run replaces the pending draft buffer.
+        if error_message is not None:
+            if show_error:
+                self.renderer.render_error(error_message)
             return
-        if assistant_event.get("type") == "text_delta":
-            delta = assistant_event.get("delta")
-            if isinstance(delta, str):
-                self.renderer.write_assistant_delta(delta)
+        self.renderer.end_assistant(final_text)
 
-    def _handle_message_end(self, event: dict[str, Any]) -> None:
-        message = event.get("message")
-        role = getattr(message, "role", None)
-        if role == "assistant":
-            if self._render_assistant_error(message):
-                return
-            self.renderer.end_assistant(extract_text(message))
-        elif role == "toolResult":
-            tool_call_id = str(getattr(message, "tool_call_id", "") or "")
-            if tool_call_id and tool_call_id in self.rendered_tool_results:
-                return
-            if tool_call_id:
-                self.rendered_tool_results.add(tool_call_id)
-            self.renderer.render_tool_block(self._tool_projector.project_tool_result_message(message))
-
-    def _handle_agent_end(self, event: dict[str, Any]) -> None:
-        messages = event.get("messages")
-        if not isinstance(messages, list):
-            return
-        for message in reversed(messages):
-            if getattr(message, "role", None) == "assistant":
-                self._render_assistant_error(message)
-                return
-
-    def _render_assistant_error(self, message: object) -> bool:
-        error_message = getattr(message, "error_message", None)
-        stop_reason = getattr(message, "stop_reason", None)
-        if not isinstance(error_message, str) or not error_message:
-            return False
-        if stop_reason not in {"error", "aborted"}:
-            return False
-        if _is_intentional_abort_error(stop_reason, error_message):
-            self.last_error_message = error_message
-            return True
-        message_id = id(message)
-        if message_id in self.rendered_assistant_errors:
-            return True
-        self.rendered_assistant_errors.add(message_id)
-        self.last_error_message = error_message
+    def assistant_error(self, error_message: str) -> None:
         self.renderer.render_error(error_message)
-        return True
 
-    def _handle_tool_end(self, event: dict[str, Any]) -> None:
-        tool_call_id = str(event.get("tool_call_id") or event.get("tool_name") or "tool")
-        snapshot = self.tool_calls.pop(tool_call_id, None)
-        self.rendered_tool_results.add(tool_call_id)
-        self.renderer.render_tool_block(self._tool_projector.project_result(event, snapshot))
+    def tool_started(
+        self,
+        tool_call_id: str,
+        snapshot: ToolCallSnapshot,
+    ) -> None:
+        del tool_call_id, snapshot
 
+    def tool_finished(
+        self,
+        block: ToolTranscriptBlock,
+        *,
+        elapsed_seconds: float,
+    ) -> None:
+        del elapsed_seconds
+        self.renderer.render_tool_block(block)
 
-def _is_intentional_abort_error(stop_reason: object, error_message: object) -> bool:
-    if stop_reason != "aborted":
-        return False
-    if not isinstance(error_message, str):
-        return True
-    normalized = error_message.strip().lower()
-    return normalized in {
-        "request cancelled.",
-        "request cancelled",
-        "operation aborted",
-        "request aborted by user",
-    } or "aborted" in normalized
+    def tool_result_message(self, block: ToolTranscriptBlock) -> None:
+        self.renderer.render_tool_block(block)
+
+    def retry_started(
+        self,
+        *,
+        attempt: int | None,
+        max_attempts: int | None,
+        delay_ms: int | float | None,
+        error_message: str | None,
+    ) -> None:
+        self.renderer.render_status(
+            f"[retry] attempt {attempt}/{max_attempts} in {delay_ms}ms: {error_message}"
+        )
+
+    def compaction_started(self, *, reason: str | None) -> None:
+        self.renderer.render_status(f"[compact] start: {reason}")
+
+    def compaction_finished(
+        self,
+        *,
+        error_message: str | None,
+        summary: str,
+        tokens_before: int | None,
+    ) -> None:
+        del summary, tokens_before
+        if error_message:
+            self.renderer.render_status(f"[compact] error: {error_message}")
+        else:
+            self.renderer.render_status("[compact] done")
 
 
 __all__ = ["PlainCodingEventRenderer"]

--- a/src/loushang/coding/ui/screen_events.py
+++ b/src/loushang/coding/ui/screen_events.py
@@ -5,15 +5,18 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from loushang.coding.ui.event_policy import is_cancelled_error_message
+from loushang.coding.ui.conversation_event_adapter import (
+    CodingConversationEventAdapter,
+)
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
-from loushang.coding.ui.tool_blocks import (
+from loushang.coding.ui.tool_blocks import ToolTranscriptProjector
+from loushang.coding.ui.transcript_projection import tool_block_to_record
+from loushang.harnesstui.conversation.projection import ConversationProjector
+from loushang.harnesstui.conversation.tool_transcript import (
     ToolCallSnapshot,
     ToolTranscriptBlock,
-    ToolTranscriptProjector,
 )
-from loushang.coding.ui.transcript_projection import tool_block_to_record
-from loushang.tui.transcript import ToolExecutionRecord
+from loushang.tui.transcript import ToolExecutionRecord, UserPromptRecord
 
 QueueReader = Callable[[], tuple[str, ...] | list[str]]
 TraceFn = Callable[[str], None]
@@ -21,6 +24,8 @@ TraceFn = Callable[[str], None]
 
 @dataclass(slots=True)
 class ScreenCodingEventProjector:
+    """Coding raw-event facade for the full-screen conversation target."""
+
     app: ScreenCodingTuiApp
     tool_definition_resolver: Any | None = None
     max_tool_body_lines: int = 8
@@ -28,224 +33,156 @@ class ScreenCodingEventProjector:
     read_pending_followups: QueueReader = tuple
     now: Callable[[], float] = time.monotonic
     _tool_projector: ToolTranscriptProjector = field(init=False, repr=False)
-    _tool_calls: dict[str, ToolCallSnapshot] = field(default_factory=dict, init=False, repr=False)
-    _tool_started_at: dict[str, float] = field(default_factory=dict, init=False, repr=False)
-    _rendered_assistant_error_ids: set[int] = field(default_factory=set, init=False, repr=False)
+    _projection: ConversationProjector = field(init=False, repr=False)
+    _adapter: CodingConversationEventAdapter = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._tool_projector = ToolTranscriptProjector(
             tool_definition_resolver=self.tool_definition_resolver,
             max_body_lines=self.max_tool_body_lines,
         )
-
-    def handle(self, event: dict[str, Any]) -> None:
-        event_type = event.get("type")
-        if event_type == "agent_start":
-            self._handle_agent_start()
-            return
-        if event_type == "queue_update":
-            self._sync_queues()
-            return
-        if event_type == "message_start":
-            self._handle_message_start(event)
-            return
-        if event_type == "message_update":
-            self._handle_message_update(event)
-            return
-        if event_type == "message_end":
-            self._handle_message_end(event)
-            return
-        if event_type == "agent_end":
-            self._handle_agent_end(event)
-            return
-        if event_type == "tool_execution_start":
-            self._handle_tool_start(event)
-            return
-        if event_type == "tool_execution_update":
-            self._handle_tool_update(event)
-            return
-        if event_type == "tool_execution_end":
-            self._handle_tool_end(event)
-            return
-        if event_type == "auto_retry_start":
-            self.app.set_status(
-                "retry "
-                f"{event.get('attempt')}/{event.get('max_attempts')} "
-                f"in {event.get('delay_ms')}ms: {event.get('error_message')}"
-            )
-            return
-        if event_type == "compaction_start":
-            self.app.set_status(f"compact start: {event.get('reason')}")
-            return
-        if event_type == "compaction_end":
-            if event.get("error_message"):
-                self.app.set_status(f"compact error: {event.get('error_message')}")
-            else:
-                self.app.set_status("compact done")
-                summary = _compaction_summary(event)
-                if summary:
-                    self.app.append_context_compaction_record(
-                        summary=summary,
-                        tokens_before=_compaction_tokens_before(event),
-                    )
-
-    def _handle_agent_start(self) -> None:
-        self._tool_calls.clear()
-        self._tool_started_at.clear()
-        if not self.app.state.running:
-            self.app.begin_run(started_at=self.now())
-
-    def _sync_queues(self) -> None:
-        self.app.sync_queues(
-            steers=tuple(self.read_pending_steers()),
-            followups=tuple(self.read_pending_followups()),
+        self._projection = ConversationProjector(
+            target=_ScreenProjectionTarget(self.app),
+            tool_projector=self._tool_projector.neutral_projector,
+            now=self.now,
+            track_rendered_tool_results=False,
+        )
+        self._adapter = CodingConversationEventAdapter(
+            self._projection,
+            self._tool_projector,
+            read_pending_steers=self.read_pending_steers,
+            read_pending_followups=self.read_pending_followups,
+            recover_tool_updates=True,
+            project_tool_result_messages=False,
+            require_assistant_message_for_delta=True,
+            project_run_starts=True,
+            project_queue_updates=True,
+            project_user_messages=True,
+            project_assistant_error_text=True,
+            project_compaction_details=True,
         )
 
-    def _handle_message_start(self, event: dict[str, Any]) -> None:
-        message = event.get("message")
-        role = getattr(message, "role", None)
-        if role == "user":
-            text = _extract_text(message).strip()
-            if text and not self.app.state.consume_pending_user_echo(text):
-                self.app.state.records.append(_user_record(text))
-                self.app.state.mark_records_changed()
-            return
-        if role == "assistant":
-            self.app.begin_assistant()
+    def handle(self, event: dict[str, Any]) -> None:
+        self._adapter.handle(event)
 
-    def _handle_message_update(self, event: dict[str, Any]) -> None:
-        message = event.get("message")
-        if getattr(message, "role", None) != "assistant":
-            return
-        assistant_event = event.get("assistant_message_event")
-        if not isinstance(assistant_event, dict):
-            return
-        if assistant_event.get("type") != "text_delta":
-            return
-        delta = assistant_event.get("delta")
-        if isinstance(delta, str):
-            self.app.append_assistant_chunk(delta)
 
-    def _handle_message_end(self, event: dict[str, Any]) -> None:
-        message = event.get("message")
-        role = getattr(message, "role", None)
-        if role == "assistant":
-            text = _extract_text(message)
-            self.app.end_assistant(text)
-            self._render_assistant_error(message)
+@dataclass(slots=True)
+class _ScreenProjectionTarget:
+    app: ScreenCodingTuiApp
 
-    def _handle_agent_end(self, event: dict[str, Any]) -> None:
-        messages = event.get("messages")
-        if not isinstance(messages, list):
-            return
-        for message in reversed(messages):
-            if getattr(message, "role", None) == "assistant":
-                self._render_assistant_error(message)
-                return
+    def run_started(self, *, start_time: Callable[[], float]) -> None:
+        if not self.app.state.running:
+            self.app.begin_run(started_at=start_time())
 
-    def _render_assistant_error(self, message: object) -> bool:
-        error_message = getattr(message, "error_message", None)
-        stop_reason = getattr(message, "stop_reason", None)
-        if not isinstance(error_message, str) or not error_message:
-            return False
-        if stop_reason not in {"error", "aborted"}:
-            return False
-        if stop_reason == "aborted" and is_cancelled_error_message(error_message):
-            return True
-        message_id = id(message)
-        if message_id in self._rendered_assistant_error_ids:
-            return True
-        self._rendered_assistant_error_ids.add(message_id)
+    def queues_updated(
+        self,
+        *,
+        steers: tuple[str, ...],
+        followups: tuple[str, ...],
+    ) -> None:
+        self.app.sync_queues(steers=steers, followups=followups)
+
+    def user_message(self, text: str) -> None:
+        text = text.strip()
+        if text and not self.app.state.consume_pending_user_echo(text):
+            self.app.state.records.append(UserPromptRecord(text))
+            self.app.state.mark_records_changed()
+
+    def assistant_started(self) -> None:
+        self.app.begin_assistant()
+
+    def assistant_delta(self, delta: str) -> None:
+        self.app.append_assistant_chunk(delta)
+
+    def assistant_finished(
+        self,
+        final_text: str,
+        *,
+        error_message: str | None,
+        show_error: bool,
+    ) -> None:
+        # Screen commits the final assistant text even when the message reports an
+        # error, then adds only errors that product policy says should be visible.
+        self.app.end_assistant(final_text)
+        if error_message is not None and show_error:
+            self.app.add_error(error_message)
+
+    def assistant_error(self, error_message: str) -> None:
         self.app.add_error(error_message)
-        return True
 
-    def _handle_tool_start(self, event: dict[str, Any]) -> None:
-        tool_call_id = _tool_call_id(event)
-        snapshot = self._tool_projector.remember_call(event)
-        self._tool_calls[tool_call_id] = snapshot
-        self._tool_started_at[tool_call_id] = self.now()
+    def tool_started(
+        self,
+        tool_call_id: str,
+        snapshot: ToolCallSnapshot,
+    ) -> None:
         self.app.state.upsert_tool_record(
             tool_call_id,
             ToolExecutionRecord(
-                name=_tool_title(snapshot, event),
+                name=_tool_title(snapshot),
                 state="running",
                 elapsed_seconds=0.0,
             ),
         )
 
-    def _handle_tool_update(self, event: dict[str, Any]) -> None:
-        tool_call_id = _tool_call_id(event)
-        if tool_call_id not in self._tool_calls:
-            self._handle_tool_start(event)
-
-    def _handle_tool_end(self, event: dict[str, Any]) -> None:
-        tool_call_id = _tool_call_id(event)
-        snapshot = self._tool_calls.get(tool_call_id)
-        started_at = self._tool_started_at.get(tool_call_id, self.now())
-        block = self._tool_projector.project_result(event, snapshot)
+    def tool_finished(
+        self,
+        block: ToolTranscriptBlock,
+        *,
+        elapsed_seconds: float,
+    ) -> None:
         self.app.state.upsert_tool_record(
-            tool_call_id,
-            tool_block_to_record(block, elapsed_seconds=max(0.0, self.now() - started_at)),
+            block.tool_call_id,
+            tool_block_to_record(block, elapsed_seconds=elapsed_seconds),
         )
-        self._tool_calls.pop(tool_call_id, None)
-        self._tool_started_at.pop(tool_call_id, None)
+
+    def tool_result_message(self, block: ToolTranscriptBlock) -> None:
+        # Full-screen mode already projects tool execution lifecycle records.
+        del block
+
+    def retry_started(
+        self,
+        *,
+        attempt: int | None,
+        max_attempts: int | None,
+        delay_ms: int | float | None,
+        error_message: str | None,
+    ) -> None:
+        self.app.set_status(
+            f"retry {attempt}/{max_attempts} in {delay_ms}ms: {error_message}"
+        )
+
+    def compaction_started(self, *, reason: str | None) -> None:
+        self.app.set_status(f"compact start: {reason}")
+
+    def compaction_finished(
+        self,
+        *,
+        error_message: str | None,
+        summary: str,
+        tokens_before: int | None,
+    ) -> None:
+        if error_message:
+            self.app.set_status(f"compact error: {error_message}")
+            return
+        self.app.set_status("compact done")
+        if summary:
+            self.app.append_context_compaction_record(
+                summary=summary,
+                tokens_before=tokens_before,
+            )
 
 
-def _tool_call_id(event: dict[str, Any]) -> str:
-    value = event.get("tool_call_id", event.get("toolCallId"))
-    if isinstance(value, str) and value:
-        return value
-    value = event.get("tool_name", event.get("toolName"))
-    return value if isinstance(value, str) and value else "tool"
-
-
-def _tool_title(snapshot: ToolCallSnapshot, event: dict[str, Any]) -> str:
+def _tool_title(snapshot: ToolCallSnapshot) -> str:
     if snapshot.rendered_call_text:
         return snapshot.rendered_call_text.splitlines()[0].strip()
     block = ToolTranscriptBlock(
-        tool_call_id=_tool_call_id(event),
+        tool_call_id="tool",
         tool_name=snapshot.tool_name,
         status="running",
         verb="Ran",
         title=snapshot.tool_name,
     )
     return tool_block_to_record(block).name
-
-
-def _extract_text(value: object) -> str:
-    content = getattr(value, "content", value)
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for part in content:
-            text = getattr(part, "text", None)
-            if isinstance(text, str):
-                parts.append(text)
-        return "".join(parts)
-    return ""
-
-
-def _compaction_summary(event: dict[str, Any]) -> str:
-    result = event.get("result")
-    if not isinstance(result, dict):
-        return ""
-    summary = result.get("summary")
-    return summary.strip() if isinstance(summary, str) else ""
-
-
-def _compaction_tokens_before(event: dict[str, Any]) -> int | None:
-    result = event.get("result")
-    if not isinstance(result, dict):
-        return None
-    tokens_before = result.get("tokens_before")
-    return tokens_before if isinstance(tokens_before, int) else None
-
-
-def _user_record(text: str):
-    from loushang.tui.transcript import UserPromptRecord
-
-    return UserPromptRecord(text)
 
 
 __all__ = ["ScreenCodingEventProjector"]

--- a/src/loushang/coding/ui/tool_blocks.py
+++ b/src/loushang/coding/ui/tool_blocks.py
@@ -40,14 +40,68 @@ class ToolTranscriptProjector:
             max_body_lines=self.max_body_lines,
         )
 
+    @property
+    def neutral_projector(self) -> NeutralToolTranscriptProjector:
+        """Return the product-neutral projector used by this Coding adapter."""
+
+        return self._projector
+
+    def call_id(self, event: Mapping[str, Any]) -> str:
+        """Read a tool-call id without invoking presentation renderers."""
+
+        return _tool_call_id(event)
+
+    def message_id(self, message: object) -> str:
+        """Read a tool-result message id without adapting its result body."""
+
+        value = getattr(message, "tool_call_id", None)
+        return value if isinstance(value, str) and value else ""
+
+    def call_view(self, event: Mapping[str, Any]) -> ToolCallView:
+        """Adapt a raw Coding tool-call event to a neutral view."""
+
+        return ToolCallView(
+            tool_call_id=self.call_id(event),
+            tool_name=_tool_name(event),
+            args=event.get("args"),
+            rendered_text=self._render_event_text(event, expanded=False),
+        )
+
     def remember_call(self, event: Mapping[str, Any]) -> ToolCallSnapshot:
-        return self._projector.remember_call(
-            ToolCallView(
-                tool_call_id=_tool_call_id(event),
-                tool_name=_tool_name(event),
-                args=event.get("args"),
-                rendered_text=self._render_event_text(event, expanded=False),
+        return self._projector.remember_call(self.call_view(event))
+
+    def result_view(
+        self,
+        event: Mapping[str, Any],
+        snapshot: ToolCallSnapshot | None = None,
+        *,
+        tool_call_id: str | None = None,
+    ) -> ToolResultView:
+        """Adapt a raw Coding tool-result event to a neutral view."""
+
+        result = _event_result(event)
+        status = _result_status(event, result=result)
+        event_tool_name = _tool_name(event)
+        policy_tool_name = (
+            snapshot.tool_name if snapshot is not None else event_tool_name
+        )
+        result_text = ""
+        if _should_show_body(policy_tool_name, status):
+            result_text = _fallback_result_text(
+                result,
+                max_lines=self.max_body_lines,
             )
+        return ToolResultView(
+            tool_call_id=(
+                self.call_id(event) if tool_call_id is None else tool_call_id
+            ),
+            tool_name=event_tool_name,
+            status=status,
+            args=event.get("args"),
+            result_text=result_text,
+            rendered_text=self._render_event_text(event, expanded=False),
+            details=_transcript_result_details(result),
+            error_summary=_tool_error_summary(result),
         )
 
     def project_result(
@@ -55,32 +109,16 @@ class ToolTranscriptProjector:
         event: Mapping[str, Any],
         snapshot: ToolCallSnapshot | None = None,
     ) -> ToolTranscriptBlock:
-        result = _event_result(event)
-        status = _result_status(event, result=result)
-        tool_name = snapshot.tool_name if snapshot is not None else _tool_name(event)
-        result_text = ""
-        if _should_show_body(tool_name, status):
-            result_text = _fallback_result_text(
-                result,
-                max_lines=self.max_body_lines,
-            )
         return self._projector.project_result(
-            ToolResultView(
-                tool_call_id=_tool_call_id(event),
-                tool_name=_tool_name(event),
-                status=status,
-                args=event.get("args"),
-                result_text=result_text,
-                rendered_text=self._render_event_text(event, expanded=False),
-                details=_transcript_result_details(result),
-                error_summary=_tool_error_summary(result),
-            ),
-            snapshot,
+            self.result_view(event, snapshot=snapshot), snapshot
         )
 
-    def project_tool_result_message(self, message: object) -> ToolTranscriptBlock:
+    def tool_result_message_view(self, message: object) -> ToolResultView:
+        """Adapt a raw Coding tool-result message to a neutral view."""
+
         tool_name = str(getattr(message, "tool_name", "tool"))
-        tool_call_id = str(getattr(message, "tool_call_id", tool_name))
+        raw_tool_call_id = self.message_id(message)
+        tool_call_id = raw_tool_call_id or tool_name
         event = {
             "type": "tool_execution_end",
             "tool_call_id": tool_call_id,
@@ -92,7 +130,10 @@ class ToolTranscriptProjector:
             ),
             "is_error": bool(getattr(message, "is_error", False)),
         }
-        return self.project_result(event)
+        return self.result_view(event, tool_call_id=tool_call_id)
+
+    def project_tool_result_message(self, message: object) -> ToolTranscriptBlock:
+        return self._projector.project_result(self.tool_result_message_view(message))
 
     def _render_event_text(
         self,

--- a/src/loushang/harnesstui/conversation/projection.py
+++ b/src/loushang/harnesstui/conversation/projection.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal, Protocol
+
+from loushang.harnesstui.conversation.tool_transcript import (
+    ToolCallSnapshot,
+    ToolCallView,
+    ToolResultView,
+    ToolTranscriptBlock,
+    ToolTranscriptProjector,
+)
+
+ErrorId = int | str
+ToolFinishCleanup = Literal["before_projection", "after_target"]
+
+
+@dataclass(frozen=True, slots=True)
+class ToolFinishContext:
+    """Snapshot the state needed to finish one tool without mutating it yet."""
+
+    tool_call_id: str
+    snapshot: ToolCallSnapshot | None
+    started_at: float
+
+
+class ConversationProjectionTarget(Protocol):
+    """Receive product-neutral conversation facts for one UI surface."""
+
+    def run_started(self, *, start_time: Callable[[], float]) -> None: ...
+
+    def queues_updated(
+        self,
+        *,
+        steers: tuple[str, ...],
+        followups: tuple[str, ...],
+    ) -> None: ...
+
+    def user_message(self, text: str) -> None: ...
+
+    def assistant_started(self) -> None: ...
+
+    def assistant_delta(self, delta: str) -> None: ...
+
+    def assistant_finished(
+        self,
+        final_text: str,
+        *,
+        error_message: str | None,
+        show_error: bool,
+    ) -> None: ...
+
+    def assistant_error(self, error_message: str) -> None: ...
+
+    def tool_started(
+        self,
+        tool_call_id: str,
+        snapshot: ToolCallSnapshot,
+    ) -> None: ...
+
+    def tool_finished(
+        self,
+        block: ToolTranscriptBlock,
+        *,
+        elapsed_seconds: float,
+    ) -> None: ...
+
+    def tool_result_message(self, block: ToolTranscriptBlock) -> None: ...
+
+    def retry_started(
+        self,
+        *,
+        attempt: int | None,
+        max_attempts: int | None,
+        delay_ms: int | float | None,
+        error_message: str | None,
+    ) -> None: ...
+
+    def compaction_started(self, *, reason: str | None) -> None: ...
+
+    def compaction_finished(
+        self,
+        *,
+        error_message: str | None,
+        summary: str,
+        tokens_before: int | None,
+    ) -> None: ...
+
+
+@dataclass(slots=True)
+class ConversationProjector:
+    """Coordinate reusable conversation projection state for a UI target."""
+
+    target: ConversationProjectionTarget
+    tool_projector: ToolTranscriptProjector = field(
+        default_factory=ToolTranscriptProjector
+    )
+    now: Callable[[], float] = time.monotonic
+    track_rendered_tool_results: bool = True
+    measure_tool_elapsed: bool = True
+    tool_finish_cleanup: ToolFinishCleanup = "after_target"
+    tool_calls: dict[str, ToolCallSnapshot] = field(
+        default_factory=dict,
+        repr=False,
+    )
+    rendered_tool_results: set[str] = field(default_factory=set, repr=False)
+    rendered_assistant_errors: set[ErrorId] = field(
+        default_factory=set,
+        repr=False,
+    )
+    last_error_message: str | None = None
+    _tool_started_at: dict[str, float] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+
+    def run_started(self) -> None:
+        self.tool_calls.clear()
+        self._tool_started_at.clear()
+        self.target.run_started(start_time=self.now)
+
+    def queues_updated(
+        self,
+        *,
+        steers: tuple[str, ...],
+        followups: tuple[str, ...],
+    ) -> None:
+        self.target.queues_updated(steers=steers, followups=followups)
+
+    def user_message(self, text: str) -> None:
+        self.target.user_message(text)
+
+    def assistant_started(self) -> None:
+        self.target.assistant_started()
+
+    def assistant_delta(self, delta: str) -> None:
+        self.target.assistant_delta(delta)
+
+    def assistant_finished(
+        self,
+        final_text: str,
+        *,
+        error_message: str | None = None,
+        show_error: bool = False,
+        error_id: ErrorId | None = None,
+    ) -> None:
+        show_error = self._remember_assistant_error(
+            error_message,
+            show_error=show_error,
+            error_id=error_id,
+        )
+        self.target.assistant_finished(
+            final_text,
+            error_message=error_message,
+            show_error=show_error,
+        )
+
+    def assistant_error(
+        self,
+        error_message: str,
+        *,
+        show_error: bool,
+        error_id: ErrorId | None = None,
+    ) -> None:
+        if self._remember_assistant_error(
+            error_message,
+            show_error=show_error,
+            error_id=error_id,
+        ):
+            self.target.assistant_error(error_message)
+
+    def tool_started(self, view: ToolCallView) -> None:
+        snapshot = self.tool_projector.remember_call(view)
+        self.tool_calls[view.tool_call_id] = snapshot
+        if self.measure_tool_elapsed:
+            self._tool_started_at[view.tool_call_id] = self.now()
+        self.target.tool_started(view.tool_call_id, snapshot)
+
+    def tool_updated(self, view: ToolCallView) -> None:
+        if view.tool_call_id not in self.tool_calls:
+            self.tool_started(view)
+
+    def has_active_tool_call(self, tool_call_id: str) -> bool:
+        return tool_call_id in self.tool_calls
+
+    def tool_call_snapshot(self, tool_call_id: str) -> ToolCallSnapshot | None:
+        return self.tool_calls.get(tool_call_id)
+
+    def has_rendered_tool_result(self, tool_call_id: str) -> bool:
+        return (
+            self.track_rendered_tool_results
+            and tool_call_id in self.rendered_tool_results
+        )
+
+    def begin_tool_finish(self, tool_call_id: str) -> ToolFinishContext:
+        fallback_started_at = self.now() if self.measure_tool_elapsed else 0.0
+        context = ToolFinishContext(
+            tool_call_id=tool_call_id,
+            snapshot=self.tool_calls.get(tool_call_id),
+            started_at=self._tool_started_at.get(
+                tool_call_id,
+                fallback_started_at,
+            ),
+        )
+        if self.tool_finish_cleanup == "before_projection":
+            self._complete_tool_finish(context)
+        return context
+
+    def tool_finished(
+        self,
+        view: ToolResultView,
+        *,
+        context: ToolFinishContext | None = None,
+    ) -> None:
+        context = context or self.begin_tool_finish(view.tool_call_id)
+        block = self.tool_projector.project_result(view, context.snapshot)
+        finished_at = self.now() if self.measure_tool_elapsed else context.started_at
+        self.target.tool_finished(
+            block,
+            elapsed_seconds=max(0.0, finished_at - context.started_at),
+        )
+        if self.tool_finish_cleanup == "after_target":
+            self._complete_tool_finish(context)
+
+    def tool_result_message(
+        self,
+        view: ToolResultView,
+        *,
+        deduplicate: bool = True,
+    ) -> None:
+        if deduplicate and self.has_rendered_tool_result(view.tool_call_id):
+            return
+        if deduplicate and self.track_rendered_tool_results:
+            self.rendered_tool_results.add(view.tool_call_id)
+        self.target.tool_result_message(self.tool_projector.project_result(view))
+
+    def _complete_tool_finish(self, context: ToolFinishContext) -> None:
+        self.tool_calls.pop(context.tool_call_id, None)
+        self._tool_started_at.pop(context.tool_call_id, None)
+        if self.track_rendered_tool_results:
+            self.rendered_tool_results.add(context.tool_call_id)
+
+    def retry_started(
+        self,
+        *,
+        attempt: int | None,
+        max_attempts: int | None,
+        delay_ms: int | float | None,
+        error_message: str | None,
+    ) -> None:
+        self.target.retry_started(
+            attempt=attempt,
+            max_attempts=max_attempts,
+            delay_ms=delay_ms,
+            error_message=error_message,
+        )
+
+    def compaction_started(self, *, reason: str | None) -> None:
+        self.target.compaction_started(reason=reason)
+
+    def compaction_finished(
+        self,
+        *,
+        error_message: str | None,
+        summary: str,
+        tokens_before: int | None,
+    ) -> None:
+        self.target.compaction_finished(
+            error_message=error_message,
+            summary=summary,
+            tokens_before=tokens_before,
+        )
+
+    def _remember_assistant_error(
+        self,
+        error_message: str | None,
+        *,
+        show_error: bool,
+        error_id: ErrorId | None,
+    ) -> bool:
+        if not error_message:
+            return False
+        self.last_error_message = error_message
+        if not show_error:
+            return False
+        if error_id is None:
+            return True
+        if error_id in self.rendered_assistant_errors:
+            return False
+        self.rendered_assistant_errors.add(error_id)
+        return True
+
+
+__all__ = [
+    "ConversationProjectionTarget",
+    "ConversationProjector",
+    "ToolFinishContext",
+]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -166,12 +166,14 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.coding.ui` -> `loushang.harnesstui`" in text
     assert "`loushang.harnesstui.conversation.reader`" in text
     assert "`loushang.harnesstui.conversation.source`" in text
+    assert "`loushang.harnesstui.conversation.projection`" in text
     assert "`loushang.harnesstui.conversation.tool_transcript`" in text
     assert "`loushang.harnesstui.status.line`" in text
 
 
-def test_harnesstui_tool_and_status_entrypoints_exist() -> None:
+def test_harnesstui_capability_entrypoints_exist() -> None:
     paths = (
+        Path("src/loushang/harnesstui/conversation/projection.py"),
         Path("src/loushang/harnesstui/conversation/tool_transcript.py"),
         Path("src/loushang/harnesstui/status/line.py"),
     )

--- a/tests/coding/test_screen_coding_tui_events.py
+++ b/tests/coding/test_screen_coding_tui_events.py
@@ -49,6 +49,24 @@ def test_screen_event_projector_streams_assistant_to_draft_then_commits_once() -
     ]
 
 
+def test_screen_event_projector_requires_assistant_message_for_delta() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_events import ScreenCodingEventProjector
+
+    app = ScreenCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 1.0)
+    projector = ScreenCodingEventProjector(app)
+
+    projector.handle({"type": "message_start", "message": _assistant()})
+    projector.handle(
+        {
+            "type": "message_update",
+            "assistant_message_event": {"type": "text_delta", "delta": "ignored"},
+        }
+    )
+
+    assert app.state.assistant_draft is None
+
+
 def test_screen_event_projector_renders_assistant_error_from_agent_end() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
     from loushang.coding.ui.screen_events import ScreenCodingEventProjector
@@ -64,6 +82,46 @@ def test_screen_event_projector_renders_assistant_error_from_agent_end() -> None
     )
 
     assert app.state.records == [ErrorRecord("provider failure")]
+
+
+def test_screen_event_projector_commits_error_message_and_deduplicates_error() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_events import ScreenCodingEventProjector
+
+    app = ScreenCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 1.0)
+    projector = ScreenCodingEventProjector(app)
+    message = _assistant(
+        "partial answer",
+        stop_reason="error",
+        error_message="provider failure",
+    )
+
+    projector.handle({"type": "message_start", "message": message})
+    projector.handle({"type": "message_end", "message": message})
+    projector.handle({"type": "agent_end", "messages": [message]})
+
+    assert app.state.records == [
+        AssistantMessageRecord("partial answer"),
+        ErrorRecord("provider failure"),
+    ]
+
+
+def test_screen_event_projector_commits_intentional_abort_without_error_record() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_events import ScreenCodingEventProjector
+
+    app = ScreenCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 1.0)
+    projector = ScreenCodingEventProjector(app)
+    message = _assistant(
+        "partial answer",
+        stop_reason="aborted",
+        error_message="Request aborted by user",
+    )
+
+    projector.handle({"type": "message_start", "message": message})
+    projector.handle({"type": "message_end", "message": message})
+
+    assert app.state.records == [AssistantMessageRecord("partial answer")]
 
 
 def test_screen_event_projector_renders_user_message_and_skips_optimistic_echo() -> None:
@@ -142,6 +200,91 @@ def test_screen_event_projector_updates_tool_record_in_place() -> None:
     assert isinstance(record, ToolExecutionRecord)
     assert record.state == "completed"
     assert record.name == "read README.md"
+
+
+def test_screen_event_projector_preserves_tool_elapsed_clock_boundaries() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_events import ScreenCodingEventProjector
+
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        now=lambda: 1.0,
+    )
+    clock = iter((10.0, 11.0, 15.0)).__next__
+    projector = ScreenCodingEventProjector(app, now=clock)
+    result: AgentToolResult[dict[str, object]] = AgentToolResult(
+        content=[TextPart(type="text", text="ok")],
+        details={},
+    )
+
+    projector.handle(
+        {
+            "type": "tool_execution_start",
+            "tool_call_id": "tc1",
+            "tool_name": "read",
+        }
+    )
+    projector.handle(
+        {
+            "type": "tool_execution_end",
+            "tool_call_id": "tc1",
+            "tool_name": "read",
+            "result": result,
+            "is_error": False,
+        }
+    )
+
+    record = app.state.records[0]
+    assert isinstance(record, ToolExecutionRecord)
+    assert record.elapsed_seconds == 5.0
+
+
+def test_screen_agent_start_does_not_read_clock_while_run_is_active() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_events import ScreenCodingEventProjector
+
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        now=lambda: 1.0,
+    )
+    app.begin_run(started_at=1.0)
+    clock_calls = 0
+
+    def clock() -> float:
+        nonlocal clock_calls
+        clock_calls += 1
+        return 2.0
+
+    ScreenCodingEventProjector(app, now=clock).handle({"type": "agent_start"})
+
+    assert clock_calls == 0
+
+
+def test_screen_event_projector_recovers_tool_update_without_start() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_events import ScreenCodingEventProjector
+
+    app = ScreenCodingTuiApp(model_label="kimi", cwd="/repo", branch="main", session_label="abcd", now=lambda: 5.0)
+    projector = ScreenCodingEventProjector(app, now=lambda: 5.0)
+
+    projector.handle(
+        {
+            "type": "tool_execution_update",
+            "tool_call_id": "tc1",
+            "tool_name": "read",
+            "args": {"path": "README.md"},
+        }
+    )
+
+    assert len(app.state.records) == 1
+    assert isinstance(app.state.records[0], ToolExecutionRecord)
+    assert app.state.records[0].state == "running"
 
 
 def test_screen_event_projector_syncs_pending_queues() -> None:

--- a/tests/coding/test_ui_conversation_event_adapter.py
+++ b/tests/coding/test_ui_conversation_event_adapter.py
@@ -1,0 +1,740 @@
+from __future__ import annotations
+
+import dis
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from loushang.agent import AgentToolResult
+from loushang.ai import TextPart, ToolResultMessage
+from loushang.harnesstui.conversation.tool_transcript import (
+    ToolCallSnapshot,
+    ToolCallView,
+    ToolResultView,
+)
+
+
+class _RecordingProjector:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
+        self.tool_calls: dict[str, ToolCallSnapshot] = {}
+        self.rendered_tool_results: set[str] = set()
+
+    def has_active_tool_call(self, tool_call_id: str) -> bool:
+        return tool_call_id in self.tool_calls
+
+    def tool_call_snapshot(self, tool_call_id: str) -> ToolCallSnapshot | None:
+        return self.tool_calls.get(tool_call_id)
+
+    def begin_tool_finish(self, tool_call_id: str) -> object:
+        return SimpleNamespace(
+            tool_call_id=tool_call_id,
+            snapshot=self.tool_calls.get(tool_call_id),
+            started_at=0.0,
+        )
+
+    def has_rendered_tool_result(self, tool_call_id: str) -> bool:
+        return tool_call_id in self.rendered_tool_results
+
+    def tool_started(self, view: ToolCallView) -> None:
+        self.calls.append(("tool_started", (view,), {}))
+        self.tool_calls[view.tool_call_id] = ToolCallSnapshot(
+            tool_name=view.tool_name,
+            args=view.args,
+            rendered_call_text=view.rendered_text,
+        )
+
+    def tool_updated(self, view: ToolCallView) -> None:
+        self.calls.append(("tool_updated", (view,), {}))
+        self.tool_calls[view.tool_call_id] = ToolCallSnapshot(
+            tool_name=view.tool_name,
+            args=view.args,
+            rendered_call_text=view.rendered_text,
+        )
+
+    def tool_finished(self, view: ToolResultView, *, context: object) -> None:
+        self.calls.append(("tool_finished", (view,), {"context": context}))
+        self.tool_calls.pop(view.tool_call_id, None)
+        self.rendered_tool_results.add(view.tool_call_id)
+
+    def tool_result_message(
+        self,
+        view: ToolResultView,
+        *,
+        deduplicate: bool,
+    ) -> None:
+        self.calls.append(
+            ("tool_result_message", (view,), {"deduplicate": deduplicate})
+        )
+        if deduplicate:
+            self.rendered_tool_results.add(view.tool_call_id)
+
+    def __getattr__(self, name: str):
+        def record(*args: object, **kwargs: object) -> None:
+            self.calls.append((name, args, kwargs))
+
+        return record
+
+
+def _adapter(
+    projector: _RecordingProjector,
+    *,
+    tool_projector: object | None = None,
+    **kwargs: object,
+):
+    from loushang.coding.ui.conversation_event_adapter import (
+        CodingConversationEventAdapter,
+    )
+    from loushang.coding.ui.tool_blocks import ToolTranscriptProjector
+
+    return CodingConversationEventAdapter(
+        projector=cast(Any, projector),
+        tool_projector=cast(
+            Any,
+            tool_projector
+            if tool_projector is not None
+            else ToolTranscriptProjector(),
+        ),
+        **kwargs,
+    )
+
+
+def test_coding_event_adapter_maps_message_and_queue_events_to_neutral_facts() -> None:
+    projector = _RecordingProjector()
+    adapter = _adapter(
+        projector,
+        read_pending_steers=lambda: ["steer"],
+        read_pending_followups=lambda: ("follow",),
+    )
+    user = SimpleNamespace(
+        role="user",
+        content=[SimpleNamespace(text="hello "), SimpleNamespace(text="world")],
+    )
+    assistant = SimpleNamespace(
+        role="assistant",
+        content=[SimpleNamespace(text="answer")],
+        stop_reason="stop",
+        error_message=None,
+    )
+    delta = " streamed"
+
+    adapter.handle({"type": "agent_start"})
+    adapter.handle({"type": "queue_update"})
+    adapter.handle({"type": "message_start", "message": user})
+    adapter.handle({"type": "message_start", "message": assistant})
+    adapter.handle(
+        {
+            "type": "message_update",
+            "message": assistant,
+            "assistant_message_event": {"type": "text_delta", "delta": delta},
+        }
+    )
+    adapter.handle({"type": "message_end", "message": assistant})
+
+    assert projector.calls[:4] == [
+        ("run_started", (), {}),
+        ("queues_updated", (), {"steers": ("steer",), "followups": ("follow",)}),
+        ("user_message", ("hello world",), {}),
+        ("assistant_started", (), {}),
+    ]
+    assert projector.calls[4][0] == "assistant_delta"
+    assert projector.calls[4][1][0] is delta
+    assert projector.calls[5] == (
+        "assistant_finished",
+        ("answer",),
+        {"error_message": None, "show_error": False, "error_id": id(assistant)},
+    )
+
+
+def test_coding_event_adapter_applies_coding_assistant_error_policy() -> None:
+    projector = _RecordingProjector()
+    adapter = _adapter(projector)
+    cancelled = SimpleNamespace(
+        role="assistant",
+        content=[],
+        stop_reason="aborted",
+        error_message="Request aborted by user",
+    )
+    failed = SimpleNamespace(
+        role="assistant",
+        content=[],
+        stop_reason="error",
+        error_message="provider failure",
+    )
+
+    adapter.handle({"type": "message_end", "message": cancelled})
+    adapter.handle({"type": "agent_end", "messages": [cancelled, failed]})
+
+    assert projector.calls == [
+        (
+            "assistant_finished",
+            ("",),
+            {
+                "error_message": "Request aborted by user",
+                "show_error": False,
+                "error_id": id(cancelled),
+            },
+        ),
+        (
+            "assistant_error",
+            ("provider failure",),
+            {"show_error": True, "error_id": id(failed)},
+        ),
+    ]
+
+
+def test_coding_event_adapter_maps_raw_tool_events_to_neutral_views() -> None:
+    projector = _RecordingProjector()
+    adapter = _adapter(projector)
+    result = AgentToolResult(
+        content=[TextPart(type="text", text="ok")],
+        details={},
+    )
+    start = {
+        "type": "tool_execution_start",
+        "tool_call_id": "tc1",
+        "tool_name": "read",
+        "args": {"path": "README.md"},
+    }
+
+    adapter.handle(start)
+    adapter.handle({**start, "type": "tool_execution_update"})
+    adapter.handle(
+        {
+            "type": "tool_execution_end",
+            "tool_call_id": "tc1",
+            "tool_name": "read",
+            "result": result,
+            "is_error": False,
+        }
+    )
+    adapter.handle(
+        {
+            "type": "message_end",
+            "message": ToolResultMessage(
+                role="toolResult",
+                tool_call_id="tc2",
+                tool_name="finish",
+                content=result.content,
+                details=result.details,
+                is_error=False,
+                terminate=True,
+                timestamp=0.0,
+            ),
+        }
+    )
+
+    start_view = projector.calls[0][1][0]
+    result_view = projector.calls[1][1][0]
+    replay_view = projector.calls[2][1][0]
+    assert isinstance(start_view, ToolCallView)
+    assert start_view.tool_call_id == "tc1"
+    assert start_view.args == {"path": "README.md"}
+    assert isinstance(result_view, ToolResultView)
+    assert result_view.tool_call_id == "tc1"
+    assert result_view.status == "ok"
+    assert isinstance(replay_view, ToolResultView)
+    assert replay_view.tool_call_id == "tc2"
+    assert replay_view.status == "terminate"
+
+
+def test_coding_event_adapter_extracts_retry_and_compaction_values() -> None:
+    projector = _RecordingProjector()
+    adapter = _adapter(projector)
+
+    adapter.handle(
+        {
+            "type": "auto_retry_start",
+            "attempt": 2,
+            "max_attempts": 3,
+            "delay_ms": 1000,
+            "error_message": "rate limit",
+        }
+    )
+    adapter.handle({"type": "compaction_start", "reason": "threshold"})
+    adapter.handle(
+        {
+            "type": "compaction_end",
+            "result": {"summary": "  condensed  ", "tokens_before": 500_000},
+        }
+    )
+
+    assert projector.calls == [
+        (
+            "retry_started",
+            (),
+            {
+                "attempt": 2,
+                "max_attempts": 3,
+                "delay_ms": 1000,
+                "error_message": "rate limit",
+            },
+        ),
+        ("compaction_started", (), {"reason": "threshold"}),
+        (
+            "compaction_finished",
+            (),
+            {
+                "error_message": None,
+                "summary": "condensed",
+                "tokens_before": 500_000,
+            },
+        ),
+    ]
+
+
+def test_coding_tool_adapter_exposes_read_only_neutral_views_and_projector() -> None:
+    from loushang.coding.ui.tool_blocks import ToolTranscriptProjector
+    from loushang.harnesstui.conversation.tool_transcript import (
+        ToolTranscriptProjector as NeutralToolTranscriptProjector,
+    )
+
+    projector = ToolTranscriptProjector()
+    call = projector.call_view(
+        {
+            "type": "tool_execution_start",
+            "toolCallId": "tc1",
+            "toolName": "bash",
+            "args": {"command": "pytest -q"},
+        }
+    )
+    result = projector.result_view(
+        {
+            "type": "tool_execution_end",
+            "toolCallId": "tc1",
+            "toolName": "bash",
+            "result": AgentToolResult(
+                content=[TextPart(type="text", text="1 passed")], details={}
+            ),
+        }
+    )
+
+    assert isinstance(projector.neutral_projector, NeutralToolTranscriptProjector)
+    assert call.tool_call_id == result.tool_call_id == "tc1"
+    assert call.tool_name == result.tool_name == "bash"
+    assert result.result_text == "1 passed"
+
+
+class _CountingRenderRuntime:
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def render_event(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+        self.call_count += 1
+
+
+def _counting_tool_projector(runtime: _CountingRenderRuntime):
+    from loushang.coding.ui.tool_blocks import ToolTranscriptProjector
+
+    return ToolTranscriptProjector(
+        tool_definition_resolver=lambda name: None,
+        render_runtime=cast(Any, runtime),
+    )
+
+
+def test_tool_update_interest_short_circuits_expensive_call_projection() -> None:
+    projector = _RecordingProjector()
+    runtime = _CountingRenderRuntime()
+    adapter = _adapter(
+        projector,
+        tool_projector=_counting_tool_projector(runtime),
+        recover_tool_updates=True,
+    )
+    start = {
+        "type": "tool_execution_start",
+        "tool_call_id": "tc1",
+        "tool_name": "bash",
+        "args": {"command": "pytest -q"},
+    }
+
+    adapter.handle(start)
+    assert runtime.call_count == 1
+    projector.calls.clear()
+    runtime.call_count = 0
+
+    adapter.handle({**start, "type": "tool_execution_update"})
+
+    assert runtime.call_count == 0
+    assert projector.calls == []
+
+    adapter.handle(
+        {
+            **start,
+            "type": "tool_execution_update",
+            "tool_call_id": "tc-missing",
+        }
+    )
+
+    assert runtime.call_count == 1
+    assert projector.calls[0][0] == "tool_updated"
+
+
+def test_disabled_tool_update_recovery_skips_missing_call_projection() -> None:
+    projector = _RecordingProjector()
+    runtime = _CountingRenderRuntime()
+    adapter = _adapter(
+        projector,
+        tool_projector=_counting_tool_projector(runtime),
+        recover_tool_updates=False,
+    )
+
+    adapter.handle(
+        {
+            "type": "tool_execution_update",
+            "tool_call_id": "tc-missing",
+            "tool_name": "bash",
+        }
+    )
+
+    assert runtime.call_count == 0
+    assert projector.calls == []
+
+
+def test_tool_result_message_interest_and_dedup_skip_result_projection() -> None:
+    result = AgentToolResult(
+        content=[TextPart(type="text", text="done")], details={}
+    )
+    rendered_message = ToolResultMessage(
+        role="toolResult",
+        tool_call_id="tc-rendered",
+        tool_name="bash",
+        content=result.content,
+        details=result.details,
+        is_error=False,
+        timestamp=0.0,
+    )
+    fresh_message = ToolResultMessage(
+        role="toolResult",
+        tool_call_id="tc-fresh",
+        tool_name="bash",
+        content=result.content,
+        details=result.details,
+        is_error=False,
+        timestamp=0.0,
+    )
+    projector = _RecordingProjector()
+    projector.rendered_tool_results.add("tc-rendered")
+    runtime = _CountingRenderRuntime()
+    tool_projector = _counting_tool_projector(runtime)
+    adapter = _adapter(
+        projector,
+        tool_projector=tool_projector,
+        project_tool_result_messages=True,
+    )
+
+    adapter.handle({"type": "message_end", "message": rendered_message})
+    assert runtime.call_count == 0
+    assert projector.calls == []
+
+    ignored_adapter = _adapter(
+        projector,
+        tool_projector=tool_projector,
+        project_tool_result_messages=False,
+    )
+    ignored_adapter.handle({"type": "message_end", "message": fresh_message})
+    assert runtime.call_count == 0
+    assert projector.calls == []
+
+    adapter.handle({"type": "message_end", "message": fresh_message})
+    assert runtime.call_count == 1
+    assert projector.calls[0][0] == "tool_result_message"
+
+
+def test_delta_message_role_requirement_is_surface_configurable() -> None:
+    delta_event = {
+        "type": "message_update",
+        "message": SimpleNamespace(role="user"),
+        "assistant_message_event": {"type": "text_delta", "delta": "delta"},
+    }
+    strict_projector = _RecordingProjector()
+    loose_projector = _RecordingProjector()
+
+    _adapter(
+        strict_projector, require_assistant_message_for_delta=True
+    ).handle(delta_event)
+    _adapter(
+        loose_projector, require_assistant_message_for_delta=False
+    ).handle(delta_event)
+
+    assert strict_projector.calls == []
+    assert loose_projector.calls == [("assistant_delta", ("delta",), {})]
+
+
+def test_result_view_uses_started_tool_name_for_body_policy() -> None:
+    from loushang.coding.ui.tool_blocks import ToolTranscriptProjector
+
+    tool_projector = ToolTranscriptProjector(max_body_lines=4)
+    snapshot = tool_projector.remember_call(
+        {
+            "type": "tool_execution_start",
+            "tool_call_id": "tc1",
+            "tool_name": "bash",
+            "args": {"command": "pytest -q"},
+        }
+    )
+    block = tool_projector.project_result(
+        {
+            "type": "tool_execution_end",
+            "tool_call_id": "tc1",
+            "result": AgentToolResult(
+                content=[TextPart(type="text", text="1 passed")], details={}
+            ),
+            "is_error": False,
+        },
+        snapshot,
+    )
+
+    assert block.tool_name == "bash"
+    assert block.body == "1 passed"
+
+
+def test_tool_end_reads_active_snapshot_before_adapting_result() -> None:
+    projector = _RecordingProjector()
+    adapter = _adapter(projector)
+    adapter.handle(
+        {
+            "type": "tool_execution_start",
+            "tool_call_id": "tc1",
+            "tool_name": "bash",
+            "args": {"command": "pytest -q"},
+        }
+    )
+    projector.calls.clear()
+
+    adapter.handle(
+        {
+            "type": "tool_execution_end",
+            "tool_call_id": "tc1",
+            "result": AgentToolResult(
+                content=[TextPart(type="text", text="1 passed")], details={}
+            ),
+            "is_error": False,
+        }
+    )
+
+    result_view = projector.calls[0][1][0]
+    assert isinstance(result_view, ToolResultView)
+    assert result_view.result_text == "1 passed"
+
+
+def test_tool_finish_timing_begins_before_result_projection() -> None:
+    order: list[str] = []
+
+    class OrderedProjector(_RecordingProjector):
+        def begin_tool_finish(self, tool_call_id: str) -> object:
+            order.append("begin")
+            return super().begin_tool_finish(tool_call_id)
+
+        def tool_finished(self, view: ToolResultView, *, context: object) -> None:
+            order.append("finish")
+            super().tool_finished(view, context=context)
+
+    class OrderedRenderRuntime(_CountingRenderRuntime):
+        def render_event(self, *args: object, **kwargs: object) -> None:
+            order.append("project")
+            super().render_event(*args, **kwargs)
+
+    projector = OrderedProjector()
+    runtime = OrderedRenderRuntime()
+    adapter = _adapter(
+        projector,
+        tool_projector=_counting_tool_projector(runtime),
+    )
+    adapter.handle(
+        {
+            "type": "tool_execution_start",
+            "tool_call_id": "tc1",
+            "tool_name": "bash",
+            "args": {"command": "pytest -q"},
+        }
+    )
+    order.clear()
+
+    adapter.handle(
+        {
+            "type": "tool_execution_end",
+            "tool_call_id": "tc1",
+            "tool_name": "bash",
+            "result": AgentToolResult(
+                content=[TextPart(type="text", text="1 passed")], details={}
+            ),
+            "is_error": False,
+        }
+    )
+
+    assert order == ["begin", "project", "finish"]
+
+
+def test_run_and_queue_interest_short_circuit_before_queue_reads() -> None:
+    def poison_queue_reader() -> tuple[str, ...]:
+        raise AssertionError("queue reader must not run")
+
+    projector = _RecordingProjector()
+    adapter = _adapter(
+        projector,
+        read_pending_steers=poison_queue_reader,
+        read_pending_followups=poison_queue_reader,
+        project_run_starts=False,
+        project_queue_updates=False,
+    )
+
+    adapter.handle({"type": "agent_start"})
+    adapter.handle({"type": "queue_update"})
+
+    assert projector.calls == []
+
+
+class _PoisonUserMessage:
+    role = "user"
+
+    @property
+    def content(self) -> object:
+        raise AssertionError("user content must not be read")
+
+
+class _PoisonAssistantError:
+    role = "assistant"
+    stop_reason = "error"
+    error_message = "provider failure"
+
+    @property
+    def content(self) -> object:
+        raise AssertionError("errored assistant content must not be read")
+
+
+def test_message_interest_short_circuits_before_text_extraction() -> None:
+    projector = _RecordingProjector()
+    adapter = _adapter(
+        projector,
+        project_user_messages=False,
+        project_assistant_error_text=False,
+    )
+    assistant = _PoisonAssistantError()
+
+    adapter.handle({"type": "message_start", "message": _PoisonUserMessage()})
+    adapter.handle({"type": "message_end", "message": assistant})
+
+    assert projector.calls == [
+        (
+            "assistant_finished",
+            ("",),
+            {
+                "error_message": "provider failure",
+                "show_error": True,
+                "error_id": id(assistant),
+            },
+        )
+    ]
+
+
+class _PoisonCompactionResult(dict[str, object]):
+    def get(self, key: str, default: object = None) -> object:
+        del key, default
+        raise AssertionError("compaction result must not be read")
+
+
+def test_compaction_interest_and_error_short_circuit_detail_reads() -> None:
+    projector = _RecordingProjector()
+    adapter = _adapter(projector, project_compaction_details=False)
+    poison_result = _PoisonCompactionResult()
+
+    adapter.handle(
+        {
+            "type": "compaction_end",
+            "error_message": 503,
+            "result": poison_result,
+        }
+    )
+    adapter.handle({"type": "compaction_end", "result": poison_result})
+
+    assert projector.calls == [
+        (
+            "compaction_finished",
+            (),
+            {"error_message": "503", "summary": "", "tokens_before": None},
+        ),
+        (
+            "compaction_finished",
+            (),
+            {"error_message": None, "summary": "", "tokens_before": None},
+        ),
+    ]
+
+
+def test_anonymous_tool_result_messages_are_not_deduplicated() -> None:
+    result = AgentToolResult(
+        content=[TextPart(type="text", text="done")], details={}
+    )
+    message = SimpleNamespace(
+        role="toolResult",
+        tool_name="read",
+        content=result.content,
+        details=result.details,
+        is_error=False,
+        terminate=False,
+    )
+    projector = _RecordingProjector()
+    adapter = _adapter(projector)
+
+    adapter.handle({"type": "message_end", "message": message})
+    adapter.handle({"type": "message_end", "message": message})
+
+    assert len(projector.calls) == 2
+    for name, args, kwargs in projector.calls:
+        assert name == "tool_result_message"
+        view = args[0]
+        assert isinstance(view, ToolResultView)
+        assert view.tool_call_id == "read"
+        assert kwargs == {"deduplicate": False}
+
+
+@pytest.mark.tui_render_contract
+def test_delta_hot_path_preserves_identity_without_container_construction() -> None:
+    from loushang.coding.ui.conversation_event_adapter import (
+        CodingConversationEventAdapter,
+    )
+    from loushang.coding.ui.tool_blocks import ToolTranscriptProjector
+    from loushang.harnesstui.conversation.projection import ConversationProjector
+
+    class DeltaTarget:
+        delta: str | None = None
+
+        def assistant_delta(self, delta: str) -> None:
+            self.delta = delta
+
+    target = DeltaTarget()
+    adapter = CodingConversationEventAdapter(
+        projector=ConversationProjector(target=cast(Any, target)),
+        tool_projector=ToolTranscriptProjector(),
+        require_assistant_message_for_delta=False,
+    )
+    delta = "identity-sensitive delta"
+
+    adapter.handle(
+        {
+            "type": "message_update",
+            "assistant_message_event": {"type": "text_delta", "delta": delta},
+        }
+    )
+
+    assert target.delta is delta
+    forbidden = {
+        "BUILD_LIST",
+        "BUILD_TUPLE",
+        "BUILD_MAP",
+        "BUILD_CONST_KEY_MAP",
+        "BUILD_SET",
+        "LIST_APPEND",
+        "MAP_ADD",
+        "SET_ADD",
+    }
+    for hot_method in (
+        CodingConversationEventAdapter._handle_message_update,
+        ConversationProjector.assistant_delta,
+    ):
+        opnames = {
+            instruction.opname for instruction in dis.get_instructions(hot_method)
+        }
+        assert opnames.isdisjoint(forbidden)

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -56,6 +56,19 @@ else:
     assert result.returncode == 0, result.stderr
 
 
+def test_conversation_raw_event_dispatch_stays_in_coding_adapter() -> None:
+    adapter = Path(
+        "src/loushang/coding/ui/conversation_event_adapter.py"
+    ).read_text(encoding="utf-8")
+    assert 'event.get("type")' in adapter
+
+    for path in (
+        Path("src/loushang/coding/ui/plain_events.py"),
+        Path("src/loushang/coding/ui/screen_events.py"),
+    ):
+        assert 'event.get("type")' not in path.read_text(encoding="utf-8")
+
+
 def test_old_coding_ui_app_module_is_removed() -> None:
     result = _run_python_import_boundary_check(
         """

--- a/tests/coding/test_ui_plain_renderer.py
+++ b/tests/coding/test_ui_plain_renderer.py
@@ -84,6 +84,73 @@ def test_event_renderer_buffers_assistant_deltas_until_final_block() -> None:
     assert stdout.getvalue() == "• hi there\n"
 
 
+def test_event_renderer_accepts_legacy_delta_without_message() -> None:
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
+
+    stdout = StringIO()
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+
+    event_renderer.handle({"type": "message_start", "message": _assistant("")})
+    event_renderer.handle(
+        {
+            "type": "message_update",
+            "assistant_message_event": {"type": "text_delta", "delta": "legacy"},
+        }
+    )
+    event_renderer.handle({"type": "message_end", "message": _assistant("legacy")})
+
+    assert stdout.getvalue() == "• legacy\n"
+
+
+def test_event_renderer_preserves_legacy_constructor_and_injected_state() -> None:
+    from inspect import signature
+
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
+    from loushang.harnesstui.conversation.tool_transcript import ToolCallSnapshot
+
+    assert tuple(signature(PlainCodingEventRenderer).parameters) == (
+        "renderer",
+        "tool_definition_resolver",
+        "max_tool_body_lines",
+        "tool_calls",
+        "rendered_tool_results",
+        "rendered_assistant_errors",
+        "last_error_message",
+        "render_user_messages",
+    )
+
+    tool_calls = {"tc-pending": ToolCallSnapshot(tool_name="read")}
+    rendered_tool_results = {"tc-done"}
+    rendered_assistant_errors = {123}
+    event_renderer = PlainCodingEventRenderer(
+        PlainCodingUiRenderer(stdout=StringIO()),
+        None,
+        4,
+        tool_calls,
+        rendered_tool_results,
+        rendered_assistant_errors,
+        "old error",
+        False,
+    )
+
+    assert event_renderer.tool_calls is tool_calls
+    assert event_renderer.rendered_tool_results is rendered_tool_results
+    assert event_renderer.rendered_assistant_errors is rendered_assistant_errors
+    assert event_renderer.last_error_message == "old error"
+    event_renderer.last_error_message = "new error"
+    assert event_renderer.last_error_message == "new error"
+
+    event_renderer.handle({"type": "agent_start"})
+    event_renderer.handle({"type": "queue_update"})
+
+    assert event_renderer.tool_calls is tool_calls
+    assert event_renderer.tool_calls == {
+        "tc-pending": ToolCallSnapshot(tool_name="read")
+    }
+
+
 def test_event_renderer_renders_completed_assistant_markdown_without_raw_markers() -> None:
     from loushang.coding.ui.plain_events import PlainCodingEventRenderer
     from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
@@ -152,6 +219,45 @@ def test_event_renderer_prints_assistant_error_from_agent_end() -> None:
     )
 
     assert stdout.getvalue() == "■ Error: provider failure\n"
+
+
+def test_event_renderer_deduplicates_assistant_error_and_keeps_last_error() -> None:
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
+
+    stdout = StringIO()
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    message = _assistant(
+        "partial answer",
+        stop_reason="error",
+        error_message="provider failure",
+    )
+
+    event_renderer.handle({"type": "message_start", "message": message})
+    event_renderer.handle({"type": "message_end", "message": message})
+    event_renderer.handle({"type": "agent_end", "messages": [message]})
+
+    assert stdout.getvalue() == "■ Error: provider failure\n"
+    assert event_renderer.last_error_message == "provider failure"
+
+
+def test_event_renderer_suppresses_intentional_abort_without_committing_draft() -> None:
+    from loushang.coding.ui.plain_events import PlainCodingEventRenderer
+    from loushang.coding.ui.plain_renderer import PlainCodingUiRenderer
+
+    stdout = StringIO()
+    event_renderer = PlainCodingEventRenderer(PlainCodingUiRenderer(stdout=stdout))
+    message = _assistant(
+        "partial answer",
+        stop_reason="aborted",
+        error_message="Request aborted by user",
+    )
+
+    event_renderer.handle({"type": "message_start", "message": message})
+    event_renderer.handle({"type": "message_end", "message": message})
+
+    assert stdout.getvalue() == ""
+    assert event_renderer.last_error_message == "Request aborted by user"
 
 
 def test_event_renderer_prints_user_message_start() -> None:

--- a/tests/harnesstui/conversation/test_projection.py
+++ b/tests/harnesstui/conversation/test_projection.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import dis
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import pytest
+
+from loushang.harnesstui.conversation.projection import ConversationProjector
+from loushang.harnesstui.conversation.tool_transcript import (
+    ToolCallSnapshot,
+    ToolCallView,
+    ToolResultView,
+    ToolTranscriptBlock,
+    ToolTranscriptProjector,
+)
+
+
+@dataclass
+class RecordingTarget:
+    events: list[tuple[object, ...]] = field(default_factory=list)
+    last_delta: str | None = None
+
+    def run_started(self, *, start_time: Callable[[], float]) -> None:
+        self.events.append(("run_started", start_time()))
+
+    def queues_updated(
+        self,
+        *,
+        steers: tuple[str, ...],
+        followups: tuple[str, ...],
+    ) -> None:
+        self.events.append(("queues_updated", steers, followups))
+
+    def user_message(self, text: str) -> None:
+        self.events.append(("user_message", text))
+
+    def assistant_started(self) -> None:
+        self.events.append(("assistant_started",))
+
+    def assistant_delta(self, delta: str) -> None:
+        self.last_delta = delta
+
+    def assistant_finished(
+        self,
+        final_text: str,
+        *,
+        error_message: str | None,
+        show_error: bool,
+    ) -> None:
+        self.events.append(
+            ("assistant_finished", final_text, error_message, show_error)
+        )
+
+    def assistant_error(self, error_message: str) -> None:
+        self.events.append(("assistant_error", error_message))
+
+    def tool_started(
+        self,
+        tool_call_id: str,
+        snapshot: ToolCallSnapshot,
+    ) -> None:
+        self.events.append(("tool_started", tool_call_id, snapshot))
+
+    def tool_finished(
+        self,
+        block: ToolTranscriptBlock,
+        *,
+        elapsed_seconds: float,
+    ) -> None:
+        self.events.append(("tool_finished", block, elapsed_seconds))
+
+    def tool_result_message(self, block: ToolTranscriptBlock) -> None:
+        self.events.append(("tool_result_message", block))
+
+    def retry_started(
+        self,
+        *,
+        attempt: int | None,
+        max_attempts: int | None,
+        delay_ms: int | float | None,
+        error_message: str | None,
+    ) -> None:
+        self.events.append(
+            (
+                "retry_started",
+                attempt,
+                max_attempts,
+                delay_ms,
+                error_message,
+            )
+        )
+
+    def compaction_started(self, *, reason: str | None) -> None:
+        self.events.append(("compaction_started", reason))
+
+    def compaction_finished(
+        self,
+        *,
+        error_message: str | None,
+        summary: str,
+        tokens_before: int | None,
+    ) -> None:
+        self.events.append(
+            ("compaction_finished", error_message, summary, tokens_before)
+        )
+
+
+def test_assistant_delta_forwards_the_same_object_without_building_containers() -> None:
+    target = RecordingTarget()
+    projector = ConversationProjector(target)
+    delta = "".join(("streamed", " ", "text"))
+
+    projector.assistant_delta(delta)
+
+    assert target.last_delta is delta
+    opnames = {
+        instruction.opname
+        for instruction in dis.get_instructions(ConversationProjector.assistant_delta)
+    }
+    assert opnames.isdisjoint(
+        {
+            "BUILD_LIST",
+            "BUILD_TUPLE",
+            "BUILD_MAP",
+            "BUILD_CONST_KEY_MAP",
+            "BUILD_SET",
+            "BUILD_STRING",
+            "MAKE_FUNCTION",
+            "RETURN_GENERATOR",
+        }
+    )
+
+
+def test_tool_call_snapshot_and_elapsed_time_are_shared_with_target() -> None:
+    target = RecordingTarget()
+    clock = iter((10.0, 11.0, 12.5)).__next__
+    projector = ConversationProjector(
+        target,
+        tool_projector=ToolTranscriptProjector(
+            verb_resolver=lambda tool_name, args: "Ran",
+        ),
+        now=clock,
+    )
+
+    projector.tool_started(
+        ToolCallView(
+            tool_call_id="call-1",
+            tool_name="bash",
+            args={"command": "pytest"},
+            rendered_text="$ pytest",
+        )
+    )
+    projector.tool_finished(
+        ToolResultView(
+            tool_call_id="call-1",
+            tool_name="ignored-after-snapshot",
+            status="ok",
+        )
+    )
+
+    assert target.events == [
+        (
+            "tool_started",
+            "call-1",
+            ToolCallSnapshot(
+                tool_name="bash",
+                args={"command": "pytest"},
+                rendered_call_text="$ pytest",
+            ),
+        ),
+        (
+            "tool_finished",
+            ToolTranscriptBlock(
+                tool_call_id="call-1",
+                tool_name="bash",
+                status="ok",
+                verb="Ran",
+                title="bash pytest",
+            ),
+            2.5,
+        ),
+    ]
+
+
+def test_tool_elapsed_clock_wraps_neutral_result_projection() -> None:
+    order: list[str] = []
+    values = iter((10.0, 11.0, 14.0))
+
+    def clock() -> float:
+        order.append("clock")
+        return next(values)
+
+    class OrderedToolProjector(ToolTranscriptProjector):
+        def project_result(
+            self,
+            view: ToolResultView,
+            snapshot: ToolCallSnapshot | None = None,
+        ) -> ToolTranscriptBlock:
+            order.append("project")
+            return super().project_result(view, snapshot)
+
+    target = RecordingTarget()
+    projector = ConversationProjector(
+        target,
+        tool_projector=OrderedToolProjector(),
+        now=clock,
+    )
+    projector.tool_started(ToolCallView(tool_call_id="call-1", tool_name="bash"))
+
+    context = projector.begin_tool_finish("call-1")
+    projector.tool_finished(
+        ToolResultView(tool_call_id="call-1", tool_name="bash", status="ok"),
+        context=context,
+    )
+
+    assert order == ["clock", "clock", "project", "clock"]
+    assert target.events[-1][2] == 4.0
+
+
+def test_tool_finish_cleanup_policy_preserves_surface_exception_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    view = ToolCallView(tool_call_id="call-1", tool_name="bash")
+    result = ToolResultView(tool_call_id="call-1", tool_name="bash", status="ok")
+
+    def fail_projection(*args: object, **kwargs: object) -> ToolTranscriptBlock:
+        del args, kwargs
+        raise RuntimeError("projection failed")
+
+    after_projector = ToolTranscriptProjector()
+    monkeypatch.setattr(after_projector, "project_result", fail_projection)
+    after = ConversationProjector(
+        RecordingTarget(),
+        tool_projector=after_projector,
+        now=lambda: 1.0,
+        tool_finish_cleanup="after_target",
+    )
+    after.tool_started(view)
+    after_context = after.begin_tool_finish("call-1")
+
+    with pytest.raises(RuntimeError, match="projection failed"):
+        after.tool_finished(result, context=after_context)
+
+    assert after.has_active_tool_call("call-1")
+
+    before_projector = ToolTranscriptProjector()
+    monkeypatch.setattr(before_projector, "project_result", fail_projection)
+    before = ConversationProjector(
+        RecordingTarget(),
+        tool_projector=before_projector,
+        measure_tool_elapsed=False,
+        tool_finish_cleanup="before_projection",
+    )
+    before.tool_started(view)
+    before_context = before.begin_tool_finish("call-1")
+
+    with pytest.raises(RuntimeError, match="projection failed"):
+        before.tool_finished(result, context=before_context)
+
+    assert not before.has_active_tool_call("call-1")
+
+
+def test_tool_update_without_start_creates_running_snapshot() -> None:
+    target = RecordingTarget()
+    clock = iter((4.0, 4.5, 5.0)).__next__
+    projector = ConversationProjector(target, now=clock)
+    view = ToolCallView(tool_call_id="call-1", tool_name="search")
+
+    projector.tool_updated(view)
+    projector.tool_finished(
+        ToolResultView(tool_call_id="call-1", tool_name="search", status="ok")
+    )
+
+    assert target.events[0] == (
+        "tool_started",
+        "call-1",
+        ToolCallSnapshot(tool_name="search"),
+    )
+    assert target.events[1][0] == "tool_finished"
+    assert target.events[1][2] == 1.0
+
+
+def test_tool_state_can_be_queried_without_projecting_an_event() -> None:
+    target = RecordingTarget()
+    projector = ConversationProjector(target, now=lambda: 1.0)
+    view = ToolCallView(tool_call_id="call-1", tool_name="search")
+
+    assert not projector.has_active_tool_call("call-1")
+    assert projector.tool_call_snapshot("call-1") is None
+
+    projector.tool_started(view)
+
+    assert projector.has_active_tool_call("call-1")
+    assert projector.tool_call_snapshot("call-1") == ToolCallSnapshot(
+        tool_name="search"
+    )
+
+
+def test_tool_result_message_is_deduplicated_after_execution_end() -> None:
+    target = RecordingTarget()
+    projector = ConversationProjector(target, now=lambda: 1.0)
+    result = ToolResultView(
+        tool_call_id="call-1",
+        tool_name="search",
+        status="ok",
+    )
+
+    projector.tool_finished(result)
+    projector.tool_result_message(result)
+    projector.tool_result_message(result)
+
+    assert [event[0] for event in target.events] == ["tool_finished"]
+
+
+def test_target_without_tool_result_messages_does_not_retain_finished_ids() -> None:
+    target = RecordingTarget()
+    projector = ConversationProjector(
+        target,
+        now=lambda: 1.0,
+        track_rendered_tool_results=False,
+    )
+    result = ToolResultView(
+        tool_call_id="call-1",
+        tool_name="search",
+        status="ok",
+    )
+
+    projector.tool_finished(result)
+
+    assert not projector.has_rendered_tool_result("call-1")
+    assert projector.rendered_tool_results == set()
+
+
+def test_visible_assistant_error_is_recorded_and_deduplicated_by_id() -> None:
+    target = RecordingTarget()
+    projector = ConversationProjector(target)
+
+    projector.assistant_finished(
+        "partial",
+        error_message="provider failed",
+        show_error=True,
+        error_id=17,
+    )
+    projector.assistant_finished(
+        "partial",
+        error_message="provider failed",
+        show_error=True,
+        error_id=17,
+    )
+    projector.assistant_error(
+        "provider failed",
+        show_error=True,
+        error_id=17,
+    )
+
+    assert projector.last_error_message == "provider failed"
+    assert target.events == [
+        ("assistant_finished", "partial", "provider failed", True),
+        ("assistant_finished", "partial", "provider failed", False),
+    ]
+
+
+def test_hidden_assistant_error_updates_last_error_without_rendering() -> None:
+    target = RecordingTarget()
+    projector = ConversationProjector(target)
+
+    projector.assistant_finished(
+        "partial",
+        error_message="request cancelled",
+        show_error=False,
+        error_id=23,
+    )
+    projector.assistant_error(
+        "request cancelled",
+        show_error=False,
+        error_id=23,
+    )
+
+    assert projector.last_error_message == "request cancelled"
+    assert target.events == [
+        ("assistant_finished", "partial", "request cancelled", False),
+    ]
+
+
+def test_run_start_clears_pending_tool_timing() -> None:
+    target = RecordingTarget()
+    clock = iter((10.0, 20.0, 30.0, 40.0)).__next__
+    projector = ConversationProjector(target, now=clock)
+    projector.tool_started(ToolCallView(tool_call_id="call-1", tool_name="bash"))
+
+    projector.run_started()
+    projector.tool_finished(
+        ToolResultView(tool_call_id="call-1", tool_name="bash", status="ok")
+    )
+
+    assert target.events[1] == ("run_started", 20.0)
+    assert target.events[2][0] == "tool_finished"
+    assert target.events[2][2] == 10.0
+
+
+def test_run_start_time_is_lazy_for_targets_that_do_not_need_it() -> None:
+    clock_calls = 0
+
+    def clock() -> float:
+        nonlocal clock_calls
+        clock_calls += 1
+        return 1.0
+
+    @dataclass
+    class LazyRunTarget(RecordingTarget):
+        def run_started(self, *, start_time: Callable[[], float]) -> None:
+            self.events.append(("run_started", start_time))
+
+    target = LazyRunTarget()
+    projector = ConversationProjector(target, now=clock)
+
+    projector.run_started()
+
+    assert clock_calls == 0
+    assert target.events[0][0] == "run_started"
+
+
+def test_neutral_lifecycle_facts_are_forwarded_without_product_policy() -> None:
+    target = RecordingTarget()
+    projector = ConversationProjector(target)
+
+    projector.queues_updated(steers=("correct it",), followups=("then test",))
+    projector.user_message("hello")
+    projector.assistant_started()
+    projector.retry_started(
+        attempt=2,
+        max_attempts=3,
+        delay_ms=250.0,
+        error_message="rate limited",
+    )
+    projector.compaction_started(reason="token budget")
+    projector.compaction_finished(
+        error_message=None,
+        summary="Earlier context",
+        tokens_before=8192,
+    )
+
+    assert target.events == [
+        ("queues_updated", ("correct it",), ("then test",)),
+        ("user_message", "hello"),
+        ("assistant_started",),
+        ("retry_started", 2, 3, 250.0, "rate limited"),
+        ("compaction_started", "token budget"),
+        ("compaction_finished", None, "Earlier context", 8192),
+    ]


### PR DESCRIPTION
## English

### Summary

- Add the product-neutral `ConversationProjectionTarget` and `ConversationProjector` for assistant streaming, tool lifecycle/timing, result deduplication, and assistant-error deduplication.
- Centralize raw Coding event interpretation in `CodingConversationEventAdapter`; Plain and Screen keep their product-specific rendering, copy, cancellation policy, and surface interests.
- Preserve the mature behavior contract, including lazy run clocks, Plain/Screen tool cleanup order, snapshot-based body policy, legacy Plain constructor state, optimistic echo handling, and early rejection before expensive tool or text projection.
- Add architecture guards and a marked adapter-to-projector-to-target delta contract with object-identity and bytecode allocation checks.

### Stack

- Prerequisite: #272 — tool/status foundation, merged
- This PR: conversation projection core and Plain/Screen integration
- Next: settings, selection, and surface extraction

### Boundaries

This does not move session lifecycle, approval lifecycle, runtime orchestration, or render-engine mechanics. Raw Agent/AI objects remain in Coding. Harnesstui receives only neutral facts, tool views, state identifiers, and clock ports. No render threshold is changed.

### Validation

- `144 passed` — Harnesstui conversation plus affected Coding event/app/mode/import suites
- `65 passed` — architecture import boundaries
- `152 passed, 3321 deselected in 11.91s` — `make test-tui-render-contract`
- Ruff, targeted mypy, and `git diff --check` passed

## 中文

### 摘要

- 新增产品中性的 `ConversationProjectionTarget` 与 `ConversationProjector`，统一管理 assistant 流式投影、工具生命周期与耗时、工具结果去重和 assistant 错误去重。
- 将 Coding 原始事件解释集中到 `CodingConversationEventAdapter`；Plain 与 Screen 继续保留各自的渲染方式、文案、取消策略和界面事件兴趣。
- 保持成熟行为契约，包括运行时钟懒读取、Plain/Screen 原有工具异常清理顺序、基于 start snapshot 的 body 策略、Plain 旧构造状态兼容、乐观回显，以及在昂贵工具/文本投影前短路无关事件。
- 增加架构门禁，以及带 `tui_render_contract` 标记的 adapter→projector→target delta 契约，锁定对象原样透传与字节码零容器构造。

### 堆叠关系

- 前置：#272 — 工具/状态基础层，已合并
- 本 PR：会话投影核心与 Plain/Screen 接入
- 下一 PR：settings、selection、surface 抽取

### 边界

本 PR 不迁移 Session 生命周期、Approval 生命周期、运行时编排或渲染引擎机制。原始 Agent/AI 对象仍留在 Coding；Harnesstui 只接收中性事实、工具 View、状态标识和时钟端口。没有修改任何渲染阈值。

### 验证

- `144 passed` — Harnesstui conversation 与受影响的 Coding event/app/mode/import 套件
- `65 passed` — 架构导入边界
- `152 passed, 3321 deselected in 11.91s` — `make test-tui-render-contract`
- Ruff、定向 mypy、`git diff --check` 均通过