### PR TITLE
refactor(harness): share product transcript lifecycle store / 重用产品 transcript 生命周期存储

### DIFF
--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -29,6 +29,9 @@ planning, work event persistence, or AI provider behavior.
   for turning Coding into a declarative Product adapter.
 - [Coding Shared-Layer Migration Ledger](coding-shared-layer-migration-ledger.md)
   records the concrete source-to-owner cutover scope for each delivery wave.
+- [Coding Shared-Layer Owner Rebaseline](coding-shared-layer-owner-rebaseline.md)
+  records shared owners, actual Coding adapters and kernels, and the source
+  boundary required before a further migration wave can claim LOC.
 - [Diagnostics Export Boundary](diagnostics-export-boundary.md) defines the
   reusable archive, structural redaction, and product projection contract.
 - [Slice 1 Closure Status](slice-1-status.md) records the approval, tools-core,

--- a/docs/internals/architecture/harness/coding-shared-layer-migration-ledger.md
+++ b/docs/internals/architecture/harness/coding-shared-layer-migration-ledger.md
@@ -6,6 +6,11 @@ It is deliberately a ledger, not a second design document: a wave cannot start
 until its source regions, final owners, injection points, and deletion condition
 are listed here.
 
+[Coding Shared-Layer Owner Rebaseline](coding-shared-layer-owner-rebaseline.md)
+is the Wave R evidence for this ledger. It distinguishes shared mechanisms that
+are already adopted from actual Coding duplicates; only the latter may support a
+future migration LOC claim.
+
 ## Ownership Rules
 
 Move an implementation out of `loushang.coding` when it implements a mechanism,
@@ -122,3 +127,22 @@ Wave 3 closure probes:
   result, then deletes the admitted duplicate handlers;
 - `harness.session.command_pack` has no Coding, provider/auth, transport, or
   UI import.
+
+### Wave 4 First Slice: Product Transcript Lifecycle Store (Complete)
+
+| Source region | Shared owner | Product injection or retained Coding owner | Deletion condition |
+| --- | --- | --- | --- |
+| removed `coding.runtime.agent_session_runtime._CodingSessionLifecycleStore` | `harness.session.ProductTranscriptSessionLifecycleStore` | Coding supplies transcript create/restore/fork/dispose ports, CWD restore validation, session construction, fork selection, lifecycle hooks, and extension/diagnostic behavior. | Complete: Harness owns the common transcript-to-runtime lifecycle adapter and releases a transcript when Product runtime construction fails. |
+| proposed bootstrap transaction | existing `ConfigActivationRuntime` and capability/session runtimes | Coding retains activation callbacks, Product services, prompt/model/resource/tool policy, CWD/session-file acceptance, and final session construction. | Deferred: no second bootstrap engine is admitted while the existing activation runtime owns ordering and rollback. |
+
+Wave 4 first-slice accounting: `coding.runtime.agent_session_runtime` is 1,187
+to 1,158 LOC (-29); `harness.session.transcript_lifecycle` is 216 to 371 LOC
+(+155). Tests and documentation do not count as migrated implementation.
+
+Wave 4 first-slice probes:
+
+- a fake Product creates and forks a runtime session through the shared store
+  without importing Coding;
+- failed Product runtime construction disposes the opened transcript;
+- Coding lifecycle, bootstrap, and import-boundary regressions preserve CWD,
+  fork, extension, and diagnostic behavior.

--- a/docs/internals/architecture/harness/coding-shared-layer-migration-plan.md
+++ b/docs/internals/architecture/harness/coding-shared-layer-migration-plan.md
@@ -103,7 +103,9 @@ transfer remains a stretch interval until the following rebaseline is complete.
 
 ### Wave R: Owner And Duplicate Rebaseline
 
-Wave R is mandatory and does not claim migration LOC. It must produce a
+Wave R is complete at `lane/harness` commit `336adbf2`; its reviewable result is
+[Coding Shared-Layer Owner Rebaseline](coding-shared-layer-owner-rebaseline.md).
+It does not claim migration LOC. The rebaseline must produce a
 machine-readable or reviewable ledger for every planned source region with:
 
 - pre-change Coding canonical LOC;

--- a/docs/internals/architecture/harness/coding-shared-layer-owner-rebaseline.md
+++ b/docs/internals/architecture/harness/coding-shared-layer-owner-rebaseline.md
@@ -1,0 +1,110 @@
+# Coding Shared-Layer Owner Rebaseline
+
+## Status
+
+Status: Wave R baseline for `lane/harness`.
+
+This is the mandatory owner rebaseline from
+[Coding To Shared-Layer Migration Plan](coding-shared-layer-migration-plan.md).
+It records the state after `lane/harness` commit `336adbf2`. Figures are
+production Python LOC from `wc -l`, excluding tests, documentation, re-exports,
+and resource assets. A later wave may claim migration LOC only after it deletes
+the identified Coding implementation and records the actual delta here.
+
+## Classification
+
+| Classification | Meaning |
+| --- | --- |
+| `shared adopted` | A shared owner already performs the mechanism. The Coding code is a Product binding, projection, or adapter and must not be counted again. |
+| `duplicate candidate` | Coding still implements a reusable mechanism, pending a concrete port/profile contract and a fake-Product probe. |
+| `product adapter` | Coding binds shared mechanisms to Product policy, content, or compatibility. It may shrink but is not a mechanical move. |
+| `product kernel` | Coding owns semantics, compatibility, UI, provider/model policy, or final presentation. It stays in Coding. |
+
+## Session And Host
+
+| Source region | LOC | Current shared owner or adopted mechanism | Classification | Next action |
+| --- | ---: | --- | --- | --- |
+| `coding.bootstrap` | 1,491 | Config activation, capability composition, resources, diagnostics, `SessionRuntime` | `product adapter` + `duplicate candidate` | Wave 4 bootstrap-transaction contract |
+| `coding.runtime.agent_session_runtime` | 1,187 | `SessionLifecycleRuntime`, `AgentTranscriptSessionRuntime`, transcript catalog | `product adapter` | First transcript-store cutover complete; retain Product ports and continue facade audit |
+| `coding.session.agent_session` | 1,890 | `SessionRuntime`, `SessionFacade`, transcript maintenance, queue, retry, compaction | `product adapter` | Facade deletion only after the factory contract |
+| `coding.session.builtin_commands` | 716 | `harness.session.command_pack` | `shared adopted` | Close descriptor/projection deletion only |
+| `coding.session.command_controller` | 239 | `SessionCommandRuntime`, command sources | `shared adopted` | Retain Product source/result binding |
+| `coding.mode.rpc_mode` | 2,739 | Channel JSONL host/router/task tracker; `SessionOperationRuntime` | `product adapter` | Wave 5 golden-contract cutover |
+| `coding.mode.print_mode`, `channel_mode`, `base` | 1,201 | Channel host lifecycle, HarnessTUI plain-conversation primitives | `product adapter` + `shared adopted` | Wave 5 neutral host probe |
+| `coding.prompt_command` | 323 | Prompt assembly and command parsing | `product kernel` | Retain Coding Work semantics |
+
+Coding remains responsible in this group for service factories, the Coding
+transcript store, CWD/session-file acceptance, model/provider decisions,
+extension API, prompts, resource package, final RPC schema, and output wording.
+
+## Extensions, Events, And Configuration
+
+| Source region | LOC | Current shared owner or adopted mechanism | Classification | Next action |
+| --- | ---: | --- | --- | --- |
+| `coding.extensions.runner` | 495 | `harness.extensions.agent.*`, `harness.extensions.session_runtime` | `product adapter` | Shrink-only adapter audit |
+| `coding.extensions.api/loader/policy` | 210 | Harness extension contracts and loader | `product adapter` | Retain Coding API and permission delta |
+| `coding.event.*` | 1,045 | Harness facts/views and Channel delivery | `product kernel` | Retain aliases, render enrichment, transcript decision, camelCase schema |
+| `coding.control.settings_manager` | 1,400 | `ScopedConfigRuntime`, schema codec, JSON store | `product kernel` | Wave 6 only by proven shared field group |
+| `coding.control.types` | 177 | No complete shared owner | `product kernel` | Split only cross-product settings |
+| `coding.policy.*` | 515 | Harness rule, approval, and resource-policy mechanisms | `product adapter` + `product kernel` | Extract profiles, not rules mechanically |
+| `coding.tool_pack`, `resource_runtime` | 346 | Workspace tool composition and resource/package engines | `product adapter` | Retain Coding membership, order, descriptions, context-file conventions |
+| `coding.compaction.adapter`, `profiles` | 359 | Transcript capability and summary-profile mechanism | `product adapter` + `product kernel` | Retain Coding executor and prompt text |
+
+## Leaf And Interaction Regions
+
+| Source region | LOC | Current shared owner or adopted mechanism | Classification | Next action |
+| --- | ---: | --- | --- | --- |
+| `coding.source_info`, `model_selection` | 187 | `harness.resources.source`, `observability.runtime_identity`, `ai.model`, session model selection | `shared adopted` | Remove residual facade imports only |
+| `coding.interaction.*` | 777 | TUI and HarnessTUI primitives | `product adapter` + `product kernel` | Wave 5/6 only after neutral screen-host probe |
+| `coding.model_selection_tui` | 279 | AI model values and TUI primitives | `product adapter` | Require a second Product workflow before extraction |
+| `coding.diagnostics.*`, `diag_export`, `observability` | 472 | Harness diagnostics/export and observability runtime | `shared adopted` | Retain Coding JSON/CLI/path adapters |
+| `coding.sdk_surface` | 138 | No universal SDK contract | `product kernel` | Retain; only a generic verifier may enter test support |
+
+## Non-Duplicates
+
+Do not recreate the existing shared implementations for session
+runtime/facade/lifecycle, transcript factory and directory, retry/compaction/
+queue, resources/packages, configuration layering, command composition, JSONL
+parsing, or extension Agent hooks. Replacing a Coding call to one of these with
+another wrapper does not count as migration.
+
+## Wave 4 Scope Gate: Product Bootstrap Transaction
+
+The remaining material duplicate candidate is the Product bootstrap
+transaction: activation ordering, cleanup, failure capture, and final factory
+invocation around already-bound ports. A narrow Harness contract is admitted
+only when it:
+
+1. sequences injected activation steps, cleanup, failure capture, and final
+   factory invocation without importing Coding;
+2. reuses `ConfigActivationRuntime`, `CapabilityCompositionRuntime`,
+   `SessionLifecycleRuntime`, and `SessionRuntime`, rather than adding a
+   resolver, lifecycle, or service locator;
+3. receives prompt, model/auth, resource, tool/command, approval,
+   session-file/CWD, and extension behavior from typed Product ports or the
+   existing runtime profile binding; and
+4. is exercised by a fake Product through success, failed activation with
+   reverse cleanup, and final disposal.
+
+The initial boundary is the transaction portions of `coding.bootstrap` and
+`coding.runtime.agent_session_runtime`. `AgentSession` remains a Product
+adapter until a separate facade audit identifies methods that only forward the
+existing Harness surface.
+
+The first admitted slice is narrower than a bootstrap engine:
+`ProductTranscriptSessionLifecycleStore` now owns transcript create, restore,
+fork, runtime-session association, and failed-build cleanup. Coding provides
+its transcript session type, CWD restore validation, fork policy, and runtime
+session constructor. `ConfigActivationRuntime` already owns ordered activation
+and optional rollback; no second bootstrap transaction is admitted until a
+later adapter audit finds a reusable remainder.
+
+## Measurement Rule
+
+The first Wave 4 implementation records exact pre-change LOC for each extracted
+function/class, post-cutover Coding LOC, shared LOC added, and net deleted
+Coding implementation. The first store cutover changes
+`coding.runtime.agent_session_runtime` from 1,187 to 1,158 LOC (-29) and
+`harness.session.transcript_lifecycle` from 216 to 371 LOC (+155); tests do not
+enter either figure. Historical 18,000--20,000 LOC estimates are not a delivery
+metric.

--- a/src/loushang/coding/runtime/agent_session_runtime.py
+++ b/src/loushang/coding/runtime/agent_session_runtime.py
@@ -40,6 +40,8 @@ from loushang.harness.session import (
     AgentTranscriptSessionRuntime,
     ForkProfile,
     ForkSelection,
+    ProductTranscriptSessionLifecyclePorts,
+    ProductTranscriptSessionLifecycleStore,
     SessionCwdIssue,
     SessionDiagnosticScope,
     SessionDiagnosticsRuntime,
@@ -96,121 +98,6 @@ def get_missing_session_cwd_issue(
     )
 
 
-class _CodingSessionLifecycleStore:
-    """Bind the generic lifecycle transaction to Coding's transcript session."""
-
-    def __init__(self, runtime: AgentSessionRuntime) -> None:
-        self._runtime = runtime
-        self._known_cwds: dict[int, str] = {}
-
-    async def create(
-        self,
-        current_session: AgentSession | None,
-        transition: SessionLifecycleTransition,
-        *,
-        cwd: str,
-        parent_session_ref: str | None,
-    ) -> AgentSession:
-        manager = await SessionManager.new(
-            session_dir=self._runtime.session_dir,
-            cwd=cwd,
-            persist=self._runtime.persist,
-            parent_session=parent_session_ref,
-        )
-        return self._build_session(
-            manager,
-            current=current_session,
-            transition=transition,
-        )
-
-    async def restore(
-        self,
-        current_session: AgentSession | None,
-        transition: SessionLifecycleTransition,
-        session_ref: str | Path,
-        *,
-        cwd_override: str | None = None,
-    ) -> AgentSession:
-        session_file = self._runtime.resolve_session_file(session_ref)
-        manager = await SessionManager.open(
-            session_file,
-            session_dir=self._runtime.session_dir,
-            cwd_override=(
-                self._runtime._resolve_import_cwd(cwd_override)
-                if cwd_override is not None
-                else None
-            ),
-            persist=self._runtime.persist,
-        )
-        missing_issue = get_missing_session_cwd_issue(manager)
-        if missing_issue is not None:
-            await manager.dispose_runtime_profile()
-            raise HarnessMissingSessionCwdError(
-                SessionCwdIssue(
-                    session_cwd=missing_issue.session_cwd,
-                    session_ref=(
-                        str(missing_issue.session_file)
-                        if missing_issue.session_file is not None
-                        else None
-                    ),
-                )
-            )
-        return self._build_session(
-            manager,
-            current=current_session,
-            transition=transition,
-        )
-
-    async def fork(
-        self,
-        session: AgentSession,
-        transition: SessionLifecycleTransition,
-        target_entry_id: str | None,
-    ) -> AgentSession:
-        if target_entry_id is None:
-            manager = await SessionManager.new(
-                session_dir=self._runtime.session_dir,
-                cwd=session.session_manager.get_cwd(),
-                persist=self._runtime.persist,
-                parent_session=_session_file_from_session(session),
-            )
-        else:
-            manager = await session.session_manager.fork(target_entry_id)
-        return self._build_session(
-            manager,
-            current=session,
-            transition=transition,
-        )
-
-    def get_cwd(self, session: AgentSession) -> str:
-        manager = getattr(session, "session_manager", None)
-        getter = getattr(manager, "get_cwd", None)
-        if callable(getter):
-            return getter()
-        return self._known_cwds[id(session)]
-
-    def get_session_ref(self, session: AgentSession) -> str | None:
-        return _session_file_from_session(session)
-
-    def get_leaf_entry_id(self, session: AgentSession) -> str | None:
-        return session.session_manager.get_leaf_id()
-
-    def _build_session(
-        self,
-        manager: SessionManager,
-        *,
-        current: AgentSession | None,
-        transition: SessionLifecycleTransition,
-    ) -> AgentSession:
-        session = self._runtime._create_session_for_transition(
-            manager,
-            current=current,
-            transition=transition,
-        )
-        self._known_cwds[id(session)] = manager.get_cwd()
-        return session
-
-
 class AgentSessionRuntime(AgentTranscriptSessionRuntime[AgentSession, str]):
     def __init__(
         self,
@@ -231,7 +118,26 @@ class AgentSessionRuntime(AgentTranscriptSessionRuntime[AgentSession, str]):
         )
         self.persist = persist
         lifecycle = SessionLifecycleRuntime[AgentSession, str](
-            store=_CodingSessionLifecycleStore(self),
+            store=ProductTranscriptSessionLifecycleStore(
+                ports=ProductTranscriptSessionLifecyclePorts(
+                    create_transcript=self._create_transcript_session,
+                    restore_transcript=self._restore_transcript_session,
+                    fork_transcript=self._fork_transcript_session,
+                    dispose_transcript=_dispose_transcript_session,
+                    transcript_for_session=lambda session: session.session_manager,
+                    transcript_cwd=lambda manager: manager.get_cwd(),
+                    transcript_session_ref=_session_manager_ref,
+                    transcript_leaf_entry_id=lambda manager: manager.get_leaf_id(),
+                ),
+                build_session=lambda manager, current, transition: (
+                    self._create_session_for_transition(
+                        manager,
+                        current=current,
+                        transition=transition,
+                    )
+                ),
+                validate_restored_transcript=self._validate_restored_transcript,
+            ),
             current_session=current_session,
             fork_profile=_CODING_FORK_PROFILE,
             fork_target_resolver=_resolve_coding_fork_target,
@@ -797,6 +703,62 @@ class AgentSessionRuntime(AgentTranscriptSessionRuntime[AgentSession, str]):
             ),
         )
 
+    async def _create_transcript_session(
+        self,
+        cwd: str,
+        parent_session_ref: str | None,
+    ) -> SessionManager:
+        return await SessionManager.new(
+            session_dir=self.session_dir,
+            cwd=cwd,
+            persist=self.persist,
+            parent_session=parent_session_ref,
+        )
+
+    async def _restore_transcript_session(
+        self,
+        session_ref: str | Path,
+        cwd_override: str | None,
+    ) -> SessionManager:
+        return await SessionManager.open(
+            self.resolve_session_file(session_ref),
+            session_dir=self.session_dir,
+            cwd_override=(
+                self._resolve_import_cwd(cwd_override)
+                if cwd_override is not None
+                else None
+            ),
+            persist=self.persist,
+        )
+
+    async def _fork_transcript_session(
+        self,
+        manager: SessionManager,
+        target_entry_id: str | None,
+    ) -> SessionManager:
+        if target_entry_id is not None:
+            return await manager.fork(target_entry_id)
+        return await self._create_transcript_session(
+            manager.get_cwd(),
+            _session_manager_ref(manager),
+        )
+
+    @staticmethod
+    def _validate_restored_transcript(manager: SessionManager) -> None:
+        missing_issue = get_missing_session_cwd_issue(manager)
+        if missing_issue is None:
+            return
+        raise HarnessMissingSessionCwdError(
+            SessionCwdIssue(
+                session_cwd=missing_issue.session_cwd,
+                session_ref=(
+                    str(missing_issue.session_file)
+                    if missing_issue.session_file is not None
+                    else None
+                ),
+            )
+        )
+
     async def _prepare_session_shutdown(
         self, session: AgentSession, event: SessionShutdownEvent
     ) -> None:
@@ -1184,4 +1146,13 @@ def _session_file_from_session(session: AgentSession | None) -> str | None:
 
 def _session_file_from_manager(manager: SessionManager) -> str | None:
     session_file = getattr(manager, "session_file", None)
+    return str(session_file) if session_file is not None else None
+
+
+async def _dispose_transcript_session(manager: SessionManager) -> None:
+    await manager.dispose_runtime_profile()
+
+
+def _session_manager_ref(manager: SessionManager) -> str | None:
+    session_file = manager.get_session_file()
     return str(session_file) if session_file is not None else None

--- a/src/loushang/harness/session/__init__.py
+++ b/src/loushang/harness/session/__init__.py
@@ -131,6 +131,8 @@ from loushang.harness.session.runtime import (
 )
 from loushang.harness.session.transcript_lifecycle import (
     AgentTranscriptSessionRuntime,
+    ProductTranscriptSessionLifecyclePorts,
+    ProductTranscriptSessionLifecycleStore,
     require_session_operation_session,
 )
 
@@ -165,6 +167,8 @@ __all__ = [
     "ModelCandidates",
     "ModelSelectionApplyResult",
     "PromptController",
+    "ProductTranscriptSessionLifecyclePorts",
+    "ProductTranscriptSessionLifecycleStore",
     "PersistModelSelection",
     "QueueController",
     "RefreshFailureRecorder",

--- a/src/loushang/harness/session/transcript_lifecycle.py
+++ b/src/loushang/harness/session/transcript_lifecycle.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import errno
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from inspect import isawaitable
 from pathlib import Path
 from typing import Generic, TypeVar
 
@@ -17,13 +19,152 @@ from loushang.harness.agent_transcript.directory import (
     AgentTranscriptDirectoryRuntime,
 )
 from loushang.harness.runtime import SessionOperationResult
-from loushang.harness.session.lifecycle import MissingCwdPolicy, SessionLifecycleRuntime
+from loushang.harness.session.lifecycle import (
+    MissingCwdPolicy,
+    SessionLifecycleRuntime,
+    SessionLifecycleTransition,
+)
 
 SessionT = TypeVar("SessionT")
 PayloadT = TypeVar("PayloadT")
+TranscriptSessionT = TypeVar("TranscriptSessionT")
+ValueT = TypeVar("ValueT")
 
 SessionCallback = Callable[[SessionT], Awaitable[None] | None]
 LifecycleCallback = Callable[[], Awaitable[None] | None]
+TranscriptSessionBuilder = Callable[
+    [TranscriptSessionT, SessionT | None, SessionLifecycleTransition],
+    SessionT | Awaitable[SessionT],
+]
+TranscriptSessionValidator = Callable[[TranscriptSessionT], None | Awaitable[None]]
+
+
+@dataclass(frozen=True)
+class ProductTranscriptSessionLifecyclePorts(Generic[TranscriptSessionT, SessionT]):
+    """Product transcript storage operations used by the lifecycle store.
+
+    The ports deliberately deal in a Product's transcript-session type rather
+    than Agent or provider types. The generic store joins those transcript
+    operations to ``SessionLifecycleRuntime`` and releases a transcript if the
+    Product runtime session cannot be built.
+    """
+
+    create_transcript: Callable[
+        [str, str | None], Awaitable[TranscriptSessionT] | TranscriptSessionT
+    ]
+    restore_transcript: Callable[
+        [str | Path, str | None], Awaitable[TranscriptSessionT] | TranscriptSessionT
+    ]
+    fork_transcript: Callable[
+        [TranscriptSessionT, str | None],
+        Awaitable[TranscriptSessionT] | TranscriptSessionT,
+    ]
+    dispose_transcript: Callable[[TranscriptSessionT], Awaitable[None] | None]
+    transcript_for_session: Callable[[SessionT], TranscriptSessionT]
+    transcript_cwd: Callable[[TranscriptSessionT], str]
+    transcript_session_ref: Callable[[TranscriptSessionT], str | None]
+    transcript_leaf_entry_id: Callable[[TranscriptSessionT], str | None]
+
+
+class ProductTranscriptSessionLifecycleStore(Generic[TranscriptSessionT, SessionT]):
+    """Adapt Product transcript sessions to the common lifecycle store port.
+
+    A Product supplies transcript persistence and runtime-session construction.
+    This class owns the common create, restore, fork, association, and failed
+    construction cleanup path without selecting a transcript format, store, or
+    Product runtime.
+    """
+
+    def __init__(
+        self,
+        *,
+        ports: ProductTranscriptSessionLifecyclePorts[TranscriptSessionT, SessionT],
+        build_session: TranscriptSessionBuilder[TranscriptSessionT, SessionT],
+        validate_restored_transcript: TranscriptSessionValidator[TranscriptSessionT]
+        | None = None,
+    ) -> None:
+        self._ports = ports
+        self._build_session = build_session
+        self._validate_restored_transcript = validate_restored_transcript
+        self._transcripts_by_session_id: dict[int, TranscriptSessionT] = {}
+
+    async def create(
+        self,
+        current_session: SessionT | None,
+        transition: SessionLifecycleTransition,
+        *,
+        cwd: str,
+        parent_session_ref: str | None,
+    ) -> SessionT:
+        transcript = await _maybe_await(
+            self._ports.create_transcript(cwd, parent_session_ref)
+        )
+        return await self._build_or_dispose(transcript, current_session, transition)
+
+    async def restore(
+        self,
+        current_session: SessionT | None,
+        transition: SessionLifecycleTransition,
+        session_ref: str | Path,
+        *,
+        cwd_override: str | None = None,
+    ) -> SessionT:
+        transcript = await _maybe_await(
+            self._ports.restore_transcript(session_ref, cwd_override)
+        )
+        try:
+            if self._validate_restored_transcript is not None:
+                await _maybe_await(self._validate_restored_transcript(transcript))
+        except BaseException:
+            await _maybe_await(self._ports.dispose_transcript(transcript))
+            raise
+        return await self._build_or_dispose(transcript, current_session, transition)
+
+    async def fork(
+        self,
+        session: SessionT,
+        transition: SessionLifecycleTransition,
+        target_entry_id: str | None,
+    ) -> SessionT:
+        transcript = await _maybe_await(
+            self._ports.fork_transcript(
+                self._transcript_for_session(session), target_entry_id
+            )
+        )
+        return await self._build_or_dispose(transcript, session, transition)
+
+    def get_cwd(self, session: SessionT) -> str:
+        return self._ports.transcript_cwd(self._transcript_for_session(session))
+
+    def get_session_ref(self, session: SessionT) -> str | None:
+        return self._ports.transcript_session_ref(self._transcript_for_session(session))
+
+    def get_leaf_entry_id(self, session: SessionT) -> str | None:
+        return self._ports.transcript_leaf_entry_id(
+            self._transcript_for_session(session)
+        )
+
+    async def _build_or_dispose(
+        self,
+        transcript: TranscriptSessionT,
+        current_session: SessionT | None,
+        transition: SessionLifecycleTransition,
+    ) -> SessionT:
+        try:
+            session = await _maybe_await(
+                self._build_session(transcript, current_session, transition)
+            )
+        except BaseException:
+            await _maybe_await(self._ports.dispose_transcript(transcript))
+            raise
+        self._transcripts_by_session_id[id(session)] = transcript
+        return session
+
+    def _transcript_for_session(self, session: SessionT) -> TranscriptSessionT:
+        try:
+            return self._transcripts_by_session_id[id(session)]
+        except KeyError:
+            return self._ports.transcript_for_session(session)
 
 
 class AgentTranscriptSessionRuntime(
@@ -210,7 +351,15 @@ def require_session_operation_session(
     return result.current
 
 
+async def _maybe_await(value: ValueT | Awaitable[ValueT]) -> ValueT:
+    if isawaitable(value):
+        return await value
+    return value
+
+
 __all__ = [
     "AgentTranscriptSessionRuntime",
+    "ProductTranscriptSessionLifecyclePorts",
+    "ProductTranscriptSessionLifecycleStore",
     "require_session_operation_session",
 ]

--- a/tests/harness/session/test_transcript_lifecycle.py
+++ b/tests/harness/session/test_transcript_lifecycle.py
@@ -4,8 +4,12 @@ import asyncio
 from dataclasses import dataclass
 from pathlib import Path
 
+import pytest
+
 from loushang.harness.session import (
     AgentTranscriptSessionRuntime,
+    ProductTranscriptSessionLifecyclePorts,
+    ProductTranscriptSessionLifecycleStore,
     SessionLifecycleHooks,
     SessionLifecycleRuntime,
     SessionLifecycleTransition,
@@ -69,6 +73,76 @@ class _Store:
         return session.leaf_id
 
 
+@dataclass
+class _TranscriptSession:
+    ref: str
+    cwd: str
+    leaf_id: str = "leaf"
+
+
+class _ProductPorts:
+    def __init__(self) -> None:
+        self.actions: list[tuple[object, ...]] = []
+        self.disposed: list[str] = []
+
+    async def create(
+        self,
+        cwd: str,
+        parent_session_ref: str | None,
+    ) -> _TranscriptSession:
+        self.actions.append(("create", cwd, parent_session_ref))
+        return _TranscriptSession("new.jsonl", cwd)
+
+    async def restore(
+        self,
+        session_ref: str | Path,
+        cwd_override: str | None,
+    ) -> _TranscriptSession:
+        self.actions.append(("restore", str(session_ref), cwd_override))
+        return _TranscriptSession(str(session_ref), cwd_override or "/restored")
+
+    async def fork(
+        self,
+        transcript: _TranscriptSession,
+        target_entry_id: str | None,
+    ) -> _TranscriptSession:
+        self.actions.append(("fork", transcript.ref, target_entry_id))
+        return _TranscriptSession("fork.jsonl", transcript.cwd)
+
+    async def dispose(self, transcript: _TranscriptSession) -> None:
+        self.disposed.append(transcript.ref)
+
+    @staticmethod
+    def transcript_for_session(session: _Session) -> _TranscriptSession:
+        return _TranscriptSession(session.ref, session.cwd, session.leaf_id)
+
+    @staticmethod
+    def cwd(transcript: _TranscriptSession) -> str:
+        return transcript.cwd
+
+    @staticmethod
+    def session_ref(transcript: _TranscriptSession) -> str:
+        return transcript.ref
+
+    @staticmethod
+    def leaf_entry_id(transcript: _TranscriptSession) -> str:
+        return transcript.leaf_id
+
+    def lifecycle_ports(
+        self,
+    ) -> ProductTranscriptSessionLifecyclePorts[_TranscriptSession, _Session]:
+        return ProductTranscriptSessionLifecyclePorts(
+            create_transcript=self.create,
+            restore_transcript=self.restore,
+            fork_transcript=self.fork,
+            dispose_transcript=self.dispose,
+            transcript_for_session=self.transcript_for_session,
+            transcript_cwd=self.cwd,
+            transcript_session_ref=self.session_ref,
+            transcript_leaf_entry_id=self.leaf_entry_id,
+        )
+
+
 def test_transcript_session_runtime_delegates_lifecycle_operations(tmp_path) -> None:
     async def scenario() -> None:
         store = _Store()
@@ -119,3 +193,56 @@ def test_transcript_session_runtime_resolves_current_native_session_id(
     runtime = AgentTranscriptSessionRuntime(session_dir=tmp_path, lifecycle=lifecycle)
 
     assert runtime.resolve_session_file("demo-session") == session_file
+
+
+def test_product_transcript_store_creates_and_forks_runtime_sessions() -> None:
+    async def scenario() -> None:
+        ports = _ProductPorts()
+        store = ProductTranscriptSessionLifecycleStore(
+            ports=ports.lifecycle_ports(),
+            build_session=lambda transcript, _current, _transition: _Session(
+                transcript.ref,
+                transcript.cwd,
+                transcript.leaf_id,
+            ),
+        )
+        lifecycle = SessionLifecycleRuntime[_Session, object](
+            store=store,
+            hooks=SessionLifecycleHooks(dispose_session=lambda _session: None),
+        )
+
+        created = await lifecycle.new(cwd="/project", parent_session_ref="parent")
+        forked = await lifecycle.fork("leaf")
+
+        assert created.current == _Session("new.jsonl", "/project")
+        assert forked.current == _Session("fork.jsonl", "/project")
+        assert ports.actions == [
+            ("create", "/project", "parent"),
+            ("fork", "new.jsonl", "leaf"),
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_product_transcript_store_disposes_restore_when_runtime_build_fails() -> None:
+    async def scenario() -> None:
+        ports = _ProductPorts()
+        store = ProductTranscriptSessionLifecycleStore(
+            ports=ports.lifecycle_ports(),
+            build_session=lambda _transcript, _current, _transition: _raise_build(),
+        )
+        lifecycle = SessionLifecycleRuntime[_Session, object](
+            store=store,
+            hooks=SessionLifecycleHooks(dispose_session=lambda _session: None),
+        )
+
+        with pytest.raises(RuntimeError, match="build failed"):
+            await lifecycle.restore("saved.jsonl")
+
+        assert ports.disposed == ["saved.jsonl"]
+
+    asyncio.run(scenario())
+
+
+def _raise_build() -> _Session:
+    raise RuntimeError("build failed")


### PR DESCRIPTION
## English

### Summary
- Complete Wave R ownership rebaseline so later Coding-to-shared-layer work reports only actual deleted implementation.
- Add `ProductTranscriptSessionLifecycleStore`, a port-driven Harness adapter for transcript create, restore, fork, runtime-session association, and failed-build cleanup.
- Replace Coding's private lifecycle store while retaining Coding CWD validation, fork policy, extension hooks, diagnostics, and runtime-session construction.

### Validation
- `uv --cache-dir .uv-cache run ruff format --check ...`
- `uv --cache-dir .uv-cache run ruff check ...`
- `uv --cache-dir .uv-cache run pytest tests/harness/session/test_transcript_lifecycle.py tests/coding/test_agent_session_runtime.py tests/coding/test_bootstrap.py tests/architecture/test_import_boundaries.py -q`
- Focused baseline: `79 passed`; cutover and architecture regression: `135 passed`.

### Scope
No second bootstrap transaction was added: `ConfigActivationRuntime` already owns ordered activation and optional rollback. This slice only centralizes the reusable transcript-to-runtime lifecycle adapter.

## 中文

### 变更概要
- 完成 Wave R 归属重基线，后续 Coding 到共享层的工作只统计实际删除的实现。
- 新增 ports 驱动的 `ProductTranscriptSessionLifecycleStore`，由 Harness 负责 transcript 的创建、恢复、fork、runtime-session 关联及构建失败清理。
- 删除 Coding 私有生命周期 store；CWD 校验、fork 策略、扩展 hook、诊断和 runtime-session 组装仍由 Coding 明确注入。

### 验证
- 已通过 Ruff format/check、共享 fake Product 探针、Coding bootstrap/runtime 回归及架构导入边界测试。
- 聚焦基线 `79 passed`；切换与架构回归 `135 passed`。

### 范围
未新建第二套 bootstrap transaction：现有 `ConfigActivationRuntime` 已负责有序激活和可选回滚。本切片只收敛可复用的 transcript 到 runtime 生命周期适配机制。