### PR TITLE
refactor(harnesstui): extract catalog interaction workflows

### DIFF
--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -44,6 +44,35 @@ presentation primitives.
 contracts. Product adapters such as `loushang.coding.ui` continue to own raw
 product-event interpretation, commands, policy, branding, and runtime assembly.
 
+## Catalog Interaction Workflows
+
+`loushang.harnesstui.commands.interaction` and
+`loushang.harnesstui.selection.interaction` own the product-neutral
+snapshot-to-resolution workflow for command and model catalogs. A product
+captures one immutable interaction snapshot, Harnesstui projects its generic
+palette, and the resolver returns a structural `list`, `selected`, `empty`,
+`ambiguous`, or `cancelled` outcome. Sync and async palette choosers are both
+supported. Command descriptors remain opaque and the selected descriptor is
+returned by identity; model interactions consume only product-prepared
+`ModelChoice` values and return the selected choice without applying it.
+
+These workflows do not acquire a Session catalog, parse Coding intents,
+normalize model/provider objects, mutate the active model, persist settings,
+or choose product wording. Coding continues to own `CodingCommandCatalog`,
+which commands count as local and their precedence, Session and model-detail
+adaptation, endpoint preference policy, `ModelSelection` application,
+default-model persistence, slash-command aliases, and all selection status,
+ambiguity-hint, and failure copy. Harnesstui applies caller-selected
+source-aware ordering, including local-last ordering, or value-only ordering,
+and resolves the prepared catalog. Generic palette widgets, completion
+containers, search lists, and terminal interaction mechanics remain in
+`loushang.tui`; the existing Harnesstui presentation modules only project
+caller-supplied descriptors and choices.
+
+The explicit module paths `loushang.harnesstui.commands.interaction` and
+`loushang.harnesstui.selection.interaction` are the stable entrypoints for
+these workflows. Package initializers do not add convenience re-exports.
+
 ## Conversation Attachments
 
 `loushang.harnesstui.conversation.attachments` owns product-neutral prompt-image

--- a/src/loushang/coding/ui/command_list.py
+++ b/src/loushang/coding/ui/command_list.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable, Iterable
+from collections.abc import Iterable
 from typing import Any
 
 from loushang.coding.commands.catalog import CodingCommandCatalog
+from loushang.harnesstui.commands.interaction import (
+    CommandInteractionResult,
+    CommandInteractionSnapshot,
+    CommandPaletteChooser,
+    run_command_interaction,
+)
 from loushang.harnesstui.commands.presentation import (
+    command_completion_item,
     command_completion_provider,
     format_commands,
-    matching_command_items,
 )
 from loushang.tui import (
     CommandPalette,
@@ -18,19 +24,9 @@ from loushang.tui import (
     CompletionItem as CompletionItem,
 )
 
-CommandPaletteChooser = Callable[[CommandPalette], Awaitable[str | None] | str | None]
-
 
 async def format_session_commands(session: Any, *, query: str = "") -> str:
-    getter = getattr(session, "list_commands", None)
-    if not callable(getter):
-        return "No commands available."
-
-    raw_commands = await _maybe_await(getter())
-    if not isinstance(raw_commands, Iterable):
-        return "No commands available."
-
-    return format_commands(raw_commands, query=query)
+    return format_commands(await _session_command_items(session), query=query)
 
 
 async def format_coding_commands(
@@ -40,20 +36,16 @@ async def format_coding_commands(
     command_catalog: CodingCommandCatalog | None = None,
 ) -> str:
     return format_commands(
-        _catalog_commands(session, command_catalog=command_catalog), query=query
+        await _catalog_commands(session, command_catalog=command_catalog),
+        query=query,
     )
 
 
 async def session_command_completion_provider(session: Any) -> CompletionProvider:
-    getter = getattr(session, "list_commands", None)
-    if not callable(getter):
-        return CompletionProvider(())
-
-    raw_commands = await _maybe_await(getter())
-    if not isinstance(raw_commands, Iterable):
-        return CompletionProvider(())
-
-    return command_completion_provider(raw_commands, local_last=False)
+    return command_completion_provider(
+        await _session_command_items(session),
+        local_last=False,
+    )
 
 
 async def coding_command_completion_provider(
@@ -62,7 +54,7 @@ async def coding_command_completion_provider(
     command_catalog: CodingCommandCatalog | None = None,
 ) -> CompletionProvider:
     return command_completion_provider(
-        _catalog_commands(session, command_catalog=command_catalog)
+        await _catalog_commands(session, command_catalog=command_catalog)
     )
 
 
@@ -80,7 +72,8 @@ async def coding_command_palette(
     command_catalog: CodingCommandCatalog | None = None,
 ) -> CommandPalette:
     provider = await coding_command_completion_provider(
-        session, command_catalog=command_catalog
+        session,
+        command_catalog=command_catalog,
     )
     return CommandPalette.from_completion_provider(provider, title=title)
 
@@ -91,31 +84,13 @@ async def select_session_command(
     query: str = "",
     choose: CommandPaletteChooser | None = None,
 ) -> str:
-    stripped_query = query.strip()
-    if not stripped_query:
-        if choose is not None:
-            selected = await _maybe_await(
-                choose(await session_command_palette(session, title="Commands"))
-            )
-            if selected is None:
-                return "Command selection cancelled."
-            return await select_session_command(session, query=selected)
-        return await format_session_commands(session)
-
-    provider = await session_command_completion_provider(session)
-    matches = matching_command_items(provider, stripped_query)
-    if not matches:
-        return f"No commands match: {stripped_query}"
-    if len(matches) != 1:
-        return "\n".join(
-            [
-                "Multiple commands match:",
-                *(f"  {item.value}" for item in matches),
-                "Use /command <full command> to select one.",
-            ]
-        )
-
-    return f"Command selected: {matches[0].value}"
+    items = await _session_command_items(session)
+    result = await run_command_interaction(
+        CommandInteractionSnapshot(items, local_last=False),
+        query=query,
+        choose=choose,
+    )
+    return _format_command_interaction(result)
 
 
 async def select_coding_command(
@@ -125,55 +100,64 @@ async def select_coding_command(
     choose: CommandPaletteChooser | None = None,
     command_catalog: CodingCommandCatalog | None = None,
 ) -> str:
-    stripped_query = query.strip()
-    if not stripped_query:
-        if choose is not None:
-            selected = await _maybe_await(
-                choose(
-                    await coding_command_palette(
-                        session, title="Commands", command_catalog=command_catalog
-                    )
-                )
-            )
-            if selected is None:
-                return "Command selection cancelled."
-            return await select_coding_command(
-                session, query=selected, command_catalog=command_catalog
-            )
-        return await format_coding_commands(session, command_catalog=command_catalog)
-
-    provider = await coding_command_completion_provider(
-        session, command_catalog=command_catalog
+    items = await _catalog_commands(session, command_catalog=command_catalog)
+    result = await run_command_interaction(
+        CommandInteractionSnapshot(items),
+        query=query,
+        choose=choose,
     )
-    matches = matching_command_items(provider, stripped_query)
-    if not matches:
-        return f"No commands match: {stripped_query}"
-    if len(matches) != 1:
-        return "\n".join(
-            [
-                "Multiple commands match:",
-                *(f"  {item.value}" for item in matches),
-                "Use /command <full command> to select one.",
-            ]
-        )
-
-    return f"Command selected: {matches[0].value}"
+    return _format_command_interaction(result)
 
 
-def _catalog_commands(
-    session: Any, *, command_catalog: CodingCommandCatalog | None = None
+async def _catalog_commands(
+    session: Any,
+    *,
+    command_catalog: CodingCommandCatalog | None = None,
 ) -> tuple[object, ...]:
-    catalog = command_catalog or CodingCommandCatalog(
-        session_commands=_session_commands_provider(session)
+    if command_catalog is not None:
+        return tuple(command_catalog.commands())
+    session_commands = await _session_command_items(session)
+    catalog = CodingCommandCatalog(
+        session_commands=lambda: session_commands,
     )
     return catalog.commands()
 
 
-def _session_commands_provider(session: Any):
+async def _session_command_items(session: Any) -> tuple[object, ...]:
     getter = getattr(session, "list_commands", None)
     if not callable(getter):
-        return None
-    return getter
+        return ()
+    raw_commands = await _maybe_await(getter())
+    if not isinstance(raw_commands, Iterable):
+        return ()
+    return tuple(raw_commands)
+
+
+def _format_command_interaction(result: CommandInteractionResult[object]) -> str:
+    if result.kind == "list":
+        return format_commands(result.matches)
+    if result.kind == "cancelled":
+        return "Command selection cancelled."
+    if result.kind == "empty":
+        if result.query:
+            return f"No commands match: {result.query}"
+        return "No commands available."
+    if result.kind == "ambiguous":
+        return "\n".join(
+            [
+                "Multiple commands match:",
+                *(f"  {_command_value(item)}" for item in result.matches),
+                "Use /command <full command> to select one.",
+            ]
+        )
+    if result.item is not None:
+        return f"Command selected: {_command_value(result.item)}"
+    return "No commands available."
+
+
+def _command_value(item: object) -> str:
+    completion = command_completion_item(item)
+    return completion.value if completion is not None else ""
 
 
 async def _maybe_await(value: Any) -> Any:

--- a/src/loushang/coding/ui/model_list.py
+++ b/src/loushang/coding/ui/model_list.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -19,14 +19,18 @@ from loushang.harnesstui.selection.catalog import (
     dedupe_preferred_model_choices,
     filter_model_choices,
     format_model_choices,
-    matching_model_choices,
     model_choice_display_label,
     model_choice_value,
     model_completion_provider,
 )
+from loushang.harnesstui.selection.interaction import (
+    ModelInteractionChooser as ModelPaletteChooser,
+)
+from loushang.harnesstui.selection.interaction import (
+    ModelInteractionSnapshot,
+    run_model_interaction,
+)
 from loushang.tui import CommandPalette, CompletionProvider
-
-ModelPaletteChooser = Callable[[CommandPalette], Awaitable[str | None] | str | None]
 
 
 @dataclass(frozen=True)
@@ -64,41 +68,46 @@ async def select_available_model(
     choose: ModelPaletteChooser | None = None,
     settings_manager: object | None = None,
 ) -> str:
-    stripped_query = query.strip()
-    if not stripped_query:
-        if choose is not None:
-            selected = await _maybe_await(
-                choose(await available_model_palette(session, title="Models"))
-            )
-            if selected is None:
-                return "Model selection cancelled."
-            return await select_available_model(
-                session,
-                query=selected,
-                settings_manager=settings_manager,
-            )
-        return await format_available_models(session)
-
-    matches = matching_model_choices(
-        await available_model_choices(session), stripped_query
+    choices = await available_model_choices(session)
+    snapshot = ModelInteractionSnapshot(
+        choices=tuple(choices),
+        current_value=await current_model_choice_value(session, choices=choices),
     )
-    if not matches:
-        return f"No models match: {stripped_query}"
-    if len(matches) != 1:
+    resolution = await run_model_interaction(
+        snapshot,
+        query=query,
+        choose=choose,
+    )
+    if resolution.kind == "list":
+        return format_model_choices(
+            resolution.matches,
+            current_value=snapshot.current_value,
+        )
+    if resolution.kind == "cancelled":
+        return "Model selection cancelled."
+    if resolution.kind == "empty":
+        if resolution.query:
+            return f"No models match: {resolution.query}"
+        return "No models available."
+    if resolution.kind == "ambiguous":
         hint = (
             "Use /model <provider:endpoint:model> or choose one from the model list."
-            if any(choice.endpoint_id for choice in matches)
+            if any(choice.endpoint_id for choice in resolution.matches)
             else "Use /model <full model> to select one."
         )
         return "\n".join(
             [
                 "Multiple models match:",
-                *(f"  {model_choice_display_label(choice)}" for choice in matches),
+                *(
+                    f"  {model_choice_display_label(choice)}"
+                    for choice in resolution.matches
+                ),
                 hint,
             ]
         )
 
-    choice = matches[0]
+    assert resolution.choice is not None
+    choice = resolution.choice
     setter = getattr(session, "set_model", None)
     if not callable(setter):
         return "Model selection is not available."

--- a/src/loushang/harnesstui/commands/interaction.py
+++ b/src/loushang/harnesstui/commands/interaction.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Generic, Literal, TypeVar, cast
+
+from loushang.harnesstui.commands.presentation import (
+    command_completion_item,
+    command_item_matches,
+    command_source_priority,
+)
+from loushang.tui import CommandPalette, CompletionItem, CompletionProvider
+
+CommandInteractionKind = Literal[
+    "list",
+    "selected",
+    "empty",
+    "ambiguous",
+    "cancelled",
+]
+CommandPaletteChooser = Callable[
+    [CommandPalette],
+    Awaitable[str | None] | str | None,
+]
+_CommandDescriptorT = TypeVar("_CommandDescriptorT")
+
+
+@dataclass(frozen=True, slots=True)
+class CommandInteractionSnapshot(Generic[_CommandDescriptorT]):
+    """A product-prepared, immutable view of available command descriptors.
+
+    Command descriptors remain opaque to this layer.  Presentation only reads
+    the duck-typed fields supported by :mod:`commands.presentation`; the
+    selected descriptor is returned unchanged to the product adapter.
+    """
+
+    items: tuple[_CommandDescriptorT, ...]
+    title: str = "Commands"
+    local_last: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class CommandInteractionResult(Generic[_CommandDescriptorT]):
+    """Structural outcome of a command catalog interaction."""
+
+    kind: CommandInteractionKind
+    query: str = ""
+    item: _CommandDescriptorT | None = None
+    matches: tuple[_CommandDescriptorT, ...] = ()
+    palette: CommandPalette | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _CommandEntry(Generic[_CommandDescriptorT]):
+    item: _CommandDescriptorT
+    completion: CompletionItem
+    position: int
+    source_priority: int
+
+
+def resolve_command_interaction(
+    snapshot: CommandInteractionSnapshot[_CommandDescriptorT],
+    *,
+    query: str = "",
+) -> CommandInteractionResult[_CommandDescriptorT]:
+    """Resolve a command query without acquiring or executing a command."""
+
+    entries = _command_entries(snapshot)
+    palette = _command_palette(entries, title=snapshot.title)
+    stripped_query = query.strip()
+    if not entries:
+        return CommandInteractionResult(
+            kind="empty",
+            query=stripped_query,
+            palette=palette,
+        )
+    if not stripped_query:
+        return CommandInteractionResult(
+            kind="list",
+            matches=tuple(entry.item for entry in entries),
+            palette=palette,
+        )
+
+    matches = _matching_entries(entries, stripped_query)
+    if not matches:
+        return CommandInteractionResult(
+            kind="empty",
+            query=stripped_query,
+            palette=palette,
+        )
+    if len(matches) > 1:
+        return CommandInteractionResult(
+            kind="ambiguous",
+            query=stripped_query,
+            matches=tuple(entry.item for entry in matches),
+            palette=palette,
+        )
+    return CommandInteractionResult(
+        kind="selected",
+        query=stripped_query,
+        item=matches[0].item,
+        matches=(matches[0].item,),
+        palette=palette,
+    )
+
+
+async def run_command_interaction(
+    snapshot: CommandInteractionSnapshot[_CommandDescriptorT],
+    *,
+    query: str = "",
+    choose: CommandPaletteChooser | None = None,
+) -> CommandInteractionResult[_CommandDescriptorT]:
+    """Resolve a query, optionally asking a sync or async palette chooser."""
+
+    initial = resolve_command_interaction(snapshot, query=query)
+    if query.strip() or choose is None:
+        return initial
+
+    palette = cast(CommandPalette, initial.palette)
+    selected = choose(palette)
+    if inspect.isawaitable(selected):
+        selected = await selected
+    if selected is None:
+        return CommandInteractionResult(
+            kind="cancelled",
+            matches=initial.matches,
+            palette=palette,
+        )
+    return resolve_command_interaction(snapshot, query=selected)
+
+
+def _command_entries(
+    snapshot: CommandInteractionSnapshot[_CommandDescriptorT],
+) -> tuple[_CommandEntry[_CommandDescriptorT], ...]:
+    entries = [
+        _CommandEntry(
+            item=item,
+            completion=completion,
+            position=position,
+            source_priority=command_source_priority(item),
+        )
+        for position, item in enumerate(snapshot.items)
+        if (completion := command_completion_item(item)) is not None
+    ]
+    if snapshot.local_last:
+        entries.sort(
+            key=lambda entry: (
+                entry.source_priority,
+                entry.completion.value,
+                entry.position,
+            )
+        )
+    else:
+        entries.sort(key=lambda entry: (entry.completion.value, entry.position))
+    return tuple(entries)
+
+
+def _command_palette(
+    entries: tuple[_CommandEntry[_CommandDescriptorT], ...],
+    *,
+    title: str,
+) -> CommandPalette:
+    provider = CompletionProvider(tuple(entry.completion for entry in entries))
+    return CommandPalette.from_completion_provider(provider, title=title)
+
+
+def _matching_entries(
+    entries: tuple[_CommandEntry[_CommandDescriptorT], ...],
+    query: str,
+) -> tuple[_CommandEntry[_CommandDescriptorT], ...]:
+    needle = query.lower()
+    matches = tuple(
+        entry for entry in entries if command_item_matches(entry.completion, needle)
+    )
+    exact = tuple(
+        entry
+        for entry in matches
+        if entry.completion.value.lower() == needle
+        or entry.completion.display_label().lower() == needle
+    )
+    return exact or matches
+
+
+__all__ = [
+    "CommandInteractionKind",
+    "CommandInteractionResult",
+    "CommandInteractionSnapshot",
+    "CommandPaletteChooser",
+    "resolve_command_interaction",
+    "run_command_interaction",
+]

--- a/src/loushang/harnesstui/selection/interaction.py
+++ b/src/loushang/harnesstui/selection/interaction.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from loushang.harnesstui.selection.catalog import (
+    ModelChoice,
+    current_model_choice_first,
+    matching_model_choices,
+    model_palette,
+)
+from loushang.tui import CommandPalette
+
+ModelInteractionChooser = Callable[[CommandPalette], Awaitable[str | None] | str | None]
+ModelInteractionKind = Literal["list", "selected", "empty", "ambiguous", "cancelled"]
+
+
+@dataclass(frozen=True, slots=True)
+class ModelInteractionSnapshot:
+    """Product-neutral model choices captured for one interaction."""
+
+    choices: tuple[ModelChoice, ...]
+    current_value: str | None = None
+    title: str = "Models"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelInteractionResult:
+    """A model-selection resolution without applying the selected model."""
+
+    kind: ModelInteractionKind
+    query: str = ""
+    choice: ModelChoice | None = None
+    matches: tuple[ModelChoice, ...] = ()
+    palette: CommandPalette | None = None
+
+
+def resolve_model_interaction(
+    snapshot: ModelInteractionSnapshot,
+    *,
+    query: str = "",
+) -> ModelInteractionResult:
+    """Resolve a query against a stable model-choice snapshot."""
+
+    stripped_query = query.strip()
+    choices = tuple(
+        current_model_choice_first(
+            snapshot.choices,
+            current_value=snapshot.current_value,
+        )
+    )
+    palette = model_palette(
+        choices,
+        current_value=snapshot.current_value,
+        title=snapshot.title,
+    )
+    if not choices:
+        return ModelInteractionResult(
+            kind="empty",
+            query=stripped_query,
+            palette=palette,
+        )
+    if not stripped_query:
+        return ModelInteractionResult(
+            kind="list",
+            matches=choices,
+            palette=palette,
+        )
+
+    matches = tuple(matching_model_choices(choices, stripped_query))
+    if not matches:
+        return ModelInteractionResult(
+            kind="empty",
+            query=stripped_query,
+            palette=palette,
+        )
+    if len(matches) > 1:
+        return ModelInteractionResult(
+            kind="ambiguous",
+            query=stripped_query,
+            matches=matches,
+            palette=palette,
+        )
+    return ModelInteractionResult(
+        kind="selected",
+        query=stripped_query,
+        choice=matches[0],
+        matches=matches,
+        palette=palette,
+    )
+
+
+async def run_model_interaction(
+    snapshot: ModelInteractionSnapshot,
+    *,
+    query: str = "",
+    choose: ModelInteractionChooser | None = None,
+) -> ModelInteractionResult:
+    """Optionally choose from a palette, then resolve without side effects."""
+
+    resolution = resolve_model_interaction(snapshot, query=query)
+    if query.strip() or choose is None:
+        return resolution
+
+    assert resolution.palette is not None
+    selected = choose(resolution.palette)
+    if inspect.isawaitable(selected):
+        selected = await selected
+    if selected is None:
+        return ModelInteractionResult(
+            kind="cancelled",
+            matches=resolution.matches,
+            palette=resolution.palette,
+        )
+    return resolve_model_interaction(snapshot, query=selected)
+
+
+__all__ = [
+    "ModelInteractionChooser",
+    "ModelInteractionKind",
+    "ModelInteractionResult",
+    "ModelInteractionSnapshot",
+    "resolve_model_interaction",
+    "run_model_interaction",
+]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -645,8 +645,10 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.harnesstui.conversation.tool_transcript`" in text
     assert "`loushang.harnesstui.conversation.transcript_style`" in text
     assert "`loushang.harnesstui.plain.renderer`" in text
+    assert "`loushang.harnesstui.commands.interaction`" in text
     assert "`loushang.harnesstui.commands.presentation`" in text
     assert "`loushang.harnesstui.selection.catalog`" in text
+    assert "`loushang.harnesstui.selection.interaction`" in text
     assert "`loushang.harnesstui.selection.model`" in text
     assert "`loushang.harnesstui.settings.dashboard`" in text
     assert "`loushang.harnesstui.settings.model`" in text
@@ -691,8 +693,10 @@ def test_harnesstui_capability_entrypoints_exist() -> None:
         Path("src/loushang/harnesstui/conversation/transcript_style.py"),
         Path("src/loushang/harnesstui/conversation/window_budget.py"),
         Path("src/loushang/harnesstui/plain/renderer.py"),
+        Path("src/loushang/harnesstui/commands/interaction.py"),
         Path("src/loushang/harnesstui/commands/presentation.py"),
         Path("src/loushang/harnesstui/selection/catalog.py"),
+        Path("src/loushang/harnesstui/selection/interaction.py"),
         Path("src/loushang/harnesstui/selection/model.py"),
         Path("src/loushang/harnesstui/settings/dashboard.py"),
         Path("src/loushang/harnesstui/settings/model.py"),
@@ -739,6 +743,40 @@ for module_name in (
     "loushang.harnesstui.conversation.screen_runner",
     "loushang.harnesstui.conversation.transcript_style",
     "loushang.harnesstui.conversation.window_budget",
+):
+    importlib.import_module(module_name)
+
+forbidden_prefixes = (
+    "loushang.agent",
+    "loushang.ai",
+    "loushang.coding",
+    "loushang.harness",
+)
+forbidden = sorted(
+    name
+    for name in sys.modules
+    if any(name == prefix or name.startswith(prefix + ".") for prefix in forbidden_prefixes)
+)
+assert forbidden == [], forbidden
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_importing_catalog_interaction_entrypoints_stays_product_neutral() -> None:
+    script = """
+import importlib
+import sys
+
+for module_name in (
+    "loushang.harnesstui.commands.interaction",
+    "loushang.harnesstui.selection.interaction",
 ):
     importlib.import_module(module_name)
 

--- a/tests/coding/test_ui_command_list.py
+++ b/tests/coding/test_ui_command_list.py
@@ -38,6 +38,23 @@ class _BuiltinSession:
         return list_builtin_command_descriptors()
 
 
+class _AsyncSession:
+    async def list_commands(self) -> list[object]:
+        await asyncio.sleep(0)
+        return [
+            SimpleNamespace(
+                name="inspect",
+                description="Inspect asynchronously",
+                source="session",
+            )
+        ]
+
+
+class _EmptyCatalog:
+    def commands(self) -> tuple[object, ...]:
+        return ()
+
+
 def test_command_list_keeps_completion_item_compatibility_alias() -> None:
     from loushang.coding.ui.command_list import CompletionItem as CodingCompletionItem
     from loushang.tui import CompletionItem
@@ -114,6 +131,19 @@ def test_session_command_completion_provider_uses_argument_hint_in_label() -> No
             ),
         )
     )
+
+
+def test_command_apis_await_session_command_getter() -> None:
+    from loushang.coding.ui.command_list import (
+        coding_command_completion_provider,
+        session_command_completion_provider,
+    )
+
+    session_provider = asyncio.run(session_command_completion_provider(_AsyncSession()))
+    coding_provider = asyncio.run(coding_command_completion_provider(_AsyncSession()))
+
+    assert [item.value for item in session_provider.items] == ["/inspect"]
+    assert "/inspect" in {item.value for item in coding_provider.items}
 
 
 def test_format_coding_commands_includes_local_and_session_commands() -> None:
@@ -213,3 +243,32 @@ def test_select_session_command_reports_cancelled_palette() -> None:
     result = asyncio.run(select_session_command(_Session(), choose=lambda _palette: None))
 
     assert result == "Command selection cancelled."
+
+
+def test_select_coding_command_invokes_chooser_for_empty_catalog() -> None:
+    from loushang.coding.ui.command_list import select_coding_command
+    from loushang.tui import CommandPalette
+
+    seen: list[CommandPalette] = []
+
+    def cancel(palette: CommandPalette) -> None:
+        seen.append(palette)
+
+    cancelled = asyncio.run(
+        select_coding_command(
+            object(),
+            command_catalog=_EmptyCatalog(),  # type: ignore[arg-type]
+            choose=cancel,
+        )
+    )
+    missing = asyncio.run(
+        select_coding_command(
+            object(),
+            command_catalog=_EmptyCatalog(),  # type: ignore[arg-type]
+            choose=lambda _palette: "/missing",
+        )
+    )
+
+    assert seen == [CommandPalette((), title="Commands")]
+    assert cancelled == "Command selection cancelled."
+    assert missing == "No commands match: /missing"

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -400,6 +400,54 @@ def test_shared_surface_controller_does_not_own_coding_policy_or_copy() -> None:
         assert token in coding
 
 
+def test_shared_catalog_interactions_do_not_own_coding_policy_or_copy() -> None:
+    command_interaction = Path(
+        "src/loushang/harnesstui/commands/interaction.py"
+    ).read_text(encoding="utf-8")
+    model_interaction = Path(
+        "src/loushang/harnesstui/selection/interaction.py"
+    ).read_text(encoding="utf-8")
+    shared = command_interaction + model_interaction
+    command_adapter = Path("src/loushang/coding/ui/command_list.py").read_text(
+        encoding="utf-8"
+    )
+    model_adapter = Path("src/loushang/coding/ui/model_list.py").read_text(
+        encoding="utf-8"
+    )
+    coding = command_adapter + model_adapter
+
+    for token in (
+        "loushang.coding",
+        "CodingCommandCatalog",
+        "ModelSelection",
+        "apply_model_selection",
+        "persistence_warning_message",
+        "settings_manager",
+        "set_model",
+        "Command selected:",
+        "Use /command <full command> to select one.",
+        "Model set:",
+        "Use /model <full model> to select one.",
+    ):
+        assert token not in shared
+
+    for token in (
+        "CodingCommandCatalog",
+        "apply_model_selection",
+        "persistence_warning_message",
+        "settings_manager",
+        "set_model",
+        "Command selected:",
+        "Use /command <full command> to select one.",
+        "Model set:",
+        "Use /model <full model> to select one.",
+    ):
+        assert token in coding
+
+    assert "loushang.harnesstui.commands.interaction" in command_adapter
+    assert "loushang.harnesstui.selection.interaction" in model_adapter
+
+
 def test_shared_status_provider_does_not_own_settings_manager_adaptation() -> None:
     source = Path("src/loushang/harnesstui/status/provider.py").read_text(
         encoding="utf-8"

--- a/tests/coding/test_ui_model_list.py
+++ b/tests/coding/test_ui_model_list.py
@@ -50,6 +50,11 @@ class _AmbiguousSession(_Session):
         ]
 
 
+class _EmptySession(_Session):
+    def get_available_models(self) -> list[object]:
+        return []
+
+
 class _SessionWithModelDetails(_Session):
     def get_available_model_details(self) -> list[object]:
         return [
@@ -160,6 +165,23 @@ def test_format_available_models_reports_empty_matches() -> None:
     text = asyncio.run(format_available_models(_Session(), query="missing"))
 
     assert text == "No models match: missing"
+
+
+def test_format_available_models_keeps_longer_substring_with_exact_label() -> None:
+    from loushang.coding.ui.model_list import format_available_models
+
+    class _FormattingSession(_Session):
+        def get_available_models(self) -> list[object]:
+            return [
+                ModelSelection(provider="provider", model_id="model"),
+                ModelSelection(provider="provider", model_id="model-plus"),
+            ]
+
+    text = asyncio.run(
+        format_available_models(_FormattingSession(), query="provider/model")
+    )
+
+    assert text == ("Available models:\n  provider/model\n  provider/model-plus")
 
 
 def test_available_model_completion_provider_exposes_structured_items() -> None:
@@ -289,6 +311,24 @@ def test_select_available_model_reports_cancelled_palette_choice() -> None:
     text = asyncio.run(select_available_model(session, query="", choose=lambda _palette: None))
 
     assert text == "Model selection cancelled."
+    assert session.set_model_calls == []
+
+
+def test_select_available_model_passes_empty_palette_to_chooser() -> None:
+    from loushang.coding.ui.model_list import select_available_model
+    from loushang.tui import CommandPalette
+
+    session = _EmptySession()
+    seen: list[CommandPalette] = []
+
+    def choose(palette: CommandPalette) -> None:
+        seen.append(palette)
+
+    text = asyncio.run(select_available_model(session, choose=choose))
+
+    assert text == "Model selection cancelled."
+    assert len(seen) == 1
+    assert seen[0].items == ()
     assert session.set_model_calls == []
 
 

--- a/tests/harnesstui/commands/test_interaction.py
+++ b/tests/harnesstui/commands/test_interaction.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+from loushang.harnesstui.commands.interaction import (
+    CommandInteractionSnapshot,
+    resolve_command_interaction,
+    run_command_interaction,
+)
+from loushang.harnesstui.commands.presentation import (
+    command_completion_item,
+    command_completion_provider,
+    matching_command_items,
+)
+from loushang.tui import CommandPalette
+
+
+@dataclass(frozen=True)
+class _Command:
+    name: str
+    description: str = ""
+    source: str = "extension"
+    invocation_name: str = ""
+    argument_hint: str = ""
+
+
+def _snapshot() -> tuple[CommandInteractionSnapshot[_Command], tuple[_Command, ...]]:
+    commands = (
+        _Command(
+            name="review",
+            invocation_name="review:pr",
+            argument_hint="<PR-URL>",
+            description="Review a pull request",
+        ),
+        _Command(name="restart", description="Restart a service"),
+        _Command(name="settings", description="Open settings", source="local"),
+    )
+    return CommandInteractionSnapshot(commands, title="Actions"), commands
+
+
+def test_command_interaction_lists_projectable_opaque_items() -> None:
+    snapshot, commands = _snapshot()
+    palette_order = (commands[1], commands[0], commands[2])
+
+    result = resolve_command_interaction(snapshot)
+
+    assert result.kind == "list"
+    assert result.query == ""
+    assert result.item is None
+    assert result.matches == palette_order
+    assert result.palette is not None
+    assert result.palette.title == "Actions"
+    assert tuple(item.value for item in result.palette.items) == (
+        "/restart",
+        "/review:pr",
+        "/settings",
+    )
+    assert all(
+        actual is expected for actual, expected in zip(result.matches, palette_order)
+    )
+
+
+def test_command_interaction_reports_empty_snapshot_or_query() -> None:
+    empty = resolve_command_interaction(
+        CommandInteractionSnapshot((object(),)),
+        query="  absent  ",
+    )
+    snapshot, _commands = _snapshot()
+    missing = resolve_command_interaction(snapshot, query="absent")
+
+    assert empty.kind == "empty"
+    assert empty.query == "absent"
+    assert empty.matches == ()
+    assert empty.palette == CommandPalette((), title="Commands")
+    assert missing.kind == "empty"
+    assert missing.query == "absent"
+
+
+def test_command_interaction_resolves_unique_query_to_original_item() -> None:
+    snapshot, commands = _snapshot()
+
+    result = resolve_command_interaction(snapshot, query="  /REVIEW:PR  ")
+
+    assert result.kind == "selected"
+    assert result.query == "/REVIEW:PR"
+    assert result.item is commands[0]
+    assert result.matches == (commands[0],)
+
+
+def test_command_interaction_reports_ambiguous_query_in_palette_order() -> None:
+    snapshot, commands = _snapshot()
+
+    result = resolve_command_interaction(snapshot, query="re")
+
+    assert result.kind == "ambiguous"
+    assert result.query == "re"
+    assert result.item is None
+    assert result.matches == (commands[1], commands[0])
+
+
+def test_command_interaction_matches_canonical_presentation_contracts() -> None:
+    snapshot, _commands = _snapshot()
+
+    for local_last in (False, True):
+        ordered_snapshot = CommandInteractionSnapshot(
+            snapshot.items,
+            title=snapshot.title,
+            local_last=local_last,
+        )
+        provider = command_completion_provider(
+            ordered_snapshot.items,
+            local_last=local_last,
+        )
+        result = resolve_command_interaction(ordered_snapshot)
+
+        assert result.palette == CommandPalette.from_completion_provider(
+            provider,
+            title=ordered_snapshot.title,
+        )
+        projected = tuple(command_completion_item(item) for item in result.matches)
+        assert projected == provider.items
+
+    provider = command_completion_provider(snapshot.items)
+    for query in ("re", "/review:pr", "service", "missing"):
+        result = resolve_command_interaction(snapshot, query=query)
+
+        projected = tuple(command_completion_item(item) for item in result.matches)
+        assert projected == matching_command_items(provider, query)
+
+
+def test_command_interaction_uses_sync_chooser_and_returns_original_item() -> None:
+    snapshot, commands = _snapshot()
+    seen: list[CommandPalette] = []
+
+    def choose(palette: CommandPalette) -> str:
+        seen.append(palette)
+        return "/settings"
+
+    result = asyncio.run(run_command_interaction(snapshot, choose=choose))
+
+    assert seen == [result.palette]
+    assert result.kind == "selected"
+    assert result.item is commands[2]
+
+
+def test_command_interaction_reports_cancelled_chooser() -> None:
+    snapshot, commands = _snapshot()
+
+    result = asyncio.run(
+        run_command_interaction(snapshot, choose=lambda _palette: None)
+    )
+
+    assert result.kind == "cancelled"
+    assert result.item is None
+    assert result.matches == (commands[1], commands[0], commands[2])
+    assert result.palette is not None
+
+
+def test_empty_command_interaction_still_invokes_chooser() -> None:
+    snapshot = CommandInteractionSnapshot(())
+    seen: list[CommandPalette] = []
+
+    def cancel(palette: CommandPalette) -> None:
+        seen.append(palette)
+
+    cancelled = asyncio.run(run_command_interaction(snapshot, choose=cancel))
+    missing = asyncio.run(
+        run_command_interaction(snapshot, choose=lambda _palette: "/missing")
+    )
+
+    assert seen == [CommandPalette((), title="Commands")]
+    assert cancelled.kind == "cancelled"
+    assert missing.kind == "empty"
+    assert missing.query == "/missing"
+
+
+def test_command_interaction_awaits_async_chooser() -> None:
+    snapshot, commands = _snapshot()
+
+    async def choose(_palette: CommandPalette) -> str:
+        await asyncio.sleep(0)
+        return "/restart"
+
+    result = asyncio.run(run_command_interaction(snapshot, choose=choose))
+
+    assert result.kind == "selected"
+    assert result.item is commands[1]
+
+
+def test_command_interaction_query_does_not_invoke_chooser() -> None:
+    snapshot, commands = _snapshot()
+
+    def choose(_palette: CommandPalette) -> str:
+        raise AssertionError("chooser should only run for an empty query")
+
+    result = asyncio.run(
+        run_command_interaction(snapshot, query="settings", choose=choose)
+    )
+
+    assert result.kind == "selected"
+    assert result.item is commands[2]

--- a/tests/harnesstui/selection/test_interaction.py
+++ b/tests/harnesstui/selection/test_interaction.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import asyncio
+
+from loushang.harnesstui.selection.catalog import ModelChoice
+from loushang.harnesstui.selection.interaction import (
+    ModelInteractionSnapshot,
+    resolve_model_interaction,
+    run_model_interaction,
+)
+from loushang.tui import CommandPalette
+
+
+def _choices() -> tuple[ModelChoice, ...]:
+    return (
+        ModelChoice(
+            label="provider/model",
+            value="provider:primary:model",
+            selection=object(),
+            endpoint_id="primary",
+        ),
+        ModelChoice(
+            label="provider/model",
+            value="provider:primary-canary:model",
+            selection=object(),
+            endpoint_id="primary-canary",
+        ),
+        ModelChoice(
+            label="other/large",
+            value="other/large",
+            selection=object(),
+        ),
+    )
+
+
+def test_model_interaction_resolves_empty_unique_and_ambiguous_queries() -> None:
+    choices = _choices()
+    snapshot = ModelInteractionSnapshot(choices)
+
+    empty = resolve_model_interaction(ModelInteractionSnapshot(()))
+    selected = resolve_model_interaction(snapshot, query="large")
+    ambiguous = resolve_model_interaction(snapshot, query="provider/model")
+
+    assert empty.kind == "empty"
+    assert empty.matches == ()
+    assert selected.kind == "selected"
+    assert selected.choice is choices[2]
+    assert selected.choice.selection is choices[2].selection
+    assert selected.palette is not None
+    assert ambiguous.kind == "ambiguous"
+    assert ambiguous.matches == choices[:2]
+    assert ambiguous.palette is not None
+
+
+def test_model_interaction_prefers_exact_endpoint_qualified_value() -> None:
+    choices = _choices()
+    snapshot = ModelInteractionSnapshot(choices)
+
+    by_value = resolve_model_interaction(
+        snapshot,
+        query="provider:primary-canary:model",
+    )
+
+    assert by_value.kind == "selected"
+    assert by_value.choice is choices[1]
+
+
+def test_model_interaction_does_not_prioritize_bare_endpoint_match() -> None:
+    choices = _choices()
+
+    result = resolve_model_interaction(
+        ModelInteractionSnapshot(choices),
+        query="primary",
+    )
+
+    assert result.kind == "ambiguous"
+    assert result.matches == choices[:2]
+
+
+def test_model_interaction_lists_current_choice_first_for_chooser() -> None:
+    choices = _choices()
+    snapshot = ModelInteractionSnapshot(
+        choices,
+        current_value=choices[2].value,
+        title="Available runtime models",
+    )
+    seen: list[CommandPalette] = []
+
+    async def choose(palette: CommandPalette) -> str:
+        seen.append(palette)
+        return choices[0].value
+
+    result = asyncio.run(run_model_interaction(snapshot, choose=choose))
+
+    assert result.kind == "selected"
+    assert result.choice is choices[0]
+    assert seen[0].title == "Available runtime models"
+    assert tuple(item.value for item in seen[0].items) == (
+        choices[2].value,
+        choices[0].value,
+        choices[1].value,
+    )
+    assert seen[0].items[0].description == "current"
+
+
+def test_model_interaction_reports_cancelled_chooser_without_losing_snapshot() -> None:
+    choices = _choices()
+    snapshot = ModelInteractionSnapshot(choices, current_value=choices[1].value)
+
+    result = asyncio.run(run_model_interaction(snapshot, choose=lambda _palette: None))
+
+    assert result.kind == "cancelled"
+    assert result.choice is None
+    assert result.matches == (choices[1], choices[0], choices[2])
+    assert result.palette is not None
+
+
+def test_model_interaction_passes_empty_palette_to_chooser() -> None:
+    seen: list[CommandPalette] = []
+
+    def choose(palette: CommandPalette) -> None:
+        seen.append(palette)
+
+    result = asyncio.run(
+        run_model_interaction(ModelInteractionSnapshot(()), choose=choose)
+    )
+
+    assert result.kind == "cancelled"
+    assert len(seen) == 1
+    assert seen[0].items == ()
+
+
+def test_model_interaction_does_not_choose_for_explicit_query() -> None:
+    chooser_called = False
+
+    def choose(_palette: CommandPalette) -> str:
+        nonlocal chooser_called
+        chooser_called = True
+        return "other/large"
+
+    result = asyncio.run(
+        run_model_interaction(
+            ModelInteractionSnapshot(_choices()),
+            query="missing",
+            choose=choose,
+        )
+    )
+
+    assert result.kind == "empty"
+    assert result.palette is not None
+    assert not chooser_called


### PR DESCRIPTION
## English

### What changed

- Add product-neutral command and model catalog interaction workflows under `loushang.harnesstui`.
- Introduce immutable snapshots and structural `list`, `selected`, `empty`, `ambiguous`, and `cancelled` outcomes.
- Support synchronous and asynchronous palette choosers while preserving empty-catalog behavior.
- Keep opaque command descriptor identity and static typing through generic command snapshot/result APIs.
- Refactor Coding command/model selectors into product adapters while retaining Session acquisition, model application, persistence, endpoint policy, and product copy in `loushang.coding`.
- Add stable-entrypoint, import-light, product-boundary, compatibility, and canonical presentation-equivalence tests.

### Why

Command and model catalog interaction mechanics are reusable across terminal products. Moving snapshot-to-resolution behavior into Harnesstui gives products one neutral interaction contract without moving Coding policy or side effects into the shared layer.

### Validation

- `make check-harnesstui`
  - Ruff passed
  - mypy passed for 127 source files
  - 869 passed, 37 deselected
- `make test-tui-render-contract`
  - 161 passed, 3591 deselected
- `git diff --check`

The Screen rendering hot path is unchanged.

## 中文

### 变更内容

- 在 `loushang.harnesstui` 中新增产品中立的 command/model catalog interaction workflow。
- 引入不可变 snapshot，以及 `list`、`selected`、`empty`、`ambiguous`、`cancelled` 五种结构化结果。
- 支持同步和异步 palette chooser，并保持空 catalog 仍调用空 palette 的既有行为。
- command snapshot/result 使用泛型，保留 opaque descriptor 的对象身份与静态类型。
- 将 Coding 的 command/model selector 收敛为产品适配层；Session 获取、模型应用、持久化、endpoint 策略和产品文案仍留在 `loushang.coding`。
- 增加稳定入口、轻量导入、产品职责边界、兼容性以及 canonical presentation 等价契约测试。

### 原因

命令与模型 catalog 的交互机制可以被多个终端产品复用。将 snapshot 到 resolution 的流程放入 Harnesstui，可以形成统一的中性交互契约，同时避免把 Coding 的策略和副作用迁入共享层。

### 验证

- `make check-harnesstui`
  - Ruff 通过
  - mypy 覆盖 127 个源文件并通过
  - 869 passed，37 deselected
- `make test-tui-render-contract`
  - 161 passed，3591 deselected
- `git diff --check`

本次未修改 Screen 渲染热路径。
