### PR TITLE
fix(tui): restore Control-V image attachment flow

### DIFF
--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -40,6 +40,27 @@ presentation primitives.
 contracts. Product adapters such as `loushang.coding.ui` continue to own raw
 product-event interpretation, commands, policy, branding, and runtime assembly.
 
+## Conversation Attachments
+
+`loushang.harnesstui.conversation.attachments` owns product-neutral prompt-image
+attachment coordination after the host clipboard has been read. It persists a
+neutral `ClipboardImage` into a caller-supplied directory, derives a composer
+marker relative to a caller-supplied display root, and tracks pending
+attachments so submission order follows marker order in the composed text.
+Read, unsupported-type, and persistence failures are returned as neutral
+outcomes; products supply their own status copy.
+
+The host clipboard backend and MIME detection remain in
+`loushang.tui.clipboard_image`. Products continue to choose workspace and
+storage-directory policy and adapt a neutral prompt attachment into model-facing
+values such as `ImagePart`. Harnesstui does not import AI message types or
+hard-code a Coding workspace layout.
+
+The explicit module path
+`loushang.harnesstui.conversation.attachments` is the stable entrypoint for this
+capability. The conversation package initializer does not add a convenience
+re-export.
+
 ## First Slice: Conversation Reader
 
 The reusable transcript source protocol, record-composition helpers, and modal

--- a/docs/internals/architecture/tui/README.md
+++ b/docs/internals/architecture/tui/README.md
@@ -48,8 +48,10 @@ Product shells remain responsible for supplying values and applying decisions.
 
 Host clipboard-image acquisition lives in
 `loushang.tui.clipboard_image`. This generic capability owns platform fallback,
-neutral image bytes and MIME normalization. Product shells remain responsible
-for workspace persistence, composer markers, UI copy, and conversion into
+neutral image bytes and MIME normalization. Product-neutral persistence into a
+caller-supplied directory, composer-marker tracking, and prompt-order recovery
+live in `loushang.harnesstui.conversation.attachments`. Product shells remain
+responsible for workspace-directory policy, UI copy, and conversion into
 model-specific attachment values such as `ImagePart`.
 
 Clipboard-image acquisition resolves the host once into an ordered backend

--- a/src/loushang/coding/ui/screen_input.py
+++ b/src/loushang/coding/ui/screen_input.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -9,11 +8,15 @@ from typing import Literal
 
 from loushang.ai.types import ImagePart
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
-from loushang.tui.clipboard_image import (
-    ClipboardImage,
-    extension_for_image_mime_type,
-    read_clipboard_image,
+from loushang.harnesstui.conversation.attachments import (
+    ClipboardImageNameFactory,
+    ClipboardImageReader,
+    PendingPromptImageRegistry,
+    PromptImageAttachment,
+    new_prompt_image_name_token,
+    stage_clipboard_image,
 )
+from loushang.tui.clipboard_image import read_clipboard_image
 from loushang.tui.input import (
     ComposerInputTarget,
     InputEvent,
@@ -25,14 +28,6 @@ from loushang.tui.input import (
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
 
 RunningSubmitMode = Literal["steer", "follow_up"]
-ClipboardImageReader = Callable[[], ClipboardImage | None]
-ClipboardImageNameFactory = Callable[[], str]
-
-
-@dataclass(frozen=True, slots=True)
-class _PendingClipboardImage:
-    marker: str
-    image: ImagePart
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,9 +57,15 @@ class ScreenInputRouter:
     height: int = 12
     clipboard_image_reader: ClipboardImageReader = read_clipboard_image
     clipboard_image_dir: Path | str | None = None
-    clipboard_image_name_factory: ClipboardImageNameFactory = field(default_factory=lambda: lambda: uuid.uuid4().hex)
+    clipboard_image_name_factory: ClipboardImageNameFactory = (
+        new_prompt_image_name_token
+    )
     _jump_mode: Literal["forward", "backward"] | None = None
-    _pending_clipboard_images: list[_PendingClipboardImage] = field(default_factory=list, init=False, repr=False)
+    _pending_clipboard_images: PendingPromptImageRegistry = field(
+        default_factory=PendingPromptImageRegistry,
+        init=False,
+        repr=False,
+    )
     _composer_target: ComposerInputTarget = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -257,84 +258,58 @@ class ScreenInputRouter:
         return ScreenInputResult()
 
     def _paste_clipboard_image(self) -> ScreenInputResult:
-        try:
-            image = self.clipboard_image_reader()
-        except Exception as error:
-            self.app.set_status(f"Unable to read clipboard image: {_exception_message(error)}")
-            return ScreenInputResult()
-        if image is None:
+        directory = (
+            Path(self.clipboard_image_dir)
+            if self.clipboard_image_dir is not None
+            else Path(self.app.cwd) / ".loushang" / "clipboard"
+        )
+        outcome = stage_clipboard_image(
+            self.clipboard_image_reader,
+            directory=directory,
+            display_root=Path(self.app.cwd),
+            name_factory=self.clipboard_image_name_factory,
+        )
+        if outcome.kind == "empty":
             self.app.set_status("No clipboard image found.")
             return ScreenInputResult()
-        extension = extension_for_image_mime_type(image.mime_type)
-        if extension is None:
-            self.app.set_status(f"Unsupported clipboard image type: {image.mime_type or 'unknown'}")
-            return ScreenInputResult()
-        try:
-            path = self._write_clipboard_image(image, extension=extension)
-        except OSError as error:
-            self.app.set_status(f"Unable to attach clipboard image: {error}")
-            return ScreenInputResult()
-        marker_path = _display_path(path, cwd=Path(self.app.cwd))
-        marker = f"@{marker_path}"
-        self.app.composer.paste(f"{marker} ")
-        self._pending_clipboard_images.append(
-            _PendingClipboardImage(
-                marker=marker,
-                image=ImagePart(
-                    type="image",
-                    data=base64.b64encode(image.bytes).decode("ascii"),
-                    mime_type=_base_mime_type(image.mime_type),
-                ),
+        if outcome.kind == "read_error":
+            self.app.set_status(
+                f"Unable to read clipboard image: {outcome.error_message}"
             )
-        )
-        self.app.set_status(f"Attached clipboard image: {marker_path}")
+            return ScreenInputResult()
+        if outcome.kind == "unsupported":
+            self.app.set_status(
+                f"Unsupported clipboard image type: {outcome.mime_type or 'unknown'}"
+            )
+            return ScreenInputResult()
+        if outcome.kind == "write_error":
+            self.app.set_status(
+                f"Unable to attach clipboard image: {outcome.error_message}"
+            )
+            return ScreenInputResult()
+        attachment = outcome.attachment
+        if attachment is None:
+            raise RuntimeError("attached clipboard outcome requires an attachment")
+        self.app.composer.paste(f"{attachment.marker} ")
+        self._pending_clipboard_images.add(attachment)
+        self.app.set_status(f"Attached clipboard image: {attachment.display_path}")
         return ScreenInputResult()
 
-    def _write_clipboard_image(self, image: ClipboardImage, *, extension: str) -> Path:
-        directory = Path(self.clipboard_image_dir) if self.clipboard_image_dir is not None else Path(self.app.cwd) / ".loushang" / "clipboard"
-        directory.mkdir(parents=True, exist_ok=True)
-        token = _safe_filename_token(self.clipboard_image_name_factory())
-        path = directory / f"clipboard-{token}.{extension}"
-        path.write_bytes(image.bytes)
-        return path
-
     def _prompt_images_for_text(self, text: str) -> tuple[ImagePart, ...] | None:
-        present = [
-            (position, pending.image)
-            for pending in self._pending_clipboard_images
-            if (position := text.find(pending.marker)) >= 0
-        ]
-        images = tuple(image for _position, image in sorted(present, key=lambda item: item[0]))
+        attachments = self._pending_clipboard_images.select_for_text(text)
+        images = tuple(_image_part(attachment) for attachment in attachments)
         return images or None
 
     def _clear_prompt_attachments(self) -> None:
         self._pending_clipboard_images.clear()
 
 
-def _display_path(path: Path, *, cwd: Path) -> str:
-    try:
-        return path.relative_to(cwd).as_posix()
-    except ValueError:
-        return path.as_posix()
-
-
-def _safe_filename_token(value: str) -> str:
-    token = value.strip() or uuid.uuid4().hex
-    safe = "".join(character if _is_safe_filename_character(character) else "_" for character in token)
-    safe = safe.strip("._")
-    return safe or uuid.uuid4().hex
-
-
-def _is_safe_filename_character(character: str) -> bool:
-    return character.isascii() and (character.isalnum() or character in {"-", "_", "."})
-
-
-def _exception_message(error: BaseException) -> str:
-    return str(error) or error.__class__.__name__
-
-
-def _base_mime_type(mime_type: str) -> str:
-    return mime_type.split(";", 1)[0].strip().lower()
+def _image_part(attachment: PromptImageAttachment) -> ImagePart:
+    return ImagePart(
+        type="image",
+        data=base64.b64encode(attachment.bytes).decode("ascii"),
+        mime_type=attachment.mime_type,
+    )
 
 
 __all__ = ["ScreenInputResult", "ScreenInputRouter", "RunningSubmitMode"]

--- a/src/loushang/harnesstui/conversation/attachments.py
+++ b/src/loushang/harnesstui/conversation/attachments.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from loushang.tui.clipboard_image import (
+    ClipboardImage,
+    extension_for_image_mime_type,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PromptImageAttachment:
+    """Product-neutral image data staged for one prompt."""
+
+    bytes: bytes
+    mime_type: str
+    path: Path
+    display_path: str
+    marker: str
+
+
+PromptImageAttachmentOutcomeKind = Literal[
+    "attached",
+    "empty",
+    "unsupported",
+    "read_error",
+    "write_error",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PromptImageAttachmentOutcome:
+    """Neutral result of reading and staging one clipboard image."""
+
+    kind: PromptImageAttachmentOutcomeKind
+    attachment: PromptImageAttachment | None = None
+    mime_type: str = ""
+    error_message: str = ""
+
+
+ClipboardImageReader = Callable[[], ClipboardImage | None]
+ClipboardImageNameFactory = Callable[[], str]
+
+
+def new_prompt_image_name_token() -> str:
+    """Return an opaque filename token for a newly staged prompt image."""
+
+    return uuid.uuid4().hex
+
+
+@dataclass(slots=True)
+class PendingPromptImageRegistry:
+    """Track staged images until a product submits or clears its prompt."""
+
+    _attachments: list[PromptImageAttachment] = field(
+        default_factory=list,
+        init=False,
+        repr=False,
+    )
+
+    def add(self, attachment: PromptImageAttachment) -> None:
+        self._attachments.append(attachment)
+
+    def select_for_text(self, text: str) -> tuple[PromptImageAttachment, ...]:
+        positioned = (
+            (position, insertion_index, attachment)
+            for insertion_index, attachment in enumerate(self._attachments)
+            if (position := text.find(attachment.marker)) >= 0
+        )
+        return tuple(
+            attachment
+            for _position, _insertion_index, attachment in sorted(positioned)
+        )
+
+    def clear(self) -> None:
+        self._attachments.clear()
+
+    def __len__(self) -> int:
+        return len(self._attachments)
+
+
+def persist_clipboard_image(
+    image: ClipboardImage,
+    *,
+    directory: Path | str,
+    display_root: Path | str,
+    name_token: str | None = None,
+) -> PromptImageAttachment:
+    """Persist clipboard bytes and return their neutral prompt attachment."""
+
+    mime_type = _base_mime_type(image.mime_type)
+    extension = extension_for_image_mime_type(mime_type)
+    if extension is None:
+        raise ValueError(f"unsupported clipboard image type: {mime_type or 'unknown'}")
+
+    target_directory = Path(directory)
+    target_directory.mkdir(parents=True, exist_ok=True)
+    token = _safe_filename_token(name_token)
+    path = target_directory / f"clipboard-{token}.{extension}"
+    path.write_bytes(image.bytes)
+
+    display_path = _display_path(
+        path,
+        relative_to=Path(display_root),
+    )
+    return PromptImageAttachment(
+        bytes=image.bytes,
+        mime_type=mime_type,
+        path=path,
+        display_path=display_path,
+        marker=f"@{display_path}",
+    )
+
+
+def stage_clipboard_image(
+    reader: ClipboardImageReader,
+    *,
+    directory: Path | str,
+    display_root: Path | str,
+    name_token: str | None = None,
+    name_factory: ClipboardImageNameFactory | None = None,
+) -> PromptImageAttachmentOutcome:
+    """Read and persist one clipboard image without applying product copy."""
+
+    try:
+        image = reader()
+    except Exception as error:
+        return PromptImageAttachmentOutcome(
+            kind="read_error",
+            error_message=_exception_message(error),
+        )
+    if image is None or not image.bytes:
+        return PromptImageAttachmentOutcome(kind="empty")
+
+    mime_type = _base_mime_type(image.mime_type)
+    if extension_for_image_mime_type(mime_type) is None:
+        return PromptImageAttachmentOutcome(
+            kind="unsupported",
+            mime_type=mime_type,
+        )
+
+    try:
+        if name_factory is not None:
+            name_token = name_factory()
+        attachment = persist_clipboard_image(
+            image,
+            directory=directory,
+            display_root=display_root,
+            name_token=name_token,
+        )
+    except OSError as error:
+        return PromptImageAttachmentOutcome(
+            kind="write_error",
+            mime_type=mime_type,
+            error_message=_exception_message(error),
+        )
+    return PromptImageAttachmentOutcome(
+        kind="attached",
+        attachment=attachment,
+        mime_type=attachment.mime_type,
+    )
+
+
+def _display_path(path: Path, *, relative_to: Path | None) -> str:
+    if relative_to is not None:
+        try:
+            return path.relative_to(relative_to).as_posix()
+        except ValueError:
+            return path.as_posix()
+    return path.as_posix()
+
+
+def _safe_filename_token(value: str | None) -> str:
+    token = value.strip() if value is not None else ""
+    if not token:
+        token = new_prompt_image_name_token()
+    safe = "".join(
+        character if _is_safe_filename_character(character) else "_"
+        for character in token
+    )
+    safe = safe.strip("._")
+    return safe or new_prompt_image_name_token()
+
+
+def _is_safe_filename_character(character: str) -> bool:
+    return character.isascii() and (
+        character.isalnum() or character in {"-", "_", "."}
+    )
+
+
+def _base_mime_type(mime_type: str) -> str:
+    return mime_type.split(";", 1)[0].strip().lower()
+
+
+def _exception_message(error: BaseException) -> str:
+    return str(error) or error.__class__.__name__
+
+
+__all__ = [
+    "ClipboardImageNameFactory",
+    "ClipboardImageReader",
+    "PendingPromptImageRegistry",
+    "PromptImageAttachment",
+    "PromptImageAttachmentOutcome",
+    "PromptImageAttachmentOutcomeKind",
+    "new_prompt_image_name_token",
+    "persist_clipboard_image",
+    "stage_clipboard_image",
+]

--- a/src/loushang/tui/terminal_input.py
+++ b/src/loushang/tui/terminal_input.py
@@ -87,6 +87,7 @@ class TerminalInputMode:
             termios_module.ECHO
             | termios_module.ICANON
             | getattr(termios_module, "ISIG", 0)
+            | getattr(termios_module, "IEXTEN", 0)
         )
         attrs[6][termios_module.VMIN] = 1
         attrs[6][termios_module.VTIME] = 0

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -332,6 +332,7 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.coding.ui` -> `loushang.harnesstui`" in text
     assert "`loushang.harnesstui.conversation.reader`" in text
     assert "`loushang.harnesstui.conversation.source`" in text
+    assert "`loushang.harnesstui.conversation.attachments`" in text
     assert "`loushang.harnesstui.conversation.projection`" in text
     assert "`loushang.harnesstui.conversation.plain_target`" in text
     assert "`loushang.harnesstui.conversation.tool_transcript`" in text
@@ -354,6 +355,7 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
 
 def test_harnesstui_capability_entrypoints_exist() -> None:
     paths = (
+        Path("src/loushang/harnesstui/conversation/attachments.py"),
         Path("src/loushang/harnesstui/conversation/plain_target.py"),
         Path("src/loushang/harnesstui/conversation/projection.py"),
         Path("src/loushang/harnesstui/conversation/tool_transcript.py"),

--- a/tests/coding/test_screen_coding_tui_input.py
+++ b/tests/coding/test_screen_coding_tui_input.py
@@ -259,6 +259,39 @@ def test_screen_input_router_reports_empty_clipboard_image_without_editing(tmp_p
     assert not (tmp_path / ".clips").exists()
 
 
+def test_screen_input_router_reports_unsupported_clipboard_image_without_writing(
+    tmp_path,
+) -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_input import ScreenInputRouter
+    from loushang.tui.clipboard_image import ClipboardImage
+
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd=str(tmp_path),
+        branch="main",
+        session_label="abcd",
+        now=lambda: 12.0,
+    )
+    router = ScreenInputRouter(
+        app,
+        should_exit=lambda text: False,
+        clipboard_image_reader=lambda: ClipboardImage(
+            bytes=b"svg",
+            mime_type=" IMAGE/SVG+XML ",
+        ),
+        clipboard_image_dir=tmp_path / ".clips",
+        clipboard_image_name_factory=lambda: "unused",
+    )
+
+    result = router.handle(InputEvent(kind="key", key="ctrl+v"))
+
+    assert result.render_requested is True
+    assert app.composer.value == ""
+    assert app.state.status_message == "Unsupported clipboard image type: image/svg+xml"
+    assert not (tmp_path / ".clips").exists()
+
+
 def test_screen_input_router_reports_clipboard_image_read_failure_without_crashing(tmp_path) -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
     from loushang.coding.ui.screen_input import ScreenInputRouter
@@ -360,6 +393,48 @@ def test_screen_input_router_orders_clipboard_images_by_marker_position(tmp_path
         base64.b64encode(b"second").decode("ascii"),
         base64.b64encode(b"first").decode("ascii"),
     ]
+
+
+def test_screen_input_router_uses_default_workspace_clipboard_directory_and_clears_registry(
+    tmp_path,
+) -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_input import ScreenInputRouter
+    from loushang.tui.clipboard_image import ClipboardImage
+
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd=str(tmp_path),
+        branch="main",
+        session_label="abcd",
+        now=lambda: 12.0,
+    )
+    router = ScreenInputRouter(
+        app,
+        should_exit=lambda text: False,
+        clipboard_image_reader=lambda: ClipboardImage(
+            bytes=b"png",
+            mime_type="image/png",
+        ),
+        clipboard_image_name_factory=lambda: "image",
+    )
+
+    router.handle(InputEvent(kind="key", key="ctrl+v"))
+
+    marker = "@.loushang/clipboard/clipboard-image.png"
+    saved_path = tmp_path / ".loushang" / "clipboard" / "clipboard-image.png"
+    assert saved_path.read_bytes() == b"png"
+    assert app.composer.value == f"{marker} "
+
+    first_submit = router.handle(InputEvent(kind="key", key="enter"))
+    assert first_submit.prompt_images is not None
+
+    app.complete_run(elapsed_seconds=0.1)
+    app.composer.set_text(f"reuse {marker}")
+    second_submit = router.handle(InputEvent(kind="key", key="enter"))
+
+    assert second_submit.prompt_images is None
+    assert saved_path.read_bytes() == b"png"
 
 
 def test_screen_input_router_exit_command_returns_exit_code_without_transcript() -> None:

--- a/tests/harnesstui/conversation/test_attachments.py
+++ b/tests/harnesstui/conversation/test_attachments.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from loushang.harnesstui.conversation.attachments import (
+    PendingPromptImageRegistry,
+    PromptImageAttachment,
+    persist_clipboard_image,
+    stage_clipboard_image,
+)
+from loushang.tui.clipboard_image import ClipboardImage
+
+
+def test_persist_clipboard_image_creates_neutral_relative_attachment(tmp_path) -> None:
+    payload = b"png bytes"
+
+    attachment = persist_clipboard_image(
+        ClipboardImage(bytes=payload, mime_type=" IMAGE/PNG; charset=binary "),
+        directory=tmp_path / ".clips",
+        display_root=tmp_path,
+        name_token="abc123",
+    )
+
+    expected_path = tmp_path / ".clips" / "clipboard-abc123.png"
+    assert expected_path.read_bytes() == payload
+    assert attachment == PromptImageAttachment(
+        bytes=payload,
+        mime_type="image/png",
+        path=expected_path,
+        display_path=".clips/clipboard-abc123.png",
+        marker="@.clips/clipboard-abc123.png",
+    )
+
+
+def test_persist_clipboard_image_sanitizes_filename_token(tmp_path) -> None:
+    attachment = persist_clipboard_image(
+        ClipboardImage(bytes=b"jpeg", mime_type="image/jpeg"),
+        directory=tmp_path / "images",
+        display_root=tmp_path,
+        name_token="../bad name:\n",
+    )
+
+    assert attachment.path == tmp_path / "images" / "clipboard-bad_name.jpg"
+    assert attachment.path.read_bytes() == b"jpeg"
+    assert attachment.marker == "@images/clipboard-bad_name.jpg"
+
+
+def test_persist_clipboard_image_uses_full_path_outside_display_root(tmp_path) -> None:
+    directory = tmp_path / "outside"
+
+    attachment = persist_clipboard_image(
+        ClipboardImage(bytes=b"gif", mime_type="image/gif"),
+        directory=directory,
+        display_root=tmp_path / "workspace",
+        name_token="image",
+    )
+
+    assert attachment.display_path == (directory / "clipboard-image.gif").as_posix()
+    assert attachment.marker == f"@{attachment.display_path}"
+
+
+def test_persist_clipboard_image_rejects_unsupported_mime_before_writing(tmp_path) -> None:
+    directory = tmp_path / "images"
+
+    with pytest.raises(
+        ValueError,
+        match=r"unsupported clipboard image type: image/svg\+xml",
+    ):
+        persist_clipboard_image(
+            ClipboardImage(bytes=b"svg", mime_type="image/svg+xml"),
+            directory=directory,
+            display_root=tmp_path,
+            name_token="image",
+        )
+
+    assert not directory.exists()
+
+
+def test_prompt_image_attachment_is_immutable(tmp_path) -> None:
+    attachment = persist_clipboard_image(
+        ClipboardImage(bytes=b"webp", mime_type="image/webp"),
+        directory=tmp_path,
+        display_root=tmp_path,
+        name_token="image",
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        attachment.marker = "@different"  # type: ignore[misc]
+
+
+def test_pending_registry_selects_images_in_body_marker_order(tmp_path) -> None:
+    first = persist_clipboard_image(
+        ClipboardImage(bytes=b"first", mime_type="image/png"),
+        directory=tmp_path,
+        display_root=tmp_path,
+        name_token="first",
+    )
+    second = persist_clipboard_image(
+        ClipboardImage(bytes=b"second", mime_type="image/png"),
+        directory=tmp_path,
+        display_root=tmp_path,
+        name_token="second",
+    )
+    unused = persist_clipboard_image(
+        ClipboardImage(bytes=b"unused", mime_type="image/png"),
+        directory=tmp_path,
+        display_root=tmp_path,
+        name_token="unused",
+    )
+    registry = PendingPromptImageRegistry()
+    registry.add(first)
+    registry.add(second)
+    registry.add(unused)
+
+    selected = registry.select_for_text(
+        f"Compare {second.marker} with {first.marker}; ignore the other image."
+    )
+
+    assert selected == (second, first)
+    assert len(registry) == 3
+
+
+def test_pending_registry_clear_removes_all_images(tmp_path) -> None:
+    attachment = persist_clipboard_image(
+        ClipboardImage(bytes=b"png", mime_type="image/png"),
+        directory=tmp_path,
+        display_root=tmp_path,
+        name_token="image",
+    )
+    registry = PendingPromptImageRegistry()
+    registry.add(attachment)
+
+    registry.clear()
+
+    assert len(registry) == 0
+    assert registry.select_for_text(attachment.marker) == ()
+
+
+def test_stage_clipboard_image_returns_attached_outcome(tmp_path) -> None:
+    outcome = stage_clipboard_image(
+        lambda: ClipboardImage(bytes=b"png", mime_type="image/png"),
+        directory=tmp_path / "images",
+        display_root=tmp_path,
+        name_token="image",
+    )
+
+    assert outcome.kind == "attached"
+    assert outcome.mime_type == "image/png"
+    assert outcome.error_message == ""
+    assert outcome.attachment is not None
+    assert outcome.attachment.marker == "@images/clipboard-image.png"
+
+
+@pytest.mark.parametrize("image", (None, ClipboardImage(bytes=b"", mime_type="image/png")))
+def test_stage_clipboard_image_returns_empty_outcome_without_writing(
+    tmp_path,
+    image: ClipboardImage | None,
+) -> None:
+    directory = tmp_path / "images"
+
+    outcome = stage_clipboard_image(
+        lambda: image,
+        directory=directory,
+        display_root=tmp_path,
+        name_token="image",
+    )
+
+    assert outcome.kind == "empty"
+    assert outcome.attachment is None
+    assert not directory.exists()
+
+
+def test_stage_clipboard_image_returns_unsupported_outcome_without_writing(
+    tmp_path,
+) -> None:
+    directory = tmp_path / "images"
+
+    outcome = stage_clipboard_image(
+        lambda: ClipboardImage(bytes=b"svg", mime_type=" IMAGE/SVG+XML "),
+        directory=directory,
+        display_root=tmp_path,
+        name_token="image",
+    )
+
+    assert outcome.kind == "unsupported"
+    assert outcome.mime_type == "image/svg+xml"
+    assert outcome.attachment is None
+    assert not directory.exists()
+
+
+def test_stage_clipboard_image_returns_read_error_outcome(tmp_path) -> None:
+    def fail() -> ClipboardImage | None:
+        raise RuntimeError("clipboard unavailable")
+
+    outcome = stage_clipboard_image(
+        fail,
+        directory=tmp_path / "images",
+        display_root=tmp_path,
+        name_token="image",
+    )
+
+    assert outcome.kind == "read_error"
+    assert outcome.error_message == "clipboard unavailable"
+    assert outcome.attachment is None
+
+
+def test_stage_clipboard_image_returns_write_error_outcome(tmp_path) -> None:
+    blocked_directory = tmp_path / "not-a-directory"
+    blocked_directory.write_text("blocked", encoding="utf-8")
+
+    outcome = stage_clipboard_image(
+        lambda: ClipboardImage(bytes=b"png", mime_type="image/png"),
+        directory=blocked_directory,
+        display_root=tmp_path,
+        name_token="image",
+    )
+
+    assert outcome.kind == "write_error"
+    assert outcome.mime_type == "image/png"
+    assert outcome.error_message
+    assert outcome.attachment is None

--- a/tests/tui/test_terminal_input.py
+++ b/tests/tui/test_terminal_input.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import os
 import sys
 import threading
 import time
@@ -44,7 +45,18 @@ def test_terminal_input_mode_enables_and_restores_tty_modes(monkeypatch: Any) ->
     pytest.importorskip("tty")
     stdin = _TtyInput()
     stdout = StringIO()
-    original_attrs = [0, 0, 0, 0, 0, 0, [0] * 32]
+    original_attrs = [
+        getattr(termios, "ICRNL", 0),
+        0,
+        0,
+        termios.ECHO
+        | termios.ICANON
+        | getattr(termios, "ISIG", 0)
+        | getattr(termios, "IEXTEN", 0),
+        0,
+        0,
+        [0] * 32,
+    ]
     tcsetattr_calls: list[tuple[int, int, list[Any]]] = []
 
     monkeypatch.setattr("termios.tcgetattr", lambda fd: original_attrs)
@@ -68,7 +80,34 @@ def test_terminal_input_mode_enables_and_restores_tty_modes(monkeypatch: Any) ->
     assert "\x1b[?2004l" in output
     assert "\x1b[?1004l" in output
     assert MODIFY_OTHER_KEYS_DISABLE_SEQUENCE in output
+    active_attrs = tcsetattr_calls[0][2]
+    assert active_attrs[3] & getattr(termios, "IEXTEN", 0) == 0
     assert tcsetattr_calls[-1] == (stdin.fileno(), termios.TCSADRAIN, original_attrs)
+
+
+def test_terminal_input_mode_delivers_control_v() -> None:
+    if os.name == "nt":
+        pytest.skip("PTY input test uses POSIX termios")
+    pty = pytest.importorskip("pty")
+    select = pytest.importorskip("select")
+    master_fd, slave_fd = pty.openpty()
+    try:
+        with os.fdopen(slave_fd, "r", closefd=False) as stdin:
+            with TerminalInputMode(
+                stdin=stdin,
+                stdout=StringIO(),
+                bracketed_paste=False,
+                focus_events=False,
+                keyboard_protocols=False,
+                drain_on_exit=False,
+            ):
+                os.write(master_fd, b"\x16")
+                readable, _, _ = select.select([slave_fd], [], [], 1.0)
+                assert readable == [slave_fd]
+                assert os.read(slave_fd, 1) == b"\x16"
+    finally:
+        os.close(master_fd)
+        os.close(slave_fd)
 
 
 def test_terminal_input_mode_writes_control_modes_on_windows_without_posix_modules(


### PR DESCRIPTION
## English

### What changed

- Disable `IEXTEN` while the terminal input mode is active so Control-V reaches the TUI instead of being consumed as the POSIX literal-next character.
- Add `loushang.harnesstui.conversation.attachments` for neutral clipboard-image staging, persistence outcomes, safe markers, and prompt-order tracking.
- Keep Coding responsible for workspace-directory policy, product copy, and conversion to `ImagePart`.
- Document and test the dependency boundary: `coding.ui -> harnesstui -> tui`.

### Why

The macOS clipboard backend could read image bytes and the keybinding resolved to `ctrl+v`, but the terminal line discipline still swallowed Control-V because `IEXTEN` remained enabled. Clipboard persistence and pending-attachment bookkeeping also lived directly in the Coding input router even though those interactions are reusable across Harness-backed terminal products.

### Impact

Control-V image paste now reaches the application on POSIX terminals. Existing `ScreenInputRouter` construction and `prompt_images`, `steer_images`, and `followup_images` contracts remain compatible. No Screen rendering, segmentation, or cache behavior changed.

### Validation

- `make check-harnesstui` — 565 passed, 26 deselected
- `make test-tui-render-contract` — 152 passed, 3317 deselected
- Targeted terminal Control-V PTY tests — 2 passed
- Targeted attachment integration tests — 18 passed
- Ruff, Mypy, and `git diff --check`

## 中文

### 变更内容

- Terminal input mode 期间关闭 `IEXTEN`，避免 Control-V 被 POSIX 行规程当作 literal-next 字符吞掉。
- 新增 `loushang.harnesstui.conversation.attachments`，承接中性的剪贴板图片暂存、持久化结果、安全 marker 和正文顺序跟踪。
- Coding 继续负责工作区目录策略、产品提示文案以及到 `ImagePart` 的转换。
- 补充并验证 `coding.ui -> harnesstui -> tui` 的依赖边界。

### 原因与影响

此前 macOS 后端已经能读取图片，按键也能解析为 `ctrl+v`，但终端仍启用了 `IEXTEN`，导致 Control-V 在进入应用前被吞掉。同时，图片写盘和待提交附件管理属于可被多个 Harness TUI 产品复用的交互能力，不应直接固化在 Coding 输入路由中。

现在 POSIX 终端能够正常把 Control-V 图片粘贴送入应用；现有 `ScreenInputRouter` 和图片提交字段保持兼容，并且没有修改 Screen 渲染、分段或缓存逻辑。
