### PR TITLE
  docs(harness): add multi-agent architecture design (draft) / 新增 multi-agent 架构设计（草案）

### DIFF
--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -191,6 +191,19 @@ planning, work event persistence, or AI provider behavior.
   OEM customisation, extension contributions, and harness upgrades interact,
   including override mechanisms, extension categories, surface-type gaps, and
   upgrade-compatibility guarantees.
+- [Multi-Agent Architecture](multiagent/system-context.md) (draft proposal)
+  defines the target boundary for `loushang.harness.multiagent`: sub-agent
+  spawning, context isolation and forking, agent input facade notification,
+  concurrency and residency limits, and approval bubbling, with ownership in
+  [ARD-001](multiagent/ARD-001-harness-ownership.md) and async / recovery
+  semantics in [ARD-002](multiagent/ARD-002-async-execution-and-recovery.md).
+  Component boundaries: [run handle](multiagent/run-handle-boundary.md),
+  [agent input facade](multiagent/agent-input-facade-boundary.md),
+  [context fork](multiagent/context-fork-boundary.md),
+  [control](multiagent/control-boundary.md),
+  [registry](multiagent/registry-boundary.md),
+  [limits and projection](multiagent/limits-and-projection-boundary.md),
+  [tool surface](multiagent/tool-surface-boundary.md).
 - [Workspace Execution Boundary](workspace-execution-boundary.md) defines
   harness-owned truncation, exec records, backend protocols, process execution,
   and coding compatibility ownership.

--- a/docs/internals/architecture/harness/multiagent/ARD-001-harness-ownership.md
+++ b/docs/internals/architecture/harness/multiagent/ARD-001-harness-ownership.md
@@ -1,0 +1,114 @@
+# ARD-001: Multi-Agent Harness Ownership
+
+## Status
+
+Proposed（目标设计，待接受）
+
+## Context
+
+Multi-agent 运行能力（子 agent 派生、隔离、通信与生命周期管控）需要一个
+子系统归属。候选落点有三个：
+
+- **A. `loushang.harness` 内的子模块**（`loushang.harness.multiagent`）
+- **B. 新的顶层包**（`loushang.multiagent`）
+- **C. `loushang.agent` 内核内**
+
+约束来自已接受的架构口径：
+
+- [subsystem.md](../../subsystem.md)：`loushang.agent` 负责 Agent / AgentLoop /
+  AgentMessage / AgentEvent / AgentTool / AgentContext / AgentState，
+  **不负责 prepared agent run contract**；`loushang.harness` 负责
+  `AgentRunSpec` / `AgentRunResult` / `run_agent()`、product-neutral
+  host lifecycle contracts。
+- [ARD-002](../../agent/ARD-002-harness-product-adapter-substrate.md)：harness
+  是 cross-product product-adapter substrate，host mechanics
+  （abort / idle / queue / steering / lifecycle coordination）归属
+  harness；并明确否决新建平行顶层 substrate 包（`loushang.product`
+  先例）。
+- 环境图结论：multi-agent 是纯技术态，不得依赖 method / work /
+  channel / tui；agent 类型注册表由产品装配层注入，不是归属层的资产。
+
+## Decision
+
+**采用 A：multi-agent 作为 `loushang.harness` 的子模块
+`loushang.harness.multiagent`。**
+
+目标模块形态（ownership markers，不要求一次落地）：
+
+```text
+loushang.harness.multiagent
+  __init__      # 公开面：spawn / send / wait 契约、AgentPath、状态机类型
+  control       # 控制面：spawn 流水线、消息路由、interrupt、close
+  registry      # agent path 寻址、两阶段 reservation、树拓扑、path↔handle 映射
+  run_handle    # 运行载体：多轮 run 驱动、cancel token、事件转接、恢复入口
+  context       # SubagentContextFactory：隔离 fork、历史过滤、审批冒泡装配
+  input_facade  # 通知合成与 wait 唤醒（基于 harness.host.HostInputQueue）
+  limits        # 并发闸门、depth 上限、驻留 / 回收
+  projection    # 生命周期状态机推导与技术事实发射
+  tools         # ToolSurfaceAdapter：spawn / send / wait 工具封装
+  types         # SpawnRequest / SpawnHandle / SubagentStatus / AgentTypeRecord
+```
+
+模块边界复用 harness 既有机制：`input_facade` 以 `HostInputQueue` 为底层；
+审批冒泡复用 `harness.approval` 的 `ApprovalRequest` 管道（不单列审批
+组件）；`run_handle` 参照 `HostRuntime` 生命周期编排。
+
+### 为什么不选 B（顶层包）
+
+1. 职责重叠：multi-agent 的核心能力（派生 prepared run、queue/steering、
+   lifecycle coordination、abort 传播）与 ARD-002 已划给 harness 的
+   host mechanics 高度同构；独立顶层包会产生第二条边界。
+2. ARD-002 已否决过同构方向：不为 substrate 能力新建平行顶层包
+   （`loushang.product` 先例）。
+3. 依赖边新增：顶层包仍需依赖 harness（run_agent 是唯一 prepared-run
+   contract），多一层依赖而无职责收益。
+4. 演化路径安全：先作为 harness 子模块生长，若未来职责显著超出
+   harness 边界，提升为顶层包是纯移动；反之先顶层再发现与 harness
+   纠缠，则难以回退。
+
+### 为什么不选 C（agent 内核）
+
+1. 违反 subsystem.md：agent 内核的词汇表是"单 agent 的一次运行"；
+   AgentRegistry、agent 树拓扑、跨 agent input 路由不是单 agent 概念，
+   放入会扩大内核语义。
+2. 违反"不负责 prepared agent run contract"的明文排除。
+3. 内核污染会迫使所有 agent 消费者（包括不需要 multi-agent 的产品）
+   承担内核复杂度。
+
+### 边界纪律
+
+1. `harness.multiagent` 不实现自己的 agent loop；子 agent 本体是经
+   `AgentRunSpec` / `run_agent()` 的 prepared run 重入（ARD-002 第 4 条：
+   不写第二套 loop）。
+2. `harness.multiagent` 不依赖 method / work / channel / tui，不包含
+   产品 agent 类型定义；类型注册表、策略参数（并发上限、depth、超时
+   边界）与工具面开关由产品装配层注入。
+3. spawn / send / wait 的模型可见工具面不属于本模块本体；本模块提供
+   机制，工具的注册与暴露由产品装配层（或 harness 共享 tool
+   contract）决定。
+4. `loushang.agent` 不反向依赖 `harness.multiagent`；multi-agent 只消费
+   agent 的稳定原语。
+
+## Consequences
+
+### Positive
+
+- 无需新增子系统职责声明；subsystem.md 只需在 harness 职责清单补一条。
+- 依赖零新增：`multiagent -> harness.runner / agent` 的边已存在。
+- 多产品线（design / research / ppt / cowork）经 harness 零成本继承
+  multi-agent 能力，不依赖 coding 语义。
+- 与 harness 现有 host/queue/lifecycle 模块自然组合。
+
+### Negative / Costs
+
+- harness 包继续增大，需靠内部模块边界与 boundary 文档维持清晰度。
+- 若未来 multi-agent 需要跨越 harness 边界的能力（如直接驱动 channel
+  transport），需重新评估归属；当前判断是该需求应由装配层组合而非
+  本模块内化。
+
+### Follow-ups
+
+- 在 subsystem.md 的 `loushang-harness` 职责清单补 multi-agent 一条
+  （接受本 ARD 后执行）。
+- candidate-components 文档按本归属细化组件与 harness 现有
+  host / runner / lifecycle 模块的接缝。

--- a/docs/internals/architecture/harness/multiagent/ARD-002-async-execution-and-recovery.md
+++ b/docs/internals/architecture/harness/multiagent/ARD-002-async-execution-and-recovery.md
@@ -1,0 +1,91 @@
+# ARD-002: Async-Only Execution And Message-Driven Recovery
+
+## Status
+
+Proposed（目标设计，待接受）
+
+## Context
+
+`loushang.harness.multiagent` 需要决定两个相互关联的执行语义：
+
+1. **spawn 执行模式**：是否支持同步 spawn（父 agent 阻塞等待子结果作为
+   工具返回），还是一期全异步。
+2. **回收后恢复语义**：已完成/被回收的子 agent 再次收到消息时，如何
+   恢复运行。
+
+两个参考实现的做法：
+
+- **Codex v2**：spawn 后立即返回（异步）；v1 的显式 `resume_agent` 工具
+  在 v2 被废除，改为 `ensure_v2_agent_loaded`——LRU 回收（
+  `V2Residency`）只卸载状态已外置的 idle 终态 agent，父子边保持 open，
+  消息到达时透明重载，调用方无感知。close 后不可寻址。
+- **Claude Code**：`SendMessageTool` 对停止的 agent 自动
+  `resumeAgentBackground`（任务表内），甚至任务表淘汰后从磁盘
+  transcript 恢复——同样消息驱动、调用方透明。cc 的 fork gate 趋势是
+  所有 spawn 强制异步，统一 `<task-notification>` 交互模型。
+
+两家共识：**异步 + 通知是终局形态；恢复是消息驱动的自动行为，不需要
+显式 resume 工具**。差异仅在 Codex 有显式的 open/closed 区分（回收只
+针对 open agent），cc 的边界更模糊。
+
+loushang 一期的约束：
+
+- 并发上限小（个位数），没有真实的容量压力源，LRU 回收不是一期需求。
+- 全异步使 ToolSurfaceAdapter 只有一条路径（spawn → 注册 → 立即返回
+  引用），无需阻塞聚合、同步转后台等机制。
+
+## Decision
+
+### 1. 一期全异步执行，不支持同步 spawn
+
+- `spawn_agent` 工具总是立即返回结构化引用（agent path / 任务名），
+  子 agent 在后台运行。
+- 父 agent 获取结果的唯一途径是通知：子 agent 终态时经 AgentInputFacade 向父
+  input 注入完成通知（user-role 消息进入后续 turn）；`wait_agent`
+  等待自己 input 的 activity。
+- 不实现：阻塞式 spawn、前台 run 注册、同步转后台 race。
+
+后续若引入同步 spawn，作为增量设计（ToolSurfaceAdapter 增加阻塞聚合
+路径），不改变本 ARD 的异步语义。
+
+### 2. 恢复 = 消息驱动自动唤醒，无显式 resume 工具
+
+- **open / closed 区分**（采纳 Codex v2 语义）：
+  - `send_message` 到 idle / 已完成未关闭（open）的 agent = 自动驱动
+    新一轮 run（等价 Codex `followup_task` 与 cc auto-resume）。
+  - `send_message` 到已 close 的 agent = 结构化工具错误（不可寻址）。
+- **一期不做 LRU 回收**：并发上限小，无容量压力；没有回收就没有
+  "回收后恢复"问题，idle agent 的 send_message 即唤醒。
+- **二期预留**：引入容量压力下的回收时，回收前状态必须已外置、父子
+  边保持 open、send_message 透明重载（Codex v2 语义）；不引入显式
+  resume 工具。
+
+### 3. 取消传播双模式（配套规则）
+
+- 全异步下所有子 agent 均为后台运行：**不链接**父 run 的取消——父被
+  取消（如用户 ESC）不杀子 agent，只能显式 interrupt / close
+  （cc 的后台 ESC 语义）。
+- 子树取消是显式操作：close 父时递归 close 后代。
+
+## Consequences
+
+### Positive
+
+- 一期路径唯一：ToolSurfaceAdapter / RunHandle 无同步分支，实现与测试
+  面最小。
+- 通知模型统一：完成、消息、steer 都是 input 事件，wait 语义单一。
+- 恢复语义与两家参考实现的终局形态一致，避免发明第三种。
+- 一期不回收使"状态外置"可以二期再落地，不阻塞一期。
+
+### Negative / Costs
+
+- 需要"等结果再继续"的场景必须由 spawn + wait + 通知组合表达，提示
+  纪律需明确告知模型这一模式。
+- 取消传播双模式在一期实际只有一种（异步不链接），规则文档先行，
+  实现从简。
+
+### Follow-ups
+
+- ToolSurfaceAdapter 的提示纪律资源写明"spawn 立即返回、结果经通知
+  到达、wait 等待活动"。
+- 二期回收设计时，本 ARD 第 2 条三期预留语义作为输入。

--- a/docs/internals/architecture/harness/multiagent/README.md
+++ b/docs/internals/architecture/harness/multiagent/README.md
@@ -1,0 +1,79 @@
+# Loushang Multi-Agent Architecture
+
+> Status: **draft proposal**（目标设计，未经接受）。本目录的所有文档
+> 表达 should-be 的目标边界，不描述当前实现状态；与代码冲突时以代码
+> 与已接受 ARD 为准（见
+> [Loushang Documentation Model](../../loushang-documentation-model.md)）。
+
+`loushang.harness.multiagent` 提供子 agent 的派生、隔离、通信与生命
+周期管控——是**纯技术态**能力：它不理解 stage / acceptance / artifact
+等业务语义；业务编排（method / work）经产品装配层间接消费本能力。
+
+## Reading Order
+
+1. [System Context](system-context.md)
+   黑盒边界：直接上游（产品装配层）、直接下游（harness prepared run）、
+   逻辑 actor（parent agent、user/host）；明确不在边界上的子系统。
+2. [Candidate Components](candidate-components.md)
+   8 个候选组件的职责、独立性理由与参照来源。
+3. Accepted-direction ARDs:
+   - [ARD-001: Harness Ownership](ARD-001-harness-ownership.md) —
+     为什么是 `loushang.harness.multiagent` 而非顶层包或 agent 内核。
+   - [ARD-002: Async-Only Execution And Recovery](ARD-002-async-execution-and-recovery.md) —
+     一期全异步、消息驱动恢复、open/closed 区分。
+4. Component boundaries（按依赖序阅读）:
+   - [Tool Surface](tool-surface-boundary.md) — 模型可见的三件套
+     （spawn_agent / send_message / wait_agent）与提示纪律。
+   - [Control](control-boundary.md) — spawn 流水线与消息路由的编排。
+   - [Registry](registry-boundary.md) — AgentPath 寻址、两阶段预留、
+     树拓扑。
+   - [Run Handle](run-handle-boundary.md) — 子 agent 运行载体：多轮
+     驱动、取消双模式、事件转接。
+   - [Agent Input Facade](agent-input-facade-boundary.md) — 通知合成
+     与 wait 原语（复用 HostInputQueue）。
+   - [Context Fork](context-fork-boundary.md) — 隔离矩阵、fork 档位、
+     历史过滤、审批冒泡装配、可参数化 `fork_history()`。
+   - [Limits And Projection](limits-and-projection-boundary.md) — 并发
+     闸门、depth 上限、驻留回收（二期）、生命周期状态机与事实。
+
+## Core Invariants
+
+所有组件与注入缝必须遵守的不变式（产品/OEM 可定制策略，不可改写
+这些语义）：
+
+1. **不写第二套 agent loop**：子 agent 本体是 `run_agent(AgentRunSpec)`
+   的 prepared run 重入。
+2. **默认隔离，显式共享**：子上下文默认全隔离；任务注册穿透 root；
+   审批冒泡到 root 交互出口。
+3. **全异步 + 通知**：无同步 spawn；结果经完成通知到达；wait 等自己
+   input 的 activity，不轮询子状态。
+4. **先状态后收尾**：终态事实先于清理/汇总；收尾失败不反转状态。
+5. **open / closed 区分**：close 后不可寻址；open 的 idle/终态 agent
+   可被消息唤醒。
+6. **fork 的字节约束**：fork 档的父前缀字节级一致；历史过滤确定性；
+   fork 档不可改 model。
+7. **机制写死、策略注入**：上限值、过滤规则、通知模板、纪律文本等
+   是产品/OEM 注入缝；组件语义不变式不是。
+
+## Relationship To Other Subsystems
+
+- `loushang.harness`：本目录归属其中；复用其 `run_agent`、
+  `HostInputQueue`、`ApprovalRequest`、transcript（fork 历史源）、
+  host lifecycle 编排。
+- `loushang.agent`：提供 agent loop 与稳定原语；multiagent 不扩大其
+  内核语义。
+- `loushang.method` / `loushang.work`：业务态编排层；method 角色可
+  编译为 agent 类型（装配层职责），work 可消费 agent 树事实做业务
+  投影——multiagent 不依赖它们。
+- `loushang.channel`：未来承载远端/多客户端订阅；multiagent 的事实
+  经装配层投影后才可能进入 channel。
+- 产品装配层（coding / design / …）：注入类型注册表、策略参数、
+  事件消费者、审批出口；决定工具面暴露范围。
+
+## Evolution Path
+
+1. **一期**：三件套工具、全异步、消息驱动唤醒、内存 registry、无回收。
+2. **二期**：LRU 驻留回收（状态外置 + 透明重载）、同步 spawn（增量）、
+   transcript 持久化拓扑。
+3. **远期**：远端子 agent（channel 承载 transport）、method 编排的
+   stage 级派生与验收（业务态结合点，属 method/work 侧设计）。

--- a/docs/internals/architecture/harness/multiagent/agent-input-facade-boundary.md
+++ b/docs/internals/architecture/harness/multiagent/agent-input-facade-boundary.md
@@ -1,0 +1,179 @@
+# Multi-Agent AgentInputFacade Boundary
+
+> Status: **draft proposal**（目标设计，未经接受）。本文定义
+> `loushang.harness.multiagent` 的 agent input facade 边界：通知合成、投递与
+> `wait_agent` 等待原语。不描述当前实现状态。
+
+## Scope
+
+AgentInputFacade 是 multi-agent 的统一同步原语：子 agent 完成通知、其他 agent
+的消息、用户 steer 都经同一机制进入目标 agent 的运行，而 `wait_agent`
+以"等待自己 input activity"为唯一等待语义。
+
+本文定义：
+
+- AgentInputFacade 的职责与 `HostInputQueue` 复用关系
+- 消息类型与投递语义（steering / follow_up 映射）
+- 完成通知合成（终态 → 父 input）
+- wait 原语（activity watch、超时、唤醒源）
+- open / closed 投递规则（ARD-002）
+
+本文不定义：
+
+- 消息如何驱动新一轮 run（属 SubagentRunHandle）
+- 终态如何推导（属 LifecycleProjection）
+- 寻址与拓扑（属 AgentRegistry）
+- 模型可见的 wait 工具参数面（属 ToolSurfaceAdapter）
+
+## Reuse Of HostInputQueue
+
+AgentInputFacade **不是新队列**。harness 已有 `HostInputQueue`，原生支持：
+
+- `QueueKind = steering | follow_up` 两种入队模式
+- `snapshot()` / `drain()` / `has_pending()` 等账本操作
+- 与 agent 内核挂点天然对齐：loop 在每个工具边界消费
+  `get_steering_messages`，turn 结束消费 `get_follow_up_messages`
+
+AgentInputFacade 是 HostInputQueue 之上的 **multiagent 门面**，新增的只是：
+
+1. **来源标注**：每条入队消息携带 sender（agent_path / user / system）
+   与 kind，供接收方区分"用户输入"与"agent 间消息"。
+2. **activity 信号**：入队、steer 注入时发出 activity 通知，供
+   `wait_agent` watch（HostInputQueue 本身无 watch 语义，门面补一层
+   `asyncio.Condition` / watch channel 级别的活动信号）。
+3. **通知合成**：终态事实 → 父 input 的完成通知消息。
+
+底层排队、消费、丢弃一律复用 HostInputQueue；AgentInputFacade 不复制队列语义。
+
+## Message Types And Delivery Mapping
+
+```text
+AgentInputMessage
+  sender: AgentPath | "user" | "system"
+  kind:   "follow_up" | "steering" | "completion_notice"
+  text:   str                    # 消息正文（user-role 注入）
+  payload: AgentInputPayload        # 结构化附加（终态摘要、usage 等）
+```
+
+投递映射（默认 DeliveryPolicy，产品可注入覆盖）：
+
+| 消息 kind | 目标 running | 目标 idle/终态 |
+|---|---|---|
+| `follow_up` | 入 follow_up 队列，本轮结束后消费 | 驱动新一轮 run（ARD-002 唤醒） |
+| `steering` | 入 steering 队列，下一工具边界注入 | 驱动新一轮 run（作为首条输入） |
+| `completion_notice` | 入 follow_up 队列（`trigger_turn=false`，不抢轮） | 入队列；是否驱动新轮由接收方策略决定 |
+
+默认规则来自两家参考实现的对齐：
+
+- Codex v2：send_message 不触发 turn（follow_up），followup_task 触发；
+  完成通知 `trigger_turn=false`。
+- cc：SendMessage 到 running agent "queued for delivery at its next tool
+  round"（steering），到 stopped agent 自动 resume。
+
+loushang 统一为：**消息的 kind 决定排队语义，目标状态决定是否唤醒**；
+唤醒本身是 RunHandle 的 deliver 驱动，AgentInputFacade 只负责排队与标注。
+
+## Completion Notice Synthesis
+
+子 agent 终态时，由 AgentInputFacade 合成完成通知投递到父 input：
+
+```text
+completion_notice
+  sender: 子 agent_path
+  text:   人可读的完成摘要（终态消息截断 + 状态）
+  payload:
+    status:  completed | failed | interrupted
+    final_message: str           # 终态消息全文
+    usage:   { tokens, tool_uses, duration_ms }
+    worktree / artifact refs     # 经 LifecycleProjection 丰富的事实字段（TerminalFactMapper 归 projection）
+```
+
+时序链：RunHandle 转接原始 result → LifecycleProjection 推导终态并
+经 `TerminalFactMapper` 丰富事实 → AgentInputFacade 消费该事实合成
+完成通知。facade 不直接调用 mapper。
+
+纪律（cc gh-20236 教训）：
+
+1. **先写终态事实**：LifecycleProjection 的状态转移先发生，
+   `await_terminal` 的等待者立即解阻塞。
+2. **再合成通知**：通知合成与投递不得阻塞状态转移；合成失败只影响
+   通知内容，不反转状态。
+3. 通知进入父 input 后，父的 wait（若在等待）以 `AgentInputActivity`
+   唤醒——**唤醒不等于消费**，父 agent 在自己的后续 turn 读到通知。
+
+## Wait Primitive
+
+`wait_agent` 的语义：**等待自己 input activity，不轮询子状态**。
+
+```text
+wait_agent(timeout_ms?) -> WaitOutcome
+  AgentInputActivity   # 有消息到达（含完成通知）；返回摘要，不返回内容
+  Steered           # 用户 steer 注入打断了等待
+  TimedOut          # 超时；返回 timed_out=true
+```
+
+规则：
+
+1. **单一事件源**：完成通知、agent 消息、用户 steer 都唤醒 wait——
+   模型不需要区分"等哪个 agent"，等待的是"我的 input 有动静"。
+   （Codex v2 的 InputQueueActivity 模型。）
+2. **唤醒只给摘要不给内容**：WaitOutcome 说明"哪个/哪些 sender 有
+   更新"；内容在接收方的后续 turn 作为 user-role 消息自然出现——
+   防止模型在 wait 结果里读到半截内容后绕过正常消息通道（Codex
+   v2 的 wait 同样不返回内容）。
+3. **超时边界**：timeout 有 min/max/default，由策略参数注入（产品
+   可调）；超时返回是正常结果不是错误。
+4. **steer 优先**：等待期间用户 steer 注入立即结束等待（
+   `Steered`），保证用户输入永远不被 agent 间等待阻塞。
+
+## Open / Closed Delivery Rules（ARD-002）
+
+| 目标状态 | deliver 结果 |
+|---|---|
+| open + running | 按 kind 排队（steering/follow_up），返回投递回执 |
+| open + idle/终态 | 排队 + 触发 RunHandle 新一轮 run（唤醒），返回回执 |
+| closed | 结构化工具错误（不可寻址），**不**自动恢复 |
+| 已回收（二期） | 透明重载后按 open 处理（Codex v2 语义；一期无此态） |
+
+寻址解析（名字/相对路径 → agent_path）在 AgentRegistry；AgentInputFacade 只
+消费解析后的 path。
+
+## Product Injection Seams
+
+AgentInputFacade 的机制写死，以下为产品/OEM 可注入的缝：
+
+| 缝 | 注入内容 | 默认 |
+|---|---|---|
+| `DeliveryPolicy` | 消息 kind → 排队/唤醒的路由判定 | 上表映射 |
+| `NoticeComposer` | 终态事实 → 完成通知文本的合成 | 标准模板（状态 + 截断终态消息 + usage） |
+| `WaitTimeouts` | min / max / default 超时 | 策略参数（装配层注入，如 10s / 1h / 30s） |
+| `ActivitySink` | activity 信号的额外消费者（如 UI 未读标记） | 仅 wait watch |
+
+OEM 场景示例：替换 `NoticeComposer` 以本地化完成通知、或在通知中附
+加其审计系统要求的字段——经扩展贡献注册，AgentInputFacade 机制不变。
+
+## Ownership And Boundaries
+
+拥有：
+
+- 消息类型、来源标注与排队语义（经 HostInputQueue）
+- activity 信号与 wait 原语
+- 完成通知合成与投递
+- open / closed 投递判定（closed 拒绝）
+
+不拥有：
+
+- 新一轮 run 的驱动（RunHandle）
+- 终态推导与事实发射（LifecycleProjection）
+- 寻址解析（AgentRegistry）
+- 队列本身的账本操作（HostInputQueue）
+- 通知的业务解释（是否构成"产物"由装配层/work 判定）
+
+## Failure Semantics
+
+- 投递到 closed：结构化工具错误（`agent_not_addressable`），返回给
+  调用方作为正常工具结果。
+- 通知合成失败：记录诊断，投递降级通知（仅状态，无终态消息全文），
+  不阻塞、不重试。
+- wait 期间目标 agent input facade 被 clear（如 session 重置）：以
+  `AgentInputActivity` 唤醒并注明清空，由模型决定是否继续。

--- a/docs/internals/architecture/harness/multiagent/candidate-components.md
+++ b/docs/internals/architecture/harness/multiagent/candidate-components.md
@@ -1,0 +1,293 @@
+# Loushang Multi-Agent Candidate Components
+
+> Status: **draft proposal**（目标设计，未经接受）。按
+> [Loushang Documentation Model](../../loushang-documentation-model.md)，
+> 本文表达 should-be 的组件候选，不描述当前实现状态。
+>
+> 本版已按评审修订：核对 harness 现有模块（`host/queue.py`、
+> `host/runtime.py`、`approval.py`、`session/`）后，组件按**复用关系**
+> 定义，不平行重造已有机制。
+
+## Scope
+
+本文档给出 `loushang.harness.multiagent` 的候选组件列表。
+
+目标不是立即定版，而是为后续白盒组件设计提供候选清单。本文不讨论：
+
+- 最终组件定版与文件级映射
+- 模型可见工具面的具体 JSON schema（属组件设计）
+- method 角色编译规则（属 `loushang-method`）
+- 各产品装配层如何注册类型与暴露工具面
+
+## Design Basis
+
+组件识别基于以下已确定前提：
+
+- 归属：`loushang.harness.multiagent`，见
+  [ARD-001](./ARD-001-harness-ownership.md)
+- 系统边界：[system-context](./system-context.md)——直接下游是
+  `loushang.harness` 的 prepared-run contract（`AgentRunSpec` /
+  `run_agent()` / `AgentEventSink`），直接上游是产品装配层
+- 纯技术态：组件不得 import method / work / channel / tui 类型
+
+已核对的 harness 复用点：
+
+- `harness.host.queue.HostInputQueue`：原生支持 `QueueKind =
+  steering | follow_up` 两种入队模式与快照——AgentInputFacade 以它为底层机制
+- `harness.host.runtime.HostRuntime`：run/abort/wait_for_idle/dispose
+  生命周期与事件订阅——子 agent 运行载体的编排参照
+- `harness.approval.ApprovalRequest`：审批请求值对象与既有管道——审批
+  冒泡复用此管道，不新建组件
+
+参照来源（机制参照，非代码照搬）：
+
+- Codex：`core/src/agent/control.rs`（AgentControl）、`agent/registry.rs`、
+  `agent/control/spawn.rs`、`agent/control/residency.rs`、
+  `tools/handlers/multi_agents_v2/`、`CodexThread`（运行载体）
+- Claude Code：`tools/AgentTool/AgentTool.tsx`、`utils/forkedAgent.ts`、
+  `tasks/LocalAgentTask/`（运行载体）、`AgentTool/forkSubagent.ts`
+
+## Candidate Components
+
+### 1. MultiAgentControl（控制面）
+
+职责：
+
+- spawn 流水线：容量检查 → registry 预留 → 上下文构造 → 创建运行载体
+  → 初始输入投递 → 事实发射
+- 消息路由：send_message 投递（follow_up 或 steering）、interrupt、
+  close（含子树递归关闭）
+- 审批冒泡规则的执行：确保子 agent 的审批请求经 RunHandle 路由到 root
+  交互出口（复用 `harness.approval` 管道，附加 agent_path 冒泡链）
+
+为什么是独立组件：
+
+- 它是唯一的协调者，所有其他组件被它编排；与 registry（存储）、
+  context（构造）、limits（准入）职责不同层
+- 参照：Codex `AgentControl`（每 root 树一个实例，session 级共享）
+
+关键约束：
+
+- 作用域为 root run 树：同一实例被整棵子 agent 树共享，registry 不按
+  全局进程作用域
+- 不持有 agent loop；执行一律经 RunHandle → `run_agent(AgentRunSpec)`
+
+### 2. AgentRegistry（寻址与拓扑）
+
+职责：
+
+- `AgentPath` 层级寻址（`/root/research/auth`），相对名与全路径解析
+- 两阶段 reservation：spawn 时先预留 path（防并发同名冲突），run 建立
+  后 commit；失败自动回滚
+- agent 树拓扑：parent→child 边、子树枚举、按前缀列举
+- 逻辑映射：path ↔ 运行载体引用（物理执行由 RunHandle 持有，registry
+  只存映射与元数据：type、状态、创建时间）
+
+为什么是独立组件：
+
+- 寻址与拓扑是纯数据问题，与 spawn 协调、执行载体解耦
+- 两阶段预留是并发安全的独立关注点
+- 参照：Codex `agent/registry.rs`（reserve_spawn_slot / commit）
+
+### 3. SubagentRunHandle（运行载体）
+
+职责：
+
+- 每个子 agent 一个载体：持有当前 run 的 asyncio task、cancel token、
+  事件订阅，驱动多轮 run（子 agent 生命周期内可能经历多次
+  `run_agent()`，不是一次性调用）
+- `deliver(message)`：把 input 消息转为下一轮 run 输入或当前 turn
+  的 steering；目标 agent 处于 idle / 已完成未关闭状态时，deliver 自动
+  驱动新一轮 run（消息驱动唤醒，见
+  [ARD-002](./ARD-002-async-execution-and-recovery.md)）
+- `interrupt()` / `close()`：中断当前 turn、关闭并释放；close 后 agent
+  不可再寻址（open / closed 区分）
+- `await_terminal()`：等待终态（供 wait 与装配层复用）
+- 事件流转接：`AgentEventSink` → LifecycleProjection / 装配层消费者
+- 恢复语义入口：二期引入驻留回收后，被回收 agent 经消息透明重载
+  （状态已外置、父子边保持 open，Codex v2 语义）
+
+为什么是独立组件（评审新增）：
+
+- 原清单缺失：`run_agent()` 是一次性 async 调用，谁持有 task、谁接
+  事件流、interrupt 找谁的 cancel token、同步 spawn 谁聚合结果，都
+  需要明确归属
+- 对照：Codex `CodexThread`（ThreadManager 托管）、cc `LocalAgentTask`
+  （任务表 + runAsyncAgentLifecycle）
+- 编排参照：`HostRuntime` 的 run/abort/wait_for_idle/dispose 生命周期
+
+关键约束：
+
+- 取消传播双模式：**同步（前台）子 agent** 的 cancel token 链接父 run
+  （父取消传播）；**异步（后台）子 agent** 不链接父——父被取消不杀
+  后台子 agent，只能显式 interrupt/close（cc 的 ESC 语义）
+
+### 4. SubagentContextFactory（上下文构造）
+
+职责：
+
+- 从父上下文构造子 agent 的隔离上下文：默认全隔离（消息、策略状态、
+  denial 计数），显式 opt-in 共享
+- fork 档位实现：`none`（零上下文）/ `all`（全量历史）/ `last N turns`
+- fork 历史过滤：只保留 system / user / final-assistant 消息，丢弃工具
+  中间态与 multi-agent 自身的控制消息
+- 装配 AgentRunSpec：裁剪后的工具集、类型系统提示、模型覆盖
+- **审批冒泡装配**：子上下文的审批回调闭包固定绑定 root 交互出口，
+  ApprovalRequest 附加 agent_path 冒泡链（评审修订：原 ApprovalBubble
+  组件降级为本契约）
+
+为什么是独立组件：
+
+- "子 agent 看到什么"是最复杂也最容易出安全问题的关注点，必须独立于
+  协调逻辑可测试
+- cc 的教训（`createSubagentContext`）：默认隔离、显式共享、但任务注册
+  必须穿透到 root——这条纪律属于本组件的契约
+- fork 的字节级 cache 一致性约束（占位 tool result、透传已渲染前缀）
+  集中在这里
+
+关键约束：
+
+- 字节级前缀一致是 fork 的硬约束，不是优化项
+- 审批/策略状态默认不继承；继承项必须显式声明
+- 子 agent 不得自行发起交互；交互出口在 root（呈现由装配层决定）
+
+### 5. AgentInputFacade（通知与等待门面）
+
+职责（评审修订：基于 HostInputQueue 的门面，非平行队列）：
+
+- 以 `HostInputQueue` 为底层机制：send_message 的投递按语义映射为
+  `follow_up`（不中断、下轮消费）或 `steering`（注入当前 turn）
+- 通知合成：子 agent 终态时合成完成通知（终态消息、usage、时长），
+  投递到父 input
+- `wait_agent` 语义：watch **自己**队列的 activity（消息到达 / 完成
+  通知 / steer 统一唤醒），不轮询子状态；超时边界由策略参数控制
+- 每个 agent 的逻辑 input 视图：跨多次入队的消息序列
+
+为什么是独立组件：
+
+- 通知模型是 multi-agent 的统一同步原语；与 registry（谁知道谁）、
+  control（何时触发）解耦
+- "wait 等自己 input" 是 Codex 验证过的简化：把等待语义统一为单一
+  事件源
+- 参照：Codex `multi_agents_v2/wait.rs`（InputQueueActivity watch）、
+  cc `enqueueAgentNotification`
+
+关键约束：
+
+- 先写终态事实，再做收尾（清理、汇总）——cc gh-20236 教训：状态转移
+  不得被可能挂起的收尾操作阻塞
+- open / closed 区分：send_message 到 idle / 已完成未关闭的 agent =
+  自动唤醒新一轮 run；到已 close 的 agent = 结构化工具错误（不可寻址）
+
+### 6. Limits（并发、深度与驻留）
+
+职责：
+
+- 名额 = open agent 数：spawn 预留时获取、close 时释放；持有期内
+  活跃/空闲切换不计数（agent 数被上限封住，并发 turn 数被同一上限
+  封住，一期无 per-turn 闸门）；超限向调用方返回结构化错误
+- depth 上限：超过 spawn depth 拒绝派生（结构性递归防护）
+- 驻留与回收：已完成 agent 仍占名额直至 close 或 idle 超时；满载时按
+  LRU 回收 idle 完成的 agent（其状态已外置，可经 RunHandle 恢复）
+- 策略参数入口：上限值由装配层注入，组件不硬编码默认值
+
+为什么是独立组件：
+
+- 资源准入是独立的横切关注点，与"如何 spawn"（control）和"spawn 后
+  看到什么"（context）解耦
+- 参照：Codex `execution.rs`（AgentExecutionLimiter）、`residency.rs`
+  （V2Residency LRU）
+
+关键约束：
+
+- 准入失败是正常工具结果，不是异常——模型可以据此调整策略
+- 回收只针对状态已外置的 agent；运行中 agent 不可回收
+
+### 7. LifecycleProjection（状态机与事实发射）
+
+职责：
+
+- 子 agent 生命周期状态机：`pending → running → completed | failed |
+  interrupted | closed`，由 RunHandle 转接的 run 事件与终态推导
+- 向装配层发射事实：spawn、状态变更、终态（含终态消息、usage、时长）
+- agent 树事实的持久化接缝：父子边、终态，供装配层（或 work）投影为
+  业务事件；本组件只发射技术事实，不写 work event log
+
+为什么是独立组件：
+
+- "状态是什么"与"如何改变状态"（control）分离，使 UI / 审计 / 业务
+  投影共享同一事实源
+- 参照：Codex `agent/status.rs`（从事件流推导 AgentStatus）
+
+关键约束：
+
+- 终态消息是技术事实；是否构成业务"产物"由装配层 / work 判定
+
+### 8. ToolSurfaceAdapter（工具面适配）
+
+职责：
+
+- 把 control / agent input facade / registry 的能力封装为 agent 工具：
+  `spawn_agent` / `send_message` / `wait_agent`（三件套起步）
+- 参数严格校验（类型白名单、fork 档位、目标寻址）
+- 工具结果结构化（spawn 引用、投递回执、wait 活动摘要）
+- 准入失败、类型非法等返回正常工具错误结果（非异常）
+
+为什么是独立组件：
+
+- 机制（control）与模型可见面（工具 schema、提示纪律）是不同变化频率
+  的关注点；工具面可被产品裁剪（暴露子集、限制类型白名单）
+- 参照：Codex `multi_agents_v2/spawn.rs` 与 `AgentControl` 的分离
+
+关键约束：
+
+- 本组件是 multiagent 内部唯一依赖 agent 工具框架的位置
+- 提示词纪律文本（简报要求、禁止窥探、防 race）是资源，可被 OEM 替换
+
+## Component Relationship
+
+```text
+ToolSurfaceAdapter
+  -> MultiAgentControl
+      -> Limits                 (准入)
+      -> AgentRegistry          (寻址、预留、path↔handle 映射)
+      -> SubagentContextFactory (构造 AgentRunSpec、审批冒泡装配)
+      -> SubagentRunHandle      (运行载体：task/cancel/事件转接/多轮驱动)
+          -> harness.run_agent  (执行)
+          -> harness.host.HostInputQueue (经 AgentInputFacade)
+      -> AgentInputFacade      (通知合成、投递、wait 唤醒)
+      -> LifecycleProjection    (状态推导与事实发射)
+```
+
+装配层位于 ToolSurfaceAdapter 之上：注入类型注册表、策略参数、事件
+消费者，决定工具面暴露范围。
+
+## Non-Candidates（明确不列为组件）
+
+- **Agent loop / turn 执行**：属 `loushang.agent`，经 harness 复用
+- **审批管道**：`harness.approval` 已有 ApprovalRequest 管道；审批冒泡
+  是 ContextFactory 装配 + Control 执行的一条规则，不是新组件（评审
+  修订）
+- **输入队列**：`harness.host.HostInputQueue` 已有 steering/follow_up
+  语义；AgentInputFacade 是其上的门面，不是新队列（评审修订）
+- **Agent 类型资源解析与编译**：类型对 multiagent 只是注入的
+  `AgentTypeRecord`；资源加载属产品装配层，method 角色编译属 method
+- **业务编排（stage join、acceptance 判定）**：属 method / work
+- **事件持久化与 replay**：multiagent 只发射技术事实；持久化属装配层
+  或 work
+- **UI 面板**：属 harnesstui / 产品 UI，消费 LifecycleProjection 的事实
+- **远端子 agent transport**：未来扩展，由 channel 承载
+
+## Open Questions（留待拍板 / 组件设计）
+
+1. ~~AgentInputFacade 与内核 pending queue 关系~~（评审已答：AgentInputFacade 复用
+   HostInputQueue，与内核无关）
+2. ~~同步 spawn 是否一期支持~~（已拍板：一期全异步 + 通知，无同步
+   spawn；见 [ARD-002](./ARD-002-async-execution-and-recovery.md)）
+3. ~~驻留回收后恢复的触发时机~~（已拍板：消息驱动自动恢复，不引入显式
+   resume 工具；一期不做回收，idle agent 的 send_message 即唤醒；见
+   [ARD-002](./ARD-002-async-execution-and-recovery.md)）
+4. ~~AgentPath 与 session id 映射归属~~（评审已答：registry 存逻辑
+   映射，RunHandle 持物理执行）
+
+全部已关闭；后续问题在组件设计与 ARD 中展开。

--- a/docs/internals/architecture/harness/multiagent/context-fork-boundary.md
+++ b/docs/internals/architecture/harness/multiagent/context-fork-boundary.md
@@ -1,0 +1,260 @@
+# Multi-Agent Context Fork Boundary
+
+> Status: **draft proposal**（目标设计，未经接受）。本文定义
+> `loushang.harness.multiagent` 的子 agent 上下文构造边界：隔离模型、
+> fork 档位、历史过滤、审批冒泡装配。不描述当前实现状态。
+
+## Scope
+
+`SubagentContextFactory` 回答一个问题：**子 agent 出生时看到什么**。
+它从父上下文构造子 agent 的 `AgentContext`（system_prompt、messages、
+tools）与运行配置，是 multi-agent 中最复杂、安全问题最集中的组件。
+
+本文定义：
+
+- 默认隔离模型（什么隔离、什么可共享）
+- fork 三档语义与历史过滤规则
+- 字节级 prompt cache 一致性约束
+- 审批冒泡装配（复用 `ApprovalRequest` 管道）
+- AgentRunSpec 的最终组装
+
+本文不定义：
+
+- spawn 流水线的协调顺序（属 MultiAgentControl）
+- agent 类型的业务定义（类型只是注入的 `AgentTypeRecord`）
+- 消息投递与唤醒（属 AgentInputFacade / RunHandle）
+- 模型的提示词纪律文本内容（属 ToolSurfaceAdapter 的资源）
+
+## Why This Component
+
+cc 的 `createSubagentContext` 证明了这条边界的重要性：默认全隔离、
+显式 opt-in 共享，但**任务注册必须穿透到 root**（否则后台 agent 的
+子任务成为僵尸）。Codex 的 fork 过滤（`keep_forked_rollout_item`）
+证明了另一件事：fork 不是"复制历史"，而是"按规则重建一份对子 agent
+有意义的历史"。两条规则合并，就是本组件的契约。
+
+## Isolation Model
+
+构造子上下文时，按以下矩阵处理父上下文的每一部分：
+
+| 父上下文部分 | 默认 | 可 opt-in 共享 | 说明 |
+|---|---|---|---|
+| messages（对话历史） | **隔离**（fresh spawn 为空） | fork 档位共享（见下节） | 核心决策点 |
+| system_prompt | **替换**为类型系统提示 | fork 时透传父前缀 | 类型决定子 agent 的角色 |
+| tools | **按类型裁剪**（白/黑名单） | 不可共享原表 | 递归防护也在此（类型不含 spawn 工具） |
+| model / reasoning | **继承父** | spawn 参数显式覆盖 | fork 档不可覆盖（cache 约束） |
+| 审批回调 | **冒泡装配**（见下节） | 不可继承父状态 | denial 计数等策略状态重置 |
+| cancel token | **独立**（ARD-002 异步不链接） | 同步 spawn（二期）链接父 | 父 ESC 不杀后台子 agent |
+| 任务注册 | **穿透到 root** | 不可隔离 | cc 僵尸进程教训：注册必须全局可见 |
+| 文件状态缓存（readFileState 类） | **克隆** | 可共享只读 | 防止父子互相污染"已读文件"状态 |
+
+纪律：**默认隔离，共享必须显式声明且逐条审查**。任何新增的上下文
+部分默认落入"隔离"列，除非有明确理由。
+
+## Fork Tiers
+
+spawn 的 `fork` 参数决定子 agent 的消息历史来源：
+
+| 档 | 语义 | messages | system_prompt | model 可覆盖 |
+|---|---|---|---|---|
+| `none` | 零上下文 | 空 | 类型系统提示 | ✅ |
+| `all` | 全量 fork | 父历史（过滤后） | 父前缀 + 子追加 | ❌（cache 硬约束） |
+| `last N` | 最近 N 轮 | 父历史末尾 N 轮（过滤后） | 父前缀 + 子追加 | ❌ |
+
+- `none` 是默认档：子 agent 是"刚进门的同事"，简报（spawn prompt）
+  是它的全部上下文。
+- `all` / `last N` 用于：父希望子继承对话背景（如"接着调查这个
+  问题"），同时保持 prompt cache 前缀一致。
+- 档位的**边界单位是轮（turn）不是消息条数**：一轮 = 一组 user
+  输入 + assistant 响应 + 其工具往返。`last N` 截断在轮边界。
+
+## Fork History Source（与 session fork 的统一）
+
+fork 档的父历史**以 harness transcript 为源**，不从内存
+`AgentContext.messages` 读取。这是 Codex 统一路线的采纳：
+
+- Codex 用一个 `fork_thread` 原语同时承载用户分叉与 spawn fork，
+  差异只在快照策略；其关键是父的历史本就持久化在 rollout 里。
+- loushang 的 harness transcript（`ConversationRecord` 图 +
+  `path_to` / `fork_plan`）与 Codex rollout 同构，同样可以作为
+  统一历史源。
+
+因此 spawn fork 与 session fork 的关系是**底层共用、语义分层**：
+
+| | session fork（已有） | spawn fork（本组件） |
+|---|---|---|
+| 历史读取 | `TranscriptRepository.path_to` / `fork_plan` | **复用同一机制** |
+| 选择粒度 | entry_id + `fork_position` | 轮数（none/all/last N） |
+| 内容处理 | 全量保留 | **过滤重建**（下节，独有） |
+| 一致性约束 | branch 图完整性 | **字节级 cache 前缀**（独有） |
+| 产出 | 新 TranscriptRepository（持久化分支） | 子 AgentRunSpec.messages（内存） |
+| 驱动者 | 用户/产品 | agent |
+
+共用带来两个直接收益：
+
+1. **父回收场景天然解决**（二期）：父 agent 已被 LRU 回收时，
+   其历史仍在 transcript 中，spawn fork 不要求父在线。
+2. **不新写历史读取**：轮边界的截取映射为对
+   `path_to` 结果的后处理，不另起一套。
+
+约束：transcript 记录的 payload 是产品格式（`ConversationRecord[T]`），
+因此“记录 → AgentMessage”的映射是**产品注入的缝**（见后文
+`TranscriptMessageMapper`）；本组件不假设产品记录格式。
+
+## History Filter Rules（fork 档适用）
+
+fork 的历史**不是复制**，而是按规则重建。对父历史中的每条
+消息（经 `TranscriptMessageMapper` 映射为 AgentMessage 后逐条判定）：
+
+保留：
+
+- `UserMessage`（用户输入）
+- `AssistantMessage` 中属于**最终答复**的部分（无 tool_call 的纯文本
+  助手消息；含 tool_call 的助手消息整体见下）
+- system / developer 消息（保留，但剥离 multi-agent 控制提示，见下）
+
+丢弃：
+
+- **工具中间态**：`ToolResultMessage`、assistant 消息中的 tool_call
+  部分——子 agent 不需要看到父如何调用工具的细节，只需要结论
+- **multi-agent 控制消息**：spawn / send / wait 工具的调用与结果、
+  agent 间通信标记——子 agent 不应看到父的编排痕迹（Codex 丢弃
+  `InterAgentCommunication` 的同款规则）
+- **usage hint 类注入**：父上下文中的 multi-agent 使用提示文本
+  （Codex 过滤 usage_hint_texts 的同款规则）；子 agent 的系统提示
+  由类型重新提供
+
+重建后追加：
+
+- 子 agent 自己的类型系统提示（作为前缀追加或独立 system 消息）
+- spawn 简报（作为首条 user 消息）
+
+## Fork Function（可参数化工具函数）
+
+历史选择与过滤重建封装为一个纯、可参数化的工具函数，
+供不同调用方（spawn 流水线、产品自定义流程、OEM 扩展）复用：
+
+```text
+fork_history(
+  source: TranscriptSource,        # 父 transcript 引用（复用 path_to 读取）
+  tier: ForkTier,                  # none | all | last(N)
+  *,
+  filter: HistoryFilter | None,    # 可注入；默认为下节规则
+  mapper: TranscriptMessageMapper, # 可注入；记录 → AgentMessage，产品提供
+  cache_prefix: RenderedPrefix | None,  # fork 档透传的父已渲染前缀
+) -> ForkedHistory
+  # ForkedHistory:
+  #   messages: [AgentMessage]     # 过滤重建后的历史（含占位 tool_result 配对）
+  #   prefix_bytes: bytes | None   # 透传的前缀（cache 约束，fork 档非空）
+  #   diagnostics: [Diagnostic]    # 降级与过滤记录（如历史为空降 none）
+```
+
+约束：
+
+- **纯函数**：同一输入必产生字节级相同的输出（cache 硬约杘）；
+  不得依赖时间、随机数、可变全局状态。
+- **参数化**：过滤规则、记录映射、前缀透传均为参数，不内嵌
+  产品逻辑；产品/OEM 经参数定制，不修改函数本体。
+- 调用方不得绕过它直接拼装 fork 历史——cache 约束的维护
+  集中在此函数。
+
+这与 harness 现有的 `ForkProfile` / `ForkTargetResolver`模式一致：
+harness 提供保守默认，产品通过注入扩展位置与解析器。
+
+## Byte-Level Cache Constraint（fork 档硬约束）
+
+`all` / `last N` 档存在的理由主要是 **prompt cache 共享**：同一父
+fork 出的多个子 agent，其首轮 API 请求的前缀必须**字节级一致**，
+只有末尾的子追加部分不同。因此：
+
+1. **透传父已渲染的 system prompt 字节**，不重新组装（cc 的
+   `renderedSystemPrompt` 透传教训：重组装可能因状态变化产生字节
+   偏差，击穿 cache）。
+2. **历史过滤是确定性的**：同一父上下文 + 同一档位，过滤结果逐字节
+   相同；过滤规则不得依赖运行时状态（时间、随机数、可变配置）。
+3. **占位 tool_result**：若过滤后父历史的末尾 assistant 消息仍带
+   tool_call（如父在 fork 时正处于工具调用中），为其配字节级一致的
+   占位 tool_result（cc 的 `FORK_PLACEHOLDER_RESULT` 模式），保证
+   消息配对完整且所有 fork 孩子前缀一致。
+4. **fork 档禁止 model 覆盖**：不同 model 的请求参数不同，前缀
+   无法共享（cc 的 "Don't set `model` on a fork" 纪律）。
+
+`none` 档不受此约束（无共享前缀可言）。
+
+## Approval Bubbling Assembly
+
+子上下文的审批回调（`can_use_tool` 类）在构造时**固定装配为冒泡
+闭包**：
+
+1. 子 agent 的高风险工具操作产生 `ApprovalRequest`（harness 既有
+   值对象），附加**冒泡链**：`agent_path`（发起者）与父链。
+2. 请求经管道直达 **root 交互出口**——子 agent 无自己的交互出口，
+   不得自行弹窗/询问（呈现由装配层决定：TUI 弹窗 / RPC
+   interaction）。
+3. 审批结果沿管道回传到子 agent 的工具执行。
+4. 策略状态（denial 计数、allowlist 会话记忆）在子 agent 边界
+   **重置**：子 agent 不继承父的"本会话已批准"状态（cc 的
+   `localDenialTracking` 隔离）。
+
+## AgentRunSpec Assembly
+
+工厂的最终产出是给 RunHandle 的 `AgentRunSpec` 初值：
+
+```text
+AgentRunSpec
+  context:
+    system_prompt = 类型系统提示（none 档）或 父前缀 + 子追加（fork 档）
+    messages      = []（none）或 过滤重建后的父历史 + 简报（fork 档）
+    tools         = 类型裁剪后的工具集
+  config:
+    model         = spawn 覆盖（none 档）或 父继承（fork 档）
+    can_use_tool  = 冒泡闭包（固定装配）
+    signal        = handle 自有 AbortController（异步不链接）
+    get_steering_messages / get_follow_up_messages
+                  = AgentInputFacade 队列适配（由 RunHandle 接线）
+  mode = "prompt"（首轮）
+```
+
+后续轮由 RunHandle 以 `mode="continue"` 驱动，context.messages 在
+运行中累积——工厂只负责首轮的出生状态。
+
+## Product Injection Seams
+
+| 缝 | 注入内容 | 默认 |
+|---|---|---|
+| `HistoryFilter` | fork 历史过滤规则 | 上述保留/丢弃规则 |
+| `TranscriptMessageMapper` | transcript 记录 → AgentMessage 的映射 | 产品提供（记录 payload 是产品格式） |
+| `TypeSystemPrompt` | 类型的系统提示文本 | AgentTypeRecord 携带 |
+| `IsolationOverrides` | 隔离矩阵的逐条覆盖 | 默认隔离 |
+| `ApprovalExitPort` | root 交互出口的适配 | 装配层提供（TUI / RPC） |
+
+护栏：注入改变的是**策略与内容**（过滤哪些消息、提示文本、审批
+出口呈现），不改变**结构不变式**（默认隔离、cache 字节约束、冒泡
+必须到 root、任务注册穿透）。
+
+## Ownership And Boundaries
+
+拥有：
+
+- 隔离矩阵与共享 opt-in 判定
+- fork 档位语义与历史过滤重建
+- cache 字节一致性约束的维护
+- 审批冒泡闭包的装配
+- 首轮 AgentRunSpec 的组装
+
+不拥有：
+
+- spawn 协调顺序（Control）
+- 类型的业务定义与编译（装配层 / method）
+- 多轮驱动与 context 跨轮传递（RunHandle）
+- 审批请求的策略判定与呈现（harness approval / 装配层）
+- 消息投递（AgentInputFacade）
+
+## Failure Semantics
+
+- fork 档历史为空或过滤后为空：降级为 `none` 档语义（仅简报），
+  记录诊断，不报错——fork 是优化，不是正确性依赖。
+- 类型裁剪后工具集为空：构造失败，spawn 以结构化错误返回（类型
+  定义非法，属装配期问题，不应拖到运行期）。
+- cache 约束无法满足（如父前缀不可得）：降级为重组装并记录诊断，
+  不阻塞 spawn——cache 击穿是性能损失，不是错误。

--- a/docs/internals/architecture/harness/multiagent/control-boundary.md
+++ b/docs/internals/architecture/harness/multiagent/control-boundary.md
@@ -1,0 +1,176 @@
+# Multi-Agent Control Boundary
+
+> Status: **draft proposal**（目标设计，未经接受）。本文定义
+> `loushang.harness.multiagent` 的控制面边界：spawn 流水线、消息路由、
+> interrupt / close 的编排。不描述当前实现状态。
+
+## Scope
+
+`MultiAgentControl` 是 multiagent 的唯一协调者。它不实现任何具体机制
+（上下文构造、队列、准入、执行载体各自独立），而是按确定的顺序编排
+这些组件，把"spawn 一个子 agent"、"给某 agent 发消息"这类请求落实为
+一系列组件调用。
+
+本文定义：
+
+- 控制面的作用域与持有关系
+- spawn 流水线的步骤序列与失败回滚
+- send_message / interrupt / close 的路由规则
+- 与装配层的接缝（注入点、事件出口）
+
+本文不定义：
+
+- 各组件的内部机制（见各自 boundary 文档）
+- 模型可见的工具参数面（属 ToolSurfaceAdapter）
+- 并发名额与回收的具体策略（属 Limits）
+
+## Scope And Ownership
+
+- **每 root run 树一个实例**：Control 由装配层在 root run 建立时创建，
+  同一棵树的所有子 agent（无论深度）共享它。registry 按树作用域，
+  不按进程全局——两棵独立的 root 树互不寻址。
+- **持有关系**：Control 持有 AgentRegistry、Limits、各 RunHandle（经
+  registry 映射）、AgentInputFacade 的投递口、装配层注入的策略参数
+  与事件消费者。
+- **不持有**：agent loop（loushang.agent）、历史读取
+  （TranscriptRepository，经 ContextFactory 使用）、类型定义
+  （AgentTypeRecord，装配层注入）。
+
+## Spawn Pipeline
+
+spawn 请求（来自 ToolSurfaceAdapter 或装配层）按以下固定顺序执行：
+
+```text
+spawn(request: SpawnRequest) -> SpawnHandle | SpawnError
+
+ 1. 类型解析    按 request.agent_type 查 AgentTypeRecord（装配层注入的
+                类型注册表）；未知类型 → 结构化错误（装配期问题）
+ 2. 准入检查    Limits.ensure_capacity()——并发名额 + depth 上限；
+                超限 → 结构化错误（正常工具结果，非异常）
+ 3. 寻址预留    registry.reserve(agent_path)——两阶段预留，防并发同名
+ 4. 上下文构造  ContextFactory.build(...)——隔离矩阵 + fork 档（经
+                fork_history() 工具函数）+ 审批冒泡装配 → AgentRunSpec
+ 5. 载体创建    创建 RunHandle（独立 cancel token，ARD-002 异步不链接），
+                注册到 registry 映射
+ 6. 提交预留    registry.commit(agent_path → handle)；任一步失败到此前
+                → reserve 自动回滚，无残留
+ 7. 初始投递    handle.deliver(初始简报)——驱动首轮 run
+ 8. 事实发射    LifecycleProjection 记录 spawn 事实（path、type、parent、
+                时间）→ 装配层消费者
+```
+
+关键规则：
+
+- **顺序不可变**：准入在寻址前，寻址在构造前，构造在载体前——任何
+  重排都会破坏回滚语义（如先构造后准入会留下未消费的 AgentRunSpec）。
+- **失败即回滚**：步骤 3-6 构成预留窗口；窗口内任何失败回滚预留，
+  不产生半注册的 agent。这是 registry 两阶段预留的存在理由。
+- **步骤 7 的异步性**：deliver 驱动首轮 run 后立即返回（ARD-002 全
+  异步）；spawn 的返回值是 SpawnHandle 引用，不是子 agent 的结果。
+- **步骤 1-2 的错误是正常工具结果**：类型未知、名额已满都返回
+  结构化错误给调用方（模型可据此调整策略），不抛异常。
+
+## Message Routing
+
+`send_message(target, message, kind?)` 的路由规则：
+
+```text
+send_message(request) -> DeliveryReceipt | DeliveryError
+
+ 1. 寻址解析    registry.resolve(target)——支持相对名（相对调用者
+                agent_path）与全路径；未找到 → 结构化错误
+ 2. 状态判定    经 registry 查目标 handle 的状态：
+                - closed       → 结构化错误（不可寻址，ARD-002）
+                - 已回收(二期) → 透明重载后按 open 处理
+                - open         → 继续
+ 3. 投递        经 AgentInputFacade 按 kind（follow_up / steering）入队
+                目标 handle 的队列；目标 idle/终态 → 触发新一轮 run
+ 4. 回执        返回投递回执（queued / triggered_new_round）
+```
+
+`interrupt(target)`：
+
+```text
+ 1. 寻址解析 + open 判定（同上）
+ 2. handle.interrupt()——停当前 turn，实体转 interrupted，保持 open
+ 3. 返回中断前状态（供调用方确认）
+```
+
+`close(target)`：
+
+```text
+ 1. 寻址解析
+ 2. 子树枚举    registry.subtree(target)——含全部后代
+ 3. 自底向上    对每个后代（深到浅）执行 handle.close()：
+                interrupt 当前轮（若有）→ 释放 → registry 注销 → limits.release()
+ 4. 目标自身 close；返回关闭前状态
+```
+
+规则：
+
+- **close 递归**：关闭父必须递归关闭后代（不留孤儿 agent 占用名额）。
+- **interrupt 不递归**：中断只作用于目标自身（子 agent 的后代继续
+  运行，除非显式逐个中断）。
+- **幂等**：重复 close / interrupt 返回当前状态，不报错。
+
+## Event Egress
+
+Control 是 multiagent 事实的唯一出口（经 LifecycleProjection 发射，
+Control 触发时机）：
+
+| 时机 | 事实 |
+|---|---|
+| spawn 流水线完成 | agent_spawned（path、type、parent） |
+| RunHandle 状态转移 | agent_status_changed（经 projection 推导） |
+| 终态 | agent_terminal（status、终态消息、usage、时长） |
+| close 完成 | agent_closed（path、关闭前状态） |
+
+装配层消费者：UI 面板、审计日志、（经装配层投影的）work 业务事件。
+Control 不知道消费者的形态，只保证事实按序、不丢。
+
+## Assembly Injection Points
+
+装配层（产品 / OEM）在创建 Control 时注入：
+
+| 注入 | 内容 | 默认 |
+|---|---|---|
+| `AgentTypeRegistry` | 类型注册表（AgentTypeRecord 集合） | 空（必须注入才能 spawn） |
+| `MultiAgentPolicy` | 并发上限、depth 上限、wait 超时边界 | harness 保守默认 |
+| `RunDriver` 等缝 | RunHandle 的各注入缝（见 run-handle-boundary） | harness 默认 |
+| `EventConsumers` | 事实消费者（UI / 审计 / work 投影适配） | 无 |
+| `ApprovalExitPort` | root 交互出口适配（TUI / RPC） | 装配层必须提供 |
+| `TranscriptSource` | fork 历史读取的 transcript 引用 | root run 的 transcript |
+
+OEM 场景：OEM 注入自己的类型注册表（品牌化 agent 类型）、调整
+policy 上限、注册审计消费者——Control 机制不变。
+
+## Ownership And Boundaries
+
+拥有：
+
+- spawn 流水线的步骤序列与回滚
+- send_message / interrupt / close 的路由与递归规则
+- 组件编排（registry、limits、factory、handle、facade 的调用顺序）
+- 事实发射的时机（内容属 LifecycleProjection）
+
+不拥有：
+
+- 任何组件的内部机制
+- 类型定义与业务编译（装配层 / method）
+- 模型工具面（ToolSurfaceAdapter）
+- 业务编排与终局判定（method / work）
+- 审批的策略判定与呈现（harness approval / 装配层）
+
+## Failure Semantics
+
+| 失败 | 语义 |
+|---|---|
+| 类型未知 | 结构化工具错误（装配期问题），spawn 不发生 |
+| 名额/depth 超限 | 结构化工具错误（正常结果），无预留残留 |
+| 预留冲突（同名） | 结构化错误，已有 agent 不受影响 |
+| 构造失败（如类型工具为空） | 预留回滚，结构化错误 |
+| deliver 失败（首轮启动失败） | handle 转 failed（保持 open 可恢复），预留已 commit 不回滚 |
+| close 中某后代 close 失败 | 记录诊断，继续其余后代；目标自身的 close 最后执行 |
+
+纪律：预留窗口（步骤 3-6）内的失败必须回滚；窗口后的失败
+（deliver 起）agent 已存在，以 failed 状态呈现而非假装未创建。

--- a/docs/internals/architecture/harness/multiagent/limits-and-projection-boundary.md
+++ b/docs/internals/architecture/harness/multiagent/limits-and-projection-boundary.md
@@ -1,0 +1,146 @@
+# Multi-Agent Limits And Lifecycle Projection Boundary
+
+> Status: **draft proposal**（目标设计，未经接受）。本文定义
+> `loushang.harness.multiagent` 的资源准入（Limits）与生命周期事实投影
+> （LifecycleProjection）边界。不描述当前实现状态。
+
+## Scope
+
+两个小组件合写一文：Limits 决定"**能不能生**"（准入），
+LifecycleProjection 决定"**现在是什么状态、发生了什么**"（事实）。
+它们都不做协调，分别被 MultiAgentControl 调用与触发。
+
+本文定义：
+
+- 并发闸门、depth 上限、驻留回收（二期）的准入语义
+- 生命周期状态机与推导规则
+- 技术事实的形状与发射纪律
+
+本文不定义：
+
+- 准入失败后的调用方行为（属 Control / ToolSurfaceAdapter）
+- 事实的消费者形态（属装配层）
+- 回收的状态外置编解码（属 SnapshotCodec 缝 / RunHandle）
+
+## Limits
+
+### Concurrency Gate
+
+一期名额模型（简化：避免 per-turn 计数的时序问题）：
+
+- **名额 = open agent 数**，按 root run 树计数（整棵树共享上限，不是每个
+  agent 一份）。
+- **获取：spawn 预留时**（registry.reserve 成功即占名额）；
+  **释放：close 完成时**（唯一释放点）。
+- 持有期内活跃/空闲切换不计数：已 spawn 的 agent 在 idle /
+  终态后仍占名额，唤醒新一轮不再检查名额（名额在 spawn 时已计入）。
+  agent 数被上限封住，并发 turn 数被同一上限封住，一期不需
+  per-turn 闸门。
+- 超限 → `AgentLimitReached(max)` 结构化错误（**正常工具结果**，模型
+  可据此改用 wait/串行策略）。
+
+二期演进：若引入驻留制（见 Residency），名额语义升级为
+"已加载 agent 数（LRU 回收）、registry 不设限"——与 Codex v2 的演进一致，
+届时 close 释放名额、回收释放加载位。
+
+### Depth Limit
+
+- spawn depth = 父 depth + 1（root 为 0）；超过 `max_spawn_depth`
+  拒绝派生。
+- 这是**结构性递归防护的兜底**；首要防线是类型工具裁剪（类型不含
+  spawn 工具即不可再派生，见 context-fork 隔离矩阵）。
+
+### Residency（二期，一期不实现）
+
+- 已完成 agent 保持 open 占名额直至 close；容量压力下
+  按 LRU 回收 **idle 终态且无待收消息** 的 agent。
+- 回收前状态外置（经 `SnapshotCodec`），父子边保持 open；回收后
+  send_message 透明重载（ARD-002）。
+- 回收候选判定、idle 阈值、保护规则（如"pinned" agent 不回收）均为
+  可注入策略。
+
+### Policy Parameters
+
+全部由装配层注入，harness 只提供保守默认：
+
+| 参数 | 默认 | 说明 |
+|---|---|---|
+| `max_concurrent_agents` | 保守小值（如 6，含 root） | 树级 open agent 上限 |
+| `max_spawn_depth` | 保守小值（如 3） | 递归防护兜底 |
+| `idle_eviction_timeout` | 二期 | 驻留超时 |
+| `wait_timeouts` | min 10s / max 1h / default 30s | wait 边界（Codex v2 同量级） |
+
+## LifecycleProjection
+
+### State Machine
+
+```text
+pending ──首轮 run 开始──► running ──终态──► completed | failed
+                              │
+                              └─interrupt──► interrupted ──deliver──► running
+任何 open 态 ──close──► closed
+```
+
+- `pending`：已注册未开跑（spawn 流水线内）；`running`：有活跃轮；
+  `completed` / `failed`：终态（保持 open 可唤醒，ARD-002）；
+  `interrupted`：被中断（保持 open）；`closed`：已关闭（不可寻址）。
+- 推导来源：RunHandle 转接的 run 事件（turn_start → running；
+  run result → completed/failed；interrupt → interrupted；close →
+  closed）。projection 不监听模型内容，只映射 run 生命周期。
+
+### Technical Facts
+
+```text
+AgentFact
+  kind: spawned | status_changed | terminal | closed
+  agent_path, parent_path, agent_type
+  status: SubagentStatus
+  terminal_payload: { final_message, usage, duration_ms, tool_uses } | None
+  at: Timestamp
+  metadata: Mapping                  # 产品经 TerminalFactMapper 追加
+```
+
+发射纪律：
+
+1. **先状态后收尾**：registry 状态回写与 `await_terminal` 解阻塞先于
+   事实发射；发射失败不反转状态（cc gh-20236）。
+2. **有序**：同一 agent 的事实按其发生顺序；不同 agent 间不保证全局
+   序（消费者按 path 分组）。
+3. **技术事实不是业务产物**：terminal 的 final_message 是否构成业务
+   "产物/验收依据"由装配层 / work 判定；projection 不解释。
+4. **registry ↔ projection 分工**：registry 是控制面视图（协调以它为
+   准），projection 是事实视图（展示/审计/work 投影以它为准）。
+
+### Consumer Interface
+
+```text
+subscribe(consumer: AgentFactConsumer)
+  # 装配层注册：UI 面板、审计日志、work 投影适配器
+  # 消费者收到的是不可变事实快照；不回调进 multiagent
+```
+
+## Product Injection Seams
+
+| 缝 | 注入内容 | 默认 |
+|---|---|---|
+| `LimitPolicy` | 上限值与超限行为（拒绝/排队等待） | 拒绝（结构化错误） |
+| `EvictionPolicy` | 二期：回收候选、阈值、保护规则 | LRU + idle 终态 |
+| `TerminalFactMapper` | 终态事实的产品附加字段（经 metadata，不改核心 shape） | 标准终态（status/终态消息/usage/时长/tool 计数） |
+| `FactSinks` | 额外事实消费者（OEM 审计等） | 无 |
+
+## Ownership And Boundaries
+
+Limits 拥有：名额计数（spawn 获取、close 释放）、depth 判定、回收决策（二期执行由
+Control/RunHandle 完成）。不拥有：spawn 协调、状态存储。
+
+LifecycleProjection 拥有：状态机推导、事实 shape 与发射（经 `TerminalFactMapper`
+丰富终态事实；丰富后的事实供 AgentInputFacade 合成完成通知）。不拥有：
+registry 的协调视图、消费者的处理、业务解释。
+
+## Failure Semantics
+
+- 超限/超深：结构化错误返回调用方，无预留残留。
+- 回收冲突（回收与 deliver 并发）：deliver 优先——回收前检查
+  "无待收消息"，deliver 到达即取消本次回收。
+- 事实发射失败（消费者异常）：记录诊断、跳过该消费者，不影响
+  状态机与其他消费者。

--- a/docs/internals/architecture/harness/multiagent/registry-boundary.md
+++ b/docs/internals/architecture/harness/multiagent/registry-boundary.md
@@ -1,0 +1,148 @@
+# Multi-Agent Registry Boundary
+
+> Status: **draft proposal**（目标设计，未经接受）。本文定义
+> `loushang.harness.multiagent` 的寻址与拓扑边界：`AgentPath`、两阶段
+> 预留、agent 树拓扑。不描述当前实现状态。
+
+## Scope
+
+`AgentRegistry` 回答两个问题：**这个 agent 叫什么**（寻址）与**谁和
+谁是父子**（拓扑）。它是纯数据组件，不含执行与协调逻辑。
+
+本文定义：
+
+- `AgentPath` 的形态与解析规则
+- 两阶段预留（reserve / commit / 回滚）
+- 树拓扑的维护与查询
+- path ↔ RunHandle 的逻辑映射
+
+本文不定义：
+
+- spawn 的协调顺序（属 MultiAgentControl）
+- RunHandle 的执行语义（属 run-handle-boundary）
+- 状态机推导（属 LifecycleProjection；registry 只存控制面写入的状态）
+
+## AgentPath
+
+层级化寻址，形如：
+
+```text
+/root
+/root/research
+/root/research/auth
+```
+
+规则：
+
+- root agent 固定为 `/root`；每次 spawn 在调用者的 path 下追加一段
+  （`task_name`）形成子 path。深度即 path 段数 - 1。
+- `task_name` 约束：小写字母、数字、下划线/连字符，非空、不含
+  `/`——在 ToolSurfaceAdapter 参数校验时强制。
+- **同名冲突**：同一父 path 下不允许两个 open agent 同名（预留阶段
+  拦截）；已 close 的名字可在预留时复用（close 释放名字）。
+- path 是**逻辑寻址**，不是物理执行标识：path ↔ RunHandle 的映射由
+  registry 持有，RunHandle 重建（二期回收恢复）后 path 不变、映射
+  更新。
+
+### Resolution
+
+工具面与路由收到目标引用时的解析规则：
+
+1. **全路径**（以 `/` 开头）：直接匹配。
+2. **相对名**：相对调用者的 agent_path 解析——先查调用者的直接子
+   agent，再查调用者子树内同名唯一者；歧义（子树内多个同名）返回
+   结构化错误，要求用全路径。
+3. 解析失败（未找到 / 歧义）返回结构化错误，不猜测。
+
+参照 Codex v2 的语义："You are able to refer to this agent as `task_3`
+or `/root/task1/task_3` interchangeably. However an agent
+`/root/task2/task_3` would only be able to communicate with this agent
+via its canonical name"——相对名只在调用者自己的子树内有意义。
+
+## Two-Phase Reservation
+
+spawn 的寻址安全依赖两阶段预留：
+
+```text
+reservation = registry.reserve(agent_path, metadata)
+    # 校验：父存在且 open、path 未占用、名字合法
+    # 占用该 path（pending 态），并发同名 reserve 失败
+    ...
+reservation.commit(handle)   # spawn 流水线步骤 6：绑定 RunHandle
+# 或
+reservation.rollback()       # 窗口内任一步失败：释放 path，无残留
+```
+
+- `reserve` 返回的 reservation 对象是唯一提交/回滚凭证；超期未
+  commit 的 reservation 由 Control 在 spawn 流水线退出时统一回滚
+  （RAII 语义，不依赖调用方记得回滚）。
+- **pending 可见性**：pending 条目对 reserve 冲突检测可见（防并发
+  同名），对 `list_agents` / `subtree` 等查询不可见——防止模型在未就绪
+  的半注册态下对 agent 发消息。
+- `commit` 后条目转为 open；此后状态变更（running / 终态 /
+  interrupted / closed）由 Control 经 LifecycleProjection 推导结果
+  回写。
+- 参照：Codex `reserve_spawn_slot` / `SpawnReservation.commit`。
+
+## Tree Topology
+
+registry 维护 parent→child 边，支持：
+
+- `children(path)`：直接子 agent（按 path 排序，确定性输出）。
+- `subtree(path)`：深度优先枚举全部后代（close 递归用）。
+- `list(prefix?)`：按前缀过滤列出条目（list_agents 工具的基础）。
+- `parent(path)`：父引用（完成通知路由、审批冒泡链用）。
+
+拓扑事实（spawn 边、close）同时经 LifecycleProjection 发射给装配层
+消费者——registry 是**控制面视图**，projection 是**事实视图**；两者
+以 registry 为准做协调，以 projection 为准做展示/审计。
+
+二期持久化：父子边与元数据外置（供回收恢复重建 registry），一期
+内存态；接口一期定型，持久化是 SnapshotCodec 缝的实现细节。
+
+## Entry Shape
+
+```text
+RegistryEntry
+  agent_path: AgentPath        # 逻辑寻址（主键）
+  parent_path: AgentPath       # 父引用（root 的父是自己）
+  agent_type: str              # 类型名（AgentTypeRecord 的键）
+  status: SubagentStatus       # pending | open 各态 | closed（控制面回写）
+  handle: RunHandle | None     # 物理执行映射（None = pending 或已回收）
+  created_at: Timestamp
+  snapshot_ref: str | None     # 二期：已回收条目的状态外置引用
+```
+
+## Product Injection Seams
+
+| 缝 | 注入内容 | 默认 |
+|---|---|---|
+| `NamingPolicy` | task_name 合法性与保留名 | 小写字母/数字/下划线/连字符 |
+| `ResolutionPolicy` | 相对名解析顺序与歧义处理 | 先直接子、后子树唯一者 |
+| `RegistryStore` | 二期：条目与拓扑的持久化 | 一期内存 |
+
+## Ownership And Boundaries
+
+拥有：
+
+- AgentPath 形态、解析、同名冲突拦截
+- 两阶段预留与回滚
+- 树拓扑与查询
+- path ↔ handle 映射
+
+不拥有：
+
+- spawn 时机与顺序（Control）
+- handle 的执行（RunHandle）
+- 状态的推导（LifecycleProjection 推导后由 Control 回写）
+- 类型的内容（AgentTypeRecord 由装配层注入）
+
+## Failure Semantics
+
+- 同名 reserve 冲突：结构化错误（`agent_name_conflict`），已有 agent
+  不受影响。
+- 父 closed 时 reserve：结构化错误（`parent_not_open`）。
+- commit 时 reservation 已回滚/过期：结构化错误（`reservation_stale`），
+  不产生半注册条目。
+- 解析歧义：结构化错误（`agent_reference_ambiguous`），附候选全路径
+  列表——让模型能立即修正调用。

--- a/docs/internals/architecture/harness/multiagent/run-handle-boundary.md
+++ b/docs/internals/architecture/harness/multiagent/run-handle-boundary.md
@@ -1,0 +1,210 @@
+# Multi-Agent Run Handle Boundary
+
+> Status: **draft proposal**（目标设计，未经接受）。本文定义
+> `loushang.harness.multiagent` 的子 agent 运行载体边界，不描述当前
+> 实现状态。
+
+## Scope
+
+`SubagentRunHandle` 是每个子 agent 一份的运行载体：它把一次性的
+`run_agent()` 调用组织成跨多轮、可投递、可中断、可关闭、可恢复的长生命
+周期执行实体。
+
+本文定义：
+
+- 运行载体的职责与接口
+- 多轮 run 的驱动模型（输入如何变为新一轮 run）
+- 取消 / 中断 / 关闭语义（ARD-002 异步双模式）
+- 事件转接与终态产出
+- 恢复入口（二期回收语义的挂点）
+
+本文不定义：
+
+- AgentRunSpec 的构造规则（属 SubagentContextFactory）
+- 消息如何到达 handle（属 AgentInputFacade / Control）
+- 状态机推导与事实发射（属 LifecycleProjection）
+- 并发名额与回收决策（属 Limits）
+
+## Why A Dedicated Handle
+
+`run_agent(spec)` 是一次性 async 调用：给一个 `AgentRunSpec`，返回
+`AgentRunResult`。子 agent 需要的能力超出单次调用：
+
+- 生命周期内经历**多轮** run（初始 turn、消息唤醒的后续 turn）
+- 运行中可被**投递消息**（下一轮输入或当前 turn steering）
+- 可被**中断**（停当前 turn，实体存活）与**关闭**（实体释放）
+- 事件流需要持续转接给状态机与装配层消费者
+
+这些职责不属于 `run_agent()`（一次性），也不属于 MultiAgentControl
+（协调多 agent 的控制面），因此独立为 RunHandle。
+
+参照：Codex `CodexThread`（ThreadManager 托管的线程句柄）、cc
+`LocalAgentTask`（任务表条目 + 后台生命周期闭包）、harness
+`HostRuntime` 的 run / abort / wait_for_idle / dispose 编排。
+
+## Interface
+
+```text
+SubagentRunHandle
+  # 身份
+  agent_path: AgentPath            # 逻辑寻址（registry 持有映射）
+  agent_type: AgentTypeRecord      # 类型裁剪视图
+
+  # 投递与驱动
+  async deliver(message: AgentInputMessage) -> DeliveryOutcome
+      # open 且 idle/终态 → 驱动新一轮 run（消息驱动唤醒，ARD-002）
+      # open 且 running → 按消息语义走 steering / follow_up
+      # closed → 结构化错误（不可寻址）
+
+  # 控制
+  async interrupt() -> SubagentStatus    # 停当前 turn，实体存活
+  async close() -> SubagentStatus        # 递归 close 后代后释放
+
+  # 等待
+  async await_terminal(timeout: Seconds | None) -> SubagentStatus
+      # 等待终态；不改变投递语义（wait_agent 的门面在 AgentInputFacade）
+
+  # 状态
+  status: SubagentStatus                  # 当前状态（由事件推导）
+  events: EventSubscription               # 事件订阅入口（转接给
+                                          # LifecycleProjection / 装配层）
+```
+
+关键形状说明：
+
+- `deliver` 是唯一输入口：所有消息（spawn 初始简报、send_message、
+  完成通知的进一步接力）都经它进入运行实体。
+- `await_terminal` 只等待、不消费消息：等待原语的"唤醒"语义由
+  AgentInputFacade 以 HostInputQueue activity 实现，handle 不重复实现。
+- `events` 是转接而非源头：源头是 `run_agent()` 的 `AgentEventSink`
+  回调，handle 把它组织成可订阅流。
+
+## Product Injection Seams（参数化与扩展）
+
+RunHandle 的机制是产品中立、写死的；但以下行为是**产品可注入的缝**，
+由装配层（产品或 OEM 经扩展贡献）提供，handle 不内置默认值：
+
+| 缝 | 注入内容 | 默认（harness 提供） | 扩展面 |
+|---|---|---|---|
+| `RunDriver` | 如何执行一轮 run | `harness.run_agent(AgentRunSpec)` | 产品可替换（如加 product hooks）；扩展点类型 `tool`/`hook` |
+| `SnapshotCodec` | 二期回收的状态外置编码 | 无（一期不回收） | 产品/OEM 提供快照编解码，决定哪些状态外置 |
+| `EventDecorator` | 事件转接时的产品级装饰/过滤 | 原样转接 | 产品可注入装饰器链（如附加 product 元数据） |
+
+不在本组件的缝（避免双重定义）：`TerminalFactMapper` 归
+LifecycleProjection（事实由它 shape，handle 只转接原始 result）；
+`DeliveryPolicy` 归 AgentInputFacade（QueueKind 映射发生在入队时）。
+
+注入方式：
+
+- **产品装配层**：构造 Control 时经 `MultiAgentPolicy` 参数传入各缝的
+  实现；harness 提供上表中的默认实现，产品按需覆写。
+- **OEM / extension**：经 harness 既有扩展贡献机制
+  （`ExtensionSurfaceDescriptor`，`tool` / `hook` / `policy` 面）贡献
+  缝实现；优先级与冲突解析复用 extensions 的 priority / before / after
+  排序，不新发明机制。
+- 缝的实现必须遵守本文件的语义不变式（多轮驱动规则、取消双模式、
+  先状态后收尾）；缝注入的是**策略与装饰**，不是语义改写——这是
+  "产品装配不破坏内核一致性"（architecture principles 第 8 条）的
+  具体落实。
+
+示例（OEM 场景）：OEM 想在事件流中附加其审计系统所需的 trace id——
+实现 `EventDecorator` 包装默认转接、追加 metadata，经扩展贡献注册；
+handle、状态机、通知合成全部不受影响。
+
+## Multi-Round Driving Model
+
+子 agent 的执行被组织为"轮（round）"序列：
+
+```text
+round 1: spec(初始简报) ──run_agent()──► 终态/中断
+round 2: deliver(消息)  ──run_agent(continue)──► ...
+...
+```
+
+驱动规则：
+
+1. **初始轮**由 Control 在 spawn 流水线末尾触发（`deliver(初始简报)`）。
+2. **后续轮**只在实体 idle（无活跃 run）时由 `deliver` 触发；实体
+   running 时 deliver 不新起 run，而是：
+   - `steering` 语义：经 `AgentLoopConfig.get_steering_messages` 挂点
+     注入当前 turn 的下一工具边界（harness host queue 的既有语义）
+   - `follow_up` 语义：排队，当前 run 结束后作为下一轮输入
+3. 每轮复用 `run_agent_loop_continue` 路径（`AgentRunSpec.mode =
+   "continue"`），历史在 `AgentContext.messages` 内累积——handle 持有
+   并跨轮传递 context。
+4. 一轮终态后，handle 先把终态事实交给 LifecycleProjection，再做收尾
+   （"先状态、后收尾"纪律）。
+
+这一模型直接复用 agent 内核已有的挂点（`get_steering_messages` /
+`get_follow_up_messages` / `mode="continue"`），不新增 loop 语义。
+
+## Cancellation Semantics（ARD-002 双模式）
+
+一期全异步，只有一种模式，但接口按双模式定型：
+
+- **不链接父 run 取消**：子 agent 的 cancel token 独立于父；父被取消
+  （用户 ESC）不杀子 agent。`AgentRunSpec.signal` 使用 handle 自有的
+  AbortController，不从父 context 派生。
+- **显式控制**：
+  - `interrupt()` = abort 当前轮（signal.aborted），实体转为
+    interrupted，可继续 deliver。
+  - `close()` = interrupt 当前轮（若有）→ 递归 close 全部后代 → 释放
+    实体与 registry 名额。
+- 后续若引入同步 spawn：同步子 agent 的 signal 链接父 AbortController
+  （父取消传播），异步维持独立——接口无需变更，仅 signal 来源不同。
+
+## Event Tap And Terminal Production
+
+- `run_agent()` 的 `event_sink` 由 handle 提供：每个事件先转接给订阅者
+  （LifecycleProjection 必须最先订阅，保证状态推导先于装配层消费者
+  看到事实），再按订阅顺序分发。
+- 终态产出：`AgentRunResult` → 终态事实（status、终态消息、usage、
+  时长、tool 计数）。usage / 计数从事件与 result 聚合，handle 不解释
+  业务含义。
+- 终态后实体**保持 open**（除非 close）——这是消息驱动唤醒的前提
+  （ARD-002）。
+
+## Recovery Hook（二期挂点，一期不实现）
+
+- 一期：无回收，handle 常驻内存直至 close。
+- 二期引入 Limits 的 LRU 回收时：
+  - 回收前由 Control 触发 `handle.snapshot()`（状态外置，经注入的
+    `SnapshotCodec` 编码：context messages、path、type、父子边），随后
+    释放 handle。
+  - `deliver` 到已回收 path 时，Control 经 registry 找到快照，重建
+    handle 并恢复（透明重载，Codex v2 语义）。
+  - 回收候选判定也是可注入的（Limits 的策略缝：产品可定义 idle
+    超时阈值与保护规则）。
+- 因此 handle 的构造必须允许"从快照重建"路径，接口一期就定型
+  （`from_snapshot` 可作为二期工厂方法预留，一期不实现）。
+
+## Ownership And Boundaries
+
+拥有：
+
+- 子 agent 的多轮执行组织与 task 持有
+- cancel token 所有权与中断 / 关闭语义
+- 事件转接与终态转发（原始 AgentRunResult 转给 LifecycleProjection；
+  事实 shape 与产品附加字段归 projection）
+- open / closed 实体状态（与 LifecycleProjection 的推导状态区分：
+  handle 是物理实体态，projection 是事实视图）
+
+不拥有：
+
+- 消息来源与寻址（AgentInputFacade / Control）
+- AgentRunSpec 的内容构造（ContextFactory）
+- 并发名额与回收决策（Limits 决策，handle 执行）
+- 状态机的业务解释（LifecycleProjection）
+- agent loop 语义（loushang.agent）
+- **各注入缝的具体实现**：RunDriver / SnapshotCodec / EventDecorator
+  的实现归产品装配层
+  或 OEM 扩展；handle 只定义缝的契约与默认
+
+## Failure Semantics
+
+- run 抛错 → `AgentRunResult(status="failed")` → 实体转为 failed
+  （终态），保持 open 可 deliver 恢复（新一轮 run）。
+- `deliver` 到 closed 实体 → 结构化错误返回给投递方（经 AgentInputFacade 作为
+  工具错误结果，不抛异常）。
+- `close` 幂等：重复 close 返回当前状态。
+- `interrupt` 对 idle 实体是 no-op，返回当前状态。

--- a/docs/internals/architecture/harness/multiagent/system-context.md
+++ b/docs/internals/architecture/harness/multiagent/system-context.md
@@ -1,0 +1,242 @@
+# Loushang Multi-Agent System Context
+
+> Status: **draft proposal**（目标设计，未经接受）。按
+> [Loushang Documentation Model](../../loushang-documentation-model.md) 的分层，
+> 本文表达 should-be 的目标边界，不描述当前实现状态；与代码冲突时以代码与
+> 已接受 ARD 为准。
+
+## Scope
+
+本文档将 `loushang.harness.multiagent`（归属决策见
+[ARD-001](./ARD-001-harness-ownership.md)：作为
+`loushang.harness` 内的子模块，不新建顶层包）视为一个黑盒子系统，
+描述它的直接外部子系统、依赖关系与信息流关系。
+
+目标是先确定 multi-agent 运行能力的系统边界，为后续候选组件识别与组件设计
+提供落点。
+
+本文不展开：
+
+- multi-agent 内部类型系统与组件分解（见后续 candidate-components 文档）
+- spawn / fork / agent input facade 的具体实现
+- method 角色编译的规则细节（属 `loushang-method`）
+- 工具面的模型可见参数细节（属组件设计）
+- 各产品（coding / design / …）如何装配 multi-agent（属产品装配层）
+
+## Positioning
+
+multi-agent 是**技术态**子系统：它提供子 agent 的派生、隔离、通信与生命周期
+管控，不理解业务语义（stage / acceptance / artifact）。
+
+与它平行的业务态分层：
+
+- `loushang.method` 定义"该有哪些 agent、按什么流程接力、如何验收"（可选）
+- `loushang.work` 拥有业务履约的权威终态与事件日志
+
+multi-agent 不知道 method 的存在；method/work 通过**装配层**消费 multi-agent
+的技术能力，并把 agent 终态投影为业务事实。两态各自可独立存在、独立测试：
+
+- 无 method 的轻量场景（"并行查三个问题"）直接使用 multi-agent
+- 有 method 的结构化场景由产品装配层把 method plan 翻译为 spawn 计划
+
+## External Entities
+
+收敛后的直接外部实体只保留三类。
+
+### External Systems
+
+- `loushang-harness`
+  - multi-agent 的**执行底座**。子 agent 的本体是一次 prepared agent run，
+    通过 `AgentRunSpec` / `AgentRunResult` / `run_agent()` 重入执行
+  - multi-agent 不实现自己的 agent loop，不复制第二套运行语义
+
+- `loushang-coding`（代表一切产品装配层：coding / design / research / …）
+  - multi-agent 的**直接上游装配子系统**
+  - 负责把 multi-agent 的工具面暴露给模型、注册 agent 类型、决定并发与
+    depth 策略参数、消费子 agent 事件做 UI / 业务投影
+
+### Actors
+
+- `Parent Agent`
+  - 逻辑调用主体：正在运行的某个 agent（root 或子 agent），通过工具面
+    发起 spawn / send / wait
+  - multi-agent 的工具面对它可见
+
+- `User / Host`
+  - 间接主体：通过产品装配层接收子 agent 的审批冒泡、取消请求与进度事件
+  - multi-agent 不直接面向它，但审批路由与取消传播以其为终点
+
+## Deliberately Not Direct
+
+以下子系统与 multi-agent 有重要关系，但**不在**它的直接边界上：
+
+- `loushang.method`：业务态编排图纸。它通过产品装配层间接驱动 spawn，
+  multi-agent 不 import method 类型。
+- `loushang.work`：业务权威终态。agent 树的生命周期事实以事件形式输出给
+  装配层，由装配层（或 work 自身）投影为 WorkEvent；multi-agent 不写
+  work event log。
+- `loushang.channel`：边界 transport。子 agent 事件经装配层投影后才可能
+  进入 channel；multi-agent 不产生 RuntimeEventView。
+- `loushang.tui` / `loushang.harnesstui`：UI 呈现，消费装配层的事件投影。
+- `loushang.ai`：模型调用。multi-agent 不直接调用 ai；模型能力经
+  harness → agent → ai 链路到达。
+
+这一收敛遵循
+[loushang-agent-system-context](../../agent/loushang-agent-system-context.md)
+的同一原则：环境图只画真正跨黑盒边界的信息流。
+
+## Dependency Relations
+
+本节只描述依赖方向，不描述运行时信息流。
+
+```text
+product assembly (coding / design / ...) --> multi-agent
+multi-agent --> harness
+harness --> agent --> ai
+```
+
+- `multi-agent -> harness`：子 agent 执行复用 prepared-run contract。
+  multi-agent 依赖 harness，harness 不依赖 multi-agent。
+- `product assembly -> multi-agent`：产品层装配工具面、类型与策略参数。
+  multi-agent 不依赖任何产品包。
+- multi-agent 不依赖 method / work / channel / tui。
+
+## Information Flow Relations
+
+### product assembly <-> multi-agent
+
+装配层向 multi-agent 输入：
+
+- agent 类型注册表（类型的工具裁剪、模型偏好、max_turns、isolation、
+  may_spawn 等声明；来源可以是内置资源或 method 角色编译产物——对
+  multi-agent 而言只是类型记录）
+- 策略参数：并发上限、depth 上限、wait 超时边界
+- 工具面开关：是否暴露 spawn / send / wait，允许的类型白名单
+- 事件消费者：子 agent 进度 / 终态 / 审批冒泡的回调
+
+multi-agent 向装配层输出：
+
+- spawn 事实（agent_path、parent、type、时间）
+- 子 agent 状态变更与终态消息（含 usage / tool 计数 / 时长）
+- 审批冒泡请求（子 agent 内高风险操作的 approval，路由到 root 交互出口）
+- agent 树拓扑（parent→child 边，供 UI 面板 / 审计 / 持久化）
+
+### parent agent <-> multi-agent（工具面）
+
+parent agent 通过工具调用输入：
+
+- `spawn_agent`：类型 + 任务简报 + 可选 fork 档位
+- `send_message`：目标寻址 + 消息（可触发 turn）
+- `wait_agent`：等待自己 input 的 activity（不轮询子状态）
+
+multi-agent 向 parent agent 输出：
+
+- 工具结果：spawn 的 agent 引用、send 的投递回执、wait 的活动摘要
+- input 注入消息：子 agent 完成通知、其他 agent 的消息、用户 steer
+  ——统一以 user-role 消息进入 parent 的后续 turn
+
+### multi-agent <-> harness
+
+multi-agent 向 harness 输入：
+
+- `AgentRunSpec`：为子 agent 构造的 prepared run（隔离后的 context、
+  裁剪后的 tools、类型系统提示、fork 历史）
+- 多轮运行驱动：一个子 agent 在其生命周期内可能经历多次
+  `run_agent()`（初始 turn、follow-up 触发的后续 turn、回收后恢复）；
+  运行载体（SubagentRunHandle）持有跨多轮的长生命周期，重入的是
+  "多轮"，不是一次性调用
+
+harness 向 multi-agent 输出：
+
+- `AgentRunResult` 与运行期事件流（经 AgentEventSink）
+- 终态：completed / failed + stop_reason + error
+
+multi-agent 复用 harness 既有机制：
+
+- `HostInputQueue`（steering / follow_up 双模式）作为 input facade 底层
+- `ApprovalRequest` 管道承载审批冒泡（附加 agent_path 冒泡链）
+- `HostRuntime` 的 run / abort / wait_for_idle / dispose 作为运行载体
+  的编排参照
+
+multi-agent 把这些技术终态翻译成自己的子 agent 状态机，但不改变
+harness 的 run 语义。
+
+## Functional Boundary
+
+### multi-agent 应承载
+
+- 子 agent 派生（spawn）与寻址（agent path / registry）
+- 子 agent 上下文构造：隔离 fork、历史过滤、fork 档位
+- agent input facade 与通知注入（完成通知、消息路由、wait 唤醒），底层复用
+  `HostInputQueue`
+- 并发闸门、depth 上限、驻留 / 回收
+- 子 agent 生命周期状态机与 agent 树拓扑
+- 异步执行（一期唯一模式，见 ARD-002）；子 agent 为后台运行，不链接父 run
+  的取消，只能显式 interrupt / close；close 父时递归 close 后代
+- 审批冒泡路由（复用 `ApprovalRequest` 管道到 root 交互出口）
+
+### multi-agent 不承载
+
+- agent loop / turn / 工具编排语义（属 `loushang.agent`）
+- prepared-run contract 本身（属 `loushang.harness`）
+- 业务编排：stage 流程、acceptance 判定、artifact 语义（属 method/work）
+- agent 类型的业务定义与编译（类型对 multi-agent 只是记录；method 角色
+  编译属 method，产品默认类型属产品装配层）
+- 边界 transport / 多客户端订阅（属 channel）
+- UI 呈现（属 tui / harnesstui）
+- 模型调用、provider 差异（属 ai）
+
+## Data Boundary
+
+multi-agent 自有的一等数据（候选，最终以组件设计为准）：
+
+- `AgentPath`：层级寻址（如 `/root/research/auth`）
+- `SubagentRecord`：registry 条目（path、parent、type、status、引用）
+- `SubagentStatus`：生命周期状态机
+- `AgentInputMessage`：通知 / 消息的投递单元
+- `SpawnRequest` / `SpawnHandle`：派生请求与句柄
+- `AgentTypeRecord`：类型的技术裁剪视图（工具集、模型偏好、隔离、
+  may_spawn），不含业务文本
+
+边界上不进入 multi-agent 的数据：
+
+- `MethodPlan` / `WorkRun` / `ArtifactRef`（业务态，留 method/work）
+- `AgentRunSpec` 的组装规则之外的产品配置（留装配层）
+
+## Physical Protocol Boundary
+
+- product assembly <-> multi-agent：进程内 API（注册、配置、事件回调）
+- parent agent <-> multi-agent：工具调用协议（经 agent 工具框架，
+  参数为严格校验的 JSON schema）
+- multi-agent <-> harness：进程内 prepared-run contract
+  （`AgentRunSpec` / `run_agent()` / `AgentEventSink`）
+
+multi-agent 不引入网络协议；跨进程 / 远端子 agent 是未来扩展，届时
+由 channel 承载 transport，multi-agent 的契约不变。
+
+## Key Boundary Decisions（预告，详见 ARD）
+
+0. 归属：`loushang.harness.multiagent`，不新建顶层包——见
+   [ARD-001](./ARD-001-harness-ownership.md)
+1. 子 agent 本体 = harness prepared run 重入，不新建执行语义
+2. multi-agent 是纯技术态；method/work 只经装配层间接到达
+3. 同步原语：wait = 等待自己 input 的 activity，不轮询子状态
+4. 审批冒泡统一路由到 root 交互出口，channel 无关
+5. 一期全异步执行（无同步 spawn）、消息驱动恢复、open / closed 区分——见
+   [ARD-002](./ARD-002-async-execution-and-recovery.md)
+
+边界纪律：`harness.multiagent` 不得依赖 method / work / channel / tui，
+不得包含产品 agent 类型定义——类型注册表是装配层注入的参数，不是
+harness 的资产。
+
+## Conclusion
+
+`loushang.multi-agent` 的直接环境收敛为：
+
+- 上游：`loushang-coding`（代表产品装配层）
+- 下游：`loushang-harness`（执行底座）
+- 逻辑 actor：`Parent Agent`（工具面调用者）、`User / Host`（审批与取消终点）
+
+method / work / channel / tui 均不进入它的直接边界——业务编排与呈现都
+经过装配层投影。这一收敛保证 multi-agent 可以独立于业务态演化，并被
+未来任意产品线复用。

--- a/docs/internals/architecture/harness/multiagent/tool-surface-boundary.md
+++ b/docs/internals/architecture/harness/multiagent/tool-surface-boundary.md
@@ -1,0 +1,177 @@
+# Multi-Agent Tool Surface Boundary
+
+> Status: **draft proposal**（目标设计，未经接受）。本文定义
+> `loushang.harness.multiagent` 的模型可见工具面边界：`spawn_agent` /
+> `send_message` / `wait_agent` 三件套的参数、结果与提示纪律。不描述
+> 当前实现状态。
+
+## Scope
+
+`ToolSurfaceAdapter` 是 multiagent 内部**唯一**依赖 agent 工具框架的
+位置：它把 Control / AgentInputFacade / Registry 的能力封装为模型可
+调用的工具，并承载提示纪律（briefing 要求、通知纪律）这一模型行为
+的关键杠杆。
+
+本文定义：
+
+- 三件套工具的参数面与结果 shape
+- 参数校验与错误语义
+- 提示纪律资源（可替换）
+- 产品裁剪（暴露子集、类型白名单）
+
+本文不定义：
+
+- 工具的执行机制（属 Control 等各组件）
+- 类型的业务内容（属装配层注入的 AgentTypeRecord）
+- 工具在 UI 中的呈现（属产品 UI）
+
+## Tool Set
+
+### `spawn_agent`
+
+派生子 agent 处理一个有界子任务。
+
+```json
+{
+  "task_name": "research_auth",        // 必填；小写字母/数字/下划线
+  "message": "调查 src/auth/ 的 token 刷新逻辑，找出竞态。不写代码，200 字内报告。",
+                                       // 必填；完整简报（fresh spawn 零上下文）
+  "agent_type": "Explore",             // 可选；缺省用产品默认类型
+  "fork": "none",                      // 可选；none（默认）| all | last_N
+  "model": "..."                       // 可选；仅 fork=none 可覆盖
+}
+```
+
+结果（成功）：
+
+```json
+{
+  "status": "spawned",
+  "agent_path": "/root/research_auth",
+  "task_name": "research_auth"
+}
+```
+
+spawn 立即返回（ARD-002 全异步）；子 agent 的结果**不在此返回**，
+经完成通知到达。
+
+### `send_message`
+
+给 open agent 发消息。
+
+```json
+{
+  "target": "research_auth",           // 必填；相对名或全路径
+  "message": "补充：也看一下 refresh 的 backoff 策略。",
+  "kind": "follow_up"                  // 可选；follow_up（默认，下轮消费）
+                                       // | steering（注入当前 turn）
+}
+```
+
+结果：
+
+```json
+{ "status": "delivered", "triggered_new_round": true }
+```
+
+- 目标 idle/终态（open）：`triggered_new_round=true`，唤醒新一轮 run。
+- 目标 running：入队，`triggered_new_round=false`。
+- 目标 closed：错误 `agent_not_addressable`。
+
+### `wait_agent`
+
+等待自己 input 的 activity（ARD-002：不轮询子状态）。
+
+```json
+{ "timeout_ms": 30000 }                // 可选；边界由策略注入
+```
+
+结果：
+
+```json
+{
+  "status": "activity",                // activity | steered | timed_out
+  "senders": ["/root/research_auth"],  // 哪些 sender 有更新（摘要）
+  "timed_out": false
+}
+```
+
+只给摘要不给内容——通知全文在后续 turn 作为 user-role 消息出现。
+
+## Validation And Error Semantics
+
+- 所有参数严格校验（task_name 形态、fork 档位、target 解析、类型
+  白名单）；校验失败返回**结构化工具错误**，不抛异常。
+- 错误结果带稳定 `code`，供模型与测试依赖；消息文本人可读，
+  不作为程序契约。底层组件的错误经工具面统一映射：
+
+| code | 来源 | 语义 |
+|---|---|---|
+| `invalid_agent_type` | Registry/Control | 未知类型或不在白名单 |
+| `agent_limit_reached` | Limits | 并发名额已满 |
+| `agent_depth_exceeded` | Limits | 超过 max_spawn_depth |
+| `agent_name_conflict` | Registry | 同父下同名 open agent |
+| `agent_reference_ambiguous` | Registry | 相对名歧义（附候选全路径） |
+| `agent_not_found` | Registry | 目标不存在 |
+| `agent_not_addressable` | AgentInputFacade | 目标已 close，不可投递 |
+| `invalid_fork_option` | ContextFactory | fork 档位非法或与 model 覆盖冲突 |
+| `spawn_rejected` | Control | 其他 spawn 拒绝（如类型工具为空） |
+
+## Prompt Discipline Resources
+
+工具描述与纪律文本是**可替换资源**（OEM 可覆盖），核心内容：
+
+1. **何时 spawn**：只为具体、有界、可独立运行的子任务 spawn；简单
+   任务直接做。
+2. **简报纪律**（cc 对齐）："像简报刚进门的同事"——fresh spawn 零
+   上下文，必须含目标、已知约束、判定所需背景；"never delegate
+   understanding"（不写"基于你的发现修 bug"）；要短报告就明说。
+3. **fork 纪律**：`fork` 仅当需要子 agent 继承对话背景；fork 档
+   不可改 model（cache）；fork 后**不要窥探**（不读子 agent 的中间
+   输出）也**不要编造**（通知到达前不知道结果）。
+4. **等待纪律**：spawn 后用 wait_agent 等通知；通知到达前可以给
+   用户状态（"还在查"），不给猜测的结果。
+5. **并行纪律**：并行 spawn 时告知子 agent 环境中有其他 agent，
+   不要回滚他人工作；跑测试类子 agent 的类型不得含 spawn 工具
+   （防递归——结构性防线在类型裁剪，提示只是补强）。
+6. **结果归属**：子 agent 的终态消息用户看不到；由父 agent 总结
+   给用户。子 agent 的输出一般应当信任。
+
+## Product Customization
+
+产品装配层对工具面的裁剪（不改变工具语义）：
+
+| 裁剪 | 机制 |
+|---|---|
+| 暴露子集 | 如只暴露 spawn + wait，不暴露 send_message |
+| 类型白名单 | spawn 的 `agent_type` 限定子集（如 method 场景只能派生图纸内角色） |
+| 默认类型 | 缺省 `agent_type` 的产品默认 |
+| 超时边界 | wait 的 min/max/default（经 MultiAgentPolicy） |
+| 纪律文本 | 替换提示资源（OEM 本地化、行业纪律） |
+
+工具面的 schema 变化会击穿 prompt cache，因此：类型列表**不嵌入**
+工具描述（cc 的 agent_listing_delta 教训），类型清单经系统消息/
+附件注入，工具描述保持静态。
+
+## Ownership And Boundaries
+
+拥有：
+
+- 三件套工具的 schema、参数校验、结果 shape
+- 结构化错误码
+- 提示纪律资源（默认文本）
+- 产品裁剪的接入点
+
+不拥有：
+
+- spawn / send / wait 的执行（Control / AgentInputFacade / RunHandle）
+- 类型注册表内容（装配层注入）
+- 工具 UI 呈现（产品 UI）
+- 审批冒泡（ContextFactory 装配）
+
+## Failure Semantics
+
+- 校验/准入/寻址失败：结构化工具错误（正常结果），无副作用。
+- spawn 后首轮启动失败：spawn 已返回（异步），子 agent 以 failed
+  终态呈现并经通知到达——不反转为 spawn 工具错误。
+- wait 期间被 steer：返回 `steered`，模型转处理用户输入。


### PR DESCRIPTION
 ## Summary / 概要
  
  12 份架构文档定义 `loushang.harness.multiagent` 的目标边界：子 agent
  的派生、隔离、通信与生命周期管控。
  12 architecture documents defining the target boundary for `loushang.harness.multiagent`:
  sub-agent spawning, isolation, communication, and lifecycle management.
  
  ## Documents / 文档
  
  - **System Context** / 系统环境图 — black-box boundary: upstream = product assembly, downstream =
  harness prepared run
  - **8 Candidate Components** / 候选组件 — MultiAgentControl, AgentRegistry, SubagentRunHandle,
  SubagentContextFactory, AgentInputFacade, Limits, LifecycleProjection, ToolSurfaceAdapter
  - **ARD-001** — harness 归属决策（harness ownership: submodule, not top-level package）
  - **ARD-002** — 全异步执行 + 消息驱动恢复（async-only execution + message-driven recovery,
  open/closed distinction）
  - **7 Component Boundaries** / 组件边界 — run-handle, agent-input-facade, context-fork, control,
  registry, limits-and-projection, tool-surface
  - **README** — reading order, core invariants (7 rules), subsystem relationships, evolution path
  
  ## Key Decisions / 关键决策
  
  | Decision / 决策 | Rationale / 依据 |
  |---|---|
  | 子 agent = harness prepared run 重入（不写第二套 loop） | 复用 `AgentRunSpec` /
  `run_agent()`，对齐 ARD-002 |
  | 纯技术态，不依赖 method / work / channel / tui | 业务态经装配层间接消费；技术态独立演化 |
  | agent 类型 = 装配层注入的 registry（method 角色编译 + OEM 扩展缝） | 类型只是
  `AgentTypeRecord`，内容归装配层 |
  | 一期全异步 + 完成通知模型 + open/closed 区分 | 对齐 Codex v2 + cc fork gate 终局形态 |
  | wait = 等自己 input 的 activity（不轮询子状态） | Codex v2 InputQueueActivity 简化，等效 |
  | fork 三档（none/all/last N），字节级 cache 约束 | 复用 harness transcript 为历史源，与 session
  fork 统一路线 |
  | 名额 = per-agent（spawn 获取 / close 释放） | 避免 per-turn 计数的时序问题；一期 agent
  数封上限自然封并发 |
  | 默认隔离、显式共享；任务注册穿透 root | cc zombie 进程教训 + architecture principles 结构性安全
  |
  | 所有策略/提示/映射经产品注入缝可定制 | 机制语义不变式不可改写（architecture principles 第 8
  条） |
  
  ## Status / 状态
  
  Draft proposal（should-be 目标设计）。按 Loushang Documentation Model 分层：architecture 表达
  target boundary，不等同于当前实现状态。
  Draft proposal (should-be target design). Per Loushang Documentation Model: architecture
  expresses target boundaries, not current implementation status.