### PR TITLE
feat(work): add operation runtime

### DIFF
--- a/src/loushang/coding/work_executor.py
+++ b/src/loushang/coding/work_executor.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from loushang.coding.event import project_runtime_event_to_session_event
+from loushang.coding.work_projection import (
+    CodingWorkFactProjectionContext,
+    project_agent_event_to_work_facts,
+)
+from loushang.harness.agent_transcript import create_agent_transcript_message_codec
+from loushang.harness.events import RuntimeEvent
+from loushang.work.ports import WorkExecutionContext
+from loushang.work.types import WorkOperation, WorkRunSpec
+
+RuntimeEventListener = Callable[[RuntimeEvent[object]], Awaitable[None] | None]
+_MESSAGE_CODEC = create_agent_transcript_message_codec()
+serialize_agent_message = _MESSAGE_CODEC.serialize
+
+
+class PromptSession(Protocol):
+    def subscribe_runtime_events(
+        self,
+        listener: RuntimeEventListener,
+    ) -> Callable[[], None]: ...
+
+    def prompt(
+        self, text: str, *, images: Sequence[object] | None = None
+    ) -> Awaitable[None]: ...
+
+
+@dataclass(frozen=True)
+class SubmitCodingTurn:
+    text: str
+    images: Sequence[object] | None = None
+    method_id: str | None = None
+    plan_id: str | None = None
+    step_id: str | None = None
+    step_index: int | None = None
+    step_title: str | None = None
+    planned_constraint: Mapping[str, object] | None = None
+    audit_policy: Mapping[str, object] | None = None
+    plan_facts: Mapping[str, object] | None = None
+    step_facts: Mapping[str, object] | None = None
+    emit_plan_start: bool = True
+    emit_plan_completion: bool = True
+    emit_plan_failure: bool = True
+
+    def to_operation(self, *, session_id: str, operation_id: str) -> WorkOperation:
+        payload: dict[str, object] = {"text": self.text}
+        if self.images is not None:
+            payload["image_count"] = len(self.images)
+        if self.method_id is not None:
+            payload["method_id"] = self.method_id
+        if self.plan_id is not None:
+            payload["plan_id"] = self.plan_id
+        if self.step_id is not None:
+            payload["step_id"] = self.step_id
+        if self.step_index is not None:
+            payload["step_index"] = self.step_index
+        if self.step_title is not None:
+            payload["step_title"] = self.step_title
+        if self.planned_constraint:
+            payload["planned_constraint"] = dict(self.planned_constraint)
+        if self.audit_policy:
+            payload["audit_policy"] = dict(self.audit_policy)
+        if self.plan_facts:
+            payload["plan_facts"] = dict(self.plan_facts)
+        if self.step_facts:
+            payload["step_facts"] = dict(self.step_facts)
+        return WorkOperation(
+            operation_id=operation_id,
+            kind="SubmitCodingTurn",
+            session_id=session_id,
+            domain="coding",
+            payload=payload,
+        )
+
+    def to_run_spec(self, *, run_id: str | None) -> WorkRunSpec:
+        scope_payload: dict[str, object] = {"source_type": "work_shell"}
+        if self.step_index is not None:
+            scope_payload["step_index"] = self.step_index
+        if self.step_title is not None:
+            scope_payload["step_title"] = self.step_title
+        if self.planned_constraint:
+            scope_payload["planned_constraint"] = dict(self.planned_constraint)
+        if self.audit_policy:
+            scope_payload["audit_policy"] = dict(self.audit_policy)
+        if self.plan_facts:
+            scope_payload["plan_facts"] = dict(self.plan_facts)
+        if self.step_facts:
+            scope_payload["step_facts"] = dict(self.step_facts)
+        return WorkRunSpec(
+            run_id=run_id,
+            method_id=self.method_id,
+            plan_id=self.plan_id,
+            step_id=self.step_id,
+            run_event_payload={"source_type": "work_shell"},
+            scope_event_payload=scope_payload,
+            emit_plan_start=self.emit_plan_start,
+            emit_plan_completion=self.emit_plan_completion,
+            emit_plan_failure=self.emit_plan_failure,
+        )
+
+
+@dataclass(frozen=True)
+class CodingDomainExecutor:
+    session: PromptSession
+    turn: SubmitCodingTurn
+
+    async def execute(
+        self,
+        operation: WorkOperation,
+        context: WorkExecutionContext,
+    ) -> object:
+        if operation.kind != "SubmitCodingTurn" or operation.domain != "coding":
+            raise ValueError(
+                f"Coding executor cannot execute {operation.domain}:{operation.kind}"
+            )
+
+        async def listener(event: RuntimeEvent[object]) -> None:
+            projected = project_runtime_event_to_session_event(event)
+            if projected is None:
+                return
+            facts = project_agent_event_to_work_facts(
+                projected,
+                context=CodingWorkFactProjectionContext(
+                    source_event_ref=event.event_id,
+                    message_serializer=serialize_agent_message,
+                ),
+            )
+            for fact in facts:
+                context.publish(fact)
+
+        unsubscribe = self.session.subscribe_runtime_events(listener)
+        try:
+            if self.turn.images is None:
+                await self.session.prompt(self.turn.text)
+            else:
+                await self.session.prompt(self.turn.text, images=self.turn.images)
+        finally:
+            unsubscribe()
+        return None
+
+
+__all__ = ["CodingDomainExecutor", "PromptSession", "SubmitCodingTurn"]

--- a/src/loushang/coding/work_projection.py
+++ b/src/loushang/coding/work_projection.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from loushang.agent.json_codec import serialize_tool_result
+from loushang.agent.types import AgentToolResult
+from loushang.ai.json_codec import serialize_assistant_message_event, serialize_message
+from loushang.ai.types import AssistantMessageEvent, Message
+from loushang.protocol import JsonValueError, require_json_mapping, require_json_value
+from loushang.work.types import DeliveryHint, WorkEventFact
+
+AgentMessageSerializer = Callable[[object], Mapping[str, object]]
+
+
+@dataclass(frozen=True)
+class CodingWorkFactProjectionContext:
+    source_event_ref: str | None = None
+    message_serializer: AgentMessageSerializer | None = None
+
+
+def project_agent_event_to_work_facts(
+    event: Mapping[str, object],
+    *,
+    context: CodingWorkFactProjectionContext,
+) -> list[WorkEventFact]:
+    source_type = event.get("type")
+    if not isinstance(source_type, str):
+        raise ValueError("Agent event must include a string type")
+
+    if source_type == "agent_start":
+        return [
+            _event(
+                context,
+                kind="AgentInvocationStarted",
+                delivery_hint="coalesce",
+                payload={"source_type": source_type},
+            )
+        ]
+    if source_type == "agent_end":
+        messages = event.get("messages", [])
+        return [
+            _event(
+                context,
+                kind="AgentInvocationCompleted",
+                delivery_hint="coalesce",
+                payload={
+                    "source_type": source_type,
+                    "messages": _serialize_messages(
+                        messages,
+                        name="agent_event.messages",
+                        serializer=context.message_serializer,
+                    ),
+                },
+            ),
+        ]
+    if source_type == "turn_start":
+        return [
+            _event(
+                context,
+                kind="TaskStarted",
+                delivery_hint="immediate",
+                payload={"source_type": source_type},
+            )
+        ]
+    if source_type == "turn_end":
+        payload = _payload(event)
+        if "message" in event:
+            payload["message"] = _serialize_message(
+                event["message"],
+                name="agent_event.message",
+                serializer=context.message_serializer,
+            )
+        if "tool_results" in event:
+            payload["tool_results"] = _serialize_messages(
+                event["tool_results"],
+                name="agent_event.tool_results",
+                serializer=context.message_serializer,
+            )
+        return [
+            _event(
+                context,
+                kind="TaskCompleted",
+                delivery_hint="immediate",
+                payload=payload,
+            )
+        ]
+    if source_type in {"message_start", "message_update", "message_end"}:
+        payload = _payload(event)
+        if "message" in event:
+            payload["message"] = _serialize_message(
+                event["message"],
+                name="agent_event.message",
+                serializer=context.message_serializer,
+            )
+        if "assistant_message_event" in event:
+            payload["assistant_message_event"] = _serialize_assistant_event(
+                event["assistant_message_event"]
+            )
+        return [
+            _event(
+                context, kind="ContentDelta", delivery_hint="coalesce", payload=payload
+            )
+        ]
+    if source_type == "tool_execution_start":
+        payload = _payload(event, "tool_call_id", "tool_name")
+        if "args" in event:
+            payload["args"] = require_json_value(
+                event["args"],
+                name="agent_event.args",
+            )
+        return [
+            _event(
+                context,
+                kind="ToolCallStarted",
+                delivery_hint="coalesce",
+                payload=payload,
+            )
+        ]
+    if source_type == "tool_execution_update":
+        payload = _payload(event, "tool_call_id", "tool_name")
+        if "args" in event:
+            payload["args"] = require_json_value(
+                event["args"],
+                name="agent_event.args",
+            )
+        if "partial_result" in event:
+            payload["partial_result"] = _serialize_agent_tool_result(
+                event["partial_result"],
+                name="agent_event.partial_result",
+            )
+        return [
+            _event(
+                context,
+                kind="ToolCallProgress",
+                delivery_hint="coalesce",
+                payload=payload,
+            )
+        ]
+    if source_type == "tool_execution_end":
+        payload = _payload(
+            event,
+            "tool_call_id",
+            "tool_name",
+            "is_error",
+            "duration_ms",
+        )
+        if "result" in event:
+            payload["result"] = _serialize_agent_tool_result(
+                event["result"],
+                name="agent_event.result",
+            )
+        delivery_hint: DeliveryHint = (
+            "immediate" if event.get("is_error") is True else "coalesce"
+        )
+        return [
+            _event(
+                context,
+                kind="ToolCallCompleted",
+                delivery_hint=delivery_hint,
+                payload=payload,
+            )
+        ]
+    if source_type == "tool_policy_evaluated":
+        payload = _payload(
+            event,
+            "tool_call_id",
+            "tool_name",
+            "cwd",
+            "policy_disposition",
+            "policy_code",
+            "policy_reason",
+            "approval_required",
+            "argument_keys",
+            "path",
+            "file_path",
+            "command",
+        )
+        return [
+            _event(
+                context,
+                kind="ToolPolicyEvaluated",
+                delivery_hint="immediate",
+                payload=payload,
+            )
+        ]
+    if source_type == "tool_approval_requested":
+        payload = _payload(
+            event,
+            "tool_call_id",
+            "tool_name",
+            "cwd",
+            "action_id",
+            "policy_code",
+            "policy_reason",
+            "argument_keys",
+            "path",
+            "file_path",
+            "command",
+        )
+        return [
+            _event(
+                context,
+                kind="ToolApprovalRequested",
+                delivery_hint="immediate",
+                payload=payload,
+            )
+        ]
+    if source_type == "tool_approval_resolved":
+        payload = _payload(
+            event,
+            "tool_call_id",
+            "tool_name",
+            "cwd",
+            "action_id",
+            "approval_decision",
+            "approval_reason",
+            "policy_code",
+            "policy_reason",
+            "argument_keys",
+            "path",
+            "file_path",
+            "command",
+        )
+        return [
+            _event(
+                context,
+                kind="ToolApprovalResolved",
+                delivery_hint="immediate",
+                payload=payload,
+            )
+        ]
+    if source_type == "queue_update":
+        payload = _payload(event, "steering", "follow_up")
+        return [
+            _event(
+                context, kind="QueueUpdated", delivery_hint="coalesce", payload=payload
+            )
+        ]
+    if source_type in {"auto_retry_start", "auto_retry_end"}:
+        return [
+            _event(
+                context,
+                kind="RetryDiagnostic",
+                delivery_hint="immediate"
+                if event.get("success") is False
+                else "coalesce",
+                payload=dict(event),
+            ),
+        ]
+    if source_type in {"compaction_start", "compaction_end", "package_progress"}:
+        return [
+            _event(
+                context,
+                kind="MaintenanceProgress",
+                delivery_hint="coalesce",
+                payload=dict(event),
+            )
+        ]
+
+    return [
+        _event(context, kind="WorkEvent", delivery_hint="coalesce", payload=dict(event))
+    ]
+
+
+def _event(
+    context: CodingWorkFactProjectionContext,
+    *,
+    kind: str,
+    delivery_hint: DeliveryHint,
+    payload: Mapping[str, object],
+) -> WorkEventFact:
+    return WorkEventFact(
+        kind=kind,
+        delivery_hint=delivery_hint,
+        payload=cast(
+            Mapping[str, object],
+            require_json_mapping(
+                dict(payload),
+                name="work_event.payload",
+            ),
+        ),
+        source_event_ref=context.source_event_ref,
+    )
+
+
+def _payload(event: Mapping[str, object], *keys: str) -> dict[str, object]:
+    payload: dict[str, object] = {"source_type": event["type"]}
+    for key in keys:
+        if key in event:
+            payload[key] = event[key]
+    return payload
+
+
+def _serialize_messages(
+    value: object,
+    *,
+    name: str,
+    serializer: AgentMessageSerializer | None,
+) -> list[object]:
+    if not isinstance(value, list):
+        raise TypeError(f"{name} must be a list")
+    return [
+        _serialize_message(
+            message,
+            name=f"{name}[{index}]",
+            serializer=serializer,
+        )
+        for index, message in enumerate(value)
+    ]
+
+
+def _serialize_message(
+    value: object,
+    *,
+    name: str,
+    serializer: AgentMessageSerializer | None,
+) -> dict[str, object]:
+    if isinstance(value, Mapping):
+        return cast(
+            dict[str, object],
+            require_json_mapping(dict(value), name=name),
+        )
+    encoded = (
+        serializer(value)
+        if serializer is not None
+        else serialize_message(cast(Message, value))
+    )
+    return cast(
+        dict[str, object],
+        require_json_mapping(encoded, name=name),
+    )
+
+
+def _serialize_assistant_event(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError("agent_event.assistant_message_event must be a mapping")
+    try:
+        return cast(
+            dict[str, object],
+            require_json_mapping(
+                dict(value),
+                name="agent_event.assistant_message_event",
+            ),
+        )
+    except JsonValueError:
+        encoded = serialize_assistant_message_event(cast(AssistantMessageEvent, value))
+        return cast(
+            dict[str, object],
+            require_json_mapping(
+                encoded,
+                name="agent_event.assistant_message_event",
+            ),
+        )
+
+
+def _serialize_agent_tool_result(value: object, *, name: str) -> dict[str, object]:
+    if isinstance(value, AgentToolResult):
+        encoded = serialize_tool_result(value, target="event")
+    elif isinstance(value, Mapping):
+        encoded = dict(value)
+    else:
+        raise TypeError(f"{name} must be AgentToolResult or a projected JSON object")
+    return cast(
+        dict[str, object],
+        require_json_mapping(encoded, name=name),
+    )
+
+
+__all__ = [
+    "CodingWorkFactProjectionContext",
+    "project_agent_event_to_work_facts",
+]

--- a/src/loushang/coding/work_shell.py
+++ b/src/loushang/coding/work_shell.py
@@ -1,38 +1,24 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Protocol
 from uuid import uuid4
 
-from loushang.coding.event import project_runtime_event_to_session_event
-from loushang.harness.agent_transcript import create_agent_transcript_message_codec
-from loushang.harness.events import RuntimeEvent
-from loushang.work.event_log import EventLogBackend, EventLogEntry
-from loushang.work.projection import (
-    WorkEventProjectionContext,
-    project_agent_event_to_work_events,
+from loushang.coding.work_executor import (
+    CodingDomainExecutor,
+    PromptSession,
+    SubmitCodingTurn,
 )
-from loushang.work.types import WorkEvent, WorkOperation, WorkRun
-
-RuntimeEventListener = Callable[[RuntimeEvent[object]], Awaitable[None] | None]
-_MESSAGE_CODEC = create_agent_transcript_message_codec()
-serialize_agent_message = _MESSAGE_CODEC.serialize
-
-
-class PromptSession(Protocol):
-    def subscribe_runtime_events(
-        self, listener: RuntimeEventListener
-    ) -> Callable[[], None]: ...
-
-    def prompt(
-        self, text: str, *, images: Sequence[object] | None = None
-    ) -> Awaitable[None]: ...
+from loushang.work.event_log import EventLogBackend
+from loushang.work.runtime import WorkRuntime
+from loushang.work.types import WorkRun
 
 
 @dataclass
 class CodingWorkShell:
+    """Compatibility facade from the Coding prompt API to ``WorkRuntime``."""
+
     session: PromptSession
     event_log: EventLogBackend
     clock: Callable[[], datetime] = lambda: datetime.now(UTC)
@@ -58,373 +44,36 @@ class CodingWorkShell:
         emit_plan_completion: bool = True,
         emit_plan_failure: bool = True,
     ) -> WorkRun:
-        operation_id = operation_id or f"op-{uuid4().hex}"
-        run_id = run_id or f"run-{uuid4().hex}"
-        sequence = 0
-        operation = WorkOperation(
-            operation_id=operation_id,
-            kind="SubmitCodingTurn",
-            session_id=session_id,
-            domain="coding",
-            payload=_operation_payload(
-                text=text,
-                images=images,
-                method_id=method_id,
-                plan_id=plan_id,
-                step_id=step_id,
-                step_index=step_index,
-                step_title=step_title,
-                planned_constraint=planned_constraint,
-                audit_policy=audit_policy,
-                plan_facts=plan_facts,
-                step_facts=step_facts,
-            ),
-        )
-        self._append_operation(operation, run_id=run_id, sequence=sequence)
-
-        run = WorkRun(
-            run_id=run_id,
-            operation_id=operation_id,
-            session_id=session_id,
-            domain="coding",
-            status="running",
+        turn = SubmitCodingTurn(
+            text=text,
+            images=images,
             method_id=method_id,
             plan_id=plan_id,
-            current_step_id=step_id,
+            step_id=step_id,
+            step_index=step_index,
+            step_title=step_title,
+            planned_constraint=planned_constraint,
+            audit_policy=audit_policy,
+            plan_facts=plan_facts,
+            step_facts=step_facts,
+            emit_plan_start=emit_plan_start,
+            emit_plan_completion=emit_plan_completion,
+            emit_plan_failure=emit_plan_failure,
         )
-        sequence += 1
-        self._append_event(
-            _work_event(
-                kind="WorkRunStarted",
-                run=run,
-                sequence=sequence,
-                created_at=self.clock(),
-                payload={"source_type": "work_shell"},
-            ),
-        )
-        if plan_id is not None and emit_plan_start:
-            sequence += 1
-            self._append_event(
-                _work_event(
-                    kind="WorkPlanStarted",
-                    run=run,
-                    sequence=sequence,
-                    created_at=self.clock(),
-                    delivery_hint="coalesce",
-                    payload=_step_payload(
-                        step_index=step_index,
-                        step_title=step_title,
-                        planned_constraint=planned_constraint,
-                        audit_policy=audit_policy,
-                        plan_facts=plan_facts,
-                        step_facts=step_facts,
-                    ),
-                ),
-            )
-        if step_id is not None:
-            sequence += 1
-            self._append_event(
-                _work_event(
-                    kind="WorkStepStarted",
-                    run=run,
-                    sequence=sequence,
-                    created_at=self.clock(),
-                    delivery_hint="coalesce",
-                    payload=_step_payload(
-                        step_index=step_index,
-                        step_title=step_title,
-                        planned_constraint=planned_constraint,
-                        audit_policy=audit_policy,
-                        plan_facts=plan_facts,
-                        step_facts=step_facts,
-                    ),
-                ),
-            )
-
-        async def listener(event: RuntimeEvent[object]) -> None:
-            nonlocal sequence
-            projected = project_runtime_event_to_session_event(event)
-            if projected is None:
-                return
-            sequence += 1
-            context = WorkEventProjectionContext(
-                run_id=run_id,
-                session_id=session_id,
-                domain="coding",
-                operation_id=operation_id,
-                sequence=sequence,
-                created_at=self.clock(),
-                event_id_prefix=f"{run_id}-event",
-                source_event_ref=event.event_id,
-                message_serializer=serialize_agent_message,
-            )
-            for work_event in project_agent_event_to_work_events(
-                projected, context=context
-            ):
-                self._append_event(work_event)
-
-        unsubscribe = self.session.subscribe_runtime_events(listener)
-        try:
-            if images is None:
-                await self.session.prompt(text)
-            else:
-                await self.session.prompt(text, images=images)
-        except Exception as error:
-            sequence += 1
-            failed_run = WorkRun(
-                run_id=run_id,
-                operation_id=operation_id,
-                session_id=session_id,
-                domain="coding",
-                status="failed",
-                method_id=method_id,
-                plan_id=plan_id,
-                current_step_id=step_id,
-            )
-            failure_payload = _step_payload(
-                step_index=step_index,
-                step_title=step_title,
-                planned_constraint=planned_constraint,
-                audit_policy=audit_policy,
-                plan_facts=plan_facts,
-                step_facts=step_facts,
-                error=error,
-            )
-            if step_id is not None:
-                self._append_event(
-                    _work_event(
-                        kind="WorkStepFailed",
-                        run=failed_run,
-                        sequence=sequence,
-                        created_at=self.clock(),
-                        delivery_hint="immediate",
-                        payload=failure_payload,
-                    ),
-                )
-                sequence += 1
-            if plan_id is not None and emit_plan_failure:
-                self._append_event(
-                    _work_event(
-                        kind="WorkPlanFailed",
-                        run=failed_run,
-                        sequence=sequence,
-                        created_at=self.clock(),
-                        delivery_hint="immediate",
-                        payload=failure_payload,
-                    ),
-                )
-                sequence += 1
-            self._append_event(
-                _work_event(
-                    kind="WorkRunFailed",
-                    run=failed_run,
-                    sequence=sequence,
-                    created_at=self.clock(),
-                    payload={"source_type": "work_shell"},
-                ),
-            )
-            raise
-        finally:
-            unsubscribe()
-
-        sequence += 1
-        completed_run = WorkRun(
-            run_id=run_id,
-            operation_id=operation_id,
+        operation = turn.to_operation(
             session_id=session_id,
-            domain="coding",
-            status="completed",
-            method_id=method_id,
-            plan_id=plan_id,
-            current_step_id=step_id,
+            operation_id=operation_id or f"op-{uuid4().hex}",
         )
-        if step_id is not None:
-            self._append_event(
-                _work_event(
-                    kind="WorkStepCompleted",
-                    run=completed_run,
-                    sequence=sequence,
-                    created_at=self.clock(),
-                    delivery_hint="coalesce",
-                    payload=_step_payload(
-                        step_index=step_index,
-                        step_title=step_title,
-                        planned_constraint=planned_constraint,
-                        audit_policy=audit_policy,
-                        plan_facts=plan_facts,
-                        step_facts=step_facts,
-                    ),
-                ),
-            )
-            sequence += 1
-        if plan_id is not None and emit_plan_completion:
-            self._append_event(
-                _work_event(
-                    kind="WorkPlanCompleted",
-                    run=completed_run,
-                    sequence=sequence,
-                    created_at=self.clock(),
-                    delivery_hint="final_only",
-                    payload=_step_payload(
-                        step_index=step_index,
-                        step_title=step_title,
-                        planned_constraint=planned_constraint,
-                        audit_policy=audit_policy,
-                        plan_facts=plan_facts,
-                        step_facts=step_facts,
-                    ),
-                ),
-            )
-            sequence += 1
-        self._append_event(
-            _work_event(
-                kind="WorkRunCompleted",
-                run=completed_run,
-                sequence=sequence,
-                created_at=self.clock(),
-                payload={"source_type": "work_shell"},
-            ),
+        runtime = WorkRuntime(
+            executor=CodingDomainExecutor(session=self.session, turn=turn),
+            event_log=self.event_log,
+            clock=self.clock,
         )
-        return completed_run
-
-    def _append_operation(
-        self, operation: WorkOperation, *, run_id: str, sequence: int
-    ) -> None:
-        self.event_log.append(
-            EventLogEntry(
-                entry_id=f"{run_id}-operation-{sequence}",
-                entry_type="operation",
-                operation_id=operation.operation_id,
-                event_id=None,
-                run_id=run_id,
-                session_id=operation.session_id or "",
-                sequence=sequence,
-                payload={
-                    "kind": operation.kind,
-                    "domain": operation.domain,
-                    "payload": dict(operation.payload),
-                },
-                created_at=self.clock(),
-            ),
+        accepted = await runtime.accept(
+            operation,
+            spec=turn.to_run_spec(run_id=run_id),
         )
-
-    def _append_event(self, event: WorkEvent) -> None:
-        self.event_log.append(_event_log_entry_from_work_event(event))
-
-
-def _work_event(
-    *,
-    kind: str,
-    run: WorkRun,
-    sequence: int,
-    created_at: datetime,
-    payload: Mapping[str, object],
-    delivery_hint: str = "immediate",
-) -> WorkEvent:
-    event_payload = dict(payload)
-    if run.method_id is not None:
-        event_payload["method_id"] = run.method_id
-    if run.plan_id is not None:
-        event_payload["plan_id"] = run.plan_id
-    if run.current_step_id is not None:
-        event_payload["step_id"] = run.current_step_id
-    return WorkEvent(
-        event_id=f"{run.run_id}-event-{sequence}",
-        kind=kind,
-        run_id=run.run_id,
-        session_id=run.session_id,
-        domain=run.domain,
-        operation_id=run.operation_id,
-        sequence=sequence,
-        created_at=created_at,
-        delivery_hint=delivery_hint,
-        payload=event_payload,
-    )
-
-
-def _operation_payload(
-    *,
-    text: str,
-    images: Sequence[object] | None,
-    method_id: str | None,
-    plan_id: str | None,
-    step_id: str | None,
-    step_index: int | None,
-    step_title: str | None,
-    planned_constraint: Mapping[str, object] | None,
-    audit_policy: Mapping[str, object] | None,
-    plan_facts: Mapping[str, object] | None,
-    step_facts: Mapping[str, object] | None,
-) -> dict[str, object]:
-    payload: dict[str, object] = {"text": text}
-    if images is not None:
-        payload["image_count"] = len(images)
-    if method_id is not None:
-        payload["method_id"] = method_id
-    if plan_id is not None:
-        payload["plan_id"] = plan_id
-    if step_id is not None:
-        payload["step_id"] = step_id
-    if step_index is not None:
-        payload["step_index"] = step_index
-    if step_title is not None:
-        payload["step_title"] = step_title
-    if planned_constraint:
-        payload["planned_constraint"] = dict(planned_constraint)
-    if audit_policy:
-        payload["audit_policy"] = dict(audit_policy)
-    if plan_facts:
-        payload["plan_facts"] = dict(plan_facts)
-    if step_facts:
-        payload["step_facts"] = dict(step_facts)
-    return payload
-
-
-def _step_payload(
-    *,
-    step_index: int | None,
-    step_title: str | None,
-    planned_constraint: Mapping[str, object] | None = None,
-    audit_policy: Mapping[str, object] | None = None,
-    plan_facts: Mapping[str, object] | None = None,
-    step_facts: Mapping[str, object] | None = None,
-    error: BaseException | None = None,
-) -> dict[str, object]:
-    payload: dict[str, object] = {"source_type": "work_shell"}
-    if step_index is not None:
-        payload["step_index"] = step_index
-    if step_title is not None:
-        payload["step_title"] = step_title
-    if planned_constraint:
-        payload["planned_constraint"] = dict(planned_constraint)
-    if audit_policy:
-        payload["audit_policy"] = dict(audit_policy)
-    if plan_facts:
-        payload["plan_facts"] = dict(plan_facts)
-    if step_facts:
-        payload["step_facts"] = dict(step_facts)
-    if error is not None:
-        payload["error"] = str(error)
-    return payload
-
-
-def _event_log_entry_from_work_event(event: WorkEvent) -> EventLogEntry:
-    return EventLogEntry(
-        entry_id=f"{event.run_id}-entry-{event.sequence}",
-        entry_type="event",
-        operation_id=event.operation_id,
-        event_id=event.event_id,
-        run_id=event.run_id,
-        session_id=event.session_id,
-        sequence=event.sequence,
-        payload={
-            "kind": event.kind,
-            "delivery_hint": event.delivery_hint,
-            "payload": dict(event.payload),
-            "source_event_ref": event.source_event_ref,
-        },
-        created_at=event.created_at,
-    )
+        return await runtime.wait(accepted.run_id)
 
 
 __all__ = ["CodingWorkShell", "PromptSession"]

--- a/src/loushang/work/__init__.py
+++ b/src/loushang/work/__init__.py
@@ -6,9 +6,11 @@ from loushang.work.types import (
     ArtifactStatus,
     DeliveryHint,
     WorkEvent,
+    WorkEventFact,
     WorkOperation,
     WorkPlanRun,
     WorkRun,
+    WorkRunSpec,
     WorkRunStatus,
     WorkStepDeviation,
     WorkStepRun,
@@ -24,9 +26,26 @@ if TYPE_CHECKING:
         JsonlEventLogBackend,
     )
     from loushang.work.plan_projection import project_work_plan_runs
+    from loushang.work.ports import (
+        WorkAcceptPort,
+        WorkCancelPort,
+        WorkDomainExecutor,
+        WorkExecutionContext,
+        WorkQueryPort,
+        WorkSubscribePort,
+        WorkWaitPort,
+    )
     from loushang.work.projection import (
         WorkEventProjectionContext,
         project_agent_event_to_work_events,
+    )
+    from loushang.work.runtime import (
+        DuplicateWorkOperationError,
+        UnknownWorkRunError,
+        WorkLifecycleOwnershipError,
+        WorkRunTerminalError,
+        WorkRuntime,
+        WorkRuntimeError,
     )
 
 _LAZY_EXPORTS = {
@@ -53,6 +72,25 @@ _LAZY_EXPORTS = {
         "loushang.work.plan_projection",
         "project_work_plan_runs",
     ),
+    "WorkAcceptPort": ("loushang.work.ports", "WorkAcceptPort"),
+    "WorkCancelPort": ("loushang.work.ports", "WorkCancelPort"),
+    "WorkDomainExecutor": ("loushang.work.ports", "WorkDomainExecutor"),
+    "WorkExecutionContext": ("loushang.work.ports", "WorkExecutionContext"),
+    "WorkQueryPort": ("loushang.work.ports", "WorkQueryPort"),
+    "WorkSubscribePort": ("loushang.work.ports", "WorkSubscribePort"),
+    "WorkWaitPort": ("loushang.work.ports", "WorkWaitPort"),
+    "DuplicateWorkOperationError": (
+        "loushang.work.runtime",
+        "DuplicateWorkOperationError",
+    ),
+    "UnknownWorkRunError": ("loushang.work.runtime", "UnknownWorkRunError"),
+    "WorkLifecycleOwnershipError": (
+        "loushang.work.runtime",
+        "WorkLifecycleOwnershipError",
+    ),
+    "WorkRunTerminalError": ("loushang.work.runtime", "WorkRunTerminalError"),
+    "WorkRuntime": ("loushang.work.runtime", "WorkRuntime"),
+    "WorkRuntimeError": ("loushang.work.runtime", "WorkRuntimeError"),
 }
 
 
@@ -70,6 +108,7 @@ __all__ = [
     "ArtifactRef",
     "ArtifactStatus",
     "DeliveryHint",
+    "DuplicateWorkOperationError",
     "EventLogBackend",
     "EventLogEntry",
     "EventPosition",
@@ -77,10 +116,24 @@ __all__ = [
     "JsonlEventLogBackend",
     "WorkEventProjectionContext",
     "WorkEvent",
+    "WorkEventFact",
+    "WorkAcceptPort",
+    "WorkCancelPort",
+    "WorkDomainExecutor",
+    "WorkExecutionContext",
+    "WorkLifecycleOwnershipError",
     "WorkOperation",
     "WorkPlanRun",
     "WorkRun",
     "WorkRunStatus",
+    "WorkRunSpec",
+    "WorkRunTerminalError",
+    "WorkRuntime",
+    "WorkRuntimeError",
+    "UnknownWorkRunError",
+    "WorkQueryPort",
+    "WorkSubscribePort",
+    "WorkWaitPort",
     "WorkStepDeviation",
     "WorkStepRun",
     "WorkStepStatus",

--- a/src/loushang/work/plan_projection.py
+++ b/src/loushang/work/plan_projection.py
@@ -39,7 +39,10 @@ def project_work_plan_runs(entries: Iterable[EventLogEntry]) -> tuple[WorkPlanRu
 
 
 def _starts_new_plan_attempt(kind: str, plan_state: _PlanState) -> bool:
-    return plan_state.status in {"completed", "failed", "cancelled"} and kind in {"SubmitCodingTurn", "WorkPlanStarted"}
+    return plan_state.status in {"completed", "failed", "cancelled"} and kind in {
+        "SubmitCodingTurn",
+        "WorkPlanStarted",
+    }
 
 
 @dataclass
@@ -71,6 +74,8 @@ class _PlanState:
         elif kind == "WorkPlanFailed":
             self.status = "failed"
             self.error = _entry_string_payload_value(entry, "error") or self.error
+        elif kind == "WorkPlanCancelled":
+            self.status = "cancelled"
         elif self.status == "accepted" and kind != "SubmitCodingTurn":
             self.status = "running"
 
@@ -137,6 +142,7 @@ class _StepState:
     started_sequence: int | None = None
     completed_sequence: int | None = None
     failed_sequence: int | None = None
+    cancelled_sequence: int | None = None
     error: str | None = None
     deviation: WorkStepDeviation | None = None
     planned_constraint: dict[str, object] | None = None
@@ -186,6 +192,9 @@ class _StepState:
             self.status = "failed"
             self.failed_sequence = entry.sequence
             self.error = _entry_string_payload_value(entry, "error") or self.error
+        elif kind == "WorkStepCancelled":
+            self.status = "cancelled"
+            self.cancelled_sequence = entry.sequence
 
     def to_step_run(self) -> WorkStepRun:
         metadata = _without_none(
@@ -195,6 +204,7 @@ class _StepState:
                 "started_sequence": self.started_sequence,
                 "completed_sequence": self.completed_sequence,
                 "failed_sequence": self.failed_sequence,
+                "cancelled_sequence": self.cancelled_sequence,
                 "error": self.error,
                 "deviation": asdict(self.deviation) if self.deviation is not None else None,
                 "planned_constraint": self.planned_constraint,

--- a/src/loushang/work/ports.py
+++ b/src/loushang/work/ports.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Protocol
+
+from loushang.work.event_log import EventLogEntry, EventPosition
+from loushang.work.types import (
+    WorkEvent,
+    WorkEventFact,
+    WorkOperation,
+    WorkRun,
+    WorkRunSpec,
+)
+
+
+class WorkExecutionContext(Protocol):
+    """The only Work capability exposed to a domain executor."""
+
+    @property
+    def run_id(self) -> str: ...
+
+    def publish(self, fact: WorkEventFact) -> WorkEvent: ...
+
+
+class WorkDomainExecutor(Protocol):
+    """Execute one accepted operation without owning its Work lifecycle."""
+
+    def execute(
+        self,
+        operation: WorkOperation,
+        context: WorkExecutionContext,
+    ) -> Awaitable[object]: ...
+
+
+class WorkAcceptPort(Protocol):
+    async def accept(
+        self,
+        operation: WorkOperation,
+        *,
+        spec: WorkRunSpec | None = None,
+    ) -> WorkRun: ...
+
+
+class WorkWaitPort(Protocol):
+    async def wait(self, run_id: str) -> WorkRun: ...
+
+
+class WorkCancelPort(Protocol):
+    async def cancel(self, run_id: str) -> WorkRun: ...
+
+
+class WorkSubscribePort(Protocol):
+    def subscribe(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+    ) -> AsyncIterator[EventLogEntry]: ...
+
+
+class WorkQueryPort(Protocol):
+    def query(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+        limit: int | None = None,
+    ) -> list[EventLogEntry]: ...
+
+
+WorkEventPublisher = Callable[[WorkEventFact], WorkEvent]
+
+
+__all__ = [
+    "WorkAcceptPort",
+    "WorkCancelPort",
+    "WorkDomainExecutor",
+    "WorkEventPublisher",
+    "WorkExecutionContext",
+    "WorkQueryPort",
+    "WorkSubscribePort",
+    "WorkWaitPort",
+]

--- a/src/loushang/work/projection.py
+++ b/src/loushang/work/projection.py
@@ -1,16 +1,16 @@
+"""Compatibility projection surface; Coding owns Agent-event product policy."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
-from typing import cast
 
-from loushang.agent.json_codec import serialize_tool_result
-from loushang.agent.types import AgentToolResult
-from loushang.ai.json_codec import serialize_assistant_message_event, serialize_message
-from loushang.ai.types import AssistantMessageEvent, Message
-from loushang.protocol import JsonValueError, require_json_mapping, require_json_value
-from loushang.work.types import DeliveryHint, WorkEvent
+from loushang.coding.work_projection import (
+    CodingWorkFactProjectionContext,
+    project_agent_event_to_work_facts,
+)
+from loushang.work.types import WorkEvent
 
 AgentMessageSerializer = Callable[[object], Mapping[str, object]]
 
@@ -33,354 +33,29 @@ def project_agent_event_to_work_events(
     *,
     context: WorkEventProjectionContext,
 ) -> list[WorkEvent]:
-    source_type = event.get("type")
-    if not isinstance(source_type, str):
-        raise ValueError("Agent event must include a string type")
-
-    if source_type == "agent_start":
-        return [
-            _event(
-                context,
-                kind="WorkRunStarted",
-                delivery_hint="immediate",
-                payload={"source_type": source_type},
-            )
-        ]
-    if source_type == "agent_end":
-        messages = event.get("messages", [])
-        return [
-            _event(
-                context,
-                kind="WorkRunCompleted",
-                delivery_hint="immediate",
-                payload={
-                    "source_type": source_type,
-                    "messages": _serialize_messages(
-                        messages,
-                        name="agent_event.messages",
-                        serializer=context.message_serializer,
-                    ),
-                },
-            ),
-        ]
-    if source_type == "turn_start":
-        return [
-            _event(
-                context,
-                kind="TaskStarted",
-                delivery_hint="immediate",
-                payload={"source_type": source_type},
-            )
-        ]
-    if source_type == "turn_end":
-        payload = _payload(event)
-        if "message" in event:
-            payload["message"] = _serialize_message(
-                event["message"],
-                name="agent_event.message",
-                serializer=context.message_serializer,
-            )
-        if "tool_results" in event:
-            payload["tool_results"] = _serialize_messages(
-                event["tool_results"],
-                name="agent_event.tool_results",
-                serializer=context.message_serializer,
-            )
-        return [
-            _event(
-                context,
-                kind="TaskCompleted",
-                delivery_hint="immediate",
-                payload=payload,
-            )
-        ]
-    if source_type in {"message_start", "message_update", "message_end"}:
-        payload = _payload(event)
-        if "message" in event:
-            payload["message"] = _serialize_message(
-                event["message"],
-                name="agent_event.message",
-                serializer=context.message_serializer,
-            )
-        if "assistant_message_event" in event:
-            payload["assistant_message_event"] = _serialize_assistant_event(
-                event["assistant_message_event"]
-            )
-        return [
-            _event(
-                context, kind="ContentDelta", delivery_hint="coalesce", payload=payload
-            )
-        ]
-    if source_type == "tool_execution_start":
-        payload = _payload(event, "tool_call_id", "tool_name")
-        if "args" in event:
-            payload["args"] = require_json_value(
-                event["args"],
-                name="agent_event.args",
-            )
-        return [
-            _event(
-                context,
-                kind="ToolCallStarted",
-                delivery_hint="coalesce",
-                payload=payload,
-            )
-        ]
-    if source_type == "tool_execution_update":
-        payload = _payload(event, "tool_call_id", "tool_name")
-        if "args" in event:
-            payload["args"] = require_json_value(
-                event["args"],
-                name="agent_event.args",
-            )
-        if "partial_result" in event:
-            payload["partial_result"] = _serialize_agent_tool_result(
-                event["partial_result"],
-                name="agent_event.partial_result",
-            )
-        return [
-            _event(
-                context,
-                kind="ToolCallProgress",
-                delivery_hint="coalesce",
-                payload=payload,
-            )
-        ]
-    if source_type == "tool_execution_end":
-        payload = _payload(
-            event,
-            "tool_call_id",
-            "tool_name",
-            "is_error",
-            "duration_ms",
-        )
-        if "result" in event:
-            payload["result"] = _serialize_agent_tool_result(
-                event["result"],
-                name="agent_event.result",
-            )
-        delivery_hint: DeliveryHint = (
-            "immediate" if event.get("is_error") is True else "coalesce"
-        )
-        return [
-            _event(
-                context,
-                kind="ToolCallCompleted",
-                delivery_hint=delivery_hint,
-                payload=payload,
-            )
-        ]
-    if source_type == "tool_policy_evaluated":
-        payload = _payload(
-            event,
-            "tool_call_id",
-            "tool_name",
-            "cwd",
-            "policy_disposition",
-            "policy_code",
-            "policy_reason",
-            "approval_required",
-            "argument_keys",
-            "path",
-            "file_path",
-            "command",
-        )
-        return [
-            _event(
-                context,
-                kind="ToolPolicyEvaluated",
-                delivery_hint="immediate",
-                payload=payload,
-            )
-        ]
-    if source_type == "tool_approval_requested":
-        payload = _payload(
-            event,
-            "tool_call_id",
-            "tool_name",
-            "cwd",
-            "action_id",
-            "policy_code",
-            "policy_reason",
-            "argument_keys",
-            "path",
-            "file_path",
-            "command",
-        )
-        return [
-            _event(
-                context,
-                kind="ToolApprovalRequested",
-                delivery_hint="immediate",
-                payload=payload,
-            )
-        ]
-    if source_type == "tool_approval_resolved":
-        payload = _payload(
-            event,
-            "tool_call_id",
-            "tool_name",
-            "cwd",
-            "action_id",
-            "approval_decision",
-            "approval_reason",
-            "policy_code",
-            "policy_reason",
-            "argument_keys",
-            "path",
-            "file_path",
-            "command",
-        )
-        return [
-            _event(
-                context,
-                kind="ToolApprovalResolved",
-                delivery_hint="immediate",
-                payload=payload,
-            )
-        ]
-    if source_type == "queue_update":
-        payload = _payload(event, "steering", "follow_up")
-        return [
-            _event(
-                context, kind="QueueUpdated", delivery_hint="coalesce", payload=payload
-            )
-        ]
-    if source_type in {"auto_retry_start", "auto_retry_end"}:
-        return [
-            _event(
-                context,
-                kind="RetryDiagnostic",
-                delivery_hint="immediate"
-                if event.get("success") is False
-                else "coalesce",
-                payload=dict(event),
-            ),
-        ]
-    if source_type in {"compaction_start", "compaction_end", "package_progress"}:
-        return [
-            _event(
-                context,
-                kind="MaintenanceProgress",
-                delivery_hint="coalesce",
-                payload=dict(event),
-            )
-        ]
-
-    return [
-        _event(context, kind="WorkEvent", delivery_hint="coalesce", payload=dict(event))
-    ]
-
-
-def _event(
-    context: WorkEventProjectionContext,
-    *,
-    kind: str,
-    delivery_hint: DeliveryHint,
-    payload: Mapping[str, object],
-) -> WorkEvent:
-    return WorkEvent(
-        event_id=f"{context.event_id_prefix}-{context.sequence}",
-        kind=kind,
-        run_id=context.run_id,
-        session_id=context.session_id,
-        domain=context.domain,
-        operation_id=context.operation_id,
-        sequence=context.sequence,
-        created_at=context.created_at,
-        delivery_hint=delivery_hint,
-        payload=cast(
-            Mapping[str, object],
-            require_json_mapping(
-                dict(payload),
-                name="work_event.payload",
-            ),
+    facts = project_agent_event_to_work_facts(
+        event,
+        context=CodingWorkFactProjectionContext(
+            source_event_ref=context.source_event_ref,
+            message_serializer=context.message_serializer,
         ),
-        source_event_ref=context.source_event_ref,
     )
-
-
-def _payload(event: Mapping[str, object], *keys: str) -> dict[str, object]:
-    payload: dict[str, object] = {"source_type": event["type"]}
-    for key in keys:
-        if key in event:
-            payload[key] = event[key]
-    return payload
-
-
-def _serialize_messages(
-    value: object,
-    *,
-    name: str,
-    serializer: AgentMessageSerializer | None,
-) -> list[object]:
-    if not isinstance(value, list):
-        raise TypeError(f"{name} must be a list")
     return [
-        _serialize_message(
-            message,
-            name=f"{name}[{index}]",
-            serializer=serializer,
+        WorkEvent(
+            event_id=f"{context.event_id_prefix}-{context.sequence + index}",
+            kind=fact.kind,
+            run_id=context.run_id,
+            session_id=context.session_id,
+            domain=context.domain,
+            operation_id=context.operation_id,
+            sequence=context.sequence + index,
+            created_at=context.created_at,
+            delivery_hint=fact.delivery_hint,
+            payload=fact.payload,
+            source_event_ref=fact.source_event_ref,
         )
-        for index, message in enumerate(value)
+        for index, fact in enumerate(facts)
     ]
-
-
-def _serialize_message(
-    value: object,
-    *,
-    name: str,
-    serializer: AgentMessageSerializer | None,
-) -> dict[str, object]:
-    if isinstance(value, Mapping):
-        return cast(
-            dict[str, object],
-            require_json_mapping(dict(value), name=name),
-        )
-    encoded = (
-        serializer(value)
-        if serializer is not None
-        else serialize_message(cast(Message, value))
-    )
-    return cast(
-        dict[str, object],
-        require_json_mapping(encoded, name=name),
-    )
-
-
-def _serialize_assistant_event(value: object) -> dict[str, object]:
-    if not isinstance(value, Mapping):
-        raise TypeError("agent_event.assistant_message_event must be a mapping")
-    try:
-        return cast(
-            dict[str, object],
-            require_json_mapping(
-                dict(value),
-                name="agent_event.assistant_message_event",
-            ),
-        )
-    except JsonValueError:
-        encoded = serialize_assistant_message_event(cast(AssistantMessageEvent, value))
-        return cast(
-            dict[str, object],
-            require_json_mapping(
-                encoded,
-                name="agent_event.assistant_message_event",
-            ),
-        )
-
-
-def _serialize_agent_tool_result(value: object, *, name: str) -> dict[str, object]:
-    if isinstance(value, AgentToolResult):
-        encoded = serialize_tool_result(value, target="event")
-    elif isinstance(value, Mapping):
-        encoded = dict(value)
-    else:
-        raise TypeError(f"{name} must be AgentToolResult or a projected JSON object")
-    return cast(
-        dict[str, object],
-        require_json_mapping(encoded, name=name),
-    )
 
 
 __all__ = [

--- a/src/loushang/work/runtime.py
+++ b/src/loushang/work/runtime.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from loushang.work.event_log import (
+    EventLogBackend,
+    EventLogEntry,
+    EventPosition,
+)
+from loushang.work.ports import WorkDomainExecutor, WorkExecutionContext
+from loushang.work.types import (
+    DeliveryHint,
+    WorkEvent,
+    WorkEventFact,
+    WorkOperation,
+    WorkRun,
+    WorkRunSpec,
+)
+
+_LIFECYCLE_EVENT_KINDS = frozenset(
+    {
+        "WorkRunStarted",
+        "WorkRunCancelling",
+        "WorkRunCompleted",
+        "WorkRunFailed",
+        "WorkRunCancelled",
+        "WorkPlanStarted",
+        "WorkPlanCompleted",
+        "WorkPlanFailed",
+        "WorkPlanCancelled",
+        "WorkStepStarted",
+        "WorkStepCompleted",
+        "WorkStepFailed",
+        "WorkStepCancelled",
+    }
+)
+
+
+class WorkRuntimeError(RuntimeError):
+    pass
+
+
+class UnknownWorkRunError(WorkRuntimeError):
+    pass
+
+
+class DuplicateWorkOperationError(WorkRuntimeError):
+    pass
+
+
+class WorkRunTerminalError(WorkRuntimeError):
+    pass
+
+
+class WorkLifecycleOwnershipError(WorkRuntimeError):
+    pass
+
+
+@dataclass
+class _RunState:
+    operation: WorkOperation
+    spec: WorkRunSpec
+    run: WorkRun
+    sequence: int = 0
+    task: asyncio.Task[None] | None = None
+    error: BaseException | None = None
+    terminal: bool = False
+
+
+@dataclass(frozen=True)
+class _ExecutionContext(WorkExecutionContext):
+    runtime: WorkRuntime
+    state: _RunState
+
+    @property
+    def run_id(self) -> str:
+        return self.state.run.run_id
+
+    def publish(self, fact: WorkEventFact) -> WorkEvent:
+        return self.runtime._publish_domain_fact(self.state, fact)
+
+
+class WorkRuntime:
+    """Accept operations and own their complete observable Work lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        executor: WorkDomainExecutor,
+        event_log: EventLogBackend,
+        clock: Callable[[], datetime] = lambda: datetime.now(UTC),
+    ) -> None:
+        self._executor = executor
+        self._event_log = event_log
+        self._clock = clock
+        self._states: dict[str, _RunState] = {}
+        self._operation_runs: dict[str, str] = {}
+
+    async def accept(
+        self,
+        operation: WorkOperation,
+        *,
+        spec: WorkRunSpec | None = None,
+    ) -> WorkRun:
+        if operation.operation_id in self._operation_runs:
+            raise DuplicateWorkOperationError(
+                f"operation already accepted: {operation.operation_id}"
+            )
+        resolved_spec = spec or WorkRunSpec()
+        run_id = resolved_spec.run_id or f"run-{uuid4().hex}"
+        if run_id in self._states:
+            raise DuplicateWorkOperationError(f"run already exists: {run_id}")
+        run = WorkRun(
+            run_id=run_id,
+            operation_id=operation.operation_id,
+            session_id=operation.session_id or "",
+            domain=operation.domain,
+            status="accepted",
+            method_id=resolved_spec.method_id,
+            plan_id=resolved_spec.plan_id,
+            current_step_id=resolved_spec.step_id,
+        )
+        state = _RunState(operation=operation, spec=resolved_spec, run=run)
+        self._append_operation(state)
+        self._states[run_id] = state
+        self._operation_runs[operation.operation_id] = run_id
+        state.task = asyncio.create_task(
+            self._execute(state), name=f"work-runtime:{run_id}"
+        )
+        return run
+
+    async def wait(self, run_id: str) -> WorkRun:
+        state = self._state(run_id)
+        task = state.task
+        if task is None:
+            raise WorkRuntimeError(f"run has no execution task: {run_id}")
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            await self.cancel(run_id)
+            raise
+        if state.error is not None:
+            if isinstance(state.error, asyncio.CancelledError):
+                raise asyncio.CancelledError(*state.error.args)
+            raise state.error
+        return state.run
+
+    async def cancel(self, run_id: str) -> WorkRun:
+        state = self._state(run_id)
+        if state.terminal:
+            return state.run
+        if state.run.status == "accepted":
+            self._start(state)
+        if state.run.status == "running":
+            self._begin_cancelling(state)
+        task = state.task
+        if task is not None and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        if not state.terminal:
+            self._finish_cancelled(state, asyncio.CancelledError())
+        return state.run
+
+    def get_run(self, run_id: str) -> WorkRun:
+        return self._state(run_id).run
+
+    def query(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+        limit: int | None = None,
+    ) -> list[EventLogEntry]:
+        return self._event_log.query(
+            run_id=run_id,
+            session_id=session_id,
+            after=after,
+            limit=limit,
+        )
+
+    def subscribe(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        after: EventPosition | None = None,
+    ) -> AsyncIterator[EventLogEntry]:
+        return self._event_log.subscribe(
+            run_id=run_id,
+            session_id=session_id,
+            after=after,
+        )
+
+    async def _execute(self, state: _RunState) -> None:
+        try:
+            if state.run.status == "accepted":
+                self._start(state)
+            await self._executor.execute(
+                state.operation,
+                _ExecutionContext(runtime=self, state=state),
+            )
+        except asyncio.CancelledError as error:
+            if not state.terminal:
+                if state.run.status == "accepted":
+                    self._start(state)
+                if state.run.status == "running":
+                    self._begin_cancelling(state)
+                self._finish_cancelled(state, error)
+        except Exception as error:
+            if not state.terminal:
+                if state.run.status == "cancelling":
+                    self._finish_cancelled(state, asyncio.CancelledError())
+                else:
+                    self._finish_failed(state, error)
+        else:
+            if not state.terminal:
+                if state.run.status == "cancelling":
+                    self._finish_cancelled(state, asyncio.CancelledError())
+                else:
+                    self._finish_completed(state)
+
+    def _start(self, state: _RunState) -> None:
+        if state.run.status != "accepted":
+            return
+        state.run = replace(state.run, status="running")
+        self._publish_lifecycle(
+            state,
+            kind="WorkRunStarted",
+            payload=state.spec.run_event_payload,
+        )
+        if state.spec.plan_id is not None and state.spec.emit_plan_start:
+            self._publish_lifecycle(
+                state,
+                kind="WorkPlanStarted",
+                payload=state.spec.scope_event_payload,
+                delivery_hint="coalesce",
+            )
+        if state.spec.step_id is not None:
+            self._publish_lifecycle(
+                state,
+                kind="WorkStepStarted",
+                payload=state.spec.scope_event_payload,
+                delivery_hint="coalesce",
+            )
+
+    def _begin_cancelling(self, state: _RunState) -> None:
+        if state.run.status != "running":
+            return
+        state.run = replace(state.run, status="cancelling")
+        self._publish_lifecycle(
+            state,
+            kind="WorkRunCancelling",
+            payload=state.spec.run_event_payload,
+        )
+
+    def _finish_completed(self, state: _RunState) -> None:
+        terminal_run = replace(state.run, status="completed")
+        if state.spec.step_id is not None:
+            self._publish_lifecycle(
+                state,
+                kind="WorkStepCompleted",
+                payload=state.spec.scope_event_payload,
+                delivery_hint="coalesce",
+            )
+        if state.spec.plan_id is not None and state.spec.emit_plan_completion:
+            self._publish_lifecycle(
+                state,
+                kind="WorkPlanCompleted",
+                payload=state.spec.scope_event_payload,
+                delivery_hint="final_only",
+            )
+        state.run = terminal_run
+        self._publish_terminal(
+            state,
+            kind="WorkRunCompleted",
+            payload=state.spec.run_event_payload,
+        )
+
+    def _finish_failed(self, state: _RunState, error: Exception) -> None:
+        state.error = error
+        failure_payload = {**dict(state.spec.scope_event_payload), "error": str(error)}
+        terminal_run = replace(state.run, status="failed")
+        if state.spec.step_id is not None:
+            self._publish_lifecycle(
+                state,
+                kind="WorkStepFailed",
+                payload=failure_payload,
+            )
+        if state.spec.plan_id is not None and state.spec.emit_plan_failure:
+            self._publish_lifecycle(
+                state,
+                kind="WorkPlanFailed",
+                payload=failure_payload,
+            )
+        state.run = terminal_run
+        self._publish_terminal(
+            state,
+            kind="WorkRunFailed",
+            payload=state.spec.run_event_payload,
+        )
+
+    def _finish_cancelled(
+        self, state: _RunState, error: asyncio.CancelledError
+    ) -> None:
+        if state.terminal:
+            return
+        state.error = error
+        terminal_run = replace(state.run, status="cancelled")
+        if state.spec.step_id is not None:
+            self._publish_lifecycle(
+                state,
+                kind="WorkStepCancelled",
+                payload=state.spec.scope_event_payload,
+            )
+        if state.spec.plan_id is not None:
+            self._publish_lifecycle(
+                state,
+                kind="WorkPlanCancelled",
+                payload=state.spec.scope_event_payload,
+            )
+        state.run = terminal_run
+        self._publish_terminal(
+            state,
+            kind="WorkRunCancelled",
+            payload=state.spec.run_event_payload,
+        )
+
+    def _publish_domain_fact(self, state: _RunState, fact: WorkEventFact) -> WorkEvent:
+        if fact.kind in _LIFECYCLE_EVENT_KINDS:
+            raise WorkLifecycleOwnershipError(
+                f"domain executor cannot publish Work lifecycle event: {fact.kind}"
+            )
+        if state.terminal:
+            raise WorkRunTerminalError(
+                f"cannot publish event after terminal run: {state.run.run_id}"
+            )
+        return self._append_event(
+            state,
+            kind=fact.kind,
+            payload=fact.payload,
+            delivery_hint=fact.delivery_hint,
+            source_event_ref=fact.source_event_ref,
+        )
+
+    def _publish_lifecycle(
+        self,
+        state: _RunState,
+        *,
+        kind: str,
+        payload: Mapping[str, object],
+        delivery_hint: DeliveryHint = "immediate",
+    ) -> WorkEvent:
+        if state.terminal:
+            raise WorkRunTerminalError(
+                f"cannot publish lifecycle after terminal run: {state.run.run_id}"
+            )
+        return self._append_event(
+            state,
+            kind=kind,
+            payload=self._lifecycle_payload(state, payload),
+            delivery_hint=delivery_hint,
+        )
+
+    def _publish_terminal(
+        self,
+        state: _RunState,
+        *,
+        kind: str,
+        payload: Mapping[str, object],
+    ) -> WorkEvent:
+        if state.terminal:
+            raise WorkRunTerminalError(
+                f"terminal event already published: {state.run.run_id}"
+            )
+        event = self._append_event(
+            state,
+            kind=kind,
+            payload=self._lifecycle_payload(state, payload),
+            delivery_hint="immediate",
+        )
+        state.terminal = True
+        return event
+
+    def _append_operation(self, state: _RunState) -> EventPosition:
+        operation = state.operation
+        return self._event_log.append(
+            EventLogEntry(
+                entry_id=f"{state.run.run_id}-operation-0",
+                entry_type="operation",
+                operation_id=operation.operation_id,
+                event_id=None,
+                run_id=state.run.run_id,
+                session_id=operation.session_id or "",
+                sequence=0,
+                payload={
+                    "kind": operation.kind,
+                    "domain": operation.domain,
+                    "payload": dict(operation.payload),
+                },
+                created_at=self._clock(),
+            )
+        )
+
+    def _append_event(
+        self,
+        state: _RunState,
+        *,
+        kind: str,
+        payload: Mapping[str, object],
+        delivery_hint: DeliveryHint,
+        source_event_ref: str | None = None,
+    ) -> WorkEvent:
+        state.sequence += 1
+        event = WorkEvent(
+            event_id=f"{state.run.run_id}-event-{state.sequence}",
+            kind=kind,
+            run_id=state.run.run_id,
+            session_id=state.run.session_id,
+            domain=state.run.domain,
+            operation_id=state.run.operation_id,
+            sequence=state.sequence,
+            created_at=self._clock(),
+            delivery_hint=delivery_hint,
+            payload=payload,
+            source_event_ref=source_event_ref,
+        )
+        self._event_log.append(_event_log_entry(event))
+        return event
+
+    def _lifecycle_payload(
+        self, state: _RunState, payload: Mapping[str, object]
+    ) -> dict[str, object]:
+        result = dict(payload)
+        if state.run.method_id is not None:
+            result["method_id"] = state.run.method_id
+        if state.run.plan_id is not None:
+            result["plan_id"] = state.run.plan_id
+        if state.run.current_step_id is not None:
+            result["step_id"] = state.run.current_step_id
+        return result
+
+    def _state(self, run_id: str) -> _RunState:
+        try:
+            return self._states[run_id]
+        except KeyError as error:
+            raise UnknownWorkRunError(f"unknown work run: {run_id}") from error
+
+
+def _event_log_entry(event: WorkEvent) -> EventLogEntry:
+    return EventLogEntry(
+        entry_id=f"{event.run_id}-entry-{event.sequence}",
+        entry_type="event",
+        operation_id=event.operation_id,
+        event_id=event.event_id,
+        run_id=event.run_id,
+        session_id=event.session_id,
+        sequence=event.sequence,
+        payload={
+            "kind": event.kind,
+            "delivery_hint": event.delivery_hint,
+            "payload": dict(event.payload),
+            "source_event_ref": event.source_event_ref,
+        },
+        created_at=event.created_at,
+    )
+
+
+__all__ = [
+    "DuplicateWorkOperationError",
+    "UnknownWorkRunError",
+    "WorkLifecycleOwnershipError",
+    "WorkRunTerminalError",
+    "WorkRuntime",
+    "WorkRuntimeError",
+]

--- a/src/loushang/work/types.py
+++ b/src/loushang/work/types.py
@@ -53,6 +53,31 @@ class WorkOperation:
 
 
 @dataclass(frozen=True)
+class WorkEventFact:
+    """A domain fact that Work will correlate, sequence, and persist."""
+
+    kind: str
+    payload: Mapping[str, object]
+    delivery_hint: DeliveryHint = "coalesce"
+    source_event_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkRunSpec:
+    """Work-owned lifecycle metadata supplied when an operation is accepted."""
+
+    run_id: str | None = None
+    method_id: str | None = None
+    plan_id: str | None = None
+    step_id: str | None = None
+    run_event_payload: Mapping[str, object] = field(default_factory=dict)
+    scope_event_payload: Mapping[str, object] = field(default_factory=dict)
+    emit_plan_start: bool = True
+    emit_plan_completion: bool = True
+    emit_plan_failure: bool = True
+
+
+@dataclass(frozen=True)
 class WorkRun:
     run_id: str
     operation_id: str
@@ -129,10 +154,12 @@ __all__ = [
     "ArtifactStatus",
     "DeliveryHint",
     "WorkEvent",
+    "WorkEventFact",
     "WorkOperation",
     "WorkPlanRun",
     "WorkRun",
     "WorkRunStatus",
+    "WorkRunSpec",
     "WorkStepDeviation",
     "WorkStepRun",
     "WorkStepStatus",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -363,10 +363,17 @@ def test_scenario_runtime_is_product_neutral_and_never_executes_shell() -> None:
 
 
 def test_coding_work_projection_subscribes_to_runtime_events() -> None:
-    source = Path("src/loushang/coding/work_shell.py").read_text(encoding="utf-8")
+    shell_source = Path("src/loushang/coding/work_shell.py").read_text(
+        encoding="utf-8"
+    )
+    executor_source = Path("src/loushang/coding/work_executor.py").read_text(
+        encoding="utf-8"
+    )
 
-    assert "subscribe_runtime_events" in source
-    assert "self.session.subscribe(listener)" not in source
+    assert "subscribe_runtime_events" in executor_source
+    assert "self.session.subscribe(listener)" not in executor_source
+    assert "WorkRuntime" in shell_source
+    assert "subscribe_runtime_events" not in shell_source
 
 
 def test_coding_session_uses_harness_runtime_events_as_the_only_internal_stream() -> (

--- a/tests/coding/test_work_shell.py
+++ b/tests/coding/test_work_shell.py
@@ -570,3 +570,109 @@ def test_coding_work_shell_records_step_and_plan_failures_before_run_failure() -
         assert entries[6].payload["payload"]["step_id"] == "inspect"
 
     asyncio.run(scenario())
+
+
+def test_coding_work_shell_unsubscribes_once_on_success_failure_and_cancellation() -> (
+    None
+):
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import InMemoryEventLogBackend
+
+    class TrackingSession:
+        def __init__(self, outcome: str) -> None:
+            self.outcome = outcome
+            self.listener = None
+            self.prompt_started = asyncio.Event()
+            self.unsubscribe_calls = 0
+
+        def subscribe_runtime_events(self, listener):
+            self.listener = listener
+
+            def unsubscribe() -> None:
+                self.unsubscribe_calls += 1
+                self.listener = None
+
+            return unsubscribe
+
+        async def prompt(self, text: str, images=None) -> None:
+            del text, images
+            self.prompt_started.set()
+            if self.outcome == "failure":
+                raise RuntimeError("prompt failed")
+            if self.outcome == "cancellation":
+                await asyncio.Event().wait()
+
+    async def scenario() -> None:
+        for outcome in ("success", "failure", "cancellation"):
+            event_log = InMemoryEventLogBackend()
+            session = TrackingSession(outcome)
+            shell = CodingWorkShell(session=session, event_log=event_log)
+            task = asyncio.create_task(
+                shell.submit_coding_turn(
+                    outcome,
+                    session_id="session-1",
+                    operation_id=f"op-{outcome}",
+                    run_id=f"run-{outcome}",
+                )
+            )
+            await session.prompt_started.wait()
+            if outcome == "cancellation":
+                task.cancel()
+            try:
+                await task
+            except RuntimeError:
+                assert outcome == "failure"
+            except asyncio.CancelledError:
+                assert outcome == "cancellation"
+
+            assert session.unsubscribe_calls == 1
+            assert session.listener is None
+            entries = event_log.query(run_id=f"run-{outcome}")
+            terminal_kinds = {
+                "WorkRunCompleted",
+                "WorkRunFailed",
+                "WorkRunCancelled",
+            }
+            assert sum(
+                entry.payload["kind"] in terminal_kinds for entry in entries
+            ) == 1
+            assert entries[-1].payload["kind"] in terminal_kinds
+
+    asyncio.run(scenario())
+
+
+def test_agent_start_and_end_are_non_terminal_invocation_facts() -> None:
+    from loushang.coding.work_shell import CodingWorkShell
+    from loushang.work import InMemoryEventLogBackend
+
+    async def scenario() -> None:
+        event_log = InMemoryEventLogBackend()
+        shell = CodingWorkShell(
+            session=FakePromptSession(
+                events=[
+                    {"type": "agent_start"},
+                    {"type": "agent_end", "messages": []},
+                ]
+            ),
+            event_log=event_log,
+        )
+
+        await shell.submit_coding_turn(
+            "run",
+            session_id="session-1",
+            operation_id="op-1",
+            run_id="run-1",
+        )
+
+        kinds = [entry.payload["kind"] for entry in event_log.query(run_id="run-1")]
+        assert kinds == [
+            "SubmitCodingTurn",
+            "WorkRunStarted",
+            "AgentInvocationStarted",
+            "AgentInvocationCompleted",
+            "WorkRunCompleted",
+        ]
+        assert kinds.count("WorkRunStarted") == 1
+        assert kinds.count("WorkRunCompleted") == 1
+
+    asyncio.run(scenario())

--- a/tests/work/test_agent_event_projection.py
+++ b/tests/work/test_agent_event_projection.py
@@ -28,15 +28,15 @@ def test_project_agent_start_and_end_events() -> None:
         {"type": "agent_end", "messages": []}, context=_context(2)
     )
 
-    assert [event.kind for event in started] == ["WorkRunStarted"]
+    assert [event.kind for event in started] == ["AgentInvocationStarted"]
     assert started[0].event_id == "event-1"
-    assert started[0].delivery_hint == "immediate"
+    assert started[0].delivery_hint == "coalesce"
     assert started[0].payload == {"source_type": "agent_start"}
     assert started[0].source_event_ref == "agent-event-1"
 
-    assert [event.kind for event in completed] == ["WorkRunCompleted"]
+    assert [event.kind for event in completed] == ["AgentInvocationCompleted"]
     assert completed[0].event_id == "event-2"
-    assert completed[0].delivery_hint == "immediate"
+    assert completed[0].delivery_hint == "coalesce"
     assert completed[0].payload == {"source_type": "agent_end", "messages": []}
 
 

--- a/tests/work/test_package_boundaries.py
+++ b/tests/work/test_package_boundaries.py
@@ -8,3 +8,33 @@ def test_work_package_does_not_own_coding_work_shell_implementation() -> None:
 
     assert "class CodingWorkShell" not in text
     assert "SubmitCodingTurn" not in text
+
+
+def test_work_runtime_is_product_neutral_and_harness_does_not_import_work() -> None:
+    work_runtime = Path("src/loushang/work/runtime.py").read_text(encoding="utf-8")
+    coding_shell = Path("src/loushang/coding/work_shell.py").read_text(
+        encoding="utf-8"
+    )
+    coding_executor = Path("src/loushang/coding/work_executor.py").read_text(
+        encoding="utf-8"
+    )
+    harness_source = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in Path("src/loushang/harness").rglob("*.py")
+    )
+
+    assert "loushang.coding" not in work_runtime
+    assert "loushang.harness" not in work_runtime
+    assert "loushang.agent" not in work_runtime
+    assert "class WorkRuntime" in work_runtime
+    assert "WorkRunStarted" in work_runtime
+    assert "WorkRunCompleted" in work_runtime
+
+    assert "WorkRunStarted" not in coding_shell
+    assert "WorkRunCompleted" not in coding_shell
+    assert "event_log.append" not in coding_shell
+    assert "WorkRunStarted" not in coding_executor
+    assert "WorkRunCompleted" not in coding_executor
+
+    assert "loushang.work" not in harness_source
+    assert not Path("src/loushang/harness/work").exists()

--- a/tests/work/test_plan_projection.py
+++ b/tests/work/test_plan_projection.py
@@ -235,6 +235,60 @@ def test_project_work_plan_runs_replays_failed_step_and_plan_error() -> None:
     assert plan.steps[0].metadata["failed_sequence"] == 4
 
 
+def test_project_work_plan_runs_replays_cancelled_step_and_plan() -> None:
+    from loushang.work import project_work_plan_runs
+
+    plans = project_work_plan_runs(
+        [
+            _entry(
+                "run-verify-plan-started",
+                kind="WorkPlanStarted",
+                run_id="run-verify",
+                sequence=1,
+                step_id="verify",
+                step_index=1,
+            ),
+            _entry(
+                "run-verify-step-started",
+                kind="WorkStepStarted",
+                run_id="run-verify",
+                sequence=2,
+                step_id="verify",
+                step_index=1,
+            ),
+            _entry(
+                "run-verify-step-cancelled",
+                kind="WorkStepCancelled",
+                run_id="run-verify",
+                sequence=3,
+                step_id="verify",
+                step_index=1,
+            ),
+            _entry(
+                "run-verify-plan-cancelled",
+                kind="WorkPlanCancelled",
+                run_id="run-verify",
+                sequence=4,
+                step_id="verify",
+                step_index=1,
+            ),
+            _entry(
+                "run-verify-run-cancelled",
+                kind="WorkRunCancelled",
+                run_id="run-verify",
+                sequence=5,
+                step_id="verify",
+                step_index=1,
+            ),
+        ]
+    )
+
+    assert len(plans) == 1
+    assert plans[0].status == "cancelled"
+    assert plans[0].steps[0].status == "cancelled"
+    assert plans[0].steps[0].metadata["cancelled_sequence"] == 3
+
+
 def test_project_work_plan_runs_replays_step_deviation_metadata() -> None:
     from loushang.work import project_work_plan_runs
 

--- a/tests/work/test_public_api.py
+++ b/tests/work/test_public_api.py
@@ -8,17 +8,32 @@ def test_work_public_api_exposes_current_work_surface_without_multi_agent_types(
         "ArtifactRef",
         "ArtifactStatus",
         "DeliveryHint",
+        "DuplicateWorkOperationError",
         "EventLogBackend",
         "EventLogEntry",
         "EventPosition",
         "InMemoryEventLogBackend",
         "JsonlEventLogBackend",
         "WorkEvent",
+        "WorkEventFact",
         "WorkEventProjectionContext",
+        "WorkAcceptPort",
+        "WorkCancelPort",
+        "WorkDomainExecutor",
+        "WorkExecutionContext",
+        "WorkLifecycleOwnershipError",
         "WorkOperation",
         "WorkPlanRun",
         "WorkRun",
         "WorkRunStatus",
+        "WorkRunSpec",
+        "WorkRunTerminalError",
+        "WorkRuntime",
+        "WorkRuntimeError",
+        "UnknownWorkRunError",
+        "WorkQueryPort",
+        "WorkSubscribePort",
+        "WorkWaitPort",
         "WorkStepDeviation",
         "WorkStepRun",
         "WorkStepStatus",
@@ -31,6 +46,26 @@ def test_work_public_api_exposes_current_work_surface_without_multi_agent_types(
     assert not hasattr(work, "CollaborationBus")
     assert not hasattr(work, "CodingWorkShell")
     assert not hasattr(work, "PromptSession")
+
+
+def test_work_ports_are_split_by_runtime_capability() -> None:
+    from loushang.work.ports import (
+        WorkAcceptPort,
+        WorkCancelPort,
+        WorkDomainExecutor,
+        WorkExecutionContext,
+        WorkQueryPort,
+        WorkSubscribePort,
+        WorkWaitPort,
+    )
+
+    assert set(WorkAcceptPort.__dict__) >= {"accept"}
+    assert set(WorkWaitPort.__dict__) >= {"wait"}
+    assert set(WorkCancelPort.__dict__) >= {"cancel"}
+    assert set(WorkSubscribePort.__dict__) >= {"subscribe"}
+    assert set(WorkQueryPort.__dict__) >= {"query"}
+    assert set(WorkDomainExecutor.__dict__) >= {"execute"}
+    assert set(WorkExecutionContext.__dict__) >= {"run_id", "publish"}
 
 
 def test_work_projection_exports_remain_available_from_the_root_package() -> None:

--- a/tests/work/test_runtime.py
+++ b/tests/work/test_runtime.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+
+def _operation():
+    from loushang.work import WorkOperation
+
+    return WorkOperation(
+        operation_id="op-1",
+        kind="TestOperation",
+        session_id="session-1",
+        domain="test",
+        payload={"input": "hello"},
+    )
+
+
+def _spec():
+    from loushang.work import WorkRunSpec
+
+    return WorkRunSpec(
+        run_id="run-1",
+        method_id="method-1",
+        plan_id="plan-1",
+        step_id="step-1",
+        run_event_payload={"source_type": "test"},
+        scope_event_payload={"step_index": 0, "step_title": "Test step"},
+    )
+
+
+def _clock():
+    return datetime(2026, 7, 20, 10, 0, tzinfo=UTC)
+
+
+@dataclass
+class _ControlledExecutor:
+    started: asyncio.Event
+    release: asyncio.Event
+    context: object | None = None
+
+    async def execute(self, operation, context):
+        from loushang.work import WorkEventFact
+
+        self.context = context
+        context.publish(
+            WorkEventFact(
+                kind="DomainFact",
+                payload={"operation_kind": operation.kind},
+                source_event_ref="source-1",
+            )
+        )
+        self.started.set()
+        await self.release.wait()
+        return {"ok": True}
+
+
+def test_work_runtime_accepts_runs_and_owns_success_lifecycle() -> None:
+    from loushang.work import InMemoryEventLogBackend, WorkEventFact, WorkRuntime
+
+    async def scenario() -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+        executor = _ControlledExecutor(started=started, release=release)
+        runtime = WorkRuntime(
+            executor=executor,
+            event_log=InMemoryEventLogBackend(),
+            clock=_clock,
+        )
+
+        accepted = await runtime.accept(_operation(), spec=_spec())
+
+        assert accepted.status == "accepted"
+        assert runtime.get_run("run-1").status == "accepted"
+        assert [entry.payload["kind"] for entry in runtime.query(run_id="run-1")] == [
+            "TestOperation"
+        ]
+
+        await started.wait()
+        assert runtime.get_run("run-1").status == "running"
+        release.set()
+        completed = await runtime.wait("run-1")
+
+        assert completed.status == "completed"
+        entries = runtime.query(run_id="run-1")
+        assert [entry.sequence for entry in entries] == list(range(len(entries)))
+        assert [entry.payload["kind"] for entry in entries] == [
+            "TestOperation",
+            "WorkRunStarted",
+            "WorkPlanStarted",
+            "WorkStepStarted",
+            "DomainFact",
+            "WorkStepCompleted",
+            "WorkPlanCompleted",
+            "WorkRunCompleted",
+        ]
+        assert entries[4].payload["source_event_ref"] == "source-1"
+        assert entries[-1].payload["payload"] == {
+            "source_type": "test",
+            "method_id": "method-1",
+            "plan_id": "plan-1",
+            "step_id": "step-1",
+        }
+
+        assert executor.context is not None
+        try:
+            executor.context.publish(WorkEventFact(kind="LateFact", payload={}))
+        except Exception as error:
+            assert type(error).__name__ == "WorkRunTerminalError"
+        else:
+            raise AssertionError("expected terminal event rejection")
+        assert runtime.query(run_id="run-1") == entries
+
+    asyncio.run(scenario())
+
+
+def test_work_runtime_orders_step_plan_and_run_failure_and_reraises() -> None:
+    from loushang.work import InMemoryEventLogBackend, WorkRuntime
+
+    class FailingExecutor:
+        async def execute(self, operation, context):
+            del operation, context
+            raise RuntimeError("domain failed")
+
+    async def scenario() -> None:
+        runtime = WorkRuntime(
+            executor=FailingExecutor(),
+            event_log=InMemoryEventLogBackend(),
+            clock=_clock,
+        )
+        await runtime.accept(_operation(), spec=_spec())
+
+        try:
+            await runtime.wait("run-1")
+        except RuntimeError as error:
+            assert str(error) == "domain failed"
+        else:
+            raise AssertionError("expected domain failure")
+
+        assert runtime.get_run("run-1").status == "failed"
+        entries = runtime.query(run_id="run-1")
+        assert [entry.payload["kind"] for entry in entries][-3:] == [
+            "WorkStepFailed",
+            "WorkPlanFailed",
+            "WorkRunFailed",
+        ]
+        assert entries[-3].payload["payload"]["error"] == "domain failed"
+        assert (
+            sum(
+                entry.payload["kind"]
+                in {"WorkRunCompleted", "WorkRunFailed", "WorkRunCancelled"}
+                for entry in entries
+            )
+            == 1
+        )
+
+    asyncio.run(scenario())
+
+
+def test_work_runtime_cancel_transitions_and_terminal_order_are_deterministic() -> None:
+    from loushang.work import InMemoryEventLogBackend, WorkRuntime
+
+    async def scenario() -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+        runtime = WorkRuntime(
+            executor=_ControlledExecutor(started=started, release=release),
+            event_log=InMemoryEventLogBackend(),
+            clock=_clock,
+        )
+        await runtime.accept(_operation(), spec=_spec())
+        await started.wait()
+
+        cancelled = await runtime.cancel("run-1")
+
+        assert cancelled.status == "cancelled"
+        assert [entry.payload["kind"] for entry in runtime.query(run_id="run-1")][
+            -4:
+        ] == [
+            "WorkRunCancelling",
+            "WorkStepCancelled",
+            "WorkPlanCancelled",
+            "WorkRunCancelled",
+        ]
+        try:
+            await runtime.wait("run-1")
+        except asyncio.CancelledError:
+            pass
+        else:
+            raise AssertionError("expected cancellation")
+
+        entries = runtime.query(run_id="run-1")
+        assert entries[-1].payload["kind"] == "WorkRunCancelled"
+        assert (
+            sum(entry.payload["kind"] == "WorkRunCancelled" for entry in entries) == 1
+        )
+
+    asyncio.run(scenario())
+
+
+def test_work_runtime_cancel_before_executor_starts_still_follows_full_state_path() -> (
+    None
+):
+    from loushang.work import InMemoryEventLogBackend, WorkRuntime
+
+    async def scenario() -> None:
+        runtime = WorkRuntime(
+            executor=_ControlledExecutor(
+                started=asyncio.Event(), release=asyncio.Event()
+            ),
+            event_log=InMemoryEventLogBackend(),
+            clock=_clock,
+        )
+        await runtime.accept(_operation(), spec=_spec())
+
+        cancelled = await runtime.cancel("run-1")
+
+        assert cancelled.status == "cancelled"
+        assert [entry.payload["kind"] for entry in runtime.query(run_id="run-1")] == [
+            "TestOperation",
+            "WorkRunStarted",
+            "WorkPlanStarted",
+            "WorkStepStarted",
+            "WorkRunCancelling",
+            "WorkStepCancelled",
+            "WorkPlanCancelled",
+            "WorkRunCancelled",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_executor_cancelled_error_is_a_cancelled_run_not_a_failure() -> None:
+    from loushang.work import InMemoryEventLogBackend, WorkRuntime
+
+    class CancelledExecutor:
+        async def execute(self, operation, context):
+            del operation, context
+            raise asyncio.CancelledError("executor cancelled")
+
+    async def scenario() -> None:
+        runtime = WorkRuntime(
+            executor=CancelledExecutor(),
+            event_log=InMemoryEventLogBackend(),
+            clock=_clock,
+        )
+        await runtime.accept(_operation(), spec=_spec())
+
+        try:
+            await runtime.wait("run-1")
+        except asyncio.CancelledError as error:
+            assert error.args == ("executor cancelled",)
+        else:
+            raise AssertionError("expected cancellation")
+
+        kinds = [entry.payload["kind"] for entry in runtime.query(run_id="run-1")]
+        assert "WorkRunFailed" not in kinds
+        assert kinds[-4:] == [
+            "WorkRunCancelling",
+            "WorkStepCancelled",
+            "WorkPlanCancelled",
+            "WorkRunCancelled",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_domain_executor_cannot_publish_work_lifecycle_events() -> None:
+    from loushang.work import InMemoryEventLogBackend, WorkEventFact, WorkRuntime
+
+    class InvalidExecutor:
+        async def execute(self, operation, context):
+            del operation
+            context.publish(WorkEventFact(kind="WorkRunCompleted", payload={}))
+
+    async def scenario() -> None:
+        runtime = WorkRuntime(
+            executor=InvalidExecutor(),
+            event_log=InMemoryEventLogBackend(),
+            clock=_clock,
+        )
+        await runtime.accept(_operation(), spec=_spec())
+
+        try:
+            await runtime.wait("run-1")
+        except Exception as error:
+            assert type(error).__name__ == "WorkLifecycleOwnershipError"
+        else:
+            raise AssertionError("expected lifecycle ownership failure")
+
+        kinds = [entry.payload["kind"] for entry in runtime.query(run_id="run-1")]
+        assert kinds.count("WorkRunCompleted") == 0
+        assert kinds[-1] == "WorkRunFailed"
+
+    asyncio.run(scenario())
+
+
+def test_work_runtime_subscribe_replays_and_streams_runtime_owned_log() -> None:
+    from loushang.work import InMemoryEventLogBackend, WorkRuntime
+
+    class ImmediateExecutor:
+        async def execute(self, operation, context):
+            del operation, context
+            return None
+
+    async def scenario() -> None:
+        runtime = WorkRuntime(
+            executor=ImmediateExecutor(),
+            event_log=InMemoryEventLogBackend(),
+            clock=_clock,
+        )
+        accepted = await runtime.accept(_operation(), spec=_spec())
+        stream = runtime.subscribe(run_id=accepted.run_id)
+
+        operation_entry = await asyncio.wait_for(anext(stream), timeout=0.1)
+        assert operation_entry.payload["kind"] == "TestOperation"
+        await runtime.wait(accepted.run_id)
+
+        streamed = [
+            await asyncio.wait_for(anext(stream), timeout=0.1) for _ in range(6)
+        ]
+        assert streamed[-1].payload["kind"] == "WorkRunCompleted"
+        await stream.aclose()
+
+    asyncio.run(scenario())
+
+
+def test_work_runtime_allocates_unique_run_ids_and_rejects_duplicate_operations() -> (
+    None
+):
+    from loushang.work import InMemoryEventLogBackend, WorkOperation, WorkRuntime
+    from loushang.work.runtime import DuplicateWorkOperationError
+
+    class ImmediateExecutor:
+        async def execute(self, operation, context):
+            del operation, context
+            return None
+
+    async def scenario() -> None:
+        runtime = WorkRuntime(
+            executor=ImmediateExecutor(),
+            event_log=InMemoryEventLogBackend(),
+            clock=_clock,
+        )
+        first_operation = _operation()
+        second_operation = WorkOperation(
+            operation_id="op-2",
+            kind="TestOperation",
+            session_id="session-1",
+            domain="test",
+            payload={},
+        )
+
+        first = await runtime.accept(first_operation)
+        second = await runtime.accept(second_operation)
+
+        assert first.run_id.startswith("run-")
+        assert second.run_id.startswith("run-")
+        assert first.run_id != second.run_id
+        await runtime.wait(first.run_id)
+        await runtime.wait(second.run_id)
+        try:
+            await runtime.accept(first_operation)
+        except DuplicateWorkOperationError:
+            pass
+        else:
+            raise AssertionError("expected duplicate operation rejection")
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## What changed

- Add focused Work accept/wait/cancel/subscribe/query ports and an injected domain-executor contract.
- Make `WorkRuntime` the sole owner of operation acceptance, run IDs, run/plan/step lifecycle events, sequence allocation, terminal state, event-log append, subscription, and query.
- Move generic lifecycle and logging behavior out of `CodingWorkShell`; keep Coding payload, images, session prompt, product event projection, method/plan metadata, and error policy in a thin executor/facade.
- Project `agent_start`/`agent_end` as non-terminal invocation facts so they cannot create duplicate Work run lifecycle events.
- Add cancellation replay support and state-machine, unique-terminal, ordering, unsubscribe, replay, compatibility, and import-boundary coverage.

## Why

The Coding shell previously duplicated Work ownership and agent lifecycle projection could produce a second run start or terminal event. This change establishes the existing top-level `loushang.work` package as the single Work owner while keeping Harness product-neutral and preserving prompt/print behavior.

## Validation

- Ruff checks for changed Work/Coding/test modules
- 66 Work, work-shell, compatibility, and prompt tests
- 271 print-mode and CLI tests
- 85 architecture-boundary, Channel, and Method tests
- `git diff --check`

## Impact

Public prompt parameters, image forwarding, print output, JSONL work-log replay, and compatibility imports remain intact. `agent_start` and `agent_end` now appear as `AgentInvocationStarted` and `AgentInvocationCompleted` facts instead of Work run lifecycle events.
