### PR TITLE
fix host deferred continuation race

### DIFF
--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -399,7 +399,7 @@ class AgentSession(SessionFacade):
             set_messages=self.agent.state.set_messages,
             get_context_window=lambda: self.agent.model.context_window,
             dispatch_event=self._dispatch_event,
-            continue_run=lambda: self.continue_run(),
+            continue_run=self._schedule_continue_run,
             record_runtime_exception=self._record_runtime_exception,
             sleep_for_retry=lambda delay_ms, signal: _sleep_for_retry(delay_ms, signal),
             is_context_overflow_fn=is_context_overflow,
@@ -1654,9 +1654,12 @@ class AgentSession(SessionFacade):
         return await self._compaction_runtime.maybe_compact_after_turn(
             assistant_message,
             compact_internal_fn=self._compact_internal,
-            continue_run_fn=self.continue_run,
+            continue_run_fn=self._schedule_continue_run,
             is_context_overflow_fn=is_context_overflow,
         )
+
+    def _schedule_continue_run(self) -> Awaitable[None]:
+        return self._session_runtime.schedule_continue_run()
 
     async def _compact_before_prompt(self) -> CompactionResult | None:
         assistant_message = self._last_assistant_message()

--- a/src/loushang/harness/host/retry.py
+++ b/src/loushang/harness/host/retry.py
@@ -64,6 +64,7 @@ class RetryCoordinator(Generic[C]):
         self._future: asyncio.Future[None] | object | None = None
         self._cancel_handle: C | None = None
         self._delay_active = False
+        self._continuation_task: asyncio.Task[None] | None = None
 
     @property
     def attempt(self) -> int:
@@ -133,6 +134,8 @@ class RetryCoordinator(Generic[C]):
         if self._delay_active:
             raise RuntimeError("Retry delay already in progress")
 
+        self._cancel_pending_continuation()
+
         self.ensure_waiter()
         self._attempt += 1
         if self._attempt > max(0, policy.max_attempts):
@@ -176,10 +179,57 @@ class RetryCoordinator(Generic[C]):
         finally:
             self._delay_active = False
 
-        asyncio.ensure_future(self._continue_run())
+        attempt_number = self._attempt
+        self._continuation_task = asyncio.create_task(
+            self._run_continuation(attempt_number)
+        )
         return True
 
+    async def _run_continuation(self, attempt: int) -> None:
+        try:
+            await self._continue_run()
+        except asyncio.CancelledError:
+            # A later user action or retry attempt may invalidate this
+            # deferred continuation. Its cancellation is intentional and
+            # must not become an unhandled background-task exception.
+            return
+        except Exception as error:
+            if not self._is_current_attempt(attempt):
+                return
+            try:
+                await self.finish(
+                    RetryOutcome(
+                        success=False,
+                        attempt=attempt,
+                        error=str(error),
+                    )
+                )
+            except BaseException:
+                # This task has no caller to receive an exception. Preserve
+                # the retry state invariant even if the failure event sink
+                # itself fails.
+                self._resolve_and_reset()
+
+    def _is_current_attempt(self, attempt: int) -> bool:
+        return self._future is not None and self._attempt == attempt
+
+    def _cancel_pending_continuation(self) -> None:
+        task = self._continuation_task
+        if task is None or task.done() or task is asyncio.current_task():
+            return
+        self._continuation_task = None
+        task.cancel()
+
     def _resolve_and_reset(self) -> None:
+        continuation_task = self._continuation_task
+        self._continuation_task = None
+        if (
+            continuation_task is not None
+            and continuation_task is not asyncio.current_task()
+            and not continuation_task.done()
+        ):
+            continuation_task.cancel()
+
         future = self._future
         if isinstance(future, asyncio.Future) and not future.done():
             future.set_result(None)

--- a/src/loushang/harness/host/runtime.py
+++ b/src/loushang/harness/host/runtime.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, cast
 
 from loushang.harness.host.events import EventListener, OrderedEventBus
 from loushang.harness.host.types import (
@@ -44,6 +44,8 @@ class HostRuntime(Generic[T]):
         self._abort_requested = False
         self._next_run_id = 1
         self._dispose_lock = asyncio.Lock()
+        self._deferred_tasks: set[asyncio.Task[object]] = set()
+        self._deferred_by_key: dict[str, asyncio.Task[object]] = {}
 
     @property
     def status(self) -> HostStatus:
@@ -117,6 +119,78 @@ class HostRuntime(Generic[T]):
             run_id=resolved_run_id,
         )
         return result
+
+    async def run_after_idle(
+        self,
+        operation: RunOperation[T],
+        *,
+        run_id: str | None = None,
+    ) -> T:
+        """Run an operation once this host and its external driver are idle.
+
+        ``run()`` intentionally rejects concurrent callers. Deferred work
+        such as an automatic retry needs different semantics: it waits for the
+        current run to finish, then enters ``run()`` from the same task without
+        yielding between the idle check and the state transition.
+        """
+
+        current_task = asyncio.current_task()
+        while True:
+            active_task = self._active_task
+            if active_task is current_task:
+                raise HostStateError(
+                    "cannot run after idle from the active host run"
+                )
+            if active_task is not None:
+                await active_task
+                continue
+
+            if self._status in {"running", "aborting"} or self._driver_is_running():
+                await self.wait_for_idle()
+                continue
+
+            # There is no await between the final idle check above and the
+            # state transition performed by run(), so another asyncio task
+            # cannot claim the host in between.
+            return await self.run(operation, run_id=run_id)
+
+    def defer_run(
+        self,
+        operation: RunOperation[T],
+        *,
+        key: str | None = None,
+        run_id: str | None = None,
+    ) -> asyncio.Task[T]:
+        """Schedule one operation to run after this host becomes idle.
+
+        The returned task is also owned by the host runtime.  A caller may
+        await it for the result, but dropping it cannot create an unhandled
+        background-task exception.  ``key`` coalesces equivalent deferred
+        operations, such as retry and compaction requests for one continuation.
+        """
+
+        if key is not None:
+            existing = self._deferred_by_key.get(key)
+            if existing is not None:
+                if not existing.done():
+                    return cast(asyncio.Task[T], existing)
+                self._deferred_by_key.pop(key, None)
+
+        task = asyncio.create_task(self.run_after_idle(operation, run_id=run_id))
+        task_object = cast(asyncio.Task[object], task)
+        self._deferred_tasks.add(task_object)
+        if key is not None:
+            self._deferred_by_key[key] = task_object
+        task.add_done_callback(self._observe_deferred_task)
+        return task
+
+    def _observe_deferred_task(self, task: asyncio.Task[object]) -> None:
+        self._deferred_tasks.discard(task)
+        for key, pending in tuple(self._deferred_by_key.items()):
+            if pending is task:
+                self._deferred_by_key.pop(key, None)
+        if not task.cancelled():
+            task.exception()
 
     def abort(self) -> bool:
         if self._status == "disposed" or not self.is_active:

--- a/src/loushang/harness/session/runtime.py
+++ b/src/loushang/harness/session/runtime.py
@@ -247,7 +247,13 @@ class SessionRuntime:
         self._queue_controller.follow_up(user_input, images=images)
 
     async def continue_run(self) -> None:
-        await self._host_runtime.run(self.agent.continue_run)
+        await self._host_runtime.run_after_idle(self.agent.continue_run)
+
+    def schedule_continue_run(self) -> asyncio.Task[None]:
+        return self._host_runtime.defer_run(
+            self.agent.continue_run,
+            key="agent-continue",
+        )
 
     def abort(self) -> bool:
         return self._host_runtime.abort()

--- a/tests/coding/test_agent_session_compaction.py
+++ b/tests/coding/test_agent_session_compaction.py
@@ -1349,7 +1349,9 @@ def test_agent_session_overflow_recovery_emits_compaction_with_retry_flag(
         nonlocal continue_runs
         continue_runs += 1
 
-    monkeypatch.setattr(session, "continue_run", _continue_run)
+    monkeypatch.setattr(
+        session._session_runtime, "schedule_continue_run", _continue_run
+    )
     session.subscribe(events.append)
 
     async def scenario() -> None:
@@ -1462,7 +1464,9 @@ def test_agent_session_overflow_recovery_is_limited_to_one_attempt(
         "loushang.coding.session.agent_session._execute_coding_compaction",
         _fake_compact,
     )
-    monkeypatch.setattr(session, "continue_run", _continue_run)
+    monkeypatch.setattr(
+        session._session_runtime, "schedule_continue_run", _continue_run
+    )
     session.subscribe(events.append)
 
     async def scenario() -> None:

--- a/tests/coding/test_agent_session_retry.py
+++ b/tests/coding/test_agent_session_retry.py
@@ -106,7 +106,9 @@ def test_agent_session_retryable_error_starts_retry_and_removes_error_message(
     monkeypatch.setattr(
         "loushang.coding.session.agent_session._sleep_for_retry", _instant_sleep
     )
-    monkeypatch.setattr(session, "continue_run", _fake_continue_run)
+    monkeypatch.setattr(
+        session._session_runtime, "schedule_continue_run", _fake_continue_run
+    )
     session.subscribe(events.append)
 
     async def scenario() -> None:
@@ -174,7 +176,9 @@ def test_agent_session_retry_success_emits_end_event_and_resolves_waiter(
     monkeypatch.setattr(
         "loushang.coding.session.agent_session._sleep_for_retry", _instant_sleep
     )
-    monkeypatch.setattr(session, "continue_run", _fake_continue_run)
+    monkeypatch.setattr(
+        session._session_runtime, "schedule_continue_run", _fake_continue_run
+    )
     session.subscribe(events.append)
 
     async def scenario() -> None:
@@ -247,7 +251,9 @@ def test_agent_session_retry_preserves_queued_messages_until_retry_continues(
     monkeypatch.setattr(
         "loushang.coding.session.agent_session._sleep_for_retry", _instant_sleep
     )
-    monkeypatch.setattr(session, "continue_run", _fake_continue_run)
+    monkeypatch.setattr(
+        session._session_runtime, "schedule_continue_run", _fake_continue_run
+    )
     session.subscribe(events.append)
 
     async def scenario() -> None:
@@ -318,7 +324,9 @@ def test_agent_session_abort_retry_ends_retry_with_failure(
     monkeypatch.setattr(
         "loushang.coding.session.agent_session._sleep_for_retry", _blocking_sleep
     )
-    monkeypatch.setattr(session, "continue_run", _fake_continue_run)
+    monkeypatch.setattr(
+        session._session_runtime, "schedule_continue_run", _fake_continue_run
+    )
     session.subscribe(events.append)
 
     async def scenario() -> None:
@@ -389,7 +397,9 @@ def test_agent_session_retry_max_retries_emits_final_failure(
     monkeypatch.setattr(
         "loushang.coding.session.agent_session._sleep_for_retry", _instant_sleep
     )
-    monkeypatch.setattr(session, "continue_run", _fake_continue_run)
+    monkeypatch.setattr(
+        session._session_runtime, "schedule_continue_run", _fake_continue_run
+    )
 
     async def scenario() -> None:
         session.agent.state.messages.append(error_message)
@@ -523,7 +533,9 @@ def test_agent_session_overflow_routes_to_compaction_instead_of_retry(
         raise AssertionError("overflow should not trigger retry continue_run")
 
     monkeypatch.setattr(session, "_compact_internal", _fake_compact_internal)
-    monkeypatch.setattr(session, "continue_run", _fake_continue_run)
+    monkeypatch.setattr(
+        session._session_runtime, "schedule_continue_run", _fake_continue_run
+    )
     session.subscribe(events.append)
 
     async def scenario() -> None:

--- a/tests/harness/host/test_retry.py
+++ b/tests/harness/host/test_retry.py
@@ -138,6 +138,37 @@ def test_retry_coordinator_cleans_up_when_a_driver_fails() -> None:
     assert coordinator.attempt == 0
 
 
+def test_retry_coordinator_observes_deferred_continuation_failure() -> None:
+    outcomes: list[RetryOutcome] = []
+
+    async def fail_continue() -> None:
+        raise RuntimeError("host is already running")
+
+    coordinator = RetryCoordinator(
+        create_cancel_handle=CancelHandle,
+        cancel=lambda handle: setattr(handle, "cancelled", True),
+        delay=lambda delay_ms, handle: _noop(),
+        continue_run=fail_continue,
+        on_started=lambda attempt: _noop(),
+        on_finished=lambda outcome: _append(outcomes, outcome),
+    )
+
+    async def scenario() -> None:
+        assert await coordinator.retry("busy", policy=RetryPolicy(True, 1, 1))
+        await coordinator.wait()
+
+    asyncio.run(scenario())
+
+    assert outcomes == [
+        RetryOutcome(
+            success=False,
+            attempt=1,
+            error="host is already running",
+        )
+    ]
+    assert coordinator.is_retrying is False
+
+
 def _coordinator(
     attempts: list[RetryAttempt],
     outcomes: list[RetryOutcome],

--- a/tests/harness/host/test_runtime.py
+++ b/tests/harness/host/test_runtime.py
@@ -46,6 +46,10 @@ def _runtime(driver: ReferenceDriver) -> HostRuntime[str]:
     )
 
 
+async def _async_value(value: str) -> str:
+    return value
+
+
 def test_host_runtime_runs_reference_driver_and_publishes_lifecycle() -> None:
     async def scenario() -> None:
         driver = ReferenceDriver()
@@ -146,6 +150,48 @@ def test_host_runtime_rejects_concurrent_and_external_driver_runs() -> None:
         driver.running = True
         with pytest.raises(HostStateError, match="already running"):
             await runtime.run(driver.run)
+
+    asyncio.run(scenario())
+
+
+def test_host_runtime_runs_deferred_operation_after_active_run() -> None:
+    async def scenario() -> None:
+        driver = ReferenceDriver()
+        runtime = _runtime(driver)
+        first = asyncio.create_task(runtime.run(driver.run))
+        await driver.started.wait()
+
+        second = asyncio.create_task(
+            runtime.run_after_idle(lambda: _async_value("deferred-result"))
+        )
+        await asyncio.sleep(0)
+        assert not second.done()
+
+        driver.release.set()
+        assert await first == "reference-result"
+        assert await second == "deferred-result"
+        assert runtime.status == "idle"
+
+    asyncio.run(scenario())
+
+
+def test_host_runtime_coalesces_deferred_operations_by_key() -> None:
+    async def scenario() -> None:
+        driver = ReferenceDriver()
+        runtime = _runtime(driver)
+        calls: list[str] = []
+
+        async def operation() -> str:
+            calls.append("continue")
+            return "continued"
+
+        first = runtime.defer_run(operation, key="agent-continue")
+        second = runtime.defer_run(operation, key="agent-continue")
+        assert first is second
+
+        assert await first == "continued"
+        assert calls == ["continue"]
+        assert runtime.status == "idle"
 
     asyncio.run(scenario())
 

--- a/tests/harness/session/test_runtime.py
+++ b/tests/harness/session/test_runtime.py
@@ -185,6 +185,48 @@ def test_session_runtime_publishes_transcript_commit_receipts_in_order() -> None
     asyncio.run(scenario())
 
 
+def test_session_runtime_defers_continue_until_host_is_idle() -> None:
+    async def scenario() -> None:
+        agent = Agent()
+        release = asyncio.Event()
+        continued: list[bool] = []
+
+        async def continue_run() -> None:
+            continued.append(True)
+
+        agent.continue_run = continue_run  # type: ignore[method-assign]
+        runtime = SessionRuntime(
+            agent=agent,
+            transcript=TranscriptRuntimePort(
+                session_id="session-3",
+                append_message=lambda message: _append_message(message),
+                commit_application_message=lambda message: _commit_application_message(
+                    message
+                ),
+                refresh_context=lambda: None,
+                set_commit_observer=lambda observer: None,
+            ),
+            turn_policy=_turn_policy(),
+            after_turn_policy=_after_turn_policy(),
+        )
+
+        active = asyncio.create_task(
+            runtime.host_runtime.run(lambda: release.wait())
+        )
+        await asyncio.sleep(0)
+        deferred = asyncio.create_task(runtime.continue_run())
+        await asyncio.sleep(0)
+        assert not deferred.done()
+
+        release.set()
+        await active
+        await deferred
+        assert continued == [True]
+        await runtime.dispose()
+
+    asyncio.run(scenario())
+
+
 def _turn_policy() -> TurnPolicyPort:
     async def preflight(text: str, **kwargs: object) -> _PreflightResult:
         del kwargs


### PR DESCRIPTION
## What changed

- Add `HostRuntime.run_after_idle()` and `defer_run()` for serialized deferred continuations.
- Coalesce equivalent continuation requests with a stable key and observe background task failures.
- Route retry and automatic compaction continuations through `SessionRuntime`.
- Track retry continuation tasks, cancel stale continuations, and emit retry failure outcomes.
- Add host, session, retry, and compaction regression tests.

## Why

Retry and compaction can both request a follow-up agent turn while the current host run is still active. The old path scheduled raw background tasks, which could race with `HostRuntime.run()` and raise `HostStateError("host is already running")`; dropped task exceptions were also reported as unhandled.

The business state machines remain separate, while HostRuntime owns the physical deferred-run lifecycle.

## Validation

- Targeted tests: 54 passed.
- `tests/harness tests/coding`: 2993 passed, 1 pre-existing legacy import contract failure.
- Ruff check passed.
- `git diff --check` passed.
