### PR TITLE
test(harness): stress runtime approval boundaries

### DIFF
--- a/tests/coding/test_agent_session_tools.py
+++ b/tests/coding/test_agent_session_tools.py
@@ -619,6 +619,160 @@ def test_agent_session_extension_registers_explicit_tool_routes_live(
     assert "runtime_save" in session.agent.system_prompt
 
 
+def test_live_extension_authorized_tool_runs_through_session_gateway(
+    tmp_path,
+) -> None:
+    import json
+    from pathlib import Path
+
+    from loushang.agent import Agent
+    from loushang.coding import SessionManager
+    from loushang.coding.session import AgentSession
+    from loushang.harness.approval import (
+        HeadlessApprovalResolver,
+        InteractiveApprovalResolver,
+    )
+    from loushang.harness.extensions.agent import ExtensionRunner, LoadedExtension
+    from loushang.harness.policy import PolicyDecision
+    from loushang.harness.tools import (
+        FilesystemActionAdapter,
+        authorized_tool,
+        tool,
+    )
+    from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
+
+    class AskForRuntimeWrite:
+        def evaluate(self, _subject: object) -> PolicyDecision:
+            return PolicyDecision.ask(
+                "Confirm the runtime extension write",
+                code="runtime_extension_write",
+            )
+
+    handler_calls = 0
+
+    @tool(prompt_snippet="- extension_save: Save one approved extension note")
+    async def extension_save(
+        path: str,
+        content: str,
+        context: ToolContext,
+    ) -> str:
+        nonlocal handler_calls
+        handler_calls += 1
+        target = Path(context.cwd or ".") / path
+        target.write_text(content, encoding="utf-8")
+        return str(target.resolve())
+
+    def _session_start(event, ctx) -> None:
+        del event
+        ctx.register_tool(
+            authorized_tool(
+                extension_save,
+                action=FilesystemActionAdapter(
+                    "write",
+                    authorization_fields=("content",),
+                ),
+            )
+        )
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+    presented = asyncio.Event()
+    approval_payloads: list[dict[str, object]] = []
+
+    def present(payload: dict[str, object]) -> None:
+        approval_payloads.append(dict(payload))
+        presented.set()
+
+    session = AgentSession(
+        agent=Agent(initial_state={"system_prompt": "Base prompt.", "tools": []}),
+        session_manager=asyncio.run(
+            SessionManager.new(
+                session_dir=tmp_path,
+                cwd=str(tmp_path),
+                persist=False,
+            )
+        ),
+        tool_registry=WorkspaceToolRegistry(),
+        extension_runner=ExtensionRunner(
+            [
+                LoadedExtension(
+                    name="authorized-runtime",
+                    source_path=tmp_path / "extension.py",
+                    source="inline",
+                    hooks={"session_start": [_session_start]},
+                )
+            ]
+        ),
+        approval_resolver=resolver,
+        tool_policy_evaluator=AskForRuntimeWrite(),
+        base_prompt="Base prompt.",
+    )
+    session.set_approval_presenter(present)
+    product_events: list[dict[str, object]] = []
+    session.subscribe(product_events.append)
+
+    async def scenario() -> object:
+        await session.reload_extension_runtime()
+        tool = next(
+            item for item in session.agent.tools if item.name == "extension_save"
+        )
+        pending = asyncio.create_task(
+            tool.execute(
+                "runtime-extension-call",
+                {
+                    "path": "runtime-note.txt",
+                    "content": "private-runtime-content",
+                },
+            )
+        )
+        await presented.wait()
+        assert handler_calls == 0
+        assert not (tmp_path / "runtime-note.txt").exists()
+        action_id = approval_payloads[0]["action_id"]
+        assert isinstance(action_id, str)
+        assert await session.handle_screen_approval(
+            {
+                "action_id": action_id,
+                "outcome": "allow_once",
+            }
+        )
+        return await pending
+
+    result = asyncio.run(scenario())
+    audit_events = [
+        event
+        for event in product_events
+        if str(event.get("type", "")).startswith("tool_")
+    ]
+
+    assert result.details == str((tmp_path / "runtime-note.txt").resolve())
+    assert handler_calls == 1
+    assert (tmp_path / "runtime-note.txt").read_text(encoding="utf-8") == (
+        "private-runtime-content"
+    )
+    assert [event["type"] for event in audit_events] == [
+        "tool_action_frozen",
+        "tool_policy_evaluated",
+        "tool_approval_requested",
+        "tool_approval_resolved",
+        "tool_execution_started",
+        "tool_execution_completed",
+    ]
+    assert {event["tool_call_id"] for event in audit_events} == {
+        "runtime-extension-call"
+    }
+    assert len({event["action_fingerprint"] for event in audit_events}) == 1
+    assert audit_events[1]["policy_code"] == "runtime_extension_write"
+    action_id = audit_events[2]["action_id"]
+    assert audit_events[3]["action_id"] == action_id
+    assert audit_events[4]["approval_action_id"] == action_id
+    assert audit_events[5]["approval_action_id"] == action_id
+    serialized = json.dumps(audit_events)
+    assert "private-runtime-content" not in serialized
+    assert str(tmp_path / "runtime-note.txt") not in serialized
+
+
 def test_agent_session_extension_api_register_tool_after_runtime_bind_updates_session_tools(
     tmp_path,
 ) -> None:

--- a/tests/harness/session/test_multiagent_approval_stress.py
+++ b/tests/harness/session/test_multiagent_approval_stress.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import Awaitable, Callable
+from itertools import product
+from random import Random
+
+from loushang.harness.approval import (
+    ActorBoundApprovalResolver,
+    ApprovalRequest,
+    HeadlessApprovalResolver,
+    InteractiveApprovalResolver,
+    resolve_approval,
+)
+from loushang.harness.multiagent import (
+    AgentInputMessage,
+    AgentPath,
+    AgentRef,
+    AgentTypeRegistry,
+    AgentTypeSpec,
+    HostCaller,
+    MultiAgentControl,
+    SubagentRoundResult,
+)
+from loushang.harness.multiagent.run_handle import RoundMode
+from loushang.harness.session.multiagent import (
+    SessionMultiAgentRuntime,
+    SessionSubagentRequest,
+)
+
+HOST = HostCaller()
+
+
+class _ApprovalStressDriver:
+    def __init__(
+        self,
+        *,
+        ref: AgentRef,
+        resolver: InteractiveApprovalResolver,
+        effect_calls: dict[AgentRef, int],
+        cycle: int,
+    ) -> None:
+        self.ref = ref
+        self._approval = ActorBoundApprovalResolver(
+            resolver=resolver,
+            actor_id=str(ref),
+        )
+        self._effect_calls = effect_calls
+        self._cycle = cycle
+        self.messages: list[AgentInputMessage] = []
+        self.dispose_calls = 0
+
+    def deliver(self, message: AgentInputMessage) -> None:
+        self.messages.append(message)
+
+    async def run_round(
+        self,
+        *,
+        round_id: int,
+        mode: RoundMode,
+    ) -> SubagentRoundResult:
+        del mode
+        self._approval.open_session()
+        decision = await resolve_approval(
+            self._approval,
+            ApprovalRequest(
+                tool_name="bash",
+                arguments={
+                    "command": f"rm -r stress-target-{self._cycle}-{self.ref.path.name}"
+                },
+                action_id=f"stress-{self._cycle}-{self.ref}-round-{round_id}",
+                reason="Filesystem content would be deleted",
+            ),
+        )
+        if decision.disposition == "allow":
+            # Widen the window in which close/interrupt can race an accepted
+            # decision without letting the protected effect run twice.
+            await asyncio.sleep(0)
+            self._effect_calls[self.ref] += 1
+            return SubagentRoundResult(
+                status="completed",
+                final_message="Protected effect completed.",
+            )
+        return SubagentRoundResult(
+            status="failed",
+            final_message=decision.reason or decision.disposition,
+        )
+
+    def abort(self) -> None:
+        self._approval.close_session("Child agent interrupted")
+
+    async def dispose(self) -> None:
+        self.dispose_calls += 1
+        self._approval.end_session("Child agent closed")
+
+
+class _ApprovalStressFactory:
+    def __init__(
+        self,
+        *,
+        resolver: InteractiveApprovalResolver,
+        effect_calls: dict[AgentRef, int],
+        cycle: int,
+    ) -> None:
+        self._resolver = resolver
+        self._effect_calls = effect_calls
+        self._cycle = cycle
+        self.drivers: dict[AgentRef, _ApprovalStressDriver] = {}
+
+    async def create_driver(
+        self,
+        request: SessionSubagentRequest,
+    ) -> _ApprovalStressDriver:
+        driver = _ApprovalStressDriver(
+            ref=request.record.ref,
+            resolver=self._resolver,
+            effect_calls=self._effect_calls,
+            cycle=self._cycle,
+        )
+        self.drivers[request.record.ref] = driver
+        return driver
+
+
+async def _wait_until(predicate: Callable[[], bool]) -> None:
+    for _ in range(100):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("approval stress condition was not reached")
+
+
+async def _after_ticks(
+    ticks: int,
+    operation: Callable[[], Awaitable[object]],
+) -> object:
+    for _ in range(ticks):
+        await asyncio.sleep(0)
+    return await operation()
+
+
+def test_concurrent_child_approval_races_preserve_lifecycle_invariants() -> None:
+    async def scenario() -> None:
+        cases = list(
+            product(
+                ("allow_once", "deny", "abort"),
+                ("allow_once", "deny", "abort"),
+                ("interrupt", "close"),
+            )
+        )
+        cases *= 2
+        random = Random(20260729)
+        random.shuffle(cases)
+
+        for cycle, (first_outcome, second_outcome, lifecycle) in enumerate(cases):
+            payloads: list[dict[str, object]] = []
+            resolver = InteractiveApprovalResolver(
+                fallback=HeadlessApprovalResolver(mode="deny")
+            )
+            resolver.set_request_presenter(
+                lambda payload, payloads=payloads: payloads.append(dict(payload))
+            )
+            effect_calls: dict[AgentRef, int] = defaultdict(int)
+            spec = AgentTypeSpec(name="worker", maximum_children=2)
+            control = MultiAgentControl(agent_types=AgentTypeRegistry((spec,)))
+            factory = _ApprovalStressFactory(
+                resolver=resolver,
+                effect_calls=effect_calls,
+                cycle=cycle,
+            )
+            runtime = SessionMultiAgentRuntime(
+                control=control,
+                child_factory=factory,
+            )
+
+            first, second = await asyncio.gather(
+                runtime.spawn_child(
+                    caller=HOST,
+                    parent_path=AgentPath.root(),
+                    name="worker-a",
+                    agent_type="worker",
+                    initial_prompt="Request the first protected effect.",
+                ),
+                runtime.spawn_child(
+                    caller=HOST,
+                    parent_path=AgentPath.root(),
+                    name="worker-b",
+                    agent_type="worker",
+                    initial_prompt="Request the second protected effect.",
+                ),
+            )
+            await _wait_until(lambda payloads=payloads: len(payloads) == 2)
+            by_actor = {str(payload["actor_id"]): payload for payload in payloads}
+            assert set(by_actor) == {str(first.ref), str(second.ref)}
+            first_action = str(by_actor[str(first.ref)]["action_id"])
+            second_action = str(by_actor[str(second.ref)]["action_id"])
+            assert first_action != second_action
+
+            first_accepted = await resolver.handle_result(
+                first_action,
+                outcome=first_outcome,  # type: ignore[arg-type]
+            )
+
+            async def resolve_second(
+                resolver=resolver,
+                second_action=second_action,
+                second_outcome=second_outcome,
+            ) -> object:
+                return await resolver.handle_result(
+                    second_action,
+                    outcome=second_outcome,  # type: ignore[arg-type]
+                )
+
+            async def release_second(
+                lifecycle=lifecycle,
+                runtime=runtime,
+                second=second,
+            ) -> object:
+                if lifecycle == "interrupt":
+                    return await runtime.interrupt_agent(
+                        caller=HOST,
+                        target=second.path,
+                    )
+                return await runtime.close_agent(
+                    caller=HOST,
+                    target=second.path,
+                )
+
+            second_accepted, _ = await asyncio.gather(
+                _after_ticks(random.randrange(3), resolve_second),
+                _after_ticks(random.randrange(3), release_second),
+            )
+            first_terminal = await runtime.await_terminal(
+                caller=HOST,
+                target=first.path,
+                timeout=1,
+            )
+            assert first_terminal.status != "running"
+            if lifecycle == "interrupt":
+                second_terminal = control.registry.get(
+                    second.ref,
+                    include_closed=True,
+                )
+                assert second_terminal is not None
+                # The approval result and interrupt are intentionally raced.
+                # Whichever linearizes first owns the terminal state, but the
+                # child must never remain running.
+                assert second_terminal.status in {
+                    "completed",
+                    "failed",
+                    "interrupted",
+                }
+            else:
+                second_terminal = control.registry.get(
+                    second.ref,
+                    include_closed=True,
+                )
+                assert second_terminal is not None
+                assert second_terminal.status == "closed"
+
+            assert effect_calls[first.ref] == int(
+                first_accepted and first_outcome == "allow_once"
+            )
+            assert effect_calls[second.ref] == int(
+                second_accepted and second_outcome == "allow_once"
+            )
+            assert effect_calls[first.ref] <= 1
+            assert effect_calls[second.ref] <= 1
+            assert resolver.permissions_snapshot().pending == ()
+            assert not await resolver.handle_result(
+                first_action,
+                outcome="allow_once",
+            )
+            assert not await resolver.handle_result(
+                second_action,
+                outcome="allow_once",
+            )
+
+            await runtime.close_agent(caller=HOST, target=first.path)
+            if lifecycle == "interrupt":
+                await runtime.close_agent(caller=HOST, target=second.path)
+
+            reincarnated = await runtime.spawn_child(
+                caller=HOST,
+                parent_path=AgentPath.root(),
+                name="worker-a",
+                agent_type="worker",
+                initial_prompt="Request one effect in the new incarnation.",
+            )
+            assert reincarnated.ref.incarnation == first.ref.incarnation + 1
+            await _wait_until(lambda payloads=payloads: len(payloads) == 3)
+            reincarnated_payload = payloads[-1]
+            assert reincarnated_payload["actor_id"] == str(reincarnated.ref)
+            reincarnated_action = str(reincarnated_payload["action_id"])
+            assert reincarnated_action not in {first_action, second_action}
+            assert not await resolver.handle_result(
+                first_action,
+                outcome="allow_once",
+            )
+            assert await resolver.handle_result(
+                reincarnated_action,
+                outcome="allow_once",
+            )
+            reincarnated_terminal = await runtime.await_terminal(
+                caller=HOST,
+                target=reincarnated.path,
+                timeout=1,
+            )
+            assert reincarnated_terminal.status == "completed"
+            assert effect_calls[reincarnated.ref] == 1
+
+            await runtime.close_agent(caller=HOST, target=reincarnated.path)
+            await runtime.dispose()
+            assert resolver.permissions_snapshot().pending == ()
+            assert resolver.permissions_snapshot().grants == ()
+            assert [record.path for record in runtime.list_agents(caller=HOST)] == [
+                AgentPath.root()
+            ]
+            assert all(driver.dispose_calls == 1 for driver in factory.drivers.values())
+            assert not any(
+                record.status == "running"
+                for record in control.registry.records(include_closed=True)
+            )
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## What changed

- execute a dynamically registered extension `authorized_tool` through the live AgentSession Policy, Approval, Gateway, handler, and audit pipeline
- verify the handler cannot run before approval and audit projection excludes raw path/content values
- add 36 shuffled concurrent child-approval race cases across allow, deny, abort, interrupt, and close
- verify late approval results are ignored, same-name incarnations remain isolated, effects run at most once, and no pending/grant/running state leaks

## Why

The initial authoring acceptance proved registration and deterministic approval flows. These tests close the remaining gaps around real live-session execution and lifecycle races.

## Impact

Runtime extension authors now have end-to-end contract coverage, while multi-agent approval handling is exercised under concurrent terminal transitions without adding a new runtime abstraction.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests -q` — 6675 passed, 7 skipped
- focused approval/session suite — 103 passed
- Ruff and `git diff --check`