### PR TITLE
test(harness): complete tool authoring acceptance

### DIFF
--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -81,6 +81,8 @@ planning, work event persistence, or AI provider behavior.
   authorized bindings, typed common effects, a session-owned authorization
   gateway, and the migration that removes raw tool execution bypasses without
   changing permission behavior.
+- [Harness Tool Authoring](tool-authoring-guide.md) is the short developer guide
+  for pure tools, common filesystem actions, and custom action adapters.
 - [Sandbox Runtime Boundary](sandbox-runtime-boundary.md) defines the optional,
   disabled-by-default process containment service, its cross-platform
   Protocols, centralized host detection and backend selection, existing

--- a/docs/internals/architecture/harness/tool-authoring-guide.md
+++ b/docs/internals/architecture/harness/tool-authoring-guide.md
@@ -1,0 +1,147 @@
+# Harness Tool Authoring
+
+Use the Product-neutral authoring surface for every model-visible tool:
+
+```python
+from loushang.harness.tools import (
+    authorized_tool,
+    direct_tool,
+    tool,
+)
+```
+
+The Registry accepts only a completed `ToolDefinition`. Choose exactly one
+execution route when defining the tool; do not call Policy or Approval from the
+handler.
+
+The complete versions of the three examples below live in
+[`examples/harness/tool_authoring.py`](../../../../../examples/harness/tool_authoring.py)
+and run without a model or network connection:
+
+```bash
+uv run python examples/harness/tool_authoring.py
+```
+
+## Pure In-Process Tool
+
+Use `direct_tool` when the handler consumes no common protected resource:
+
+```python
+from loushang.harness.tools import direct_tool, tool
+
+
+@tool()
+async def add(left: int, right: int) -> int:
+    return left + right
+
+
+definition = direct_tool(add)
+registry.register_tool(definition)
+```
+
+A direct handler does not receive the authorization Gateway, process execution,
+or generic filesystem/network services.
+
+## Filesystem Tool
+
+Use `authorized_tool` and a common action adapter when the operation touches a
+protected resource:
+
+```python
+from pathlib import Path
+
+from loushang.harness.tools import (
+    FilesystemActionAdapter,
+    ToolContext,
+    authorized_tool,
+    tool,
+)
+
+
+@tool()
+async def save_note(path: str, content: str, context: ToolContext) -> str:
+    target = Path(context.cwd or ".") / path
+    target.write_text(content, encoding="utf-8")
+    return str(target)
+
+
+definition = authorized_tool(
+    save_note,
+    action=FilesystemActionAdapter(
+        "write",
+        authorization_fields=("content",),
+    ),
+)
+registry.register_tool(definition)
+```
+
+The adapter resolves and freezes the authority-bearing path. The session-owned
+Host sends that immutable action through Policy, Approval, execution-profile
+revalidation, and audit before invoking the handler.
+
+## Custom Action Adapter
+
+Implement `ToolActionAdapter` only when the common adapters cannot describe the
+tool input. Reuse a common typed effect whenever it represents the protected
+resource:
+
+```python
+from dataclasses import dataclass
+
+from loushang.ai.types import ToolCall
+from loushang.harness.effects import PublicationEffect
+from loushang.harness.tools import authorized_tool, tool
+from loushang.harness.tools.execution import (
+    PreparedToolAction,
+    ToolCallContext,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DeployActionAdapter:
+    def prepare(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+    ) -> PreparedToolAction:
+        target = call.arguments.get("target")
+        if not isinstance(target, str) or not target:
+            raise TypeError("target must be a non-empty string")
+        effect = PublicationEffect(target)
+        return PreparedToolAction(
+            tool_name=call.name,
+            authorization_arguments={"target": target},
+            execution_arguments=call.arguments,
+            cwd=context.cwd,
+            effects=(effect,),
+        )
+
+
+@tool()
+async def deploy(target: str) -> str:
+    return f"deployed {target}"
+
+
+definition = authorized_tool(deploy, action=DeployActionAdapter())
+registry.register_tool(definition)
+```
+
+Keep the adapter deterministic: validate input, resolve authority-bearing
+resources, and return immutable action data. It must not perform the operation.
+
+## Selection Checklist
+
+```text
+Does the handler consume a common protected resource?
+  no  -> direct_tool(...)
+  yes -> authorized_tool(..., action=...)
+```
+
+- Use `FilesystemActionAdapter`, `ProcessActionAdapter`,
+  `NetworkActionAdapter`, or `PublicationActionAdapter` first.
+- Put effect-changing values in `authorization_arguments`.
+- Keep the operation in the handler; keep Policy and Approval in Harness.
+- Pass only completed definitions to `ToolRegistry.register_tool`.
+- Do not expand `AuthorizedToolContext` with another optional service. A new
+  live protected-resource port requires a separate boundary decision based on
+  demonstrated consumers.

--- a/examples/harness/tool_authoring.py
+++ b/examples/harness/tool_authoring.py
@@ -1,0 +1,140 @@
+"""Executable smoke for the Product-neutral Harness tool authoring surface."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from loushang.ai.types import ToolCall
+from loushang.harness.effects import PublicationEffect
+from loushang.harness.policy import PolicyDecision
+from loushang.harness.tools import (
+    FilesystemActionAdapter,
+    ToolContext,
+    ToolRegistry,
+    authorized_tool,
+    direct_tool,
+    tool,
+)
+from loushang.harness.tools.execution import PreparedToolAction, ToolCallContext
+from loushang.harness.tools.workspace.authorization import (
+    create_workspace_tool_execution_host,
+)
+
+
+@tool()
+async def add(left: int, right: int) -> int:
+    """Add two integers without consuming a protected resource."""
+
+    return left + right
+
+
+@tool()
+async def save_note(path: str, content: str, context: ToolContext) -> str:
+    """Write one note after its filesystem action has been authorized."""
+
+    target = Path(context.cwd or ".") / path
+    target.write_text(content, encoding="utf-8")
+    return str(target.resolve())
+
+
+@dataclass(frozen=True, slots=True)
+class DeployActionAdapter:
+    """Describe one publication without performing it during authorization."""
+
+    def prepare(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+    ) -> PreparedToolAction:
+        target = call.arguments.get("target")
+        if not isinstance(target, str) or not target:
+            raise TypeError("target must be a non-empty string")
+        return PreparedToolAction(
+            tool_name=call.name,
+            authorization_arguments={"target": target},
+            execution_arguments=call.arguments,
+            cwd=context.cwd,
+            effects=(PublicationEffect(target),),
+        )
+
+
+@tool()
+async def deploy(target: str) -> str:
+    """Return the publication target after authorization."""
+
+    return f"deployed {target}"
+
+
+@dataclass(frozen=True, slots=True)
+class AllowExamplePolicy:
+    def evaluate(self, _subject: object) -> PolicyDecision:
+        return PolicyDecision.allow()
+
+
+async def run_example(cwd: Path) -> dict[str, object]:
+    registry = ToolRegistry(
+        execution_host=create_workspace_tool_execution_host(
+            policy_evaluator=AllowExamplePolicy(),
+        )
+    )
+    definitions = (
+        direct_tool(add),
+        authorized_tool(
+            save_note,
+            action=FilesystemActionAdapter(
+                "write",
+                authorization_fields=("content",),
+            ),
+        ),
+        authorized_tool(deploy, action=DeployActionAdapter()),
+    )
+    for definition in definitions:
+        registry.register_tool(definition)
+    materialized = {
+        item.name: item
+        for item in registry.materialize_definitions(
+            definitions,
+            context_provider=lambda *, tool_call_id: ToolContext(
+                tool_call_id=tool_call_id,
+                cwd=str(cwd),
+            ),
+        )
+    }
+
+    add_result = await materialized["add"].execute(
+        "example-add",
+        {"left": 2, "right": 3},
+    )
+    note_result = await materialized["save_note"].execute(
+        "example-save",
+        {"path": "note.txt", "content": "hello"},
+    )
+    deploy_result = await materialized["deploy"].execute(
+        "example-deploy",
+        {"target": "staging"},
+    )
+    return {
+        "add": add_result.details,
+        "note": note_result.details,
+        "note_content": (cwd / "note.txt").read_text(encoding="utf-8"),
+        "deploy": deploy_result.details,
+    }
+
+
+def main() -> None:
+    with TemporaryDirectory(prefix="loushang-tool-authoring-") as directory:
+        print(
+            json.dumps(
+                asyncio.run(run_example(Path(directory))),
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/loushang/coding/multiagent.py
+++ b/src/loushang/coding/multiagent.py
@@ -521,6 +521,8 @@ class _CodingSubagentDriver:
         mode: RoundMode,
     ) -> SubagentRoundResult:
         del round_id
+        if self._approval_resolver is not None:
+            self._approval_resolver.open_session()
         message_count = len(self._session.agent.state.messages)
         self._rounds_started += 1
         if mode == "prompt":
@@ -548,6 +550,8 @@ class _CodingSubagentDriver:
         )
 
     def abort(self) -> None:
+        if self._approval_resolver is not None:
+            self._approval_resolver.close_session("Child agent interrupted")
         self._session.abort()
 
     async def dispose(self) -> None:

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3715,10 +3715,27 @@ def test_tool_authoring_and_execution_scope_have_single_harness_owners() -> None
     ).read_text(encoding="utf-8")
     assert "create_workspace_tool_execution_host" in controller_source
 
+    authoring_source = Path(
+        "src/loushang/harness/tools/authoring.py"
+    ).read_text(encoding="utf-8")
+    assert "loushang.coding" not in authoring_source
+
     for path in Path("src/loushang/coding").rglob("*.py"):
         source = path.read_text(encoding="utf-8")
         assert "WorkspaceToolAuthorizationGateway" not in source, path
         assert "create_workspace_tool_execution_host" not in source, path
+
+    guide = " ".join(
+        Path(
+            "docs/internals/architecture/harness/tool-authoring-guide.md"
+        )
+        .read_text(encoding="utf-8")
+        .split()
+    )
+    assert "Pure In-Process Tool" in guide
+    assert "Filesystem Tool" in guide
+    assert "Custom Action Adapter" in guide
+    assert "do not call Policy or Approval from the handler" in guide
 
 
 def test_resource_package_runtime_has_harness_owners() -> None:

--- a/tests/coding/test_agent_session_tools.py
+++ b/tests/coding/test_agent_session_tools.py
@@ -531,6 +531,94 @@ def test_agent_session_extension_context_register_tool_refreshes_active_tools_an
     }
 
 
+def test_agent_session_extension_registers_explicit_tool_routes_live(
+    tmp_path,
+) -> None:
+    from loushang.agent import Agent
+    from loushang.coding import SessionManager
+    from loushang.coding.session import AgentSession
+    from loushang.harness.extensions.agent import ExtensionRunner, LoadedExtension
+    from loushang.harness.tools import (
+        FilesystemActionAdapter,
+        authorized_tool,
+        direct_tool,
+        tool,
+    )
+    from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
+
+    @tool(prompt_snippet="- runtime_ping: Ping the live extension")
+    async def runtime_ping() -> str:
+        """Return one direct runtime result."""
+
+        return "pong"
+
+    @tool(prompt_snippet="- runtime_save: Save an authorized runtime note")
+    async def runtime_save(
+        path: str,
+        content: str,
+        context: ToolContext,
+    ) -> str:
+        """Save one runtime note through the authorization Gateway."""
+
+        del content
+        return str(context.cwd or "") + "/" + path
+
+    def _session_start(event, ctx) -> None:
+        del event
+        ctx.register_tool(direct_tool(runtime_ping))
+        ctx.register_tool(
+            authorized_tool(
+                runtime_save,
+                action=FilesystemActionAdapter(
+                    "write",
+                    authorization_fields=("content",),
+                ),
+            )
+        )
+        with pytest.raises(
+            TypeError,
+            match=r"direct_tool\(\.\.\.\) or authorized_tool",
+        ):
+            ctx.register_tool(runtime_ping)
+
+    session = AgentSession(
+        agent=Agent(initial_state={"system_prompt": "Base prompt.", "tools": []}),
+        session_manager=asyncio.run(
+            SessionManager.new(
+                session_dir=tmp_path,
+                cwd=str(tmp_path),
+                persist=False,
+            )
+        ),
+        tool_registry=WorkspaceToolRegistry(),
+        extension_runner=ExtensionRunner(
+            [
+                LoadedExtension(
+                    name="explicit-authoring",
+                    source_path=tmp_path / "extension.py",
+                    source="inline",
+                    hooks={"session_start": [_session_start]},
+                )
+            ]
+        ),
+        base_prompt="Base prompt.",
+    )
+
+    asyncio.run(session.reload_extension_runtime())
+
+    assert [definition.name for definition in session.get_all_tools()] == [
+        "runtime_ping",
+        "runtime_save",
+    ]
+    assert session.get_active_tool_names() == ["runtime_ping", "runtime_save"]
+    assert [tool.name for tool in session.agent.tools] == [
+        "runtime_ping",
+        "runtime_save",
+    ]
+    assert "runtime_ping" in session.agent.system_prompt
+    assert "runtime_save" in session.agent.system_prompt
+
+
 def test_agent_session_extension_api_register_tool_after_runtime_bind_updates_session_tools(
     tmp_path,
 ) -> None:

--- a/tests/coding/test_multiagent.py
+++ b/tests/coding/test_multiagent.py
@@ -488,6 +488,146 @@ def test_factory_binds_shared_approval_resolver_to_child_incarnation(
     ) is None
 
 
+@pytest.mark.parametrize(
+    "release_mode",
+    (
+        "escape",
+        "interrupt_agent",
+        "close_agent",
+        "new",
+        "resume",
+        "session_exit",
+    ),
+)
+def test_pending_child_approval_is_cleared_by_every_lifecycle_exit(
+    tmp_path: Path,
+    release_mode: str,
+) -> None:
+    from loushang.harness.approval import (
+        ApprovalRequest,
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+        resolve_approval,
+    )
+    from loushang.harness.multiagent import AgentCaller
+    from loushang.harness.session.multiagent import (
+        SessionMultiAgentRuntime,
+        compose_multiagent_before_release,
+    )
+
+    class PendingApprovalSession(_Session):
+        def __init__(self, approval_resolver: object) -> None:
+            super().__init__(responses=[])
+            self.approval_resolver = approval_resolver
+            self.effect_calls = 0
+
+        async def prompt(self, text: str, *, source: str | None = None) -> None:
+            del text, source
+            decision = await resolve_approval(
+                self.approval_resolver,  # type: ignore[arg-type]
+                ApprovalRequest(
+                    tool_name="bash",
+                    arguments={"command": "rm -r lifecycle-target"},
+                    reason="Filesystem content would be deleted",
+                ),
+            )
+            if decision.disposition != "allow":
+                raise PermissionError(decision.reason or decision.disposition)
+            self.effect_calls += 1
+
+    async def scenario() -> None:
+        presented = asyncio.Event()
+        payloads: list[dict[str, object]] = []
+        root_resolver = InteractiveApprovalResolver(
+            fallback=HeadlessApprovalResolver(mode="deny")
+        )
+
+        def present(payload: dict[str, object]) -> None:
+            payloads.append(dict(payload))
+            presented.set()
+
+        root_resolver.set_request_presenter(present)
+        sessions: list[PendingApprovalSession] = []
+        runtimes: list[_Runtime] = []
+
+        def build_runtime(**kwargs: object) -> _Runtime:
+            session = PendingApprovalSession(kwargs["approval_resolver"])
+            runtime = _Runtime(session)
+            sessions.append(session)
+            runtimes.append(runtime)
+            return runtime
+
+        spec = coding_read_only_agent_types(maximum_children=1).resolve("explorer")
+        assert spec is not None
+        control = MultiAgentControl(agent_types=AgentTypeRegistry((spec,)))
+        runtime = SessionMultiAgentRuntime(
+            control=control,
+            child_factory=CodingSubagentFactory(
+                session_dir=tmp_path / "sessions",
+                cwd=tmp_path,
+                tool_registry=_tool_registry(*spec.allowed_tools),
+                runtime_builder=build_runtime,
+                approval_resolver=root_resolver,
+            ),
+        )
+        caller = AgentCaller(control.root_ref)
+        child = await runtime.spawn_child(
+            caller=caller,
+            parent_path=AgentPath.root(),
+            name="pending",
+            agent_type="explorer",
+            initial_prompt="Request the controlled deletion.",
+        )
+        await presented.wait()
+        assert len(root_resolver.permissions_snapshot().pending) == 1
+
+        if release_mode == "escape":
+            action_id = payloads[0]["action_id"]
+            assert isinstance(action_id, str)
+            assert await root_resolver.handle_result(
+                action_id,
+                outcome="abort",
+            )
+            record = await runtime.await_terminal(
+                caller=caller,
+                target=child.path,
+                timeout=1,
+            )
+            assert record.status == "failed"
+        elif release_mode == "interrupt_agent":
+            record = await runtime.interrupt_agent(
+                caller=caller,
+                target=child.path,
+            )
+            assert record.status == "interrupted"
+        elif release_mode == "close_agent":
+            result = await runtime.close_agent(caller=caller, target=child.path)
+            assert [record.status for record in result.closed] == ["closed"]
+        elif release_mode in {"new", "resume"}:
+            hook = compose_multiagent_before_release(
+                resolve_runtime=lambda _session: runtime,
+            )
+            await hook(
+                object(),
+                None,
+                SimpleNamespace(reason=release_mode),
+            )
+        else:
+            await runtime.dispose()
+
+        await asyncio.sleep(0)
+        assert root_resolver.permissions_snapshot().pending == ()
+        assert sessions[0].effect_calls == 0
+        current = control.registry.get(child.ref, include_closed=True)
+        assert current is not None
+        assert current.status != "running"
+
+        await runtime.dispose()
+        assert runtimes[0].dispose_calls == 1
+
+    asyncio.run(scenario())
+
+
 def test_coding_recipe_context_is_fresh_read_only_and_role_specific() -> None:
     registry = coding_read_only_agent_types()
 

--- a/tests/coding/test_screen_tui_playback_runner.py
+++ b/tests/coding/test_screen_tui_playback_runner.py
@@ -144,6 +144,7 @@ def test_screen_tui_playback_multiagent_scenarios_are_layered() -> None:
         "multiagent-isolated-artifact",
         "multiagent-shared-parallel-writers",
         "multiagent-child-approval",
+        "multiagent-concurrent-child-approval",
         "multiagent-render",
     ]
 
@@ -381,6 +382,16 @@ def test_screen_tui_playback_runner_runs_child_approval_scenario(capsys) -> None
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "PASS multiagent-child-approval" in captured.out
+
+
+def test_screen_tui_playback_runner_runs_concurrent_child_approval_scenario(
+    capsys,
+) -> None:
+    exit_code = run_playback_cli(["multiagent-concurrent-child-approval"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "PASS multiagent-concurrent-child-approval" in captured.out
 
 
 def test_screen_tui_playback_runner_runs_tagged_command_scenarios(capsys) -> None:

--- a/tests/coding/tui_support/scenarios/multiagent.py
+++ b/tests/coding/tui_support/scenarios/multiagent.py
@@ -1801,9 +1801,14 @@ def _child_approval_playback() -> object:
             actor_id = str(getattr(profile, "actor_ref"))
             profiles[actor_id] = profile
             commands = (
-                ("git push origin main", "git push origin release")
+                (
+                    "printf safe > child-note.txt",
+                    "git push origin main",
+                    "git push origin release",
+                    "rm -r reusable-delete",
+                )
                 if "/reusable@" in actor_id
-                else ("git push origin main",)
+                else ("rm -r sibling-delete",)
             )
             exec_service = ExecService(
                 backend=exec_backend,
@@ -1866,34 +1871,7 @@ def _child_approval_playback() -> object:
 
         def present(payload: dict[str, object]) -> None:
             approval_payloads.append(dict(payload))
-            options = payload.get("approval_options")
-            choices = (
-                tuple(
-                    ApprovalChoice(
-                        value=str(option["outcome"]),
-                        label=str(option["label"]),
-                        shortcut=str(option["shortcut"]),
-                        tone=str(option["tone"]),
-                    )
-                    for option in options
-                    if isinstance(option, dict)
-                )
-                if isinstance(options, (tuple, list))
-                else ()
-            )
-            manager.open_approval(
-                action=str(payload.get("action") or "Approve child tool call"),
-                risk=str(payload.get("risk") or ""),
-                requester=str(payload.get("actor_id") or "root"),
-                cwd=str(payload.get("cwd") or ""),
-                environment=str(payload.get("environment") or ""),
-                grant_summary=str(payload.get("grant_summary") or ""),
-                action_id=str(payload["action_id"]),
-                allow_session=any(
-                    choice.value == "allow_session" for choice in choices
-                ),
-                options=choices,
-            )
+            _open_approval_payload(manager, payload)
 
         resolver.set_request_presenter(
             present,
@@ -1906,7 +1884,7 @@ def _child_approval_playback() -> object:
                 parent_path=AgentPath.root(),
                 name="reusable",
                 agent_type="explorer",
-                initial_prompt="Publish main.",
+                initial_prompt="Write one ordinary note without approval.",
             )
             await runtime.await_completion(
                 caller=caller,
@@ -1916,7 +1894,27 @@ def _child_approval_playback() -> object:
             await runtime.send_message(
                 caller=caller,
                 target=reusable.path,
-                text="Publish release with the same non-force remote permission.",
+                text="Publish main after Root grants this child session access.",
+            )
+            await runtime.await_completion(
+                caller=caller,
+                target=reusable.path,
+                timeout=2,
+            )
+            await runtime.send_message(
+                caller=caller,
+                target=reusable.path,
+                text="Reuse the same child-scoped publication grant.",
+            )
+            await runtime.await_completion(
+                caller=caller,
+                target=reusable.path,
+                timeout=2,
+            )
+            await runtime.send_message(
+                caller=caller,
+                target=reusable.path,
+                text="Delete the test directory after one-time Root approval.",
             )
             await runtime.await_completion(
                 caller=caller,
@@ -1928,7 +1926,7 @@ def _child_approval_playback() -> object:
                 parent_path=AgentPath.root(),
                 name="sibling",
                 agent_type="explorer",
-                initial_prompt="Publish main independently.",
+                initial_prompt="Request an independent deletion that Root denies.",
             )
             await runtime.await_terminal(
                 caller=caller,
@@ -1940,12 +1938,15 @@ def _child_approval_playback() -> object:
             sibling_actor = str(sibling.ref)
             assert [payload.get("actor_id") for payload in approval_payloads] == [
                 reusable_actor,
+                reusable_actor,
                 sibling_actor,
             ]
-            assert len(executed) == 2
+            assert len(executed) == 4
             assert [command for _cwd, command in executed] == [
+                "printf safe > child-note.txt",
                 "git push origin main",
                 "git push origin release",
+                "rm -r reusable-delete",
             ]
             assert set(profiles) == {reusable_actor, sibling_actor}
             assert {
@@ -1964,17 +1965,19 @@ def _child_approval_playback() -> object:
         result = playback.run(
             (0.00, "run child approval\r"),
             (0.10, "s"),
-            (0.25, "\x1b"),
-            (0.40, ""),
+            (0.25, "y"),
+            (0.40, "\x1b"),
+            (0.55, ""),
             handle_prompt=handle_prompt,
             handle_surface_intent=manager.handle_surface_intent,
         )
 
-        result.assert_exit_code(0)
+        assert result.exit_code == 0, result.text
         result.assert_text_contains("Approval")
         result.assert_text_contains("/root/sibling@1")
         result.assert_no_clear_screen()
         assert result.app.active_surface is None
+        assert result.app.state.running is False
         assert all(child_runtime.disposed for child_runtime in child_runtimes)
         assert {
             event.get("actor_id")
@@ -1982,6 +1985,223 @@ def _child_approval_playback() -> object:
             if event.get("type") == "tool_policy_evaluated"
         } == {"/root/reusable@1", "/root/sibling@1"}
         return result
+
+
+def _concurrent_child_approval_playback() -> object:
+    """Resolve simultaneous child approvals without crossing actor boundaries."""
+
+    with TemporaryDirectory(
+        prefix="loushang-concurrent-child-approval-",
+        dir="/tmp",
+    ) as directory:
+        cwd = Path(directory).resolve()
+        playback = ScreenTuiLoopPlayback(
+            width=112,
+            height=22,
+            model_label="playback/concurrent-child-approval",
+            cwd=str(cwd),
+            branch="lane/harness",
+        )
+        resolver = InteractiveApprovalResolver(
+            fallback=HeadlessApprovalResolver(mode="deny")
+        )
+        approval_payloads: list[dict[str, object]] = []
+        audit_events: list[dict[str, object]] = []
+        executed: list[str] = []
+        child_runtimes: list[_ApprovalPlaybackRuntime] = []
+
+        def exec_backend(
+            request: ExecRequest,
+            **_kwargs: object,
+        ) -> ExecResult:
+            command = request.command[-1]
+            executed.append(command)
+            return ExecResult(exit_code=0, stdout="deleted\n")
+
+        root_registry = WorkspaceToolRegistry()
+        register_coding_builtin_tools(
+            root_registry,
+            exec_service=ExecService(backend=exec_backend),
+        )
+
+        def build_runtime(**kwargs: object) -> _ApprovalPlaybackRuntime:
+            profile = kwargs["delegated_execution_profile"]
+            actor_id = str(getattr(profile, "actor_ref"))
+            command = (
+                "rm -r allowed-delete"
+                if "/allowed@" in actor_id
+                else "rm -r denied-delete"
+            )
+            child_registry = kwargs["tool_registry"]
+            assert isinstance(child_registry, WorkspaceToolRegistry)
+            from loushang.harness.tools.workspace.authorization import (
+                create_workspace_tool_execution_host,
+            )
+
+            child_registry.bind_execution_host(
+                create_workspace_tool_execution_host(
+                    policy_evaluator=PolicyEngine(),
+                    approval_resolver=kwargs["approval_resolver"],  # type: ignore[arg-type]
+                )
+            )
+            session = _ApprovalPlaybackSession(
+                cwd=str(cwd),
+                commands=(command,),
+                registry=child_registry,
+                approval_resolver=kwargs["approval_resolver"],
+                exec_service=ExecService(
+                    backend=exec_backend,
+                    execution_profile=getattr(
+                        profile,
+                        "execution_profile_ceiling",
+                    ),
+                ),
+                audit_events=audit_events,
+            )
+            runtime = _ApprovalPlaybackRuntime(session)
+            child_runtimes.append(runtime)
+            return runtime
+
+        factory = CodingSubagentFactory(
+            session_dir=cwd / ".sessions",
+            cwd=cwd,
+            tool_registry=root_registry,
+            runtime_builder=build_runtime,
+            approval_resolver=resolver,
+        )
+        control = MultiAgentControl(agent_types=coding_agent_types(maximum_children=3))
+        runtime = SessionMultiAgentRuntime(
+            control=control,
+            child_factory=factory,
+        )
+        caller = AgentCaller(control.root_ref)
+
+        async def on_approval(payload: dict[str, object]) -> bool:
+            action_id = payload.get("action_id")
+            assert isinstance(action_id, str)
+            return await resolver.handle_result(
+                action_id,
+                outcome=str(payload["outcome"]),
+            )
+
+        manager = ScreenSurfaceManager(
+            app=playback.app,
+            session=object(),
+            status_provider=_approval_status_provider(playback.app),
+            on_approval=on_approval,
+        )
+
+        def present(payload: dict[str, object]) -> None:
+            approval_payloads.append(dict(payload))
+            _open_approval_payload(manager, payload)
+
+        resolver.set_request_presenter(
+            present,
+            dismisser=manager.dismiss_approval,
+        )
+
+        async def handle_prompt(_text: str) -> None:
+            allowed, denied = await asyncio.gather(
+                runtime.spawn_child(
+                    caller=caller,
+                    parent_path=AgentPath.root(),
+                    name="allowed",
+                    agent_type="explorer",
+                    initial_prompt="Request deletion and wait for Root.",
+                ),
+                runtime.spawn_child(
+                    caller=caller,
+                    parent_path=AgentPath.root(),
+                    name="denied",
+                    agent_type="explorer",
+                    initial_prompt="Request an independent deletion and wait for Root.",
+                ),
+            )
+            terminal = await asyncio.gather(
+                runtime.await_terminal(
+                    caller=caller,
+                    target=allowed.path,
+                    timeout=2,
+                ),
+                runtime.await_terminal(
+                    caller=caller,
+                    target=denied.path,
+                    timeout=2,
+                ),
+            )
+
+            assert len(approval_payloads) == 2
+            action_ids = [str(payload["action_id"]) for payload in approval_payloads]
+            assert len(set(action_ids)) == 2
+            assert [payload["actor_id"] for payload in approval_payloads] == [
+                str(allowed.ref),
+                str(denied.ref),
+            ]
+            assert [record.status for record in terminal] == [
+                "completed",
+                "failed",
+            ]
+            assert executed == ["rm -r allowed-delete"]
+            assert resolver.permissions_snapshot().pending == ()
+            assert resolver.permissions_snapshot().grants == ()
+
+            await runtime.close_agent(caller=caller, target=allowed.path)
+            await runtime.close_agent(caller=caller, target=denied.path)
+            await runtime.dispose()
+
+        result = playback.run(
+            (0.00, "run concurrent child approvals\r"),
+            (0.10, "y"),
+            (0.20, "n"),
+            (0.35, ""),
+            handle_prompt=handle_prompt,
+            handle_surface_intent=manager.handle_surface_intent,
+        )
+
+        assert result.exit_code == 0, result.text
+        result.assert_text_contains("Approval")
+        result.assert_no_clear_screen()
+        assert result.app.active_surface is None
+        assert result.app.state.running is False
+        assert all(child_runtime.disposed for child_runtime in child_runtimes)
+        assert {
+            event.get("actor_id")
+            for event in audit_events
+            if event.get("type") == "tool_policy_evaluated"
+        } == {"/root/allowed@1", "/root/denied@1"}
+        return result
+
+
+def _open_approval_payload(
+    manager: ScreenSurfaceManager,
+    payload: dict[str, object],
+) -> None:
+    options = payload.get("approval_options")
+    choices = (
+        tuple(
+            ApprovalChoice(
+                value=str(option["outcome"]),
+                label=str(option["label"]),
+                shortcut=str(option["shortcut"]),
+                tone=str(option["tone"]),
+            )
+            for option in options
+            if isinstance(option, dict)
+        )
+        if isinstance(options, (tuple, list))
+        else ()
+    )
+    manager.open_approval(
+        action=str(payload.get("action") or "Approve child tool call"),
+        risk=str(payload.get("risk") or ""),
+        requester=str(payload.get("actor_id") or "root"),
+        cwd=str(payload.get("cwd") or ""),
+        environment=str(payload.get("environment") or ""),
+        grant_summary=str(payload.get("grant_summary") or ""),
+        action_id=str(payload["action_id"]),
+        allow_session=any(choice.value == "allow_session" for choice in choices),
+        options=choices,
+    )
 
 
 def _approval_status_provider(app: object) -> StatusProvider:
@@ -2113,11 +2333,21 @@ MULTIAGENT_SCENARIOS = (
     PlaybackScenarioSpec(
         name="multiagent-child-approval",
         description=(
-            "Replay child-scoped approval presentation, same-child grant reuse, "
-            "sibling isolation, and close-time grant cleanup."
+            "Replay an unprompted child write, same-child publication grant "
+            "reuse, approved deletion and automatic resume, sibling Esc denial, "
+            "and cleanup."
         ),
         run=_child_approval_playback,
         tags=("multiagent", "approval", "surface", "gateway"),
+    ),
+    PlaybackScenarioSpec(
+        name="multiagent-concurrent-child-approval",
+        description=(
+            "Replay two simultaneous child deletion approvals with one allow, "
+            "one denial, isolated action ids, and no grant leakage."
+        ),
+        run=_concurrent_child_approval_playback,
+        tags=("multiagent", "approval", "surface", "gateway", "concurrency"),
     ),
     PlaybackScenarioSpec(
         name="multiagent-render",

--- a/tests/examples/test_harness_tool_authoring_example.py
+++ b/tests/examples/test_harness_tool_authoring_example.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_example() -> ModuleType:
+    path = Path("examples/harness/tool_authoring.py")
+    spec = importlib.util.spec_from_file_location(
+        "examples_harness_tool_authoring",
+        path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_harness_tool_authoring_example_runs_all_three_routes(
+    tmp_path: Path,
+) -> None:
+    module = _load_example()
+
+    result = asyncio.run(module.run_example(tmp_path))
+
+    assert result == {
+        "add": 5,
+        "note": str((tmp_path / "note.txt").resolve()),
+        "note_content": "hello",
+        "deploy": "deployed staging",
+    }

--- a/tests/harness/tools/test_authoring.py
+++ b/tests/harness/tools/test_authoring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import FrozenInstanceError, fields
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,9 @@ from loushang.harness.effects import (
     NetworkEffect,
     ProcessEffect,
     PublicationEffect,
+    effect_audit_summary,
+    effect_capability,
+    effect_snapshot,
 )
 from loushang.harness.policy import build_tool_policy_subject
 from loushang.harness.policy_effects import detect_policy_effects
@@ -122,6 +126,137 @@ def test_process_network_and_publication_adapters_declare_typed_effects(
 
 
 @pytest.mark.parametrize(
+    ("effect", "capability", "raw_markers"),
+    (
+        (
+            FilesystemEffect(
+                "write",
+                ("/private/effect-matrix/filesystem-secret.txt",),
+            ),
+            "filesystem.write",
+            ("filesystem-secret.txt",),
+        ),
+        (
+            ProcessEffect(("private-process-binary", "--token=process-secret")),
+            "process.execute",
+            ("private-process-binary", "process-secret"),
+        ),
+        (
+            NetworkEffect(
+                "https://network-secret.example.test/private",
+                mutation=True,
+            ),
+            "network.mutate",
+            ("network-secret.example.test",),
+        ),
+        (
+            PublicationEffect(
+                "refs/heads/publication-secret",
+                repository="/private/publication-repository",
+                remote="publication-secret-remote",
+            ),
+            "repository.publish",
+            ("publication-secret", "publication-repository"),
+        ),
+    ),
+)
+def test_common_effect_contract_matrix_is_typed_frozen_and_audit_redacted(
+    effect,
+    capability: str,
+    raw_markers: tuple[str, ...],
+) -> None:
+    snapshot = effect_snapshot(effect)
+    audit = effect_audit_summary(effect)
+
+    assert effect_capability(effect) == capability
+    assert snapshot["capability"] == capability
+    assert audit["capability"] == capability
+    assert any(marker in repr(snapshot) for marker in raw_markers)
+    assert all(marker not in repr(audit) for marker in raw_markers)
+
+    field_name = fields(effect)[0].name
+    with pytest.raises(FrozenInstanceError):
+        setattr(effect, field_name, "changed")
+
+
+@pytest.mark.parametrize(
+    ("adapter", "arguments", "expected_codes"),
+    (
+        (
+            FilesystemActionAdapter("read"),
+            {"path": "/tmp/effect-matrix.txt"},
+            frozenset(),
+        ),
+        (
+            FilesystemActionAdapter("write"),
+            {"path": "/tmp/effect-matrix.txt"},
+            frozenset(),
+        ),
+        (
+            FilesystemActionAdapter("delete"),
+            {"path": "/tmp/effect-matrix.txt"},
+            frozenset({"filesystem_deletion"}),
+        ),
+        (
+            ProcessActionAdapter(),
+            {"command": ["rm", "-rf", "/tmp/effect-matrix"]},
+            frozenset({"filesystem_deletion"}),
+        ),
+        (
+            NetworkActionAdapter(mutation=False),
+            {"url": "https://example.test/read"},
+            frozenset(),
+        ),
+        (
+            NetworkActionAdapter(mutation=True),
+            {"url": "https://example.test/write"},
+            frozenset({"external_system_effect"}),
+        ),
+        (
+            PublicationActionAdapter(),
+            {"target": "refs/heads/main", "remote": "origin"},
+            frozenset({"external_publication"}),
+        ),
+    ),
+)
+def test_common_action_adapters_feed_the_expected_policy_effects(
+    adapter,
+    arguments: dict[str, object],
+    expected_codes: frozenset[str],
+) -> None:
+    prepared = _prepare(adapter, arguments, cwd="/tmp")
+    subject = prepared.policy_subject or build_tool_policy_subject(
+        tool_name=prepared.tool_name,
+        arguments=prepared.authorization_arguments,
+        cwd=prepared.cwd,
+        effects=prepared.effects,
+    )
+
+    assert {effect.code for effect in detect_policy_effects(subject)} == expected_codes
+
+
+def test_effects_are_part_of_the_frozen_action_fingerprint() -> None:
+    def authorize(effect):
+        return asyncio.run(
+            _execute_authorized_tool_action(
+                None,
+                tool_name="custom",
+                arguments={"resource": "same"},
+                effects=(effect,),
+                executor=lambda action: action,
+            )
+        )
+
+    first = authorize(FilesystemEffect("read", ("/tmp/example",)))
+    repeated = authorize(FilesystemEffect("read", ("/tmp/example",)))
+    changed = authorize(FilesystemEffect("write", ("/tmp/example",)))
+
+    assert first.effects == (FilesystemEffect("read", ("/tmp/example",)),)
+    assert first.fingerprint == repeated.fingerprint
+    assert first.fingerprint != changed.fingerprint
+
+
+@pytest.mark.parametrize(
     ("effect", "code"),
     (
         (FilesystemEffect("delete", ("/tmp/example",)), "filesystem_deletion"),
@@ -151,6 +286,7 @@ def test_effect_audit_summary_does_not_copy_raw_resource_values() -> None:
         arguments={},
         effects=(
             FilesystemEffect("write", ("/private/workspace/secret.txt",)),
+            ProcessEffect(("private-command", "--token=private-process-secret")),
             NetworkEffect("https://secret.example.test/token", mutation=True),
             PublicationEffect(
                 "refs/heads/private",
@@ -169,6 +305,8 @@ def test_effect_audit_summary_does_not_copy_raw_resource_values() -> None:
 
     rendered = repr(details)
     assert "/private" not in rendered
+    assert "private-command" not in rendered
+    assert "private-process-secret" not in rendered
     assert "secret.example.test" not in rendered
     assert "secret-origin" not in rendered
 

--- a/tests/harness/tools/test_authoring_acceptance.py
+++ b/tests/harness/tools/test_authoring_acceptance.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from loushang.harness.approval import HeadlessApprovalResolver
+from loushang.harness.policy import PolicyDecision
+from loushang.harness.tools import (
+    FilesystemActionAdapter,
+    ToolContext,
+    ToolRegistry,
+    authorized_tool,
+    direct_tool,
+    tool,
+)
+from loushang.harness.tools.workspace.authorization import (
+    create_workspace_tool_execution_host,
+)
+
+
+@tool()
+async def _add(left: int, right: int) -> int:
+    """Add two integers without consuming a protected resource."""
+
+    return left + right
+
+
+@tool()
+async def _write_note(
+    path: str,
+    content: str,
+    context: ToolContext,
+) -> str:
+    """Write one note after the filesystem action has been authorized."""
+
+    target = Path(context.cwd or ".") / path
+    target.write_text(content, encoding="utf-8")
+    return str(target.resolve())
+
+
+@dataclass
+class _Policy:
+    decision: PolicyDecision
+    subjects: list[object] = field(default_factory=list)
+
+    def evaluate(self, subject: object) -> PolicyDecision:
+        self.subjects.append(subject)
+        return self.decision
+
+
+def _materialize_note_tool(
+    tmp_path: Path,
+    *,
+    policy: _Policy,
+    approval_resolver: object | None = None,
+    events: list[dict[str, object]] | None = None,
+):
+    registry = ToolRegistry(
+        execution_host=create_workspace_tool_execution_host(
+            policy_evaluator=policy,
+            approval_resolver=approval_resolver,  # type: ignore[arg-type]
+        )
+    )
+    definition = authorized_tool(
+        _write_note,
+        action=FilesystemActionAdapter(
+            "write",
+            authorization_fields=("content",),
+        ),
+    )
+    registry.register_tool(definition)
+    return registry.materialize_definitions(
+        [definition],
+        context_provider=lambda *, tool_call_id: ToolContext(
+            tool_call_id=tool_call_id,
+            cwd=str(tmp_path),
+            event_sink=events.append if events is not None else None,
+        ),
+    )[0]
+
+
+def test_harness_only_product_registers_and_runs_explicit_tool_bindings(
+    tmp_path: Path,
+) -> None:
+    policy = _Policy(PolicyDecision.allow())
+    events: list[dict[str, object]] = []
+    registry = ToolRegistry(
+        execution_host=create_workspace_tool_execution_host(
+            policy_evaluator=policy,
+        )
+    )
+    direct = direct_tool(_add)
+    authorized = authorized_tool(
+        _write_note,
+        action=FilesystemActionAdapter(
+            "write",
+            authorization_fields=("content",),
+        ),
+    )
+    registry.register_tool(direct)
+    registry.register_tool(authorized)
+
+    with pytest.raises(TypeError, match="explicitly bound ToolDefinition"):
+        registry.register_tool(_add)  # type: ignore[arg-type]
+
+    materialized = {
+        item.name: item
+        for item in registry.materialize_definitions(
+            registry.list_definitions(),
+            context_provider=lambda *, tool_call_id: ToolContext(
+                tool_call_id=tool_call_id,
+                cwd=str(tmp_path),
+                event_sink=events.append,
+            ),
+        )
+    }
+    direct_result = asyncio.run(
+        materialized["_add"].execute(
+            "direct-call",
+            {"left": 2, "right": 3},
+        )
+    )
+    authorized_result = asyncio.run(
+        materialized["_write_note"].execute(
+            "authorized-call",
+            {"path": "note.txt", "content": "hello"},
+        )
+    )
+
+    assert direct_result.details == 5
+    assert authorized_result.details == str((tmp_path / "note.txt").resolve())
+    assert (tmp_path / "note.txt").read_text(encoding="utf-8") == "hello"
+    assert len(policy.subjects) == 1
+    assert [event["type"] for event in events] == [
+        "tool_action_frozen",
+        "tool_policy_evaluated",
+        "tool_execution_started",
+        "tool_execution_completed",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("decision", "approval_mode", "expected_events", "executes"),
+    (
+        (
+            PolicyDecision.allow(),
+            None,
+            (
+                "tool_action_frozen",
+                "tool_policy_evaluated",
+                "tool_execution_started",
+                "tool_execution_completed",
+            ),
+            True,
+        ),
+        (
+            PolicyDecision.ask("confirm write", code="test_write"),
+            "allow",
+            (
+                "tool_action_frozen",
+                "tool_policy_evaluated",
+                "tool_approval_requested",
+                "tool_approval_resolved",
+                "tool_execution_started",
+                "tool_execution_completed",
+            ),
+            True,
+        ),
+        (
+            PolicyDecision.ask("confirm write", code="test_write"),
+            "deny",
+            (
+                "tool_action_frozen",
+                "tool_policy_evaluated",
+                "tool_approval_requested",
+                "tool_approval_resolved",
+            ),
+            False,
+        ),
+        (
+            PolicyDecision.deny("managed deny", code="managed_deny"),
+            None,
+            (
+                "tool_action_frozen",
+                "tool_policy_evaluated",
+            ),
+            False,
+        ),
+    ),
+)
+def test_public_authorized_tool_runs_the_complete_gateway_decision_matrix(
+    tmp_path: Path,
+    decision: PolicyDecision,
+    approval_mode: str | None,
+    expected_events: tuple[str, ...],
+    executes: bool,
+) -> None:
+    events: list[dict[str, object]] = []
+    resolver = (
+        HeadlessApprovalResolver(mode=approval_mode)
+        if approval_mode is not None
+        else None
+    )
+    tool = _materialize_note_tool(
+        tmp_path,
+        policy=_Policy(decision),
+        approval_resolver=resolver,
+        events=events,
+    )
+
+    async def execute() -> object:
+        return await tool.execute(
+            "matrix-call",
+            {"path": "matrix.txt", "content": "allowed"},
+        )
+
+    if executes:
+        result = asyncio.run(execute())
+        assert getattr(result, "details") == str((tmp_path / "matrix.txt").resolve())
+    else:
+        with pytest.raises(PermissionError):
+            asyncio.run(execute())
+
+    assert (tmp_path / "matrix.txt").exists() is executes
+    assert tuple(event["type"] for event in events) == expected_events

--- a/tests/harness/tools/test_authorization_gateway.py
+++ b/tests/harness/tools/test_authorization_gateway.py
@@ -272,7 +272,10 @@ def test_workspace_gateway_includes_approval_in_the_same_audit_sequence(
         execute_workspace_tool_action(
             AskPolicy(),
             tool_name="write",
-            arguments={"path": str(tmp_path / "notes.txt"), "content": "hello"},
+            arguments={
+                "path": str(tmp_path / "notes.txt"),
+                "content": "private-audit-content",
+            },
             cwd=str(tmp_path),
             tool_call_id="call-2",
             approval_resolver=ActorBoundApprovalResolver(
@@ -296,6 +299,21 @@ def test_workspace_gateway_includes_approval_in_the_same_audit_sequence(
     assert events[2]["action_id"] == events[3]["action_id"]
     assert events[3]["approval_decision"] == "allow"
     assert {event["actor_id"] for event in events} == {"/root/reviewer#2"}
+    assert {event["tool_call_id"] for event in events} == {"call-2"}
+    assert len({event["action_fingerprint"] for event in events}) == 1
+    approval_id = events[2]["action_id"]
+    assert {
+        event["approval_action_id"]
+        for event in events
+        if event["type"]
+        in {
+            "tool_execution_started",
+            "tool_execution_completed",
+        }
+    } == {approval_id}
+    serialized = json.dumps(events)
+    assert "private-audit-content" not in serialized
+    assert str(tmp_path / "notes.txt") not in serialized
 
 
 def test_workspace_gateway_reuses_policy_scoped_session_approval(


### PR DESCRIPTION
## What changed

- add a Product-neutral Harness tool authoring guide and executable direct/authorized/custom-adapter example
- verify live extension registration activates explicit direct and authorized tools while rejecting raw decorated tools
- add complete Gateway decision, effect, correlation, and redaction acceptance coverage
- add deterministic sequential and concurrent child-approval TUI playbacks
- clear actor-bound pending approvals on child interruption and reopen the approval channel on a reused child round
- cover Esc, interrupt, close, /new, /resume, and session-exit approval cleanup

## Why

The unified tool authoring boundary needed end-to-end evidence across runtime extension registration, Gateway authorization, multi-agent lifecycle cleanup, audit correlation, and developer-facing examples. Child interruption also previously stopped the model turn without explicitly cancelling that child incarnation pending approval request.

## Impact

Extension and Product authors have one executable authoring path. Concurrent child approvals remain actor-isolated, lifecycle exits cannot leave a child Working on stale approval state, and audit events retain correlation while excluding raw paths and contents.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests -q` — 6673 passed, 7 skipped
- focused Ruff and `git diff --check`
- `scripts/run_tui_playback.py multiagent-child-approval multiagent-concurrent-child-approval`
- executable example and smoke test