### PR TITLE
refactor(harnesstui): share transcript source and status provider

### DIFF
--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -39,9 +39,13 @@ product-event interpretation, commands, policy, branding, and runtime assembly.
 
 ## First Slice: Conversation Reader
 
-The first migration slice is deliberately narrow: the reusable transcript
-source protocol and modal conversation reader move here while Coding-specific
-session-backed source adapters remain in `loushang.coding.ui`.
+The reusable transcript source protocol, record-composition helpers, and modal
+conversation reader live here while Coding-specific Session- and ScreenState-
+backed source adapters remain in `loushang.coding.ui`. Record composition may
+merge history with a live window, preserve presentation-only decorations,
+deduplicate the projected history suffix shared with the active-window prefix,
+and select recent assistant text, but it only operates on product-supplied
+`DisplayRecord` values.
 
 This slice does not own session lifecycle, persistence, runtime orchestration,
 or raw Agent/Coding event projection. It does not enter the render hot path.
@@ -83,10 +87,12 @@ values and decides when those values change. This capability is not the generic
 styling primitives, invalidation, and frame rendering. Harnesstui must not
 reach into those mechanics or introduce a second status-bar runtime.
 
-`loushang.harnesstui.status.snapshot` owns the neutral status facts populated by
-a product status provider. `loushang.harnesstui.status.plain` owns the compact,
-line-oriented toolbar projection over presentation-ready status values. Coding
-continues to own live Session reads, settings persistence, and provider update
+`loushang.harnesstui.status.snapshot` owns the neutral status facts.
+`loushang.harnesstui.status.provider` owns the callback-fed status profile and
+product-neutral status-line setting transitions.
+`loushang.harnesstui.status.plain` owns the compact, line-oriented toolbar
+projection over presentation-ready status values. Coding continues to own live
+Session reads, SettingsManager adaptation and persistence, and provider update
 timing; its former status and toolbar imports are direct compatibility aliases.
 
 These explicit module paths are the stable imports for this slice. The package

--- a/src/loushang/coding/ui/status_provider.py
+++ b/src/loushang/coding/ui/status_provider.py
@@ -1,142 +1,21 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import replace
-from typing import cast
 
 from loushang.harnesstui.status.line import (
-    StatusLineAutoValue,
-    StatusLineSeparator,
     StatusLineSettings,
-    StatusLineStyle,
     status_line_settings_from_control,
     status_line_settings_to_patch,
 )
+from loushang.harnesstui.status.provider import StatusProvider as StatusProvider
 from loushang.harnesstui.status.snapshot import StatusSnapshot as StatusSnapshot
 
-
-class CodingTuiStatusProvider:
-    def __init__(
-        self,
-        *,
-        model_label: str | None,
-        cwd: str,
-        branch: str | None,
-        session_label: Callable[[], str | None],
-        thinking_level: Callable[[], str | None],
-        running: Callable[[], bool],
-        statusline_settings: StatusLineSettings | None = None,
-        on_statusline_settings_changed: Callable[[StatusLineSettings], None] | None = None,
-    ) -> None:
-        self._model_label = model_label
-        self._cwd = cwd
-        self._branch = branch
-        self._session_label = session_label
-        self._thinking_level = thinking_level
-        self._running = running
-        self._statusline_settings = statusline_settings or StatusLineSettings()
-        self._on_statusline_settings_changed = on_statusline_settings_changed
-
-    def is_visible(self) -> bool:
-        return self._statusline_settings.enabled
-
-    def statusline_settings(self) -> StatusLineSettings:
-        return self._statusline_settings
-
-    def snapshot(self) -> StatusSnapshot:
-        return StatusSnapshot(
-            model_label=self._model_label,
-            cwd=self._cwd,
-            branch=self._branch,
-            session_label=self._session_label(),
-            thinking_level=self._thinking_level(),
-            running=self._running(),
-            statusline_visible=self.is_visible(),
-            statusline_settings=self._statusline_settings,
-        )
-
-    def set_visible(self, visible: bool | None) -> str:
-        if visible is not None:
-            self._set_statusline_settings(replace(self._statusline_settings, enabled=visible))
-        return f"Status line: {'on' if self.is_visible() else 'off'}"
-
-    def apply_statusline_settings(self, settings: StatusLineSettings) -> str:
-        self._set_statusline_settings(settings)
-        return self.set_visible(None)
-
-    def apply_statusline_setting(self, item_id: str, value: str) -> str:
-        normalized = value.casefold()
-        if item_id in {"statusline", "statusline.enabled"}:
-            enabled = _as_bool(normalized)
-            if enabled is None:
-                return "Invalid status line enabled value."
-            return self.set_visible(enabled)
-        bool_field = _bool_statusline_field(item_id)
-        if bool_field is not None:
-            enabled = _as_bool(normalized)
-            if enabled is None:
-                return f"Invalid status line {bool_field.replace('_', ' ')} value."
-            # The validated field name and value are compatible, but mypy cannot
-            # express field-sensitive typing for dynamic dataclass replacement.
-            self._set_statusline_settings(
-                replace(self._statusline_settings, **{bool_field: enabled})  # type: ignore[arg-type]
-            )
-            return f"Status line {bool_field.replace('_', ' ')}: {normalized}"
-        if item_id in {"statusline.field.queue", "statusline.field.message"}:
-            field_name = item_id.rsplit(".", 1)[-1]
-            if normalized not in {"auto", "true", "false"}:
-                return f"Invalid status line {field_name} value."
-            self._set_statusline_settings(
-                replace(
-                    self._statusline_settings,
-                    **{field_name: cast(StatusLineAutoValue, normalized)},  # type: ignore[arg-type]
-                )
-            )
-            return f"Status line {field_name}: {normalized}"
-        if item_id == "statusline.separator":
-            if normalized not in {"pipe", "dot"}:
-                return "Invalid status line separator value."
-            self._set_statusline_settings(
-                replace(self._statusline_settings, separator=cast(StatusLineSeparator, normalized))
-            )
-            return f"Status line separator: {normalized}"
-        if item_id == "statusline.style":
-            if normalized not in {"codex-like", "muted", "plain"}:
-                return "Invalid status line style value."
-            self._set_statusline_settings(
-                replace(self._statusline_settings, style=cast(StatusLineStyle, normalized))
-            )
-            return f"Status line style: {normalized}"
-        return f"Unknown status line setting: {item_id}"
-
-    def settings_summary_text(self) -> str:
-        return f"Settings\nStatus line: {'true' if self.is_visible() else 'false'}"
-
-    def _set_statusline_settings(self, settings: StatusLineSettings) -> None:
-        self._statusline_settings = settings
-        if self._on_statusline_settings_changed is not None:
-            self._on_statusline_settings_changed(settings)
+CodingTuiStatusProvider = StatusProvider
 
 
-def _as_bool(value: str) -> bool | None:
-    if value == "true":
-        return True
-    if value == "false":
-        return False
-    return None
-
-
-def _bool_statusline_field(item_id: str) -> str | None:
-    return {
-        "statusline.field.model": "model",
-        "statusline.field.workspace": "workspace",
-        "statusline.field.branch": "branch",
-        "statusline.field.session": "session",
-        "statusline.field.runtime": "runtime",
-    }.get(item_id)
-
-
-def statusline_settings_from_settings_manager(settings_manager: object | None) -> StatusLineSettings | None:
+def statusline_settings_from_settings_manager(
+    settings_manager: object | None,
+) -> StatusLineSettings | None:
     if settings_manager is None:
         return None
     getter = getattr(settings_manager, "get_statusline_settings", None)

--- a/src/loushang/coding/ui/transcript_source.py
+++ b/src/loushang/coding/ui/transcript_source.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
 from loushang.coding.ui.screen_state import ScreenCodingTuiState
 from loushang.coding.ui.session_history import session_history_records
-from loushang.harnesstui.conversation.source import TranscriptSnapshot, TranscriptSource
-from loushang.tui.transcript import (
-    AssistantMessageRecord,
-    ContextCompactionRecord,
-    DisplayRecord,
-    ToolExecutionRecord,
-    UserPromptRecord,
+from loushang.harnesstui.conversation.source import (
+    TranscriptSnapshot,
+    TranscriptSource,
+    merge_history_and_active_records,
+    recent_assistant_texts,
 )
+from loushang.tui.transcript import DisplayRecord
 
 
 # Transcript reader sources intentionally separate three data shapes:
@@ -33,7 +31,7 @@ class ActiveWindowTranscriptSource:
         )
 
     def recent_assistant_texts(self) -> tuple[str, ...]:
-        return _recent_assistant_texts(_active_window_records(self.state))
+        return recent_assistant_texts(_active_window_records(self.state))
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,7 +53,9 @@ class SessionTranscriptSource:
         source_label = self.source_label
         if self.active_window_state is not None:
             active_records = _active_window_records(self.active_window_state)
-            merged_records = _merge_active_window_records(session_records, active_records)
+            merged_records = merge_history_and_active_records(
+                session_records, active_records
+            )
             if merged_records != session_records:
                 records = merged_records
                 complete = False
@@ -68,17 +68,7 @@ class SessionTranscriptSource:
         )
 
     def recent_assistant_texts(self) -> tuple[str, ...]:
-        return _recent_assistant_texts(self.snapshot().records)
-
-
-def _recent_assistant_texts(records: Iterable[DisplayRecord]) -> tuple[str, ...]:
-    texts: list[str] = []
-    for record in reversed(tuple(records)):
-        if not isinstance(record, AssistantMessageRecord):
-            continue
-        if record.text.strip():
-            texts.append(record.text)
-    return tuple(texts)
+        return recent_assistant_texts(self.snapshot().records)
 
 
 def _active_window_records(state: ScreenCodingTuiState) -> tuple[DisplayRecord, ...]:
@@ -87,40 +77,6 @@ def _active_window_records(state: ScreenCodingTuiState) -> tuple[DisplayRecord, 
     if assistant_draft is not None:
         return (*records, assistant_draft)
     return records
-
-
-def _merge_active_window_records(
-    session_records: tuple[DisplayRecord, ...],
-    active_records: tuple[DisplayRecord, ...],
-) -> tuple[DisplayRecord, ...]:
-    if not active_records:
-        return session_records
-    overlap = _decorated_suffix_prefix_overlap(session_records, active_records)
-    if overlap is None:
-        return (*session_records, *active_records)
-    session_start, active_start = overlap
-    return (*session_records[:session_start], *active_records[active_start:])
-
-
-def _decorated_suffix_prefix_overlap(
-    left: tuple[DisplayRecord, ...],
-    right: tuple[DisplayRecord, ...],
-) -> tuple[int, int] | None:
-    right_history_records = tuple(
-        (index, record) for index, record in enumerate(right) if _history_projected_record(record)
-    )
-    max_overlap = min(len(left), len(right_history_records))
-    for overlap_count in range(max_overlap, 0, -1):
-        right_prefix = tuple(record for _, record in right_history_records[:overlap_count])
-        if left[-overlap_count:] == right_prefix:
-            return len(left) - overlap_count, 0
-    return None
-
-
-def _history_projected_record(record: DisplayRecord) -> bool:
-    if isinstance(record, AssistantMessageRecord):
-        return record.stable
-    return isinstance(record, (UserPromptRecord, ToolExecutionRecord, ContextCompactionRecord))
 
 
 __all__ = [

--- a/src/loushang/harnesstui/conversation/source.py
+++ b/src/loushang/harnesstui/conversation/source.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Protocol
 
-from loushang.tui.transcript import DisplayRecord
+from loushang.tui.transcript import (
+    AssistantMessageRecord,
+    ContextCompactionRecord,
+    DisplayRecord,
+    ToolExecutionRecord,
+    UserPromptRecord,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -24,4 +31,59 @@ class TranscriptSource(Protocol):
     def recent_assistant_texts(self) -> tuple[str, ...]: ...
 
 
-__all__ = ["TranscriptSnapshot", "TranscriptSource"]
+def recent_assistant_texts(records: Iterable[DisplayRecord]) -> tuple[str, ...]:
+    """Return non-empty assistant messages in newest-first order."""
+
+    texts: list[str] = []
+    for record in reversed(tuple(records)):
+        if not isinstance(record, AssistantMessageRecord):
+            continue
+        if record.text.strip():
+            texts.append(record.text)
+    return tuple(texts)
+
+
+def merge_history_and_active_records(
+    history_records: tuple[DisplayRecord, ...],
+    active_records: tuple[DisplayRecord, ...],
+) -> tuple[DisplayRecord, ...]:
+    """Merge a projected history with its decorated active-window suffix."""
+
+    if not active_records:
+        return history_records
+    history_start = _decorated_suffix_prefix_overlap(history_records, active_records)
+    if history_start is None:
+        return (*history_records, *active_records)
+    return (*history_records[:history_start], *active_records)
+
+
+def _is_history_projected_record(record: DisplayRecord) -> bool:
+    """Whether a display record can originate from materialized history."""
+
+    if isinstance(record, AssistantMessageRecord):
+        return record.stable
+    return isinstance(
+        record, (UserPromptRecord, ToolExecutionRecord, ContextCompactionRecord)
+    )
+
+
+def _decorated_suffix_prefix_overlap(
+    history_records: tuple[DisplayRecord, ...],
+    active_records: tuple[DisplayRecord, ...],
+) -> int | None:
+    active_history_records = tuple(
+        record for record in active_records if _is_history_projected_record(record)
+    )
+    max_overlap = min(len(history_records), len(active_history_records))
+    for overlap_count in range(max_overlap, 0, -1):
+        if history_records[-overlap_count:] == active_history_records[:overlap_count]:
+            return len(history_records) - overlap_count
+    return None
+
+
+__all__ = [
+    "TranscriptSnapshot",
+    "TranscriptSource",
+    "merge_history_and_active_records",
+    "recent_assistant_texts",
+]

--- a/src/loushang/harnesstui/status/provider.py
+++ b/src/loushang/harnesstui/status/provider.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import replace
+from typing import cast
+
+from loushang.harnesstui.status.line import (
+    StatusLineAutoValue,
+    StatusLineSeparator,
+    StatusLineSettings,
+    StatusLineStyle,
+)
+from loushang.harnesstui.status.snapshot import StatusSnapshot
+
+
+class StatusProvider:
+    def __init__(
+        self,
+        *,
+        model_label: str | None,
+        cwd: str,
+        branch: str | None,
+        session_label: Callable[[], str | None],
+        thinking_level: Callable[[], str | None],
+        running: Callable[[], bool],
+        statusline_settings: StatusLineSettings | None = None,
+        on_statusline_settings_changed: Callable[[StatusLineSettings], None]
+        | None = None,
+    ) -> None:
+        self._model_label = model_label
+        self._cwd = cwd
+        self._branch = branch
+        self._session_label = session_label
+        self._thinking_level = thinking_level
+        self._running = running
+        self._statusline_settings = statusline_settings or StatusLineSettings()
+        self._on_statusline_settings_changed = on_statusline_settings_changed
+
+    def is_visible(self) -> bool:
+        return self._statusline_settings.enabled
+
+    def statusline_settings(self) -> StatusLineSettings:
+        return self._statusline_settings
+
+    def snapshot(self) -> StatusSnapshot:
+        return StatusSnapshot(
+            model_label=self._model_label,
+            cwd=self._cwd,
+            branch=self._branch,
+            session_label=self._session_label(),
+            thinking_level=self._thinking_level(),
+            running=self._running(),
+            statusline_visible=self.is_visible(),
+            statusline_settings=self._statusline_settings,
+        )
+
+    def set_visible(self, visible: bool | None) -> str:
+        if visible is not None:
+            self._set_statusline_settings(
+                replace(self._statusline_settings, enabled=visible)
+            )
+        return f"Status line: {'on' if self.is_visible() else 'off'}"
+
+    def apply_statusline_settings(self, settings: StatusLineSettings) -> str:
+        self._set_statusline_settings(settings)
+        return self.set_visible(None)
+
+    def apply_statusline_setting(self, item_id: str, value: str) -> str:
+        normalized = value.casefold()
+        if item_id in {"statusline", "statusline.enabled"}:
+            enabled = _as_bool(normalized)
+            if enabled is None:
+                return "Invalid status line enabled value."
+            return self.set_visible(enabled)
+        bool_field = _bool_statusline_field(item_id)
+        if bool_field is not None:
+            enabled = _as_bool(normalized)
+            if enabled is None:
+                return f"Invalid status line {bool_field.replace('_', ' ')} value."
+            # The validated field name and value are compatible, but mypy cannot
+            # express field-sensitive typing for dynamic dataclass replacement.
+            self._set_statusline_settings(
+                replace(self._statusline_settings, **{bool_field: enabled})  # type: ignore[arg-type]
+            )
+            return f"Status line {bool_field.replace('_', ' ')}: {normalized}"
+        if item_id in {"statusline.field.queue", "statusline.field.message"}:
+            field_name = item_id.rsplit(".", 1)[-1]
+            if normalized not in {"auto", "true", "false"}:
+                return f"Invalid status line {field_name} value."
+            self._set_statusline_settings(
+                replace(
+                    self._statusline_settings,
+                    **{field_name: cast(StatusLineAutoValue, normalized)},  # type: ignore[arg-type]
+                )
+            )
+            return f"Status line {field_name}: {normalized}"
+        if item_id == "statusline.separator":
+            if normalized not in {"pipe", "dot"}:
+                return "Invalid status line separator value."
+            self._set_statusline_settings(
+                replace(
+                    self._statusline_settings,
+                    separator=cast(StatusLineSeparator, normalized),
+                )
+            )
+            return f"Status line separator: {normalized}"
+        if item_id == "statusline.style":
+            if normalized not in {"codex-like", "muted", "plain"}:
+                return "Invalid status line style value."
+            self._set_statusline_settings(
+                replace(
+                    self._statusline_settings, style=cast(StatusLineStyle, normalized)
+                )
+            )
+            return f"Status line style: {normalized}"
+        return f"Unknown status line setting: {item_id}"
+
+    def settings_summary_text(self) -> str:
+        return f"Settings\nStatus line: {'true' if self.is_visible() else 'false'}"
+
+    def _set_statusline_settings(self, settings: StatusLineSettings) -> None:
+        self._statusline_settings = settings
+        if self._on_statusline_settings_changed is not None:
+            self._on_statusline_settings_changed(settings)
+
+
+def _as_bool(value: str) -> bool | None:
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    return None
+
+
+def _bool_statusline_field(item_id: str) -> str | None:
+    return {
+        "statusline.field.model": "model",
+        "statusline.field.workspace": "workspace",
+        "statusline.field.branch": "branch",
+        "statusline.field.session": "session",
+        "statusline.field.runtime": "runtime",
+    }.get(item_id)
+
+
+__all__ = ["StatusProvider"]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -325,6 +325,7 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.harnesstui.status.settings`" in text
     assert "`loushang.harnesstui.status.line`" in text
     assert "`loushang.harnesstui.status.plain`" in text
+    assert "`loushang.harnesstui.status.provider`" in text
     assert "`loushang.harnesstui.status.snapshot`" in text
     assert "`loushang.harnesstui.surface.factory`" in text
     assert "`loushang.harnesstui.surface.view`" in text
@@ -343,6 +344,7 @@ def test_harnesstui_capability_entrypoints_exist() -> None:
         Path("src/loushang/harnesstui/settings/page.py"),
         Path("src/loushang/harnesstui/status/line.py"),
         Path("src/loushang/harnesstui/status/plain.py"),
+        Path("src/loushang/harnesstui/status/provider.py"),
         Path("src/loushang/harnesstui/status/settings.py"),
         Path("src/loushang/harnesstui/status/snapshot.py"),
         Path("src/loushang/harnesstui/surface/factory.py"),

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -88,7 +88,14 @@ def test_shared_interaction_types_are_not_redefined_in_coding_ui() -> None:
             "def render_plain_toolbar",
         ),
         Path("src/loushang/coding/ui/status_provider.py"): (
+            "class CodingTuiStatusProvider",
             "class StatusSnapshot",
+        ),
+        Path("src/loushang/coding/ui/transcript_source.py"): (
+            "def _recent_assistant_texts",
+            "def _merge_active_window_records",
+            "def _decorated_suffix_prefix_overlap",
+            "def _history_projected_record",
         ),
         Path("src/loushang/coding/ui/screen_surfaces.py"): (
             "class ModelSelectorSurface",
@@ -104,6 +111,16 @@ def test_shared_interaction_types_are_not_redefined_in_coding_ui() -> None:
     ]
 
     assert offenders == []
+
+
+def test_shared_status_provider_does_not_own_settings_manager_adaptation() -> None:
+    source = Path("src/loushang/harnesstui/status/provider.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "settings_manager" not in source
+    assert "status_line_settings_from_control" not in source
+    assert "status_line_settings_to_patch" not in source
 
 
 def test_old_coding_ui_app_module_is_removed() -> None:

--- a/tests/coding/test_ui_status_provider.py
+++ b/tests/coding/test_ui_status_provider.py
@@ -1,5 +1,30 @@
 from __future__ import annotations
 
+from loushang.coding.control import StatusLineControlSettings
+from loushang.harnesstui.status.line import (
+    StatusLineSettings,
+    status_line_settings_to_patch,
+)
+
+
+class _SettingsManager:
+    def __init__(self, settings: object) -> None:
+        self.settings = settings
+        self.saved: list[tuple[dict[str, object], str]] = []
+
+    def get_statusline_settings(self) -> object:
+        return self.settings
+
+    def set_statusline_settings(self, patch: dict[str, object], *, scope: str) -> None:
+        self.saved.append((patch, scope))
+
+
+def test_status_provider_compatibility_export_is_identical() -> None:
+    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+    from loushang.harnesstui.status.provider import StatusProvider
+
+    assert CodingTuiStatusProvider is StatusProvider
+
 
 def test_status_snapshot_compatibility_export_is_identical() -> None:
     from loushang.coding.ui.status_provider import (
@@ -10,154 +35,46 @@ def test_status_snapshot_compatibility_export_is_identical() -> None:
     assert CodingStatusSnapshot is StatusSnapshot
 
 
-def test_status_provider_returns_shared_snapshot() -> None:
-    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-    from loushang.harnesstui.status.line import StatusLineSettings
-    from loushang.harnesstui.status.snapshot import StatusSnapshot
-
-    provider = CodingTuiStatusProvider(
-        model_label="moonshot/kimi-for-coding",
-        cwd="/repo",
-        branch="main",
-        session_label=lambda: "abcd",
-        thinking_level=lambda: "high",
-        running=lambda: True,
-        statusline_settings=StatusLineSettings(enabled=False),
+def test_statusline_settings_adapter_reads_settings_manager() -> None:
+    from loushang.coding.ui.status_provider import (
+        statusline_settings_from_settings_manager,
     )
 
-    snapshot = provider.snapshot()
+    control_settings = StatusLineControlSettings(
+        enabled=False,
+        queue="true",
+        separator="dot",
+        style="muted",
+    )
+    manager = _SettingsManager(control_settings)
 
-    assert type(snapshot) is StatusSnapshot
-    assert snapshot == StatusSnapshot(
-        model_label="moonshot/kimi-for-coding",
-        cwd="/repo",
-        branch="main",
-        session_label="abcd",
-        thinking_level="high",
-        running=True,
-        statusline_visible=False,
-        statusline_settings=StatusLineSettings(enabled=False),
+    assert statusline_settings_from_settings_manager(manager) == StatusLineSettings(
+        enabled=False,
+        queue="true",
+        separator="dot",
+        style="muted",
+    )
+    assert statusline_settings_from_settings_manager(None) is None
+    assert statusline_settings_from_settings_manager(object()) is None
+
+
+def test_statusline_settings_adapter_persists_patch_in_requested_scope() -> None:
+    from loushang.coding.ui.status_provider import (
+        statusline_settings_persistence_callback,
     )
 
+    settings = StatusLineSettings(enabled=False, queue="true", style="plain")
+    manager = _SettingsManager(StatusLineSettings())
 
-def test_status_provider_tracks_statusline_visibility() -> None:
-    from loushang.coding.ui.status_line import StatusLineSettings
-    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
+    callback = statusline_settings_persistence_callback(manager, scope="workspace")
 
-    saved: list[StatusLineSettings] = []
-    provider = CodingTuiStatusProvider(
-        model_label=None,
-        cwd="/repo",
-        branch=None,
-        session_label=lambda: None,
-        thinking_level=lambda: None,
-        running=lambda: False,
-        statusline_settings=StatusLineSettings(enabled=False, style="muted"),
-        on_statusline_settings_changed=saved.append,
-    )
+    assert callback is not None
+    callback(settings)
+    assert manager.saved == [(status_line_settings_to_patch(settings), "workspace")]
 
-    assert provider.is_visible() is False
-    assert provider.statusline_settings() == StatusLineSettings(enabled=False, style="muted")
-    assert provider.set_visible(True) == "Status line: on"
-    assert provider.is_visible() is True
-    assert provider.statusline_settings().enabled is True
-    assert provider.set_visible(None) == "Status line: on"
-    assert saved == [StatusLineSettings(enabled=True, style="muted")]
-
-
-def test_status_provider_applies_full_statusline_settings() -> None:
-    from loushang.coding.ui.status_line import StatusLineSettings
-    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-
-    saved: list[StatusLineSettings] = []
-    provider = CodingTuiStatusProvider(
-        model_label=None,
-        cwd="/repo",
-        branch=None,
-        session_label=lambda: None,
-        thinking_level=lambda: None,
-        running=lambda: False,
-        on_statusline_settings_changed=saved.append,
-    )
-    settings = StatusLineSettings(enabled=False, queue="true", message="false", separator="dot", style="muted")
-
-    assert provider.apply_statusline_settings(settings) == "Status line: off"
-
-    assert provider.statusline_settings() == settings
-    assert provider.is_visible() is False
-    assert saved == [settings]
-
-
-def test_status_provider_applies_individual_statusline_settings() -> None:
-    from loushang.coding.ui.status_line import StatusLineSettings
-    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-
-    saved: list[StatusLineSettings] = []
-    provider = CodingTuiStatusProvider(
-        model_label=None,
-        cwd="/repo",
-        branch=None,
-        session_label=lambda: None,
-        thinking_level=lambda: None,
-        running=lambda: False,
-        on_statusline_settings_changed=saved.append,
-    )
-
-    assert provider.apply_statusline_setting("statusline.enabled", "false") == "Status line: off"
-    assert provider.apply_statusline_setting("statusline.field.queue", "true") == "Status line queue: true"
-    assert provider.apply_statusline_setting("statusline.separator", "dot") == "Status line separator: dot"
-    assert provider.apply_statusline_setting("statusline.style", "plain") == "Status line style: plain"
-
-    settings = provider.statusline_settings()
-    assert settings.enabled is False
-    assert settings.queue == "true"
-    assert settings.separator == "dot"
-    assert settings.style == "plain"
-    assert saved == [
-        StatusLineSettings(enabled=False),
-        StatusLineSettings(enabled=False, queue="true"),
-        StatusLineSettings(enabled=False, queue="true", separator="dot"),
-        StatusLineSettings(enabled=False, queue="true", separator="dot", style="plain"),
-    ]
-
-
-def test_status_provider_rejects_invalid_statusline_setting_values() -> None:
-    from loushang.coding.ui.status_line import StatusLineSettings
-    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-
-    saved: list[StatusLineSettings] = []
-    provider = CodingTuiStatusProvider(
-        model_label=None,
-        cwd="/repo",
-        branch=None,
-        session_label=lambda: None,
-        thinking_level=lambda: None,
-        running=lambda: False,
-        on_statusline_settings_changed=saved.append,
-    )
-
-    assert provider.apply_statusline_setting("statusline.field.queue", "maybe") == "Invalid status line queue value."
-    assert provider.apply_statusline_setting("statusline.separator", "slash") == "Invalid status line separator value."
-    assert provider.apply_statusline_setting("statusline.unknown", "true") == "Unknown status line setting: statusline.unknown"
-    assert provider.statusline_settings().queue == "auto"
-    assert provider.statusline_settings().separator == "pipe"
-    assert saved == []
-
-
-def test_status_provider_formats_plain_settings_summary_without_legacy_tui_models() -> None:
-    from loushang.coding.ui.status_provider import CodingTuiStatusProvider
-
-    provider = CodingTuiStatusProvider(
-        model_label="moonshot/kimi",
-        cwd="/repo",
-        branch="main",
-        session_label=lambda: "abc",
-        thinking_level=lambda: "high",
-        running=lambda: False,
-    )
-
-    assert provider.settings_summary_text() == "Settings\nStatus line: true"
-    assert not hasattr(provider, "legacy_settings_list")
-    assert not hasattr(provider, "legacy_settings_text")
-    provider.set_visible(False)
-    assert provider.settings_summary_text() == "Settings\nStatus line: false"
+    default_callback = statusline_settings_persistence_callback(manager)
+    assert default_callback is not None
+    default_callback(settings)
+    assert manager.saved[-1] == (status_line_settings_to_patch(settings), "global")
+    assert statusline_settings_persistence_callback(None) is None
+    assert statusline_settings_persistence_callback(object()) is None

--- a/tests/coding/test_ui_transcript_source.py
+++ b/tests/coding/test_ui_transcript_source.py
@@ -147,6 +147,35 @@ def test_session_transcript_source_merges_live_active_window_records() -> None:
     )
 
 
+def test_session_transcript_source_keeps_complete_metadata_for_identical_window() -> None:
+    session = _Session(
+        messages=[
+            UserMessage(role="user", content=[TextPart(type="text", text="full question")], timestamp=1.0),
+            _assistant_message("full answer", timestamp=2.0),
+        ]
+    )
+    state = ScreenCodingTuiState(model_label="model", cwd="/tmp/project", branch=None, session_label=None)
+    state.replace_transcript_window(
+        (
+            UserPromptRecord("full question"),
+            AssistantMessageRecord("full answer", stable=True),
+        )
+    )
+
+    snapshot = SessionTranscriptSource(
+        session,
+        source_label="Session history",
+        active_window_state=state,
+    ).snapshot()
+
+    assert snapshot.complete is True
+    assert snapshot.source_label == "Session history"
+    assert snapshot.records == (
+        UserPromptRecord("full question"),
+        AssistantMessageRecord("full answer", stable=True),
+    )
+
+
 def test_session_transcript_source_deduplicates_decorated_active_window_history() -> None:
     session = _Session(
         messages=[

--- a/tests/harnesstui/conversation/test_source.py
+++ b/tests/harnesstui/conversation/test_source.py
@@ -4,11 +4,20 @@ from dataclasses import FrozenInstanceError, dataclass
 
 import pytest
 
-from loushang.harnesstui.conversation.source import TranscriptSnapshot, TranscriptSource
+from loushang.harnesstui.conversation.source import (
+    TranscriptSnapshot,
+    TranscriptSource,
+    merge_history_and_active_records,
+    recent_assistant_texts,
+)
 from loushang.tui.transcript import (
     AssistantMessageRecord,
+    ContextCompactionRecord,
     DisplayRecord,
+    StatusRecord,
+    ToolExecutionRecord,
     UserPromptRecord,
+    WorkedDividerRecord,
 )
 
 
@@ -67,3 +76,98 @@ def test_transcript_source_is_a_structural_contract() -> None:
 
     assert snapshot.records == source.records
     assert recent_assistant_texts == ("second", "first")
+
+
+def test_recent_assistant_texts_filters_blank_messages_newest_first() -> None:
+    records: tuple[DisplayRecord, ...] = (
+        AssistantMessageRecord("  first  "),
+        AssistantMessageRecord("   "),
+        ToolExecutionRecord(name="read", state="completed", elapsed_seconds=0.1),
+        AssistantMessageRecord("second", stable=False),
+    )
+
+    assert recent_assistant_texts(iter(records)) == ("second", "  first  ")
+
+
+@pytest.mark.parametrize(
+    ("record", "projected"),
+    (
+        (UserPromptRecord("question"), True),
+        (AssistantMessageRecord("answer", stable=True), True),
+        (AssistantMessageRecord("draft", stable=False), False),
+        (
+            ToolExecutionRecord(name="read", state="completed", elapsed_seconds=0.1),
+            True,
+        ),
+        (ContextCompactionRecord("summary"), True),
+        (WorkedDividerRecord(1.0), False),
+        (StatusRecord("working"), False),
+    ),
+)
+def test_merge_history_and_active_records_uses_only_projected_history_records(
+    record: DisplayRecord, projected: bool
+) -> None:
+    decoration = StatusRecord("working")
+
+    merged = merge_history_and_active_records(
+        (record,),
+        (record, decoration),
+    )
+
+    expected = (record, decoration) if projected else (record, record, decoration)
+    assert merged == expected
+
+
+def test_merge_history_and_active_records_returns_history_when_active_window_is_empty() -> (
+    None
+):
+    history: tuple[DisplayRecord, ...] = (UserPromptRecord("question"),)
+
+    merged = merge_history_and_active_records(history, ())
+
+    assert merged is history
+
+
+def test_merge_history_and_active_records_appends_unmatched_window() -> None:
+    history: tuple[DisplayRecord, ...] = (UserPromptRecord("history"),)
+    active: tuple[DisplayRecord, ...] = (UserPromptRecord("active"),)
+
+    assert merge_history_and_active_records(history, active) == (*history, *active)
+
+
+def test_merge_history_and_active_records_appends_ui_only_window() -> None:
+    history: tuple[DisplayRecord, ...] = (UserPromptRecord("history"),)
+    active: tuple[DisplayRecord, ...] = (
+        WorkedDividerRecord(1.0),
+        StatusRecord("working"),
+        AssistantMessageRecord("draft", stable=False),
+    )
+
+    assert merge_history_and_active_records(history, active) == (*history, *active)
+
+
+def test_merge_history_and_active_records_replaces_maximal_overlap_with_decorated_window() -> (
+    None
+):
+    first_question = UserPromptRecord("first question")
+    first_answer = AssistantMessageRecord("first answer")
+    second_question = UserPromptRecord("second question")
+    second_answer = AssistantMessageRecord("second answer")
+    history: tuple[DisplayRecord, ...] = (
+        first_question,
+        first_answer,
+        second_question,
+        second_answer,
+    )
+    active: tuple[DisplayRecord, ...] = (
+        second_question,
+        WorkedDividerRecord(1.0),
+        second_answer,
+        AssistantMessageRecord("streaming draft", stable=False),
+    )
+
+    assert merge_history_and_active_records(history, active) == (
+        first_question,
+        first_answer,
+        *active,
+    )

--- a/tests/harnesstui/status/test_provider.py
+++ b/tests/harnesstui/status/test_provider.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import pytest
+
+from loushang.harnesstui.status.line import StatusLineSettings
+from loushang.harnesstui.status.provider import StatusProvider
+from loushang.harnesstui.status.snapshot import StatusSnapshot
+
+
+def _provider(
+    *,
+    settings: StatusLineSettings | None = None,
+    on_changed: list[StatusLineSettings] | None = None,
+) -> StatusProvider:
+    return StatusProvider(
+        model_label=None,
+        cwd="/repo",
+        branch=None,
+        session_label=lambda: None,
+        thinking_level=lambda: None,
+        running=lambda: False,
+        statusline_settings=settings,
+        on_statusline_settings_changed=None
+        if on_changed is None
+        else on_changed.append,
+    )
+
+
+def test_status_provider_returns_shared_snapshot() -> None:
+    provider = StatusProvider(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label=lambda: "abcd",
+        thinking_level=lambda: "high",
+        running=lambda: True,
+        statusline_settings=StatusLineSettings(enabled=False),
+    )
+
+    snapshot = provider.snapshot()
+
+    assert type(snapshot) is StatusSnapshot
+    assert snapshot == StatusSnapshot(
+        model_label="moonshot/kimi-for-coding",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        thinking_level="high",
+        running=True,
+        statusline_visible=False,
+        statusline_settings=StatusLineSettings(enabled=False),
+    )
+
+
+def test_status_provider_tracks_statusline_visibility() -> None:
+    saved: list[StatusLineSettings] = []
+    provider = _provider(
+        settings=StatusLineSettings(enabled=False, style="muted"),
+        on_changed=saved,
+    )
+
+    assert provider.is_visible() is False
+    assert provider.statusline_settings() == StatusLineSettings(
+        enabled=False, style="muted"
+    )
+    assert provider.set_visible(True) == "Status line: on"
+    assert provider.is_visible() is True
+    assert provider.statusline_settings().enabled is True
+    assert provider.set_visible(None) == "Status line: on"
+    assert saved == [StatusLineSettings(enabled=True, style="muted")]
+
+
+def test_status_provider_notifies_for_explicit_same_value_but_not_for_read_only_visibility() -> (
+    None
+):
+    saved: list[StatusLineSettings] = []
+    provider = _provider(on_changed=saved)
+
+    assert provider.set_visible(True) == "Status line: on"
+    assert saved == [StatusLineSettings()]
+
+    assert provider.set_visible(None) == "Status line: on"
+    assert saved == [StatusLineSettings()]
+
+
+def test_status_provider_reloads_dynamic_snapshot_values() -> None:
+    state: dict[str, str | bool | None] = {
+        "session": "first",
+        "thinking": "low",
+        "running": False,
+    }
+    provider = StatusProvider(
+        model_label="model",
+        cwd="/repo",
+        branch="main",
+        session_label=lambda: (
+            state["session"] if isinstance(state["session"], str) else None
+        ),
+        thinking_level=lambda: (
+            state["thinking"] if isinstance(state["thinking"], str) else None
+        ),
+        running=lambda: state["running"] is True,
+    )
+
+    first = provider.snapshot()
+    state.update(session="second", thinking="high", running=True)
+    second = provider.snapshot()
+
+    assert (first.session_label, first.thinking_level, first.running) == (
+        "first",
+        "low",
+        False,
+    )
+    assert (second.session_label, second.thinking_level, second.running) == (
+        "second",
+        "high",
+        True,
+    )
+
+
+def test_status_provider_applies_full_statusline_settings() -> None:
+    saved: list[StatusLineSettings] = []
+    provider = _provider(on_changed=saved)
+    settings = StatusLineSettings(
+        enabled=False,
+        queue="true",
+        message="false",
+        separator="dot",
+        style="muted",
+    )
+
+    assert provider.apply_statusline_settings(settings) == "Status line: off"
+
+    assert provider.statusline_settings() == settings
+    assert provider.is_visible() is False
+    assert saved == [settings]
+
+
+def test_status_provider_applies_individual_statusline_settings() -> None:
+    saved: list[StatusLineSettings] = []
+    provider = _provider(on_changed=saved)
+
+    assert (
+        provider.apply_statusline_setting("statusline.enabled", "false")
+        == "Status line: off"
+    )
+    assert (
+        provider.apply_statusline_setting("statusline.field.queue", "true")
+        == "Status line queue: true"
+    )
+    assert (
+        provider.apply_statusline_setting("statusline.separator", "dot")
+        == "Status line separator: dot"
+    )
+    assert (
+        provider.apply_statusline_setting("statusline.style", "plain")
+        == "Status line style: plain"
+    )
+
+    settings = provider.statusline_settings()
+    assert settings.enabled is False
+    assert settings.queue == "true"
+    assert settings.separator == "dot"
+    assert settings.style == "plain"
+    assert saved == [
+        StatusLineSettings(enabled=False),
+        StatusLineSettings(enabled=False, queue="true"),
+        StatusLineSettings(enabled=False, queue="true", separator="dot"),
+        StatusLineSettings(enabled=False, queue="true", separator="dot", style="plain"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("item_id", "field_name"),
+    [
+        ("statusline.field.model", "model"),
+        ("statusline.field.workspace", "workspace"),
+        ("statusline.field.branch", "branch"),
+        ("statusline.field.session", "session"),
+        ("statusline.field.runtime", "runtime"),
+    ],
+)
+def test_status_provider_applies_each_boolean_field(
+    item_id: str, field_name: str
+) -> None:
+    saved: list[StatusLineSettings] = []
+    provider = _provider(on_changed=saved)
+
+    assert provider.apply_statusline_setting(item_id, "false") == (
+        f"Status line {field_name}: false"
+    )
+    assert getattr(provider.statusline_settings(), field_name) is False
+    assert saved == [provider.statusline_settings()]
+
+
+def test_status_provider_keeps_statusline_alias_and_casefold_contract() -> None:
+    saved: list[StatusLineSettings] = []
+    provider = _provider(on_changed=saved)
+
+    assert (
+        provider.apply_statusline_setting("statusline", "FALSE") == "Status line: off"
+    )
+    current = provider.statusline_settings()
+    assert provider.apply_statusline_setting("statusline", " false ") == (
+        "Invalid status line enabled value."
+    )
+    assert provider.statusline_settings() == current
+    assert saved == [current]
+
+
+def test_status_provider_rejects_invalid_statusline_setting_values() -> None:
+    saved: list[StatusLineSettings] = []
+    provider = _provider(on_changed=saved)
+
+    assert provider.apply_statusline_setting("statusline.field.queue", "maybe") == (
+        "Invalid status line queue value."
+    )
+    assert provider.apply_statusline_setting("statusline.separator", "slash") == (
+        "Invalid status line separator value."
+    )
+    assert provider.apply_statusline_setting("statusline.unknown", "true") == (
+        "Unknown status line setting: statusline.unknown"
+    )
+    assert provider.statusline_settings().queue == "auto"
+    assert provider.statusline_settings().separator == "pipe"
+    assert provider.statusline_settings() == StatusLineSettings()
+    assert saved == []
+
+
+def test_status_provider_formats_plain_settings_summary() -> None:
+    provider = StatusProvider(
+        model_label="moonshot/kimi",
+        cwd="/repo",
+        branch="main",
+        session_label=lambda: "abc",
+        thinking_level=lambda: "high",
+        running=lambda: False,
+    )
+
+    assert provider.settings_summary_text() == "Settings\nStatus line: true"
+    assert not hasattr(provider, "legacy_settings_list")
+    assert not hasattr(provider, "legacy_settings_text")
+    provider.set_visible(False)
+    assert provider.settings_summary_text() == "Settings\nStatus line: false"


### PR DESCRIPTION
## Summary

- Move product-neutral transcript source composition into `loushang.harnesstui.conversation.source`, including recent-assistant selection and decorated history/live-window merging.
- Extract the callback-fed `StatusProvider` into `loushang.harnesstui.status.provider`.
- Keep Session/ScreenState projection and SettingsManager adaptation/persistence in `loushang.coding.ui` through thin compatibility adapters.
- Add architecture boundaries, behavior tests, and documentation for the new ownership split.

## Why

This continues separating reusable Harness TUI interaction from the Coding product shell. The migration is deliberately limited to cold-path composition and does not modify Screen rendering, segmentation, caching, frame composition, or terminal writes.

## Impact

- Reduces `loushang.coding.ui` production code by 165 lines.
- Preserves the existing Coding imports and behavior through direct compatibility aliases and adapters.
- Gives other Harness-backed terminal products reusable transcript composition and status-provider capabilities.

## Validation

- `make check-harnesstui` — Ruff and mypy passed; 505 tests passed, 26 deselected.
- `make test-tui-render-contract` — 152 tests passed, 3285 deselected.
- `git diff --check` passed.
- Two independent read-only reviews found no blockers.

---

## 中文说明

### 变更内容

- 将通用 transcript source 组合能力迁入 `loushang.harnesstui.conversation.source`，包括最近助手消息选择，以及带 UI 装饰的历史记录与活动窗口合并。
- 将回调驱动的中性 `StatusProvider` 迁入 `loushang.harnesstui.status.provider`。
- Coding 继续负责 Session/ScreenState 投影、SettingsManager 适配与持久化，并通过薄兼容层保留原有导入和行为。
- 增加架构边界、行为测试和职责文档。

### 迁移原因

继续拆分可复用的 Harness TUI 交互能力与 Coding 产品外壳。本次只迁移冷路径组合逻辑，不修改 Screen 渲染、分段、缓存、帧合成或终端写入。

### 影响

- `loushang.coding.ui` 生产代码净减少 165 行。
- 通过直接兼容别名和适配器保持现有 Coding API 与行为。
- 其他 Harness 产品可以复用 transcript composition 和 status provider。

### 验证

- `make check-harnesstui`：Ruff、mypy 通过；505 tests passed，26 deselected。
- `make test-tui-render-contract`：152 tests passed，3285 deselected。
- `git diff --check` 通过。
- 两轮独立只读复审均未发现阻断问题。
