### PR TITLE
test(harness): verify permission behavior end to end

### DIFF
--- a/docs/internals/architecture/harness/policy-approval-redesign.md
+++ b/docs/internals/architecture/harness/policy-approval-redesign.md
@@ -1358,6 +1358,28 @@ effective mode appears in the status line, changes emit a typed session audit
 event, and playback covers scoped mode selection, Full Access confirmation,
 pending-request reopening, and retained-permission revocation.
 
+Behavior checkpoint (2026-07-29): `permission-behavior-matrix` now executes
+real Coding read/write/Bash definitions through the live
+Policy → Approval → Gateway path. It proves that Standard allows routine
+workspace work, tests, Git inspection, public HTTP reads, and harmless unknown
+commands while asking for deletion, publication, privilege, secrets, and
+remote mutation; Cautious additionally asks for direct writes; Full Access
+skips only those discretionary prompts. The same playback proves that an
+explicit managed deny still wins, a managed Standard ceiling keeps a requested
+Full Access session at Standard, and a Full Access child cannot widen its
+read-only delegated execution profile. Execution-profile rejection is recorded
+as `tool_execution_failed` with `phase=pre_execution` and never invokes the
+executor. When Full Access suppresses a prompt, the allowed decision retains
+the original Policy code for audit classification while
+`approval_required=false` makes the absence of a prompt explicit. The playback
+writes a compact outcome table plus the redacted Gateway JSONL:
+
+```console
+uv run python scripts/run_tui_playback.py \
+  permission-behavior-matrix \
+  --artifacts /tmp/loushang-permission-playback
+```
+
 Exit gate:
 
 - local/remote/timeout/cancel races accept one result;
@@ -1432,6 +1454,8 @@ At minimum, cover:
 - MCP server/tool/schema identity;
 - extension evaluator failure;
 - audit event ordering and structural redaction;
+- Standard/Cautious/Full Access behavior through real Product tools, including
+  managed deny, profile ceiling, and child execution containment;
 - TUI playback for queued approvals and navigation between common surfaces.
 
 ## 19. Non-goals For The First Three Batches

--- a/src/loushang/harness/permissions.py
+++ b/src/loushang/harness/permissions.py
@@ -179,7 +179,10 @@ class PermissionProfilePolicyEvaluator:
         )
         if profile.approval_behavior == "allow_optional":
             return (
-                PolicyDecision.allow()
+                PolicyDecision(
+                    disposition="allow",
+                    code=managed.code,
+                )
                 if managed.disposition == "ask"
                 else managed
             )

--- a/src/loushang/harness/tools/workspace/authorization.py
+++ b/src/loushang/harness/tools/workspace/authorization.py
@@ -114,8 +114,6 @@ async def _authorize_workspace_tool_action(
         if execution_profile_ceiling is not None
         else None
     )
-    if effective is not None:
-        _validate_path_authority(tool_name, frozen_arguments, effective)
     return AuthorizedWorkspaceAction(
         tool_name=action.tool_name,
         arguments=action.arguments,

--- a/tests/coding/test_permission_behavior_acceptance.py
+++ b/tests/coding/test_permission_behavior_acceptance.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from loushang.coding.sandbox import bind_coding_sandbox_runtime
+from loushang.harness.authorization import EffectiveExecutionProfile
+from loushang.harness.config.agent import (
+    ControlConfig,
+    PermissionSettings,
+    SettingsManager,
+)
+from loushang.harness.environment import LocalHostEnvironmentProbe
+from loushang.harness.permissions import PermissionProfileCeiling
+from loushang.harness.sandbox import (
+    SandboxBackendRegistry,
+    SandboxSettings,
+    SandboxUnavailableError,
+)
+from loushang.harness.workspace.exec import ExecService
+from tests.coding.tui_support.permission_behavior import (
+    PermissionBehaviorHarness,
+    run_permission_behavior_matrix,
+)
+
+
+def test_permission_profiles_drive_real_coding_tools_through_the_gateway(
+    tmp_path: Path,
+) -> None:
+    evidence = asyncio.run(run_permission_behavior_matrix(tmp_path / "workspace"))
+    cases = {case.name: case for case in evidence.cases}
+
+    for name in (
+        "standard-read",
+        "standard-write",
+        "standard-test",
+        "standard-git-status",
+        "standard-public-http-read",
+        "standard-unknown-harmless",
+        "cautious-read",
+    ):
+        assert cases[name].outcome == "allowed"
+        assert cases[name].approval_count == 0
+        assert cases[name].event_types[-2:] == (
+            "tool_execution_started",
+            "tool_execution_completed",
+        )
+
+    expected_risks = {
+        "delete": "filesystem_deletion",
+        "publish": "external_publication",
+        "privilege": "privilege_escalation",
+        "secret": "secret_access",
+        "external-effect": "external_api_mutation",
+    }
+    for risk, policy_code in expected_risks.items():
+        standard = cases[f"standard-{risk}"]
+        assert standard.outcome == "asked"
+        assert standard.policy_code == policy_code
+        assert standard.approval_count == 1
+        assert standard.event_types[-2:] == (
+            "tool_approval_requested",
+            "tool_approval_resolved",
+        )
+
+        full_access = cases[f"full-access-{risk}"]
+        assert full_access.outcome == "allowed"
+        assert full_access.effective_profile == "full_access"
+        assert full_access.policy_code == policy_code
+        assert full_access.approval_count == 0
+        assert full_access.event_types[-2:] == (
+            "tool_execution_started",
+            "tool_execution_completed",
+        )
+
+    cautious = cases["cautious-write"]
+    assert cautious.outcome == "asked"
+    assert cautious.policy_code == "cautious_workspace_mutation"
+    assert cautious.approval_count == 1
+    assert cases["managed-deny"].outcome == "denied"
+    assert cases["managed-profile-ceiling"].outcome == "asked"
+    assert cases["root-full-access-write"].outcome == "allowed"
+    assert cases["child-delegated-ceiling"].outcome == "contained"
+    assert cases["child-delegated-ceiling"].actor_id == "/root/reviewer@2"
+    assert evidence.audit_events
+
+
+def test_full_access_cannot_override_a_managed_policy_deny(tmp_path: Path) -> None:
+    harness = PermissionBehaviorHarness(
+        tmp_path / "workspace",
+        initial_profile="full_access",
+        blocked_tools=("bash",),
+    )
+
+    result = asyncio.run(
+        harness.run(
+            "managed-deny",
+            tool_name="bash",
+            arguments={"command": "git status --short"},
+        )
+    )
+
+    assert result.outcome == "denied"
+    assert result.policy_code == "tool_blocked"
+    assert result.approval_count == 0
+    assert result.event_types == (
+        "tool_action_frozen",
+        "tool_policy_evaluated",
+    )
+    assert harness.executions == []
+
+
+def test_managed_profile_ceiling_keeps_a_full_access_request_at_standard(
+    tmp_path: Path,
+) -> None:
+    harness = PermissionBehaviorHarness(
+        tmp_path / "workspace",
+        initial_profile="full_access",
+        ceiling=PermissionProfileCeiling(
+            maximum_profile="standard",
+            reason="Managed session ceiling",
+        ),
+    )
+
+    result = asyncio.run(
+        harness.run(
+            "managed-profile-ceiling",
+            tool_name="bash",
+            arguments={"command": "git push origin main"},
+        )
+    )
+
+    assert result.requested_profile == "full_access"
+    assert result.effective_profile == "standard"
+    assert result.outcome == "asked"
+    assert result.policy_code == "external_publication"
+    assert harness.executions == []
+
+
+def test_full_access_cannot_widen_a_child_execution_ceiling(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    root = PermissionBehaviorHarness(
+        workspace,
+        initial_profile="full_access",
+        execution_profile=EffectiveExecutionProfile(
+            readable_roots=(workspace,),
+            writable_roots=(workspace,),
+        ),
+    )
+    child = PermissionBehaviorHarness(
+        workspace,
+        initial_profile="full_access",
+        actor_id="/root/reviewer@2",
+        execution_profile=EffectiveExecutionProfile(
+            readable_roots=(workspace,),
+            writable_roots=(),
+        ),
+    )
+
+    root_result = asyncio.run(
+        root.run(
+            "root-write",
+            tool_name="write",
+            arguments={"path": "root.txt", "content": "root"},
+        )
+    )
+    child_result = asyncio.run(
+        child.run(
+            "child-write",
+            tool_name="write",
+            arguments={"path": "child.txt", "content": "child"},
+        )
+    )
+
+    assert root_result.outcome == "allowed"
+    assert (workspace / "root.txt").read_text(encoding="utf-8") == "root"
+    assert child_result.outcome == "contained"
+    assert child_result.actor_id == "/root/reviewer@2"
+    assert child_result.approval_count == 0
+    assert child_result.event_types[-1] == "tool_execution_failed"
+    assert not (workspace / "child.txt").exists()
+
+
+def test_full_access_does_not_downgrade_a_required_sandbox(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    settings = SettingsManager(
+        ControlConfig(permissions=PermissionSettings("full_access"))
+    )
+
+    assert (
+        settings.get_permission_profile_snapshot().effective_profile.profile_id
+        == "full_access"
+    )
+    with pytest.raises(SandboxUnavailableError, match="no sandbox backend"):
+        bind_coding_sandbox_runtime(
+            workspace_root=workspace,
+            writable_workspace=True,
+            settings=SandboxSettings(enabled=True, requirement="required"),
+            base_exec_service=ExecService(),
+            registry=SandboxBackendRegistry(),
+            environment_probe=LocalHostEnvironmentProbe(
+                platform_name="linux",
+                architecture="x86_64",
+                environ={},
+            ),
+        )

--- a/tests/coding/test_screen_tui_playback_runner.py
+++ b/tests/coding/test_screen_tui_playback_runner.py
@@ -27,6 +27,7 @@ from tests.coding.tui_support.scenarios.command import COMMAND_ROUTING_SCENARIOS
 from tests.coding.tui_support.scenarios.composer import COMPOSER_SCENARIOS
 from tests.coding.tui_support.scenarios.lifecycle import LIFECYCLE_SCENARIOS
 from tests.coding.tui_support.scenarios.multiagent import MULTIAGENT_SCENARIOS
+from tests.coding.tui_support.scenarios.permissions import PERMISSION_SCENARIOS
 from tests.coding.tui_support.scenarios.product import PRODUCT_SCENARIOS
 from tests.coding.tui_support.scenarios.surface import SURFACE_SCENARIOS
 from tests.coding.tui_support.scenarios.terminal import TERMINAL_SCENARIOS
@@ -145,6 +146,39 @@ def test_screen_tui_playback_multiagent_scenarios_are_layered() -> None:
         "multiagent-child-approval",
         "multiagent-render",
     ]
+
+
+def test_screen_tui_playback_permission_scenarios_are_layered() -> None:
+    assert [scenario.name for scenario in PERMISSION_SCENARIOS] == [
+        "permission-behavior-matrix",
+    ]
+
+
+def test_screen_tui_playback_runs_permission_behavior_matrix(tmp_path) -> None:
+    results = run_playback_scenarios(
+        ["permission-behavior-matrix"],
+        artifacts_dir=tmp_path,
+    )
+
+    assert [result.ok for result in results] == [True]
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "permission-behavior-matrix-events.jsonl")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert any(
+        row["layer"] == "behavior"
+        and row["data"]["name"] == "child-delegated-ceiling"
+        and row["data"]["outcome"] == "contained"
+        for row in rows
+    )
+    assert any(
+        row["layer"] == "gateway"
+        and row["event"] == "tool_execution_failed"
+        and row["data"]["phase"] == "pre_execution"
+        for row in rows
+    )
 
 
 def test_screen_tui_playback_runs_multiagent_topology_matrix(tmp_path) -> None:

--- a/tests/coding/tui_support/permission_behavior.py
+++ b/tests/coding/tui_support/permission_behavior.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loushang.coding.tool_pack import register_coding_builtin_tools
+from loushang.harness.approval import (
+    ActorBoundApprovalResolver,
+    ApprovalDecision,
+    ApprovalRequest,
+)
+from loushang.harness.authorization import (
+    EffectiveExecutionProfile,
+    ExecutionAuthorizationError,
+)
+from loushang.harness.config.agent import (
+    ControlConfig,
+    PermissionSettings,
+    SettingsManager,
+    ToolSettings,
+)
+from loushang.harness.permissions import (
+    PermissionProfileCeiling,
+    PermissionProfileId,
+)
+from loushang.harness.tools.workspace import (
+    PolicyEnforcementError,
+    ToolContext,
+    workspace_tool_runtime_settings,
+)
+from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
+from loushang.harness.workspace.exec import ExecRequest, ExecResult, ExecService
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionBehaviorCase:
+    name: str
+    requested_profile: PermissionProfileId
+    effective_profile: PermissionProfileId
+    outcome: str
+    policy_code: str | None
+    capability: str
+    actor_id: str
+    approval_count: int
+    event_types: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionBehaviorEvidence:
+    cases: tuple[PermissionBehaviorCase, ...]
+    audit_events: tuple[dict[str, object], ...]
+
+
+class PermissionBehaviorHarness:
+    """Run real Coding tools through the live Policy/Approval/Gateway path."""
+
+    def __init__(
+        self,
+        workspace: Path,
+        *,
+        initial_profile: PermissionProfileId = "standard",
+        ceiling: PermissionProfileCeiling | None = None,
+        blocked_tools: tuple[str, ...] = (),
+        actor_id: str = "root",
+        execution_profile: EffectiveExecutionProfile | None = None,
+    ) -> None:
+        self.workspace = workspace.resolve()
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        (self.workspace / "notes.txt").write_text("public notes\n", encoding="utf-8")
+        (self.workspace / ".env").write_text(
+            "PRIVATE_TOKEN=not-for-audit\n",
+            encoding="utf-8",
+        )
+        self.settings = SettingsManager(
+            ControlConfig(
+                permissions=PermissionSettings(initial_profile),
+                tools=ToolSettings(blocked_tools=blocked_tools),
+            ),
+            permission_profile_ceiling=ceiling,
+        )
+        self.approvals = _RecordingDenyResolver()
+        approval_resolver: object = self.approvals
+        if actor_id != "root":
+            approval_resolver = ActorBoundApprovalResolver(
+                resolver=self.approvals,
+                actor_id=actor_id,
+            )
+        self.events: list[dict[str, object]] = []
+        self.executions: list[ExecRequest] = []
+        self.exec_service = ExecService(
+            backend=self._execute,
+            execution_profile=execution_profile,
+        )
+        runtime_settings = workspace_tool_runtime_settings(self.settings)
+        self.registry = WorkspaceToolRegistry()
+        register_coding_builtin_tools(
+            self.registry,
+            policy_engine=runtime_settings.policy_engine,  # type: ignore[arg-type]
+            approval_resolver=approval_resolver,  # type: ignore[arg-type]
+            exec_service=self.exec_service,
+        )
+        self._approval_resolver = approval_resolver
+        self._call_sequence = 0
+
+    async def run(
+        self,
+        name: str,
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        profile: PermissionProfileId | None = None,
+    ) -> PermissionBehaviorCase:
+        if profile is not None:
+            self.settings.set_permission_profile(profile, scope="session")
+        event_start = len(self.events)
+        approval_start = len(self.approvals.requests)
+        self._call_sequence += 1
+        tool = self.registry.materialize_tool(
+            tool_name,
+            context_provider=lambda *, tool_call_id: ToolContext(
+                tool_call_id=tool_call_id,
+                cwd=str(self.workspace),
+                event_sink=self.events.append,
+                exec_service=self.exec_service,
+                approval_resolver=self._approval_resolver,  # type: ignore[arg-type]
+            ),
+        )
+        outcome = "allowed"
+        try:
+            await tool.execute(
+                f"permission-behavior-{self._call_sequence}",
+                arguments,
+            )
+        except ExecutionAuthorizationError:
+            outcome = "contained"
+        except PolicyEnforcementError as error:
+            disposition = error.tool_result_details.get("policy_disposition")
+            outcome = "asked" if disposition == "ask" else "denied"
+
+        events = tuple(self.events[event_start:])
+        policy_event = next(
+            event for event in events if event["type"] == "tool_policy_evaluated"
+        )
+        snapshot = self.settings.get_permission_profile_snapshot()
+        return PermissionBehaviorCase(
+            name=name,
+            requested_profile=snapshot.requested_profile_id,
+            effective_profile=snapshot.effective_profile.profile_id,
+            outcome=outcome,
+            policy_code=_optional_string(policy_event.get("policy_code")),
+            capability=str(policy_event["capability"]),
+            actor_id=str(policy_event["actor_id"]),
+            approval_count=len(self.approvals.requests) - approval_start,
+            event_types=tuple(str(event["type"]) for event in events),
+        )
+
+    async def _execute(
+        self,
+        request: ExecRequest,
+        **_kwargs: object,
+    ) -> ExecResult:
+        self.executions.append(request)
+        return ExecResult(exit_code=0, stdout="simulated execution\n")
+
+
+class _RecordingDenyResolver:
+    def __init__(self) -> None:
+        self.requests: list[ApprovalRequest] = []
+
+    def resolve(self, request: ApprovalRequest) -> ApprovalDecision:
+        self.requests.append(request)
+        return ApprovalDecision.deny("permission behavior playback denied the prompt")
+
+
+async def run_permission_behavior_matrix(
+    workspace: Path,
+) -> PermissionBehaviorEvidence:
+    harness = PermissionBehaviorHarness(workspace)
+    cases: list[PermissionBehaviorCase] = []
+
+    cases.append(
+        await harness.run(
+            "standard-read",
+            tool_name="read",
+            arguments={"path": "notes.txt"},
+            profile="standard",
+        )
+    )
+    cases.append(
+        await harness.run(
+            "standard-write",
+            tool_name="write",
+            arguments={"path": "standard.txt", "content": "allowed"},
+        )
+    )
+    for name, command in (
+        ("standard-test", "pytest -q"),
+        ("standard-git-status", "git status --short"),
+        ("standard-public-http-read", "curl https://example.com"),
+        ("standard-unknown-harmless", "custom-inspector --summary"),
+    ):
+        cases.append(
+            await harness.run(
+                name,
+                tool_name="bash",
+                arguments={"command": command},
+            )
+        )
+
+    for name, tool_name, arguments in _RISK_CASES:
+        cases.append(
+            await harness.run(
+                f"standard-{name}",
+                tool_name=tool_name,
+                arguments=dict(arguments),
+            )
+        )
+
+    cases.append(
+        await harness.run(
+            "cautious-write",
+            tool_name="write",
+            arguments={"path": "cautious.txt", "content": "requires approval"},
+            profile="cautious",
+        )
+    )
+    cases.append(
+        await harness.run(
+            "cautious-read",
+            tool_name="read",
+            arguments={"path": "notes.txt"},
+        )
+    )
+
+    for name, tool_name, arguments in _RISK_CASES:
+        cases.append(
+            await harness.run(
+                f"full-access-{name}",
+                tool_name=tool_name,
+                arguments=dict(arguments),
+                profile="full_access" if name == "delete" else None,
+            )
+        )
+
+    managed_deny = PermissionBehaviorHarness(
+        workspace / "managed-deny",
+        initial_profile="full_access",
+        blocked_tools=("bash",),
+    )
+    cases.append(
+        await managed_deny.run(
+            "managed-deny",
+            tool_name="bash",
+            arguments={"command": "git status --short"},
+        )
+    )
+
+    managed_ceiling = PermissionBehaviorHarness(
+        workspace / "managed-ceiling",
+        initial_profile="full_access",
+        ceiling=PermissionProfileCeiling(
+            maximum_profile="standard",
+            reason="Managed session ceiling",
+        ),
+    )
+    cases.append(
+        await managed_ceiling.run(
+            "managed-profile-ceiling",
+            tool_name="bash",
+            arguments={"command": "git push origin main"},
+        )
+    )
+
+    delegated_workspace = workspace / "delegated"
+    root = PermissionBehaviorHarness(
+        delegated_workspace,
+        initial_profile="full_access",
+        execution_profile=EffectiveExecutionProfile(
+            readable_roots=(delegated_workspace,),
+            writable_roots=(delegated_workspace,),
+        ),
+    )
+    child = PermissionBehaviorHarness(
+        delegated_workspace,
+        initial_profile="full_access",
+        actor_id="/root/reviewer@2",
+        execution_profile=EffectiveExecutionProfile(
+            readable_roots=(delegated_workspace,),
+            writable_roots=(),
+        ),
+    )
+    cases.append(
+        await root.run(
+            "root-full-access-write",
+            tool_name="write",
+            arguments={"path": "root.txt", "content": "root"},
+        )
+    )
+    cases.append(
+        await child.run(
+            "child-delegated-ceiling",
+            tool_name="write",
+            arguments={"path": "child.txt", "content": "child"},
+        )
+    )
+
+    return PermissionBehaviorEvidence(
+        cases=tuple(cases),
+        audit_events=tuple(
+            (
+                *harness.events,
+                *managed_deny.events,
+                *managed_ceiling.events,
+                *root.events,
+                *child.events,
+            )
+        ),
+    )
+
+
+_RISK_CASES: tuple[tuple[str, str, dict[str, object]], ...] = (
+    ("delete", "bash", {"command": "rm -rf ./build"}),
+    ("publish", "bash", {"command": "git push origin main"}),
+    ("privilege", "bash", {"command": "sudo true"}),
+    ("secret", "read", {"path": ".env"}),
+    (
+        "external-effect",
+        "bash",
+        {"command": "curl -X POST https://example.com/resource"},
+    ),
+)
+
+
+def _optional_string(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+__all__ = [
+    "PermissionBehaviorCase",
+    "PermissionBehaviorEvidence",
+    "PermissionBehaviorHarness",
+    "run_permission_behavior_matrix",
+]

--- a/tests/coding/tui_support/runner.py
+++ b/tests/coding/tui_support/runner.py
@@ -19,6 +19,7 @@ from tests.coding.tui_support.scenarios.command import COMMAND_ROUTING_SCENARIOS
 from tests.coding.tui_support.scenarios.composer import COMPOSER_SCENARIOS
 from tests.coding.tui_support.scenarios.lifecycle import LIFECYCLE_SCENARIOS
 from tests.coding.tui_support.scenarios.multiagent import MULTIAGENT_SCENARIOS
+from tests.coding.tui_support.scenarios.permissions import PERMISSION_SCENARIOS
 from tests.coding.tui_support.scenarios.product import PRODUCT_SCENARIOS
 from tests.coding.tui_support.scenarios.surface import SURFACE_SCENARIOS
 from tests.coding.tui_support.scenarios.terminal import TERMINAL_SCENARIOS
@@ -29,6 +30,7 @@ DEFAULT_SUITE = ScreenPlaybackSuite(
         *COMPOSER_SCENARIOS,
         *LIFECYCLE_SCENARIOS,
         *MULTIAGENT_SCENARIOS,
+        *PERMISSION_SCENARIOS,
         *PRODUCT_SCENARIOS,
         *COMMAND_ROUTING_SCENARIOS,
         *SURFACE_SCENARIOS,

--- a/tests/coding/tui_support/scenarios/permissions.py
+++ b/tests/coding/tui_support/scenarios/permissions.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from loushang.tui.playback_suite import PlaybackScenarioSpec
+from tests.coding.tui_support.permission_behavior import (
+    PermissionBehaviorEvidence,
+    run_permission_behavior_matrix,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionBehaviorPlaybackArtifacts:
+    events: Path
+    summary: Path
+
+
+@dataclass(frozen=True, slots=True)
+class PermissionBehaviorPlaybackResult:
+    """Gateway behavior and sanitized audit evidence for all permission modes."""
+
+    evidence: PermissionBehaviorEvidence
+
+    def write_artifacts(
+        self,
+        directory: str | Path,
+        *,
+        basename: str = "permission-behavior",
+        include_frames: bool = False,
+    ) -> PermissionBehaviorPlaybackArtifacts:
+        del include_frames
+        output_dir = Path(directory)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        events_path = output_dir / f"{basename}-events.jsonl"
+        summary_path = output_dir / f"{basename}-summary.txt"
+        rows = _event_rows(self.evidence)
+        with events_path.open("w", encoding="utf-8") as stream:
+            for row in rows:
+                stream.write(json.dumps(row, ensure_ascii=False))
+                stream.write("\n")
+        summary_path.write_text(_summary(self.evidence), encoding="utf-8")
+        return PermissionBehaviorPlaybackArtifacts(
+            events=events_path,
+            summary=summary_path,
+        )
+
+
+def _run_permission_behavior_playback() -> PermissionBehaviorPlaybackResult:
+    with TemporaryDirectory(prefix="loushang-permission-playback-") as directory:
+        evidence = asyncio.run(
+            run_permission_behavior_matrix(Path(directory) / "workspace")
+        )
+    cases = {case.name: case for case in evidence.cases}
+    assert cases["standard-write"].outcome == "allowed"
+    assert cases["standard-delete"].outcome == "asked"
+    assert cases["cautious-write"].outcome == "asked"
+    assert cases["full-access-delete"].outcome == "allowed"
+    assert cases["full-access-delete"].policy_code == "filesystem_deletion"
+    assert cases["managed-deny"].outcome == "denied"
+    assert cases["managed-profile-ceiling"].effective_profile == "standard"
+    assert cases["child-delegated-ceiling"].outcome == "contained"
+    assert cases["child-delegated-ceiling"].actor_id == "/root/reviewer@2"
+    assert any(
+        event["type"] == "tool_execution_failed"
+        and event.get("phase") == "pre_execution"
+        and event.get("outcome") == "denied"
+        for event in evidence.audit_events
+    )
+    return PermissionBehaviorPlaybackResult(evidence)
+
+
+def _event_rows(
+    evidence: PermissionBehaviorEvidence,
+) -> tuple[dict[str, object], ...]:
+    rows: list[dict[str, object]] = []
+    for case in evidence.cases:
+        rows.append(
+            {
+                "sequence": len(rows) + 1,
+                "layer": "behavior",
+                "event": "permission.case.completed",
+                "data": asdict(case),
+            }
+        )
+    for audit_event in evidence.audit_events:
+        rows.append(
+            {
+                "sequence": len(rows) + 1,
+                "layer": "gateway",
+                "event": audit_event["type"],
+                "data": audit_event,
+            }
+        )
+    return tuple(rows)
+
+
+def _summary(evidence: PermissionBehaviorEvidence) -> str:
+    headings = (
+        "Permission behavior acceptance",
+        "",
+        "case | requested | effective | outcome | policy | approvals | actor",
+        "--- | --- | --- | --- | --- | --- | ---",
+    )
+    lines = tuple(
+        " | ".join(
+            (
+                case.name,
+                case.requested_profile,
+                case.effective_profile,
+                case.outcome,
+                case.policy_code or "-",
+                str(case.approval_count),
+                case.actor_id,
+            )
+        )
+        for case in evidence.cases
+    )
+    return "\n".join((*headings, *lines, ""))
+
+
+PERMISSION_SCENARIOS = (
+    PlaybackScenarioSpec(
+        name="permission-behavior-matrix",
+        description=(
+            "Exercise Standard, Cautious, and Full Access through real Coding "
+            "tools, managed ceilings, child containment, and Gateway audit."
+        ),
+        run=_run_permission_behavior_playback,
+        tags=("permissions", "policy", "approval", "gateway"),
+    ),
+)
+
+
+__all__ = [
+    "PERMISSION_SCENARIOS",
+    "PermissionBehaviorPlaybackArtifacts",
+    "PermissionBehaviorPlaybackResult",
+]

--- a/tests/harness/test_permissions.py
+++ b/tests/harness/test_permissions.py
@@ -74,7 +74,7 @@ def test_full_access_skips_optional_approval_but_never_managed_deny() -> None:
     assert _evaluate(
         profile="full_access",
         decision=PolicyDecision.ask("Delete files", code="delete"),
-    ) == PolicyDecision.allow()
+    ) == PolicyDecision(disposition="allow", code="delete")
 
     deny = PolicyDecision.deny("Managed deny", code="managed_deny")
     assert _evaluate(profile="full_access", decision=deny) == deny

--- a/tests/harness/tools/test_authorization_gateway.py
+++ b/tests/harness/tools/test_authorization_gateway.py
@@ -60,6 +60,7 @@ def test_workspace_gateway_enforces_file_roots_from_execution_profile() -> None:
     profile = EffectiveExecutionProfile(
         readable_roots=(Path("/workspace"),),
     )
+    events: list[dict[str, object]] = []
 
     with pytest.raises(ExecutionAuthorizationError, match="outside"):
         asyncio.run(
@@ -69,9 +70,18 @@ def test_workspace_gateway_enforces_file_roots_from_execution_profile() -> None:
                 arguments={"path": "/outside/secret"},
                 cwd="/workspace",
                 execution_profile_ceiling=profile,
+                audit_sink=events.append,
                 executor=lambda _action: pytest.fail("executor must not run"),
             )
         )
+
+    assert [event["type"] for event in events] == [
+        "tool_action_frozen",
+        "tool_policy_evaluated",
+        "tool_execution_failed",
+    ]
+    assert events[-1]["phase"] == "pre_execution"
+    assert events[-1]["outcome"] == "denied"
 
 
 def test_workspace_gateway_binds_policy_and_approval_to_execution_profile(


### PR DESCRIPTION
## What changed

- add a real Coding-tool behavior matrix for Standard, Cautious, and Full Access permission profiles
- cover managed policy deny, managed profile ceilings, delegated child execution ceilings, and required sandbox behavior
- add `permission-behavior-matrix` playback with a compact summary and redacted Gateway JSONL artifacts
- preserve the original Policy code when Full Access suppresses a discretionary approval
- record execution-profile containment failures as pre-execution `tool_execution_failed` audit events

## Why

The permission profiles previously had strong unit coverage but lacked one cross-layer acceptance path proving that live Product tools, Policy, Approval, Gateway enforcement, child ceilings, sandbox requirements, audit, and playback agreed.

## User impact

Normal work remains interruption-free in Standard mode, risky effects still prompt, Cautious adds workspace-mutation prompts, and Full Access skips discretionary prompts without bypassing managed or delegated ceilings. Audit output now explains Full Access decisions and containment failures more clearly.

## Validation

- `uv --cache-dir .uv-cache run pytest tests -q` — 6635 passed, 7 skipped
- all 76 playback scenarios passed
- final permission-focused regressions — 105 passed
- Ruff and `git diff --check` passed
