### PR TITLE
feat(session): complete session lifecycle commands

### DIFF
--- a/docs/en/reference/README.md
+++ b/docs/en/reference/README.md
@@ -80,8 +80,11 @@ Built-in interactive commands include:
 ```text
 /settings /model /scoped-models /export /import /share /copy /rename
 /session /terminal /tools /changelog /hotkeys /fork /clone /tree
-/new /compact /resume /reload /quit
+/new /compact /resume /delete /reload /quit
 ```
+
+`/new` starts an empty session in the current context and accepts no arguments.
+`/delete` opens a confirmed picker for deleting a previous session; it never deletes the active session.
 
 ## Authentication Migration
 

--- a/docs/en/reference/README.md
+++ b/docs/en/reference/README.md
@@ -78,7 +78,7 @@ loushang --command <command-name> --command-result-format json
 Built-in interactive commands include:
 
 ```text
-/settings /model /scoped-models /export /import /share /copy /name
+/settings /model /scoped-models /export /import /share /copy /rename
 /session /terminal /tools /changelog /hotkeys /fork /clone /tree
 /new /compact /resume /reload /quit
 ```

--- a/docs/zh-CN/reference/README.md
+++ b/docs/zh-CN/reference/README.md
@@ -80,8 +80,11 @@ loushang --command <command-name> --command-result-format json
 ```text
 /settings /model /scoped-models /export /import /share /copy /rename
 /session /terminal /tools /changelog /hotkeys /fork /clone /tree
-/new /compact /resume /reload /quit
+/new /compact /resume /delete /reload /quit
 ```
+
+`/new` 会在当前上下文中新建空会话，不接受参数。
+`/delete` 会打开带确认步骤的历史会话选择器；它不会删除当前活跃会话。
 
 ## 认证迁移
 

--- a/docs/zh-CN/reference/README.md
+++ b/docs/zh-CN/reference/README.md
@@ -78,7 +78,7 @@ loushang --command <command-name> --command-result-format json
 内置交互命令包括：
 
 ```text
-/settings /model /scoped-models /export /import /share /copy /name
+/settings /model /scoped-models /export /import /share /copy /rename
 /session /terminal /tools /changelog /hotkeys /fork /clone /tree
 /new /compact /resume /reload /quit
 ```

--- a/src/loushang/coding/continuity.py
+++ b/src/loushang/coding/continuity.py
@@ -78,6 +78,8 @@ class CodingContinuityRuntimePort(Protocol):
 
     def get_current_session_ref(self) -> str | None: ...
 
+    async def delete_session(self, session_id: str | Path) -> bool: ...
+
     async def prepare_restore_session_operation(
         self,
         session_id: str | Path,
@@ -266,6 +268,36 @@ class CodingContinuityProvider:
             consume=candidate.consume,
             abort=candidate.abort,
         )
+
+    async def delete(self, target: ContinuityTarget) -> bool:
+        indexed = self._cached_target(target)
+        expected_revision = str(indexed.source_revision)
+        if target.revision != expected_revision:
+            raise StaleContinuityTargetError(
+                "The selected Coding session summary is stale."
+            )
+        reference: str | Path = (
+            indexed.projection.session_file or indexed.projection.session_id
+        )
+        if _same_session_reference(
+            self._runtime.get_current_session_ref(),
+            reference,
+        ):
+            raise ValueError("Cannot delete the currently active session")
+        current_revision = await asyncio.to_thread(
+            AgentTranscriptSessionCatalog(
+                self._runtime.session_dir
+            ).load_authoritative_revision,
+            indexed.locator,
+        )
+        if current_revision != indexed.source_revision:
+            raise StaleContinuityTargetError(
+                "The selected Coding session changed after it was listed."
+            )
+        deleted = await self._runtime.delete_session(reference)
+        if deleted:
+            self._preview_items.pop(target.opaque_id, None)
+        return deleted
 
     def _cached_target(
         self,

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -154,7 +154,7 @@ async def _run_screen_interactive_tui(
                 getattr(next_session, "session_id", None)
             )
             app.add_error(
-                "Session resumed, but the TUI could not refresh its history.",
+                "Session changed, but the TUI could not refresh its history.",
                 str(refresh_error) or refresh_error.__class__.__name__,
             )
             log.problem(
@@ -168,7 +168,7 @@ async def _run_screen_interactive_tui(
         if event_source.last_rebind_error is not None:
             rebind_error = event_source.last_rebind_error
             app.add_error(
-                "Session resumed, but event subscription could not be rebound.",
+                "Session changed, but event subscription could not be rebound.",
                 str(rebind_error) or rebind_error.__class__.__name__,
             )
             log.problem(

--- a/src/loushang/coding/ui/screen_surfaces.py
+++ b/src/loushang/coding/ui/screen_surfaces.py
@@ -18,6 +18,9 @@ from loushang.harnesstui.conversation.fork import (
     ForkPromptCandidate,
     build_fork_prompt_surface_view,
 )
+from loushang.harnesstui.conversation.rename import (
+    build_session_rename_surface_view,
+)
 from loushang.harnesstui.conversation.side_question import (
     build_side_question_surface_view,
 )
@@ -86,6 +89,8 @@ class ScreenSurfaceManager(ScreenSurfaceWorkflow):
             fork_session=(
                 self._fork_session if runtime is not None else None
             ),
+            build_rename_surface=self._build_rename_surface,
+            rename_session=self._rename_session,
             build_side_question_surface=self._build_side_question_surface,
             command_catalog=command_catalog,
             model_selector_profile=_CODING_MODEL_SELECTOR_PROFILE,
@@ -186,6 +191,24 @@ class ScreenSurfaceManager(ScreenSurfaceWorkflow):
             status="Forked from selected prompt",
             composer_text=selected_text,
         )
+
+    def _build_rename_surface(self):
+        session = self._current_session()
+        name = getattr(session, "session_name", None)
+        return build_session_rename_surface_view(
+            current_name=name if isinstance(name, str) else None
+        )
+
+    async def _rename_session(self, name: str | None) -> str:
+        session = self._current_session()
+        rename = getattr(session, "set_session_name", None)
+        if not callable(rename):
+            raise RuntimeError("Session renaming is not available")
+        await rename(name)
+        self.coding_app.state.session_label = (
+            name or getattr(session, "session_id", None)
+        )
+        return f"Session renamed to {name}" if name else "Session name cleared"
 
     async def _build_settings_content(self) -> object:
         session = self._current_session()

--- a/src/loushang/coding/ui/screen_surfaces.py
+++ b/src/loushang/coding/ui/screen_surfaces.py
@@ -83,6 +83,12 @@ class ScreenSurfaceManager(ScreenSurfaceWorkflow):
             activate_continuity=(
                 self._activate_continuity if runtime is not None else None
             ),
+            build_delete_surface=(
+                self._build_delete_surface if runtime is not None else None
+            ),
+            delete_continuity=(
+                self._delete_continuity if runtime is not None else None
+            ),
             build_fork_surface=(
                 self._build_fork_surface if runtime is not None else None
             ),
@@ -149,6 +155,30 @@ class ScreenSurfaceManager(ScreenSurfaceWorkflow):
         if getattr(result, "cancelled", False):
             raise RuntimeError("Session resume was cancelled")
         return f"Resumed session {target.opaque_id}"
+
+    def _build_delete_surface(self):
+        if self.continuity is None:
+            raise RuntimeError("Session runtime is not available")
+        current = self._current_session()
+        current_id = getattr(current, "session_id", None)
+        return build_continuity_surface_view(
+            hub=self.continuity.hub,
+            request_render=self.coding_app.request_render,
+            include_summary=lambda summary: summary.target.opaque_id != current_id,
+            title="Delete a previous session",
+            selection_action="delete",
+            purpose="delete",
+        )
+
+    async def _delete_continuity(self, target: object) -> str:
+        if self.continuity is None:
+            raise RuntimeError("Session runtime is not available")
+        if not isinstance(target, ContinuityTarget):
+            raise TypeError("Delete requires a provider-qualified continuity target")
+        deleted = await self.continuity.hub.delete(target)
+        if not deleted:
+            raise RuntimeError("The selected session was already deleted")
+        return f"Deleted session {target.opaque_id}"
 
     def _build_fork_surface(self):
         session = self._current_session()

--- a/src/loushang/harness/continuity/__init__.py
+++ b/src/loushang/harness/continuity/__init__.py
@@ -11,6 +11,7 @@ from loushang.harness.continuity.composition import (
 )
 from loushang.harness.continuity.hub import ContinuityHub, InvalidContinuityCursor
 from loushang.harness.continuity.provider import (
+    ContinuityDeletionProvider,
     ContinuityProvider,
     PreparedActivationLease,
 )
@@ -44,6 +45,7 @@ __all__ = [
     "ContinuityArtifactReference",
     "ContinuityCompositionError",
     "ContinuityDiagnostic",
+    "ContinuityDeletionProvider",
     "ContinuityIndexState",
     "ContinuityHub",
     "ContinuityPage",

--- a/src/loushang/harness/continuity/hub.py
+++ b/src/loushang/harness/continuity/hub.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from loushang.harness.continuity.composition import ExperienceComposition
 from loushang.harness.continuity.provider import (
+    ContinuityDeletionProvider,
     ContinuityProvider,
     PreparedActivationLease,
 )
@@ -262,6 +263,17 @@ class ContinuityHub:
         provider = self._provider_for_target(target)
         return await asyncio.wait_for(
             provider.prepare(target),
+            timeout=self._provider_timeout,
+        )
+
+    async def delete(self, target: ContinuityTarget) -> bool:
+        """Delete a target only when its owning Provider explicitly supports it."""
+
+        provider = self._provider_for_target(target)
+        if not isinstance(provider, ContinuityDeletionProvider):
+            raise RuntimeError("The selected continuity item cannot be deleted")
+        return await asyncio.wait_for(
+            provider.delete(target),
             timeout=self._provider_timeout,
         )
 

--- a/src/loushang/harness/continuity/provider.py
+++ b/src/loushang/harness/continuity/provider.py
@@ -48,4 +48,15 @@ class ContinuityProvider(Protocol):
     async def prepare(self, target: ContinuityTarget) -> PreparedActivationLease: ...
 
 
-__all__ = ["ContinuityProvider", "PreparedActivationLease"]
+@runtime_checkable
+class ContinuityDeletionProvider(Protocol):
+    """Optional Product-owned deletion operation for a continuity target."""
+
+    async def delete(self, target: ContinuityTarget) -> bool: ...
+
+
+__all__ = [
+    "ContinuityDeletionProvider",
+    "ContinuityProvider",
+    "PreparedActivationLease",
+]

--- a/src/loushang/harness/session/command_pack.py
+++ b/src/loushang/harness/session/command_pack.py
@@ -23,7 +23,7 @@ class StandardSessionCommandId(str, Enum):
     """Stable identifiers for shared session command mechanics."""
 
     SESSION = "session"
-    NAME = "name"
+    RENAME = "rename"
     EXPORT = "export"
     IMPORT = "import"
     COMPACT = "compact"
@@ -45,6 +45,7 @@ class StandardSessionCommandDefinition:
 
     command_id: StandardSessionCommandId
     description: str
+    argument_hint: str | None = None
 
     @property
     def name(self) -> str:
@@ -64,7 +65,11 @@ STANDARD_SESSION_COMMANDS: tuple[StandardSessionCommandDefinition, ...] = (
         StandardSessionCommandId.COPY,
         "Copy an assistant message to clipboard",
     ),
-    StandardSessionCommandDefinition(StandardSessionCommandId.NAME, "Set session display name"),
+    StandardSessionCommandDefinition(
+        StandardSessionCommandId.RENAME,
+        "Rename the current session",
+        "<name>",
+    ),
     StandardSessionCommandDefinition(StandardSessionCommandId.SESSION, "Show session info and stats"),
     StandardSessionCommandDefinition(StandardSessionCommandId.CHANGELOG, "Show changelog entries"),
     StandardSessionCommandDefinition(StandardSessionCommandId.FORK, "Create a new fork from a previous user message"),
@@ -89,6 +94,7 @@ def list_standard_session_command_descriptors() -> list[SessionCommandDescriptor
             description=definition.description,
             source="builtin",
             source_info=source_info,
+            argument_hint=definition.argument_hint,
         )
         for definition in STANDARD_SESSION_COMMANDS
     ]
@@ -247,7 +253,7 @@ async def execute_standard_session_command_async(
             return StandardSessionCommandResult.completed(
                 command_id, ports.get_session_info()
             )
-        case StandardSessionCommandId.NAME:
+        case StandardSessionCommandId.RENAME:
             if ports.set_session_name is None:
                 return StandardSessionCommandResult.unavailable(command_id)
             name = args.strip() or None
@@ -686,8 +692,17 @@ def project_standard_session_command_result(
             if isinstance(session, Mapping):
                 session = dict(session)
             return _ok_command_result(command, session=session)
-        case StandardSessionCommandId.NAME:
-            return _ok_command_result(command, name=result.value)
+        case StandardSessionCommandId.RENAME:
+            name = result.value
+            return _ok_command_result(
+                command,
+                name=name,
+                message=(
+                    f"Session renamed to {name}"
+                    if isinstance(name, str)
+                    else "Session name cleared"
+                ),
+            )
         case StandardSessionCommandId.EXPORT:
             export = result.value
             if not isinstance(export, StandardSessionExport):

--- a/src/loushang/harness/session/command_pack.py
+++ b/src/loushang/harness/session/command_pack.py
@@ -30,6 +30,7 @@ class StandardSessionCommandId(str, Enum):
     RELOAD = "reload"
     NEW = "new"
     RESUME = "resume"
+    DELETE = "delete"
     FORK = "fork"
     CLONE = "clone"
     TREE = "tree"
@@ -77,9 +78,16 @@ STANDARD_SESSION_COMMANDS: tuple[StandardSessionCommandDefinition, ...] = (
     StandardSessionCommandDefinition(StandardSessionCommandId.TREE, "Navigate session tree (switch branches)"),
     StandardSessionCommandDefinition(StandardSessionCommandId.TOOLS, "Show or update active tools for this session"),
     StandardSessionCommandDefinition(StandardSessionCommandId.EXTENSIONS, "Show loaded extensions and diagnostics"),
-    StandardSessionCommandDefinition(StandardSessionCommandId.NEW, "Start a new session"),
+    StandardSessionCommandDefinition(
+        StandardSessionCommandId.NEW,
+        "Start a new session in the current context",
+    ),
     StandardSessionCommandDefinition(StandardSessionCommandId.COMPACT, "Manually compact the session context"),
     StandardSessionCommandDefinition(StandardSessionCommandId.RESUME, "Resume a different session"),
+    StandardSessionCommandDefinition(
+        StandardSessionCommandId.DELETE,
+        "Delete a previous session",
+    ),
     StandardSessionCommandDefinition(StandardSessionCommandId.RELOAD, "Reload keybindings, extensions, skills, prompts, and themes"),
 )
 
@@ -307,13 +315,13 @@ async def execute_standard_session_command_async(
         case StandardSessionCommandId.NEW:
             if ports.new_session is None:
                 return StandardSessionCommandResult.unavailable(command_id)
-            tokens = _split_args(args)
-            options: dict[str, object] = {}
-            if tokens:
-                options["cwd"] = tokens[0]
+            if args.strip():
+                return StandardSessionCommandResult.invalid_arguments(
+                    command_id, "unexpected_arguments"
+                )
             return StandardSessionCommandResult.completed(
                 command_id,
-                await _resolve(ports.new_session(options or None)),
+                await _resolve(ports.new_session()),
             )
         case StandardSessionCommandId.RESUME:
             if ports.resume_session is None:
@@ -327,6 +335,12 @@ async def execute_standard_session_command_async(
                 command_id,
                 await _resolve(ports.resume_session(tokens[0], None)),
             )
+        case StandardSessionCommandId.DELETE:
+            if args.strip():
+                return StandardSessionCommandResult.invalid_arguments(
+                    command_id, "unexpected_arguments"
+                )
+            return StandardSessionCommandResult.unavailable(command_id)
         case StandardSessionCommandId.FORK:
             if ports.fork_session is None:
                 return StandardSessionCommandResult.unavailable(command_id)
@@ -712,9 +726,20 @@ def project_standard_session_command_result(
             return _ok_command_result(command, result=_to_plain_data(result.value))
         case StandardSessionCommandId.RELOAD:
             return _ok_command_result(command, reloaded=True)
+        case StandardSessionCommandId.NEW:
+            value = _to_plain_data(result.value)
+            cancelled = isinstance(value, Mapping) and value.get("cancelled") is True
+            return _ok_command_result(
+                command,
+                result=value,
+                message=(
+                    "New session creation cancelled."
+                    if cancelled
+                    else "Started a new session."
+                ),
+            )
         case (
-            StandardSessionCommandId.NEW
-            | StandardSessionCommandId.RESUME
+            StandardSessionCommandId.RESUME
             | StandardSessionCommandId.FORK
             | StandardSessionCommandId.CLONE
             | StandardSessionCommandId.TREE
@@ -831,6 +856,10 @@ def _standard_argument_error(result: StandardSessionCommandResult) -> str:
             return "Unknown tool"
         case StandardSessionCommandId.RESUME, "missing_reference":
             return "Usage: /resume <session-id-or-path>"
+        case StandardSessionCommandId.NEW, "unexpected_arguments":
+            return "Usage: /new"
+        case StandardSessionCommandId.DELETE, "unexpected_arguments":
+            return "Usage: /delete"
         case StandardSessionCommandId.FORK, "missing_record_id":
             return "Usage: /fork <entry-id> [before|at]"
         case StandardSessionCommandId.FORK, "invalid_fork_position":

--- a/src/loushang/harness/session/product_runtime.py
+++ b/src/loushang/harness/session/product_runtime.py
@@ -251,7 +251,7 @@ class ProductSessionRuntime(
             if inspect.isawaitable(deleted):
                 deleted = await deleted
             if deleted and self.auto_refresh_session_index:
-                self.request_session_index_refresh()
+                self.request_session_index_repair()
             return deleted
         except Exception as exc:
             self._record_operation_failure(

--- a/src/loushang/harness/transcript/product_session.py
+++ b/src/loushang/harness/transcript/product_session.py
@@ -9,7 +9,6 @@ and the binding input to reuse for a fork.
 
 from __future__ import annotations
 
-import asyncio
 import builtins
 from pathlib import Path
 from typing import Generic, Self, TypeVar
@@ -109,16 +108,14 @@ class ProductTranscriptSession(
         if not catalog.index_path.exists():
             return
         try:
-            summaries = await asyncio.to_thread(catalog.repair_index)
+            await catalog.upsert_summary(
+                self.get_session_summary(),
+                source_revision=revision,
+            )
         except Exception:
             # The index is an auxiliary cache; the durable transcript already won.
             return
-        if any(
-            summary.session_id == self.header.conversation_id
-            and summary.entry_count == revision
-            for summary in summaries
-        ):
-            self._published_index_revision = revision
+        self._published_index_revision = revision
 
     @classmethod
     async def new(
@@ -268,7 +265,9 @@ class ProductTranscriptSession(
         return await self.append_custom_entry("diagnostic", payload)
 
     async def append_session_info(self, name: str | None) -> str:
-        return await self.append_conversation_name(name)
+        record_id = await self.append_conversation_name(name)
+        await self.publish_index_summary()
+        return record_id
 
     async def fork(self, leaf_id: str) -> Self:
         lifecycle_session = await self._session_factory().fork(
@@ -296,7 +295,6 @@ class ProductTranscriptSession(
             summary = manager.get_session_summary()
         finally:
             await manager.dispose_runtime_profile()
-        cls._refresh_index_if_present(Path(session_file).expanduser().parent)
         return summary
 
     @classmethod

--- a/src/loushang/harness/transcript/product_session.py
+++ b/src/loushang/harness/transcript/product_session.py
@@ -310,14 +310,14 @@ class ProductTranscriptSession(
             current_session_file=current_session_file,
         )
         if deleted:
-            cls._refresh_index_if_present(target.parent)
+            cls._repair_index_if_present(target.parent)
         return deleted
 
     @classmethod
-    def _refresh_index_if_present(cls, session_dir: Path) -> None:
+    def _repair_index_if_present(cls, session_dir: Path) -> None:
         if cls.index_file(session_dir).exists():
             try:
-                cls.refresh_index(session_dir)
+                AgentTranscriptSessionCatalog(session_dir).repair_index()
             except Exception:
                 # Indexes are auxiliary caches; primary transcript writes won.
                 return

--- a/src/loushang/harnesstui/continuity/__init__.py
+++ b/src/loushang/harnesstui/continuity/__init__.py
@@ -1,3 +1,7 @@
+from loushang.harnesstui.continuity.delete import (
+    DeleteContinuityConfirmation,
+    build_delete_continuity_confirmation_surface,
+)
 from loushang.harnesstui.continuity.runner import (
     ContinuityActivationHandler,
     ContinuityPickerSelection,
@@ -10,8 +14,10 @@ from loushang.harnesstui.continuity.surface import (
 
 __all__ = [
     "ContinuitySurface",
+    "DeleteContinuityConfirmation",
     "ContinuityActivationHandler",
     "ContinuityPickerSelection",
     "build_continuity_surface_view",
+    "build_delete_continuity_confirmation_surface",
     "run_continuity_picker",
 ]

--- a/src/loushang/harnesstui/continuity/delete.py
+++ b/src/loushang/harnesstui/continuity/delete.py
@@ -1,0 +1,103 @@
+"""Confirmation surface for deleting one selected continuity item."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.harness.continuity import ContinuityTarget
+from loushang.harnesstui.surface.view import ScreenSurfaceView
+from loushang.tui import InputEvent, InputIntent, RenderConstraints, RenderResult
+from loushang.tui.cell_width import truncate_to_width, wrap_cells
+from loushang.tui.theme import ThemeResolver, apply_theme_style
+
+DELETE_CONTINUITY_CONFIRMATION_THEME = ThemeResolver(
+    defaults={
+        "surface.title": {"bold": True, "color": "red"},
+        "surface.subtitle": {"color": "yellow"},
+        "delete.session": {"bold": True, "color": "bright_red"},
+        "delete.warning": {"color": "yellow"},
+        "delete.action": {"bold": True, "color": "red"},
+        "delete.cancel": {"color": "bright_black", "dim": True},
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DeleteContinuityConfirmation:
+    """Explicit, irreversible confirmation for a selected continuity target."""
+
+    target: ContinuityTarget
+    title: str
+
+    def handle_input(self, event: InputEvent) -> InputIntent | None:
+        if event.kind != "key":
+            return None
+        if event.key == "enter":
+            return InputIntent(kind="dialog_confirm")
+        if event.key in {"esc", "escape"}:
+            return InputIntent(kind="dialog_cancel")
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        lines = [
+            _styled("Session", "delete.warning"),
+            *(
+                _styled(line, "delete.session")
+                for line in wrap_cells(self.title, width=constraints.width)
+            ),
+            "",
+            *(
+                _styled(line, "delete.warning")
+                for line in wrap_cells(
+                    "This permanently deletes its saved transcript. It cannot be undone.",
+                    width=constraints.width,
+                )
+            ),
+            *(
+                line
+                for line in wrap_cells(
+                    (
+                        f"{_styled('Enter delete permanently', 'delete.action')} · "
+                        f"{_styled('Esc cancel', 'delete.cancel')}"
+                    ),
+                    width=constraints.width,
+                )
+            ),
+        ]
+        return RenderResult.from_text(
+            "\n".join(
+                truncate_to_width(line, max_width=constraints.width)
+                for line in lines[: constraints.max_height]
+            ),
+            constraints=constraints,
+        )
+
+
+def build_delete_continuity_confirmation_surface(
+    *,
+    target: ContinuityTarget,
+    title: str,
+) -> ScreenSurfaceView:
+    return ScreenSurfaceView(
+        title="Delete session",
+        subtitle="Permanently delete the selected session",
+        purpose="delete",
+        content=DeleteContinuityConfirmation(target=target, title=title),
+        footer="",
+        presentation="page",
+        theme=DELETE_CONTINUITY_CONFIRMATION_THEME,
+    )
+
+
+def _styled(text: str, token: str) -> str:
+    return apply_theme_style(
+        text,
+        DELETE_CONTINUITY_CONFIRMATION_THEME.resolve(token),
+    )
+
+
+__all__ = [
+    "DeleteContinuityConfirmation",
+    "DELETE_CONTINUITY_CONFIRMATION_THEME",
+    "build_delete_continuity_confirmation_surface",
+]

--- a/src/loushang/harnesstui/continuity/surface.py
+++ b/src/loushang/harnesstui/continuity/surface.py
@@ -80,10 +80,14 @@ class ContinuitySurface:
         page_size: int = 25,
         keybindings: KeybindingManager | KeybindingConfig | None = None,
         theme: ThemeResolver | None = None,
+        include_summary: Callable[[ContinuitySummary], bool] | None = None,
+        selection_action: str = "resume",
     ) -> None:
         self._hub = hub
         self._request_render = request_render
         self._theme = theme if theme is not None else CONTINUITY_PAGE_THEME
+        self._include_summary = include_summary or (lambda _summary: True)
+        self._selection_action = selection_action
         self._keybindings = (
             keybindings
             if isinstance(keybindings, KeybindingManager)
@@ -117,6 +121,16 @@ class ContinuitySurface:
         if selected is None:
             return None
         return self._targets.get(selected.selected_value)
+
+    @property
+    def selected_summary(self) -> ContinuitySummary | None:
+        target = self.selected_target
+        if target is None:
+            return None
+        return next(
+            (summary for summary in self._summaries if summary.target == target),
+            None,
+        )
 
     @property
     def query(self) -> ContinuityQuery:
@@ -201,7 +215,7 @@ class ContinuitySurface:
         if self._activating:
             return ""
         hints = [
-            f"{self._key_label('tui.select.confirm')} resume",
+            f"{self._key_label('tui.select.confirm')} {self._selection_action}",
             f"{self._key_label('tui.select.cancel')} exit",
         ]
         if len(self._domain_options) > 1:
@@ -300,7 +314,9 @@ class ContinuitySurface:
         previous_page = self._page
         previous_summaries = tuple(self._summaries)
         if reset:
-            self._summaries = list(page.items)
+            self._summaries = [
+                item for item in page.items if self._include_summary(item)
+            ]
         else:
             existing = {
                 (item.target.provider_id, item.target.opaque_id)
@@ -309,6 +325,7 @@ class ContinuitySurface:
             self._summaries.extend(
                 item
                 for item in page.items
+                if self._include_summary(item)
                 if (item.target.provider_id, item.target.opaque_id) not in existing
             )
         self._page = page
@@ -629,7 +646,19 @@ class ContinuitySurface:
 
     def _state_lines(self, *, width: int) -> list[RenderLine]:
         if self._activating:
-            return [RenderLine(""), RenderLine("Resuming selected item…")]
+            action = (
+                "Resuming"
+                if self._selection_action == "resume"
+                else (
+                    f"{self._selection_action[:-1].capitalize()}ing"
+                    if self._selection_action.endswith("e")
+                    else f"{self._selection_action.capitalize()}ing"
+                )
+            )
+            return [
+                RenderLine(""),
+                RenderLine(f"{action} selected item…"),
+            ]
         if self._error:
             return [
                 RenderLine(""),
@@ -719,6 +748,10 @@ def build_continuity_surface_view(
     request_render: Callable[[str], None],
     keybindings: KeybindingManager | KeybindingConfig | None = None,
     theme: ThemeResolver | None = None,
+    include_summary: Callable[[ContinuitySummary], bool] | None = None,
+    title: str = "Resume a previous session",
+    selection_action: str = "resume",
+    purpose: Literal["session", "delete"] = "session",
 ) -> ScreenSurfaceView:
     resolved_theme = theme if theme is not None else CONTINUITY_PAGE_THEME
     content = ContinuitySurface(
@@ -726,10 +759,12 @@ def build_continuity_surface_view(
         request_render=request_render,
         keybindings=keybindings,
         theme=resolved_theme,
+        include_summary=include_summary,
+        selection_action=selection_action,
     )
     return ScreenSurfaceView(
-        title="Resume a previous session",
-        purpose="session",
+        title=title,
+        purpose=purpose,
         content=content,
         footer=content.footer_help,
         presentation="page",

--- a/src/loushang/harnesstui/conversation/agent_application.py
+++ b/src/loushang/harnesstui/conversation/agent_application.py
@@ -258,6 +258,8 @@ def build_agent_screen_surface_workflow_ports(
     on_approval: AgentScreenApprovalHandler | None = None,
     build_resume_surface: Callable[[], ScreenSurfaceView] | None = None,
     activate_continuity: Callable[[object], Awaitable[str]] | None = None,
+    build_delete_surface: Callable[[], ScreenSurfaceView] | None = None,
+    delete_continuity: Callable[[object], Awaitable[str]] | None = None,
     build_fork_surface: Callable[[], ScreenSurfaceView] | None = None,
     fork_session: (
         Callable[[object], Awaitable[ScreenSurfaceForkResult]] | None
@@ -333,6 +335,7 @@ def build_agent_screen_surface_workflow_ports(
             normalize_standard_conversation_interactive_command
             if (
                 build_resume_surface is not None
+                or build_delete_surface is not None
                 or build_fork_surface is not None
                 or build_rename_surface is not None
             )
@@ -340,6 +343,8 @@ def build_agent_screen_surface_workflow_ports(
         ),
         build_resume_surface=build_resume_surface,
         activate_continuity=activate_continuity,
+        build_delete_surface=build_delete_surface,
+        delete_continuity=delete_continuity,
         build_fork_surface=build_fork_surface,
         fork_session=fork_session,
         build_rename_surface=build_rename_surface,

--- a/src/loushang/harnesstui/conversation/agent_application.py
+++ b/src/loushang/harnesstui/conversation/agent_application.py
@@ -175,6 +175,10 @@ class AgentScreenConversationApplicationBinding(Generic[SurfaceT]):
             reader = getattr(active_session(), method_name, None)
             return reader() if callable(reader) else ()
 
+        def refresh_session_label() -> None:
+            self.app.state.session_label = session_label(active_session())
+            self.app.request_render("product")
+
         status_provider = StatusProvider(
             model_label=self.startup.model_label,
             cwd=self.startup.cwd,
@@ -206,6 +210,7 @@ class AgentScreenConversationApplicationBinding(Generic[SurfaceT]):
                     read_pending_followups=stable_string_queue_reader(
                         lambda: read_pending("get_follow_up_messages")
                     ),
+                    on_session_info_changed=refresh_session_label,
                     now=self.now,
                 ).handle
             ),
@@ -257,6 +262,8 @@ def build_agent_screen_surface_workflow_ports(
     fork_session: (
         Callable[[object], Awaitable[ScreenSurfaceForkResult]] | None
     ) = None,
+    build_rename_surface: Callable[[], ScreenSurfaceView] | None = None,
+    rename_session: Callable[[str | None], Awaitable[str]] | None = None,
     build_side_question_surface: Callable[[str], ScreenSurfaceView] | None = None,
     command_catalog: ScreenSurfaceCommandCatalog | None = None,
     model_selector_profile: SessionModelSelectorSurfaceProfile = (
@@ -324,13 +331,19 @@ def build_agent_screen_surface_workflow_ports(
         decide_approval=decide_approval,
         normalize_interactive_command=(
             normalize_standard_conversation_interactive_command
-            if build_resume_surface is not None or build_fork_surface is not None
+            if (
+                build_resume_surface is not None
+                or build_fork_surface is not None
+                or build_rename_surface is not None
+            )
             else None
         ),
         build_resume_surface=build_resume_surface,
         activate_continuity=activate_continuity,
         build_fork_surface=build_fork_surface,
         fork_session=fork_session,
+        build_rename_surface=build_rename_surface,
+        rename_session=rename_session,
         build_side_question_surface=build_side_question_surface,
     )
 

--- a/src/loushang/harnesstui/conversation/agent_binding.py
+++ b/src/loushang/harnesstui/conversation/agent_binding.py
@@ -604,6 +604,7 @@ def build_agent_screen_conversation_projection(
     max_tool_body_lines: int = 8,
     read_pending_steers: StringQueueReader = tuple,
     read_pending_followups: StringQueueReader = tuple,
+    on_session_info_changed: Callable[[], None] | None = None,
     status_copy: ScreenProjectionStatusCopy | None = None,
     now: Callable[[], float] = time.monotonic,
 ) -> ConversationProjectionBinding[dict[str, Any]]:
@@ -625,6 +626,7 @@ def build_agent_screen_conversation_projection(
                 tool_projection,
                 read_pending_steers=read_pending_steers,
                 read_pending_followups=read_pending_followups,
+                on_session_info_changed=on_session_info_changed,
                 project_tool_result_messages=False,
             ).handle
         ),

--- a/src/loushang/harnesstui/conversation/projection.py
+++ b/src/loushang/harnesstui/conversation/projection.py
@@ -357,6 +357,7 @@ class SessionConversationEventAdapter:
     tool_projection: ToolTranscriptProjectionBinding[Mapping[str, Any], object]
     read_pending_steers: StringQueueReader = tuple
     read_pending_followups: StringQueueReader = tuple
+    on_session_info_changed: Callable[[], None] | None = None
     is_cancelled_error: CancellationErrorPredicate = is_cancelled_error_message
     recover_tool_updates: bool = True
     project_tool_result_messages: bool = True
@@ -379,6 +380,10 @@ class SessionConversationEventAdapter:
                     steers=tuple(self.read_pending_steers()),
                     followups=tuple(self.read_pending_followups()),
                 )
+            return
+        if event_type == "session_info_changed":
+            if self.on_session_info_changed is not None:
+                self.on_session_info_changed()
             return
         if event_type == "message_start":
             self._handle_message_start(event)

--- a/src/loushang/harnesstui/conversation/rename.py
+++ b/src/loushang/harnesstui/conversation/rename.py
@@ -1,0 +1,64 @@
+"""Small shared surface for renaming the current session."""
+
+from __future__ import annotations
+
+from loushang.harnesstui.surface.view import ScreenSurfaceView
+from loushang.tui import InputEvent, InputIntent, RenderConstraints, RenderResult
+from loushang.tui.ui_parts import TextInput
+
+
+class SessionRenameSurface:
+    """Edit a session name without exposing Product persistence details."""
+
+    def __init__(self, *, current_name: str | None = None) -> None:
+        self._input = TextInput(
+            prompt="Name: ",
+            placeholder="Enter a session name",
+        )
+        self._input.set_text(current_name or "")
+        self._input.focus()
+
+    @property
+    def value(self) -> str:
+        return self._input.value
+
+    def focus(self) -> None:
+        self._input.focus()
+
+    def blur(self) -> None:
+        self._input.blur()
+
+    def editor_input_target(self) -> object:
+        return self._input.editor_input_target()
+
+    def handle_input(self, event: InputEvent) -> InputIntent | None:
+        if event.kind == "key" and event.key == "enter":
+            return InputIntent(kind="select", text=self.value)
+        if event.kind == "key" and event.key in {"esc", "escape"}:
+            return None
+        if self._input.handle_input(event):
+            return InputIntent(kind="consumed", note="rename_input")
+        return None
+
+    def render(self, constraints: RenderConstraints) -> RenderResult:
+        return self._input.render(constraints)
+
+
+def build_session_rename_surface_view(
+    *,
+    current_name: str | None = None,
+) -> ScreenSurfaceView:
+    """Build the standard bottom rename prompt."""
+
+    return ScreenSurfaceView(
+        title="Rename session",
+        subtitle="Set a name shown in the status line and session history",
+        purpose="rename",
+        content=SessionRenameSurface(current_name=current_name),
+        footer="Enter rename · Esc cancel",
+        presentation="bottom-exclusive",
+        preferred_height=7,
+    )
+
+
+__all__ = ["SessionRenameSurface", "build_session_rename_surface_view"]

--- a/src/loushang/harnesstui/conversation/resume.py
+++ b/src/loushang/harnesstui/conversation/resume.py
@@ -43,6 +43,8 @@ def resume_hint_for_session(
 ) -> ConversationResumeHint | None:
     """Resolve the stable resume reference from standard Product session shapes."""
 
+    if not _has_resumable_messages(session):
+        return None
     session_file = _session_file_for_resume(session)
     if session_file is None:
         return None
@@ -73,6 +75,20 @@ def _session_file_for_resume(session: object) -> object | None:
         except Exception:
             return None
     return getattr(session, "session_file", None)
+
+
+def _has_resumable_messages(session: object) -> bool:
+    """Suppress hints for known-empty sessions without imposing a Product type."""
+
+    manager = getattr(session, "session_manager", None)
+    get_summary = getattr(manager, "get_session_summary", None)
+    if not callable(get_summary):
+        return True
+    try:
+        message_count = getattr(get_summary(), "message_count", None)
+    except Exception:
+        return True
+    return not isinstance(message_count, int) or message_count > 0
 
 
 __all__ = [

--- a/src/loushang/harnesstui/surface/controller.py
+++ b/src/loushang/harnesstui/surface/controller.py
@@ -15,7 +15,14 @@ from loushang.tui import (
 
 SurfaceEventKind = Literal["surface_submit", "surface_close"]
 SurfaceEventSource = Literal[
-    "model", "command", "settings", "session", "fork", "dialog", "approval"
+    "model",
+    "command",
+    "settings",
+    "session",
+    "fork",
+    "rename",
+    "dialog",
+    "approval",
 ]
 SurfaceSubmitHandler = Callable[[Any], Awaitable[None]]
 
@@ -263,6 +270,12 @@ def normalize_surface_intent(
                 if selected_entry_id is not None
                 else intent.text
             ),
+        )
+    if surface.purpose == "rename" and intent.kind == "select":
+        return SurfaceEvent(
+            kind="surface_submit",
+            source="rename",
+            payload=intent.text,
         )
     if surface.purpose == "dialog" and intent.kind == "dialog_confirm":
         return SurfaceEvent(kind="surface_submit", source="dialog")

--- a/src/loushang/harnesstui/surface/controller.py
+++ b/src/loushang/harnesstui/surface/controller.py
@@ -19,6 +19,7 @@ SurfaceEventSource = Literal[
     "command",
     "settings",
     "session",
+    "delete",
     "fork",
     "rename",
     "dialog",
@@ -259,6 +260,16 @@ def normalize_surface_intent(
             kind="surface_submit",
             source="session",
             payload=selected_target if selected_target is not None else intent.text,
+        )
+    if surface.purpose == "delete" and intent.kind in {"select", "dialog_confirm"}:
+        selected_target = getattr(surface.content, "selected_target", None)
+        target = selected_target
+        if target is None:
+            target = getattr(surface.content, "target", None)
+        return SurfaceEvent(
+            kind="surface_submit",
+            source="delete",
+            payload=target if target is not None else intent.text,
         )
     if surface.purpose == "fork" and intent.kind == "select":
         selected_entry_id = getattr(surface.content, "selected_entry_id", None)

--- a/src/loushang/harnesstui/surface/view.py
+++ b/src/loushang/harnesstui/surface/view.py
@@ -23,6 +23,7 @@ ScreenSurfacePurpose = Literal[
     "command",
     "settings",
     "session",
+    "delete",
     "fork",
     "rename",
     "dialog",

--- a/src/loushang/harnesstui/surface/view.py
+++ b/src/loushang/harnesstui/surface/view.py
@@ -24,6 +24,7 @@ ScreenSurfacePurpose = Literal[
     "settings",
     "session",
     "fork",
+    "rename",
     "dialog",
     "approval",
 ]

--- a/src/loushang/harnesstui/surface/workflow.py
+++ b/src/loushang/harnesstui/surface/workflow.py
@@ -37,6 +37,7 @@ ScreenSurfaceCommandKind = Literal[
     "list_commands",
     "resume_session",
     "fork_session",
+    "rename_session",
     "side_question",
     "terminal_diagnostics",
     "hotkeys",
@@ -151,6 +152,8 @@ class ScreenSurfaceWorkflowPorts:
     fork_session: (
         Callable[[object], Awaitable[ScreenSurfaceForkResult]] | None
     ) = None
+    build_rename_surface: Callable[[], ScreenSurfaceView] | None = None
+    rename_session: Callable[[str | None], Awaitable[str]] | None = None
     build_side_question_surface: (
         Callable[[str], ScreenSurfaceView] | None
     ) = None
@@ -190,6 +193,7 @@ class ScreenSurfaceWorkflow:
                 "settings": self._handle_settings_submit,
                 "session": self._handle_session_submit,
                 "fork": self._handle_fork_submit,
+                "rename": self._handle_rename_submit,
                 "dialog": self._handle_dialog_submit,
                 "approval": self._handle_approval_submit,
             },
@@ -255,6 +259,16 @@ class ScreenSurfaceWorkflow:
                 self.app.set_status(self.copy.recoverable_error(error))
             else:
                 self.open(picker)
+        elif (
+            command.kind == "rename_session"
+            and self.ports.build_rename_surface is not None
+        ):
+            try:
+                surface = self.ports.build_rename_surface()
+            except Exception as error:
+                self.app.set_status(self.copy.recoverable_error(error))
+            else:
+                self.open(surface)
         elif command.kind == "side_question":
             question = command.query.strip()
             if not question:
@@ -454,6 +468,20 @@ class ScreenSurfaceWorkflow:
             return
         await self._activate_fork(payload, surface)
 
+    async def _handle_rename_submit(self, payload: object) -> None:
+        rename = self.ports.rename_session
+        if rename is None:
+            return
+        name = payload.strip() if isinstance(payload, str) else ""
+        try:
+            message = await rename(name or None)
+        except Exception as error:
+            self.app.set_status(self.copy.recoverable_error(error))
+            return
+        self.close()
+        self.app.set_status(message)
+        self.app.request_render(self.request_render_reason)
+
     async def _run_fork_activation(
         self,
         payload: object,
@@ -606,6 +634,8 @@ def normalize_standard_conversation_interactive_command(
         return ScreenSurfaceCommand("resume_session")
     if text.strip() == "/fork":
         return ScreenSurfaceCommand("fork_session")
+    if text.strip() == "/rename":
+        return ScreenSurfaceCommand("rename_session")
     return None
 
 

--- a/src/loushang/harnesstui/surface/workflow.py
+++ b/src/loushang/harnesstui/surface/workflow.py
@@ -36,6 +36,7 @@ ScreenSurfaceCommandKind = Literal[
     "select_command",
     "list_commands",
     "resume_session",
+    "delete_session",
     "fork_session",
     "rename_session",
     "side_question",
@@ -148,6 +149,8 @@ class ScreenSurfaceWorkflowPorts:
     ) = None
     build_resume_surface: Callable[[], ScreenSurfaceView] | None = None
     activate_continuity: Callable[[object], Awaitable[str]] | None = None
+    build_delete_surface: Callable[[], ScreenSurfaceView] | None = None
+    delete_continuity: Callable[[object], Awaitable[str]] | None = None
     build_fork_surface: Callable[[], ScreenSurfaceView] | None = None
     fork_session: (
         Callable[[object], Awaitable[ScreenSurfaceForkResult]] | None
@@ -192,6 +195,7 @@ class ScreenSurfaceWorkflow:
                 "command": self._handle_command_submit,
                 "settings": self._handle_settings_submit,
                 "session": self._handle_session_submit,
+                "delete": self._handle_delete_submit,
                 "fork": self._handle_fork_submit,
                 "rename": self._handle_rename_submit,
                 "dialog": self._handle_dialog_submit,
@@ -245,6 +249,16 @@ class ScreenSurfaceWorkflow:
         ):
             try:
                 picker = self.ports.build_resume_surface()
+            except Exception as error:
+                self.app.set_status(self.copy.recoverable_error(error))
+            else:
+                self.open(picker)
+        elif (
+            command.kind == "delete_session"
+            and self.ports.build_delete_surface is not None
+        ):
+            try:
+                picker = self.ports.build_delete_surface()
             except Exception as error:
                 self.app.set_status(self.copy.recoverable_error(error))
             else:
@@ -468,6 +482,31 @@ class ScreenSurfaceWorkflow:
             return
         await self._activate_fork(payload, surface)
 
+    async def _handle_delete_submit(self, payload: object) -> None:
+        if self.ports.delete_continuity is None:
+            return
+        surface = self.current
+        content = surface.content if isinstance(surface, ScreenSurfaceView) else None
+        if getattr(content, "target", None) is not None:
+            await self._perform_continuity_deletion(payload, surface)
+            return
+        target = payload
+        summary = getattr(content, "selected_summary", None)
+        title = getattr(summary, "title", None)
+        if not isinstance(title, str) or not title:
+            title = getattr(target, "opaque_id", "selected session")
+        from loushang.harnesstui.continuity import (
+            build_delete_continuity_confirmation_surface,
+        )
+
+        if hasattr(target, "provider_id") and hasattr(target, "opaque_id"):
+            self.open(
+                build_delete_continuity_confirmation_surface(
+                    target=target,
+                    title=title,
+                )
+            )
+
     async def _handle_rename_submit(self, payload: object) -> None:
         rename = self.ports.rename_session
         if rename is None:
@@ -535,6 +574,26 @@ class ScreenSurfaceWorkflow:
             self.app.set_status(self.copy.recoverable_error(error))
             return
         if self.current is surface:
+            self.close()
+        self.app.set_status(message)
+        self.app.request_render(self.request_render_reason)
+
+    async def _perform_continuity_deletion(
+        self,
+        payload: object,
+        surface: ScreenSurfaceView | object | None,
+    ) -> None:
+        delete = self.ports.delete_continuity
+        if delete is None:  # pragma: no cover - guarded by submit handler
+            return
+        try:
+            message = await delete(payload)
+        except Exception as error:
+            self.app.set_status(self.copy.recoverable_error(error))
+            return
+        if self.current is surface and self.ports.build_delete_surface is not None:
+            self.open(self.ports.build_delete_surface())
+        elif self.current is surface:
             self.close()
         self.app.set_status(message)
         self.app.request_render(self.request_render_reason)
@@ -632,6 +691,8 @@ def normalize_standard_conversation_interactive_command(
 
     if text.strip() == "/resume":
         return ScreenSurfaceCommand("resume_session")
+    if text.strip() == "/delete":
+        return ScreenSurfaceCommand("delete_session")
     if text.strip() == "/fork":
         return ScreenSurfaceCommand("fork_session")
     if text.strip() == "/rename":

--- a/tests/coding/test_agent_session.py
+++ b/tests/coding/test_agent_session.py
@@ -1488,7 +1488,7 @@ def test_agent_session_get_commands_aggregates_extension_prompt_and_skill_source
 
     assert {descriptor.name for descriptor in descriptors} >= {
         "copy",
-        "name",
+        "rename",
         "session",
         "changelog",
     }

--- a/tests/coding/test_agent_session_runtime.py
+++ b/tests/coding/test_agent_session_runtime.py
@@ -2950,6 +2950,36 @@ async def test_runtime_new_session_reuses_current_cwd_and_disposes_previous_sess
 
 
 @_async_test
+async def test_builtin_new_command_replaces_current_session_without_materializing_empty_files(
+    tmp_path,
+) -> None:
+    from loushang.coding.bootstrap import create_agent_session_runtime
+
+    session_dir = tmp_path / "sessions"
+    runtime = create_agent_session_runtime(
+        session_dir=session_dir,
+        model=_model(),
+        persist=True,
+    )
+    first = await runtime.create_session(cwd=str(tmp_path))
+
+    execution = await first.execute_command_async("new", "")
+    current = runtime.get_current_session()
+
+    assert execution.result == {
+        "source": "builtin",
+        "command": "new",
+        "status": "ok",
+        "result": {"cancelled": False},
+        "message": "Started a new session.",
+    }
+    assert current is not None
+    assert current is not first
+    assert current.session_manager.get_cwd() == str(tmp_path.resolve())
+    assert list(session_dir.glob("*.jsonl")) == []
+
+
+@_async_test
 async def test_runtime_session_replacement_keeps_shared_approval_presenter(
     tmp_path,
 ) -> None:

--- a/tests/coding/test_commands.py
+++ b/tests/coding/test_commands.py
@@ -35,7 +35,7 @@ def test_standard_session_commands_have_shared_metadata() -> None:
         "export": "Export session (HTML default, or specify path: .html/.jsonl)",
         "import": "Import and resume a session from a JSONL file",
         "copy": "Copy an assistant message to clipboard",
-        "name": "Set session display name",
+        "rename": "Rename the current session",
         "session": "Show session info and stats",
         "changelog": "Show changelog entries",
         "fork": "Create a new fork from a previous user message",

--- a/tests/coding/test_commands.py
+++ b/tests/coding/test_commands.py
@@ -43,9 +43,10 @@ def test_standard_session_commands_have_shared_metadata() -> None:
         "tree": "Navigate session tree (switch branches)",
         "tools": "Show or update active tools for this session",
         "extensions": "Show loaded extensions and diagnostics",
-        "new": "Start a new session",
+        "new": "Start a new session in the current context",
         "compact": "Manually compact the session context",
         "resume": "Resume a different session",
+        "delete": "Delete a previous session",
         "reload": "Reload keybindings, extensions, skills, prompts, and themes",
     }
 

--- a/tests/coding/test_continuity.py
+++ b/tests/coding/test_continuity.py
@@ -49,6 +49,7 @@ class _Runtime(AgentTranscriptDirectoryRuntime):
         )
         self.prepared: list[str] = []
         self.restored: list[str] = []
+        self.deleted: list[str] = []
         self.current_session: object | None = None
         self.current_session_ref: str | None = None
 
@@ -76,6 +77,12 @@ class _Runtime(AgentTranscriptDirectoryRuntime):
                 return None
 
         return _Candidate()
+
+    async def delete_session(self, session_id: str | Path) -> bool:
+        reference = str(session_id)
+        self.deleted.append(reference)
+        Path(reference).unlink()
+        return True
 
 
 def test_coding_provider_projects_common_summary_preview_and_activation(
@@ -144,6 +151,49 @@ def test_coding_prepare_treats_current_session_as_noop(tmp_path: Path) -> None:
         assert result.changed is False
         assert runtime.prepared == []
         assert runtime.restored == []
+        await shutdown_coding_continuity(runtime)
+
+    asyncio.run(scenario())
+
+
+def test_coding_provider_deletes_only_a_fresh_noncurrent_target(tmp_path: Path) -> None:
+    runtime = _Runtime(tmp_path)
+    transcript = tmp_path / "session-1.jsonl"
+    write_agent_transcript_export(
+        transcript,
+        _header("session-1"),
+        [_record("record-1", "Delete this session")],
+    )
+    runtime.refresh_session_index()
+    composition = bind_coding_continuity(runtime)
+
+    async def scenario() -> None:
+        page = await composition.hub.query(ContinuityQuery(page_size=10))
+        assert await composition.hub.delete(page.items[0].target) is True
+        assert runtime.deleted == [str(transcript)]
+        assert transcript.exists() is False
+        await shutdown_coding_continuity(runtime)
+
+    asyncio.run(scenario())
+
+
+def test_coding_provider_refuses_to_delete_current_session(tmp_path: Path) -> None:
+    runtime = _Runtime(tmp_path)
+    transcript = tmp_path / "session-1.jsonl"
+    write_agent_transcript_export(
+        transcript,
+        _header("session-1"),
+        [_record("record-1", "Keep this session")],
+    )
+    runtime.refresh_session_index()
+    runtime.current_session_ref = str(transcript)
+    composition = bind_coding_continuity(runtime)
+
+    async def scenario() -> None:
+        page = await composition.hub.query(ContinuityQuery(page_size=10))
+        with pytest.raises(ValueError, match="currently active"):
+            await composition.hub.delete(page.items[0].target)
+        assert transcript.exists() is True
         await shutdown_coding_continuity(runtime)
 
     asyncio.run(scenario())

--- a/tests/coding/test_screen_coding_tui_loop.py
+++ b/tests/coding/test_screen_coding_tui_loop.py
@@ -874,12 +874,12 @@ def test_screen_loop_dispatches_session_command_without_prompting_agent() -> Non
     )
 
     result = playback.run(
-        (0.0, "/name Project Alpha\r"),
+        (0.0, "/rename Project Alpha\r"),
         handle_prompt=_bind_host_action(host.submit, source="prompt"),
     )
 
     assert result.exit_code == 0
-    assert session.commands == [("name", "Project Alpha")]
+    assert session.commands == [("rename", "Project Alpha")]
     assert session.prompt_calls == []
     assert "Session name set: Project Alpha" in result.text
     result.assert_no_clear_screen()
@@ -1032,8 +1032,8 @@ class _NameCommandSession:
     def list_commands(self) -> list[object]:
         return [
             SimpleNamespace(
-                name="name",
-                description="Set session display name",
+                name="rename",
+                description="Rename the current session",
                 source="builtin",
                 argument_hint="<name>",
             )

--- a/tests/coding/test_screen_coding_tui_mode.py
+++ b/tests/coding/test_screen_coding_tui_mode.py
@@ -1098,13 +1098,16 @@ def test_screen_tui_projector_failure_still_unbinds_presenter(
     assert resolver._broker.pending_requests() == ()
 
 
-def test_screen_session_transition_binding_clears_approval_surfaces() -> None:
+def test_screen_session_transition_binding_clears_approval_surfaces_and_rebinds() -> None:
 
     subscribers: list[Callable[[], None]] = []
     primary_calls = 0
     clears = 0
+    rebound: list[object] = []
 
     class Runtime:
+        rebind = None
+
         def subscribe_before_session_invalidate(self, callback):
             subscribers.append(callback)
 
@@ -1119,6 +1122,14 @@ def test_screen_session_transition_binding_clears_approval_surfaces() -> None:
             for callback in tuple(subscribers):
                 callback()
 
+        def set_rebind_session(self, callback) -> None:
+            self.rebind = callback
+
+        def replace(self, next_session: object) -> None:
+            self.invalidate()
+            if self.rebind is not None:
+                self.rebind(next_session)
+
     class SurfaceManager:
         def clear_approval_surfaces(self) -> None:
             nonlocal clears
@@ -1128,13 +1139,17 @@ def test_screen_session_transition_binding_clears_approval_surfaces() -> None:
     unbind = tui_policy.bind_agent_screen_session_transition(
         runtime,
         SurfaceManager(),  # type: ignore[arg-type]
+        on_rebind=rebound.append,
     )
-    runtime.invalidate()
+    next_session = object()
+    runtime.replace(next_session)
     unbind()
     runtime.invalidate()
 
     assert clears == 1
     assert primary_calls == 2
+    assert rebound == [next_session]
+    assert runtime.rebind is None
     assert subscribers == []
 
 

--- a/tests/coding/test_screen_tui_playback_runner.py
+++ b/tests/coding/test_screen_tui_playback_runner.py
@@ -52,7 +52,7 @@ def test_screen_tui_playback_fake_session_lists_command_sources() -> None:
     commands = session.list_commands()
 
     assert [(command.name, command.source) for command in commands] == [
-        ("name", "builtin"),
+        ("rename", "builtin"),
         ("export", "builtin"),
         ("review", "prompt"),
         ("debugging", "skill"),
@@ -62,7 +62,7 @@ def test_screen_tui_playback_fake_session_lists_command_sources() -> None:
 def test_screen_tui_playback_command_scenarios_live_in_command_module() -> None:
     assert [scenario.name for scenario in COMMAND_ROUTING_SCENARIOS] == [
         "local-command",
-        "session-name-command",
+        "session-rename-command",
         "session-command-error",
         "unknown-slash-prompt",
         "non-executable-session-command",
@@ -175,7 +175,7 @@ def test_screen_tui_playback_runner_lists_default_scenarios(capsys) -> None:
     assert "idle-escape-pops-pending-steer" in captured.out
     assert "escape-pending-steer-fifo" in captured.out
     assert "escape-pending-steer-preserves-draft" in captured.out
-    assert "session-name-command" in captured.out
+    assert "session-rename-command" in captured.out
     assert "session-command-error" in captured.out
     assert "unknown-slash-prompt" in captured.out
     assert "non-executable-session-command" in captured.out
@@ -220,7 +220,7 @@ def test_screen_tui_playback_runner_runs_tagged_command_scenarios(capsys) -> Non
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert "PASS session-name-command" in captured.out
+    assert "PASS session-rename-command" in captured.out
     assert "PASS command-palette-session-command" in captured.out
     assert "PASS commands-info-session-command" in captured.out
     assert "PASS model-select" not in captured.out
@@ -243,7 +243,7 @@ def test_screen_tui_playback_runner_lists_tagged_command_scenarios(capsys) -> No
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert "session-name-command" in captured.out
+    assert "session-rename-command" in captured.out
     assert "command-palette-session-command" in captured.out
     assert "model-select" not in captured.out
     assert "long-transcript-input" not in captured.out
@@ -371,11 +371,11 @@ def test_screen_tui_playback_runner_runs_lifecycle_scenario(capsys) -> None:
 
 
 def test_screen_tui_playback_runner_runs_session_name_command_scenario(capsys) -> None:
-    exit_code = run_playback_cli(["session-name-command"])
+    exit_code = run_playback_cli(["session-rename-command"])
 
     captured = capsys.readouterr()
     assert exit_code == 0
-    assert "PASS session-name-command" in captured.out
+    assert "PASS session-rename-command" in captured.out
 
 
 def test_screen_tui_playback_runner_runs_session_command_error_scenario(capsys) -> None:

--- a/tests/coding/test_session_command_controller.py
+++ b/tests/coding/test_session_command_controller.py
@@ -141,11 +141,11 @@ def test_command_controller_lists_builtin_commands_before_extension_and_resource
         "export",
         "import",
         "copy",
-        "name",
+        "rename",
     ]
     assert {command.name for command in commands} >= {
         "copy",
-        "name",
+        "rename",
         "session",
         "changelog",
         "tools",
@@ -254,9 +254,11 @@ def test_command_controller_dispatches_extension_before_builtin_and_resource(
     runner = ExtensionRunner(
         [
             LoadedExtension(
-                name="name-ext",
-                source_path=Path("/tmp/project/extensions/name.py"),
-                commands={"name": RegisteredCommand(name="name", handler=_handler)},
+                name="rename-ext",
+                source_path=Path("/tmp/project/extensions/rename.py"),
+                commands={
+                    "rename": RegisteredCommand(name="rename", handler=_handler)
+                },
             )
         ]
     )
@@ -264,9 +266,9 @@ def test_command_controller_dispatches_extension_before_builtin_and_resource(
         cwd=Path("/tmp/project"),
         prompts=[
             PromptFragmentDescriptor(
-                name="name",
-                source_path=Path("/tmp/project/prompts/name.md"),
-                text="Resource name $ARGUMENTS",
+                name="rename",
+                source_path=Path("/tmp/project/prompts/rename.md"),
+                text="Resource rename $ARGUMENTS",
             )
         ],
     )
@@ -278,16 +280,18 @@ def test_command_controller_dispatches_extension_before_builtin_and_resource(
         standard_ports=StandardSessionCommandPorts(set_session_name=builtin_names.append),
     )
 
-    result = asyncio.run(controller.execute_command_async("/name", "Project Alpha"))
+    result = asyncio.run(
+        controller.execute_command_async("/rename", "Project Alpha")
+    )
 
     assert result is not None
-    assert result.invocation_name == "name"
+    assert result.invocation_name == "rename"
     assert result.result is None
     assert calls == [("Project Alpha", "/tmp/project")]
     assert builtin_names == []
 
 
-def test_command_controller_executes_builtin_name_session_and_unsupported_commands(
+def test_command_controller_executes_builtin_rename_session_and_unsupported_commands(
     tmp_path,
 ) -> None:
     names: list[str | None] = []
@@ -309,17 +313,18 @@ def test_command_controller_executes_builtin_name_session_and_unsupported_comman
         ),
     )
 
-    name_result = asyncio.run(
-        controller.execute_command_async("/name", "Project Alpha")
+    rename_result = asyncio.run(
+        controller.execute_command_async("/rename", "Project Alpha")
     )
     session_result = asyncio.run(controller.execute_command_async("/session", ""))
 
-    assert name_result is not None
-    assert name_result.result == {
+    assert rename_result is not None
+    assert rename_result.result == {
         "source": "builtin",
-        "command": "name",
+        "command": "rename",
         "status": "ok",
         "name": "Project Alpha",
+        "message": "Session renamed to Project Alpha",
     }
     assert names == ["Project Alpha"]
     assert session_result is not None
@@ -998,8 +1003,10 @@ def test_command_controller_preflight_async_consumes_builtin_command(tmp_path) -
         standard_ports=StandardSessionCommandPorts(set_session_name=names.append),
     )
 
-    result = asyncio.run(controller.preflight_user_input_async("/name Project Alpha"))
+    result = asyncio.run(
+        controller.preflight_user_input_async("/rename Project Alpha")
+    )
 
     assert result.consumed is True
-    assert result.text == "/name Project Alpha"
+    assert result.text == "/rename Project Alpha"
     assert names == ["Project Alpha"]

--- a/tests/coding/test_session_command_controller.py
+++ b/tests/coding/test_session_command_controller.py
@@ -777,7 +777,7 @@ def test_command_controller_executes_builtin_runtime_session_commands(tmp_path) 
     )
 
     results = [
-        asyncio.run(controller.execute_command_async("/new", "/tmp/next")),
+        asyncio.run(controller.execute_command_async("/new", "")),
         asyncio.run(controller.execute_command_async("/resume", "/tmp/session.jsonl")),
         asyncio.run(controller.execute_command_async("/fork", "entry-1 before")),
         asyncio.run(controller.execute_command_async("/clone", "")),
@@ -799,6 +799,7 @@ def test_command_controller_executes_builtin_runtime_session_commands(tmp_path) 
             "command": "new",
             "status": "ok",
             "result": {"cancelled": False},
+            "message": "Started a new session.",
         },
         {
             "source": "builtin",
@@ -832,7 +833,7 @@ def test_command_controller_executes_builtin_runtime_session_commands(tmp_path) 
         },
     ]
     assert calls == [
-        ("new", {"cwd": "/tmp/next"}),
+        ("new", None),
         ("resume", ("/tmp/session.jsonl", None)),
         ("fork", ("entry-1", {"position": "before"})),
         ("clone", None),
@@ -858,6 +859,10 @@ def test_command_controller_projects_standard_session_argument_errors(tmp_path) 
         del target_id, options
         return {"cancelled": False}
 
+    async def _new_session(options: object | None = None) -> dict[str, object]:
+        del options
+        return {"cancelled": False}
+
     controller = CommandController(
         session_manager=asyncio.run(
             SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
@@ -866,6 +871,7 @@ def test_command_controller_projects_standard_session_argument_errors(tmp_path) 
         get_resource_bundle=lambda: None,
         get_diagnostics_service=lambda: None,
         standard_ports=StandardSessionCommandPorts(
+            new_session=_new_session,
             resume_session=_resume,
             fork_session=_fork,
             navigate_tree=_navigate_tree,
@@ -873,6 +879,7 @@ def test_command_controller_projects_standard_session_argument_errors(tmp_path) 
     )
 
     resume = asyncio.run(controller.execute_command_async("/resume", ""))
+    new = asyncio.run(controller.execute_command_async("/new", "/tmp/project"))
     fork = asyncio.run(controller.execute_command_async("/fork", "entry elsewhere"))
     tree = asyncio.run(controller.execute_command_async("/tree", ""))
 
@@ -882,6 +889,13 @@ def test_command_controller_projects_standard_session_argument_errors(tmp_path) 
         "command": "resume",
         "status": "error",
         "message": "Usage: /resume <session-id-or-path>",
+    }
+    assert new is not None
+    assert new.result == {
+        "source": "builtin",
+        "command": "new",
+        "status": "error",
+        "message": "Usage: /new",
     }
     assert fork is not None
     assert fork.result == {

--- a/tests/coding/test_session_manager.py
+++ b/tests/coding/test_session_manager.py
@@ -805,6 +805,56 @@ async def test_session_manager_rename_and_delete_refresh_existing_index(
 
 
 @_async_test
+async def test_current_session_rename_incrementally_updates_existing_index(
+    tmp_path, monkeypatch
+) -> None:
+    from loushang.ai.types import UserMessage
+    from loushang.coding.session_manager import SessionManager
+    from loushang.harness.transcript import AgentTranscriptSessionCatalog
+
+    manager = await SessionManager.new(
+        session_dir=tmp_path,
+        cwd="/tmp/project",
+        persist=True,
+    )
+    await manager.append_message(
+        UserMessage(role="user", content="hello", timestamp=1.0)
+    )
+    SessionManager.refresh_index(tmp_path)
+
+    def fail_repair(_self):
+        raise AssertionError("rename must not rebuild the full index")
+
+    monkeypatch.setattr(AgentTranscriptSessionCatalog, "repair_index", fail_repair)
+
+    await manager.append_session_info("Renamed now")
+
+    snapshot = AgentTranscriptSessionCatalog(tmp_path).try_query_index_snapshot()
+    assert snapshot.index_state == "fresh"
+    assert len(snapshot.items) == 1
+    assert snapshot.items[0].projection.name == "Renamed now"
+    assert snapshot.items[0].source_revision == 2
+
+
+@_async_test
+async def test_renaming_empty_session_does_not_materialize_transcript(tmp_path) -> None:
+    from loushang.coding.session_manager import SessionManager
+
+    SessionManager.refresh_index(tmp_path)
+    manager = await SessionManager.new(
+        session_dir=tmp_path,
+        cwd="/tmp/project",
+        persist=True,
+    )
+
+    await manager.append_session_info("Still empty")
+
+    assert manager.is_persisted() is False
+    assert list(tmp_path.glob("*.jsonl")) == []
+    assert SessionManager.list_indexed_summaries(tmp_path) == []
+
+
+@_async_test
 async def test_session_manager_dispose_upserts_changed_summary_into_existing_index(
     tmp_path,
 ) -> None:

--- a/tests/coding/test_ui_controller.py
+++ b/tests/coding/test_ui_controller.py
@@ -190,8 +190,8 @@ def test_controller_dispatches_catalog_session_command_without_prompting_agent()
         def list_commands(self) -> list[object]:
             return [
                 SimpleNamespace(
-                    name="name",
-                    description="Set session display name",
+                    name="rename",
+                    description="Rename the current session",
                     source="builtin",
                     argument_hint="<name>",
                 )
@@ -212,11 +212,13 @@ def test_controller_dispatches_catalog_session_command_without_prompting_agent()
     session = CommandSession()
     controller = build_coding_ui_controller(session=session)
 
-    result = asyncio.run(controller.dispatch(PromptIntent(text="/name Project Alpha")))
+    result = asyncio.run(
+        controller.dispatch(PromptIntent(text="/rename Project Alpha"))
+    )
 
     assert result.error_message is None
     assert result.status_message == "Session name set: Project Alpha"
-    assert session.commands == [("name", "Project Alpha")]
+    assert session.commands == [("rename", "Project Alpha")]
     assert session.prompts == []
 
 

--- a/tests/coding/test_ui_resume.py
+++ b/tests/coding/test_ui_resume.py
@@ -62,3 +62,15 @@ def test_coding_resume_hint_requires_a_session_file() -> None:
     )
 
     assert _coding_resume_hint(session) is None
+
+
+def test_coding_resume_hint_suppresses_a_known_empty_session() -> None:
+    session = SimpleNamespace(
+        session_id="empty-session",
+        session_manager=SimpleNamespace(
+            get_session_file=lambda: Path("/tmp/empty-session.jsonl"),
+            get_session_summary=lambda: SimpleNamespace(message_count=0),
+        ),
+    )
+
+    assert _coding_resume_hint(session) is None

--- a/tests/coding/tui_support/fakes.py
+++ b/tests/coding/tui_support/fakes.py
@@ -82,8 +82,8 @@ class SessionCommandPlaybackSession:
     def list_commands(self) -> list[object]:
         return [
             SimpleNamespace(
-                name="name",
-                description="Set session display name",
+                name="rename",
+                description="Rename the current session",
                 source="builtin",
                 argument_hint="<name>",
             ),

--- a/tests/coding/tui_support/scenarios/command.py
+++ b/tests/coding/tui_support/scenarios/command.py
@@ -40,7 +40,7 @@ def _run_local_command() -> ScreenTuiInputPlaybackResult:
     return result
 
 
-def _run_session_name_command() -> object:
+def _run_session_rename_command() -> object:
     playback = ScreenTuiLoopPlayback(
         width=100, height=18, model_label="moonshot/kimi-for-coding"
     )
@@ -49,7 +49,7 @@ def _run_session_name_command() -> object:
     manager = _surface_manager(playback.app, session=session)
 
     result = playback.run(
-        (0.00, "/name Project Alpha\r"),
+        (0.00, "/rename Project Alpha\r"),
         (0.03, ""),
         handle_prompt=coding_screen_prompt_handler(
             presenter=playback.app,
@@ -63,9 +63,9 @@ def _run_session_name_command() -> object:
 
     result.assert_exit_code(0)
     result.assert_idle()
-    assert session.commands == [("name", "Project Alpha")]
+    assert session.commands == [("rename", "Project Alpha")]
     assert session.prompts == []
-    result.assert_text_contains("› /name Project Alpha")
+    result.assert_text_contains("› /rename Project Alpha")
     result.assert_text_contains("Session name set: Project Alpha")
     result.assert_no_clear_screen()
     return result
@@ -196,9 +196,9 @@ COMMAND_ROUTING_SCENARIOS = (
         tags=("command", "local"),
     ),
     ScreenPlaybackScenarioSpec(
-        name="session-name-command",
-        description="Dispatch /name through the screen session command path without prompting the agent.",
-        run=_run_session_name_command,
+        name="session-rename-command",
+        description="Dispatch /rename through the screen session command path without prompting the agent.",
+        run=_run_session_rename_command,
         tags=("command", "session"),
     ),
     ScreenPlaybackScenarioSpec(

--- a/tests/coding/tui_support/scenarios/composer.py
+++ b/tests/coding/tui_support/scenarios/composer.py
@@ -30,8 +30,8 @@ def _run_completion_session_command() -> ScreenTuiInputPlaybackResult:
 
     result = scenario.render().type_text("/na").tab().run()
 
-    result.assert_composer_text("/name ")
-    result.assert_visible_contains("› /name")
+    result.assert_composer_text("/rename ")
+    result.assert_visible_contains("› /rename")
     result.assert_no_clear_screen()
     result.assert_cursor_matches_diagnostics()
     assert session.commands == []

--- a/tests/coding/tui_support/scenarios/surface.py
+++ b/tests/coding/tui_support/scenarios/surface.py
@@ -66,7 +66,7 @@ def _run_commands_info_session_command() -> object:
 
     result.assert_exit_code(0)
     result.assert_text_contains("Commands")
-    result.assert_text_contains("/name <name> - Set session display name (builtin)")
+    result.assert_text_contains("/rename <name> - Rename the current session (builtin)")
     result.assert_text_not_contains("/terminal - Show terminal diagnostics (local)")
     result.assert_no_clear_screen()
     assert session.commands == []
@@ -117,8 +117,8 @@ def _run_command_palette_session_command() -> object:
     )
 
     result.assert_exit_code(0)
-    result.assert_composer_text("/name ")
-    result.assert_text_contains("Command selected: /name")
+    result.assert_composer_text("/rename ")
+    result.assert_text_contains("Command selected: /rename")
     result.assert_no_clear_screen()
     assert session.commands == []
     assert session.prompts == []

--- a/tests/harness/session/test_command_pack.py
+++ b/tests/harness/session/test_command_pack.py
@@ -12,6 +12,7 @@ from loushang.harness.session.command_pack import (
     StandardSessionExport,
     execute_standard_session_command_async,
     is_standard_session_command,
+    list_standard_session_command_descriptors,
 )
 
 
@@ -29,6 +30,18 @@ def test_standard_session_command_profile_selects_and_removes_commands() -> None
 
     with pytest.raises(ValueError, match="unknown standard session command"):
         profile.select({"not-a-command"})
+
+
+def test_standard_session_commands_expose_rename_without_name_alias() -> None:
+    descriptors = {
+        descriptor.name: descriptor
+        for descriptor in list_standard_session_command_descriptors()
+    }
+
+    assert "name" not in descriptors
+    assert descriptors["rename"].argument_hint == "<name>"
+    assert is_standard_session_command("/rename")
+    assert not is_standard_session_command("/name")
 
 
 def test_standard_session_command_pack_delegates_common_operations() -> None:
@@ -79,7 +92,7 @@ def test_standard_session_command_pack_delegates_identity_and_transcript_operati
     calls: list[tuple[str, object]] = []
 
     async def _set_name(name: str | None) -> None:
-        calls.append(("name", name))
+        calls.append(("rename", name))
 
     def _export_jsonl(path: str | None) -> str:
         calls.append(("export", ("jsonl", path)))
@@ -95,7 +108,9 @@ def test_standard_session_command_pack_delegates_identity_and_transcript_operati
         import_session=_import,
     )
 
-    name = asyncio.run(execute_standard_session_command_async("name", "Alpha", ports))
+    renamed = asyncio.run(
+        execute_standard_session_command_async("rename", "Alpha", ports)
+    )
     export = asyncio.run(
         execute_standard_session_command_async("export", "saved.jsonl", ports)
     )
@@ -108,8 +123,8 @@ def test_standard_session_command_pack_delegates_identity_and_transcript_operati
         execute_standard_session_command_async("import", "", ports)
     )
 
-    assert name is not None
-    assert name.value == "Alpha"
+    assert renamed is not None
+    assert renamed.value == "Alpha"
     assert export is not None
     assert export.value == StandardSessionExport(
         format="jsonl", path="/tmp/session.jsonl"
@@ -119,7 +134,7 @@ def test_standard_session_command_pack_delegates_identity_and_transcript_operati
     assert invalid_import is not None
     assert invalid_import.error_code == "missing_import_path"
     assert calls == [
-        ("name", "Alpha"),
+        ("rename", "Alpha"),
         ("export", ("jsonl", "saved.jsonl")),
         ("import", ("saved.jsonl", "/tmp/project")),
     ]

--- a/tests/harness/session/test_command_pack.py
+++ b/tests/harness/session/test_command_pack.py
@@ -13,6 +13,7 @@ from loushang.harness.session.command_pack import (
     execute_standard_session_command_async,
     is_standard_session_command,
     list_standard_session_command_descriptors,
+    project_standard_session_command_result,
 )
 
 
@@ -161,7 +162,7 @@ def test_standard_session_command_pack_requires_the_selected_export_port() -> No
 def test_standard_session_command_pack_parses_lifecycle_and_tree_arguments() -> None:
     calls: list[tuple[str, object]] = []
 
-    async def _new(options: object) -> dict[str, object]:
+    async def _new(options: object | None = None) -> dict[str, object]:
         calls.append(("new", options))
         return {"cancelled": False}
 
@@ -190,7 +191,7 @@ def test_standard_session_command_pack_parses_lifecycle_and_tree_arguments() -> 
     )
 
     results = [
-        asyncio.run(execute_standard_session_command_async("new", "/next", ports)),
+        asyncio.run(execute_standard_session_command_async("new", "", ports)),
         asyncio.run(
             execute_standard_session_command_async("resume", "session-2", ports)
         ),
@@ -209,6 +210,9 @@ def test_standard_session_command_pack_parses_lifecycle_and_tree_arguments() -> 
     missing_resume = asyncio.run(
         execute_standard_session_command_async("resume", "", ports)
     )
+    invalid_new = asyncio.run(
+        execute_standard_session_command_async("new", "/next", ports)
+    )
     invalid_fork = asyncio.run(
         execute_standard_session_command_async("fork", "entry-1 elsewhere", ports)
     )
@@ -219,12 +223,15 @@ def test_standard_session_command_pack_parses_lifecycle_and_tree_arguments() -> 
     assert missing_resume is not None
     assert missing_resume.disposition == "invalid_arguments"
     assert missing_resume.error_code == "missing_reference"
+    assert invalid_new is not None
+    assert invalid_new.disposition == "invalid_arguments"
+    assert invalid_new.error_code == "unexpected_arguments"
     assert invalid_fork is not None
     assert invalid_fork.disposition == "invalid_arguments"
     assert invalid_fork.error_code == "invalid_fork_position"
     assert invalid_fork.value == "elsewhere"
     assert calls == [
-        ("new", {"cwd": "/next"}),
+        ("new", None),
         ("resume", ("session-2", None)),
         ("fork", ("entry-1", {"position": "before"})),
         ("clone", None),
@@ -240,6 +247,27 @@ def test_standard_session_command_pack_parses_lifecycle_and_tree_arguments() -> 
             ),
         ),
     ]
+
+
+def test_standard_new_command_projects_cancelled_operation_explicitly() -> None:
+    result = asyncio.run(
+        execute_standard_session_command_async(
+            "new",
+            "",
+            StandardSessionCommandPorts(
+                new_session=lambda: {"cancelled": True},
+            ),
+        )
+    )
+
+    assert result is not None
+    assert project_standard_session_command_result(result) == {
+        "source": "builtin",
+        "command": "new",
+        "status": "ok",
+        "result": {"cancelled": True},
+        "message": "New session creation cancelled.",
+    }
 
 
 def test_standard_session_command_pack_manages_tools_without_coding() -> None:

--- a/tests/harnesstui/commands/test_catalog.py
+++ b/tests/harnesstui/commands/test_catalog.py
@@ -34,8 +34,8 @@ def test_classifies_local_and_session_commands() -> None:
     catalog = ConversationCommandCatalog(
         session_commands=lambda: [
             _command(
-                "name",
-                description="Set session display name",
+                "rename",
+                description="Rename the current session",
                 source="builtin",
                 argument_hint="<name>",
             )
@@ -48,16 +48,16 @@ def test_classifies_local_and_session_commands() -> None:
     assert settings_effect.command.kind is CommandKind.LOCAL_UI
     assert settings_effect.command.id == "harness.ui.settings"
 
-    name_effect = catalog.effect_for_route(
+    rename_effect = catalog.effect_for_route(
         ConversationHostRoute.DISPATCH,
-        PromptIntent("/name Project Alpha"),
+        PromptIntent("/rename Project Alpha"),
     )
-    assert name_effect is not None
-    assert name_effect.kind is CommandEffectKind.SESSION
-    assert name_effect.command.kind is CommandKind.SESSION
-    assert name_effect.command.name == "name"
-    assert name_effect.payload == {
-        "invocation_name": "name",
+    assert rename_effect is not None
+    assert rename_effect.kind is CommandEffectKind.SESSION
+    assert rename_effect.command.kind is CommandKind.SESSION
+    assert rename_effect.command.name == "rename"
+    assert rename_effect.payload == {
+        "invocation_name": "rename",
         "args": "Project Alpha",
     }
 

--- a/tests/harnesstui/continuity/test_delete.py
+++ b/tests/harnesstui/continuity/test_delete.py
@@ -1,0 +1,33 @@
+from loushang.harness.continuity import ContinuityTarget
+from loushang.harnesstui.continuity import (
+    DeleteContinuityConfirmation,
+    build_delete_continuity_confirmation_surface,
+)
+from loushang.tui import RenderConstraints, strip_control_sequences
+
+
+def test_delete_confirmation_uses_compact_danger_copy() -> None:
+    target = ContinuityTarget(
+        provider_id="coding.sessions",
+        opaque_id="session-1",
+        revision="1",
+    )
+    view = build_delete_continuity_confirmation_surface(
+        target=target,
+        title="Review the parser",
+    )
+    content = view.content
+
+    assert isinstance(content, DeleteContinuityConfirmation)
+    rendered = strip_control_sequences(
+        "\n".join(
+            line.text
+            for line in content.render(
+                RenderConstraints(width=80, max_height=10)
+            ).lines
+        )
+    )
+    assert view.subtitle == "Permanently delete the selected session"
+    assert "Permanently delete this session?" not in rendered
+    assert "Review the parser" in rendered
+    assert "Enter delete permanently · Esc cancel" in rendered

--- a/tests/harnesstui/continuity/test_surface.py
+++ b/tests/harnesstui/continuity/test_surface.py
@@ -124,6 +124,36 @@ def test_common_resume_view_is_a_real_page_and_renders_loading_first() -> None:
     assert renders
 
 
+def test_continuity_surface_can_exclude_non_selectable_summaries() -> None:
+    hub = _Hub()
+    surface = ContinuitySurface(
+        hub=hub,  # type: ignore[arg-type]
+        request_render=lambda _kind: None,
+        include_summary=lambda _summary: False,
+        selection_action="delete",
+    )
+
+    async def scenario() -> None:
+        await surface.start()
+        assert surface.selected_target is None
+        assert "delete" in surface.footer_help
+        surface.close()
+
+    asyncio.run(scenario())
+
+
+def test_delete_continuity_view_uses_the_delete_surface_purpose() -> None:
+    view = build_continuity_surface_view(
+        hub=_Hub(),  # type: ignore[arg-type]
+        request_render=lambda _kind: None,
+        title="Delete a previous session",
+        selection_action="delete",
+        purpose="delete",
+    )
+
+    assert view.purpose == "delete"
+
+
 def test_common_resume_requeries_after_background_index_rebuild() -> None:
     class _RebuildingHub(_Hub):
         async def query(self, request: ContinuityQuery) -> ContinuityPage:

--- a/tests/harnesstui/conversation/test_projection.py
+++ b/tests/harnesstui/conversation/test_projection.py
@@ -225,6 +225,35 @@ def test_session_event_adapter_routes_structural_events_without_product_types() 
     assert target.last_delta == "part"
 
 
+def test_session_event_adapter_notifies_session_info_changes() -> None:
+    target = RecordingTarget()
+    changed: list[str] = []
+    adapter = SessionConversationEventAdapter(
+        ConversationProjector(target),
+        ToolTranscriptProjectionBinding[dict[str, object], object](
+            neutral_projector=ToolTranscriptProjector(),
+            call_id=lambda _event: "",
+            message_id=lambda _message: "",
+            call_view=lambda _event: ToolCallView(tool_call_id="", tool_name=""),
+            result_view=lambda _event, _snapshot, _tool_call_id: ToolResultView(
+                tool_call_id="",
+                tool_name="",
+                status="ok",
+            ),
+            tool_result_message_view=lambda _message: ToolResultView(
+                tool_call_id="",
+                tool_name="",
+                status="ok",
+            ),
+        ),
+        on_session_info_changed=lambda: changed.append("changed"),
+    )
+
+    adapter.handle({"type": "session_info_changed", "name": "Project Alpha"})
+
+    assert changed == ["changed"]
+
+
 def test_tool_call_snapshot_and_elapsed_time_are_shared_with_target() -> None:
     target = RecordingTarget()
     clock = iter((10.0, 11.0, 12.5)).__next__

--- a/tests/harnesstui/conversation/test_rename.py
+++ b/tests/harnesstui/conversation/test_rename.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from loushang.harnesstui.conversation.rename import (
+    SessionRenameSurface,
+    build_session_rename_surface_view,
+)
+from loushang.tui import InputEvent, RenderConstraints
+
+
+def test_session_rename_surface_edits_and_submits_name() -> None:
+    surface = SessionRenameSurface()
+
+    consumed = surface.handle_input(InputEvent(kind="text", text="Project Alpha"))
+    selected = surface.handle_input(InputEvent(kind="key", key="enter"))
+
+    assert consumed is not None
+    assert consumed.kind == "consumed"
+    assert selected is not None
+    assert selected.kind == "select"
+    assert selected.text == "Project Alpha"
+
+
+def test_session_rename_view_prefills_current_name() -> None:
+    view = build_session_rename_surface_view(current_name="Existing")
+
+    result = view.render(RenderConstraints(width=80, max_height=7))
+
+    assert view.purpose == "rename"
+    assert view.presentation == "bottom-exclusive"
+    assert "Name: Existing" in "\n".join(line.text for line in result.lines)

--- a/tests/harnesstui/surface/test_controller.py
+++ b/tests/harnesstui/surface/test_controller.py
@@ -56,6 +56,7 @@ def _recording_handlers(
             "command",
             "settings",
             "session",
+            "delete",
             "fork",
             "dialog",
             "approval",
@@ -92,6 +93,7 @@ def _recording_handlers(
             "entry-1",
         ),
         ("dialog", InputIntent(kind="dialog_confirm"), "dialog", None),
+        ("delete", InputIntent(kind="dialog_confirm"), "delete", ""),
     ),
 )
 def test_screen_surface_coordinator_routes_submit_intents_by_purpose(

--- a/tests/harnesstui/surface/test_workflow.py
+++ b/tests/harnesstui/surface/test_workflow.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field, replace
+from types import SimpleNamespace
 
 from loushang.harness.commands import CommandDef, CommandKind
+from loushang.harness.continuity import ContinuityTarget
 from loushang.harnesstui.settings.workflow import SettingsApplyResult
 from loushang.harnesstui.status.line import StatusLineSettings
 from loushang.harnesstui.surface.controller import ApprovalSurfaceDecision
@@ -53,6 +55,7 @@ class _State:
     model_values: list[str] = field(default_factory=list)
     approvals: list[ApprovalSurfaceDecision | None] = field(default_factory=list)
     resumed_sessions: list[str] = field(default_factory=list)
+    deleted_sessions: list[str] = field(default_factory=list)
     forked_entries: list[str] = field(default_factory=list)
     renamed_sessions: list[str | None] = field(default_factory=list)
     side_questions: list[str] = field(default_factory=list)
@@ -133,7 +136,11 @@ def _normalize(text: str, command: CommandDef) -> ScreenSurfaceCommand:
     return ScreenSurfaceCommand(kinds[command.name], query)  # type: ignore[arg-type]
 
 
-def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _State]:
+def _workflow(
+    *,
+    state: _State | None = None,
+    workflow_type: type[ScreenSurfaceWorkflow] = ScreenSurfaceWorkflow,
+) -> tuple[ScreenSurfaceWorkflow, _State]:
     state = state or _State()
 
     async def select_model(value: str) -> str:
@@ -168,6 +175,28 @@ def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _S
         state.resumed_sessions.append(reference)
         return f"resumed:{reference}"
 
+    delete_target = ContinuityTarget(
+        provider_id="coding.sessions",
+        opaque_id="session-1",
+        revision="1",
+    )
+
+    def delete_surface() -> ScreenSurfaceView:
+        return ScreenSurfaceView(
+            title="Delete session",
+            purpose="delete",
+            content=SimpleNamespace(
+                selected_target=delete_target,
+                selected_summary=SimpleNamespace(title="Parser review"),
+            ),
+            presentation="bottom-exclusive",
+        )
+
+    async def delete_continuity(target: object) -> str:
+        reference = str(getattr(target, "opaque_id", target))
+        state.deleted_sessions.append(reference)
+        return f"deleted:{reference}"
+
     def fork_surface() -> ScreenSurfaceView:
         return _surface("Fork prompt", "fork")
 
@@ -196,7 +225,7 @@ def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _S
         state.side_questions.append(question)
         return _surface("BTW", "dialog")
 
-    workflow = ScreenSurfaceWorkflow(
+    workflow = workflow_type(
         app=_App(state),
         ports=ScreenSurfaceWorkflowPorts(
             select_model=select_model,
@@ -221,12 +250,18 @@ def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _S
                     else (
                         ScreenSurfaceCommand("rename_session")
                         if text.strip() == "/rename"
-                        else None
+                        else (
+                            ScreenSurfaceCommand("delete_session")
+                            if text.strip() == "/delete"
+                            else None
+                        )
                     )
                 )
             ),
             build_resume_surface=resume_surface,
             activate_continuity=activate_continuity,
+            build_delete_surface=delete_surface,
+            delete_continuity=delete_continuity,
             build_fork_surface=fork_surface,
             fork_session=fork_session,
             build_rename_surface=rename_surface,
@@ -247,6 +282,38 @@ def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _S
         ),
     )
     return workflow, state
+
+
+def test_surface_workflow_confirms_before_deleting_a_continuity_item() -> None:
+    workflow, state = _workflow()
+
+    asyncio.run(workflow.handle_text("/delete"))
+    assert isinstance(workflow.current, ScreenSurfaceView)
+    assert workflow.current.purpose == "delete"
+
+    asyncio.run(workflow.handle_intent(InputIntent(kind="select")))
+    assert isinstance(workflow.current, ScreenSurfaceView)
+    assert workflow.current.title == "Delete session"
+
+    asyncio.run(workflow.handle_intent(InputIntent(kind="dialog_confirm")))
+    assert state.deleted_sessions == ["session-1"]
+    assert state.statuses[-1] == "deleted:session-1"
+    assert isinstance(workflow.current, ScreenSurfaceView)
+    assert workflow.current.purpose == "delete"
+
+
+def test_delete_workflow_does_not_collide_with_a_product_delete_callback() -> None:
+    class _ProductWorkflow(ScreenSurfaceWorkflow):
+        async def _delete_continuity(self, _target: object) -> str:
+            return "product deletion callback"
+
+    workflow, state = _workflow(workflow_type=_ProductWorkflow)
+
+    asyncio.run(workflow.handle_text("/delete"))
+    asyncio.run(workflow.handle_intent(InputIntent(kind="select")))
+    asyncio.run(workflow.handle_intent(InputIntent(kind="dialog_confirm")))
+
+    assert state.deleted_sessions == ["session-1"]
 
 
 def test_surface_workflow_opens_and_submits_session_rename() -> None:

--- a/tests/harnesstui/surface/test_workflow.py
+++ b/tests/harnesstui/surface/test_workflow.py
@@ -54,6 +54,7 @@ class _State:
     approvals: list[ApprovalSurfaceDecision | None] = field(default_factory=list)
     resumed_sessions: list[str] = field(default_factory=list)
     forked_entries: list[str] = field(default_factory=list)
+    renamed_sessions: list[str | None] = field(default_factory=list)
     side_questions: list[str] = field(default_factory=list)
     statusline_visible: list[bool] = field(default_factory=list)
     statusline_settings: list[StatusLineSettings] = field(default_factory=list)
@@ -178,6 +179,13 @@ def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _S
             composer_text="selected prompt",
         )
 
+    def rename_surface() -> ScreenSurfaceView:
+        return _surface("Rename session", "rename")
+
+    async def rename_session(name: str | None) -> str:
+        state.renamed_sessions.append(name)
+        return f"renamed:{name}"
+
     async def decide_approval(
         decision: ApprovalSurfaceDecision | None,
     ) -> bool | None:
@@ -210,13 +218,19 @@ def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _S
                 else (
                     ScreenSurfaceCommand("fork_session")
                     if text.strip() == "/fork"
-                    else None
+                    else (
+                        ScreenSurfaceCommand("rename_session")
+                        if text.strip() == "/rename"
+                        else None
+                    )
                 )
             ),
             build_resume_surface=resume_surface,
             activate_continuity=activate_continuity,
             build_fork_surface=fork_surface,
             fork_session=fork_session,
+            build_rename_surface=rename_surface,
+            rename_session=rename_session,
             build_side_question_surface=side_question_surface,
         ),
         copy=ScreenSurfaceWorkflowCopy(
@@ -233,6 +247,21 @@ def _workflow(*, state: _State | None = None) -> tuple[ScreenSurfaceWorkflow, _S
         ),
     )
     return workflow, state
+
+
+def test_surface_workflow_opens_and_submits_session_rename() -> None:
+    workflow, state = _workflow()
+
+    asyncio.run(workflow.handle_text("/rename"))
+    surface = workflow.current
+    assert isinstance(surface, ScreenSurfaceView)
+    assert surface.purpose == "rename"
+
+    asyncio.run(workflow.handle_intent(InputIntent(kind="select", text="Project Alpha")))
+
+    assert workflow.current is None
+    assert state.renamed_sessions == ["Project Alpha"]
+    assert state.statuses == ["renamed:Project Alpha"]
 
 
 def test_surface_workflow_routes_product_normalized_commands_and_copy() -> None:


### PR DESCRIPTION
## Summary\n- complete /new, /resume, and /delete session lifecycle flows\n- suppress resume hints for empty sessions and repair session indexes incrementally after deletion\n- add delete confirmation and continuity deletion support\n\n## Validation\n- uv --cache-dir .uv-cache run ruff check .\n- 277 focused session, continuity, and TUI tests passed