### PR TITLE
test(agent): stabilize post-tool abort scenario

### DIFF
--- a/tests/agent/test_agent_loop_scenarios.py
+++ b/tests/agent/test_agent_loop_scenarios.py
@@ -130,10 +130,25 @@ class Abort:
     clear_queues: bool = True
 
     async def run(self, runtime: ScenarioRuntime) -> None:
-        runtime.agent.abort()
-        if self.clear_queues:
-            runtime.agent.clear_all_queues()
-        runtime.signal_abort()
+        runtime.abort(clear_queues=self.clear_queues)
+
+
+@dataclass(frozen=True)
+class AbortOnToolFinished:
+    name: str = "scenario_tool"
+    clear_queues: bool = True
+
+    async def run(self, runtime: ScenarioRuntime) -> None:
+        def abort_after_public_tool_result(event: dict, signal: object) -> None:
+            del signal
+            if event.get("type") != "tool_execution_end":
+                return
+            if event.get("tool_name") != self.name:
+                return
+            unsubscribe()
+            runtime.abort(clear_queues=self.clear_queues)
+
+        unsubscribe = runtime.agent.subscribe(abort_after_public_tool_result)
 
 
 @dataclass(frozen=True)
@@ -218,7 +233,6 @@ class ScenarioTool:
         del tool_call_id, params, on_update
         self.runtime.signal(ToolStarted(self.name))
         response = await self.runtime.next_tool_result(signal=signal)
-        self.runtime.signal(ToolFinished(self.name))
         return AgentToolResult(
             content=[TextPart(type="text", text=response.text)],
             details={"text": response.text},
@@ -261,7 +275,14 @@ class ScenarioRuntime:
         self.current_abort_event = None
 
     async def wait_for(self, checkpoint: object, *, timeout: float = 1.0) -> None:
-        await asyncio.wait_for(self._event_for(checkpoint).wait(), timeout=timeout)
+        async with asyncio.timeout(timeout):
+            await self._event_for(checkpoint).wait()
+
+    def abort(self, *, clear_queues: bool) -> None:
+        self.agent.abort()
+        if clear_queues:
+            self.agent.clear_all_queues()
+        self.signal_abort()
 
     def signal(self, checkpoint: object) -> None:
         self._event_for(checkpoint).set()
@@ -319,6 +340,9 @@ class ScenarioRuntime:
 
     async def _handle_event(self, event: dict, signal: object) -> None:
         del signal
+        if event.get("type") == "tool_execution_end":
+            self.signal(ToolFinished(str(event.get("tool_name", ""))))
+            return
         if event.get("type") != "message_start":
             return
         message = event.get("message")
@@ -433,14 +457,22 @@ SCENARIOS = [
             WaitFor(ModelCall(1)),
             ModelToolCall(),
             WaitFor(ToolStarted()),
+            AbortOnToolFinished(),
             ToolResult("done"),
             WaitFor(ToolFinished()),
-            Abort(),
             WaitIdle(),
             Prompt("你好", ModelText("hello")),
             Expect(
                 model_user_inputs=["use tool", "你好"],
                 consumed_users=["use tool", "你好"],
+                roles=[
+                    "user",
+                    "assistant",
+                    "toolResult",
+                    "assistant",
+                    "user",
+                    "assistant",
+                ],
                 abort_boundaries=1,
             ),
         ],


### PR DESCRIPTION
## What changed

- publish the scenario `ToolFinished` checkpoint from the public `tool_execution_end` event instead of inside the test tool before it returns
- abort synchronously from a one-shot Agent listener at that public event boundary
- replace `asyncio.wait_for(event.wait())` with `asyncio.timeout()` plus a direct event wait
- assert that the completed tool result remains in the transcript across cancellation

## Why

The previous scenario depended on the internal scheduling implementation of `asyncio.wait_for()`. Python 3.11 adds an intermediate task around `Event.wait()`, allowing the agent task to resume and enter another model call before the scenario driver runs its separate abort step. Python 3.14 happens to schedule that path differently.

The revised scenario exercises the actual Agent event contract and does not add scheduler sleeps or change production runtime behavior.

## Validation

- Python 3.11.15: `tests/agent` — 134 passed
- Python 3.14.4: `tests/agent` — 134 passed
- Ruff on the changed test file
- `git diff --check`

Refs #305
