### PR TITLE
refactor(harness): centralize session capabilities / 重构(harness)：集中会话能力运行时

### DIFF
--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -98,6 +98,10 @@ planning, work event persistence, or AI provider behavior.
 - [Agent Transcript Maintenance Runtime Boundary](agent-transcript-maintenance-boundary.md)
   defines common context accounting, compaction/retry lifecycle, checkpoint
   persistence, and runtime events while Products retain strategy and policy.
+- [Session Capabilities Runtime Boundary](session-capabilities-boundary.md)
+  defines live tool activation, dynamic command composition and dispatch, and
+  selected command-tool execution while Products retain policy, command
+  implementations, extension semantics, prompts, and presentation.
 - [Store And Runtime Event Protocol Migration](store-event-protocol-migration.md)
   records the implemented protocol-based Store cutover, Memory/File reference
   adapters, Agent transcript persistence facade, common runtime-event envelope,

--- a/docs/internals/architecture/harness/coding-to-harness-migration-inventory.md
+++ b/docs/internals/architecture/harness/coding-to-harness-migration-inventory.md
@@ -320,9 +320,11 @@ concrete execution remain coding-owned.
 
 The reusable `ToolContext` now lives with the workspace tool pack after a
 Coding adapter and independent contract probe validated its shape. Keep
-`ExtensionRuntimeBindings`, `ToolController`, active-tool policy, prompt
-rebuilds, session mutation, and product model/diagnostic interpretation in
-Coding.
+`ExtensionRuntimeBindings`, active-tool policy, prompt rebuilds, session
+mutation, and product model/diagnostic interpretation in Coding. The shared
+live capability application now belongs to
+`harness.session.capabilities`; Coding `ToolController`, `CommandController`,
+and `BashController` bind Product policy and protocol behavior to that runtime.
 
 ### Workspace Execution
 

--- a/docs/internals/architecture/harness/session-capabilities-boundary.md
+++ b/docs/internals/architecture/harness/session-capabilities-boundary.md
@@ -1,0 +1,65 @@
+# Session Capabilities Runtime Boundary
+
+## Decision
+
+`loushang.harness.session.capabilities` owns the live application of
+Product-selected session capabilities:
+
+- tool selection, allowed-name filtering, live Agent-tool rebind, and prompt
+  rebuild notification;
+- ordered composition of approved command sources and ordered command dispatch;
+- selected workspace command-tool invocation, incremental output forwarding,
+  cancellation, portable command-result normalization, transcript commit, and
+  context refresh.
+
+It reuses the existing `ToolActivationCoordinator`, `CapabilityPackComposer`,
+command dispatch primitives, workspace execution types, and
+`CommandExecutionRecord`. It does not create another tool registry, command
+catalog, workspace backend, or transcript repository.
+
+## Product Binding
+
+Products supply callback ports for:
+
+- default and initial tool selection, contribution admission, and tool context;
+- prompt construction after the active tool set changes;
+- command-source descriptors, priorities, and concrete command handlers;
+- current workspace, selected command-tool definition, command parameter
+  construction, call ID, transcript append, and context refresh;
+- approval/extension interception and Product diagnostics translation.
+
+The runtime deliberately permits a different descriptor priority and handler
+priority for a command source. A Product can display its built-in command
+before an extension command while allowing the extension to handle that
+invocation first. Source admission and Product policy happen before values are
+passed to Harness.
+
+## Coding Binding
+
+Coding binds `ToolController`, `CommandController`, and `BashController` as
+thin adapters. Coding keeps its prompt text, default built-in tools, concrete
+tool context, tool admission diagnostics, built-in command implementations,
+resource and extension command mapping, `user_bash` extension protocol,
+Pi-style result projection, and TUI/RPC/HTML presentation.
+
+`BashController` currently chooses the `bash` workspace tool and constructs
+`['/bin/bash', '-lc', command]`. That shell choice is a Coding binding decision;
+the Harness runtime only owns selected command-tool lifecycle and portable
+result commit mechanics.
+
+## Dependency Rule
+
+This optional Agent-session profile may import public Agent tool contracts,
+Harness capability primitives, workspace execution types, and portable
+conversation records. It must not import Coding, Product prompts, extension
+runner APIs, providers, model/auth resolution, Product stores, or UI/RPC
+types. Those concerns are supplied through explicit ports.
+
+## Verification
+
+- Harness tests verify neutral tool rebind, separate command catalog/dispatch
+  precedence, and a command execution's single transcript commit.
+- Coding tests preserve active-tool policy, command precedence, extension
+  interception, Bash protocol output, and transcript context projection.
+- Architecture tests require the Harness runtime to stay free of Coding imports
+  and the three Coding controllers to adopt the Harness runtime classes.

--- a/src/loushang/coding/session/bash_controller.py
+++ b/src/loushang/coding/session/bash_controller.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
-from loushang.agent import AbortController, Agent
+from loushang.agent import Agent
 from loushang.coding.extensions import ExtensionRunner
 from loushang.coding.store import SessionManager
 from loushang.coding.tools import ToolRegistry
-from loushang.harness.conversation import CommandExecutionRecord
+from loushang.harness.session import (
+    SessionCommandExecutionRuntime,
+    UserCommandHookResult,
+    UserCommandRequest,
+)
+from loushang.harness.tools.core import ToolDefinition
 from loushang.harness.tools.workspace.protocol import (
     normalize_bash_result_from_protocol,
     project_bash_result_for_protocol,
@@ -28,6 +33,8 @@ def _noop_sync_extension_diagnostics(*, phase: str) -> None:
 
 @dataclass
 class BashController:
+    """Coding extension and protocol adapter for Harness command execution."""
+
     agent: Agent
     session_manager: SessionManager
     get_extension_runner: ExtensionRunnerProvider
@@ -35,12 +42,23 @@ class BashController:
     sync_extension_diagnostics: ExtensionDiagnosticsSync = (
         _noop_sync_extension_diagnostics
     )
+    _runtime: SessionCommandExecutionRuntime = field(init=False, repr=False)
 
-    _bash_abort_controller: AbortController | None = None
+    def __post_init__(self) -> None:
+        self._runtime = SessionCommandExecutionRuntime(
+            command_name="Bash",
+            get_cwd=self.session_manager.get_cwd,
+            get_definition=self._get_bash_definition,
+            build_execution_params=_build_bash_execution_params,
+            create_call_id=self._create_call_id,
+            append_record=self.session_manager.append_message,
+            refresh_context=self._refresh_context,
+            before_execute=self._before_bash,
+        )
 
     @property
     def is_running(self) -> bool:
-        return self._bash_abort_controller is not None
+        return self._runtime.is_running
 
     @property
     def has_pending_messages(self) -> bool:
@@ -60,111 +78,16 @@ class BashController:
         on_output: OutputCallback | None = None,
         operations: object | None = None,
     ) -> dict[str, object]:
-        if self._bash_abort_controller is not None:
-            raise RuntimeError("Bash execution already in progress")
-        effective_cwd = cwd or self.session_manager.get_cwd()
-        selected_operations = operations
-        extension_runner = self.get_extension_runner()
-        if extension_runner is not None and extension_runner.has_handlers("user_bash"):
-            event_result = await extension_runner.emit_user_bash(
-                {
-                    "type": "user_bash",
-                    "command": command,
-                    "exclude_from_context": exclude_from_context,
-                    "cwd": effective_cwd,
-                },
-                cwd=effective_cwd,
-            )
-            bash_result = _bash_result_from_extension_user_bash_result(event_result)
-            if bash_result is not None:
-                await self.record_result(
-                    command=command,
-                    result=bash_result,
-                    exclude_from_context=exclude_from_context,
-                )
-                self.sync_extension_diagnostics(phase="runtime")
-                return bash_result
-            extension_operations = _bash_operations_from_extension_user_bash_result(
-                event_result
-            )
-            if extension_operations is not None:
-                selected_operations = extension_operations
-            self.sync_extension_diagnostics(phase="runtime")
-
-        tool_registry = self.get_tool_registry()
-        if tool_registry is None:
-            raise RuntimeError("Bash execution requires a tool registry")
-
-        try:
-            bash_definition = tool_registry.get_definition("bash")
-        except KeyError as exc:
-            raise RuntimeError("Bash tool is not registered") from exc
-
-        controller = AbortController()
-        self._bash_abort_controller = controller
-        streamed_chunks: list[str] = []
-
-        async def _forward_update(partial_result) -> None:
-            details = getattr(partial_result, "details", None)
-            stream = details.get("stream") if isinstance(details, dict) else None
-            if stream not in {"stdout", "stderr"}:
-                return
-            text = "".join(
-                block.text
-                for block in partial_result.content
-                if getattr(block, "type", None) == "text"
-            )
-            if not text:
-                return
-            streamed_chunks.append(text)
-            if on_output is None:
-                return
-            forwarded = on_output(ExecOutputChunk(stream=stream, text=text))
-            if inspect.isawaitable(forwarded):
-                await forwarded
-
-        params: dict[str, object] = {
-            "command": ["/bin/bash", "-lc", command],
-            "cwd": effective_cwd,
-        }
-        if env is not None:
-            params["env"] = [list(pair) for pair in env]
-        if timeout_seconds is not None:
-            params["timeout_seconds"] = timeout_seconds
-        if stdin is not None:
-            params["stdin"] = stdin
-        if selected_operations is not None:
-            params["__operations"] = selected_operations
-
-        try:
-            tool_result = await bash_definition.execute(
-                f"bash-{self.session_manager.get_session_record().session_id}-{len(self.session_manager.get_entries())}",
-                params,
-                controller.signal,
-                _forward_update,
-            )
-            bash_result = _bash_result_from_tool_result(tool_result)
-        except RuntimeError as exc:
-            if "Command aborted" not in str(exc) or not getattr(
-                controller.signal, "aborted", False
-            ):
-                raise
-            bash_result = {
-                "output": "".join(streamed_chunks),
-                "exit_code": None,
-                "cancelled": True,
-                "truncated": False,
-                "full_output_path": None,
-            }
-        finally:
-            self._bash_abort_controller = None
-
-        await self.record_result(
-            command=command,
-            result=bash_result,
+        return await self._runtime.execute(
+            command,
+            cwd=cwd,
+            env=env,
+            timeout_seconds=timeout_seconds,
+            stdin=stdin,
             exclude_from_context=exclude_from_context,
+            on_output=on_output,
+            operations=operations,
         )
-        return bash_result
 
     async def execute_pi_style(
         self,
@@ -180,21 +103,15 @@ class BashController:
                 await result
 
         options = dict(options or {})
+        cwd = options.get("cwd")
+        stdin = options.get("stdin")
         result = await self.execute_bash(
             command,
-            cwd=options.get("cwd") if isinstance(options.get("cwd"), str) else None,
-            timeout_seconds=(
-                float(options["timeout_seconds"])
-                if isinstance(options.get("timeout_seconds"), int | float)
-                else (
-                    float(options["timeoutSeconds"])
-                    if isinstance(options.get("timeoutSeconds"), int | float)
-                    else None
-                )
+            cwd=cwd if isinstance(cwd, str) else None,
+            timeout_seconds=_option_float(
+                options.get("timeout_seconds", options.get("timeoutSeconds"))
             ),
-            stdin=options.get("stdin")
-            if isinstance(options.get("stdin"), str)
-            else None,
+            stdin=stdin if isinstance(stdin, str) else None,
             exclude_from_context=bool(
                 options.get(
                     "excludeFromContext", options.get("exclude_from_context", False)
@@ -206,8 +123,7 @@ class BashController:
         return project_bash_result_for_protocol(result)
 
     def abort(self) -> None:
-        if self._bash_abort_controller is not None:
-            self._bash_abort_controller.abort()
+        self._runtime.abort()
 
     async def record_result(
         self,
@@ -216,25 +132,11 @@ class BashController:
         result: dict[str, object],
         exclude_from_context: bool,
     ) -> None:
-        exit_code = result.get("exit_code")
-        await self.session_manager.append_message(
-            CommandExecutionRecord(
-                command=command,
-                output=str(result.get("output") or ""),
-                exit_code=exit_code if type(exit_code) is int else None,
-                cancelled=bool(result.get("cancelled", False)),
-                truncated=bool(result.get("truncated", False)),
-                full_output_path=(
-                    str(result["full_output_path"])
-                    if isinstance(result.get("full_output_path"), str)
-                    and result.get("full_output_path")
-                    else None
-                ),
-                exclude_from_context=exclude_from_context,
-            )
+        await self._runtime.record_result(
+            command=command,
+            result=result,
+            exclude_from_context=exclude_from_context,
         )
-        session_context = self.session_manager.build_session_context()
-        self.agent.state.set_messages(session_context.messages)
 
     async def record_pi_style_result(
         self,
@@ -243,10 +145,9 @@ class BashController:
         options: dict[str, object] | None = None,
     ) -> None:
         options = dict(options or {})
-        normalized = normalize_bash_result_from_protocol(result)
         await self.record_result(
             command=command,
-            result=normalized,
+            result=normalize_bash_result_from_protocol(result),
             exclude_from_context=bool(
                 options.get(
                     "excludeFromContext", options.get("exclude_from_context", False)
@@ -254,27 +155,49 @@ class BashController:
             ),
         )
 
+    def _get_bash_definition(self) -> ToolDefinition | None:
+        tool_registry = self.get_tool_registry()
+        if tool_registry is None:
+            raise RuntimeError("Bash execution requires a tool registry")
+        try:
+            return tool_registry.get_definition("bash")
+        except KeyError as exc:
+            raise RuntimeError("Bash tool is not registered") from exc
 
-def _bash_result_from_tool_result(tool_result) -> dict[str, object]:
-    details = tool_result.details if isinstance(tool_result.details, dict) else {}
-    output = "".join(
-        block.text
-        for block in tool_result.content
-        if getattr(block, "type", None) == "text"
-    )
-    stderr = details.get("stderr")
-    if isinstance(stderr, str) and stderr and not output.endswith(stderr):
-        output = output + stderr
-    return {
-        "output": output,
-        "exit_code": details.get("exit_code"),
-        "cancelled": bool(details.get("cancelled", False)),
-        "truncated": bool(
-            details.get("truncated", False) or details.get("stderr_truncated", False)
-        ),
-        "full_output_path": details.get("stdout_artifact_path")
-        or details.get("stderr_artifact_path"),
-    }
+    def _create_call_id(self) -> str:
+        return (
+            f"bash-{self.session_manager.get_session_record().session_id}-"
+            f"{len(self.session_manager.get_entries())}"
+        )
+
+    def _refresh_context(self) -> None:
+        self.agent.state.set_messages(
+            list(self.session_manager.build_session_context().messages)
+        )
+
+    async def _before_bash(
+        self,
+        request: UserCommandRequest,
+    ) -> UserCommandHookResult | None:
+        extension_runner = self.get_extension_runner()
+        if extension_runner is None or not extension_runner.has_handlers("user_bash"):
+            return None
+        event_result = await extension_runner.emit_user_bash(
+            {
+                "type": "user_bash",
+                "command": request.command,
+                "exclude_from_context": request.exclude_from_context,
+                "cwd": request.cwd,
+            },
+            cwd=request.cwd,
+        )
+        self.sync_extension_diagnostics(phase="runtime")
+        result = _bash_result_from_extension_user_bash_result(event_result)
+        if result is not None:
+            return UserCommandHookResult(result=result)
+        return UserCommandHookResult(
+            operations=_bash_operations_from_extension_user_bash_result(event_result)
+        )
 
 
 def _bash_result_from_extension_user_bash_result(
@@ -292,6 +215,10 @@ def _bash_result_from_extension_user_bash_result(
     return normalize_bash_result_from_protocol(result)
 
 
+def _build_bash_execution_params(command: str, cwd: str) -> dict[str, object]:
+    return {"command": ["/bin/bash", "-lc", command], "cwd": cwd}
+
+
 def _bash_operations_from_extension_user_bash_result(
     event_result: object | None,
 ) -> object | None:
@@ -300,3 +227,7 @@ def _bash_operations_from_extension_user_bash_result(
     if isinstance(event_result, dict):
         return event_result.get("operations")
     return getattr(event_result, "operations", None)
+
+
+def _option_float(value: object) -> float | None:
+    return float(value) if isinstance(value, int | float) else None

--- a/src/loushang/coding/session/command_controller.py
+++ b/src/loushang/coding/session/command_controller.py
@@ -28,16 +28,10 @@ from loushang.coding.source_info import (
 from loushang.coding.store import SessionManager
 from loushang.harness.capabilities.commands import (
     CommandDispatchOutcome,
-    CommandHandlerBinding,
     ParsedSlashCommand,
-    dispatch_command_async,
-    normalize_command_name,
     split_slash_command,
 )
-from loushang.harness.capabilities.packs import (
-    CapabilityPack,
-    CapabilityPackComposer,
-)
+from loushang.harness.capabilities.packs import CapabilityPackComposer
 from loushang.harness.diagnostics.service import DiagnosticsService
 from loushang.harness.resources.diagnostics import ResourceDiagnostic
 from loushang.harness.resources.frontmatter import strip_frontmatter
@@ -47,6 +41,7 @@ from loushang.harness.resources.types import (
     ResourceBundle,
     SkillDescriptor,
 )
+from loushang.harness.session import CommandRuntimeSource, SessionCommandRuntime
 
 
 @dataclass
@@ -59,12 +54,59 @@ class CommandController:
     pack_composer: CapabilityPackComposer = field(
         default_factory=CapabilityPackComposer
     )
+    _runtime: SessionCommandRuntime[SessionCommandDescriptor, CommandExecutionResult] = (
+        field(init=False, repr=False)
+    )
+
+    def __post_init__(self) -> None:
+        self._runtime = SessionCommandRuntime(
+            sources=(
+                CommandRuntimeSource(
+                    pack_id="coding.builtin-commands",
+                    source="product",
+                    descriptor_priority=300,
+                    handler_priority=200,
+                    list_descriptors=self._list_builtin_commands,
+                    handler_name="builtin",
+                    handler=self._dispatch_builtin_command,
+                ),
+                CommandRuntimeSource(
+                    pack_id="coding.extension-commands",
+                    source="extension",
+                    descriptor_priority=200,
+                    handler_priority=300,
+                    list_descriptors=self._list_extension_commands,
+                    handler_name="extension",
+                    handler=self._dispatch_extension_command,
+                ),
+                CommandRuntimeSource(
+                    pack_id="coding.resource-commands",
+                    source="product",
+                    descriptor_priority=100,
+                    handler_priority=100,
+                    list_descriptors=self._list_resource_commands,
+                    handler_name="resource",
+                    handler=self._dispatch_resource_command,
+                ),
+            ),
+            pack_composer=self.pack_composer,
+        )
 
     def list_commands(self) -> list[SessionCommandDescriptor]:
+        return self._runtime.list_commands()
+
+    async def execute_command_async(
+        self, invocation_name: str, args: str
+    ) -> CommandExecutionResult | None:
+        return await self._runtime.execute(invocation_name, args)
+
+    def _list_builtin_commands(self) -> list[SessionCommandDescriptor]:
         builtin_commands: list[SessionCommandDescriptor] = []
         if self.builtin_backend is not None:
             builtin_commands.extend(list_builtin_command_descriptors())
+        return builtin_commands
 
+    def _list_extension_commands(self) -> list[SessionCommandDescriptor]:
         extension_commands: list[SessionCommandDescriptor] = []
         extension_runner = self.get_extension_runner()
         if extension_runner is not None:
@@ -83,7 +125,9 @@ class CommandController:
                         else None,
                     )
                 )
+        return extension_commands
 
+    def _list_resource_commands(self) -> list[SessionCommandDescriptor]:
         resource_commands: list[SessionCommandDescriptor] = []
         resource_bundle = self.get_resource_bundle()
         if resource_bundle is not None:
@@ -112,78 +156,7 @@ class CommandController:
                         ),
                     )
                 )
-        return list(
-            self.pack_composer.compose(
-                (
-                    CapabilityPack(
-                        pack_id="coding.builtin-commands",
-                        source="product",
-                        priority=300,
-                        items=tuple(builtin_commands),
-                    ),
-                    CapabilityPack(
-                        pack_id="coding.extension-commands",
-                        source="extension",
-                        priority=200,
-                        items=tuple(extension_commands),
-                    ),
-                    CapabilityPack(
-                        pack_id="coding.resource-commands",
-                        source="product",
-                        priority=100,
-                        items=tuple(resource_commands),
-                    ),
-                )
-            ).items
-        )
-
-    async def execute_command_async(
-        self, invocation_name: str, args: str
-    ) -> CommandExecutionResult | None:
-        invocation_name = normalize_command_name(invocation_name)
-        invocation = ParsedSlashCommand(
-            name=invocation_name,
-            args=args,
-            is_mcp=invocation_name.endswith(" (MCP)"),
-        )
-        outcome = await dispatch_command_async(
-            invocation,
-            self.pack_composer.compose(
-                (
-                    CapabilityPack(
-                        pack_id="coding.extension-command-handler",
-                        source="extension",
-                        priority=300,
-                        items=(
-                            CommandHandlerBinding(
-                                "extension", self._dispatch_extension_command
-                            ),
-                        ),
-                    ),
-                    CapabilityPack(
-                        pack_id="coding.builtin-command-handler",
-                        source="product",
-                        priority=200,
-                        items=(
-                            CommandHandlerBinding(
-                                "builtin", self._dispatch_builtin_command
-                            ),
-                        ),
-                    ),
-                    CapabilityPack(
-                        pack_id="coding.resource-command-handler",
-                        source="product",
-                        priority=100,
-                        items=(
-                            CommandHandlerBinding(
-                                "resource", self._dispatch_resource_command
-                            ),
-                        ),
-                    ),
-                )
-            ).items,
-        )
-        return outcome.result if outcome.handled else None
+        return resource_commands
 
     async def _dispatch_extension_command(
         self,

--- a/src/loushang/coding/session/tool_controller.py
+++ b/src/loushang/coding/session/tool_controller.py
@@ -5,27 +5,18 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
-from loushang.agent.types import AgentTool, ensure_agent_tool, is_agent_tool_like
+from loushang.agent.types import AgentTool
 from loushang.coding.prompt import assemble_prompt
 from loushang.coding.store import SessionManager
 from loushang.coding.tools import ToolRegistry
 from loushang.harness.capabilities.prompt import PromptSectionComposer
-from loushang.harness.capabilities.tools import (
-    ToolActivationChange,
-    ToolActivationCoordinator,
-)
 from loushang.harness.diagnostics.service import DiagnosticsService
 from loushang.harness.resources.activation import ResourceActivationRuntime
 from loushang.harness.resources.types import ResourceBundle
-from loushang.harness.tools.contribution import (
-    ToolContribution,
-    ToolResolutionResult,
-    resolve_tool_contributions,
-)
+from loushang.harness.session import SessionToolRuntime
+from loushang.harness.tools.contribution import resolve_tool_contributions
 from loushang.harness.tools.core import ToolDefinition
 from loushang.harness.tools.workspace.context import ToolContext
-from loushang.harness.tools.workspace.normalize import tool_to_definition
-from loushang.harness.tools.workspace.wrapper import create_tool_definition_from_tool
 
 _DEFAULT_ACTIVE_TOOL_NAMES: tuple[str, ...] = (
     "read",
@@ -57,6 +48,8 @@ class AgentPort(Protocol):
 
 @dataclass
 class ToolController:
+    """Coding prompt and policy adapter for ``SessionToolRuntime``."""
+
     agent: AgentPort
     session_manager: SessionManager
     tool_registry: ToolRegistry | None
@@ -74,25 +67,26 @@ class ToolController:
     prompt_section_composer: PromptSectionComposer = field(
         default_factory=PromptSectionComposer
     )
-    _activation: ToolActivationCoordinator[ToolDefinition] = field(
-        init=False,
-        repr=False,
-    )
+    _runtime: SessionToolRuntime = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        self._activation = ToolActivationCoordinator(
-            available=self._available_definitions(),
-            requested_names=self.initial_active_tool_names,
-            allowed_names=self.allowed_tool_names,
-            should_activate_new=self._should_activate_new_tool,
-            rebind=self._rebind_active_tools,
+        self._runtime = SessionToolRuntime(
+            agent=self.agent,
+            tool_registry=self.tool_registry,
+            allowed_tool_names=self.allowed_tool_names,
+            initial_active_tool_names=self.initial_active_tool_names,
+            default_active_tool_names=self._default_active_tool_names,
+            should_activate_new_tool=self._should_activate_new_tool,
+            build_tool_context=self.build_tool_context,
+            rebuild_prompt=self._rebuild_prompt,
+            resolve_contributions=resolve_tool_contributions,
         )
 
     def get_active_tool_names(self) -> list[str]:
-        return list(self._activation.snapshot().active_names)
+        return self._runtime.get_active_tool_names()
 
     def get_all_tools(self) -> list[ToolDefinition]:
-        return list(self._activation.filter_items(self._available_definitions()))
+        return self._runtime.get_all_tools()
 
     def get_all_tool_infos(self) -> list[dict[str, object]]:
         return [
@@ -104,23 +98,10 @@ class ToolController:
         ]
 
     def get_tool_definition(self, name: str) -> ToolDefinition | None:
-        if not self.is_tool_allowed(name):
-            return None
-        if self.tool_registry is not None:
-            try:
-                return self.tool_registry.get_definition(name)
-            except KeyError:
-                return None
-        for definition in self.get_all_tools():
-            if definition.name == name:
-                return definition
-        return None
+        return self._runtime.get_tool_definition(name)
 
     def apply_active_tools(self, tool_names: list[str]) -> None:
-        if self.tool_registry is None:
-            raise RuntimeError("Active tool selection requires a tool registry")
-        self._sync_available(activate_new=False, rebind=False)
-        self._activation.request(tool_names)
+        self._runtime.apply_active_tools(tool_names)
 
     def build_tool_context(self, *, tool_call_id: str) -> ToolContext:
         return ToolContext(
@@ -138,32 +119,41 @@ class ToolController:
     def resolve_active_tool_definitions(
         self, tool_names: list[str]
     ) -> tuple[list[ToolDefinition], list[str]]:
-        if self.tool_registry is None:
-            raise RuntimeError("Active tool selection requires a tool registry")
-        self._sync_available(activate_new=False, rebind=False)
-        resolution = self._activation.resolve(tool_names)
-        return list(resolution.items), list(resolution.names)
+        return self._runtime.resolve_active_tool_definitions(tool_names)
 
     def is_tool_allowed(self, name: str) -> bool:
-        return self._activation.is_allowed(name)
+        return self._runtime.is_tool_allowed(name)
 
     def filter_allowed_tool_names(self, tool_names: list[str]) -> list[str]:
-        return list(self._activation.filter_names(tool_names))
+        return self._runtime.filter_allowed_tool_names(tool_names)
 
     def filter_allowed_tool_definitions(
         self, definitions: list[ToolDefinition]
     ) -> list[ToolDefinition]:
-        return list(self._activation.filter_items(definitions))
+        return self._runtime.filter_allowed_tool_definitions(definitions)
 
     def tool_source_info(self, name: str) -> object | None:
-        if self.tool_registry is None:
-            return None
-        try:
-            return self.tool_registry.get_source_info(name)
-        except KeyError:
-            return None
+        return self._runtime.tool_source_info(name)
 
     def default_active_tool_names(self) -> list[str]:
+        return self._runtime.default_active_names()
+
+    def ensure_tool_registry(self) -> ToolRegistry:
+        if self.tool_registry is None:
+            self.tool_registry = ToolRegistry()
+            self._runtime.set_tool_registry(self.tool_registry)
+        return self.tool_registry
+
+    def register_runtime_tool(
+        self, tool: object, *, source_info: object | None = None
+    ) -> ToolDefinition:
+        self.ensure_tool_registry()
+        return self._runtime.register_runtime_tool(tool, source_info=source_info)
+
+    def rebuild_prompt_and_tools_view(self) -> None:
+        self._runtime.rebuild_prompt_and_tools_view()
+
+    def _default_active_tool_names(self) -> list[str]:
         if self.tool_registry is None:
             return []
         enabled_names = [
@@ -183,48 +173,20 @@ class ToolController:
         )
         return active_names
 
-    def ensure_tool_registry(self) -> ToolRegistry:
-        if self.tool_registry is None:
-            self.tool_registry = ToolRegistry()
-        return self.tool_registry
+    def _should_activate_new_tool(self, name: str, definition: ToolDefinition) -> bool:
+        del definition
+        return self.default_activate_new_tools and name not in _BUILTIN_TOOL_NAMES
 
-    def register_runtime_tool(
-        self, tool: object, *, source_info: object | None = None
-    ) -> ToolDefinition:
-        registry = self.ensure_tool_registry()
-        contribution = _runtime_tool_contribution(tool, source_info=source_info)
-        resolution = resolve_tool_contributions(
-            (
-                *registry.list_contributions(),
-                contribution,
-            ),
-            fail_on_errors=False,
-        )
-        registration_contribution = _runtime_tool_registration_contribution(
-            resolution,
-            fallback=contribution,
-        )
-        definition = registry.register_tool(
-            registration_contribution.definition,
-            source_info=registration_contribution.source_info,
-        )
-        if not self.is_tool_allowed(definition.name):
-            self.rebuild_prompt_and_tools_view()
-            return definition
-
-        self._sync_available(activate_new=True, rebind=True)
-        return definition
-
-    def rebuild_prompt_and_tools_view(self) -> None:
-        active_definitions: list[ToolDefinition] | None = None
-        tool_prompt: str | None = None
-        if self.tool_registry is not None:
-            self._sync_available(activate_new=False, rebind=False)
-            active_definitions = list(self._activation.active_items())
-        elif self.show_empty_tool_prompt:
+    def _rebuild_prompt(
+        self, active_definitions: list[ToolDefinition] | None
+    ) -> None:
+        if self.show_empty_tool_prompt and active_definitions is None:
             active_definitions = []
-        if self.show_empty_tool_prompt and active_definitions == []:
-            tool_prompt = "Available tools:\n(none)"
+        tool_prompt = (
+            "Available tools:\n(none)"
+            if self.show_empty_tool_prompt and active_definitions == []
+            else None
+        )
         prompt_assembly = assemble_prompt(
             base_prompt=self.base_prompt,
             resource_bundle=self.get_resource_bundle(),
@@ -236,38 +198,6 @@ class ToolController:
             prompt_section_composer=self.prompt_section_composer,
         )
         self.agent.system_prompt = prompt_assembly.system_prompt
-
-    def _available_definitions(self) -> list[ToolDefinition]:
-        if self.tool_registry is not None:
-            return self.tool_registry.list_definitions()
-        return [
-            create_tool_definition_from_tool(tool)
-            if isinstance(tool, AgentTool)
-            else tool_to_definition(tool)
-            for tool in self.agent.tools
-        ]
-
-    def _sync_available(self, *, activate_new: bool, rebind: bool) -> None:
-        self._activation.refresh(
-            self._available_definitions(),
-            activate_new=activate_new,
-            rebind=rebind,
-        )
-
-    def _should_activate_new_tool(self, name: str, definition: ToolDefinition) -> bool:
-        del definition
-        return self.default_activate_new_tools and name not in _BUILTIN_TOOL_NAMES
-
-    def _rebind_active_tools(
-        self,
-        change: ToolActivationChange[ToolDefinition],
-    ) -> None:
-        if self.tool_registry is not None:
-            self.agent.tools = self.tool_registry.materialize_definitions(
-                list(change.active_items),
-                context_provider=self.build_tool_context,
-            )
-        self.rebuild_prompt_and_tools_view()
 
     async def _emit_tool_audit_event(
         self,
@@ -288,41 +218,6 @@ def _tool_info_from_definition(
         if source_info is not None
         else _synthetic_tool_source_info(definition.name),
     }
-
-
-def _runtime_tool_contribution(
-    tool: object, *, source_info: object | None = None
-) -> ToolContribution:
-    definition = _runtime_tool_definition(tool)
-    return ToolContribution(
-        definition,
-        source_info=source_info,
-        metadata={
-            "kind": "runtime_tool",
-            "runtime_tool": definition.name,
-        },
-    )
-
-
-def _runtime_tool_definition(tool: object) -> ToolDefinition:
-    if isinstance(tool, ToolDefinition):
-        return tool
-    if is_agent_tool_like(tool):
-        return create_tool_definition_from_tool(ensure_agent_tool(tool))
-    return tool_to_definition(tool)
-
-
-def _runtime_tool_registration_contribution(
-    resolution: ToolResolutionResult,
-    *,
-    fallback: ToolContribution,
-) -> ToolContribution:
-    for contribution in resolution.contributions:
-        if contribution.definition.name != fallback.definition.name:
-            continue
-        if contribution.metadata.get("kind") == "runtime_tool":
-            return contribution
-    return fallback
 
 
 def _synthetic_tool_source_info(name: str) -> dict[str, object]:

--- a/src/loushang/harness/session/__init__.py
+++ b/src/loushang/harness/session/__init__.py
@@ -9,6 +9,17 @@ from loushang.harness.session.application_input import (
     ApplicationInputDelivery,
     ApplicationInputRuntime,
 )
+from loushang.harness.session.capabilities import (
+    AgentToolPort,
+    CommandRuntimeSource,
+    SessionCommandExecutionRuntime,
+    SessionCommandRuntime,
+    SessionToolRuntime,
+    ToolRegistryPort,
+    UserCommandHookResult,
+    UserCommandRequest,
+    command_result_from_tool_result,
+)
 from loushang.harness.session.lifecycle import (
     DEFAULT_FORK_PROFILE,
     FileCopy,
@@ -38,8 +49,10 @@ from loushang.harness.session.runtime import (
 __all__ = [
     "AgentEventRouter",
     "AfterTurnPolicyPort",
+    "AgentToolPort",
     "ApplicationInputDelivery",
     "ApplicationInputRuntime",
+    "CommandRuntimeSource",
     "DEFAULT_FORK_PROFILE",
     "FileCopy",
     "ForkProfile",
@@ -49,7 +62,10 @@ __all__ = [
     "MissingSessionCwdError",
     "PromptController",
     "QueueController",
+    "SessionCommandExecutionRuntime",
+    "SessionCommandRuntime",
     "SessionRuntime",
+    "SessionToolRuntime",
     "SessionCwdIssue",
     "SessionLifecycleDecision",
     "SessionLifecycleHooks",
@@ -59,5 +75,9 @@ __all__ = [
     "TransitionCandidateCallback",
     "TransitionReleaseCallback",
     "TranscriptRuntimePort",
+    "ToolRegistryPort",
     "TurnPolicyPort",
+    "UserCommandHookResult",
+    "UserCommandRequest",
+    "command_result_from_tool_result",
 ]

--- a/src/loushang/harness/session/capabilities.py
+++ b/src/loushang/harness/session/capabilities.py
@@ -1,0 +1,554 @@
+"""Runtime binding for Product-selected tools and commands in one session.
+
+The generic capability primitives resolve names, packs, and command dispatch.
+This module owns their live session application: selected tools are rebound to
+the Agent, command providers are composed in order, and user-triggered command
+tools can stream output into a transcript.  Products inject prompt wording,
+tool contexts, command handlers, and extension interception.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Generic, Protocol, TypeVar
+
+from loushang.agent import AbortController
+from loushang.agent.types import AgentTool, ensure_agent_tool, is_agent_tool_like
+from loushang.harness.capabilities.commands import (
+    CommandHandler,
+    CommandHandlerBinding,
+    ParsedSlashCommand,
+    dispatch_command_async,
+    normalize_command_name,
+)
+from loushang.harness.capabilities.packs import (
+    CapabilityPack,
+    CapabilityPackComposer,
+    CapabilityPackSource,
+)
+from loushang.harness.capabilities.tools import (
+    ToolActivationChange,
+    ToolActivationCoordinator,
+)
+from loushang.harness.conversation import CommandExecutionRecord
+from loushang.harness.tools.contribution import (
+    ToolContribution,
+    ToolResolutionResult,
+    resolve_tool_contributions,
+)
+from loushang.harness.tools.core import ToolDefinition
+from loushang.harness.tools.workspace.context import ToolContextProvider
+from loushang.harness.tools.workspace.normalize import tool_to_definition
+from loushang.harness.tools.workspace.wrapper import create_tool_definition_from_tool
+from loushang.harness.workspace.exec import ExecOutputChunk
+
+
+class AgentToolPort(Protocol):
+    """The mutable Agent tool surface required by the session tool runtime."""
+
+    @property
+    def tools(self) -> list[AgentTool[Any]]: ...
+
+    @tools.setter
+    def tools(self, value: list[AgentTool[Any]]) -> None: ...
+
+
+class ToolRegistryPort(Protocol):
+    """Registry operations needed after a Product admits a tool contribution."""
+
+    def get_definition(self, name: str) -> ToolDefinition: ...
+
+    def get_source_info(self, name: str) -> object | None: ...
+
+    def list_contributions(self) -> tuple[ToolContribution, ...]: ...
+
+    def list_definitions(self) -> list[ToolDefinition]: ...
+
+    def list_enabled_definitions(self) -> list[ToolDefinition]: ...
+
+    def materialize_definitions(
+        self,
+        definitions: list[ToolDefinition],
+        *,
+        context_provider: ToolContextProvider | None = None,
+    ) -> list[AgentTool[Any]]: ...
+
+    def register_tool(
+        self,
+        tool: ToolDefinition | object,
+        *,
+        enabled: bool = True,
+        source_info: object | None = None,
+    ) -> ToolDefinition: ...
+
+
+ToolPromptRebuilder = Callable[[list[ToolDefinition] | None], None]
+ToolActivationPolicy = Callable[[str, ToolDefinition], bool]
+ToolDefaultSelection = Callable[[], Iterable[str]]
+ToolContributionResolver = Callable[..., ToolResolutionResult]
+
+
+@dataclass
+class SessionToolRuntime:
+    """Apply the Product-selected tool capability set to one live Agent."""
+
+    agent: AgentToolPort
+    tool_registry: ToolRegistryPort | None
+    allowed_tool_names: set[str] | None
+    initial_active_tool_names: Iterable[str]
+    default_active_tool_names: ToolDefaultSelection
+    should_activate_new_tool: ToolActivationPolicy
+    build_tool_context: ToolContextProvider
+    rebuild_prompt: ToolPromptRebuilder
+    resolve_contributions: ToolContributionResolver = resolve_tool_contributions
+    _activation: ToolActivationCoordinator[ToolDefinition] = field(
+        init=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        self._activation = ToolActivationCoordinator(
+            available=self._available_definitions(),
+            requested_names=self.initial_active_tool_names,
+            allowed_names=self.allowed_tool_names,
+            should_activate_new=self.should_activate_new_tool,
+            rebind=self._rebind_active_tools,
+        )
+
+    def get_active_tool_names(self) -> list[str]:
+        return list(self._activation.snapshot().active_names)
+
+    def get_all_tools(self) -> list[ToolDefinition]:
+        return list(self._activation.filter_items(self._available_definitions()))
+
+    def get_tool_definition(self, name: str) -> ToolDefinition | None:
+        if not self.is_tool_allowed(name):
+            return None
+        if self.tool_registry is not None:
+            try:
+                return self.tool_registry.get_definition(name)
+            except KeyError:
+                return None
+        for definition in self.get_all_tools():
+            if definition.name == name:
+                return definition
+        return None
+
+    def apply_active_tools(self, tool_names: Iterable[str]) -> None:
+        self._require_registry()
+        self._sync_available(activate_new=False, rebind=False)
+        self._activation.request(tool_names)
+
+    def resolve_active_tool_definitions(
+        self, tool_names: Iterable[str]
+    ) -> tuple[list[ToolDefinition], list[str]]:
+        self._require_registry()
+        self._sync_available(activate_new=False, rebind=False)
+        resolution = self._activation.resolve(tool_names)
+        return list(resolution.items), list(resolution.names)
+
+    def is_tool_allowed(self, name: str) -> bool:
+        return self._activation.is_allowed(name)
+
+    def filter_allowed_tool_names(self, tool_names: Iterable[str]) -> list[str]:
+        return list(self._activation.filter_names(tool_names))
+
+    def filter_allowed_tool_definitions(
+        self, definitions: Iterable[ToolDefinition]
+    ) -> list[ToolDefinition]:
+        return list(self._activation.filter_items(definitions))
+
+    def tool_source_info(self, name: str) -> object | None:
+        if self.tool_registry is None:
+            return None
+        try:
+            return self.tool_registry.get_source_info(name)
+        except KeyError:
+            return None
+
+    def default_active_names(self) -> list[str]:
+        if self.tool_registry is None:
+            return []
+        return self.filter_allowed_tool_names(self.default_active_tool_names())
+
+    def set_tool_registry(self, registry: ToolRegistryPort) -> None:
+        self.tool_registry = registry
+        self._sync_available(activate_new=False, rebind=False)
+
+    def register_runtime_tool(
+        self,
+        tool: object,
+        *,
+        source_info: object | None = None,
+    ) -> ToolDefinition:
+        registry = self._require_registry()
+        contribution = _runtime_tool_contribution(tool, source_info=source_info)
+        resolution = self.resolve_contributions(
+            (*registry.list_contributions(), contribution),
+            fail_on_errors=False,
+        )
+        registration = _runtime_tool_registration_contribution(
+            resolution,
+            fallback=contribution,
+        )
+        definition = registry.register_tool(
+            registration.definition,
+            source_info=registration.source_info,
+        )
+        if not self.is_tool_allowed(definition.name):
+            self.rebuild_prompt_and_tools_view()
+            return definition
+        self._sync_available(activate_new=True, rebind=True)
+        return definition
+
+    def rebuild_prompt_and_tools_view(self) -> None:
+        active_definitions: list[ToolDefinition] | None = None
+        if self.tool_registry is not None:
+            self._sync_available(activate_new=False, rebind=False)
+            active_definitions = list(self._activation.active_items())
+        self.rebuild_prompt(active_definitions)
+
+    def _available_definitions(self) -> list[ToolDefinition]:
+        if self.tool_registry is not None:
+            return self.tool_registry.list_definitions()
+        return [
+            create_tool_definition_from_tool(tool)
+            if isinstance(tool, AgentTool)
+            else tool_to_definition(tool)
+            for tool in self.agent.tools
+        ]
+
+    def _sync_available(self, *, activate_new: bool, rebind: bool) -> None:
+        self._activation.refresh(
+            self._available_definitions(),
+            activate_new=activate_new,
+            rebind=rebind,
+        )
+
+    def _rebind_active_tools(
+        self,
+        change: ToolActivationChange[ToolDefinition],
+    ) -> None:
+        if self.tool_registry is not None:
+            self.agent.tools = self.tool_registry.materialize_definitions(
+                list(change.active_items),
+                context_provider=self.build_tool_context,
+            )
+        self.rebuild_prompt(list(change.active_items))
+
+    def _require_registry(self) -> ToolRegistryPort:
+        if self.tool_registry is None:
+            raise RuntimeError("Active tool selection requires a tool registry")
+        return self.tool_registry
+
+
+DescriptorT = TypeVar("DescriptorT")
+ResultT = TypeVar("ResultT")
+
+
+@dataclass(frozen=True)
+class CommandRuntimeSource(Generic[DescriptorT, ResultT]):
+    """A Product-approved dynamic command contribution source."""
+
+    pack_id: str
+    source: CapabilityPackSource
+    descriptor_priority: int
+    handler_priority: int
+    list_descriptors: Callable[[], Iterable[DescriptorT]]
+    handler_name: str
+    handler: CommandHandler[ResultT]
+
+
+@dataclass
+class SessionCommandRuntime(Generic[DescriptorT, ResultT]):
+    """Compose and dispatch dynamic command sources for one live session."""
+
+    sources: tuple[CommandRuntimeSource[DescriptorT, ResultT], ...]
+    pack_composer: CapabilityPackComposer = field(
+        default_factory=CapabilityPackComposer
+    )
+
+    def list_commands(self) -> list[DescriptorT]:
+        packs = tuple(
+            CapabilityPack(
+                pack_id=source.pack_id,
+                source=source.source,
+                priority=source.descriptor_priority,
+                items=tuple(source.list_descriptors()),
+            )
+            for source in self.sources
+        )
+        return list(self.pack_composer.compose(packs).items)
+
+    async def execute(
+        self,
+        invocation_name: str,
+        args: str,
+    ) -> ResultT | None:
+        normalized_name = normalize_command_name(invocation_name)
+        invocation = ParsedSlashCommand(
+            name=normalized_name,
+            args=args,
+            is_mcp=normalized_name.endswith(" (MCP)"),
+        )
+        handlers = self.pack_composer.compose(
+            CapabilityPack(
+                pack_id=source.pack_id,
+                source=source.source,
+                priority=source.handler_priority,
+                items=(CommandHandlerBinding(source.handler_name, source.handler),),
+            )
+            for source in self.sources
+        ).items
+        outcome = await dispatch_command_async(invocation, handlers)
+        return outcome.result if outcome.handled else None
+
+
+CommandHook = Callable[["UserCommandRequest"], Awaitable["UserCommandHookResult | None"]]
+CommandOutputCallback = Callable[[ExecOutputChunk], Awaitable[None] | None]
+AppendCommandRecord = Callable[[CommandExecutionRecord], Awaitable[object]]
+ContextRefresher = Callable[[], None]
+CommandDefinitionProvider = Callable[[], ToolDefinition | None]
+CommandCallIdFactory = Callable[[], str]
+CommandParametersBuilder = Callable[[str, str], Mapping[str, object]]
+
+
+@dataclass(frozen=True)
+class UserCommandRequest:
+    command: str
+    cwd: str
+    exclude_from_context: bool
+
+
+@dataclass(frozen=True)
+class UserCommandHookResult:
+    """Optional intercepted result or execution operations for a command."""
+
+    result: Mapping[str, object] | None = None
+    operations: object | None = None
+
+
+@dataclass
+class SessionCommandExecutionRuntime:
+    """Run a selected command tool and commit its result to the transcript."""
+
+    command_name: str
+    get_cwd: Callable[[], str]
+    get_definition: CommandDefinitionProvider
+    build_execution_params: CommandParametersBuilder
+    create_call_id: CommandCallIdFactory
+    append_record: AppendCommandRecord
+    refresh_context: ContextRefresher
+    before_execute: CommandHook | None = None
+    _abort_controller: AbortController | None = field(default=None, init=False)
+
+    @property
+    def is_running(self) -> bool:
+        return self._abort_controller is not None
+
+    async def execute(
+        self,
+        command: str,
+        *,
+        cwd: str | None = None,
+        env: list[list[str] | tuple[str, str]]
+        | tuple[tuple[str, str], ...]
+        | None = None,
+        timeout_seconds: float | None = None,
+        stdin: str | None = None,
+        exclude_from_context: bool = False,
+        on_output: CommandOutputCallback | None = None,
+        operations: object | None = None,
+    ) -> dict[str, object]:
+        if self._abort_controller is not None:
+            raise RuntimeError(f"{self.command_name} execution already in progress")
+        effective_cwd = cwd or self.get_cwd()
+        selected_operations = operations
+        if self.before_execute is not None:
+            interception = await self.before_execute(
+                UserCommandRequest(
+                    command=command,
+                    cwd=effective_cwd,
+                    exclude_from_context=exclude_from_context,
+                )
+            )
+            if interception is not None:
+                if interception.result is not None:
+                    result = dict(interception.result)
+                    await self.record_result(
+                        command=command,
+                        result=result,
+                        exclude_from_context=exclude_from_context,
+                    )
+                    return result
+                if interception.operations is not None:
+                    selected_operations = interception.operations
+
+        definition = self.get_definition()
+        if definition is None:
+            raise RuntimeError(f"{self.command_name} tool is not registered")
+        controller = AbortController()
+        self._abort_controller = controller
+        streamed_chunks: list[str] = []
+
+        async def forward_update(partial_result: object) -> None:
+            details = getattr(partial_result, "details", None)
+            stream = details.get("stream") if isinstance(details, dict) else None
+            if stream not in {"stdout", "stderr"}:
+                return
+            text = "".join(
+                block.text
+                for block in getattr(partial_result, "content", ())
+                if getattr(block, "type", None) == "text"
+                and isinstance(getattr(block, "text", None), str)
+            )
+            if not text:
+                return
+            streamed_chunks.append(text)
+            if on_output is None:
+                return
+            forwarded = on_output(ExecOutputChunk(stream=stream, text=text))
+            if inspect.isawaitable(forwarded):
+                await forwarded
+
+        params = dict(self.build_execution_params(command, effective_cwd))
+        if env is not None:
+            params["env"] = [list(pair) for pair in env]
+        if timeout_seconds is not None:
+            params["timeout_seconds"] = timeout_seconds
+        if stdin is not None:
+            params["stdin"] = stdin
+        if selected_operations is not None:
+            params["__operations"] = selected_operations
+
+        try:
+            tool_result = await definition.execute(
+                self.create_call_id(),
+                params,
+                controller.signal,
+                forward_update,
+            )
+            result = command_result_from_tool_result(tool_result)
+        except RuntimeError as exc:
+            if "Command aborted" not in str(exc) or not getattr(
+                controller.signal, "aborted", False
+            ):
+                raise
+            result = {
+                "output": "".join(streamed_chunks),
+                "exit_code": None,
+                "cancelled": True,
+                "truncated": False,
+                "full_output_path": None,
+            }
+        finally:
+            self._abort_controller = None
+
+        await self.record_result(
+            command=command,
+            result=result,
+            exclude_from_context=exclude_from_context,
+        )
+        return result
+
+    def abort(self) -> None:
+        if self._abort_controller is not None:
+            self._abort_controller.abort()
+
+    async def record_result(
+        self,
+        *,
+        command: str,
+        result: Mapping[str, object],
+        exclude_from_context: bool,
+    ) -> None:
+        exit_code = result.get("exit_code")
+        await self.append_record(
+            CommandExecutionRecord(
+                command=command,
+                output=str(result.get("output") or ""),
+                exit_code=exit_code if type(exit_code) is int else None,
+                cancelled=bool(result.get("cancelled", False)),
+                truncated=bool(result.get("truncated", False)),
+                full_output_path=(
+                    str(result["full_output_path"])
+                    if isinstance(result.get("full_output_path"), str)
+                    and result.get("full_output_path")
+                    else None
+                ),
+                exclude_from_context=exclude_from_context,
+            )
+        )
+        self.refresh_context()
+
+
+def command_result_from_tool_result(tool_result: object) -> dict[str, object]:
+    """Normalize the stable workspace-tool result into a transcript record."""
+
+    details = getattr(tool_result, "details", None)
+    details = details if isinstance(details, Mapping) else {}
+    output = "".join(
+        block.text
+        for block in getattr(tool_result, "content", ())
+        if getattr(block, "type", None) == "text"
+        and isinstance(getattr(block, "text", None), str)
+    )
+    stderr = details.get("stderr")
+    if isinstance(stderr, str) and stderr and not output.endswith(stderr):
+        output = output + stderr
+    return {
+        "output": output,
+        "exit_code": details.get("exit_code"),
+        "cancelled": bool(details.get("cancelled", False)),
+        "truncated": bool(
+            details.get("truncated", False) or details.get("stderr_truncated", False)
+        ),
+        "full_output_path": details.get("stdout_artifact_path")
+        or details.get("stderr_artifact_path"),
+    }
+
+
+def _runtime_tool_contribution(
+    tool: object, *, source_info: object | None = None
+) -> ToolContribution:
+    definition = _runtime_tool_definition(tool)
+    return ToolContribution(
+        definition,
+        source_info=source_info,
+        metadata={"kind": "runtime_tool", "runtime_tool": definition.name},
+    )
+
+
+def _runtime_tool_definition(tool: object) -> ToolDefinition:
+    if isinstance(tool, ToolDefinition):
+        return tool
+    if is_agent_tool_like(tool):
+        return create_tool_definition_from_tool(ensure_agent_tool(tool))
+    return tool_to_definition(tool)
+
+
+def _runtime_tool_registration_contribution(
+    resolution: ToolResolutionResult,
+    *,
+    fallback: ToolContribution,
+) -> ToolContribution:
+    for contribution in resolution.contributions:
+        if contribution.definition.name != fallback.definition.name:
+            continue
+        if contribution.metadata.get("kind") == "runtime_tool":
+            return contribution
+    return fallback
+
+
+__all__ = [
+    "AgentToolPort",
+    "CommandRuntimeSource",
+    "SessionCommandExecutionRuntime",
+    "SessionCommandRuntime",
+    "SessionToolRuntime",
+    "ToolRegistryPort",
+    "UserCommandHookResult",
+    "UserCommandRequest",
+    "command_result_from_tool_result",
+]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -339,6 +339,31 @@ def test_agent_transcript_maintenance_runtime_is_neutral_and_adopted() -> None:
     assert "Coding keeps" in boundary
 
 
+def test_session_capabilities_runtime_is_neutral_and_adopted() -> None:
+    capabilities_source = Path(
+        "src/loushang/harness/session/capabilities.py"
+    ).read_text(encoding="utf-8")
+    tool_source = Path(
+        "src/loushang/coding/session/tool_controller.py"
+    ).read_text(encoding="utf-8")
+    command_source = Path(
+        "src/loushang/coding/session/command_controller.py"
+    ).read_text(encoding="utf-8")
+    bash_source = Path(
+        "src/loushang/coding/session/bash_controller.py"
+    ).read_text(encoding="utf-8")
+    boundary = Path(
+        "docs/internals/architecture/harness/session-capabilities-boundary.md"
+    ).read_text(encoding="utf-8")
+
+    assert "loushang.coding" not in capabilities_source
+    assert "SessionToolRuntime" in tool_source
+    assert "SessionCommandRuntime" in command_source
+    assert "SessionCommandExecutionRuntime" in bash_source
+    assert "Product Binding" in boundary
+    assert "Coding keeps" in boundary
+
+
 def test_extension_message_controller_is_a_product_api_adapter() -> None:
     source = Path(
         "src/loushang/coding/session/extension_message_controller.py"

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2430,10 +2430,10 @@ def test_product_capability_composition_core_is_documented_and_adopted() -> None
             "loushang.harness.capabilities.prompt.PromptSectionComposer",
         },
         Path("src/loushang/coding/session/command_controller.py"): {
-            "loushang.harness.capabilities.commands.dispatch_command_async",
+            "loushang.harness.session.SessionCommandRuntime",
         },
         Path("src/loushang/coding/session/tool_controller.py"): {
-            "loushang.harness.capabilities.tools.ToolActivationCoordinator",
+            "loushang.harness.session.SessionToolRuntime",
         },
     }
     missing: list[str] = []

--- a/tests/harness/session/test_capabilities.py
+++ b/tests/harness/session/test_capabilities.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from loushang.agent.types import AgentTool, AgentToolResult
+from loushang.ai.types import TextPart
+from loushang.harness.capabilities.commands import (
+    CommandDescriptor,
+    CommandDispatchOutcome,
+)
+from loushang.harness.conversation import CommandExecutionRecord
+from loushang.harness.session import (
+    CommandRuntimeSource,
+    SessionCommandExecutionRuntime,
+    SessionCommandRuntime,
+    SessionToolRuntime,
+)
+from loushang.harness.tools.contribution import ToolContribution
+from loushang.harness.tools.core import ToolDefinition
+from loushang.harness.workspace.exec import ExecOutputChunk
+
+
+async def _noop_execute(
+    tool_call_id: str,
+    params: dict[str, Any],
+    signal: object | None,
+    on_update: object | None,
+) -> AgentToolResult[object]:
+    del tool_call_id, params, signal, on_update
+    return AgentToolResult(content=[], details={})
+
+
+def _tool_definition(name: str) -> ToolDefinition:
+    return ToolDefinition(
+        name=name,
+        label=name.title(),
+        description=f"{name} tool",
+        parameters={
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": False,
+        },
+        execute=_noop_execute,
+    )
+
+
+class _Agent:
+    def __init__(self) -> None:
+        self.tools: list[AgentTool[Any]] = []
+
+
+class _ToolRegistry:
+    def __init__(self, definitions: list[ToolDefinition]) -> None:
+        self.definitions = list(definitions)
+        self.materialized: list[list[str]] = []
+
+    def get_definition(self, name: str) -> ToolDefinition:
+        return next(definition for definition in self.definitions if definition.name == name)
+
+    def get_source_info(self, name: str) -> object | None:
+        self.get_definition(name)
+        return None
+
+    def list_contributions(self) -> tuple[ToolContribution, ...]:
+        return ()
+
+    def list_definitions(self) -> list[ToolDefinition]:
+        return list(self.definitions)
+
+    def list_enabled_definitions(self) -> list[ToolDefinition]:
+        return list(self.definitions)
+
+    def materialize_definitions(
+        self,
+        definitions: list[ToolDefinition],
+        *,
+        context_provider: Callable[..., object] | None = None,
+    ) -> list[AgentTool[Any]]:
+        del context_provider
+        self.materialized.append([definition.name for definition in definitions])
+        return []
+
+    def register_tool(
+        self,
+        tool: ToolDefinition | object,
+        *,
+        enabled: bool = True,
+        source_info: object | None = None,
+    ) -> ToolDefinition:
+        del enabled, source_info
+        assert isinstance(tool, ToolDefinition)
+        self.definitions.append(tool)
+        return tool
+
+
+def test_session_tool_runtime_rebinds_only_product_selected_tools() -> None:
+    registry = _ToolRegistry([_tool_definition("read"), _tool_definition("bash")])
+    prompt_rebuilds: list[list[str]] = []
+    runtime = SessionToolRuntime(
+        agent=_Agent(),
+        tool_registry=registry,
+        allowed_tool_names={"read", "bash"},
+        initial_active_tool_names=["read"],
+        default_active_tool_names=lambda: ["read"],
+        should_activate_new_tool=lambda name, definition: name == definition.name,
+        build_tool_context=lambda *, tool_call_id: {"call_id": tool_call_id},
+        rebuild_prompt=lambda definitions: prompt_rebuilds.append(
+            [definition.name for definition in definitions or ()]
+        ),
+    )
+
+    runtime.apply_active_tools(["bash", "missing"])
+
+    assert runtime.get_active_tool_names() == ["bash"]
+    assert registry.materialized == [["bash"]]
+    assert prompt_rebuilds == [["bash"]]
+
+
+def test_session_command_runtime_keeps_catalog_and_dispatch_precedence_separate() -> (
+    None
+):
+    builtin_descriptor = CommandDescriptor[None](
+        name="review",
+        description="Built-in review command",
+        source="builtin",
+    )
+    extension_descriptor = CommandDescriptor[None](
+        name="review",
+        description="Extension review command",
+        source="extension",
+    )
+
+    def _builtin_handler(command: object) -> CommandDispatchOutcome[str]:
+        del command
+        return CommandDispatchOutcome.handled_result("builtin")
+
+    def _extension_handler(command: object) -> CommandDispatchOutcome[str]:
+        del command
+        return CommandDispatchOutcome.handled_result("extension")
+
+    runtime = SessionCommandRuntime(
+        sources=(
+            CommandRuntimeSource(
+                pack_id="product.commands",
+                source="product",
+                descriptor_priority=300,
+                handler_priority=200,
+                list_descriptors=lambda: [builtin_descriptor],
+                handler_name="builtin",
+                handler=_builtin_handler,
+            ),
+            CommandRuntimeSource(
+                pack_id="extension.commands",
+                source="extension",
+                descriptor_priority=200,
+                handler_priority=300,
+                list_descriptors=lambda: [extension_descriptor],
+                handler_name="extension",
+                handler=_extension_handler,
+            ),
+        )
+    )
+
+    descriptors = runtime.list_commands()
+    result = asyncio.run(runtime.execute("review", "current change"))
+
+    assert [descriptor.source for descriptor in descriptors] == [
+        "builtin",
+        "extension",
+    ]
+    assert result == "extension"
+
+
+def test_command_execution_runtime_streams_and_commits_one_record() -> None:
+    records: list[CommandExecutionRecord] = []
+    chunks: list[ExecOutputChunk] = []
+    refreshes = 0
+    executed: list[dict[str, object]] = []
+
+    async def _execute(
+        tool_call_id: str,
+        params: dict[str, object],
+        signal: object | None,
+        on_update: Callable[[object], Awaitable[None]] | None,
+    ) -> AgentToolResult[object]:
+        del tool_call_id, signal
+        executed.append(params)
+        assert on_update is not None
+        await on_update(
+            AgentToolResult(
+                content=[TextPart(type="text", text="partial\\n")],
+                details={"stream": "stdout"},
+            )
+        )
+        return AgentToolResult(
+            content=[TextPart(type="text", text="complete\\n")],
+            details={"exit_code": 0},
+        )
+
+    async def _append(record: CommandExecutionRecord) -> None:
+        records.append(record)
+
+    def _refresh() -> None:
+        nonlocal refreshes
+        refreshes += 1
+
+    definition = ToolDefinition(
+        name="bash",
+        label="Bash",
+        description="Run a shell command",
+        parameters={},
+        execute=_execute,
+    )
+    runtime = SessionCommandExecutionRuntime(
+        command_name="Bash",
+        get_cwd=lambda: "/project",
+        get_definition=lambda: definition,
+        build_execution_params=lambda command, cwd: {
+            "command": ["/bin/bash", "-lc", command],
+            "cwd": cwd,
+        },
+        create_call_id=lambda: "call-1",
+        append_record=_append,
+        refresh_context=_refresh,
+    )
+
+    result = asyncio.run(
+        runtime.execute("printf done", on_output=chunks.append)
+    )
+
+    assert result["output"] == "complete\\n"
+    assert executed == [
+        {"command": ["/bin/bash", "-lc", "printf done"], "cwd": "/project"}
+    ]
+    assert chunks == [ExecOutputChunk(stream="stdout", text="partial\\n")]
+    assert records == [
+        CommandExecutionRecord(
+            command="printf done",
+            output="complete\\n",
+            exit_code=0,
+        )
+    ]
+    assert refreshes == 1


### PR DESCRIPTION
## Summary
- Add `harness.session.capabilities` for live tool activation, Agent rebind, command-source composition and dispatch, and command-tool execution with transcript commit.
- Reduce Coding `ToolController`, `CommandController`, and `BashController` to product adapters; prompt, built-in command, extension, and Pi protocol policy remain in Coding.
- Keep command parameter construction product-injected, so Bash is one Coding binding rather than a Harness runtime assumption.

## Validation
- `ruff check` on changed source and tests
- `mypy` on Harness runtime and Coding adapters
- `pytest tests/harness/session tests/coding/test_session*.py tests/coding/test_agent_session_tools.py -q` (`285 passed`)
- Targeted architecture and controller regressions
- `git diff --check`

## 中文说明
- 新增 `harness.session.capabilities`，负责实时工具激活、Agent 工具重绑、命令源组合与分发，以及命令工具执行后的 transcript 提交。
- 将 Coding 的 `ToolController`、`CommandController`、`BashController` 收敛为产品适配层；提示词、内置命令、扩展语义与 Pi 协议仍归 Coding。
- 命令执行参数由产品注入，Bash 仅是 Coding 的一种绑定，不再成为 Harness 运行时假设。

## 验证
- 已完成 Ruff、Mypy、285 项会话相关回归、架构/控制器定向回归及变更空白检查。