### PR TITLE
feat(runtime): add safe deferred host handles

### DIFF
--- a/docs/internals/architecture/harness/host-runtime-boundary.md
+++ b/docs/internals/architecture/harness/host-runtime-boundary.md
@@ -60,11 +60,21 @@ needed.
 - legal host state transitions;
 - one-active-run enforcement;
 - run identity tracking;
+- state-based idle notification that does not couple deferred callers to the
+  result or cancellation of the preceding run;
 - delegation to an injected async operation;
 - abort requests and wait-for-idle coordination;
+- host-owned deferred-task settlement during disposal;
 - idempotent disposal;
 - ordered lifecycle event publication;
 - rejection of new work after disposal.
+
+`defer_run_handle()` returns a `HostTaskHandle` for one deferred run. The
+handle exposes its reserved `run_id`, observational `wait()` semantics, and
+runtime-routed cancellation without exposing the underlying task. Its
+`wait()` shields the hosted operation from cancellation of a waiter.
+`defer_run()` continues to return the underlying `asyncio.Task` for accepted
+compatibility callers.
 
 The injected driver still owns the actual task and cancellation mechanics.
 Host Runtime does not inspect prompts, messages, models, tools, diagnostics,

--- a/src/loushang/harness/runtime/__init__.py
+++ b/src/loushang/harness/runtime/__init__.py
@@ -7,7 +7,11 @@ from loushang.harness.runtime.context import (
     BoundProductRuntimeContext,
     UnboundProductRuntimeContext,
 )
-from loushang.harness.runtime.execution import HostRuntime, HostStateError
+from loushang.harness.runtime.execution import (
+    HostRuntime,
+    HostStateError,
+    HostTaskHandle,
+)
 from loushang.harness.runtime.input_queue import HostInputQueue
 from loushang.harness.runtime.navigation import (
     CancellationController,
@@ -105,6 +109,7 @@ __all__ = [
     "HostRuntime",
     "HostSnapshot",
     "HostStateError",
+    "HostTaskHandle",
     "PROMPT_SECTIONS_SLOT",
     "NavigationFailure",
     "NavigationTransactionCoordinator",

--- a/src/loushang/harness/runtime/execution.py
+++ b/src/loushang/harness/runtime/execution.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Generic, TypeVar, cast
 
 from loushang.harness.events import EventListener, OrderedEventBus
@@ -24,6 +25,27 @@ class HostStateError(RuntimeError):
     pass
 
 
+@dataclass(frozen=True, slots=True)
+class HostTaskHandle(Generic[T]):
+    """Address and control one deferred Host run without exposing its task."""
+
+    run_id: str
+    _task: asyncio.Task[T]
+    _cancel: Callable[[], bool]
+
+    def cancel(self) -> bool:
+        return self._cancel()
+
+    async def wait(self) -> T:
+        return await asyncio.shield(self._task)
+
+    def done(self) -> bool:
+        return self._task.done()
+
+    def cancelled(self) -> bool:
+        return self._task.cancelled()
+
+
 class HostRuntime(Generic[T]):
     def __init__(
         self,
@@ -43,9 +65,12 @@ class HostRuntime(Generic[T]):
         self._active_task: asyncio.Task[object] | None = None
         self._abort_requested = False
         self._next_run_id = 1
+        self._idle_event = asyncio.Event()
+        self._idle_event.set()
         self._dispose_lock = asyncio.Lock()
         self._deferred_tasks: set[asyncio.Task[object]] = set()
-        self._deferred_by_key: dict[str, asyncio.Task[object]] = {}
+        self._deferred_by_key: dict[str, HostTaskHandle[object]] = {}
+        self._driver_idle_task: asyncio.Task[None] | None = None
 
     @property
     def status(self) -> HostStatus:
@@ -79,19 +104,29 @@ class HostRuntime(Generic[T]):
         *,
         run_id: str | None = None,
     ) -> T:
+        resolved_run_id = self._reserve_run_id(run_id)
+        return await self._run_resolved(operation, run_id=resolved_run_id)
+
+    async def _run_resolved(
+        self,
+        operation: RunOperation[T],
+        *,
+        run_id: str,
+    ) -> T:
         self._ensure_can_run()
-        resolved_run_id = run_id or f"run-{self._next_run_id}"
-        self._next_run_id += 1
+        self._idle_event.clear()
         self._status = "running"
-        self._active_run_id = resolved_run_id
+        self._active_run_id = run_id
         self._active_task = asyncio.current_task()
         self._abort_requested = False
         try:
-            await self._publish("run_started", run_id=resolved_run_id)
+            await self._publish("run_started", run_id=run_id)
         except (Exception, asyncio.CancelledError):
-            self._status = "idle"
+            if self._status not in {"disposing", "disposed"}:
+                self._status = "idle"
             self._active_run_id = None
             self._active_task = None
+            self._idle_event.set()
             raise
 
         try:
@@ -102,21 +137,21 @@ class HostRuntime(Generic[T]):
             )
             await self._finish_run(
                 event_kind,
-                run_id=resolved_run_id,
+                run_id=run_id,
                 error=type(error).__name__,
             )
             raise
         except Exception as error:
             await self._finish_run(
                 "run_failed",
-                run_id=resolved_run_id,
+                run_id=run_id,
                 error=str(error),
             )
             raise
 
         await self._finish_run(
             "run_aborted" if self._abort_requested else "run_completed",
-            run_id=resolved_run_id,
+            run_id=run_id,
         )
         return result
 
@@ -134,6 +169,18 @@ class HostRuntime(Generic[T]):
         yielding between the idle check and the state transition.
         """
 
+        resolved_run_id = self._reserve_run_id(run_id)
+        return await self._run_after_idle_resolved(
+            operation,
+            run_id=resolved_run_id,
+        )
+
+    async def _run_after_idle_resolved(
+        self,
+        operation: RunOperation[T],
+        *,
+        run_id: str,
+    ) -> T:
         current_task = asyncio.current_task()
         while True:
             active_task = self._active_task
@@ -142,7 +189,7 @@ class HostRuntime(Generic[T]):
                     "cannot run after idle from the active host run"
                 )
             if active_task is not None:
-                await active_task
+                await self._idle_event.wait()
                 continue
 
             if self._status in {"running", "aborting"} or self._driver_is_running():
@@ -152,7 +199,7 @@ class HostRuntime(Generic[T]):
             # There is no await between the final idle check above and the
             # state transition performed by run(), so another asyncio task
             # cannot claim the host in between.
-            return await self.run(operation, run_id=run_id)
+            return await self._run_resolved(operation, run_id=run_id)
 
     def defer_run(
         self,
@@ -169,25 +216,68 @@ class HostRuntime(Generic[T]):
         operations, such as retry and compaction requests for one continuation.
         """
 
+        return self.defer_run_handle(
+            operation,
+            key=key,
+            run_id=run_id,
+        )._task
+
+    def defer_run_handle(
+        self,
+        operation: RunOperation[T],
+        *,
+        key: str | None = None,
+        run_id: str | None = None,
+    ) -> HostTaskHandle[T]:
+        """Schedule a deferred run and return its stable identity and controls."""
+
         if key is not None:
             existing = self._deferred_by_key.get(key)
             if existing is not None:
                 if not existing.done():
-                    return cast(asyncio.Task[T], existing)
+                    return cast(HostTaskHandle[T], existing)
                 self._deferred_by_key.pop(key, None)
 
-        task = asyncio.create_task(self.run_after_idle(operation, run_id=run_id))
+        resolved_run_id = self._reserve_run_id(run_id)
+        task = asyncio.create_task(
+            self._run_after_idle_resolved(
+                operation,
+                run_id=resolved_run_id,
+            )
+        )
         task_object = cast(asyncio.Task[object], task)
+        handle = HostTaskHandle(
+            run_id=resolved_run_id,
+            _task=task,
+            _cancel=lambda: self._cancel_deferred(
+                task_object,
+                run_id=resolved_run_id,
+            ),
+        )
         self._deferred_tasks.add(task_object)
         if key is not None:
-            self._deferred_by_key[key] = task_object
+            self._deferred_by_key[key] = cast(HostTaskHandle[object], handle)
         task.add_done_callback(self._observe_deferred_task)
-        return task
+        return handle
+
+    def _cancel_deferred(
+        self,
+        task: asyncio.Task[object],
+        *,
+        run_id: str,
+    ) -> bool:
+        if task.done():
+            return False
+        if task is self._active_task:
+            if run_id != self._active_run_id:
+                raise HostStateError("active run identity mismatch")
+            return self.abort()
+        return task.cancel()
 
     def _observe_deferred_task(self, task: asyncio.Task[object]) -> None:
         self._deferred_tasks.discard(task)
         for key, pending in tuple(self._deferred_by_key.items()):
-            if pending is task:
+            if pending._task is task:
                 self._deferred_by_key.pop(key, None)
         if not task.cancelled():
             task.exception()
@@ -204,14 +294,16 @@ class HostRuntime(Generic[T]):
         return True
 
     async def wait_for_idle(self) -> None:
-        active_task = self._active_task
         current_task = asyncio.current_task()
-        if active_task is not None and active_task is current_task:
-            raise HostStateError("cannot wait for idle from the active host run")
-        if active_task is not None:
-            await active_task
+        while True:
+            active_task = self._active_task
+            if active_task is None:
+                break
+            if active_task is current_task:
+                raise HostStateError("cannot wait for idle from the active host run")
+            await self._idle_event.wait()
         if self._wait_for_idle_driver is not None:
-            await self._await_driver(self._wait_for_idle_driver)
+            await self._wait_for_external_idle()
         if self._active_task is None and self._status in {"running", "aborting"}:
             self._status = "idle"
             self._active_run_id = None
@@ -224,11 +316,24 @@ class HostRuntime(Generic[T]):
             if self.is_active:
                 self.abort()
             self._status = "disposing"
+            active_task = self._active_task
+            queued_tasks = tuple(
+                task
+                for task in self._deferred_tasks
+                if task is not active_task and not task.done()
+            )
+            for task in queued_tasks:
+                task.cancel()
             await self._publish("host_disposing", run_id=self._active_run_id)
             try:
                 try:
                     await self.wait_for_idle()
                 finally:
+                    if queued_tasks:
+                        await asyncio.gather(
+                            *queued_tasks,
+                            return_exceptions=True,
+                        )
                     if self._dispose_driver is not None:
                         await self._await_driver(self._dispose_driver)
             finally:
@@ -248,7 +353,16 @@ class HostRuntime(Generic[T]):
             self._status = "idle"
         self._active_run_id = None
         self._active_task = None
-        await self._publish(kind, run_id=run_id, error=error)
+        try:
+            await self._publish(kind, run_id=run_id, error=error)
+        finally:
+            if self._active_task is None:
+                self._idle_event.set()
+
+    def _reserve_run_id(self, run_id: str | None) -> str:
+        resolved_run_id = run_id or f"run-{self._next_run_id}"
+        self._next_run_id += 1
+        return resolved_run_id
 
     def _ensure_can_run(self) -> None:
         if self._status in {"disposing", "disposed"}:
@@ -260,6 +374,23 @@ class HostRuntime(Generic[T]):
         return bool(
             self._is_running_driver is not None and self._is_running_driver()
         )
+
+    async def _wait_for_external_idle(self) -> None:
+        callback = self._wait_for_idle_driver
+        if callback is None:
+            return
+        task = self._driver_idle_task
+        if task is None or task.done():
+            task = asyncio.create_task(self._await_driver(callback))
+            self._driver_idle_task = task
+            task.add_done_callback(self._observe_driver_idle_task)
+        await asyncio.shield(task)
+
+    def _observe_driver_idle_task(self, task: asyncio.Task[None]) -> None:
+        if self._driver_idle_task is task:
+            self._driver_idle_task = None
+        if not task.cancelled():
+            task.exception()
 
     async def _publish(
         self,

--- a/tests/harness/runtime/test_execution.py
+++ b/tests/harness/runtime/test_execution.py
@@ -5,7 +5,11 @@ import asyncio
 import pytest
 
 from loushang.harness.events.host import HostLifecycleEvent
-from loushang.harness.runtime.execution import HostRuntime, HostStateError
+from loushang.harness.runtime.execution import (
+    HostRuntime,
+    HostStateError,
+    HostTaskHandle,
+)
 
 
 class ReferenceDriver:
@@ -196,6 +200,300 @@ def test_host_runtime_coalesces_deferred_operations_by_key() -> None:
     asyncio.run(scenario())
 
 
+def test_canceling_deferred_run_does_not_cancel_active_run() -> None:
+    async def scenario() -> None:
+        driver = ReferenceDriver()
+        runtime = _runtime(driver)
+        events: list[HostLifecycleEvent] = []
+        runtime.subscribe(events.append)
+        active = asyncio.create_task(runtime.run(driver.run, run_id="active"))
+        await driver.started.wait()
+
+        deferred = runtime.defer_run(
+            lambda: _async_value("must-not-run"),
+            run_id="queued",
+        )
+        await asyncio.sleep(0)
+
+        assert deferred.cancel() is True
+        with pytest.raises(asyncio.CancelledError):
+            await deferred
+        assert not active.done()
+
+        driver.release.set()
+        assert await active == "reference-result"
+        assert [
+            (event.kind, event.run_id)
+            for event in events
+            if event.kind in {"run_started", "run_completed", "run_failed"}
+        ] == [
+            ("run_started", "active"),
+            ("run_completed", "active"),
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_failed_active_run_does_not_poison_deferred_run() -> None:
+    async def scenario() -> None:
+        runtime: HostRuntime[str] = HostRuntime()
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        calls: list[str] = []
+
+        async def first() -> str:
+            calls.append("first")
+            first_started.set()
+            await release_first.wait()
+            raise ValueError("first failed")
+
+        async def second() -> str:
+            calls.append("second")
+            return "second-ok"
+
+        first_task = runtime.defer_run(first, run_id="first")
+        await first_started.wait()
+        second_task = runtime.defer_run(second, run_id="second")
+        await asyncio.sleep(0)
+        release_first.set()
+
+        with pytest.raises(ValueError, match="first failed"):
+            await first_task
+        assert await second_task == "second-ok"
+        assert calls == ["first", "second"]
+        assert runtime.status == "idle"
+
+    asyncio.run(scenario())
+
+
+def test_canceling_idle_waiter_does_not_cancel_active_run() -> None:
+    async def scenario() -> None:
+        driver = ReferenceDriver()
+        runtime = _runtime(driver)
+        active = asyncio.create_task(runtime.run(driver.run))
+        await driver.started.wait()
+        waiter = asyncio.create_task(runtime.wait_for_idle())
+        await asyncio.sleep(0)
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        assert not active.done()
+
+        driver.release.set()
+        assert await active == "reference-result"
+
+    asyncio.run(scenario())
+
+
+def test_canceling_external_idle_waiter_does_not_cancel_driver_task() -> None:
+    async def scenario() -> None:
+        running = True
+        release = asyncio.Event()
+
+        async def external_run() -> None:
+            nonlocal running
+            try:
+                await release.wait()
+            finally:
+                running = False
+
+        external_task = asyncio.create_task(external_run())
+        runtime: HostRuntime[None] = HostRuntime(
+            wait_for_idle_driver=lambda: external_task,
+            is_running_driver=lambda: running,
+        )
+        waiter = asyncio.create_task(runtime.wait_for_idle())
+        await asyncio.sleep(0)
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        assert not external_task.done()
+
+        release.set()
+        await external_task
+        await runtime.wait_for_idle()
+        assert runtime.status == "idle"
+
+    asyncio.run(scenario())
+
+
+def test_start_listener_failure_releases_deferred_waiters() -> None:
+    async def scenario() -> None:
+        runtime: HostRuntime[str] = HostRuntime()
+        listener_started = asyncio.Event()
+        release_listener = asyncio.Event()
+        fail_once = True
+        calls: list[str] = []
+
+        async def listener(event: HostLifecycleEvent) -> None:
+            nonlocal fail_once
+            if event.kind == "run_started" and fail_once:
+                fail_once = False
+                listener_started.set()
+                await release_listener.wait()
+                raise RuntimeError("listener failure")
+
+        runtime.subscribe(listener)
+
+        async def first() -> str:
+            calls.append("first")
+            return "must-not-run"
+
+        async def second() -> str:
+            calls.append("second")
+            return "second-ok"
+
+        first_task = runtime.defer_run(first, run_id="first")
+        await listener_started.wait()
+        second_task = runtime.defer_run(second, run_id="second")
+        await asyncio.sleep(0)
+        release_listener.set()
+
+        with pytest.raises(RuntimeError, match="listener failure"):
+            await first_task
+        assert await asyncio.wait_for(second_task, timeout=1) == "second-ok"
+        assert calls == ["second"]
+        assert runtime.status == "idle"
+
+    asyncio.run(scenario())
+
+
+def test_deferred_broadcast_wakeups_preserve_single_active_run() -> None:
+    async def scenario() -> None:
+        runtime: HostRuntime[int | None] = HostRuntime()
+        blocker_started = asyncio.Event()
+        release_blocker = asyncio.Event()
+        active_operations = 0
+        max_active_operations = 0
+        calls: list[int] = []
+
+        async def blocker() -> None:
+            blocker_started.set()
+            await release_blocker.wait()
+
+        async def operation(index: int) -> int:
+            nonlocal active_operations, max_active_operations
+            active_operations += 1
+            max_active_operations = max(max_active_operations, active_operations)
+            calls.append(index)
+            try:
+                await asyncio.sleep(0)
+                if index % 7 == 0:
+                    raise ValueError(f"failure-{index}")
+                return index
+            finally:
+                active_operations -= 1
+
+        blocker_task = asyncio.create_task(runtime.run(blocker))
+        await blocker_started.wait()
+        deferred = [
+            runtime.defer_run(lambda index=index: operation(index))
+            for index in range(30)
+        ]
+        await asyncio.sleep(0)
+        release_blocker.set()
+
+        await blocker_task
+        results = await asyncio.gather(*deferred, return_exceptions=True)
+
+        assert sorted(calls) == list(range(30))
+        assert max_active_operations == 1
+        for index, result in enumerate(results):
+            if index % 7 == 0:
+                assert isinstance(result, ValueError)
+            else:
+                assert result == index
+        assert runtime.status == "idle"
+
+    asyncio.run(scenario())
+
+
+def test_host_task_handle_wait_is_observational() -> None:
+    async def scenario() -> None:
+        runtime: HostRuntime[str] = HostRuntime()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def operation() -> str:
+            started.set()
+            await release.wait()
+            return "background-result"
+
+        handle = runtime.defer_run_handle(operation)
+        assert isinstance(handle, HostTaskHandle)
+        await started.wait()
+        waiter = asyncio.create_task(handle.wait())
+        await asyncio.sleep(0)
+
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        assert handle.done() is False
+
+        release.set()
+        assert await handle.wait() == "background-result"
+        assert handle.done() is True
+        assert handle.cancelled() is False
+        assert handle.cancel() is False
+
+    asyncio.run(scenario())
+
+
+def test_host_task_handle_cancel_aborts_only_its_active_run() -> None:
+    async def scenario() -> None:
+        driver = ReferenceDriver()
+        runtime = _runtime(driver)
+        events: list[HostLifecycleEvent] = []
+        runtime.subscribe(events.append)
+        handle = runtime.defer_run_handle(driver.run, run_id="child-round")
+        await driver.started.wait()
+
+        assert handle.run_id == "child-round"
+        assert handle.cancel() is True
+        assert await handle.wait() == "reference-result"
+        await runtime.wait_for_idle()
+
+        assert driver.abort_calls == 1
+        assert handle.cancel() is False
+        assert [event.kind for event in events] == [
+            "run_started",
+            "abort_requested",
+            "run_aborted",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_host_task_handle_coalesces_identity_and_run_id_by_key() -> None:
+    async def scenario() -> None:
+        runtime: HostRuntime[str] = HostRuntime()
+        calls: list[str] = []
+
+        async def operation() -> str:
+            calls.append("continued")
+            return "continued"
+
+        first = runtime.defer_run_handle(
+            operation,
+            key="agent-continue",
+            run_id="original-run",
+        )
+        second = runtime.defer_run_handle(
+            operation,
+            key="agent-continue",
+            run_id="ignored-run",
+        )
+
+        assert first is second
+        assert second.run_id == "original-run"
+        assert await first.wait() == "continued"
+        assert calls == ["continued"]
+
+    asyncio.run(scenario())
+
+
 def test_host_runtime_abort_and_wait_recovers_an_external_driver_run() -> None:
     async def scenario() -> None:
         driver = ReferenceDriver()
@@ -233,6 +531,40 @@ def test_host_runtime_disposes_idempotently_and_rejects_new_runs() -> None:
         assert events[-1].kind == "host_disposed"
         with pytest.raises(HostStateError, match="disposed"):
             await runtime.run(driver.run)
+
+    asyncio.run(scenario())
+
+
+def test_host_runtime_dispose_cancels_queued_deferred_runs() -> None:
+    async def scenario() -> None:
+        driver = ReferenceDriver()
+        runtime = _runtime(driver)
+        queued_calls: list[str] = []
+        active = runtime.defer_run_handle(driver.run, run_id="active")
+        await driver.started.wait()
+
+        async def queued_operation() -> str:
+            queued_calls.append("queued")
+            return "queued-result"
+
+        queued = [
+            runtime.defer_run_handle(
+                queued_operation,
+                run_id=f"queued-{index}",
+            )
+            for index in range(3)
+        ]
+        await asyncio.sleep(0)
+
+        await runtime.dispose()
+
+        assert await active.wait() == "reference-result"
+        for handle in queued:
+            with pytest.raises(asyncio.CancelledError):
+                await handle.wait()
+            assert handle.cancelled() is True
+        assert queued_calls == []
+        assert runtime.is_disposed is True
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary

- add `HostTaskHandle` with a stable `run_id`, runtime-routed cancellation,
  and observational shielded waiting
- replace task-to-task idle waits with Host-owned idle state notification so
  failures and cancellation do not propagate between runs
- shield and coalesce external driver idle waiting
- preserve the existing `defer_run()` Task contract while adding
  `defer_run_handle()`
- cancel and settle queued deferred runs during Host disposal

## Root cause

`run_after_idle()` and `wait_for_idle()` directly awaited the active task.
That coupled deferred waiters to the preceding run in both directions: a
preceding failure poisoned a queued run, while cancelling a queued waiter
could cancel the active foreground run. Waiting for Host idle state instead
of another task's result removes that coupling.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests -q` — 6296 passed,
  7 skipped on the source task branch
- `uv --cache-dir .uv-cache run --extra dev pytest tests/harness/runtime
  tests/coding/test_host_runtime_core_compatibility.py -q` — 79 passed on the
  clean `lane/harness`-based branch
- Ruff — passed
- Mypy — passed
- architecture boundary tests — passed
- `git diff --check` — passed
