### PR TITLE
refactor(harnesstui): extract screen conversation view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ HARNESSTUI_SHARED_SOURCES := \
 	src/loushang/tui/playback_suite.py \
 	src/loushang/tui/settings.py \
 	src/loushang/tui/terminal_diagnostics.py \
+	src/loushang/tui/ui_parts/layout.py \
+	src/loushang/tui/ui_parts/transcript.py \
 	src/loushang/harnesstui
 HARNESSTUI_CODING_ADAPTERS := \
 	src/loushang/coding/platform/__init__.py \
@@ -74,6 +76,7 @@ HARNESSTUI_TEST_PATHS := \
 	tests/tui/test_playback_suite.py \
 	tests/tui/test_settings.py \
 	tests/tui/test_terminal_diagnostics.py \
+	tests/tui/test_transcript_region.py \
 	tests/architecture/test_import_boundaries.py \
 	tests/coding/test_coding_tui_playback_compatibility.py \
 	tests/coding/test_playback_suite_compatibility.py \

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -96,10 +96,11 @@ a session-like port. Products retain queue availability policy, tracing sinks,
 and the decision about when to present or restore queued input.
 
 This slice does not own session lifecycle, persistence, runtime orchestration,
-or raw Agent/Coding event projection. It does not enter the render hot path.
-The state and active-window algorithms retain their existing semantics after
-moving here. Incremental transcript segmentation, render caches, committed and
-draft segments, and frame composition remain untouched in their current owner.
+or raw Agent/Coding event projection. The state and active-window algorithms
+retain their existing semantics after moving here. Incremental transcript
+segmentation, render caches, committed and draft segments, streaming Markdown
+reuse, and tail clipping live in `loushang.tui.ui_parts.transcript`; Harnesstui
+does not duplicate or wrap that rendering engine.
 
 Compatibility modules in `loushang.coding.ui` may temporarily re-export moved
 symbols. They must depend inward on `loushang.harnesstui`; this package must
@@ -196,6 +197,27 @@ existing `make test-tui-render-contract` gate covers this new boundary.
 The explicit `projection`, `plain_target`, and `screen_target` module paths
 above are the stable imports for this capability. The package initializer does
 not provide convenience re-exports.
+
+## Conversation Screen Composition
+
+`loushang.harnesstui.conversation.screen_frame` builds the product-neutral
+working line, pending queue, status bar, and bottom-frame geometry from
+`ScreenConversationState`. Products inject immutable copy once when the screen
+binding is constructed; no copy profile is allocated while rendering.
+
+`loushang.harnesstui.conversation.screen_app` owns the reusable full-screen
+conversation shell: state transitions, assistant streaming coordination,
+transcript-reader surfaces, render requests, elapsed-time scheduling, active
+window replacement, transcript-region synchronization, and screen layout.
+It holds the canonical `loushang.tui.ui_parts.transcript.TranscriptRegion`
+directly and preserves the records list, cache, and segment identities.
+
+Coding retains a real `ScreenCodingTuiApp` subclass. That binding supplies its
+composer prompts, frame copy, theme, welcome panel, transcript presentation,
+320-line budget, compaction wording, path compaction, and tool-output preview
+policy. The shared app does not import Coding, AI, Agent, or raw product events.
+The explicit `screen_frame` and `screen_app` module paths are stable; the
+conversation package initializer does not re-export them.
 
 ## Conversation Transcript Styling
 

--- a/docs/internals/architecture/tui/README.md
+++ b/docs/internals/architecture/tui/README.md
@@ -67,3 +67,22 @@ Generic playback-suite orchestration lives in `loushang.tui.playback_suite`.
 It owns neutral scenario specifications and results, scenario selection,
 timing, and artifact dispatch. Product scenario catalogs, command-line runners,
 and product-specific playback hosts remain in their product adapter packages.
+
+## Screen Transcript Region
+
+The explicit entrypoint `loushang.tui.ui_parts.transcript` owns the generic
+incremental transcript region used by full-screen layouts. It owns stable and
+transient record caches, committed and draft render segments, streaming
+Markdown segment reuse, tail clipping, cache promotion, and bounded eviction.
+These are terminal rendering mechanics over `DisplayRecord` values; the module
+does not know about Harness conversations, Coding sessions, tools, or products.
+
+Products bind a long-lived `TranscriptPresentation` implementation that
+projects presentation-ready records, chooses record width, decorates rendered
+lines, and supplies a cache token. Coding therefore keeps its glyphs, theme,
+path compaction, tool-output preview, and cwd policy. The presentation object is
+not recreated per frame, and the region preserves the frozen cache keys,
+segment identities, records-list identity, and streaming call shape.
+
+`loushang.tui.ui_parts.layout.CappedRenderable` owns the corresponding generic
+height cap used when the transcript and bottom frame share a screen layout.

--- a/docs/internals/architecture/tui/native-terminal-core/render-performance-contract.md
+++ b/docs/internals/architecture/tui/native-terminal-core/render-performance-contract.md
@@ -6,6 +6,13 @@ Frozen on 2026-07-16 against `main` commit
 `5fbf2674a82b1585bae729e93e7c63fb6ae45a5f`.
 The initial isolated contract run contains 151 passing cases.
 
+The screen-presentation extraction extends the isolated contract to 161 passing
+cases on 2026-07-19: the existing 154 cases plus direct ownership, identity,
+streaming-presentation parity, cache-promotion parity, and segment-invalidation
+checks, including the flat streaming fallback. Moving ownership into TUI and
+Harnesstui may not change the existing thresholds, exceptional repaint reasons,
+or structural work bounds in the same change.
+
 This contract is the guardrail for later TUI extraction and refactoring. The
 freeze itself changes tests, test entry points, and documentation only. It does
 not change the renderer, markdown renderer, transcript projection, or coding UI

--- a/src/loushang/coding/ui/screen_app.py
+++ b/src/loushang/coding/ui/screen_app.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import os
 import re
-import time
-from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field, replace
 from typing import Any
 
@@ -13,67 +11,51 @@ from loushang.harness.tools.workspace.output_preview import (
     drop_tool_timing_tail_line,
     prefers_tail_tool_output,
 )
-from loushang.harnesstui.conversation.reader import TranscriptReaderSurface
-from loushang.harnesstui.conversation.screen_state import (
-    ActiveTranscriptWindow,
-    ScreenConversationState,
+from loushang.harnesstui.conversation.screen_app import (
+    ACTIVE_RENDER_INTERVAL_MS as ACTIVE_RENDER_INTERVAL_MS,
 )
-from loushang.harnesstui.conversation.source import (
-    ActiveWindowTranscriptSource,
-    TranscriptSource,
+from loushang.harnesstui.conversation.screen_app import ScreenConversationApp
+from loushang.harnesstui.conversation.screen_frame import (
+    ScreenFrameCopy,
+    ScreenFramePresentation,
 )
+from loushang.harnesstui.conversation.screen_state import ActiveTranscriptWindow
 from loushang.harnesstui.conversation.transcript_style import (
     apply_transcript_style as apply_coding_transcript_style,
 )
 from loushang.harnesstui.conversation.window_budget import (
     trim_records_to_line_budget,
 )
-from loushang.harnesstui.status.line import (
-    StatusLinePreviewSnapshot,
-    StatusLineSettings,
-    status_line_fields,
-    status_line_separator,
-    status_line_style_mode,
-)
 from loushang.tui import (
-    BottomFrame,
     Composer,
     LoushangWelcomePanel,
-    PendingQueueView,
-    PendingSection,
-    RenderConstraints,
-    RenderLine,
-    RenderRequestKind,
-    RenderResult,
-    ScreenLayout,
-    StatusBar,
-    Surface,
-    SurfaceHost,
-    TerminalRuntimeCapabilities,
-    WorkingLine,
     loushang_welcome_theme,
-    theme_capabilities_from_runtime,
 )
-from loushang.tui.core import RenderLineSegment, SegmentedRenderLines
-from loushang.tui.markdown.renderer import MarkdownRenderCache
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.transcript import (
     AssistantMessageRecord,
     ContextCompactionRecord,
     DisplayRecord,
     ErrorRecord,
-    StreamingTextBuffer,
     ToolExecutionRecord,
-    TranscriptView,
     UserPromptRecord,
     WorkedDividerRecord,
-    _prefix_streaming_assistant_segment,
-    _render_streaming_assistant_markdown_segments,
+)
+from loushang.tui.ui_parts.transcript import (
+    DEFAULT_STABLE_TRANSCRIPT_CACHE_ENTRY_LIMIT,
+    TranscriptRegion,
 )
 
-ACTIVE_RENDER_INTERVAL_MS = 80
 DEFAULT_ACTIVE_TRANSCRIPT_LINE_BUDGET = 320
-DEFAULT_STABLE_RENDER_CACHE_ENTRY_LIMIT = 128
+DEFAULT_STABLE_RENDER_CACHE_ENTRY_LIMIT = DEFAULT_STABLE_TRANSCRIPT_CACHE_ENTRY_LIMIT
+
+_CODING_SCREEN_FRAME_COPY = ScreenFrameCopy(
+    working_label="Working",
+    steer_label="Messages to be submitted after next tool call",
+    steer_hint="press esc to interrupt and send immediately",
+    followup_label="Queued follow-up inputs",
+    followup_hint="alt + ↑ edit last queued message",
+)
 
 
 def _terminal_transcript_theme() -> ThemeResolver:
@@ -104,161 +86,88 @@ def _terminal_transcript_theme() -> ThemeResolver:
 
 
 @dataclass(slots=True)
-class ScreenCodingTuiApp:
-    model_label: str | None
-    cwd: str
-    branch: str | None
-    session_label: str | None
-    now: Callable[[], float] = time.monotonic
-    composer: Composer = field(default_factory=lambda: Composer(prompt="› ", continuation_prompt="  "))
-    state: ScreenConversationState = field(init=False)
-    active_surface: Any | None = None
-    surface_host: SurfaceHost | None = None
+class _CodingTranscriptPresentation:
+    cwd: str = ""
+
+    @property
+    def cache_token(self) -> str:
+        return self.cwd
+
+    def project_record(self, record: DisplayRecord) -> DisplayRecord:
+        return _screen_coding_display_record(record, cwd=self.cwd)
+
+    def record_render_width(
+        self,
+        record: DisplayRecord,
+        *,
+        width: int,
+    ) -> int:
+        return _screen_transcript_record_render_width(record, width=width)
+
+    def present_lines(
+        self,
+        lines: tuple[str, ...],
+        record: DisplayRecord,
+        *,
+        theme: ThemeResolver | None,
+        capabilities: Any | None,
+    ) -> tuple[str, ...]:
+        return _coding_lines(
+            lines,
+            record,
+            theme=theme,
+            capabilities=capabilities,
+        )
+
+
+def _ScreenTranscriptRegion(
+    *args: Any, cwd: str = "", **kwargs: Any
+) -> TranscriptRegion:
+    """Construct the former private Coding region with Coding presentation."""
+    if "presentation" not in kwargs:
+        kwargs["presentation"] = _CodingTranscriptPresentation(cwd=cwd)
+    return TranscriptRegion(*args, **kwargs)
+
+
+@dataclass(slots=True)
+class ScreenCodingTuiApp(ScreenConversationApp):
+    composer: Composer = field(
+        default_factory=lambda: Composer(prompt="› ", continuation_prompt="  ")
+    )
     transcript_theme: ThemeResolver = field(default_factory=_terminal_transcript_theme)
     welcome_theme: ThemeResolver | None = field(default_factory=loushang_welcome_theme)
     active_transcript_line_budget: int = DEFAULT_ACTIVE_TRANSCRIPT_LINE_BUDGET
-    stable_render_cache_entry_limit: int = DEFAULT_STABLE_RENDER_CACHE_ENTRY_LIMIT
-    render_requester: Callable[[RenderRequestKind], object] | None = None
-    terminal_diagnostics_provider: Callable[[], str] | None = None
-    terminal_capabilities: TerminalRuntimeCapabilities | None = None
-    transcript_source_factory: Callable[[], TranscriptSource] | None = None
-    _transcript_region: _ScreenTranscriptRegion = field(init=False, repr=False)
-    _bottom_frame_component: BottomFrame = field(init=False, repr=False)
-    _render_baseline_reset_reason: str | None = field(default=None, init=False, repr=False)
+    _transcript_presentation: _CodingTranscriptPresentation = field(
+        init=False,
+        repr=False,
+    )
 
-    def __post_init__(self) -> None:
-        self.state = ScreenConversationState(
-            model_label=self.model_label,
-            cwd=self.cwd,
-            branch=self.branch,
-            session_label=self.session_label,
-        )
-        self._transcript_region = _ScreenTranscriptRegion(theme=self.transcript_theme)
-        self._bottom_frame_component = BottomFrame(composer=self.composer)
+    def _create_transcript_presentation(self) -> _CodingTranscriptPresentation:
+        return _CodingTranscriptPresentation(cwd=self.cwd)
 
-    def start_prompt(self, text: str, *, started_at: float | None = None) -> None:
-        self.state.start_prompt(text, started_at=self.now() if started_at is None else started_at)
-        self.composer.add_history(text)
-        self.composer.clear()
+    def _create_frame_presentation(self) -> ScreenFramePresentation:
+        return ScreenFramePresentation(_CODING_SCREEN_FRAME_COPY)
 
-    def start_pending_prompt(self, text: str, *, started_at: float | None = None) -> None:
-        self.state.start_prompt(text, started_at=self.now() if started_at is None else started_at)
-        self.composer.add_history(text)
+    def _prepare_transcript_presentation(self) -> None:
+        self._transcript_presentation.cwd = self.state.cwd
 
-    def begin_run(self, *, started_at: float | None = None) -> None:
-        self.state.begin_run(started_at=self.now() if started_at is None else started_at)
-
-    def begin_assistant(self) -> None:
-        self.state.begin_assistant()
-        self._transcript_region.clear_transient_cache()
-        self._request_render("product")
-
-    def append_assistant_chunk(self, chunk: str) -> None:
-        self.state.append_assistant_chunk(chunk)
-        self._request_render("stream")
-
-    def end_assistant(self, final_text: str | None = None) -> None:
-        draft_buffer = self.state.assistant_draft_buffer
-        draft_text = final_text
-        if draft_text is None and draft_buffer is not None:
-            draft_text = draft_buffer.text
-        self.state.end_assistant(draft_text)
-        committed = self.state.records[-1] if self.state.records else None
-        if isinstance(committed, AssistantMessageRecord) and committed.text == draft_text:
-            self._transcript_region.promote_transient_cache(committed, source_buffer=draft_buffer)
-        self._transcript_region.clear_transient_cache()
-
-    def complete_run(self, *, elapsed_seconds: float | None = None) -> None:
-        elapsed = self.elapsed_seconds() if elapsed_seconds is None else elapsed_seconds
-        self.state.complete_run(elapsed_seconds=elapsed)
-        self._transcript_region.clear_transient_cache()
-
-    def queue_followup(self, text: str) -> None:
-        self.state.queue_followup(text)
-
-    def queue_steer(self, text: str) -> None:
-        self.state.queue_steer(text)
-
-    def sync_queues(self, *, steers: tuple[str, ...] | list[str], followups: tuple[str, ...] | list[str]) -> None:
-        self.state.sync_queues(steers=steers, followups=followups)
-
-    def set_status(self, message: str | None) -> None:
-        self.state.set_status(message)
-        self._request_render("product")
-
-    def set_statusline_visible(self, visible: bool) -> None:
-        self.set_statusline_settings(replace(self.state.statusline_settings, enabled=visible))
-
-    def set_statusline_settings(self, settings: StatusLineSettings) -> None:
-        self.state.statusline_settings = settings
-        self.state.statusline_visible = settings.enabled
-        self._request_render("product")
-
-    def request_render(self, kind: RenderRequestKind = "product") -> None:
-        self._request_render(kind)
-
-    def statusline_preview_snapshot(self) -> StatusLinePreviewSnapshot:
-        return StatusLinePreviewSnapshot(
-            model_label=self.state.model_label,
-            cwd=self.state.cwd,
-            branch=self.state.branch,
-            session_label=self.state.session_label,
-            running=self.state.running,
-            pending_followups=len(self.state.pending_followups),
-            pending_steers=len(self.state.pending_steers),
-            status_message=self.state.status_message,
-        )
-
-    def open_transcript_reader(self) -> bool:
-        if self.surface_host is None:
-            return False
-        source = (
-            self.transcript_source_factory()
-            if self.transcript_source_factory is not None
-            else ActiveWindowTranscriptSource(self.state)
-        )
-        reader = TranscriptReaderSurface(source)
-        self.surface_host.open_surface(
-            Surface(
-                renderable=reader,
-                focus_target=reader,
-                presentation="modal",
-                max_height="100%",
-            )
-        )
-        self._request_render("input")
-        return True
-
-    def add_error(self, summary: str, diagnostics: str = "") -> None:
-        self.state.add_error(summary, diagnostics)
-        self._request_render("product")
-
-    def add_status(self, message: str) -> None:
-        self.state.add_status(message)
-        self._request_render("product")
-
-    def replace_transcript_window(
+    def compact_transcript_window(
         self,
-        records: Iterable[DisplayRecord] | ActiveTranscriptWindow,
         *,
-        evicted_prefix_record_count: int = 0,
-        reason: str = "replace",
+        summary: str,
+        max_records: int = 80,
     ) -> None:
-        self.state.replace_transcript_window(
-            records,
-            evicted_prefix_record_count=evicted_prefix_record_count,
+        summary_record = AssistantMessageRecord(
+            f"Compacted summary:\n\n{summary.strip()}"
         )
-        self._render_baseline_reset_reason = f"transcript_window_replaced:{reason}" if reason else "transcript_window_replaced"
-
-    def compact_transcript_window(self, *, summary: str, max_records: int = 80) -> None:
-        summary_record = AssistantMessageRecord(f"Compacted summary:\n\n{summary.strip()}")
         active_records = tuple(self.state.records)
         keep_count = max(0, max_records - 1)
         kept_records = active_records[-keep_count:] if keep_count else ()
         evicted_count = max(0, len(active_records) - len(kept_records))
         self.replace_transcript_window(
             (summary_record, *kept_records),
-            evicted_prefix_record_count=self.state.evicted_prefix_record_count + evicted_count,
+            evicted_prefix_record_count=self.state.evicted_prefix_record_count
+            + evicted_count,
             reason="compaction",
         )
 
@@ -269,51 +178,15 @@ class ScreenCodingTuiApp:
         tokens_before: int | None = None,
         max_records: int = 80,
     ) -> None:
-        self.state.records.append(ContextCompactionRecord(summary=summary, tokens_before=tokens_before))
+        self.state.records.append(
+            ContextCompactionRecord(summary=summary, tokens_before=tokens_before)
+        )
         self.state.mark_records_changed()
         evicted = self.state.trim_transcript_prefix(max_records=max_records)
         if evicted:
-            self._render_baseline_reset_reason = "transcript_window_trimmed:context_compaction"
-
-    def consume_render_baseline_reset_reason(self) -> str | None:
-        reason = self._render_baseline_reset_reason
-        self._render_baseline_reset_reason = None
-        return reason
-
-    def elapsed_seconds(self) -> float:
-        if self.state.active_started_at is None:
-            return 0.0
-        return max(0.0, self.now() - self.state.active_started_at)
-
-    def next_frame_due_ms(self, *, after_ms: int) -> int | None:
-        completion_due_ms = self.composer.next_frame_due_ms(after_ms=after_ms)
-        if not self.state.running:
-            return completion_due_ms
-        active_due_ms = after_ms + ACTIVE_RENDER_INTERVAL_MS
-        if completion_due_ms is None:
-            return active_due_ms
-        return min(active_due_ms, completion_due_ms)
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        visible_height = constraints.visible_height or constraints.max_height
-        editor_height = self._bottom_frame_height(visible_height)
-        self._transcript_region.records = self.state.records
-        self._transcript_region.records_revision = self.state.records_revision
-        self._transcript_region.draft = None
-        self._transcript_region.draft_buffer = self.state.assistant_draft_buffer
-        self._transcript_region.cwd = self.state.cwd
-        self._transcript_region.theme = self.transcript_theme
-        self._transcript_region.capabilities = (
-            theme_capabilities_from_runtime(self.terminal_capabilities) if self.terminal_capabilities is not None else None
-        )
-        self._transcript_region.window_generation = self.state.transcript_window_generation
-        self._transcript_region.stable_cache_entry_limit = self.stable_render_cache_entry_limit
-        layout = ScreenLayout(
-            transcript=self._transcript_region,
-            editor=_CappedRenderable(self._bottom_frame(), max_height=editor_height),
-            editor_min_height=editor_height,
-        )
-        return layout.render(constraints)
+            self._render_baseline_reset_reason = (
+                "transcript_window_trimmed:context_compaction"
+            )
 
     def startup_welcome_panel(self) -> LoushangWelcomePanel:
         return LoushangWelcomePanel(
@@ -333,633 +206,12 @@ class ScreenCodingTuiApp:
         self.state.replace_transcript_window(
             ActiveTranscriptWindow(
                 records=records,
-                evicted_prefix_record_count=self.state.evicted_prefix_record_count + evicted_count,
+                evicted_prefix_record_count=self.state.evicted_prefix_record_count
+                + evicted_count,
             )
         )
-        self._render_baseline_reset_reason = "transcript_window_trimmed:active_line_budget"
-
-    def _expanded_bottom_frame(self) -> bool:
-        return (
-            self.active_surface is not None
-            or self.state.running
-            or bool(self.state.pending_steers)
-            or bool(self.state.pending_followups)
-            or bool(self.state.interruption_message)
-        )
-
-    def _bottom_frame_height(self, visible_height: int) -> int:
-        height = 12
-        if self._expanded_bottom_frame():
-            height = 16
-            preferred = getattr(self.active_surface, "preferred_height", None)
-            if isinstance(preferred, int) and preferred > 0:
-                height = max(height, preferred)
-        return max(1, min(height, visible_height))
-
-    def _request_render(self, kind: RenderRequestKind) -> None:
-        if self.render_requester is not None:
-            self.render_requester(kind)
-
-    def _bottom_frame(self) -> BottomFrame:
-        self._bottom_frame_component.composer = self.composer
-        self._bottom_frame_component.surface = self.active_surface
-        self._bottom_frame_component.working_line = self._working_line()
-        self._bottom_frame_component.pending_queue = self._pending_queue()
-        self._bottom_frame_component.status_bar = self._status_bar() if self.state.statusline_visible else None
-        return self._bottom_frame_component
-
-    def _working_line(self) -> WorkingLine | None:
-        if not self.state.running:
-            return None
-        return WorkingLine(label="Working", elapsed_seconds=self.elapsed_seconds())
-
-    def _pending_queue(self) -> PendingQueueView | None:
-        sections: list[PendingSection] = []
-        if self.state.interruption_message:
-            sections.append(
-                PendingSection(
-                    label=self.state.interruption_message,
-                    marker="■",
-                    show_when_empty=True,
-                )
-            )
-        if self.state.pending_steers:
-            sections.append(
-                PendingSection(
-                    label="Messages to be submitted after next tool call",
-                    items=tuple(self.state.pending_steers),
-                    hint="press esc to interrupt and send immediately",
-                    hint_placement="header",
-                )
-            )
-        if self.state.pending_followups:
-            sections.append(
-                PendingSection(
-                    label="Queued follow-up inputs",
-                    items=tuple(self.state.pending_followups),
-                    hint="alt + ↑ edit last queued message",
-                )
-            )
-        if not sections:
-            return None
-        return PendingQueueView(sections=tuple(sections))
-
-    def _status_bar(self) -> StatusBar:
-        settings = self.state.statusline_settings
-        return StatusBar(
-            status_line_fields(self.statusline_preview_snapshot(), settings),
-            separator=status_line_separator(settings),
-            style_mode=status_line_style_mode(settings),
-        )
-
-
-@dataclass(slots=True)
-class _ScreenTranscriptRegion:
-    records: list[DisplayRecord] = field(default_factory=list)
-    records_revision: int = 0
-    draft: AssistantMessageRecord | None = None
-    draft_buffer: StreamingTextBuffer | None = None
-    cwd: str = ""
-    theme: ThemeResolver | None = None
-    capabilities: Any | None = None
-    window_generation: int = 0
-    stable_cache_entry_limit: int = DEFAULT_STABLE_RENDER_CACHE_ENTRY_LIMIT
-    _stable_line_cache: dict[tuple[DisplayRecord, int, tuple[object, ...]], tuple[str, ...]] = field(
-        default_factory=dict,
-        init=False,
-        repr=False,
-    )
-    _transient_line_cache_key: tuple[DisplayRecord, int, tuple[object, ...]] | None = field(
-        default=None,
-        init=False,
-        repr=False,
-    )
-    _transient_line_cache_lines: tuple[str, ...] | None = field(default=None, init=False, repr=False)
-    _transient_source_text: str = field(default="", init=False, repr=False)
-    _transient_source_width: int = field(default=0, init=False, repr=False)
-    _transient_source_style_signature: tuple[object, ...] | None = field(default=None, init=False, repr=False)
-    _transient_source_buffer_id: int | None = field(default=None, init=False, repr=False)
-    _transient_source_buffer_version: int = field(default=-1, init=False, repr=False)
-    _markdown_render_cache: MarkdownRenderCache = field(default_factory=MarkdownRenderCache, init=False, repr=False)
-    _cache_generation: int = field(default=-1, init=False, repr=False)
-    _committed_segment_key: tuple[object, ...] | None = field(default=None, init=False, repr=False)
-    _committed_segment: RenderLineSegment | None = field(default=None, init=False, repr=False)
-    _committed_separator_rows: frozenset[int] = field(
-        default_factory=frozenset,
-        init=False,
-        repr=False,
-    )
-    _draft_segments_key: tuple[object, ...] | None = field(default=None, init=False, repr=False)
-    _draft_segments: tuple[RenderLineSegment, ...] = field(default=(), init=False, repr=False)
-    _draft_stream_context: tuple[object, ...] | None = field(default=None, init=False, repr=False)
-    _draft_stable_segment_cache: dict[tuple[object, ...], RenderLineSegment] = field(
-        default_factory=dict,
-        init=False,
-        repr=False,
-    )
-    _draft_separator_identity: object = field(default_factory=object, init=False, repr=False)
-    _draft_separator_segment: RenderLineSegment | None = field(default=None, init=False, repr=False)
-    _draft_has_leading_separator: bool = field(default=False, init=False, repr=False)
-    _segmented_transient_content_segments: tuple[RenderLineSegment, ...] = field(
-        default=(),
-        init=False,
-        repr=False,
-    )
-    _segmented_transient_buffer_id: int | None = field(default=None, init=False, repr=False)
-    _segmented_transient_buffer_version: int = field(default=-1, init=False, repr=False)
-    _segmented_transient_width: int = field(default=0, init=False, repr=False)
-    _segmented_transient_style_signature: tuple[object, ...] | None = field(
-        default=None,
-        init=False,
-        repr=False,
-    )
-
-    @property
-    def has_content(self) -> bool:
-        return bool(self.records or self.draft is not None or self.draft_buffer is not None)
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        self._reset_cache_if_window_changed()
-        style_signature = (*_screen_transcript_style_signature(self.theme, self.capabilities), self.cwd)
-        lines = self._render_tail_segments(
-            max_height=constraints.max_height,
-            width=constraints.width,
-            style_signature=style_signature,
-        )
-        return RenderResult(lines=lines)
-
-    def _render_record_lines(
-        self,
-        record: DisplayRecord | StreamingTextBuffer,
-        *,
-        width: int,
-        style_signature: tuple[object, ...],
-    ) -> tuple[str, ...]:
-        if isinstance(record, StreamingTextBuffer):
-            return self._render_streaming_buffer_lines(record, width=width, style_signature=style_signature)
-        if isinstance(record, AssistantMessageRecord) and not record.stable:
-            return self._render_transient_record_lines(record, width=width, style_signature=style_signature)
-
-        key = (record, width, style_signature)
-        cached = self._stable_line_cache.get(key)
-        if cached is not None:
-            return cached
-        rendered = self._render_record_uncached(record, width=width)
-        self._stable_line_cache[key] = rendered
-        self._enforce_stable_cache_entry_limit()
-        return rendered
-
-    def _render_streaming_buffer_lines(
-        self,
-        buffer: StreamingTextBuffer,
-        *,
-        width: int,
-        style_signature: tuple[object, ...],
-    ) -> tuple[str, ...]:
-        if (
-            self._transient_line_cache_lines is not None
-            and self._transient_source_width == width
-            and self._transient_source_style_signature == style_signature
-            and self._transient_source_buffer_id == id(buffer)
-            and self._transient_source_buffer_version == buffer.version
-        ):
-            return self._transient_line_cache_lines
-
-        rendered = self._render_record_uncached(
-            AssistantMessageRecord(_streaming_buffer_render_text(buffer), stable=False),
-            width=width,
-            markdown_streaming_key=buffer,
-        )
-        self._remember_streaming_buffer_cache(
-            buffer,
-            width=width,
-            style_signature=style_signature,
-            lines=rendered,
-        )
-        return rendered
-
-    def _render_transient_record_lines(
-        self,
-        record: AssistantMessageRecord,
-        *,
-        width: int,
-        style_signature: tuple[object, ...],
-    ) -> tuple[str, ...]:
-        key = (record, width, style_signature)
-        if key == self._transient_line_cache_key and self._transient_line_cache_lines is not None:
-            return self._transient_line_cache_lines
-
-        rendered = self._render_record_uncached(record, width=width)
-        self._transient_line_cache_key = key
-        self._transient_line_cache_lines = rendered
-        self._transient_source_text = record.text
-        self._transient_source_width = width
-        self._transient_source_style_signature = style_signature
-        self._transient_source_buffer_id = None
-        self._transient_source_buffer_version = -1
-        return rendered
-
-    def _render_record_uncached(
-        self,
-        record: DisplayRecord,
-        *,
-        width: int,
-        markdown_streaming_key: object | None = None,
-    ) -> tuple[str, ...]:
-        display_record = _screen_coding_display_record(record, cwd=self.cwd)
-        render_width = _screen_transcript_record_render_width(display_record, width=width)
-        view = TranscriptView(
-            [display_record],
-            theme=self.theme,
-            capabilities=self.capabilities,
-            markdown_cache=self._markdown_render_cache,
-            markdown_streaming_key=markdown_streaming_key,
-        )
-        rendered = view.render(RenderConstraints(width=render_width, max_height=1_000_000))
-        return _coding_lines(
-            tuple(line.text for line in rendered.lines),
-            display_record,
-            theme=self.theme,
-            capabilities=self.capabilities,
-        )
-
-    def _remember_streaming_buffer_cache(
-        self,
-        buffer: StreamingTextBuffer,
-        *,
-        width: int,
-        style_signature: tuple[object, ...],
-        lines: tuple[str, ...],
-    ) -> None:
-        self._transient_line_cache_key = None
-        self._transient_line_cache_lines = lines
-        self._transient_source_text = ""
-        self._transient_source_width = width
-        self._transient_source_style_signature = style_signature
-        self._transient_source_buffer_id = id(buffer)
-        self._transient_source_buffer_version = buffer.version
-
-    def _render_tail_rows(
-        self,
-        *,
-        max_height: int,
-        width: int,
-        style_signature: tuple[object, ...],
-    ) -> list[str]:
-        return [
-            line.text
-            for line in self._render_tail_segments(
-                max_height=max_height,
-                width=width,
-                style_signature=style_signature,
-            )
-        ]
-
-    def _render_tail_segments(
-        self,
-        *,
-        max_height: int,
-        width: int,
-        style_signature: tuple[object, ...],
-    ) -> SegmentedRenderLines:
-        if max_height <= 0:
-            return SegmentedRenderLines()
-
-        committed = self._render_committed_segment(width=width, style_signature=style_signature)
-        draft_segments = self._render_draft_segments(
-            width=width,
-            style_signature=style_signature,
-            has_committed=committed is not None,
-        )
-        segments = (
-            *((committed,) if committed is not None else ()),
-            *draft_segments,
-        )
-        lines = SegmentedRenderLines.from_segments(segments)
-        if len(lines) <= max_height:
-            return lines
-
-        start = len(lines) - max_height
-        committed_rows = committed.line_count if committed is not None else 0
-        starts_at_draft_separator = (
-            committed is not None
-            and bool(draft_segments)
-            and self._draft_has_leading_separator
-            and start == committed_rows
-        )
-        if start in self._committed_separator_rows or starts_at_draft_separator:
-            start += 1
-        return lines[start:]
-
-    def _render_committed_segment(
-        self,
-        *,
-        width: int,
-        style_signature: tuple[object, ...],
-    ) -> RenderLineSegment | None:
-        first_record_id = id(self.records[0]) if self.records else 0
-        last_record_id = id(self.records[-1]) if self.records else 0
-        key = (
-            id(self.records),
-            self.records_revision,
-            len(self.records),
-            first_record_id,
-            last_record_id,
-            self.window_generation,
-            width,
-            style_signature,
-        )
-        if key == self._committed_segment_key:
-            return self._committed_segment
-
-        rows: list[str] = []
-        separator_rows: set[int] = set()
-        for record in self.records:
-            block = self._render_record_lines(record, width=width, style_signature=style_signature)
-            if not block:
-                continue
-            if rows:
-                separator_rows.add(len(rows))
-                rows.append("")
-            rows.extend(block)
-        segment = (
-            RenderLineSegment(
-                lines=tuple(RenderLine(row) for row in rows),
-                revision=key,
-            )
-            if rows
-            else None
-        )
-        self._committed_segment_key = key
-        self._committed_segment = segment
-        self._committed_separator_rows = frozenset(separator_rows)
-        return segment
-
-    def _render_draft_segments(
-        self,
-        *,
-        width: int,
-        style_signature: tuple[object, ...],
-        has_committed: bool,
-    ) -> tuple[RenderLineSegment, ...]:
-        draft: DisplayRecord | StreamingTextBuffer | None = self.draft_buffer or self.draft
-        if draft is None:
-            self._clear_draft_segment_cache()
-            return ()
-        source_revision: object
-        if isinstance(draft, StreamingTextBuffer):
-            source_revision = (id(draft), draft.version)
-        else:
-            source_revision = draft
-        key = (
-            source_revision,
-            has_committed,
-            self.window_generation,
-            width,
-            style_signature,
-        )
-        if key == self._draft_segments_key:
-            return self._draft_segments
-
-        if isinstance(draft, StreamingTextBuffer):
-            segmented = self._render_streaming_draft_segments(
-                draft,
-                width=width,
-                style_signature=style_signature,
-                has_committed=has_committed,
-            )
-            if segmented is not None:
-                self._draft_segments_key = key
-                self._draft_segments = segmented
-                return segmented
-
-        block = self._render_record_lines(draft, width=width, style_signature=style_signature)
-        rows = (("", *block) if has_committed and block else block)
-        segment = (
-            RenderLineSegment(
-                lines=tuple(RenderLine(row) for row in rows),
-                revision=key,
-            )
-            if rows
-            else None
-        )
-        segments = (segment,) if segment is not None else ()
-        self._draft_segments_key = key
-        self._draft_segments = segments
-        self._draft_has_leading_separator = bool(has_committed and block)
-        self._segmented_transient_content_segments = ()
-        self._segmented_transient_buffer_id = None
-        self._segmented_transient_buffer_version = -1
-        return segments
-
-    def _render_streaming_draft_segments(
-        self,
-        buffer: StreamingTextBuffer,
-        *,
-        width: int,
-        style_signature: tuple[object, ...],
-        has_committed: bool,
-    ) -> tuple[RenderLineSegment, ...] | None:
-        stream_context = (
-            id(buffer),
-            self.window_generation,
-            width,
-            style_signature,
-        )
-        if stream_context != self._draft_stream_context:
-            self._draft_stream_context = stream_context
-            self._draft_stable_segment_cache.clear()
-            self._draft_separator_segment = None
-
-        source = _streaming_buffer_render_text(buffer)
-        rendered = _render_streaming_assistant_markdown_segments(
-            source,
-            width=width,
-            theme=self.theme,
-            capabilities=self.capabilities,
-            code_highlighter=None,
-            markdown_cache=self._markdown_render_cache,
-            markdown_streaming_key=buffer,
-        )
-        if rendered is None:
-            self._draft_stable_segment_cache.clear()
-            self._draft_separator_segment = None
-            self._segmented_transient_content_segments = ()
-            self._segmented_transient_buffer_id = None
-            self._segmented_transient_buffer_version = -1
-            return None
-
-        content_segments: list[RenderLineSegment] = []
-        first_prefix_available = True
-        display_record = AssistantMessageRecord(source, stable=False)
-        for markdown_segment in rendered.segments:
-            has_nonblank = markdown_segment.has_nonblank
-            use_first_prefix = first_prefix_available and has_nonblank
-            if has_nonblank:
-                first_prefix_available = False
-            cache_key = (
-                markdown_segment.identity,
-                markdown_segment.revision,
-                use_first_prefix,
-            )
-            segment = (
-                self._draft_stable_segment_cache.get(cache_key)
-                if markdown_segment.stable
-                else None
-            )
-            if segment is None:
-                prefixed = _prefix_streaming_assistant_segment(
-                    markdown_segment.lines,
-                    width=width,
-                    use_first_prefix=use_first_prefix,
-                )
-                coding_lines = _coding_lines(
-                    prefixed,
-                    display_record,
-                    theme=self.theme,
-                    capabilities=self.capabilities,
-                )
-                segment = RenderLineSegment(
-                    lines=tuple(RenderLine(line) for line in coding_lines),
-                    identity=("streaming-markdown", markdown_segment.identity),
-                    revision=(markdown_segment.revision, use_first_prefix),
-                )
-                if markdown_segment.stable:
-                    self._draft_stable_segment_cache[cache_key] = segment
-            content_segments.append(segment)
-
-        content = tuple(content_segments)
-        segments: tuple[RenderLineSegment, ...] = content
-        if has_committed and content:
-            if self._draft_separator_segment is None:
-                self._draft_separator_segment = RenderLineSegment(
-                    lines=(RenderLine(""),),
-                    identity=self._draft_separator_identity,
-                    revision=stream_context,
-                )
-            segments = (self._draft_separator_segment, *content)
-        self._draft_has_leading_separator = bool(has_committed and content)
-
-        self._segmented_transient_content_segments = content
-        self._segmented_transient_buffer_id = id(buffer)
-        self._segmented_transient_buffer_version = buffer.version
-        self._segmented_transient_width = width
-        self._segmented_transient_style_signature = style_signature
-        return segments
-
-    def _clear_draft_segment_cache(self) -> None:
-        self._draft_segments_key = None
-        self._draft_segments = ()
-        self._draft_stream_context = None
-        self._draft_stable_segment_cache.clear()
-        self._draft_separator_segment = None
-        self._draft_has_leading_separator = False
-        self._segmented_transient_content_segments = ()
-        self._segmented_transient_buffer_id = None
-        self._segmented_transient_buffer_version = -1
-        self._segmented_transient_width = 0
-        self._segmented_transient_style_signature = None
-
-    def _iter_records(self) -> Iterable[DisplayRecord | StreamingTextBuffer]:
-        yield from self.records
-        if self.draft_buffer is not None:
-            yield self.draft_buffer
-        elif self.draft is not None:
-            yield self.draft
-
-    def _reset_cache_if_window_changed(self) -> None:
-        if self._cache_generation == self.window_generation:
-            return
-        self._stable_line_cache.clear()
-        self._transient_line_cache_key = None
-        self._transient_line_cache_lines = None
-        self._markdown_render_cache.clear()
-        self._committed_segment_key = None
-        self._committed_segment = None
-        self._committed_separator_rows = frozenset()
-        self._clear_draft_segment_cache()
-        self._cache_generation = self.window_generation
-
-    def clear_transient_cache(self) -> None:
-        self._transient_line_cache_key = None
-        self._transient_line_cache_lines = None
-        self._transient_source_text = ""
-        self._transient_source_width = 0
-        self._transient_source_style_signature = None
-        self._transient_source_buffer_id = None
-        self._transient_source_buffer_version = -1
-        self._clear_draft_segment_cache()
-        self._markdown_render_cache.clear_streaming()
-
-    def promote_transient_cache(
-        self,
-        record: AssistantMessageRecord,
-        *,
-        source_buffer: StreamingTextBuffer | None = None,
-    ) -> None:
-        if source_buffer is not None and self._segmented_transient_content_segments:
-            if self._segmented_transient_buffer_id != id(source_buffer):
-                return
-            if self._segmented_transient_buffer_version != source_buffer.version:
-                return
-            if record.text != source_buffer.text:
-                return
-            if (
-                self._segmented_transient_width <= 0
-                or self._segmented_transient_style_signature is None
-            ):
-                return
-            canonical_lines = tuple(
-                line.text
-                for segment in self._segmented_transient_content_segments
-                for line in segment.lines
-            )
-            self._stable_line_cache[
-                (
-                    record,
-                    self._segmented_transient_width,
-                    self._segmented_transient_style_signature,
-                )
-            ] = canonical_lines
-            self._enforce_stable_cache_entry_limit()
-            return
-        if self._transient_line_cache_lines is None:
-            return
-        if source_buffer is None and record.text != self._transient_source_text:
-            return
-        if source_buffer is not None and self._transient_source_buffer_id != id(source_buffer):
-            return
-        if source_buffer is not None and self._transient_source_buffer_version != source_buffer.version:
-            return
-        if self._transient_source_width <= 0 or self._transient_source_style_signature is None:
-            return
-        canonical_lines = self._render_record_uncached(record, width=self._transient_source_width)
-        self._stable_line_cache[
-            (record, self._transient_source_width, self._transient_source_style_signature)
-        ] = canonical_lines
-        self._enforce_stable_cache_entry_limit()
-
-    def _enforce_stable_cache_entry_limit(self) -> None:
-        limit = max(0, self.stable_cache_entry_limit)
-        if limit == 0:
-            self._stable_line_cache.clear()
-            return
-        while len(self._stable_line_cache) > limit:
-            self._stable_line_cache.pop(next(iter(self._stable_line_cache)))
-
-
-@dataclass(frozen=True, slots=True)
-class _CappedRenderable:
-    renderable: Any
-    max_height: int
-
-    def render(self, constraints: RenderConstraints) -> RenderResult:
-        return self.renderable.render(
-            RenderConstraints(
-                width=constraints.width,
-                max_height=max(1, min(self.max_height, constraints.max_height)),
-                visible_height=constraints.visible_height,
-            )
+        self._render_baseline_reset_reason = (
+            "transcript_window_trimmed:active_line_budget"
         )
 
 
@@ -972,31 +224,51 @@ def _coding_line(
 ) -> str:
     if isinstance(record, UserPromptRecord) and line.startswith("> "):
         line = "› " + line[2:]
-        return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
+        return apply_coding_transcript_style(
+            line, record, theme=theme, capabilities=capabilities
+        )
     if isinstance(record, AssistantMessageRecord) and line.startswith("* "):
         line = "• " + line[2:]
-        return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
+        return apply_coding_transcript_style(
+            line, record, theme=theme, capabilities=capabilities
+        )
     if isinstance(record, ErrorRecord) and line.startswith("! Error: "):
         line = "■ Error: " + line[len("! Error: ") :]
-        return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
+        return apply_coding_transcript_style(
+            line, record, theme=theme, capabilities=capabilities
+        )
     if isinstance(record, ContextCompactionRecord) and line.startswith("* "):
         line = "• " + line[2:]
-        return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
+        return apply_coding_transcript_style(
+            line, record, theme=theme, capabilities=capabilities
+        )
     if isinstance(record, ToolExecutionRecord):
         if line.startswith("- Ran "):
             line = "• Ran " + line[len("- Ran ") :]
-            return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
+            return apply_coding_transcript_style(
+                line, record, theme=theme, capabilities=capabilities
+            )
         if line.startswith("! Ran "):
             line = "■ Ran " + line[len("! Ran ") :]
-            return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
-        return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
+            return apply_coding_transcript_style(
+                line, record, theme=theme, capabilities=capabilities
+            )
+        return apply_coding_transcript_style(
+            line, record, theme=theme, capabilities=capabilities
+        )
     if isinstance(record, WorkedDividerRecord) and line.startswith("- Worked for "):
         line = line.replace("-", "─", 1).replace("-", "─")
-        return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
-    return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
+        return apply_coding_transcript_style(
+            line, record, theme=theme, capabilities=capabilities
+        )
+    return apply_coding_transcript_style(
+        line, record, theme=theme, capabilities=capabilities
+    )
 
 
-def _screen_coding_display_record(record: DisplayRecord, *, cwd: str = "") -> DisplayRecord:
+def _screen_coding_display_record(
+    record: DisplayRecord, *, cwd: str = ""
+) -> DisplayRecord:
     if not isinstance(record, ToolExecutionRecord):
         return record
     name = _compact_display_paths(record.name, cwd=cwd)
@@ -1060,24 +332,39 @@ def _coding_lines(
     capabilities: Any | None,
 ) -> tuple[str, ...]:
     if not isinstance(record, ToolExecutionRecord):
-        return tuple(_coding_line(line, record, theme=theme, capabilities=capabilities) for line in lines)
+        return tuple(
+            _coding_line(line, record, theme=theme, capabilities=capabilities)
+            for line in lines
+        )
 
     rendered: list[str] = []
     output_started = False
     for line in lines:
         if line.startswith("- Ran ") or line.startswith("! Ran "):
-            rendered.append(_coding_line(line, record, theme=theme, capabilities=capabilities))
+            rendered.append(
+                _coding_line(line, record, theme=theme, capabilities=capabilities)
+            )
             continue
         if line.startswith("  $ "):
-            rendered.append(_style_tool_body_line(f"  │ {line[2:]}", record, theme=theme, capabilities=capabilities))
+            rendered.append(
+                _style_tool_body_line(
+                    f"  │ {line[2:]}", record, theme=theme, capabilities=capabilities
+                )
+            )
             continue
         if line.startswith("  "):
             content = line[2:]
             prefix = "  └ " if not output_started else "    "
             output_started = True
-            rendered.append(_style_tool_body_line(f"{prefix}{content}", record, theme=theme, capabilities=capabilities))
+            rendered.append(
+                _style_tool_body_line(
+                    f"{prefix}{content}", record, theme=theme, capabilities=capabilities
+                )
+            )
             continue
-        rendered.append(_coding_line(line, record, theme=theme, capabilities=capabilities))
+        rendered.append(
+            _coding_line(line, record, theme=theme, capabilities=capabilities)
+        )
     return tuple(rendered)
 
 
@@ -1088,26 +375,15 @@ def _style_tool_body_line(
     theme: ThemeResolver | None,
     capabilities: Any | None,
 ) -> str:
-    return apply_coding_transcript_style(line, record, theme=theme, capabilities=capabilities)
+    return apply_coding_transcript_style(
+        line, record, theme=theme, capabilities=capabilities
+    )
 
 
 def _screen_transcript_record_render_width(record: DisplayRecord, *, width: int) -> int:
     if isinstance(record, ToolExecutionRecord):
         return max(1, width - 2)
     return width
-
-
-def _streaming_buffer_render_text(buffer: StreamingTextBuffer) -> str:
-    return "\n".join(buffer.logical_lines())
-
-
-def _screen_transcript_style_signature(theme: ThemeResolver | None, capabilities: Any | None) -> tuple[object, ...]:
-    capabilities_signature: tuple[bool, bool] | None = None
-    if capabilities is not None:
-        capabilities_signature = (bool(capabilities.truecolor), bool(capabilities.hyperlinks))
-    if theme is None:
-        return (None, capabilities_signature)
-    return (id(theme), theme.version, capabilities_signature)
 
 
 def _cwd_label(cwd: str) -> str:

--- a/src/loushang/harnesstui/conversation/screen_app.py
+++ b/src/loushang/harnesstui/conversation/screen_app.py
@@ -1,0 +1,338 @@
+"""Reusable full-screen conversation application shell."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from loushang.harnesstui.conversation.reader import TranscriptReaderSurface
+from loushang.harnesstui.conversation.screen_frame import ScreenFramePresentation
+from loushang.harnesstui.conversation.screen_state import (
+    ActiveTranscriptWindow,
+    ScreenConversationState,
+)
+from loushang.harnesstui.conversation.source import (
+    ActiveWindowTranscriptSource,
+    TranscriptSource,
+)
+from loushang.harnesstui.status.line import (
+    StatusLinePreviewSnapshot,
+    StatusLineSettings,
+)
+from loushang.tui import (
+    BottomFrame,
+    Composer,
+    PendingQueueView,
+    RenderConstraints,
+    RenderRequestKind,
+    RenderResult,
+    ScreenLayout,
+    StatusBar,
+    Surface,
+    SurfaceHost,
+    TerminalRuntimeCapabilities,
+    WorkingLine,
+    theme_capabilities_from_runtime,
+)
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.transcript import AssistantMessageRecord, DisplayRecord
+from loushang.tui.ui_parts.layout import CappedRenderable
+from loushang.tui.ui_parts.transcript import (
+    DEFAULT_STABLE_TRANSCRIPT_CACHE_ENTRY_LIMIT,
+    NeutralTranscriptPresentation,
+    TranscriptPresentation,
+    TranscriptRegion,
+)
+
+ACTIVE_RENDER_INTERVAL_MS = 80
+
+
+@dataclass(slots=True)
+class ScreenConversationApp:
+    """Coordinate product-neutral conversation state with a TUI screen."""
+
+    model_label: str | None
+    cwd: str
+    branch: str | None
+    session_label: str | None
+    now: Callable[[], float] = time.monotonic
+    composer: Composer = field(default_factory=Composer)
+    state: ScreenConversationState = field(init=False)
+    active_surface: Any | None = None
+    surface_host: SurfaceHost | None = None
+    transcript_theme: ThemeResolver | None = None
+    welcome_theme: ThemeResolver | None = None
+    active_transcript_line_budget: int = 0
+    stable_render_cache_entry_limit: int = DEFAULT_STABLE_TRANSCRIPT_CACHE_ENTRY_LIMIT
+    render_requester: Callable[[RenderRequestKind], object] | None = None
+    terminal_diagnostics_provider: Callable[[], str] | None = None
+    terminal_capabilities: TerminalRuntimeCapabilities | None = None
+    transcript_source_factory: Callable[[], TranscriptSource] | None = None
+    _transcript_presentation: TranscriptPresentation = field(
+        init=False,
+        repr=False,
+    )
+    _transcript_region: TranscriptRegion = field(init=False, repr=False)
+    _bottom_frame_component: BottomFrame = field(init=False, repr=False)
+    _frame_presentation: ScreenFramePresentation = field(init=False, repr=False)
+    _render_baseline_reset_reason: str | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+
+    def __post_init__(self) -> None:
+        self.state = ScreenConversationState(
+            model_label=self.model_label,
+            cwd=self.cwd,
+            branch=self.branch,
+            session_label=self.session_label,
+        )
+        self._transcript_presentation = self._create_transcript_presentation()
+        self._transcript_region = TranscriptRegion(
+            theme=self.transcript_theme,
+            presentation=self._transcript_presentation,
+        )
+        self._bottom_frame_component = BottomFrame(composer=self.composer)
+        self._frame_presentation = self._create_frame_presentation()
+
+    def _create_transcript_presentation(self) -> TranscriptPresentation:
+        return NeutralTranscriptPresentation()
+
+    def _create_frame_presentation(self) -> ScreenFramePresentation:
+        raise NotImplementedError("a product screen binding must supply frame copy")
+
+    def _prepare_transcript_presentation(self) -> None:
+        """Synchronize product context before a frame without allocating a profile."""
+
+    def start_prompt(self, text: str, *, started_at: float | None = None) -> None:
+        self.state.start_prompt(
+            text,
+            started_at=self.now() if started_at is None else started_at,
+        )
+        self.composer.add_history(text)
+        self.composer.clear()
+
+    def start_pending_prompt(
+        self,
+        text: str,
+        *,
+        started_at: float | None = None,
+    ) -> None:
+        self.state.start_prompt(
+            text,
+            started_at=self.now() if started_at is None else started_at,
+        )
+        self.composer.add_history(text)
+
+    def begin_run(self, *, started_at: float | None = None) -> None:
+        self.state.begin_run(
+            started_at=self.now() if started_at is None else started_at,
+        )
+
+    def begin_assistant(self) -> None:
+        self.state.begin_assistant()
+        self._transcript_region.clear_transient_cache()
+        self._request_render("product")
+
+    def append_assistant_chunk(self, chunk: str) -> None:
+        self.state.append_assistant_chunk(chunk)
+        self._request_render("stream")
+
+    def end_assistant(self, final_text: str | None = None) -> None:
+        draft_buffer = self.state.assistant_draft_buffer
+        draft_text = final_text
+        if draft_text is None and draft_buffer is not None:
+            draft_text = draft_buffer.text
+        self.state.end_assistant(draft_text)
+        committed = self.state.records[-1] if self.state.records else None
+        if (
+            isinstance(committed, AssistantMessageRecord)
+            and committed.text == draft_text
+        ):
+            self._transcript_region.promote_transient_cache(
+                committed,
+                source_buffer=draft_buffer,
+            )
+        self._transcript_region.clear_transient_cache()
+
+    def complete_run(self, *, elapsed_seconds: float | None = None) -> None:
+        elapsed = self.elapsed_seconds() if elapsed_seconds is None else elapsed_seconds
+        self.state.complete_run(elapsed_seconds=elapsed)
+        self._transcript_region.clear_transient_cache()
+
+    def queue_followup(self, text: str) -> None:
+        self.state.queue_followup(text)
+
+    def queue_steer(self, text: str) -> None:
+        self.state.queue_steer(text)
+
+    def sync_queues(
+        self,
+        *,
+        steers: tuple[str, ...] | list[str],
+        followups: tuple[str, ...] | list[str],
+    ) -> None:
+        self.state.sync_queues(steers=steers, followups=followups)
+
+    def set_status(self, message: str | None) -> None:
+        self.state.set_status(message)
+        self._request_render("product")
+
+    def set_statusline_visible(self, visible: bool) -> None:
+        self.set_statusline_settings(
+            replace(self.state.statusline_settings, enabled=visible)
+        )
+
+    def set_statusline_settings(self, settings: StatusLineSettings) -> None:
+        self.state.statusline_settings = settings
+        self.state.statusline_visible = settings.enabled
+        self._request_render("product")
+
+    def request_render(self, kind: RenderRequestKind = "product") -> None:
+        self._request_render(kind)
+
+    def statusline_preview_snapshot(self) -> StatusLinePreviewSnapshot:
+        return self._frame_presentation.statusline_preview_snapshot(self.state)
+
+    def open_transcript_reader(self) -> bool:
+        if self.surface_host is None:
+            return False
+        source = (
+            self.transcript_source_factory()
+            if self.transcript_source_factory is not None
+            else ActiveWindowTranscriptSource(self.state)
+        )
+        reader = TranscriptReaderSurface(source)
+        self.surface_host.open_surface(
+            Surface(
+                renderable=reader,
+                focus_target=reader,
+                presentation="modal",
+                max_height="100%",
+            )
+        )
+        self._request_render("input")
+        return True
+
+    def add_error(self, summary: str, diagnostics: str = "") -> None:
+        self.state.add_error(summary, diagnostics)
+        self._request_render("product")
+
+    def add_status(self, message: str) -> None:
+        self.state.add_status(message)
+        self._request_render("product")
+
+    def replace_transcript_window(
+        self,
+        records: Iterable[DisplayRecord] | ActiveTranscriptWindow,
+        *,
+        evicted_prefix_record_count: int = 0,
+        reason: str = "replace",
+    ) -> None:
+        self.state.replace_transcript_window(
+            records,
+            evicted_prefix_record_count=evicted_prefix_record_count,
+        )
+        self._render_baseline_reset_reason = (
+            f"transcript_window_replaced:{reason}"
+            if reason
+            else "transcript_window_replaced"
+        )
+
+    def consume_render_baseline_reset_reason(self) -> str | None:
+        reason = self._render_baseline_reset_reason
+        self._render_baseline_reset_reason = None
+        return reason
+
+    def elapsed_seconds(self) -> float:
+        if self.state.active_started_at is None:
+            return 0.0
+        return max(0.0, self.now() - self.state.active_started_at)
+
+    def next_frame_due_ms(self, *, after_ms: int) -> int | None:
+        completion_due_ms = self.composer.next_frame_due_ms(after_ms=after_ms)
+        if not self.state.running:
+            return completion_due_ms
+        active_due_ms = after_ms + ACTIVE_RENDER_INTERVAL_MS
+        if completion_due_ms is None:
+            return active_due_ms
+        return min(active_due_ms, completion_due_ms)
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        visible_height = constraints.visible_height or constraints.max_height
+        editor_height = self._bottom_frame_height(visible_height)
+        self._transcript_region.records = self.state.records
+        self._transcript_region.records_revision = self.state.records_revision
+        self._transcript_region.draft = None
+        self._transcript_region.draft_buffer = self.state.assistant_draft_buffer
+        self._prepare_transcript_presentation()
+        self._transcript_region.theme = self.transcript_theme
+        self._transcript_region.capabilities = (
+            theme_capabilities_from_runtime(self.terminal_capabilities)
+            if self.terminal_capabilities is not None
+            else None
+        )
+        self._transcript_region.window_generation = (
+            self.state.transcript_window_generation
+        )
+        self._transcript_region.stable_cache_entry_limit = (
+            self.stable_render_cache_entry_limit
+        )
+        layout = ScreenLayout(
+            transcript=self._transcript_region,
+            editor=CappedRenderable(
+                self._bottom_frame(),
+                max_height=editor_height,
+            ),
+            editor_min_height=editor_height,
+        )
+        return layout.render(constraints)
+
+    def startup_welcome_panel(self) -> Any:
+        raise NotImplementedError(
+            "a product screen binding must supply a welcome panel"
+        )
+
+    def _expanded_bottom_frame(self) -> bool:
+        return self._frame_presentation.expanded_bottom_frame(
+            self.state,
+            active_surface=self.active_surface,
+        )
+
+    def _bottom_frame_height(self, visible_height: int) -> int:
+        return self._frame_presentation.bottom_frame_height(
+            self.state,
+            active_surface=self.active_surface,
+            visible_height=visible_height,
+        )
+
+    def _request_render(self, kind: RenderRequestKind) -> None:
+        if self.render_requester is not None:
+            self.render_requester(kind)
+
+    def _bottom_frame(self) -> BottomFrame:
+        return self._frame_presentation.populate_bottom_frame(
+            self._bottom_frame_component,
+            composer=self.composer,
+            state=self.state,
+            active_surface=self.active_surface,
+            elapsed_seconds=self.elapsed_seconds(),
+        )
+
+    def _working_line(self) -> WorkingLine | None:
+        return self._frame_presentation.working_line(
+            self.state,
+            elapsed_seconds=self.elapsed_seconds(),
+        )
+
+    def _pending_queue(self) -> PendingQueueView | None:
+        return self._frame_presentation.pending_queue(self.state)
+
+    def _status_bar(self) -> StatusBar:
+        return self._frame_presentation.status_bar(self.state)
+
+
+__all__ = ["ACTIVE_RENDER_INTERVAL_MS", "ScreenConversationApp"]

--- a/src/loushang/harnesstui/conversation/screen_frame.py
+++ b/src/loushang/harnesstui/conversation/screen_frame.py
@@ -1,0 +1,163 @@
+"""Product-neutral screen conversation frame presentation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from loushang.harnesstui.conversation.screen_state import ScreenConversationState
+from loushang.harnesstui.status.line import (
+    StatusLinePreviewSnapshot,
+    status_line_fields,
+    status_line_separator,
+    status_line_style_mode,
+)
+from loushang.tui import (
+    BottomFrame,
+    Composer,
+    PendingQueueView,
+    PendingSection,
+    StatusBar,
+    WorkingLine,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ScreenFrameCopy:
+    """Presentation copy supplied by a product screen binding."""
+
+    working_label: str
+    steer_label: str
+    steer_hint: str
+    followup_label: str
+    followup_hint: str
+    interruption_marker: str = "■"
+
+
+@dataclass(frozen=True, slots=True)
+class ScreenFramePresentation:
+    """Build the reusable bottom frame around conversation state."""
+
+    copy: ScreenFrameCopy
+
+    def statusline_preview_snapshot(
+        self, state: ScreenConversationState
+    ) -> StatusLinePreviewSnapshot:
+        return StatusLinePreviewSnapshot(
+            model_label=state.model_label,
+            cwd=state.cwd,
+            branch=state.branch,
+            session_label=state.session_label,
+            running=state.running,
+            pending_followups=len(state.pending_followups),
+            pending_steers=len(state.pending_steers),
+            status_message=state.status_message,
+        )
+
+    def expanded_bottom_frame(
+        self,
+        state: ScreenConversationState,
+        *,
+        active_surface: Any | None,
+    ) -> bool:
+        return (
+            active_surface is not None
+            or state.running
+            or bool(state.pending_steers)
+            or bool(state.pending_followups)
+            or bool(state.interruption_message)
+        )
+
+    def bottom_frame_height(
+        self,
+        state: ScreenConversationState,
+        *,
+        active_surface: Any | None,
+        visible_height: int,
+    ) -> int:
+        height = 12
+        if self.expanded_bottom_frame(state, active_surface=active_surface):
+            height = 16
+            preferred = getattr(active_surface, "preferred_height", None)
+            if isinstance(preferred, int) and preferred > 0:
+                height = max(height, preferred)
+        return max(1, min(height, visible_height))
+
+    def populate_bottom_frame(
+        self,
+        component: BottomFrame,
+        *,
+        composer: Composer,
+        state: ScreenConversationState,
+        active_surface: Any | None,
+        elapsed_seconds: float,
+    ) -> BottomFrame:
+        component.composer = composer
+        component.surface = active_surface
+        component.working_line = self.working_line(
+            state,
+            elapsed_seconds=elapsed_seconds,
+        )
+        component.pending_queue = self.pending_queue(state)
+        component.status_bar = (
+            self.status_bar(state) if state.statusline_visible else None
+        )
+        return component
+
+    def working_line(
+        self,
+        state: ScreenConversationState,
+        *,
+        elapsed_seconds: float,
+    ) -> WorkingLine | None:
+        if not state.running:
+            return None
+        return WorkingLine(
+            label=self.copy.working_label,
+            elapsed_seconds=elapsed_seconds,
+        )
+
+    def pending_queue(self, state: ScreenConversationState) -> PendingQueueView | None:
+        sections: list[PendingSection] = []
+        if state.interruption_message:
+            sections.append(
+                PendingSection(
+                    label=state.interruption_message,
+                    marker=self.copy.interruption_marker,
+                    show_when_empty=True,
+                )
+            )
+        if state.pending_steers:
+            sections.append(
+                PendingSection(
+                    label=self.copy.steer_label,
+                    items=tuple(state.pending_steers),
+                    hint=self.copy.steer_hint,
+                    hint_placement="header",
+                )
+            )
+        if state.pending_followups:
+            sections.append(
+                PendingSection(
+                    label=self.copy.followup_label,
+                    items=tuple(state.pending_followups),
+                    hint=self.copy.followup_hint,
+                )
+            )
+        if not sections:
+            return None
+        return PendingQueueView(sections=tuple(sections))
+
+    def status_bar(self, state: ScreenConversationState) -> StatusBar:
+        settings = state.statusline_settings
+        return StatusBar(
+            status_line_fields(
+                self.statusline_preview_snapshot(state),
+                settings,
+            ),
+            separator=status_line_separator(settings),
+            style_mode=status_line_style_mode(settings),
+        )
+
+
+__all__ = ["ScreenFrameCopy", "ScreenFramePresentation"]

--- a/src/loushang/tui/ui_parts/layout.py
+++ b/src/loushang/tui/ui_parts/layout.py
@@ -20,6 +20,23 @@ class RegionRenderable(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
+class CappedRenderable:
+    """Render another region within a fixed height cap."""
+
+    renderable: RegionRenderable
+    max_height: int
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        return self.renderable.render(
+            RenderConstraints(
+                width=constraints.width,
+                max_height=max(1, min(self.max_height, constraints.max_height)),
+                visible_height=constraints.visible_height,
+            )
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class ScreenRegion:
     name: str
     renderable: RegionRenderable
@@ -240,6 +257,7 @@ def _ephemeral_segment(lines: tuple[RenderLine, ...]) -> RenderLineSegment:
 
 
 __all__ = [
+    "CappedRenderable",
     "RegionRenderable",
     "ScreenLayout",
     "ScreenRegion",

--- a/src/loushang/tui/ui_parts/transcript.py
+++ b/src/loushang/tui/ui_parts/transcript.py
@@ -1,0 +1,754 @@
+"""Generic incremental transcript region for full-screen terminal layouts."""
+
+from __future__ import annotations
+
+from collections.abc import Hashable, Iterable
+from dataclasses import dataclass, field, replace
+from typing import Any, Protocol
+
+from loushang.tui.core import (
+    RenderConstraints,
+    RenderLine,
+    RenderLineSegment,
+    RenderResult,
+    SegmentedRenderLines,
+)
+from loushang.tui.markdown.renderer import MarkdownRenderCache
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.transcript import (
+    AssistantMessageRecord,
+    DisplayRecord,
+    StreamingTextBuffer,
+    TranscriptView,
+    _prefix_streaming_assistant_segment,
+    _render_streaming_assistant_markdown_segments,
+)
+
+DEFAULT_STABLE_TRANSCRIPT_CACHE_ENTRY_LIMIT = 128
+
+
+class TranscriptPresentation(Protocol):
+    """Project and decorate transcript records without owning render mechanics.
+
+    ``cache_token`` is read on every frame and must be cheap, hashable, and
+    stable until presentation output changes. The remaining hooks are cached
+    across unchanged records and streaming segments. Assistant ``stable`` is
+    render-cache lifecycle metadata and is normalized before these hooks; it is
+    not a presentation semantic.
+    """
+
+    @property
+    def cache_token(self) -> Hashable: ...
+
+    def project_record(self, record: DisplayRecord) -> DisplayRecord: ...
+
+    def record_render_width(
+        self,
+        record: DisplayRecord,
+        *,
+        width: int,
+    ) -> int: ...
+
+    def present_lines(
+        self,
+        lines: tuple[str, ...],
+        record: DisplayRecord,
+        *,
+        theme: ThemeResolver | None,
+        capabilities: Any | None,
+    ) -> tuple[str, ...]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class NeutralTranscriptPresentation:
+    """Preserve the generic TranscriptView result without product decoration."""
+
+    @property
+    def cache_token(self) -> None:
+        return None
+
+    def project_record(self, record: DisplayRecord) -> DisplayRecord:
+        return record
+
+    def record_render_width(
+        self,
+        record: DisplayRecord,
+        *,
+        width: int,
+    ) -> int:
+        del record
+        return width
+
+    def present_lines(
+        self,
+        lines: tuple[str, ...],
+        record: DisplayRecord,
+        *,
+        theme: ThemeResolver | None,
+        capabilities: Any | None,
+    ) -> tuple[str, ...]:
+        del record, theme, capabilities
+        return lines
+
+
+@dataclass(slots=True)
+class TranscriptRegion:
+    records: list[DisplayRecord] = field(default_factory=list)
+    records_revision: int = 0
+    draft: AssistantMessageRecord | None = None
+    draft_buffer: StreamingTextBuffer | None = None
+    theme: ThemeResolver | None = None
+    capabilities: Any | None = None
+    presentation: TranscriptPresentation = field(
+        default_factory=NeutralTranscriptPresentation
+    )
+    window_generation: int = 0
+    stable_cache_entry_limit: int = DEFAULT_STABLE_TRANSCRIPT_CACHE_ENTRY_LIMIT
+    _stable_line_cache: dict[
+        tuple[DisplayRecord, int, tuple[object, ...]], tuple[str, ...]
+    ] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _transient_line_cache_key: tuple[DisplayRecord, int, tuple[object, ...]] | None = (
+        field(
+            default=None,
+            init=False,
+            repr=False,
+        )
+    )
+    _transient_line_cache_lines: tuple[str, ...] | None = field(
+        default=None, init=False, repr=False
+    )
+    _transient_source_text: str = field(default="", init=False, repr=False)
+    _transient_source_width: int = field(default=0, init=False, repr=False)
+    _transient_source_style_signature: tuple[object, ...] | None = field(
+        default=None, init=False, repr=False
+    )
+    _transient_source_buffer_id: int | None = field(
+        default=None, init=False, repr=False
+    )
+    _transient_source_buffer_version: int = field(default=-1, init=False, repr=False)
+    _markdown_render_cache: MarkdownRenderCache = field(
+        default_factory=MarkdownRenderCache, init=False, repr=False
+    )
+    _cache_generation: int = field(default=-1, init=False, repr=False)
+    _committed_segment_key: tuple[object, ...] | None = field(
+        default=None, init=False, repr=False
+    )
+    _committed_segment: RenderLineSegment | None = field(
+        default=None, init=False, repr=False
+    )
+    _committed_separator_rows: frozenset[int] = field(
+        default_factory=frozenset,
+        init=False,
+        repr=False,
+    )
+    _draft_segments_key: tuple[object, ...] | None = field(
+        default=None, init=False, repr=False
+    )
+    _draft_segments: tuple[RenderLineSegment, ...] = field(
+        default=(), init=False, repr=False
+    )
+    _draft_stream_context: tuple[object, ...] | None = field(
+        default=None, init=False, repr=False
+    )
+    _draft_stable_segment_cache: dict[tuple[object, ...], RenderLineSegment] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _draft_separator_identity: object = field(
+        default_factory=object, init=False, repr=False
+    )
+    _draft_separator_segment: RenderLineSegment | None = field(
+        default=None, init=False, repr=False
+    )
+    _draft_has_leading_separator: bool = field(default=False, init=False, repr=False)
+    _segmented_transient_content_segments: tuple[RenderLineSegment, ...] = field(
+        default=(),
+        init=False,
+        repr=False,
+    )
+    _segmented_transient_buffer_id: int | None = field(
+        default=None, init=False, repr=False
+    )
+    _segmented_transient_buffer_version: int = field(default=-1, init=False, repr=False)
+    _segmented_transient_width: int = field(default=0, init=False, repr=False)
+    _segmented_transient_style_signature: tuple[object, ...] | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
+
+    @property
+    def has_content(self) -> bool:
+        return bool(
+            self.records or self.draft is not None or self.draft_buffer is not None
+        )
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        self._reset_cache_if_window_changed()
+        style_signature = (
+            *_transcript_style_signature(self.theme, self.capabilities),
+            self.presentation.cache_token,
+        )
+        lines = self._render_tail_segments(
+            max_height=constraints.max_height,
+            width=constraints.width,
+            style_signature=style_signature,
+        )
+        return RenderResult(lines=lines)
+
+    def _render_record_lines(
+        self,
+        record: DisplayRecord | StreamingTextBuffer,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+    ) -> tuple[str, ...]:
+        if isinstance(record, StreamingTextBuffer):
+            return self._render_streaming_buffer_lines(
+                record, width=width, style_signature=style_signature
+            )
+        if isinstance(record, AssistantMessageRecord) and not record.stable:
+            return self._render_transient_record_lines(
+                record, width=width, style_signature=style_signature
+            )
+
+        key = (record, width, style_signature)
+        cached = self._stable_line_cache.get(key)
+        if cached is not None:
+            return cached
+        rendered = self._render_record_uncached(record, width=width)
+        self._stable_line_cache[key] = rendered
+        self._enforce_stable_cache_entry_limit()
+        return rendered
+
+    def _render_streaming_buffer_lines(
+        self,
+        buffer: StreamingTextBuffer,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+    ) -> tuple[str, ...]:
+        if (
+            self._transient_line_cache_lines is not None
+            and self._transient_source_width == width
+            and self._transient_source_style_signature == style_signature
+            and self._transient_source_buffer_id == id(buffer)
+            and self._transient_source_buffer_version == buffer.version
+        ):
+            return self._transient_line_cache_lines
+
+        rendered = self._render_record_uncached(
+            AssistantMessageRecord(_streaming_buffer_render_text(buffer), stable=False),
+            width=width,
+            markdown_streaming_key=buffer,
+        )
+        self._remember_streaming_buffer_cache(
+            buffer,
+            width=width,
+            style_signature=style_signature,
+            lines=rendered,
+        )
+        return rendered
+
+    def _render_transient_record_lines(
+        self,
+        record: AssistantMessageRecord,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+    ) -> tuple[str, ...]:
+        key = (record, width, style_signature)
+        if (
+            key == self._transient_line_cache_key
+            and self._transient_line_cache_lines is not None
+        ):
+            return self._transient_line_cache_lines
+
+        rendered = self._render_record_uncached(record, width=width)
+        self._transient_line_cache_key = key
+        self._transient_line_cache_lines = rendered
+        self._transient_source_text = record.text
+        self._transient_source_width = width
+        self._transient_source_style_signature = style_signature
+        self._transient_source_buffer_id = None
+        self._transient_source_buffer_version = -1
+        return rendered
+
+    def _render_record_uncached(
+        self,
+        record: DisplayRecord,
+        *,
+        width: int,
+        markdown_streaming_key: object | None = None,
+    ) -> tuple[str, ...]:
+        display_record = _presentation_record(
+            self.presentation.project_record(_presentation_record(record))
+        )
+        render_width = self.presentation.record_render_width(
+            display_record, width=width
+        )
+        render_record = display_record
+        if (
+            isinstance(record, AssistantMessageRecord)
+            and not record.stable
+            and isinstance(display_record, AssistantMessageRecord)
+        ):
+            render_record = replace(display_record, stable=False)
+        view = TranscriptView(
+            [render_record],
+            theme=self.theme,
+            capabilities=self.capabilities,
+            markdown_cache=self._markdown_render_cache,
+            markdown_streaming_key=markdown_streaming_key,
+        )
+        rendered = view.render(
+            RenderConstraints(width=render_width, max_height=1_000_000)
+        )
+        return self.presentation.present_lines(
+            tuple(line.text for line in rendered.lines),
+            display_record,
+            theme=self.theme,
+            capabilities=self.capabilities,
+        )
+
+    def _remember_streaming_buffer_cache(
+        self,
+        buffer: StreamingTextBuffer,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+        lines: tuple[str, ...],
+    ) -> None:
+        self._transient_line_cache_key = None
+        self._transient_line_cache_lines = lines
+        self._transient_source_text = ""
+        self._transient_source_width = width
+        self._transient_source_style_signature = style_signature
+        self._transient_source_buffer_id = id(buffer)
+        self._transient_source_buffer_version = buffer.version
+
+    def _render_tail_rows(
+        self,
+        *,
+        max_height: int,
+        width: int,
+        style_signature: tuple[object, ...],
+    ) -> list[str]:
+        return [
+            line.text
+            for line in self._render_tail_segments(
+                max_height=max_height,
+                width=width,
+                style_signature=style_signature,
+            )
+        ]
+
+    def _render_tail_segments(
+        self,
+        *,
+        max_height: int,
+        width: int,
+        style_signature: tuple[object, ...],
+    ) -> SegmentedRenderLines:
+        if max_height <= 0:
+            return SegmentedRenderLines()
+
+        committed = self._render_committed_segment(
+            width=width, style_signature=style_signature
+        )
+        draft_segments = self._render_draft_segments(
+            width=width,
+            style_signature=style_signature,
+            has_committed=committed is not None,
+        )
+        segments = (
+            *((committed,) if committed is not None else ()),
+            *draft_segments,
+        )
+        lines = SegmentedRenderLines.from_segments(segments)
+        if len(lines) <= max_height:
+            return lines
+
+        start = len(lines) - max_height
+        committed_rows = committed.line_count if committed is not None else 0
+        starts_at_draft_separator = (
+            committed is not None
+            and bool(draft_segments)
+            and self._draft_has_leading_separator
+            and start == committed_rows
+        )
+        if start in self._committed_separator_rows or starts_at_draft_separator:
+            start += 1
+        return lines[start:]
+
+    def _render_committed_segment(
+        self,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+    ) -> RenderLineSegment | None:
+        first_record_id = id(self.records[0]) if self.records else 0
+        last_record_id = id(self.records[-1]) if self.records else 0
+        key = (
+            id(self.records),
+            self.records_revision,
+            len(self.records),
+            first_record_id,
+            last_record_id,
+            self.window_generation,
+            width,
+            style_signature,
+        )
+        if key == self._committed_segment_key:
+            return self._committed_segment
+
+        rows: list[str] = []
+        separator_rows: set[int] = set()
+        for record in self.records:
+            block = self._render_record_lines(
+                record, width=width, style_signature=style_signature
+            )
+            if not block:
+                continue
+            if rows:
+                separator_rows.add(len(rows))
+                rows.append("")
+            rows.extend(block)
+        segment = (
+            RenderLineSegment(
+                lines=tuple(RenderLine(row) for row in rows),
+                revision=key,
+            )
+            if rows
+            else None
+        )
+        self._committed_segment_key = key
+        self._committed_segment = segment
+        self._committed_separator_rows = frozenset(separator_rows)
+        return segment
+
+    def _render_draft_segments(
+        self,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+        has_committed: bool,
+    ) -> tuple[RenderLineSegment, ...]:
+        draft: DisplayRecord | StreamingTextBuffer | None = (
+            self.draft_buffer or self.draft
+        )
+        if draft is None:
+            self._clear_draft_segment_cache()
+            return ()
+        source_revision: object
+        if isinstance(draft, StreamingTextBuffer):
+            source_revision = (id(draft), draft.version)
+        else:
+            source_revision = draft
+        key = (
+            source_revision,
+            has_committed,
+            self.window_generation,
+            width,
+            style_signature,
+        )
+        if key == self._draft_segments_key:
+            return self._draft_segments
+
+        if isinstance(draft, StreamingTextBuffer):
+            segmented = self._render_streaming_draft_segments(
+                draft,
+                width=width,
+                style_signature=style_signature,
+                has_committed=has_committed,
+            )
+            if segmented is not None:
+                self._draft_segments_key = key
+                self._draft_segments = segmented
+                return segmented
+
+        block = self._render_record_lines(
+            draft, width=width, style_signature=style_signature
+        )
+        rows = ("", *block) if has_committed and block else block
+        segment = (
+            RenderLineSegment(
+                lines=tuple(RenderLine(row) for row in rows),
+                revision=key,
+            )
+            if rows
+            else None
+        )
+        segments = (segment,) if segment is not None else ()
+        self._draft_segments_key = key
+        self._draft_segments = segments
+        self._draft_has_leading_separator = bool(has_committed and block)
+        self._segmented_transient_content_segments = ()
+        self._segmented_transient_buffer_id = None
+        self._segmented_transient_buffer_version = -1
+        return segments
+
+    def _render_streaming_draft_segments(
+        self,
+        buffer: StreamingTextBuffer,
+        *,
+        width: int,
+        style_signature: tuple[object, ...],
+        has_committed: bool,
+    ) -> tuple[RenderLineSegment, ...] | None:
+        source_record = _presentation_record(
+            AssistantMessageRecord(
+                _streaming_buffer_render_text(buffer),
+                stable=False,
+            )
+        )
+        display_record = _presentation_record(
+            self.presentation.project_record(source_record)
+        )
+        if not isinstance(display_record, AssistantMessageRecord):
+            return None
+        render_width = self.presentation.record_render_width(
+            display_record,
+            width=width,
+        )
+        stream_context = (
+            id(buffer),
+            self.window_generation,
+            render_width,
+            style_signature,
+        )
+        if stream_context != self._draft_stream_context:
+            self._draft_stream_context = stream_context
+            self._draft_stable_segment_cache.clear()
+            self._draft_separator_segment = None
+
+        rendered = _render_streaming_assistant_markdown_segments(
+            display_record.text,
+            width=render_width,
+            theme=self.theme,
+            capabilities=self.capabilities,
+            code_highlighter=None,
+            markdown_cache=self._markdown_render_cache,
+            markdown_streaming_key=buffer,
+        )
+        if rendered is None:
+            self._draft_stable_segment_cache.clear()
+            self._draft_separator_segment = None
+            self._segmented_transient_content_segments = ()
+            self._segmented_transient_buffer_id = None
+            self._segmented_transient_buffer_version = -1
+            return None
+
+        content_segments: list[RenderLineSegment] = []
+        first_prefix_available = True
+        for markdown_segment in rendered.segments:
+            has_nonblank = markdown_segment.has_nonblank
+            use_first_prefix = first_prefix_available and has_nonblank
+            if has_nonblank:
+                first_prefix_available = False
+            cache_key = (
+                markdown_segment.identity,
+                markdown_segment.revision,
+                use_first_prefix,
+            )
+            segment = (
+                self._draft_stable_segment_cache.get(cache_key)
+                if markdown_segment.stable
+                else None
+            )
+            if segment is None:
+                prefixed = _prefix_streaming_assistant_segment(
+                    markdown_segment.lines,
+                    width=render_width,
+                    use_first_prefix=use_first_prefix,
+                )
+                presented_lines = self.presentation.present_lines(
+                    prefixed,
+                    display_record,
+                    theme=self.theme,
+                    capabilities=self.capabilities,
+                )
+                segment = RenderLineSegment(
+                    lines=tuple(RenderLine(line) for line in presented_lines),
+                    identity=("streaming-markdown", markdown_segment.identity),
+                    revision=(
+                        markdown_segment.revision,
+                        use_first_prefix,
+                        render_width,
+                        style_signature,
+                    ),
+                )
+                if markdown_segment.stable:
+                    self._draft_stable_segment_cache[cache_key] = segment
+            content_segments.append(segment)
+
+        content = tuple(content_segments)
+        segments: tuple[RenderLineSegment, ...] = content
+        if has_committed and content:
+            if self._draft_separator_segment is None:
+                self._draft_separator_segment = RenderLineSegment(
+                    lines=(RenderLine(""),),
+                    identity=self._draft_separator_identity,
+                    revision=stream_context,
+                )
+            segments = (self._draft_separator_segment, *content)
+        self._draft_has_leading_separator = bool(has_committed and content)
+
+        self._segmented_transient_content_segments = content
+        self._segmented_transient_buffer_id = id(buffer)
+        self._segmented_transient_buffer_version = buffer.version
+        self._segmented_transient_width = width
+        self._segmented_transient_style_signature = style_signature
+        return segments
+
+    def _clear_draft_segment_cache(self) -> None:
+        self._draft_segments_key = None
+        self._draft_segments = ()
+        self._draft_stream_context = None
+        self._draft_stable_segment_cache.clear()
+        self._draft_separator_segment = None
+        self._draft_has_leading_separator = False
+        self._segmented_transient_content_segments = ()
+        self._segmented_transient_buffer_id = None
+        self._segmented_transient_buffer_version = -1
+        self._segmented_transient_width = 0
+        self._segmented_transient_style_signature = None
+
+    def _iter_records(self) -> Iterable[DisplayRecord | StreamingTextBuffer]:
+        yield from self.records
+        if self.draft_buffer is not None:
+            yield self.draft_buffer
+        elif self.draft is not None:
+            yield self.draft
+
+    def _reset_cache_if_window_changed(self) -> None:
+        if self._cache_generation == self.window_generation:
+            return
+        self._stable_line_cache.clear()
+        self._transient_line_cache_key = None
+        self._transient_line_cache_lines = None
+        self._markdown_render_cache.clear()
+        self._committed_segment_key = None
+        self._committed_segment = None
+        self._committed_separator_rows = frozenset()
+        self._clear_draft_segment_cache()
+        self._cache_generation = self.window_generation
+
+    def clear_transient_cache(self) -> None:
+        self._transient_line_cache_key = None
+        self._transient_line_cache_lines = None
+        self._transient_source_text = ""
+        self._transient_source_width = 0
+        self._transient_source_style_signature = None
+        self._transient_source_buffer_id = None
+        self._transient_source_buffer_version = -1
+        self._clear_draft_segment_cache()
+        self._markdown_render_cache.clear_streaming()
+
+    def promote_transient_cache(
+        self,
+        record: AssistantMessageRecord,
+        *,
+        source_buffer: StreamingTextBuffer | None = None,
+    ) -> None:
+        if source_buffer is not None and self._segmented_transient_content_segments:
+            if self._segmented_transient_buffer_id != id(source_buffer):
+                return
+            if self._segmented_transient_buffer_version != source_buffer.version:
+                return
+            if record.text != source_buffer.text:
+                return
+            if (
+                self._segmented_transient_width <= 0
+                or self._segmented_transient_style_signature is None
+            ):
+                return
+            canonical_lines = tuple(
+                line.text
+                for segment in self._segmented_transient_content_segments
+                for line in segment.lines
+            )
+            self._stable_line_cache[
+                (
+                    record,
+                    self._segmented_transient_width,
+                    self._segmented_transient_style_signature,
+                )
+            ] = canonical_lines
+            self._enforce_stable_cache_entry_limit()
+            return
+        if self._transient_line_cache_lines is None:
+            return
+        if source_buffer is None and record.text != self._transient_source_text:
+            return
+        if source_buffer is not None and self._transient_source_buffer_id != id(
+            source_buffer
+        ):
+            return
+        if (
+            source_buffer is not None
+            and self._transient_source_buffer_version != source_buffer.version
+        ):
+            return
+        if (
+            self._transient_source_width <= 0
+            or self._transient_source_style_signature is None
+        ):
+            return
+        canonical_lines = self._render_record_uncached(
+            record, width=self._transient_source_width
+        )
+        self._stable_line_cache[
+            (
+                record,
+                self._transient_source_width,
+                self._transient_source_style_signature,
+            )
+        ] = canonical_lines
+        self._enforce_stable_cache_entry_limit()
+
+    def _enforce_stable_cache_entry_limit(self) -> None:
+        limit = max(0, self.stable_cache_entry_limit)
+        if limit == 0:
+            self._stable_line_cache.clear()
+            return
+        while len(self._stable_line_cache) > limit:
+            self._stable_line_cache.pop(next(iter(self._stable_line_cache)))
+
+
+def _streaming_buffer_render_text(buffer: StreamingTextBuffer) -> str:
+    return "\n".join(buffer.logical_lines())
+
+
+def _presentation_record(record: DisplayRecord) -> DisplayRecord:
+    if isinstance(record, AssistantMessageRecord) and not record.stable:
+        return replace(record, stable=True)
+    return record
+
+
+def _transcript_style_signature(
+    theme: ThemeResolver | None,
+    capabilities: Any | None,
+) -> tuple[object, ...]:
+    capabilities_signature: tuple[bool, bool] | None = None
+    if capabilities is not None:
+        capabilities_signature = (
+            bool(capabilities.truecolor),
+            bool(capabilities.hyperlinks),
+        )
+    if theme is None:
+        return (None, capabilities_signature)
+    return (id(theme), theme.version, capabilities_signature)
+
+
+__all__ = [
+    "DEFAULT_STABLE_TRANSCRIPT_CACHE_ENTRY_LIMIT",
+    "NeutralTranscriptPresentation",
+    "TranscriptPresentation",
+    "TranscriptRegion",
+]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -178,6 +178,26 @@ def test_harnesstui_does_not_import_product_or_model_layers() -> None:
     assert offenders == []
 
 
+def test_production_harnesstui_imports_only_approved_loushang_layers() -> None:
+    root = Path("src/loushang/harnesstui")
+    testing_root = root / "testing"
+    allowed_prefixes = (
+        "loushang.harnesstui",
+        "loushang.tui",
+        "loushang.harness",
+    )
+    offenders = [
+        f"{path.as_posix()} imports {imported}"
+        for path in sorted(root.rglob("*.py"))
+        if testing_root not in path.parents
+        for imported in _absolute_imports(path)
+        if imported.startswith("loushang.")
+        and not _matches_any(imported, allowed_prefixes)
+    ]
+
+    assert offenders == []
+
+
 def test_harnesstui_testing_does_not_import_runtime_or_product_layers() -> None:
     offenders = _find_forbidden_imports(
         ImportBoundary(
@@ -191,6 +211,23 @@ def test_harnesstui_testing_does_not_import_runtime_or_product_layers() -> None:
             ),
         )
     )
+
+    assert offenders == []
+
+
+def test_harnesstui_testing_imports_only_approved_loushang_layers() -> None:
+    root = Path("src/loushang/harnesstui/testing")
+    allowed_prefixes = (
+        "loushang.harnesstui",
+        "loushang.tui",
+    )
+    offenders = [
+        f"{path.as_posix()} imports {imported}"
+        for path in sorted(root.rglob("*.py"))
+        for imported in _absolute_imports(path)
+        if imported.startswith("loushang.")
+        and not _matches_any(imported, allowed_prefixes)
+    ]
 
     assert offenders == []
 
@@ -527,6 +564,38 @@ def test_tui_does_not_import_runtime_product_or_model_layers() -> None:
     assert _find_forbidden_imports(boundary) == []
 
 
+def test_importing_transcript_region_stays_tui_only() -> None:
+    script = """
+import importlib
+import sys
+
+importlib.import_module("loushang.tui.ui_parts.transcript")
+forbidden_prefixes = (
+    "loushang.agent",
+    "loushang.ai",
+    "loushang.coding",
+    "loushang.harness",
+    "loushang.harnesstui",
+    "loushang.method",
+    "loushang.work",
+)
+forbidden = sorted(
+    name
+    for name in sys.modules
+    if any(name == prefix or name.startswith(prefix + ".") for prefix in forbidden_prefixes)
+)
+assert forbidden == [], forbidden
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
 def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     path = Path("docs/internals/architecture/harnesstui/README.md")
     text = path.read_text(encoding="utf-8")
@@ -537,6 +606,8 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     )
     assert "`loushang.harnesstui.conversation.queue`" in text
     assert "`loushang.harnesstui.conversation.reader`" in text
+    assert "`loushang.harnesstui.conversation.screen_app`" in text
+    assert "`loushang.harnesstui.conversation.screen_frame`" in text
     assert "`loushang.harnesstui.conversation.screen_state`" in text
     assert "`loushang.harnesstui.conversation.window_budget`" in text
     assert "`loushang.harnesstui.conversation.source`" in text
@@ -574,6 +645,7 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.harnesstui.testing.scenarios`" in text
     assert "`loushang.coding.testing.tui.scenarios`" in text
     assert "`loushang.tui.settings`" in text
+    assert "`loushang.tui.ui_parts.transcript`" in text
 
 
 def test_harnesstui_capability_entrypoints_exist() -> None:
@@ -586,6 +658,8 @@ def test_harnesstui_capability_entrypoints_exist() -> None:
         Path("src/loushang/harnesstui/conversation/projection.py"),
         Path("src/loushang/harnesstui/conversation/queue.py"),
         Path("src/loushang/harnesstui/conversation/reader.py"),
+        Path("src/loushang/harnesstui/conversation/screen_app.py"),
+        Path("src/loushang/harnesstui/conversation/screen_frame.py"),
         Path("src/loushang/harnesstui/conversation/screen_state.py"),
         Path("src/loushang/harnesstui/conversation/screen_target.py"),
         Path("src/loushang/harnesstui/conversation/run_context.py"),
@@ -620,6 +694,7 @@ def test_harnesstui_capability_entrypoints_exist() -> None:
         Path("src/loushang/harnesstui/testing/scenarios/transcript.py"),
         Path("src/loushang/harnesstui/testing/scenarios/surface.py"),
         Path("src/loushang/tui/settings.py"),
+        Path("src/loushang/tui/ui_parts/transcript.py"),
     )
 
     missing = [path.as_posix() for path in paths if not path.is_file()]
@@ -637,6 +712,8 @@ for module_name in (
     "loushang.harnesstui.conversation.dispatch",
     "loushang.harnesstui.conversation.input",
     "loushang.harnesstui.conversation.run_context",
+    "loushang.harnesstui.conversation.screen_app",
+    "loushang.harnesstui.conversation.screen_frame",
     "loushang.harnesstui.conversation.screen_runner",
     "loushang.harnesstui.conversation.transcript_style",
     "loushang.harnesstui.conversation.window_budget",

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -491,6 +491,71 @@ def test_shared_window_budget_does_not_own_screen_runtime_policy() -> None:
     assert "trim_records_to_line_budget" in coding
 
 
+def test_tui_owns_transcript_region_while_coding_owns_presentation_policy() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.tui.ui_parts.transcript import TranscriptRegion
+
+    shared = Path("src/loushang/tui/ui_parts/transcript.py").read_text(encoding="utf-8")
+    coding = Path("src/loushang/coding/ui/screen_app.py").read_text(encoding="utf-8")
+
+    assert "class _ScreenTranscriptRegion" not in coding
+    for token in (
+        "_screen_coding_display_record",
+        "_coding_lines",
+        "_compact_display_paths",
+        "collapse_tool_output_preview",
+        "DEFAULT_TOOL_OUTPUT_PREVIEW_LINES",
+        "bright_cyan",
+    ):
+        assert token not in shared
+        assert token in coding
+
+    app = ScreenCodingTuiApp(
+        model_label=None,
+        cwd="/workspace",
+        branch=None,
+        session_label=None,
+    )
+    assert type(app._transcript_region) is TranscriptRegion
+
+
+def test_shared_screen_frame_does_not_own_coding_copy() -> None:
+    shared = Path("src/loushang/harnesstui/conversation/screen_frame.py").read_text(
+        encoding="utf-8"
+    )
+    coding = Path("src/loushang/coding/ui/screen_app.py").read_text(encoding="utf-8")
+
+    assert "loushang.coding" not in shared
+    for copy in (
+        "Working",
+        "Messages to be submitted after next tool call",
+        "Queued follow-up inputs",
+    ):
+        literal = f'"{copy}"'
+        assert literal not in shared
+        assert literal in coding
+
+
+def test_shared_screen_app_does_not_own_coding_presentation_policy() -> None:
+    shared = Path("src/loushang/harnesstui/conversation/screen_app.py").read_text(
+        encoding="utf-8"
+    )
+    coding = Path("src/loushang/coding/ui/screen_app.py").read_text(encoding="utf-8")
+
+    for token in (
+        "ScreenCodingTuiApp",
+        "_CodingTranscriptPresentation",
+        "LoushangWelcomePanel",
+        "Compacted summary:",
+        "trim_records_to_line_budget",
+        "DEFAULT_ACTIVE_TRANSCRIPT_LINE_BUDGET = 320",
+        "collapse_tool_output_preview",
+    ):
+        assert token not in shared
+        assert token in coding
+    assert "class ScreenCodingTuiApp(ScreenConversationApp)" in coding
+
+
 def test_old_coding_ui_app_module_is_removed() -> None:
     result = _run_python_import_boundary_check(
         """

--- a/tests/harnesstui/conversation/test_screen_app.py
+++ b/tests/harnesstui/conversation/test_screen_app.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from loushang.harnesstui.conversation.screen_app import ScreenConversationApp
+from loushang.harnesstui.conversation.screen_frame import (
+    ScreenFrameCopy,
+    ScreenFramePresentation,
+)
+from loushang.tui import RenderConstraints
+from loushang.tui.ui_parts.transcript import TranscriptRegion
+
+
+class _TestScreenConversationApp(ScreenConversationApp):
+    def _create_frame_presentation(self) -> ScreenFramePresentation:
+        return ScreenFramePresentation(
+            ScreenFrameCopy(
+                working_label="Running",
+                steer_label="Steers",
+                steer_hint="interrupt",
+                followup_label="Follow-ups",
+                followup_hint="edit",
+            )
+        )
+
+
+def _app() -> _TestScreenConversationApp:
+    return _TestScreenConversationApp(
+        model_label="model",
+        cwd="/workspace",
+        branch="main",
+        session_label="session",
+        now=lambda: 2.0,
+    )
+
+
+@pytest.mark.tui_render_contract
+def test_screen_conversation_app_coordinates_neutral_streaming_state() -> None:
+    app = _app()
+    app.start_prompt("hello", started_at=1.0)
+    app.begin_assistant()
+    app.append_assistant_chunk("world")
+
+    result = app.render(RenderConstraints(width=60, max_height=24, visible_height=24))
+
+    assert type(app._transcript_region) is TranscriptRegion
+    assert app._transcript_region.records is app.state.records
+    assert tuple(line.text for line in result.lines)[:3] == (
+        "> hello",
+        "",
+        "* world",
+    )
+
+
+@pytest.mark.tui_render_contract
+def test_screen_conversation_app_keeps_presentation_and_region_instances() -> None:
+    app = _app()
+    presentation = app._transcript_presentation
+    region = app._transcript_region
+    app.add_status("ready")
+
+    app.render(RenderConstraints(width=60, max_height=24, visible_height=24))
+    app.render(RenderConstraints(width=60, max_height=24, visible_height=24))
+
+    assert app._transcript_presentation is presentation
+    assert app._transcript_region is region
+
+
+def test_screen_conversation_app_reports_window_replacement_reason_once() -> None:
+    app = _app()
+
+    app.replace_transcript_window((), reason="test")
+
+    assert app.consume_render_baseline_reset_reason() == (
+        "transcript_window_replaced:test"
+    )
+    assert app.consume_render_baseline_reset_reason() is None

--- a/tests/harnesstui/conversation/test_screen_frame.py
+++ b/tests/harnesstui/conversation/test_screen_frame.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.harnesstui.conversation.screen_frame import (
+    ScreenFrameCopy,
+    ScreenFramePresentation,
+)
+from loushang.harnesstui.conversation.screen_state import ScreenConversationState
+from loushang.harnesstui.status.line import StatusLinePreviewSnapshot
+from loushang.tui import BottomFrame, Composer
+
+
+def _presentation() -> ScreenFramePresentation:
+    return ScreenFramePresentation(
+        ScreenFrameCopy(
+            working_label="Working",
+            steer_label="Steers",
+            steer_hint="interrupt hint",
+            followup_label="Follow-ups",
+            followup_hint="edit hint",
+        )
+    )
+
+
+def _state() -> ScreenConversationState:
+    return ScreenConversationState(
+        model_label="openai:gpt-test",
+        cwd="/workspace/demo",
+        branch="main",
+        session_label="session-1",
+    )
+
+
+def test_screen_frame_snapshot_projects_live_conversation_facts() -> None:
+    state = _state()
+    state.begin_run(started_at=1.0)
+    state.pending_steers[:] = ["steer"]
+    state.pending_followups[:] = ["follow"]
+    state.set_status("running")
+
+    assert _presentation().statusline_preview_snapshot(state) == (
+        StatusLinePreviewSnapshot(
+            model_label="openai:gpt-test",
+            cwd="/workspace/demo",
+            branch="main",
+            session_label="session-1",
+            running=True,
+            pending_followups=1,
+            pending_steers=1,
+            status_message="running",
+        )
+    )
+
+
+def test_screen_frame_populates_existing_component_with_injected_copy() -> None:
+    state = _state()
+    state.begin_run(started_at=1.0)
+    state.interruption_message = "Interrupted"
+    state.pending_steers[:] = ["steer"]
+    state.pending_followups[:] = ["follow"]
+    composer = Composer()
+    component = BottomFrame(composer=composer)
+
+    result = _presentation().populate_bottom_frame(
+        component,
+        composer=composer,
+        state=state,
+        active_surface=None,
+        elapsed_seconds=2.5,
+    )
+
+    assert result is component
+    assert result.working_line is not None
+    assert result.working_line.label == "Working"
+    assert result.working_line.elapsed_seconds == 2.5
+    assert result.pending_queue is not None
+    assert tuple(
+        (
+            section.label,
+            section.items,
+            section.hint,
+            section.marker,
+            section.hint_placement,
+        )
+        for section in result.pending_queue.sections
+    ) == (
+        ("Interrupted", (), None, "■", "footer"),
+        ("Steers", ("steer",), "interrupt hint", "•", "header"),
+        ("Follow-ups", ("follow",), "edit hint", "•", "footer"),
+    )
+
+    state.complete_run(elapsed_seconds=2.5)
+    state.interruption_message = None
+    state.pending_steers.clear()
+    state.pending_followups.clear()
+    presentation = _presentation()
+    presentation.populate_bottom_frame(
+        component,
+        composer=composer,
+        state=state,
+        active_surface=None,
+        elapsed_seconds=0.0,
+    )
+    assert component.working_line is None
+    assert component.pending_queue is None
+
+
+def test_screen_frame_height_honors_surface_preference_and_visible_cap() -> None:
+    @dataclass
+    class Surface:
+        preferred_height: int
+
+    state = _state()
+    presentation = _presentation()
+
+    assert (
+        presentation.bottom_frame_height(
+            state,
+            active_surface=None,
+            visible_height=40,
+        )
+        == 12
+    )
+    assert (
+        presentation.bottom_frame_height(
+            state,
+            active_surface=Surface(preferred_height=24),
+            visible_height=20,
+        )
+        == 20
+    )

--- a/tests/tui/test_transcript_region.py
+++ b/tests/tui/test_transcript_region.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+import pytest
+
+import loushang.tui.ui_parts.transcript as transcript_region_module
+from loushang.tui import RenderConstraints, RenderLoop, TerminalSize
+from loushang.tui.theme import ThemeResolver
+from loushang.tui.transcript import (
+    AssistantMessageRecord,
+    DisplayRecord,
+    StreamingTextBuffer,
+    UserPromptRecord,
+)
+from loushang.tui.ui_parts.transcript import TranscriptRegion
+
+_STREAMING_MARKDOWN = "Intro\n\n```python\nprint(1)\n```\n\nTail"
+
+
+@dataclass(slots=True)
+class _SpyPresentation:
+    token_reads: int = 0
+    project_calls: int = 0
+    width_calls: int = 0
+    present_calls: int = 0
+
+    @property
+    def cache_token(self) -> str:
+        self.token_reads += 1
+        return "stable"
+
+    def project_record(self, record: DisplayRecord) -> DisplayRecord:
+        self.project_calls += 1
+        return record
+
+    def record_render_width(
+        self,
+        record: DisplayRecord,
+        *,
+        width: int,
+    ) -> int:
+        del record
+        self.width_calls += 1
+        return width
+
+    def present_lines(
+        self,
+        lines: tuple[str, ...],
+        record: DisplayRecord,
+        *,
+        theme: ThemeResolver | None,
+        capabilities: Any | None,
+    ) -> tuple[str, ...]:
+        del record, theme, capabilities
+        self.present_calls += 1
+        return lines
+
+
+class _ProjectingPresentation:
+    cache_token = "projecting"
+
+    def project_record(self, record: DisplayRecord) -> DisplayRecord:
+        if isinstance(record, AssistantMessageRecord):
+            return replace(record, text="PROJECTED")
+        return record
+
+    def record_render_width(
+        self,
+        record: DisplayRecord,
+        *,
+        width: int,
+    ) -> int:
+        del record, width
+        return 5
+
+    def present_lines(
+        self,
+        lines: tuple[str, ...],
+        record: DisplayRecord,
+        *,
+        theme: ThemeResolver | None,
+        capabilities: Any | None,
+    ) -> tuple[str, ...]:
+        del record, theme, capabilities
+        return lines
+
+
+@dataclass(slots=True)
+class _TokenPresentation:
+    token: str = "A"
+
+    @property
+    def cache_token(self) -> str:
+        return self.token
+
+    def project_record(self, record: DisplayRecord) -> DisplayRecord:
+        return record
+
+    def record_render_width(
+        self,
+        record: DisplayRecord,
+        *,
+        width: int,
+    ) -> int:
+        del record
+        return width
+
+    def present_lines(
+        self,
+        lines: tuple[str, ...],
+        record: DisplayRecord,
+        *,
+        theme: ThemeResolver | None,
+        capabilities: Any | None,
+    ) -> tuple[str, ...]:
+        del record, theme, capabilities
+        return tuple(f"{self.token}:{line}" for line in lines)
+
+
+class _StabilityPresentation:
+    cache_token = "stable-parity"
+
+    def project_record(self, record: DisplayRecord) -> DisplayRecord:
+        return record
+
+    def record_render_width(
+        self,
+        record: DisplayRecord,
+        *,
+        width: int,
+    ) -> int:
+        del record
+        return width
+
+    def present_lines(
+        self,
+        lines: tuple[str, ...],
+        record: DisplayRecord,
+        *,
+        theme: ThemeResolver | None,
+        capabilities: Any | None,
+    ) -> tuple[str, ...]:
+        del theme, capabilities
+        prefix = (
+            "S:"
+            if not isinstance(record, AssistantMessageRecord) or record.stable
+            else "D:"
+        )
+        return tuple(f"{prefix}{line}" for line in lines)
+
+
+def test_transcript_region_neutral_presentation_renders_generic_records() -> None:
+    region = TranscriptRegion(records=[UserPromptRecord("hello")], records_revision=1)
+
+    result = region.render(RenderConstraints(width=40, max_height=10))
+
+    assert tuple(line.text for line in result.lines) == ("> hello",)
+
+
+@pytest.mark.tui_render_contract
+def test_transcript_region_stable_frame_reuses_projection_and_lines() -> None:
+    presentation = _SpyPresentation()
+    records = [UserPromptRecord("hello")]
+    region = TranscriptRegion(
+        records=records,
+        records_revision=1,
+        presentation=presentation,
+    )
+    constraints = RenderConstraints(width=40, max_height=10)
+
+    first = region.render(constraints)
+    first_segment = region._committed_segment
+    second = region.render(constraints)
+
+    assert tuple(line.text for line in first.lines) == tuple(
+        line.text for line in second.lines
+    )
+    assert region.records is records
+    assert region.presentation is presentation
+    assert region._committed_segment is first_segment
+    assert presentation.token_reads == 2
+    assert presentation.project_calls == 1
+    assert presentation.width_calls == 1
+    assert presentation.present_calls == 1
+
+
+@pytest.mark.tui_render_contract
+def test_streaming_segments_honor_projection_and_effective_width() -> None:
+    presentation = _ProjectingPresentation()
+    theme = ThemeResolver()
+    buffer = StreamingTextBuffer.from_text(_STREAMING_MARKDOWN)
+    constraints = RenderConstraints(width=40, max_height=30)
+    flat = TranscriptRegion(
+        draft=AssistantMessageRecord(_STREAMING_MARKDOWN, stable=False),
+        presentation=presentation,
+        theme=theme,
+    )
+    streaming = TranscriptRegion(
+        draft_buffer=buffer,
+        presentation=presentation,
+        theme=theme,
+    )
+
+    flat_lines = tuple(line.text for line in flat.render(constraints).lines)
+    streaming_lines = tuple(line.text for line in streaming.render(constraints).lines)
+
+    assert streaming._segmented_transient_content_segments
+    assert streaming_lines == flat_lines
+    assert all(len(line) <= 5 for line in streaming_lines)
+
+
+@pytest.mark.tui_render_contract
+def test_streaming_segment_revision_changes_with_presentation_token() -> None:
+    presentation = _TokenPresentation()
+    region = TranscriptRegion(
+        draft_buffer=StreamingTextBuffer.from_text(_STREAMING_MARKDOWN),
+        presentation=presentation,
+        theme=ThemeResolver(),
+    )
+    loop = RenderLoop(region)
+    size = TerminalSize(columns=40, rows=20)
+
+    first = loop.plan(size)
+    loop.commit(first, size=size)
+    assert tuple(first.current_logical_lines)[0] == "A:* Intro"
+
+    presentation.token = "B"
+    second = loop.plan(size)
+
+    assert tuple(second.current_logical_lines)[0] == "B:* Intro"
+
+
+@pytest.mark.tui_render_contract
+def test_streaming_cache_promotion_hides_assistant_stability_metadata() -> None:
+    presentation = _StabilityPresentation()
+    theme = ThemeResolver()
+    buffer = StreamingTextBuffer.from_text(_STREAMING_MARKDOWN)
+    constraints = RenderConstraints(width=40, max_height=30)
+    region = TranscriptRegion(
+        draft_buffer=buffer,
+        presentation=presentation,
+        theme=theme,
+    )
+
+    draft_lines = tuple(line.text for line in region.render(constraints).lines)
+    committed_record = AssistantMessageRecord(buffer.text)
+    region.promote_transient_cache(committed_record, source_buffer=buffer)
+    region.clear_transient_cache()
+    region.draft_buffer = None
+    region.records.append(committed_record)
+    region.records_revision += 1
+    committed_lines = tuple(line.text for line in region.render(constraints).lines)
+    fresh_lines = tuple(
+        line.text
+        for line in TranscriptRegion(
+            records=[committed_record],
+            records_revision=1,
+            presentation=presentation,
+            theme=theme,
+        )
+        .render(constraints)
+        .lines
+    )
+
+    assert draft_lines == committed_lines == fresh_lines
+    assert draft_lines[0] == "S:* Intro"
+
+
+@pytest.mark.tui_render_contract
+def test_streaming_flat_fallback_preserves_markdown_streaming_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        transcript_region_module,
+        "_render_streaming_assistant_markdown_segments",
+        lambda *args, **kwargs: None,
+    )
+    buffer = StreamingTextBuffer.from_text(_STREAMING_MARKDOWN)
+    region = TranscriptRegion(
+        draft_buffer=buffer,
+        presentation=_StabilityPresentation(),
+        theme=ThemeResolver(),
+    )
+
+    lines = tuple(
+        line.text
+        for line in region.render(RenderConstraints(width=40, max_height=30)).lines
+    )
+
+    assert lines[0] == "S:* Intro"
+    assert not region._segmented_transient_content_segments
+    assert region._markdown_render_cache._streaming_key is buffer


### PR DESCRIPTION
## Summary / 概要

- Extract the generic incremental transcript region into `loushang.tui`, including stable/transient caches, committed/draft segments, streaming Markdown reuse, promotion, clipping, and bounded eviction.
- 将通用增量会话渲染区域迁入 `loushang.tui`，统一负责稳定/流式缓存、committed/draft segments、Markdown 流式复用、缓存晋升、裁剪和有界淘汰。
- Add product-neutral screen frame and conversation application composition under `loushang.harnesstui`.
- 在 `loushang.harnesstui` 增加中性的 Screen Frame 与 Conversation Application 组合能力。
- Keep `ScreenCodingTuiApp` as the Coding binding for themes, copy, path compaction, tool previews, compaction wording, and transcript budgets.
- Coding 层继续保留主题、文案、路径压缩、工具预览、压缩措辞与 transcript budget 等产品策略。

## Why / 原因

This separates terminal rendering mechanics, reusable harness-facing conversation composition, and Coding-specific presentation policy without changing session lifecycle ownership. It also preserves the frozen render-performance contract and hot-path identity/reuse behavior.

此次提取明确区分终端渲染机制、可跨产品复用的 Harness 会话界面组合，以及 Coding 产品展示策略；不改变 Session 生命周期归属，并保持已冻结的渲染性能契约与热路径 identity/reuse 行为。

## Impact / 影响

- `src/loushang/coding/ui/screen_app.py`: 1119 lines to 395 lines, a net reduction of 724 lines.
- TUI remains independent of Harness, Harnesstui, Coding, AI, Agent, Method, and Work layers.
- Harnesstui depends only on approved TUI/Harness-neutral layers; Coding remains the outward product adapter.
- No public session lifecycle or approval-policy ownership changes.

## Validation / 验证

- `make test-tui-render-contract` — 161 passed
- `make check-harnesstui` — Ruff passed, mypy passed, 845 passed / 37 deselected
- Focused extraction, architecture-boundary, and Coding compatibility suite — 180 passed
- `git diff --check` — passed

Full-suite environment note: two legacy offline examples initially inherited a stale external model-catalog path and API key; both passed when those variables were cleared. The sandbox-only OpenAI live check cannot chmod the read-only `/home/dev/.loushang` credential directory.

