### PR TITLE
test(harness): harden authorization gateway boundaries

### DIFF
--- a/docs/internals/architecture/harness/policy-approval-redesign.md
+++ b/docs/internals/architecture/harness/policy-approval-redesign.md
@@ -1,15 +1,35 @@
 # Policy And Approval Redesign
 
-Status: proposed replacement architecture
+Status: implemented local/session baseline; durable Work/daemon and MCP
+integration remain deferred
 
 Owner: `loushang.harness`
 
-Compatibility: no compatibility guarantee for the current Policy/Approval API
+Compatibility: the implemented public tool-authoring, Policy, Approval,
+execution-profile, and Gateway contracts identified by the checkpoints below
+are the current baseline. Illustrative durable target types are not public
+APIs and carry no compatibility guarantee.
+
+Implementation checkpoint (2026-07-29):
+
+- Product-neutral tools select exactly one explicit `direct_tool` or
+  `authorized_tool` execution route.
+- Authorized actions declare typed effects, freeze one fingerprint, and pass
+  through the session-owned Gateway for Policy, Approval, execution-profile
+  revalidation, execution, and structurally redacted audit.
+- Coding supplies the experience-first Standard/Cautious/Full Access profiles
+  and is the first Product adapter. Extensions and child Agents use the same
+  live Gateway rather than Product-local permission code.
+- The interactive approval broker is complete-once and actor/incarnation
+  scoped. Session and persistent grants, presenter detach/rebind, stale-result
+  rejection, and child lifecycle cleanup have acceptance coverage.
+- Durable pending approval across process restart, authenticated remote
+  reviewers, Work/daemon recovery, and MCP adapters are explicitly deferred.
 
 ## 1. Decision
 
-Replace the current tool-shaped Policy/Approval implementation with a
-product-neutral **authorization runtime**:
+Use a product-neutral **authorization runtime** instead of Product-local,
+tool-shaped Policy/Approval implementations:
 
 ```text
 Action proposal
@@ -22,13 +42,18 @@ Action proposal
   -> audit events
 ```
 
-The new owner is:
+The runtime is a composition of focused Harness modules, not a requirement to
+place every concern in one package:
 
 ```text
-loushang.harness.authorization
+loushang.harness.tools             explicit authoring and execution bindings
+loushang.harness.policy            decisions, subjects, normalization, traces
+loushang.harness.approval          consent lifecycle and bounded grants
+loushang.harness.authorization     effective execution-profile intersection
+loushang.harness.tools.workspace   live Gateway and common action adapters
 ```
 
-`Policy` remains the decision mechanism inside this package. `Approval` is a
+`Policy` remains the decision mechanism inside this composition. `Approval` is a
 separate consent lifecycle. A sandbox or another executor is the enforcement
 mechanism. These three concepts must not be collapsed:
 
@@ -38,10 +63,15 @@ mechanism. These three concepts must not be collapsed:
 | Approval | Who may grant a bounded exception, and for how long? | approval coordinator |
 | Enforcement | What can the process actually read, write, execute, or reach? | executor/sandbox using the authorized profile |
 
-This design is intentionally not a compatibility extension of
-`PolicyDecision(allow|deny|ask)` and `ApprovalDecision(allow|deny)`. Those
-types are too small to represent rule provenance, delegated authority,
-session grants, durable pending approval, or execution-time validation.
+`PolicyDecision(allow|deny|ask)` intentionally remains a narrow verdict.
+Action fingerprints, typed effects, actor provenance, grants, approval
+options, and execution profiles are separate immutable values around that
+verdict; they are not optional fields accumulated on one decision object.
+`ApprovalDecision` distinguishes allow, deny, abort, and scoped retention
+metadata for the local/session lifecycle. Timeout, cancellation, and stale
+responses are coordinator transitions that resolve to or reject those bounded
+decisions. Durable ownership and rehydration will add stores and records
+without widening a decision into a runtime container.
 
 ## 2. Scope
 
@@ -78,18 +108,18 @@ It does **not** replace:
 Those domains may call the authorization runtime before an effect, but they
 retain their own domain models.
 
-## 3. Why The Current Design Should Be Replaced
+## 3. Why The Previous Product-Local Design Was Replaced
 
-The current implementation has useful foundations—immutable requests,
+The previous implementation had useful foundations—immutable requests,
 command normalization, evaluator composition, pending request correlation,
 TUI presentation, and Work event projection—but its central model is not
 strong enough.
 
-### 3.1 Policy is tool-shaped and under-specified
+### 3.1 Policy was tool-shaped and under-specified
 
-Current policy subjects are primarily tool, command, and path values. The
-default engine relies heavily on string and substring matching and falls back
-to allow. It does not model:
+Previous Product-local policy subjects were primarily tool, command, and path
+values. The default engine relied heavily on string and substring matching
+and fell back to allow. It did not model:
 
 - the caller identity and delegation chain;
 - requested effects and resources;
@@ -99,10 +129,10 @@ to allow. It does not model:
 - a stable action fingerprint;
 - whether an approval can legally widen the current authority.
 
-### 3.2 Approval is only a boolean
+### 3.2 Approval was only a boolean
 
-The current request carries a tool name, arguments, and a reason. The result is
-only allow or deny. It cannot express:
+The previous request carried a tool name, arguments, and a reason. The result
+was only allow or deny. It could not express:
 
 - allow once versus allow for this session;
 - a safely scoped persistent rule;
@@ -112,10 +142,11 @@ only allow or deny. It cannot express:
 - an expiry or revocation;
 - a durable pending request across daemon restart.
 
-### 3.3 Presentation owns too much lifecycle
+### 3.3 Presentation owned too much lifecycle
 
-The current interactive broker is bound to one event loop and one live
-presenter. That is adequate for a single interactive session, but not for:
+The previous interactive broker treated one event loop and one live presenter
+as the lifecycle boundary. That was adequate for a single interactive
+session, but not for:
 
 - a TUI detaching and reattaching;
 - multiple authenticated review channels;
@@ -126,10 +157,10 @@ presenter. That is adequate for a single interactive session, but not for:
 The presenter must be a projection of pending state, not the owner of pending
 state.
 
-### 3.4 Enforcement is scattered
+### 3.4 Enforcement was scattered
 
-Workspace tools call `enforce_tool_policy()` individually. This makes it
-difficult to guarantee that every effectful path performs:
+Workspace tools previously called `enforce_tool_policy()` individually. That
+made it difficult to guarantee that every effectful path performed:
 
 1. the same canonicalization;
 2. the same policy evaluation;
@@ -390,7 +421,7 @@ arguments.
 
 The implementation must enforce these invariants:
 
-1. **Every effectful execution has one canonical `ActionRequest`.**
+1. **Every effectful execution has one canonical action snapshot.**
 2. **Hard and managed denies cannot be overridden by approval.**
 3. **A child cannot gain more authority than its delegated envelope.**
 4. **A grant is bounded by actor, action matcher, resource scope, lifetime, and
@@ -409,7 +440,13 @@ The implementation must enforce these invariants:
 
 ## 7. Core Domain Model
 
-The examples below define the intended shape, not final Python syntax.
+The examples below define the durable target shape, not current public Python
+syntax. The local/session implementation uses `PreparedToolAction`,
+`AuthorizedToolAction`, `ToolPolicySubject`, `PolicyDecision`,
+`ApprovalRequest`, `ApprovalDecision`, and `EffectiveExecutionProfile`.
+Names such as `ActorRef`, `ActionRequest`, `PolicyVerdict`, and the durable
+stores below remain design vocabulary until Work/daemon provides their second
+runtime consumer.
 
 ### 7.1 Actor
 
@@ -793,8 +830,10 @@ configured ceiling; high-risk actions may require a user reviewer.
 ### 10.4 Presentation is a projection
 
 Closing the TUI surface does not mutate authorization state unless the user
-explicitly selects deny or abort. Detaching a client leaves a durable request
-pending until expiry or another policy-defined terminal transition.
+explicitly selects deny or abort. In the implemented session baseline,
+detaching a presenter leaves the request in the live coordinator. A future
+Work/daemon owner may persist that request until expiry or another
+policy-defined terminal transition.
 
 The presentation model includes:
 
@@ -878,7 +917,18 @@ started. A pre-execution revalidation or observation-hook failure publishes
 `phase=execution`. All events for one attempt carry the same action
 fingerprint.
 
+Audit transport failure before `tool_execution_started` is fail-closed and the
+effect is not invoked. After a successful non-idempotent effect, failure to
+publish `tool_execution_completed` is logged but does not turn the committed
+effect into a retryable tool failure. If the executor itself fails, that
+original failure remains primary and a terminal-audit failure is attached as
+diagnostic context.
+
 ## 12. Runtime Components And Ports
+
+This is the conceptual durable composition. The implemented local/session
+composition is the focused module layout in section 15; it deliberately does
+not publish a monolithic `AuthorizationRuntime` object or durable store ports.
 
 ```text
 AuthorizationRuntime
@@ -1180,63 +1230,61 @@ Products may choose aliases, but they operate on the shared runtime.
 
 ## 15. Physical Module Layout
 
-Keep the first implementation compact:
+The implemented layout keeps each mechanism focused:
 
 ```text
-src/loushang/harness/authorization/
-  __init__.py
-  types.py          # actor, action, claims, profiles, verdicts, grants
-  policy.py         # modes, rule sources, evaluation and trace
-  approval.py       # request/resolution state and coordinator
-  store.py          # in-memory ports and persistence contracts
-  enforcement.py    # mandatory gateway and revalidation
+src/loushang/harness/
+  effects.py                         # typed protected-resource effects
+  policy.py                          # subjects, decisions, normalization
+  policy_engine.py                   # default Product-injected rule engine
+  approval.py                        # broker, options, grants, rule stores
+  authorization/
+    execution_profile.py             # non-widening effective authority
+  tools/
+    authoring.py                     # direct/authorized tool bindings
+    execution.py                     # prepared/authorized action contracts
+    workspace/
+      authorization.py               # mandatory live Gateway
+      policy.py                      # Policy/Approval enforcement adapter
+      audit.py                       # redacted action/execution projection
 ```
 
-Product adapters remain outside:
+Product adapters remain thin and outside these modules:
 
 ```text
-src/loushang/coding/authorization.py
-src/loushang/harnesstui/...approval...
-src/loushang/work/...authorization projection...
+src/loushang/coding/                 # profile, wording, composition
+src/loushang/harnesstui/approval/    # common interactive projection
+src/loushang/work/                   # event projection; durability deferred
 ```
 
-After cutover, remove:
+`harness.policy`, `harness.approval`, and `harness.authorization` are
+cooperating public boundaries. Merging them into one physical package would
+not improve enforcement and would needlessly invalidate the implemented
+surface. Product packages must not reimplement or re-export these mechanisms.
 
-```text
-src/loushang/harness/policy.py
-src/loushang/harness/policy_engine.py
-src/loushang/harness/approval.py
-src/loushang/coding/policy/
-```
+## 16. Implemented Owner Ledger
 
-Command normalization code that remains generally useful should move into the
-process action adapter rather than being discarded.
+The local/session cutover is complete:
 
-## 16. Current-to-target Cutover Ledger
-
-There must be one cutover, not a permanent legacy bridge:
-
-| Current owner | Target |
+| Concern | Implemented owner |
 |---|---|
-| `harness/policy.py` value types and evaluator chain | replace with `authorization/types.py` and `authorization/policy.py` |
-| command normalization inside `harness/policy.py` | retain behind Coding/process `ActionAdapter` |
-| `harness/policy_engine.py` default string rules | delete; replace with Product profile plus typed rules |
-| `harness/approval.py` resolver/broker | replace with `authorization/approval.py` coordinator and stores |
-| `harness/tools/workspace/policy.py` | replace with the common enforcement gateway |
-| per-tool `policy_engine` / `approval_resolver` arguments | replace with one bound `AuthorizationRuntime` |
-| `harness/tools/workspace/factory.py` policy/approval assembly | compose the Product authorization profile and runtime |
-| `coding/policy/` | delete after Coding action adapters/profile are active |
-| `harness/session/agent_adapter.py` presenter binding | bind/unbind a review channel; pending state stays in the coordinator |
-| `harnesstui` boolean approval surface | select typed `ApprovalOption` values |
-| `harness/multiagent/context.py` approval resolver | replace with actor/delegation context and root coordinator reference |
-| `work/agent_projection.py` tool-specific approval events | project common authorization events |
-| `WorkStepRun.approval_ref` | retain as a reference to the common approval record |
-| extension `register_approval()` replacement slot | remove; add bounded rule/reviewer/detail contributions |
-| extension routing machinery | retain; it is outside the authorization replacement |
+| Policy values, subjects, normalization, evaluation | `harness.policy` and `harness.policy_engine` |
+| Approval request, broker, grants, retained rules | `harness.approval` |
+| Effective sandbox/executor authority | `harness.authorization` |
+| Tool route and immutable action contracts | `harness.tools.authoring` and `harness.tools.execution` |
+| Mandatory Policy → Approval → execution boundary | `harness.tools.workspace.authorization` |
+| Common action adapters and typed effects | `harness.tools.authoring` and `harness.effects` |
+| Session binding and audit event projection | `harness.session` |
+| Interactive approval and permission presentation | `harnesstui.approval` |
+| Coding profile, defaults, and Product wording | `loushang.coding` |
+| Child actor/delegation provenance | `harness.multiagent` plus the Product child factory |
 
-Temporary adapters may exist only inside an implementation branch while a
-batch is being migrated. They are not public compatibility contracts and must
-be removed before the batch exit gate.
+Still deferred:
+
+- durable pending approval and grants across daemon restart;
+- Work waiting/checkpoint/rehydration semantics;
+- authenticated remote reviewer channels;
+- MCP connect/invoke action adapters.
 
 ## 17. Delivery Plan
 
@@ -1489,15 +1537,20 @@ reuse.
 
 ## 20. Acceptance Summary
 
-The redesign is complete only when:
+The implemented local/session baseline satisfies:
 
 1. the same action model drives Policy, Approval, enforcement, and audit;
 2. a user can distinguish allow once, bounded grant, deny, and abort;
 3. a changed action cannot reuse an old approval;
-4. child and durable executions use the same authorization semantics;
-5. TUI/CLI/daemon are review channels rather than lifecycle owners;
+4. root, extension, and child execution use the same Gateway semantics;
+5. TUI presentation is a review channel rather than the approval lifecycle
+   owner;
 6. no approval can exceed managed, Product, delegated, or sandbox ceilings;
-7. the old tool-shaped Policy/Approval stack is deleted.
+7. Product-local tool-shaped Policy/Approval implementations are removed.
+
+The durable extension is complete only when Work and daemon execution can
+persist, rehydrate, review, cancel, and revoke the same bounded actions without
+weakening those invariants.
 
 ## 21. Reference Implementation Evidence
 

--- a/docs/internals/architecture/harness/tool-authoring-guide.md
+++ b/docs/internals/architecture/harness/tool-authoring-guide.md
@@ -22,6 +22,16 @@ and run without a model or network connection:
 uv run python examples/harness/tool_authoring.py
 ```
 
+[`examples/harness/document_product.py`](../../../../../examples/harness/document_product.py)
+is a minimal executable non-Coding Product. It owns a word-count/export tool
+set and Product-specific approval wording while reusing Harness authoring,
+Policy, Approval, Gateway, and audit. The adapter defaults to headless deny;
+the deterministic example runner explicitly injects an allow reviewer:
+
+```bash
+uv run python examples/harness/document_product.py
+```
+
 ## Pure In-Process Tool
 
 Use `direct_tool` when the handler consumes no common protected resource:

--- a/examples/harness/document_product.py
+++ b/examples/harness/document_product.py
@@ -1,0 +1,157 @@
+"""A minimal non-Coding Product that consumes the public Harness tool runtime."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from loushang.agent.types import AgentTool
+from loushang.harness.approval import ApprovalResolver, HeadlessApprovalResolver
+from loushang.harness.effects import FilesystemEffect
+from loushang.harness.policy import PolicyDecision, ToolPolicySubject
+from loushang.harness.tools import (
+    FilesystemActionAdapter,
+    ToolContext,
+    ToolRegistry,
+    authorized_tool,
+    direct_tool,
+    tool,
+)
+from loushang.harness.tools.workspace.authorization import (
+    create_workspace_tool_execution_host,
+)
+
+
+@tool()
+async def count_words(text: str) -> int:
+    """Count words without consuming a protected resource."""
+
+    return len(text.split())
+
+
+@tool()
+async def export_document(
+    path: str,
+    content: str,
+    context: ToolContext,
+) -> str:
+    """Export one document after the write effect has been authorized."""
+
+    target = Path(context.cwd or ".") / path
+    target.write_text(content, encoding="utf-8")
+    return str(target.resolve())
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentProductPolicy:
+    """Own Product wording and defaults without reimplementing the Gateway."""
+
+    def evaluate(self, subject: ToolPolicySubject) -> PolicyDecision:
+        if any(
+            isinstance(effect, FilesystemEffect)
+            and effect.operation == "write"
+            for effect in subject.effects
+        ):
+            return PolicyDecision.ask(
+                "Confirm document export",
+                code="document_export",
+            )
+        return PolicyDecision.allow()
+
+
+@dataclass(slots=True)
+class DocumentProduct:
+    """Small executable Product adapter over the common Harness boundaries."""
+
+    export_root: Path
+    approval_resolver: ApprovalResolver = field(
+        default_factory=lambda: HeadlessApprovalResolver(mode="deny"),
+        repr=False,
+    )
+    events: list[dict[str, object]] = field(default_factory=list)
+    _tools: dict[str, AgentTool[Any]] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.export_root.mkdir(parents=True, exist_ok=True)
+        registry = ToolRegistry(
+            execution_host=create_workspace_tool_execution_host(
+                policy_evaluator=DocumentProductPolicy(),
+                approval_resolver=self.approval_resolver,
+            )
+        )
+        definitions = (
+            direct_tool(count_words),
+            authorized_tool(
+                export_document,
+                action=FilesystemActionAdapter(
+                    "write",
+                    authorization_fields=("content",),
+                ),
+            ),
+        )
+        for definition in definitions:
+            registry.register_tool(definition)
+        self._tools = {
+            item.name: item
+            for item in registry.materialize_definitions(
+                definitions,
+                context_provider=lambda *, tool_call_id: ToolContext(
+                    tool_call_id=tool_call_id,
+                    cwd=str(self.export_root),
+                    event_sink=self.events.append,
+                ),
+            )
+        }
+
+    async def count(self, text: str) -> int:
+        tool = self._tools["count_words"]
+        result = await tool.execute("document-count", {"text": text})
+        return int(result.details)
+
+    async def export(self, path: str, content: str) -> Path:
+        tool = self._tools["export_document"]
+        result = await tool.execute(
+            "document-export",
+            {"path": path, "content": content},
+        )
+        return Path(str(result.details))
+
+
+async def run_example(export_root: Path) -> dict[str, object]:
+    product = DocumentProduct(
+        export_root,
+        approval_resolver=HeadlessApprovalResolver(mode="allow"),
+    )
+    content = "Harness keeps Product policy thin."
+    word_count = await product.count(content)
+    exported = await product.export("brief.txt", content)
+    return {
+        "word_count": word_count,
+        "exported": exported.name,
+        "content": exported.read_text(encoding="utf-8"),
+        "audit_events": [event["type"] for event in product.events],
+        "policy_code": next(
+            event["policy_code"]
+            for event in product.events
+            if event["type"] == "tool_policy_evaluated"
+        ),
+    }
+
+
+def main() -> None:
+    with TemporaryDirectory(prefix="loushang-document-product-") as directory:
+        print(
+            json.dumps(
+                asyncio.run(run_example(Path(directory))),
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/loushang/harness/authorization/execution_profile.py
+++ b/src/loushang/harness/authorization/execution_profile.py
@@ -51,7 +51,7 @@ def resolve_effective_execution_profile(
     approval: ApprovalDecision | None = None,
     approval_action_id: str | None = None,
 ) -> EffectiveExecutionProfile:
-    """Resolve legacy Policy/Approval into a non-widening execution profile."""
+    """Resolve Policy/Approval into a non-widening execution profile."""
 
     if decision.disposition == "deny":
         raise ExecutionAuthorizationError(decision.reason or "execution denied by policy")

--- a/src/loushang/harness/tools/workspace/authorization.py
+++ b/src/loushang/harness/tools/workspace/authorization.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import logging
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,6 +39,7 @@ from .audit import (
 from .policy import ToolPolicyEvaluator, enforce_tool_policy
 
 T = TypeVar("T")
+_LOGGER = logging.getLogger(__name__)
 WorkspaceActionExecutor = Callable[
     [AuthorizedToolAction],
     T | Awaitable[T],
@@ -285,18 +287,26 @@ async def _execute_authorized_tool_action(
         except BaseException as audit_error:
             error.add_note(f"terminal audit emission failed: {audit_error}")
         raise
-    await _emit_audit_event(
-        audit_sink,
-        {
-            "type": "tool_execution_completed",
-            **_execution_audit_details(
-                action,
-                tool_call_id=tool_call_id,
-                outcome="completed",
-                phase="execution",
-            ),
-        },
-    )
+    try:
+        await _emit_audit_event(
+            audit_sink,
+            {
+                "type": "tool_execution_completed",
+                **_execution_audit_details(
+                    action,
+                    tool_call_id=tool_call_id,
+                    outcome="completed",
+                    phase="execution",
+                ),
+            },
+        )
+    except Exception:
+        # The protected effect has already committed. Turning a terminal audit
+        # transport failure into a tool failure would invite an unsafe retry
+        # of a delete, publication, or other non-idempotent operation.
+        _LOGGER.exception(
+            "terminal tool audit emission failed after successful execution",
+        )
     return result
 
 

--- a/tests/examples/test_harness_document_product_example.py
+++ b/tests/examples/test_harness_document_product_example.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_example() -> ModuleType:
+    path = Path("examples/harness/document_product.py")
+    spec = importlib.util.spec_from_file_location(
+        "examples_harness_document_product",
+        path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+    return module
+
+
+def test_document_reference_product_uses_public_harness_gateway(
+    tmp_path: Path,
+) -> None:
+    module = _load_example()
+
+    result = asyncio.run(module.run_example(tmp_path))
+
+    assert result == {
+        "word_count": 5,
+        "exported": "brief.txt",
+        "content": "Harness keeps Product policy thin.",
+        "audit_events": [
+            "tool_action_frozen",
+            "tool_policy_evaluated",
+            "tool_approval_requested",
+            "tool_approval_resolved",
+            "tool_execution_started",
+            "tool_execution_completed",
+        ],
+        "policy_code": "document_export",
+    }
+    assert "loushang.coding" not in Path(
+        "examples/harness/document_product.py"
+    ).read_text(encoding="utf-8")
+
+
+def test_document_reference_product_denies_export_without_an_injected_reviewer(
+    tmp_path: Path,
+) -> None:
+    module = _load_example()
+    product = module.DocumentProduct(tmp_path)
+
+    with pytest.raises(PermissionError, match="Confirm document export"):
+        asyncio.run(product.export("denied.txt", "not exported"))
+
+    assert not (tmp_path / "denied.txt").exists()

--- a/tests/harness/session/test_multiagent_approval_stress.py
+++ b/tests/harness/session/test_multiagent_approval_stress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from itertools import product
@@ -8,10 +9,8 @@ from random import Random
 
 from loushang.harness.approval import (
     ActorBoundApprovalResolver,
-    ApprovalRequest,
     HeadlessApprovalResolver,
     InteractiveApprovalResolver,
-    resolve_approval,
 )
 from loushang.harness.multiagent import (
     AgentInputMessage,
@@ -24,12 +23,31 @@ from loushang.harness.multiagent import (
     SubagentRoundResult,
 )
 from loushang.harness.multiagent.run_handle import RoundMode
+from loushang.harness.policy import PolicyDecision
 from loushang.harness.session.multiagent import (
     SessionMultiAgentRuntime,
     SessionSubagentRequest,
 )
+from loushang.harness.tools import (
+    FilesystemActionAdapter,
+    ToolContext,
+    ToolRegistry,
+    authorized_tool,
+    tool,
+)
+from loushang.harness.tools.workspace.authorization import (
+    create_workspace_tool_execution_host,
+)
 
 HOST = HostCaller()
+
+
+class _AskForStressEffect:
+    def evaluate(self, _subject: object) -> PolicyDecision:
+        return PolicyDecision.ask(
+            "Confirm the protected stress effect",
+            code="stress_effect",
+        )
 
 
 class _ApprovalStressDriver:
@@ -48,8 +66,40 @@ class _ApprovalStressDriver:
         )
         self._effect_calls = effect_calls
         self._cycle = cycle
+        self.audit_events: list[dict[str, object]] = []
         self.messages: list[AgentInputMessage] = []
         self.dispose_calls = 0
+
+        @tool(name="delete_stress_target")
+        async def delete_stress_target(
+            path: str,
+            context: ToolContext,
+        ) -> str:
+            del context
+            # Leave one scheduling boundary after authorization so lifecycle
+            # operations can race the admitted effect.
+            await asyncio.sleep(0)
+            self._effect_calls[self.ref] += 1
+            return path
+
+        definition = authorized_tool(
+            delete_stress_target,
+            action=FilesystemActionAdapter("delete"),
+        )
+        registry = ToolRegistry(
+            execution_host=create_workspace_tool_execution_host(
+                policy_evaluator=_AskForStressEffect(),
+                approval_resolver=self._approval,
+            )
+        )
+        registry.register_tool(definition)
+        self._tool = registry.materialize_definitions(
+            [definition],
+            context_provider=lambda *, tool_call_id: ToolContext(
+                tool_call_id=tool_call_id,
+                event_sink=self.audit_events.append,
+            ),
+        )[0]
 
     def deliver(self, message: AgentInputMessage) -> None:
         self.messages.append(message)
@@ -62,29 +112,17 @@ class _ApprovalStressDriver:
     ) -> SubagentRoundResult:
         del mode
         self._approval.open_session()
-        decision = await resolve_approval(
-            self._approval,
-            ApprovalRequest(
-                tool_name="bash",
-                arguments={
-                    "command": f"rm -r stress-target-{self._cycle}-{self.ref.path.name}"
-                },
-                action_id=f"stress-{self._cycle}-{self.ref}-round-{round_id}",
-                reason="Filesystem content would be deleted",
-            ),
+        result = await self._tool.execute(
+            f"stress-{self._cycle}-{self.ref}-round-{round_id}",
+            {
+                "path": (
+                    f"/tmp/stress-target-{self._cycle}-{self.ref.path.name}"
+                )
+            },
         )
-        if decision.disposition == "allow":
-            # Widen the window in which close/interrupt can race an accepted
-            # decision without letting the protected effect run twice.
-            await asyncio.sleep(0)
-            self._effect_calls[self.ref] += 1
-            return SubagentRoundResult(
-                status="completed",
-                final_message="Protected effect completed.",
-            )
         return SubagentRoundResult(
-            status="failed",
-            final_message=decision.reason or decision.disposition,
+            status="completed",
+            final_message=str(result.details),
         )
 
     def abort(self) -> None:
@@ -261,11 +299,35 @@ def test_concurrent_child_approval_races_preserve_lifecycle_invariants() -> None
             assert effect_calls[first.ref] == int(
                 first_accepted and first_outcome == "allow_once"
             )
-            assert effect_calls[second.ref] == int(
-                second_accepted and second_outcome == "allow_once"
-            )
+            if not second_accepted or second_outcome != "allow_once":
+                assert effect_calls[second.ref] == 0
             assert effect_calls[first.ref] <= 1
             assert effect_calls[second.ref] <= 1
+            for ref in (first.ref, second.ref):
+                events = factory.drivers[ref].audit_events
+                event_types = [str(event["type"]) for event in events]
+                assert event_types[:3] == [
+                    "tool_action_frozen",
+                    "tool_policy_evaluated",
+                    "tool_approval_requested",
+                ]
+                assert event_types.count("tool_execution_started") <= 1
+                terminal_audit_count = sum(
+                    event_type
+                    in {"tool_execution_completed", "tool_execution_failed"}
+                    for event_type in event_types
+                )
+                assert terminal_audit_count == event_types.count(
+                    "tool_execution_started"
+                )
+                assert len(
+                    {
+                        event["action_fingerprint"]
+                        for event in events
+                        if "action_fingerprint" in event
+                    }
+                ) == 1
+                assert "stress-target" not in json.dumps(events)
             assert resolver.permissions_snapshot().pending == ()
             assert not await resolver.handle_result(
                 first_action,
@@ -308,6 +370,13 @@ def test_concurrent_child_approval_races_preserve_lifecycle_invariants() -> None
             )
             assert reincarnated_terminal.status == "completed"
             assert effect_calls[reincarnated.ref] == 1
+            reincarnated_events = factory.drivers[
+                reincarnated.ref
+            ].audit_events
+            assert [event["type"] for event in reincarnated_events][-2:] == [
+                "tool_execution_started",
+                "tool_execution_completed",
+            ]
 
             await runtime.close_agent(caller=HOST, target=reincarnated.path)
             await runtime.dispose()

--- a/tests/harness/tools/test_authorization_gateway_faults.py
+++ b/tests/harness/tools/test_authorization_gateway_faults.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+import pytest
+
+from loushang.harness.approval import (
+    HeadlessApprovalResolver,
+    InteractiveApprovalResolver,
+)
+from loushang.harness.policy import PolicyDecision
+from loushang.harness.sandbox import SandboxUnavailableError
+from loushang.harness.tools import (
+    PublicationActionAdapter,
+    ToolContext,
+    ToolRegistry,
+    authorized_tool,
+    tool,
+)
+from loushang.harness.tools.workspace.authorization import (
+    create_workspace_tool_execution_host,
+)
+
+
+@dataclass
+class _Policy:
+    decision: PolicyDecision | None = None
+    error: Exception | None = None
+
+    def evaluate(self, _subject: object) -> PolicyDecision:
+        if self.error is not None:
+            raise self.error
+        assert self.decision is not None
+        return self.decision
+
+
+class _AuditSink:
+    def __init__(self, *, fail_on: str | None = None) -> None:
+        self.fail_on = fail_on
+        self.events: list[dict[str, object]] = []
+
+    def __call__(self, event: dict[str, object]) -> None:
+        self.events.append(dict(event))
+        if event["type"] == self.fail_on:
+            raise RuntimeError(f"audit transport failed at {self.fail_on}")
+
+
+def _materialize_effect_tool(
+    *,
+    policy: _Policy,
+    handler: Callable[[str], str | Awaitable[str]],
+    audit_sink: _AuditSink,
+    approval_resolver: object | None = None,
+):
+    @tool(name="publish_artifact")
+    async def publish_artifact(target: str, context: ToolContext) -> str:
+        del context
+        result = handler(target)
+        return await result if isinstance(result, Awaitable) else result
+
+    definition = authorized_tool(
+        publish_artifact,
+        action=PublicationActionAdapter(),
+    )
+    registry = ToolRegistry(
+        execution_host=create_workspace_tool_execution_host(
+            policy_evaluator=policy,
+            approval_resolver=approval_resolver,  # type: ignore[arg-type]
+        )
+    )
+    registry.register_tool(definition)
+    return registry.materialize_definitions(
+        [definition],
+        context_provider=lambda *, tool_call_id: ToolContext(
+            tool_call_id=tool_call_id,
+            event_sink=audit_sink,
+        ),
+    )[0]
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_types"),
+    (
+        (
+            "action_audit",
+            ("tool_action_frozen",),
+        ),
+        (
+            "policy",
+            ("tool_action_frozen",),
+        ),
+        (
+            "policy_audit",
+            ("tool_action_frozen", "tool_policy_evaluated"),
+        ),
+        (
+            "approval_resolved_audit",
+            (
+                "tool_action_frozen",
+                "tool_policy_evaluated",
+                "tool_approval_requested",
+                "tool_approval_resolved",
+            ),
+        ),
+        (
+            "execution_started_audit",
+            (
+                "tool_action_frozen",
+                "tool_policy_evaluated",
+                "tool_execution_started",
+            ),
+        ),
+    ),
+)
+def test_gateway_fails_closed_when_a_pre_effect_stage_fails(
+    failure: str,
+    expected_types: tuple[str, ...],
+) -> None:
+    handler_calls = 0
+
+    def handler(_target: str) -> str:
+        nonlocal handler_calls
+        handler_calls += 1
+        return "published"
+
+    policy = _Policy(
+        error=RuntimeError("policy unavailable") if failure == "policy" else None,
+        decision=(
+            None
+            if failure == "policy"
+            else (
+                PolicyDecision.ask(
+                    "Confirm publication",
+                    code="publication",
+                )
+                if failure == "approval_resolved_audit"
+                else PolicyDecision.allow()
+            )
+        ),
+    )
+    sink = _AuditSink(
+        fail_on={
+            "action_audit": "tool_action_frozen",
+            "policy_audit": "tool_policy_evaluated",
+            "approval_resolved_audit": "tool_approval_resolved",
+            "execution_started_audit": "tool_execution_started",
+        }.get(failure)
+    )
+    runtime_tool = _materialize_effect_tool(
+        policy=policy,
+        handler=handler,
+        audit_sink=sink,
+        approval_resolver=(
+            HeadlessApprovalResolver(mode="allow")
+            if failure == "approval_resolved_audit"
+            else None
+        ),
+    )
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(
+            runtime_tool.execute(
+                f"call-{failure}",
+                {"target": "registry.example.invalid/release"},
+            )
+        )
+
+    assert handler_calls == 0
+    assert tuple(event["type"] for event in sink.events) == expected_types
+
+
+def test_gateway_cleans_pending_approval_when_presenter_fails() -> None:
+    handler_calls = 0
+
+    def handler(_target: str) -> str:
+        nonlocal handler_calls
+        handler_calls += 1
+        return "published"
+
+    resolver = InteractiveApprovalResolver(
+        fallback=HeadlessApprovalResolver(mode="deny")
+    )
+    resolver.open_session()
+
+    def fail_presenter(_payload: dict[str, object]) -> None:
+        raise RuntimeError("approval presenter unavailable")
+
+    resolver.set_request_presenter(fail_presenter)
+    sink = _AuditSink()
+    runtime_tool = _materialize_effect_tool(
+        policy=_Policy(
+            decision=PolicyDecision.ask(
+                "Confirm publication",
+                code="publication",
+            )
+        ),
+        handler=handler,
+        audit_sink=sink,
+        approval_resolver=resolver,
+    )
+
+    with pytest.raises(RuntimeError, match="approval presenter unavailable"):
+        asyncio.run(
+            runtime_tool.execute(
+                "call-presenter-failure",
+                {"target": "registry.example.invalid/release"},
+            )
+        )
+
+    assert handler_calls == 0
+    assert resolver.permissions_snapshot().pending == ()
+    assert [event["type"] for event in sink.events] == [
+        "tool_action_frozen",
+        "tool_policy_evaluated",
+        "tool_approval_requested",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("error", "outcome"),
+    (
+        (RuntimeError("executor failed to start"), "error"),
+        (TimeoutError("executor timed out"), "timeout"),
+        (SandboxUnavailableError("sandbox unavailable"), "error"),
+    ),
+)
+def test_gateway_records_one_terminal_failure_for_executor_faults(
+    error: Exception,
+    outcome: str,
+) -> None:
+    handler_calls = 0
+
+    def handler(_target: str) -> str:
+        nonlocal handler_calls
+        handler_calls += 1
+        raise error
+
+    sink = _AuditSink()
+    runtime_tool = _materialize_effect_tool(
+        policy=_Policy(decision=PolicyDecision.allow()),
+        handler=handler,
+        audit_sink=sink,
+    )
+
+    with pytest.raises(type(error), match=str(error)):
+        asyncio.run(
+            runtime_tool.execute(
+                "call-executor-fault",
+                {"target": "registry.example.invalid/release"},
+            )
+        )
+
+    assert handler_calls == 1
+    assert [event["type"] for event in sink.events][-2:] == [
+        "tool_execution_started",
+        "tool_execution_failed",
+    ]
+    assert sink.events[-1]["outcome"] == outcome
+    assert sum(
+        event["type"] in {"tool_execution_completed", "tool_execution_failed"}
+        for event in sink.events
+    ) == 1
+
+
+def test_gateway_records_cancellation_without_reinvoking_handler() -> None:
+    async def scenario() -> tuple[int, list[dict[str, object]]]:
+        handler_calls = 0
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def handler(_target: str) -> str:
+            nonlocal handler_calls
+            handler_calls += 1
+            entered.set()
+            await release.wait()
+            return "published"
+
+        sink = _AuditSink()
+        runtime_tool = _materialize_effect_tool(
+            policy=_Policy(decision=PolicyDecision.allow()),
+            handler=handler,
+            audit_sink=sink,
+        )
+        pending = asyncio.create_task(
+            runtime_tool.execute(
+                "call-cancelled",
+                {"target": "registry.example.invalid/release"},
+            )
+        )
+        await entered.wait()
+        pending.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        return handler_calls, sink.events
+
+    handler_calls, events = asyncio.run(scenario())
+
+    assert handler_calls == 1
+    assert [event["type"] for event in events][-2:] == [
+        "tool_execution_started",
+        "tool_execution_failed",
+    ]
+    assert events[-1]["outcome"] == "cancelled"
+
+
+def test_terminal_audit_failure_after_success_does_not_invite_effect_retry(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    handler_calls = 0
+
+    def handler(_target: str) -> str:
+        nonlocal handler_calls
+        handler_calls += 1
+        return "published"
+
+    sink = _AuditSink(fail_on="tool_execution_completed")
+    runtime_tool = _materialize_effect_tool(
+        policy=_Policy(decision=PolicyDecision.allow()),
+        handler=handler,
+        audit_sink=sink,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        result = asyncio.run(
+            runtime_tool.execute(
+                "call-terminal-audit-failure",
+                {"target": "registry.example.invalid/release"},
+            )
+        )
+
+    assert result.details == "published"
+    assert handler_calls == 1
+    assert sink.events[-1]["type"] == "tool_execution_completed"
+    assert (
+        "terminal tool audit emission failed after successful execution"
+        in caplog.text
+    )
+
+
+def test_terminal_audit_failure_preserves_original_executor_error() -> None:
+    def handler(_target: str) -> str:
+        raise ValueError("publication failed")
+
+    sink = _AuditSink(fail_on="tool_execution_failed")
+    runtime_tool = _materialize_effect_tool(
+        policy=_Policy(decision=PolicyDecision.allow()),
+        handler=handler,
+        audit_sink=sink,
+    )
+
+    with pytest.raises(ValueError, match="publication failed") as caught:
+        asyncio.run(
+            runtime_tool.execute(
+                "call-double-fault",
+                {"target": "registry.example.invalid/release"},
+            )
+        )
+
+    assert any(
+        "terminal audit emission failed" in note
+        for note in (caught.value.__notes__ or ())
+    )


### PR DESCRIPTION
## Summary

- run concurrent child approval stress through the real authorized-tool Gateway, including actor/incarnation isolation, fingerprints, audit terminals, and effect-at-most-once checks
- add Gateway fault injection for Policy, Approval presentation, audit transport, executor/sandbox startup, timeout, cancellation, and double-fault behavior
- prevent a successful protected effect from being surfaced as retryable solely because terminal audit delivery failed
- reconcile the Policy/Approval architecture document with the implemented local/session baseline and explicitly deferred durable work
- add an executable non-Coding Document reference Product with direct and authorized tools, safe headless-deny defaults, and Product-owned approval wording

## Impact

Effectful tools remain fail-closed before execution. Once an effect has completed, a terminal audit transport error is logged instead of turning the completed operation into a tool failure that could trigger an unsafe retry.

The Document reference Product demonstrates that a second Product can consume the public Harness tool, Policy, Approval, Gateway, and audit contracts without importing Coding.

## Validation

- Full test suite: 6689 passed, 7 skipped
- Focused Harness/session/Coding/examples/import-boundary suite: 445 passed
- Ruff on all touched Python files
- git diff --check
- executable Document Product smoke test
