### PR TITLE
docs(harness): define product and OEM vocabulary

### DIFF
--- a/docs/internals/architecture/architecture-overview.md
+++ b/docs/internals/architecture/architecture-overview.md
@@ -125,6 +125,8 @@ CLI / TUI
 - [Loushang Agent](../glossary/loushang-agent.md)
 - [Loushang Agent Types](../glossary/loushang-agent-types.md)
 - [Loushang Channel Glossary](../glossary/loushang-channel.md)
+- [Loushang Product And OEM Glossary](../glossary/loushang-product.md)
+- [Loushang Product And OEM Chinese Terms](../glossary/loushang-product-zh.md)
 - [Legacy Channel Boundary Protocol](../legacy/loushang-channel-boundary-protocol.md)
 
 ## Next Steps

--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -14,6 +14,9 @@ planning, work event persistence, or AI provider behavior.
 
 ## Documents
 
+- [Product And OEM Glossary](../../glossary/loushang-product.md) defines the
+  canonical Product, OEM, Product Package, Capability Pack, Product Capability
+  Bundle, Plugin, and multi-Product launch vocabulary used by these boundaries.
 - [Refactoring Principles](refactoring-principles.md) defines what may move
   into harness and how migration slices should be shaped.
 - [Shared Capability Boundaries](shared-capability-boundaries.md) maps tools,

--- a/docs/internals/architecture/harness/oem-extension-architecture.md
+++ b/docs/internals/architecture/harness/oem-extension-architecture.md
@@ -8,6 +8,11 @@ This document describes how OEM customisation, extension contributions, and
 harness upgrades interact. It is a cross-cutting design reference, not a
 boundary decision for a single module.
 
+Canonical Product, OEM, package, plugin, and capability terms are defined in
+the [Product And OEM Glossary](../../glossary/loushang-product.md). In
+particular, this draft's older phrase "OEM product" must not be read as a
+synonym for every OEM Package or OEM Profile.
+
 Accepted boundary decisions that inform this document:
 
 - [Shared Capability Boundaries](shared-capability-boundaries.md)

--- a/docs/internals/glossary/loushang-product-zh.md
+++ b/docs/internals/glossary/loushang-product-zh.md
@@ -1,0 +1,145 @@
+# Loushang Product 与 OEM 中文术语对照表
+
+本文档是 [Loushang Product And OEM Glossary](./loushang-product.md) 的中文
+对照表，用于团队讨论、架构评审和实现计划编写。英文术语及完整边界定义以
+`loushang-product.md` 为规范源。
+
+## 核心心智模型
+
+```text
+平台 CLI 或 OEM CLI
+  → 平台宿主
+  → OEM 配置
+  → Product 注册表
+  → Product 路由器
+  → Product 工厂
+  → 每个 Product Session 只有一个活跃 Product Runtime
+       → Product 内核
+       → 已准入的 Capability Pack
+       → 已激活的 Product Capability Bundle
+       → Product 批准的 Plugin 贡献
+```
+
+Harness 提供产品中立机制；Product 提供领域语义、默认值与策略；OEM 选择并
+覆盖多个 Product；Plugin 只能在 Product 和 OEM 准入后贡献可选资源或行为。
+
+## 平台与启动模型
+
+| 英文术语 | 中文术语 | 中文简介 |
+| --- | --- | --- |
+| Platform | 平台 | 可发现、注册并承载一个或多个 Product 的 Loushang 系统；平台本身不是领域 Product。 |
+| Platform Host | 平台宿主 | 进程级组合根，负责 Product 发现、OEM 选择、Product 路由、共享服务和运行时释放。 |
+| Platform CLI | 平台 CLI | 中立的 `loushang` 命令入口，根据显式参数或配置选择 OEM 与 Product。 |
+| OEM CLI | OEM CLI／OEM 品牌命令 | 如 `acme` 的 OEM 品牌入口；调用共享平台启动机制，不复制 Product 启动逻辑。 |
+| Default OEM | 缺省 OEM | 启动请求未指定 OEM 时使用的 OEM Profile。 |
+| Default Product | 缺省 Product | OEM 或平台未收到显式 Product 选择时启动的 Product。 |
+
+`loushang.<OEM>.cli` 可以是某个实现模块路径，但不是架构概念或强制打包规范。
+平台应通过已注册且已信任的描述符加载 OEM，而不是从未校验字符串拼接导入路径。
+
+## Product 模型
+
+| 英文术语 | 中文术语 | 中文简介 |
+| --- | --- | --- |
+| Product | 产品 | 拥有领域目标、语言、Prompt、能力默认值、策略、上下文、Artifact、Session 兼容性和呈现语义的完整领域体验。 |
+| Product Kernel | Product 内核／产品内核 | 不能因 Harness 可复用机制增加而迁出的领域语义与策略。 |
+| Product Adapter | Product 适配器／产品适配器 | 把 Product 内核绑定到 Harness、Agent、Work、Channel、TUI 等共享机制的代码。 |
+| Product Package | Product 包／产品包 | 提供 Product Descriptor、Factory、Adapter 和内置资源的可安装软件分发。 |
+| Product Descriptor | Product 描述符 | 不创建运行时的数据注册记录，至少包含稳定 `product_id`、版本、API 兼容信息和工厂引用。 |
+| Product Factory | Product 工厂 | 根据已准入的平台、OEM、工作区、Channel 和 Session 上下文创建 Product Runtime。 |
+| Product Registry | Product 注册表 | 当前 Platform Host 已准入 Product Descriptor 的确定性目录。 |
+| Product Router | Product 路由器 | 为启动、请求、工作区或持久化 Session 选择已注册 Product 的机制。 |
+| Product Runtime Plan | Product 运行时计划 | Product 声明的能力槽、默认选择、可覆盖来源和配置；不包含 live object 或凭证。 |
+| Resolved Runtime Profile | 已解析运行时配置 | 将 Product、OEM、Extension 和 Session 层确定性合成后的能力选择。 |
+| Product Runtime | Product 运行时 | Product Factory 创建的一个活跃、已绑定执行实例。 |
+| Active Product | 活跃 Product | 拥有当前 Product Session，并解释其输入、上下文、策略、Artifact 和呈现的 Product。 |
+| Product Session | Product 会话 | 由一个 Product 及其 Session schema 和兼容策略拥有的持久或临时交互范围。 |
+| Product Handoff | Product 移交 | 在不同 Product Session 之间显式转交 Work、Artifact 引用或用户意图。 |
+
+一个 Product Session 恰好有一个 Active Product。平台可以同时承载多个 Product，
+但不能在不迁移的情况下把一个 Session 的 `product_id` 原地改成另一个 Product。
+
+## OEM 模型
+
+| 英文术语 | 中文术语 | 中文简介 |
+| --- | --- | --- |
+| OEM | OEM／OEM 配置 | 选择 Product，并覆盖其允许配置、资源、能力、模型、权限、Channel 和品牌呈现的平台配置。 |
+| OEM Package | OEM 包 | 提供 OEM Profile、可选 OEM CLI、资源覆盖、Extension、品牌与 Product 可用策略的可安装分发。 |
+| OEM Profile | OEM 配置描述 | 声明启用的 Product、缺省 Product、Product 覆盖、共享 Extension、品牌、模型和权限策略的数据配置。 |
+| OEM Layer | OEM 层 | 应用到 Product 已声明覆盖点的 OEM 选择或资源；不能修改 Product 封闭的 Capability Slot。 |
+| Multi-Product OEM | 多 Product OEM | 在同一个 Platform Host 中准入并配置多个 Product 的 OEM Profile。 |
+| OEM Product | OEM 自有 Product | 仅指 OEM 确实定义独立 Product 内核与 `product_id` 的情况。 |
+
+OEM 通常不是 Product。一个 OEM Package 可以启用 `coding`、`ppt` 和
+`environmental` 等多个 Product，也可以把 Coding 设为缺省 Product。
+
+## 能力组合模型
+
+| 英文术语 | 中文术语 | 中文简介 |
+| --- | --- | --- |
+| Capability | 能力 | 可命名的运行时或领域关注点，如 Store、Memory、Tool、Command、Deck Renderer 或 Artifact Handler。 |
+| Capability Slot | 能力槽 | Product 声明的能力绑定位置，定义组合形态、生命周期范围、刷新边界和允许来源。 |
+| Capability Pack | 能力包 | 运行时准入后，针对单一能力项类型的有序贡献组；对应代码中的 `CapabilityPack[T]`。 |
+| Product Capability Bundle | Product 能力组合包 | 面向装配或分发、包含多种能力与资源类型的组合，如 `ppt-authoring`。 |
+| Capability Mount | 能力挂载 | Product 在特定运行时范围内激活已准入 Capability Pack 或 Product Capability Bundle 的动作。 |
+
+`CapabilityPack[T]` 不是安装包。它只组合一种 `T`，例如 Tool 或 Command。
+`ppt-authoring` 如果同时包含 Skill、Prompt、Tool、Command、Deck Asset、
+Renderer 和 Artifact Handler，应称为 Product Capability Bundle。
+
+Coding 挂载 `ppt-authoring` 后仍是 Active Product；如果需要 PPT 专属 Canvas、
+Session、Compaction、审批或 Deck 生命周期，应通过 Product Handoff 进入 PPT
+Product。
+
+## Package、Plugin、Extension 与资源模型
+
+| 英文术语 | 中文术语 | 中文简介 |
+| --- | --- | --- |
+| Package | 包（需加限定词） | 架构文档中必须写成 Product Package、OEM Package 或 Resource Package。 |
+| Resource Package | 资源包 | 可安装或物化的 Skill、Prompt、Theme、Extension 和 Product Asset 集合。 |
+| Plugin | 插件 | 可选、可独立启停的资源根或 Extension 贡献来源；受 Product/OEM 信任与激活策略控制。 |
+| Extension | 扩展 | 通过约定扩展面贡献的可执行或声明式行为，如 Tool、Command、Hook、Policy、Renderer 或 Channel Adapter。 |
+| Skill | 技能／Skill | 教给模型专业工作流、领域约定或 Tool 使用方式的指令资源，不代表执行权限。 |
+| Product Asset | Product 素材／产品素材 | 由 Product 解释的领域文件，如模板、布局、品牌包、图片或设计素材。 |
+| Deck Asset | Deck 素材／演示文稿素材 | PPT 领域的 Product Asset，如演示模板、Slide Layout、Master、Theme、Brand Kit 或媒体。 |
+
+Deck Asset 可以来自 PPT Product、OEM 覆盖或 Product Capability Bundle，但不应
+为了复用相对文件路径而被建模成 Skill。
+
+## 启动关系示例
+
+缺省平台启动：
+
+```text
+loushang
+  → 解析 Default OEM
+  → 解析该 OEM 的 Default Product
+  → 创建对应 Product Runtime
+```
+
+OEM 品牌启动 Coding 并挂载 PPT 创作能力：
+
+```text
+acme
+  → 使用 "acme" OEM Profile 启动共享 Platform Host
+  → 选择 "coding" Product
+  → 挂载已准入的 OEM 能力与 ppt-authoring 能力组合包
+```
+
+完整 PPT Product：
+
+```text
+loushang ppt
+  → 选择 "ppt" Product
+  → 创建 PPT Product Session
+```
+
+## 避免混用的术语
+
+| 避免术语 | 应改用 |
+| --- | --- |
+| Product Plugin | Product Package；如果同时实现 Plugin 合约，明确写出两个角色。 |
+| PPT Skill Pack | 仅包含 Skill 时使用；跨 Skill、Tool、素材等类型时用 Product Capability Bundle。 |
+| OEM Product | OEM CLI、OEM Profile、OEM Package、带 OEM Layer 的 Product，或真正拥有独立 `product_id` 的 OEM Product。 |
+| Multi-Product Session | 部署可用性用 Multi-Product OEM；跨 Product 转交用 Product Handoff；真正统一语义时定义新的 Product。 |
+| `loushang.<OEM>.cli` | 这是实现路径；架构术语用 OEM CLI、注册入口和 Platform Host。 |

--- a/docs/internals/glossary/loushang-product.md
+++ b/docs/internals/glossary/loushang-product.md
@@ -1,0 +1,453 @@
+# Loushang Product And OEM Glossary
+
+This glossary defines the canonical Product, OEM, package, plugin, and
+capability-composition terms used by Loushang architecture documents and
+implementations. Use these terms consistently in new Product, Harness, OEM,
+resource, and launch-surface documents.
+
+The glossary defines vocabulary and boundaries. It does not claim that every
+described discovery, registration, or routing mechanism is already implemented.
+Current implementation status belongs in the relevant architecture boundary
+document and code.
+
+For Chinese discussion terms, see the
+[Chinese terminology table](./loushang-product-zh.md).
+
+## Core Mental Model
+
+```text
+Platform CLI or OEM CLI
+  -> Platform Host
+  -> OEM Profile
+  -> Product Registry
+  -> Product Router
+  -> Product Factory
+  -> one active Product Runtime per Product Session
+       -> Product Kernel
+       -> admitted Capability Packs
+       -> activated Product Capability Bundles
+       -> Product-approved Plugin contributions
+```
+
+Harness supplies product-neutral mechanisms. A Product supplies domain
+semantics, defaults, and policy. An OEM selects and overlays Products. Plugins
+contribute optional resources or behavior only after Product and OEM admission.
+
+## Platform And Launch Model
+
+### Platform
+
+The installable and runnable Loushang system that can discover, register, and
+host one or more Products. The Platform is not itself a domain Product.
+
+### Platform Host
+
+The process-level composition root that owns Product discovery, OEM selection,
+Product routing, shared process or tenant services, and runtime disposal.
+
+A Platform Host may expose a CLI, TUI, RPC, web, embedded, or other channel. It
+does not supply Coding, PPT, Research, or other domain semantics.
+
+### Platform CLI
+
+The neutral `loushang` command entry point. It resolves an explicitly selected
+or configured default OEM and Product, then delegates startup through registered
+descriptors and factories.
+
+A Platform CLI should not derive an import path such as
+`loushang.<oem>.cli` from an unvalidated string. Registration and trust precede
+loading.
+
+### OEM CLI
+
+An OEM-branded command entry point, such as `acme`, that starts the same Platform
+Host with a predetermined or selectable OEM Profile.
+
+An OEM CLI is a launch surface, not a separate runtime architecture. It should
+call the shared Platform bootstrap rather than copy Product startup,
+registration, session, or disposal mechanisms.
+
+### Default OEM
+
+The OEM Profile selected when a launch request does not specify an OEM.
+
+A default is configuration, not code ownership. Selecting a Default OEM must
+not make the neutral Platform import one hard-coded OEM module.
+
+### Default Product
+
+The Product selected by an OEM or Platform launch when the user does not
+explicitly choose one.
+
+For example, an OEM may define `coding` as its Default Product while also
+making the `ppt` Product and a `ppt-authoring` Product Capability Bundle
+available.
+
+## Product Model
+
+### Product
+
+A domain-specific Loushang experience with its own goals, language, completion
+criteria, prompts, capability defaults, policy, context behavior, artifact
+semantics, session compatibility, commands, configuration, and presentation.
+
+Examples include Coding, PPT, Research, Design, Cowork, and Environmental.
+
+A Product is not merely a collection of Skills or Tools. It owns the domain
+decisions required to compose those capabilities into a coherent runtime.
+
+### Product Kernel
+
+The irreducible Product-owned semantics and policy that must not migrate into
+Harness merely because another Product could reuse the surrounding mechanism.
+
+The Product Kernel includes domain goals, system-prompt content, capability
+selection, context salience, compaction and summary policy, risk and approval
+defaults, artifact semantics, session compatibility, and Product presentation.
+
+### Product Adapter
+
+The code that binds one Product Kernel to Harness, Agent, Work, Channel, TUI,
+and other shared mechanisms.
+
+A Product Adapter should remain small as shared mechanisms improve, but it must
+retain Product-exclusive semantics and policy.
+
+### Product Package
+
+An installable software distribution that provides a Product Descriptor,
+Product Factory, Product Adapter, and any built-in Product resources.
+
+A Product Package may be first-party or independently distributed. Installation
+does not automatically grant activation or trust. A Product Package is distinct
+from the current resource-oriented Package and Plugin abstractions.
+
+### Product Descriptor
+
+The data-only registration record for one Product. It identifies the Product
+and its compatibility boundary without constructing a live runtime.
+
+A Product Descriptor should include at least a stable `product_id`, display
+name, Product version, supported Product API version, factory reference, and
+declared compatibility or host requirements.
+
+### Product Factory
+
+The Product-supplied factory that creates a Product Runtime from an admitted
+Platform, OEM, workspace, channel, and session context.
+
+The factory owns Product assembly. Product discovery and Product selection do
+not construct live Product services as side effects.
+
+### Product Registry
+
+The deterministic catalog of admitted Product Descriptors available to one
+Platform Host.
+
+The Product Registry rejects ambiguous Product identities and does not choose a
+default Product. Discovery populates the registry; OEM policy filters it; the
+Product Router selects from it.
+
+### Product Router
+
+The Platform or OEM mechanism that selects a registered Product for a launch,
+request, workspace, or persisted session.
+
+When restoring a session, the persisted `product_id` is authoritative unless an
+explicit migration is performed. Routing must not silently reinterpret one
+Product's session as another Product.
+
+### Product Runtime Plan
+
+The Product-owned, data-only declaration of runtime capability slots, baseline
+selections, allowed override sources, and configuration.
+
+A Product Runtime Plan does not contain factories, credentials, plugin
+discovery, or live objects.
+
+### Resolved Runtime Profile
+
+The deterministic result of applying admitted Product, OEM, extension, and
+session layers to a Product Runtime Plan.
+
+Its durable snapshot explains which capability implementations and
+configuration were used by a Product Session.
+
+### Product Runtime
+
+One live, bound execution of a Product for a specific lifecycle scope. It is
+created by a Product Factory from a Resolved Runtime Profile and admitted
+resources and services.
+
+A Product Runtime is not a global singleton. Process- or tenant-scoped services
+may be shared, but Product, workspace, session, and channel state follow their
+declared scopes.
+
+### Active Product
+
+The Product whose runtime owns the current Product Session and interprets the
+current input, context, policy, artifacts, and presentation.
+
+One Product Session has exactly one Active Product. A Platform or OEM may host
+many Product Runtimes and Product Sessions concurrently.
+
+### Product Session
+
+A durable or ephemeral interaction scope owned by one Product and identified by
+that Product's session schema and compatibility policy.
+
+A Product Session records its `product_id` and the runtime selections required
+for resume, fork, replay, diagnostics, and migration. Adding a capability does
+not change the owning Product identity.
+
+### Product Handoff
+
+An explicit transfer of a Work item, artifact reference, or user intent from
+one Product Session to another Product.
+
+For example, Coding may create a deck artifact and hand it to a PPT Product
+Session for canvas-level editing. A Product Handoff is not an in-place mutation
+of the source session's `product_id`.
+
+## OEM Model
+
+### OEM
+
+A branded or policy-specific Platform configuration that selects Products and
+overlays their allowed configuration, resources, capabilities, models,
+permissions, channels, and presentation.
+
+An OEM is not automatically a Product. It becomes a Product only when it defines
+a distinct Product Kernel and registers its own Product identity.
+
+### OEM Package
+
+An installable distribution that provides an OEM Descriptor or OEM Profile,
+optional OEM CLI, resource overlays, extension contributions, branding, and
+Product availability policy.
+
+One OEM Package may enable and configure multiple Product Packages.
+
+### OEM Profile
+
+The data-only configuration that identifies an OEM's enabled Products, Default
+Product, Product-specific overlays, shared extensions, branding, model policy,
+and permission policy.
+
+An OEM Profile must not contain live runtime objects or credentials.
+
+### OEM Layer
+
+An admitted set of OEM-owned selections or resources applied to a Product's
+declared override points.
+
+An OEM Layer cannot alter a capability slot sealed by the Product and does not
+gain authority merely by being discovered.
+
+### Multi-Product OEM
+
+An OEM Profile that admits more than one Product, such as Coding and PPT, into
+the same Platform Host.
+
+Multi-Product means co-installed and routable Products. It does not mean that
+one Product Session simultaneously has multiple owning Product identities.
+
+### OEM Product
+
+Use this term only when an OEM Package defines and registers a distinct Product
+Kernel and Product identity.
+
+Do not use OEM Product as a synonym for OEM Package, OEM Profile, a branded
+Coding launch, or a Product with OEM overlays.
+
+## Capability Composition
+
+### Capability
+
+A named runtime or domain concern, such as a conversation store, memory
+provider, compaction planner, tool definition, command descriptor, deck
+renderer, or artifact handler.
+
+### Capability Slot
+
+A Product-declared location at which one or more implementations of a
+Capability may bind. The slot defines composition shape, lifecycle scope,
+refresh boundary, and allowed contribution sources.
+
+### Capability Pack
+
+One Product-approved, ordered contribution group for a single capability item
+family after runtime-profile admission.
+
+In code, `CapabilityPack[T]` contains a `pack_id`, source, priority, enabled
+state, and ordered `T` items. Tool packs and command packs are examples.
+
+A Capability Pack is not an installable archive, Product Package, Plugin, or
+multi-family bundle. It does not discover contributions or grant authority.
+
+### Product Capability Bundle
+
+An assembly or distribution-level grouping of several related capability and
+resource families that can be admitted into a Product.
+
+For example, a `ppt-authoring` Product Capability Bundle may provide Skills,
+prompt fragments, tool and command Capability Packs, deck assets, renderers,
+and artifact handlers. Each family still passes through its own Product-owned
+admission, trust, composition, and lifecycle rules.
+
+A Product Capability Bundle does not become the Active Product. If PPT-specific
+canvas state, session compatibility, compaction, approval, or artifact lifecycle
+is required, use the PPT Product and an explicit Product Handoff.
+
+### Capability Mount
+
+The Product-owned activation of an admitted Product Capability Bundle or
+Capability Pack for a specific runtime scope.
+
+For example, Coding may mount `ppt-authoring` while remaining the Active
+Product. The Product Session should snapshot continuity-critical mounted
+identities and compatible versions.
+
+## Package, Plugin, Extension, And Resource Model
+
+### Package
+
+An overloaded implementation word that must be qualified in architecture
+documents.
+
+Use Product Package for an installable Product, OEM Package for an installable
+OEM configuration, and Resource Package for an installable resource
+collection. Do not use unqualified Package when ownership matters.
+
+### Resource Package
+
+An installable or materialized collection of resources such as Skills, prompts,
+themes, extensions, and Product-specific assets.
+
+A Resource Package contributes content to an admitted Product. It does not
+register or start a Product unless it also implements the separate Product
+Package registration contract.
+
+### Plugin
+
+An optional, independently enabled contribution source resolved into resource
+roots and, where supported, extension contributions.
+
+A Plugin runs under Product and OEM activation and trust policy. It does not own
+the Product lifecycle, select the Active Product, or acquire execution authority
+merely by being installed.
+
+### Extension
+
+Executable or declarative optional behavior contributed through a defined
+extension surface, such as a Tool, command, hook, policy interceptor, approval
+replacement, renderer, or channel adapter.
+
+An Extension is one possible contribution carried by a Plugin or Resource
+Package. Product or OEM policy decides whether it is admitted and active.
+
+### Skill
+
+An instruction resource that teaches the model a specialized workflow,
+domain convention, or Tool-usage pattern.
+
+A Skill is Product content or an optional contribution. It is not executable
+authority, a Product, or a replacement for a Tool or Extension.
+
+### Product Asset
+
+A Product-interpreted file used to create or present domain artifacts, such as
+a deck template, slide layout, brand kit, image, document template, or design
+asset.
+
+Harness may discover and track the asset as a resource, while the Product owns
+its semantic type, validation, preview, activation, and artifact behavior.
+
+### Deck Asset
+
+A PPT-domain Product Asset, such as a presentation template, slide layout,
+master, theme, brand kit, or reusable media item.
+
+A Deck Asset may be shipped with the PPT Product, an OEM overlay, or a
+Product Capability Bundle. It is not a Skill and should not be modeled as one
+merely to reuse relative filesystem paths.
+
+## Canonical Launch Interpretations
+
+### Neutral Platform Launch
+
+```text
+loushang
+  -> resolve Default OEM
+  -> resolve that OEM's Default Product
+  -> create the selected Product Runtime
+```
+
+### OEM-Branded Launch
+
+```text
+acme
+  -> start the shared Platform Host with OEM Profile "acme"
+  -> select Product "coding"
+  -> mount admitted OEM and ppt-authoring capabilities
+```
+
+In this example, `coding` remains the Active Product. The OEM Profile and
+mounted capability identities are recorded separately.
+
+### Full PPT Launch Or Handoff
+
+```text
+loushang ppt
+  -> select Product "ppt"
+  -> create a PPT Product Session
+```
+
+Use this path when PPT owns the session, canvas, deck lifecycle, compaction,
+policy, or presentation semantics.
+
+## Relationship Rules
+
+- Harness provides mechanisms; Products provide domain defaults and semantics.
+- A Product Package registers a Product; a Plugin contributes to a Product.
+- An OEM Package may configure multiple Product Packages.
+- One Platform Host may run multiple Products concurrently.
+- One Product Session has exactly one Active Product.
+- A Product may mount many admitted Capability Packs and Product Capability
+  Bundles.
+- A Product Capability Bundle augments a Product; it does not silently replace
+  it.
+- Product Handoff crosses Product-session boundaries explicitly.
+- Installation, discovery, admission, activation, and execution are separate
+  lifecycle decisions.
+
+## Terms To Avoid
+
+### Product Plugin
+
+Avoid this term because it conflates Product registration with optional Plugin
+contribution. Use Product Package unless the subject specifically implements
+both contracts, and name both roles explicitly.
+
+### PPT Skill Pack
+
+Avoid this term when the package also contains Tools, commands, renderers, or
+deck assets. Use `ppt-authoring` Product Capability Bundle. Use Skill pack only
+for a collection containing Skills.
+
+### OEM Product
+
+Avoid this term for a branded launcher or Product overlay. Use OEM CLI, OEM
+Profile, OEM Package, or Product with OEM Layer as appropriate.
+
+### Multi-Product Session
+
+Avoid this term. Use Multi-Product OEM for deployment availability, Product
+Handoff for cross-Product transfer, or Composed Product if a genuinely new
+Product Kernel owns the unified session.
+
+### `loushang.<OEM>.cli`
+
+Treat this as a possible Python module path, not an architecture concept or
+required packaging convention. The canonical concepts are OEM CLI, OEM
+Descriptor/Profile, registered launch entry point, and shared Platform Host.


### PR DESCRIPTION
## What changed

- add the canonical English Product and OEM architecture glossary
- add the corresponding Chinese terminology table
- link both glossaries from the architecture overview and Harness documentation
- clarify that OEM Product is not a synonym for OEM Package or OEM Profile

## Why

Product, OEM, package, plugin, runtime, and capability-composition terms were being used inconsistently across architecture discussions. These documents establish one vocabulary and make the boundary references discoverable.

## Impact

Architecture and implementation work now has a shared bilingual terminology source. The documents describe boundaries and do not claim that every discovery or routing mechanism is already implemented.

## Validation

- git diff --check passed
- verified the PR contains only the five intended documentation files