### PR TITLE
feat(harness): add side questions and interactive forks

### DIFF
--- a/src/loushang/coding/product_plan.py
+++ b/src/loushang/coding/product_plan.py
@@ -1,7 +1,10 @@
 """Coding's declarative selections for shared Product runtimes."""
 
 from loushang.harness.capabilities import standard_capability_composition_plan
-from loushang.harness.runtime import RuntimeProfileResolver
+from loushang.harness.runtime import (
+    SIDE_QUESTION_PROVIDER_SLOT,
+    RuntimeProfileResolver,
+)
 from loushang.harness.transcript import (
     AgentTranscriptProfileRuntime,
     AgentTranscriptRuntimeSpec,
@@ -25,6 +28,11 @@ CODING_TRANSCRIPT_RUNTIME = AgentTranscriptProfileRuntime(
 
 CODING_CAPABILITY_PLAN = standard_capability_composition_plan(
     product_id=CODING_PRODUCT_ID,
+    slot_allowed_sources={
+        SIDE_QUESTION_PROVIDER_SLOT.key: frozenset(
+            {"product", "oem", "extension"}
+        )
+    },
 )
 CODING_CAPABILITY_PROFILE = RuntimeProfileResolver().resolve(CODING_CAPABILITY_PLAN)
 

--- a/src/loushang/coding/session_manager.py
+++ b/src/loushang/coding/session_manager.py
@@ -8,6 +8,7 @@ from loushang.coding.product_plan import (
 )
 from loushang.harness.conversation import ConversationHeader
 from loushang.harness.runtime import (
+    SIDE_QUESTION_PROVIDER_SLOT,
     ResolvedRuntimeProfile,
     RuntimeProfileBinding,
     RuntimeProfileSnapshot,
@@ -69,12 +70,13 @@ def _validate_coding_restored_header(
 def _selected_capabilities(
     snapshot: RuntimeProfileSnapshot,
 ) -> tuple[RuntimeProfileSnapshotCapability, ...]:
-    """Compare only slots that bind behavior; empty slots are additive."""
+    """Compare continuity-critical slots; auxiliary interaction is additive."""
 
     return tuple(
         capability
         for capability in snapshot.capabilities
         if capability.selections
+        and capability.slot != SIDE_QUESTION_PROVIDER_SLOT.key
     )
 
 

--- a/src/loushang/coding/ui/screen_surfaces.py
+++ b/src/loushang/coding/ui/screen_surfaces.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
 from loushang.coding.continuity import bind_coding_continuity
@@ -14,6 +14,13 @@ from loushang.harnesstui.conversation.agent_application import (
     build_agent_screen_surface_workflow_ports,
     current_agent_runtime_session,
 )
+from loushang.harnesstui.conversation.fork import (
+    ForkPromptCandidate,
+    build_fork_prompt_surface_view,
+)
+from loushang.harnesstui.conversation.side_question import (
+    build_side_question_surface_view,
+)
 from loushang.harnesstui.selection.binding import (
     SessionModelSelectorSurfaceProfile,
 )
@@ -21,6 +28,7 @@ from loushang.harnesstui.status.provider import StatusProvider
 from loushang.harnesstui.surface.workflow import (
     STANDARD_SCREEN_SURFACE_WORKFLOW_COPY,
     ScreenSurfaceCommandCatalog,
+    ScreenSurfaceForkResult,
     ScreenSurfaceWorkflow,
 )
 
@@ -72,6 +80,13 @@ class ScreenSurfaceManager(ScreenSurfaceWorkflow):
             activate_continuity=(
                 self._activate_continuity if runtime is not None else None
             ),
+            build_fork_surface=(
+                self._build_fork_surface if runtime is not None else None
+            ),
+            fork_session=(
+                self._fork_session if runtime is not None else None
+            ),
+            build_side_question_surface=self._build_side_question_surface,
             command_catalog=command_catalog,
             model_selector_profile=_CODING_MODEL_SELECTOR_PROFILE,
         )
@@ -130,6 +145,48 @@ class ScreenSurfaceManager(ScreenSurfaceWorkflow):
             raise RuntimeError("Session resume was cancelled")
         return f"Resumed session {target.opaque_id}"
 
+    def _build_fork_surface(self):
+        session = self._current_session()
+        getter = getattr(session, "get_user_messages_for_forking", None)
+        if not callable(getter):
+            raise RuntimeError("Prompt history is not available for this session")
+        candidates: list[ForkPromptCandidate] = []
+        for value in getter():
+            if not isinstance(value, Mapping):
+                raise TypeError("Fork prompt candidates must be mappings")
+            entry_id = value.get("entry_id")
+            text = value.get("text")
+            if not isinstance(entry_id, str) or not entry_id.strip():
+                raise TypeError("Fork prompt candidates require an entry_id")
+            if not isinstance(text, str) or not text.strip():
+                continue
+            candidates.append(
+                ForkPromptCandidate(entry_id=entry_id, text=text)
+            )
+        return build_fork_prompt_surface_view(
+            candidates=candidates,
+            request_render=lambda: self.coding_app.request_render("product"),
+        )
+
+    async def _fork_session(self, target: object) -> ScreenSurfaceForkResult:
+        if self.runtime is None:
+            raise RuntimeError("Session runtime is not available")
+        if not isinstance(target, str) or not target.strip():
+            raise TypeError("Fork requires a selected prompt")
+        operation = getattr(self.runtime, "fork_session_operation", None)
+        if not callable(operation):
+            raise RuntimeError("Session forking is not available")
+        result = await operation(target, position="before")
+        if getattr(result, "cancelled", False):
+            raise RuntimeError("Session fork was cancelled")
+        selected_text = getattr(result, "payload", None)
+        if not isinstance(selected_text, str):
+            raise RuntimeError("Forked session did not return the selected prompt")
+        return ScreenSurfaceForkResult(
+            status="Forked from selected prompt",
+            composer_text=selected_text,
+        )
+
     async def _build_settings_content(self) -> object:
         session = self._current_session()
         return await build_coding_settings_page(
@@ -137,6 +194,19 @@ class ScreenSurfaceManager(ScreenSurfaceWorkflow):
             status_provider=self.status_provider,
             settings_manager=getattr(session, "settings_manager", None),
             statusline_preview=self.coding_app.statusline_preview_snapshot,
+        )
+
+    def _build_side_question_surface(self, question: str):
+        session = self._current_session()
+        ask = getattr(session, "ask_side_question", None)
+        cancel = getattr(session, "cancel_side_question", None)
+        if not callable(ask) or not callable(cancel):
+            raise RuntimeError("Side questions are not available for this session.")
+        return build_side_question_surface_view(
+            question=question,
+            ask=ask,
+            cancel=cancel,
+            request_render=lambda: self.coding_app.request_render("product"),
         )
 
 

--- a/src/loushang/harness/capabilities/composition_runtime.py
+++ b/src/loushang/harness/capabilities/composition_runtime.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, replace
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from loushang.harness.capabilities.packs import (
     CapabilityPack,
@@ -28,6 +28,7 @@ from loushang.harness.runtime import (
     COMMAND_PACKS_SLOT,
     PROMPT_SECTIONS_SLOT,
     RESOURCE_RUNTIME_SLOT,
+    SIDE_QUESTION_PROVIDER_SLOT,
     SKILL_ACTIVATION_SLOT,
     TOOL_PACKS_SLOT,
     ProductRuntimePlan,
@@ -38,6 +39,8 @@ from loushang.harness.runtime import (
     RuntimeProfileBinder,
     RuntimeProfileBinding,
     RuntimeProfileSource,
+    SessionSideQuestionProviderFactory,
+    SideQuestionProviderFactory,
     standard_capability_composition_slots,
 )
 
@@ -45,6 +48,7 @@ RESOURCE_ACTIVATION_IMPLEMENTATION = "harness.resource_activation"
 PROMPT_SECTIONS_IMPLEMENTATION = "harness.prompt_sections"
 DISABLED_SKILL_ACTIVATION_IMPLEMENTATION = "harness.disabled_skill_activation"
 ORDERED_CAPABILITY_PACKS_IMPLEMENTATION = "harness.ordered_capability_packs"
+AGENT_SIDE_QUESTION_IMPLEMENTATION = "harness.agent_side_question"
 CAPABILITY_COMPOSITION_IMPLEMENTATION_VERSION = 1
 
 T = TypeVar("T")
@@ -55,13 +59,26 @@ def standard_capability_composition_plan(
     *,
     product_id: str,
     allowed_sources: frozenset[RuntimeProfileSource] = frozenset({"product"}),
+    slot_allowed_sources: Mapping[str, frozenset[RuntimeProfileSource]] | None = None,
     prompt_separator: str = "\n\n",
     strip_prompt_sections: bool = True,
 ) -> ProductRuntimePlan:
     """Declare the standard composition mechanisms for one Product."""
 
+    source_overrides = dict(slot_allowed_sources or {})
+    unknown_overrides = source_overrides.keys() - {
+        slot.key for slot in standard_capability_composition_slots()
+    }
+    if unknown_overrides:
+        raise ValueError(
+            "unknown capability-composition source override: "
+            + ", ".join(sorted(unknown_overrides))
+        )
     slots = tuple(
-        replace(slot, allowed_sources=allowed_sources)
+        replace(
+            slot,
+            allowed_sources=source_overrides.get(slot.key, allowed_sources),
+        )
         for slot in standard_capability_composition_slots()
     )
     return ProductRuntimePlan(
@@ -95,6 +112,11 @@ def standard_capability_composition_plan(
             RuntimeCapabilitySelection(
                 slot=COMMAND_PACKS_SLOT.key,
                 implementation=ORDERED_CAPABILITY_PACKS_IMPLEMENTATION,
+                implementation_version=CAPABILITY_COMPOSITION_IMPLEMENTATION_VERSION,
+            ),
+            RuntimeCapabilitySelection(
+                slot=SIDE_QUESTION_PROVIDER_SLOT.key,
+                implementation=AGENT_SIDE_QUESTION_IMPLEMENTATION,
                 implementation_version=CAPABILITY_COMPOSITION_IMPLEMENTATION_VERSION,
             ),
         ),
@@ -183,6 +205,18 @@ class CapabilityCompositionRuntime:
             COMMAND_PACKS_SLOT.key,
         )
 
+    @property
+    def side_question_provider_factory(self) -> SideQuestionProviderFactory | None:
+        value = self.binding.values().get(SIDE_QUESTION_PROVIDER_SLOT.key)
+        if value is None:
+            return None
+        if not callable(getattr(value, "bind", None)):
+            raise TypeError(
+                f"runtime slot {SIDE_QUESTION_PROVIDER_SLOT.key!r} returned "
+                "an invalid side-question Provider factory"
+            )
+        return cast(SideQuestionProviderFactory, value)
+
     def dispose(self) -> None:
         self._binder.dispose_sync(self.binding)
 
@@ -244,6 +278,12 @@ def standard_capability_composition_implementations() -> tuple[
             implementation_version=CAPABILITY_COMPOSITION_IMPLEMENTATION_VERSION,
             create=_create_capability_pack_composer,
         ),
+        RuntimeCapabilityImplementation(
+            slot=SIDE_QUESTION_PROVIDER_SLOT.key,
+            implementation=AGENT_SIDE_QUESTION_IMPLEMENTATION,
+            implementation_version=CAPABILITY_COMPOSITION_IMPLEMENTATION_VERSION,
+            create=_create_agent_side_question_provider_factory,
+        ),
     )
 
 
@@ -293,6 +333,15 @@ def _create_capability_pack_composer(
     return CapabilityPackComposer()
 
 
+def _create_agent_side_question_provider_factory(
+    selection: RuntimeCapabilitySelection,
+    context: object | None,
+) -> SideQuestionProviderFactory:
+    del context
+    _require_exact_config(selection, expected=set())
+    return SessionSideQuestionProviderFactory()
+
+
 def _require_exact_config(
     selection: RuntimeCapabilitySelection,
     *,
@@ -327,6 +376,7 @@ def _require_value(
 
 
 __all__ = [
+    "AGENT_SIDE_QUESTION_IMPLEMENTATION",
     "CAPABILITY_COMPOSITION_IMPLEMENTATION_VERSION",
     "CapabilityCompositionRuntime",
     "DISABLED_SKILL_ACTIVATION_IMPLEMENTATION",

--- a/src/loushang/harness/commands/catalog.py
+++ b/src/loushang/harness/commands/catalog.py
@@ -243,6 +243,14 @@ DEFAULT_LOCAL_COMMANDS_PROFILE = LocalCommandCatalogProfile(
             description="Show terminal diagnostics",
             source="local",
         ),
+        "btw": CommandDef(
+            id="harness.ui.btw",
+            name="btw",
+            kind=CommandKind.LOCAL_UI,
+            description="Ask a quick side question without interrupting the main task",
+            source="local",
+            argument_hint="<question>",
+        ),
     },
     local_command_names_by_route={
         "model_select": "model",
@@ -255,7 +263,7 @@ DEFAULT_LOCAL_COMMANDS_PROFILE = LocalCommandCatalogProfile(
         "terminal": "terminal",
     },
     local_commands_accepting_args=frozenset(
-        {"command", "commands", "model", "models"}
+        {"btw", "command", "commands", "model", "models"}
     ),
 )
 

--- a/src/loushang/harness/runtime/__init__.py
+++ b/src/loushang/harness/runtime/__init__.py
@@ -23,6 +23,7 @@ from loushang.harness.runtime.profile import (
     CONVERSATION_STORE_SLOT,
     PROMPT_SECTIONS_SLOT,
     RESOURCE_RUNTIME_SLOT,
+    SIDE_QUESTION_PROVIDER_SLOT,
     SKILL_ACTIVATION_SLOT,
     TOOL_PACKS_SLOT,
     ProductRuntimePlan,
@@ -70,6 +71,14 @@ from loushang.harness.runtime.session_operations import (
     copy_file_exclusive,
     run_replacement_callbacks,
     stage_file_import,
+)
+from loushang.harness.runtime.side_question import (
+    SessionSideQuestionProviderFactory,
+    SideQuestionAnswer,
+    SideQuestionCoordinator,
+    SideQuestionProvider,
+    SideQuestionProviderFactory,
+    SideQuestionUpdate,
 )
 from loushang.harness.runtime.transition import SessionTransitionHost
 from loushang.harness.runtime.turn import (
@@ -134,6 +143,7 @@ __all__ = [
     "RetryPolicy",
     "RunState",
     "RESOURCE_RUNTIME_SLOT",
+    "SIDE_QUESTION_PROVIDER_SLOT",
     "SKILL_ACTIVATION_SLOT",
     "SessionOperationCandidate",
     "SessionOperationCoordinator",
@@ -141,6 +151,12 @@ __all__ = [
     "SessionOperationPhase",
     "SessionOperationPreparation",
     "SessionOperationResult",
+    "SessionSideQuestionProviderFactory",
+    "SideQuestionAnswer",
+    "SideQuestionCoordinator",
+    "SideQuestionProvider",
+    "SideQuestionProviderFactory",
+    "SideQuestionUpdate",
     "SessionTransitionHost",
     "StreamingBehavior",
     "StagedFileImport",

--- a/src/loushang/harness/runtime/profile.py
+++ b/src/loushang/harness/runtime/profile.py
@@ -1491,6 +1491,14 @@ COMMAND_PACKS_SLOT = RuntimeCapabilitySlot(
     refresh_boundary="turn",
     allowed_sources=frozenset({"product", "oem", "extension"}),
 )
+SIDE_QUESTION_PROVIDER_SLOT = RuntimeCapabilitySlot(
+    key="interaction.side_question",
+    shape="single",
+    scope="session",
+    refresh_boundary="sealed",
+    allowed_sources=frozenset({"product", "oem", "extension"}),
+    required=False,
+)
 CONTINUITY_PROVIDER_PACKS_SLOT = RuntimeCapabilitySlot(
     key="continuity.provider_packs",
     shape="ordered",
@@ -1520,6 +1528,7 @@ def standard_capability_composition_slots() -> tuple[RuntimeCapabilitySlot, ...]
         SKILL_ACTIVATION_SLOT,
         TOOL_PACKS_SLOT,
         COMMAND_PACKS_SLOT,
+        SIDE_QUESTION_PROVIDER_SLOT,
         CONTINUITY_PROVIDER_PACKS_SLOT,
     )
 
@@ -1557,6 +1566,7 @@ __all__ = [
     "RuntimeProfileSnapshotSelection",
     "RuntimeProfileSource",
     "RuntimeRefreshBoundary",
+    "SIDE_QUESTION_PROVIDER_SLOT",
     "SealedRuntimeCapabilityError",
     "RESOURCE_RUNTIME_SLOT",
     "SKILL_ACTIVATION_SLOT",

--- a/src/loushang/harness/runtime/side_question.py
+++ b/src/loushang/harness/runtime/side_question.py
@@ -1,0 +1,110 @@
+"""Product-neutral contracts for one-shot side questions."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Protocol, cast
+
+SideQuestionUpdate = Callable[[str], Awaitable[None] | None]
+
+
+@dataclass(frozen=True, slots=True)
+class SideQuestionAnswer:
+    """One transient answer produced outside the active conversation."""
+
+    text: str
+    context_revision: str | None = None
+    usage: object | None = None
+
+
+class SideQuestionProvider(Protocol):
+    """Execute one question against an immutable Product context snapshot."""
+
+    async def ask(
+        self,
+        question: str,
+        *,
+        on_update: SideQuestionUpdate | None = None,
+    ) -> SideQuestionAnswer: ...
+
+    def cancel(self) -> None: ...
+
+
+class SideQuestionProviderFactory(Protocol):
+    """Bind a selected side-question implementation to one live session."""
+
+    def bind(self, context: object) -> SideQuestionProvider: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSideQuestionProviderFactory:
+    """Delegate concrete Provider creation back to the bound Product session."""
+
+    def bind(self, context: object) -> SideQuestionProvider:
+        create = getattr(context, "create_side_question_provider", None)
+        if not callable(create):
+            raise TypeError(
+                "Side-question capability requires a Product session Provider factory."
+            )
+        provider = create()
+        if not callable(getattr(provider, "ask", None)) or not callable(
+            getattr(provider, "cancel", None)
+        ):
+            raise TypeError(
+                "Product session returned an invalid side-question Provider."
+            )
+        return cast(SideQuestionProvider, provider)
+
+
+class SideQuestionCoordinator:
+    """Own the single active side question for one session."""
+
+    def __init__(self, provider: SideQuestionProvider) -> None:
+        self._provider = provider
+        self._active_task: asyncio.Task[object] | None = None
+
+    @property
+    def active(self) -> bool:
+        task = self._active_task
+        return task is not None and not task.done()
+
+    async def ask(
+        self,
+        question: str,
+        *,
+        on_update: SideQuestionUpdate | None = None,
+    ) -> SideQuestionAnswer:
+        normalized = question.strip()
+        if not normalized:
+            raise ValueError("Side question must not be empty.")
+        if self.active:
+            raise RuntimeError("A side question is already running.")
+        task = asyncio.current_task()
+        if task is None:  # pragma: no cover - an async function always has a task here
+            raise RuntimeError("Side question requires an active event loop task.")
+        self._active_task = task
+        try:
+            return await self._provider.ask(normalized, on_update=on_update)
+        finally:
+            if self._active_task is task:
+                self._active_task = None
+
+    def cancel(self) -> bool:
+        task = self._active_task
+        if task is None or task.done():
+            return False
+        self._provider.cancel()
+        task.cancel()
+        return True
+
+
+__all__ = [
+    "SideQuestionAnswer",
+    "SideQuestionCoordinator",
+    "SideQuestionProvider",
+    "SideQuestionProviderFactory",
+    "SideQuestionUpdate",
+    "SessionSideQuestionProviderFactory",
+]

--- a/src/loushang/harness/session/agent_product.py
+++ b/src/loushang/harness/session/agent_product.py
@@ -31,7 +31,12 @@ from loushang.harness.resources.packages.catalog import PackageSummaryProvider
 from loushang.harness.resources.packages.materializer import PackageMaterializer
 from loushang.harness.resources.packages.session import SessionPackageController
 from loushang.harness.resources.types import ResourceBundle
-from loushang.harness.runtime import CancellationSignal
+from loushang.harness.runtime import (
+    CancellationSignal,
+    SideQuestionAnswer,
+    SideQuestionCoordinator,
+    SideQuestionUpdate,
+)
 from loushang.harness.session.agent_adapter import (
     AgentSessionAdapterMixin,
     initialize_composed_session,
@@ -48,6 +53,10 @@ from loushang.harness.session.diagnostics import SessionDiagnosticsRuntime
 from loushang.harness.session.facade import SessionFacade
 from loushang.harness.session.operations_runtime import SessionOperationsPorts
 from loushang.harness.session.settings import SessionSettingsBinding
+from loushang.harness.session.side_question import (
+    SIDE_QUESTION_BOUNDARY_PROMPT,
+    AgentSideQuestionProvider,
+)
 from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
 from loushang.harness.transcript import (
     BranchSummaryOutput,
@@ -123,6 +132,12 @@ class AgentProductSession(AgentSessionAdapterMixin, SessionFacade):
         self._package_materializer = package_materializer
         self._exec_service = exec_service or ExecService()
         self._capability_runtime = capability_runtime
+        side_question_factory = capability_runtime.side_question_provider_factory
+        self._side_question = (
+            SideQuestionCoordinator(side_question_factory.bind(self))
+            if side_question_factory is not None
+            else None
+        )
         self.footer_data_provider = footer_data_provider
         self._base_prompt = (
             base_prompt if base_prompt is not None else self.agent.system_prompt
@@ -365,7 +380,29 @@ class AgentProductSession(AgentSessionAdapterMixin, SessionFacade):
     def get_context_usage(self):
         return serialize_context_usage_payload(super().get_context_usage())
 
+    async def ask_side_question(
+        self,
+        question: str,
+        *,
+        on_update: SideQuestionUpdate | None = None,
+    ) -> SideQuestionAnswer:
+        coordinator = self._side_question
+        if coordinator is None:
+            raise RuntimeError("Side questions are not available for this session.")
+        return await coordinator.ask(question, on_update=on_update)
+
+    def create_side_question_provider(self) -> AgentSideQuestionProvider:
+        return AgentSideQuestionProvider(
+            session=self,
+            boundary_prompt=SIDE_QUESTION_BOUNDARY_PROMPT,
+        )
+
+    def cancel_side_question(self) -> bool:
+        coordinator = self._side_question
+        return coordinator.cancel() if coordinator is not None else False
+
     def _finalize_after_session_shutdown(self) -> None:
+        self.cancel_side_question()
         self._close_session_approvals()
         if self._extension_runner is not None:
             self._invalidate_extension_contexts(

--- a/src/loushang/harness/session/side_question.py
+++ b/src/loushang/harness/session/side_question.py
@@ -1,0 +1,169 @@
+"""Agent-backed implementation of transient one-shot side questions."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+from loushang.agent import Agent, BeforeToolCallResult
+from loushang.ai.types import AssistantMessage
+from loushang.harness.runtime.side_question import (
+    SideQuestionAnswer,
+    SideQuestionUpdate,
+)
+from loushang.harness.transcript import assistant_message_text
+
+SIDE_QUESTION_BOUNDARY_PROMPT = """\
+You are answering a one-shot side question that is separate from the main task.
+Treat the inherited conversation as reference only. Do not continue its plans or
+perform work on its behalf. Tool use is disabled, and you must not claim to have
+changed state. Answer the side question directly and say when the inherited
+context is insufficient."""
+
+
+class AgentSideQuestionProvider:
+    """Run an in-memory child Agent without a transcript or SessionManager."""
+
+    def __init__(self, *, session: object, boundary_prompt: str) -> None:
+        self._session = session
+        self._boundary_prompt = boundary_prompt
+        self._active_agent: Agent | None = None
+
+    async def ask(
+        self,
+        question: str,
+        *,
+        on_update: SideQuestionUpdate | None = None,
+    ) -> SideQuestionAnswer:
+        if self._active_agent is not None:
+            raise RuntimeError("A side question is already running.")
+        parent = _require_agent(self._session)
+        manager = _require_session_manager(self._session)
+        context = manager.build_session_context()
+        context_messages = list(getattr(context, "messages", ()))
+        revision = _context_revision(manager)
+        child = Agent(
+            initial_state={
+                # Keep the parent's cacheable request prefix byte-for-byte
+                # compatible. The side-question boundary is appended as the
+                # new user turn instead of changing the system prompt.
+                "system_prompt": parent.system_prompt,
+                "model": parent.model,
+                "thinking_level": parent.thinking_level,
+                "tools": parent.tools,
+                "messages": context_messages,
+            },
+            convert_to_llm=parent.convert_to_llm,
+            transform_context=parent.transform_context,
+            stream_fn=parent.stream_fn,
+            call_options=parent.call_options,
+            before_tool_call=_block_side_question_tool_call,
+            steering_mode=parent.steering_mode,
+            follow_up_mode=parent.follow_up_mode,
+            session_id=parent.session_id,
+            thinking_budgets=parent.thinking_budgets,
+            max_retry_delay_ms=parent.max_retry_delay_ms,
+            tool_execution=parent.tool_execution,
+        )
+        self._active_agent = child
+        unsubscribe = child.subscribe(
+            lambda event, _signal: _publish_side_question_update(event, on_update)
+        )
+        try:
+            await child.prompt(
+                _side_question_prompt(self._boundary_prompt, question)
+            )
+            message = _last_assistant_message(child)
+            if message.stop_reason in {"aborted", "error"}:
+                raise RuntimeError(
+                    message.error_message
+                    or f"Side question request {message.stop_reason}."
+                )
+            text = assistant_message_text(message)
+            if text is None:
+                raise RuntimeError("Side question returned no text.")
+            return SideQuestionAnswer(
+                text=text,
+                context_revision=revision,
+                usage=message.usage,
+            )
+        except asyncio.CancelledError:
+            child.abort()
+            raise
+        finally:
+            unsubscribe()
+            if self._active_agent is child:
+                self._active_agent = None
+
+    def cancel(self) -> None:
+        child = self._active_agent
+        if child is not None:
+            child.abort()
+
+
+def _require_agent(session: object) -> Agent:
+    agent = getattr(session, "agent", None)
+    if not isinstance(agent, Agent):
+        raise TypeError("Side questions require an Agent-backed Product session.")
+    return agent
+
+
+def _require_session_manager(session: object) -> object:
+    manager = getattr(session, "session_manager", None)
+    if manager is None or not callable(getattr(manager, "build_session_context", None)):
+        raise TypeError("Side questions require a session context provider.")
+    return manager
+
+
+def _context_revision(manager: object) -> str | None:
+    get_leaf_id = getattr(manager, "get_leaf_id", None)
+    if not callable(get_leaf_id):
+        return None
+    revision = get_leaf_id()
+    return revision if isinstance(revision, str) and revision else None
+
+
+def _side_question_prompt(boundary_prompt: str, question: str) -> str:
+    return f"{boundary_prompt.strip()}\n\nQuestion:\n{question.strip()}"
+
+
+async def _block_side_question_tool_call(
+    _context: object,
+    _signal: object | None,
+) -> BeforeToolCallResult:
+    return BeforeToolCallResult(
+        block=True,
+        reason="Side questions cannot use tools.",
+    )
+
+
+async def _publish_side_question_update(
+    event: object,
+    on_update: SideQuestionUpdate | None,
+) -> None:
+    if on_update is None or not isinstance(event, dict):
+        return
+    if event.get("type") != "message_update":
+        return
+    message = event.get("message")
+    if not isinstance(message, AssistantMessage):
+        return
+    text = assistant_message_text(message)
+    if not text:
+        return
+    result = on_update(text)
+    if inspect.isawaitable(result):
+        await result
+
+
+def _last_assistant_message(agent: Agent) -> AssistantMessage:
+    for message in reversed(agent.state.messages):
+        if isinstance(message, AssistantMessage):
+            return message
+    raise RuntimeError("Side question returned no assistant message.")
+
+
+__all__ = [
+    "AgentSideQuestionProvider",
+    "SIDE_QUESTION_BOUNDARY_PROMPT",
+]

--- a/src/loushang/harnesstui/continuity/surface.py
+++ b/src/loushang/harnesstui/continuity/surface.py
@@ -199,7 +199,7 @@ class ContinuitySurface:
     @property
     def footer_help(self) -> str:
         if self._activating:
-            return "Resuming selected item…"
+            return ""
         hints = [
             f"{self._key_label('tui.select.confirm')} resume",
             f"{self._key_label('tui.select.cancel')} exit",

--- a/src/loushang/harnesstui/conversation/agent_application.py
+++ b/src/loushang/harnesstui/conversation/agent_application.py
@@ -84,6 +84,7 @@ from loushang.harnesstui.surface.factory import command_catalog_surface_view
 from loushang.harnesstui.surface.view import ScreenSurfaceView
 from loushang.harnesstui.surface.workflow import (
     ScreenSurfaceCommandCatalog,
+    ScreenSurfaceForkResult,
     ScreenSurfaceWorkflowPorts,
     normalize_standard_conversation_interactive_command,
     normalize_standard_conversation_surface_command,
@@ -252,6 +253,11 @@ def build_agent_screen_surface_workflow_ports(
     on_approval: AgentScreenApprovalHandler | None = None,
     build_resume_surface: Callable[[], ScreenSurfaceView] | None = None,
     activate_continuity: Callable[[object], Awaitable[str]] | None = None,
+    build_fork_surface: Callable[[], ScreenSurfaceView] | None = None,
+    fork_session: (
+        Callable[[object], Awaitable[ScreenSurfaceForkResult]] | None
+    ) = None,
+    build_side_question_surface: Callable[[str], ScreenSurfaceView] | None = None,
     command_catalog: ScreenSurfaceCommandCatalog | None = None,
     model_selector_profile: SessionModelSelectorSurfaceProfile = (
         SessionModelSelectorSurfaceProfile()
@@ -318,11 +324,14 @@ def build_agent_screen_surface_workflow_ports(
         decide_approval=decide_approval,
         normalize_interactive_command=(
             normalize_standard_conversation_interactive_command
-            if build_resume_surface is not None
+            if build_resume_surface is not None or build_fork_surface is not None
             else None
         ),
         build_resume_surface=build_resume_surface,
         activate_continuity=activate_continuity,
+        build_fork_surface=build_fork_surface,
+        fork_session=fork_session,
+        build_side_question_surface=build_side_question_surface,
     )
 
 
@@ -416,7 +425,7 @@ def bind_agent_screen_session_transition(
     *,
     on_rebind: Callable[[object], object | Awaitable[object]] | None = None,
 ) -> Cleanup:
-    """Clear approval surfaces before or after a runtime session transition."""
+    """Close transient surfaces before or after a runtime session transition."""
 
     subscribe = getattr(runtime, "subscribe_after_session_invalidate", None)
     if not callable(subscribe):
@@ -424,7 +433,7 @@ def bind_agent_screen_session_transition(
     if not callable(subscribe):
         unsubscribe = _no_cleanup
     else:
-        subscribed = subscribe(surface.clear_approval_surfaces)
+        subscribed = subscribe(lambda: _clear_agent_screen_surfaces(surface))
         unsubscribe = subscribed if callable(subscribed) else _no_cleanup
 
     set_rebind = getattr(runtime, "set_rebind_session", None)
@@ -478,6 +487,13 @@ def _unbind_agent_screen_approval_presenter(session: object) -> None:
     setter = getattr(session, "set_approval_presenter", None)
     if callable(setter):
         setter(None)
+
+
+def _clear_agent_screen_surfaces(surface: AgentScreenApprovalSurface) -> None:
+    close = getattr(surface, "close_surface", None)
+    if callable(close):
+        close()
+    surface.clear_approval_surfaces()
 
 
 PlainAppFactory = Callable[

--- a/src/loushang/harnesstui/conversation/fork.py
+++ b/src/loushang/harnesstui/conversation/fork.py
@@ -1,0 +1,294 @@
+"""Full-screen prompt picker for branching an Agent conversation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from loushang.harnesstui.surface.view import ScreenSurfaceView
+from loushang.tui import (
+    InputEvent,
+    InputIntent,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+    SelectionSurface,
+    SelectItem,
+)
+from loushang.tui.cell_width import truncate_to_width, wrap_cells
+from loushang.tui.theme import ThemeResolver, apply_theme_style
+
+FORK_PROMPT_PAGE_THEME = ThemeResolver(
+    defaults={
+        "surface.title": {"bold": True, "color": "cyan"},
+        "surface.subtitle": {"color": "bright_black"},
+        "surface.footer": {"color": "bright_black", "dim": True},
+        "selection.selected": {"bold": True, "color": "cyan"},
+        "fork.state": {"color": "bright_black", "dim": True, "italic": True},
+        "fork.preview.label": {"bold": True, "color": "cyan"},
+        "fork.error": {"color": "red"},
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ForkPromptCandidate:
+    """One user-visible prompt paired with its opaque transcript identity."""
+
+    entry_id: str
+    text: str
+
+
+class ForkPromptSurface:
+    """Select one previous user prompt without exposing transcript IDs."""
+
+    def __init__(
+        self,
+        *,
+        candidates: Sequence[ForkPromptCandidate],
+        request_render: Callable[[], None],
+        theme: ThemeResolver | None = None,
+    ) -> None:
+        self._candidates = tuple(candidates)
+        self._request_render = request_render
+        self._theme = theme if theme is not None else FORK_PROMPT_PAGE_THEME
+        self._candidate_by_id = {
+            candidate.entry_id: candidate for candidate in self._candidates
+        }
+        self._ordinal_by_id = {
+            candidate.entry_id: ordinal
+            for ordinal, candidate in enumerate(self._candidates, start=1)
+        }
+        self._selection = SelectionSurface(
+            items=[
+                SelectItem(
+                    label=_prompt_label(candidate.text),
+                    value=candidate.entry_id,
+                    description=f"Prompt {self._ordinal_by_id[candidate.entry_id]}",
+                )
+                for candidate in reversed(self._candidates)
+            ],
+            max_visible=20,
+            empty_text=self._styled("No prompts to fork yet", "fork.state"),
+            wrap_navigation=False,
+            enable_search=True,
+            search_prompt="Search: ",
+            search_placeholder=self._styled("Type to search", "fork.state"),
+            search_gap_lines=1,
+            filter_mode="fuzzy",
+            preserve_description_spacing=True,
+            theme=self._theme,
+        )
+        self._preview_visible = False
+        self._preview_offset = 0
+        self._last_preview_height = 1
+        self._max_preview_offset = 0
+        self._activating = False
+        self._error: str | None = None
+
+    @property
+    def selected_entry_id(self) -> str | None:
+        selected = self._selection.selected_item()
+        return selected.selected_value if selected is not None else None
+
+    @property
+    def footer_help(self) -> str:
+        if self._activating:
+            return ""
+        if self._preview_visible:
+            return (
+                "Enter fork and edit · Space/Esc back · "
+                "↑/↓ scroll · PgUp/PgDn page"
+            )
+        return "Enter fork and edit · Space preview · Esc cancel · ↑/↓ browse"
+
+    def begin_activation(self) -> bool:
+        if self._activating or self.selected_entry_id is None:
+            return False
+        self._activating = True
+        self._error = None
+        self._request_render()
+        return True
+
+    def fail_activation(self, error: BaseException) -> None:
+        self._activating = False
+        self._error = str(error).strip() or error.__class__.__name__
+        self._request_render()
+
+    def handle_input(self, event: InputEvent) -> InputIntent | bool | None:
+        if self._activating:
+            return InputIntent(kind="consumed", note="fork_activating")
+        if self._preview_visible:
+            return self._handle_preview_input(event)
+        if event.kind == "key" and event.key == "space":
+            if self.selected_entry_id is None:
+                return InputIntent(kind="consumed", note="fork_preview_unavailable")
+            self._preview_visible = True
+            self._preview_offset = 0
+            self._request_render()
+            return InputIntent(kind="consumed", note="fork_preview")
+        return self._selection.handle_input(event)
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        state_lines = self._state_lines(width=constraints.width)
+        body_height = max(1, constraints.max_height - len(state_lines))
+        if self._preview_visible:
+            body = self._render_preview(
+                RenderConstraints(
+                    width=constraints.width,
+                    max_height=body_height,
+                    visible_height=constraints.visible_height,
+                )
+            )
+        else:
+            self._selection.max_visible = min(20, max(1, body_height))
+            self._selection.primary_column_width = max(
+                16,
+                min(72, constraints.width - 14),
+            )
+            body = self._selection.render(
+                RenderConstraints(
+                    width=constraints.width,
+                    max_height=body_height,
+                    visible_height=constraints.visible_height,
+                )
+            )
+        return RenderResult.from_lines(
+            [*body.lines, *state_lines],
+            constraints=constraints,
+            cursor=body.cursor,
+        )
+
+    def _handle_preview_input(self, event: InputEvent) -> InputIntent | bool | None:
+        if event.kind == "text":
+            return InputIntent(kind="consumed", note="fork_preview")
+        if event.kind != "key":
+            return InputIntent(kind="consumed", note="fork_preview")
+        if event.key in {"esc", "escape", "space"}:
+            self._preview_visible = False
+            self._request_render()
+            return InputIntent(kind="consumed", note="fork_preview_close")
+        if event.key == "enter":
+            selected = self.selected_entry_id
+            if selected is None:
+                return InputIntent(kind="consumed", note="fork_preview_unavailable")
+            return InputIntent(kind="select", text=selected)
+        if event.key == "up":
+            self._scroll_preview(-1)
+        elif event.key == "down":
+            self._scroll_preview(1)
+        elif event.key == "pageUp":
+            self._scroll_preview(-self._last_preview_height)
+        elif event.key == "pageDown":
+            self._scroll_preview(self._last_preview_height)
+        elif event.key == "home":
+            self._set_preview_offset(0)
+        elif event.key == "end":
+            self._set_preview_offset(self._max_preview_offset)
+        return InputIntent(kind="consumed", note="fork_preview")
+
+    def _render_preview(self, constraints: RenderConstraints) -> RenderResult:
+        candidate = self._selected_candidate()
+        if candidate is None:
+            return RenderResult.from_lines(
+                [RenderLine(self._styled("No prompt selected", "fork.state"))],
+                constraints=constraints,
+            )
+        ordinal = self._ordinal_by_id[candidate.entry_id]
+        lines = [
+            RenderLine(
+                self._styled(
+                    f"Prompt {ordinal} of {len(self._candidates)}",
+                    "fork.preview.label",
+                )
+            ),
+            RenderLine(""),
+            *(
+                RenderLine(line)
+                for line in (
+                    wrap_cells(candidate.text, width=max(1, constraints.width)) or [""]
+                )
+            ),
+        ]
+        self._last_preview_height = max(1, constraints.max_height)
+        self._max_preview_offset = max(0, len(lines) - constraints.max_height)
+        self._preview_offset = max(
+            0,
+            min(self._preview_offset, self._max_preview_offset),
+        )
+        return RenderResult.from_lines(
+            lines[
+                self._preview_offset : self._preview_offset
+                + constraints.max_height
+            ],
+            constraints=constraints,
+        )
+
+    def _selected_candidate(self) -> ForkPromptCandidate | None:
+        entry_id = self.selected_entry_id
+        return self._candidate_by_id.get(entry_id) if entry_id is not None else None
+
+    def _scroll_preview(self, delta: int) -> None:
+        self._set_preview_offset(self._preview_offset + delta)
+
+    def _set_preview_offset(self, offset: int) -> None:
+        next_offset = max(0, min(offset, self._max_preview_offset))
+        if next_offset != self._preview_offset:
+            self._preview_offset = next_offset
+            self._request_render()
+
+    def _state_lines(self, *, width: int) -> list[RenderLine]:
+        if self._activating:
+            return [RenderLine(""), RenderLine("Forking selected prompt…")]
+        if self._error is not None:
+            return [
+                RenderLine(""),
+                RenderLine(
+                    self._styled(
+                        truncate_to_width(
+                            f"Error: {self._error}",
+                            max_width=width,
+                        ),
+                        "fork.error",
+                    )
+                ),
+            ]
+        return []
+
+    def _styled(self, text: str, token: str) -> str:
+        return apply_theme_style(text, self._theme.resolve(token))
+
+
+def build_fork_prompt_surface_view(
+    *,
+    candidates: Sequence[ForkPromptCandidate],
+    request_render: Callable[[], None],
+    theme: ThemeResolver | None = None,
+) -> ScreenSurfaceView:
+    resolved_theme = theme if theme is not None else FORK_PROMPT_PAGE_THEME
+    content = ForkPromptSurface(
+        candidates=candidates,
+        request_render=request_render,
+        theme=resolved_theme,
+    )
+    return ScreenSurfaceView(
+        title="Fork from a previous prompt",
+        subtitle="Choose a prompt to edit in a new session",
+        purpose="fork",
+        content=content,
+        footer=content.footer_help,
+        presentation="page",
+        theme=resolved_theme,
+    )
+
+
+def _prompt_label(text: str) -> str:
+    return " ".join(text.split())
+
+
+__all__ = [
+    "FORK_PROMPT_PAGE_THEME",
+    "ForkPromptCandidate",
+    "ForkPromptSurface",
+    "build_fork_prompt_surface_view",
+]

--- a/src/loushang/harnesstui/conversation/side_question.py
+++ b/src/loushang/harnesstui/conversation/side_question.py
@@ -1,0 +1,250 @@
+"""Transient screen surface for one-shot side questions."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Literal, Protocol
+
+from loushang.harness.runtime import SideQuestionAnswer, SideQuestionUpdate
+from loushang.harnesstui.surface.view import ScreenSurfaceView
+from loushang.tui import (
+    InputEvent,
+    InputIntent,
+    MarkdownRenderCache,
+    MarkdownRenderer,
+    RenderConstraints,
+    RenderLine,
+    RenderResult,
+)
+from loushang.tui.theme import ThemeResolver, apply_theme_style
+
+SideQuestionStatus = Literal["answering", "answered", "failed", "closed"]
+_PROGRESS_GLYPHS = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+
+SIDE_QUESTION_PAGE_THEME = ThemeResolver(
+    defaults={
+        "surface.title": {"bold": True, "color": "yellow"},
+        "surface.subtitle": {"bold": True, "color": "bright_cyan"},
+        "surface.footer": {"color": "bright_black", "dim": True},
+        "side_question.progress": {"color": "yellow"},
+        "side_question.error": {"color": "red"},
+        "markdown.heading": {"color": "yellow"},
+        "markdown.link": {"color": "blue"},
+        "markdown.link.url": {"color": "bright_black"},
+        "markdown.code.inline": {"color": "cyan"},
+        "markdown.code.block": {"color": "green"},
+        "markdown.code.block.border": {"color": "bright_black"},
+        "markdown.quote.text": {"color": "bright_black"},
+        "markdown.quote.border": {"color": "bright_black"},
+        "markdown.hr": {"color": "bright_black"},
+        "markdown.list.bullet": {"color": "green"},
+        "markdown.strong": {"bold": True},
+        "markdown.emphasis": {"italic": True},
+    }
+)
+
+
+class SideQuestionRunner(Protocol):
+    async def __call__(
+        self,
+        question: str,
+        *,
+        on_update: SideQuestionUpdate | None = None,
+    ) -> SideQuestionAnswer: ...
+
+
+@dataclass(slots=True)
+class SideQuestionSurface:
+    """Render and cancel a transient side-question request."""
+
+    question: str
+    ask: SideQuestionRunner
+    cancel: Callable[[], object]
+    request_render: Callable[[], object]
+    theme: ThemeResolver = field(default_factory=lambda: SIDE_QUESTION_PAGE_THEME)
+    status: SideQuestionStatus = field(default="answering", init=False)
+    answer: str = field(default="", init=False)
+    error: str = field(default="", init=False)
+    _scroll_offset: int = field(default=0, init=False, repr=False)
+    _last_body_height: int = field(default=1, init=False, repr=False)
+    _last_line_count: int = field(default=0, init=False, repr=False)
+    _progress_frame: int = field(default=0, init=False, repr=False)
+    _started_at: float = field(default_factory=time.monotonic, init=False, repr=False)
+    _follow_output: bool = field(default=True, init=False, repr=False)
+    _markdown_cache: MarkdownRenderCache = field(
+        default_factory=MarkdownRenderCache,
+        init=False,
+        repr=False,
+    )
+
+    async def start(self) -> None:
+        progress_task = asyncio.create_task(self._animate_progress())
+        try:
+            result = await self.ask(
+                self.question,
+                on_update=self._accept_answer_update,
+            )
+        except asyncio.CancelledError:
+            self.status = "closed"
+            raise
+        except Exception as exc:
+            self.status = "failed"
+            self.error = str(exc).strip() or exc.__class__.__name__
+        else:
+            self.status = "answered"
+            self.answer = result.text
+        finally:
+            progress_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await progress_task
+        self.request_render()
+
+    def close(self) -> None:
+        if self.status == "answering":
+            self.cancel()
+        self.status = "closed"
+
+    @property
+    def footer_help(self) -> str:
+        if self.status == "answering":
+            if self._max_scroll_offset() > 0:
+                return "Up/Down/Page scroll · Esc cancel · Main task continues"
+            return "Esc cancel · Main task continues"
+        if self._max_scroll_offset() > 0:
+            return "Up/Down/Page scroll · Enter/Esc close"
+        return "Enter/Esc close"
+
+    def handle_input(self, event: InputEvent) -> InputIntent | None:
+        if event.kind != "key":
+            return None
+        if event.key in {"escape", "esc"}:
+            return InputIntent(kind="surface_close")
+        if event.key in {"enter", "space"} and self.status != "answering":
+            return InputIntent(kind="surface_close")
+        page = max(1, self._last_body_height)
+        deltas = {
+            "down": 1,
+            "up": -1,
+            "pageDown": page,
+            "pageUp": -page,
+        }
+        if event.key in deltas:
+            return self._scroll(deltas[event.key])
+        if event.key == "home":
+            return self._set_scroll(0)
+        if event.key == "end":
+            return self._set_scroll(self._max_scroll_offset())
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        lines: list[str] = []
+        if self.answer:
+            rendered = MarkdownRenderer(
+                self.answer,
+                theme=self.theme,
+                render_cache=self._markdown_cache,
+                streaming_key=self.question if self.status == "answering" else None,
+            ).render(
+                RenderConstraints(width=constraints.width, max_height=100_000)
+            )
+            lines.extend(line.text for line in rendered.lines)
+        if self.status == "answering":
+            if lines:
+                lines.append("")
+            elapsed = max(0, int(time.monotonic() - self._started_at))
+            glyph = _PROGRESS_GLYPHS[self._progress_frame % len(_PROGRESS_GLYPHS)]
+            lines.append(
+                apply_theme_style(
+                    f"{glyph} Answering… {elapsed}s",
+                    self.theme.resolve("side_question.progress"),
+                )
+            )
+        elif self.status == "failed":
+            lines.append(
+                apply_theme_style(
+                    f"Error: {self.error}",
+                    self.theme.resolve("side_question.error"),
+                )
+            )
+
+        self._last_body_height = constraints.max_height
+        self._last_line_count = len(lines)
+        max_offset = self._max_scroll_offset()
+        self._scroll_offset = (
+            max_offset
+            if self.status == "answering" and self._follow_output
+            else min(self._scroll_offset, max_offset)
+        )
+        visible = lines[
+            self._scroll_offset : self._scroll_offset + constraints.max_height
+        ]
+        return RenderResult.from_lines(
+            [RenderLine(line) for line in visible],
+            constraints=constraints,
+        )
+
+    def _scroll(self, delta: int) -> InputIntent | None:
+        return self._set_scroll(self._scroll_offset + delta)
+
+    def _set_scroll(self, offset: int) -> InputIntent | None:
+        max_offset = self._max_scroll_offset()
+        next_offset = max(0, min(offset, max_offset))
+        if next_offset == self._scroll_offset:
+            return None
+        self._scroll_offset = next_offset
+        self._follow_output = next_offset == max_offset
+        return InputIntent(kind="consumed", note="side_question_scroll")
+
+    def _max_scroll_offset(self) -> int:
+        return max(0, self._last_line_count - self._last_body_height)
+
+    async def _animate_progress(self) -> None:
+        while self.status == "answering":
+            await asyncio.sleep(0.12)
+            self._progress_frame += 1
+            self.request_render()
+
+    def _accept_answer_update(self, text: str) -> None:
+        if self.status != "answering" or text == self.answer:
+            return
+        self.answer = text
+        self.request_render()
+
+
+def build_side_question_surface_view(
+    *,
+    question: str,
+    ask: SideQuestionRunner,
+    cancel: Callable[[], object],
+    request_render: Callable[[], object],
+) -> ScreenSurfaceView:
+    """Build the standard framed BTW surface."""
+
+    return ScreenSurfaceView(
+        title="/btw",
+        subtitle=question,
+        purpose="dialog",
+        content=SideQuestionSurface(
+            question=question,
+            ask=ask,
+            cancel=cancel,
+            request_render=request_render,
+            theme=SIDE_QUESTION_PAGE_THEME,
+        ),
+        footer="",
+        presentation="page",
+        theme=SIDE_QUESTION_PAGE_THEME,
+    )
+
+
+__all__ = [
+    "SideQuestionRunner",
+    "SideQuestionStatus",
+    "SideQuestionSurface",
+    "SIDE_QUESTION_PAGE_THEME",
+    "build_side_question_surface_view",
+]

--- a/src/loushang/harnesstui/surface/controller.py
+++ b/src/loushang/harnesstui/surface/controller.py
@@ -15,7 +15,7 @@ from loushang.tui import (
 
 SurfaceEventKind = Literal["surface_submit", "surface_close"]
 SurfaceEventSource = Literal[
-    "model", "command", "settings", "session", "dialog", "approval"
+    "model", "command", "settings", "session", "fork", "dialog", "approval"
 ]
 SurfaceSubmitHandler = Callable[[Any], Awaitable[None]]
 
@@ -252,6 +252,17 @@ def normalize_surface_intent(
             kind="surface_submit",
             source="session",
             payload=selected_target if selected_target is not None else intent.text,
+        )
+    if surface.purpose == "fork" and intent.kind == "select":
+        selected_entry_id = getattr(surface.content, "selected_entry_id", None)
+        return SurfaceEvent(
+            kind="surface_submit",
+            source="fork",
+            payload=(
+                selected_entry_id
+                if selected_entry_id is not None
+                else intent.text
+            ),
         )
     if surface.purpose == "dialog" and intent.kind == "dialog_confirm":
         return SurfaceEvent(kind="surface_submit", source="dialog")

--- a/src/loushang/harnesstui/surface/view.py
+++ b/src/loushang/harnesstui/surface/view.py
@@ -18,7 +18,14 @@ from loushang.tui.input import InputIntentKind
 from loushang.tui.theme import ThemeResolver, apply_theme_style
 
 ScreenSurfacePurpose = Literal[
-    "info", "model", "command", "settings", "session", "dialog", "approval"
+    "info",
+    "model",
+    "command",
+    "settings",
+    "session",
+    "fork",
+    "dialog",
+    "approval",
 ]
 ScreenSurfacePresentation = Literal["bottom", "bottom-exclusive", "page"]
 

--- a/src/loushang/harnesstui/surface/workflow.py
+++ b/src/loushang/harnesstui/surface/workflow.py
@@ -36,6 +36,8 @@ ScreenSurfaceCommandKind = Literal[
     "select_command",
     "list_commands",
     "resume_session",
+    "fork_session",
+    "side_question",
     "terminal_diagnostics",
     "hotkeys",
     "settings",
@@ -81,6 +83,14 @@ class ScreenSurfaceCommand:
 
     kind: ScreenSurfaceCommandKind
     query: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class ScreenSurfaceForkResult:
+    """Effects produced after a Product forks one selected prompt."""
+
+    status: str
+    composer_text: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,6 +147,13 @@ class ScreenSurfaceWorkflowPorts:
     ) = None
     build_resume_surface: Callable[[], ScreenSurfaceView] | None = None
     activate_continuity: Callable[[object], Awaitable[str]] | None = None
+    build_fork_surface: Callable[[], ScreenSurfaceView] | None = None
+    fork_session: (
+        Callable[[object], Awaitable[ScreenSurfaceForkResult]] | None
+    ) = None
+    build_side_question_surface: (
+        Callable[[str], ScreenSurfaceView] | None
+    ) = None
 
 
 @dataclass(slots=True)
@@ -158,6 +175,11 @@ class ScreenSurfaceWorkflow:
         init=False,
         repr=False,
     )
+    _fork_activation_task: asyncio.Task[None] | None = field(
+        default=None,
+        init=False,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         self.coordinator = ScreenSurfaceCoordinator(
@@ -167,6 +189,7 @@ class ScreenSurfaceWorkflow:
                 "command": self._handle_command_submit,
                 "settings": self._handle_settings_submit,
                 "session": self._handle_session_submit,
+                "fork": self._handle_fork_submit,
                 "dialog": self._handle_dialog_submit,
                 "approval": self._handle_approval_submit,
             },
@@ -222,6 +245,29 @@ class ScreenSurfaceWorkflow:
                 self.app.set_status(self.copy.recoverable_error(error))
             else:
                 self.open(picker)
+        elif (
+            command.kind == "fork_session"
+            and self.ports.build_fork_surface is not None
+        ):
+            try:
+                picker = self.ports.build_fork_surface()
+            except Exception as error:
+                self.app.set_status(self.copy.recoverable_error(error))
+            else:
+                self.open(picker)
+        elif command.kind == "side_question":
+            question = command.query.strip()
+            if not question:
+                self.app.set_status("Usage: /btw <question>")
+            elif self.ports.build_side_question_surface is None:
+                self.app.set_status("Side questions are not available.")
+            else:
+                try:
+                    surface = self.ports.build_side_question_surface(question)
+                except Exception as error:
+                    self.app.set_status(self.copy.recoverable_error(error))
+                else:
+                    self.open(surface)
         elif command.kind == "terminal_diagnostics":
             self.open_info(
                 title=self.copy.terminal_title,
@@ -317,6 +363,9 @@ class ScreenSurfaceWorkflow:
         risk: str = "",
         action_id: str | None = None,
     ) -> None:
+        current = self.current
+        if isinstance(current, ScreenSurfaceView) and current.purpose != "approval":
+            self._close_surface_content()
         self.coordinator.present_approval(
             action=action,
             risk=risk,
@@ -389,6 +438,56 @@ class ScreenSurfaceWorkflow:
         finally:
             if self._session_activation_task is asyncio.current_task():
                 self._session_activation_task = None
+
+    async def _handle_fork_submit(self, payload: object) -> None:
+        if self.ports.fork_session is None:
+            return
+        surface = self.current
+        content = surface.content if isinstance(surface, ScreenSurfaceView) else None
+        begin_activation = getattr(content, "begin_activation", None)
+        if isinstance(surface, ScreenSurfaceView) and callable(begin_activation):
+            if not begin_activation():
+                return
+            self._fork_activation_task = asyncio.create_task(
+                self._run_fork_activation(payload, surface)
+            )
+            return
+        await self._activate_fork(payload, surface)
+
+    async def _run_fork_activation(
+        self,
+        payload: object,
+        surface: ScreenSurfaceView,
+    ) -> None:
+        try:
+            await self._activate_fork(payload, surface)
+        finally:
+            if self._fork_activation_task is asyncio.current_task():
+                self._fork_activation_task = None
+
+    async def _activate_fork(
+        self,
+        payload: object,
+        surface: ScreenSurfaceView | object | None,
+    ) -> None:
+        fork_session = self.ports.fork_session
+        if fork_session is None:  # pragma: no cover - guarded by submit handler
+            return
+        try:
+            result = await fork_session(payload)
+        except Exception as error:
+            if isinstance(surface, ScreenSurfaceView) and self.current is surface:
+                fail_activation = getattr(surface.content, "fail_activation", None)
+                if callable(fail_activation):
+                    fail_activation(error)
+            self.app.set_status(self.copy.recoverable_error(error))
+            return
+        if self.current is surface:
+            self.close()
+        if result.composer_text is not None:
+            self.app.composer.set_text(result.composer_text)
+        self.app.set_status(result.status)
+        self.app.request_render(self.request_render_reason)
 
     async def _activate_session(
         self,
@@ -478,6 +577,11 @@ def normalize_standard_conversation_surface_command(
         )
     if command.name == "commands" and isinstance(intent, CommandsIntent):
         return ScreenSurfaceCommand("list_commands", intent.query)
+    if command.name == "btw":
+        stripped = text.strip()
+        parts = stripped.split(maxsplit=1)
+        query = parts[1] if len(parts) == 2 else ""
+        return ScreenSurfaceCommand("side_question", query)
     if command.name == "terminal" and isinstance(
         intent,
         TerminalDiagnosticsIntent,
@@ -500,6 +604,8 @@ def normalize_standard_conversation_interactive_command(
 
     if text.strip() == "/resume":
         return ScreenSurfaceCommand("resume_session")
+    if text.strip() == "/fork":
+        return ScreenSurfaceCommand("fork_session")
     return None
 
 
@@ -519,6 +625,7 @@ __all__ = [
     "ScreenSurfaceCommandCatalog",
     "ScreenSurfaceCommandKind",
     "ScreenSurfaceComposerPort",
+    "ScreenSurfaceForkResult",
     "ScreenSurfaceWorkflowAppPort",
     "STANDARD_SCREEN_SURFACE_WORKFLOW_COPY",
     "normalize_standard_conversation_interactive_command",

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -81,6 +81,7 @@ def test_core_runtime_packages_do_not_import_product_layers() -> None:
                     "src/loushang/harness/session/agent_product.py",
                     "src/loushang/harness/session/composition.py",
                     "src/loushang/harness/session/operations_runtime.py",
+                    "src/loushang/harness/session/side_question.py",
                 }
             ),
         ),

--- a/tests/coding/test_capability_profile.py
+++ b/tests/coding/test_capability_profile.py
@@ -13,7 +13,10 @@ from loushang.harness.capabilities import (
 from loushang.harness.capabilities.prompt import PromptSection
 from loushang.harness.conversation import ConversationHeader
 from loushang.harness.resources.types import ResourceBundle, SkillDescriptor
-from loushang.harness.runtime import RuntimeProfileSnapshot
+from loushang.harness.runtime import (
+    SIDE_QUESTION_PROVIDER_SLOT,
+    RuntimeProfileSnapshot,
+)
 
 
 def test_coding_capability_profile_binds_all_default_capabilities(tmp_path) -> None:
@@ -79,9 +82,15 @@ def test_coding_capability_snapshot_is_separate_from_other_header_metadata() -> 
         "skill.activation",
         "tool.packs",
         "command.packs",
+        "interaction.side_question",
         "continuity.provider_packs",
     }
     assert all(
         slot.allowed_sources == frozenset({"product"})
         for slot in CODING_CAPABILITY_PLAN.slots
+        if slot.key != SIDE_QUESTION_PROVIDER_SLOT.key
+    )
+    assert (
+        CODING_CAPABILITY_PLAN.slot(SIDE_QUESTION_PROVIDER_SLOT.key).allowed_sources
+        == frozenset({"product", "oem", "extension"})
     )

--- a/tests/coding/test_runtime_profile.py
+++ b/tests/coding/test_runtime_profile.py
@@ -126,6 +126,46 @@ def test_persistent_session_resumes_the_snapshotted_file_profile(tmp_path) -> No
     asyncio.run(scenario())
 
 
+def test_persistent_session_accepts_snapshot_without_auxiliary_side_question(
+    tmp_path,
+) -> None:
+    async def scenario() -> None:
+        manager = await SessionManager.new(
+            session_dir=tmp_path,
+            cwd="/tmp/project",
+            persist=True,
+        )
+        assert manager.session_file is not None
+        await manager.append_message(
+            UserMessage(role="user", content="materialize", timestamp=0.0)
+        )
+        capability_snapshot = dict(
+            manager.header.metadata[CODING_CAPABILITY_PROFILE_METADATA_KEY]
+        )
+        capabilities = capability_snapshot["capabilities"]
+        assert isinstance(capabilities, list)
+        capability_snapshot["capabilities"] = [
+            capability
+            for capability in capabilities
+            if isinstance(capability, dict)
+            and capability.get("slot") != "interaction.side_question"
+        ]
+        header = replace(
+            manager.header,
+            metadata={
+                **manager.header.metadata,
+                CODING_CAPABILITY_PROFILE_METADATA_KEY: capability_snapshot,
+            },
+        )
+        write_session_file(manager.session_file, header, manager.get_entries())
+        await manager.dispose_runtime_profile()
+
+        resumed = await SessionManager.load(manager.session_file, persist=True)
+        await resumed.dispose_runtime_profile()
+
+    asyncio.run(scenario())
+
+
 def test_persistent_session_rejects_a_different_capability_profile(tmp_path) -> None:
     async def scenario() -> None:
         manager = await SessionManager.new(

--- a/tests/coding/test_screen_coding_tui_surfaces.py
+++ b/tests/coding/test_screen_coding_tui_surfaces.py
@@ -8,6 +8,7 @@ from loushang.ai import Model
 from loushang.ai.model import ModelSelection
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 from loushang.coding.ui.screen_surfaces import ScreenSurfaceManager
+from loushang.harnesstui.conversation.fork import ForkPromptSurface
 from loushang.harnesstui.selection.model import (
     ModelSelectorSurface as SharedModelSelectorSurface,
 )
@@ -366,6 +367,61 @@ def test_screen_surface_manager_opens_resume_as_full_screen_continuity_page() ->
     assert surface.presentation == "page"
     assert isinstance(surface.renderable, ScreenSurfaceView)
     assert surface.renderable.purpose == "session"
+
+
+def test_screen_surface_manager_forks_selected_prompt_and_restores_composer() -> None:
+    session = _Session()
+    session.fork_messages = [
+        {"entry_id": "entry-1", "text": "first prompt"},
+        {"entry_id": "entry-2", "text": "latest prompt"},
+    ]
+
+    class Runtime:
+        def __init__(self) -> None:
+            self.current_session = session
+            self.calls: list[tuple[str, str]] = []
+
+        async def fork_session_operation(self, entry_id: str, *, position: str):
+            self.calls.append((entry_id, position))
+            return SimpleNamespace(
+                cancelled=False,
+                current=self.current_session,
+                payload="latest prompt",
+            )
+
+    async def scenario() -> None:
+        runtime = Runtime()
+        app = _app()
+        app.surface_host = SurfaceHost()
+        manager = ScreenSurfaceManager(
+            app=app,
+            session=session,
+            runtime=runtime,
+            status_provider=_status_provider(app),
+        )
+
+        assert manager.is_local_command("/fork")
+        assert not manager.is_local_command("/fork entry-2 before")
+        await manager.handle_text("/fork")
+
+        view = _only_overlay_view(app)
+        assert view.purpose == "fork"
+        assert isinstance(view.content, ForkPromptSurface)
+        assert view.content.selected_entry_id == "entry-2"
+        intent = view.handle_input(InputEvent(kind="key", key="enter"))
+        assert intent == InputIntent(kind="select", text="entry-2")
+
+        await manager.handle_surface_intent(intent)
+        task = manager._fork_activation_task
+        assert task is not None
+        await task
+
+        assert runtime.calls == [("entry-2", "before")]
+        assert app.composer.value == "latest prompt"
+        assert app.state.status_message == "Forked from selected prompt"
+        assert app.surface_host.entries == []
+
+    asyncio.run(scenario())
 
 
 def test_screen_surface_manager_opens_models_info_in_bottom_frame_with_runtime_overlay_host() -> (
@@ -1248,6 +1304,7 @@ class _Session:
         self.commands: list[object] = []
         self.model_details: list[Model] = []
         self.scoped_models: list[object] = []
+        self.fork_messages: list[dict[str, str]] = []
 
     def get_model_selection(self) -> object:
         return self.current_model
@@ -1276,6 +1333,9 @@ class _Session:
 
     def list_commands(self) -> list[object]:
         return self.commands
+
+    def get_user_messages_for_forking(self) -> list[dict[str, str]]:
+        return list(self.fork_messages)
 
 
 class _FailingModelSession(_Session):

--- a/tests/coding/tui_support/scenarios/surface.py
+++ b/tests/coding/tui_support/scenarios/surface.py
@@ -83,7 +83,7 @@ def _run_command_palette_select() -> object:
 
     result = playback.run(
         (0.00, "/command\r"),
-        (0.01, "ter"),
+        (0.01, "term"),
         (0.03, "\r"),
         (0.05, ""),
         handle_local=manager.handle_text,

--- a/tests/harness/capabilities/test_composition_runtime.py
+++ b/tests/harness/capabilities/test_composition_runtime.py
@@ -16,6 +16,7 @@ from loushang.harness.capabilities.composition_runtime import (
 from loushang.harness.capabilities.prompt import PromptSection
 from loushang.harness.resources.types import ResourceBundle, SkillDescriptor
 from loushang.harness.runtime import (
+    SIDE_QUESTION_PROVIDER_SLOT,
     ProductRuntimePlan,
     RuntimeCapabilityBindingError,
     RuntimeCapabilitySelection,
@@ -114,6 +115,27 @@ def test_standard_composition_plan_is_reusable_by_another_product() -> None:
     assert all(
         slot.allowed_sources == frozenset({"product", "oem"}) for slot in plan.slots
     )
+    runtime.dispose()
+
+
+def test_standard_composition_plan_supports_per_slot_source_boundaries() -> None:
+    plan = standard_capability_composition_plan(
+        product_id="coding",
+        slot_allowed_sources={
+            SIDE_QUESTION_PROVIDER_SLOT.key: frozenset(
+                {"product", "oem", "extension"}
+            )
+        },
+    )
+    profile = RuntimeProfileResolver().resolve(plan)
+    runtime = bind_capability_composition_runtime(profile)
+    slots = {slot.key: slot for slot in plan.slots}
+
+    assert slots["resource.runtime"].allowed_sources == frozenset({"product"})
+    assert slots[SIDE_QUESTION_PROVIDER_SLOT.key].allowed_sources == frozenset(
+        {"product", "oem", "extension"}
+    )
+    assert runtime.side_question_provider_factory is not None
     runtime.dispose()
 
 

--- a/tests/harness/runtime/test_profile.py
+++ b/tests/harness/runtime/test_profile.py
@@ -12,6 +12,7 @@ from loushang.harness.runtime import (
     CONVERSATION_STORE_SLOT,
     PROMPT_SECTIONS_SLOT,
     RESOURCE_RUNTIME_SLOT,
+    SIDE_QUESTION_PROVIDER_SLOT,
     SKILL_ACTIVATION_SLOT,
     TOOL_PACKS_SLOT,
     ProductRuntimePlan,
@@ -514,6 +515,7 @@ def test_capability_composition_slots_have_deliberate_source_boundaries() -> Non
         "skill.activation",
         "tool.packs",
         "command.packs",
+        "interaction.side_question",
         "continuity.provider_packs",
     }
     assert slots == {
@@ -522,6 +524,7 @@ def test_capability_composition_slots_have_deliberate_source_boundaries() -> Non
         "skill.activation": SKILL_ACTIVATION_SLOT,
         "tool.packs": TOOL_PACKS_SLOT,
         "command.packs": COMMAND_PACKS_SLOT,
+        "interaction.side_question": SIDE_QUESTION_PROVIDER_SLOT,
         "continuity.provider_packs": CONTINUITY_PROVIDER_PACKS_SLOT,
     }
     assert slots["resource.runtime"].allowed_sources == frozenset({"product", "oem"})
@@ -531,6 +534,10 @@ def test_capability_composition_slots_have_deliberate_source_boundaries() -> Non
     assert slots["command.packs"].allowed_sources == frozenset(
         {"product", "oem", "extension"}
     )
+    assert slots["interaction.side_question"].allowed_sources == frozenset(
+        {"product", "oem", "extension"}
+    )
+    assert slots["interaction.side_question"].required is False
     assert "session" not in slots["tool.packs"].allowed_sources
     assert slots["continuity.provider_packs"].scope == "process"
     assert slots["continuity.provider_packs"].refresh_boundary == "sealed"

--- a/tests/harness/session/test_side_question.py
+++ b/tests/harness/session/test_side_question.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from loushang.agent import Agent
+from loushang.ai.event_stream.stream import AssistantMessageEventStream
+from loushang.ai.types import AssistantMessage, TextPart, Usage, UserMessage
+from loushang.coding.session import AgentSession
+from loushang.coding.session_manager import SessionManager
+from loushang.harness.runtime import (
+    SideQuestionAnswer,
+    SideQuestionCoordinator,
+)
+
+
+def _assistant_message(text: str) -> AssistantMessage:
+    return AssistantMessage(
+        role="assistant",
+        content=[TextPart(type="text", text=text)],
+        api="anthropic-messages",
+        provider="faux",
+        model="faux-model",
+        response_id=None,
+        usage=Usage(
+            input=3,
+            output=2,
+            cache_read=1,
+            cache_write=0,
+            total_tokens=5,
+            cost={},
+        ),
+        stop_reason="stop",
+        error_message=None,
+        timestamp=0.0,
+    )
+
+
+def _completed_stream(message: AssistantMessage) -> AssistantMessageEventStream:
+    stream = AssistantMessageEventStream()
+    stream.push({"type": "start", "partial": message})
+    stream.push({"type": "text_start", "content_index": 0, "partial": message})
+    stream.push(
+        {
+            "type": "text_delta",
+            "content_index": 0,
+            "delta": message.content[0].text,
+            "partial": message,
+        }
+    )
+    stream.push(
+        {
+            "type": "text_end",
+            "content_index": 0,
+            "content": message.content[0].text,
+            "partial": message,
+        }
+    )
+    stream.push({"type": "done", "reason": "stop", "message": message})
+    return stream
+
+
+def test_agent_side_question_uses_committed_context_without_persisting(
+    tmp_path,
+) -> None:
+    class _NeverRunTool:
+        name = "dangerous"
+        description = "Must stay advertised for cache compatibility."
+        parameters: dict[str, object] = {"type": "object", "properties": {}}
+        label = "Dangerous"
+
+        async def execute(self, *args, **kwargs):
+            del args, kwargs
+            raise AssertionError("side-question tools must be blocked")
+
+    async def scenario() -> None:
+        captured_contexts: list[object] = []
+
+        async def stream_fn(model, context, options=None):
+            del model, options
+            captured_contexts.append(context)
+            return _completed_stream(_assistant_message("A transient answer."))
+
+        manager = await SessionManager.new(
+            session_dir=tmp_path,
+            cwd="/tmp/project",
+            persist=False,
+        )
+        await manager.append_message(
+            UserMessage(
+                role="user",
+                content=[TextPart(type="text", text="Committed context")],
+                timestamp=0.0,
+            )
+        )
+        parent = Agent(
+            initial_state={
+                "system_prompt": "Stable parent prompt",
+                "tools": [_NeverRunTool()],
+            },
+            stream_fn=stream_fn,
+        )
+        session = AgentSession(agent=parent, session_manager=manager)
+        entries_before = list(manager.get_entries())
+        parent_messages_before = list(parent.state.messages)
+        updates: list[str] = []
+
+        answer = await session.ask_side_question(
+            "What matters here?",
+            on_update=updates.append,
+        )
+
+        assert answer.text == "A transient answer."
+        assert updates[-1] == "A transient answer."
+        assert answer.context_revision == manager.get_leaf_id()
+        assert manager.get_entries() == entries_before
+        assert parent.state.messages == parent_messages_before
+        assert len(captured_contexts) == 1
+        context = captured_contexts[0]
+        assert [tool.name for tool in getattr(context, "tools")] == ["dangerous"]
+        assert [
+            getattr(message, "role", None) for message in getattr(context, "messages")
+        ] == ["user", "user"]
+        assert getattr(context, "system_prompt") == "Stable parent prompt"
+        side_prompt = getattr(context, "messages")[-1].content[0].text
+        assert "one-shot side question" in side_prompt
+        assert side_prompt.endswith("Question:\nWhat matters here?")
+        await session.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_side_question_coordinator_cancels_only_its_active_request() -> None:
+    class _Provider:
+        def __init__(self) -> None:
+            self.started = asyncio.Event()
+            self.cancelled = False
+
+        async def ask(
+            self,
+            question: str,
+            *,
+            on_update=None,
+        ) -> SideQuestionAnswer:
+            assert question == "question"
+            assert on_update is None
+            self.started.set()
+            await asyncio.Future()
+            raise AssertionError("unreachable")
+
+        def cancel(self) -> None:
+            self.cancelled = True
+
+    async def scenario() -> None:
+        provider = _Provider()
+        coordinator = SideQuestionCoordinator(provider)
+        task = asyncio.create_task(coordinator.ask("question"))
+        await provider.started.wait()
+
+        assert coordinator.active is True
+        assert coordinator.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert provider.cancelled is True
+        assert coordinator.active is False
+
+    asyncio.run(scenario())

--- a/tests/harnesstui/continuity/test_surface.py
+++ b/tests/harnesstui/continuity/test_surface.py
@@ -626,8 +626,9 @@ def test_common_resume_surface_shows_activation_progress_and_inline_failure() ->
         )
         activating = view.render(RenderConstraints(width=80, max_height=12))
         assert (
-            sum("Resuming selected item" in line.text for line in activating.lines) == 2
+            sum("Resuming selected item" in line.text for line in activating.lines) == 1
         )
+        assert surface.footer_help == ""
 
         surface.fail_activation(RuntimeError("restore failed"))
         failed = view.render(RenderConstraints(width=80, max_height=12))

--- a/tests/harnesstui/conversation/test_fork.py
+++ b/tests/harnesstui/conversation/test_fork.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from loushang.harnesstui.conversation.fork import (
+    ForkPromptCandidate,
+    ForkPromptSurface,
+    build_fork_prompt_surface_view,
+)
+from loushang.tui import InputEvent, InputIntent, RenderConstraints
+from loushang.tui.cell_width import strip_control_sequences
+
+
+def _candidates() -> tuple[ForkPromptCandidate, ...]:
+    return (
+        ForkPromptCandidate(entry_id="entry-first", text="first prompt"),
+        ForkPromptCandidate(
+            entry_id="entry-latest",
+            text="latest prompt with\nmultiple lines",
+        ),
+    )
+
+
+def _plain_lines(surface: ForkPromptSurface) -> tuple[str, ...]:
+    rendered = surface.render(RenderConstraints(width=80, max_height=12))
+    return tuple(strip_control_sequences(line.text) for line in rendered.lines)
+
+
+def test_fork_prompt_surface_selects_recent_prompts_without_exposing_ids() -> None:
+    surface = ForkPromptSurface(candidates=_candidates(), request_render=lambda: None)
+
+    lines = _plain_lines(surface)
+
+    assert surface.selected_entry_id == "entry-latest"
+    assert any("latest prompt with multiple lines" in line for line in lines)
+    assert all("entry-latest" not in line for line in lines)
+    assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
+        kind="select",
+        text="entry-latest",
+    )
+
+    surface.handle_input(InputEvent(kind="text", text="first"))
+    assert surface.selected_entry_id == "entry-first"
+
+
+def test_fork_prompt_surface_previews_selected_prompt_and_returns_to_list() -> None:
+    renders: list[None] = []
+    surface = ForkPromptSurface(
+        candidates=_candidates(),
+        request_render=lambda: renders.append(None),
+    )
+
+    assert surface.handle_input(InputEvent(kind="key", key="space")) == InputIntent(
+        kind="consumed",
+        note="fork_preview",
+    )
+    lines = _plain_lines(surface)
+    assert "Prompt 2 of 2" in lines
+    assert "latest prompt with" in lines
+    assert "multiple lines" in lines
+    assert "Space/Esc back" in surface.footer_help
+
+    assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
+        kind="select",
+        text="entry-latest",
+    )
+    assert surface.handle_input(InputEvent(kind="key", key="escape")) == InputIntent(
+        kind="consumed",
+        note="fork_preview_close",
+    )
+    assert "Space preview" in surface.footer_help
+    assert len(renders) == 2
+
+
+def test_fork_prompt_surface_shows_one_activation_state_and_inline_failure() -> None:
+    surface = ForkPromptSurface(candidates=_candidates(), request_render=lambda: None)
+
+    assert surface.begin_activation() is True
+    assert surface.begin_activation() is False
+    assert surface.footer_help == ""
+    lines = _plain_lines(surface)
+    assert sum("Forking selected prompt" in line for line in lines) == 1
+    assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
+        kind="consumed",
+        note="fork_activating",
+    )
+
+    surface.fail_activation(RuntimeError("fork denied"))
+    lines = _plain_lines(surface)
+    assert any("Error: fork denied" in line for line in lines)
+    assert surface.begin_activation() is True
+
+
+def test_fork_prompt_surface_handles_an_empty_conversation() -> None:
+    view = build_fork_prompt_surface_view(
+        candidates=(),
+        request_render=lambda: None,
+    )
+    surface = view.content
+
+    assert isinstance(surface, ForkPromptSurface)
+    assert surface.selected_entry_id is None
+    assert surface.begin_activation() is False
+    rendered = view.render(RenderConstraints(width=80, max_height=12))
+    lines = tuple(strip_control_sequences(line.text) for line in rendered.lines)
+    assert "No prompts to fork yet" in lines

--- a/tests/harnesstui/conversation/test_side_question.py
+++ b/tests/harnesstui/conversation/test_side_question.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import asyncio
+
+from loushang.harness.runtime import SideQuestionAnswer
+from loushang.harnesstui.conversation.side_question import (
+    SideQuestionSurface,
+    build_side_question_surface_view,
+)
+from loushang.tui import InputEvent, RenderConstraints
+
+
+def test_side_question_surface_renders_answer_and_scrolls() -> None:
+    renders: list[None] = []
+
+    async def ask(question: str, *, on_update=None) -> SideQuestionAnswer:
+        assert question == "Explain"
+        assert on_update is not None
+        return SideQuestionAnswer("\n".join(f"line {index}" for index in range(8)))
+
+    surface = SideQuestionSurface(
+        question="Explain",
+        ask=ask,
+        cancel=lambda: None,
+        request_render=lambda: renders.append(None),
+    )
+
+    asyncio.run(surface.start())
+    result = surface.render(RenderConstraints(width=40, max_height=4))
+
+    assert surface.status == "answered"
+    assert renders == [None]
+    assert len(result.lines) == 4
+    assert "scroll" in surface.footer_help
+    intent = surface.handle_input(InputEvent(kind="key", key="down"))
+    assert intent is not None
+    assert intent.kind == "consumed"
+
+
+def test_side_question_surface_close_cancels_only_answering_request() -> None:
+    cancellations: list[None] = []
+
+    async def ask(question: str, *, on_update=None) -> SideQuestionAnswer:
+        del question
+        assert on_update is not None
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+    surface = SideQuestionSurface(
+        question="Wait",
+        ask=ask,
+        cancel=lambda: cancellations.append(None),
+        request_render=lambda: None,
+    )
+
+    surface.close()
+
+    assert cancellations == [None]
+    assert surface.status == "closed"
+
+
+def test_side_question_surface_uses_a_full_screen_page() -> None:
+    async def ask(question: str, *, on_update=None) -> SideQuestionAnswer:
+        assert on_update is not None
+        return SideQuestionAnswer(question)
+
+    view = build_side_question_surface_view(
+        question="Explain",
+        ask=ask,
+        cancel=lambda: None,
+        request_render=lambda: None,
+    )
+
+    assert view.presentation == "page"
+    assert view.preferred_height is None
+    assert view.title == "/btw"
+    assert view.subtitle == "Explain"
+    assert view.theme is not None
+    assert view.theme.resolve("surface.subtitle") == {
+        "bold": True,
+        "color": "bright_cyan",
+    }
+
+
+def test_side_question_surface_streams_themed_markdown() -> None:
+    async def scenario() -> None:
+        partial_ready = asyncio.Event()
+        release = asyncio.Event()
+
+        async def ask(question: str, *, on_update=None) -> SideQuestionAnswer:
+            assert question == "Explain"
+            assert on_update is not None
+            on_update("A **partial** answer")
+            partial_ready.set()
+            await release.wait()
+            return SideQuestionAnswer("A **complete** answer")
+
+        surface = SideQuestionSurface(
+            question="Explain",
+            ask=ask,
+            cancel=lambda: None,
+            request_render=lambda: None,
+        )
+        task = asyncio.create_task(surface.start())
+        await partial_ready.wait()
+
+        result = surface.render(RenderConstraints(width=40, max_height=8))
+        rendered = "\n".join(line.text for line in result.lines)
+        assert "partial" in rendered
+        assert "**" not in rendered
+        assert "\x1b[1m" in rendered
+        assert "Answering" in rendered
+
+        release.set()
+        await task
+        assert surface.answer == "A **complete** answer"
+        assert surface.status == "answered"
+
+    asyncio.run(scenario())

--- a/tests/harnesstui/surface/test_controller.py
+++ b/tests/harnesstui/surface/test_controller.py
@@ -56,6 +56,7 @@ def _recording_handlers(
             "command",
             "settings",
             "session",
+            "fork",
             "dialog",
             "approval",
         )
@@ -83,6 +84,12 @@ def _recording_handlers(
             InputIntent(kind="select", text="/tmp/session.jsonl"),
             "session",
             "/tmp/session.jsonl",
+        ),
+        (
+            "fork",
+            InputIntent(kind="select", text="entry-1"),
+            "fork",
+            "entry-1",
         ),
         ("dialog", InputIntent(kind="dialog_confirm"), "dialog", None),
     ),

--- a/tests/harnesstui/surface/test_workflow.py
+++ b/tests/harnesstui/surface/test_workflow.py
@@ -10,6 +10,7 @@ from loushang.harnesstui.surface.controller import ApprovalSurfaceDecision
 from loushang.harnesstui.surface.view import ScreenSurfaceView
 from loushang.harnesstui.surface.workflow import (
     ScreenSurfaceCommand,
+    ScreenSurfaceForkResult,
     ScreenSurfaceWorkflow,
     ScreenSurfaceWorkflowCopy,
     ScreenSurfaceWorkflowPorts,
@@ -33,6 +34,7 @@ class _Catalog:
                 "terminal",
                 "hotkeys",
                 "settings",
+                "btw",
             )
         }
 
@@ -51,6 +53,8 @@ class _State:
     model_values: list[str] = field(default_factory=list)
     approvals: list[ApprovalSurfaceDecision | None] = field(default_factory=list)
     resumed_sessions: list[str] = field(default_factory=list)
+    forked_entries: list[str] = field(default_factory=list)
+    side_questions: list[str] = field(default_factory=list)
     statusline_visible: list[bool] = field(default_factory=list)
     statusline_settings: list[StatusLineSettings] = field(default_factory=list)
     model_refreshes: int = 0
@@ -121,6 +125,7 @@ def _normalize(text: str, command: CommandDef) -> ScreenSurfaceCommand:
         "terminal": "terminal_diagnostics",
         "hotkeys": "hotkeys",
         "settings": "settings",
+        "btw": "side_question",
     }
     if command.name == "command" and query:
         query = f"/{query.removeprefix('/')}"
@@ -162,11 +167,26 @@ def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _S
         state.resumed_sessions.append(reference)
         return f"resumed:{reference}"
 
+    def fork_surface() -> ScreenSurfaceView:
+        return _surface("Fork prompt", "fork")
+
+    async def fork_session(target: object) -> ScreenSurfaceForkResult:
+        entry_id = str(target)
+        state.forked_entries.append(entry_id)
+        return ScreenSurfaceForkResult(
+            status=f"forked:{entry_id}",
+            composer_text="selected prompt",
+        )
+
     async def decide_approval(
         decision: ApprovalSurfaceDecision | None,
     ) -> bool | None:
         state.approvals.append(decision)
         return state.accept_approval
+
+    def side_question_surface(question: str) -> ScreenSurfaceView:
+        state.side_questions.append(question)
+        return _surface("BTW", "dialog")
 
     workflow = ScreenSurfaceWorkflow(
         app=_App(state),
@@ -187,10 +207,17 @@ def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _S
             normalize_interactive_command=lambda text: (
                 ScreenSurfaceCommand("resume_session")
                 if text.strip() == "/resume"
-                else None
+                else (
+                    ScreenSurfaceCommand("fork_session")
+                    if text.strip() == "/fork"
+                    else None
+                )
             ),
             build_resume_surface=resume_surface,
             activate_continuity=activate_continuity,
+            build_fork_surface=fork_surface,
+            fork_session=fork_session,
+            build_side_question_surface=side_question_surface,
         ),
         copy=ScreenSurfaceWorkflowCopy(
             recoverable_error=lambda error: f"recoverable:{error}",
@@ -299,6 +326,45 @@ def test_surface_workflow_opens_resume_picker_and_submits_reference() -> None:
     assert workflow.current is None
 
 
+def test_surface_workflow_routes_btw_as_an_immediate_side_question() -> None:
+    workflow, state = _workflow()
+
+    assert workflow.is_local_command("/btw why now?") is True
+    asyncio.run(workflow.handle_text("/btw why now?"))
+
+    surface = workflow.current
+    assert isinstance(surface, ScreenSurfaceView)
+    assert surface.title == "BTW"
+    assert state.side_questions == ["why now?"]
+
+    workflow.close()
+    asyncio.run(workflow.handle_text("/btw"))
+    assert state.statuses[-1] == "Usage: /btw <question>"
+
+
+def test_surface_workflow_opens_fork_picker_and_restores_selected_prompt() -> None:
+    workflow, state = _workflow()
+
+    assert workflow.is_local_command("/fork") is True
+    assert workflow.is_local_command("/fork entry-1 before") is False
+    asyncio.run(workflow.handle_text("/fork"))
+
+    picker = workflow.current
+    assert isinstance(picker, ScreenSurfaceView)
+    assert picker.purpose == "fork"
+
+    asyncio.run(
+        workflow.handle_surface_intent(
+            InputIntent(kind="select", text="entry-1")
+        )
+    )
+
+    assert state.forked_entries == ["entry-1"]
+    assert state.command_texts == ["selected prompt"]
+    assert state.statuses == ["forked:entry-1"]
+    assert workflow.current is None
+
+
 def test_surface_workflow_runs_continuity_activation_without_freezing_page() -> None:
     class _ActivationContent:
         selected_target = "typed-target"
@@ -399,6 +465,49 @@ def test_surface_workflow_keeps_continuity_failure_visible_on_page() -> None:
         assert workflow.current is picker
         assert isinstance(content.failure, RuntimeError)
         assert state.statuses == ["recoverable:restore failed"]
+
+    asyncio.run(scenario())
+
+
+def test_surface_workflow_keeps_fork_failure_visible_on_page() -> None:
+    class _ActivationContent:
+        selected_entry_id = "entry-1"
+
+        def __init__(self) -> None:
+            self.failure: Exception | None = None
+
+        def begin_activation(self) -> bool:
+            return True
+
+        def fail_activation(self, error: Exception) -> None:
+            self.failure = error
+
+    async def scenario() -> None:
+        workflow, state = _workflow()
+
+        async def fail(_target: object) -> ScreenSurfaceForkResult:
+            raise RuntimeError("fork failed")
+
+        workflow.ports = replace(workflow.ports, fork_session=fail)
+        content = _ActivationContent()
+        picker = ScreenSurfaceView(
+            title="Fork",
+            purpose="fork",
+            content=content,
+            presentation="page",
+        )
+        workflow.open(picker)
+
+        await workflow.handle_surface_intent(
+            InputIntent(kind="select", text="opaque-render-value")
+        )
+        task = workflow._fork_activation_task
+        assert task is not None
+        await task
+
+        assert workflow.current is picker
+        assert isinstance(content.failure, RuntimeError)
+        assert state.statuses == ["recoverable:fork failed"]
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## What changed

- add a product-neutral side-question runtime and the Coding `/btw` experience
- render side-question answers in a dedicated full-screen surface with streaming updates
- add an interactive `/fork` prompt picker that hides opaque entry IDs
- fork before the selected user prompt and refill the composer so the prompt can be edited and resent
- keep the existing `/fork <entry-id> before|at` command path for advanced/non-interactive use
- extend capability profiles, surface routing, and architecture boundaries for the new workflows

## Why

Users should be able to ask a quick contextual question without interrupting the main task, and branch a conversation from a visible prompt without discovering or typing an internal entry ID.

## User impact

- `/btw <question>` opens a dedicated answer surface while the main task continues
- bare `/fork` opens a searchable full-screen prompt picker
- selecting a prompt creates a new session from immediately before that prompt and restores the prompt to the composer
- empty and failure states remain local to their surfaces

## Validation

- `make check-harnesstui` — Ruff and mypy passed; 1186 tests passed
- TUI render contract — 161 tests passed
- architecture boundary tests — 180 tests passed
- focused session/surface lifecycle suite — 211 tests passed
- `git diff --check`
