### PR TITLE
test(harness): keep tool context boundary closed

### DIFF
--- a/docs/internals/architecture/harness/tool-execution-binding-boundary.md
+++ b/docs/internals/architecture/harness/tool-execution-binding-boundary.md
@@ -354,6 +354,15 @@ The handler receives the already-authorized immutable action plus an
 enforce that action, such as the session `ExecService` carrying the effective
 profile.
 
+`AuthorizedToolContext` is a closed invocation-state contract, not a
+capability registry or service locator. Its existing `exec_service` and
+`operation_bindings` fields support the current session-scoped process/Bash
+override; filesystem tools must not consume them. New filesystem, network,
+publication, credential, or Product service clients must not be added to this
+context. A second demonstrated need for a live protected-resource port requires
+a separate boundary decision based on the real consumers rather than another
+optional context field.
+
 The handler does not receive `PolicyEngine` or `ApprovalResolver`.
 
 The implementation preserves the proven Workspace authorization sequence

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4,7 +4,7 @@ import ast
 import importlib
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 
 import pytest
@@ -3665,6 +3665,37 @@ def test_core_workspace_effects_only_execute_through_gateway() -> None:
     assert "ProcessEffect" in (workspace_root / "bash.py").read_text(
         encoding="utf-8"
     )
+
+
+def test_authorized_tool_context_does_not_become_a_capability_bag() -> None:
+    from loushang.harness.tools.execution import AuthorizedToolContext
+
+    assert tuple(field.name for field in fields(AuthorizedToolContext)) == (
+        "tool_call_id",
+        "cwd",
+        "diagnostics",
+        "signal",
+        "model",
+        "event_sink",
+        "exec_service",
+        "on_update",
+        "operation_bindings",
+    )
+
+    workspace_root = Path("src/loushang/harness/tools/workspace")
+    for tool_name in ("read", "write", "edit", "grep", "find", "ls"):
+        source = (workspace_root / f"{tool_name}.py").read_text(encoding="utf-8")
+        assert "context.exec_service" not in source, tool_name
+        assert "context.operation_bindings" not in source, tool_name
+
+    boundary = " ".join(
+        Path(
+            "docs/internals/architecture/harness/tool-execution-binding-boundary.md"
+        )
+        .read_text(encoding="utf-8")
+        .split()
+    )
+    assert "not a capability registry or service locator" in boundary
 
 
 def test_tool_authoring_and_execution_scope_have_single_harness_owners() -> None:


### PR DESCRIPTION
## What changed

- document that AuthorizedToolContext is a closed invocation-state contract rather than a capability registry or service locator
- prohibit adding filesystem, network, publication, credential, or Product services as optional context fields without a separate boundary decision
- add an architecture test that freezes the current context shape and ensures filesystem tools do not consume process/Bash bindings

## Why

Typed effects do not currently justify a generalized capability injection framework. This guard prevents the authorized context from gradually becoming an untyped service bag while preserving the existing Bash/session override.

## Validation

- Ruff passed
- focused architecture test passed
- git diff --check passed