### PR TITLE
fix(harnesstui): restore /quit and /exit completion hints

### DIFF
--- a/src/loushang/coding/ui/completion.py
+++ b/src/loushang/coding/ui/completion.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from loushang.harnesstui.completion.host import (
     CatalogCompletionProfile,
-    CatalogSlashAlias,
     PreparedCatalogCompletionHost,
     build_session_catalog_completion_host,
 )
@@ -34,5 +33,4 @@ def coding_completion_host(session: object) -> PreparedCatalogCompletionHost:
 _CODING_COMPLETION_PROFILE = CatalogCompletionProfile(
     model_command_value="/model",
     model_argument_group="Models",
-    slash_aliases=(CatalogSlashAlias("/quit", "/exit", "Quit loushang"),),
 )

--- a/src/loushang/harness/commands/catalog.py
+++ b/src/loushang/harness/commands/catalog.py
@@ -265,6 +265,23 @@ DEFAULT_LOCAL_COMMANDS_PROFILE = LocalCommandCatalogProfile(
             source="local",
             argument_hint="<question>",
         ),
+        # Quit/exit are conversation-host controls (QuitIntent), not session
+        # operations, so they declare no routes: listing and completion pick
+        # them up here while dispatch keeps handling them as exits.
+        "quit": CommandDef(
+            id="harness.ui.quit",
+            name="quit",
+            kind=CommandKind.LOCAL_UI,
+            description="Quit the conversation",
+            source="local",
+        ),
+        "exit": CommandDef(
+            id="harness.ui.exit",
+            name="exit",
+            kind=CommandKind.LOCAL_UI,
+            description="Quit the conversation",
+            source="local",
+        ),
     },
     local_command_names_by_route={
         "model_select": "model",

--- a/src/loushang/harnesstui/completion/host.py
+++ b/src/loushang/harnesstui/completion/host.py
@@ -27,21 +27,11 @@ CompletionProviderSource = Callable[
 
 
 @dataclass(frozen=True, slots=True)
-class CatalogSlashAlias:
-    """A product-declared alias enabled by another prepared command."""
-
-    trigger_value: str
-    value: str
-    description: str
-
-
-@dataclass(frozen=True, slots=True)
 class CatalogCompletionProfile:
     """Product policy and wording for prepared catalog completion."""
 
     model_command_value: str
     model_argument_group: str
-    slash_aliases: tuple[CatalogSlashAlias, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -98,17 +88,6 @@ class PreparedCatalogCompletionHost:
             )
             for item in command_provider.items
         ]
-        command_values = {item.value for item in command_provider.items}
-        commands.extend(
-            SlashCommand(
-                name=alias.value.removeprefix("/"),
-                label=alias.value,
-                description=alias.description,
-            )
-            for alias in self.profile.slash_aliases
-            if alias.trigger_value in command_values
-            and alias.value not in command_values
-        )
         return SlashCommandCompletionProvider(tuple(commands))
 
 
@@ -145,7 +124,6 @@ async def _resolve_provider(source: CompletionProviderSource) -> CompletionProvi
 
 __all__ = [
     "CatalogCompletionProfile",
-    "CatalogSlashAlias",
     "CompletionProviderSource",
     "PreparedCatalogCompletionHost",
     "build_session_catalog_completion_host",

--- a/tests/coding/test_ui_completion.py
+++ b/tests/coding/test_ui_completion.py
@@ -30,13 +30,6 @@ class _SessionWithCwd(_Session):
         self.session_manager = SimpleNamespace(get_cwd=lambda: str(cwd))
 
 
-class _SessionWithQuit(_SessionWithCwd):
-    def list_commands(self) -> list[object]:
-        return [
-            SimpleNamespace(name="quit", description="Quit loushang", source="builtin"),
-        ]
-
-
 class _AsyncSession(_Session):
     async def list_commands(self) -> list[object]:
         await asyncio.sleep(0)
@@ -271,7 +264,18 @@ def test_coding_inline_completion_provider_keeps_slash_commands_ahead_of_paths(
     assert composer.value == "/model "
 
 
-def test_coding_inline_completion_provider_completes_exit_alias_without_file_fallback(
+def test_coding_completion_host_lists_quit_and_exit_local_commands() -> None:
+    from loushang.coding.ui.completion import coding_completion_host
+
+    host = coding_completion_host(_Session())
+    quit_values = {item.value for item in asyncio.run(host.complete("/qu"))}
+    exit_values = {item.value for item in asyncio.run(host.complete("/ex"))}
+
+    assert "/quit" in quit_values
+    assert "/exit" in exit_values
+
+
+def test_coding_inline_completion_provider_completes_exit_without_file_fallback(
     tmp_path: Path,
 ) -> None:
     from loushang.coding.ui.completion import coding_inline_completion_provider
@@ -280,9 +284,7 @@ def test_coding_inline_completion_provider_completes_exit_alias_without_file_fal
     (tmp_path / "exit").write_text("", encoding="utf-8")
     composer = Composer(prompt="> ")
     provider = asyncio.run(
-        coding_inline_completion_provider(
-            _SessionWithQuit(tmp_path), base_path=tmp_path
-        )
+        coding_inline_completion_provider(_SessionWithCwd(tmp_path), base_path=tmp_path)
     )
     composer.set_completion_provider(provider)
 
@@ -292,5 +294,5 @@ def test_coding_inline_completion_provider_completes_exit_alias_without_file_fal
     assert tuple(strip_control_sequences(line.text) for line in result.lines) == (
         "> /ex",
         "",
-        "  /exit  Quit loushang",
+        "  /exit  Quit the conversation (local)",
     )

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -1202,7 +1202,7 @@ def test_shared_completion_host_does_not_own_coding_catalog_or_path_policy() -> 
         "PreparedCatalogCompletionHost",
         'model_command_value="/model"',
         'model_argument_group="Models"',
-        'CatalogSlashAlias("/quit", "/exit", "Quit loushang")',
+        "build_session_catalog_completion_host",
         "coding_completion_host",
         "base_path=base_path",
     ):

--- a/tests/harnesstui/commands/test_catalog.py
+++ b/tests/harnesstui/commands/test_catalog.py
@@ -10,6 +10,7 @@ from loushang.harnesstui.conversation.host import ConversationHostRoute
 from loushang.harnesstui.conversation.intents import (
     FollowUpIntent,
     PromptIntent,
+    QuitIntent,
     SettingsIntent,
 )
 
@@ -99,6 +100,24 @@ def test_preserves_local_command_argument_rules() -> None:
     assert catalog.lookup("/commands model").name == "commands"
     assert catalog.lookup("/config").name == "config"
     assert catalog.lookup("/terminal extra") is None
+
+
+def test_quit_and_exit_are_listed_without_owning_dispatch() -> None:
+    catalog = ConversationCommandCatalog(session_commands=lambda: [])
+
+    by_name = {command.name: command for command in catalog.commands()}
+    assert by_name["quit"].kind is CommandKind.LOCAL_UI
+    assert by_name["exit"].kind is CommandKind.LOCAL_UI
+
+    assert catalog.lookup("/quit").name == "quit"
+    assert catalog.lookup("/exit").name == "exit"
+    assert catalog.lookup("/quit now") is None
+
+    # Dispatch still owns QuitIntent exits; the catalog declares no routes.
+    assert catalog.effect_for_route("quit", QuitIntent()) is None
+    assert (
+        catalog.effect_for_route(ConversationHostRoute.DISPATCH, QuitIntent()) is None
+    )
 
 
 def test_lists_local_and_session_commands_once() -> None:

--- a/tests/harnesstui/completion/test_host.py
+++ b/tests/harnesstui/completion/test_host.py
@@ -7,7 +7,6 @@ from loushang.ai.model import ModelSelection
 from loushang.harness.commands import CommandDescriptor
 from loushang.harnesstui.completion.host import (
     CatalogCompletionProfile,
-    CatalogSlashAlias,
     PreparedCatalogCompletionHost,
     build_session_catalog_completion_host,
 )
@@ -18,13 +17,6 @@ def _profile() -> CatalogCompletionProfile:
     return CatalogCompletionProfile(
         model_command_value="/choose-model",
         model_argument_group="Prepared models",
-        slash_aliases=(
-            CatalogSlashAlias(
-                trigger_value="/quit",
-                value="/leave",
-                description="Leave this product",
-            ),
-        ),
     )
 
 
@@ -51,19 +43,18 @@ def _host() -> PreparedCatalogCompletionHost:
     )
 
 
-def test_prepared_completion_host_builds_arguments_and_product_aliases() -> None:
+def test_prepared_completion_host_builds_model_command_arguments() -> None:
     provider = asyncio.run(_host().slash_provider())
 
     assert tuple(command.name for command in provider.commands) == (
         "/choose-model",
         "/quit",
-        "leave",
     )
     assert provider.commands[0].argument_group == "Prepared models"
     assert [item.value for item in provider.complete("/choose-model pro")] == [
         "/choose-model provider/model"
     ]
-    assert [item.value for item in provider.complete("/lea")] == ["/leave"]
+    assert [item.value for item in provider.complete("/qui")] == ["/quit"]
 
 
 def test_prepared_completion_host_limits_input_completion_to_slash_context() -> None:
@@ -87,7 +78,7 @@ def test_prepared_completion_host_optionally_composes_recursive_path_source(
     slash_only = asyncio.run(_host().inline_provider())
     combined = asyncio.run(_host().inline_provider(base_path=tmp_path))
 
-    assert [item.value for item in slash_only.complete("/lea")] == ["/leave"]
+    assert [item.value for item in slash_only.complete("/qui")] == ["/quit"]
     suggestions = combined.get_suggestions(("@example",), 0, len("@example"))
     assert suggestions is not None
     assert [item.value for item in suggestions.items] == ["@src/example.py"]
@@ -120,3 +111,6 @@ def test_session_completion_host_binds_structural_product_catalogs() -> None:
     assert [
         item.value for item in asyncio.run(host.complete("/choose-model res"))
     ] == ["/choose-model provider/research"]
+    # Quit/exit are default local conversation commands, not session commands.
+    assert {item.value for item in asyncio.run(host.complete("/qu"))} >= {"/quit"}
+    assert {item.value for item in asyncio.run(host.complete("/ex"))} >= {"/exit"}


### PR DESCRIPTION
## User-visible change

Typing `/qu` / `/ex` (or bare `/`) in the TUI shows `/quit` and `/exit` completion hints again. The commands themselves never broke — only the suggestions disappeared.

## Root cause

`quit` used to be a builtin session command, so `/quit` appeared in the session command catalog and the completion layer appended `/exit` via a trigger-conditioned alias (`CatalogSlashAlias`: offer `/exit` only when `/quit` exists in the catalog). When standard session commands moved into the harness command pack (`a1254b08`), `quit` was intentionally removed — exit is now a TUI-level `QuitIntent`, not a session operation. The completion side kept depending on the catalog containing `/quit`, so both hints vanished.

## Fix

- Declare `quit` and `exit` as default **local conversation commands** in `DEFAULT_LOCAL_COMMANDS_PROFILE` (`harness/commands/catalog.py`). They declare **no routes**, so listing and completion pick them up while `QuitIntent` dispatch is unchanged (verified: `lookup("/quit now")` is still `None`, `effect_for_route` returns `None` for quit).
- Retire the `CatalogSlashAlias` mechanism in `harnesstui/completion/host.py` (its only consumer was the coding profile) and drop the alias declaration from `coding/ui/completion.py`.

One visible wording change: the hint now reads "Quit the conversation (local)" instead of "Quit loushang", consistent with other local commands like `/settings`. Products can override via `LocalCommandCatalogProfile.with_additions` if desired.

## Validation

- New contract tests: quit/exit listed as `LOCAL_UI`, no dispatch routes; completion host exposes both even when the session catalog lacks them.
- Updated: `tests/harnesstui/completion/test_host.py`, `tests/harnesstui/commands/test_catalog.py`, `tests/coding/test_ui_completion.py`, `tests/coding/test_ui_import_boundaries.py`.
- `tests/harnesstui` (457), plus completion/command-focused `tests/tui` + `tests/coding` selection (450), plus harness/commands suites: all pass.
- `ruff check` clean on touched files (two files carry pre-existing format drift from the migration; left untouched to keep the diff focused).

Per the harness lane workflow, this small fix lands on `main` first; `lane/harness` can pick it up on its next sync with `origin/main`.