### PR TITLE
Refresh MiniMax catalog with regional routes and pricing

### DIFF
--- a/src/loushang/ai/model/models.json
+++ b/src/loushang/ai/model/models.json
@@ -251,9 +251,10 @@
       },
       "endpoints": {
         "anthropic-messages": {
-          "displayName": "MiniMax Anthropic-compatible Messages",
+          "displayName": "MiniMax Anthropic-compatible Messages (Global)",
           "api": "anthropic-messages",
           "baseUrl": "https://api.minimax.io/anthropic",
+          "region": "global",
           "preferred": true,
           "docs": "https://platform.minimax.io/docs/api-reference/api-overview",
           "adapter": {
@@ -279,6 +280,12 @@
                 "structuredOutput": false,
                 "attachment": false,
                 "temperature": true
+              },
+              "pricing": {
+                "currency": "USD",
+                "input": 0.6,
+                "output": 2.4,
+                "cacheRead": 0.12
               }
             },
             "MiniMax-M2.7": {
@@ -300,6 +307,232 @@
                 "structuredOutput": false,
                 "attachment": false,
                 "temperature": true
+              },
+              "pricing": {
+                "currency": "USD",
+                "input": 0.3,
+                "output": 1.2,
+                "cacheRead": 0.06,
+                "cacheWrite": 0.375
+              }
+            }
+          }
+        },
+        "openai-completions": {
+          "displayName": "MiniMax OpenAI-compatible Chat Completions (Global)",
+          "api": "openai-completions",
+          "baseUrl": "https://api.minimax.io/v1",
+          "region": "global",
+          "docs": "https://platform.minimax.io/docs/api-reference/api-overview",
+          "auth": {
+            "kind": "apiKey",
+            "apiKeyEnv": "MINIMAX_API_KEY",
+            "header": "Authorization",
+            "prefix": "Bearer "
+          },
+          "adapter": {
+            "store": false,
+            "developerRole": false,
+            "streamingUsage": true,
+            "strictSchema": false
+          },
+          "models": {
+            "MiniMax-M3": {
+              "displayName": "MiniMax-M3",
+              "family": "MiniMax-M3",
+              "alias": "default-chat",
+              "capabilities": {
+                "contextWindow": 1000000,
+                "input": [
+                  "text",
+                  "image"
+                ],
+                "output": [
+                  "text"
+                ],
+                "reasoning": true,
+                "stream": true,
+                "toolUse": true,
+                "structuredOutput": false,
+                "attachment": false,
+                "temperature": true
+              },
+              "pricing": {
+                "currency": "USD",
+                "input": 0.6,
+                "output": 2.4,
+                "cacheRead": 0.12
+              }
+            },
+            "MiniMax-M2.7": {
+              "displayName": "MiniMax-M2.7",
+              "family": "MiniMax-M2.7",
+              "alias": "balanced-chat",
+              "capabilities": {
+                "contextWindow": 204800,
+                "maxTokens": 131072,
+                "input": [
+                  "text"
+                ],
+                "output": [
+                  "text"
+                ],
+                "reasoning": true,
+                "stream": true,
+                "toolUse": true,
+                "structuredOutput": false,
+                "attachment": false,
+                "temperature": true
+              },
+              "pricing": {
+                "currency": "USD",
+                "input": 0.3,
+                "output": 1.2,
+                "cacheRead": 0.06,
+                "cacheWrite": 0.375
+              }
+            }
+          }
+        },
+        "anthropic-messages-cn": {
+          "displayName": "MiniMax Anthropic-compatible Messages (China)",
+          "api": "anthropic-messages",
+          "baseUrl": "https://api.minimaxi.com/anthropic",
+          "region": "cn",
+          "docs": "https://platform.minimaxi.com/docs/api-reference/api-overview",
+          "adapter": {
+            "longCacheRetention": false
+          },
+          "models": {
+            "MiniMax-M3": {
+              "displayName": "MiniMax-M3",
+              "family": "MiniMax-M3",
+              "alias": "default-chat",
+              "capabilities": {
+                "contextWindow": 1000000,
+                "input": [
+                  "text",
+                  "image"
+                ],
+                "output": [
+                  "text"
+                ],
+                "reasoning": true,
+                "stream": true,
+                "toolUse": true,
+                "structuredOutput": false,
+                "attachment": false,
+                "temperature": true
+              },
+              "pricing": {
+                "currency": "USD",
+                "input": 0.6,
+                "output": 2.4,
+                "cacheRead": 0.12
+              }
+            },
+            "MiniMax-M2.7": {
+              "displayName": "MiniMax-M2.7",
+              "family": "MiniMax-M2.7",
+              "alias": "balanced-chat",
+              "capabilities": {
+                "contextWindow": 204800,
+                "maxTokens": 131072,
+                "input": [
+                  "text"
+                ],
+                "output": [
+                  "text"
+                ],
+                "reasoning": true,
+                "stream": true,
+                "toolUse": true,
+                "structuredOutput": false,
+                "attachment": false,
+                "temperature": true
+              },
+              "pricing": {
+                "currency": "USD",
+                "input": 0.3,
+                "output": 1.2,
+                "cacheRead": 0.06,
+                "cacheWrite": 0.375
+              }
+            }
+          }
+        },
+        "openai-completions-cn": {
+          "displayName": "MiniMax OpenAI-compatible Chat Completions (China)",
+          "api": "openai-completions",
+          "baseUrl": "https://api.minimaxi.com/v1",
+          "region": "cn",
+          "docs": "https://platform.minimaxi.com/docs/api-reference/api-overview",
+          "auth": {
+            "kind": "apiKey",
+            "apiKeyEnv": "MINIMAX_API_KEY",
+            "header": "Authorization",
+            "prefix": "Bearer "
+          },
+          "adapter": {
+            "store": false,
+            "developerRole": false,
+            "streamingUsage": true,
+            "strictSchema": false
+          },
+          "models": {
+            "MiniMax-M3": {
+              "displayName": "MiniMax-M3",
+              "family": "MiniMax-M3",
+              "alias": "default-chat",
+              "capabilities": {
+                "contextWindow": 1000000,
+                "input": [
+                  "text",
+                  "image"
+                ],
+                "output": [
+                  "text"
+                ],
+                "reasoning": true,
+                "stream": true,
+                "toolUse": true,
+                "structuredOutput": false,
+                "attachment": false,
+                "temperature": true
+              },
+              "pricing": {
+                "currency": "USD",
+                "input": 0.6,
+                "output": 2.4,
+                "cacheRead": 0.12
+              }
+            },
+            "MiniMax-M2.7": {
+              "displayName": "MiniMax-M2.7",
+              "family": "MiniMax-M2.7",
+              "alias": "balanced-chat",
+              "capabilities": {
+                "contextWindow": 204800,
+                "maxTokens": 131072,
+                "input": [
+                  "text"
+                ],
+                "output": [
+                  "text"
+                ],
+                "reasoning": true,
+                "stream": true,
+                "toolUse": true,
+                "structuredOutput": false,
+                "attachment": false,
+                "temperature": true
+              },
+              "pricing": {
+                "currency": "USD",
+                "input": 0.3,
+                "output": 1.2,
+                "cacheRead": 0.06,
+                "cacheWrite": 0.375
               }
             }
           }

--- a/tests/ai/test_curated_catalog.py
+++ b/tests/ai/test_curated_catalog.py
@@ -88,6 +88,9 @@ def test_curated_catalog_tracks_current_primary_model_roster() -> None:
             "deepseek-v4-pro",
         },
         ("minimax", "anthropic-messages"): {"MiniMax-M3", "MiniMax-M2.7"},
+        ("minimax", "openai-completions"): {"MiniMax-M3", "MiniMax-M2.7"},
+        ("minimax", "anthropic-messages-cn"): {"MiniMax-M3", "MiniMax-M2.7"},
+        ("minimax", "openai-completions-cn"): {"MiniMax-M3", "MiniMax-M2.7"},
         ("moonshot", "openai-completions"): {
             "kimi-k2.6",
             "kimi-k2.7-code",
@@ -146,6 +149,41 @@ def test_minimax_anthropic_catalog_uses_sdk_base_url_and_short_cache() -> None:
     assert endpoint.base_url == "https://api.minimax.io/anthropic"
     assert isinstance(endpoint.adapter, AnthropicMessagesConfig)
     assert endpoint.adapter.long_cache_retention is False
+
+
+def test_minimax_catalog_exposes_global_and_cn_routes_with_pricing() -> None:
+    registry = _load_curated_registry()
+
+    routes = {
+        (endpoint.id, endpoint.region): endpoint.base_url
+        for endpoint in registry.list_endpoints()
+        if endpoint.provider_id == "minimax"
+    }
+
+    assert routes == {
+        ("anthropic-messages", "global"): "https://api.minimax.io/anthropic",
+        ("openai-completions", "global"): "https://api.minimax.io/v1",
+        ("anthropic-messages-cn", "cn"): "https://api.minimaxi.com/anthropic",
+        ("openai-completions-cn", "cn"): "https://api.minimaxi.com/v1",
+    }
+
+    openai_global = registry.get_endpoint("minimax", "openai-completions")
+    assert isinstance(openai_global.adapter, OpenAICompletionsConfig)
+
+    m3 = registry.get_model("minimax", "anthropic-messages", "MiniMax-M3")
+    assert m3.pricing is not None
+    assert m3.pricing.currency == "USD"
+    assert m3.pricing.input == 0.6
+    assert m3.pricing.output == 2.4
+    assert m3.pricing.cache_read == 0.12
+    assert m3.pricing.cache_write is None
+
+    m27 = registry.get_model("minimax", "openai-completions-cn", "MiniMax-M2.7")
+    assert m27.pricing is not None
+    assert m27.pricing.input == 0.3
+    assert m27.pricing.output == 1.2
+    assert m27.pricing.cache_read == 0.06
+    assert m27.pricing.cache_write == 0.375
 
 
 def test_kimi_code_catalog_uses_its_own_api_key_not_moonshot_platform_key() -> None:
@@ -208,7 +246,10 @@ def test_curated_catalog_keeps_key_model_defaults() -> None:
     assert kimi.supports_temperature is False
     assert kimi_code.defaults["maxOutputTokens"] == 32000
     assert kimi_code.defaults["reasoningEffort"] == "medium"
-    assert minimax.pricing is None
+    assert minimax.pricing is not None
+    assert minimax.pricing.input == 0.6
+    assert minimax.pricing.output == 2.4
+    assert minimax.pricing.cache_read == 0.12
     assert gpt.capabilities.context_window == 1050000
     assert sol.capabilities.context_window == 1050000
     assert coding.capabilities.context_window == 400000


### PR DESCRIPTION
Reason: Refresh the MiniMax catalog so it exposes the current regional routes, models, and pricing metadata.

The curated MiniMax entry only exposed MiniMax-M3 on the global Anthropic-compatible
endpoint and carried no pricing. This change brings the catalog in line with the
current MiniMax surface:

- Add the global OpenAI-compatible Chat Completions route
  (`https://api.minimax.io/v1`).
- Add the China Anthropic-compatible route
  (`https://api.minimaxi.com/anthropic`).
- Add the China OpenAI-compatible Chat Completions route
  (`https://api.minimaxi.com/v1`).
- Register both MiniMax-M3 and MiniMax-M2.7 on every route, so M2.7 is no longer
  limited to the global Anthropic endpoint.
- Add current USD pricing (input/output/cache-read, plus cache-write for M2.7) to
  MiniMax-M3 and MiniMax-M2.7.
- Mark the global Anthropic endpoint with `region: "global"` and the China endpoints
  with `region: "cn"`; the OpenAI-compatible endpoints declare a Bearer-auth
  endpoint override and a non-empty adapter config as required by the catalog
  contract.
- Update the curated catalog tests: the roster now lists the four MiniMax
  endpoints, the MiniMax-M3 pricing assertion flips from "absent" to the current
  USD values, and a new test covers the regional base URLs, adapter types, and
  per-model pricing.

Checks run:
- `pytest tests/ai` (648 passed, 7 skipped)
- `ruff check src/loushang/ai tests/ai` (all checks passed)
- `mypy src/loushang/ai` (no issues)
- `python scripts/ai/check_examples.py` (offline examples OK)
