### PR TITLE
De-internalize Harness compatibility facades / 清理 Harness 兼容门面的内部依赖

### DIFF
--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -59,16 +59,13 @@ from loushang.coding.source_info import (
 from loushang.coding.tools import ToolRegistry, register_builtin_tools
 from loushang.coding.types import ModelSelection
 from loushang.coding.ui.mode import run_coding_tui
-from loushang.coding.workflow import (
-    load_workflow,
-    resolve_workflow_files,
-    run_prompt_steps_workflow,
-)
+from loushang.coding.workflow import run_prompt_steps_workflow
 from loushang.harness.agent_transcript import SessionQuery
 from loushang.harness.resources.plugins import (
     PluginManager,
     is_remote_plugin_source,
 )
+from loushang.harness.scenario.loader import load_workflow, resolve_workflow_files
 from loushang.harness.tools.workspace.path_utils import resolve_tool_path
 from loushang.harness.tools.workspace.read import (
     PillowReadImageResizer,

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -56,7 +56,6 @@ from loushang.coding.source_info import (
     executable_source_identity,
     format_source_identity_text,
 )
-from loushang.coding.store import SessionQuery
 from loushang.coding.tools import ToolRegistry, register_builtin_tools
 from loushang.coding.types import ModelSelection
 from loushang.coding.ui.mode import run_coding_tui
@@ -65,6 +64,7 @@ from loushang.coding.workflow import (
     resolve_workflow_files,
     run_prompt_steps_workflow,
 )
+from loushang.harness.agent_transcript import SessionQuery
 from loushang.harness.resources.plugins import (
     PluginManager,
     is_remote_plugin_source,

--- a/src/loushang/coding/mode/rpc_mode.py
+++ b/src/loushang/coding/mode/rpc_mode.py
@@ -30,9 +30,11 @@ from loushang.coding.event import (
 )
 from loushang.coding.mode.base import ModeAdapter, ModeState
 from loushang.coding.mode.rpc_json import project_rpc_value
-from loushang.coding.store import SessionQuery
 from loushang.coding.types import ModelSelection
-from loushang.harness.agent_transcript import create_agent_transcript_message_codec
+from loushang.harness.agent_transcript import (
+    SessionQuery,
+    create_agent_transcript_message_codec,
+)
 from loushang.harness.diagnostics.types import DiagnosticsQuery
 from loushang.harness.events import RuntimeEvent
 from loushang.harness.presentation import ToolDefinitionResolver, ToolRenderRuntime

--- a/src/loushang/coding/runtime/agent_session_runtime.py
+++ b/src/loushang/coding/runtime/agent_session_runtime.py
@@ -17,13 +17,13 @@ from loushang.coding.extensions import (
     SessionStartEvent,
 )
 from loushang.coding.session import AgentSession
-from loushang.coding.store import (
-    SessionManager,
+from loushang.coding.store import SessionManager
+from loushang.harness.agent_transcript import (
+    AGENT_MESSAGE_KIND,
     SessionQuery,
     SessionRecord,
     SessionSummary,
 )
-from loushang.harness.agent_transcript import AGENT_MESSAGE_KIND
 from loushang.harness.diagnostics.service import DiagnosticsService
 from loushang.harness.diagnostics.types import (
     DiagnosticPhase,

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -15,12 +15,13 @@ from loushang.ai.api_registry import (
     ApiProviderRegistry,
     get_default_api_provider_registry,
 )
-from loushang.ai.model import Model, Provider
+from loushang.ai.model import Model, ModelSelection, Provider
 from loushang.ai.types import AssistantMessage, ImagePart
 from loushang.coding.capability_profile import (
     CodingCapabilityRuntimeBinding,
     bind_coding_capability_runtime,
 )
+from loushang.coding.commands import SessionCommandDescriptor
 from loushang.coding.compaction import (
     compact,
     generate_branch_summary,
@@ -85,19 +86,17 @@ from loushang.coding.session.session_view_controller import SessionViewControlle
 from loushang.coding.session.tool_controller import ToolController
 from loushang.coding.session.tree_controller import TreeController
 from loushang.coding.session.types import (
-    AgentSessionState,
     CommandExecutionResult,
-    ModelSelection,
-    SessionCommandDescriptor,
-    TreeNavigationResult,
 )
 from loushang.coding.session.usage_payload import serialize_context_usage_payload
-from loushang.coding.store import SessionManager, SessionRecord
+from loushang.coding.store import SessionManager
 from loushang.coding.tools import ToolRegistry
 from loushang.harness.agent_transcript import (
     AgentTranscriptContext,
     CompactionResult,
     CompactionStatus,
+    SessionRecord,
+    TranscriptNavigationResult,
 )
 from loushang.harness.diagnostics.service import DiagnosticsService
 from loushang.harness.diagnostics.types import (
@@ -129,6 +128,7 @@ from loushang.harness.session import (
     TranscriptRuntimePort,
     TurnPolicyPort,
 )
+from loushang.harness.session.inspection import AgentSessionState
 from loushang.harness.tools.core import ToolDefinition
 from loushang.harness.workspace.exec import (
     ExecOutputChunk,
@@ -1275,7 +1275,7 @@ class AgentSession:
         custom_instructions: str | None = None,
         replace_instructions: bool = False,
         label: str | None = None,
-    ) -> TreeNavigationResult:
+    ) -> TranscriptNavigationResult:
         return await self._tree_controller.navigate_tree(
             target_id,
             summarize=summarize,

--- a/src/loushang/coding/session/command_controller.py
+++ b/src/loushang/coding/session/command_controller.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import cast
 
+from loushang.coding.commands import CommandSourceInfo, SessionCommandDescriptor
 from loushang.coding.extensions import ExtensionRunner, ResolvedCommand
 from loushang.coding.prompt import (
     PromptPreflightResult,
@@ -16,11 +17,7 @@ from loushang.coding.session.builtin_commands import (
     is_builtin_command,
     list_builtin_command_descriptors,
 )
-from loushang.coding.session.types import (
-    CommandExecutionResult,
-    CommandSourceInfo,
-    SessionCommandDescriptor,
-)
+from loushang.coding.session.types import CommandExecutionResult
 from loushang.coding.source_info import (
     SourceDescriptor,
     source_info_from_resource_descriptor,

--- a/src/loushang/coding/session/export_jsonl.py
+++ b/src/loushang/coding/session/export_jsonl.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from loushang.coding.store.file_codec import write_session_file
+from loushang.harness.agent_transcript import write_agent_transcript_file
 
 if TYPE_CHECKING:
     from loushang.coding.session.agent_session import AgentSession
@@ -18,7 +18,7 @@ def export_session_to_jsonl(session: AgentSession, output_path: str | None = Non
         else _default_export_path(session)
     )
     path.parent.mkdir(parents=True, exist_ok=True)
-    write_session_file(
+    write_agent_transcript_file(
         path,
         session.session_manager.header,
         _linearize_branch(session.session_manager.get_branch()),

--- a/src/loushang/coding/session/extension_runtime_bindings.py
+++ b/src/loushang/coding/session/extension_runtime_bindings.py
@@ -4,8 +4,9 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from loushang.agent import ThinkingLevel
+from loushang.ai.model import ModelSelection
+from loushang.coding.commands import SessionCommandDescriptor
 from loushang.coding.extensions import ExtensionRuntimeBindings
-from loushang.coding.session.types import ModelSelection, SessionCommandDescriptor
 from loushang.coding.session.usage_payload import serialize_context_usage_payload
 from loushang.harness.resources.diagnostics import ResourceDiagnostic
 from loushang.harness.workspace.exec import ExecResult

--- a/src/loushang/coding/session/introspection.py
+++ b/src/loushang/coding/session/introspection.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 from loushang.ai.types import AssistantMessage, ToolCall, ToolResultMessage, UserMessage
-from loushang.coding.session.types import ContextUsage, SessionStats, TokenUsageTotals
 from loushang.harness.agent_transcript import (
     AGENT_MESSAGE_KIND,
     APPLICATION_MESSAGE_KIND,
@@ -14,6 +13,11 @@ from loushang.harness.agent_transcript import (
     SessionTreeNode,
     calculate_context_tokens,
     estimate_context_tokens,
+)
+from loushang.harness.session.inspection import (
+    ContextUsage,
+    SessionStats,
+    TokenUsageTotals,
 )
 
 if TYPE_CHECKING:

--- a/src/loushang/coding/session/selection_controller.py
+++ b/src/loushang/coding/session/selection_controller.py
@@ -5,8 +5,7 @@ from dataclasses import dataclass, field
 from typing import Protocol
 
 from loushang.agent import Agent, ThinkingLevel
-from loushang.ai.model import Model
-from loushang.coding.session.types import ModelSelection
+from loushang.ai.model import Model, ModelSelection
 from loushang.coding.store import SessionManager
 from loushang.harness.agent_transcript import AgentTranscriptSelectionRuntime
 

--- a/src/loushang/coding/session/session_view_controller.py
+++ b/src/loushang/coding/session/session_view_controller.py
@@ -4,12 +4,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 
 from loushang.agent import Agent
-from loushang.coding.session.types import (
-    AgentSessionState,
-    ContextUsage,
-    ModelSelection,
-    SessionStats,
-)
+from loushang.ai.model import ModelSelection
 from loushang.coding.session.usage_payload import serialize_context_usage_payload
 from loushang.coding.store import SessionManager
 from loushang.harness.agent_transcript import (
@@ -17,7 +12,12 @@ from loushang.harness.agent_transcript import (
     AgentTranscriptRecord,
     ContextCompactionCheckpoint,
 )
-from loushang.harness.session.inspection import AgentSessionInspector
+from loushang.harness.session.inspection import (
+    AgentSessionInspector,
+    AgentSessionState,
+    ContextUsage,
+    SessionStats,
+)
 
 
 @dataclass

--- a/src/loushang/coding/session/tree_controller.py
+++ b/src/loushang/coding/session/tree_controller.py
@@ -10,13 +10,13 @@ from loushang.coding.compaction import (
     generate_branch_summary,
 )
 from loushang.coding.extensions import ExtensionRunner, SessionBeforeTreeEvent
-from loushang.coding.session.types import TreeNavigationResult
 from loushang.coding.store import SessionManager
 from loushang.harness.agent_transcript import (
     AgentTranscriptContext,
     AgentTranscriptNavigationRuntime,
     BranchSummaryOutput,
     TranscriptNavigationPlan,
+    TranscriptNavigationResult,
 )
 from loushang.harness.events import SessionRuntimeEventPayload
 from loushang.harness.runtime import CancellationSignal
@@ -81,10 +81,10 @@ class TreeController:
         replace_instructions: bool = False,
         label: str | None = None,
         generate_branch_summary_fn: BranchSummaryGenerator | None = None,
-    ) -> TreeNavigationResult:
+    ) -> TranscriptNavigationResult:
         plan = self._runtime.prepare(target_id)
         if plan is None:
-            return TreeNavigationResult(cancelled=False)
+            return TranscriptNavigationResult(cancelled=False)
 
         summary_override: BranchSummaryOutput | None = None
         if self.extension_runner is not None:
@@ -102,7 +102,7 @@ class TreeController:
                 label=label,
             )
             if cancelled:
-                return TreeNavigationResult(cancelled=True)
+                return TranscriptNavigationResult(cancelled=True)
 
         result = await self._runtime.navigate(
             plan,

--- a/src/loushang/coding/session/usage_payload.py
+++ b/src/loushang/coding/session/usage_payload.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Any
 
-from loushang.coding.session.types import ContextUsage, ContextUsageSnapshot
+from loushang.harness.agent_transcript import ContextUsageSnapshot
+from loushang.harness.session.inspection import ContextUsage
 from loushang.protocol import JSONValue, require_json_mapping
 
 

--- a/src/loushang/coding/workflow/command.py
+++ b/src/loushang/coding/workflow/command.py
@@ -7,13 +7,14 @@ from pathlib import Path
 from typing import Any, TextIO
 
 from loushang.coding.ui.model import ensure_usable_session_model
-from loushang.coding.workflow.fake_runtime import FakeWorkflowAdapter
-from loushang.coding.workflow.loader import load_workflow, resolve_workflow_files
 from loushang.coding.workflow.report import (
     format_workflow_json_report,
     format_workflow_report,
 )
-from loushang.coding.workflow.runner import AgentSessionWorkflowAdapter, run_workflow
+from loushang.coding.workflow.runner import run_workflow
+from loushang.harness.scenario.fake_runtime import FakeWorkflowAdapter
+from loushang.harness.scenario.loader import load_workflow, resolve_workflow_files
+from loushang.harness.scenario.runner import AgentSessionWorkflowAdapter
 
 
 async def run_prompt_steps_workflow(

--- a/src/loushang/coding/workflow/report.py
+++ b/src/loushang/coding/workflow/report.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 
-from loushang.coding.workflow.schema import WorkflowResult
+from loushang.harness.scenario.schema import WorkflowResult
 
 
 def format_workflow_report(

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2968,6 +2968,56 @@ def test_coding_internal_store_alias_imports_use_harness_owners() -> None:
     assert offenders == []
 
 
+def test_coding_internal_scenario_imports_use_harness_owner() -> None:
+    compatibility_paths = {
+        "src/loushang/coding/workflow/__init__.py",
+        "src/loushang/coding/workflow/assertions.py",
+        "src/loushang/coding/workflow/events.py",
+        "src/loushang/coding/workflow/fake_runtime.py",
+        "src/loushang/coding/workflow/loader.py",
+        "src/loushang/coding/workflow/schema.py",
+    }
+    legacy_prefixes = (
+        "loushang.coding.workflow.assertions",
+        "loushang.coding.workflow.events",
+        "loushang.coding.workflow.fake_runtime",
+        "loushang.coding.workflow.loader",
+        "loushang.coding.workflow.schema",
+    )
+    offenders: list[str] = []
+    for path in sorted(Path("src/loushang/coding").rglob("*.py")):
+        if path.as_posix() in compatibility_paths:
+            continue
+        for imported in _absolute_imports(path):
+            if imported.startswith(legacy_prefixes):
+                offenders.append(f"{path.as_posix()} imports {imported}")
+
+    assert offenders == []
+
+
+def test_coding_internal_compaction_type_imports_use_harness_owner() -> None:
+    compatibility_paths = {
+        "src/loushang/coding/compaction/__init__.py",
+        "src/loushang/coding/compaction/types.py",
+    }
+    legacy_symbols = (
+        "loushang.coding.compaction.types.CompactionPlan",
+        "loushang.coding.compaction.types.CompactionPreparation",
+        "loushang.coding.compaction.types.CompactionResult",
+        "loushang.coding.compaction.types.CompactionStatus",
+        "loushang.coding.compaction.types.ContextUsageEstimate",
+    )
+    offenders: list[str] = []
+    for path in sorted(Path("src/loushang/coding").rglob("*.py")):
+        if path.as_posix() in compatibility_paths:
+            continue
+        for imported in _absolute_imports(path):
+            if _matches_any(imported, legacy_symbols):
+                offenders.append(f"{path.as_posix()} imports {imported}")
+
+    assert offenders == []
+
+
 def test_harness_product_kernel_ownership_is_documented() -> None:
     path = Path("docs/internals/architecture/harness/shared-capability-boundaries.md")
     text = " ".join(path.read_text(encoding="utf-8").split())

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2926,6 +2926,48 @@ def test_coding_internal_session_type_imports_use_owners() -> None:
     assert offenders == []
 
 
+def test_coding_internal_store_alias_imports_use_harness_owners() -> None:
+    compatibility_paths = {
+        "src/loushang/coding/__init__.py",
+        "src/loushang/coding/store/__init__.py",
+        "src/loushang/coding/store/backend.py",
+        "src/loushang/coding/store/file_codec.py",
+        "src/loushang/coding/store/file_lock.py",
+        "src/loushang/coding/store/types.py",
+    }
+    legacy_symbols = (
+        "loushang.coding.store.CodingSessionFileLayout",
+        "loushang.coding.store.SessionFileError",
+        "loushang.coding.store.SessionMetadata",
+        "loushang.coding.store.SessionQuery",
+        "loushang.coding.store.SessionRecord",
+        "loushang.coding.store.SessionSummary",
+        "loushang.coding.store.SessionTreeNode",
+        "loushang.coding.store.append_session_entry",
+        "loushang.coding.store.create_coding_file_store",
+        "loushang.coding.store.create_session_repository",
+        "loushang.coding.store.load_current_session_header",
+        "loushang.coding.store.load_session_file",
+        "loushang.coding.store.load_session_repository",
+        "loushang.coding.store.session_file_lock",
+        "loushang.coding.store.session_journal",
+        "loushang.coding.store.write_session_file",
+        "loushang.coding.store.backend",
+        "loushang.coding.store.file_codec",
+        "loushang.coding.store.file_lock",
+        "loushang.coding.store.types",
+    )
+    offenders: list[str] = []
+    for path in sorted(Path("src/loushang/coding").rglob("*.py")):
+        if path.as_posix() in compatibility_paths:
+            continue
+        for imported in _absolute_imports(path):
+            if _matches_any(imported, legacy_symbols):
+                offenders.append(f"{path.as_posix()} imports {imported}")
+
+    assert offenders == []
+
+
 def test_harness_product_kernel_ownership_is_documented() -> None:
     path = Path("docs/internals/architecture/harness/shared-capability-boundaries.md")
     text = " ".join(path.read_text(encoding="utf-8").split())

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2900,6 +2900,32 @@ def test_coding_internal_run_state_imports_use_harness_owner() -> None:
     assert offenders == []
 
 
+def test_coding_internal_session_type_imports_use_owners() -> None:
+    compatibility_paths = {
+        "src/loushang/coding/session/__init__.py",
+        "src/loushang/coding/session/types.py",
+    }
+    legacy_symbols = (
+        "loushang.coding.session.types.AgentSessionState",
+        "loushang.coding.session.types.CompactionDecision",
+        "loushang.coding.session.types.ContextUsage",
+        "loushang.coding.session.types.ContextUsageSnapshot",
+        "loushang.coding.session.types.ModelSelection",
+        "loushang.coding.session.types.SessionStats",
+        "loushang.coding.session.types.TokenUsageTotals",
+        "loushang.coding.session.types.TreeNavigationResult",
+    )
+    offenders: list[str] = []
+    for path in sorted(Path("src/loushang/coding").rglob("*.py")):
+        if path.as_posix() in compatibility_paths:
+            continue
+        for imported in _absolute_imports(path):
+            if _matches_any(imported, legacy_symbols):
+                offenders.append(f"{path.as_posix()} imports {imported}")
+
+    assert offenders == []
+
+
 def test_harness_product_kernel_ownership_is_documented() -> None:
     path = Path("docs/internals/architecture/harness/shared-capability-boundaries.md")
     text = " ".join(path.read_text(encoding="utf-8").split())


### PR DESCRIPTION
## Summary
- Route Coding internal consumers directly to their Harness or AI owners for session inspection, transcript navigation, catalog records, file persistence, and scenario contracts.
- Keep public `loushang.coding.*` compatibility imports intact.
- Add architecture guards that prevent internal dependency regressions through session, store, scenario, and compaction aliases.

## Validation
- `ruff check` for all changed modules and architecture tests.
- `tests/harness tests/architecture`: 846 passed.
- Targeted Coding session, store, workflow, branch-summary, and compaction tests passed.
- Full Coding suite: 2242 passed; two unrelated flaky TUI timing/PTY smoke tests failed once, then passed in 10 isolated repetitions.

---

## 中文说明
- 将 Coding 内部消费者直接切换到 Harness 或 AI 的真实 owner，覆盖 session inspection、transcript navigation、catalog read model、文件持久化与 scenario 契约。
- 保留全部公开 `loushang.coding.*` 兼容导入路径。
- 新增架构门禁，防止 session、store、scenario、compaction alias 被内部代码重新依赖。

## 验证
- 已运行变更模块与架构测试的 Ruff 检查。
- `tests/harness tests/architecture`：846 passed。
- Coding 的 session、store、workflow、branch-summary、compaction 定向测试通过。
- 全量 Coding：2242 passed；两项无关的 TUI 时序/PTY smoke 曾单次失败，随后隔离连续 10 轮均通过。