### PR TITLE
refactor(session): cut over lifecycle RPC ports / 收敛会话生命周期 RPC ports

### DIFF
--- a/docs/internals/architecture/harness/coding-shared-layer-migration-ledger.md
+++ b/docs/internals/architecture/harness/coding-shared-layer-migration-ledger.md
@@ -146,3 +146,24 @@ Wave 4 first-slice probes:
 - failed Product runtime construction disposes the opened transcript;
 - Coding lifecycle, bootstrap, and import-boundary regressions preserve CWD,
   fork, extension, and diagnostic behavior.
+
+### Session Adapter Cull And RPC Lifecycle Port (Complete)
+
+The requested public-facade and RPC audit confirms that most of the proposed
+cutover already landed in earlier waves. Prompt, queue, abort, compaction, and
+retry handlers already use `SessionOperationRuntime`; moving them again would
+create a duplicate engine. The remaining lifecycle handlers now use explicit
+Harness `SessionLifecycleOperationPorts`, while Channel continues to own JSONL
+framing and Coding retains validation, error wording, compatibility fields, and
+response projection.
+
+| Source region | Actual change | Ownership result |
+| --- | ---: | --- |
+| `coding.session.agent_session` | 1,890 to 1,874 LOC (-16) | Removed only `abort`, `compact_session`, and bash state aliases that forwarded Harness methods. Coding compaction, bash, diagnostics, package, model, extension, and event behavior remains Product-owned. |
+| `coding.mode.rpc_mode` | 2,739 to 2,758 LOC (+19) | Added explicit lifecycle port binding; no RPC capability was deleted. The increase is intentional wiring, not a migration reduction. |
+| `harness.session.operations` | shared port/runtime contract | Owns neutral lifecycle callback dispatch for Product hosts. |
+
+This wave's net Coding reduction is 0 after the explicit RPC binding is
+included. The earlier 800--1,200 LOC projection is superseded by this audit;
+future reduction must come from a separately proven handler or Product adapter
+removal, not from reclassifying existing Harness calls.

--- a/src/loushang/coding/mode/rpc_mode.py
+++ b/src/loushang/coding/mode/rpc_mode.py
@@ -47,6 +47,7 @@ from loushang.harness.diagnostics.types import DiagnosticsQuery
 from loushang.harness.events import RuntimeEvent
 from loushang.harness.presentation import ToolDefinitionResolver, ToolRenderRuntime
 from loushang.harness.session import (
+    SessionLifecycleOperationPorts,
     SessionOperationRuntime,
     SessionPromptRequest,
     require_session_operation_session,
@@ -722,7 +723,7 @@ class RpcMode(ModeAdapter):
     ) -> None:
         previous = self.session
         try:
-            operation = await self.runtime.new_session_operation(
+            operation = await self._require_session_operations().new_session(
                 cwd=self._optional_path(payload.get("cwd")),
                 parent_session=self._optional_string(
                     payload, "parentSession", "parent_session"
@@ -755,7 +756,9 @@ class RpcMode(ModeAdapter):
         if not isinstance(session_id, str) or not session_id:
             raise ValueError("switch_session requires sessionId")
         try:
-            operation = await self.runtime.restore_session_operation(session_id)
+            operation = await self._require_session_operations().restore_session(
+                session_id
+            )
             session = require_session_operation_session(operation)
         except Exception as error:
             self._write_response_error(
@@ -784,7 +787,7 @@ class RpcMode(ModeAdapter):
             position = payload.get("position", "before")
             if position not in {"before", "at"}:
                 raise ValueError("fork position must be 'before' or 'at'")
-            operation = await self.runtime.fork_session_operation(
+            operation = await self._require_session_operations().fork_session(
                 entry_id,
                 position=position,
             )
@@ -813,7 +816,9 @@ class RpcMode(ModeAdapter):
         del payload
         previous = self.session
         try:
-            operation = await self.runtime.fork_session_operation(None, position="at")
+            operation = await self._require_session_operations().fork_session(
+                None, position="at"
+            )
             session = require_session_operation_session(operation)
         except Exception as error:
             self._write_response_error(
@@ -2022,7 +2027,21 @@ class RpcMode(ModeAdapter):
         control = getattr(session, "session_control", None)
         if control is None:
             return None
-        return SessionOperationRuntime(cast(Any, control))
+        runtime = self.runtime
+        return SessionOperationRuntime(
+            cast(Any, control),
+            lifecycle=SessionLifecycleOperationPorts(
+                new_session=lambda cwd, parent: runtime.new_session_operation(
+                    cwd=cwd, parent_session=parent
+                ),
+                restore_session=lambda session_ref: runtime.restore_session_operation(
+                    session_ref
+                ),
+                fork_session=lambda entry_id, position: runtime.fork_session_operation(
+                    entry_id, position=position
+                ),
+            ),
+        )
 
     def _require_session_operations(self) -> SessionOperationRuntime:
         if self._session_operations is None:

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -976,14 +976,6 @@ class AgentSession(SessionFacade):
             exclude_from_context=exclude_from_context,
         )
 
-    @property
-    def is_bash_running(self) -> bool:
-        return super().is_command_running
-
-    @property
-    def has_pending_bash_messages(self) -> bool:
-        return super().has_pending_command_messages
-
     # Public facade: extension runtime configuration.
 
     async def reload_extension_runtime(self) -> None:
@@ -1050,9 +1042,6 @@ class AgentSession(SessionFacade):
 
     # Public facade: run controls, retry, compaction, and tree navigation.
 
-    def abort(self) -> bool:
-        return super().abort()
-
     def abort_bash(self) -> None:
         super().abort_command()
 
@@ -1081,11 +1070,6 @@ class AgentSession(SessionFacade):
         )
         assert result is not None
         return result
-
-    async def compact_session(
-        self, custom_instructions: str | None = None
-    ) -> CompactionResult:
-        return await self.compact(custom_instructions=custom_instructions)
 
     async def maybe_compact_after_turn(
         self, assistant_message: AssistantMessage

--- a/src/loushang/harness/session/__init__.py
+++ b/src/loushang/harness/session/__init__.py
@@ -106,6 +106,7 @@ from loushang.harness.session.model_selection import (
     iter_scoped_model_selections,
 )
 from loushang.harness.session.operations import (
+    SessionLifecycleOperationPorts,
     SessionOperationAvailability,
     SessionOperationCapability,
     SessionOperationRuntime,
@@ -206,6 +207,7 @@ __all__ = [
     "SessionOperationCapability",
     "SessionOperationRuntime",
     "SessionOperationUnavailableError",
+    "SessionLifecycleOperationPorts",
     "SessionResourcePort",
     "SessionRetryPort",
     "SessionDiagnosticScope",

--- a/src/loushang/harness/session/operations.py
+++ b/src/loushang/harness/session/operations.py
@@ -7,11 +7,14 @@ project their own responses and errors.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
+from typing import Any
 
 from loushang.ai.types import ImagePart
+from loushang.harness.runtime import SessionOperationResult
 from loushang.harness.session.facade import SessionControlPort
 
 
@@ -79,6 +82,19 @@ class SessionPromptRequest:
             raise TypeError("Session prompt source must be a string.")
 
 
+@dataclass(frozen=True)
+class SessionLifecycleOperationPorts:
+    """Product callbacks for standard session replacement operations."""
+
+    new_session: Callable[
+        [str | None, str | None], Awaitable[SessionOperationResult[Any, Any]]
+    ]
+    restore_session: Callable[[str | Path], Awaitable[SessionOperationResult[Any, Any]]]
+    fork_session: Callable[
+        [str | None, str], Awaitable[SessionOperationResult[Any, Any]]
+    ]
+
+
 class SessionOperationRuntime:
     """Execute admitted session control groups through one explicit port.
 
@@ -92,6 +108,7 @@ class SessionOperationRuntime:
         control: SessionControlPort,
         *,
         availability: SessionOperationAvailability | None = None,
+        lifecycle: SessionLifecycleOperationPorts | None = None,
     ) -> None:
         self._control = control
         self._availability = (
@@ -99,6 +116,7 @@ class SessionOperationRuntime:
             if availability is None
             else availability
         )
+        self._lifecycle = lifecycle
 
     @property
     def availability(self) -> SessionOperationAvailability:
@@ -121,6 +139,31 @@ class SessionOperationRuntime:
             prompt_kwargs["images"] = list(request.images)
         await self._control.prompt(request.text, **prompt_kwargs)
         await self._control.wait_for_idle()
+
+    async def new_session(
+        self,
+        *,
+        cwd: str | None = None,
+        parent_session: str | None = None,
+    ) -> SessionOperationResult[Any, Any]:
+        self._require_lifecycle_port()
+        return await self._lifecycle.new_session(cwd, parent_session)
+
+    async def restore_session(
+        self,
+        session_ref: str | Path,
+    ) -> SessionOperationResult[Any, Any]:
+        self._require_lifecycle_port()
+        return await self._lifecycle.restore_session(session_ref)
+
+    async def fork_session(
+        self,
+        entry_id: str | None,
+        *,
+        position: str = "at",
+    ) -> SessionOperationResult[Any, Any]:
+        self._require_lifecycle_port()
+        return await self._lifecycle.fork_session(entry_id, position)
 
     def steer(self, text: str, *, images: Iterable[ImagePart] = ()) -> None:
         self._require(SessionOperationCapability.INPUT)
@@ -220,11 +263,19 @@ class SessionOperationRuntime:
     def _require(self, capability: SessionOperationCapability) -> None:
         self._availability.require(capability)
 
+    def _require_lifecycle_port(self) -> None:
+        self._require(SessionOperationCapability.LIFECYCLE)
+        if self._lifecycle is None:
+            raise SessionOperationUnavailableError(
+                "Session lifecycle operation ports are not bound"
+            )
+
 
 __all__ = [
     "SessionOperationAvailability",
     "SessionOperationCapability",
     "SessionOperationRuntime",
     "SessionOperationUnavailableError",
+    "SessionLifecycleOperationPorts",
     "SessionPromptRequest",
 ]

--- a/tests/coding/test_agent_session.py
+++ b/tests/coding/test_agent_session.py
@@ -3045,8 +3045,8 @@ def test_agent_session_exposes_standard_runtime_facades(tmp_path) -> None:
     session.abort_compaction()
     session.abort_compaction()
     session.abort_branch_summary()
-    assert session.is_bash_running is False
-    assert session.has_pending_bash_messages is False
+    assert session.is_command_running is False
+    assert session.has_pending_command_messages is False
     asyncio.run(
         session.record_bash_result(
             "echo hi",

--- a/tests/coding/test_agent_session_compaction.py
+++ b/tests/coding/test_agent_session_compaction.py
@@ -273,7 +273,7 @@ def test_agent_session_exposes_compaction_service_surface(
     )
 
     assert session.get_compaction_status().is_compacting is False
-    result = asyncio.run(session.compact_session(custom_instructions="preserve tasks"))
+    result = asyncio.run(session.compact(custom_instructions="preserve tasks"))
 
     assert result.summary == "public surface summary"
     assert result.first_kept_entry_id == assistant_id

--- a/tests/harness/session/test_operations.py
+++ b/tests/harness/session/test_operations.py
@@ -4,7 +4,9 @@ import asyncio
 
 import pytest
 
+from loushang.harness.runtime import SessionOperationResult
 from loushang.harness.session import (
+    SessionLifecycleOperationPorts,
     SessionOperationAvailability,
     SessionOperationCapability,
     SessionOperationRuntime,
@@ -98,6 +100,23 @@ class _Control:
         return lambda: None
 
 
+class _Lifecycle:
+    def __init__(self) -> None:
+        self.calls: list[tuple[object, ...]] = []
+
+    async def new_session(self, cwd, parent_session):
+        self.calls.append(("new", cwd, parent_session))
+        return SessionOperationResult(None, "new", None, False)
+
+    async def restore_session(self, session_ref):
+        self.calls.append(("restore", session_ref))
+        return SessionOperationResult("old", "restored", None, True)
+
+    async def fork_session(self, entry_id, position):
+        self.calls.append(("fork", entry_id, position))
+        return SessionOperationResult("old", "forked", "text", False)
+
+
 def test_session_operation_runtime_runs_input_and_maintenance_through_control() -> None:
     async def scenario() -> None:
         control = _Control()
@@ -148,6 +167,32 @@ def test_session_operation_runtime_runs_input_and_maintenance_through_control() 
         assert control.auto_compaction_enabled is False
         assert control.compact_requests == ["retain decisions"]
         assert control.compaction_aborted is True
+
+    asyncio.run(scenario())
+
+
+def test_session_operation_runtime_routes_lifecycle_through_product_ports() -> None:
+    async def scenario() -> None:
+        lifecycle = _Lifecycle()
+        runtime = SessionOperationRuntime(
+            _Control(),
+            lifecycle=SessionLifecycleOperationPorts(
+                new_session=lifecycle.new_session,
+                restore_session=lifecycle.restore_session,
+                fork_session=lifecycle.fork_session,
+            ),
+        )
+
+        assert (
+            await runtime.new_session(cwd="/project", parent_session="parent")
+        ).current == "new"
+        assert (await runtime.restore_session("saved.jsonl")).current == "restored"
+        assert (await runtime.fork_session("leaf", position="before")).payload == "text"
+        assert lifecycle.calls == [
+            ("new", "/project", "parent"),
+            ("restore", "saved.jsonl"),
+            ("fork", "leaf", "before"),
+        ]
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## English

### Summary
- Audit `AgentSession` and remove only Harness-forwarding aliases: `abort`, `compact_session`, and bash state aliases.
- Add neutral `SessionLifecycleOperationPorts` to Harness `SessionOperationRuntime`.
- Route Coding RPC `new_session`, `switch_session`, `fork`, and `clone` through the injected Harness lifecycle ports.
- Keep Coding validation, fork position semantics, model/auth, bash behavior, extension behavior, error wording, camelCase/Pi compatibility, and response projection.
- Record the owner audit: prompt/queue/abort/compact/retry were already cut over in earlier waves, so the projected 800--1,200 LOC reduction is not claimed.

### Validation
- Ruff format/check passed.
- Focused Harness, RPC, AgentSession, compaction, and import-boundary tests passed (`236 passed`).

## 中文

### 变更概要
- 审计 `AgentSession`，只删除转发 Harness 的 `abort`、`compact_session` 和 bash 状态别名。
- 在 Harness `SessionOperationRuntime` 增加中性的 `SessionLifecycleOperationPorts`。
- 将 Coding RPC 的 `new_session`、`switch_session`、`fork`、`clone` 切换到注入的 Harness 生命周期 ports。
- 保留 Coding 的校验、fork 位置语义、模型/认证、bash、扩展行为、错误文案、camelCase/Pi 兼容和响应投影。
- 账本明确记录：prompt/queue/abort/compact/retry 已在前序波次切换，不能重复计算 800--1,200 行迁移收益。

### 验证
- Ruff format/check 通过。
- Harness、RPC、AgentSession、compaction 和导入边界聚焦测试通过（`236 passed`）。