### PR TITLE
refactor(harnesstui): extract surface presentation builders

### DIFF
--- a/.github/workflows/harnesstui-quality.yml
+++ b/.github/workflows/harnesstui-quality.yml
@@ -1,0 +1,25 @@
+name: Harnesstui Quality
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  harnesstui-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: make bootstrap
+
+      - name: Harnesstui quality gate
+        run: make check-harnesstui

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,14 @@ HARNESSTUI_SHARED_SOURCES := \
 	src/loushang/tui/settings.py \
 	src/loushang/harnesstui
 HARNESSTUI_CODING_ADAPTERS := \
+	src/loushang/coding/ui/command_list.py \
+	src/loushang/coding/ui/completion.py \
 	src/loushang/coding/ui/conversation_event_adapter.py \
+	src/loushang/coding/ui/model_list.py \
+	src/loushang/coding/ui/plain_app.py \
 	src/loushang/coding/ui/plain_events.py \
+	src/loushang/coding/ui/plain_renderer.py \
+	src/loushang/coding/ui/plain_toolbar.py \
 	src/loushang/coding/ui/playback_scenarios/surface.py \
 	src/loushang/coding/ui/screen_app.py \
 	src/loushang/coding/ui/screen_events.py \
@@ -39,6 +45,7 @@ HARNESSTUI_CODING_ADAPTERS := \
 	src/loushang/coding/ui/transcript_source.py
 HARNESSTUI_TEST_PATHS := \
 	tests/harnesstui \
+	tests/tui/test_import_boundaries.py \
 	tests/tui/test_settings.py \
 	tests/architecture/test_import_boundaries.py \
 	tests/coding/test_ui_import_boundaries.py \
@@ -51,7 +58,12 @@ HARNESSTUI_TEST_PATHS := \
 	tests/coding/test_screen_settings_page.py \
 	tests/coding/test_screen_tui_transcript_reader.py \
 	tests/coding/test_tool_transcript_blocks.py \
+	tests/coding/test_ui_command_list.py \
+	tests/coding/test_ui_completion.py \
 	tests/coding/test_ui_conversation_event_adapter.py \
+	tests/coding/test_ui_model_list.py \
+	tests/coding/test_ui_plain_app.py \
+	tests/coding/test_ui_plain_toolbar.py \
 	tests/coding/test_ui_plain_renderer.py \
 	tests/coding/test_ui_status_line.py \
 	tests/coding/test_ui_status_provider.py \

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,50 @@ BINARY_NAME := loushang$(EXE_EXT)
 DIST_BINARY := dist/$(BINARY_NAME)
 AI_OFFLINE_ENV := env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN -u ANTHROPIC_OAUTH_TOKEN -u ANTHROPIC_BASE_URL -u ARK_API_KEY -u BAIDU_QIANFAN_API_KEY -u COPILOT_GITHUB_TOKEN -u DASHSCOPE_API_KEY -u DEEPSEEK_API_KEY -u GH_TOKEN -u GITHUB_TOKEN -u HUNYUAN_API_KEY -u MINIMAX_API_KEY -u MOONSHOT_API_KEY -u OPENAI_API_KEY -u QIANFAN_API_KEY -u STEPFUN_API_KEY -u STEP_API_KEY -u ZAI_API_KEY
 
+HARNESSTUI_SHARED_SOURCES := \
+	src/loushang/tui/settings.py \
+	src/loushang/harnesstui
+HARNESSTUI_CODING_ADAPTERS := \
+	src/loushang/coding/ui/conversation_event_adapter.py \
+	src/loushang/coding/ui/plain_events.py \
+	src/loushang/coding/ui/playback_scenarios/surface.py \
+	src/loushang/coding/ui/screen_app.py \
+	src/loushang/coding/ui/screen_events.py \
+	src/loushang/coding/ui/screen_state.py \
+	src/loushang/coding/ui/screen_surfaces.py \
+	src/loushang/coding/ui/settings_common.py \
+	src/loushang/coding/ui/settings_config.py \
+	src/loushang/coding/ui/settings_page.py \
+	src/loushang/coding/ui/settings_status_line.py \
+	src/loushang/coding/ui/status_line.py \
+	src/loushang/coding/ui/tool_blocks.py \
+	src/loushang/coding/ui/transcript_projection.py \
+	src/loushang/coding/ui/transcript_reader.py \
+	src/loushang/coding/ui/transcript_source.py
+HARNESSTUI_TEST_PATHS := \
+	tests/harnesstui \
+	tests/tui/test_settings.py \
+	tests/architecture/test_import_boundaries.py \
+	tests/coding/test_ui_import_boundaries.py \
+	tests/coding/test_screen_coding_tui_app.py \
+	tests/coding/test_screen_coding_tui_events.py \
+	tests/coding/test_screen_coding_tui_input.py \
+	tests/coding/test_screen_coding_tui_mode.py \
+	tests/coding/test_screen_coding_tui_state.py \
+	tests/coding/test_screen_coding_tui_surfaces.py \
+	tests/coding/test_screen_settings_page.py \
+	tests/coding/test_screen_tui_transcript_reader.py \
+	tests/coding/test_tool_transcript_blocks.py \
+	tests/coding/test_ui_conversation_event_adapter.py \
+	tests/coding/test_ui_plain_renderer.py \
+	tests/coding/test_ui_status_line.py \
+	tests/coding/test_ui_status_provider.py \
+	tests/coding/test_ui_transcript_projection.py \
+	tests/coding/test_ui_transcript_source.py
+
 .PHONY: bootstrap test test-ai check-ai test-tui test-tui-render-contract lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools vendor-ai-openai-codex-complete example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-advanced-openai-codex-login example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip
 .PHONY: check-ai-catalog check-ai-examples check-ai-imports check-ai-coverage
+.PHONY: check-harnesstui lint-harnesstui typecheck-harnesstui test-harnesstui
 
 bootstrap:
 	test -d .venv || uv venv .venv
@@ -45,6 +87,17 @@ check-ai-coverage:
 	mkdir -p .artifacts/ai
 	. .venv/bin/activate && $(AI_OFFLINE_ENV) uv run pytest tests/ai tests/providers -m "not live" --cov=src/loushang/ai --cov-report=term-missing:skip-covered --cov-report=xml:.artifacts/ai/coverage.xml --cov-fail-under=80 -q
 	uv run python scripts/ai/check_coverage_targets.py .artifacts/ai/coverage.xml
+
+check-harnesstui: lint-harnesstui typecheck-harnesstui test-harnesstui
+
+lint-harnesstui:
+	uv --cache-dir .uv-cache run --extra dev ruff check $(HARNESSTUI_SHARED_SOURCES) $(HARNESSTUI_CODING_ADAPTERS) src/loushang/coding/ui/status_provider.py $(HARNESSTUI_TEST_PATHS)
+
+typecheck-harnesstui:
+	uv --cache-dir .uv-cache run --extra dev mypy --follow-imports=silent $(HARNESSTUI_SHARED_SOURCES) $(HARNESSTUI_CODING_ADAPTERS) src/loushang/coding/ui/status_provider.py
+
+test-harnesstui:
+	uv --cache-dir .uv-cache run --extra dev pytest $(HARNESSTUI_TEST_PATHS) -m "not tui_render_contract" -q
 
 test-tui:
 	. .venv/bin/activate && python -m pytest tests/tui -q

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -153,18 +153,24 @@ Harnesstui owns the reusable interaction assembled from those generic widgets:
   and interaction over the neutral status profile;
 - `loushang.harnesstui.surface.view` owns the framed bottom-surface view and its
   information-panel scrolling behavior;
+- `loushang.harnesstui.surface.factory` owns pure information and command
+  surface builders over presentation-ready text and neutral `SelectItem`
+  values;
 - `loushang.harnesstui.selection.model` owns scoped/all model selection over
   product-supplied `SelectItem` values;
 - `loushang.harnesstui.selection.catalog` owns the opaque `ModelChoice` and its
-  text, completion, palette, matching, and settings-list projections;
+  text, completion, palette, matching, settings-list, and selector-row
+  projections;
 - `loushang.harnesstui.commands.presentation` owns duck-typed command text,
-  completion, palette, matching, and display ordering.
+  completion, palette, matching, display ordering, and selector-row
+  projection.
 
 These modules own interaction mechanics, layout, existing copy, and visual
 behavior, but not product data or decisions. Coding continues to own settings
 manager persistence, model and command discovery, model application, command
 catalog and slash-command policy, status-provider updates, approval routing,
-surface lifecycle, and construction of neutral rows and choices. Generic
+surface lifecycle, and adaptation of product data into neutral labels and
+choices. Generic
 `Surface`, `SurfaceHost`, `SelectionSurface`, and `SearchableList` mechanics
 remain in `loushang.tui`.
 

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -83,6 +83,12 @@ values and decides when those values change. This capability is not the generic
 styling primitives, invalidation, and frame rendering. Harnesstui must not
 reach into those mechanics or introduce a second status-bar runtime.
 
+`loushang.harnesstui.status.snapshot` owns the neutral status facts populated by
+a product status provider. `loushang.harnesstui.status.plain` owns the compact,
+line-oriented toolbar projection over presentation-ready status values. Coding
+continues to own live Session reads, settings persistence, and provider update
+timing; its former status and toolbar imports are direct compatibility aliases.
+
 These explicit module paths are the stable imports for this slice. The package
 initializers do not need to provide convenience re-exports.
 
@@ -130,25 +136,42 @@ package initializer does not provide a convenience re-export.
 
 Generic settings vocabulary belongs to the terminal framework.
 `loushang.tui.settings` owns `ConfigRow`, the shared settings theme, value
-formatting, row lookup, and input helpers. It has no Harness or product
-dependency and can be used by any terminal application.
+formatting, row lookup, input helpers, and the reusable `SettingsListPage`.
+It has no Harness or product dependency and can be used by any terminal
+application.
 
 Harnesstui owns the reusable interaction assembled from those generic widgets:
 
-- `loushang.harnesstui.settings.page` owns `ConfigSettingsPage`;
+- `loushang.harnesstui.settings.page` provides the compatibility name
+  `ConfigSettingsPage` for the generic TUI settings list;
+- `loushang.harnesstui.settings.dashboard` owns the tabbed settings shell,
+  static information pages, focus/footer interaction, and neutral status and
+  usage view-models;
+- `loushang.harnesstui.settings.model` owns model-settings interaction over
+  product-supplied neutral choices;
 - `loushang.harnesstui.status.settings` owns status-line settings rows, preview,
   and interaction over the neutral status profile;
 - `loushang.harnesstui.surface.view` owns the framed bottom-surface view and its
   information-panel scrolling behavior;
 - `loushang.harnesstui.selection.model` owns scoped/all model selection over
-  product-supplied `SelectItem` values.
+  product-supplied `SelectItem` values;
+- `loushang.harnesstui.selection.catalog` owns the opaque `ModelChoice` and its
+  text, completion, palette, matching, and settings-list projections;
+- `loushang.harnesstui.commands.presentation` owns duck-typed command text,
+  completion, palette, matching, and display ordering.
 
 These modules own interaction mechanics, layout, existing copy, and visual
 behavior, but not product data or decisions. Coding continues to own settings
-manager persistence, model discovery and selection, status providers, command
-and approval routing, surface lifecycle, and construction of the neutral rows
-and selection items. Generic `Surface`, `SurfaceHost`, `SelectionSurface`, and
-`SearchableList` mechanics remain in `loushang.tui`.
+manager persistence, model and command discovery, model application, command
+catalog and slash-command policy, status-provider updates, approval routing,
+surface lifecycle, and construction of neutral rows and choices. Generic
+`Surface`, `SurfaceHost`, `SelectionSurface`, and `SearchableList` mechanics
+remain in `loushang.tui`.
+
+The model settings page emits the shared UI intent
+`InputIntent(kind="setting", text="model.current", note=<choice value>)`.
+Products decide how that opaque choice value is resolved, applied, and
+persisted; Harnesstui never calls a Session or settings manager.
 
 Compatibility modules in `loushang.coding.ui` re-export the moved class objects
 without subclassing or wrapping them. The explicit module paths above are the

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -153,3 +153,19 @@ and selection items. Generic `Surface`, `SurfaceHost`, `SelectionSurface`, and
 Compatibility modules in `loushang.coding.ui` re-export the moved class objects
 without subclassing or wrapping them. The explicit module paths above are the
 stable imports; package initializers do not add convenience re-exports.
+
+## Quality Gate
+
+Run `make check-harnesstui` for the product-neutral composition boundary. The
+gate lints and type-checks Harnesstui, its shared TUI settings vocabulary, and
+the explicit Coding adapters, then runs Harnesstui, import-boundary, and direct
+Coding integration tests. Marked render-contract cases are excluded from this
+behavior gate and remain owned by the independent render-performance job.
+Known dynamic dataclass-replacement typing limitations are suppressed only at
+the exact expressions involved; the enclosing adapters remain under the normal
+mypy gate so new diagnostics are enforced.
+
+The deterministic render-performance contract remains a separate gate. Run
+`make test-tui-render-contract` independently when changing render-path code or
+moving a marked contract test; `check-harnesstui` does not change or duplicate
+its thresholds.

--- a/src/loushang/coding/ui/command_list.py
+++ b/src/loushang/coding/ui/command_list.py
@@ -5,7 +5,18 @@ from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 
 from loushang.coding.commands.catalog import CodingCommandCatalog
-from loushang.tui import CommandPalette, CompletionItem, CompletionProvider
+from loushang.harnesstui.commands.presentation import (
+    command_completion_provider,
+    format_commands,
+    matching_command_items,
+)
+from loushang.tui import (
+    CommandPalette,
+    CompletionProvider,
+)
+from loushang.tui import (
+    CompletionItem as CompletionItem,
+)
 
 CommandPaletteChooser = Callable[[CommandPalette], Awaitable[str | None] | str | None]
 
@@ -19,19 +30,7 @@ async def format_session_commands(session: Any, *, query: str = "") -> str:
     if not isinstance(raw_commands, Iterable):
         return "No commands available."
 
-    lines = [_format_command(command) for command in raw_commands]
-    lines = [line for line in lines if line]
-    stripped_query = query.strip()
-    if stripped_query:
-        needle = stripped_query.lower()
-        lines = [line for line in lines if needle in line.lower()]
-
-    if not lines:
-        if stripped_query:
-            return f"No commands match: {stripped_query}"
-        return "No commands available."
-
-    return "\n".join(["Commands:", *sorted(lines)])
+    return format_commands(raw_commands, query=query)
 
 
 async def format_coding_commands(
@@ -40,7 +39,9 @@ async def format_coding_commands(
     query: str = "",
     command_catalog: CodingCommandCatalog | None = None,
 ) -> str:
-    return _format_commands(_catalog_commands(session, command_catalog=command_catalog), query=query)
+    return format_commands(
+        _catalog_commands(session, command_catalog=command_catalog), query=query
+    )
 
 
 async def session_command_completion_provider(session: Any) -> CompletionProvider:
@@ -52,11 +53,7 @@ async def session_command_completion_provider(session: Any) -> CompletionProvide
     if not isinstance(raw_commands, Iterable):
         return CompletionProvider(())
 
-    items = sorted(
-        (item for command in raw_commands if (item := _command_completion_item(command)) is not None),
-        key=lambda item: item.value,
-    )
-    return CompletionProvider(tuple(items))
+    return command_completion_provider(raw_commands, local_last=False)
 
 
 async def coding_command_completion_provider(
@@ -64,10 +61,14 @@ async def coding_command_completion_provider(
     *,
     command_catalog: CodingCommandCatalog | None = None,
 ) -> CompletionProvider:
-    return _completion_provider_from_commands(_catalog_commands(session, command_catalog=command_catalog))
+    return command_completion_provider(
+        _catalog_commands(session, command_catalog=command_catalog)
+    )
 
 
-async def session_command_palette(session: Any, *, title: str = "Commands") -> CommandPalette:
+async def session_command_palette(
+    session: Any, *, title: str = "Commands"
+) -> CommandPalette:
     provider = await session_command_completion_provider(session)
     return CommandPalette.from_completion_provider(provider, title=title)
 
@@ -78,7 +79,9 @@ async def coding_command_palette(
     title: str = "Commands",
     command_catalog: CodingCommandCatalog | None = None,
 ) -> CommandPalette:
-    provider = await coding_command_completion_provider(session, command_catalog=command_catalog)
+    provider = await coding_command_completion_provider(
+        session, command_catalog=command_catalog
+    )
     return CommandPalette.from_completion_provider(provider, title=title)
 
 
@@ -91,14 +94,16 @@ async def select_session_command(
     stripped_query = query.strip()
     if not stripped_query:
         if choose is not None:
-            selected = await _maybe_await(choose(await session_command_palette(session, title="Commands")))
+            selected = await _maybe_await(
+                choose(await session_command_palette(session, title="Commands"))
+            )
             if selected is None:
                 return "Command selection cancelled."
             return await select_session_command(session, query=selected)
         return await format_session_commands(session)
 
     provider = await session_command_completion_provider(session)
-    matches = _matching_command_items(provider, stripped_query)
+    matches = matching_command_items(provider, stripped_query)
     if not matches:
         return f"No commands match: {stripped_query}"
     if len(matches) != 1:
@@ -124,15 +129,23 @@ async def select_coding_command(
     if not stripped_query:
         if choose is not None:
             selected = await _maybe_await(
-                choose(await coding_command_palette(session, title="Commands", command_catalog=command_catalog))
+                choose(
+                    await coding_command_palette(
+                        session, title="Commands", command_catalog=command_catalog
+                    )
+                )
             )
             if selected is None:
                 return "Command selection cancelled."
-            return await select_coding_command(session, query=selected, command_catalog=command_catalog)
+            return await select_coding_command(
+                session, query=selected, command_catalog=command_catalog
+            )
         return await format_coding_commands(session, command_catalog=command_catalog)
 
-    provider = await coding_command_completion_provider(session, command_catalog=command_catalog)
-    matches = _matching_command_items(provider, stripped_query)
+    provider = await coding_command_completion_provider(
+        session, command_catalog=command_catalog
+    )
+    matches = matching_command_items(provider, stripped_query)
     if not matches:
         return f"No commands match: {stripped_query}"
     if len(matches) != 1:
@@ -147,101 +160,13 @@ async def select_coding_command(
     return f"Command selected: {matches[0].value}"
 
 
-def _format_commands(raw_commands: Iterable[object], *, query: str = "") -> str:
-    lines = [_format_command(command) for command in raw_commands]
-    lines = [line for line in lines if line]
-    stripped_query = query.strip()
-    if stripped_query:
-        needle = stripped_query.lower()
-        lines = [line for line in lines if needle in line.lower()]
-
-    if not lines:
-        if stripped_query:
-            return f"No commands match: {stripped_query}"
-        return "No commands available."
-
-    return "\n".join(["Commands:", *sorted(lines)])
-
-
-def _completion_provider_from_commands(raw_commands: Iterable[object]) -> CompletionProvider:
-    items = sorted(
-        (
-            (item, _command_source_priority(command))
-            for command in raw_commands
-            if (item := _command_completion_item(command)) is not None
-        ),
-        key=lambda pair: (pair[1], pair[0].value),
+def _catalog_commands(
+    session: Any, *, command_catalog: CodingCommandCatalog | None = None
+) -> tuple[object, ...]:
+    catalog = command_catalog or CodingCommandCatalog(
+        session_commands=_session_commands_provider(session)
     )
-    return CompletionProvider(tuple(item for item, _priority in items))
-
-
-def _catalog_commands(session: Any, *, command_catalog: CodingCommandCatalog | None = None) -> tuple[object, ...]:
-    catalog = command_catalog or CodingCommandCatalog(session_commands=_session_commands_provider(session))
     return catalog.commands()
-
-
-def _format_command(command: object) -> str:
-    name = _string_attr(command, "invocation_name") or _string_attr(command, "name")
-    if name is None:
-        return ""
-    label = _command_label(name, _string_attr(command, "argument_hint"))
-    description = _string_attr(command, "description")
-    source = _string_attr(command, "source")
-    if description:
-        label = f"{label} - {description}"
-    if source:
-        label = f"{label} ({source})"
-    return label
-
-
-def _command_completion_item(command: object) -> CompletionItem | None:
-    name = _string_attr(command, "invocation_name") or _string_attr(command, "name")
-    if name is None:
-        return None
-    argument_hint = _string_attr(command, "argument_hint")
-    description = _string_attr(command, "description") or ""
-    source = _string_attr(command, "source")
-    if source:
-        description = f"{description} ({source})" if description else f"({source})"
-    value = f"/{name}"
-    return CompletionItem(value=value, label=_command_label(name, argument_hint), description=description)
-
-
-def _command_source_priority(command: object) -> int:
-    return 1 if _string_attr(command, "source") == "local" else 0
-
-
-def _command_label(name: str, argument_hint: str | None) -> str:
-    if argument_hint:
-        return f"/{name} {argument_hint}"
-    return f"/{name}"
-
-
-def _matching_command_items(provider: CompletionProvider, query: str) -> tuple[CompletionItem, ...]:
-    needle = query.lower()
-    matches = tuple(item for item in provider.items if _command_item_matches(item, needle))
-    exact = tuple(
-        item
-        for item in matches
-        if item.value.lower() == needle or item.display_label().lower() == needle
-    )
-    return exact or matches
-
-
-def _command_item_matches(item: CompletionItem, needle: str) -> bool:
-    haystacks = (item.value, item.display_label(), item.description)
-    for haystack in haystacks:
-        lowered = haystack.lower()
-        if needle in lowered:
-            return True
-        if not needle.startswith("/") and needle in lowered.removeprefix("/"):
-            return True
-    return False
-
-
-def _string_attr(value: object, name: str) -> str | None:
-    raw = getattr(value, name, None)
-    return raw if isinstance(raw, str) and raw else None
 
 
 def _session_commands_provider(session: Any):

--- a/src/loushang/coding/ui/model_list.py
+++ b/src/loushang/coding/ui/model_list.py
@@ -13,22 +13,20 @@ from loushang.coding.ui.model import (
     iter_available_model_selections,
     model_label_from_selection,
 )
-from loushang.tui import CommandPalette, CompletionItem, CompletionProvider
+from loushang.harnesstui.selection.catalog import (
+    ModelChoice,
+    current_model_choice_first,
+    dedupe_preferred_model_choices,
+    filter_model_choices,
+    format_model_choices,
+    matching_model_choices,
+    model_choice_display_label,
+    model_choice_value,
+    model_completion_provider,
+)
+from loushang.tui import CommandPalette, CompletionProvider
 
 ModelPaletteChooser = Callable[[CommandPalette], Awaitable[str | None] | str | None]
-
-
-@dataclass(frozen=True)
-class ModelChoice:
-    label: str
-    value: str
-    selection: object
-    endpoint_id: str = ""
-    region: str = ""
-    lane: str = ""
-    api: str = ""
-    preferred_endpoint: bool = False
-    description: str = ""
 
 
 @dataclass(frozen=True)
@@ -41,35 +39,20 @@ async def format_available_models(session: Any, *, query: str = "") -> str:
     choices = await available_model_choices(session)
     stripped_query = query.strip()
     if stripped_query:
-        needle = stripped_query.lower()
-        choices = [choice for choice in choices if _choice_matches_text(choice, needle)]
+        choices = filter_model_choices(choices, stripped_query)
     current_value = await current_model_choice_value(session, choices=choices)
-
-    if not choices:
-        if stripped_query:
-            return f"No models match: {stripped_query}"
-        return "No models available."
-
-    lines = ["Available models:"]
-    for choice in choices:
-        is_current = choice.value == current_value
-        marker = "*" if is_current else " "
-        suffix = " (current)" if is_current else ""
-        lines.append(f"{marker} {_choice_display_label(choice)}{suffix}")
-    return "\n".join(lines)
+    return format_model_choices(choices, query=query, current_value=current_value)
 
 
 async def available_model_completion_provider(session: Any) -> CompletionProvider:
-    items: list[CompletionItem] = []
     choices = await available_model_choices(session)
     current_value = await current_model_choice_value(session, choices=choices)
-    for choice in choices:
-        description = _choice_description(choice, current_value=current_value)
-        items.append(CompletionItem(value=choice.value, label=choice.label, description=description))
-    return CompletionProvider(tuple(items))
+    return model_completion_provider(choices, current_value=current_value)
 
 
-async def available_model_palette(session: Any, *, title: str = "Models") -> CommandPalette:
+async def available_model_palette(
+    session: Any, *, title: str = "Models"
+) -> CommandPalette:
     provider = await available_model_completion_provider(session)
     return CommandPalette.from_completion_provider(provider, title=title)
 
@@ -84,7 +67,9 @@ async def select_available_model(
     stripped_query = query.strip()
     if not stripped_query:
         if choose is not None:
-            selected = await _maybe_await(choose(await available_model_palette(session, title="Models")))
+            selected = await _maybe_await(
+                choose(await available_model_palette(session, title="Models"))
+            )
             if selected is None:
                 return "Model selection cancelled."
             return await select_available_model(
@@ -94,7 +79,9 @@ async def select_available_model(
             )
         return await format_available_models(session)
 
-    matches = _matching_model_choices(await available_model_choices(session), stripped_query)
+    matches = matching_model_choices(
+        await available_model_choices(session), stripped_query
+    )
     if not matches:
         return f"No models match: {stripped_query}"
     if len(matches) != 1:
@@ -106,7 +93,7 @@ async def select_available_model(
         return "\n".join(
             [
                 "Multiple models match:",
-                *(f"  {_choice_display_label(choice)}" for choice in matches),
+                *(f"  {model_choice_display_label(choice)}" for choice in matches),
                 hint,
             ]
         )
@@ -120,7 +107,7 @@ async def select_available_model(
         choice.selection,
         settings_manager=settings_manager,
     )
-    message = f"Model set: {_choice_display_label(choice)}"
+    message = f"Model set: {model_choice_display_label(choice)}"
     if warning := persistence_warning_message(result):
         return f"{message}, but {warning}"
     return message
@@ -128,9 +115,13 @@ async def select_available_model(
 
 async def available_model_choices(session: Any) -> list[ModelChoice]:
     current_identity = await _current_model_identity(session)
-    detail_choices = _model_choices_from_details(await _available_model_details(session))
-    current_detail_value = _selected_current_choice_value(detail_choices, current_identity)
-    detail_choices = _dedupe_preferred_detail_choices(
+    detail_choices = _model_choices_from_details(
+        await _available_model_details(session)
+    )
+    current_detail_value = _selected_current_choice_value(
+        detail_choices, current_identity
+    )
+    detail_choices = dedupe_preferred_model_choices(
         detail_choices,
         current_value=current_detail_value,
     )
@@ -147,22 +138,31 @@ async def available_model_choices(session: Any) -> list[ModelChoice]:
             *(
                 choice
                 for choice in selection_choices
-                if choice.label not in detail_labels and choice.value not in detail_values
+                if choice.label not in detail_labels
+                and choice.value not in detail_values
             ),
         ]
-        return _current_choice_first(
+        return current_model_choice_first(
             choices,
             current_value=_selected_current_choice_value(choices, current_identity),
         )
-    return _current_choice_first(
+    return current_model_choice_first(
         selection_choices,
-        current_value=_selected_current_choice_value(selection_choices, current_identity),
+        current_value=_selected_current_choice_value(
+            selection_choices, current_identity
+        ),
     )
 
 
-async def current_model_choice_value(session: Any, *, choices: list[ModelChoice] | None = None) -> str | None:
-    model_choices = choices if choices is not None else await available_model_choices(session)
-    return _selected_current_choice_value(model_choices, await _current_model_identity(session))
+async def current_model_choice_value(
+    session: Any, *, choices: list[ModelChoice] | None = None
+) -> str | None:
+    model_choices = (
+        choices if choices is not None else await available_model_choices(session)
+    )
+    return _selected_current_choice_value(
+        model_choices, await _current_model_identity(session)
+    )
 
 
 async def model_detail_descriptions_by_label(session: Any) -> dict[str, str]:
@@ -181,18 +181,10 @@ async def model_detail_descriptions_by_label(session: Any) -> dict[str, str]:
     return descriptions
 
 
-def _matching_model_choices(choices: list[ModelChoice], query: str) -> list[ModelChoice]:
-    needle = query.lower()
-    exact_value = [choice for choice in choices if choice.value.lower() == needle]
-    if exact_value:
-        return exact_value
-    labelled = [choice for choice in choices if _choice_matches_text(choice, needle)]
-    exact_label = [choice for choice in labelled if choice.label.lower() == needle]
-    return exact_label or labelled
-
-
 async def _current_model_identity(session: Any) -> _CurrentModelIdentity:
-    agent_model_identity = _model_identity_from_value(getattr(getattr(session, "agent", None), "model", None))
+    agent_model_identity = _model_identity_from_value(
+        getattr(getattr(session, "agent", None), "model", None)
+    )
     if agent_model_identity.value is not None:
         return agent_model_identity
     getter = getattr(session, "get_model_selection", None)
@@ -208,7 +200,12 @@ def _model_identity_from_value(selection: object | None) -> _CurrentModelIdentit
     endpoint_id = _string_attr(selection, "endpoint_id", "endpoint", "endpointId")
     model_id = _string_attr(selection, "id", "model_id", "modelId")
     value = (
-        _model_choice_value(provider=provider, endpoint_id=endpoint_id, model_id=model_id, fallback=label or "")
+        model_choice_value(
+            provider=provider,
+            endpoint_id=endpoint_id,
+            model_id=model_id,
+            fallback=label or "",
+        )
         if provider and endpoint_id and model_id
         else None
     )
@@ -228,15 +225,6 @@ def _selected_current_choice_value(
             if choice.label == current_identity.label:
                 return choice.value
     return None
-
-
-def _current_choice_first(choices: list[ModelChoice], *, current_value: str | None) -> list[ModelChoice]:
-    if current_value is None:
-        return choices
-    current = [choice for choice in choices if choice.value == current_value]
-    if not current:
-        return choices
-    return [*current, *(choice for choice in choices if choice.value != current_value)]
 
 
 async def _available_model_details(session: Any) -> list[object]:
@@ -259,7 +247,12 @@ def _model_choices_from_details(details: list[object]) -> list[ModelChoice]:
         provider = _string_attr(detail, "provider_id", "provider", "providerId")
         endpoint_id = _string_attr(detail, "endpoint_id", "endpoint", "endpointId")
         model_id = _string_attr(detail, "id", "model_id", "modelId")
-        value = _model_choice_value(provider=provider, endpoint_id=endpoint_id, model_id=model_id, fallback=label)
+        value = model_choice_value(
+            provider=provider,
+            endpoint_id=endpoint_id,
+            model_id=model_id,
+            fallback=label,
+        )
         if value in seen:
             continue
         seen.add(value)
@@ -284,83 +277,12 @@ def _model_choices_from_details(details: list[object]) -> list[ModelChoice]:
     return choices
 
 
-def _dedupe_preferred_detail_choices(
-    choices: list[ModelChoice],
-    *,
-    current_value: str | None,
-) -> list[ModelChoice]:
-    by_label: dict[str, list[ModelChoice]] = {}
-    for choice in choices:
-        by_label.setdefault(choice.label, []).append(choice)
-
-    result: list[ModelChoice] = []
-    for choice in choices:
-        group = by_label[choice.label]
-        if len(group) == 1:
-            result.append(choice)
-            continue
-        preferred = [item for item in group if item.preferred_endpoint]
-        if len(preferred) != 1:
-            result.append(choice)
-            continue
-        keep_values = {preferred[0].value}
-        if current_value in {item.value for item in group}:
-            keep_values.add(str(current_value))
-        if choice.value in keep_values:
-            result.append(choice)
-    return result
-
-
-def _model_choice_value(
-    *,
-    provider: str | None,
-    endpoint_id: str | None,
-    model_id: str | None,
-    fallback: str,
-) -> str:
-    if provider and endpoint_id and model_id:
-        return f"{provider}:{endpoint_id}:{model_id}"
-    return fallback
-
-
 def _bool_attr(value: object, *names: str) -> bool:
     for name in names:
         attr = getattr(value, name, None)
         if isinstance(attr, bool):
             return attr
     return False
-
-
-def _choice_matches_text(choice: ModelChoice, needle: str) -> bool:
-    return (
-        needle in choice.label.lower()
-        or needle in choice.value.lower()
-        or bool(choice.endpoint_id and needle in choice.endpoint_id.lower())
-        or bool(choice.description and needle in choice.description.lower())
-    )
-
-
-def _choice_description(choice: ModelChoice, *, current_value: str | None) -> str:
-    parts: list[str] = []
-    if choice.value == current_value:
-        parts.append("current")
-    if choice.endpoint_id:
-        parts.append(f"endpoint: {choice.endpoint_id}")
-    if choice.region:
-        parts.append(f"region: {choice.region}")
-    if choice.lane:
-        parts.append(f"lane: {choice.lane}")
-    if choice.api:
-        parts.append(f"protocol: {choice.api}")
-    if choice.description:
-        parts.append(choice.description)
-    return " - ".join(parts)
-
-
-def _choice_display_label(choice: ModelChoice) -> str:
-    if choice.endpoint_id:
-        return f"{choice.label} (endpoint: {choice.endpoint_id})"
-    return choice.label
 
 
 def _string_attr(item: object, *names: str) -> str | None:

--- a/src/loushang/coding/ui/plain_toolbar.py
+++ b/src/loushang/coding/ui/plain_toolbar.py
@@ -1,48 +1,10 @@
-from __future__ import annotations
+"""Compatibility imports for the shared plain status toolbar."""
 
-from dataclasses import dataclass
-
-from loushang.tui.cell_width import strip_control_sequences
-from loushang.tui.text_utils import fixed_width
-
-
-@dataclass(frozen=True)
-class PlainToolbarSnapshot:
-    model: str | None = None
-    cwd: str | None = None
-    branch: str | None = None
-    session: str | None = None
-    thinking: str | None = None
-    context: str | None = None
-    window: str | None = None
-    tokens: str | None = None
-    message: str | None = None
-    running: bool = False
-
-
-def render_plain_toolbar(snapshot: PlainToolbarSnapshot, *, width: int | None = None) -> str:
-    parts: list[str] = []
-    _append_part(parts, "model", snapshot.model)
-    _append_part(parts, "cwd", snapshot.cwd)
-    _append_part(parts, "branch", snapshot.branch)
-    _append_part(parts, "session", snapshot.session)
-    _append_part(parts, "thinking", snapshot.thinking)
-    _append_part(parts, "context", snapshot.context)
-    _append_part(parts, "window", snapshot.window)
-    _append_part(parts, "tokens", snapshot.tokens)
-    if snapshot.running:
-        parts.append("running")
-    if snapshot.message:
-        parts.append(snapshot.message)
-    text = " | ".join(parts)
-    if width is None:
-        return text
-    return strip_control_sequences(fixed_width(text, width=width))
-
-
-def _append_part(parts: list[str], name: str, value: str | None) -> None:
-    if value:
-        parts.append(f"{name}={value}")
-
+from loushang.harnesstui.status.plain import (
+    PlainToolbarSnapshot as PlainToolbarSnapshot,
+)
+from loushang.harnesstui.status.plain import (
+    render_plain_toolbar as render_plain_toolbar,
+)
 
 __all__ = ["PlainToolbarSnapshot", "render_plain_toolbar"]

--- a/src/loushang/coding/ui/screen_surfaces.py
+++ b/src/loushang/coding/ui/screen_surfaces.py
@@ -21,13 +21,11 @@ from loushang.coding.ui.intent import (
     parse_prompt_intent,
 )
 from loushang.coding.ui.model import (
-    current_model_first,
     get_session_model_selection,
     iter_scoped_model_selections,
     model_label_from_selection,
 )
 from loushang.coding.ui.model_list import (
-    ModelChoice,
     available_model_choices,
     current_model_choice_value,
     format_available_models,
@@ -38,11 +36,20 @@ from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 from loushang.coding.ui.settings_page import SettingsPageView
 from loushang.coding.ui.status_provider import CodingTuiStatusProvider
 from loushang.harness.commands import CommandDef, CommandKind
+from loushang.harnesstui.commands.presentation import command_palette_select_items
+from loushang.harnesstui.selection.catalog import (
+    model_choice_select_items,
+    model_label_select_items,
+)
 from loushang.harnesstui.selection.model import (
     MODEL_SELECTOR_SELECTED_STYLE as MODEL_SELECTOR_SELECTED_STYLE,
 )
 from loushang.harnesstui.selection.model import (
     ModelSelectorSurface,
+)
+from loushang.harnesstui.surface.factory import (
+    command_surface_view,
+    info_surface_view,
 )
 from loushang.harnesstui.surface.view import (
     ScreenSurfacePresentation,
@@ -54,10 +61,7 @@ from loushang.harnesstui.surface.view import (
 from loushang.tui import (
     ApprovalSurface,
     CommandPalette,
-    CommandSurface,
-    InfoPanel,
     InputIntent,
-    SelectItem,
     Surface,
     SurfaceHandle,
 )
@@ -335,9 +339,13 @@ class ScreenSurfaceManager:
         *,
         purpose: Literal["model", "command"],
     ) -> None:
-        surface = CommandSurface(_palette_items(palette), max_visible=8)
         self._open_surface(
-            ScreenSurfaceView(title=title, purpose=purpose, content=surface)
+            command_surface_view(
+                title=title,
+                purpose=purpose,
+                items=command_palette_select_items(palette),
+                max_visible=8,
+            )
         )
 
     async def _open_model_selector(self) -> None:
@@ -347,14 +355,19 @@ class ScreenSurfaceManager:
         choices = await available_model_choices(self.session)
         current_value = await current_model_choice_value(self.session, choices=choices)
         scoped_selections = await iter_scoped_model_selections(self.session)
+        scoped_labels = [
+            label
+            for selection in scoped_selections
+            if (label := model_label_from_selection(selection)) is not None
+        ]
         descriptions = await model_detail_descriptions_by_label(self.session)
         surface = ModelSelectorSurface(
             all_items=tuple(
-                _model_choice_selector_items(choices, current_value=current_value)
+                model_choice_select_items(choices, current_value=current_value)
             ),
             scoped_items=tuple(
-                _model_selector_items(
-                    scoped_selections,
+                model_label_select_items(
+                    scoped_labels,
                     current_label=current_label,
                     descriptions=descriptions,
                 )
@@ -381,11 +394,9 @@ class ScreenSurfaceManager:
         presentation: ScreenSurfacePresentation = "bottom",
     ) -> None:
         self._open_surface(
-            ScreenSurfaceView(
+            info_surface_view(
                 title=title,
-                purpose="info",
-                content=InfoPanel.from_text(title=title, text=text, footer=""),
-                footer="Enter/Esc to close",
+                text=text,
                 presentation=presentation,
             )
         )
@@ -499,92 +510,9 @@ def _approval_surface_event(
     )
 
 
-def _palette_items(palette: CommandPalette) -> list[SelectItem]:
-    return [
-        SelectItem(
-            label=item.display_label(), value=item.value, description=item.description
-        )
-        for item in palette.items
-    ]
-
-
-def _model_selector_description(
-    label: str, *, current_label: str | None, descriptions: dict[str, str]
-) -> str:
-    if label == current_label:
-        return "current"
-    return descriptions.get(label, "")
-
-
-def _model_selector_items(
-    selections: list[Any],
-    *,
-    current_label: str | None,
-    descriptions: dict[str, str],
-) -> list[SelectItem]:
-    labels = current_model_first(
-        [
-            label
-            for selection in selections
-            if (label := model_label_from_selection(selection)) is not None
-        ],
-        current_label=current_label,
-        label_of=lambda label: label,
-    )
-    ordinal_width = max(2, len(f"{len(labels)}."))
-    items: list[SelectItem] = []
-    for index, label in enumerate(labels, start=1):
-        ordinal = f"{index}.".ljust(ordinal_width)
-        items.append(
-            SelectItem(
-                label=f"{ordinal} {label}",
-                value=label,
-                description=_model_selector_description(
-                    label, current_label=current_label, descriptions=descriptions
-                ),
-            )
-        )
-    return items
-
-
-def _model_choice_selector_items(
-    choices: list[ModelChoice],
-    *,
-    current_value: str | None,
-) -> list[SelectItem]:
-    ordinal_width = max(2, len(f"{len(choices)}."))
-    items: list[SelectItem] = []
-    for index, choice in enumerate(choices, start=1):
-        ordinal = f"{index}.".ljust(ordinal_width)
-        items.append(
-            SelectItem(
-                label=f"{ordinal} {choice.label}",
-                value=choice.value,
-                description=_model_choice_selector_description(
-                    choice, current_value=current_value
-                ),
-            )
-        )
-    return items
-
-
-def _model_choice_selector_description(
-    choice: ModelChoice, *, current_value: str | None
-) -> str:
-    parts: list[str] = []
-    if choice.value == current_value:
-        parts.append("current")
-    if choice.endpoint_id:
-        parts.append(f"endpoint: {choice.endpoint_id}")
-    if choice.region:
-        parts.append(f"region: {choice.region}")
-    if choice.lane:
-        parts.append(f"lane: {choice.lane}")
-    if choice.api:
-        parts.append(f"protocol: {choice.api}")
-    if choice.description:
-        parts.append(choice.description)
-    return " - ".join(parts)
+# Temporary private compatibility name for downstream imports. New code should use
+# the Harnesstui presentation builder directly.
+_palette_items = command_palette_select_items
 
 
 def _recoverable_surface_error(error: Exception) -> str:

--- a/src/loushang/coding/ui/settings_page.py
+++ b/src/loushang/coding/ui/settings_page.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
 from loushang.coding.ui.model_list import (
-    ModelChoice,
     available_model_choices,
     current_model_choice_value,
     select_available_model,
@@ -14,35 +13,28 @@ from loushang.coding.ui.settings_config import (
     config_rows,
     manager_bool_config,
 )
-from loushang.coding.ui.status_provider import CodingTuiStatusProvider, StatusSnapshot
+from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+from loushang.harnesstui.selection.catalog import ModelChoice
+from loushang.harnesstui.settings.dashboard import (
+    SettingsDashboard,
+    StaticLinesPage,
+    model_usage_lines,
+    stats_overview_lines,
+    status_lines,
+    usage_lines,
+)
+from loushang.harnesstui.settings.model import ModelPage
 from loushang.harnesstui.settings.page import ConfigSettingsPage
 from loushang.harnesstui.status.line import (
     StatusLinePreviewSnapshot,
     StatusLineSettings,
 )
 from loushang.harnesstui.status.settings import StatusLineSettingsPage
-from loushang.tui import (
-    CursorDeclaration,
-    InputEvent,
-    InputIntent,
-    RenderConstraints,
-    RenderLine,
-    RenderResult,
-    SearchableList,
-    SearchableListItem,
-    SearchableListSelect,
-    TabGroup,
-    TabPage,
-    truncate_to_width,
-)
+from loushang.tui import TabGroup, TabPage
 from loushang.tui.settings import (
     SETTINGS_PAGE_THEME,
-    SETTINGS_VALUE_COLUMN,
     ConfigRow,
     as_bool,
-    bool_text,
-    is_space_event,
-    is_tab_fallback_key,
 )
 
 __all__ = [
@@ -63,99 +55,7 @@ class SettingsApplyResult:
 
 
 @dataclass(slots=True)
-class StaticLinesPage:
-    lines: tuple[str, ...]
-    focused: bool = False
-
-    def focus(self) -> None:
-        self.focused = True
-
-    def blur(self) -> None:
-        self.focused = False
-
-    def handle_input(self, event: object) -> object:
-        if getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"left", "right", "home", "end"}:
-            return True
-        return None
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        rows = [
-            RenderLine(truncate_to_width(line, max_width=constraints.width, ellipsis=""))
-            for line in self.lines[: constraints.max_height]
-        ]
-        return RenderResult.from_lines(rows, constraints=constraints)
-
-
-@dataclass(slots=True)
-class ModelPage:
-    choices: tuple[ModelChoice, ...]
-    current_value: str | None = None
-    error: str = ""
-    focused: bool = False
-    models: SearchableList = field(init=False)
-
-    def __post_init__(self) -> None:
-        self.models = self._make_list(focused=False)
-
-    @property
-    def unavailable(self) -> bool:
-        return bool(self.error) or not self.choices
-
-    def focus(self) -> None:
-        self.focused = True
-        self.models.focus()
-
-    def blur(self) -> None:
-        self.focused = False
-        self.models.blur()
-
-    def editor_input_target(self) -> object | None:
-        if self.unavailable:
-            return None
-        return self.models.editor_input_target()
-
-    def set_choices(self, choices: tuple[ModelChoice, ...], *, current_value: str | None, error: str = "") -> None:
-        self.choices = choices
-        self.current_value = current_value
-        self.error = error
-        self.models.set_items(_model_items(choices, current_value=current_value), preserve_active_key=current_value or "")
-
-    def handle_input(self, event: object) -> object:
-        if self.unavailable:
-            return True if is_tab_fallback_key(event) else None
-        result = self.models.handle_input(event)
-        if isinstance(result, SearchableListSelect):
-            return InputIntent(kind="setting", text="model.current", note=result.key)
-        if result is not None:
-            return result
-        if self.models.focus_region == "list" and is_space_event(event):
-            item = self.models.active_item
-            if item is not None:
-                return InputIntent(kind="setting", text="model.current", note=item.key)
-        if is_tab_fallback_key(event):
-            return True
-        return None
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        if self.unavailable:
-            lines = ("Model selection unavailable", self.error or "No models available.")
-            return StaticLinesPage(lines).render(constraints)
-        return self.models.render(constraints)
-
-    def _make_list(self, *, focused: bool) -> SearchableList:
-        return SearchableList(
-            _model_items(self.choices, current_value=self.current_value),
-            placeholder="Search models...",
-            empty_text="No matching models",
-            focused=focused,
-            search_box=True,
-            detail_column=SETTINGS_VALUE_COLUMN,
-            theme=SETTINGS_PAGE_THEME,
-        )
-
-
-@dataclass(slots=True)
-class SettingsPageView:
+class SettingsPageView(SettingsDashboard):
     session: Any
     status_provider: CodingTuiStatusProvider
     settings_manager: object | None = None
@@ -166,10 +66,7 @@ class SettingsPageView:
     statusline_page: StatusLineSettingsPage = field(init=False)
     usage_page: StaticLinesPage = field(init=False)
     stats_page: TabGroup = field(init=False)
-    tabs: TabGroup = field(init=False)
-    focused: bool = field(default=False, init=False)
     statusline_preview: Callable[[], StatusLinePreviewSnapshot] | None = None
-    feedback_message: str | None = field(default=None, init=False)
 
     @classmethod
     async def create(
@@ -237,43 +134,8 @@ class SettingsPageView:
         self.feedback_message = message
         return SettingsApplyResult(message)
 
-    def focus(self) -> None:
-        self.focused = True
-        self.tabs.focus_content()
-
-    def blur(self) -> None:
-        self.focused = False
-        self.tabs.blur()
-
-    def editor_input_target(self) -> object | None:
-        return self.tabs.editor_input_target()
-
-    def handle_input(self, event: InputEvent) -> object:
-        result = self.tabs.handle_input(event)
-        if result is not None:
-            return result
-        if _is_escape_event(event):
-            return InputIntent(kind="surface_close")
-        if _is_q_event(event) and self._focus_context() in {"tabs", "page", "settings-list", "model-list"}:
-            return InputIntent(kind="surface_close")
-        return None
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        if constraints.max_height <= 0:
-            return RenderResult.from_lines([], constraints=constraints)
-        body_height = max(1, constraints.max_height - 2)
-        result = self.tabs.render(RenderConstraints(width=constraints.width, max_height=body_height))
-        rows = _with_separator(result.lines, width=constraints.width)
-        cursor = _offset_cursor_after_separator(result.cursor)
-        footer = _footer_text(self._focus_context(), self.feedback_message, width=constraints.width)
-        while len(rows) < constraints.max_height - 1:
-            rows.append(RenderLine(""))
-        if len(rows) < constraints.max_height:
-            rows.append(RenderLine(footer))
-        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
-
     async def _build(self) -> None:
-        self.status_page = StaticLinesPage(_status_lines(self.status_provider.snapshot()))
+        self.status_page = StaticLinesPage(status_lines(self.status_provider.snapshot()))
         self.config_page = ConfigSettingsPage(config_rows(self.settings_manager))
         choices, current_value, error = await _load_model_choices(self.session)
         self.model_page = ModelPage(choices, current_value=current_value, error=error)
@@ -281,11 +143,11 @@ class SettingsPageView:
             self.status_provider.statusline_settings(),
             self._statusline_preview_snapshot,
         )
-        self.usage_page = StaticLinesPage(_usage_lines(self.usage_provider))
+        self.usage_page = StaticLinesPage(usage_lines(self.usage_provider))
         self.stats_page = TabGroup(
             (
-                TabPage("overview", "Overview", StaticLinesPage(_stats_overview_lines(self.status_provider.snapshot()))),
-                TabPage("model-usage", "Model Usage", StaticLinesPage(_model_usage_lines(current_value))),
+                TabPage("overview", "Overview", StaticLinesPage(stats_overview_lines(self.status_provider.snapshot()))),
+                TabPage("model-usage", "Model Usage", StaticLinesPage(model_usage_lines(current_value))),
             ),
             value="overview",
             level=1,
@@ -305,7 +167,7 @@ class SettingsPageView:
         )
 
     def _refresh_status_page(self) -> None:
-        self.status_page.lines = _status_lines(self.status_provider.snapshot())
+        self.status_page.lines = status_lines(self.status_provider.snapshot())
 
     def _refresh_config_rows(self, *, preserve_active_key: str = "") -> None:
         self.config_page.set_rows(config_rows(self.settings_manager), preserve_active_key=preserve_active_key)
@@ -321,22 +183,7 @@ class SettingsPageView:
         self.model_page.set_choices(choices, current_value=current_value, error=error)
         selected = self.stats_page.selected_page
         if selected is not None and isinstance(selected.content, StaticLinesPage):
-            selected.content.lines = _model_usage_lines(current_value)
-
-    def _focus_context(self) -> str:
-        if self.tabs.header_focused:
-            return "tabs"
-        page = self.tabs.selected_page
-        content = page.content if page is not None else None
-        if isinstance(content, ConfigSettingsPage):
-            return "search" if content.settings.focus_region == "search" else "settings-list"
-        if isinstance(content, StatusLineSettingsPage):
-            return "search" if content.settings.focus_region == "search" else "settings-list"
-        if isinstance(content, ModelPage):
-            return "search" if content.models.focus_region == "search" else "model-list"
-        if isinstance(content, TabGroup):
-            return "tabs" if content.header_focused else "page"
-        return "page"
+            selected.content.lines = model_usage_lines(current_value)
 
     def _statusline_preview_snapshot(self) -> StatusLinePreviewSnapshot:
         if self.statusline_preview is not None:
@@ -358,113 +205,3 @@ async def _load_model_choices(session: Any) -> tuple[tuple[ModelChoice, ...], st
     except Exception as error:
         return (), None, str(error)
     return tuple(choices), current_value, ""
-
-
-def _model_items(choices: tuple[ModelChoice, ...], *, current_value: str | None) -> tuple[SearchableListItem, ...]:
-    return tuple(
-        SearchableListItem(
-            choice.value,
-            choice.label,
-            "current" if choice.value == current_value else "",
-            choice.description,
-        )
-        for choice in choices
-    )
-
-
-def _status_lines(snapshot: StatusSnapshot) -> tuple[str, ...]:
-    return (
-        "Status",
-        "",
-        f"Model              {snapshot.model_label or 'Unavailable'}",
-        f"Workspace          {snapshot.cwd}",
-        f"Branch             {snapshot.branch or 'Unavailable'}",
-        f"Session            {snapshot.session_label or 'Unavailable'}",
-        f"Thinking           {snapshot.thinking_level or 'Unavailable'}",
-        f"Runtime            {'running' if snapshot.running else 'idle'}",
-        f"Status line        {bool_text(snapshot.statusline_visible)}",
-    )
-
-
-def _usage_lines(provider: Callable[[], object | None] | None) -> tuple[str, ...]:
-    if provider is None:
-        return ("Usage", "", "Usage data unavailable")
-    try:
-        snapshot = provider()
-    except Exception:
-        snapshot = None
-    if snapshot is None:
-        return ("Usage", "", "Usage data unavailable")
-    return (
-        "Usage",
-        "",
-        f"Current context    {getattr(snapshot, 'tokens', 'Unavailable')}",
-        f"Context window     {getattr(snapshot, 'context_window', 'Unavailable')}",
-        f"Percent used       {getattr(snapshot, 'percent', 'Unavailable')}",
-        f"Source             {getattr(snapshot, 'source', 'Unavailable')}",
-    )
-
-
-def _stats_overview_lines(snapshot: StatusSnapshot) -> tuple[str, ...]:
-    return (
-        "Session Overview",
-        "",
-        f"Session            {snapshot.session_label or 'Unavailable'}",
-        f"Runtime            {'running' if snapshot.running else 'idle'}",
-        "Historical stats   Unavailable",
-    )
-
-
-def _model_usage_lines(current_value: str | None) -> tuple[str, ...]:
-    return (
-        "Model Usage",
-        "",
-        f"Current model      {current_value or 'Unavailable'}",
-        "Historical usage   Unavailable",
-    )
-
-
-def _separator(width: int) -> str:
-    return "-" * max(1, width)
-
-
-def _with_separator(lines: Sequence[RenderLine], *, width: int) -> list[RenderLine]:
-    if not lines:
-        return []
-    return [lines[0], RenderLine(_separator(width)), *lines[1:]]
-
-
-def _offset_cursor_after_separator(cursor: CursorDeclaration | None) -> CursorDeclaration | None:
-    if cursor is None:
-        return None
-    if cursor.row == 0:
-        return cursor
-    return CursorDeclaration(row=cursor.row + 1, column=cursor.column)
-
-
-def _footer_text(focus_context: str, feedback_message: str | None = None, *, width: int) -> str:
-    if focus_context == "search":
-        text = "Type to filter · Enter/↓ to select · ↑ to tabs · Esc to clear"
-    elif focus_context in {"settings-list", "model-list"}:
-        text = "↑/↓ to move · Enter/Space to select · ↑ on first row to search · q to close"
-    elif focus_context == "tabs":
-        text = "←/→ to switch tabs · ↓ to enter · q to close"
-    else:
-        text = "↑ to tabs · q to close"
-    if feedback_message:
-        text = f"{feedback_message} · {text}"
-    return truncate_to_width(text, max_width=width, ellipsis="")
-
-
-def _is_escape_event(event: object) -> bool:
-    return getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"escape", "esc"}
-
-
-def _is_q_event(event: object) -> bool:
-    return (
-        getattr(event, "kind", "") == "key"
-        and getattr(event, "key", "").casefold() == "q"
-    ) or (
-        getattr(event, "kind", "") == "text"
-        and getattr(event, "text", "").casefold() == "q"
-    )

--- a/src/loushang/coding/ui/status_provider.py
+++ b/src/loushang/coding/ui/status_provider.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
+from typing import cast
 
 from loushang.harnesstui.status.line import (
+    StatusLineAutoValue,
+    StatusLineSeparator,
     StatusLineSettings,
+    StatusLineStyle,
     status_line_settings_from_control,
     status_line_settings_to_patch,
 )
@@ -83,23 +87,36 @@ class CodingTuiStatusProvider:
             enabled = _as_bool(normalized)
             if enabled is None:
                 return f"Invalid status line {bool_field.replace('_', ' ')} value."
-            self._set_statusline_settings(replace(self._statusline_settings, **{bool_field: enabled}))
+            # The validated field name and value are compatible, but mypy cannot
+            # express field-sensitive typing for dynamic dataclass replacement.
+            self._set_statusline_settings(
+                replace(self._statusline_settings, **{bool_field: enabled})  # type: ignore[arg-type]
+            )
             return f"Status line {bool_field.replace('_', ' ')}: {normalized}"
         if item_id in {"statusline.field.queue", "statusline.field.message"}:
             field_name = item_id.rsplit(".", 1)[-1]
             if normalized not in {"auto", "true", "false"}:
                 return f"Invalid status line {field_name} value."
-            self._set_statusline_settings(replace(self._statusline_settings, **{field_name: normalized}))
+            self._set_statusline_settings(
+                replace(
+                    self._statusline_settings,
+                    **{field_name: cast(StatusLineAutoValue, normalized)},  # type: ignore[arg-type]
+                )
+            )
             return f"Status line {field_name}: {normalized}"
         if item_id == "statusline.separator":
             if normalized not in {"pipe", "dot"}:
                 return "Invalid status line separator value."
-            self._set_statusline_settings(replace(self._statusline_settings, separator=normalized))
+            self._set_statusline_settings(
+                replace(self._statusline_settings, separator=cast(StatusLineSeparator, normalized))
+            )
             return f"Status line separator: {normalized}"
         if item_id == "statusline.style":
             if normalized not in {"codex-like", "muted", "plain"}:
                 return "Invalid status line style value."
-            self._set_statusline_settings(replace(self._statusline_settings, style=normalized))
+            self._set_statusline_settings(
+                replace(self._statusline_settings, style=cast(StatusLineStyle, normalized))
+            )
             return f"Status line style: {normalized}"
         return f"Unknown status line setting: {item_id}"
 

--- a/src/loushang/coding/ui/status_provider.py
+++ b/src/loushang/coding/ui/status_provider.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field, replace
+from dataclasses import replace
 from typing import cast
 
 from loushang.harnesstui.status.line import (
@@ -12,18 +12,7 @@ from loushang.harnesstui.status.line import (
     status_line_settings_from_control,
     status_line_settings_to_patch,
 )
-
-
-@dataclass(frozen=True, slots=True)
-class StatusSnapshot:
-    model_label: str | None
-    cwd: str
-    branch: str | None
-    session_label: str | None
-    thinking_level: str | None
-    running: bool
-    statusline_visible: bool
-    statusline_settings: StatusLineSettings = field(default_factory=StatusLineSettings)
+from loushang.harnesstui.status.snapshot import StatusSnapshot as StatusSnapshot
 
 
 class CodingTuiStatusProvider:

--- a/src/loushang/harnesstui/commands/__init__.py
+++ b/src/loushang/harnesstui/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Product-neutral command presentation helpers."""

--- a/src/loushang/harnesstui/commands/presentation.py
+++ b/src/loushang/harnesstui/commands/presentation.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
-from loushang.tui import CommandPalette, CompletionItem, CompletionProvider
+from loushang.tui import (
+    CommandPalette,
+    CompletionItem,
+    CompletionProvider,
+    SelectItem,
+)
 
 
 def format_commands(raw_commands: Iterable[object], *, query: str = "") -> str:
@@ -49,6 +54,19 @@ def command_palette(
 ) -> CommandPalette:
     provider = command_completion_provider(raw_commands)
     return CommandPalette.from_completion_provider(provider, title=title)
+
+
+def command_palette_select_items(palette: CommandPalette) -> list[SelectItem]:
+    """Project a command palette into the generic selection-surface model."""
+
+    return [
+        SelectItem(
+            label=item.display_label(),
+            value=item.value,
+            description=item.description,
+        )
+        for item in palette.items
+    ]
 
 
 def format_command(command: object) -> str:
@@ -131,6 +149,7 @@ __all__ = [
     "command_item_matches",
     "command_label",
     "command_palette",
+    "command_palette_select_items",
     "command_source_priority",
     "format_command",
     "format_commands",

--- a/src/loushang/harnesstui/commands/presentation.py
+++ b/src/loushang/harnesstui/commands/presentation.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from loushang.tui import CommandPalette, CompletionItem, CompletionProvider
+
+
+def format_commands(raw_commands: Iterable[object], *, query: str = "") -> str:
+    """Render command descriptors without acquiring or executing commands."""
+
+    lines = [format_command(command) for command in raw_commands]
+    lines = [line for line in lines if line]
+    stripped_query = query.strip()
+    if stripped_query:
+        needle = stripped_query.lower()
+        lines = [line for line in lines if needle in line.lower()]
+
+    if not lines:
+        if stripped_query:
+            return f"No commands match: {stripped_query}"
+        return "No commands available."
+
+    return "\n".join(["Commands:", *sorted(lines)])
+
+
+def command_completion_provider(
+    raw_commands: Iterable[object],
+    *,
+    local_last: bool = True,
+) -> CompletionProvider:
+    """Project duck-typed command descriptors into completion items."""
+
+    items = [
+        (item, command_source_priority(command))
+        for command in raw_commands
+        if (item := command_completion_item(command)) is not None
+    ]
+    if local_last:
+        items.sort(key=lambda pair: (pair[1], pair[0].value))
+    else:
+        items.sort(key=lambda pair: pair[0].value)
+    return CompletionProvider(tuple(item for item, _priority in items))
+
+
+def command_palette(
+    raw_commands: Iterable[object],
+    *,
+    title: str = "Commands",
+) -> CommandPalette:
+    provider = command_completion_provider(raw_commands)
+    return CommandPalette.from_completion_provider(provider, title=title)
+
+
+def format_command(command: object) -> str:
+    name = _string_attr(command, "invocation_name") or _string_attr(command, "name")
+    if name is None:
+        return ""
+    label = command_label(name, _string_attr(command, "argument_hint"))
+    description = _string_attr(command, "description")
+    source = _string_attr(command, "source")
+    if description:
+        label = f"{label} - {description}"
+    if source:
+        label = f"{label} ({source})"
+    return label
+
+
+def command_completion_item(command: object) -> CompletionItem | None:
+    name = _string_attr(command, "invocation_name") or _string_attr(command, "name")
+    if name is None:
+        return None
+    argument_hint = _string_attr(command, "argument_hint")
+    description = _string_attr(command, "description") or ""
+    source = _string_attr(command, "source")
+    if source:
+        description = f"{description} ({source})" if description else f"({source})"
+    value = f"/{name}"
+    return CompletionItem(
+        value=value,
+        label=command_label(name, argument_hint),
+        description=description,
+    )
+
+
+def command_source_priority(command: object) -> int:
+    return 1 if _string_attr(command, "source") == "local" else 0
+
+
+def command_label(name: str, argument_hint: str | None) -> str:
+    if argument_hint:
+        return f"/{name} {argument_hint}"
+    return f"/{name}"
+
+
+def matching_command_items(
+    provider: CompletionProvider,
+    query: str,
+) -> tuple[CompletionItem, ...]:
+    needle = query.lower()
+    matches = tuple(
+        item for item in provider.items if command_item_matches(item, needle)
+    )
+    exact = tuple(
+        item
+        for item in matches
+        if item.value.lower() == needle or item.display_label().lower() == needle
+    )
+    return exact or matches
+
+
+def command_item_matches(item: CompletionItem, query: str) -> bool:
+    needle = query.lower()
+    haystacks = (item.value, item.display_label(), item.description)
+    for haystack in haystacks:
+        lowered = haystack.lower()
+        if needle in lowered:
+            return True
+        if not needle.startswith("/") and needle in lowered.removeprefix("/"):
+            return True
+    return False
+
+
+def _string_attr(value: object, name: str) -> str | None:
+    raw = getattr(value, name, None)
+    return raw if isinstance(raw, str) and raw else None
+
+
+__all__ = [
+    "command_completion_item",
+    "command_completion_provider",
+    "command_item_matches",
+    "command_label",
+    "command_palette",
+    "command_source_priority",
+    "format_command",
+    "format_commands",
+    "matching_command_items",
+]

--- a/src/loushang/harnesstui/selection/catalog.py
+++ b/src/loushang/harnesstui/selection/catalog.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from loushang.tui import (
+    CommandPalette,
+    CompletionItem,
+    CompletionProvider,
+    SearchableListItem,
+)
+
+
+@dataclass(frozen=True)
+class ModelChoice:
+    """Product-neutral model choice prepared by a product adapter."""
+
+    label: str
+    value: str
+    selection: object
+    endpoint_id: str = ""
+    region: str = ""
+    lane: str = ""
+    api: str = ""
+    preferred_endpoint: bool = False
+    description: str = ""
+
+
+def format_model_choices(
+    choices: Iterable[ModelChoice],
+    *,
+    query: str = "",
+    current_value: str | None = None,
+) -> str:
+    """Render a stable text listing without acquiring model data."""
+
+    model_choices = list(choices)
+    stripped_query = query.strip()
+    if stripped_query:
+        model_choices = filter_model_choices(model_choices, stripped_query)
+
+    if not model_choices:
+        if stripped_query:
+            return f"No models match: {stripped_query}"
+        return "No models available."
+
+    lines = ["Available models:"]
+    for choice in model_choices:
+        is_current = choice.value == current_value
+        marker = "*" if is_current else " "
+        suffix = " (current)" if is_current else ""
+        lines.append(f"{marker} {model_choice_display_label(choice)}{suffix}")
+    return "\n".join(lines)
+
+
+def model_completion_provider(
+    choices: Iterable[ModelChoice],
+    *,
+    current_value: str | None = None,
+) -> CompletionProvider:
+    """Project model choices into generic TUI completion items."""
+
+    return CompletionProvider(
+        tuple(
+            CompletionItem(
+                value=choice.value,
+                label=choice.label,
+                description=model_choice_description(
+                    choice,
+                    current_value=current_value,
+                ),
+            )
+            for choice in choices
+        )
+    )
+
+
+def model_palette(
+    choices: Iterable[ModelChoice],
+    *,
+    current_value: str | None = None,
+    title: str = "Models",
+) -> CommandPalette:
+    """Project model choices into a generic command palette."""
+
+    provider = model_completion_provider(choices, current_value=current_value)
+    return CommandPalette.from_completion_provider(provider, title=title)
+
+
+def model_search_items(
+    choices: Iterable[ModelChoice],
+    *,
+    current_value: str | None = None,
+) -> tuple[SearchableListItem, ...]:
+    """Project model choices into settings/search list rows."""
+
+    return tuple(
+        SearchableListItem(
+            key=choice.value,
+            label=choice.label,
+            value="current" if choice.value == current_value else "",
+            description=choice.description,
+        )
+        for choice in choices
+    )
+
+
+def matching_model_choices(
+    choices: Iterable[ModelChoice],
+    query: str,
+) -> list[ModelChoice]:
+    """Match choices while preferring an exact value and then exact label."""
+
+    model_choices = list(choices)
+    needle = query.lower()
+    exact_value = [choice for choice in model_choices if choice.value.lower() == needle]
+    if exact_value:
+        return exact_value
+    labelled = [
+        choice for choice in model_choices if model_choice_matches(choice, needle)
+    ]
+    exact_label = [choice for choice in labelled if choice.label.lower() == needle]
+    return exact_label or labelled
+
+
+def filter_model_choices(
+    choices: Iterable[ModelChoice],
+    query: str,
+) -> list[ModelChoice]:
+    """Return every choice whose searchable presentation matches ``query``."""
+
+    return [choice for choice in choices if model_choice_matches(choice, query)]
+
+
+def model_choice_matches(choice: ModelChoice, query: str) -> bool:
+    needle = query.lower()
+    return (
+        needle in choice.label.lower()
+        or needle in choice.value.lower()
+        or bool(choice.endpoint_id and needle in choice.endpoint_id.lower())
+        or bool(choice.description and needle in choice.description.lower())
+    )
+
+
+def model_choice_description(
+    choice: ModelChoice,
+    *,
+    current_value: str | None = None,
+) -> str:
+    parts: list[str] = []
+    if choice.value == current_value:
+        parts.append("current")
+    if choice.endpoint_id:
+        parts.append(f"endpoint: {choice.endpoint_id}")
+    if choice.region:
+        parts.append(f"region: {choice.region}")
+    if choice.lane:
+        parts.append(f"lane: {choice.lane}")
+    if choice.api:
+        parts.append(f"protocol: {choice.api}")
+    if choice.description:
+        parts.append(choice.description)
+    return " - ".join(parts)
+
+
+def model_choice_display_label(choice: ModelChoice) -> str:
+    if choice.endpoint_id:
+        return f"{choice.label} (endpoint: {choice.endpoint_id})"
+    return choice.label
+
+
+def current_model_choice_first(
+    choices: Iterable[ModelChoice],
+    *,
+    current_value: str | None,
+) -> list[ModelChoice]:
+    model_choices = list(choices)
+    if current_value is None:
+        return model_choices
+    current = [choice for choice in model_choices if choice.value == current_value]
+    if not current:
+        return model_choices
+    return [
+        *current,
+        *(choice for choice in model_choices if choice.value != current_value),
+    ]
+
+
+def dedupe_preferred_model_choices(
+    choices: Iterable[ModelChoice],
+    *,
+    current_value: str | None,
+) -> list[ModelChoice]:
+    """Collapse duplicate labels only when a unique preferred endpoint exists."""
+
+    model_choices = list(choices)
+    by_label: dict[str, list[ModelChoice]] = {}
+    for choice in model_choices:
+        by_label.setdefault(choice.label, []).append(choice)
+
+    result: list[ModelChoice] = []
+    for choice in model_choices:
+        group = by_label[choice.label]
+        if len(group) == 1:
+            result.append(choice)
+            continue
+        preferred = [item for item in group if item.preferred_endpoint]
+        if len(preferred) != 1:
+            result.append(choice)
+            continue
+        keep_values = {preferred[0].value}
+        if current_value in {item.value for item in group}:
+            keep_values.add(str(current_value))
+        if choice.value in keep_values:
+            result.append(choice)
+    return result
+
+
+def model_choice_value(
+    *,
+    provider: str | None,
+    endpoint_id: str | None,
+    model_id: str | None,
+    fallback: str,
+) -> str:
+    if provider and endpoint_id and model_id:
+        return f"{provider}:{endpoint_id}:{model_id}"
+    return fallback
+
+
+__all__ = [
+    "ModelChoice",
+    "current_model_choice_first",
+    "dedupe_preferred_model_choices",
+    "filter_model_choices",
+    "format_model_choices",
+    "matching_model_choices",
+    "model_choice_description",
+    "model_choice_display_label",
+    "model_choice_matches",
+    "model_choice_value",
+    "model_completion_provider",
+    "model_palette",
+    "model_search_items",
+]

--- a/src/loushang/harnesstui/selection/catalog.py
+++ b/src/loushang/harnesstui/selection/catalog.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
 from loushang.tui import (
@@ -8,6 +8,7 @@ from loushang.tui import (
     CompletionItem,
     CompletionProvider,
     SearchableListItem,
+    SelectItem,
 )
 
 
@@ -103,6 +104,53 @@ def model_search_items(
         )
         for choice in choices
     )
+
+
+def model_label_select_items(
+    labels: Iterable[str],
+    *,
+    current_label: str | None = None,
+    descriptions: Mapping[str, str] | None = None,
+) -> list[SelectItem]:
+    """Build numbered selector rows from product-normalized model labels."""
+
+    model_labels = _current_model_label_first(labels, current_label=current_label)
+    description_by_label = descriptions or {}
+    ordinal_width = _ordinal_width(len(model_labels))
+    return [
+        SelectItem(
+            label=f"{_ordinal(index, width=ordinal_width)} {label}",
+            value=label,
+            description=(
+                "current"
+                if label == current_label
+                else description_by_label.get(label, "")
+            ),
+        )
+        for index, label in enumerate(model_labels, start=1)
+    ]
+
+
+def model_choice_select_items(
+    choices: Iterable[ModelChoice],
+    *,
+    current_value: str | None = None,
+) -> list[SelectItem]:
+    """Build numbered selector rows from presentation-ready model choices."""
+
+    model_choices = list(choices)
+    ordinal_width = _ordinal_width(len(model_choices))
+    return [
+        SelectItem(
+            label=f"{_ordinal(index, width=ordinal_width)} {choice.label}",
+            value=choice.value,
+            description=model_choice_description(
+                choice,
+                current_value=current_value,
+            ),
+        )
+        for index, choice in enumerate(model_choices, start=1)
+    ]
 
 
 def matching_model_choices(
@@ -228,6 +276,31 @@ def model_choice_value(
     return fallback
 
 
+def _current_model_label_first(
+    labels: Iterable[str],
+    *,
+    current_label: str | None,
+) -> list[str]:
+    model_labels = list(labels)
+    if current_label is None:
+        return model_labels
+    current = [label for label in model_labels if label == current_label]
+    if not current:
+        return model_labels
+    return [
+        *current,
+        *(label for label in model_labels if label != current_label),
+    ]
+
+
+def _ordinal_width(item_count: int) -> int:
+    return max(2, len(f"{item_count}."))
+
+
+def _ordinal(index: int, *, width: int) -> str:
+    return f"{index}.".ljust(width)
+
+
 __all__ = [
     "ModelChoice",
     "current_model_choice_first",
@@ -235,11 +308,13 @@ __all__ = [
     "filter_model_choices",
     "format_model_choices",
     "matching_model_choices",
+    "model_choice_select_items",
     "model_choice_description",
     "model_choice_display_label",
     "model_choice_matches",
     "model_choice_value",
     "model_completion_provider",
+    "model_label_select_items",
     "model_palette",
     "model_search_items",
 ]

--- a/src/loushang/harnesstui/settings/dashboard.py
+++ b/src/loushang/harnesstui/settings/dashboard.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from loushang.tui import (
+    CursorDeclaration,
+    InputIntent,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    SearchableList,
+    TabGroup,
+    truncate_to_width,
+)
+from loushang.tui.settings import bool_text
+
+
+class StatusSnapshotView(Protocol):
+    @property
+    def model_label(self) -> str | None: ...
+
+    @property
+    def cwd(self) -> str: ...
+
+    @property
+    def branch(self) -> str | None: ...
+
+    @property
+    def session_label(self) -> str | None: ...
+
+    @property
+    def thinking_level(self) -> str | None: ...
+
+    @property
+    def running(self) -> bool: ...
+
+    @property
+    def statusline_visible(self) -> bool: ...
+
+
+UsageProvider = Callable[[], object | None]
+
+
+@dataclass(slots=True)
+class StaticLinesPage:
+    lines: tuple[str, ...]
+    focused: bool = False
+
+    def focus(self) -> None:
+        self.focused = True
+
+    def blur(self) -> None:
+        self.focused = False
+
+    def handle_input(self, event: object) -> object:
+        if getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {
+            "left",
+            "right",
+            "home",
+            "end",
+        }:
+            return True
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        rows = [
+            RenderLine(truncate_to_width(line, max_width=constraints.width, ellipsis=""))
+            for line in self.lines[: constraints.max_height]
+        ]
+        return RenderResult.from_lines(rows, constraints=constraints)
+
+
+@dataclass(slots=True)
+class SettingsDashboard:
+    """Product-neutral tabbed settings shell.
+
+    Products provide the populated ``TabGroup`` and handle setting intents.
+    This class owns only focus routing, close interaction, chrome, and footer
+    presentation shared by Harness-backed terminal products.
+    """
+
+    tabs: TabGroup = field(init=False)
+    focused: bool = field(default=False, init=False)
+    feedback_message: str | None = field(default=None, init=False)
+
+    def focus(self) -> None:
+        self.focused = True
+        self.tabs.focus_content()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.tabs.blur()
+
+    def editor_input_target(self) -> object | None:
+        return self.tabs.editor_input_target()
+
+    def handle_input(self, event: object) -> object:
+        result = self.tabs.handle_input(event)
+        if result is not None:
+            return result
+        if _is_escape_event(event):
+            return InputIntent(kind="surface_close")
+        if _is_q_event(event) and self.focus_context() in {
+            "tabs",
+            "page",
+            "settings-list",
+            "model-list",
+        }:
+            return InputIntent(kind="surface_close")
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        if constraints.max_height <= 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        body_height = max(1, constraints.max_height - 2)
+        result = self.tabs.render(
+            RenderConstraints(width=constraints.width, max_height=body_height)
+        )
+        rows = _with_separator(result.lines, width=constraints.width)
+        cursor = _offset_cursor_after_separator(result.cursor)
+        footer = settings_footer_text(
+            self.focus_context(),
+            self.feedback_message,
+            width=constraints.width,
+        )
+        while len(rows) < constraints.max_height - 1:
+            rows.append(RenderLine(""))
+        if len(rows) < constraints.max_height:
+            rows.append(RenderLine(footer))
+        return RenderResult.from_lines(
+            rows[: constraints.max_height],
+            constraints=constraints,
+            cursor=cursor,
+        )
+
+    def focus_context(self) -> str:
+        if self.tabs.header_focused:
+            return "tabs"
+        page = self.tabs.selected_page
+        content = page.content if page is not None else None
+        settings = getattr(content, "settings", None)
+        if isinstance(settings, SearchableList):
+            return "search" if settings.focus_region == "search" else "settings-list"
+        models = getattr(content, "models", None)
+        if isinstance(models, SearchableList):
+            return "search" if models.focus_region == "search" else "model-list"
+        if isinstance(content, TabGroup):
+            return "tabs" if content.header_focused else "page"
+        return "page"
+
+
+def status_lines(snapshot: StatusSnapshotView) -> tuple[str, ...]:
+    return (
+        "Status",
+        "",
+        f"Model              {snapshot.model_label or 'Unavailable'}",
+        f"Workspace          {snapshot.cwd}",
+        f"Branch             {snapshot.branch or 'Unavailable'}",
+        f"Session            {snapshot.session_label or 'Unavailable'}",
+        f"Thinking           {snapshot.thinking_level or 'Unavailable'}",
+        f"Runtime            {'running' if snapshot.running else 'idle'}",
+        f"Status line        {bool_text(snapshot.statusline_visible)}",
+    )
+
+
+def usage_lines(provider: UsageProvider | None) -> tuple[str, ...]:
+    if provider is None:
+        return ("Usage", "", "Usage data unavailable")
+    try:
+        snapshot = provider()
+    except Exception:
+        snapshot = None
+    if snapshot is None:
+        return ("Usage", "", "Usage data unavailable")
+    return (
+        "Usage",
+        "",
+        f"Current context    {getattr(snapshot, 'tokens', 'Unavailable')}",
+        f"Context window     {getattr(snapshot, 'context_window', 'Unavailable')}",
+        f"Percent used       {getattr(snapshot, 'percent', 'Unavailable')}",
+        f"Source             {getattr(snapshot, 'source', 'Unavailable')}",
+    )
+
+
+def stats_overview_lines(snapshot: StatusSnapshotView) -> tuple[str, ...]:
+    return (
+        "Session Overview",
+        "",
+        f"Session            {snapshot.session_label or 'Unavailable'}",
+        f"Runtime            {'running' if snapshot.running else 'idle'}",
+        "Historical stats   Unavailable",
+    )
+
+
+def model_usage_lines(current_value: str | None) -> tuple[str, ...]:
+    return (
+        "Model Usage",
+        "",
+        f"Current model      {current_value or 'Unavailable'}",
+        "Historical usage   Unavailable",
+    )
+
+
+def settings_footer_text(
+    focus_context: str,
+    feedback_message: str | None = None,
+    *,
+    width: int,
+) -> str:
+    if focus_context == "search":
+        text = "Type to filter · Enter/↓ to select · ↑ to tabs · Esc to clear"
+    elif focus_context in {"settings-list", "model-list"}:
+        text = "↑/↓ to move · Enter/Space to select · ↑ on first row to search · q to close"
+    elif focus_context == "tabs":
+        text = "←/→ to switch tabs · ↓ to enter · q to close"
+    else:
+        text = "↑ to tabs · q to close"
+    if feedback_message:
+        text = f"{feedback_message} · {text}"
+    return truncate_to_width(text, max_width=width, ellipsis="")
+
+
+def _separator(width: int) -> str:
+    return "-" * max(1, width)
+
+
+def _with_separator(lines: Sequence[RenderLine], *, width: int) -> list[RenderLine]:
+    if not lines:
+        return []
+    return [lines[0], RenderLine(_separator(width)), *lines[1:]]
+
+
+def _offset_cursor_after_separator(
+    cursor: CursorDeclaration | None,
+) -> CursorDeclaration | None:
+    if cursor is None or cursor.row == 0:
+        return cursor
+    return CursorDeclaration(row=cursor.row + 1, column=cursor.column)
+
+
+def _is_escape_event(event: object) -> bool:
+    return getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {
+        "escape",
+        "esc",
+    }
+
+
+def _is_q_event(event: object) -> bool:
+    return (
+        getattr(event, "kind", "") == "key"
+        and getattr(event, "key", "").casefold() == "q"
+    ) or (
+        getattr(event, "kind", "") == "text"
+        and getattr(event, "text", "").casefold() == "q"
+    )
+
+
+__all__ = [
+    "SettingsDashboard",
+    "StaticLinesPage",
+    "StatusSnapshotView",
+    "UsageProvider",
+    "model_usage_lines",
+    "settings_footer_text",
+    "stats_overview_lines",
+    "status_lines",
+    "usage_lines",
+]

--- a/src/loushang/harnesstui/settings/model.py
+++ b/src/loushang/harnesstui/settings/model.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loushang.harnesstui.selection.catalog import ModelChoice, model_search_items
+from loushang.harnesstui.settings.dashboard import StaticLinesPage
+from loushang.tui import (
+    InputIntent,
+    RenderConstraints,
+    RenderResult,
+    SearchableList,
+    SearchableListSelect,
+)
+from loushang.tui.settings import (
+    SETTINGS_PAGE_THEME,
+    SETTINGS_VALUE_COLUMN,
+    is_space_event,
+    is_tab_fallback_key,
+)
+
+
+@dataclass(slots=True)
+class ModelPage:
+    """Model-selection page over choices prepared by a product adapter."""
+
+    choices: tuple[ModelChoice, ...]
+    current_value: str | None = None
+    error: str = ""
+    focused: bool = False
+    models: SearchableList = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.models = self._make_list(focused=False)
+
+    @property
+    def unavailable(self) -> bool:
+        return bool(self.error) or not self.choices
+
+    def focus(self) -> None:
+        self.focused = True
+        self.models.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.models.blur()
+
+    def editor_input_target(self) -> object | None:
+        if self.unavailable:
+            return None
+        return self.models.editor_input_target()
+
+    def set_choices(
+        self,
+        choices: tuple[ModelChoice, ...],
+        *,
+        current_value: str | None,
+        error: str = "",
+    ) -> None:
+        self.choices = choices
+        self.current_value = current_value
+        self.error = error
+        self.models.set_items(
+            model_search_items(choices, current_value=current_value),
+            preserve_active_key=current_value or "",
+        )
+
+    def handle_input(self, event: object) -> object:
+        if self.unavailable:
+            return True if is_tab_fallback_key(event) else None
+        result = self.models.handle_input(event)
+        if isinstance(result, SearchableListSelect):
+            return InputIntent(kind="setting", text="model.current", note=result.key)
+        if result is not None:
+            return result
+        if self.models.focus_region == "list" and is_space_event(event):
+            item = self.models.active_item
+            if item is not None:
+                return InputIntent(
+                    kind="setting",
+                    text="model.current",
+                    note=item.key,
+                )
+        if is_tab_fallback_key(event):
+            return True
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        if self.unavailable:
+            lines = ("Model selection unavailable", self.error or "No models available.")
+            return StaticLinesPage(lines).render(constraints)
+        return self.models.render(constraints)
+
+    def _make_list(self, *, focused: bool) -> SearchableList:
+        return SearchableList(
+            model_search_items(self.choices, current_value=self.current_value),
+            placeholder="Search models...",
+            empty_text="No matching models",
+            focused=focused,
+            search_box=True,
+            detail_column=SETTINGS_VALUE_COLUMN,
+            theme=SETTINGS_PAGE_THEME,
+        )
+
+
+__all__ = ["ModelPage"]

--- a/src/loushang/harnesstui/settings/page.py
+++ b/src/loushang/harnesstui/settings/page.py
@@ -1,96 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from loushang.tui.settings import SettingsListPage
 
-from loushang.tui import (
-    CursorDeclaration,
-    InputIntent,
-    RenderConstraints,
-    RenderLine,
-    RenderResult,
-    SearchableList,
-    SearchableListSelect,
-)
-from loushang.tui.settings import (
-    SETTINGS_PAGE_THEME,
-    SETTINGS_VALUE_COLUMN,
-    ConfigRow,
-    config_items,
-    is_space_event,
-    is_tab_fallback_key,
-    next_bool_value,
-    row_for_key,
-    settings_header,
-)
+__all__ = ["ConfigSettingsPage"]
 
 
-@dataclass(slots=True)
-class ConfigSettingsPage:
-    rows: tuple[ConfigRow, ...]
-    focused: bool = False
-    settings: SearchableList = field(init=False)
-
-    def __post_init__(self) -> None:
-        self.settings = self._make_list(focused=False)
-
-    def focus(self) -> None:
-        self.focused = True
-        self.settings.focus()
-
-    def blur(self) -> None:
-        self.focused = False
-        self.settings.blur()
-
-    def editor_input_target(self) -> object | None:
-        return self.settings.editor_input_target()
-
-    def set_rows(self, rows: tuple[ConfigRow, ...], *, preserve_active_key: str = "") -> None:
-        self.rows = rows
-        self.settings.set_items(config_items(rows), preserve_active_key=preserve_active_key)
-
-    def handle_input(self, event: object) -> object:
-        result = self.settings.handle_input(event)
-        if isinstance(result, SearchableListSelect):
-            return self._setting_intent(result.key)
-        if result is not None:
-            return result
-        if self.settings.focus_region == "list" and is_space_event(event):
-            item = self.settings.active_item
-            if item is not None:
-                return self._setting_intent(item.key)
-        if is_tab_fallback_key(event):
-            return True
-        return None
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        if constraints.max_height <= 0:
-            return RenderResult.from_lines([], constraints=constraints)
-        if constraints.max_height <= 4:
-            return self.settings.render(constraints)
-        result = self.settings.render(
-            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2))
-        )
-        header = RenderLine(settings_header(constraints.width))
-        rows = [*result.lines[:3], RenderLine(""), header, *result.lines[3:]]
-        cursor = result.cursor
-        if cursor is not None and cursor.row >= 3:
-            cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
-        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
-
-    def _make_list(self, *, focused: bool) -> SearchableList:
-        return SearchableList(
-            config_items(self.rows),
-            placeholder="Search settings...",
-            empty_text="No matching settings",
-            focused=focused,
-            search_box=True,
-            detail_column=SETTINGS_VALUE_COLUMN,
-            theme=SETTINGS_PAGE_THEME,
-        )
-
-    def _setting_intent(self, key: str) -> InputIntent | None:
-        row = row_for_key(self.rows, key)
-        if row is None or row.disabled:
-            return None
-        value = next_bool_value(row.value)
-        return InputIntent(kind="setting", text=row.id, note=value)
+# Compatibility name for the product-neutral settings list page.  Keep this a
+# direct alias so callers see one class identity across TUI, Harnesstui, and
+# product adapters.
+ConfigSettingsPage = SettingsListPage

--- a/src/loushang/harnesstui/status/plain.py
+++ b/src/loushang/harnesstui/status/plain.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.tui.cell_width import strip_control_sequences
+from loushang.tui.text_utils import fixed_width
+
+
+@dataclass(frozen=True)
+class PlainToolbarSnapshot:
+    model: str | None = None
+    cwd: str | None = None
+    branch: str | None = None
+    session: str | None = None
+    thinking: str | None = None
+    context: str | None = None
+    window: str | None = None
+    tokens: str | None = None
+    message: str | None = None
+    running: bool = False
+
+
+def render_plain_toolbar(
+    snapshot: PlainToolbarSnapshot,
+    *,
+    width: int | None = None,
+) -> str:
+    parts: list[str] = []
+    _append_part(parts, "model", snapshot.model)
+    _append_part(parts, "cwd", snapshot.cwd)
+    _append_part(parts, "branch", snapshot.branch)
+    _append_part(parts, "session", snapshot.session)
+    _append_part(parts, "thinking", snapshot.thinking)
+    _append_part(parts, "context", snapshot.context)
+    _append_part(parts, "window", snapshot.window)
+    _append_part(parts, "tokens", snapshot.tokens)
+    if snapshot.running:
+        parts.append("running")
+    if snapshot.message:
+        parts.append(snapshot.message)
+    text = " | ".join(parts)
+    if width is None:
+        return text
+    return strip_control_sequences(fixed_width(text, width=width))
+
+
+def _append_part(parts: list[str], name: str, value: str | None) -> None:
+    if value:
+        parts.append(f"{name}={value}")
+
+
+__all__ = ["PlainToolbarSnapshot", "render_plain_toolbar"]

--- a/src/loushang/harnesstui/status/settings.py
+++ b/src/loushang/harnesstui/status/settings.py
@@ -11,26 +11,19 @@ from loushang.harnesstui.status.line import (
     status_line_style_mode,
 )
 from loushang.tui import (
-    CursorDeclaration,
     InputIntent,
     RenderConstraints,
     RenderLine,
     RenderResult,
     SearchableList,
-    SearchableListSelect,
     StatusBar,
 )
 from loushang.tui.settings import (
-    SETTINGS_PAGE_THEME,
-    SETTINGS_VALUE_COLUMN,
     ConfigRow,
+    SettingsListPage,
     bool_text,
-    config_items,
-    is_space_event,
-    is_tab_fallback_key,
     next_bool_value,
     row_for_key,
-    settings_header,
 )
 
 __all__ = [
@@ -46,75 +39,64 @@ class StatusLineSettingsPage:
     statusline_preview: Callable[[], StatusLinePreviewSnapshot]
     focused: bool = False
     settings: SearchableList = field(init=False)
+    _list_page: SettingsListPage = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        self.settings = self._make_list(focused=False)
+        self._list_page = SettingsListPage(
+            statusline_rows(self.statusline_settings),
+            placeholder="Search status line...",
+            empty_text="No matching status line settings",
+            on_select=self._setting_intent,
+        )
+        self.settings = self._list_page.settings
 
     def focus(self) -> None:
         self.focused = True
-        self.settings.focus()
+        self._list_page.focus()
 
     def blur(self) -> None:
         self.focused = False
-        self.settings.blur()
+        self._list_page.blur()
 
     def editor_input_target(self) -> object | None:
-        return self.settings.editor_input_target()
+        return self._list_page.editor_input_target()
 
     def set_statusline_settings(self, settings: StatusLineSettings, *, preserve_active_key: str = "") -> None:
         self.statusline_settings = settings
-        self.settings.set_items(config_items(statusline_rows(settings)), preserve_active_key=preserve_active_key)
+        self._list_page.set_rows(statusline_rows(settings), preserve_active_key=preserve_active_key)
 
     def handle_input(self, event: object) -> object:
-        result = self.settings.handle_input(event)
-        if isinstance(result, SearchableListSelect):
-            return self._setting_intent(result.key)
-        if result is not None:
-            return result
-        if self.settings.focus_region == "list" and is_space_event(event):
-            item = self.settings.active_item
-            if item is not None:
-                return self._setting_intent(item.key)
-        if is_tab_fallback_key(event):
-            return True
-        return None
+        return self._list_page.handle_input(event)
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         if constraints.max_height <= 0:
             return RenderResult.from_lines([], constraints=constraints)
         if constraints.max_height <= 6:
             return self.settings.render(constraints)
-        result = self.settings.render(
-            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 4))
+        result = self._list_page.render(
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2))
         )
-        header = RenderLine(settings_header(constraints.width))
         preview = _statusline_preview_lines(
             self.statusline_preview(),
             self.statusline_settings,
             width=constraints.width,
         )
-        rows = [*result.lines[:3], RenderLine(""), header, *result.lines[3:], RenderLine(""), *preview]
-        cursor = result.cursor
-        if cursor is not None and cursor.row >= 3:
-            cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
-        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
-
-    def _make_list(self, *, focused: bool) -> SearchableList:
-        return SearchableList(
-            config_items(statusline_rows(self.statusline_settings)),
-            placeholder="Search status line...",
-            empty_text="No matching status line settings",
-            focused=focused,
-            search_box=True,
-            detail_column=SETTINGS_VALUE_COLUMN,
-            theme=SETTINGS_PAGE_THEME,
+        rows = [*result.lines, RenderLine(""), *preview]
+        return RenderResult.from_lines(
+            rows[: constraints.max_height],
+            constraints=constraints,
+            cursor=result.cursor,
         )
 
-    def _setting_intent(self, key: str) -> InputIntent | None:
-        row = row_for_key(statusline_rows(self.statusline_settings), key)
-        if row is None or row.disabled:
+    def _setting_intent(self, row: ConfigRow) -> InputIntent | None:
+        current = row_for_key(statusline_rows(self.statusline_settings), row.id)
+        if current is None or current.disabled:
             return None
-        return InputIntent(kind="setting", text=row.id, note=next_statusline_value(row.id, row.value))
+        return InputIntent(
+            kind="setting",
+            text=current.id,
+            note=next_statusline_value(current.id, current.value),
+        )
 
 
 def statusline_rows(settings: StatusLineSettings) -> tuple[ConfigRow, ...]:

--- a/src/loushang/harnesstui/status/snapshot.py
+++ b/src/loushang/harnesstui/status/snapshot.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from loushang.harnesstui.status.line import StatusLineSettings
+
+
+@dataclass(frozen=True, slots=True)
+class StatusSnapshot:
+    model_label: str | None
+    cwd: str
+    branch: str | None
+    session_label: str | None
+    thinking_level: str | None
+    running: bool
+    statusline_visible: bool
+    statusline_settings: StatusLineSettings = field(default_factory=StatusLineSettings)
+
+
+__all__ = ["StatusSnapshot"]

--- a/src/loushang/harnesstui/surface/factory.py
+++ b/src/loushang/harnesstui/surface/factory.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Literal
+
+from loushang.harnesstui.surface.view import (
+    ScreenSurfacePresentation,
+    ScreenSurfaceView,
+)
+from loushang.tui import CommandSurface, InfoPanel, SelectItem
+
+
+def info_surface_view(
+    *,
+    title: str,
+    text: str,
+    subtitle: str = "",
+    footer: str = "Enter/Esc to close",
+    presentation: ScreenSurfacePresentation = "bottom",
+    preferred_height: int | None = None,
+    panel_title: str | None = None,
+    panel_footer: str = "",
+) -> ScreenSurfaceView:
+    """Build a reusable information surface from presentation-ready text."""
+
+    content = InfoPanel.from_text(
+        title=title if panel_title is None else panel_title,
+        text=text,
+        footer=panel_footer,
+    )
+    return ScreenSurfaceView(
+        title=title,
+        purpose="info",
+        content=content,
+        footer=footer,
+        subtitle=subtitle,
+        presentation=presentation,
+        preferred_height=preferred_height,
+    )
+
+
+def command_surface_view(
+    *,
+    title: str,
+    purpose: Literal["model", "command"],
+    items: Iterable[SelectItem],
+    subtitle: str = "",
+    footer: str = "Enter to select - Esc to close",
+    presentation: ScreenSurfacePresentation = "bottom",
+    preferred_height: int | None = None,
+    query: str = "",
+    max_visible: int = 8,
+) -> ScreenSurfaceView:
+    """Build a searchable command-style surface over neutral selection items."""
+
+    content = CommandSurface(
+        list(items),
+        query=query,
+        max_visible=max_visible,
+    )
+    return ScreenSurfaceView(
+        title=title,
+        purpose=purpose,
+        content=content,
+        footer=footer,
+        subtitle=subtitle,
+        presentation=presentation,
+        preferred_height=preferred_height,
+    )
+
+
+__all__ = ["command_surface_view", "info_surface_view"]

--- a/src/loushang/tui/settings.py
+++ b/src/loushang/tui/settings.py
@@ -1,16 +1,31 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 
 from loushang.tui.cell_width import truncate_to_width
+from loushang.tui.core import (
+    CursorDeclaration,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+)
+from loushang.tui.input import InputIntent
 from loushang.tui.theme import ThemeResolver
-from loushang.tui.ui_parts import SearchableListItem
+from loushang.tui.ui_parts import (
+    SearchableList,
+    SearchableListItem,
+    SearchableListSelect,
+)
 
 __all__ = [
     "SETTINGS_PAGE_THEME",
     "SETTINGS_VALUE_COLUMN",
     "ConfigRow",
+    "SettingsListPage",
+    "SettingsRowSelect",
     "as_bool",
+    "boolean_setting_intent",
     "bool_text",
     "config_items",
     "is_space_event",
@@ -103,3 +118,90 @@ def is_space_event(event: object) -> bool:
 
 def is_tab_fallback_key(event: object) -> bool:
     return getattr(event, "kind", "") == "key" and getattr(event, "key", "") in {"left", "right", "home", "end"}
+
+
+SettingsRowSelect = Callable[[ConfigRow], object | None]
+
+
+def boolean_setting_intent(row: ConfigRow) -> InputIntent | None:
+    if row.disabled:
+        return None
+    return InputIntent(kind="setting", text=row.id, note=next_bool_value(row.value))
+
+
+@dataclass(slots=True)
+class SettingsListPage:
+    """Searchable settings rows with the shared table layout and input contract."""
+
+    rows: tuple[ConfigRow, ...]
+    focused: bool = False
+    placeholder: str = "Search settings..."
+    empty_text: str = "No matching settings"
+    on_select: SettingsRowSelect | None = boolean_setting_intent
+    settings: SearchableList = field(init=False)
+
+    def __post_init__(self) -> None:
+        # Pages are focused by their containing surface after assembly.  Keeping
+        # construction unfocused preserves the existing settings-page contract.
+        self.settings = self._make_list(focused=False)
+
+    def focus(self) -> None:
+        self.focused = True
+        self.settings.focus()
+
+    def blur(self) -> None:
+        self.focused = False
+        self.settings.blur()
+
+    def editor_input_target(self) -> object | None:
+        return self.settings.editor_input_target()
+
+    def set_rows(self, rows: tuple[ConfigRow, ...], *, preserve_active_key: str = "") -> None:
+        self.rows = rows
+        self.settings.set_items(config_items(rows), preserve_active_key=preserve_active_key)
+
+    def handle_input(self, event: object) -> object:
+        result = self.settings.handle_input(event)
+        if isinstance(result, SearchableListSelect):
+            return self._select(result.key)
+        if result is not None:
+            return result
+        if self.settings.focus_region == "list" and is_space_event(event):
+            item = self.settings.active_item
+            if item is not None:
+                return self._select(item.key)
+        if is_tab_fallback_key(event):
+            return True
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        if constraints.max_height <= 0:
+            return RenderResult.from_lines([], constraints=constraints)
+        if constraints.max_height <= 4:
+            return self.settings.render(constraints)
+        result = self.settings.render(
+            RenderConstraints(width=constraints.width, max_height=max(1, constraints.max_height - 2))
+        )
+        header = RenderLine(settings_header(constraints.width))
+        rows = [*result.lines[:3], RenderLine(""), header, *result.lines[3:]]
+        cursor = result.cursor
+        if cursor is not None and cursor.row >= 3:
+            cursor = CursorDeclaration(row=cursor.row + 2, column=cursor.column)
+        return RenderResult.from_lines(rows[: constraints.max_height], constraints=constraints, cursor=cursor)
+
+    def _make_list(self, *, focused: bool) -> SearchableList:
+        return SearchableList(
+            config_items(self.rows),
+            placeholder=self.placeholder,
+            empty_text=self.empty_text,
+            focused=focused,
+            search_box=True,
+            detail_column=SETTINGS_VALUE_COLUMN,
+            theme=SETTINGS_PAGE_THEME,
+        )
+
+    def _select(self, key: str) -> object | None:
+        row = row_for_key(self.rows, key)
+        if row is None or row.disabled or self.on_select is None:
+            return None
+        return self.on_select(row)

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -316,10 +316,16 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.harnesstui.conversation.source`" in text
     assert "`loushang.harnesstui.conversation.projection`" in text
     assert "`loushang.harnesstui.conversation.tool_transcript`" in text
+    assert "`loushang.harnesstui.commands.presentation`" in text
+    assert "`loushang.harnesstui.selection.catalog`" in text
     assert "`loushang.harnesstui.selection.model`" in text
+    assert "`loushang.harnesstui.settings.dashboard`" in text
+    assert "`loushang.harnesstui.settings.model`" in text
     assert "`loushang.harnesstui.settings.page`" in text
     assert "`loushang.harnesstui.status.settings`" in text
     assert "`loushang.harnesstui.status.line`" in text
+    assert "`loushang.harnesstui.status.plain`" in text
+    assert "`loushang.harnesstui.status.snapshot`" in text
     assert "`loushang.harnesstui.surface.view`" in text
     assert "`loushang.tui.settings`" in text
 
@@ -328,10 +334,16 @@ def test_harnesstui_capability_entrypoints_exist() -> None:
     paths = (
         Path("src/loushang/harnesstui/conversation/projection.py"),
         Path("src/loushang/harnesstui/conversation/tool_transcript.py"),
+        Path("src/loushang/harnesstui/commands/presentation.py"),
+        Path("src/loushang/harnesstui/selection/catalog.py"),
         Path("src/loushang/harnesstui/selection/model.py"),
+        Path("src/loushang/harnesstui/settings/dashboard.py"),
+        Path("src/loushang/harnesstui/settings/model.py"),
         Path("src/loushang/harnesstui/settings/page.py"),
         Path("src/loushang/harnesstui/status/line.py"),
+        Path("src/loushang/harnesstui/status/plain.py"),
         Path("src/loushang/harnesstui/status/settings.py"),
+        Path("src/loushang/harnesstui/status/snapshot.py"),
         Path("src/loushang/harnesstui/surface/view.py"),
         Path("src/loushang/tui/settings.py"),
     )

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -326,6 +326,7 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.harnesstui.status.line`" in text
     assert "`loushang.harnesstui.status.plain`" in text
     assert "`loushang.harnesstui.status.snapshot`" in text
+    assert "`loushang.harnesstui.surface.factory`" in text
     assert "`loushang.harnesstui.surface.view`" in text
     assert "`loushang.tui.settings`" in text
 
@@ -344,6 +345,7 @@ def test_harnesstui_capability_entrypoints_exist() -> None:
         Path("src/loushang/harnesstui/status/plain.py"),
         Path("src/loushang/harnesstui/status/settings.py"),
         Path("src/loushang/harnesstui/status/snapshot.py"),
+        Path("src/loushang/harnesstui/surface/factory.py"),
         Path("src/loushang/harnesstui/surface/view.py"),
         Path("src/loushang/tui/settings.py"),
     )

--- a/tests/coding/test_screen_coding_tui_surfaces.py
+++ b/tests/coding/test_screen_coding_tui_surfaces.py
@@ -21,6 +21,7 @@ from loushang.harnesstui.surface.view import (
 )
 from loushang.tui import (
     ApprovalSurface,
+    CommandSurface,
     CursorDeclaration,
     DialogSurface,
     InputEvent,
@@ -128,6 +129,8 @@ def test_screen_surface_manager_opens_model_surface_and_selects_model() -> None:
     assert app.active_surface.title == "Select Model"
     assert app.active_surface.presentation == "bottom-exclusive"
     assert app.active_surface.exclusive_bottom is True
+    assert isinstance(app.active_surface.content, ModelSelectorSurface)
+    assert app.active_surface.content.max_visible == 10
 
     rendered = app.active_surface.render(RenderConstraints(width=80, max_height=10))
     plain_lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
@@ -1075,13 +1078,22 @@ def test_screen_surface_manager_command_surface_inserts_selected_command() -> No
     asyncio.run(manager.handle_text("/command"))
 
     assert isinstance(app.active_surface, ScreenSurfaceView)
+    assert app.active_surface.title == "Commands"
+    assert app.active_surface.purpose == "command"
+    assert app.active_surface.footer == "Enter to select - Esc to close"
+    assert app.active_surface.presentation == "bottom"
+    assert isinstance(app.active_surface.content, CommandSurface)
+    assert app.active_surface.content.max_visible == 8
+    assert app.active_surface.handle_input(
+        InputEvent(kind="text", text="report")
+    ) is None
     intent = app.active_surface.handle_input(InputEvent(kind="key", key="enter"))
-    assert intent == InputIntent(kind="command", text="/model")
+    assert intent == InputIntent(kind="command", text="/report")
 
     asyncio.run(manager.handle_surface_intent(intent))
 
     assert app.active_surface is None
-    assert app.composer.value == "/model "
+    assert app.composer.value == "/report "
 
 
 def test_screen_surface_manager_handles_dialog_surface_confirm() -> None:

--- a/tests/coding/test_screen_settings_page.py
+++ b/tests/coding/test_screen_settings_page.py
@@ -157,7 +157,18 @@ def _raw(page: SettingsPageView, *, width: int = 100, height: int = 18) -> tuple
 def test_settings_page_tab_modules_export_page_components() -> None:
     from loushang.coding.ui.settings_common import ConfigRow
     from loushang.coding.ui.settings_config import ConfigSettingsPage
+    from loushang.coding.ui.settings_page import (
+        ModelPage,
+    )
+    from loushang.coding.ui.settings_page import (
+        StaticLinesPage as CodingStaticLinesPage,
+    )
     from loushang.coding.ui.settings_status_line import StatusLineSettingsPage
+    from loushang.harnesstui.settings.dashboard import (
+        SettingsDashboard,
+        StaticLinesPage,
+    )
+    from loushang.harnesstui.settings.model import ModelPage as SharedModelPage
     from loushang.harnesstui.settings.page import (
         ConfigSettingsPage as SharedConfigSettingsPage,
     )
@@ -170,7 +181,11 @@ def test_settings_page_tab_modules_export_page_components() -> None:
 
     assert ConfigSettingsPage is SharedConfigSettingsPage
     assert StatusLineSettingsPage is SharedStatusLineSettingsPage
+    assert ModelPage is SharedModelPage
+    assert CodingStaticLinesPage is StaticLinesPage
     assert ConfigRow is SharedConfigRow
+    assert isinstance(page, SettingsDashboard)
+    assert type(page.status_page) is StaticLinesPage
     assert isinstance(page.config_page, ConfigSettingsPage)
     assert isinstance(page.statusline_page, StatusLineSettingsPage)
 

--- a/tests/coding/test_ui_command_list.py
+++ b/tests/coding/test_ui_command_list.py
@@ -38,6 +38,13 @@ class _BuiltinSession:
         return list_builtin_command_descriptors()
 
 
+def test_command_list_keeps_completion_item_compatibility_alias() -> None:
+    from loushang.coding.ui.command_list import CompletionItem as CodingCompletionItem
+    from loushang.tui import CompletionItem
+
+    assert CodingCompletionItem is CompletionItem
+
+
 def test_format_session_commands_lists_sorted_commands() -> None:
     from loushang.coding.ui.command_list import format_session_commands
 

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -71,12 +71,24 @@ def test_conversation_raw_event_dispatch_stays_in_coding_adapter() -> None:
 
 def test_shared_interaction_types_are_not_redefined_in_coding_ui() -> None:
     moved_definitions = {
+        Path("src/loushang/coding/ui/model_list.py"): ("class ModelChoice",),
         Path("src/loushang/coding/ui/settings_common.py"): ("class ConfigRow",),
         Path("src/loushang/coding/ui/settings_config.py"): (
             "class ConfigSettingsPage",
         ),
+        Path("src/loushang/coding/ui/settings_page.py"): (
+            "class ModelPage",
+            "class StaticLinesPage",
+        ),
         Path("src/loushang/coding/ui/settings_status_line.py"): (
             "class StatusLineSettingsPage",
+        ),
+        Path("src/loushang/coding/ui/plain_toolbar.py"): (
+            "class PlainToolbarSnapshot",
+            "def render_plain_toolbar",
+        ),
+        Path("src/loushang/coding/ui/status_provider.py"): (
+            "class StatusSnapshot",
         ),
         Path("src/loushang/coding/ui/screen_surfaces.py"): (
             "class ModelSelectorSurface",

--- a/tests/coding/test_ui_model_list.py
+++ b/tests/coding/test_ui_model_list.py
@@ -115,6 +115,13 @@ class _AmbiguousDuplicateEndpointSession(_DuplicateEndpointSession):
             detail.preferred_endpoint = False
 
 
+def test_model_choice_is_the_shared_harnesstui_view_model() -> None:
+    from loushang.coding.ui.model_list import ModelChoice as CodingModelChoice
+    from loushang.harnesstui.selection.catalog import ModelChoice
+
+    assert CodingModelChoice is ModelChoice
+
+
 def test_format_available_models_marks_current_model() -> None:
     from loushang.coding.ui.model_list import format_available_models
 

--- a/tests/coding/test_ui_status_provider.py
+++ b/tests/coding/test_ui_status_provider.py
@@ -1,6 +1,45 @@
 from __future__ import annotations
 
 
+def test_status_snapshot_compatibility_export_is_identical() -> None:
+    from loushang.coding.ui.status_provider import (
+        StatusSnapshot as CodingStatusSnapshot,
+    )
+    from loushang.harnesstui.status.snapshot import StatusSnapshot
+
+    assert CodingStatusSnapshot is StatusSnapshot
+
+
+def test_status_provider_returns_shared_snapshot() -> None:
+    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+    from loushang.harnesstui.status.line import StatusLineSettings
+    from loushang.harnesstui.status.snapshot import StatusSnapshot
+
+    provider = CodingTuiStatusProvider(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label=lambda: "abcd",
+        thinking_level=lambda: "high",
+        running=lambda: True,
+        statusline_settings=StatusLineSettings(enabled=False),
+    )
+
+    snapshot = provider.snapshot()
+
+    assert type(snapshot) is StatusSnapshot
+    assert snapshot == StatusSnapshot(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        thinking_level="high",
+        running=True,
+        statusline_visible=False,
+        statusline_settings=StatusLineSettings(enabled=False),
+    )
+
+
 def test_status_provider_tracks_statusline_visibility() -> None:
     from loushang.coding.ui.status_line import StatusLineSettings
     from loushang.coding.ui.status_provider import CodingTuiStatusProvider

--- a/tests/harnesstui/commands/test_presentation.py
+++ b/tests/harnesstui/commands/test_presentation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from loushang.harnesstui.commands.presentation import (
+    command_completion_provider,
+    command_palette,
+    format_commands,
+    matching_command_items,
+)
+from loushang.tui import CommandPalette, CommandPaletteItem, CompletionItem
+
+
+def _commands() -> tuple[object, ...]:
+    return (
+        SimpleNamespace(
+            name="settings",
+            description="Open settings",
+            source="local",
+        ),
+        SimpleNamespace(
+            name="review",
+            invocation_name="review:pr",
+            argument_hint="<PR-URL>",
+            description="Review a pull request",
+            source="extension",
+        ),
+    )
+
+
+def test_format_commands_projects_and_filters_descriptors() -> None:
+    assert format_commands(_commands()) == (
+        "Commands:\n"
+        "/review:pr <PR-URL> - Review a pull request (extension)\n"
+        "/settings - Open settings (local)"
+    )
+    assert format_commands(_commands(), query="pull REQUEST") == (
+        "Commands:\n/review:pr <PR-URL> - Review a pull request (extension)"
+    )
+    assert format_commands(_commands(), query="missing") == "No commands match: missing"
+
+
+def test_command_completion_projection_orders_product_commands_before_local() -> None:
+    provider = command_completion_provider(_commands())
+
+    assert provider.items == (
+        CompletionItem(
+            value="/review:pr",
+            label="/review:pr <PR-URL>",
+            description="Review a pull request (extension)",
+        ),
+        CompletionItem(
+            value="/settings",
+            label="/settings",
+            description="Open settings (local)",
+        ),
+    )
+    assert command_palette(_commands(), title="Actions") == CommandPalette(
+        items=(
+            CommandPaletteItem(
+                value="/review:pr",
+                label="/review:pr <PR-URL>",
+                description="Review a pull request (extension)",
+            ),
+            CommandPaletteItem(
+                value="/settings",
+                label="/settings",
+                description="Open settings (local)",
+            ),
+        ),
+        title="Actions",
+    )
+
+
+def test_command_completion_projection_can_keep_session_alphabetical_order() -> None:
+    commands = (
+        SimpleNamespace(name="a-local", source="local"),
+        SimpleNamespace(name="z-product", source="builtin"),
+    )
+
+    provider = command_completion_provider(commands, local_last=False)
+
+    assert [item.value for item in provider.items] == ["/a-local", "/z-product"]
+
+
+def test_matching_commands_prefers_exact_value_or_label() -> None:
+    provider = command_completion_provider(_commands())
+
+    assert matching_command_items(provider, "/settings") == (provider.items[1],)
+    assert matching_command_items(provider, "PR-URL") == (provider.items[0],)
+    assert matching_command_items(provider, "open") == (provider.items[1],)

--- a/tests/harnesstui/commands/test_presentation.py
+++ b/tests/harnesstui/commands/test_presentation.py
@@ -5,10 +5,17 @@ from types import SimpleNamespace
 from loushang.harnesstui.commands.presentation import (
     command_completion_provider,
     command_palette,
+    command_palette_select_items,
     format_commands,
     matching_command_items,
 )
-from loushang.tui import CommandPalette, CommandPaletteItem, CompletionItem
+from loushang.tui import (
+    CommandPalette,
+    CommandPaletteItem,
+    CommandSurface,
+    CompletionItem,
+    SelectItem,
+)
 
 
 def _commands() -> tuple[object, ...]:
@@ -81,6 +88,45 @@ def test_command_completion_projection_can_keep_session_alphabetical_order() -> 
     provider = command_completion_provider(commands, local_last=False)
 
     assert [item.value for item in provider.items] == ["/a-local", "/z-product"]
+
+
+def test_command_palette_select_items_preserve_surface_fields_and_filtering() -> None:
+    palette = CommandPalette(
+        (
+            CommandPaletteItem(
+                value="/deploy",
+                label="Deploy service",
+                description="Run deployment pipeline",
+            ),
+            CommandPaletteItem(
+                value="/archive",
+                description="Unavailable action",
+                disabled=True,
+            ),
+        )
+    )
+
+    items = command_palette_select_items(palette)
+
+    assert items == [
+        SelectItem(
+            label="Deploy service",
+            value="/deploy",
+            description="Run deployment pipeline",
+        ),
+        SelectItem(
+            label="/archive",
+            value="/archive",
+            description="Unavailable action",
+        ),
+    ]
+    assert [item.selected_value for item in items] == ["/deploy", "/archive"]
+
+    surface = CommandSurface(items)
+    surface.set_filter("PIPELINE")
+    assert surface.selected_item() == items[0]
+    surface.set_filter("unavailable")
+    assert surface.selected_item() == items[1]
 
 
 def test_matching_commands_prefers_exact_value_or_label() -> None:

--- a/tests/harnesstui/selection/test_catalog.py
+++ b/tests/harnesstui/selection/test_catalog.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from loushang.harnesstui.selection.catalog import (
+    ModelChoice,
+    dedupe_preferred_model_choices,
+    format_model_choices,
+    matching_model_choices,
+    model_choice_description,
+    model_choice_display_label,
+    model_choice_value,
+    model_completion_provider,
+    model_search_items,
+)
+from loushang.tui import CompletionItem, CompletionProvider, SearchableListItem
+
+
+def _choices() -> tuple[ModelChoice, ...]:
+    return (
+        ModelChoice(
+            label="openai/gpt-5",
+            value="openai:primary:gpt-5",
+            selection=object(),
+            endpoint_id="primary",
+            region="us",
+            lane="coding",
+            api="responses",
+            description="General coding model",
+        ),
+        ModelChoice(
+            label="moonshot/kimi",
+            value="moonshot/kimi",
+            selection=object(),
+            description="Long-context model",
+        ),
+    )
+
+
+def test_model_choice_text_and_completion_projection() -> None:
+    choices = _choices()
+
+    assert format_model_choices(
+        choices,
+        current_value="openai:primary:gpt-5",
+    ) == (
+        "Available models:\n"
+        "* openai/gpt-5 (endpoint: primary) (current)\n"
+        "  moonshot/kimi"
+    )
+    assert model_completion_provider(
+        choices,
+        current_value="openai:primary:gpt-5",
+    ) == CompletionProvider(
+        (
+            CompletionItem(
+                value="openai:primary:gpt-5",
+                label="openai/gpt-5",
+                description=(
+                    "current - endpoint: primary - region: us - lane: coding - "
+                    "protocol: responses - General coding model"
+                ),
+            ),
+            CompletionItem(
+                value="moonshot/kimi",
+                label="moonshot/kimi",
+                description="Long-context model",
+            ),
+        )
+    )
+
+
+def test_model_choice_filtering_and_exact_match_priority() -> None:
+    choices = _choices()
+
+    assert format_model_choices(choices, query="LONG-CONTEXT") == (
+        "Available models:\n  moonshot/kimi"
+    )
+    assert matching_model_choices(choices, "openai:primary:gpt-5") == [choices[0]]
+    assert matching_model_choices(choices, "moonshot/kimi") == [choices[1]]
+    assert format_model_choices(choices, query="missing") == "No models match: missing"
+
+
+def test_model_choice_metadata_helpers_and_settings_rows() -> None:
+    choice = _choices()[0]
+
+    assert model_choice_display_label(choice) == "openai/gpt-5 (endpoint: primary)"
+    assert model_choice_description(
+        choice,
+        current_value=choice.value,
+    ).startswith("current - endpoint: primary")
+    assert (
+        model_choice_value(
+            provider="openai",
+            endpoint_id="primary",
+            model_id="gpt-5",
+            fallback="openai/gpt-5",
+        )
+        == "openai:primary:gpt-5"
+    )
+    assert model_search_items(_choices(), current_value=choice.value) == (
+        SearchableListItem(
+            key="openai:primary:gpt-5",
+            label="openai/gpt-5",
+            value="current",
+            description="General coding model",
+        ),
+        SearchableListItem(
+            key="moonshot/kimi",
+            label="moonshot/kimi",
+            description="Long-context model",
+        ),
+    )
+
+
+def test_preferred_endpoint_dedupe_preserves_current_nonpreferred_choice() -> None:
+    preferred = ModelChoice(
+        label="provider/model",
+        value="provider:preferred:model",
+        selection=object(),
+        preferred_endpoint=True,
+    )
+    current = ModelChoice(
+        label="provider/model",
+        value="provider:current:model",
+        selection=object(),
+    )
+    other = ModelChoice(
+        label="other/model",
+        value="other/model",
+        selection=object(),
+    )
+
+    assert dedupe_preferred_model_choices(
+        (preferred, current, other),
+        current_value=current.value,
+    ) == [preferred, current, other]
+    assert dedupe_preferred_model_choices(
+        (preferred, current, other),
+        current_value=None,
+    ) == [preferred, other]

--- a/tests/harnesstui/selection/test_catalog.py
+++ b/tests/harnesstui/selection/test_catalog.py
@@ -7,11 +7,21 @@ from loushang.harnesstui.selection.catalog import (
     matching_model_choices,
     model_choice_description,
     model_choice_display_label,
+    model_choice_select_items,
     model_choice_value,
     model_completion_provider,
+    model_label_select_items,
     model_search_items,
 )
-from loushang.tui import CompletionItem, CompletionProvider, SearchableListItem
+from loushang.harnesstui.selection.model import ModelSelectorSurface
+from loushang.tui import (
+    CompletionItem,
+    CompletionProvider,
+    InputEvent,
+    InputIntent,
+    SearchableListItem,
+    SelectItem,
+)
 
 
 def _choices() -> tuple[ModelChoice, ...]:
@@ -108,6 +118,73 @@ def test_model_choice_metadata_helpers_and_settings_rows() -> None:
             label="moonshot/kimi",
             description="Long-context model",
         ),
+    )
+
+
+def test_model_label_select_items_preserve_current_order_ordinals_and_details() -> None:
+    labels = tuple(f"provider/model-{index}" for index in range(1, 13))
+
+    items = model_label_select_items(
+        labels,
+        current_label="provider/model-12",
+        descriptions={
+            "provider/model-12": "Current detail is intentionally hidden",
+            "provider/model-1": "First model detail",
+        },
+    )
+
+    assert items[0] == SelectItem(
+        label="1.  provider/model-12",
+        value="provider/model-12",
+        description="current",
+    )
+    assert items[1] == SelectItem(
+        label="2.  provider/model-1",
+        value="provider/model-1",
+        description="First model detail",
+    )
+    assert items[9].label == "10. provider/model-9"
+    assert [item.selected_value for item in items[:2]] == [
+        "provider/model-12",
+        "provider/model-1",
+    ]
+
+
+def test_model_choice_select_items_preserve_metadata_and_description_filtering() -> (
+    None
+):
+    choices = _choices()
+
+    items = model_choice_select_items(
+        choices,
+        current_value="openai:primary:gpt-5",
+    )
+
+    assert items == [
+        SelectItem(
+            label="1. openai/gpt-5",
+            value="openai:primary:gpt-5",
+            description=(
+                "current - endpoint: primary - region: us - lane: coding - "
+                "protocol: responses - General coding model"
+            ),
+        ),
+        SelectItem(
+            label="2. moonshot/kimi",
+            value="moonshot/kimi",
+            description="Long-context model",
+        ),
+    ]
+    assert [item.selected_value for item in items] == [
+        "openai:primary:gpt-5",
+        "moonshot/kimi",
+    ]
+
+    surface = ModelSelectorSurface(all_items=tuple(items))
+    surface.handle_input(InputEvent(kind="text", text="REGION: US"))
+    assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
+        kind="select",
+        text="openai:primary:gpt-5",
     )
 
 

--- a/tests/harnesstui/settings/test_dashboard.py
+++ b/tests/harnesstui/settings/test_dashboard.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.harnesstui.settings.dashboard import (
+    SettingsDashboard,
+    StaticLinesPage,
+    model_usage_lines,
+    stats_overview_lines,
+    status_lines,
+    usage_lines,
+)
+from loushang.harnesstui.settings.page import ConfigSettingsPage
+from loushang.tui import InputEvent, InputIntent, RenderConstraints, TabGroup, TabPage
+from loushang.tui.cell_width import strip_control_sequences
+from loushang.tui.settings import ConfigRow
+
+
+@dataclass(frozen=True)
+class _Status:
+    model_label: str | None = "provider/model"
+    cwd: str = "/repo"
+    branch: str | None = "main"
+    session_label: str | None = "abcd"
+    thinking_level: str | None = "medium"
+    running: bool = False
+    statusline_visible: bool = True
+
+
+def _dashboard() -> SettingsDashboard:
+    page = ConfigSettingsPage((ConfigRow("feature", "Feature", "false"),))
+    dashboard = SettingsDashboard()
+    dashboard.tabs = TabGroup(
+        (TabPage("config", "Config", page),),
+        value="config",
+    )
+    dashboard.focus()
+    return dashboard
+
+
+def test_dashboard_owns_shared_focus_chrome_footer_and_close_interaction() -> None:
+    dashboard = _dashboard()
+
+    assert dashboard.focus_context() == "search"
+    lines = tuple(
+        strip_control_sequences(line.text)
+        for line in dashboard.render(RenderConstraints(width=80, max_height=12)).lines
+    )
+    assert lines[1] == "-" * 80
+    assert lines[-1] == "Type to filter · Enter/↓ to select · ↑ to tabs · Esc to clear"
+
+    assert dashboard.handle_input(InputEvent(kind="key", key="down")) is True
+    assert dashboard.focus_context() == "settings-list"
+    assert dashboard.handle_input(InputEvent(kind="text", text="q")) == InputIntent(
+        kind="surface_close"
+    )
+
+
+def test_dashboard_escape_closes_from_any_focus_context() -> None:
+    dashboard = _dashboard()
+
+    assert dashboard.handle_input(InputEvent(kind="key", key="escape")) == InputIntent(
+        kind="surface_close"
+    )
+
+
+def test_static_lines_page_truncates_and_consumes_horizontal_navigation() -> None:
+    page = StaticLinesPage(("123456", "second"))
+
+    rendered = page.render(RenderConstraints(width=4, max_height=1))
+
+    assert tuple(strip_control_sequences(line.text) for line in rendered.lines) == ("1234",)
+    assert page.handle_input(InputEvent(kind="key", key="left")) is True
+
+
+def test_dashboard_view_models_format_neutral_status_and_usage_snapshots() -> None:
+    status = _Status()
+
+    assert status_lines(status)[2:] == (
+        "Model              provider/model",
+        "Workspace          /repo",
+        "Branch             main",
+        "Session            abcd",
+        "Thinking           medium",
+        "Runtime            idle",
+        "Status line        true",
+    )
+    assert stats_overview_lines(status)[2:] == (
+        "Session            abcd",
+        "Runtime            idle",
+        "Historical stats   Unavailable",
+    )
+    assert model_usage_lines("provider/model")[2] == "Current model      provider/model"
+    assert usage_lines(None) == ("Usage", "", "Usage data unavailable")
+
+
+def test_dashboard_usage_view_model_contains_provider_failures() -> None:
+    def _failed_provider() -> object:
+        raise RuntimeError("secret product failure")
+
+    assert usage_lines(_failed_provider) == ("Usage", "", "Usage data unavailable")

--- a/tests/harnesstui/settings/test_model.py
+++ b/tests/harnesstui/settings/test_model.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from loushang.harnesstui.selection.catalog import ModelChoice
+from loushang.harnesstui.settings.model import ModelPage
+from loushang.tui import InputEvent, InputIntent, RenderConstraints
+from loushang.tui.cell_width import strip_control_sequences
+
+
+def _choice(value: str, *, description: str = "") -> ModelChoice:
+    return ModelChoice(
+        label=value,
+        value=value,
+        selection=object(),
+        description=description,
+    )
+
+
+def test_model_page_filters_and_returns_neutral_setting_intent() -> None:
+    page = ModelPage(
+        (_choice("provider/first"), _choice("provider/second")),
+        current_value="provider/first",
+    )
+    page.focus()
+
+    assert page.handle_input(InputEvent(kind="text", text="second")) is True
+    assert page.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
+        kind="setting",
+        text="model.current",
+        note="provider/second",
+    )
+
+
+def test_model_page_updates_choices_without_replacing_public_list() -> None:
+    page = ModelPage((_choice("provider/first"),))
+    public_list = page.models
+
+    page.set_choices(
+        (_choice("provider/second", description="Second model"),),
+        current_value="provider/second",
+    )
+
+    assert page.models is public_list
+    assert page.models.active_item is not None
+    assert page.models.active_item.key == "provider/second"
+    assert page.models.active_item.value == "current"
+
+
+def test_model_page_preserves_unavailable_copy_and_tab_fallback() -> None:
+    page = ModelPage((), error="catalog failed")
+
+    lines = tuple(
+        strip_control_sequences(line.text)
+        for line in page.render(RenderConstraints(width=40, max_height=4)).lines
+    )
+
+    assert lines == ("Model selection unavailable", "catalog failed")
+    assert page.editor_input_target() is None
+    assert page.handle_input(InputEvent(kind="key", key="left")) is True

--- a/tests/harnesstui/settings/test_page.py
+++ b/tests/harnesstui/settings/test_page.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 from loushang.harnesstui.settings.page import ConfigSettingsPage
 from loushang.tui import InputEvent, InputIntent, RenderConstraints
 from loushang.tui.cell_width import strip_control_sequences
-from loushang.tui.settings import ConfigRow
+from loushang.tui.settings import ConfigRow, SettingsListPage
 
 
 def _lines(page: ConfigSettingsPage, *, height: int = 12) -> tuple[str, ...]:
     result = page.render(RenderConstraints(width=72, max_height=height))
     return tuple(strip_control_sequences(line.text) for line in result.lines)
+
+
+def test_config_settings_page_is_tui_settings_list_page_compatibility_alias() -> None:
+    assert ConfigSettingsPage is SettingsListPage
 
 
 def test_config_settings_page_renders_and_filters_rows() -> None:

--- a/tests/harnesstui/status/test_plain.py
+++ b/tests/harnesstui/status/test_plain.py
@@ -1,21 +1,12 @@
 from __future__ import annotations
 
-
-def test_plain_toolbar_compatibility_exports_are_identical() -> None:
-    from loushang.coding.ui import plain_toolbar as coding_plain_toolbar
-    from loushang.harnesstui.status import plain as shared_plain_toolbar
-
-    assert coding_plain_toolbar.__all__ == shared_plain_toolbar.__all__
-    for name in shared_plain_toolbar.__all__:
-        assert getattr(coding_plain_toolbar, name) is getattr(shared_plain_toolbar, name)
+from loushang.harnesstui.status.plain import (
+    PlainToolbarSnapshot,
+    render_plain_toolbar,
+)
 
 
 def test_render_plain_toolbar_omits_empty_fields() -> None:
-    from loushang.coding.ui.plain_toolbar import (
-        PlainToolbarSnapshot,
-        render_plain_toolbar,
-    )
-
     snapshot = PlainToolbarSnapshot(
         model="moonshot/kimi-for-coding",
         cwd="/repo",
@@ -32,11 +23,6 @@ def test_render_plain_toolbar_omits_empty_fields() -> None:
 
 
 def test_render_plain_toolbar_can_return_single_fixed_width_line() -> None:
-    from loushang.coding.ui.plain_toolbar import (
-        PlainToolbarSnapshot,
-        render_plain_toolbar,
-    )
-
     snapshot = PlainToolbarSnapshot(
         model="moonshot/kimi-for-coding",
         cwd="/a/very/long/repository/path",

--- a/tests/harnesstui/status/test_settings.py
+++ b/tests/harnesstui/status/test_settings.py
@@ -52,3 +52,55 @@ def test_statusline_page_keeps_preview_layout() -> None:
 
     assert "Preview" in [line.text for line in result.lines]
     assert any("model" in line.text and "repo" in line.text for line in result.lines)
+
+
+def test_statusline_page_keeps_compact_height_and_cursor_contract() -> None:
+    page = shared_settings.StatusLineSettingsPage(
+        statusline_settings=StatusLineSettings(),
+        statusline_preview=lambda: StatusLinePreviewSnapshot(
+            model_label=None,
+            cwd="/workspace",
+            branch=None,
+            session_label=None,
+            running=False,
+        ),
+    )
+    page.focus()
+
+    compact = page.render(RenderConstraints(width=60, max_height=6))
+    expanded = page.render(RenderConstraints(width=60, max_height=7))
+    compact_lines = tuple(line.text for line in compact.lines)
+    expanded_lines = tuple(line.text for line in expanded.lines)
+
+    assert not any("Setting" in line and "Value" in line for line in compact_lines)
+    assert "Preview" not in compact_lines
+    assert any("Setting" in line and "Value" in line for line in expanded_lines)
+    assert "Preview" in expanded_lines
+    assert compact.cursor is not None and compact.cursor.row == 1
+    assert expanded.cursor is not None and expanded.cursor.row == 1
+
+
+def test_statusline_page_updates_composed_rows_without_replacing_public_list() -> None:
+    page = shared_settings.StatusLineSettingsPage(
+        statusline_settings=StatusLineSettings(),
+        statusline_preview=lambda: StatusLinePreviewSnapshot(
+            model_label=None,
+            cwd="/workspace",
+            branch=None,
+            session_label=None,
+            running=False,
+        ),
+    )
+    public_list = page.settings
+    page.focus()
+    page.settings.focus_list()
+
+    page.set_statusline_settings(
+        StatusLineSettings(enabled=False),
+        preserve_active_key="statusline.enabled",
+    )
+
+    assert page.settings is public_list
+    assert page.settings.active_item is not None
+    assert page.settings.active_item.key == "statusline.enabled"
+    assert page.settings.active_item.value == "false"

--- a/tests/harnesstui/status/test_snapshot.py
+++ b/tests/harnesstui/status/test_snapshot.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from loushang.harnesstui.status.line import StatusLineSettings
+from loushang.harnesstui.status.snapshot import StatusSnapshot
+
+
+def test_status_snapshot_preserves_neutral_status_facts() -> None:
+    snapshot = StatusSnapshot(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        thinking_level="high",
+        running=True,
+        statusline_visible=False,
+    )
+
+    assert snapshot.model_label == "moonshot/kimi-for-coding"
+    assert snapshot.cwd == "/repo"
+    assert snapshot.branch == "main"
+    assert snapshot.session_label == "abcd"
+    assert snapshot.thinking_level == "high"
+    assert snapshot.running is True
+    assert snapshot.statusline_visible is False
+    assert snapshot.statusline_settings == StatusLineSettings()

--- a/tests/harnesstui/surface/test_factory.py
+++ b/tests/harnesstui/surface/test_factory.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from loushang.harnesstui.surface.factory import (
+    command_surface_view,
+    info_surface_view,
+)
+from loushang.tui import CommandSurface, InfoPanel, SelectItem
+
+
+def test_info_surface_view_preserves_existing_coding_defaults() -> None:
+    view = info_surface_view(title="Available Models", text="first\nsecond")
+
+    assert view.title == "Available Models"
+    assert view.purpose == "info"
+    assert view.subtitle == ""
+    assert view.footer == "Enter/Esc to close"
+    assert view.presentation == "bottom"
+    assert view.preferred_height is None
+    assert view.content == InfoPanel(
+        title="Available Models",
+        text="first\nsecond",
+        footer="",
+    )
+
+
+def test_info_surface_view_keeps_all_copy_and_layout_policy_caller_supplied() -> None:
+    view = info_surface_view(
+        title="Diagnostics",
+        text="body",
+        subtitle="Terminal state",
+        footer="Esc to dismiss",
+        presentation="bottom-exclusive",
+        preferred_height=12,
+        panel_title="Plain diagnostics",
+        panel_footer="Stored output",
+    )
+
+    assert view.title == "Diagnostics"
+    assert view.subtitle == "Terminal state"
+    assert view.footer == "Esc to dismiss"
+    assert view.presentation == "bottom-exclusive"
+    assert view.preferred_height == 12
+    assert view.content == InfoPanel(
+        title="Plain diagnostics",
+        text="body",
+        footer="Stored output",
+    )
+
+
+def test_command_surface_view_preserves_existing_coding_palette_defaults() -> None:
+    items = (
+        SelectItem(label="/model", value="/model", description="Select a model"),
+        SelectItem(label="/status", value="/status"),
+    )
+
+    view = command_surface_view(
+        title="Commands",
+        purpose="command",
+        items=(item for item in items),
+    )
+
+    assert view.title == "Commands"
+    assert view.purpose == "command"
+    assert view.subtitle == ""
+    assert view.footer == "Enter to select - Esc to close"
+    assert view.presentation == "bottom"
+    assert view.preferred_height is None
+    assert isinstance(view.content, CommandSurface)
+    assert view.content.items == list(items)
+    assert view.content.max_visible == 8
+    assert view.content.filter_text == ""
+
+
+def test_command_surface_view_accepts_caller_surface_and_search_policy() -> None:
+    view = command_surface_view(
+        title="Models",
+        purpose="model",
+        items=(
+            SelectItem(label="provider/first", value="first"),
+            SelectItem(label="provider/second", value="second"),
+        ),
+        subtitle="Choose one",
+        footer="Enter to use",
+        presentation="bottom-exclusive",
+        preferred_height=10,
+        query="second",
+        max_visible=3,
+    )
+
+    assert view.purpose == "model"
+    assert view.subtitle == "Choose one"
+    assert view.footer == "Enter to use"
+    assert view.presentation == "bottom-exclusive"
+    assert view.preferred_height == 10
+    assert isinstance(view.content, CommandSurface)
+    assert view.content.max_visible == 3
+    assert view.content.filter_text == "second"
+    assert view.content.selected_item() == SelectItem(
+        label="provider/second",
+        value="second",
+    )

--- a/tests/tui/test_settings.py
+++ b/tests/tui/test_settings.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from loushang.tui import SearchableListItem, visible_width
+from loushang.tui import (
+    InputEvent,
+    InputIntent,
+    RenderConstraints,
+    SearchableListItem,
+    visible_width,
+)
 from loushang.tui import settings as tui_settings
+from loushang.tui.cell_width import strip_control_sequences
 
 
 def test_config_rows_build_searchable_items_and_lookup_by_key() -> None:
@@ -36,3 +43,52 @@ def test_settings_input_and_boolean_helpers_preserve_existing_contract() -> None
 def test_settings_header_respects_available_width() -> None:
     assert tui_settings.settings_header(80) == f"{'Setting':<42}Value"
     assert visible_width(tui_settings.settings_header(12)) <= 12
+
+
+def test_settings_list_page_preserves_compact_and_table_layout_contract() -> None:
+    page = tui_settings.SettingsListPage(
+        (
+            tui_settings.ConfigRow("first", "First", "false"),
+            tui_settings.ConfigRow("second", "Second", "true"),
+        )
+    )
+    page.focus()
+
+    compact = page.render(RenderConstraints(width=40, max_height=4))
+    table = page.render(RenderConstraints(width=40, max_height=6))
+    compact_lines = tuple(strip_control_sequences(line.text) for line in compact.lines)
+    table_lines = tuple(strip_control_sequences(line.text) for line in table.lines)
+
+    assert not any("Setting" in line and "Value" in line for line in compact_lines)
+    assert table_lines[3] == ""
+    assert "Setting" in table_lines[4] and "Value" in table_lines[4]
+    assert compact.cursor is not None and compact.cursor.row == 1
+    assert table.cursor is not None and table.cursor.row == 1
+
+
+def test_settings_list_page_supports_product_neutral_selection_and_tab_fallback() -> None:
+    selected: list[tui_settings.ConfigRow] = []
+    row = tui_settings.ConfigRow("mode", "Mode", "auto")
+    page = tui_settings.SettingsListPage(
+        (row,),
+        placeholder="Find an option...",
+        empty_text="No options",
+        on_select=lambda selected_row: selected.append(selected_row) or "selected",
+    )
+    page.focus()
+
+    assert page.handle_input(InputEvent(kind="key", key="enter")) == "selected"
+    assert selected == [row]
+    assert page.handle_input(InputEvent(kind="key", key="down")) is True
+    assert page.handle_input(InputEvent(kind="key", key="left")) is True
+
+
+def test_settings_list_page_defaults_to_boolean_setting_intent() -> None:
+    page = tui_settings.SettingsListPage((tui_settings.ConfigRow("enabled", "Enabled", "false"),))
+    page.focus()
+
+    assert page.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
+        kind="setting",
+        text="enabled",
+        note="true",
+    )


### PR DESCRIPTION
## English

### Summary

- Move reusable information and command surface builders into loushang.harnesstui.
- Move command and model SelectItem presentation builders into the shared composition layer.
- Keep Session access, product policy, surface lifecycle, overlay management, settings application, and approval routing in Coding.
- Preserve the existing private palette compatibility alias while downstream callers migrate.

### Validation

- make check-harnesstui: 480 passed, 26 deselected
- make test-tui-render-contract: 152 passed, 3286 deselected
- focused playback and compatibility tests: 27 passed, 20 deselected

## 中文

### 变更概要

- 将通用信息 surface 和命令 surface builders 迁入 loushang.harnesstui。
- 将命令和模型的 SelectItem 展示 builders 迁入共享组合层。
- Session 访问、产品策略、surface 生命周期、overlay 管理、settings 应用及 approval 路由继续留在 Coding。
- 暂时保留 palette 私有兼容别名，供下游逐步迁移。

### 验证

- make check-harnesstui：480 passed，26 deselected
- make test-tui-render-contract：152 passed，3286 deselected
- 定向 playback 与兼容测试：27 passed，20 deselected