### PR TITLE
feat(harness): complete delegated approval lifecycle

### DIFF
--- a/docs/internals/architecture/harness/multiagent/implementation-plan.md
+++ b/docs/internals/architecture/harness/multiagent/implementation-plan.md
@@ -215,7 +215,11 @@ Implementation checkpoint (2026-07-26):
   queue / `continue_run()` path, and interruption/disposal to the existing
   Coding session runtime. It follows the root session's current model and
   provider stream while copying only the role-admitted definitions from
-  Coding's Product tool registry into each child.
+  Coding's Product tool registry into each child. Every child resolver is
+  bound to its incarnation before entering the common authorization Gateway.
+  Root approval presentation and `/permissions` retain that actor provenance;
+  closing a child cancels only its pending requests and ending it revokes only
+  its session grants, without changing Root or sibling approval state.
 - The Harness-owned live `MultiAgentToolPack` is implemented with
   `spawn_agent`, `send_message`, `wait_agent`, `list_agents`,
   `interrupt_agent`, and `close_agent`. Unrestricted Coding CLI sessions bind

--- a/docs/internals/architecture/harness/policy-approval-redesign.md
+++ b/docs/internals/architecture/harness/policy-approval-redesign.md
@@ -1311,6 +1311,16 @@ Exit gate:
 - Add MCP connect/invoke adapters.
 - Add Product-specific detail projectors.
 
+Implementation checkpoint (2026-07-28): the immediate multi-agent slice binds
+each Coding child to its exact `AgentRef` incarnation while retaining the
+Root-owned interactive coordinator. The actor is present on frozen-action,
+policy, approval, and execution audit events, in approval panels, and in
+`/permissions`. Child session close cancels only that actor's pending
+requests; terminal release also revokes only that actor's retained session
+grants. Sibling and Root requests and grants remain live. Approval results
+return through the broker future and never enter the parent model mailbox.
+Extension and MCP work in this batch remains future work.
+
 Exit gate:
 
 - child authority is an intersection, never a union;

--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -26,6 +26,7 @@ from loushang.coding.runtime import AgentSessionRuntime
 from loushang.coding.sandbox import bind_coding_sandbox_runtime
 from loushang.coding.session import AgentSession
 from loushang.coding.session_manager import SessionManager
+from loushang.harness.approval import approval_actor_id
 from loushang.harness.bootstrap import (
     create_standard_resource_bootstrap_runtime,
 )
@@ -37,6 +38,7 @@ from loushang.harness.config.agent import SettingsManager
 from loushang.harness.diagnostics.types import StartupCheckResult
 from loushang.harness.extensions.agent import ExtensionRunner
 from loushang.harness.extensions.context import SessionStartEvent
+from loushang.harness.multiagent import DelegatedExecutionProfile
 from loushang.harness.resources.packages.materializer import (
     GitPackageMaterializerBackend,
     resolve_session_package_install_root,
@@ -196,12 +198,25 @@ def _create_agent_session(
     approval_resolver: InteractiveApprovalResolver | None = None,
     enable_multiagent: bool = False,
     sandbox_workspace_writable: bool = True,
+    delegated_execution_profile: DelegatedExecutionProfile | None = None,
 ) -> AgentSession:
     enable_multiagent_tools = (
         enable_multiagent
         and allowed_tool_names is None
         and normalize_no_tools(no_tools) is None
     )
+    if delegated_execution_profile is not None:
+        if tuple(allowed_tool_names or ()) != delegated_execution_profile.allowed_tools:
+            raise ValueError(
+                "child allowed tools must match its delegated execution profile"
+            )
+        if (
+            approval_actor_id(approval_resolver)
+            != delegated_execution_profile.approval_actor_id
+        ):
+            raise ValueError(
+                "child approval actor must match its delegated execution profile"
+            )
     services = services or create_services()
     multiagent_types = None
     resolved_append_system_prompt = tuple(append_system_prompt or ())
@@ -245,8 +260,13 @@ def _create_agent_session(
             base_exec_service=base_exec_service,
             diagnostics_service=services.diagnostics_service,
             session_id=session_id,
+            execution_profile=(
+                delegated_execution_profile.execution_profile_ceiling
+                if delegated_execution_profile is not None
+                else None
+            ),
         )
-        return AgentSession(
+        child_session = AgentSession(
             agent=agent,
             session_manager=session_manager,
             settings_manager=services.settings_manager,
@@ -271,7 +291,9 @@ def _create_agent_session(
             approval_resolver=approval_resolver,
             capability_runtime=capability_runtime,
             sandbox_runtime=sandbox_runtime,
+            delegated_execution_profile=delegated_execution_profile,
         )
+        return child_session
 
     result = _CODING_AGENT_PRODUCT_CONSTRUCTION.construct(
         services=services,
@@ -556,6 +578,7 @@ def _create_agent_session_runtime(
     approval_resolver: InteractiveApprovalResolver | None = None,
     enable_multiagent: bool = False,
     sandbox_workspace_writable: bool = True,
+    delegated_execution_profile: DelegatedExecutionProfile | None = None,
 ) -> AgentSessionRuntime:
     fixed_services = services if services is not None else create_services()
     return build_agent_product_session_runtime(
@@ -581,6 +604,7 @@ def _create_agent_session_runtime(
                 approval_resolver=approval_resolver,
                 enable_multiagent=enable_multiagent,
                 sandbox_workspace_writable=sandbox_workspace_writable,
+                delegated_execution_profile=delegated_execution_profile,
             )
         ),
         session_cwd=lambda manager: cast(SessionManager, manager).get_cwd(),

--- a/src/loushang/coding/multiagent.py
+++ b/src/loushang/coding/multiagent.py
@@ -19,13 +19,15 @@ from loushang.ai.types import (
 from loushang.coding.policy import InteractiveApprovalResolver
 from loushang.coding.prompt.defaults import DEFAULT_CODING_SYSTEM_PROMPT
 from loushang.coding.runtime import AgentSessionRuntime
+from loushang.coding.sandbox import coding_workspace_execution_profile
 from loushang.coding.session import AgentSession
-from loushang.harness.approval import ActorBoundApprovalResolver
+from loushang.harness.approval import ActorBoundApprovalResolver, DenyApprovalResolver
 from loushang.harness.multiagent import (
     AgentCaller,
     AgentInputMessage,
     AgentTypeRegistry,
     AgentTypeSpec,
+    DelegatedExecutionProfile,
     ForkedHistory,
     ForkTier,
     MultiAgentControl,
@@ -321,6 +323,7 @@ class CodingSubagentFactory(SessionSubagentFactory):
         workspace_lease: WorkspaceLease | None = None
         runtime: AgentSessionRuntime | None = None
         child_approval_resolver: ActorBoundApprovalResolver | None = None
+        delegated_execution_profile: DelegatedExecutionProfile | None = None
         child_cwd = self._cwd
         try:
             if request.agent_type.workspace_mode == "isolated":
@@ -350,13 +353,28 @@ class CodingSubagentFactory(SessionSubagentFactory):
             approval_resolver = (
                 plan.approval_resolver
                 if plan is not None and plan.approval_resolver is not None
-                else self._approval_resolver
+                else self._approval_resolver or DenyApprovalResolver()
             )
-            if approval_resolver is not None:
-                child_approval_resolver = ActorBoundApprovalResolver(
-                    resolver=approval_resolver,
-                    actor_id=str(request.record.ref),
-                )
+            child_approval_resolver = ActorBoundApprovalResolver(
+                resolver=approval_resolver,
+                actor_id=str(request.record.ref),
+            )
+            delegated_execution_profile = DelegatedExecutionProfile(
+                actor_ref=request.record.ref,
+                allowed_tools=allowed_tools,
+                execution_profile_ceiling=coding_workspace_execution_profile(
+                    child_cwd,
+                    writable=_sandbox_workspace_is_writable(
+                        request.agent_type.name
+                    ),
+                ),
+                approval_actor_id=str(request.record.ref),
+                workspace_ref=(
+                    workspace_lease.workspace_ref
+                    if workspace_lease is not None
+                    else None
+                ),
+            )
             runtime = self._runtime_builder(
                 session_dir=self._session_dir,
                 model=model,
@@ -373,6 +391,7 @@ class CodingSubagentFactory(SessionSubagentFactory):
                     request.agent_type.name
                 ),
                 approval_resolver=cast(Any, child_approval_resolver),
+                delegated_execution_profile=delegated_execution_profile,
             )
             session = await runtime.create_session(cwd=str(child_cwd))
             _install_forked_history(session, request)
@@ -397,6 +416,7 @@ class CodingSubagentFactory(SessionSubagentFactory):
             runtime=runtime,
             session=session,
             approval_resolver=child_approval_resolver,
+            delegated_execution_profile=delegated_execution_profile,
             workspace_lease=workspace_lease,
             workspace_leases=self._workspace_leases,
         )
@@ -458,6 +478,7 @@ class _CodingSubagentDriver:
         runtime: AgentSessionRuntime,
         session: AgentSession,
         approval_resolver: ActorBoundApprovalResolver | None = None,
+        delegated_execution_profile: DelegatedExecutionProfile | None = None,
         workspace_lease: WorkspaceLease | None = None,
         workspace_leases: WorkspaceLeasePort | None = None,
     ) -> None:
@@ -471,6 +492,7 @@ class _CodingSubagentDriver:
         self._initial_message: AgentInputMessage | None = None
         self._rounds_started = 0
         self._approval_resolver = approval_resolver
+        self.delegated_execution_profile = delegated_execution_profile
         self._workspace_lease = workspace_lease
         self._workspace_leases = workspace_leases
         self.released_workspace: WorkspaceLeaseSnapshot | None = None

--- a/src/loushang/coding/multiagent.py
+++ b/src/loushang/coding/multiagent.py
@@ -320,6 +320,7 @@ class CodingSubagentFactory(SessionSubagentFactory):
     ) -> SubagentRoundDriver:
         workspace_lease: WorkspaceLease | None = None
         runtime: AgentSessionRuntime | None = None
+        child_approval_resolver: ActorBoundApprovalResolver | None = None
         child_cwd = self._cwd
         try:
             if request.agent_type.workspace_mode == "isolated":
@@ -346,6 +347,16 @@ class CodingSubagentFactory(SessionSubagentFactory):
                 if model_ref is not None
                 else self._default_model_provider()
             )
+            approval_resolver = (
+                plan.approval_resolver
+                if plan is not None and plan.approval_resolver is not None
+                else self._approval_resolver
+            )
+            if approval_resolver is not None:
+                child_approval_resolver = ActorBoundApprovalResolver(
+                    resolver=approval_resolver,
+                    actor_id=str(request.record.ref),
+                )
             runtime = self._runtime_builder(
                 session_dir=self._session_dir,
                 model=model,
@@ -361,32 +372,31 @@ class CodingSubagentFactory(SessionSubagentFactory):
                 sandbox_workspace_writable=_sandbox_workspace_is_writable(
                     request.agent_type.name
                 ),
-                approval_resolver=(
-                    cast(Any, plan.approval_resolver)
-                    if plan is not None
-                    else (
-                        ActorBoundApprovalResolver(
-                            resolver=self._approval_resolver,
-                            actor_id=str(request.record.ref),
-                        )
-                        if self._approval_resolver is not None
-                        else None
-                    )
-                ),
+                approval_resolver=cast(Any, child_approval_resolver),
             )
             session = await runtime.create_session(cwd=str(child_cwd))
             _install_forked_history(session, request)
         except BaseException:
             try:
-                if runtime is not None:
-                    await runtime.dispose_session_runtime()
+                if child_approval_resolver is not None:
+                    child_approval_resolver.end_session(
+                        "Child session creation failed"
+                    )
             finally:
-                if workspace_lease is not None and self._workspace_leases is not None:
-                    await self._workspace_leases.release(workspace_lease)
+                try:
+                    if runtime is not None:
+                        await runtime.dispose_session_runtime()
+                finally:
+                    if (
+                        workspace_lease is not None
+                        and self._workspace_leases is not None
+                    ):
+                        await self._workspace_leases.release(workspace_lease)
             raise
         return _CodingSubagentDriver(
             runtime=runtime,
             session=session,
+            approval_resolver=child_approval_resolver,
             workspace_lease=workspace_lease,
             workspace_leases=self._workspace_leases,
         )
@@ -447,6 +457,7 @@ class _CodingSubagentDriver:
         *,
         runtime: AgentSessionRuntime,
         session: AgentSession,
+        approval_resolver: ActorBoundApprovalResolver | None = None,
         workspace_lease: WorkspaceLease | None = None,
         workspace_leases: WorkspaceLeasePort | None = None,
     ) -> None:
@@ -459,6 +470,7 @@ class _CodingSubagentDriver:
         )
         self._initial_message: AgentInputMessage | None = None
         self._rounds_started = 0
+        self._approval_resolver = approval_resolver
         self._workspace_lease = workspace_lease
         self._workspace_leases = workspace_leases
         self.released_workspace: WorkspaceLeaseSnapshot | None = None
@@ -515,6 +527,8 @@ class _CodingSubagentDriver:
 
     async def dispose(self) -> None:
         runtime_error: Exception | None = None
+        if self._approval_resolver is not None:
+            self._approval_resolver.end_session("Child agent closed")
         try:
             await self._runtime.dispose_session_runtime()
         except Exception as error:

--- a/src/loushang/coding/policy/approval.py
+++ b/src/loushang/coding/policy/approval.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from collections.abc import Mapping
 
 from loushang.harness.approval import (
@@ -18,6 +19,7 @@ from loushang.harness.approval import (
 from loushang.harness.approval import (
     InteractiveApprovalResolver as _InteractiveApprovalResolver,
 )
+from loushang.harness.diagnostics.export import redact_text
 from loushang.harness.tools.workspace.policy import PolicyEnforcementError
 
 
@@ -28,13 +30,35 @@ def _coding_approval_payload(request: ApprovalRequest) -> Mapping[str, object]:
     )
     return {
         **projection,
-        "action": (
-            grant_summary
-            or request.reason
-            or f"Approve {request.tool_name} tool call"
-        ),
+        "action": _approval_action(request),
         "risk": request.reason or "Tool call requires approval",
+        "environment": "local",
+        "grant_summary": grant_summary,
     }
+
+
+def _approval_action(request: ApprovalRequest) -> str:
+    command = request.arguments.get("command")
+    if isinstance(command, str) and command.strip():
+        return _approval_display_text(command)
+    if isinstance(command, (tuple, list)) and command and all(
+        isinstance(part, str) for part in command
+    ):
+        return _approval_display_text(shlex.join(command))
+    path = request.arguments.get("path")
+    if isinstance(path, str) and path.strip():
+        return f"{request.tool_name} {_approval_display_text(path)}"
+    return f"{request.tool_name} tool call"
+
+
+def _approval_display_text(value: str) -> str:
+    redacted = redact_text(value.strip())
+    flattened = " ⏎ ".join(redacted.splitlines())
+    safe = "".join(
+        character if character.isprintable() else "�"
+        for character in flattened
+    )
+    return safe[:2048]
 
 
 class InteractiveApprovalResolver(_InteractiveApprovalResolver):

--- a/src/loushang/coding/sandbox.py
+++ b/src/loushang/coding/sandbox.py
@@ -46,10 +46,9 @@ class CodingSandboxScopePolicy:
         )
         object.__setattr__(self, "_readable_roots", readable_roots)
         object.__setattr__(self, "_writable_roots", writable_roots)
-        ceiling = EffectiveExecutionProfile(
-            readable_roots=readable_roots,
-            writable_roots=writable_roots,
-            network="allowed",
+        ceiling = coding_workspace_execution_profile(
+            root,
+            writable=self.writable_workspace,
         )
         object.__setattr__(
             self,
@@ -103,6 +102,27 @@ def _coding_workspace_roots(
         if writable:
             _append_uncovered_root(writable_roots, metadata_root)
     return tuple(readable), tuple(writable_roots)
+
+
+def coding_workspace_execution_profile(
+    workspace_root: str | Path,
+    *,
+    writable: bool,
+) -> EffectiveExecutionProfile:
+    """Freeze Coding's filesystem/network ceiling for one materialized workspace."""
+
+    root = Path(workspace_root).expanduser().resolve(strict=False)
+    if not root.is_dir():
+        raise NotADirectoryError(20, "Not a directory", str(root))
+    readable_roots, writable_roots = _coding_workspace_roots(
+        root,
+        writable=writable,
+    )
+    return EffectiveExecutionProfile(
+        readable_roots=readable_roots,
+        writable_roots=writable_roots,
+        network="allowed",
+    )
 
 
 def _append_uncovered_root(roots: list[Path], candidate: Path) -> None:
@@ -175,4 +195,8 @@ def bind_coding_sandbox_runtime(
     )
 
 
-__all__ = ["CodingSandboxScopePolicy", "bind_coding_sandbox_runtime"]
+__all__ = [
+    "CodingSandboxScopePolicy",
+    "bind_coding_sandbox_runtime",
+    "coding_workspace_execution_profile",
+]

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -28,6 +28,7 @@ from loushang.harness.events import RuntimeEvent
 from loushang.harness.extensions.agent import ExtensionRunner
 from loushang.harness.extensions.context import SessionStartEvent
 from loushang.harness.model_catalog import ModelCatalog as ModelRegistry
+from loushang.harness.multiagent import DelegatedExecutionProfile
 from loushang.harness.resources.types import ResourceBundle
 from loushang.harness.sandbox import SandboxExecutionRuntime, SandboxStatus
 from loushang.harness.session import AgentProductSession
@@ -92,8 +93,10 @@ class AgentSession(AgentProductSession):
         approval_resolver: InteractiveApprovalResolver | None = None,
         capability_runtime: CapabilityCompositionRuntime | None = None,
         sandbox_runtime: SandboxExecutionRuntime | None = None,
+        delegated_execution_profile: DelegatedExecutionProfile | None = None,
     ) -> None:
         self._sandbox_runtime = sandbox_runtime
+        self.delegated_execution_profile = delegated_execution_profile
         resolved_capability_runtime = (
             capability_runtime
             or bind_capability_composition_runtime(CODING_CAPABILITY_PROFILE)
@@ -128,8 +131,11 @@ class AgentSession(AgentProductSession):
             exec_service=exec_service,
             tool_exec_service=(
                 exec_service
-                if sandbox_runtime is not None
-                and sandbox_runtime.status().state != "disabled"
+                if (
+                    sandbox_runtime is not None
+                    and sandbox_runtime.status().state != "disabled"
+                )
+                or getattr(exec_service, "execution_profile", None) is not None
                 else None
             ),
             approval_resolver=approval_resolver,

--- a/src/loushang/harness/approval.py
+++ b/src/loushang/harness/approval.py
@@ -130,6 +130,13 @@ class ApprovalResolver(Protocol):
     def resolve(self, request: ApprovalRequest) -> MaybeAwaitable[ApprovalDecision]: ...
 
 
+def approval_actor_id(resolver: ApprovalResolver | None) -> str:
+    """Return the stable actor bound to a resolver, defaulting to Root."""
+
+    actor_id = getattr(resolver, "actor_id", None)
+    return actor_id if isinstance(actor_id, str) and actor_id else "root"
+
+
 class ApprovalPresenter(Protocol):
     def present(self, request: ApprovalRequest) -> MaybeAwaitable[None]: ...
 
@@ -207,6 +214,14 @@ class InMemoryApprovalGrantStore:
                 return True
         return False
 
+    def revoke_actor(self, actor_id: str) -> int:
+        """Revoke grants owned by one actor without disturbing its siblings."""
+
+        keys = tuple(key for key in self._grants if key[0] == actor_id)
+        for key in keys:
+            self._grants.pop(key, None)
+        return len(keys)
+
     def clear(self) -> int:
         count = len(self._grants)
         self._grants.clear()
@@ -216,12 +231,18 @@ class InMemoryApprovalGrantStore:
         return tuple(self._grants.values())
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True)
 class ActorBoundApprovalResolver:
-    """Bind requests to one actor before sharing a session resolver."""
+    """Bind requests and approval lifecycle to one child incarnation."""
 
     resolver: ApprovalResolver
     actor_id: str
+    _session_open: bool = field(default=True, init=False, repr=False)
+    _session_close_reason: str = field(
+        default="Child agent closed before approval was resolved",
+        init=False,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         if not isinstance(self.actor_id, str) or not self.actor_id:
@@ -231,13 +252,47 @@ class ActorBoundApprovalResolver:
         self,
         request: ApprovalRequest,
     ) -> MaybeAwaitable[ApprovalDecision | None]:
+        if not self._session_open:
+            return None
         preauthorize = getattr(self.resolver, "preauthorize", None)
         if not callable(preauthorize):
             return None
         return preauthorize(replace(request, actor_id=self.actor_id))
 
     def resolve(self, request: ApprovalRequest) -> MaybeAwaitable[ApprovalDecision]:
+        if not self._session_open:
+            return ApprovalDecision.deny(self._session_close_reason)
         return self.resolver.resolve(replace(request, actor_id=self.actor_id))
+
+    def open_session(self) -> None:
+        """Open only this actor binding; the root owns the shared resolver."""
+
+        self._session_open = True
+
+    def close_session(
+        self,
+        reason: str = "Child agent closed before approval was resolved",
+    ) -> int:
+        """Cancel this actor's pending requests while retaining its grants."""
+
+        self._session_open = False
+        self._session_close_reason = reason
+        cancel_actor = getattr(self.resolver, "cancel_actor", None)
+        if not callable(cancel_actor):
+            return 0
+        return int(cancel_actor(self.actor_id, reason))
+
+    def end_session(
+        self,
+        reason: str = "Child agent closed before approval was resolved",
+    ) -> int:
+        """Release pending requests and retained grants for this incarnation."""
+
+        completed = self.close_session(reason)
+        revoke_actor_grants = getattr(self.resolver, "revoke_actor_grants", None)
+        if callable(revoke_actor_grants):
+            revoke_actor_grants(self.actor_id)
+        return completed
 
 
 @dataclass(frozen=True)
@@ -533,6 +588,22 @@ class ApprovalBroker:
             completed += 1
         return completed
 
+    def cancel_actor(self, actor_id: str, decision: ApprovalDecision) -> int:
+        """Resolve pending requests for one actor without touching siblings."""
+
+        _validate_approval_decision(decision)
+        self._require_loop_if_pending()
+        completed = 0
+        for pending in tuple(self._pending.values()):
+            if (
+                pending.request.actor_id != actor_id
+                or pending.future.done()
+            ):
+                continue
+            pending.future.set_result(decision)
+            completed += 1
+        return completed
+
     def dispose(self, decision: ApprovalDecision) -> int:
         _validate_approval_decision(decision)
         if self._disposed:
@@ -714,6 +785,23 @@ class InteractiveApprovalResolver:
 
     def revoke_grant(self, grant_id: str) -> bool:
         return self.grant_store.revoke(grant_id)
+
+    def cancel_actor(
+        self,
+        actor_id: str,
+        reason: str = "Child agent closed before approval was resolved",
+    ) -> int:
+        """Cancel pending requests owned by one child incarnation."""
+
+        return self._broker.cancel_actor(
+            actor_id,
+            ApprovalDecision.deny(reason),
+        )
+
+    def revoke_actor_grants(self, actor_id: str) -> int:
+        """Revoke retained grants owned by one child incarnation."""
+
+        return self.grant_store.revoke_actor(actor_id)
 
     async def handle_result(
         self,
@@ -943,6 +1031,7 @@ __all__ = [
     "ApprovalRequest",
     "ApprovalRequestCollisionError",
     "ApprovalResolver",
+    "approval_actor_id",
     "DenyApprovalResolver",
     "HeadlessApprovalResolver",
     "InMemoryApprovalGrantStore",

--- a/src/loushang/harness/multiagent/__init__.py
+++ b/src/loushang/harness/multiagent/__init__.py
@@ -13,6 +13,7 @@ from .context import (
     TranscriptWatermark,
 )
 from .control import DefaultAgentAuthorityPolicy, MultiAgentControl
+from .delegation import DelegatedExecutionProfile
 from .executor import (
     ImmediateRecipeExecutor,
     RecipeExecutionError,
@@ -87,6 +88,7 @@ __all__ = [
     "CollaborationRecipe",
     "CollaborationRecipeCatalog",
     "DefaultAgentAuthorityPolicy",
+    "DelegatedExecutionProfile",
     "DeliveryIntent",
     "ForkHistoryDiagnostic",
     "ForkTier",

--- a/src/loushang/harness/multiagent/delegation.py
+++ b/src/loushang/harness/multiagent/delegation.py
@@ -1,0 +1,39 @@
+"""Frozen authority delegated to one technical child incarnation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.harness.authorization import EffectiveExecutionProfile
+
+from .types import AgentRef
+
+
+@dataclass(frozen=True, slots=True)
+class DelegatedExecutionProfile:
+    """The non-widening authority snapshot consumed by one child session."""
+
+    actor_ref: AgentRef
+    allowed_tools: tuple[str, ...]
+    execution_profile_ceiling: EffectiveExecutionProfile
+    approval_actor_id: str
+    workspace_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        tools = tuple(self.allowed_tools)
+        if any(not isinstance(tool, str) or not tool for tool in tools):
+            raise ValueError("allowed_tools must contain non-empty strings")
+        if len(set(tools)) != len(tools):
+            raise ValueError("allowed_tools must not contain duplicates")
+        object.__setattr__(self, "allowed_tools", tools)
+        if not isinstance(self.execution_profile_ceiling, EffectiveExecutionProfile):
+            raise TypeError(
+                "execution_profile_ceiling must be an EffectiveExecutionProfile"
+            )
+        if self.approval_actor_id != str(self.actor_ref):
+            raise ValueError("approval_actor_id must match the child actor incarnation")
+        if self.workspace_ref is not None and not self.workspace_ref.strip():
+            raise ValueError("workspace_ref must be non-empty when provided")
+
+
+__all__ = ["DelegatedExecutionProfile"]

--- a/src/loushang/harness/sandbox/runtime.py
+++ b/src/loushang/harness/sandbox/runtime.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from loushang.harness.authorization import EffectiveExecutionProfile
+from loushang.harness.authorization import (
+    EffectiveExecutionProfile,
+    constrain_execution_profile,
+)
 from loushang.harness.environment import HostEnvironmentProbe
 from loushang.harness.workspace.exec import (
     ExecRequest,
@@ -47,6 +50,17 @@ def bind_sandbox_execution_runtime(
 ) -> SandboxExecutionRuntime:
     """Wrap one existing execution service without creating a bypass path."""
 
+    base_profile = getattr(base_exec_service, "execution_profile", None)
+    if base_profile is not None and not isinstance(
+        base_profile,
+        EffectiveExecutionProfile,
+    ):
+        raise TypeError("base execution profile must be an EffectiveExecutionProfile")
+    effective_profile = (
+        constrain_execution_profile(base_profile, execution_profile)
+        if base_profile is not None and execution_profile is not None
+        else execution_profile or base_profile
+    )
     local_backend = _ExecServiceBackend(base_exec_service)
     binding = bind_sandbox_execution(
         settings=settings,
@@ -60,10 +74,10 @@ def bind_sandbox_execution_runtime(
         binding=binding,
         exec_service=(
             base_exec_service
-            if binding.status().state == "disabled"
+            if binding.status().state == "disabled" and effective_profile is None
             else ExecService(
                 backend=binding.exec_backend,
-                execution_profile=execution_profile,
+                execution_profile=effective_profile,
             )
         ),
     )

--- a/src/loushang/harness/session/composition.py
+++ b/src/loushang/harness/session/composition.py
@@ -592,6 +592,7 @@ def _build_tool_controller(ports: SessionCompositionPorts, diagnostics: SessionD
             if ports.tool_exec_service is not None
             else None
         ),
+        get_approval_resolver=lambda: ports.approval_resolver,
         emit_tool_audit_event=ports.dispatch_event,
         resource_activation_runtime=ports.capability_runtime.resource_runtime,
         prompt_section_composer=ports.capability_runtime.prompt_section_composer,

--- a/src/loushang/harness/session/tool_controller.py
+++ b/src/loushang/harness/session/tool_controller.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 from loushang.agent.types import AgentTool
+from loushang.harness.approval import ApprovalResolver
 from loushang.harness.capabilities.prompt import PromptSectionComposer
 from loushang.harness.diagnostics.service import DiagnosticsService
 from loushang.harness.resources.activation import ResourceActivationRuntime
@@ -73,6 +74,7 @@ class SessionToolController:
         default_factory=PromptSectionComposer
     )
     get_exec_service: Callable[[], ExecService | None] | None = None
+    get_approval_resolver: Callable[[], ApprovalResolver | None] | None = None
     _runtime: SessionToolRuntime = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -147,6 +149,11 @@ class SessionToolController:
             event_sink=(
                 self._emit_tool_audit_event
                 if self.emit_tool_audit_event is not None
+                else None
+            ),
+            approval_resolver=(
+                self.get_approval_resolver()
+                if self.get_approval_resolver is not None
                 else None
             ),
         )

--- a/src/loushang/harness/tools/workspace/authorization.py
+++ b/src/loushang/harness/tools/workspace/authorization.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any, TypeVar, cast
 
-from loushang.harness.approval import ApprovalResolver
+from loushang.harness.approval import ApprovalResolver, approval_actor_id
 from loushang.harness.authorization import (
     EffectiveExecutionProfile,
     ExecutionAuthorizationError,
@@ -42,6 +42,7 @@ class AuthorizedWorkspaceAction:
     arguments: Mapping[str, Any]
     cwd: str | None
     fingerprint: str
+    actor_id: str = "root"
     execution_profile: EffectiveExecutionProfile | None = None
     policy_code: str | None = None
     approval_action_id: str | None = None
@@ -80,6 +81,7 @@ async def _authorize_workspace_tool_action(
         arguments=frozen_arguments,
         cwd=cwd,
         fingerprint=_fingerprint(tool_name, frozen_arguments, cwd),
+        actor_id=approval_actor_id(approval_resolver),
         audit_details=audit_details,
     )
     audit_context = _action_audit_context(
@@ -119,6 +121,7 @@ async def _authorize_workspace_tool_action(
         arguments=action.arguments,
         cwd=action.cwd,
         fingerprint=action.fingerprint,
+        actor_id=action.actor_id,
         execution_profile=effective,
         policy_code=authorization.decision.code,
         approval_action_id=authorization.approval_action_id,
@@ -267,6 +270,7 @@ def _action_audit_context(
     details: dict[str, object] = {
         "tool_name": action.tool_name,
         "action_fingerprint": action.fingerprint,
+        "actor_id": action.actor_id,
         **cast(dict[str, object], _json_value(action.audit_details)),
     }
     if tool_call_id is not None:

--- a/src/loushang/harness/tools/workspace/bash.py
+++ b/src/loushang/harness/tools/workspace/bash.py
@@ -26,7 +26,7 @@ from .authorization import (
     execute_workspace_tool_action,
 )
 from .builtin_renderers import render_bash_call, render_bash_result
-from .context import ToolContextProvider
+from .context import ToolContextProvider, context_approval_resolver
 from .policy import (
     ToolPolicyEvaluator,
     evaluate_legacy_policy_method,
@@ -310,7 +310,10 @@ class _BashToolExecute:
             tool_call_id=tool_call_id,
             exec_request=exec_request,
             arguments=request_params,
-            approval_resolver=self.approval_resolver,
+            approval_resolver=context_approval_resolver(
+                context,
+                self.approval_resolver,
+            ),
             executor=execute,
             on_authorized=on_authorized,
             audit_sink=getattr(context, "event_sink", None),

--- a/src/loushang/harness/tools/workspace/context.py
+++ b/src/loushang/harness/tools/workspace/context.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from typing import Protocol
 
+from loushang.harness.approval import ApprovalResolver
 from loushang.harness.diagnostics.service import DiagnosticsService
 from loushang.harness.workspace.exec import ExecService
 
@@ -19,7 +20,19 @@ class ToolContext:
     model: object | None = None
     event_sink: ToolEventSink | None = None
     exec_service: ExecService | None = None
+    approval_resolver: ApprovalResolver | None = None
 
 
 class ToolContextProvider(Protocol):
     def __call__(self, *, tool_call_id: str) -> ToolContext: ...
+
+
+def context_approval_resolver(
+    context: ToolContext | None,
+    fallback: ApprovalResolver | None,
+) -> ApprovalResolver | None:
+    """Prefer the live session binding over a reusable definition fallback."""
+
+    if context is not None and context.approval_resolver is not None:
+        return context.approval_resolver
+    return fallback

--- a/src/loushang/harness/tools/workspace/edit.py
+++ b/src/loushang/harness/tools/workspace/edit.py
@@ -11,7 +11,7 @@ from loushang.harness.workspace.operations import EditOperations, resolve_operat
 from .authoring import tool
 from .authorization import execute_workspace_tool_action
 from .builtin_renderers import render_edit_call, render_edit_result
-from .context import ToolContext
+from .context import ToolContext, context_approval_resolver
 from .edit_diff import (
     EditEntry,
     apply_text_edits,
@@ -103,7 +103,10 @@ def create_edit_tool_definition(
             arguments={"path": str(resolved), "edits": validated_edits},
             executor=execute_edit,
             cwd=ctx.cwd,
-            approval_resolver=resolved_approval_resolver,
+            approval_resolver=context_approval_resolver(
+                ctx,
+                resolved_approval_resolver,
+            ),
             tool_call_id=ctx.tool_call_id,
             audit_sink=ctx.event_sink,
             execution_profile_ceiling=getattr(

--- a/src/loushang/harness/tools/workspace/factory.py
+++ b/src/loushang/harness/tools/workspace/factory.py
@@ -729,6 +729,9 @@ def _create_context_provider(
             cwd=cwd,
             diagnostics=diagnostics,
             model=model,
+            approval_resolver=(
+                options.approval_resolver if options is not None else None
+            ),
         )
 
     return _context_provider

--- a/src/loushang/harness/tools/workspace/find.py
+++ b/src/loushang/harness/tools/workspace/find.py
@@ -11,7 +11,7 @@ from loushang.harness.workspace.operations import FindOperations, resolve_operat
 
 from .authoring import tool
 from .builtin_renderers import render_find_call, render_find_or_ls_result
-from .context import ToolContext
+from .context import ToolContext, context_approval_resolver
 from .external_tools import (
     ExternalToolDownloader,
     ExternalToolPolicy,
@@ -144,7 +144,10 @@ def create_find_tool_definition(
             tool_name="find",
             arguments={"path": str(resolved_root), "pattern": pattern},
             cwd=ctx.cwd,
-            approval_resolver=resolved_approval_resolver,
+            approval_resolver=context_approval_resolver(
+                ctx,
+                resolved_approval_resolver,
+            ),
             tool_call_id=ctx.tool_call_id,
             audit_sink=ctx.event_sink,
         )

--- a/src/loushang/harness/tools/workspace/grep.py
+++ b/src/loushang/harness/tools/workspace/grep.py
@@ -13,7 +13,7 @@ from loushang.harness.workspace.operations import GrepOperations, resolve_operat
 
 from .authoring import tool
 from .builtin_renderers import render_grep_call, render_grep_result
-from .context import ToolContext
+from .context import ToolContext, context_approval_resolver
 from .external_tools import (
     ExternalToolDownloader,
     ExternalToolPolicy,
@@ -166,7 +166,10 @@ def create_grep_tool_definition(
             tool_name="grep",
             arguments={"path": str(search_path), "pattern": pattern},
             cwd=ctx.cwd,
-            approval_resolver=resolved_approval_resolver,
+            approval_resolver=context_approval_resolver(
+                ctx,
+                resolved_approval_resolver,
+            ),
             tool_call_id=ctx.tool_call_id,
             audit_sink=ctx.event_sink,
         )

--- a/src/loushang/harness/tools/workspace/ls.py
+++ b/src/loushang/harness/tools/workspace/ls.py
@@ -8,7 +8,7 @@ from loushang.harness.workspace.operations import LsOperations, resolve_operatio
 
 from .authoring import tool
 from .builtin_renderers import render_find_or_ls_result, render_ls_call
-from .context import ToolContext
+from .context import ToolContext, context_approval_resolver
 from .normalize import tool_to_definition
 from .operations import (
     normalize_ls_operations,
@@ -89,7 +89,10 @@ def create_ls_tool_definition(
             tool_name="ls",
             arguments={"path": str(resolved)},
             cwd=ctx.cwd,
-            approval_resolver=resolved_approval_resolver,
+            approval_resolver=context_approval_resolver(
+                ctx,
+                resolved_approval_resolver,
+            ),
             tool_call_id=ctx.tool_call_id,
             audit_sink=ctx.event_sink,
         )

--- a/src/loushang/harness/tools/workspace/policy.py
+++ b/src/loushang/harness/tools/workspace/policy.py
@@ -10,6 +10,7 @@ from loushang.harness.approval import (
     ApprovalDecision,
     ApprovalRequest,
     ApprovalResolver,
+    approval_actor_id,
     ensure_approval_action_id,
     find_approval_grant,
     resolve_approval,
@@ -155,6 +156,7 @@ async def enforce_tool_policy(
                 reason=decision.reason,
                 policy_code=decision.code,
                 policy_decision=decision,
+                actor_id=approval_actor_id(approval_resolver),
                 action_fingerprint=(
                     fingerprint if isinstance(fingerprint, str) else None
                 ),

--- a/src/loushang/harness/tools/workspace/read.py
+++ b/src/loushang/harness/tools/workspace/read.py
@@ -12,7 +12,7 @@ from loushang.harness.workspace.operations import ReadOperations, resolve_operat
 from .authoring import tool
 from .authorization import execute_workspace_tool_action
 from .builtin_renderers import render_read_call, render_read_result
-from .context import ToolContext
+from .context import ToolContext, context_approval_resolver
 from .normalize import tool_to_definition
 from .operations import (
     normalize_read_operations,
@@ -146,7 +146,10 @@ def create_read_tool_definition(
             arguments={"path": str(resolved)},
             executor=lambda _action: _read_file_payload(resolved, operations=ops),
             cwd=ctx.cwd,
-            approval_resolver=resolved_approval_resolver,
+            approval_resolver=context_approval_resolver(
+                ctx,
+                resolved_approval_resolver,
+            ),
             tool_call_id=ctx.tool_call_id,
             audit_sink=ctx.event_sink,
             execution_profile_ceiling=getattr(

--- a/src/loushang/harness/tools/workspace/write.py
+++ b/src/loushang/harness/tools/workspace/write.py
@@ -10,7 +10,7 @@ from loushang.harness.workspace.operations import WriteOperations, resolve_opera
 from .authoring import tool
 from .authorization import execute_workspace_tool_action
 from .builtin_renderers import render_write_call, render_write_result
-from .context import ToolContext
+from .context import ToolContext, context_approval_resolver
 from .normalize import tool_to_definition
 from .operations import (
     normalize_write_operations,
@@ -91,7 +91,10 @@ def create_write_tool_definition(
             arguments={"path": str(resolved), "content": content},
             executor=execute_write,
             cwd=ctx.cwd,
-            approval_resolver=resolved_approval_resolver,
+            approval_resolver=context_approval_resolver(
+                ctx,
+                resolved_approval_resolver,
+            ),
             tool_call_id=ctx.tool_call_id,
             audit_sink=ctx.event_sink,
             execution_profile_ceiling=getattr(

--- a/src/loushang/harnesstui/approval/surface.py
+++ b/src/loushang/harnesstui/approval/surface.py
@@ -16,7 +16,10 @@ def build_permissions_surface_view(
         SelectItem(
             label=f"Pending · {permission.capability}",
             value=f"reopen:{permission.permission_id}",
-            description=permission.summary,
+            description=_permission_description(
+                actor_id=permission.actor_id,
+                summary=permission.summary,
+            ),
         )
         for permission in snapshot.pending
     ]
@@ -24,7 +27,10 @@ def build_permissions_surface_view(
         SelectItem(
             label=f"Session · {permission.capability}",
             value=f"revoke:{permission.permission_id}",
-            description=permission.summary,
+            description=_permission_description(
+                actor_id=permission.actor_id,
+                summary=permission.summary,
+            ),
         )
         for permission in snapshot.grants
     )
@@ -43,6 +49,11 @@ def build_permissions_surface_view(
         footer="Enter reopen/revoke · Esc close",
         presentation="page",
     )
+
+
+def _permission_description(*, actor_id: str, summary: str) -> str:
+    requester = "Root" if actor_id == "root" else actor_id
+    return f"{requester} · {summary}"
 
 
 __all__ = ["build_permissions_surface_view"]

--- a/src/loushang/harnesstui/conversation/agent_application.py
+++ b/src/loushang/harnesstui/conversation/agent_application.py
@@ -394,6 +394,9 @@ class AgentScreenApprovalSurface(Protocol):
         action: str,
         risk: str = "",
         requester: str = "",
+        cwd: str = "",
+        environment: str = "",
+        grant_summary: str = "",
         action_id: str | None = None,
         allow_session: bool = False,
     ) -> None: ...
@@ -435,6 +438,9 @@ def bind_agent_screen_approval_presenter(
         action = payload.get("action")
         risk = payload.get("risk")
         actor_id = payload.get("actor_id")
+        cwd = payload.get("cwd")
+        environment = payload.get("environment")
+        grant_summary = payload.get("grant_summary")
         action_id = payload.get("action_id")
         approval_options = payload.get("approval_options")
         allow_session = isinstance(approval_options, (list, tuple)) and (
@@ -444,6 +450,11 @@ def bind_agent_screen_approval_presenter(
             action=action if isinstance(action, str) else default_action,
             risk=risk if isinstance(risk, str) else "",
             requester=actor_id if isinstance(actor_id, str) else "",
+            cwd=cwd if isinstance(cwd, str) else "",
+            environment=environment if isinstance(environment, str) else "",
+            grant_summary=(
+                grant_summary if isinstance(grant_summary, str) else ""
+            ),
             action_id=action_id if isinstance(action_id, str) else None,
             allow_session=allow_session,
         )

--- a/src/loushang/harnesstui/conversation/agent_application.py
+++ b/src/loushang/harnesstui/conversation/agent_application.py
@@ -393,6 +393,7 @@ class AgentScreenApprovalSurface(Protocol):
         *,
         action: str,
         risk: str = "",
+        requester: str = "",
         action_id: str | None = None,
         allow_session: bool = False,
     ) -> None: ...
@@ -433,6 +434,7 @@ def bind_agent_screen_approval_presenter(
     def present(payload: dict[str, object]) -> None:
         action = payload.get("action")
         risk = payload.get("risk")
+        actor_id = payload.get("actor_id")
         action_id = payload.get("action_id")
         approval_options = payload.get("approval_options")
         allow_session = isinstance(approval_options, (list, tuple)) and (
@@ -441,6 +443,7 @@ def bind_agent_screen_approval_presenter(
         surface.open_approval(
             action=action if isinstance(action, str) else default_action,
             risk=risk if isinstance(risk, str) else "",
+            requester=actor_id if isinstance(actor_id, str) else "",
             action_id=action_id if isinstance(action_id, str) else None,
             allow_session=allow_session,
         )

--- a/src/loushang/harnesstui/surface/controller.py
+++ b/src/loushang/harnesstui/surface/controller.py
@@ -167,12 +167,14 @@ class ScreenSurfaceCoordinator:
         *,
         action: str,
         risk: str = "",
+        requester: str = "",
         action_id: str | None = None,
         allow_session: bool = False,
     ) -> None:
         approval = ApprovalSurface(
             action=action,
             risk=risk,
+            requester=requester,
             action_id=action_id,
             allow_session=allow_session,
         )

--- a/src/loushang/harnesstui/surface/controller.py
+++ b/src/loushang/harnesstui/surface/controller.py
@@ -11,6 +11,7 @@ from loushang.tui import (
     Surface,
     SurfaceHandle,
     SurfaceHost,
+    ThemeResolver,
 )
 
 SurfaceEventKind = Literal["surface_submit", "surface_close"]
@@ -27,6 +28,23 @@ SurfaceEventSource = Literal[
     "permissions",
 ]
 SurfaceSubmitHandler = Callable[[Any], Awaitable[None]]
+
+_APPROVAL_SURFACE_THEME = ThemeResolver(
+    defaults={
+        # Keep the primary text terminal-adaptive. Explicit bright yellow/white
+        # has poor contrast on light terminal themes.
+        "approval.title": {"bold": True},
+        "approval.action.label": {"bold": True},
+        "approval.action": {"color": "default", "bold": True},
+        "approval.metadata": {"color": "bright_black", "dim": True},
+        "approval.risk.label": {"color": "red", "bold": True},
+        "approval.risk": {"color": "red"},
+        "approval.choice.allow": {"color": "green"},
+        "approval.choice.session": {"color": "cyan"},
+        "approval.choice.deny": {"color": "red"},
+        "approval.choice.selected": {"bold": True, "reverse": True},
+    }
+)
 
 
 class ScreenSurfaceAppPort(Protocol):
@@ -168,6 +186,9 @@ class ScreenSurfaceCoordinator:
         action: str,
         risk: str = "",
         requester: str = "",
+        cwd: str = "",
+        environment: str = "",
+        grant_summary: str = "",
         action_id: str | None = None,
         allow_session: bool = False,
     ) -> None:
@@ -175,8 +196,12 @@ class ScreenSurfaceCoordinator:
             action=action,
             risk=risk,
             requester=requester,
+            cwd=cwd,
+            environment=environment,
+            grant_summary=grant_summary,
             action_id=action_id,
             allow_session=allow_session,
+            theme=_APPROVAL_SURFACE_THEME,
         )
         current = self.current
         if self._approval_transitioning or (
@@ -225,11 +250,13 @@ class ScreenSurfaceCoordinator:
     def _open_approval(self, approval: ApprovalSurface) -> None:
         self.open(
             ScreenSurfaceView(
-                title="Approval",
+                title="Approval required",
                 purpose="approval",
                 content=approval,
-                footer="",
+                footer="Enter confirm · ↑/↓ select · Esc deny",
                 presentation="bottom-exclusive",
+                theme=_APPROVAL_SURFACE_THEME,
+                title_theme_token="approval.title",
             )
         )
 
@@ -244,6 +271,17 @@ def normalize_surface_intent(
 ) -> SurfaceEvent | None:
     """Convert generic TUI intent into a neutral framed-surface event."""
 
+    if (
+        surface.purpose == "approval"
+        and intent.kind in {"surface_close", "dialog_cancel"}
+    ):
+        # Treat every approval close path as denial so the waiting resolver
+        # always reaches a terminal decision.
+        return _approval_surface_event(
+            surface,
+            approved=False,
+            note=intent.note,
+        )
     if intent.kind in {"surface_close", "dialog_cancel"}:
         return SurfaceEvent(kind="surface_close")
     if surface.purpose == "model" and intent.kind in {"command", "select"}:

--- a/src/loushang/harnesstui/surface/workflow.py
+++ b/src/loushang/harnesstui/surface/workflow.py
@@ -411,6 +411,7 @@ class ScreenSurfaceWorkflow:
         *,
         action: str,
         risk: str = "",
+        requester: str = "",
         action_id: str | None = None,
         allow_session: bool = False,
     ) -> None:
@@ -420,6 +421,7 @@ class ScreenSurfaceWorkflow:
         self.coordinator.present_approval(
             action=action,
             risk=risk,
+            requester=requester,
             action_id=action_id,
             allow_session=allow_session,
         )
@@ -429,12 +431,14 @@ class ScreenSurfaceWorkflow:
         *,
         action: str,
         risk: str = "",
+        requester: str = "",
         action_id: str | None = None,
         allow_session: bool = False,
     ) -> None:
         self.present_approval(
             action=action,
             risk=risk,
+            requester=requester,
             action_id=action_id,
             allow_session=allow_session,
         )

--- a/src/loushang/harnesstui/surface/workflow.py
+++ b/src/loushang/harnesstui/surface/workflow.py
@@ -412,6 +412,9 @@ class ScreenSurfaceWorkflow:
         action: str,
         risk: str = "",
         requester: str = "",
+        cwd: str = "",
+        environment: str = "",
+        grant_summary: str = "",
         action_id: str | None = None,
         allow_session: bool = False,
     ) -> None:
@@ -422,6 +425,9 @@ class ScreenSurfaceWorkflow:
             action=action,
             risk=risk,
             requester=requester,
+            cwd=cwd,
+            environment=environment,
+            grant_summary=grant_summary,
             action_id=action_id,
             allow_session=allow_session,
         )
@@ -432,6 +438,9 @@ class ScreenSurfaceWorkflow:
         action: str,
         risk: str = "",
         requester: str = "",
+        cwd: str = "",
+        environment: str = "",
+        grant_summary: str = "",
         action_id: str | None = None,
         allow_session: bool = False,
     ) -> None:
@@ -439,6 +448,9 @@ class ScreenSurfaceWorkflow:
             action=action,
             risk=risk,
             requester=requester,
+            cwd=cwd,
+            environment=environment,
+            grant_summary=grant_summary,
             action_id=action_id,
             allow_session=allow_session,
         )

--- a/src/loushang/tui/surfaces.py
+++ b/src/loushang/tui/surfaces.py
@@ -386,9 +386,14 @@ class ApprovalSurface:
     action: str
     risk: str = ""
     requester: str = ""
+    cwd: str = ""
+    environment: str = ""
+    grant_summary: str = ""
     action_id: str | None = None
     allow_session: bool = False
     focused: bool = False
+    selected_index: int = 0
+    theme: ThemeResolver | None = None
 
     def focus(self) -> None:
         self.focused = True
@@ -404,26 +409,138 @@ class ApprovalSurface:
         else:
             return None
         if value == "y":
-            return InputIntent(kind="approve", note=self.action_id or "")
+            return self._intent("once")
         if value == "a" and self.allow_session:
-            return InputIntent(kind="approve_session", note=self.action_id or "")
+            return self._intent("session")
         if value == "n":
-            return InputIntent(kind="reject", note=self.action_id or "")
+            return self._intent("deny")
+        choices = self._choices()
+        if value in {"up", "down"}:
+            delta = -1 if value == "up" else 1
+            self.selected_index = (self.selected_index + delta) % len(choices)
+            return InputIntent(kind="consumed", note="approval_selection")
+        if value == "home":
+            self.selected_index = 0
+            return InputIntent(kind="consumed", note="approval_selection")
+        if value == "end":
+            self.selected_index = len(choices) - 1
+            return InputIntent(kind="consumed", note="approval_selection")
+        if value == "enter":
+            return self._intent(choices[self.selected_index][0])
+        if value.isdigit():
+            choice_index = int(value) - 1
+            if 0 <= choice_index < len(choices):
+                return self._intent(choices[choice_index][0])
         if value in {"esc", "escape"}:
-            return InputIntent(kind="surface_close")
+            # An approval is a live execution gate. Merely hiding it would
+            # leave the guarded execution suspended indefinitely.
+            return self._intent("deny")
         return None
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
-        raw_lines = [self.action]
+        raw_lines = [
+            self._styled("Action", "approval.action.label"),
+            self._styled(f"  {self.action}", "approval.action"),
+        ]
         if self.requester:
-            raw_lines.append(f"Requested by {self.requester}")
+            raw_lines.append(
+                self._styled(
+                    f"Requested by {self.requester}",
+                    "approval.metadata",
+                )
+            )
+        if self.environment:
+            raw_lines.append(
+                self._styled(
+                    f"Environment  {self.environment}",
+                    "approval.metadata",
+                )
+            )
+        if self.cwd:
+            raw_lines.append(
+                self._styled(
+                    f"Directory    {self.cwd}",
+                    "approval.metadata",
+                )
+            )
         if self.risk:
-            raw_lines.append(self.risk)
-        choices = "[y] allow once"
-        if self.allow_session:
-            choices += "  [a] allow for session"
-        raw_lines.append(f"{choices}  [n] deny")
+            raw_lines.extend(
+                (
+                    "",
+                    self._styled("Risk", "approval.risk.label"),
+                    self._styled(f"  {self.risk}", "approval.risk"),
+                )
+            )
+        raw_lines.append("")
+        for index, (value, label, shortcut, token) in enumerate(
+            self._choices(),
+            start=1,
+        ):
+            marker = "›" if index - 1 == self.selected_index else " "
+            prefix = f"{marker} {index}. "
+            suffix = f" ({shortcut})"
+            label_width = max(
+                1,
+                autowrap_safe_width(constraints.width)
+                - visible_width(prefix)
+                - visible_width(suffix),
+            )
+            choice = (
+                f"{prefix}{truncate_to_width(label, max_width=label_width)}{suffix}"
+            )
+            raw_lines.append(
+                self._styled_choice(
+                    choice.rstrip(),
+                    token,
+                    selected=index - 1 == self.selected_index,
+                )
+            )
         return _bounded_lines(raw_lines, constraints)
+
+    def _choices(
+        self,
+    ) -> tuple[tuple[str, str, str, str], ...]:
+        choices: list[tuple[str, str, str, str]] = [
+            ("once", "Allow this action once", "y", "approval.choice.allow"),
+        ]
+        if self.allow_session:
+            choices.append(
+                (
+                    "session",
+                    self.grant_summary or "Allow matching actions for this session",
+                    "a",
+                    "approval.choice.session",
+                )
+            )
+        choices.append(("deny", "Deny", "n", "approval.choice.deny"))
+        self.selected_index = max(0, min(self.selected_index, len(choices) - 1))
+        return tuple(choices)
+
+    def _intent(self, value: str) -> InputIntent:
+        kind: InputIntentKind
+        if value == "once":
+            kind = "approve"
+        elif value == "session":
+            kind = "approve_session"
+        else:
+            kind = "reject"
+        return InputIntent(kind=kind, note=self.action_id or "")
+
+    def _styled(self, text: str, token: str) -> str:
+        if self.theme is None:
+            return text
+        return apply_theme_style(text, self.theme.resolve(token))
+
+    def _styled_choice(self, text: str, token: str, *, selected: bool) -> str:
+        if self.theme is None:
+            return text
+        style = self.theme.resolve(token)
+        if selected:
+            style = {
+                **style,
+                **self.theme.resolve("approval.choice.selected"),
+            }
+        return apply_theme_style(text, style)
 
 
 @dataclass(slots=True)

--- a/src/loushang/tui/surfaces.py
+++ b/src/loushang/tui/surfaces.py
@@ -385,6 +385,7 @@ class CommandSurface(SelectionSurface):
 class ApprovalSurface:
     action: str
     risk: str = ""
+    requester: str = ""
     action_id: str | None = None
     allow_session: bool = False
     focused: bool = False
@@ -414,6 +415,8 @@ class ApprovalSurface:
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         raw_lines = [self.action]
+        if self.requester:
+            raw_lines.append(f"Requested by {self.requester}")
         if self.risk:
             raw_lines.append(self.risk)
         choices = "[y] allow once"

--- a/tests/coding/test_approval_compatibility.py
+++ b/tests/coding/test_approval_compatibility.py
@@ -157,13 +157,69 @@ def test_coding_session_approval_presents_the_policy_bounded_scope() -> None:
 
     asyncio.run(run())
 
-    assert payloads[0]["action"] == "Publish main to origin from this repository"
+    assert payloads[0]["action"] == "git push origin main"
     assert payloads[0]["risk"] == "Commits or refs would be published"
+    assert payloads[0]["environment"] == "local"
+    assert (
+        payloads[0]["grant_summary"]
+        == "Publish main to origin from this repository"
+    )
     assert payloads[0]["approval_options"] == (
         "allow_once",
         "allow_session",
         "deny",
     )
+
+
+def test_coding_approval_action_shows_redacted_command_instead_of_repeating_risk() -> (
+    None
+):
+    from loushang.coding.policy import InteractiveApprovalResolver
+    from loushang.harness.approval import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+    )
+
+    presented = asyncio.Event()
+    payloads: list[dict[str, object]] = []
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+
+    def present(payload: dict[str, object]) -> None:
+        payloads.append(payload)
+        presented.set()
+
+    resolver.set_request_presenter(present)
+
+    async def run() -> None:
+        pending = asyncio.create_task(
+            resolver.resolve(
+                ApprovalRequest(
+                    tool_name="bash",
+                    arguments={
+                        "command": (
+                            "curl -H 'Authorization: Bearer secret-token' "
+                            "https://example.com"
+                        )
+                    },
+                    reason="A remote system would be contacted or changed",
+                )
+            )
+        )
+        await presented.wait()
+        action_id = payloads[0]["action_id"]
+        assert isinstance(action_id, str)
+        assert await resolver.handle_result(action_id, approved=False)
+        await pending
+
+    asyncio.run(run())
+
+    assert payloads[0]["action"] == (
+        "curl -H 'Authorization: Bearer [REDACTED]' https://example.com"
+    )
+    assert payloads[0]["risk"] == "A remote system would be contacted or changed"
+    assert "secret-token" not in str(payloads[0]["action"])
 
 
 def test_coding_resolve_approval_uses_harness_result_validation() -> None:

--- a/tests/coding/test_multiagent.py
+++ b/tests/coding/test_multiagent.py
@@ -416,6 +416,8 @@ def test_factory_binds_shared_approval_resolver_to_child_incarnation(
 ) -> None:
     from loushang.harness.approval import (
         ActorBoundApprovalResolver,
+        ApprovalGrantProposal,
+        ApprovalRequest,
         HeadlessApprovalResolver,
         InteractiveApprovalResolver,
     )
@@ -443,12 +445,35 @@ def test_factory_binds_shared_approval_resolver_to_child_incarnation(
     )
 
     driver = asyncio.run(factory.create_driver(request))
-    asyncio.run(driver.dispose())
-
     bound = captured["approval_resolver"]
     assert isinstance(bound, ActorBoundApprovalResolver)
     assert bound.resolver is root_resolver
     assert bound.actor_id == str(request.record.ref)
+    grant = root_resolver.grant_store.issue(
+        ApprovalRequest(
+            tool_name="bash",
+            arguments={"command": "git push origin main"},
+            action_id="child-push",
+            actor_id=bound.actor_id,
+            session_grant=ApprovalGrantProposal(
+                capability="git.publish_refs",
+                constraints=(("remote", "origin"),),
+                summary="Publish non-force refs to origin",
+            ),
+        )
+    )
+
+    asyncio.run(driver.dispose())
+
+    assert root_resolver.grant_store.find(
+        ApprovalRequest(
+            tool_name="bash",
+            arguments={"command": "git push origin main"},
+            action_id="child-push-after-close",
+            actor_id=bound.actor_id,
+            session_grant=grant.proposal,
+        )
+    ) is None
 
 
 def test_coding_recipe_context_is_fresh_read_only_and_role_specific() -> None:

--- a/tests/coding/test_multiagent.py
+++ b/tests/coding/test_multiagent.py
@@ -29,6 +29,7 @@ from loushang.harness.multiagent import (
     AgentPath,
     AgentTypeRegistry,
     AgentTypeSpec,
+    DelegatedExecutionProfile,
     ForkedHistory,
     ForkTier,
     HostCaller,
@@ -449,6 +450,16 @@ def test_factory_binds_shared_approval_resolver_to_child_incarnation(
     assert isinstance(bound, ActorBoundApprovalResolver)
     assert bound.resolver is root_resolver
     assert bound.actor_id == str(request.record.ref)
+    delegated = captured["delegated_execution_profile"]
+    assert isinstance(delegated, DelegatedExecutionProfile)
+    assert delegated.actor_ref == request.record.ref
+    assert delegated.allowed_tools == ("read",)
+    assert delegated.approval_actor_id == bound.actor_id
+    assert delegated.execution_profile_ceiling.readable_roots == (
+        tmp_path.resolve(),
+    )
+    assert delegated.execution_profile_ceiling.writable_roots == ()
+    assert driver.delegated_execution_profile is delegated
     grant = root_resolver.grant_store.issue(
         ApprovalRequest(
             tool_name="bash",
@@ -702,6 +713,12 @@ def test_factory_runs_isolated_types_in_a_lease_and_reports_changes(
 
     assert runtime.create_cwds == [str(isolated)]
     assert captured["sandbox_workspace_writable"] is True
+    delegated = captured["delegated_execution_profile"]
+    assert isinstance(delegated, DelegatedExecutionProfile)
+    assert delegated.workspace_ref == "git-workspace:test"
+    assert delegated.execution_profile_ceiling.writable_roots == (
+        isolated.resolve(),
+    )
     assert workspace.acquired[0].agent_type == "implementation_worker"
     assert workspace.released == 1
 
@@ -753,6 +770,12 @@ def test_factory_runs_shared_write_worker_in_the_exact_parent_worktree(
 
     assert runtime.create_cwds == [str(tmp_path.resolve())]
     assert captured["allowed_tool_names"] == list(spec.allowed_tools)
+    delegated = captured["delegated_execution_profile"]
+    assert isinstance(delegated, DelegatedExecutionProfile)
+    assert delegated.workspace_ref is None
+    assert delegated.execution_profile_ceiling.writable_roots == (
+        tmp_path.resolve(),
+    )
     assert "sharing the parent Coding session's current worktree" in str(
         captured["system_prompt"]
     )

--- a/tests/coding/test_screen_tui_playback_runner.py
+++ b/tests/coding/test_screen_tui_playback_runner.py
@@ -138,6 +138,7 @@ def test_screen_tui_playback_multiagent_scenarios_are_layered() -> None:
         "multiagent-shared-workspace",
         "multiagent-isolated-artifact",
         "multiagent-shared-parallel-writers",
+        "multiagent-child-approval",
         "multiagent-render",
     ]
 
@@ -332,6 +333,14 @@ def test_screen_tui_playback_runner_runs_named_scenario(capsys) -> None:
     assert exit_code == 0
     assert "PASS completion-tab" in captured.out
     assert "long-transcript-input" not in captured.out
+
+
+def test_screen_tui_playback_runner_runs_child_approval_scenario(capsys) -> None:
+    exit_code = run_playback_cli(["multiagent-child-approval"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS multiagent-child-approval" in captured.out
 
 
 def test_screen_tui_playback_runner_runs_tagged_command_scenarios(capsys) -> None:

--- a/tests/coding/test_tool_policy_integration.py
+++ b/tests/coding/test_tool_policy_integration.py
@@ -207,6 +207,63 @@ def test_sync_approval_resolver_can_allow_ask_policy_for_write(tmp_path) -> None
     assert "approved.txt" in str(resolver.requests[0].arguments["path"])
 
 
+def test_live_child_context_overrides_the_root_definition_approval_actor(
+    tmp_path,
+) -> None:
+    from loushang.coding.policy import ApprovalDecision, PolicyEngine
+    from loushang.coding.tool_pack import (
+        register_coding_builtin_tools as register_builtin_tools,
+    )
+    from loushang.harness.approval import (
+        ActorBoundApprovalResolver,
+        HeadlessApprovalResolver,
+    )
+    from loushang.harness.tools.workspace import ToolContext
+    from loushang.harness.tools.workspace.registry import (
+        WorkspaceToolRegistry as ToolRegistry,
+    )
+
+    class AllowingResolver:
+        def __init__(self) -> None:
+            self.requests = []
+
+        def resolve(self, request):
+            self.requests.append(request)
+            return ApprovalDecision.allow()
+
+    child_exit = AllowingResolver()
+    child_resolver = ActorBoundApprovalResolver(
+        resolver=child_exit,
+        actor_id="/root/worker@2",
+    )
+    registry = ToolRegistry()
+    register_builtin_tools(
+        registry,
+        policy_engine=PolicyEngine(ask_tools=["write"]),
+        approval_resolver=HeadlessApprovalResolver(mode="deny"),
+    )
+    runtime_tool = registry.materialize_tool(
+        "write",
+        context_provider=lambda *, tool_call_id: ToolContext(
+            tool_call_id=tool_call_id,
+            cwd=str(tmp_path),
+            approval_resolver=child_resolver,
+        ),
+    )
+
+    asyncio.run(
+        runtime_tool.execute(
+            "call-child-write",
+            {"path": "child.txt", "content": "approved"},
+        )
+    )
+
+    assert (tmp_path / "child.txt").read_text(encoding="utf-8") == "approved"
+    assert [request.actor_id for request in child_exit.requests] == [
+        "/root/worker@2"
+    ]
+
+
 def test_ask_policy_allow_emits_tool_approval_audit_events(tmp_path) -> None:
     from loushang.coding.policy import ApprovalDecision, PolicyEngine
     from loushang.coding.tool_pack import (

--- a/tests/coding/tui_support/scenarios/multiagent.py
+++ b/tests/coding/tui_support/scenarios/multiagent.py
@@ -1866,6 +1866,9 @@ def _child_approval_playback() -> object:
                 action=str(payload.get("action") or "Approve child tool call"),
                 risk=str(payload.get("risk") or ""),
                 requester=str(payload.get("actor_id") or "root"),
+                cwd=str(payload.get("cwd") or ""),
+                environment=str(payload.get("environment") or ""),
+                grant_summary=str(payload.get("grant_summary") or ""),
                 action_id=str(payload["action_id"]),
                 allow_session=isinstance(options, (tuple, list))
                 and "allow_session" in options,
@@ -1941,7 +1944,7 @@ def _child_approval_playback() -> object:
         result = playback.run(
             (0.00, "run child approval\r"),
             (0.10, "a"),
-            (0.25, "n"),
+            (0.25, "\x1b"),
             (0.40, ""),
             handle_prompt=handle_prompt,
             handle_surface_intent=manager.handle_surface_intent,

--- a/tests/coding/tui_support/scenarios/multiagent.py
+++ b/tests/coding/tui_support/scenarios/multiagent.py
@@ -14,7 +14,17 @@ from typing import Any
 
 from loushang.agent.types import AgentToolResult
 from loushang.ai.types import AssistantMessage, TextPart, Usage, UserMessage
-from loushang.coding.multiagent import CodingSubagentFactory, coding_agent_types
+from loushang.coding.multiagent import (
+    CodingSubagentFactory,
+    coding_agent_types,
+)
+from loushang.coding.policy import (
+    HeadlessApprovalResolver,
+    InteractiveApprovalResolver,
+    PolicyEngine,
+)
+from loushang.coding.tool_pack import register_coding_builtin_tools
+from loushang.coding.ui.screen_surfaces import ScreenSurfaceManager
 from loushang.coding.worktree import CodingGitWorktreeLeasePort
 from loushang.harness.multiagent import (
     AgentCaller,
@@ -39,13 +49,18 @@ from loushang.harness.session.multiagent import (
 )
 from loushang.harness.tools.core import ToolDefinition
 from loushang.harness.tools.multiagent import MultiAgentToolPack
+from loushang.harness.tools.workspace import ToolContext
 from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
 from loushang.harness.workspace.exec import ExecRequest, ExecResult, ExecService
 from loushang.harnesstui.multiagent import build_agent_tree_surface_view
+from loushang.harnesstui.status.provider import StatusProvider
 from loushang.tui import PlaybackResult, Surface, strip_control_sequences
 from loushang.tui.playback_suite import PlaybackScenarioSpec
 from loushang.tui.transcript import ToolExecutionRecord
-from tests.coding.tui_support.playback import ScreenTuiScenario
+from tests.coding.tui_support.playback import (
+    ScreenTuiLoopPlayback,
+    ScreenTuiScenario,
+)
 
 _PROMPT = "派生3个子agent，每个计算1到100之间的随机值，主agent计算平均值"
 _PRIOR_PROMPT = "MULTIAGENT_PLAYBACK_PRIOR_PROMPT"
@@ -1642,6 +1657,322 @@ def _render_playback() -> MultiAgentPlaybackResult:
     return asyncio.run(scenario())
 
 
+class _ApprovalPlaybackState:
+    def __init__(self) -> None:
+        self.messages: list[object] = []
+
+    def set_messages(self, messages: list[object]) -> None:
+        self.messages = list(messages)
+
+
+class _ApprovalPlaybackSession:
+    def __init__(
+        self,
+        *,
+        cwd: str,
+        commands: tuple[str, ...],
+        registry: WorkspaceToolRegistry,
+        approval_resolver: object,
+        exec_service: ExecService,
+        audit_events: list[dict[str, object]],
+    ) -> None:
+        self._cwd = cwd
+        self._commands = list(commands)
+        self._registry = registry
+        self._approval_resolver = approval_resolver
+        self._exec_service = exec_service
+        self._audit_events = audit_events
+        self.agent = SimpleNamespace(state=_ApprovalPlaybackState())
+        self.runtime = SimpleNamespace(
+            queue=SimpleNamespace(input_queue=HostInputQueue())
+        )
+
+    async def prompt(self, text: str, *, source: str | None = None) -> None:
+        del source
+        await self._run_command(text)
+
+    async def continue_run(self) -> None:
+        await self._run_command("follow-up")
+
+    def abort(self) -> bool:
+        return True
+
+    async def _run_command(self, prompt: str) -> None:
+        if not self._commands:
+            raise AssertionError("approval playback child has no command left")
+        command = self._commands.pop(0)
+
+        async def emit_event(event: dict[str, object]) -> None:
+            self._audit_events.append(dict(event))
+
+        tool = self._registry.materialize_tool(
+            "bash",
+            context_provider=lambda *, tool_call_id: ToolContext(
+                tool_call_id=tool_call_id,
+                cwd=self._cwd,
+                exec_service=self._exec_service,
+                approval_resolver=self._approval_resolver,
+                event_sink=emit_event,
+            ),
+        )
+        result = await tool.execute(
+            f"approval-playback:{len(self.agent.state.messages)}",
+            {"command": command, "cwd": self._cwd},
+        )
+        self.agent.state.messages.extend(
+            (
+                UserMessage(role="user", content=prompt, timestamp=0),
+                AssistantMessage(
+                    role="assistant",
+                    content=[
+                        TextPart(
+                            type="text",
+                            text=f"{command}: {result.content[0].text}",
+                        )
+                    ],
+                    api="playback",
+                    provider="scripted",
+                    model="approval-child",
+                    response_id=None,
+                    usage=Usage(
+                        input=10,
+                        output=3,
+                        cache_read=0,
+                        cache_write=0,
+                        total_tokens=13,
+                        cost=None,
+                    ),
+                    stop_reason="stop",
+                    error_message=None,
+                    timestamp=0,
+                ),
+            )
+        )
+
+
+class _ApprovalPlaybackRuntime:
+    def __init__(self, session: _ApprovalPlaybackSession) -> None:
+        self._session = session
+        self.disposed = False
+
+    async def create_session(self, *, cwd: str) -> _ApprovalPlaybackSession:
+        assert cwd == self._session._cwd
+        return self._session
+
+    async def dispose_session_runtime(self) -> None:
+        self.disposed = True
+
+
+def _child_approval_playback() -> object:
+    """Exercise a real Coding child factory through the common approval surface."""
+
+    with TemporaryDirectory(
+        prefix="loushang-child-approval-",
+        dir="/tmp",
+    ) as directory:
+        cwd = Path(directory).resolve()
+        playback = ScreenTuiLoopPlayback(
+            width=112,
+            height=22,
+            model_label="playback/child-approval",
+            cwd=str(cwd),
+            branch="lane/harness",
+        )
+        resolver = InteractiveApprovalResolver(
+            fallback=HeadlessApprovalResolver(mode="deny")
+        )
+        audit_events: list[dict[str, object]] = []
+        executed: list[tuple[str, str]] = []
+        profiles: dict[str, object] = {}
+        child_runtimes: list[_ApprovalPlaybackRuntime] = []
+
+        def exec_backend(
+            request: ExecRequest,
+            **_kwargs: object,
+        ) -> ExecResult:
+            command = request.command[-1]
+            executed.append((request.cwd or "", command))
+            return ExecResult(exit_code=0, stdout="published\n")
+
+        root_registry = WorkspaceToolRegistry()
+        register_coding_builtin_tools(
+            root_registry,
+            policy_engine=PolicyEngine(),
+            approval_resolver=resolver,
+            exec_service=ExecService(backend=exec_backend),
+        )
+
+        def build_runtime(**kwargs: object) -> _ApprovalPlaybackRuntime:
+            profile = kwargs["delegated_execution_profile"]
+            actor_id = str(getattr(profile, "actor_ref"))
+            profiles[actor_id] = profile
+            commands = (
+                ("git push origin main", "git push origin release")
+                if "/reusable@" in actor_id
+                else ("git push origin main",)
+            )
+            exec_service = ExecService(
+                backend=exec_backend,
+                execution_profile=getattr(profile, "execution_profile_ceiling"),
+            )
+            session = _ApprovalPlaybackSession(
+                cwd=str(cwd),
+                commands=commands,
+                registry=kwargs["tool_registry"],
+                approval_resolver=kwargs["approval_resolver"],
+                exec_service=exec_service,
+                audit_events=audit_events,
+            )
+            runtime = _ApprovalPlaybackRuntime(session)
+            child_runtimes.append(runtime)
+            return runtime
+
+        factory = CodingSubagentFactory(
+            session_dir=cwd / ".sessions",
+            cwd=cwd,
+            tool_registry=root_registry,
+            runtime_builder=build_runtime,
+            approval_resolver=resolver,
+        )
+        types = coding_agent_types(maximum_children=3)
+        control = MultiAgentControl(agent_types=types)
+        runtime = SessionMultiAgentRuntime(
+            control=control,
+            child_factory=factory,
+        )
+        caller = AgentCaller(control.root_ref)
+        approval_payloads: list[dict[str, object]] = []
+
+        async def on_approval(payload: dict[str, object]) -> bool:
+            action_id = payload.get("action_id")
+            assert isinstance(action_id, str)
+            return await resolver.handle_result(
+                action_id,
+                approved=bool(payload["approved"]),
+                scope=str(payload["scope"]),
+            )
+
+        manager = ScreenSurfaceManager(
+            app=playback.app,
+            session=object(),
+            status_provider=_approval_status_provider(playback.app),
+            on_approval=on_approval,
+        )
+
+        def present(payload: dict[str, object]) -> None:
+            approval_payloads.append(dict(payload))
+            options = payload.get("approval_options")
+            manager.open_approval(
+                action=str(payload.get("action") or "Approve child tool call"),
+                risk=str(payload.get("risk") or ""),
+                requester=str(payload.get("actor_id") or "root"),
+                action_id=str(payload["action_id"]),
+                allow_session=isinstance(options, (tuple, list))
+                and "allow_session" in options,
+            )
+
+        resolver.set_request_presenter(
+            present,
+            dismisser=manager.dismiss_approval,
+        )
+
+        async def handle_prompt(_text: str) -> None:
+            reusable = await runtime.spawn_child(
+                caller=caller,
+                parent_path=AgentPath.root(),
+                name="reusable",
+                agent_type="explorer",
+                initial_prompt="Publish main.",
+            )
+            await runtime.await_completion(
+                caller=caller,
+                target=reusable.path,
+                timeout=2,
+            )
+            await runtime.send_message(
+                caller=caller,
+                target=reusable.path,
+                text="Publish release with the same non-force remote permission.",
+            )
+            await runtime.await_completion(
+                caller=caller,
+                target=reusable.path,
+                timeout=2,
+            )
+            sibling = await runtime.spawn_child(
+                caller=caller,
+                parent_path=AgentPath.root(),
+                name="sibling",
+                agent_type="explorer",
+                initial_prompt="Publish main independently.",
+            )
+            await runtime.await_terminal(
+                caller=caller,
+                target=sibling.path,
+                timeout=2,
+            )
+
+            reusable_actor = str(reusable.ref)
+            sibling_actor = str(sibling.ref)
+            assert [payload.get("actor_id") for payload in approval_payloads] == [
+                reusable_actor,
+                sibling_actor,
+            ]
+            assert len(executed) == 2
+            assert [command for _cwd, command in executed] == [
+                "git push origin main",
+                "git push origin release",
+            ]
+            assert set(profiles) == {reusable_actor, sibling_actor}
+            assert {
+                getattr(profile, "approval_actor_id")
+                for profile in profiles.values()
+            } == {reusable_actor, sibling_actor}
+            grants = resolver.permissions_snapshot().grants
+            assert [(grant.actor_id, grant.capability) for grant in grants] == [
+                (reusable_actor, "git.publish_refs")
+            ]
+
+            await runtime.close_agent(caller=caller, target=reusable.path)
+            assert resolver.permissions_snapshot().grants == ()
+            await runtime.close_agent(caller=caller, target=sibling.path)
+            await runtime.dispose()
+
+        result = playback.run(
+            (0.00, "run child approval\r"),
+            (0.10, "a"),
+            (0.25, "n"),
+            (0.40, ""),
+            handle_prompt=handle_prompt,
+            handle_surface_intent=manager.handle_surface_intent,
+        )
+
+        result.assert_exit_code(0)
+        result.assert_text_contains("Approval")
+        result.assert_text_contains("/root/sibling@1")
+        result.assert_no_clear_screen()
+        assert result.app.active_surface is None
+        assert all(child_runtime.disposed for child_runtime in child_runtimes)
+        assert {
+            event.get("actor_id")
+            for event in audit_events
+            if event.get("type") == "tool_policy_evaluated"
+        } == {"/root/reusable@1", "/root/sibling@1"}
+        return result
+
+
+def _approval_status_provider(app: object) -> StatusProvider:
+    state = getattr(app, "state")
+    return StatusProvider(
+        model_label=state.model_label,
+        cwd=state.cwd,
+        branch=state.branch,
+        session_label=lambda: state.session_label,
+        thinking_level=lambda: None,
+        running=lambda: state.running,
+    )
+
+
 async def _yield_until(predicate: Callable[[], bool]) -> None:
     for _ in range(50):
         if predicate():
@@ -1755,6 +2086,15 @@ MULTIAGENT_SCENARIOS = (
         ),
         run=_shared_parallel_writers_playback,
         tags=("multiagent", "topology", "workspace", "concurrency"),
+    ),
+    PlaybackScenarioSpec(
+        name="multiagent-child-approval",
+        description=(
+            "Replay child-scoped approval presentation, same-child grant reuse, "
+            "sibling isolation, and close-time grant cleanup."
+        ),
+        run=_child_approval_playback,
+        tags=("multiagent", "approval", "surface", "gateway"),
     ),
     PlaybackScenarioSpec(
         name="multiagent-render",

--- a/tests/coding/tui_support/scenarios/surface.py
+++ b/tests/coding/tui_support/scenarios/surface.py
@@ -215,7 +215,7 @@ def _run_model_select_search() -> object:
 
 def _run_approval_surface() -> object:
     return _run_approval_surface_response(
-        input_text="y",
+        input_text="1",
         approved=True,
         scope="once",
         expected_status="Action confirmed: write file",
@@ -224,7 +224,7 @@ def _run_approval_surface() -> object:
 
 def _run_approval_session_surface() -> object:
     return _run_approval_surface_response(
-        input_text="a",
+        input_text="2",
         approved=True,
         scope="session",
         allow_session=True,
@@ -234,10 +234,16 @@ def _run_approval_session_surface() -> object:
 
 def _run_approval_reject_surface() -> object:
     return _run_approval_surface_response(
-        input_text="n",
+        input_text="\x1b",
         approved=False,
         scope="once",
         expected_status="Action rejected",
+        action="rm -rf -- /tmp/approval-test",
+        risk="Filesystem content would be deleted or truncated",
+        requester="/root/deletion_test@3",
+        cwd="/repo",
+        environment="local",
+        action_id="delete:approval-test",
     )
 
 
@@ -310,14 +316,17 @@ def _run_permissions_reopen_and_revoke_surface() -> object:
         requester="/root/reviewer#2",
         action_id="delete-build",
     )
+    # A presenter may be withdrawn while the broker still owns a pending
+    # request (for example during UI reattachment). User Escape is not that
+    # operation: it is an explicit denial.
+    manager.dismiss_approval("delete-build")
     result = playback.run(
-        (0.00, "\x1b"),
-        (0.03, "/permissions\r"),
-        (0.06, "\r"),
-        (0.09, "y"),
-        (0.12, "/permissions\r"),
-        (0.15, "\r"),
-        (0.18, ""),
+        (0.00, "/permissions\r"),
+        (0.03, "\r"),
+        (0.06, "y"),
+        (0.09, "/permissions\r"),
+        (0.12, "\r"),
+        (0.15, ""),
         handle_local=manager.handle_text,
         handle_surface_intent=manager.handle_surface_intent,
         is_local_command=manager.is_local_command,
@@ -353,6 +362,12 @@ def _run_approval_surface_response(
     scope: str,
     expected_status: str,
     allow_session: bool = False,
+    action: str = "write file",
+    risk: str = "Will modify /repo/app.py",
+    requester: str = "",
+    cwd: str = "",
+    environment: str = "",
+    action_id: str = "write:app.py",
 ) -> object:
     playback = ScreenTuiLoopPlayback(
         width=100, height=18, model_label="moonshot/kimi-for-coding"
@@ -364,9 +379,12 @@ def _run_approval_surface_response(
 
     manager = _surface_manager(playback.app, on_approval=on_approval)
     manager.open_approval(
-        action="write file",
-        risk="Will modify /repo/app.py",
-        action_id="write:app.py",
+        action=action,
+        risk=risk,
+        requester=requester,
+        cwd=cwd,
+        environment=environment,
+        action_id=action_id,
         allow_session=allow_session,
     )
 
@@ -379,15 +397,16 @@ def _run_approval_surface_response(
     result.assert_exit_code(0)
     assert approvals == [
         {
-            "action_id": "write:app.py",
-            "action": "write file",
+            "action_id": action_id,
+            "action": action,
             "approved": approved,
             "scope": scope,
-            "raw_note": "write:app.py",
+            "raw_note": action_id,
         }
     ]
     result.assert_text_contains("Approval")
-    result.assert_text_contains("write file")
+    result.assert_text_contains(action)
+    result.assert_text_contains(risk)
     result.assert_text_contains(expected_status)
     result.assert_no_clear_screen()
     assert result.app.active_surface is None

--- a/tests/coding/tui_support/scenarios/surface.py
+++ b/tests/coding/tui_support/scenarios/surface.py
@@ -258,7 +258,7 @@ def _run_permissions_reopen_and_revoke_surface() -> object:
                     ApprovalPermission(
                         kind="pending",
                         permission_id="delete-build",
-                        actor_id="root",
+                        actor_id="/root/reviewer#2",
                         capability="bash",
                         summary="Filesystem content would be deleted",
                     ),
@@ -269,7 +269,7 @@ def _run_permissions_reopen_and_revoke_surface() -> object:
                     ApprovalPermission(
                         kind="grant",
                         permission_id="grant-push",
-                        actor_id="root",
+                        actor_id="/root/implementer#1",
                         capability="git.publish_refs",
                         summary="Publish non-force refs to origin",
                     ),
@@ -285,6 +285,7 @@ def _run_permissions_reopen_and_revoke_surface() -> object:
                 manager.open_approval(
                     action="delete build",
                     risk="Filesystem content would be deleted",
+                    requester="/root/reviewer#2",
                     action_id="delete-build",
                 )
                 return True
@@ -306,6 +307,7 @@ def _run_permissions_reopen_and_revoke_surface() -> object:
     manager.open_approval(
         action="delete build",
         risk="Filesystem content would be deleted",
+        requester="/root/reviewer#2",
         action_id="delete-build",
     )
     result = playback.run(
@@ -337,6 +339,8 @@ def _run_permissions_reopen_and_revoke_surface() -> object:
     ]
     result.assert_text_contains("Permissions")
     result.assert_text_contains("Approval")
+    result.assert_text_contains("/root/reviewer#2")
+    result.assert_text_contains("/root/implementer#1")
     result.assert_text_contains("Publish non-force refs to origin")
     result.assert_no_clear_screen()
     return result

--- a/tests/harness/multiagent/test_delegation.py
+++ b/tests/harness/multiagent/test_delegation.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loushang.harness.authorization import EffectiveExecutionProfile
+from loushang.harness.multiagent import (
+    AgentPath,
+    AgentRef,
+    DelegatedExecutionProfile,
+)
+
+
+def test_delegated_execution_profile_freezes_one_child_incarnation(
+    tmp_path: Path,
+) -> None:
+    actor_ref = AgentRef(AgentPath.root().child("reviewer"), 2)
+    ceiling = EffectiveExecutionProfile(
+        readable_roots=(tmp_path,),
+        network="restricted",
+    )
+
+    profile = DelegatedExecutionProfile(
+        actor_ref=actor_ref,
+        allowed_tools=("read", "grep"),
+        execution_profile_ceiling=ceiling,
+        approval_actor_id=str(actor_ref),
+        workspace_ref="workspace:reviewer-2",
+    )
+
+    assert profile.allowed_tools == ("read", "grep")
+    assert profile.execution_profile_ceiling is ceiling
+    assert profile.approval_actor_id == "/root/reviewer@2"
+
+
+def test_delegated_execution_profile_rejects_widening_identity_or_tools(
+    tmp_path: Path,
+) -> None:
+    actor_ref = AgentRef(AgentPath.root().child("reviewer"), 1)
+    ceiling = EffectiveExecutionProfile(readable_roots=(tmp_path,))
+
+    with pytest.raises(ValueError, match="approval_actor_id"):
+        DelegatedExecutionProfile(
+            actor_ref=actor_ref,
+            allowed_tools=("read",),
+            execution_profile_ceiling=ceiling,
+            approval_actor_id="/root/other@1",
+        )
+    with pytest.raises(ValueError, match="duplicates"):
+        DelegatedExecutionProfile(
+            actor_ref=actor_ref,
+            allowed_tools=("read", "read"),
+            execution_profile_ceiling=ceiling,
+            approval_actor_id=str(actor_ref),
+        )

--- a/tests/harness/sandbox/test_binding.py
+++ b/tests/harness/sandbox/test_binding.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from loushang.harness.authorization import EffectiveExecutionProfile
 from loushang.harness.environment import HostEnvironment, LocalHostEnvironmentProbe
 from loushang.harness.sandbox import (
     SandboxBackendRegistration,
@@ -136,6 +137,37 @@ def test_disabled_runtime_preserves_the_injected_execution_service() -> None:
     assert runtime.status().state == "disabled"
     asyncio.run(runtime.close())
     asyncio.run(runtime.close())
+
+
+def test_disabled_runtime_retains_the_intersected_execution_ceiling(
+    tmp_path: Path,
+) -> None:
+    child_root = tmp_path / "child"
+    child_root.mkdir()
+    base_service = ExecService(
+        execution_profile=EffectiveExecutionProfile(
+            readable_roots=(tmp_path,),
+            writable_roots=(tmp_path,),
+            network="restricted",
+        )
+    )
+
+    runtime = bind_sandbox_execution_runtime(
+        base_exec_service=base_service,
+        execution_profile=EffectiveExecutionProfile(
+            readable_roots=(child_root,),
+            writable_roots=(child_root,),
+            network="allowed",
+        ),
+    )
+
+    assert runtime.exec_service is not base_service
+    assert runtime.exec_service.execution_profile == EffectiveExecutionProfile(
+        readable_roots=(child_root,),
+        writable_roots=(child_root,),
+        network="restricted",
+    )
+    assert runtime.status().state == "disabled"
 
 
 def test_degraded_runtime_falls_back_through_the_injected_execution_service(

--- a/tests/harness/test_approval.py
+++ b/tests/harness/test_approval.py
@@ -1495,3 +1495,107 @@ def test_interactive_approval_can_represent_a_dismissed_pending_request() -> Non
         assert not await resolver.represent_request("delete-build")
 
     asyncio.run(run())
+
+
+def test_actor_bound_resolver_releases_only_its_child_incarnation() -> None:
+    from dataclasses import replace
+
+    from loushang.harness.approval import (
+        ActorBoundApprovalResolver,
+        ApprovalGrantProposal,
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+        resolve_approval,
+    )
+
+    async def run() -> None:
+        presented = asyncio.Event()
+        resolver = InteractiveApprovalResolver(
+            fallback=HeadlessApprovalResolver(mode="deny")
+        )
+        resolver.set_request_presenter(lambda _payload: presented.set())
+        child_a = ActorBoundApprovalResolver(
+            resolver=resolver,
+            actor_id="/root/reviewer-a#1",
+        )
+        child_b = ActorBoundApprovalResolver(
+            resolver=resolver,
+            actor_id="/root/reviewer-b#1",
+        )
+        proposal = ApprovalGrantProposal(
+            capability="git.publish_refs",
+            constraints=(("remote", "origin"),),
+            summary="Publish non-force refs to origin",
+        )
+        request_a = ApprovalRequest(
+            tool_name="bash",
+            arguments={"command": "git push origin main"},
+            action_id="grant-a",
+            session_grant=proposal,
+        )
+        request_b = ApprovalRequest(
+            tool_name="bash",
+            arguments={"command": "git push origin main"},
+            action_id="grant-b",
+            session_grant=proposal,
+        )
+        grant_a = resolver.grant_store.issue(
+            replace(request_a, actor_id=child_a.actor_id)
+        )
+        grant_b = resolver.grant_store.issue(
+            replace(request_b, actor_id=child_b.actor_id)
+        )
+
+        pending_a = asyncio.create_task(
+            resolve_approval(
+                child_a,
+                ApprovalRequest(
+                    tool_name="bash",
+                    arguments={"command": "rm -rf build"},
+                    action_id="pending-a",
+                ),
+            )
+        )
+        await presented.wait()
+        presented.clear()
+        pending_b = asyncio.create_task(
+            resolve_approval(
+                child_b,
+                ApprovalRequest(
+                    tool_name="bash",
+                    arguments={"command": "rm -rf dist"},
+                    action_id="pending-b",
+                ),
+            )
+        )
+        await presented.wait()
+
+        assert child_a.end_session("reviewer-a closed") == 1
+        assert (await pending_a).disposition == "deny"
+        assert (await pending_a).reason == "reviewer-a closed"
+        snapshot = resolver.permissions_snapshot()
+        assert [item.actor_id for item in snapshot.pending] == [child_b.actor_id]
+        assert [item.permission_id for item in snapshot.grants] == [grant_b.grant_id]
+        assert resolver.grant_store.find(
+            replace(request_a, actor_id=child_a.actor_id)
+        ) is None
+        assert resolver.grant_store.find(
+            replace(request_b, actor_id=child_b.actor_id)
+        ) == grant_b
+        assert grant_a.grant_id != grant_b.grant_id
+
+        assert await resolver.handle_result("pending-b", approved=True)
+        assert (await pending_b).disposition == "allow"
+        denied_after_close = await resolve_approval(
+            child_a,
+            ApprovalRequest(
+                tool_name="bash",
+                arguments={"command": "git push origin release"},
+                action_id="late-a",
+            ),
+        )
+        assert denied_after_close.disposition == "deny"
+        assert denied_after_close.reason == "reviewer-a closed"
+
+    asyncio.run(run())

--- a/tests/harness/tools/test_authorization_gateway.py
+++ b/tests/harness/tools/test_authorization_gateway.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from loushang.harness.approval import (
+    ActorBoundApprovalResolver,
     ApprovalDecision,
     HeadlessApprovalResolver,
     InteractiveApprovalResolver,
@@ -258,7 +259,10 @@ def test_workspace_gateway_includes_approval_in_the_same_audit_sequence(
             arguments={"path": str(tmp_path / "notes.txt"), "content": "hello"},
             cwd=str(tmp_path),
             tool_call_id="call-2",
-            approval_resolver=HeadlessApprovalResolver(mode="allow"),
+            approval_resolver=ActorBoundApprovalResolver(
+                resolver=HeadlessApprovalResolver(mode="allow"),
+                actor_id="/root/reviewer#2",
+            ),
             audit_sink=events.append,
             executor=lambda _action: None,
         )
@@ -275,6 +279,7 @@ def test_workspace_gateway_includes_approval_in_the_same_audit_sequence(
     assert events[1]["policy_code"] == "external_effect"
     assert events[2]["action_id"] == events[3]["action_id"]
     assert events[3]["approval_decision"] == "allow"
+    assert {event["actor_id"] for event in events} == {"/root/reviewer#2"}
 
 
 def test_workspace_gateway_reuses_policy_scoped_session_approval(

--- a/tests/harnesstui/approval/test_surface.py
+++ b/tests/harnesstui/approval/test_surface.py
@@ -34,6 +34,12 @@ def test_permissions_surface_reopens_pending_and_revokes_grants() -> None:
 
     assert view.purpose == "permissions"
     assert view.title == "Permissions"
+    assert view.content.items[0].description == (
+        "Root · Filesystem content would be deleted"
+    )
+    assert view.content.items[1].description == (
+        "Root · Publish non-force refs to origin"
+    )
     assert view.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
         kind="select",
         text="reopen:approval-1",
@@ -42,4 +48,24 @@ def test_permissions_surface_reopens_pending_and_revokes_grants() -> None:
     assert view.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
         kind="select",
         text="revoke:grant-1",
+    )
+
+
+def test_permissions_surface_identifies_child_incarnations() -> None:
+    view = build_permissions_surface_view(
+        ApprovalPermissionsSnapshot(
+            pending=(
+                ApprovalPermission(
+                    kind="pending",
+                    permission_id="approval-child",
+                    actor_id="/root/reviewer#2",
+                    capability="bash",
+                    summary="Publish a release",
+                ),
+            ),
+        )
+    )
+
+    assert view.content.items[0].description == (
+        "/root/reviewer#2 · Publish a release"
     )

--- a/tests/harnesstui/conversation/test_agent_application.py
+++ b/tests/harnesstui/conversation/test_agent_application.py
@@ -269,6 +269,9 @@ def test_agent_screen_approval_binding_uses_structural_product_ports() -> None:
             "action": "Approve operation",
             "risk": "",
             "requester": "",
+            "cwd": "",
+            "environment": "",
+            "grant_summary": "",
             "action_id": "approval-1",
             "allow_session": False,
         }
@@ -277,11 +280,17 @@ def test_agent_screen_approval_binding_uses_structural_product_ports() -> None:
         {
             "action_id": "approval-2",
             "actor_id": "/root/reviewer#1",
+            "cwd": "/repo",
+            "environment": "local",
+            "grant_summary": "Publish non-force refs to origin",
             "approval_options": ("allow_once", "allow_session", "deny"),
         }
     )
     assert presented[-1]["allow_session"] is True
     assert presented[-1]["requester"] == "/root/reviewer#1"
+    assert presented[-1]["cwd"] == "/repo"
+    assert presented[-1]["environment"] == "local"
+    assert presented[-1]["grant_summary"] == "Publish non-force refs to origin"
     assert asyncio.run(handle_agent_screen_approval(session, {"approved": True}))
     assert current_agent_runtime_session(runtime, object()) is session
     assert callable(subscriptions[0])

--- a/tests/harnesstui/conversation/test_agent_application.py
+++ b/tests/harnesstui/conversation/test_agent_application.py
@@ -268,6 +268,7 @@ def test_agent_screen_approval_binding_uses_structural_product_ports() -> None:
         {
             "action": "Approve operation",
             "risk": "",
+            "requester": "",
             "action_id": "approval-1",
             "allow_session": False,
         }
@@ -275,10 +276,12 @@ def test_agent_screen_approval_binding_uses_structural_product_ports() -> None:
     session.presenter(  # type: ignore[operator]
         {
             "action_id": "approval-2",
+            "actor_id": "/root/reviewer#1",
             "approval_options": ("allow_once", "allow_session", "deny"),
         }
     )
     assert presented[-1]["allow_session"] is True
+    assert presented[-1]["requester"] == "/root/reviewer#1"
     assert asyncio.run(handle_agent_screen_approval(session, {"approved": True}))
     assert current_agent_runtime_session(runtime, object()) is session
     assert callable(subscriptions[0])

--- a/tests/harnesstui/surface/test_controller.py
+++ b/tests/harnesstui/surface/test_controller.py
@@ -134,7 +134,7 @@ def test_screen_surface_coordinator_closes_non_approval_close_intents() -> None:
 
 
 @pytest.mark.parametrize("intent_kind", ("surface_close", "dialog_cancel"))
-def test_screen_surface_coordinator_dismisses_approval_without_deciding(
+def test_screen_surface_coordinator_treats_approval_close_as_denial(
     intent_kind: str,
 ) -> None:
     decisions: list[ApprovalSurfaceDecision] = []
@@ -154,7 +154,14 @@ def test_screen_surface_coordinator_dismisses_approval_without_deciding(
         coordinator.handle_intent(InputIntent(kind=intent_kind, note="approval-1"))
     )
 
-    assert decisions == []
+    assert decisions == [
+        ApprovalSurfaceDecision(
+            action_id="approval-1",
+            action="delete cache",
+            approved=False,
+            raw_note="approval-1",
+        )
+    ]
     assert coordinator.current is None
 
 

--- a/tests/tui/test_surfaces.py
+++ b/tests/tui/test_surfaces.py
@@ -470,10 +470,15 @@ def test_command_surface_searches_from_typed_text() -> None:
 def test_approval_surface_returns_explicit_approval_or_rejection() -> None:
     surface = ApprovalSurface(action="Run command", risk="writes files")
 
-    assert rendered_text(surface, width=40, height=4) == (
-        "Run command",
-        "writes files",
-        "[y] allow once  [n] deny",
+    assert rendered_text(surface, width=56, height=10) == (
+        "Action",
+        "  Run command",
+        "",
+        "Risk",
+        "  writes files",
+        "",
+        "› 1. Allow this action once (y)",
+        "  2. Deny (n)",
     )
     assert surface.handle_input(InputEvent(kind="key", key="y")) == InputIntent(
         kind="approve"
@@ -482,12 +487,18 @@ def test_approval_surface_returns_explicit_approval_or_rejection() -> None:
         kind="reject"
     )
     assert surface.handle_input(InputEvent(kind="key", key="escape")) == InputIntent(
-        kind="surface_close"
+        kind="reject"
     )
     assert surface.handle_input(InputEvent(kind="text", text="y")) == InputIntent(
         kind="approve"
     )
     assert surface.handle_input(InputEvent(kind="text", text="n")) == InputIntent(
+        kind="reject"
+    )
+    assert surface.handle_input(InputEvent(kind="text", text="1")) == InputIntent(
+        kind="approve"
+    )
+    assert surface.handle_input(InputEvent(kind="text", text="2")) == InputIntent(
         kind="reject"
     )
 
@@ -497,13 +508,22 @@ def test_approval_surface_renders_child_requester_provenance() -> None:
         action="Publish release",
         requester="/root/reviewer#2",
         risk="writes remote refs",
+        cwd="/repo",
+        environment="local",
     )
 
-    assert rendered_text(surface, width=60, height=5) == (
-        "Publish release",
+    assert rendered_text(surface, width=60, height=12) == (
+        "Action",
+        "  Publish release",
         "Requested by /root/reviewer#2",
-        "writes remote refs",
-        "[y] allow once  [n] deny",
+        "Environment  local",
+        "Directory    /repo",
+        "",
+        "Risk",
+        "  writes remote refs",
+        "",
+        "› 1. Allow this action once (y)",
+        "  2. Deny (n)",
     )
 
 
@@ -514,19 +534,121 @@ def test_approval_surface_exposes_session_choice_only_when_policy_admits_it() ->
         action="Publish main to origin",
         action_id="git:push",
         allow_session=True,
+        grant_summary="Allow non-force pushes to origin",
     )
 
-    assert rendered_text(surface, width=80, height=4) == (
-        "Publish main to origin",
-        "[y] allow once  [a] allow for session  [n] deny",
+    assert rendered_text(surface, width=80, height=8) == (
+        "Action",
+        "  Publish main to origin",
+        "",
+        "› 1. Allow this action once (y)",
+        "  2. Allow non-force pushes to origin (a)",
+        "  3. Deny (n)",
     )
     assert surface.handle_input(InputEvent(kind="key", key="a")) == InputIntent(
         kind="approve_session",
         note="git:push",
     )
+    assert surface.handle_input(InputEvent(kind="key", key="2")) == InputIntent(
+        kind="approve_session",
+        note="git:push",
+    )
+    assert surface.handle_input(InputEvent(kind="key", key="3")) == InputIntent(
+        kind="reject",
+        note="git:push",
+    )
     assert ApprovalSurface(action="Delete cache").handle_input(
         InputEvent(kind="key", key="a")
     ) is None
+
+
+def test_approval_surface_supports_arrow_selection_and_enter() -> None:
+    surface = ApprovalSurface(
+        action="Publish main",
+        action_id="git:push",
+        allow_session=True,
+    )
+
+    assert surface.handle_input(InputEvent(kind="key", key="down")) == InputIntent(
+        kind="consumed",
+        note="approval_selection",
+    )
+    assert surface.selected_index == 1
+    assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
+        kind="approve_session",
+        note="git:push",
+    )
+    surface.handle_input(InputEvent(kind="key", key="end"))
+    assert surface.handle_input(InputEvent(kind="key", key="enter")) == InputIntent(
+        kind="reject",
+        note="git:push",
+    )
+
+
+def test_approval_surface_keeps_shortcuts_visible_when_grant_summary_is_long() -> None:
+    surface = ApprovalSurface(
+        action="git push origin main",
+        allow_session=True,
+        grant_summary=(
+            "Allow non-force refs to origin from this repository for this child session"
+        ),
+    )
+
+    lines = rendered_text(surface, width=42, height=8)
+
+    assert lines[4].endswith("(a)")
+    assert len(strip_control_sequences(lines[4])) <= 41
+
+
+def test_approval_surface_applies_semantic_theme_tokens() -> None:
+    surface = ApprovalSurface(
+        action="rm -rf -- /tmp/build",
+        risk="Filesystem content would be deleted",
+        theme=ThemeResolver(
+            defaults={
+                "approval.action.label": {"color": "yellow"},
+                "approval.action": {"color": "white"},
+                "approval.risk.label": {"color": "bright_red", "bold": True},
+                "approval.risk": {"color": "red"},
+                "approval.choice.allow": {"color": "green"},
+                "approval.choice.deny": {"color": "red"},
+                "approval.choice.selected": {"reverse": True, "bold": True},
+            }
+        ),
+    )
+
+    raw = rendered_text(surface, width=64, height=10)
+
+    assert tuple(strip_control_sequences(line) for line in raw)[0:5] == (
+        "Action",
+        "  rm -rf -- /tmp/build",
+        "",
+        "Risk",
+        "  Filesystem content would be deleted",
+    )
+    assert raw[0].startswith("\x1b[33mAction")
+    assert raw[3].startswith("\x1b[1;91mRisk")
+    assert "\x1b[1;7;32m› 1." in raw[6]
+    assert raw[7].startswith("\x1b[31m  2. Deny")
+
+
+def test_approval_primary_text_uses_terminal_adaptive_foreground() -> None:
+    surface = ApprovalSurface(
+        action="rm -r /tmp/approval-test",
+        theme=ThemeResolver(
+            defaults={
+                "approval.action.label": {"bold": True},
+                "approval.action": {"color": "default", "bold": True},
+            }
+        ),
+    )
+
+    raw = rendered_text(surface, width=64, height=6)
+
+    assert raw[0].startswith("\x1b[1mAction")
+    assert raw[1].startswith("\x1b[1;39m  rm -r /tmp/approval-test")
+    assert "\x1b[93m" not in "".join(raw)
+    assert "\x1b[97m" not in "".join(raw)
 
 
 def test_approval_surface_handle_input_carries_action_id() -> None:
@@ -536,6 +658,9 @@ def test_approval_surface_handle_input_carries_action_id() -> None:
         kind="approve", note="cache:delete"
     )
     assert surface.handle_input(InputEvent(kind="key", key="n")) == InputIntent(
+        kind="reject", note="cache:delete"
+    )
+    assert surface.handle_input(InputEvent(kind="key", key="escape")) == InputIntent(
         kind="reject", note="cache:delete"
     )
 

--- a/tests/tui/test_surfaces.py
+++ b/tests/tui/test_surfaces.py
@@ -492,6 +492,21 @@ def test_approval_surface_returns_explicit_approval_or_rejection() -> None:
     )
 
 
+def test_approval_surface_renders_child_requester_provenance() -> None:
+    surface = ApprovalSurface(
+        action="Publish release",
+        requester="/root/reviewer#2",
+        risk="writes remote refs",
+    )
+
+    assert rendered_text(surface, width=60, height=5) == (
+        "Publish release",
+        "Requested by /root/reviewer#2",
+        "writes remote refs",
+        "[y] allow once  [n] deny",
+    )
+
+
 def test_approval_surface_exposes_session_choice_only_when_policy_admits_it() -> (
     None
 ):


### PR DESCRIPTION
## What changed

- close pending child approvals and retained grants with the owning child/session lifecycle
- freeze delegated execution authority through Coding tools and sandbox bindings
- show redacted actions separately from risk, provenance, environment, directory, and bounded session grants
- add numbered choices, keyboard navigation, terminal-adaptive colors, and Escape denial
- extend playback coverage for child approvals, permissions reopening, and Escape denial

## Why

Child approvals could outlive their execution, delegated authority could drift, and Escape closed only the surface while leaving the guarded command waiting forever.

## Validation

- targeted Ruff checks passed
- targeted and playback test suite: 123 passed
- approval-reject-surface, permissions-reopen-revoke-surface, and multiagent-child-approval passed
- git diff --check passed