### PR TITLE
refactor(harnesstui): own conversation interaction control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,14 @@ HARNESSTUI_SHARED_SOURCES := \
 HARNESSTUI_CODING_ADAPTERS := \
 	src/loushang/coding/platform/__init__.py \
 	src/loushang/coding/platform/clipboard_image.py \
+	src/loushang/coding/ui/abort.py \
 	src/loushang/coding/ui/command_list.py \
 	src/loushang/coding/ui/completion.py \
 	src/loushang/coding/ui/conversation_event_adapter.py \
+	src/loushang/coding/ui/event_stream.py \
+	src/loushang/coding/ui/follow_up_queue.py \
 	src/loushang/coding/ui/handlers.py \
+	src/loushang/coding/ui/lifecycle.py \
 	src/loushang/coding/ui/model_list.py \
 	src/loushang/coding/ui/pending_queue.py \
 	src/loushang/coding/ui/plain_app.py \
@@ -39,9 +43,13 @@ HARNESSTUI_CODING_ADAPTERS := \
 	src/loushang/coding/ui/playback_runner.py \
 	src/loushang/coding/ui/playback_suite.py \
 	src/loushang/coding/ui/playback_scenarios/surface.py \
+	src/loushang/coding/ui/prompt_dispatch.py \
+	src/loushang/coding/ui/prompt_result.py \
+	src/loushang/coding/ui/run_context.py \
 	src/loushang/coding/ui/screen_app.py \
 	src/loushang/coding/ui/screen_events.py \
 	src/loushang/coding/ui/screen_input.py \
+	src/loushang/coding/ui/screen_loop.py \
 	src/loushang/coding/ui/screen_state.py \
 	src/loushang/coding/ui/screen_surfaces.py \
 	src/loushang/coding/ui/settings_common.py \
@@ -49,6 +57,7 @@ HARNESSTUI_CODING_ADAPTERS := \
 	src/loushang/coding/ui/settings_page.py \
 	src/loushang/coding/ui/settings_status_line.py \
 	src/loushang/coding/ui/status_line.py \
+	src/loushang/coding/ui/steer.py \
 	src/loushang/coding/ui/tool_blocks.py \
 	src/loushang/coding/ui/transcript_projection.py \
 	src/loushang/coding/ui/transcript_reader.py \
@@ -65,12 +74,21 @@ HARNESSTUI_TEST_PATHS := \
 	tests/coding/test_platform_utils.py \
 	tests/coding/test_terminal_diagnostics_compatibility.py \
 	tests/coding/test_ui_handlers.py \
+	tests/coding/test_ui_abort.py \
+	tests/coding/test_ui_event_stream.py \
+	tests/coding/test_ui_follow_up_queue.py \
+	tests/coding/test_ui_lifecycle.py \
 	tests/coding/test_ui_pending_queue.py \
 	tests/coding/test_ui_pending_queue_compatibility.py \
+	tests/coding/test_ui_prompt_dispatch.py \
+	tests/coding/test_ui_prompt_result.py \
+	tests/coding/test_ui_run_context.py \
+	tests/coding/test_ui_steer.py \
 	tests/coding/test_ui_import_boundaries.py \
 	tests/coding/test_screen_coding_tui_app.py \
 	tests/coding/test_screen_coding_tui_events.py \
 	tests/coding/test_screen_coding_tui_input.py \
+	tests/coding/test_screen_coding_tui_loop.py \
 	tests/coding/test_screen_coding_tui_mode.py \
 	tests/coding/test_screen_coding_tui_state.py \
 	tests/coding/test_screen_coding_tui_surfaces.py \
@@ -81,6 +99,8 @@ HARNESSTUI_TEST_PATHS := \
 	tests/coding/test_ui_command_list.py \
 	tests/coding/test_ui_completion.py \
 	tests/coding/test_ui_conversation_event_adapter.py \
+	tests/coding/test_ui_control_compatibility.py \
+	tests/coding/test_ui_dispatch_compatibility.py \
 	tests/coding/test_ui_model_list.py \
 	tests/coding/test_ui_plain_app.py \
 	tests/coding/test_ui_plain_toolbar.py \
@@ -88,7 +108,8 @@ HARNESSTUI_TEST_PATHS := \
 	tests/coding/test_ui_status_line.py \
 	tests/coding/test_ui_status_provider.py \
 	tests/coding/test_ui_transcript_projection.py \
-	tests/coding/test_ui_transcript_source.py
+	tests/coding/test_ui_transcript_source.py \
+	tests/coding/ui/test_screen_input.py
 
 .PHONY: bootstrap test test-ai check-ai test-tui test-tui-render-contract lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools vendor-ai-openai-codex-complete example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-advanced-openai-codex-login example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip
 .PHONY: check-ai-catalog check-ai-examples check-ai-imports check-ai-coverage

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -179,6 +179,37 @@ existing `make test-tui-render-contract` gate covers this new boundary.
 The explicit module path above is the stable import for this capability. The
 package initializer does not provide a convenience re-export.
 
+## Conversation Interaction Control
+
+The reusable control plane for a full-screen conversation lives behind five
+explicit entrypoints:
+
+- `loushang.harnesstui.conversation.input` coordinates decoded input,
+  completion, surfaces, running-submit modes, and neutral attachments;
+- `loushang.harnesstui.conversation.control` coordinates abort, steer, and
+  follow-up actions over caller-supplied controllers and status callbacks;
+- `loushang.harnesstui.conversation.dispatch` owns product-neutral dispatch,
+  result-presentation, and stable event-stream lifecycles;
+- `loushang.harnesstui.conversation.run_context` owns UI subscription cleanup,
+  stable emission, tracing, and context-exit ordering;
+- `loushang.harnesstui.conversation.screen_runner` owns the reusable terminal
+  read/route/run loop over explicit screen, router, and result ports.
+
+These modules build conversation interaction from neutral UI values. They do
+not own a Harness Session, persistence, runtime construction, raw product
+events, Coding intents, model-facing image types, workspace paths, command
+policy, or product copy. A product facade supplies those decisions and adapts
+neutral attachments to its runtime-facing values. In particular, Coding keeps
+`PromptIntent` and `BashIntent`, `ImagePart`, Session and observability setup,
+raw-event interpretation, `.loushang` storage policy, and its interruption,
+queue, and error messages.
+
+The screen runner coordinates existing rendering calls but does not move or
+replace transcript segmentation, invalidation, render caches, frame
+composition, or terminal writes. Those hot-path responsibilities and the
+independent render-performance contract remain unchanged. The conversation
+package initializer intentionally does not re-export these entrypoints.
+
 ## Plain Conversation Presentation
 
 `loushang.harnesstui.plain.renderer` owns the reusable plain-terminal renderer:

--- a/src/loushang/coding/ui/abort.py
+++ b/src/loushang/coding/ui/abort.py
@@ -1,36 +1,28 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from typing import Any, Protocol
 
 from loushang.coding.ui.intent import AbortIntent
+from loushang.harnesstui.conversation.control import (
+    AbortActionHandler,
+    InterruptionRenderer,
+    RunControl,
+    StableEmit,
+    TraceFn,
+)
 
-
-class Lifecycle(Protocol):
-    active: bool
-    active_id: int
-    aborted_id: int | None
-
-    def mark_abort_requested(self) -> None: ...
+Lifecycle = RunControl
+Renderer = InterruptionRenderer
 
 
 class Controller(Protocol):
     async def dispatch(self, intent: AbortIntent) -> Any: ...
 
 
-class Renderer(Protocol):
-    def render_interruption(self) -> None: ...
-
-
-class StableEmit(Protocol):
-    def __call__(self, write_callable: Callable[[], None], *, label: str) -> Awaitable[None]: ...
-
-
-class TraceFn(Protocol):
-    def __call__(self, name: str, **data: Any) -> None: ...
-
-
 class AbortHandler:
+    """Adapt Coding's ``AbortIntent`` to shared abort action control."""
+
     def __init__(
         self,
         *,
@@ -41,6 +33,7 @@ class AbortHandler:
         session_running: Callable[[], bool],
         trace: TraceFn,
     ) -> None:
+        # Preserve the historical Coding attributes as adapter seams.
         self._lifecycle = lifecycle
         self._controller = controller
         self._renderer = renderer
@@ -49,23 +42,18 @@ class AbortHandler:
         self._trace = trace
 
     async def abort(self) -> None:
-        self._trace(
-            "abort.start",
-            active_run=self._lifecycle.active,
-            active_run_id=self._lifecycle.active_id,
-            aborted_run_id=self._lifecycle.aborted_id,
-            session_running=self._session_running(),
+        async def dispatch_abort() -> Any:
+            return await self._controller.dispatch(AbortIntent())
+
+        handler = AbortActionHandler(
+            run_control=self._lifecycle,
+            abort_action=dispatch_abort,
+            renderer=self._renderer,
+            emit=self._emit,
+            session_running=self._session_running,
+            trace=self._trace,
         )
-        self._lifecycle.mark_abort_requested()
-        await self._emit(self._renderer.render_interruption, label="abort:interruption")
-        await self._controller.dispatch(AbortIntent())
-        self._trace(
-            "abort.end",
-            active_run=self._lifecycle.active,
-            active_run_id=self._lifecycle.active_id,
-            aborted_run_id=self._lifecycle.aborted_id,
-            session_running=self._session_running(),
-        )
+        await handler.abort()
 
 
 __all__ = ["AbortHandler"]

--- a/src/loushang/coding/ui/event_stream.py
+++ b/src/loushang/coding/ui/event_stream.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from typing import Any, Protocol
 
 from loushang.coding.ui.event_policy import event_writes_transcript
+from loushang.harnesstui.conversation.dispatch import (
+    EventRenderer as SharedEventRenderer,
+)
+from loushang.harnesstui.conversation.dispatch import (
+    StableEmit,
+    StableEventStreamHandler,
+    TraceFn,
+)
 
 
-class EventRenderer(Protocol):
-    def handle(self, event: dict[str, Any]) -> None: ...
+class EventRenderer(SharedEventRenderer[dict[str, Any]], Protocol):
+    """Coding-compatible raw event rendering port."""
 
 
-class TraceFn(Protocol):
-    def __call__(self, name: str, **data: Any) -> None: ...
+class CodingUiEventStreamHandler(StableEventStreamHandler[dict[str, Any]]):
+    """Adapt Coding raw-event policy to neutral stable event delivery."""
 
-
-class StableEmit(Protocol):
-    def __call__(self, write_callable: Callable[[], None], *, label: str) -> Awaitable[None]: ...
-
-
-class CodingUiEventStreamHandler:
     def __init__(
         self,
         *,
@@ -26,20 +27,17 @@ class CodingUiEventStreamHandler:
         emit: StableEmit,
         trace: TraceFn,
     ) -> None:
-        self._renderer = renderer
-        self._emit = emit
-        self._trace = trace
+        super().__init__(
+            renderer=renderer,
+            emit=emit,
+            writes_stably=event_writes_transcript,
+            event_type=_coding_event_type,
+            trace=trace,
+        )
 
-    async def handle(self, event: dict[str, Any]) -> None:
-        event_type = str(event.get("type") or "unknown")
-        self._trace("event.start", event_type=event_type)
-        try:
-            if not event_writes_transcript(event):
-                self._renderer.handle(event)
-                return
-            await self._emit(lambda: self._renderer.handle(event), label=f"event:{event_type}")
-        finally:
-            self._trace("event.end", event_type=event_type)
+
+def _coding_event_type(event: dict[str, Any]) -> str:
+    return str(event.get("type") or "unknown")
 
 
 __all__ = ["CodingUiEventStreamHandler"]

--- a/src/loushang/coding/ui/follow_up_queue.py
+++ b/src/loushang/coding/ui/follow_up_queue.py
@@ -1,31 +1,24 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from typing import Any, Protocol
+from loushang.harnesstui.conversation.control import (
+    ActiveRunControl as Lifecycle,
+)
+from loushang.harnesstui.conversation.control import (
+    FollowUpActionHandler,
+    StableEmit,
+    TraceFn,
+)
+from loushang.harnesstui.conversation.control import (
+    FollowUpController as Controller,
+)
+from loushang.harnesstui.conversation.control import (
+    StatusRenderer as Renderer,
+)
 
 
-class Lifecycle(Protocol):
-    active: bool
-    active_id: int
+class FollowUpQueueHandler(FollowUpActionHandler):
+    """Supply Coding status copy to shared follow-up action control."""
 
-
-class Controller(Protocol):
-    async def follow_up(self, text: str) -> Any: ...
-
-
-class Renderer(Protocol):
-    def render_status(self, text: str) -> None: ...
-
-
-class StableEmit(Protocol):
-    def __call__(self, write_callable: Callable[[], None], *, label: str) -> Awaitable[None]: ...
-
-
-class TraceFn(Protocol):
-    def __call__(self, name: str, **data: Any) -> None: ...
-
-
-class FollowUpQueueHandler:
     def __init__(
         self,
         *,
@@ -35,49 +28,17 @@ class FollowUpQueueHandler:
         emit: StableEmit,
         trace: TraceFn,
     ) -> None:
-        self._lifecycle = lifecycle
-        self._controller = controller
-        self._renderer = renderer
-        self._emit = emit
-        self._trace = trace
-
-    async def queue(self, text: str, *, source: str) -> int | None:
-        follow_text = text.strip()
-        self._trace(
-            "prompt.follow_up.start",
-            active_run_id=self._lifecycle.active_id,
-            active_run=self._lifecycle.active,
-            source=source,
-            text_len=len(follow_text),
+        super().__init__(
+            lifecycle=lifecycle,
+            controller=controller,
+            renderer=renderer,
+            emit=emit,
+            trace=trace,
+            idle_status_message=(
+                "Follow-up is only available while a run is active."
+            ),
+            queued_status_message="Follow-up queued.",
         )
-        if not follow_text:
-            self._trace("prompt.follow_up.ignored", reason="empty", source=source)
-            return None
-        if not self._lifecycle.active:
-            await self._emit(
-                lambda: self._renderer.render_status("Follow-up is only available while a run is active."),
-                label="follow_up:idle",
-            )
-            return None
-
-        result = await self._controller.follow_up(follow_text)
-        self._trace(
-            "prompt.follow_up.end",
-            error_message=result.error_message,
-            exit_code=result.exit_code,
-            source=source,
-        )
-        if result.error_message:
-            await self._emit(
-                lambda: self._renderer.render_status(result.error_message or "Follow-up is unavailable."),
-                label="follow_up:error",
-            )
-        else:
-            await self._emit(
-                lambda: self._renderer.render_status("Follow-up queued."),
-                label="follow_up:queued",
-            )
-        return result.exit_code
 
 
 __all__ = ["FollowUpQueueHandler"]

--- a/src/loushang/coding/ui/lifecycle.py
+++ b/src/loushang/coding/ui/lifecycle.py
@@ -1,35 +1,7 @@
-from __future__ import annotations
+"""Compatibility alias for product-neutral conversation action control."""
 
-from dataclasses import dataclass
-
-
-@dataclass
-class RunLifecycle:
-    active: bool = False
-    active_id: int = 0
-    aborted_id: int | None = None
-
-    def begin_work(self) -> int:
-        self.active = True
-        self.active_id += 1
-        return self.active_id
-
-    def end_work(self) -> None:
-        self.active = False
-
-    def mark_abort_requested(self) -> None:
-        if self.active:
-            self.aborted_id = self.active_id
-
-    def abort_is_settling(self) -> bool:
-        return self.active and self.aborted_id == self.active_id
-
-    def clear_aborted(self, run_id: int) -> None:
-        if self.aborted_id == run_id:
-            self.aborted_id = None
-
-    def visible_running(self, *, session_running: bool) -> bool:
-        return self.active or session_running
-
+from loushang.harnesstui.conversation.control import (
+    ConversationRunControl as RunLifecycle,
+)
 
 __all__ = ["RunLifecycle"]

--- a/src/loushang/coding/ui/prompt_dispatch.py
+++ b/src/loushang/coding/ui/prompt_dispatch.py
@@ -2,76 +2,49 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable
-from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Protocol
 
 from loushang.coding.ui.controller import ControllerResult
 from loushang.coding.ui.intent import BashIntent, CodingUiIntent, PromptIntent
+from loushang.harnesstui.conversation.dispatch import (
+    ConversationDispatchHandler,
+    ConversationDispatchOutcome,
+    DispatchLifecycle,
+    TraceFn,
+)
 
-
-class Lifecycle(Protocol):
-    active: bool
-
-    def begin_work(self) -> int: ...
-    def end_work(self) -> None: ...
+Lifecycle = DispatchLifecycle
+PromptDispatchOutcome = ConversationDispatchOutcome
 
 
 class Controller(Protocol):
     async def dispatch(self, intent: CodingUiIntent) -> ControllerResult: ...
 
 
-class TraceFn(Protocol):
-    def __call__(self, name: str, **data: Any) -> None: ...
+class PromptDispatchHandler(ConversationDispatchHandler[CodingUiIntent]):
+    """Adapt Coding intent classification to neutral dispatch coordination."""
 
-
-@dataclass(frozen=True)
-class PromptDispatchOutcome:
-    result: ControllerResult
-    run_id: int | None
-    work_intent: bool
-    started_at: float
-
-
-class PromptDispatchHandler:
     def __init__(
         self,
         *,
         lifecycle: Lifecycle,
         controller: Controller,
-        session_running: Any,
+        session_running: Callable[[], object],
         now: Callable[[], float] = time.monotonic,
         trace: TraceFn,
     ) -> None:
-        self._lifecycle = lifecycle
-        self._controller = controller
-        self._session_running = session_running
-        self._now = now
-        self._trace = trace
-
-    async def dispatch(self, intent: CodingUiIntent) -> PromptDispatchOutcome:
-        work_intent = isinstance(intent, PromptIntent | BashIntent)
-        started_at = self._now()
-        run_id: int | None = None
-        if work_intent:
-            run_id = self._lifecycle.begin_work()
-        self._trace(
-            "prompt.dispatch.start",
-            intent=type(intent).__name__,
-            work_intent=work_intent,
-            run_id=run_id,
+        super().__init__(
+            lifecycle=lifecycle,
+            controller=controller,
+            is_work_intent=_is_work_intent,
+            session_running=session_running,
+            now=now,
+            trace=trace,
         )
-        try:
-            result = await self._controller.dispatch(intent)
-        finally:
-            if work_intent:
-                self._lifecycle.end_work()
-            self._trace(
-                "prompt.dispatch.end",
-                run_id=run_id,
-                active_run=self._lifecycle.active,
-                session_running=bool(self._session_running()),
-            )
-        return PromptDispatchOutcome(result=result, run_id=run_id, work_intent=work_intent, started_at=started_at)
+
+
+def _is_work_intent(intent: CodingUiIntent) -> bool:
+    return isinstance(intent, PromptIntent | BashIntent)
 
 
 __all__ = ["PromptDispatchHandler", "PromptDispatchOutcome"]

--- a/src/loushang/coding/ui/prompt_result.py
+++ b/src/loushang/coding/ui/prompt_result.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-from typing import Any, Protocol, TextIO
+from collections.abc import Callable
+from typing import Protocol, TextIO
 
 from loushang.coding.ui.event_policy import is_cancelled_error_message
 from loushang.coding.ui.prompt_dispatch import PromptDispatchOutcome
+from loushang.harnesstui.conversation.dispatch import (
+    ConversationResultPresenter,
+    ResultRenderer,
+    StableEmit,
+    TraceFn,
+)
+
+Renderer = ResultRenderer
 
 
 class Lifecycle(Protocol):
@@ -13,21 +21,9 @@ class Lifecycle(Protocol):
     def clear_aborted(self, run_id: int) -> None: ...
 
 
-class Renderer(Protocol):
-    def render_status(self, text: str) -> None: ...
-    def render_error(self, text: str) -> None: ...
-    def render_worked(self, elapsed_seconds: float) -> None: ...
-
-
-class StableEmit(Protocol):
-    def __call__(self, write_callable: Callable[[], None], *, label: str) -> Awaitable[None]: ...
-
-
-class TraceFn(Protocol):
-    def __call__(self, name: str, **data: Any) -> None: ...
-
-
 class PromptResultHandler:
+    """Keep Coding cancellation policy around neutral result presentation."""
+
     def __init__(
         self,
         *,
@@ -50,8 +46,22 @@ class PromptResultHandler:
         self._session_error_message = session_error_message
         self._now = now
         self._trace = trace
+        self._presenter = ConversationResultPresenter(
+            renderer=renderer,
+            emit=emit,
+            stderr=stderr,
+            verbose=verbose,
+            last_error_message=last_error_message,
+            now=now,
+            trace=trace,
+        )
 
-    async def handle(self, outcome: PromptDispatchOutcome, *, prompt_started: float) -> int | None:
+    async def handle(
+        self,
+        outcome: PromptDispatchOutcome,
+        *,
+        prompt_started: float,
+    ) -> int | None:
         result = outcome.result
         run_id = outcome.run_id
         error_message = result.error_message or self._session_error_message()
@@ -61,31 +71,18 @@ class PromptResultHandler:
             and is_cancelled_error_message(error_message)
         ):
             self._lifecycle.clear_aborted(run_id)
-            self._trace("prompt.suppressed_cancelled", run_id=run_id, error_message=error_message)
+            self._trace(
+                "prompt.suppressed_cancelled",
+                run_id=run_id,
+                error_message=error_message,
+            )
             return result.exit_code
 
-        if error_message:
-            if self._last_error_message() != error_message:
-                await self._emit(lambda: self._renderer.render_error(error_message or "Unknown error"), label="prompt:error")
-            if self._verbose and result.traceback_text:
-                self._stderr.write(result.traceback_text)
-                self._stderr.flush()
-        elif result.status_message:
-            await self._emit(lambda: self._renderer.render_status(result.status_message or ""), label="prompt:status")
-        elif outcome.work_intent and result.exit_code is None:
-            await self._emit(
-                lambda: self._renderer.render_worked(self._now() - outcome.started_at),
-                label="prompt:worked",
-            )
-
-        self._trace(
-            "prompt.end",
-            run_id=run_id,
-            exit_code=result.exit_code,
+        return await self._presenter.handle(
+            outcome,
+            prompt_started=prompt_started,
             error_message=error_message,
-            elapsed_s=self._now() - prompt_started,
         )
-        return result.exit_code
 
 
 __all__ = ["PromptResultHandler"]

--- a/src/loushang/coding/ui/run_context.py
+++ b/src/loushang/coding/ui/run_context.py
@@ -1,41 +1,38 @@
 from __future__ import annotations
 
-import time
-from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
-from typing import Any, Protocol
+from collections.abc import Callable
+from typing import Any
 
 from loushang.coding.ui.event_stream import CodingUiEventStreamHandler
 from loushang.coding.ui.startup import CodingTuiStartupSnapshot
+from loushang.harnesstui.conversation.run_context import (
+    InteractionRunContext,
+    StableEmit,
+    TraceFn,
+    stable_emit_factory,
+    subscribe_events,
+)
 
 
-class TraceFn(Protocol):
-    def __call__(self, name: str, **data: Any) -> None: ...
+class CodingTuiRunContext(InteractionRunContext):
+    """Coding compatibility facade for a neutral interaction run context."""
 
-
-class StableEmit(Protocol):
-    def __call__(self, write_callable: Callable[[], None], *, label: str) -> Awaitable[None]: ...
-
-
-@dataclass
-class CodingTuiRunContext:
-    emit: StableEmit
-    _unsubscribe: Callable[[], None]
-    _observability_context: Any
-    _trace: TraceFn
-    _closed: bool = False
-
-    def close(self) -> None:
-        if self._closed:
-            return
-        self._closed = True
-        try:
-            try:
-                self._trace("tui.end")
-            finally:
-                self._unsubscribe()
-        finally:
-            self._observability_context.__exit__(None, None, None)
+    def __init__(
+        self,
+        emit: StableEmit,
+        _unsubscribe: Callable[[], None],
+        _observability_context: Any,
+        _trace: TraceFn,
+        _closed: bool = False,
+    ) -> None:
+        self._observability_context = _observability_context
+        super().__init__(
+            emit=emit,
+            _unsubscribe=_unsubscribe,
+            _exit_context=_observability_context,
+            _trace=_trace,
+            _closed=_closed,
+        )
 
 
 def open_coding_tui_run_context(
@@ -58,7 +55,7 @@ def open_coding_tui_run_context(
             branch=snapshot.branch,
             session=snapshot.session_label,
         )
-        stable_emit = _stable_emit_factory(trace=trace, interactive=interactive)
+        stable_emit = stable_emit_factory(trace=trace, interactive=interactive)
         event_stream_handler = CodingUiEventStreamHandler(renderer=event_renderer, emit=stable_emit, trace=trace)
         listener = event_stream_handler.handle if interactive else event_renderer.handle
         unsubscribe = subscribe_session_events(session, listener)
@@ -69,31 +66,9 @@ def open_coding_tui_run_context(
 
 
 def subscribe_session_events(session: Any, listener: Any) -> Callable[[], None]:
-    subscribe = getattr(session, "subscribe", None)
-    if callable(subscribe):
-        unsubscribe = subscribe(listener)
-        if callable(unsubscribe):
-            return unsubscribe
-    return lambda: None
+    """Coding compatibility name for subscribing to Session events."""
 
-
-def _stable_emit_factory(*, trace: TraceFn, interactive: bool) -> StableEmit:
-    async def emit(write_callable: Callable[[], None], *, label: str) -> None:
-        started = time.monotonic()
-        trace("emit.start", label=label, interactive=interactive)
-        try:
-            write_callable()
-        except Exception as error:
-            trace(
-                "emit.error",
-                label=label,
-                elapsed_s=time.monotonic() - started,
-                error=str(error) or error.__class__.__name__,
-            )
-            raise
-        trace("emit.end", label=label, elapsed_s=time.monotonic() - started)
-
-    return emit
+    return subscribe_events(session, listener)
 
 
 __all__ = ["CodingTuiRunContext", "open_coding_tui_run_context", "subscribe_session_events"]

--- a/src/loushang/coding/ui/screen_input.py
+++ b/src/loushang/coding/ui/screen_input.py
@@ -2,36 +2,34 @@ from __future__ import annotations
 
 import base64
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import cast
 
 from loushang.ai.types import ImagePart
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 from loushang.harnesstui.conversation.attachments import (
     ClipboardImageNameFactory,
     ClipboardImageReader,
-    PendingPromptImageRegistry,
     PromptImageAttachment,
+    PromptImageAttachmentOutcome,
     new_prompt_image_name_token,
     stage_clipboard_image,
 )
-from loushang.tui.clipboard_image import read_clipboard_image
-from loushang.tui.input import (
-    ComposerInputTarget,
-    InputEvent,
-    InputIntent,
-    route_editor_editing_key,
-    route_editor_selection_key,
-    route_prompt_completion_key,
+from loushang.harnesstui.conversation.input import (
+    ConversationInputResult,
+    ConversationInputRouter,
+    RunningSubmitMode,
 )
+from loushang.tui.clipboard_image import read_clipboard_image
+from loushang.tui.input import InputEvent, InputIntent
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
-
-RunningSubmitMode = Literal["steer", "follow_up"]
 
 
 @dataclass(frozen=True, slots=True)
 class ScreenInputResult:
+    """Coding result with AI image parts ready for product dispatch."""
+
     prompt_text: str | None = None
     prompt_images: tuple[ImagePart, ...] | None = None
     local_text: str | None = None
@@ -44,264 +42,200 @@ class ScreenInputResult:
     exit_code: int | None = None
     render_requested: bool = True
 
+    @property
+    def prompt_attachments(self) -> tuple[ImagePart, ...] | None:
+        return self.prompt_images
 
-@dataclass(slots=True)
+    @property
+    def steer_attachments(self) -> tuple[ImagePart, ...] | None:
+        return self.steer_images
+
+    @property
+    def followup_attachments(self) -> tuple[ImagePart, ...] | None:
+        return self.followup_images
+
+
 class ScreenInputRouter:
-    app: ScreenCodingTuiApp
-    should_exit: Callable[[str], bool]
-    is_local_command: Callable[[str], bool] = lambda _text: False
-    keybindings: KeybindingManager | KeybindingConfig | None = None
-    running_submit_mode: RunningSubmitMode = "steer"
-    follow_up_keys: tuple[str, ...] = ("alt+enter",)
-    width: int = 80
-    height: int = 12
-    clipboard_image_reader: ClipboardImageReader = read_clipboard_image
-    clipboard_image_dir: Path | str | None = None
-    clipboard_image_name_factory: ClipboardImageNameFactory = (
-        new_prompt_image_name_token
-    )
-    _jump_mode: Literal["forward", "backward"] | None = None
-    _pending_clipboard_images: PendingPromptImageRegistry = field(
-        default_factory=PendingPromptImageRegistry,
-        init=False,
-        repr=False,
-    )
-    _composer_target: ComposerInputTarget = field(init=False, repr=False)
+    """Compatibility facade around the shared conversation input router."""
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.keybindings, KeybindingManager):
-            self.keybindings = KeybindingManager(self.keybindings)
-        self._composer_target = ComposerInputTarget(self.app.composer)
+    __slots__ = (
+        "_router",
+        "clipboard_image_dir",
+        "clipboard_image_name_factory",
+        "clipboard_image_reader",
+    )
+
+    def __init__(
+        self,
+        app: ScreenCodingTuiApp,
+        should_exit: Callable[[str], bool],
+        is_local_command: Callable[[str], bool] = lambda _text: False,
+        keybindings: KeybindingManager | KeybindingConfig | None = None,
+        running_submit_mode: RunningSubmitMode = "steer",
+        follow_up_keys: tuple[str, ...] = ("alt+enter",),
+        width: int = 80,
+        height: int = 12,
+        clipboard_image_reader: ClipboardImageReader = read_clipboard_image,
+        clipboard_image_dir: Path | str | None = None,
+        clipboard_image_name_factory: ClipboardImageNameFactory = (
+            new_prompt_image_name_token
+        ),
+    ) -> None:
+        self.clipboard_image_reader = clipboard_image_reader
+        self.clipboard_image_dir = clipboard_image_dir
+        self.clipboard_image_name_factory = clipboard_image_name_factory
+        self._router = ConversationInputRouter(
+            app=app,
+            should_exit=should_exit,
+            is_local_command=is_local_command,
+            keybindings=keybindings,
+            running_submit_mode=running_submit_mode,
+            follow_up_keys=follow_up_keys,
+            width=width,
+            height=height,
+            prompt_image_stager=self._stage_clipboard_image,
+        )
+
+    @property
+    def app(self) -> ScreenCodingTuiApp:
+        return cast(ScreenCodingTuiApp, self._router.app)
+
+    @app.setter
+    def app(self, value: ScreenCodingTuiApp) -> None:
+        self._router.replace_app(value)
+
+    @property
+    def should_exit(self) -> Callable[[str], bool]:
+        return self._router.should_exit
+
+    @should_exit.setter
+    def should_exit(self, value: Callable[[str], bool]) -> None:
+        self._router.should_exit = value
+
+    @property
+    def is_local_command(self) -> Callable[[str], bool]:
+        return self._router.is_local_command
+
+    @is_local_command.setter
+    def is_local_command(self, value: Callable[[str], bool]) -> None:
+        self._router.is_local_command = value
+
+    @property
+    def width(self) -> int:
+        return self._router.width
+
+    @width.setter
+    def width(self, value: int) -> None:
+        self._router.width = value
+
+    @property
+    def height(self) -> int:
+        return self._router.height
+
+    @height.setter
+    def height(self, value: int) -> None:
+        self._router.height = value
+
+    @property
+    def keybindings(self) -> KeybindingManager | KeybindingConfig | None:
+        return self._router.keybindings
+
+    @keybindings.setter
+    def keybindings(
+        self,
+        value: KeybindingManager | KeybindingConfig | None,
+    ) -> None:
+        self._router.keybindings = value
+
+    @property
+    def running_submit_mode(self) -> RunningSubmitMode:
+        return self._router.running_submit_mode
+
+    @running_submit_mode.setter
+    def running_submit_mode(self, value: RunningSubmitMode) -> None:
+        self._router.running_submit_mode = value
+
+    @property
+    def follow_up_keys(self) -> tuple[str, ...]:
+        return self._router.follow_up_keys
+
+    @follow_up_keys.setter
+    def follow_up_keys(self, value: tuple[str, ...]) -> None:
+        self._router.follow_up_keys = value
 
     def handle(self, event: InputEvent) -> ScreenInputResult:
-        if event.kind == "key" and event.event_type == "release":
-            return ScreenInputResult(render_requested=False)
-        if self._runtime_surface_active():
-            return self._route_runtime_surface(event)
-        if self.app.active_surface is not None:
-            return self._route_active_surface(event)
-        if event.kind == "text":
-            if self._jump_mode is not None:
-                self.app.composer.jump_to_char(event.text, direction=self._jump_mode)
-                self._jump_mode = None
-                return ScreenInputResult()
-            self.app.composer.insert_text(event.text)
-            return ScreenInputResult()
-        if event.kind == "paste":
-            self._jump_mode = None
-            self.app.composer.paste(event.text)
-            return ScreenInputResult()
-        if event.kind == "resize":
-            if event.columns:
-                self.width = event.columns
-            if event.rows:
-                self.height = event.rows
-            return ScreenInputResult()
-        if event.kind != "key":
-            return ScreenInputResult(render_requested=False)
+        result = self._router.handle(event)
+        self._apply_clipboard_status(result.clipboard_outcome)
+        return _screen_input_result(result)
 
-        keybindings = self._keybindings()
-        if self._jump_mode is not None:
-            if keybindings.matches(event.key, "tui.editor.jumpForward") or keybindings.matches(
-                event.key,
-                "tui.editor.jumpBackward",
-            ):
-                self._jump_mode = None
-                return ScreenInputResult()
-            self._jump_mode = None
-        if keybindings.matches(event.key, "tui.queue.editLast"):
-            self._restore_queued_messages()
-            return ScreenInputResult()
-        if keybindings.matches(event.key, "tui.transcript.open"):
-            return ScreenInputResult(render_requested=self.app.open_transcript_reader())
-        if route_editor_selection_key(self._composer_target, event.key, keybindings=keybindings):
-            return ScreenInputResult()
-        if self.app.composer.has_completions and keybindings.matches(event.key, "tui.input.submit"):
-            return self._submit_selected_completion()
-        if self.app.composer.has_completions and self._route_completion_key(event, keybindings):
-            return ScreenInputResult()
-        if keybindings.matches(event.key, "tui.select.cancel"):
-            return self._abort_or_clear()
-        if keybindings.matches(event.key, "tui.input.tab"):
-            self.app.composer.refresh_completions(force=True, explicit=True)
-            if self.app.composer.has_completions:
-                self.app.composer.apply_selected_completion()
-            return ScreenInputResult()
-        if keybindings.matches(event.key, "app.clipboard.pasteImage"):
-            return self._paste_clipboard_image()
-        if keybindings.matches(event.key, "tui.editor.jumpForward"):
-            self._jump_mode = "forward"
-            return ScreenInputResult()
-        if keybindings.matches(event.key, "tui.editor.jumpBackward"):
-            self._jump_mode = "backward"
-            return ScreenInputResult()
-        if keybindings.matches(event.key, "tui.editor.cursorUp"):
-            if self.app.composer.browsing_history:
-                self.app.composer.history_previous()
-            elif not self.app.composer.value or not self.app.composer.move_visual_up(width=self.width):
-                self.app.composer.history_previous()
-            return ScreenInputResult()
-        if keybindings.matches(event.key, "tui.editor.cursorDown"):
-            if self.app.composer.browsing_history:
-                self.app.composer.history_next()
-            elif not self.app.composer.value or not self.app.composer.move_visual_down(width=self.width):
-                self.app.composer.history_next()
-            return ScreenInputResult()
-        if keybindings.matches(event.key, "tui.editor.pageUp"):
-            self.app.composer.move_visual_page_up(width=self.width, visible_lines=self._composer_page_lines())
-            return ScreenInputResult()
-        if keybindings.matches(event.key, "tui.editor.pageDown"):
-            self.app.composer.move_visual_page_down(width=self.width, visible_lines=self._composer_page_lines())
-            return ScreenInputResult()
-        if self.app.state.running and event.key in self.follow_up_keys:
-            return self._submit_running(mode="follow_up")
-        if keybindings.matches(event.key, "tui.input.newLine"):
-            self.app.composer.insert_newline()
-            return ScreenInputResult()
-        if keybindings.matches(event.key, "tui.input.submit"):
-            return self._submit()
-        if route_editor_editing_key(self._composer_target, event.key, keybindings=keybindings):
-            return ScreenInputResult()
-        return ScreenInputResult(render_requested=False)
-
-    def _route_completion_key(self, event: InputEvent, keybindings: KeybindingManager) -> bool:
-        return route_prompt_completion_key(self._composer_target, event.key, keybindings=keybindings)
-
-    def _submit_selected_completion(self) -> ScreenInputResult:
-        should_submit_after_completion = self.app.composer.value.lstrip().startswith("/")
-        self.app.composer.apply_selected_completion()
-        if should_submit_after_completion:
-            return self._submit()
-        return ScreenInputResult()
-
-    def _abort_or_clear(self) -> ScreenInputResult:
-        if self.app.state.running:
-            return ScreenInputResult(abort_requested=True)
-        if self.app.state.pending_steers:
-            pending_steer = self.app.state.pending_steers.pop(0)
-            return ScreenInputResult(steer_text=pending_steer)
-        if self.app.composer.value:
-            self.app.composer.clear()
-            self._clear_prompt_attachments()
-            return ScreenInputResult()
-        return ScreenInputResult(render_requested=False)
-
-    def _restore_queued_messages(self) -> None:
-        text = self.app.state.restore_queued_to_text()
-        if text:
-            self.app.composer.set_text(text)
-
-    def _submit(self) -> ScreenInputResult:
-        text = self.app.composer.value
-        if not text.strip():
-            return ScreenInputResult(render_requested=False)
-        if self.should_exit(text.strip()):
-            self.app.composer.clear()
-            self._clear_prompt_attachments()
-            return ScreenInputResult(exit_code=0)
-        if self.app.state.running:
-            return self._submit_running(mode=self.running_submit_mode)
-        if self.is_local_command(text.strip()):
-            self.app.composer.clear()
-            self._clear_prompt_attachments()
-            return ScreenInputResult(local_text=text.strip())
-        images = self._prompt_images_for_text(text)
-        self.app.start_prompt(text)
-        self._clear_prompt_attachments()
-        return ScreenInputResult(prompt_text=text, prompt_images=images)
-
-    def _submit_running(self, *, mode: RunningSubmitMode) -> ScreenInputResult:
-        text = self.app.composer.value
-        if not text.strip():
-            return ScreenInputResult(render_requested=False)
-        images = self._prompt_images_for_text(text)
-        self.app.composer.add_history(text)
-        self.app.composer.clear()
-        self._clear_prompt_attachments()
-        if mode == "follow_up":
-            self.app.queue_followup(text)
-            return ScreenInputResult(followup_text=text, followup_images=images)
-        self.app.queue_steer(text)
-        return ScreenInputResult(steer_text=text, steer_images=images)
-
-    def _keybindings(self) -> KeybindingManager:
-        return self.keybindings if isinstance(self.keybindings, KeybindingManager) else KeybindingManager(self.keybindings)
-
-    def _composer_page_lines(self) -> int:
-        return max(2, min(10, self.height))
-
-    def _route_active_surface(self, event: InputEvent) -> ScreenInputResult:
-        handler = getattr(self.app.active_surface, "handle_input", None)
-        if not callable(handler):
-            return ScreenInputResult(render_requested=False)
-        intent = handler(event)
-        if isinstance(intent, InputIntent):
-            if intent.kind == "consumed":
-                return ScreenInputResult()
-            return ScreenInputResult(surface_intent=intent)
-        return ScreenInputResult()
-
-    def _runtime_surface_active(self) -> bool:
-        surface_host = self.app.surface_host
-        return surface_host is not None and bool(surface_host.entries)
-
-    def _route_runtime_surface(self, event: InputEvent) -> ScreenInputResult:
-        surface_host = self.app.surface_host
-        if surface_host is None:
-            return ScreenInputResult(render_requested=False)
-        intents = surface_host.route_input(event, close_on_intents=("surface_close", "dialog_cancel"))
-        for intent in intents:
-            if isinstance(intent, InputIntent):
-                if intent.kind == "consumed":
-                    return ScreenInputResult()
-                return ScreenInputResult(surface_intent=intent)
-        return ScreenInputResult()
-
-    def _paste_clipboard_image(self) -> ScreenInputResult:
+    def _stage_clipboard_image(self) -> PromptImageAttachmentOutcome:
         directory = (
             Path(self.clipboard_image_dir)
             if self.clipboard_image_dir is not None
             else Path(self.app.cwd) / ".loushang" / "clipboard"
         )
-        outcome = stage_clipboard_image(
+        return stage_clipboard_image(
             self.clipboard_image_reader,
             directory=directory,
             display_root=Path(self.app.cwd),
             name_factory=self.clipboard_image_name_factory,
         )
+
+    def _apply_clipboard_status(
+        self,
+        outcome: PromptImageAttachmentOutcome | None,
+    ) -> None:
+        if outcome is None:
+            return
         if outcome.kind == "empty":
             self.app.set_status("No clipboard image found.")
-            return ScreenInputResult()
+            return
         if outcome.kind == "read_error":
             self.app.set_status(
                 f"Unable to read clipboard image: {outcome.error_message}"
             )
-            return ScreenInputResult()
+            return
         if outcome.kind == "unsupported":
             self.app.set_status(
-                f"Unsupported clipboard image type: {outcome.mime_type or 'unknown'}"
+                "Unsupported clipboard image type: "
+                f"{outcome.mime_type or 'unknown'}"
             )
-            return ScreenInputResult()
+            return
         if outcome.kind == "write_error":
             self.app.set_status(
                 f"Unable to attach clipboard image: {outcome.error_message}"
             )
-            return ScreenInputResult()
+            return
         attachment = outcome.attachment
         if attachment is None:
             raise RuntimeError("attached clipboard outcome requires an attachment")
-        self.app.composer.paste(f"{attachment.marker} ")
-        self._pending_clipboard_images.add(attachment)
-        self.app.set_status(f"Attached clipboard image: {attachment.display_path}")
-        return ScreenInputResult()
+        self.app.set_status(
+            f"Attached clipboard image: {attachment.display_path}"
+        )
 
-    def _prompt_images_for_text(self, text: str) -> tuple[ImagePart, ...] | None:
-        attachments = self._pending_clipboard_images.select_for_text(text)
-        images = tuple(_image_part(attachment) for attachment in attachments)
-        return images or None
 
-    def _clear_prompt_attachments(self) -> None:
-        self._pending_clipboard_images.clear()
+def _screen_input_result(result: ConversationInputResult) -> ScreenInputResult:
+    return ScreenInputResult(
+        prompt_text=result.prompt_text,
+        prompt_images=_image_parts(result.prompt_attachments),
+        local_text=result.local_text,
+        steer_text=result.steer_text,
+        steer_images=_image_parts(result.steer_attachments),
+        followup_text=result.followup_text,
+        followup_images=_image_parts(result.followup_attachments),
+        surface_intent=result.surface_intent,
+        abort_requested=result.abort_requested,
+        exit_code=result.exit_code,
+        render_requested=result.render_requested,
+    )
+
+
+def _image_parts(
+    attachments: tuple[PromptImageAttachment, ...] | None,
+) -> tuple[ImagePart, ...] | None:
+    if attachments is None:
+        return None
+    return tuple(_image_part(attachment) for attachment in attachments)
 
 
 def _image_part(attachment: PromptImageAttachment) -> ImagePart:

--- a/src/loushang/coding/ui/screen_loop.py
+++ b/src/loushang/coding/ui/screen_loop.py
@@ -1,30 +1,33 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
-import shutil
 from collections.abc import Awaitable, Callable
 from contextlib import AbstractContextManager
-from typing import Any, TextIO
+from typing import Any, TextIO, cast
 
 from loushang.ai.types import ImagePart
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 from loushang.coding.ui.screen_input import ScreenInputRouter
+from loushang.harnesstui.conversation.screen_runner import (
+    ConversationInputRouterPort,
+    ConversationScreenPort,
+    abort_active,
+    configure_runtime_for_terminal_context,
+    elapsed_since,
+    finish_active_task,
+    maybe_await,
+    pop_interrupt_pending_steer,
+    run_conversation_screen,
+    run_surface_intent_handler,
+    supports_keyword,
+    terminal_size,
+    write_startup_welcome,
+)
 from loushang.tui import _runner_utils
-from loushang.tui.core import RenderConstraints
-from loushang.tui.input import InputIntent, InputReader
+from loushang.tui.input import InputIntent
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
-from loushang.tui.render_loop import RenderLoop
-from loushang.tui.runtime import TuiRuntime
-from loushang.tui.scheduler import RenderRequestKind
-from loushang.tui.terminal import ProcessTerminalPort, TerminalSize
-from loushang.tui.terminal_diagnostics import (
-    format_terminal_diagnostics as _format_terminal_diagnostics,
-)
-from loushang.tui.terminal_input import (
-    read_input_chunk_or_render_tick,
-)
-from loushang.tui.terminal_session import TerminalSession
+from loushang.tui.terminal import TerminalSize
+from loushang.tui.terminal_diagnostics import format_terminal_diagnostics
 
 PromptHandler = Callable[..., Awaitable[int | None] | int | None]
 TextHandler = Callable[..., Awaitable[int | None] | int | None]
@@ -41,6 +44,33 @@ _input_events_for_chunk = _runner_utils.input_events_for_chunk
 _poll_terminal_runtime = _runner_utils.poll_terminal_runtime
 _request_runtime_render = _runner_utils.request_runtime_render
 _terminal_runtime_wakeup_ms = _runner_utils.terminal_runtime_wakeup_ms
+_format_terminal_diagnostics = format_terminal_diagnostics
+
+_write_startup_welcome = write_startup_welcome
+_configure_runtime_for_terminal_context = configure_runtime_for_terminal_context
+_elapsed_since = elapsed_since
+_pop_interrupt_pending_steer = pop_interrupt_pending_steer
+_run_surface_intent_handler = run_surface_intent_handler
+_maybe_await = maybe_await
+_supports_keyword = supports_keyword
+_terminal_size = terminal_size
+
+
+async def _finish_coding_active_task(
+    *,
+    app: ScreenCodingTuiApp,
+    active_task: asyncio.Task[int | None],
+    started_at: float | None,
+) -> int | None:
+    return await finish_active_task(
+        app=app,
+        active_task=active_task,
+        started_at=started_at,
+        cancellation_message="Operation aborted",
+    )
+
+
+_finish_active_task = _finish_coding_active_task
 
 
 async def run_screen_coding_tui(
@@ -60,206 +90,75 @@ async def run_screen_coding_tui(
     terminal_mode_factory: TerminalModeFactory | None = None,
     terminal_size_provider: TerminalSizeProvider | None = None,
 ) -> int:
-    reader = InputReader()
-    size_provider = terminal_size_provider or _terminal_size
-    initial_size = size_provider()
-    router = ScreenInputRouter(
-        app,
+    """Adapt Coding payloads and product copy to the shared screen runner."""
+
+    return await run_conversation_screen(
+        app=app,
+        stdin=stdin,
+        stdout=stdout,
+        handle_prompt=_adapt_attachment_handler(handle_prompt),
+        handle_local=handle_local,
+        handle_steer=(
+            _adapt_attachment_handler(handle_steer)
+            if handle_steer is not None
+            else None
+        ),
+        handle_followup=(
+            _adapt_attachment_handler(handle_followup)
+            if handle_followup is not None
+            else None
+        ),
+        handle_surface_intent=handle_surface_intent,
+        on_abort=on_abort,
         should_exit=should_exit,
-        is_local_command=is_local_command or (lambda _text: False),
+        is_local_command=is_local_command,
         keybindings=keybindings,
-        width=initial_size.columns,
-        height=initial_size.rows,
+        terminal_mode_factory=terminal_mode_factory,
+        terminal_size_provider=terminal_size_provider or _terminal_size,
+        input_router_factory=_coding_input_router_factory,
+        interruption_message=(
+            "Conversation interrupted - tell the model what to do differently."
+        ),
+        cancellation_message="Operation aborted",
     )
-    runtime = TuiRuntime(
-        render_loop=RenderLoop(app),
-        terminal=ProcessTerminalPort(output=stdout, size_provider=size_provider, track_screen=False),
-    )
-    app.surface_host = runtime.overlay_host()
-    mode_factory = terminal_mode_factory or (lambda input_stream, output_stream: TerminalSession(stdin=input_stream, stdout=output_stream))
-    active_task: asyncio.Task[int | None] | None = None
-    active_prompt_started_at: float | None = None
-    queued_steers_while_running: list[str] = []
-    render_wakeup = asyncio.Event()
-    previous_render_requester = app.render_requester
-    previous_terminal_diagnostics_provider = app.terminal_diagnostics_provider
-    previous_terminal_capabilities = app.terminal_capabilities
-
-    def request_app_render(kind: RenderRequestKind) -> None:
-        if previous_render_requester is not None:
-            previous_render_requester(kind)
-        runtime.request_render(kind)
-        render_wakeup.set()
-
-    app.render_requester = request_app_render
-    try:
-        with mode_factory(stdin, stdout) as terminal_context:
-            app.terminal_diagnostics_provider = lambda context=terminal_context: _format_terminal_diagnostics(context)
-            _configure_runtime_for_terminal_context(runtime, app, terminal_context)
-            _write_startup_welcome(app=app, runtime=runtime, stdout=stdout)
-            runtime.render_now()
-            while True:
-                if active_task is not None and active_task.done():
-                    exit_code = await _finish_active_task(
-                        app=app,
-                        active_task=active_task,
-                        started_at=active_prompt_started_at,
-                    )
-                    active_task = None
-                    active_prompt_started_at = None
-                    queued_steers_while_running = []
-                    runtime.render_now()
-                    if exit_code is not None:
-                        return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=exit_code)
-
-                data = await read_input_chunk_or_render_tick(
-                    stdin,
-                    runtime=runtime,
-                    active_task=active_task,
-                    render_wakeup=render_wakeup,
-                    pending_input_idle_ms=10 if reader.has_pending else None,
-                    idle_wakeup_ms=_terminal_runtime_wakeup_ms(terminal_context),
-                )
-                input_events: tuple[Any, ...]
-                if data is None:
-                    _poll_terminal_runtime(terminal_context)
-                    if not reader.has_pending:
-                        continue
-                    input_events = _flush_pending_input(reader, terminal_context=terminal_context)
-                elif data == "" and reader.has_pending:
-                    input_events = _flush_pending_input(reader, terminal_context=terminal_context)
-                elif data == "":
-                    if active_task is not None:
-                        exit_code = await _finish_active_task(
-                            app=app,
-                            active_task=active_task,
-                            started_at=active_prompt_started_at,
-                        )
-                        runtime.render_now()
-                        return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=exit_code if exit_code is not None else 0)
-                    runtime.render_now()
-                    return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=0)
-                else:
-                    input_events = _input_events_for_chunk(reader, data, terminal_context=terminal_context)
-
-                for event in input_events:
-                    result = router.handle(event)
-                    if result.exit_code is not None:
-                        runtime.render_now()
-                        return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=result.exit_code)
-                    if result.abort_requested:
-                        queued_steers_while_running = []
-                        interrupt_pending_steer = _pop_interrupt_pending_steer(app)
-                        await _abort_active(app=app, active_task=active_task, on_abort=on_abort)
-                        active_task = None
-                        active_prompt_started_at = None
-                        runtime.render_now()
-                        if interrupt_pending_steer is not None:
-                            app.start_pending_prompt(interrupt_pending_steer)
-                            active_task = asyncio.create_task(_run_prompt_handler(handle_prompt, interrupt_pending_steer))
-                            active_prompt_started_at = app.state.active_started_at
-                            runtime.render_now()
-                        continue
-                    if result.prompt_text is not None:
-                        active_prompt_started_at = app.state.active_started_at
-                        active_task = asyncio.create_task(
-                            _run_prompt_handler(handle_prompt, result.prompt_text, images=result.prompt_images)
-                        )
-                        queued_steers_while_running = []
-                    if result.local_text is not None and handle_local is not None:
-                        exit_code = await _run_text_handler(handle_local, result.local_text)
-                        if exit_code is not None:
-                            runtime.render_now()
-                            return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=exit_code)
-                    if result.steer_text is not None and handle_steer is not None:
-                        was_running = active_task is not None
-                        exit_code = await _run_text_handler(handle_steer, result.steer_text, images=result.steer_images)
-                        if was_running:
-                            queued_steers_while_running.append(result.steer_text)
-                        if exit_code is not None:
-                            runtime.render_now()
-                            return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=exit_code)
-                    if result.followup_text is not None and handle_followup is not None:
-                        exit_code = await _run_text_handler(handle_followup, result.followup_text, images=result.followup_images)
-                        if exit_code is not None:
-                            runtime.render_now()
-                            return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=exit_code)
-                    if result.surface_intent is not None and handle_surface_intent is not None:
-                        exit_code = await _run_surface_intent_handler(handle_surface_intent, result.surface_intent)
-                        if exit_code is not None:
-                            runtime.render_now()
-                            return _finish_tui_exit(runtime=runtime, stdout=stdout, exit_code=exit_code)
-                    if result.render_requested:
-                        _request_runtime_render(runtime, "input")
-    finally:
-        app.surface_host = None
-        app.terminal_diagnostics_provider = previous_terminal_diagnostics_provider
-        app.terminal_capabilities = previous_terminal_capabilities
-        app.render_requester = previous_render_requester
 
 
-async def _finish_active_task(
+def _coding_input_router_factory(
     *,
-    app: ScreenCodingTuiApp,
-    active_task: asyncio.Task[int | None],
-    started_at: float | None,
-) -> int | None:
-    try:
-        result = await active_task
-    except asyncio.CancelledError:
-        app.state.abort(message="Operation aborted", elapsed_seconds=app.elapsed_seconds())
-        return None
-    except Exception as error:  # noqa: BLE001
-        app.add_error(str(error) or error.__class__.__name__)
-        app.complete_run(elapsed_seconds=_elapsed_since(app, started_at))
-        return 1
-    app.complete_run(elapsed_seconds=_elapsed_since(app, started_at))
-    return result if isinstance(result, int) else None
-
-
-def _write_startup_welcome(*, app: ScreenCodingTuiApp, runtime: TuiRuntime, stdout: TextIO) -> None:
-    if app.state.records or app.state.running or app.state.assistant_draft_buffer is not None:
-        return
-    size = runtime.terminal.size()
-    result = app.startup_welcome_panel().render(
-        RenderConstraints(width=size.columns, max_height=size.rows, visible_height=size.rows)
+    app: ConversationScreenPort,
+    should_exit: ShouldExit,
+    is_local_command: LocalCommandPredicate,
+    keybindings: KeybindingManager | KeybindingConfig | None,
+    width: int,
+    height: int,
+) -> ConversationInputRouterPort:
+    return cast(
+        ConversationInputRouterPort,
+        ScreenInputRouter(
+            app=cast(ScreenCodingTuiApp, app),
+            should_exit=should_exit,
+            is_local_command=is_local_command,
+            keybindings=keybindings,
+            width=width,
+            height=height,
+        ),
     )
-    if not result.lines:
-        return
-    stdout.write("\n".join(line.text for line in result.lines))
-    stdout.write("\n\n")
-    stdout.flush()
-
-
-def _configure_runtime_for_terminal_context(runtime: TuiRuntime, app: ScreenCodingTuiApp, terminal_context: object) -> None:
-    capabilities = getattr(terminal_context, "capabilities", None)
-    if capabilities is not None:
-        app.terminal_capabilities = capabilities
-    _runner_utils.configure_runtime_for_terminal_context(runtime, terminal_context)
 
 
 async def _abort_active(
     *,
     app: ScreenCodingTuiApp,
-    active_task: asyncio.Task[int | None] | None,
+    active_task: Any,
     on_abort: AbortHandler,
 ) -> None:
-    await _maybe_await(on_abort())
-    if active_task is not None and not active_task.done():
-        active_task.cancel()
-        try:
-            await active_task
-        except asyncio.CancelledError:
-            pass
-    elif active_task is not None:
-        await active_task
-    app.state.abort(message="Conversation interrupted - tell the model what to do differently.", elapsed_seconds=app.elapsed_seconds())
-
-
-def _elapsed_since(app: ScreenCodingTuiApp, started_at: float | None) -> float:
-    if started_at is None:
-        return app.elapsed_seconds()
-    return max(0.0, app.now() - started_at)
+    await abort_active(
+        app=app,
+        active_task=active_task,
+        on_abort=on_abort,
+        interruption_message=(
+            "Conversation interrupted - tell the model what to do differently."
+        ),
+    )
 
 
 async def _run_prompt_handler(
@@ -282,13 +181,6 @@ async def _run_text_handler(
     return result if isinstance(result, int) else None
 
 
-def _pop_interrupt_pending_steer(app: ScreenCodingTuiApp) -> str | None:
-    if not app.state.pending_steers:
-        return None
-    pending_steer = app.state.pending_steers.pop(0)
-    return pending_steer
-
-
 async def _call_text_handler(
     handler: Callable[..., object],
     text: str,
@@ -300,31 +192,16 @@ async def _call_text_handler(
     return await _maybe_await(handler(text))
 
 
-async def _run_surface_intent_handler(handler: SurfaceIntentHandler, intent: InputIntent) -> int | None:
-    result = await _maybe_await(handler(intent))
-    return result if isinstance(result, int) else None
+def _adapt_attachment_handler(handler: TextHandler) -> TextHandler:
+    async def adapted(
+        text: str,
+        *,
+        attachments: tuple[object, ...] | None = None,
+    ) -> int | None:
+        images = cast(tuple[ImagePart, ...] | None, attachments)
+        return await _run_text_handler(handler, text, images=images)
 
-
-async def _maybe_await(value: Any) -> Any:
-    if inspect.isawaitable(value):
-        return await value
-    return value
-
-
-def _supports_keyword(method: Any, keyword: str) -> bool:
-    try:
-        signature = inspect.signature(method)
-    except (TypeError, ValueError):
-        return False
-    return any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD or parameter.name == keyword
-        for parameter in signature.parameters.values()
-    )
-
-
-def _terminal_size() -> TerminalSize:
-    size = shutil.get_terminal_size((80, 24))
-    return TerminalSize(columns=size.columns, rows=size.lines)
+    return adapted
 
 
 __all__ = ["run_screen_coding_tui"]

--- a/src/loushang/coding/ui/steer.py
+++ b/src/loushang/coding/ui/steer.py
@@ -1,55 +1,24 @@
-from __future__ import annotations
+"""Compatibility aliases for shared conversation steering control."""
 
-from collections.abc import Awaitable, Callable
-from typing import Any, Protocol
+from loushang.harnesstui.conversation.control import (
+    RunIdentity,
+    StatusRenderer,
+    SteerController,
+)
+from loushang.harnesstui.conversation.control import (
+    StableEmit as SharedStableEmit,
+)
+from loushang.harnesstui.conversation.control import (
+    SteerActionHandler as SteerHandler,
+)
+from loushang.harnesstui.conversation.control import (
+    TraceFn as SharedTraceFn,
+)
 
-
-class Lifecycle(Protocol):
-    active_id: int
-
-
-class Controller(Protocol):
-    async def steer(self, text: str) -> Any: ...
-
-
-class Renderer(Protocol):
-    def render_status(self, text: str) -> None: ...
-
-
-class StableEmit(Protocol):
-    def __call__(self, write_callable: Callable[[], None], *, label: str) -> Awaitable[None]: ...
-
-
-class TraceFn(Protocol):
-    def __call__(self, name: str, **data: Any) -> None: ...
-
-
-class SteerHandler:
-    def __init__(
-        self,
-        *,
-        lifecycle: Lifecycle,
-        controller: Controller,
-        renderer: Renderer,
-        emit: StableEmit,
-        trace: TraceFn,
-    ) -> None:
-        self._lifecycle = lifecycle
-        self._controller = controller
-        self._renderer = renderer
-        self._emit = emit
-        self._trace = trace
-
-    async def steer(self, text: str) -> int | None:
-        self._trace("prompt.steer.start", active_run_id=self._lifecycle.active_id)
-        result = await self._controller.steer(text)
-        self._trace("prompt.steer.end", error_message=result.error_message, exit_code=result.exit_code)
-        if result.error_message:
-            await self._emit(
-                lambda: self._renderer.render_status(result.error_message or "Steering is unavailable."),
-                label="steer:error",
-            )
-        return result.exit_code
-
+Lifecycle = RunIdentity
+Controller = SteerController
+Renderer = StatusRenderer
+StableEmit = SharedStableEmit
+TraceFn = SharedTraceFn
 
 __all__ = ["SteerHandler"]

--- a/src/loushang/harnesstui/conversation/control.py
+++ b/src/loushang/harnesstui/conversation/control.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from loushang.harnesstui.conversation.run_context import StableEmit, TraceFn
+
+
+class ActionResult(Protocol):
+    """Product-neutral result facts returned by a conversation action."""
+
+    @property
+    def exit_code(self) -> int | None: ...
+
+    @property
+    def error_message(self) -> str | None: ...
+
+
+class RunControl(Protocol):
+    active: bool
+    active_id: int
+    aborted_id: int | None
+
+    def mark_abort_requested(self) -> None: ...
+
+
+class ActiveRunControl(Protocol):
+    active: bool
+    active_id: int
+
+
+class RunIdentity(Protocol):
+    active_id: int
+
+
+class SteerController(Protocol):
+    async def steer(self, text: str) -> ActionResult: ...
+
+
+class FollowUpController(Protocol):
+    async def follow_up(self, text: str) -> ActionResult: ...
+
+
+class InterruptionRenderer(Protocol):
+    def render_interruption(self) -> None: ...
+
+
+class StatusRenderer(Protocol):
+    def render_status(self, text: str) -> None: ...
+
+
+@dataclass
+class ConversationRunControl:
+    """Track one product-neutral, in-memory conversation UI action run.
+
+    This state coordinates transient input and presentation behavior. It is not
+    a Harness Session lifecycle, durable state, or runtime owner.
+    """
+
+    active: bool = False
+    active_id: int = 0
+    aborted_id: int | None = None
+
+    def begin_work(self) -> int:
+        self.active = True
+        self.active_id += 1
+        return self.active_id
+
+    def end_work(self) -> None:
+        self.active = False
+
+    def mark_abort_requested(self) -> None:
+        if self.active:
+            self.aborted_id = self.active_id
+
+    def abort_is_settling(self) -> bool:
+        return self.active and self.aborted_id == self.active_id
+
+    def clear_aborted(self, run_id: int) -> None:
+        if self.aborted_id == run_id:
+            self.aborted_id = None
+
+    def visible_running(self, *, session_running: bool) -> bool:
+        return self.active or session_running
+
+
+class AbortActionHandler:
+    """Coordinate transient abort presentation around a supplied action."""
+
+    def __init__(
+        self,
+        *,
+        run_control: RunControl,
+        abort_action: Callable[[], Awaitable[Any]],
+        renderer: InterruptionRenderer,
+        emit: StableEmit,
+        session_running: Callable[[], bool],
+        trace: TraceFn,
+    ) -> None:
+        self._run_control = run_control
+        self._abort_action = abort_action
+        self._renderer = renderer
+        self._emit = emit
+        self._session_running = session_running
+        self._trace = trace
+
+    async def abort(self) -> None:
+        self._trace(
+            "abort.start",
+            active_run=self._run_control.active,
+            active_run_id=self._run_control.active_id,
+            aborted_run_id=self._run_control.aborted_id,
+            session_running=self._session_running(),
+        )
+        self._run_control.mark_abort_requested()
+        await self._emit(
+            self._renderer.render_interruption,
+            label="abort:interruption",
+        )
+        await self._abort_action()
+        self._trace(
+            "abort.end",
+            active_run=self._run_control.active,
+            active_run_id=self._run_control.active_id,
+            aborted_run_id=self._run_control.aborted_id,
+            session_running=self._session_running(),
+        )
+
+
+class SteerActionHandler:
+    """Dispatch steering text and present a caller-supplied action error."""
+
+    def __init__(
+        self,
+        *,
+        lifecycle: RunIdentity,
+        controller: SteerController,
+        renderer: StatusRenderer,
+        emit: StableEmit,
+        trace: TraceFn,
+    ) -> None:
+        # ``_lifecycle`` remains available for Coding's historical private API.
+        self._lifecycle = lifecycle
+        self._run_control = lifecycle
+        self._controller = controller
+        self._renderer = renderer
+        self._emit = emit
+        self._trace = trace
+
+    async def steer(self, text: str) -> int | None:
+        self._trace(
+            "prompt.steer.start",
+            active_run_id=self._run_control.active_id,
+        )
+        result = await self._controller.steer(text)
+        error_message = result.error_message
+        self._trace(
+            "prompt.steer.end",
+            error_message=error_message,
+            exit_code=result.exit_code,
+        )
+        if error_message:
+            await self._emit(
+                lambda: self._renderer.render_status(error_message),
+                label="steer:error",
+            )
+        return result.exit_code
+
+
+class FollowUpActionHandler:
+    """Validate, dispatch, and present a queued follow-up action."""
+
+    def __init__(
+        self,
+        *,
+        lifecycle: ActiveRunControl,
+        controller: FollowUpController,
+        renderer: StatusRenderer,
+        emit: StableEmit,
+        trace: TraceFn,
+        idle_status_message: str,
+        queued_status_message: str,
+    ) -> None:
+        # ``_lifecycle`` remains available for Coding's historical private API.
+        self._lifecycle = lifecycle
+        self._run_control = lifecycle
+        self._controller = controller
+        self._renderer = renderer
+        self._emit = emit
+        self._trace = trace
+        self._idle_status_message = idle_status_message
+        self._queued_status_message = queued_status_message
+
+    async def queue(self, text: str, *, source: str) -> int | None:
+        follow_text = text.strip()
+        self._trace(
+            "prompt.follow_up.start",
+            active_run_id=self._run_control.active_id,
+            active_run=self._run_control.active,
+            source=source,
+            text_len=len(follow_text),
+        )
+        if not follow_text:
+            self._trace(
+                "prompt.follow_up.ignored",
+                reason="empty",
+                source=source,
+            )
+            return None
+        if not self._run_control.active:
+            await self._emit(
+                lambda: self._renderer.render_status(self._idle_status_message),
+                label="follow_up:idle",
+            )
+            return None
+
+        result = await self._controller.follow_up(follow_text)
+        error_message = result.error_message
+        self._trace(
+            "prompt.follow_up.end",
+            error_message=error_message,
+            exit_code=result.exit_code,
+            source=source,
+        )
+        if error_message:
+            await self._emit(
+                lambda: self._renderer.render_status(error_message),
+                label="follow_up:error",
+            )
+        else:
+            await self._emit(
+                lambda: self._renderer.render_status(self._queued_status_message),
+                label="follow_up:queued",
+            )
+        return result.exit_code
+
+
+__all__ = [
+    "AbortActionHandler",
+    "ActionResult",
+    "ActiveRunControl",
+    "ConversationRunControl",
+    "FollowUpActionHandler",
+    "FollowUpController",
+    "InterruptionRenderer",
+    "RunControl",
+    "RunIdentity",
+    "StableEmit",
+    "StatusRenderer",
+    "SteerActionHandler",
+    "SteerController",
+    "TraceFn",
+]

--- a/src/loushang/harnesstui/conversation/dispatch.py
+++ b/src/loushang/harnesstui/conversation/dispatch.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Generic, Protocol, TextIO, TypeVar
+
+from loushang.harnesstui.conversation.run_context import StableEmit, TraceFn
+
+
+class DispatchResult(Protocol):
+    """Product-neutral facts returned by a conversation dispatcher."""
+
+    @property
+    def exit_code(self) -> int | None: ...
+
+    @property
+    def error_message(self) -> str | None: ...
+
+    @property
+    def status_message(self) -> str | None: ...
+
+    @property
+    def traceback_text(self) -> str | None: ...
+
+
+class DispatchLifecycle(Protocol):
+    active: bool
+
+    def begin_work(self) -> int: ...
+
+    def end_work(self) -> None: ...
+
+
+IntentT = TypeVar("IntentT")
+IntentT_contra = TypeVar("IntentT_contra", contravariant=True)
+
+
+class DispatchController(Protocol[IntentT_contra]):
+    async def dispatch(self, intent: IntentT_contra) -> DispatchResult: ...
+
+
+@dataclass(frozen=True)
+class ConversationDispatchOutcome:
+    """Record neutral result and interaction-run facts for one dispatch."""
+
+    result: DispatchResult
+    run_id: int | None
+    work_intent: bool
+    started_at: float
+
+
+class ConversationDispatchHandler(Generic[IntentT]):
+    """Bracket product-classified work with shared interaction control."""
+
+    def __init__(
+        self,
+        *,
+        lifecycle: DispatchLifecycle,
+        controller: DispatchController[IntentT],
+        is_work_intent: Callable[[IntentT], bool],
+        session_running: Callable[[], object],
+        now: Callable[[], float] = time.monotonic,
+        trace: TraceFn,
+    ) -> None:
+        self._lifecycle = lifecycle
+        self._controller = controller
+        self._is_work_intent = is_work_intent
+        self._session_running = session_running
+        self._now = now
+        self._trace = trace
+
+    async def dispatch(self, intent: IntentT) -> ConversationDispatchOutcome:
+        work_intent = self._is_work_intent(intent)
+        started_at = self._now()
+        run_id: int | None = None
+        if work_intent:
+            run_id = self._lifecycle.begin_work()
+        self._trace(
+            "prompt.dispatch.start",
+            intent=type(intent).__name__,
+            work_intent=work_intent,
+            run_id=run_id,
+        )
+        try:
+            result = await self._controller.dispatch(intent)
+        finally:
+            if work_intent:
+                self._lifecycle.end_work()
+            self._trace(
+                "prompt.dispatch.end",
+                run_id=run_id,
+                active_run=self._lifecycle.active,
+                session_running=bool(self._session_running()),
+            )
+        return ConversationDispatchOutcome(
+            result=result,
+            run_id=run_id,
+            work_intent=work_intent,
+            started_at=started_at,
+        )
+
+
+class ResultRenderer(Protocol):
+    def render_status(self, text: str) -> None: ...
+
+    def render_error(self, text: str) -> None: ...
+
+    def render_worked(self, elapsed_seconds: float) -> None: ...
+
+
+class ConversationResultPresenter:
+    """Present neutral dispatch facts through a supplied stable emitter."""
+
+    def __init__(
+        self,
+        *,
+        renderer: ResultRenderer,
+        emit: StableEmit,
+        stderr: TextIO,
+        verbose: bool,
+        last_error_message: Callable[[], str | None],
+        now: Callable[[], float],
+        trace: TraceFn,
+    ) -> None:
+        self._renderer = renderer
+        self._emit = emit
+        self._stderr = stderr
+        self._verbose = verbose
+        self._last_error_message = last_error_message
+        self._now = now
+        self._trace = trace
+
+    async def handle(
+        self,
+        outcome: ConversationDispatchOutcome,
+        *,
+        prompt_started: float,
+        error_message: str | None,
+    ) -> int | None:
+        result = outcome.result
+        if error_message:
+            if self._last_error_message() != error_message:
+                await self._emit(
+                    lambda: self._renderer.render_error(error_message),
+                    label="prompt:error",
+                )
+            if self._verbose and result.traceback_text:
+                self._stderr.write(result.traceback_text)
+                self._stderr.flush()
+        elif result.status_message:
+            await self._emit(
+                lambda: self._renderer.render_status(result.status_message or ""),
+                label="prompt:status",
+            )
+        elif outcome.work_intent and result.exit_code is None:
+            await self._emit(
+                lambda: self._renderer.render_worked(
+                    self._now() - outcome.started_at
+                ),
+                label="prompt:worked",
+            )
+
+        self._trace(
+            "prompt.end",
+            run_id=outcome.run_id,
+            exit_code=result.exit_code,
+            error_message=error_message,
+            elapsed_s=self._now() - prompt_started,
+        )
+        return result.exit_code
+
+
+EventT = TypeVar("EventT")
+EventT_contra = TypeVar("EventT_contra", contravariant=True)
+
+
+class EventRenderer(Protocol[EventT_contra]):
+    def handle(self, event: EventT_contra) -> None: ...
+
+
+class StableEventStreamHandler(Generic[EventT]):
+    """Route caller-selected events through a stable emit boundary."""
+
+    def __init__(
+        self,
+        *,
+        renderer: EventRenderer[EventT],
+        emit: StableEmit,
+        writes_stably: Callable[[EventT], bool],
+        event_type: Callable[[EventT], str],
+        trace: TraceFn,
+    ) -> None:
+        self._renderer = renderer
+        self._emit = emit
+        self._writes_stably = writes_stably
+        self._event_type = event_type
+        self._trace = trace
+
+    async def handle(self, event: EventT) -> None:
+        event_type = self._event_type(event)
+        self._trace("event.start", event_type=event_type)
+        try:
+            if not self._writes_stably(event):
+                self._renderer.handle(event)
+                return
+            await self._emit(
+                lambda: self._renderer.handle(event),
+                label=f"event:{event_type}",
+            )
+        finally:
+            self._trace("event.end", event_type=event_type)
+
+
+__all__ = [
+    "ConversationDispatchHandler",
+    "ConversationDispatchOutcome",
+    "ConversationResultPresenter",
+    "DispatchController",
+    "DispatchLifecycle",
+    "DispatchResult",
+    "EventRenderer",
+    "ResultRenderer",
+    "StableEmit",
+    "StableEventStreamHandler",
+    "TraceFn",
+]

--- a/src/loushang/harnesstui/conversation/input.py
+++ b/src/loushang/harnesstui/conversation/input.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Literal, Protocol
+
+from loushang.harnesstui.conversation.attachments import (
+    PendingPromptImageRegistry,
+    PromptImageAttachment,
+    PromptImageAttachmentOutcome,
+)
+from loushang.harnesstui.conversation.screen_state import ScreenConversationState
+from loushang.tui import Composer, SurfaceHost
+from loushang.tui.input import (
+    ComposerInputTarget,
+    InputEvent,
+    InputIntent,
+    route_editor_editing_key,
+    route_editor_selection_key,
+    route_prompt_completion_key,
+)
+from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
+
+RunningSubmitMode = Literal["steer", "follow_up"]
+PromptImageAttachmentStager = Callable[[], PromptImageAttachmentOutcome]
+
+
+class ConversationScreenInputPort(Protocol):
+    """Minimal screen-conversation surface needed by the input router."""
+
+    composer: Composer
+    state: ScreenConversationState
+    active_surface: object | None
+    surface_host: SurfaceHost | None
+
+    def open_transcript_reader(self) -> bool: ...
+
+    def start_prompt(self, text: str) -> None: ...
+
+    def queue_followup(self, text: str) -> None: ...
+
+    def queue_steer(self, text: str) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationInputResult:
+    """Product-neutral outcome of routing one conversation input event."""
+
+    prompt_text: str | None = None
+    prompt_attachments: tuple[PromptImageAttachment, ...] | None = None
+    local_text: str | None = None
+    steer_text: str | None = None
+    steer_attachments: tuple[PromptImageAttachment, ...] | None = None
+    followup_text: str | None = None
+    followup_attachments: tuple[PromptImageAttachment, ...] | None = None
+    surface_intent: InputIntent | None = None
+    clipboard_outcome: PromptImageAttachmentOutcome | None = None
+    abort_requested: bool = False
+    exit_code: int | None = None
+    render_requested: bool = True
+
+
+@dataclass(slots=True)
+class ConversationInputRouter:
+    """Route terminal input through surfaces and a conversation composer."""
+
+    app: ConversationScreenInputPort
+    should_exit: Callable[[str], bool]
+    is_local_command: Callable[[str], bool] = lambda _text: False
+    keybindings: KeybindingManager | KeybindingConfig | None = None
+    running_submit_mode: RunningSubmitMode = "steer"
+    follow_up_keys: tuple[str, ...] = ("alt+enter",)
+    width: int = 80
+    height: int = 12
+    prompt_image_stager: PromptImageAttachmentStager | None = None
+    _jump_mode: Literal["forward", "backward"] | None = None
+    _pending_prompt_images: PendingPromptImageRegistry = field(
+        default_factory=PendingPromptImageRegistry,
+        init=False,
+        repr=False,
+    )
+    _composer_target: ComposerInputTarget = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.keybindings, KeybindingManager):
+            self.keybindings = KeybindingManager(self.keybindings)
+        self._composer_target = ComposerInputTarget(self.app.composer)
+
+    def replace_app(self, app: ConversationScreenInputPort) -> None:
+        """Rebind the router and its composer target to another screen port."""
+
+        self.app = app
+        self._composer_target = ComposerInputTarget(app.composer)
+
+    def handle(self, event: InputEvent) -> ConversationInputResult:
+        if event.kind == "key" and event.event_type == "release":
+            return ConversationInputResult(render_requested=False)
+        if self._runtime_surface_active():
+            return self._route_runtime_surface(event)
+        if self.app.active_surface is not None:
+            return self._route_active_surface(event)
+        if event.kind == "text":
+            if self._jump_mode is not None:
+                self.app.composer.jump_to_char(
+                    event.text,
+                    direction=self._jump_mode,
+                )
+                self._jump_mode = None
+                return ConversationInputResult()
+            self.app.composer.insert_text(event.text)
+            return ConversationInputResult()
+        if event.kind == "paste":
+            self._jump_mode = None
+            self.app.composer.paste(event.text)
+            return ConversationInputResult()
+        if event.kind == "resize":
+            if event.columns:
+                self.width = event.columns
+            if event.rows:
+                self.height = event.rows
+            return ConversationInputResult()
+        if event.kind != "key":
+            return ConversationInputResult(render_requested=False)
+
+        keybindings = self._keybindings()
+        if self._jump_mode is not None:
+            if keybindings.matches(
+                event.key,
+                "tui.editor.jumpForward",
+            ) or keybindings.matches(
+                event.key,
+                "tui.editor.jumpBackward",
+            ):
+                self._jump_mode = None
+                return ConversationInputResult()
+            self._jump_mode = None
+        if keybindings.matches(event.key, "tui.queue.editLast"):
+            self._restore_queued_messages()
+            return ConversationInputResult()
+        if keybindings.matches(event.key, "tui.transcript.open"):
+            return ConversationInputResult(
+                render_requested=self.app.open_transcript_reader()
+            )
+        if route_editor_selection_key(
+            self._composer_target,
+            event.key,
+            keybindings=keybindings,
+        ):
+            return ConversationInputResult()
+        if self.app.composer.has_completions and keybindings.matches(
+            event.key,
+            "tui.input.submit",
+        ):
+            return self._submit_selected_completion()
+        if self.app.composer.has_completions and self._route_completion_key(
+            event,
+            keybindings,
+        ):
+            return ConversationInputResult()
+        if keybindings.matches(event.key, "tui.select.cancel"):
+            return self._abort_or_clear()
+        if keybindings.matches(event.key, "tui.input.tab"):
+            self.app.composer.refresh_completions(force=True, explicit=True)
+            if self.app.composer.has_completions:
+                self.app.composer.apply_selected_completion()
+            return ConversationInputResult()
+        if keybindings.matches(event.key, "app.clipboard.pasteImage"):
+            return self._paste_clipboard_image()
+        if keybindings.matches(event.key, "tui.editor.jumpForward"):
+            self._jump_mode = "forward"
+            return ConversationInputResult()
+        if keybindings.matches(event.key, "tui.editor.jumpBackward"):
+            self._jump_mode = "backward"
+            return ConversationInputResult()
+        if keybindings.matches(event.key, "tui.editor.cursorUp"):
+            if self.app.composer.browsing_history:
+                self.app.composer.history_previous()
+            elif (
+                not self.app.composer.value
+                or not self.app.composer.move_visual_up(width=self.width)
+            ):
+                self.app.composer.history_previous()
+            return ConversationInputResult()
+        if keybindings.matches(event.key, "tui.editor.cursorDown"):
+            if self.app.composer.browsing_history:
+                self.app.composer.history_next()
+            elif (
+                not self.app.composer.value
+                or not self.app.composer.move_visual_down(width=self.width)
+            ):
+                self.app.composer.history_next()
+            return ConversationInputResult()
+        if keybindings.matches(event.key, "tui.editor.pageUp"):
+            self.app.composer.move_visual_page_up(
+                width=self.width,
+                visible_lines=self._composer_page_lines(),
+            )
+            return ConversationInputResult()
+        if keybindings.matches(event.key, "tui.editor.pageDown"):
+            self.app.composer.move_visual_page_down(
+                width=self.width,
+                visible_lines=self._composer_page_lines(),
+            )
+            return ConversationInputResult()
+        if self.app.state.running and event.key in self.follow_up_keys:
+            return self._submit_running(mode="follow_up")
+        if keybindings.matches(event.key, "tui.input.newLine"):
+            self.app.composer.insert_newline()
+            return ConversationInputResult()
+        if keybindings.matches(event.key, "tui.input.submit"):
+            return self._submit()
+        if route_editor_editing_key(
+            self._composer_target,
+            event.key,
+            keybindings=keybindings,
+        ):
+            return ConversationInputResult()
+        return ConversationInputResult(render_requested=False)
+
+    def _route_completion_key(
+        self,
+        event: InputEvent,
+        keybindings: KeybindingManager,
+    ) -> bool:
+        return route_prompt_completion_key(
+            self._composer_target,
+            event.key,
+            keybindings=keybindings,
+        )
+
+    def _submit_selected_completion(self) -> ConversationInputResult:
+        should_submit_after_completion = self.app.composer.value.lstrip().startswith(
+            "/"
+        )
+        self.app.composer.apply_selected_completion()
+        if should_submit_after_completion:
+            return self._submit()
+        return ConversationInputResult()
+
+    def _abort_or_clear(self) -> ConversationInputResult:
+        if self.app.state.running:
+            return ConversationInputResult(abort_requested=True)
+        if self.app.state.pending_steers:
+            pending_steer = self.app.state.pending_steers.pop(0)
+            return ConversationInputResult(steer_text=pending_steer)
+        if self.app.composer.value:
+            self.app.composer.clear()
+            self._clear_prompt_attachments()
+            return ConversationInputResult()
+        return ConversationInputResult(render_requested=False)
+
+    def _restore_queued_messages(self) -> None:
+        text = self.app.state.restore_queued_to_text()
+        if text:
+            self.app.composer.set_text(text)
+
+    def _submit(self) -> ConversationInputResult:
+        text = self.app.composer.value
+        if not text.strip():
+            return ConversationInputResult(render_requested=False)
+        if self.should_exit(text.strip()):
+            self.app.composer.clear()
+            self._clear_prompt_attachments()
+            return ConversationInputResult(exit_code=0)
+        if self.app.state.running:
+            return self._submit_running(mode=self.running_submit_mode)
+        if self.is_local_command(text.strip()):
+            self.app.composer.clear()
+            self._clear_prompt_attachments()
+            return ConversationInputResult(local_text=text.strip())
+        attachments = self._prompt_attachments_for_text(text)
+        self.app.start_prompt(text)
+        self._clear_prompt_attachments()
+        return ConversationInputResult(
+            prompt_text=text,
+            prompt_attachments=attachments,
+        )
+
+    def _submit_running(
+        self,
+        *,
+        mode: RunningSubmitMode,
+    ) -> ConversationInputResult:
+        text = self.app.composer.value
+        if not text.strip():
+            return ConversationInputResult(render_requested=False)
+        attachments = self._prompt_attachments_for_text(text)
+        self.app.composer.add_history(text)
+        self.app.composer.clear()
+        self._clear_prompt_attachments()
+        if mode == "follow_up":
+            self.app.queue_followup(text)
+            return ConversationInputResult(
+                followup_text=text,
+                followup_attachments=attachments,
+            )
+        self.app.queue_steer(text)
+        return ConversationInputResult(
+            steer_text=text,
+            steer_attachments=attachments,
+        )
+
+    def _keybindings(self) -> KeybindingManager:
+        if isinstance(self.keybindings, KeybindingManager):
+            return self.keybindings
+        return KeybindingManager(self.keybindings)
+
+    def _composer_page_lines(self) -> int:
+        return max(2, min(10, self.height))
+
+    def _route_active_surface(self, event: InputEvent) -> ConversationInputResult:
+        handler = getattr(self.app.active_surface, "handle_input", None)
+        if not callable(handler):
+            return ConversationInputResult(render_requested=False)
+        intent = handler(event)
+        if isinstance(intent, InputIntent):
+            if intent.kind == "consumed":
+                return ConversationInputResult()
+            return ConversationInputResult(surface_intent=intent)
+        return ConversationInputResult()
+
+    def _runtime_surface_active(self) -> bool:
+        surface_host = self.app.surface_host
+        return surface_host is not None and bool(surface_host.entries)
+
+    def _route_runtime_surface(
+        self,
+        event: InputEvent,
+    ) -> ConversationInputResult:
+        surface_host = self.app.surface_host
+        if surface_host is None:
+            return ConversationInputResult(render_requested=False)
+        intents = surface_host.route_input(
+            event,
+            close_on_intents=("surface_close", "dialog_cancel"),
+        )
+        for intent in intents:
+            if isinstance(intent, InputIntent):
+                if intent.kind == "consumed":
+                    return ConversationInputResult()
+                return ConversationInputResult(surface_intent=intent)
+        return ConversationInputResult()
+
+    def _paste_clipboard_image(self) -> ConversationInputResult:
+        if self.prompt_image_stager is None:
+            return ConversationInputResult(render_requested=False)
+        outcome = self.prompt_image_stager()
+        attachment = outcome.attachment
+        if outcome.kind != "attached":
+            return ConversationInputResult(clipboard_outcome=outcome)
+        if attachment is None:
+            raise RuntimeError("attached clipboard outcome requires an attachment")
+        self.app.composer.paste(f"{attachment.marker} ")
+        self._pending_prompt_images.add(attachment)
+        return ConversationInputResult(clipboard_outcome=outcome)
+
+    def _prompt_attachments_for_text(
+        self,
+        text: str,
+    ) -> tuple[PromptImageAttachment, ...] | None:
+        attachments = self._pending_prompt_images.select_for_text(text)
+        return attachments or None
+
+    def _clear_prompt_attachments(self) -> None:
+        self._pending_prompt_images.clear()
+
+
+__all__ = [
+    "ConversationInputResult",
+    "ConversationInputRouter",
+    "ConversationScreenInputPort",
+    "PromptImageAttachmentStager",
+    "RunningSubmitMode",
+]

--- a/src/loushang/harnesstui/conversation/run_context.py
+++ b/src/loushang/harnesstui/conversation/run_context.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+class TraceFn(Protocol):
+    """Trace one interaction lifecycle fact."""
+
+    def __call__(self, name: str, **data: Any) -> None: ...
+
+
+class StableEmit(Protocol):
+    """Emit one terminal write through the caller's stable-write boundary."""
+
+    def __call__(
+        self,
+        write_callable: Callable[[], None],
+        *,
+        label: str,
+    ) -> Awaitable[None]: ...
+
+
+class ExitContext(Protocol):
+    """Minimal context-manager exit hook owned by a product adapter."""
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc: object,
+        traceback: object,
+    ) -> object: ...
+
+
+@dataclass
+class InteractionRunContext:
+    """Own close ordering for one product-neutral terminal interaction run.
+
+    The injected exit context may represent observability or another
+    product-owned resource. This object coordinates only terminal interaction
+    cleanup; it does not create Sessions or persist conversation state.
+    """
+
+    emit: StableEmit
+    _unsubscribe: Callable[[], None]
+    _exit_context: ExitContext
+    _trace: TraceFn
+    _closed: bool = False
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            try:
+                self._trace("tui.end")
+            finally:
+                self._unsubscribe()
+        finally:
+            self._exit_context.__exit__(None, None, None)
+
+
+def subscribe_events(source: object, listener: object) -> Callable[[], None]:
+    """Subscribe when supported and always return a safe unsubscribe hook."""
+
+    subscribe = getattr(source, "subscribe", None)
+    if callable(subscribe):
+        unsubscribe = subscribe(listener)
+        if callable(unsubscribe):
+            return unsubscribe
+    return lambda: None
+
+
+def stable_emit_factory(*, trace: TraceFn, interactive: bool) -> StableEmit:
+    """Create a traced stable terminal-write boundary."""
+
+    async def emit(write_callable: Callable[[], None], *, label: str) -> None:
+        started = time.monotonic()
+        trace("emit.start", label=label, interactive=interactive)
+        try:
+            write_callable()
+        except Exception as error:
+            trace(
+                "emit.error",
+                label=label,
+                elapsed_s=time.monotonic() - started,
+                error=str(error) or error.__class__.__name__,
+            )
+            raise
+        trace("emit.end", label=label, elapsed_s=time.monotonic() - started)
+
+    return emit
+
+
+__all__ = [
+    "ExitContext",
+    "InteractionRunContext",
+    "StableEmit",
+    "TraceFn",
+    "stable_emit_factory",
+    "subscribe_events",
+]

--- a/src/loushang/harnesstui/conversation/screen_runner.py
+++ b/src/loushang/harnesstui/conversation/screen_runner.py
@@ -1,0 +1,556 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import shutil
+from collections.abc import Awaitable, Callable
+from contextlib import AbstractContextManager, suppress
+from typing import Any, Protocol, TextIO
+
+from loushang.harnesstui.conversation.input import (
+    ConversationInputRouter,
+    ConversationScreenInputPort,
+)
+from loushang.tui import _runner_utils
+from loushang.tui.core import RenderConstraints, RenderResult
+from loushang.tui.framework import SurfaceHost
+from loushang.tui.input import InputEvent, InputIntent, InputReader
+from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
+from loushang.tui.render_loop import RenderLoop
+from loushang.tui.runtime import TuiRuntime
+from loushang.tui.scheduler import RenderRequestKind
+from loushang.tui.terminal import ProcessTerminalPort, TerminalSize
+from loushang.tui.terminal_capabilities import TerminalRuntimeCapabilities
+from loushang.tui.terminal_diagnostics import format_terminal_diagnostics
+from loushang.tui.terminal_input import read_input_chunk_or_render_tick
+from loushang.tui.terminal_session import TerminalSession
+
+HandlerResult = Awaitable[int | None] | int | None
+PromptHandler = Callable[..., HandlerResult]
+TextHandler = Callable[..., HandlerResult]
+SurfaceIntentHandler = Callable[[InputIntent], HandlerResult]
+AbortHandler = Callable[[], Awaitable[object] | object]
+ShouldExit = Callable[[str], bool]
+LocalCommandPredicate = Callable[[str], bool]
+TerminalModeFactory = Callable[[TextIO, TextIO], AbstractContextManager[object]]
+TerminalSizeProvider = Callable[[], TerminalSize]
+
+
+class ConversationRenderablePort(Protocol):
+    """Renderable content returned by a conversation screen."""
+
+    def render(self, constraints: RenderConstraints) -> RenderResult: ...
+
+
+class ConversationScreenPort(ConversationScreenInputPort, Protocol):
+    """Screen application capabilities required by the shared runner."""
+
+    render_requester: Callable[[RenderRequestKind], object] | None
+    terminal_diagnostics_provider: Callable[[], str] | None
+    terminal_capabilities: TerminalRuntimeCapabilities | None
+    surface_host: SurfaceHost | None
+
+    @property
+    def now(self) -> Callable[[], float]: ...
+
+    def render(self, constraints: RenderConstraints) -> RenderResult: ...
+
+    def startup_welcome_panel(self) -> ConversationRenderablePort: ...
+
+    def start_pending_prompt(self, text: str) -> None: ...
+
+    def add_error(self, summary: str, diagnostics: str = "") -> None: ...
+
+    def complete_run(self, *, elapsed_seconds: float | None = None) -> None: ...
+
+    def elapsed_seconds(self) -> float: ...
+
+
+class ConversationInputResultPort(Protocol):
+    """Neutral routed action consumed by a conversation screen runner."""
+
+    @property
+    def prompt_text(self) -> str | None: ...
+
+    @property
+    def prompt_attachments(self) -> tuple[object, ...] | None: ...
+
+    @property
+    def local_text(self) -> str | None: ...
+
+    @property
+    def steer_text(self) -> str | None: ...
+
+    @property
+    def steer_attachments(self) -> tuple[object, ...] | None: ...
+
+    @property
+    def followup_text(self) -> str | None: ...
+
+    @property
+    def followup_attachments(self) -> tuple[object, ...] | None: ...
+
+    @property
+    def surface_intent(self) -> InputIntent | None: ...
+
+    @property
+    def abort_requested(self) -> bool: ...
+
+    @property
+    def exit_code(self) -> int | None: ...
+
+    @property
+    def render_requested(self) -> bool: ...
+
+
+class ConversationInputRouterPort(Protocol):
+    """Route one decoded terminal input event to a neutral action."""
+
+    def handle(self, event: InputEvent) -> ConversationInputResultPort: ...
+
+
+class ConversationInputRouterFactoryPort(Protocol):
+    """Construct the product's conversation input adapter."""
+
+    def __call__(
+        self,
+        *,
+        app: ConversationScreenPort,
+        should_exit: ShouldExit,
+        is_local_command: LocalCommandPredicate,
+        keybindings: KeybindingManager | KeybindingConfig | None,
+        width: int,
+        height: int,
+    ) -> ConversationInputRouterPort: ...
+
+
+_finish_tui_exit = _runner_utils.finish_tui_exit
+_flush_pending_input = _runner_utils.flush_pending_input
+_input_events_for_chunk = _runner_utils.input_events_for_chunk
+_poll_terminal_runtime = _runner_utils.poll_terminal_runtime
+_request_runtime_render = _runner_utils.request_runtime_render
+_terminal_runtime_wakeup_ms = _runner_utils.terminal_runtime_wakeup_ms
+
+
+async def run_conversation_screen(
+    *,
+    app: ConversationScreenPort,
+    stdin: TextIO,
+    stdout: TextIO,
+    handle_prompt: PromptHandler,
+    handle_local: TextHandler | None = None,
+    handle_steer: TextHandler | None = None,
+    handle_followup: TextHandler | None = None,
+    handle_surface_intent: SurfaceIntentHandler | None = None,
+    on_abort: AbortHandler,
+    should_exit: ShouldExit,
+    is_local_command: LocalCommandPredicate | None = None,
+    keybindings: KeybindingManager | KeybindingConfig | None = None,
+    terminal_mode_factory: TerminalModeFactory | None = None,
+    terminal_size_provider: TerminalSizeProvider | None = None,
+    interruption_message: str,
+    cancellation_message: str,
+    input_router_factory: ConversationInputRouterFactoryPort | None = None,
+) -> int:
+    """Run one product-neutral interactive conversation screen.
+
+    The application and handlers supply presentation and product policy. This
+    runner owns terminal polling, routed interaction, task coordination, and
+    render scheduling. It does not own a Harness Session or conversation
+    storage.
+    """
+
+    reader = InputReader()
+    size_provider = terminal_size_provider or terminal_size
+    initial_size = size_provider()
+    local_predicate = is_local_command or (lambda _text: False)
+    if input_router_factory is None:
+        router: ConversationInputRouterPort = ConversationInputRouter(
+            app=app,
+            should_exit=should_exit,
+            is_local_command=local_predicate,
+            keybindings=keybindings,
+            width=initial_size.columns,
+            height=initial_size.rows,
+        )
+    else:
+        router = input_router_factory(
+            app=app,
+            should_exit=should_exit,
+            is_local_command=local_predicate,
+            keybindings=keybindings,
+            width=initial_size.columns,
+            height=initial_size.rows,
+        )
+    runtime = TuiRuntime(
+        render_loop=RenderLoop(app),
+        terminal=ProcessTerminalPort(
+            output=stdout,
+            size_provider=size_provider,
+            track_screen=False,
+        ),
+    )
+    app.surface_host = runtime.overlay_host()
+    mode_factory = terminal_mode_factory or (
+        lambda input_stream, output_stream: TerminalSession(
+            stdin=input_stream,
+            stdout=output_stream,
+        )
+    )
+    active_task: asyncio.Task[int | None] | None = None
+    active_prompt_started_at: float | None = None
+    render_wakeup = asyncio.Event()
+    previous_render_requester = app.render_requester
+    previous_terminal_diagnostics_provider = app.terminal_diagnostics_provider
+    previous_terminal_capabilities = app.terminal_capabilities
+
+    def request_app_render(kind: RenderRequestKind) -> None:
+        if previous_render_requester is not None:
+            previous_render_requester(kind)
+        runtime.request_render(kind)
+        render_wakeup.set()
+
+    app.render_requester = request_app_render
+    try:
+        with mode_factory(stdin, stdout) as terminal_context:
+            app.terminal_diagnostics_provider = (
+                lambda context=terminal_context: format_terminal_diagnostics(context)
+            )
+            configure_runtime_for_terminal_context(runtime, app, terminal_context)
+            write_startup_welcome(app=app, runtime=runtime, stdout=stdout)
+            runtime.render_now()
+            while True:
+                if active_task is not None and active_task.done():
+                    exit_code = await finish_active_task(
+                        app=app,
+                        active_task=active_task,
+                        started_at=active_prompt_started_at,
+                        cancellation_message=cancellation_message,
+                    )
+                    active_task = None
+                    active_prompt_started_at = None
+                    runtime.render_now()
+                    if exit_code is not None:
+                        return _finish_tui_exit(
+                            runtime=runtime,
+                            stdout=stdout,
+                            exit_code=exit_code,
+                        )
+
+                data = await read_input_chunk_or_render_tick(
+                    stdin,
+                    runtime=runtime,
+                    active_task=active_task,
+                    render_wakeup=render_wakeup,
+                    pending_input_idle_ms=10 if reader.has_pending else None,
+                    idle_wakeup_ms=_terminal_runtime_wakeup_ms(terminal_context),
+                )
+                input_events: tuple[Any, ...]
+                if data is None:
+                    _poll_terminal_runtime(terminal_context)
+                    if not reader.has_pending:
+                        continue
+                    input_events = _flush_pending_input(
+                        reader,
+                        terminal_context=terminal_context,
+                    )
+                elif data == "" and reader.has_pending:
+                    input_events = _flush_pending_input(
+                        reader,
+                        terminal_context=terminal_context,
+                    )
+                elif data == "":
+                    if active_task is not None:
+                        exit_code = await finish_active_task(
+                            app=app,
+                            active_task=active_task,
+                            started_at=active_prompt_started_at,
+                            cancellation_message=cancellation_message,
+                        )
+                        runtime.render_now()
+                        return _finish_tui_exit(
+                            runtime=runtime,
+                            stdout=stdout,
+                            exit_code=exit_code if exit_code is not None else 0,
+                        )
+                    runtime.render_now()
+                    return _finish_tui_exit(
+                        runtime=runtime,
+                        stdout=stdout,
+                        exit_code=0,
+                    )
+                else:
+                    input_events = _input_events_for_chunk(
+                        reader,
+                        data,
+                        terminal_context=terminal_context,
+                    )
+
+                for event in input_events:
+                    result = router.handle(event)
+                    if result.exit_code is not None:
+                        runtime.render_now()
+                        return _finish_tui_exit(
+                            runtime=runtime,
+                            stdout=stdout,
+                            exit_code=result.exit_code,
+                        )
+                    if result.abort_requested:
+                        interrupt_pending_steer = pop_interrupt_pending_steer(app)
+                        await abort_active(
+                            app=app,
+                            active_task=active_task,
+                            on_abort=on_abort,
+                            interruption_message=interruption_message,
+                        )
+                        active_task = None
+                        active_prompt_started_at = None
+                        runtime.render_now()
+                        if interrupt_pending_steer is not None:
+                            app.start_pending_prompt(interrupt_pending_steer)
+                            active_task = asyncio.create_task(
+                                run_prompt_handler(
+                                    handle_prompt,
+                                    interrupt_pending_steer,
+                                )
+                            )
+                            active_prompt_started_at = app.state.active_started_at
+                            runtime.render_now()
+                        continue
+                    if result.prompt_text is not None:
+                        active_prompt_started_at = app.state.active_started_at
+                        active_task = asyncio.create_task(
+                            run_prompt_handler(
+                                handle_prompt,
+                                result.prompt_text,
+                                attachments=result.prompt_attachments,
+                            )
+                        )
+                    if result.local_text is not None and handle_local is not None:
+                        exit_code = await run_text_handler(
+                            handle_local,
+                            result.local_text,
+                        )
+                        if exit_code is not None:
+                            runtime.render_now()
+                            return _finish_tui_exit(
+                                runtime=runtime,
+                                stdout=stdout,
+                                exit_code=exit_code,
+                            )
+                    if result.steer_text is not None and handle_steer is not None:
+                        exit_code = await run_text_handler(
+                            handle_steer,
+                            result.steer_text,
+                            attachments=result.steer_attachments,
+                        )
+                        if exit_code is not None:
+                            runtime.render_now()
+                            return _finish_tui_exit(
+                                runtime=runtime,
+                                stdout=stdout,
+                                exit_code=exit_code,
+                            )
+                    if (
+                        result.followup_text is not None
+                        and handle_followup is not None
+                    ):
+                        exit_code = await run_text_handler(
+                            handle_followup,
+                            result.followup_text,
+                            attachments=result.followup_attachments,
+                        )
+                        if exit_code is not None:
+                            runtime.render_now()
+                            return _finish_tui_exit(
+                                runtime=runtime,
+                                stdout=stdout,
+                                exit_code=exit_code,
+                            )
+                    if (
+                        result.surface_intent is not None
+                        and handle_surface_intent is not None
+                    ):
+                        exit_code = await run_surface_intent_handler(
+                            handle_surface_intent,
+                            result.surface_intent,
+                        )
+                        if exit_code is not None:
+                            runtime.render_now()
+                            return _finish_tui_exit(
+                                runtime=runtime,
+                                stdout=stdout,
+                                exit_code=exit_code,
+                            )
+                    if result.render_requested:
+                        _request_runtime_render(runtime, "input")
+    finally:
+        app.surface_host = None
+        app.terminal_diagnostics_provider = previous_terminal_diagnostics_provider
+        app.terminal_capabilities = previous_terminal_capabilities
+        app.render_requester = previous_render_requester
+
+
+async def finish_active_task(
+    *,
+    app: ConversationScreenPort,
+    active_task: asyncio.Task[int | None],
+    started_at: float | None,
+    cancellation_message: str,
+) -> int | None:
+    try:
+        result = await active_task
+    except asyncio.CancelledError:
+        app.state.abort(
+            message=cancellation_message,
+            elapsed_seconds=app.elapsed_seconds(),
+        )
+        return None
+    except Exception as error:
+        app.add_error(str(error) or error.__class__.__name__)
+        app.complete_run(elapsed_seconds=elapsed_since(app, started_at))
+        return 1
+    app.complete_run(elapsed_seconds=elapsed_since(app, started_at))
+    return result if isinstance(result, int) else None
+
+
+def write_startup_welcome(
+    *,
+    app: ConversationScreenPort,
+    runtime: TuiRuntime,
+    stdout: TextIO,
+) -> None:
+    if (
+        app.state.records
+        or app.state.running
+        or app.state.assistant_draft_buffer is not None
+    ):
+        return
+    size = runtime.terminal.size()
+    result = app.startup_welcome_panel().render(
+        RenderConstraints(
+            width=size.columns,
+            max_height=size.rows,
+            visible_height=size.rows,
+        )
+    )
+    if not result.lines:
+        return
+    stdout.write("\n".join(line.text for line in result.lines))
+    stdout.write("\n\n")
+    stdout.flush()
+
+
+def configure_runtime_for_terminal_context(
+    runtime: TuiRuntime,
+    app: ConversationScreenPort,
+    terminal_context: object,
+) -> None:
+    capabilities = getattr(terminal_context, "capabilities", None)
+    if capabilities is not None:
+        app.terminal_capabilities = capabilities
+    _runner_utils.configure_runtime_for_terminal_context(runtime, terminal_context)
+
+
+async def abort_active(
+    *,
+    app: ConversationScreenPort,
+    active_task: asyncio.Task[int | None] | None,
+    on_abort: AbortHandler,
+    interruption_message: str,
+) -> None:
+    await maybe_await(on_abort())
+    if active_task is not None and not active_task.done():
+        active_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await active_task
+    elif active_task is not None:
+        await active_task
+    app.state.abort(
+        message=interruption_message,
+        elapsed_seconds=app.elapsed_seconds(),
+    )
+
+
+def elapsed_since(app: ConversationScreenPort, started_at: float | None) -> float:
+    if started_at is None:
+        return app.elapsed_seconds()
+    return max(0.0, app.now() - started_at)
+
+
+async def run_prompt_handler(
+    handler: PromptHandler,
+    text: str,
+    *,
+    attachments: tuple[object, ...] | None = None,
+) -> int | None:
+    result = await call_text_handler(handler, text, attachments=attachments)
+    return result if isinstance(result, int) else None
+
+
+async def run_text_handler(
+    handler: TextHandler,
+    text: str,
+    *,
+    attachments: tuple[object, ...] | None = None,
+) -> int | None:
+    result = await call_text_handler(handler, text, attachments=attachments)
+    return result if isinstance(result, int) else None
+
+
+def pop_interrupt_pending_steer(app: ConversationScreenPort) -> str | None:
+    if not app.state.pending_steers:
+        return None
+    return app.state.pending_steers.pop(0)
+
+
+async def call_text_handler(
+    handler: Callable[..., object],
+    text: str,
+    *,
+    attachments: tuple[object, ...] | None = None,
+) -> object:
+    if attachments is not None and supports_keyword(handler, "attachments"):
+        return await maybe_await(handler(text, attachments=attachments))
+    return await maybe_await(handler(text))
+
+
+async def run_surface_intent_handler(
+    handler: SurfaceIntentHandler,
+    intent: InputIntent,
+) -> int | None:
+    result = await maybe_await(handler(intent))
+    return result if isinstance(result, int) else None
+
+
+async def maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def supports_keyword(method: Any, keyword: str) -> bool:
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError):
+        return False
+    return any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        or parameter.name == keyword
+        for parameter in signature.parameters.values()
+    )
+
+
+def terminal_size() -> TerminalSize:
+    size = shutil.get_terminal_size((80, 24))
+    return TerminalSize(columns=size.columns, rows=size.lines)
+
+
+__all__ = [
+    "ConversationInputResultPort",
+    "ConversationInputRouterFactoryPort",
+    "ConversationInputRouterPort",
+    "ConversationRenderablePort",
+    "ConversationScreenPort",
+    "run_conversation_screen",
+]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -353,6 +353,11 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.harnesstui.conversation.screen_state`" in text
     assert "`loushang.harnesstui.conversation.source`" in text
     assert "`loushang.harnesstui.conversation.attachments`" in text
+    assert "`loushang.harnesstui.conversation.control`" in text
+    assert "`loushang.harnesstui.conversation.dispatch`" in text
+    assert "`loushang.harnesstui.conversation.input`" in text
+    assert "`loushang.harnesstui.conversation.run_context`" in text
+    assert "`loushang.harnesstui.conversation.screen_runner`" in text
     assert "`loushang.harnesstui.conversation.projection`" in text
     assert "`loushang.harnesstui.conversation.plain_target`" in text
     assert "`loushang.harnesstui.conversation.tool_transcript`" in text
@@ -376,11 +381,16 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
 def test_harnesstui_capability_entrypoints_exist() -> None:
     paths = (
         Path("src/loushang/harnesstui/conversation/attachments.py"),
+        Path("src/loushang/harnesstui/conversation/control.py"),
+        Path("src/loushang/harnesstui/conversation/dispatch.py"),
+        Path("src/loushang/harnesstui/conversation/input.py"),
         Path("src/loushang/harnesstui/conversation/plain_target.py"),
         Path("src/loushang/harnesstui/conversation/projection.py"),
         Path("src/loushang/harnesstui/conversation/queue.py"),
         Path("src/loushang/harnesstui/conversation/reader.py"),
         Path("src/loushang/harnesstui/conversation/screen_state.py"),
+        Path("src/loushang/harnesstui/conversation/run_context.py"),
+        Path("src/loushang/harnesstui/conversation/screen_runner.py"),
         Path("src/loushang/harnesstui/conversation/source.py"),
         Path("src/loushang/harnesstui/conversation/tool_transcript.py"),
         Path("src/loushang/harnesstui/plain/renderer.py"),
@@ -403,6 +413,45 @@ def test_harnesstui_capability_entrypoints_exist() -> None:
     missing = [path.as_posix() for path in paths if not path.is_file()]
 
     assert missing == []
+
+
+def test_importing_conversation_interaction_entrypoints_stays_product_neutral() -> (
+    None
+):
+    script = """
+import importlib
+import sys
+
+for module_name in (
+    "loushang.harnesstui.conversation.control",
+    "loushang.harnesstui.conversation.dispatch",
+    "loushang.harnesstui.conversation.input",
+    "loushang.harnesstui.conversation.run_context",
+    "loushang.harnesstui.conversation.screen_runner",
+):
+    importlib.import_module(module_name)
+
+forbidden_prefixes = (
+    "loushang.agent",
+    "loushang.ai",
+    "loushang.coding",
+    "loushang.harness",
+)
+forbidden = sorted(
+    name
+    for name in sys.modules
+    if any(name == prefix or name.startswith(prefix + ".") for prefix in forbidden_prefixes)
+)
+assert forbidden == [], forbidden
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_importing_channel_types_does_not_eagerly_load_agent_or_ai() -> None:

--- a/tests/coding/test_screen_coding_tui_loop.py
+++ b/tests/coding/test_screen_coding_tui_loop.py
@@ -126,6 +126,58 @@ def test_screen_loop_passes_prompt_images_to_handler() -> None:
     assert seen == {"text": "describe", "images": (image,)}
 
 
+def test_screen_loop_adapts_neutral_attachments_to_coding_images() -> None:
+    from loushang.coding.ui.screen_loop import _adapt_attachment_handler
+
+    seen: dict[str, object] = {}
+    image = ImagePart(type="image", data="abc", mime_type="image/png")
+
+    async def handle_prompt(
+        text: str,
+        *,
+        images: tuple[ImagePart, ...] | None = None,
+    ) -> int:
+        seen["text"] = text
+        seen["images"] = images
+        return 9
+
+    adapted = _adapt_attachment_handler(handle_prompt)
+    result = asyncio.run(adapted("describe", attachments=(image,)))
+
+    assert result == 9
+    assert seen == {"text": "describe", "images": (image,)}
+
+
+def test_finish_active_task_preserves_legacy_signature_and_cancellation_copy() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_loop import _finish_active_task
+
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        now=lambda: 2.0,
+    )
+    app.start_prompt("work", started_at=1.0)
+
+    async def scenario() -> int | None:
+        async def pending() -> int:
+            await asyncio.Event().wait()
+            return 0
+
+        task = asyncio.create_task(pending())
+        task.cancel()
+        return await _finish_active_task(
+            app=app,
+            active_task=task,
+            started_at=1.0,
+        )
+
+    assert asyncio.run(scenario()) is None
+    assert app.state.interruption_message == "Operation aborted"
+
+
 def test_screen_loop_scripted_prompt_then_quit_exits_without_status_residue() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
     from loushang.coding.ui.screen_loop import run_screen_coding_tui

--- a/tests/coding/test_ui_control_compatibility.py
+++ b/tests/coding/test_ui_control_compatibility.py
@@ -1,0 +1,14 @@
+from loushang.coding.ui.follow_up_queue import FollowUpQueueHandler
+from loushang.coding.ui.lifecycle import RunLifecycle
+from loushang.coding.ui.steer import SteerHandler
+from loushang.harnesstui.conversation.control import (
+    ConversationRunControl,
+    FollowUpActionHandler,
+    SteerActionHandler,
+)
+
+
+def test_coding_action_control_names_preserve_shared_compatibility() -> None:
+    assert RunLifecycle is ConversationRunControl
+    assert issubclass(FollowUpQueueHandler, FollowUpActionHandler)
+    assert SteerHandler is SteerActionHandler

--- a/tests/coding/test_ui_dispatch_compatibility.py
+++ b/tests/coding/test_ui_dispatch_compatibility.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+def test_prompt_dispatch_compatibility_exports_share_neutral_owner() -> None:
+    from loushang.coding.ui.prompt_dispatch import (
+        Lifecycle,
+        PromptDispatchOutcome,
+    )
+    from loushang.harnesstui.conversation.dispatch import (
+        ConversationDispatchOutcome,
+        DispatchLifecycle,
+    )
+
+    assert PromptDispatchOutcome is ConversationDispatchOutcome
+    assert Lifecycle is DispatchLifecycle
+
+
+def test_prompt_result_renderer_compatibility_export_shares_neutral_owner() -> (
+    None
+):
+    from loushang.coding.ui.prompt_result import Renderer
+    from loushang.harnesstui.conversation.dispatch import ResultRenderer
+
+    assert Renderer is ResultRenderer
+
+
+def test_coding_event_renderer_remains_a_real_protocol_class() -> None:
+    from loushang.coding.ui.event_stream import EventRenderer
+
+    assert isinstance(EventRenderer, type)
+    assert issubclass(EventRenderer, Protocol)
+    assert EventRenderer._is_protocol is True

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -71,7 +71,25 @@ def test_conversation_raw_event_dispatch_stays_in_coding_adapter() -> None:
 
 def test_shared_interaction_types_are_not_redefined_in_coding_ui() -> None:
     moved_definitions = {
+        Path("src/loushang/coding/ui/lifecycle.py"): ("class RunLifecycle",),
         Path("src/loushang/coding/ui/model_list.py"): ("class ModelChoice",),
+        Path("src/loushang/coding/ui/prompt_dispatch.py"): (
+            "class PromptDispatchOutcome",
+        ),
+        Path("src/loushang/coding/ui/run_context.py"): (
+            "def _stable_emit_factory",
+        ),
+        Path("src/loushang/coding/ui/screen_loop.py"): (
+            "async def _finish_active_task",
+            "def _write_startup_welcome",
+            "def _configure_runtime_for_terminal_context",
+            "def _elapsed_since",
+            "def _pop_interrupt_pending_steer",
+            "async def _run_surface_intent_handler",
+            "async def _maybe_await",
+            "def _supports_keyword",
+            "def _terminal_size",
+        ),
         Path("src/loushang/coding/ui/settings_common.py"): ("class ConfigRow",),
         Path("src/loushang/coding/ui/settings_config.py"): (
             "class ConfigSettingsPage",
@@ -111,6 +129,7 @@ def test_shared_interaction_types_are_not_redefined_in_coding_ui() -> None:
             "class CodingTuiStatusProvider",
             "class StatusSnapshot",
         ),
+        Path("src/loushang/coding/ui/steer.py"): ("class SteerHandler",),
         Path("src/loushang/coding/ui/transcript_source.py"): (
             "class ActiveWindowTranscriptSource",
             "def _active_window_records",
@@ -133,6 +152,54 @@ def test_shared_interaction_types_are_not_redefined_in_coding_ui() -> None:
     ]
 
     assert offenders == []
+
+
+def test_shared_conversation_interaction_does_not_own_coding_policy_or_copy() -> (
+    None
+):
+    shared = "\n".join(
+        Path(f"src/loushang/harnesstui/conversation/{module}.py").read_text(
+            encoding="utf-8"
+        )
+        for module in ("control", "dispatch", "input", "run_context", "screen_runner")
+    )
+
+    for token in (
+        "Follow-up is only available while a run is active.",
+        "Follow-up queued.",
+        "Conversation interrupted - tell the model what to do differently.",
+        "Operation aborted",
+        ".loushang/clipboard",
+        "ImagePart",
+        "PromptIntent",
+        "BashIntent",
+    ):
+        assert token not in shared
+
+    follow_up = Path("src/loushang/coding/ui/follow_up_queue.py").read_text(
+        encoding="utf-8"
+    )
+    screen_loop = Path("src/loushang/coding/ui/screen_loop.py").read_text(
+        encoding="utf-8"
+    )
+    screen_input = Path("src/loushang/coding/ui/screen_input.py").read_text(
+        encoding="utf-8"
+    )
+    prompt_dispatch = Path(
+        "src/loushang/coding/ui/prompt_dispatch.py"
+    ).read_text(encoding="utf-8")
+
+    assert "Follow-up is only available while a run is active." in follow_up
+    assert "Follow-up queued." in follow_up
+    assert (
+        "Conversation interrupted - tell the model what to do differently."
+        in screen_loop
+    )
+    assert "Operation aborted" in screen_loop
+    assert "ImagePart" in screen_input
+    assert 'Path(self.app.cwd) / ".loushang" / "clipboard"' in screen_input
+    assert "PromptIntent" in prompt_dispatch
+    assert "BashIntent" in prompt_dispatch
 
 
 def test_shared_status_provider_does_not_own_settings_manager_adaptation() -> None:

--- a/tests/coding/test_ui_run_context.py
+++ b/tests/coding/test_ui_run_context.py
@@ -236,6 +236,22 @@ def test_coding_tui_run_context_close_is_idempotent() -> None:
     assert calls == ["tui.end", "unsubscribe", "observability.exit"]
 
 
+def test_coding_tui_run_context_preserves_legacy_constructor_and_context_field() -> None:
+    from loushang.coding.ui.run_context import CodingTuiRunContext
+
+    observability_context = _ObservabilityContext()
+    context = CodingTuiRunContext(
+        _emit_in_terminal,
+        lambda: None,
+        observability_context,
+        _noop_trace,
+        True,
+    )
+
+    assert context._observability_context is observability_context
+    assert context._closed is True
+
+
 class _EventRenderer:
     def handle(self, _event: dict[str, object]) -> None:
         pass

--- a/tests/coding/ui/test_screen_input.py
+++ b/tests/coding/ui/test_screen_input.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from loushang.ai.types import ImagePart
+from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+from loushang.coding.ui.screen_input import ScreenInputResult, ScreenInputRouter
+from loushang.tui import InputEvent
+from loushang.tui.keybindings import KeybindingManager
+
+
+def _app(*, cwd: str = "/repo") -> ScreenCodingTuiApp:
+    return ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd=cwd,
+        branch="main",
+        session_label="abcd",
+        now=lambda: 12.0,
+    )
+
+
+def test_screen_input_result_preserves_images_and_neutral_aliases() -> None:
+    image = ImagePart(
+        type="image",
+        data="cG5n",
+        mime_type="image/png",
+    )
+    result = ScreenInputResult(
+        prompt_images=(image,),
+        steer_images=(image,),
+        followup_images=(image,),
+    )
+
+    assert result.prompt_attachments == result.prompt_images
+    assert result.steer_attachments == result.steer_images
+    assert result.followup_attachments == result.followup_images
+
+
+def test_screen_input_router_preserves_public_read_write_configuration() -> None:
+    def exit_predicate(text: str) -> bool:
+        return text == "/bye"
+
+    def local_predicate(text: str) -> bool:
+        return text == "/help"
+
+    first_app = _app()
+    replacement_app = _app(cwd="/other")
+    router = ScreenInputRouter(
+        first_app,
+        should_exit=lambda text: text == "/quit",
+        is_local_command=lambda text: text == "/model",
+        width=80,
+        height=12,
+    )
+    keybindings = KeybindingManager(
+        {"tui.input.submit": ("alt+s",)},
+    )
+
+    router.app = replacement_app
+    router.should_exit = exit_predicate
+    router.is_local_command = local_predicate
+    router.width = 100
+    router.height = 20
+    router.keybindings = keybindings
+    router.running_submit_mode = "follow_up"
+    router.follow_up_keys = ("ctrl+enter",)
+
+    assert router.app is replacement_app
+    assert router.should_exit is exit_predicate
+    assert router.is_local_command is local_predicate
+    assert (router.width, router.height) == (100, 20)
+    assert router.keybindings is keybindings
+    assert router.running_submit_mode == "follow_up"
+    assert router.follow_up_keys == ("ctrl+enter",)
+
+    replacement_app.composer.set_text("/bye")
+    result = router.handle(InputEvent(kind="key", key="alt+s"))
+    assert result.exit_code == 0

--- a/tests/harnesstui/conversation/test_control.py
+++ b/tests/harnesstui/conversation/test_control.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from loushang.harnesstui.conversation.control import (
+    AbortActionHandler,
+    ConversationRunControl,
+    FollowUpActionHandler,
+    SteerActionHandler,
+)
+
+
+@dataclass
+class _Result:
+    exit_code: int | None = None
+    error_message: str | None = None
+
+
+class _StatusRenderer:
+    def __init__(self) -> None:
+        self.statuses: list[str] = []
+
+    def render_status(self, text: str) -> None:
+        self.statuses.append(text)
+
+
+class _ActionController:
+    def __init__(self, result: _Result) -> None:
+        self.result = result
+        self.steers: list[str] = []
+        self.follow_ups: list[str] = []
+
+    async def steer(self, text: str) -> _Result:
+        self.steers.append(text)
+        return self.result
+
+    async def follow_up(self, text: str) -> _Result:
+        self.follow_ups.append(text)
+        return self.result
+
+
+async def _emit(write, *, label: str) -> None:
+    del label
+    write()
+
+
+def test_conversation_run_control_tracks_transient_ui_work() -> None:
+    control = ConversationRunControl()
+
+    assert control.visible_running(session_running=True) is True
+    assert control.begin_work() == 1
+    assert control.active is True
+
+    control.mark_abort_requested()
+
+    assert control.aborted_id == 1
+    assert control.abort_is_settling() is True
+
+    control.end_work()
+    control.clear_aborted(1)
+
+    assert control.active is False
+    assert control.aborted_id is None
+
+
+def test_abort_action_handler_marks_and_presents_before_action() -> None:
+    calls: list[str] = []
+    traces: list[tuple[str, dict[str, object]]] = []
+    control = ConversationRunControl(active=True, active_id=5)
+
+    class Renderer:
+        def render_interruption(self) -> None:
+            calls.append("render_interruption")
+
+    async def emit(write, *, label: str) -> None:
+        calls.append(f"emit:{label}")
+        write()
+
+    async def abort_action() -> None:
+        calls.append("abort_action")
+
+    handler = AbortActionHandler(
+        run_control=control,
+        abort_action=abort_action,
+        renderer=Renderer(),
+        emit=emit,
+        session_running=lambda: False,
+        trace=lambda name, **data: traces.append((name, data)),
+    )
+
+    asyncio.run(handler.abort())
+
+    assert calls == [
+        "emit:abort:interruption",
+        "render_interruption",
+        "abort_action",
+    ]
+    assert control.aborted_id == 5
+    assert [name for name, _data in traces] == ["abort.start", "abort.end"]
+
+
+def test_steer_action_handler_uses_result_facts_without_fallback_copy() -> None:
+    controller = _ActionController(
+        _Result(exit_code=2, error_message="caller supplied steer error")
+    )
+    renderer = _StatusRenderer()
+    handler = SteerActionHandler(
+        lifecycle=ConversationRunControl(active_id=9),
+        controller=controller,
+        renderer=renderer,
+        emit=_emit,
+        trace=lambda _name, **_data: None,
+    )
+
+    assert asyncio.run(handler.steer("change")) == 2
+    assert controller.steers == ["change"]
+    assert renderer.statuses == ["caller supplied steer error"]
+
+
+def test_follow_up_action_handler_uses_injected_idle_and_queued_copy() -> None:
+    control = ConversationRunControl()
+    controller = _ActionController(_Result(exit_code=3))
+    renderer = _StatusRenderer()
+    handler = FollowUpActionHandler(
+        lifecycle=control,
+        controller=controller,
+        renderer=renderer,
+        emit=_emit,
+        trace=lambda _name, **_data: None,
+        idle_status_message="caller idle",
+        queued_status_message="caller queued",
+    )
+
+    assert asyncio.run(handler.queue("next", source="command")) is None
+    control.begin_work()
+    assert asyncio.run(handler.queue("  next step  ", source="command")) == 3
+
+    assert controller.follow_ups == ["next step"]
+    assert renderer.statuses == ["caller idle", "caller queued"]
+
+
+def test_follow_up_action_handler_presents_controller_error_verbatim() -> None:
+    control = ConversationRunControl(active=True, active_id=4)
+    controller = _ActionController(
+        _Result(exit_code=2, error_message="caller queue error")
+    )
+    renderer = _StatusRenderer()
+    handler = FollowUpActionHandler(
+        lifecycle=control,
+        controller=controller,
+        renderer=renderer,
+        emit=_emit,
+        trace=lambda _name, **_data: None,
+        idle_status_message="caller idle",
+        queued_status_message="caller queued",
+    )
+
+    assert asyncio.run(handler.queue("later", source="command")) == 2
+    assert renderer.statuses == ["caller queue error"]

--- a/tests/harnesstui/conversation/test_dispatch.py
+++ b/tests/harnesstui/conversation/test_dispatch.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from io import StringIO
+
+import pytest
+
+from loushang.harnesstui.conversation.dispatch import (
+    ConversationDispatchHandler,
+    ConversationDispatchOutcome,
+    ConversationResultPresenter,
+    StableEventStreamHandler,
+)
+
+
+@dataclass
+class _Result:
+    exit_code: int | None = None
+    error_message: str | None = None
+    status_message: str | None = None
+    traceback_text: str | None = None
+
+
+class _Lifecycle:
+    def __init__(self) -> None:
+        self.active = False
+        self.begin_calls = 0
+        self.end_calls = 0
+
+    def begin_work(self) -> int:
+        self.begin_calls += 1
+        self.active = True
+        return self.begin_calls
+
+    def end_work(self) -> None:
+        self.end_calls += 1
+        self.active = False
+
+
+class _Controller:
+    def __init__(
+        self,
+        result: _Result | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.result = result or _Result()
+        self.error = error
+
+    async def dispatch(self, _intent: str) -> _Result:
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def test_dispatch_brackets_only_caller_classified_work() -> None:
+    lifecycle = _Lifecycle()
+    traces: list[tuple[str, dict[str, object]]] = []
+    handler = ConversationDispatchHandler(
+        lifecycle=lifecycle,
+        controller=_Controller(_Result(exit_code=3)),
+        is_work_intent=lambda intent: intent.startswith("work:"),
+        session_running=lambda: False,
+        now=lambda: 10.0,
+        trace=lambda name, **data: traces.append((name, data)),
+    )
+
+    outcome = asyncio.run(handler.dispatch("work:review"))
+
+    assert outcome.run_id == 1
+    assert outcome.work_intent is True
+    assert outcome.started_at == 10.0
+    assert lifecycle.end_calls == 1
+    assert [name for name, _data in traces] == [
+        "prompt.dispatch.start",
+        "prompt.dispatch.end",
+    ]
+
+
+def test_dispatch_ends_work_when_controller_raises() -> None:
+    lifecycle = _Lifecycle()
+    handler = ConversationDispatchHandler(
+        lifecycle=lifecycle,
+        controller=_Controller(error=RuntimeError("dispatch exploded")),
+        is_work_intent=lambda _intent: True,
+        session_running=lambda: False,
+        trace=lambda _name, **_data: None,
+    )
+
+    with pytest.raises(RuntimeError, match="dispatch exploded"):
+        asyncio.run(handler.dispatch("work"))
+
+    assert lifecycle.end_calls == 1
+    assert lifecycle.active is False
+
+
+class _Renderer:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.statuses: list[str] = []
+        self.worked: list[float] = []
+
+    def render_error(self, text: str) -> None:
+        self.errors.append(text)
+
+    def render_status(self, text: str) -> None:
+        self.statuses.append(text)
+
+    def render_worked(self, elapsed_seconds: float) -> None:
+        self.worked.append(elapsed_seconds)
+
+
+def _outcome(
+    result: _Result,
+    *,
+    work_intent: bool = True,
+) -> ConversationDispatchOutcome:
+    return ConversationDispatchOutcome(
+        result=result,
+        run_id=2,
+        work_intent=work_intent,
+        started_at=10.0,
+    )
+
+
+def test_result_presenter_uses_caller_resolved_error_and_traceback() -> None:
+    renderer = _Renderer()
+    stderr = StringIO()
+
+    async def emit(write, *, label: str) -> None:
+        assert label == "prompt:error"
+        write()
+
+    presenter = ConversationResultPresenter(
+        renderer=renderer,
+        emit=emit,
+        stderr=stderr,
+        verbose=True,
+        last_error_message=lambda: None,
+        now=lambda: 12.0,
+        trace=lambda _name, **_data: None,
+    )
+
+    exit_code = asyncio.run(
+        presenter.handle(
+            _outcome(
+                _Result(exit_code=2, traceback_text="traceback text")
+            ),
+            prompt_started=9.0,
+            error_message="caller resolved error",
+        )
+    )
+
+    assert exit_code == 2
+    assert renderer.errors == ["caller resolved error"]
+    assert stderr.getvalue() == "traceback text"
+
+
+def test_result_presenter_emits_status_or_worked() -> None:
+    renderer = _Renderer()
+    labels: list[str] = []
+
+    async def emit(write, *, label: str) -> None:
+        labels.append(label)
+        write()
+
+    presenter = ConversationResultPresenter(
+        renderer=renderer,
+        emit=emit,
+        stderr=StringIO(),
+        verbose=False,
+        last_error_message=lambda: None,
+        now=lambda: 12.5,
+        trace=lambda _name, **_data: None,
+    )
+
+    asyncio.run(
+        presenter.handle(
+            _outcome(_Result(status_message="caller status")),
+            prompt_started=8.0,
+            error_message=None,
+        )
+    )
+    asyncio.run(
+        presenter.handle(
+            _outcome(_Result()),
+            prompt_started=8.0,
+            error_message=None,
+        )
+    )
+
+    assert labels == ["prompt:status", "prompt:worked"]
+    assert renderer.statuses == ["caller status"]
+    assert renderer.worked == [2.5]
+
+
+@dataclass(frozen=True)
+class _Event:
+    kind: str
+    stable: bool
+
+
+class _EventRenderer:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.events: list[_Event] = []
+        self.error = error
+
+    def handle(self, event: _Event) -> None:
+        if self.error is not None:
+            raise self.error
+        self.events.append(event)
+
+
+def test_event_stream_uses_injected_stable_write_and_event_policy() -> None:
+    renderer = _EventRenderer()
+    labels: list[str] = []
+
+    async def emit(write, *, label: str) -> None:
+        labels.append(label)
+        write()
+
+    handler = StableEventStreamHandler(
+        renderer=renderer,
+        emit=emit,
+        writes_stably=lambda event: event.stable,
+        event_type=lambda event: event.kind,
+        trace=lambda _name, **_data: None,
+    )
+    stable = _Event("committed", True)
+    transient = _Event("streaming", False)
+
+    asyncio.run(handler.handle(stable))
+    asyncio.run(handler.handle(transient))
+
+    assert renderer.events == [stable, transient]
+    assert labels == ["event:committed"]
+
+
+def test_event_stream_traces_end_when_renderer_raises() -> None:
+    traces: list[str] = []
+    handler = StableEventStreamHandler(
+        renderer=_EventRenderer(error=RuntimeError("render failed")),
+        emit=_unused_emit,
+        writes_stably=lambda _event: False,
+        event_type=lambda event: event.kind,
+        trace=lambda name, **_data: traces.append(name),
+    )
+
+    with pytest.raises(RuntimeError, match="render failed"):
+        asyncio.run(handler.handle(_Event("broken", False)))
+
+    assert traces == ["event.start", "event.end"]
+
+
+async def _unused_emit(write, *, label: str) -> None:
+    del write
+    raise AssertionError(f"unexpected stable emit: {label}")

--- a/tests/harnesstui/conversation/test_input.py
+++ b/tests/harnesstui/conversation/test_input.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from loushang.harnesstui.conversation.attachments import (
+    PromptImageAttachment,
+    PromptImageAttachmentOutcome,
+)
+from loushang.harnesstui.conversation.input import ConversationInputRouter
+from loushang.harnesstui.conversation.screen_state import ScreenConversationState
+from loushang.tui import Composer, InputEvent, InputIntent, SurfaceHost
+
+
+@dataclass(slots=True)
+class _ConversationApp:
+    composer: Composer = field(default_factory=Composer)
+    state: ScreenConversationState = field(default_factory=ScreenConversationState)
+    active_surface: object | None = None
+    surface_host: SurfaceHost | None = None
+    transcript_opened: bool = False
+
+    def open_transcript_reader(self) -> bool:
+        self.transcript_opened = True
+        return True
+
+    def start_prompt(self, text: str) -> None:
+        self.state.start_prompt(text, started_at=1.0)
+        self.composer.add_history(text)
+        self.composer.clear()
+
+    def queue_followup(self, text: str) -> None:
+        self.state.queue_followup(text)
+
+    def queue_steer(self, text: str) -> None:
+        self.state.queue_steer(text)
+
+
+def _attachment(tmp_path: Path, *, name: str = "image") -> PromptImageAttachment:
+    path = tmp_path / f"{name}.png"
+    return PromptImageAttachment(
+        bytes=name.encode(),
+        mime_type="image/png",
+        path=path,
+        display_path=path.name,
+        marker=f"@{path.name}",
+    )
+
+
+def test_conversation_input_router_submits_neutral_prompt_attachments(
+    tmp_path: Path,
+) -> None:
+    app = _ConversationApp()
+    attachment = _attachment(tmp_path)
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+        prompt_image_stager=lambda: PromptImageAttachmentOutcome(
+            kind="attached",
+            attachment=attachment,
+            mime_type=attachment.mime_type,
+        ),
+    )
+
+    paste_result = router.handle(InputEvent(kind="key", key="ctrl+v"))
+    app.composer.insert_text("describe")
+    submit_result = router.handle(InputEvent(kind="key", key="enter"))
+
+    assert paste_result.clipboard_outcome is not None
+    assert paste_result.clipboard_outcome.attachment is attachment
+    assert submit_result.prompt_text == "@image.png describe"
+    assert submit_result.prompt_attachments == (attachment,)
+    assert app.state.running is True
+    assert app.composer.value == ""
+
+
+def test_conversation_input_router_preserves_running_followup_priority(
+    tmp_path: Path,
+) -> None:
+    app = _ConversationApp()
+    app.start_prompt("question")
+    attachment = _attachment(tmp_path)
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+        prompt_image_stager=lambda: PromptImageAttachmentOutcome(
+            kind="attached",
+            attachment=attachment,
+            mime_type=attachment.mime_type,
+        ),
+    )
+    router.handle(InputEvent(kind="key", key="ctrl+v"))
+    app.composer.insert_text("later")
+
+    result = router.handle(InputEvent(kind="key", key="alt+enter"))
+
+    assert result.followup_text == "@image.png later"
+    assert result.followup_attachments == (attachment,)
+    assert result.steer_text is None
+    assert app.state.pending_followups == ["@image.png later"]
+
+
+def test_conversation_input_router_routes_active_surface_before_composer() -> None:
+    class _Surface:
+        def handle_input(self, event: InputEvent) -> InputIntent:
+            assert event.key == "enter"
+            return InputIntent(kind="select", text="choice")
+
+    app = _ConversationApp(active_surface=_Surface())
+    app.composer.set_text("draft")
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+    )
+
+    result = router.handle(InputEvent(kind="key", key="enter"))
+
+    assert result.surface_intent == InputIntent(kind="select", text="choice")
+    assert app.composer.value == "draft"
+    assert app.state.running is False
+
+
+def test_conversation_input_router_keeps_exit_and_local_policy_injected() -> None:
+    app = _ConversationApp()
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda text: text == "/quit",
+        is_local_command=lambda text: text == "/model",
+    )
+
+    app.composer.set_text("/model")
+    local_result = router.handle(InputEvent(kind="key", key="enter"))
+    app.composer.set_text("/quit")
+    exit_result = router.handle(InputEvent(kind="key", key="enter"))
+
+    assert local_result.local_text == "/model"
+    assert exit_result.exit_code == 0
+    assert app.state.running is False
+
+
+def test_conversation_input_router_restores_pending_messages() -> None:
+    app = _ConversationApp()
+    app.state.queue_steer("first")
+    app.state.queue_followup("second")
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+    )
+
+    result = router.handle(InputEvent(kind="key", key="alt+up"))
+
+    assert result.render_requested is True
+    assert app.composer.value == "first\nsecond"
+    assert app.state.pending_steers == []
+    assert app.state.pending_followups == []
+
+
+def test_conversation_input_router_reports_unconfigured_clipboard_as_unhandled() -> None:
+    app = _ConversationApp()
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+    )
+
+    result = router.handle(InputEvent(kind="key", key="ctrl+v"))
+
+    assert result.render_requested is False
+    assert result.clipboard_outcome is None

--- a/tests/harnesstui/conversation/test_run_context.py
+++ b/tests/harnesstui/conversation/test_run_context.py
@@ -1,0 +1,113 @@
+"""Tests for the shared conversation interaction run context."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+def test_interaction_run_context_closes_in_order_and_only_once() -> None:
+    from loushang.harnesstui.conversation.run_context import InteractionRunContext
+
+    calls: list[str] = []
+
+    class ExitContext:
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            del exc_type, exc, traceback
+            calls.append("context.exit")
+
+    async def emit(write_callable, *, label: str) -> None:
+        del label
+        write_callable()
+
+    context = InteractionRunContext(
+        emit=emit,
+        _unsubscribe=lambda: calls.append("unsubscribe"),
+        _exit_context=ExitContext(),
+        _trace=lambda name, **_data: calls.append(name),
+    )
+
+    context.close()
+    context.close()
+
+    assert calls == ["tui.end", "unsubscribe", "context.exit"]
+
+
+def test_interaction_run_context_exits_when_trace_or_unsubscribe_fails() -> None:
+    from loushang.harnesstui.conversation.run_context import InteractionRunContext
+
+    calls: list[str] = []
+
+    class ExitContext:
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            del exc_type, exc, traceback
+            calls.append("context.exit")
+
+    def trace(name: str, **_data: object) -> None:
+        calls.append(name)
+        raise RuntimeError("trace failed")
+
+    context = InteractionRunContext(
+        emit=_emit,
+        _unsubscribe=lambda: calls.append("unsubscribe"),
+        _exit_context=ExitContext(),
+        _trace=trace,
+    )
+
+    with pytest.raises(RuntimeError, match="trace failed"):
+        context.close()
+
+    assert calls == ["tui.end", "unsubscribe", "context.exit"]
+
+
+def test_stable_emit_factory_traces_success_and_write_error() -> None:
+    from loushang.harnesstui.conversation.run_context import stable_emit_factory
+
+    traces: list[tuple[str, dict[str, object]]] = []
+    writes: list[str] = []
+    emit = stable_emit_factory(
+        trace=lambda name, **data: traces.append((name, data)),
+        interactive=True,
+    )
+
+    asyncio.run(emit(lambda: writes.append("written"), label="event:delta"))
+
+    def fail() -> None:
+        raise RuntimeError("write failed")
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        asyncio.run(emit(fail, label="event:error"))
+
+    assert writes == ["written"]
+    assert [name for name, _data in traces] == [
+        "emit.start",
+        "emit.end",
+        "emit.start",
+        "emit.error",
+    ]
+    assert traces[0][1] == {"label": "event:delta", "interactive": True}
+    assert traces[-1][1]["error"] == "write failed"
+
+
+def test_subscribe_events_uses_returned_hook_or_safe_noop() -> None:
+    from loushang.harnesstui.conversation.run_context import subscribe_events
+
+    calls: list[object] = []
+
+    class Source:
+        def subscribe(self, listener):
+            calls.append(listener)
+            return lambda: calls.append("unsubscribe")
+
+    listener = object()
+    unsubscribe = subscribe_events(Source(), listener)
+    unsubscribe()
+
+    assert calls == [listener, "unsubscribe"]
+    assert subscribe_events(object(), listener)() is None
+
+
+async def _emit(write_callable, *, label: str) -> None:
+    del label
+    write_callable()

--- a/tests/harnesstui/conversation/test_screen_runner.py
+++ b/tests/harnesstui/conversation/test_screen_runner.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import nullcontext
+from io import StringIO
+from types import SimpleNamespace
+
+
+def test_prompt_handler_forwards_neutral_attachments() -> None:
+    from loushang.harnesstui.conversation.screen_runner import run_prompt_handler
+
+    seen: dict[str, object] = {}
+    attachments = (object(),)
+
+    async def handle_prompt(
+        text: str,
+        *,
+        attachments: tuple[object, ...] | None = None,
+    ) -> int:
+        seen["text"] = text
+        seen["attachments"] = attachments
+        return 4
+
+    result = asyncio.run(
+        run_prompt_handler(
+            handle_prompt,
+            "describe",
+            attachments=attachments,
+        )
+    )
+
+    assert result == 4
+    assert seen == {"text": "describe", "attachments": attachments}
+
+
+def test_prompt_handler_ignores_attachments_for_text_only_handler() -> None:
+    from loushang.harnesstui.conversation.screen_runner import run_prompt_handler
+
+    seen: list[str] = []
+
+    def handle_prompt(text: str) -> None:
+        seen.append(text)
+
+    asyncio.run(
+        run_prompt_handler(
+            handle_prompt,
+            "describe",
+            attachments=(object(),),
+        )
+    )
+
+    assert seen == ["describe"]
+
+
+def test_conversation_screen_forwards_neutral_attachments_end_to_end() -> None:
+    from loushang.harnesstui.conversation.input import ConversationInputResult
+    from loushang.harnesstui.conversation.screen_runner import (
+        run_conversation_screen,
+    )
+    from loushang.tui.terminal import TerminalSize
+
+    app = _RunnerApp()
+    attachment = object()
+    seen: dict[str, object] = {}
+
+    class Router:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def handle(self, event: object) -> ConversationInputResult:
+            if getattr(event, "kind", None) != "text":
+                return ConversationInputResult(render_requested=False)
+            app.state.active_started_at = app.now()
+            return ConversationInputResult(
+                prompt_text="describe",
+                prompt_attachments=(attachment,),
+            )
+
+    async def handle_prompt(
+        text: str,
+        *,
+        attachments: tuple[object, ...] | None = None,
+    ) -> None:
+        seen["text"] = text
+        seen["attachments"] = attachments
+
+    exit_code = asyncio.run(
+        run_conversation_screen(
+            app=app,
+            stdin=StringIO("x"),
+            stdout=StringIO(),
+            handle_prompt=handle_prompt,
+            on_abort=lambda: None,
+            should_exit=lambda _text: False,
+            terminal_mode_factory=lambda _stdin, _stdout: nullcontext(object()),
+            terminal_size_provider=lambda: TerminalSize(columns=80, rows=24),
+            interruption_message="interrupted",
+            cancellation_message="cancelled",
+            input_router_factory=Router,
+        )
+    )
+
+    assert exit_code == 0
+    assert seen == {
+        "text": "describe",
+        "attachments": (attachment,),
+    }
+
+
+def test_finish_active_task_preserves_success_error_and_cancellation_state() -> None:
+    from loushang.harnesstui.conversation.screen_runner import finish_active_task
+
+    async def scenario() -> tuple[int | None, int | None, int | None, _RunnerApp]:
+        app = _RunnerApp()
+
+        async def success() -> int:
+            return 7
+
+        async def failure() -> int:
+            raise RuntimeError("prompt failed")
+
+        async def pending() -> int:
+            await asyncio.Event().wait()
+            return 0
+
+        success_task = asyncio.create_task(success())
+        success_result = await finish_active_task(
+            app=app,
+            active_task=success_task,
+            started_at=0.5,
+            cancellation_message="cancelled",
+        )
+        failure_task = asyncio.create_task(failure())
+        failure_result = await finish_active_task(
+            app=app,
+            active_task=failure_task,
+            started_at=0.5,
+            cancellation_message="cancelled",
+        )
+        cancelled_task = asyncio.create_task(pending())
+        cancelled_task.cancel()
+        cancelled_result = await finish_active_task(
+            app=app,
+            active_task=cancelled_task,
+            started_at=0.5,
+            cancellation_message="cancelled",
+        )
+        return success_result, failure_result, cancelled_result, app
+
+    success, failure, cancelled, app = asyncio.run(scenario())
+
+    assert (success, failure, cancelled) == (7, 1, None)
+    assert app.errors == ["prompt failed"]
+    assert app.completions == [0.5, 0.5]
+    assert app.state.aborts == [("cancelled", 0.0)]
+
+
+def test_abort_active_waits_for_cancel_before_presenting_interruption() -> None:
+    from loushang.harnesstui.conversation.screen_runner import abort_active
+
+    calls: list[str] = []
+    app = _RunnerApp(calls=calls)
+
+    async def scenario() -> None:
+        async def pending() -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                calls.append("task.finally")
+
+        task = asyncio.create_task(pending())
+        await asyncio.sleep(0)
+        await abort_active(
+            app=app,
+            active_task=task,
+            on_abort=lambda: calls.append("on_abort"),
+            interruption_message="interrupted",
+        )
+
+    asyncio.run(scenario())
+
+    assert calls == ["on_abort", "task.finally", "state.abort"]
+    assert app.state.aborts == [("interrupted", 0.0)]
+
+
+def test_pop_interrupt_pending_steer_is_fifo_and_empty_safe() -> None:
+    from loushang.harnesstui.conversation.screen_runner import (
+        pop_interrupt_pending_steer,
+    )
+
+    app = SimpleNamespace(state=SimpleNamespace(pending_steers=[]))
+
+    assert pop_interrupt_pending_steer(app) is None
+    app.state.pending_steers.extend(["first", "second"])
+    assert pop_interrupt_pending_steer(app) == "first"
+    assert app.state.pending_steers == ["second"]
+
+
+class _RunnerState:
+    def __init__(self, *, calls: list[str] | None = None) -> None:
+        self.records: list[object] = []
+        self.active_started_at: float | None = None
+        self.pending_steers: list[str] = []
+        self.assistant_draft_buffer = None
+        self.aborts: list[tuple[str, float]] = []
+        self._calls = calls
+
+    @property
+    def running(self) -> bool:
+        return self.active_started_at is not None
+
+    def abort(self, *, message: str, elapsed_seconds: float) -> None:
+        self.aborts.append((message, elapsed_seconds))
+        self.active_started_at = None
+        if self._calls is not None:
+            self._calls.append("state.abort")
+
+
+class _RunnerApp:
+    def __init__(self, *, calls: list[str] | None = None) -> None:
+        self.state = _RunnerState(calls=calls)
+        self.surface_host = None
+        self.render_requester = None
+        self.terminal_diagnostics_provider = None
+        self.terminal_capabilities = None
+        self.errors: list[str] = []
+        self.completions: list[float] = []
+
+    def now(self) -> float:
+        return 1.0
+
+    def elapsed_seconds(self) -> float:
+        return 0.0
+
+    def start_pending_prompt(self, _text: str) -> None:
+        self.state.active_started_at = self.now()
+
+    def add_error(self, summary: str, diagnostics: str = "") -> None:
+        del diagnostics
+        self.errors.append(summary)
+
+    def complete_run(self, *, elapsed_seconds: float | None = None) -> None:
+        self.completions.append(0.0 if elapsed_seconds is None else elapsed_seconds)
+        self.state.active_started_at = None
+
+    def startup_welcome_panel(self) -> _RunnerApp:
+        return self
+
+    def render(self, constraints: object):
+        from loushang.tui.core import RenderResult
+
+        del constraints
+        return RenderResult(lines=())


### PR DESCRIPTION
## English

### Summary

- Add product-neutral conversation input, control, dispatch, run-context, and screen-runner entrypoints under `loushang.harnesstui.conversation`.
- Keep Coding-owned Session lifecycle, intents, `ImagePart` conversion, workspace paths, raw-event/error policy, and user-facing copy in thin compatibility facades.
- Preserve existing screen-loop/input behavior while leaving transcript rendering, segmentation, caches, frame composition, and terminal writes untouched.
- Extend architecture, compatibility, and direct behavior tests, and include the new adapters in `make check-harnesstui`.

### Validation

- `make check-harnesstui` — Ruff passed; mypy passed for 78 source files; 750 passed, 27 deselected.
- `make test-tui-render-contract` — 152 passed, 3340 deselected.
- `git diff --check` — passed.

## 中文

### 变更摘要

- 在 `loushang.harnesstui.conversation` 新增产品中性的输入、控制、分发、运行上下文和屏幕循环稳定入口。
- Session 生命周期、Coding intents、`ImagePart` 转换、工作区路径、原始事件/错误策略和产品文案继续由 Coding 薄兼容层负责。
- 保持现有屏幕循环与输入行为，不改动 transcript 渲染、分段、缓存、frame composition 和终端写入热路径。
- 补充架构边界、兼容性和直接行为测试，并将新增适配层纳入 `make check-harnesstui`。

### 验证

- `make check-harnesstui` — Ruff 通过；mypy 检查 78 个源文件无问题；750 passed，27 deselected。
- `make test-tui-render-contract` — 152 passed，3340 deselected。
- `git diff --check` — 通过。
