### PR TITLE
feat(tui): add native macOS clipboard backend

### DIFF
--- a/docs/internals/architecture/tui/README.md
+++ b/docs/internals/architecture/tui/README.md
@@ -51,3 +51,7 @@ Host clipboard-image acquisition lives in
 neutral image bytes and MIME normalization. Product shells remain responsible
 for workspace persistence, composer markers, UI copy, and conversion into
 model-specific attachment values such as `ImagePart`.
+
+Clipboard-image acquisition resolves the host once into an ordered backend
+plan behind a common protocol. On macOS, the system `NSPasteboard` adapter is
+preferred, with `pngpaste` retained only as a compatibility fallback.

--- a/src/loushang/tui/clipboard_image.py
+++ b/src/loushang/tui/clipboard_image.py
@@ -8,10 +8,58 @@ import uuid
 from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
+from enum import StrEnum
 from io import BytesIO
 from pathlib import Path
+from typing import Protocol
 
 SUPPORTED_IMAGE_MIME_TYPES = ("image/png", "image/jpeg", "image/webp", "image/gif")
+
+_MACOS_CLIPBOARD_IMAGE_SCRIPT = r'''
+ObjC.import("AppKit")
+ObjC.import("Foundation")
+
+function writePasteboardType(pasteboard, pasteboardType, outputPath, resultToken) {
+    var data = pasteboard.dataForType($(pasteboardType))
+    if (data.isNil()) {
+        return null
+    }
+    if (!data.writeToFileAtomically(outputPath, true)) {
+        throw new Error("failed to write pasteboard data")
+    }
+    return resultToken
+}
+
+function run(argv) {
+    if (argv.length !== 1) {
+        throw new Error("expected one output-path argument")
+    }
+
+    var pasteboard = $.NSPasteboard.generalPasteboard
+    var outputPath = $(String(argv[0]))
+    var result = writePasteboardType(
+        pasteboard,
+        "public.png",
+        outputPath,
+        "LSCB1:OK:PNG"
+    )
+    if (result !== null) {
+        return result
+    }
+
+    result = writePasteboardType(
+        pasteboard,
+        "public.tiff",
+        outputPath,
+        "LSCB1:OK:TIFF"
+    )
+    if (result !== null) {
+        return result
+    }
+
+    return "LSCB1:EMPTY"
+}
+'''.strip()
 
 
 @dataclass(frozen=True)
@@ -26,8 +74,37 @@ class CommandResult:
     stdout: bytes | str = b""
 
 
-CommandRunner = Callable[..., CommandResult]
+class CommandRunner(Protocol):
+    def __call__(
+        self,
+        command: str,
+        args: tuple[str, ...],
+        *,
+        timeout_seconds: float = 3.0,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult: ...
+
+
 NativeClipboardReader = Callable[[], ClipboardImage | None]
+
+
+class _ClipboardHostKind(StrEnum):
+    MACOS = "macos"
+    WSL = "wsl"
+    WINDOWS = "windows"
+    WAYLAND = "wayland"
+    X11 = "x11"
+
+
+@dataclass(frozen=True, slots=True)
+class _ClipboardImageReadContext:
+    environment: Mapping[str, str]
+    runner: CommandRunner
+    native_reader: NativeClipboardReader | None
+
+
+class _ClipboardImageBackend(Protocol):
+    def __call__(self, context: _ClipboardImageReadContext, /) -> ClipboardImage | None: ...
 
 
 def is_wayland_session(env: Mapping[str, str] | None = None) -> bool:
@@ -57,49 +134,82 @@ def read_clipboard_image(
     platform_name: str | None = None,
 ) -> ClipboardImage | None:
     environment = os.environ if env is None else env
-    command_runner = _run_command if runner is None else runner
-    image: ClipboardImage | None = None
     current_platform = sys.platform if platform_name is None else platform_name
-    wsl = _is_wsl(environment, probe_proc=env is None)
-    if _is_macos(current_platform):
-        image = _read_clipboard_image_via_pngpaste(command_runner)
-    if image is None and (is_wayland_session(environment) or wsl):
-        image = _read_clipboard_image_via_wl_paste(command_runner) or _read_clipboard_image_via_xclip(command_runner)
-    if image is None and wsl:
-        image = _read_clipboard_image_via_powershell(command_runner, environment)
-    if image is None and not wsl and _is_native_windows(current_platform, environment):
-        image = _read_clipboard_image_via_windows_powershell(command_runner, environment)
-    if image is None and native_reader is not None:
-        image = native_reader()
-    if image is None:
-        image = _read_clipboard_image_via_xclip(command_runner)
-    return _normalize_clipboard_image(image)
+    host_kind = _resolve_clipboard_host_kind(
+        platform_name=current_platform,
+        environment=environment,
+        probe_proc=env is None,
+    )
+    context = _ClipboardImageReadContext(
+        environment=environment,
+        runner=_run_command if runner is None else runner,
+        native_reader=native_reader,
+    )
+    for backend in _resolve_clipboard_image_backends(host_kind):
+        image = backend(context)
+        if image is None:
+            continue
+        normalized = _normalize_clipboard_image(image)
+        if normalized is not None:
+            return normalized
+    return None
 
 
-def _read_clipboard_image_via_pngpaste(runner: CommandRunner) -> ClipboardImage | None:
-    data = runner("pngpaste", ("-",), timeout_seconds=3.0)
+def _read_clipboard_image_via_macos_native(context: _ClipboardImageReadContext) -> ClipboardImage | None:
+    with tempfile.TemporaryDirectory(prefix="loushang-clipboard-") as directory:
+        output_path = Path(directory) / "image-data"
+        result = context.runner(
+            "/usr/bin/osascript",
+            (
+                "-l",
+                "JavaScript",
+                "-s",
+                "he",
+                "-e",
+                _MACOS_CLIPBOARD_IMAGE_SCRIPT,
+                str(output_path),
+            ),
+            timeout_seconds=5.0,
+        )
+        if not result.ok:
+            return None
+        protocol = _stdout_bytes(result).rstrip(b"\r\n")
+        if protocol == b"LSCB1:EMPTY":
+            return None
+        mime_type = {
+            b"LSCB1:OK:PNG": "image/png",
+            b"LSCB1:OK:TIFF": "image/tiff",
+        }.get(protocol)
+        if mime_type is None or not output_path.is_file():
+            return None
+        payload = output_path.read_bytes()
+        return ClipboardImage(bytes=payload, mime_type=mime_type) if payload else None
+
+
+def _read_clipboard_image_via_pngpaste(context: _ClipboardImageReadContext) -> ClipboardImage | None:
+    data = context.runner("pngpaste", ("-",), timeout_seconds=3.0)
     if not data.ok:
         return None
     stdout = _stdout_bytes(data)
     return ClipboardImage(bytes=stdout, mime_type="image/png") if stdout else None
 
 
-def _read_clipboard_image_via_wl_paste(runner: CommandRunner) -> ClipboardImage | None:
-    listed = runner("wl-paste", ("--list-types",), timeout_seconds=1.0)
+def _read_clipboard_image_via_wl_paste(context: _ClipboardImageReadContext) -> ClipboardImage | None:
+    listed = context.runner("wl-paste", ("--list-types",), timeout_seconds=1.0)
     if not listed.ok:
         return None
     selected = _select_preferred_image_mime_type(_stdout_text(listed).splitlines())
     if selected is None:
         return None
-    data = runner("wl-paste", ("--type", selected, "--no-newline"), timeout_seconds=3.0)
+    data = context.runner("wl-paste", ("--type", selected, "--no-newline"), timeout_seconds=3.0)
     if not data.ok:
         return None
     stdout = _stdout_bytes(data)
     return ClipboardImage(bytes=stdout, mime_type=_base_mime_type(selected)) if stdout else None
 
 
-def _read_clipboard_image_via_xclip(runner: CommandRunner) -> ClipboardImage | None:
-    targets = runner("xclip", ("-selection", "clipboard", "-t", "TARGETS", "-o"), timeout_seconds=1.0)
+def _read_clipboard_image_via_xclip(context: _ClipboardImageReadContext) -> ClipboardImage | None:
+    targets = context.runner("xclip", ("-selection", "clipboard", "-t", "TARGETS", "-o"), timeout_seconds=1.0)
     candidate_types: list[str] = []
     if not targets.ok:
         candidate_types = list(SUPPORTED_IMAGE_MIME_TYPES)
@@ -107,7 +217,7 @@ def _read_clipboard_image_via_xclip(runner: CommandRunner) -> ClipboardImage | N
         selected = _select_preferred_image_mime_type(_stdout_text(targets).splitlines())
         candidate_types = _ordered_candidate_types(selected)
     for mime_type in candidate_types:
-        data = runner("xclip", ("-selection", "clipboard", "-t", mime_type, "-o"), timeout_seconds=3.0)
+        data = context.runner("xclip", ("-selection", "clipboard", "-t", mime_type, "-o"), timeout_seconds=3.0)
         if data.ok:
             stdout = _stdout_bytes(data)
             if stdout:
@@ -115,10 +225,10 @@ def _read_clipboard_image_via_xclip(runner: CommandRunner) -> ClipboardImage | N
     return None
 
 
-def _read_clipboard_image_via_powershell(runner: CommandRunner, env: Mapping[str, str]) -> ClipboardImage | None:
+def _read_clipboard_image_via_wsl_powershell(context: _ClipboardImageReadContext) -> ClipboardImage | None:
     path = Path(tempfile.gettempdir()) / f"loushang-wsl-clip-{uuid.uuid4().hex}.png"
     try:
-        win_path = runner("wslpath", ("-w", str(path)), timeout_seconds=1.0)
+        win_path = context.runner("wslpath", ("-w", str(path)), timeout_seconds=1.0)
         if not win_path.ok:
             return None
         windows_path = _stdout_text(win_path).strip()
@@ -132,11 +242,11 @@ def _read_clipboard_image_via_powershell(runner: CommandRunner, env: Mapping[str
             "if ($img) { $img.Save($path, [System.Drawing.Imaging.ImageFormat]::Png); Write-Output 'ok' } "
             "else { Write-Output 'empty' }"
         )
-        result = runner(
+        result = context.runner(
             "powershell.exe",
             ("-NoProfile", "-Command", script),
             timeout_seconds=5.0,
-            env={**dict(env), "LOUSHANG_WSL_CLIPBOARD_IMAGE_PATH": windows_path},
+            env={**dict(context.environment), "LOUSHANG_WSL_CLIPBOARD_IMAGE_PATH": windows_path},
         )
         if not result.ok or _stdout_text(result).strip() != "ok":
             return None
@@ -149,7 +259,7 @@ def _read_clipboard_image_via_powershell(runner: CommandRunner, env: Mapping[str
             path.unlink()
 
 
-def _read_clipboard_image_via_windows_powershell(runner: CommandRunner, env: Mapping[str, str]) -> ClipboardImage | None:
+def _read_clipboard_image_via_windows_powershell(context: _ClipboardImageReadContext) -> ClipboardImage | None:
     path = Path(tempfile.gettempdir()) / f"loushang-win-clip-{uuid.uuid4().hex}.png"
     try:
         script = (
@@ -161,11 +271,11 @@ def _read_clipboard_image_via_windows_powershell(runner: CommandRunner, env: Map
             "else { Write-Output 'empty' }"
         )
         for command in ("powershell.exe", "powershell"):
-            result = runner(
+            result = context.runner(
                 command,
                 ("-NoProfile", "-Command", script),
                 timeout_seconds=5.0,
-                env={**dict(env), "LOUSHANG_CLIPBOARD_IMAGE_PATH": str(path)},
+                env={**dict(context.environment), "LOUSHANG_CLIPBOARD_IMAGE_PATH": str(path)},
             )
             if result.ok and _stdout_text(result).strip() == "ok" and path.is_file():
                 payload = path.read_bytes()
@@ -174,6 +284,62 @@ def _read_clipboard_image_via_windows_powershell(runner: CommandRunner, env: Map
     finally:
         with suppress(OSError):
             path.unlink()
+
+
+def _read_clipboard_image_via_injected_reader(context: _ClipboardImageReadContext) -> ClipboardImage | None:
+    return context.native_reader() if context.native_reader is not None else None
+
+
+def _resolve_clipboard_host_kind(
+    *,
+    platform_name: str,
+    environment: Mapping[str, str],
+    probe_proc: bool,
+) -> _ClipboardHostKind:
+    if _is_macos(platform_name):
+        return _ClipboardHostKind.MACOS
+    if _is_wsl(environment, probe_proc=probe_proc):
+        return _ClipboardHostKind.WSL
+    if _is_native_windows(platform_name, environment):
+        return _ClipboardHostKind.WINDOWS
+    if is_wayland_session(environment):
+        return _ClipboardHostKind.WAYLAND
+    return _ClipboardHostKind.X11
+
+
+def _resolve_clipboard_image_backends(
+    host_kind: _ClipboardHostKind,
+) -> tuple[_ClipboardImageBackend, ...]:
+    match host_kind:
+        case _ClipboardHostKind.MACOS:
+            return (
+                _read_clipboard_image_via_macos_native,
+                _read_clipboard_image_via_pngpaste,
+                _read_clipboard_image_via_injected_reader,
+            )
+        case _ClipboardHostKind.WSL:
+            return (
+                _read_clipboard_image_via_wl_paste,
+                _read_clipboard_image_via_xclip,
+                _read_clipboard_image_via_wsl_powershell,
+                _read_clipboard_image_via_injected_reader,
+            )
+        case _ClipboardHostKind.WINDOWS:
+            return (
+                _read_clipboard_image_via_windows_powershell,
+                _read_clipboard_image_via_injected_reader,
+            )
+        case _ClipboardHostKind.WAYLAND:
+            return (
+                _read_clipboard_image_via_wl_paste,
+                _read_clipboard_image_via_xclip,
+                _read_clipboard_image_via_injected_reader,
+            )
+        case _ClipboardHostKind.X11:
+            return (
+                _read_clipboard_image_via_injected_reader,
+                _read_clipboard_image_via_xclip,
+            )
 
 
 def _select_preferred_image_mime_type(mime_types: list[str]) -> str | None:
@@ -257,7 +423,13 @@ def _stdout_bytes(result: CommandResult) -> bytes:
     return result.stdout.encode("utf-8") if isinstance(result.stdout, str) else result.stdout
 
 
-def _run_command(command: str, args: tuple[str, ...], *, timeout_seconds: float = 3.0) -> CommandResult:
+def _run_command(
+    command: str,
+    args: tuple[str, ...],
+    *,
+    timeout_seconds: float = 3.0,
+    env: Mapping[str, str] | None = None,
+) -> CommandResult:
     try:
         result = subprocess.run(
             [command, *args],
@@ -265,6 +437,7 @@ def _run_command(command: str, args: tuple[str, ...], *, timeout_seconds: float 
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             timeout=timeout_seconds,
+            env=None if env is None else dict(env),
         )
     except (OSError, subprocess.SubprocessError):
         return CommandResult(ok=False)

--- a/tests/tui/test_clipboard_image.py
+++ b/tests/tui/test_clipboard_image.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import subprocess
+from io import BytesIO
 from pathlib import Path
+
+import pytest
 
 
 def _tiny_bmp_1x1_red() -> bytes:
@@ -18,6 +22,64 @@ def _tiny_bmp_1x1_red() -> bytes:
     payload[55] = 0x00
     payload[56] = 0xFF
     return bytes(payload)
+
+
+def _tiny_tiff_1x1_red() -> bytes:
+    from PIL import Image
+
+    output = BytesIO()
+    Image.new("RGB", (1, 1), (255, 0, 0)).save(output, format="TIFF")
+    return output.getvalue()
+
+
+@pytest.mark.parametrize(
+    ("platform_name", "env", "expected"),
+    [
+        ("darwin", {"WAYLAND_DISPLAY": "wayland-0", "WSL_DISTRO_NAME": "Ubuntu"}, "macos"),
+        ("linux", {"OS": "Windows_NT", "WSL_DISTRO_NAME": "Ubuntu"}, "wsl"),
+        ("win32", {"OS": "Windows_NT"}, "windows"),
+        ("linux", {"WAYLAND_DISPLAY": "wayland-0"}, "wayland"),
+        ("linux", {}, "x11"),
+    ],
+)
+def test_clipboard_image_resolves_host_kind(
+    platform_name: str,
+    env: dict[str, str],
+    expected: str,
+) -> None:
+    from loushang.tui.clipboard_image import _resolve_clipboard_host_kind
+
+    host_kind = _resolve_clipboard_host_kind(
+        platform_name=platform_name,
+        environment=env,
+        probe_proc=False,
+    )
+
+    assert host_kind == expected
+
+
+@pytest.mark.parametrize(
+    ("host_kind", "expected"),
+    [
+        ("macos", ("macos_native", "pngpaste", "injected_reader")),
+        ("wsl", ("wl_paste", "xclip", "wsl_powershell", "injected_reader")),
+        ("windows", ("windows_powershell", "injected_reader")),
+        ("wayland", ("wl_paste", "xclip", "injected_reader")),
+        ("x11", ("injected_reader", "xclip")),
+    ],
+)
+def test_clipboard_image_resolves_ordered_backend_plan(
+    host_kind: str,
+    expected: tuple[str, ...],
+) -> None:
+    from loushang.tui.clipboard_image import (
+        _ClipboardHostKind,
+        _resolve_clipboard_image_backends,
+    )
+
+    backends = _resolve_clipboard_image_backends(_ClipboardHostKind(host_kind))
+
+    assert tuple(backend.__name__.removeprefix("_read_clipboard_image_via_") for backend in backends) == expected
 
 
 def test_clipboard_image_reads_wayland_with_xclip_fallback() -> None:
@@ -115,7 +177,63 @@ def test_clipboard_image_uses_wsl_powershell_fallback(tmp_path) -> None:
     assert calls[-1][0] == "powershell.exe"
 
 
-def test_clipboard_image_uses_macos_pngpaste_before_xclip() -> None:
+def test_clipboard_image_prefers_macos_native_png() -> None:
+    from loushang.tui.clipboard_image import CommandResult, read_clipboard_image
+
+    payload = b"\x89PNG\r\n\x1a\nnative"
+    calls: list[tuple[str, tuple[str, ...]]] = []
+    temporary_directory: Path | None = None
+
+    def runner(command: str, args: tuple[str, ...], **kwargs) -> CommandResult:
+        nonlocal temporary_directory
+        calls.append((command, args))
+        if command == "/usr/bin/osascript":
+            assert args[:5] == ("-l", "JavaScript", "-s", "he", "-e")
+            assert "dataForType" in args[-2]
+            assert "availableTypeFromArray" not in args[-2]
+            assert args[-2].index('"public.png"') < args[-2].index('"public.tiff"')
+            output_path = Path(args[-1])
+            temporary_directory = output_path.parent
+            output_path.write_bytes(payload)
+            return CommandResult(ok=True, stdout=b"LSCB1:OK:PNG\n")
+        return CommandResult(ok=False)
+
+    image = read_clipboard_image(env={}, runner=runner, platform_name="darwin")
+
+    assert image is not None
+    assert image.bytes == payload
+    assert image.mime_type == "image/png"
+    assert [command for command, _args in calls] == ["/usr/bin/osascript"]
+    assert temporary_directory is not None
+    assert not temporary_directory.exists()
+
+
+def test_clipboard_image_normalizes_macos_native_tiff_to_png() -> None:
+    from PIL import Image
+
+    from loushang.tui.clipboard_image import CommandResult, read_clipboard_image
+
+    tiff_payload = _tiny_tiff_1x1_red()
+    calls: list[str] = []
+
+    def runner(command: str, args: tuple[str, ...], **kwargs) -> CommandResult:
+        calls.append(command)
+        if command == "/usr/bin/osascript":
+            Path(args[-1]).write_bytes(tiff_payload)
+            return CommandResult(ok=True, stdout=b"LSCB1:OK:TIFF\n")
+        return CommandResult(ok=False)
+
+    image = read_clipboard_image(env={}, runner=runner, platform_name="darwin")
+
+    assert image is not None
+    assert image.mime_type == "image/png"
+    assert image.bytes.startswith(b"\x89PNG\r\n\x1a\n")
+    with Image.open(BytesIO(image.bytes)) as decoded:
+        assert decoded.convert("RGB").getpixel((0, 0)) == (255, 0, 0)
+    assert calls == ["/usr/bin/osascript"]
+
+
+def test_clipboard_image_falls_back_to_pngpaste_on_macos() -> None:
     from loushang.tui.clipboard_image import CommandResult, read_clipboard_image
 
     calls: list[tuple[str, tuple[str, ...]]] = []
@@ -131,8 +249,68 @@ def test_clipboard_image_uses_macos_pngpaste_before_xclip() -> None:
     assert image is not None
     assert image.bytes == b"\x89PNG\r\n\x1a\nmac"
     assert image.mime_type == "image/png"
-    assert calls[0] == ("pngpaste", ("-",))
-    assert not any(command == "xclip" for command, _args in calls)
+    assert [command for command, _args in calls] == ["/usr/bin/osascript", "pngpaste"]
+
+
+def test_clipboard_image_falls_back_to_pngpaste_after_native_empty_result() -> None:
+    from loushang.tui.clipboard_image import CommandResult, read_clipboard_image
+
+    calls: list[str] = []
+
+    def runner(command: str, args: tuple[str, ...], **kwargs) -> CommandResult:
+        calls.append(command)
+        if command == "/usr/bin/osascript":
+            return CommandResult(ok=True, stdout=b"LSCB1:EMPTY\n")
+        if command == "pngpaste":
+            return CommandResult(ok=True, stdout=b"\x89PNG\r\n\x1a\nfallback")
+        return CommandResult(ok=False)
+
+    image = read_clipboard_image(env={}, runner=runner, platform_name="darwin")
+
+    assert image is not None
+    assert image.bytes == b"\x89PNG\r\n\x1a\nfallback"
+    assert calls == ["/usr/bin/osascript", "pngpaste"]
+
+
+def test_clipboard_image_does_not_probe_non_macos_backends_on_macos() -> None:
+    from loushang.tui.clipboard_image import CommandResult, read_clipboard_image
+
+    calls: list[str] = []
+
+    def runner(command: str, args: tuple[str, ...], **kwargs) -> CommandResult:
+        calls.append(command)
+        if command == "/usr/bin/osascript":
+            return CommandResult(ok=True, stdout=b"LSCB1:EMPTY\n")
+        return CommandResult(ok=False)
+
+    image = read_clipboard_image(
+        env={"WAYLAND_DISPLAY": "wayland-0", "WSL_DISTRO_NAME": "Ubuntu", "OS": "Windows_NT"},
+        runner=runner,
+        platform_name="darwin",
+    )
+
+    assert image is None
+    assert calls == ["/usr/bin/osascript", "pngpaste"]
+
+
+def test_clipboard_image_rejects_incomplete_macos_native_result_before_fallback() -> None:
+    from loushang.tui.clipboard_image import CommandResult, read_clipboard_image
+
+    calls: list[str] = []
+
+    def runner(command: str, args: tuple[str, ...], **kwargs) -> CommandResult:
+        calls.append(command)
+        if command == "/usr/bin/osascript":
+            return CommandResult(ok=True, stdout=b"LSCB1:OK:PNG\n")
+        if command == "pngpaste":
+            return CommandResult(ok=True, stdout=b"\x89PNG\r\n\x1a\nfallback")
+        return CommandResult(ok=False)
+
+    image = read_clipboard_image(env={}, runner=runner, platform_name="darwin")
+
+    assert image is not None
+    assert image.bytes == b"\x89PNG\r\n\x1a\nfallback"
+    assert calls == ["/usr/bin/osascript", "pngpaste"]
 
 
 def test_clipboard_image_uses_native_windows_powershell_without_wslpath(tmp_path) -> None:
@@ -161,3 +339,21 @@ def test_clipboard_image_uses_native_windows_powershell_without_wslpath(tmp_path
     assert len(calls) == 1
     assert calls[0][0] == "powershell.exe"
     assert calls[0][1][:2] == ("-NoProfile", "-Command")
+
+
+def test_clipboard_command_runner_forwards_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    from loushang.tui import clipboard_image
+
+    captured_environment: dict[str, str] | None = None
+
+    def fake_run(command: list[str], **kwargs) -> subprocess.CompletedProcess[bytes]:
+        nonlocal captured_environment
+        captured_environment = kwargs["env"]
+        return subprocess.CompletedProcess(command, 0, stdout=b"ok")
+
+    monkeypatch.setattr(clipboard_image.subprocess, "run", fake_run)
+
+    result = clipboard_image._run_command("helper", ("arg",), env={"CLIPBOARD_PATH": "value"})
+
+    assert result == clipboard_image.CommandResult(ok=True, stdout=b"ok")
+    assert captured_environment == {"CLIPBOARD_PATH": "value"}


### PR DESCRIPTION
## Summary

- centralize clipboard host detection and ordered backend selection behind protocols
- add a native macOS `NSPasteboard` reader that prefers `public.png`, falls back to `public.tiff`, and keeps `pngpaste` as a compatibility fallback
- normalize every backend result consistently and forward command environments correctly for Windows/WSL helpers
- document the TUI ownership boundary and add focused platform, ordering, fallback, normalization, and runner tests

## Root cause

macOS clipboard image acquisition previously depended on the optional `pngpaste` utility, so systems without Homebrew returned no image. The native adapter uses fixed-arity JXA bridge calls and sequential type reads to avoid Objective-C collection/variadic bridging incompatibilities found during real-device testing.

## 中文说明

- 通过 Protocol 集中管理剪贴板宿主平台识别和有序后端选择
- 新增 macOS 原生 `NSPasteboard` 后端，优先读取 `public.png`，再读取 `public.tiff`，并保留 `pngpaste` 兼容回退
- 统一各后端的图片归一化流程，并修复 Windows/WSL 命令环境变量转发
- 补充平台解析、后端顺序、回退、TIFF 归一化和命令执行器测试

## Validation

- `make check-harnesstui`: 550 passed, 26 deselected
- `make test-tui-render-contract`: 152 passed, 3314 deselected
- `git diff --check`
- real macOS smoke test: `NSPasteboard` read and atomically wrote a 1414×812 PNG (205,381 bytes) without `pngpaste`
