### PR TITLE
refactor(harness): unify session operation contracts

### DIFF
--- a/docs/internals/architecture/drafts/application-service-refactor.md
+++ b/docs/internals/architecture/drafts/application-service-refactor.md
@@ -554,7 +554,11 @@ Implementation status (2026-07-30): implemented. TUI and legacy RPC now use
 current-Session operation resolvers; turn-only abort and the TUI stop composite
 are distinct; approval presentation uses the explicit interaction port and a
 generation-safe lease; pending queue projection no longer discovers Session
-methods dynamically.
+methods dynamically. Shared prompt operations have one settled-return
+contract across TUI, Scenario, and Work adapters, verified by a reusable
+Product contract suite. Legacy RPC lifecycle, model/settings, transcript, and
+Bash/maintenance commands are separate command groups while preserving the
+existing JSONL wire.
 
 1. Keep shared primitive input/queue/lifecycle mutations in
    `SessionOperationRuntime`; do not move command execution, Bash, catalogs, or

--- a/docs/internals/architecture/drafts/application-service-refactor.md
+++ b/docs/internals/architecture/drafts/application-service-refactor.md
@@ -557,8 +557,10 @@ generation-safe lease; pending queue projection no longer discovers Session
 methods dynamically. Shared prompt operations have one settled-return
 contract across TUI, Scenario, and Work adapters, verified by a reusable
 Product contract suite. Legacy RPC lifecycle, model/settings, transcript, and
-Bash/maintenance commands are separate command groups while preserving the
-existing JSONL wire.
+Bash/maintenance, and command-catalog commands are separate command groups
+while preserving the existing JSONL wire. Each newly extracted group accepts
+a narrow private Product protocol instead of a shared all-capabilities RPC
+Session interface.
 
 1. Keep shared primitive input/queue/lifecycle mutations in
    `SessionOperationRuntime`; do not move command execution, Bash, catalogs, or

--- a/docs/internals/architecture/harness/mode-host-boundary.md
+++ b/docs/internals/architecture/harness/mode-host-boundary.md
@@ -23,6 +23,25 @@ The shared RPC host receives `RpcEventProjection` and
 Product's event names, diagnostic wire fields, or Work domain. The shared
 plain host receives equivalent event and Work ports.
 
+`loushang.harness.host.rpc.testing` is the canonical test driver for this
+wire. `play_rpc_wire(...)` covers finite golden traces; `RpcWirePlayback`
+supports staged dispatch, snapshots, and final task settlement for concurrent
+prompt/abort/bash scenarios. Product-specific fake sessions and expected
+payloads remain in Product tests rather than entering the Harness package.
+
+## Abort and settlement
+
+An RPC `abort` response acknowledges that the turn-abort request was accepted;
+it does not claim that the turn is already idle. The prompt task remains the
+single settlement owner and performs exactly one idle wait. RPC host shutdown
+drains tracked prompt/bash tasks before transport teardown.
+
+The screen TUI keeps its established composite intent: abort the active turn,
+clear queued input, and abort the active command. The presented action host
+then waits for idle exactly once. `SessionOperationRuntime.abort_turn()` itself
+does not clear queues, cancel commands, or wait, so other hosts can compose
+their own visible behavior without inheriting TUI policy.
+
 ## Coding surface after cutover
 
 Coding keeps only:
@@ -47,5 +66,6 @@ remain outside the shared host implementation.
 ## Verification
 
 The existing Coding RPC, print, Channel, and JSON projection behavior tests
-remain the regression suite. Architecture tests verify that HarnessTUI does
-not import Coding, and that the moved RPC implementation is neutral.
+remain the regression suite. RPC golden and concurrency playback uses the
+Harness testing API. Architecture tests verify that HarnessTUI does not import
+Coding, and that the moved RPC implementation is neutral.

--- a/docs/internals/architecture/harness/session-facade-boundary.md
+++ b/docs/internals/architecture/harness/session-facade-boundary.md
@@ -40,9 +40,20 @@ mapping, task lifecycle, and error wording.
 Hosts receive a `SessionOperationResolver` rather than retaining one runtime
 bound to a concrete Session. The resolver constructs the operation runtime
 from the Product's current control after new, restore, fork, or clone. Its
-`abort_turn()` operation stops only the active turn. TUI-level
+`prompt()` operation returns after the submitted turn has settled; hosts do
+not append a second `wait_for_idle()` to ordinary prompt dispatch. Explicit
+idle waits remain valid for independently initiated operations such as abort
+settlement and the legacy RPC wait command. Scenario and Work adapters share
+the same settled-prompt contract and do not expose a configurable
+"wait-after-prompt" mode.
+
+The runtime's `abort_turn()` operation stops only the active turn. TUI-level
 `stop_active_interaction` remains an explicit composite that also clears the
 Session queue and aborts selected command execution.
+
+Optional operation groups fail with `SessionOperationUnavailableError`.
+Missing methods and `AttributeError` raised inside a Product implementation are
+programming failures and must not be converted into an "unavailable" result.
 
 Approval presentation is an optional `SessionApprovalInteractionPort`.
 It delegates presenter binding, responses, permission snapshots, and permission

--- a/docs/internals/architecture/harness/session-facade-boundary.md
+++ b/docs/internals/architecture/harness/session-facade-boundary.md
@@ -55,6 +55,11 @@ Optional operation groups fail with `SessionOperationUnavailableError`.
 Missing methods and `AttributeError` raised inside a Product implementation are
 programming failures and must not be converted into an "unavailable" result.
 
+Legacy RPC command groups consume narrow private Product protocols for their
+direct model/settings, transcript, Bash, lifecycle-index, and command-catalog
+dependencies. These protocols are local typing boundaries, not a second
+Session facade and not a public all-capabilities RPC interface.
+
 Approval presentation is an optional `SessionApprovalInteractionPort`.
 It delegates presenter binding, responses, permission snapshots, and permission
 actions to the Product's existing resolver. `ApprovalBroker` remains the sole

--- a/src/loushang/coding/prompt_command.py
+++ b/src/loushang/coding/prompt_command.py
@@ -125,7 +125,6 @@ async def run_prompt_plan_command(
             session_id=session_identity(session),
             before_turn=before_turn,
             after_turn=after_turn,
-            wait_for_idle_after_prompt=True,
         )
 
     return await run_agent_plain_prompt_plan(

--- a/src/loushang/coding/ui/product_binding.py
+++ b/src/loushang/coding/ui/product_binding.py
@@ -11,6 +11,8 @@ from loushang.harness.commands import CommandEffectKind
 from loushang.harness.host.types import HostActionResult
 from loushang.harness.session import (
     SessionControlPort,
+    SessionOperationAvailability,
+    SessionOperationResolver,
     session_operation_resolver,
 )
 from loushang.harnesstui.commands.catalog import ConversationCommandCatalog
@@ -36,24 +38,13 @@ def build_coding_ui_controller(
     runtime: Any | None = None,
     verbose: bool = False,
 ) -> ConversationUiController:
-    def current_session() -> Any:
-        if runtime is not None:
-            getter = getattr(runtime, "get_current_session", None)
-            if callable(getter):
-                current = getter()
-                if current is not None:
-                    return current
-            current = getattr(runtime, "current_session", None)
-            if current is not None:
-                return current
-        return session
+    get_operations = build_coding_session_operation_resolver(
+        session=session,
+        runtime=runtime,
+    )
 
-    def current_control() -> SessionControlPort:
-        current = current_session()
-        return cast(
-            SessionControlPort,
-            getattr(current, "session_control", current),
-        )
+    def current_session() -> Any:
+        return _current_coding_session(session=session, runtime=runtime)
 
     async def dispatch_session_command(
         intent: object,
@@ -101,7 +92,7 @@ def build_coding_ui_controller(
             abort()
 
     return build_standard_conversation_ui_controller(
-        get_operations=session_operation_resolver(current_control),
+        get_operations=get_operations,
         dispatch_session_command=dispatch_session_command,
         execute_bash=execute_bash,
         abort_command=abort_command,
@@ -109,6 +100,43 @@ def build_coding_ui_controller(
         problem_code_prefix="coding_ui",
         problem_logger=_LOG,
     )
+
+
+def build_coding_session_operation_resolver(
+    *,
+    session: Any,
+    runtime: Any | None = None,
+    availability: SessionOperationAvailability | None = None,
+) -> SessionOperationResolver:
+    """Bind shared operations to Coding's dynamically current Session."""
+
+    def current_session() -> Any:
+        return _current_coding_session(session=session, runtime=runtime)
+
+    def current_control() -> SessionControlPort:
+        current = current_session()
+        return cast(
+            SessionControlPort,
+            getattr(current, "session_control", current),
+        )
+
+    return session_operation_resolver(
+        current_control,
+        availability=availability,
+    )
+
+
+def _current_coding_session(*, session: Any, runtime: Any | None) -> Any:
+    if runtime is not None:
+        getter = getattr(runtime, "get_current_session", None)
+        if callable(getter):
+            current = getter()
+            if current is not None:
+                return current
+        current = getattr(runtime, "current_session", None)
+        if current is not None:
+            return current
+    return session
 
 
 def _coding_result_from_command_execution(
@@ -168,6 +196,7 @@ def image_parts_from_prompt_attachments(
 
 
 __all__ = [
+    "build_coding_session_operation_resolver",
     "build_coding_ui_controller",
     "build_screen_coding_action_host",
     "image_parts_from_prompt_attachments",

--- a/src/loushang/harness/host/rpc/__init__.py
+++ b/src/loushang/harness/host/rpc/__init__.py
@@ -11,6 +11,12 @@ from .runtime import (
     RpcHost,
     run_rpc_host,
 )
+from .testing import (
+    RpcWirePlayback,
+    RpcWirePlaybackResult,
+    play_rpc_wire,
+    play_rpc_wire_async,
+)
 from .types import RpcModel, RpcModelCost, RpcSessionState
 
 __all__ = [
@@ -21,7 +27,11 @@ __all__ = [
     "RpcModel",
     "RpcModelCost",
     "RpcSessionState",
+    "RpcWirePlayback",
+    "RpcWirePlaybackResult",
     "STANDARD_AGENT_RPC_EVENT_PROJECTION",
     "STANDARD_RPC_DIAGNOSTICS_PROJECTION",
+    "play_rpc_wire",
+    "play_rpc_wire_async",
     "run_rpc_host",
 ]

--- a/src/loushang/harness/host/rpc/commands/__init__.py
+++ b/src/loushang/harness/host/rpc/commands/__init__.py
@@ -1,6 +1,7 @@
 """Cohesive command groups composed by :mod:`loushang.harness.host.rpc.runtime`."""
 
 from .bash_maintenance import RpcBashMaintenanceCommands
+from .command_catalog import RpcCommandCatalogCommands
 from .diagnostics import RpcDiagnosticsCommands
 from .model_settings import RpcModelSettingsCommands
 from .packages import RpcPackageCommands
@@ -9,6 +10,7 @@ from .transcript import RpcTranscriptCommands
 
 __all__ = [
     "RpcBashMaintenanceCommands",
+    "RpcCommandCatalogCommands",
     "RpcDiagnosticsCommands",
     "RpcModelSettingsCommands",
     "RpcPackageCommands",

--- a/src/loushang/harness/host/rpc/commands/__init__.py
+++ b/src/loushang/harness/host/rpc/commands/__init__.py
@@ -1,6 +1,17 @@
 """Cohesive command groups composed by :mod:`loushang.harness.host.rpc.runtime`."""
 
+from .bash_maintenance import RpcBashMaintenanceCommands
 from .diagnostics import RpcDiagnosticsCommands
+from .model_settings import RpcModelSettingsCommands
 from .packages import RpcPackageCommands
+from .session_lifecycle import RpcSessionLifecycleCommands
+from .transcript import RpcTranscriptCommands
 
-__all__ = ["RpcDiagnosticsCommands", "RpcPackageCommands"]
+__all__ = [
+    "RpcBashMaintenanceCommands",
+    "RpcDiagnosticsCommands",
+    "RpcModelSettingsCommands",
+    "RpcPackageCommands",
+    "RpcSessionLifecycleCommands",
+    "RpcTranscriptCommands",
+]

--- a/src/loushang/harness/host/rpc/commands/bash_maintenance.py
+++ b/src/loushang/harness/host/rpc/commands/bash_maintenance.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol
 
 from loushang.harness.host.product_host import ProductHostTaskTracker
 from loushang.harness.host.rpc.arguments import (
@@ -19,13 +19,29 @@ from loushang.harness.host.rpc.wire import camelize, project_json_value
 from loushang.harness.session import SessionRpcOperationBinding
 
 
+class _BashSession(Protocol):
+    """Only the Product execution capabilities consumed by this group."""
+
+    def execute_bash(
+        self,
+        command: str,
+        *,
+        cwd: str | None,
+        env: list[list[str]] | None,
+        timeout_seconds: float | None,
+        stdin: str | None,
+    ) -> Awaitable[object]: ...
+
+    def abort_bash(self) -> None: ...
+
+
 class RpcBashMaintenanceCommands:
     """Own Bash task state and maintenance wire projection."""
 
     def __init__(
         self,
         *,
-        get_session: Callable[[], Any],
+        get_session: Callable[[], _BashSession],
         operations: SessionRpcOperationBinding,
         output: RpcOutput,
         task_tracker: ProductHostTaskTracker,

--- a/src/loushang/harness/host/rpc/commands/bash_maintenance.py
+++ b/src/loushang/harness/host/rpc/commands/bash_maintenance.py
@@ -1,0 +1,203 @@
+"""Bash execution and Session maintenance commands for the shared RPC host."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+from loushang.harness.host.product_host import ProductHostTaskTracker
+from loushang.harness.host.rpc.arguments import (
+    optional_env_pairs,
+    optional_number,
+    optional_string,
+    require_string,
+)
+from loushang.harness.host.rpc.output import RpcOutput
+from loushang.harness.host.rpc.routing import LegacyRpcHandler
+from loushang.harness.host.rpc.wire import camelize, project_json_value
+from loushang.harness.session import SessionRpcOperationBinding
+
+
+class RpcBashMaintenanceCommands:
+    """Own Bash task state and maintenance wire projection."""
+
+    def __init__(
+        self,
+        *,
+        get_session: Callable[[], Any],
+        operations: SessionRpcOperationBinding,
+        output: RpcOutput,
+        task_tracker: ProductHostTaskTracker,
+    ) -> None:
+        self._get_session = get_session
+        self._operations = operations
+        self._output = output
+        self._task_tracker = task_tracker
+        self._active_bash_task: asyncio.Task[None] | None = None
+
+    def bindings(self) -> tuple[tuple[str, LegacyRpcHandler], ...]:
+        return (
+            ("bash", self.bash),
+            ("abort_bash", self.abort_bash),
+            ("compact", self.compact),
+            ("set_auto_retry", self.set_auto_retry),
+            ("abort_retry", self.abort_retry),
+            ("set_auto_compaction", self.set_auto_compaction),
+        )
+
+    async def bash(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        self._ensure_no_active_bash(command="bash")
+        command = require_string(payload, "command")
+        task = asyncio.create_task(
+            self._run_bash(
+                command_id=command_id,
+                command=command,
+                cwd=optional_string(payload, "cwd"),
+                env=optional_env_pairs(payload.get("env")),
+                timeout_seconds=optional_number(
+                    payload,
+                    "timeoutSeconds",
+                    "timeout_seconds",
+                ),
+                stdin=optional_string(payload, "stdin"),
+            )
+        )
+        self._active_bash_task = task
+        self._task_tracker.track(task)
+
+    def abort_bash(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        self._get_session().abort_bash()
+        self._output.success(
+            request_id=command_id,
+            command="abort_bash",
+        )
+
+    async def compact(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        try:
+            result = await self._operations.compact(payload)
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="compact",
+                error=f"Failed to compact session: {error}",
+            )
+            return
+        try:
+            data = camelize(project_json_value(result))
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="compact",
+                error=f"Failed to serialize compact response: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="compact",
+            data=data,
+        )
+
+    def set_auto_retry(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        try:
+            self._operations.set_auto_retry(payload)
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="set_auto_retry",
+                error=f"Failed to set auto-retry: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="set_auto_retry",
+        )
+
+    def abort_retry(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        self._operations.abort_retry()
+        self._output.success(
+            request_id=command_id,
+            command="abort_retry",
+        )
+
+    def set_auto_compaction(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        try:
+            self._operations.set_auto_compaction(payload)
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="set_auto_compaction",
+                error=f"Failed to set auto-compaction: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="set_auto_compaction",
+        )
+
+    async def _run_bash(
+        self,
+        *,
+        command_id: str | None,
+        command: str,
+        cwd: str | None,
+        env: list[list[str]] | None,
+        timeout_seconds: float | None,
+        stdin: str | None,
+    ) -> None:
+        try:
+            result = await self._get_session().execute_bash(
+                command,
+                cwd=cwd,
+                env=env,
+                timeout_seconds=timeout_seconds,
+                stdin=stdin,
+            )
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="bash",
+                error=str(error),
+            )
+        else:
+            try:
+                data = camelize(project_json_value(result))
+            except Exception as error:
+                self._output.error(
+                    request_id=command_id,
+                    command="bash",
+                    error=f"Failed to serialize bash result: {error}",
+                )
+                return
+            self._output.success(
+                request_id=command_id,
+                command="bash",
+                data=data,
+            )
+        finally:
+            if self._active_bash_task is asyncio.current_task():
+                self._active_bash_task = None
+
+    def _ensure_no_active_bash(self, *, command: str) -> None:
+        task = self._active_bash_task
+        if task is not None and not task.done():
+            raise RuntimeError(
+                f"{command} requires the active bash command to finish or abort first"
+            )
+
+
+__all__ = ["RpcBashMaintenanceCommands"]

--- a/src/loushang/harness/host/rpc/commands/command_catalog.py
+++ b/src/loushang/harness/host/rpc/commands/command_catalog.py
@@ -1,0 +1,183 @@
+"""Command discovery and completion commands for the shared RPC host."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, Protocol
+
+from loushang.harness.commands import complete_slash_commands
+from loushang.harness.host.rpc.output import RpcOutput
+from loushang.harness.host.rpc.routing import LegacyRpcHandler
+from loushang.harness.host.rpc.wire import project_command_descriptor
+
+
+class _CommandCatalogSession(Protocol):
+    """Only the Product command capabilities consumed by this group."""
+
+    def list_commands(self) -> Sequence[object]: ...
+
+    def get_command_argument_completions(
+        self,
+        command: str,
+        prefix: str,
+    ) -> Awaitable[Sequence[object] | None]: ...
+
+
+class RpcCommandCatalogCommands:
+    """Project Product command discovery through the stable JSONL wire."""
+
+    def __init__(
+        self,
+        *,
+        get_session: Callable[[], _CommandCatalogSession],
+        output: RpcOutput,
+    ) -> None:
+        self._get_session = get_session
+        self._output = output
+
+    def bindings(self) -> tuple[tuple[str, LegacyRpcHandler], ...]:
+        return (
+            ("get_commands", self.get_commands),
+            ("get_command_completions", self.get_command_completions),
+        )
+
+    def get_commands(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        session = self._get_session()
+        getter = getattr(session, "list_commands", None)
+        if not callable(getter):
+            self._error(
+                command_id,
+                "get_commands",
+                "Command registry is not available.",
+            )
+            return
+        try:
+            raw_commands = getter()
+        except Exception as error:
+            self._error(
+                command_id,
+                "get_commands",
+                f"Failed to query commands: {error}",
+            )
+            return
+        if not isinstance(raw_commands, list):
+            self._error(
+                command_id,
+                "get_commands",
+                "Command registry returned an invalid response.",
+            )
+            return
+        commands = []
+        for command in raw_commands:
+            try:
+                commands.append(project_command_descriptor(command))
+            except Exception:
+                continue
+        self._output.success(
+            request_id=command_id,
+            command="get_commands",
+            data={"commands": commands},
+        )
+
+    async def get_command_completions(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        prefix = payload.get("prefix", "")
+        if not isinstance(prefix, str):
+            self._error(
+                command_id,
+                "get_command_completions",
+                "Command completion prefix must be a string.",
+                code="invalid_request",
+            )
+            return
+        command_name = payload.get("command")
+        if command_name is not None:
+            if not isinstance(command_name, str) or not command_name:
+                self._error(
+                    command_id,
+                    "get_command_completions",
+                    "Command completion command must be a non-empty string.",
+                    code="invalid_request",
+                )
+                return
+            getter = getattr(
+                self._get_session(),
+                "get_command_argument_completions",
+                None,
+            )
+            if not callable(getter):
+                self._output.success(
+                    request_id=command_id,
+                    command="get_command_completions",
+                    data={"completions": []},
+                )
+                return
+            try:
+                completions = await getter(command_name, prefix)
+            except Exception as error:
+                self._error(
+                    command_id,
+                    "get_command_completions",
+                    f"Failed to query command completions: {error}",
+                    code="command_completion_failed",
+                )
+                return
+            self._output.success(
+                request_id=command_id,
+                command="get_command_completions",
+                data={
+                    "completions": completions if isinstance(completions, list) else []
+                },
+            )
+            return
+
+        session = self._get_session()
+        getter = getattr(session, "list_commands", None)
+        if not callable(getter):
+            self._error(
+                command_id,
+                "get_command_completions",
+                "Command registry is not available.",
+                code="command_registry_unavailable",
+            )
+            return
+        try:
+            raw_commands = getter()
+            if not isinstance(raw_commands, list):
+                raise TypeError("Command registry returned an invalid response.")
+            completions = complete_slash_commands(prefix, raw_commands)
+        except Exception as error:
+            self._error(
+                command_id,
+                "get_command_completions",
+                f"Failed to query command completions: {error}",
+                code="command_completion_failed",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="get_command_completions",
+            data={"completions": completions},
+        )
+
+    def _error(
+        self,
+        command_id: str | None,
+        command: str,
+        error: str,
+        *,
+        code: str | None = None,
+    ) -> None:
+        self._output.error(
+            request_id=command_id,
+            command=command,
+            error=error,
+            code=code,
+        )
+
+
+__all__ = ["RpcCommandCatalogCommands"]

--- a/src/loushang/harness/host/rpc/commands/model_settings.py
+++ b/src/loushang/harness/host/rpc/commands/model_settings.py
@@ -1,0 +1,389 @@
+"""Model and live Session settings commands for the shared RPC host."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+from loushang.ai.model import ModelSelection
+from loushang.harness.host.rpc.arguments import require_mode, require_string
+from loushang.harness.host.rpc.output import RpcOutput
+from loushang.harness.host.rpc.routing import LegacyRpcHandler
+from loushang.harness.host.rpc.wire import (
+    project_available_models,
+    project_session_state,
+    project_session_stats,
+    project_state_model,
+)
+from loushang.harness.session import SessionOperationRuntime
+
+
+class RpcModelSettingsCommands:
+    """Keep Product model/settings projection out of the RPC event loop."""
+
+    def __init__(
+        self,
+        *,
+        get_session: Callable[[], Any],
+        get_operations: Callable[[], SessionOperationRuntime],
+        output: RpcOutput,
+    ) -> None:
+        self._get_session = get_session
+        self._get_operations = get_operations
+        self._output = output
+
+    def bindings(self) -> tuple[tuple[str, LegacyRpcHandler], ...]:
+        return (
+            ("set_model", self.set_model),
+            ("get_available_models", self.get_available_models),
+            ("cycle_model", self.cycle_model),
+            ("set_active_tools", self.set_active_tools),
+            ("set_thinking_level", self.set_thinking_level),
+            ("cycle_thinking_level", self.cycle_thinking_level),
+            ("set_steering_mode", self.set_steering_mode),
+            ("set_follow_up_mode", self.set_follow_up_mode),
+            ("get_session_stats", self.get_session_stats),
+            ("set_session_name", self.set_session_name),
+        )
+
+    async def set_model(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        provider = require_string(payload, "provider")
+        model_id = require_string(payload, "modelId", "model_id")
+        endpoint_id = payload.get("endpointId") or payload.get("endpoint_id")
+        selection = ModelSelection(
+            provider=provider,
+            model_id=model_id,
+            endpoint_id=endpoint_id if isinstance(endpoint_id, str) else None,
+        )
+        session = self._get_session()
+        try:
+            available_models = session.get_available_models()
+        except Exception as error:
+            self._error(
+                command_id,
+                "set_model",
+                f"Failed to query model registry: {error}",
+            )
+            return
+        if not isinstance(available_models, list):
+            self._error(
+                command_id,
+                "set_model",
+                "Model registry returned an invalid response.",
+            )
+            return
+        if available_models and selection not in available_models:
+            self._error(
+                command_id,
+                "set_model",
+                f"Model not found: {provider}/{model_id}",
+            )
+            return
+        try:
+            await session.set_model(selection)
+        except KeyError:
+            self._error(
+                command_id,
+                "set_model",
+                f"Model not found: {provider}/{model_id}",
+            )
+            return
+        except Exception as error:
+            self._error(
+                command_id,
+                "set_model",
+                f"Failed to set model: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="set_model",
+            data=project_state_model(session, session.get_state()),
+        )
+
+    def get_available_models(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        session = self._get_session()
+        getter = getattr(session, "get_available_models", None)
+        if not callable(getter):
+            self._error(
+                command_id,
+                "get_available_models",
+                "Model registry is not available.",
+            )
+            return
+        try:
+            models = getter()
+        except Exception as error:
+            self._error(
+                command_id,
+                "get_available_models",
+                f"Failed to query model registry: {error}",
+            )
+            return
+        if not isinstance(models, list):
+            self._error(
+                command_id,
+                "get_available_models",
+                "Model registry returned an invalid response.",
+            )
+            return
+        try:
+            serialized = project_available_models(session, models)
+        except Exception as error:
+            self._error(
+                command_id,
+                "get_available_models",
+                f"Failed to serialize model registry: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="get_available_models",
+            data={"models": serialized},
+        )
+
+    async def cycle_model(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        session = self._get_session()
+        try:
+            selection = await session.cycle_model()
+        except TypeError as error:
+            message = str(error)
+            self._error(
+                command_id,
+                "cycle_model",
+                (
+                    message
+                    if message == "Model registry returned an invalid response."
+                    else f"Failed to cycle model: {error}"
+                ),
+            )
+            return
+        except Exception as error:
+            self._error(
+                command_id,
+                "cycle_model",
+                f"Failed to cycle model: {error}",
+            )
+            return
+        if selection is None:
+            self._output.success(
+                request_id=command_id,
+                command="cycle_model",
+                data=None,
+            )
+            return
+        try:
+            state = session.get_state()
+            model = project_state_model(session, state)
+        except Exception as error:
+            self._error(
+                command_id,
+                "cycle_model",
+                f"Failed to serialize model: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="cycle_model",
+            data={
+                "model": model,
+                "thinkingLevel": state.thinking_level,
+                "isScoped": False,
+            },
+        )
+
+    async def set_active_tools(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        tool_names = payload.get("toolNames", payload.get("tool_names"))
+        if not isinstance(tool_names, list) or not all(
+            isinstance(name, str) and name for name in tool_names
+        ):
+            raise ValueError("set_active_tools requires toolNames")
+        session = self._get_session()
+        try:
+            await session.set_active_tools(tool_names)
+        except Exception as error:
+            self._error(
+                command_id,
+                "set_active_tools",
+                f"Failed to set active tools: {error}",
+            )
+            return
+        try:
+            state = project_session_state(session)
+        except Exception as error:
+            self._error(
+                command_id,
+                "set_active_tools",
+                f"Failed to read session state: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="set_active_tools",
+            data=state,
+        )
+
+    async def set_thinking_level(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        level = require_string(payload, "level")
+        try:
+            result = self._get_session().set_thinking_level(level)
+            if inspect.isawaitable(result):
+                await result
+        except Exception as error:
+            self._error(
+                command_id,
+                "set_thinking_level",
+                f"Failed to set thinking level: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="set_thinking_level",
+        )
+
+    async def cycle_thinking_level(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        try:
+            result = self._get_session().cycle_thinking_level()
+            next_level = await result if inspect.isawaitable(result) else result
+        except Exception as error:
+            self._error(
+                command_id,
+                "cycle_thinking_level",
+                f"Failed to set thinking level: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="cycle_thinking_level",
+            data={"level": next_level},
+        )
+
+    def set_steering_mode(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        mode = require_mode(payload, "mode")
+        try:
+            self._get_session().set_steering_mode(mode)
+        except Exception as error:
+            self._error(
+                command_id,
+                "set_steering_mode",
+                f"Failed to set steering mode: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="set_steering_mode",
+        )
+
+    def set_follow_up_mode(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        mode = require_mode(payload, "mode")
+        try:
+            self._get_session().set_follow_up_mode(mode)
+        except Exception as error:
+            self._error(
+                command_id,
+                "set_follow_up_mode",
+                f"Failed to set follow-up mode: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="set_follow_up_mode",
+        )
+
+    def get_session_stats(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        getter = getattr(self._get_session(), "get_session_stats", None)
+        if not callable(getter):
+            self._error(
+                command_id,
+                "get_session_stats",
+                "Session stats are not available.",
+            )
+            return
+        try:
+            stats = getter()
+        except Exception as error:
+            self._error(
+                command_id,
+                "get_session_stats",
+                f"Failed to query session stats: {error}",
+            )
+            return
+        try:
+            serialized = project_session_stats(stats)
+        except Exception as error:
+            self._error(
+                command_id,
+                "get_session_stats",
+                f"Session stats returned an invalid response: {error}",
+            )
+            return
+        if not isinstance(serialized, dict):
+            self._error(
+                command_id,
+                "get_session_stats",
+                "Session stats returned an invalid response.",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="get_session_stats",
+            data=serialized,
+        )
+
+    async def set_session_name(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        name = require_string(payload, "name").strip()
+        if not name:
+            self._error(
+                command_id,
+                "set_session_name",
+                "Session name cannot be empty",
+            )
+            return
+        try:
+            await self._get_operations().set_session_name(name)
+        except Exception as error:
+            self._error(
+                command_id,
+                "set_session_name",
+                f"Failed to set session name: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="set_session_name",
+        )
+
+    def _error(self, command_id: str | None, command: str, error: str) -> None:
+        self._output.error(
+            request_id=command_id,
+            command=command,
+            error=error,
+        )
+
+
+__all__ = ["RpcModelSettingsCommands"]

--- a/src/loushang/harness/host/rpc/commands/model_settings.py
+++ b/src/loushang/harness/host/rpc/commands/model_settings.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import inspect
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, Protocol
 
 from loushang.ai.model import ModelSelection
 from loushang.harness.host.rpc.arguments import require_mode, require_string
@@ -19,13 +19,41 @@ from loushang.harness.host.rpc.wire import (
 from loushang.harness.session import SessionOperationRuntime
 
 
+class _ModelSettingsState(Protocol):
+    thinking_level: str
+
+
+class _ModelSettingsSession(Protocol):
+    """Only the Product model/settings capabilities consumed by this group."""
+
+    def get_available_models(self) -> Sequence[ModelSelection]: ...
+
+    def set_model(self, selection: ModelSelection) -> Awaitable[None]: ...
+
+    def cycle_model(self) -> Awaitable[object | None]: ...
+
+    def set_active_tools(self, tool_names: list[str]) -> Awaitable[None]: ...
+
+    def set_thinking_level(self, level: str) -> Awaitable[None] | None: ...
+
+    def cycle_thinking_level(self) -> Awaitable[object | None] | object | None: ...
+
+    def set_steering_mode(self, mode: str) -> None: ...
+
+    def set_follow_up_mode(self, mode: str) -> None: ...
+
+    def get_session_stats(self) -> object: ...
+
+    def get_state(self) -> _ModelSettingsState: ...
+
+
 class RpcModelSettingsCommands:
     """Keep Product model/settings projection out of the RPC event loop."""
 
     def __init__(
         self,
         *,
-        get_session: Callable[[], Any],
+        get_session: Callable[[], _ModelSettingsSession],
         get_operations: Callable[[], SessionOperationRuntime],
         output: RpcOutput,
     ) -> None:

--- a/src/loushang/harness/host/rpc/commands/session_lifecycle.py
+++ b/src/loushang/harness/host/rpc/commands/session_lifecycle.py
@@ -1,0 +1,304 @@
+"""Session discovery and replacement commands for the shared RPC host."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from loushang.harness.host.rpc.arguments import (
+    optional_bool,
+    optional_int,
+    optional_string,
+)
+from loushang.harness.host.rpc.output import RpcOutput
+from loushang.harness.host.rpc.routing import LegacyRpcHandler
+from loushang.harness.host.rpc.wire import project_session_listing_item
+from loushang.harness.session import SessionRpcOperationBinding
+from loushang.harness.transcript import SessionQuery
+
+
+class RpcSessionLifecycleCommands:
+    """Keep legacy session wire semantics outside the RPC event loop."""
+
+    def __init__(
+        self,
+        *,
+        runtime: object,
+        get_session: Callable[[], object],
+        operations: SessionRpcOperationBinding,
+        output: RpcOutput,
+    ) -> None:
+        self._runtime = runtime
+        self._get_session = get_session
+        self._operations = operations
+        self._output = output
+
+    def bindings(self) -> tuple[tuple[str, LegacyRpcHandler], ...]:
+        return (
+            ("list_sessions", self.list_sessions),
+            ("new_session", self.new_session),
+            ("switch_session", self.switch_session),
+            ("fork", self.fork),
+            ("clone", self.clone),
+        )
+
+    def list_sessions(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        try:
+            query = _session_query_from_payload(payload)
+        except ValueError as error:
+            self._output.error(
+                request_id=command_id,
+                command="list_sessions",
+                error=str(error),
+            )
+            return
+        all_sessions = payload.get("allSessions", payload.get("all_sessions", False))
+        if not isinstance(all_sessions, bool):
+            raise ValueError("list_sessions allSessions must be boolean")
+        use_index = payload.get("useIndex", payload.get("use_index", False))
+        refresh_index = payload.get("refreshIndex", payload.get("refresh_index", False))
+        if not isinstance(use_index, bool):
+            raise ValueError("list_sessions useIndex must be boolean")
+        if not isinstance(refresh_index, bool):
+            raise ValueError("list_sessions refreshIndex must be boolean")
+        use_index = use_index or refresh_index
+        if refresh_index and not self._refresh_index(
+            command_id=command_id,
+            all_sessions=all_sessions,
+        ):
+            return
+        lister = self._resolve_lister(
+            query=query,
+            all_sessions=all_sessions,
+            use_index=use_index,
+        )
+        if lister is None:
+            self._output.error(
+                request_id=command_id,
+                command="list_sessions",
+                error="Session listing is not available.",
+            )
+            return
+        try:
+            raw_sessions = lister()
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="list_sessions",
+                error=f"Failed to list sessions: {error}",
+            )
+            return
+        if not isinstance(raw_sessions, list):
+            self._output.error(
+                request_id=command_id,
+                command="list_sessions",
+                error="Session listing returned an invalid response.",
+            )
+            return
+        sessions = []
+        for session in raw_sessions:
+            try:
+                sessions.append(project_session_listing_item(session))
+            except Exception:
+                continue
+        self._output.success(
+            request_id=command_id,
+            command="list_sessions",
+            data={"sessions": sessions},
+        )
+
+    async def new_session(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        previous = self._get_session()
+        try:
+            operation = await self._operations.new_session(payload)
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="new_session",
+                error=f"Failed to create new session: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="new_session",
+            data={"cancelled": operation.current is previous},
+        )
+
+    async def switch_session(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        previous = self._get_session()
+        try:
+            operation = await self._operations.switch_session(payload)
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="switch_session",
+                error=f"Failed to switch session: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="switch_session",
+            data={"cancelled": operation.current is previous},
+        )
+
+    async def fork(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        previous = self._get_session()
+        try:
+            operation = await self._operations.fork(payload)
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="fork",
+                error=f"Failed to fork session: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="fork",
+            data={
+                "cancelled": operation.current is previous,
+                "text": operation.payload,
+            },
+        )
+
+    async def clone(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        previous = self._get_session()
+        try:
+            operation = await self._operations.clone()
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="clone",
+                error=f"Failed to clone session: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="clone",
+            data={"cancelled": operation.current is previous},
+        )
+
+    def _refresh_index(
+        self,
+        *,
+        command_id: str | None,
+        all_sessions: bool,
+    ) -> bool:
+        refresher = getattr(
+            self._runtime,
+            (
+                "refresh_all_session_indexes"
+                if all_sessions
+                else "refresh_session_index"
+            ),
+            None,
+        )
+        if not callable(refresher):
+            self._output.error(
+                request_id=command_id,
+                command="list_sessions",
+                error="Session index refresh is not available.",
+            )
+            return False
+        try:
+            refresher()
+        except Exception as error:
+            self._output.error(
+                request_id=command_id,
+                command="list_sessions",
+                error=f"Failed to refresh session index: {error}",
+            )
+            return False
+        return True
+
+    def _resolve_lister(
+        self,
+        *,
+        query: SessionQuery,
+        all_sessions: bool,
+        use_index: bool,
+    ) -> Callable[[], object] | None:
+        finder = (
+            getattr(
+                self._runtime,
+                (
+                    "find_all_indexed_session_summaries"
+                    if use_index
+                    else "find_all_session_summaries"
+                ),
+                None,
+            )
+            if all_sessions
+            else None
+        )
+        if not callable(finder):
+            finder = getattr(
+                self._runtime,
+                (
+                    "find_indexed_session_summaries"
+                    if use_index
+                    else "find_session_summaries"
+                ),
+                None,
+            )
+        if callable(finder):
+            return lambda: finder(query)
+        if all_sessions:
+            lister = getattr(
+                self._runtime,
+                (
+                    "list_all_indexed_session_summaries"
+                    if use_index
+                    else "list_all_session_summaries"
+                ),
+                None,
+            )
+        else:
+            lister = getattr(
+                self._runtime,
+                (
+                    "list_indexed_session_summaries"
+                    if use_index
+                    else "list_session_summaries"
+                ),
+                None,
+            )
+        if not callable(lister) and not use_index:
+            lister = getattr(self._runtime, "list_sessions", None)
+        return lister if callable(lister) else None
+
+
+def _session_query_from_payload(payload: dict[str, Any]) -> SessionQuery:
+    limit = optional_int(payload, "limit")
+    if limit is not None and limit < 0:
+        raise ValueError("Session limit must be non-negative.")
+    return SessionQuery(
+        cwd=optional_string(payload, "cwd"),
+        name=optional_string(payload, "name"),
+        parent_session=optional_string(
+            payload,
+            "parentSession",
+            "parent_session",
+        ),
+        text=optional_string(payload, "text", "query"),
+        has_diagnostics=optional_bool(
+            payload,
+            "hasDiagnostics",
+            "has_diagnostics",
+        ),
+        limit=limit,
+    )
+
+
+__all__ = ["RpcSessionLifecycleCommands"]

--- a/src/loushang/harness/host/rpc/commands/session_lifecycle.py
+++ b/src/loushang/harness/host/rpc/commands/session_lifecycle.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Protocol
 
 from loushang.harness.host.rpc.arguments import (
     optional_bool,
@@ -17,13 +17,29 @@ from loushang.harness.session import SessionRpcOperationBinding
 from loushang.harness.transcript import SessionQuery
 
 
+class _SessionLifecycleRuntime(Protocol):
+    """Only the standard discovery/index capabilities consumed here."""
+
+    def refresh_session_index(self) -> object: ...
+
+    def refresh_all_session_indexes(self) -> object: ...
+
+    def find_session_summaries(self, query: SessionQuery) -> object: ...
+
+    def find_all_session_summaries(self, query: SessionQuery) -> object: ...
+
+    def find_indexed_session_summaries(self, query: SessionQuery) -> object: ...
+
+    def find_all_indexed_session_summaries(self, query: SessionQuery) -> object: ...
+
+
 class RpcSessionLifecycleCommands:
     """Keep legacy session wire semantics outside the RPC event loop."""
 
     def __init__(
         self,
         *,
-        runtime: object,
+        runtime: _SessionLifecycleRuntime,
         get_session: Callable[[], object],
         operations: SessionRpcOperationBinding,
         output: RpcOutput,

--- a/src/loushang/harness/host/rpc/commands/transcript.py
+++ b/src/loushang/harness/host/rpc/commands/transcript.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from loushang.harness.host.rpc.arguments import optional_string
 from loushang.harness.host.rpc.output import RpcOutput
@@ -15,13 +15,23 @@ from loushang.harness.transcript import create_agent_transcript_message_codec
 _MESSAGE_CODEC = create_agent_transcript_message_codec()
 
 
+class _TranscriptSession(Protocol):
+    """Only the Product transcript capabilities consumed by this group."""
+
+    def get_last_assistant_text(self) -> str | None: ...
+
+    def get_user_messages_for_forking(self) -> object: ...
+
+    def export_to_html(self, output_path: str | None = None) -> str | Path: ...
+
+
 class RpcTranscriptCommands:
     """Project transcript reads without owning Session or wire lifecycle."""
 
     def __init__(
         self,
         *,
-        get_session: Callable[[], Any],
+        get_session: Callable[[], _TranscriptSession],
         get_messages: Callable[[object], object],
         output: RpcOutput,
     ) -> None:

--- a/src/loushang/harness/host/rpc/commands/transcript.py
+++ b/src/loushang/harness/host/rpc/commands/transcript.py
@@ -1,0 +1,155 @@
+"""Transcript query and export commands for the shared RPC host."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from loushang.harness.host.rpc.arguments import optional_string
+from loushang.harness.host.rpc.output import RpcOutput
+from loushang.harness.host.rpc.routing import LegacyRpcHandler
+from loushang.harness.host.rpc.wire import camelize, project_json_value
+from loushang.harness.transcript import create_agent_transcript_message_codec
+
+_MESSAGE_CODEC = create_agent_transcript_message_codec()
+
+
+class RpcTranscriptCommands:
+    """Project transcript reads without owning Session or wire lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        get_session: Callable[[], Any],
+        get_messages: Callable[[object], object],
+        output: RpcOutput,
+    ) -> None:
+        self._get_session = get_session
+        self._get_messages = get_messages
+        self._output = output
+
+    def bindings(self) -> tuple[tuple[str, LegacyRpcHandler], ...]:
+        return (
+            ("get_messages", self.get_messages),
+            ("get_last_assistant_text", self.get_last_assistant_text),
+            ("get_fork_messages", self.get_fork_messages),
+            ("export_html", self.export_html),
+        )
+
+    def get_messages(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        messages = self._get_messages(self._get_session())
+        if not isinstance(messages, list):
+            self._error(
+                command_id,
+                "get_messages",
+                "Message log returned an invalid response.",
+            )
+            return
+        serialized_messages: list[dict[str, Any]] = []
+        for message in messages:
+            try:
+                serialized_messages.append(_MESSAGE_CODEC.serialize(message))
+            except Exception:
+                continue
+        self._output.success(
+            request_id=command_id,
+            command="get_messages",
+            data={"messages": serialized_messages},
+        )
+
+    def get_last_assistant_text(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        getter = getattr(self._get_session(), "get_last_assistant_text", None)
+        try:
+            text = getter() if callable(getter) else None
+        except Exception as error:
+            self._error(
+                command_id,
+                "get_last_assistant_text",
+                f"Failed to read last assistant text: {error}",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="get_last_assistant_text",
+            data={"text": text},
+        )
+
+    def get_fork_messages(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        del payload
+        getter = getattr(self._get_session(), "get_user_messages_for_forking", None)
+        if not callable(getter):
+            self._error(
+                command_id,
+                "get_fork_messages",
+                "Fork messages are not available.",
+            )
+            return
+        try:
+            raw_messages = getter()
+        except Exception as error:
+            self._error(
+                command_id,
+                "get_fork_messages",
+                f"Failed to query fork messages: {error}",
+            )
+            return
+        if not isinstance(raw_messages, list):
+            self._error(
+                command_id,
+                "get_fork_messages",
+                "Fork messages returned an invalid response.",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="get_fork_messages",
+            data={"messages": camelize(project_json_value(raw_messages))},
+        )
+
+    def export_html(
+        self, command_id: str | None, payload: dict[str, Any]
+    ) -> None:
+        output_path = optional_string(payload, "outputPath", "output_path")
+        try:
+            path = self._get_session().export_to_html(output_path)
+        except Exception as error:
+            self._error(
+                command_id,
+                "export_html",
+                f"Failed to export HTML: {error}",
+            )
+            return
+        if not isinstance(path, str):
+            if isinstance(path, Path):
+                path = str(path)
+            else:
+                self._error(
+                    command_id,
+                    "export_html",
+                    "Export returned an invalid response.",
+                )
+                return
+        self._output.success(
+            request_id=command_id,
+            command="export_html",
+            data={"path": path},
+        )
+
+    def _error(self, command_id: str | None, command: str, error: str) -> None:
+        self._output.error(
+            request_id=command_id,
+            command=command,
+            error=error,
+        )
+
+
+__all__ = ["RpcTranscriptCommands"]

--- a/src/loushang/harness/host/rpc/runtime.py
+++ b/src/loushang/harness/host/rpc/runtime.py
@@ -7,7 +7,6 @@ import sys
 from collections.abc import Sequence
 from typing import Any, TextIO
 
-from loushang.harness.commands import complete_slash_commands
 from loushang.harness.events import RuntimeEvent
 from loushang.harness.host.jsonl_command_host import (
     JsonlCommand,
@@ -25,6 +24,7 @@ from loushang.harness.host.product_host import (
 )
 from loushang.harness.host.rpc.commands import (
     RpcBashMaintenanceCommands,
+    RpcCommandCatalogCommands,
     RpcDiagnosticsCommands,
     RpcModelSettingsCommands,
     RpcPackageCommands,
@@ -41,7 +41,6 @@ from loushang.harness.host.rpc.projections import (
 from loushang.harness.host.rpc.remote_ui import RpcExtensionUIContext
 from loushang.harness.host.rpc.routing import legacy_rpc_routes
 from loushang.harness.host.rpc.wire import (
-    project_command_descriptor,
     project_session_state,
     session_messages,
 )
@@ -139,6 +138,10 @@ class RpcHost(ModeAdapter):
             operations=self._rpc_operations,
             output=self._rpc_output,
             task_tracker=self._task_tracker,
+        )
+        self._command_catalog_commands = RpcCommandCatalogCommands(
+            get_session=lambda: self.session,
+            output=self._rpc_output,
         )
         self._command_router = JsonlCommandRouter(
             routes=self._command_routes(),
@@ -260,11 +263,7 @@ class RpcHost(ModeAdapter):
                     *self._session_lifecycle_commands.bindings(),
                     *self._model_settings_commands.bindings(),
                     *self._transcript_commands.bindings(),
-                    ("get_commands", self._handle_get_commands_command),
-                    (
-                        "get_command_completions",
-                        self._handle_get_command_completions_command,
-                    ),
+                    *self._command_catalog_commands.bindings(),
                     *self._diagnostics_commands.bindings(),
                     *self._package_commands.bindings(),
                     *self._bash_maintenance_commands.bindings(),
@@ -414,124 +413,6 @@ class RpcHost(ModeAdapter):
             id=command_id,
             command="get_extension_ui_state",
             data=self.extension_ui_context.get_snapshot(),
-        )
-
-
-    def _handle_get_commands_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        commands = []
-        getter = getattr(self.session, "list_commands", None)
-        if not callable(getter):
-            self._write_response_error(
-                id=command_id,
-                command="get_commands",
-                error="Command registry is not available.",
-            )
-            return
-        try:
-            raw_commands = getter()
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="get_commands",
-                error=f"Failed to query commands: {error}",
-            )
-            return
-        if not isinstance(raw_commands, list):
-            self._write_response_error(
-                id=command_id,
-                command="get_commands",
-                error="Command registry returned an invalid response.",
-            )
-            return
-        for command in raw_commands:
-            try:
-                commands.append(project_command_descriptor(command))
-            except Exception:
-                continue
-        self._write_response_success(
-            id=command_id,
-            command="get_commands",
-            data={"commands": commands},
-        )
-
-    async def _handle_get_command_completions_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        prefix = payload.get("prefix", "")
-        if not isinstance(prefix, str):
-            self._write_response_error(
-                id=command_id,
-                command="get_command_completions",
-                error="Command completion prefix must be a string.",
-                code="invalid_request",
-            )
-            return
-        command_name = payload.get("command")
-        if command_name is not None:
-            if not isinstance(command_name, str) or not command_name:
-                self._write_response_error(
-                    id=command_id,
-                    command="get_command_completions",
-                    error="Command completion command must be a non-empty string.",
-                    code="invalid_request",
-                )
-                return
-            getter = getattr(self.session, "get_command_argument_completions", None)
-            if not callable(getter):
-                self._write_response_success(
-                    id=command_id,
-                    command="get_command_completions",
-                    data={"completions": []},
-                )
-                return
-            try:
-                completions = await getter(command_name, prefix)
-            except Exception as error:
-                self._write_response_error(
-                    id=command_id,
-                    command="get_command_completions",
-                    error=f"Failed to query command completions: {error}",
-                    code="command_completion_failed",
-                )
-                return
-            self._write_response_success(
-                id=command_id,
-                command="get_command_completions",
-                data={
-                    "completions": completions if isinstance(completions, list) else []
-                },
-            )
-            return
-
-        getter = getattr(self.session, "list_commands", None)
-        if not callable(getter):
-            self._write_response_error(
-                id=command_id,
-                command="get_command_completions",
-                error="Command registry is not available.",
-                code="command_registry_unavailable",
-            )
-            return
-        try:
-            raw_commands = getter()
-            if not isinstance(raw_commands, list):
-                raise TypeError("Command registry returned an invalid response.")
-            completions = complete_slash_commands(prefix, raw_commands)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="get_command_completions",
-                error=f"Failed to query command completions: {error}",
-                code="command_completion_failed",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="get_command_completions",
-            data={"completions": completions},
         )
 
 

--- a/src/loushang/harness/host/rpc/runtime.py
+++ b/src/loushang/harness/host/rpc/runtime.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import asyncio
 import sys
 from collections.abc import Sequence
-from typing import Any, TextIO
+from pathlib import Path
+from typing import Any, Protocol, TextIO, cast
 
 from loushang.harness.events import RuntimeEvent
 from loushang.harness.host.jsonl_command_host import (
@@ -45,6 +46,7 @@ from loushang.harness.host.rpc.wire import (
     session_messages,
 )
 from loushang.harness.presentation import ToolDefinitionResolver, ToolRenderRuntime
+from loushang.harness.runtime import SessionOperationResult
 from loushang.harness.session import (
     SessionLifecycleOperationPorts,
     SessionOperationResolver,
@@ -54,6 +56,7 @@ from loushang.harness.session import (
     current_session_operation_resolver,
 )
 from loushang.harness.transcript import (
+    SessionQuery,
     create_agent_transcript_message_codec,
 )
 
@@ -62,13 +65,50 @@ _MESSAGE_CODEC = create_agent_transcript_message_codec()
 serialize_agent_message = _MESSAGE_CODEC.serialize
 
 
+class _RpcHostRuntime(Protocol):
+    """Required runtime seam; optional RPC groups keep their own leaf ports."""
+
+    def get_current_session(self) -> object | None: ...
+
+    async def new_session_operation(
+        self,
+        *,
+        cwd: str | None = None,
+        parent_session: str | None = None,
+    ) -> SessionOperationResult[Any, Any]: ...
+
+    async def restore_session_operation(
+        self,
+        session_ref: str | Path,
+    ) -> SessionOperationResult[Any, Any]: ...
+
+    async def fork_session_operation(
+        self,
+        entry_id: str | None,
+        *,
+        position: str = "at",
+    ) -> SessionOperationResult[Any, Any]: ...
+
+    def refresh_session_index(self) -> object: ...
+
+    def refresh_all_session_indexes(self) -> object: ...
+
+    def find_session_summaries(self, query: SessionQuery) -> object: ...
+
+    def find_all_session_summaries(self, query: SessionQuery) -> object: ...
+
+    def find_indexed_session_summaries(self, query: SessionQuery) -> object: ...
+
+    def find_all_indexed_session_summaries(self, query: SessionQuery) -> object: ...
+
+
 class RpcHost(ModeAdapter):
     """Product-neutral JSONL RPC host for an active Agent session."""
 
     def __init__(
         self,
         *,
-        runtime: Any,
+        runtime: object,
         stdin: TextIO,
         stdout: TextIO,
         stderr: TextIO | None = None,
@@ -82,7 +122,7 @@ class RpcHost(ModeAdapter):
     ) -> None:
         if event_view not in event_projection.supported_views:
             raise ValueError(f"unsupported json event view: {event_view}")
-        self.runtime = runtime
+        self.runtime = cast(_RpcHostRuntime, runtime)
         self.stdin = stdin
         self.stdout = stdout
         self._rpc_output = RpcOutput(stdout)
@@ -118,7 +158,7 @@ class RpcHost(ModeAdapter):
             output=self._rpc_output,
         )
         self._session_lifecycle_commands = RpcSessionLifecycleCommands(
-            runtime=runtime,
+            runtime=self.runtime,
             get_session=lambda: self.session,
             operations=self._rpc_operations,
             output=self._rpc_output,
@@ -177,6 +217,11 @@ class RpcHost(ModeAdapter):
         await self._require_session_operations().wait_for_idle()
         return 0
 
+    async def settle_background_tasks(self) -> None:
+        """Wait for prompt/bash tasks started by this host."""
+
+        await self._task_tracker.drain()
+
     def rebind_session(self, session: object | None = None) -> int:
         if session is None:
             session = self._require_current_session()
@@ -186,10 +231,13 @@ class RpcHost(ModeAdapter):
     async def dispose(self) -> int:
         self._host_runtime.stop()
         self._command_host.stop()
-        self._unsubscribe()
-        disposer = getattr(self.runtime, "dispose", None)
-        if callable(disposer):
-            await disposer()
+        try:
+            disposer = getattr(self.runtime, "dispose", None)
+            if callable(disposer):
+                await disposer()
+        finally:
+            await self.settle_background_tasks()
+            self._unsubscribe()
         return 0
 
     def render_event(self, event: object) -> None:
@@ -202,13 +250,13 @@ class RpcHost(ModeAdapter):
                 handle_failure=self._handle_host_failure,
             )
         finally:
-            await self._task_tracker.drain()
+            await self.settle_background_tasks()
             self._command_host.stop()
             self._unsubscribe()
 
     def get_mode_state(self) -> ModeState:
         try:
-            return project_session_state(self.session)
+            return cast(ModeState, project_session_state(self.session))
         except Exception:
             return {
                 "sessionId": "",
@@ -229,7 +277,7 @@ class RpcHost(ModeAdapter):
     async def _drain_background_tasks(self) -> None:
         """Compatibility hook over the Channel-owned task tracker."""
 
-        await self._task_tracker.drain()
+        await self.settle_background_tasks()
 
     async def _handle_line(self, line: str) -> None:
         """Test-facing adapter for the Channel-owned JSONL command host."""
@@ -554,7 +602,7 @@ class RpcHost(ModeAdapter):
 
 async def run_rpc_host(
     *,
-    runtime: Any,
+    runtime: object,
     stdin: TextIO,
     stdout: TextIO,
     stderr: TextIO | None = None,

--- a/src/loushang/harness/host/rpc/runtime.py
+++ b/src/loushang/harness/host/rpc/runtime.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import sys
 from collections.abc import Sequence
-from pathlib import Path
 from typing import Any, TextIO
 
-from loushang.ai.model import ModelSelection
 from loushang.harness.commands import complete_slash_commands
 from loushang.harness.events import RuntimeEvent
 from loushang.harness.host.jsonl_command_host import (
@@ -26,18 +23,13 @@ from loushang.harness.host.product_host import (
     ProductHostRuntime,
     ProductHostTaskTracker,
 )
-from loushang.harness.host.rpc.arguments import (
-    optional_bool,
-    optional_env_pairs,
-    optional_int,
-    optional_number,
-    optional_string,
-    require_mode,
-    require_string,
-)
 from loushang.harness.host.rpc.commands import (
+    RpcBashMaintenanceCommands,
     RpcDiagnosticsCommands,
+    RpcModelSettingsCommands,
     RpcPackageCommands,
+    RpcSessionLifecycleCommands,
+    RpcTranscriptCommands,
 )
 from loushang.harness.host.rpc.output import RpcOutput
 from loushang.harness.host.rpc.projections import (
@@ -49,14 +41,8 @@ from loushang.harness.host.rpc.projections import (
 from loushang.harness.host.rpc.remote_ui import RpcExtensionUIContext
 from loushang.harness.host.rpc.routing import legacy_rpc_routes
 from loushang.harness.host.rpc.wire import (
-    camelize,
-    project_available_models,
     project_command_descriptor,
-    project_json_value,
-    project_session_listing_item,
     project_session_state,
-    project_session_stats,
-    project_state_model,
     session_messages,
 )
 from loushang.harness.presentation import ToolDefinitionResolver, ToolRenderRuntime
@@ -69,7 +55,6 @@ from loushang.harness.session import (
     current_session_operation_resolver,
 )
 from loushang.harness.transcript import (
-    SessionQuery,
     create_agent_transcript_message_codec,
 )
 
@@ -120,7 +105,6 @@ class RpcHost(ModeAdapter):
         self._unsubscribe = self._subscribe_to_events(self.session)
         self._task_tracker = ProductHostTaskTracker()
         self._active_prompt_task: asyncio.Task[None] | None = None
-        self._active_bash_task: asyncio.Task[None] | None = None
         self.extension_ui_context = RpcExtensionUIContext(self._write_json_line)
         self._bind_extension_ui_context(self.session)
         self._diagnostics_commands = RpcDiagnosticsCommands(
@@ -133,6 +117,28 @@ class RpcHost(ModeAdapter):
             runtime=runtime,
             get_session=lambda: self.session,
             output=self._rpc_output,
+        )
+        self._session_lifecycle_commands = RpcSessionLifecycleCommands(
+            runtime=runtime,
+            get_session=lambda: self.session,
+            operations=self._rpc_operations,
+            output=self._rpc_output,
+        )
+        self._model_settings_commands = RpcModelSettingsCommands(
+            get_session=lambda: self.session,
+            get_operations=self._require_session_operations,
+            output=self._rpc_output,
+        )
+        self._transcript_commands = RpcTranscriptCommands(
+            get_session=lambda: self.session,
+            get_messages=lambda session: self._get_session_messages(session),
+            output=self._rpc_output,
+        )
+        self._bash_maintenance_commands = RpcBashMaintenanceCommands(
+            get_session=lambda: self.session,
+            operations=self._rpc_operations,
+            output=self._rpc_output,
+            task_tracker=self._task_tracker,
         )
         self._command_router = JsonlCommandRouter(
             routes=self._command_routes(),
@@ -251,33 +257,9 @@ class RpcHost(ModeAdapter):
                         "get_extension_ui_state",
                         self._handle_get_extension_ui_state_command,
                     ),
-                    ("get_messages", self._handle_get_messages_command),
-                    ("list_sessions", self._handle_list_sessions_command),
-                    ("new_session", self._handle_new_session_command),
-                    ("switch_session", self._handle_switch_session_command),
-                    ("fork", self._handle_fork_command),
-                    ("clone", self._handle_clone_command),
-                    ("set_model", self._handle_set_model_command),
-                    (
-                        "get_available_models",
-                        self._handle_get_available_models_command,
-                    ),
-                    ("cycle_model", self._handle_cycle_model_command),
-                    ("set_active_tools", self._handle_set_active_tools_command),
-                    ("set_thinking_level", self._handle_set_thinking_level_command),
-                    (
-                        "cycle_thinking_level",
-                        self._handle_cycle_thinking_level_command,
-                    ),
-                    ("set_steering_mode", self._handle_set_steering_mode_command),
-                    ("set_follow_up_mode", self._handle_set_follow_up_mode_command),
-                    ("get_session_stats", self._handle_get_session_stats_command),
-                    ("set_session_name", self._handle_set_session_name_command),
-                    (
-                        "get_last_assistant_text",
-                        self._handle_get_last_assistant_text_command,
-                    ),
-                    ("get_fork_messages", self._handle_get_fork_messages_command),
+                    *self._session_lifecycle_commands.bindings(),
+                    *self._model_settings_commands.bindings(),
+                    *self._transcript_commands.bindings(),
                     ("get_commands", self._handle_get_commands_command),
                     (
                         "get_command_completions",
@@ -285,16 +267,7 @@ class RpcHost(ModeAdapter):
                     ),
                     *self._diagnostics_commands.bindings(),
                     *self._package_commands.bindings(),
-                    ("bash", self._handle_bash_command),
-                    ("abort_bash", self._handle_abort_bash_command),
-                    ("compact", self._handle_compact_command),
-                    ("set_auto_retry", self._handle_set_auto_retry_command),
-                    ("abort_retry", self._handle_abort_retry_command),
-                    (
-                        "set_auto_compaction",
-                        self._handle_set_auto_compaction_command,
-                    ),
-                    ("export_html", self._handle_export_html_command),
+                    *self._bash_maintenance_commands.bindings(),
                 )
             ),
         )
@@ -443,621 +416,6 @@ class RpcHost(ModeAdapter):
             data=self.extension_ui_context.get_snapshot(),
         )
 
-    def _handle_get_messages_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        messages = self._get_session_messages(self.session)
-        if not isinstance(messages, list):
-            self._write_response_error(
-                id=command_id,
-                command="get_messages",
-                error="Message log returned an invalid response.",
-            )
-            return
-        serialized_messages: list[dict[str, Any]] = []
-        for message in messages:
-            try:
-                serialized_messages.append(serialize_agent_message(message))
-            except Exception:
-                continue
-        self._write_response_success(
-            id=command_id,
-            command="get_messages",
-            data={"messages": serialized_messages},
-        )
-
-    def _handle_list_sessions_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        try:
-            query = self._session_query_from_payload(payload)
-        except ValueError as error:
-            self._write_response_error(
-                id=command_id, command="list_sessions", error=str(error)
-            )
-            return
-        all_sessions = payload.get("allSessions", payload.get("all_sessions", False))
-        if not isinstance(all_sessions, bool):
-            raise ValueError("list_sessions allSessions must be boolean")
-        use_index = payload.get("useIndex", payload.get("use_index", False))
-        refresh_index = payload.get("refreshIndex", payload.get("refresh_index", False))
-        if not isinstance(use_index, bool):
-            raise ValueError("list_sessions useIndex must be boolean")
-        if not isinstance(refresh_index, bool):
-            raise ValueError("list_sessions refreshIndex must be boolean")
-        use_index = use_index or refresh_index
-        if refresh_index:
-            refresher = getattr(
-                self.runtime,
-                "refresh_all_session_indexes"
-                if all_sessions
-                else "refresh_session_index",
-                None,
-            )
-            if not callable(refresher):
-                self._write_response_error(
-                    id=command_id,
-                    command="list_sessions",
-                    error="Session index refresh is not available.",
-                )
-                return
-            try:
-                refresher()
-            except Exception as error:
-                self._write_response_error(
-                    id=command_id,
-                    command="list_sessions",
-                    error=f"Failed to refresh session index: {error}",
-                )
-                return
-        finder = (
-            getattr(
-                self.runtime,
-                "find_all_indexed_session_summaries"
-                if use_index
-                else "find_all_session_summaries",
-                None,
-            )
-            if all_sessions
-            else None
-        )
-        if not callable(finder):
-            finder = getattr(
-                self.runtime,
-                "find_indexed_session_summaries"
-                if use_index
-                else "find_session_summaries",
-                None,
-            )
-        if callable(finder):
-
-            def lister():
-                return finder(query)
-        else:
-            if all_sessions:
-                lister = getattr(
-                    self.runtime,
-                    "list_all_indexed_session_summaries"
-                    if use_index
-                    else "list_all_session_summaries",
-                    None,
-                )
-            else:
-                lister = getattr(
-                    self.runtime,
-                    "list_indexed_session_summaries"
-                    if use_index
-                    else "list_session_summaries",
-                    None,
-                )
-            if not callable(lister) and not use_index:
-                lister = getattr(self.runtime, "list_sessions", None)
-        if not callable(lister):
-            self._write_response_error(
-                id=command_id,
-                command="list_sessions",
-                error="Session listing is not available.",
-            )
-            return
-        try:
-            raw_sessions = lister()
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="list_sessions",
-                error=f"Failed to list sessions: {error}",
-            )
-            return
-        if not isinstance(raw_sessions, list):
-            self._write_response_error(
-                id=command_id,
-                command="list_sessions",
-                error="Session listing returned an invalid response.",
-            )
-            return
-        sessions = []
-        for session in raw_sessions:
-            try:
-                sessions.append(project_session_listing_item(session))
-            except Exception:
-                continue
-        self._write_response_success(
-            id=command_id,
-            command="list_sessions",
-            data={"sessions": sessions},
-        )
-
-    def _session_query_from_payload(self, payload: dict[str, Any]) -> SessionQuery:
-        limit = optional_int(payload, "limit")
-        if limit is not None and limit < 0:
-            raise ValueError("Session limit must be non-negative.")
-        return SessionQuery(
-            cwd=optional_string(payload, "cwd"),
-            name=optional_string(payload, "name"),
-            parent_session=optional_string(
-                payload, "parentSession", "parent_session"
-            ),
-            text=optional_string(payload, "text", "query"),
-            has_diagnostics=optional_bool(
-                payload, "hasDiagnostics", "has_diagnostics"
-            ),
-            limit=limit,
-        )
-
-    async def _handle_new_session_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        previous = self.session
-        try:
-            operation = await self._rpc_operations.new_session(payload)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="new_session",
-                error=f"Failed to create new session: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="new_session",
-            data={
-                "cancelled": operation.current is previous,
-            },
-        )
-
-    async def _handle_switch_session_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        previous = self.session
-        try:
-            operation = await self._rpc_operations.switch_session(payload)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="switch_session",
-                error=f"Failed to switch session: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="switch_session",
-            data={
-                "cancelled": operation.current is previous,
-            },
-        )
-
-    async def _handle_fork_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        previous = self.session
-        try:
-            operation = await self._rpc_operations.fork(payload)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="fork",
-                error=f"Failed to fork session: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="fork",
-            data={
-                "cancelled": operation.current is previous,
-                "text": operation.payload,
-            },
-        )
-
-    async def _handle_clone_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        previous = self.session
-        try:
-            operation = await self._rpc_operations.clone()
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="clone",
-                error=f"Failed to clone session: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="clone",
-            data={"cancelled": operation.current is previous},
-        )
-
-    async def _handle_set_model_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        provider = require_string(payload, "provider")
-        model_id = require_string(payload, "modelId", "model_id")
-        endpoint_id = payload.get("endpointId") or payload.get("endpoint_id")
-        selection = ModelSelection(
-            provider=provider,
-            model_id=model_id,
-            endpoint_id=endpoint_id if isinstance(endpoint_id, str) else None,
-        )
-        try:
-            available_models = self.session.get_available_models()
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_model",
-                error=f"Failed to query model registry: {error}",
-            )
-            return
-        if not isinstance(available_models, list):
-            self._write_response_error(
-                id=command_id,
-                command="set_model",
-                error="Model registry returned an invalid response.",
-            )
-            return
-        if available_models and selection not in available_models:
-            self._write_response_error(
-                id=command_id,
-                command="set_model",
-                error=f"Model not found: {provider}/{model_id}",
-            )
-            return
-        try:
-            await self.session.set_model(selection)
-        except KeyError:
-            self._write_response_error(
-                id=command_id,
-                command="set_model",
-                error=f"Model not found: {provider}/{model_id}",
-            )
-            return
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_model",
-                error=f"Failed to set model: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="set_model",
-            data=project_state_model(self.session, self.session.get_state()),
-        )
-
-    def _handle_get_available_models_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        getter = getattr(self.session, "get_available_models", None)
-        if not callable(getter):
-            self._write_response_error(
-                id=command_id,
-                command="get_available_models",
-                error="Model registry is not available.",
-            )
-            return
-        try:
-            models = getter()
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="get_available_models",
-                error=f"Failed to query model registry: {error}",
-            )
-            return
-        if not isinstance(models, list):
-            self._write_response_error(
-                id=command_id,
-                command="get_available_models",
-                error="Model registry returned an invalid response.",
-            )
-            return
-        try:
-            serialized = project_available_models(self.session, models)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="get_available_models",
-                error=f"Failed to serialize model registry: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="get_available_models",
-            data={"models": serialized},
-        )
-
-    async def _handle_cycle_model_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        try:
-            selection = await self.session.cycle_model()
-        except TypeError as error:
-            if str(error) == "Model registry returned an invalid response.":
-                self._write_response_error(
-                    id=command_id,
-                    command="cycle_model",
-                    error=str(error),
-                )
-                return
-            self._write_response_error(
-                id=command_id,
-                command="cycle_model",
-                error=f"Failed to cycle model: {error}",
-            )
-            return
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="cycle_model",
-                error=f"Failed to cycle model: {error}",
-            )
-            return
-        if selection is None:
-            self._write_response_success(
-                id=command_id,
-                command="cycle_model",
-                data=None,
-            )
-            return
-        try:
-            model = project_state_model(self.session, self.session.get_state())
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="cycle_model",
-                error=f"Failed to serialize model: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="cycle_model",
-            data={
-                "model": model,
-                "thinkingLevel": self.session.get_state().thinking_level,
-                "isScoped": False,
-            },
-        )
-
-    async def _handle_set_active_tools_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        tool_names = payload.get("toolNames", payload.get("tool_names"))
-        if not isinstance(tool_names, list) or not all(
-            isinstance(name, str) and name for name in tool_names
-        ):
-            raise ValueError("set_active_tools requires toolNames")
-        try:
-            await self.session.set_active_tools(tool_names)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_active_tools",
-                error=f"Failed to set active tools: {error}",
-            )
-            return
-        try:
-            state = project_session_state(self.session)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_active_tools",
-                error=f"Failed to read session state: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="set_active_tools",
-            data=state,
-        )
-
-    async def _handle_set_thinking_level_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        level = require_string(payload, "level")
-        try:
-            result = self.session.set_thinking_level(level)
-            if inspect.isawaitable(result):
-                await result
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_thinking_level",
-                error=f"Failed to set thinking level: {error}",
-            )
-            return
-        self._write_response_success(id=command_id, command="set_thinking_level")
-
-    async def _handle_cycle_thinking_level_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        try:
-            result = self.session.cycle_thinking_level()
-            next_level = await result if inspect.isawaitable(result) else result
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="cycle_thinking_level",
-                error=f"Failed to set thinking level: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="cycle_thinking_level",
-            data={"level": next_level},
-        )
-
-    def _handle_set_steering_mode_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        mode = require_mode(payload, "mode")
-        try:
-            self.session.set_steering_mode(mode)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_steering_mode",
-                error=f"Failed to set steering mode: {error}",
-            )
-            return
-        self._write_response_success(id=command_id, command="set_steering_mode")
-
-    def _handle_set_follow_up_mode_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        mode = require_mode(payload, "mode")
-        try:
-            self.session.set_follow_up_mode(mode)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_follow_up_mode",
-                error=f"Failed to set follow-up mode: {error}",
-            )
-            return
-        self._write_response_success(id=command_id, command="set_follow_up_mode")
-
-    def _handle_get_session_stats_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        getter = getattr(self.session, "get_session_stats", None)
-        if not callable(getter):
-            self._write_response_error(
-                id=command_id,
-                command="get_session_stats",
-                error="Session stats are not available.",
-            )
-            return
-        try:
-            stats = getter()
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="get_session_stats",
-                error=f"Failed to query session stats: {error}",
-            )
-            return
-        try:
-            serialized = project_session_stats(stats)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="get_session_stats",
-                error=f"Session stats returned an invalid response: {error}",
-            )
-            return
-        if not isinstance(serialized, dict):
-            self._write_response_error(
-                id=command_id,
-                command="get_session_stats",
-                error="Session stats returned an invalid response.",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="get_session_stats",
-            data=serialized,
-        )
-
-    async def _handle_set_session_name_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        name = require_string(payload, "name").strip()
-        if not name:
-            self._write_response_error(
-                id=command_id,
-                command="set_session_name",
-                error="Session name cannot be empty",
-            )
-            return
-        try:
-            await self._require_session_operations().set_session_name(name)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_session_name",
-                error=f"Failed to set session name: {error}",
-            )
-            return
-        self._write_response_success(id=command_id, command="set_session_name")
-
-    def _handle_get_last_assistant_text_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        try:
-            text = self._extract_last_assistant_text()
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="get_last_assistant_text",
-                error=f"Failed to read last assistant text: {error}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="get_last_assistant_text",
-            data={"text": text},
-        )
-
-    def _handle_get_fork_messages_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        getter = getattr(self.session, "get_user_messages_for_forking", None)
-        if not callable(getter):
-            self._write_response_error(
-                id=command_id,
-                command="get_fork_messages",
-                error="Fork messages are not available.",
-            )
-            return
-        try:
-            raw_messages = getter()
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="get_fork_messages",
-                error=f"Failed to query fork messages: {error}",
-            )
-            return
-        if not isinstance(raw_messages, list):
-            self._write_response_error(
-                id=command_id,
-                command="get_fork_messages",
-                error="Fork messages returned an invalid response.",
-            )
-            return
-        messages = camelize(project_json_value(raw_messages))
-        self._write_response_success(
-            id=command_id,
-            command="get_fork_messages",
-            data={"messages": messages},
-        )
 
     def _handle_get_commands_command(
         self, command_id: str | None, payload: dict[str, Any]
@@ -1176,162 +534,6 @@ class RpcHost(ModeAdapter):
             data={"completions": completions},
         )
 
-    async def _handle_bash_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        self._ensure_no_active_bash(command="bash")
-        command = require_string(payload, "command")
-        task = asyncio.create_task(
-            self._run_bash(
-                command_id=command_id,
-                command=command,
-                cwd=optional_string(payload, "cwd"),
-                env=optional_env_pairs(payload.get("env")),
-                timeout_seconds=optional_number(
-                    payload, "timeoutSeconds", "timeout_seconds"
-                ),
-                stdin=optional_string(payload, "stdin"),
-            )
-        )
-        self._active_bash_task = task
-        self._task_tracker.track(task)
-
-    async def _run_bash(
-        self,
-        *,
-        command_id: str | None,
-        command: str,
-        cwd: str | None,
-        env: list[list[str]] | None,
-        timeout_seconds: float | None,
-        stdin: str | None,
-    ) -> None:
-        try:
-            result = await self.session.execute_bash(
-                command,
-                cwd=cwd,
-                env=env,
-                timeout_seconds=timeout_seconds,
-                stdin=stdin,
-            )
-        except Exception as exc:
-            self._write_response_error(id=command_id, command="bash", error=str(exc))
-        else:
-            try:
-                data = camelize(project_json_value(result))
-            except Exception as exc:
-                self._write_response_error(
-                    id=command_id,
-                    command="bash",
-                    error=f"Failed to serialize bash result: {exc}",
-                )
-                return
-            self._write_response_success(
-                id=command_id,
-                command="bash",
-                data=data,
-            )
-        finally:
-            if self._active_bash_task is asyncio.current_task():
-                self._active_bash_task = None
-
-    def _handle_abort_bash_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        self.session.abort_bash()
-        self._write_response_success(id=command_id, command="abort_bash")
-
-    async def _handle_compact_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        try:
-            result = await self._rpc_operations.compact(payload)
-        except Exception as exc:
-            self._write_response_error(
-                id=command_id,
-                command="compact",
-                error=f"Failed to compact session: {exc}",
-            )
-            return
-        try:
-            data = camelize(project_json_value(result))
-        except Exception as exc:
-            self._write_response_error(
-                id=command_id,
-                command="compact",
-                error=f"Failed to serialize compact response: {exc}",
-            )
-            return
-        self._write_response_success(
-            id=command_id,
-            command="compact",
-            data=data,
-        )
-
-    def _handle_set_auto_retry_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        try:
-            self._rpc_operations.set_auto_retry(payload)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_auto_retry",
-                error=f"Failed to set auto-retry: {error}",
-            )
-            return
-        self._write_response_success(id=command_id, command="set_auto_retry")
-
-    def _handle_abort_retry_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        del payload
-        self._rpc_operations.abort_retry()
-        self._write_response_success(id=command_id, command="abort_retry")
-
-    def _handle_set_auto_compaction_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        try:
-            self._rpc_operations.set_auto_compaction(payload)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="set_auto_compaction",
-                error=f"Failed to set auto-compaction: {error}",
-            )
-            return
-        self._write_response_success(id=command_id, command="set_auto_compaction")
-
-    def _handle_export_html_command(
-        self, command_id: str | None, payload: dict[str, Any]
-    ) -> None:
-        output_path = optional_string(payload, "outputPath", "output_path")
-        try:
-            path = self.session.export_to_html(output_path)
-        except Exception as error:
-            self._write_response_error(
-                id=command_id,
-                command="export_html",
-                error=f"Failed to export HTML: {error}",
-            )
-            return
-        if not isinstance(path, str):
-            if isinstance(path, Path):
-                path = str(path)
-            else:
-                self._write_response_error(
-                    id=command_id,
-                    command="export_html",
-                    error="Export returned an invalid response.",
-                )
-                return
-        self._write_response_success(
-            id=command_id,
-            command="export_html",
-            data={"path": path},
-        )
 
     def _bind_session(self, session: Any) -> None:
         self._unsubscribe()
@@ -1398,12 +600,6 @@ class RpcHost(ModeAdapter):
         self._tool_render_runtime = ToolRenderRuntime(cwd=_session_cwd(session))
         self._tool_definition_resolver = _tool_definition_resolver(session)
 
-    def _ensure_no_active_bash(self, *, command: str) -> None:
-        task = self._active_bash_task
-        if task is not None and not task.done():
-            raise RuntimeError(
-                f"{command} requires the active bash command to finish or abort first"
-            )
 
     def _require_current_session(self) -> Any:
         getter = getattr(self.runtime, "get_current_session", None)
@@ -1447,17 +643,6 @@ class RpcHost(ModeAdapter):
 
         return session_messages(session)
 
-    def _extract_last_assistant_text(self) -> str | None:
-        getter = getattr(self.session, "get_last_assistant_text", None)
-        if callable(getter):
-            return getter()
-        return None
-
-    def _extract_session_entry_text(self, entry_id: str) -> str | None:
-        getter = getattr(self.session, "get_entry_text", None)
-        if callable(getter):
-            return getter(entry_id)
-        return None
 
     def _write_response_success(
         self, *, command: str, id: str | None = None, data: object = _MISSING

--- a/src/loushang/harness/host/rpc/testing.py
+++ b/src/loushang/harness/host/rpc/testing.py
@@ -1,0 +1,157 @@
+"""Public test support for Product-neutral RPC wire playback."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from io import StringIO
+
+from .runtime import RpcHost
+
+
+@dataclass(frozen=True, slots=True)
+class RpcWirePlaybackResult:
+    """Captured JSONL output and host status from one playback."""
+
+    records: tuple[dict[str, object], ...]
+    exit_codes: tuple[int, ...]
+    stdout: str
+    stderr: str
+
+
+class RpcWirePlayback:
+    """Drive one live ``RpcHost`` command by command in a test."""
+
+    def __init__(
+        self,
+        *,
+        runtime: object,
+        event_view: str = "full",
+        event_select: str | Sequence[str] | None = None,
+        render_tool_events: bool = False,
+    ) -> None:
+        self._stdout = StringIO()
+        self._stderr = StringIO()
+        self._host = RpcHost(
+            runtime=runtime,
+            stdin=StringIO(),
+            stdout=self._stdout,
+            stderr=self._stderr,
+            event_view=event_view,
+            event_select=event_select,
+            render_tool_events=render_tool_events,
+        )
+        self._exit_codes: list[int] = []
+        self._finished = False
+
+    @property
+    def host(self) -> RpcHost:
+        """Expose the host only for assertions outside the wire contract."""
+
+        return self._host
+
+    async def dispatch(self, command: Mapping[str, object]) -> int:
+        """Submit one strict-JSON command without waiting for background work."""
+
+        if self._finished:
+            raise RuntimeError("RPC wire playback is already finished")
+        wire_line = json.dumps(dict(command), allow_nan=False)
+        exit_code = await self._host.submit_input(wire_line)
+        self._exit_codes.append(exit_code)
+        return exit_code
+
+    def snapshot(self) -> RpcWirePlaybackResult:
+        """Return output emitted so far without changing host lifecycle."""
+
+        stdout = self._stdout.getvalue()
+        records: list[dict[str, object]] = []
+        for line in stdout.splitlines():
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            if not isinstance(record, dict):
+                raise AssertionError("RPC playback emitted a non-object JSON record")
+            records.append(record)
+        return RpcWirePlaybackResult(
+            records=tuple(records),
+            exit_codes=tuple(self._exit_codes),
+            stdout=stdout,
+            stderr=self._stderr.getvalue(),
+        )
+
+    async def finish(self) -> RpcWirePlaybackResult:
+        """Wait for Product-owned tasks and close transport subscriptions."""
+
+        if not self._finished:
+            await self._host.settle_background_tasks()
+            await self._host.stop()
+            self._finished = True
+        return self.snapshot()
+
+    async def dispose(self) -> RpcWirePlaybackResult:
+        """Dispose the Product runtime and settle its outstanding host tasks."""
+
+        if not self._finished:
+            await self._host.dispose()
+            self._finished = True
+        return self.snapshot()
+
+
+async def play_rpc_wire_async(
+    *,
+    runtime: object,
+    commands: Sequence[Mapping[str, object]],
+    event_view: str = "full",
+    event_select: str | Sequence[str] | None = None,
+    render_tool_events: bool = False,
+) -> RpcWirePlaybackResult:
+    """Play a finite command sequence through the live RPC host."""
+
+    playback = RpcWirePlayback(
+        runtime=runtime,
+        event_view=event_view,
+        event_select=event_select,
+        render_tool_events=render_tool_events,
+    )
+    result: RpcWirePlaybackResult
+    try:
+        for command in commands:
+            exit_code = await playback.dispatch(command)
+            if exit_code != 0:
+                raise RuntimeError(
+                    f"RPC command dispatch failed with exit code {exit_code}"
+                )
+    finally:
+        result = await playback.finish()
+    return result
+
+
+def play_rpc_wire(
+    *,
+    runtime: object,
+    commands: Sequence[Mapping[str, object]],
+    event_view: str = "full",
+    event_select: str | Sequence[str] | None = None,
+    render_tool_events: bool = False,
+) -> RpcWirePlaybackResult:
+    """Synchronous wrapper for tests that do not already own an event loop."""
+
+    return asyncio.run(
+        play_rpc_wire_async(
+            runtime=runtime,
+            commands=commands,
+            event_view=event_view,
+            event_select=event_select,
+            render_tool_events=render_tool_events,
+        )
+    )
+
+
+__all__ = [
+    "RpcWirePlayback",
+    "RpcWirePlaybackResult",
+    "play_rpc_wire",
+    "play_rpc_wire_async",
+]

--- a/src/loushang/harness/scenario/runner.py
+++ b/src/loushang/harness/scenario/runner.py
@@ -67,7 +67,6 @@ class AgentSessionWorkflowAdapter:
         if emit_start:
             await self._emit(WorkflowEvent(type="run.started", text=prompt))
         await self.session.prompt(prompt)
-        await self._wait_for_idle()
         assistant_text = _assistant_text_after(self.session, before_count=before_count)
         if assistant_text and not _has_assistant_message_event(
             self._events[before_event_count:]
@@ -179,13 +178,6 @@ class AgentSessionWorkflowAdapter:
         if inspect.isawaitable(result):
             await result
         await self._emit(WorkflowEvent(type=event_type, text=text))
-
-    async def _wait_for_idle(self) -> None:
-        wait_for_idle = getattr(self.session, "wait_for_idle", None)
-        if callable(wait_for_idle):
-            result = wait_for_idle()
-            if inspect.isawaitable(result):
-                await result
 
     async def _record_session_event(self, event: dict) -> None:
         if event.get("type") != "message_end":

--- a/src/loushang/harness/session/operations.py
+++ b/src/loushang/harness/session/operations.py
@@ -105,8 +105,9 @@ class SessionOperationRuntime:
     """Execute admitted session control groups through one explicit port.
 
     The runtime does not own background task scheduling, request validation,
-    error schema, model selection, or output projection.  A host may schedule
-    ``prompt`` itself while preserving the preflight callback contract.
+    error schema, model selection, or output projection. ``prompt`` is the
+    settled turn operation: it submits through the bound control and waits for
+    the Session to become idle. Hosts must not add a second idle wait after it.
     """
 
     def __init__(

--- a/src/loushang/harnesstui/conversation/agent_binding.py
+++ b/src/loushang/harnesstui/conversation/agent_binding.py
@@ -105,8 +105,6 @@ class AgentPlainPromptSession(Protocol):
         listener: Callable[[dict[str, Any]], None],
     ) -> Callable[[], None]: ...
 
-    def wait_for_idle(self) -> Awaitable[None]: ...
-
 
 STANDARD_AGENT_HISTORY_DISPOSITIONS: dict[str, HistoryRecordDisposition] = {
     AGENT_MESSAGE_KIND: "render",
@@ -525,7 +523,6 @@ async def run_agent_plain_prompt(
                 prepare=prepare,
                 subscribe=lambda: session.subscribe(event_projection.handle),
                 submit=submit,
-                wait_for_idle=session.wait_for_idle,
                 capture_failure_state=lambda: event_projection.last_error_message,
                 resolve_failure=resolve_failure,
                 render_user=renderer.render_user,

--- a/src/loushang/harnesstui/conversation/controller.py
+++ b/src/loushang/harnesstui/conversation/controller.py
@@ -179,7 +179,7 @@ class ConversationUiController:
             else:
                 operations.follow_up(text, images=normalized_images)
             return HostActionResult()
-        except (AttributeError, SessionOperationUnavailableError) as error:
+        except SessionOperationUnavailableError as error:
             self._record_problem(
                 f"{self.problem_code_prefix}_{failure_code.removeprefix('conversation_ui_')}",
                 message=str(error),

--- a/src/loushang/harnesstui/conversation/plain_prompt_host.py
+++ b/src/loushang/harnesstui/conversation/plain_prompt_host.py
@@ -23,13 +23,14 @@ class PlainPromptHostPorts(Generic[FailureStateT]):
     """Prepared product effects consumed by the one-shot prompt host.
 
     Session, model, raw event, work metadata, and failure interpretation stay
-    behind these callbacks. The shared host only owns ordering and exit state.
+    behind these callbacks. ``submit`` returns only after the Product-owned
+    turn operation has settled; the shared host does not independently wait
+    on the Session. The shared host only owns ordering and exit state.
     """
 
     prepare: Callable[[], Awaitable[object]]
     subscribe: Callable[[], Cleanup]
     submit: Callable[[str, int, int], Awaitable[None]]
-    wait_for_idle: Callable[[], Awaitable[None]]
     capture_failure_state: Callable[[], FailureStateT]
     resolve_failure: Callable[[FailureStateT], str | None]
     render_user: Callable[[str], None]
@@ -267,7 +268,6 @@ async def _run_plain_prompt_turn(
     previous_failure = run.ports.capture_failure_state()
     run.ports.render_user(prompt)
     await run.ports.submit(prompt, turn_index, turn_count)
-    await run.ports.wait_for_idle()
     if run.ports.resolve_failure(previous_failure) is not None:
         return 1
     run.ports.render_worked(run.now() - started_at)

--- a/src/loushang/work/session.py
+++ b/src/loushang/work/session.py
@@ -27,7 +27,12 @@ SessionIdReader = Callable[[], str]
 
 
 class SessionPromptPort(Protocol):
-    """Session operations required by the reusable Work binding."""
+    """Session operations required by the reusable Work binding.
+
+    ``prompt`` returns after the submitted turn has settled. ``wait_for_idle``
+    exists for independently initiated cancellation settlement, not as a
+    second step after an ordinary prompt.
+    """
 
     def subscribe_runtime_events(
         self,
@@ -196,7 +201,6 @@ class SessionTurnExecutor:
     turns: tuple[SessionWorkTurn, ...] = ()
     before_turn: SessionTurnHook | None = None
     after_turn: SessionTurnHook | None = None
-    wait_for_idle_after_prompt: bool = False
 
     async def execute(
         self,
@@ -229,8 +233,6 @@ class SessionTurnExecutor:
                     len(messages),
                 )
                 await _prompt_turn(self.session, active_turn)
-                if self.wait_for_idle_after_prompt:
-                    await self.session.wait_for_idle()
                 await _call_turn_hook(
                     self.after_turn,
                     active_turn,
@@ -420,7 +422,6 @@ class SessionWorkRuntime:
         run_id: str | None = None,
         before_turn: SessionTurnHook | None = None,
         after_turn: SessionTurnHook | None = None,
-        wait_for_idle_after_prompt: bool = False,
     ) -> WorkRun:
         resolved_turns = tuple(turns)
         if not resolved_turns:
@@ -447,7 +448,6 @@ class SessionWorkRuntime:
             turns=resolved_turns,
             before_turn=before_turn,
             after_turn=after_turn,
-            wait_for_idle_after_prompt=wait_for_idle_after_prompt,
         )
         first_spec = first.to_run_spec(profile=self.profile, run_id=run_id)
         spec = WorkRunSpec(
@@ -477,7 +477,6 @@ class SessionWorkRuntime:
         turns: tuple[SessionWorkTurn, ...] = (),
         before_turn: SessionTurnHook | None = None,
         after_turn: SessionTurnHook | None = None,
-        wait_for_idle_after_prompt: bool = False,
     ) -> SessionTurnExecutor:
         return SessionTurnExecutor(
             session=self.session,
@@ -487,7 +486,6 @@ class SessionWorkRuntime:
             turns=turns,
             before_turn=before_turn,
             after_turn=after_turn,
-            wait_for_idle_after_prompt=wait_for_idle_after_prompt,
         )
 
 
@@ -567,7 +565,6 @@ class SessionWorkHostPort:
             tuple(require_session_work_turn(turn) for turn in turns),
             session_id=session_id,
             after_turn=after_turn,
-            wait_for_idle_after_prompt=True,
         )
 
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -954,15 +954,23 @@ def test_rpc_host_package_has_leaf_first_internal_dependencies() -> None:
         "remote_ui.py",
         "routing.py",
         "runtime.py",
+        "testing.py",
         "types.py",
         "wire.py",
     }
 
     assert {path.name for path in rpc_root.glob("*.py")} == expected_modules
-    for module_name in expected_modules - {"__init__.py", "runtime.py"}:
+    for module_name in expected_modules - {"__init__.py", "runtime.py", "testing.py"}:
         imports = set(_absolute_imports(rpc_root / module_name))
         assert "loushang.harness.host.rpc" not in imports
         assert "loushang.harness.host.rpc.runtime" not in imports
+
+    testing_imports = set(_absolute_imports(rpc_root / "testing.py"))
+    assert "loushang.harness.host.rpc.runtime" in testing_imports
+    testing_source = (rpc_root / "testing.py").read_text(encoding="utf-8")
+    assert "class RpcWirePlayback:" in testing_source
+    assert "def play_rpc_wire(" in testing_source
+    assert "loushang.coding" not in testing_source
 
     command_root = rpc_root / "commands"
     assert {path.name for path in command_root.glob("*.py")} == {
@@ -992,6 +1000,8 @@ def test_rpc_host_package_has_leaf_first_internal_dependencies() -> None:
         assert f"class {protocol_name}(Protocol):" in source
 
     runtime_source = (rpc_root / "runtime.py").read_text(encoding="utf-8")
+    assert "class _RpcHostRuntime(Protocol):" in runtime_source
+    assert "runtime: Any" not in runtime_source
     assert "RpcCommandCatalogCommands" in runtime_source
     assert "_handle_get_commands_command" not in runtime_source
     assert "_handle_get_command_completions_command" not in runtime_source

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -841,8 +841,8 @@ def test_session_rpc_operations_are_neutral_and_adopted() -> None:
     assert "loushang.channel" not in binding_source
     assert "SessionRpcOperationBinding" in rpc_source
     assert "_rpc_operations.prompt_request" in rpc_source
-    assert "_rpc_operations.new_session" in rpc_source
-    assert "_rpc_operations.compact" in rpc_source
+    assert "await self._operations.new_session" in rpc_source
+    assert "await self._operations.compact" in rpc_source
     assert "SessionOperationAvailability" in operations_source
     assert "SessionOperationRuntime" in rpc_source
     assert "SessionWorkRuntime" in channel_adapter_source
@@ -967,8 +967,12 @@ def test_rpc_host_package_has_leaf_first_internal_dependencies() -> None:
     command_root = rpc_root / "commands"
     assert {path.name for path in command_root.glob("*.py")} == {
         "__init__.py",
+        "bash_maintenance.py",
         "diagnostics.py",
+        "model_settings.py",
         "packages.py",
+        "session_lifecycle.py",
+        "transcript.py",
     }
     for command_module in command_root.glob("*.py"):
         imports = set(_absolute_imports(command_module))

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -968,6 +968,7 @@ def test_rpc_host_package_has_leaf_first_internal_dependencies() -> None:
     assert {path.name for path in command_root.glob("*.py")} == {
         "__init__.py",
         "bash_maintenance.py",
+        "command_catalog.py",
         "diagnostics.py",
         "model_settings.py",
         "packages.py",
@@ -978,6 +979,22 @@ def test_rpc_host_package_has_leaf_first_internal_dependencies() -> None:
         imports = set(_absolute_imports(command_module))
         assert "loushang.harness.host.rpc" not in imports
         assert "loushang.harness.host.rpc.runtime" not in imports
+
+    private_protocols = {
+        "bash_maintenance.py": "_BashSession",
+        "command_catalog.py": "_CommandCatalogSession",
+        "model_settings.py": "_ModelSettingsSession",
+        "session_lifecycle.py": "_SessionLifecycleRuntime",
+        "transcript.py": "_TranscriptSession",
+    }
+    for module_name, protocol_name in private_protocols.items():
+        source = (command_root / module_name).read_text(encoding="utf-8")
+        assert f"class {protocol_name}(Protocol):" in source
+
+    runtime_source = (rpc_root / "runtime.py").read_text(encoding="utf-8")
+    assert "RpcCommandCatalogCommands" in runtime_source
+    assert "_handle_get_commands_command" not in runtime_source
+    assert "_handle_get_command_completions_command" not in runtime_source
 
 
 def test_prompt_input_runtime_is_harness_owned_and_coding_adopts_it() -> None:

--- a/tests/coding/test_prompt_command.py
+++ b/tests/coding/test_prompt_command.py
@@ -125,7 +125,6 @@ def test_prompt_plan_command_preserves_transcript_and_uses_one_work_run() -> Non
             self.prompts: list[str] = []
             self.listeners = []
             self.runtime_listeners = []
-            self.wait_calls = 0
 
         def get_model_selection(self):
             return None
@@ -141,9 +140,6 @@ def test_prompt_plan_command_preserves_transcript_and_uses_one_work_run() -> Non
         async def prompt(self, text: str, images=None) -> None:
             del images
             self.prompts.append(text)
-
-        async def wait_for_idle(self) -> None:
-            self.wait_calls += 1
 
     async def scenario() -> None:
         runtime = FakeRuntime()
@@ -170,7 +166,6 @@ def test_prompt_plan_command_preserves_transcript_and_uses_one_work_run() -> Non
 
         assert exit_code == 0
         assert session.prompts == ["inspect", "verify"]
-        assert session.wait_calls == 2
         assert runtime.dispose_calls == 1
         assert "› inspect\n" in stdout.getvalue()
         assert "› verify\n" in stdout.getvalue()
@@ -399,7 +394,6 @@ def test_prompt_command_runs_follow_ups_with_images_only_on_first_turn() -> None
         def __init__(self) -> None:
             self.listeners = []
             self.prompt_calls = []
-            self.wait_calls = 0
 
         def subscribe(self, listener):
             self.listeners.append(listener)
@@ -411,9 +405,6 @@ def test_prompt_command_runs_follow_ups_with_images_only_on_first_turn() -> None
 
         async def prompt(self, user_input: str, images=None) -> None:
             self.prompt_calls.append((user_input, images))
-
-        async def wait_for_idle(self) -> None:
-            self.wait_calls += 1
 
     async def scenario() -> None:
         session = FakeSession()
@@ -435,7 +426,6 @@ def test_prompt_command_runs_follow_ups_with_images_only_on_first_turn() -> None
             ("second", None),
             ("third", None),
         ]
-        assert session.wait_calls == 3
         assert session.listeners == []
         assert stdout.getvalue().count("─ Worked for ") == 3
 

--- a/tests/coding/test_rpc_wire_playback.py
+++ b/tests/coding/test_rpc_wire_playback.py
@@ -1,10 +1,6 @@
-from __future__ import annotations
-
 import asyncio
-import json
-from io import StringIO
 
-from loushang.harness.host.rpc import RpcHost
+from loushang.harness.host.rpc import RpcWirePlayback, play_rpc_wire
 from tests.coding.test_rpc_mode import (
     FakeRuntime,
     FakeSession,
@@ -16,25 +12,9 @@ def _play_rpc_wire(
     runtime: FakeRuntime,
     *commands: dict[str, object],
 ) -> list[dict[str, object]]:
-    stdin = StringIO(
-        "\n".join(json.dumps(command) for command in commands) + "\n"
-    )
-    stdout = StringIO()
-
-    async def scenario() -> None:
-        exit_code = await RpcHost(
-            runtime=runtime,
-            stdin=stdin,
-            stdout=stdout,
-        ).run()
-        assert exit_code == 0
-
-    asyncio.run(scenario())
-    return [
-        json.loads(line)
-        for line in stdout.getvalue().splitlines()
-        if line.strip()
-    ]
+    result = play_rpc_wire(runtime=runtime, commands=commands)
+    assert result.exit_codes == (0,) * len(commands)
+    return list(result.records)
 
 
 def test_rpc_wire_playback_preserves_cross_group_success_golden() -> None:
@@ -283,3 +263,78 @@ def test_rpc_wire_playback_preserves_validation_error_golden() -> None:
             },
         },
     ]
+
+
+def test_rpc_wire_playback_aborts_immediately_then_settles_prompt_once() -> None:
+    session = FakeSession(session_id="session-a", cwd="/tmp/project")
+    runtime = FakeRuntime(session)
+
+    async def scenario() -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+        session._prompt_started = asyncio.Event()
+        session._prompt_release = asyncio.Event()
+        playback = RpcWirePlayback(runtime=runtime)
+
+        assert (
+            await playback.dispatch(
+                {"id": "prompt", "type": "prompt", "message": "keep working"}
+            )
+            == 0
+        )
+        await session._prompt_started.wait()
+        assert list(playback.snapshot().records) == [
+            {
+                "id": "prompt",
+                "type": "response",
+                "command": "prompt",
+                "success": True,
+            }
+        ]
+
+        assert await playback.dispatch({"id": "abort", "type": "abort"}) == 0
+        immediate = list(playback.snapshot().records)
+        finish_task = asyncio.create_task(playback.finish())
+        await asyncio.sleep(0)
+        assert finish_task.done() is False
+
+        session._prompt_release.set()
+        settled = await finish_task
+        return immediate, list(settled.records)
+
+    immediate, settled = asyncio.run(scenario())
+
+    abort_response = {
+        "id": "abort",
+        "type": "response",
+        "command": "abort",
+        "success": True,
+    }
+    assert abort_response in immediate
+    assert settled == immediate
+    assert session.abort_calls == 1
+    assert session.wait_calls == 1
+
+
+def test_rpc_wire_playback_dispose_waits_for_outstanding_prompt() -> None:
+    session = FakeSession(session_id="session-a", cwd="/tmp/project")
+    runtime = FakeRuntime(session)
+
+    async def scenario() -> None:
+        session._prompt_started = asyncio.Event()
+        session._prompt_release = asyncio.Event()
+        playback = RpcWirePlayback(runtime=runtime)
+        await playback.dispatch(
+            {"id": "prompt", "type": "prompt", "message": "finish before close"}
+        )
+        await session._prompt_started.wait()
+
+        dispose_task = asyncio.create_task(playback.dispose())
+        await asyncio.sleep(0)
+        assert dispose_task.done() is False
+
+        session._prompt_release.set()
+        await dispose_task
+
+    asyncio.run(scenario())
+
+    assert session.wait_calls == 1
+    assert session.listeners == []

--- a/tests/coding/test_rpc_wire_playback.py
+++ b/tests/coding/test_rpc_wire_playback.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from io import StringIO
+
+from loushang.harness.host.rpc import RpcHost
+from tests.coding.test_rpc_mode import (
+    FakeRuntime,
+    FakeSession,
+    _assistant_message,
+)
+
+
+def _play_rpc_wire(
+    runtime: FakeRuntime,
+    *commands: dict[str, object],
+) -> list[dict[str, object]]:
+    stdin = StringIO(
+        "\n".join(json.dumps(command) for command in commands) + "\n"
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        exit_code = await RpcHost(
+            runtime=runtime,
+            stdin=stdin,
+            stdout=stdout,
+        ).run()
+        assert exit_code == 0
+
+    asyncio.run(scenario())
+    return [
+        json.loads(line)
+        for line in stdout.getvalue().splitlines()
+        if line.strip()
+    ]
+
+
+def test_rpc_wire_playback_preserves_cross_group_success_golden() -> None:
+    session = FakeSession(
+        session_id="session-a",
+        cwd="/tmp/project",
+        messages=[_assistant_message("ready")],
+    )
+    session.command_entries = [
+        {
+            "name": "deploy",
+            "description": "Deploy project",
+            "source": "extension",
+            "source_info": {"path": "/tmp/project/extensions/deploy.py"},
+        }
+    ]
+    session.packages = [{"name": "core", "source": "builtin"}]
+
+    assert _play_rpc_wire(
+        FakeRuntime(session),
+        {"id": "commands", "type": "get_commands"},
+        {"id": "last", "type": "get_last_assistant_text"},
+        {"id": "models", "type": "get_available_models"},
+        {"id": "packages", "type": "get_packages"},
+        {"id": "compact", "type": "compact"},
+        {
+            "id": "export",
+            "type": "export_html",
+            "outputPath": "/tmp/exported.html",
+        },
+    ) == [
+        {
+            "id": "commands",
+            "type": "response",
+            "command": "get_commands",
+            "success": True,
+            "data": {
+                "commands": [
+                    {
+                        "name": "deploy",
+                        "description": "Deploy project",
+                        "source": "extension",
+                        "sourceInfo": {
+                            "path": "/tmp/project/extensions/deploy.py",
+                            "source": "filesystem",
+                            "scope": "project",
+                            "origin": "top-level",
+                            "baseDir": "/tmp/project/extensions",
+                        },
+                    }
+                ]
+            },
+        },
+        {
+            "id": "last",
+            "type": "response",
+            "command": "get_last_assistant_text",
+            "success": True,
+            "data": {"text": "ready"},
+        },
+        {
+            "id": "models",
+            "type": "response",
+            "command": "get_available_models",
+            "success": True,
+            "data": {"models": []},
+        },
+        {
+            "id": "packages",
+            "type": "response",
+            "command": "get_packages",
+            "success": True,
+            "data": {"packages": [{"name": "core", "source": "builtin"}]},
+        },
+        {
+            "id": "compact",
+            "type": "response",
+            "command": "compact",
+            "success": True,
+            "data": {
+                "summary": "compacted",
+                "firstKeptEntryId": "entry-1",
+                "tokensBefore": 42,
+                "details": {"preserved": 3},
+            },
+        },
+        {
+            "id": "export",
+            "type": "response",
+            "command": "export_html",
+            "success": True,
+            "data": {"path": "/tmp/exported.html"},
+        },
+    ]
+
+
+def test_rpc_wire_playback_resolves_groups_against_rebound_session() -> None:
+    initial = FakeSession(
+        session_id="initial",
+        cwd="/tmp/project",
+        messages=[_assistant_message("old")],
+    )
+    replacement = FakeSession(
+        session_id="replacement",
+        cwd="/tmp/project",
+        messages=[_assistant_message("new")],
+    )
+    replacement.command_entries = [
+        {
+            "name": "replacement-command",
+            "source": "prompt",
+            "source_info": {"path": "/tmp/project/prompts/replacement.md"},
+        }
+    ]
+    runtime = FakeRuntime(initial)
+    runtime.queue_next_session(replacement)
+
+    assert _play_rpc_wire(
+        runtime,
+        {"id": "new", "type": "new_session"},
+        {"id": "last", "type": "get_last_assistant_text"},
+        {"id": "commands", "type": "get_commands"},
+    ) == [
+        {
+            "id": "new",
+            "type": "response",
+            "command": "new_session",
+            "success": True,
+            "data": {"cancelled": False},
+        },
+        {
+            "id": "last",
+            "type": "response",
+            "command": "get_last_assistant_text",
+            "success": True,
+            "data": {"text": "new"},
+        },
+        {
+            "id": "commands",
+            "type": "response",
+            "command": "get_commands",
+            "success": True,
+            "data": {
+                "commands": [
+                    {
+                        "name": "replacement-command",
+                        "description": None,
+                        "source": "prompt",
+                        "sourceInfo": {
+                            "path": "/tmp/project/prompts/replacement.md",
+                            "source": "filesystem",
+                            "scope": "project",
+                            "origin": "top-level",
+                            "baseDir": "/tmp/project/prompts",
+                        },
+                    }
+                ]
+            },
+        },
+    ]
+
+
+def test_rpc_wire_playback_preserves_async_prompt_and_bash_golden() -> None:
+    session = FakeSession(session_id="session-a", cwd="/tmp/project")
+
+    assert _play_rpc_wire(
+        FakeRuntime(session),
+        {"id": "prompt", "type": "prompt", "message": "hello"},
+        {"id": "bash", "type": "bash", "command": "printf ok"},
+    ) == [
+        {
+            "id": "prompt",
+            "type": "response",
+            "command": "prompt",
+            "success": True,
+        },
+        {
+            "id": "bash",
+            "type": "response",
+            "command": "bash",
+            "success": True,
+            "data": {
+                "output": "ok\n",
+                "exitCode": 0,
+                "cancelled": False,
+                "truncated": False,
+                "fullOutputPath": None,
+            },
+        },
+    ]
+    assert session.prompt_calls == [("hello", None)]
+    assert session.wait_calls == 1
+    assert session.bash_calls == [
+        {
+            "command": "printf ok",
+            "cwd": None,
+            "env": None,
+            "timeout_seconds": None,
+            "stdin": None,
+        }
+    ]
+
+
+def test_rpc_wire_playback_preserves_validation_error_golden() -> None:
+    session = FakeSession(session_id="session-a", cwd="/tmp/project")
+
+    assert _play_rpc_wire(
+        FakeRuntime(session),
+        {
+            "id": "prefix",
+            "type": "get_command_completions",
+            "prefix": 3,
+        },
+        {
+            "id": "command",
+            "type": "get_command_completions",
+            "command": "",
+        },
+    ) == [
+        {
+            "id": "prefix",
+            "type": "response",
+            "command": "get_command_completions",
+            "success": False,
+            "error": "Command completion prefix must be a string.",
+            "errorCode": "invalid_request",
+            "errorInfo": {
+                "code": "invalid_request",
+                "message": "Command completion prefix must be a string.",
+                "command": "get_command_completions",
+            },
+        },
+        {
+            "id": "command",
+            "type": "response",
+            "command": "get_command_completions",
+            "success": False,
+            "error": "Command completion command must be a non-empty string.",
+            "errorCode": "invalid_request",
+            "errorInfo": {
+                "code": "invalid_request",
+                "message": (
+                    "Command completion command must be a non-empty string."
+                ),
+                "command": "get_command_completions",
+            },
+        },
+    ]

--- a/tests/coding/test_screen_coding_tui_loop.py
+++ b/tests/coding/test_screen_coding_tui_loop.py
@@ -847,7 +847,6 @@ def test_screen_loop_waits_for_abort_settle_before_running_popped_pending_steer(
     )
 
     assert result.exit_code == 0
-    assert session.wait_for_idle_calls == 3
     assert session.queued_while_streaming == [fresh_prompt]
     assert session.prompt_calls == [
         ("start", None, "interactive"),
@@ -984,7 +983,6 @@ class _AbortSettlingSession:
         self.is_streaming = False
         self.prompt_calls: list[tuple[str, str | None, str | None]] = []
         self.queued_while_streaming: list[str] = []
-        self.wait_for_idle_calls = 0
         self._idle = asyncio.Event()
         self._idle.set()
         self.session_control = self
@@ -1027,7 +1025,6 @@ class _AbortSettlingSession:
         return None
 
     async def wait_for_idle(self) -> None:
-        self.wait_for_idle_calls += 1
         await self._idle.wait()
 
 

--- a/tests/coding/test_session_operation_contract.py
+++ b/tests/coding/test_session_operation_contract.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from loushang.coding.ui.product_binding import (
+    build_coding_session_operation_resolver,
+)
+from loushang.harness.session import SessionOperationAvailability
+from tests.harness.session.operation_contract import (
+    CurrentSessionSlot,
+    SessionOperationContract,
+)
+
+
+class TestCodingSessionOperationContract(SessionOperationContract):
+    @staticmethod
+    def resolver_factory(
+        slot: CurrentSessionSlot,
+        availability: SessionOperationAvailability | None,
+    ):
+        return build_coding_session_operation_resolver(
+            session=slot.current_session,
+            runtime=slot,
+            availability=availability,
+        )

--- a/tests/coding/test_ui_controller.py
+++ b/tests/coding/test_ui_controller.py
@@ -391,15 +391,19 @@ def test_controller_uses_shared_session_steering_primitive() -> None:
     assert session.calls == ["use a smaller diff"]
 
 
-def test_controller_reports_when_steering_is_unavailable() -> None:
+def test_controller_does_not_mask_attribute_error_as_unavailable() -> None:
     from loushang.coding.ui.product_binding import build_coding_ui_controller
 
-    class NoSteerSession:
-        pass
+    class BrokenSteerSession:
+        def steer(self, text: str, images=None) -> None:
+            del text, images
+            raise AttributeError("steering implementation bug")
 
-    result = asyncio.run(build_coding_ui_controller(session=NoSteerSession()).steer("wait"))
+    result = asyncio.run(
+        build_coding_ui_controller(session=BrokenSteerSession()).steer("wait")
+    )
 
-    assert result.error_message == "Steering is unavailable for this session."
+    assert result.error_message == "steering implementation bug"
 
 
 def test_controller_sends_follow_up_when_session_supports_it() -> None:

--- a/tests/harness/host/test_rpc_components.py
+++ b/tests/harness/host/test_rpc_components.py
@@ -16,6 +16,7 @@ from loushang.harness.host.rpc.arguments import (
 )
 from loushang.harness.host.rpc.commands import (
     RpcBashMaintenanceCommands,
+    RpcCommandCatalogCommands,
     RpcDiagnosticsCommands,
     RpcModelSettingsCommands,
     RpcPackageCommands,
@@ -140,6 +141,10 @@ def test_rpc_command_groups_declare_their_complete_legacy_bindings() -> None:
         output=output,
         task_tracker=ProductHostTaskTracker(),
     )
+    command_catalog = RpcCommandCatalogCommands(
+        get_session=object,
+        output=output,
+    )
 
     assert tuple(command for command, _handler in diagnostics.bindings()) == (
         "get_diagnostics",
@@ -190,6 +195,10 @@ def test_rpc_command_groups_declare_their_complete_legacy_bindings() -> None:
         "set_auto_retry",
         "abort_retry",
         "set_auto_compaction",
+    )
+    assert tuple(command for command, _handler in command_catalog.bindings()) == (
+        "get_commands",
+        "get_command_completions",
     )
 
 

--- a/tests/harness/host/test_rpc_components.py
+++ b/tests/harness/host/test_rpc_components.py
@@ -7,6 +7,7 @@ from io import StringIO
 import pytest
 
 from loushang.harness.host.jsonl_command_host import JsonlCommand
+from loushang.harness.host.product_host import ProductHostTaskTracker
 from loushang.harness.host.rpc import RpcHost, run_rpc_host
 from loushang.harness.host.rpc.arguments import (
     optional_env_pairs,
@@ -14,8 +15,12 @@ from loushang.harness.host.rpc.arguments import (
     require_string,
 )
 from loushang.harness.host.rpc.commands import (
+    RpcBashMaintenanceCommands,
     RpcDiagnosticsCommands,
+    RpcModelSettingsCommands,
     RpcPackageCommands,
+    RpcSessionLifecycleCommands,
+    RpcTranscriptCommands,
 )
 from loushang.harness.host.rpc.output import RpcOutput
 from loushang.harness.host.rpc.projections import (
@@ -113,6 +118,28 @@ def test_rpc_command_groups_declare_their_complete_legacy_bindings() -> None:
         get_session=object,
         output=output,
     )
+    lifecycle = RpcSessionLifecycleCommands(
+        runtime=object(),
+        get_session=object,
+        operations=object(),  # type: ignore[arg-type]
+        output=output,
+    )
+    model_settings = RpcModelSettingsCommands(
+        get_session=object,
+        get_operations=object,  # type: ignore[arg-type]
+        output=output,
+    )
+    transcript = RpcTranscriptCommands(
+        get_session=object,
+        get_messages=lambda _session: [],
+        output=output,
+    )
+    bash_maintenance = RpcBashMaintenanceCommands(
+        get_session=object,
+        operations=object(),  # type: ignore[arg-type]
+        output=output,
+        task_tracker=ProductHostTaskTracker(),
+    )
 
     assert tuple(command for command, _handler in diagnostics.bindings()) == (
         "get_diagnostics",
@@ -131,6 +158,39 @@ def test_rpc_command_groups_declare_their_complete_legacy_bindings() -> None:
         "remove_package",
         "uninstall_package",
     }
+    assert tuple(command for command, _handler in lifecycle.bindings()) == (
+        "list_sessions",
+        "new_session",
+        "switch_session",
+        "fork",
+        "clone",
+    )
+    assert tuple(command for command, _handler in model_settings.bindings()) == (
+        "set_model",
+        "get_available_models",
+        "cycle_model",
+        "set_active_tools",
+        "set_thinking_level",
+        "cycle_thinking_level",
+        "set_steering_mode",
+        "set_follow_up_mode",
+        "get_session_stats",
+        "set_session_name",
+    )
+    assert tuple(command for command, _handler in transcript.bindings()) == (
+        "get_messages",
+        "get_last_assistant_text",
+        "get_fork_messages",
+        "export_html",
+    )
+    assert tuple(command for command, _handler in bash_maintenance.bindings()) == (
+        "bash",
+        "abort_bash",
+        "compact",
+        "set_auto_retry",
+        "abort_retry",
+        "set_auto_compaction",
+    )
 
 
 def test_rpc_package_commands_resolve_the_current_rebound_session() -> None:

--- a/tests/harness/scenario/test_agent_runner.py
+++ b/tests/harness/scenario/test_agent_runner.py
@@ -369,3 +369,51 @@ def test_agent_session_adapter_does_not_duplicate_assistant_message_events(
         "assistant.message",
         "run.ended",
     ]
+
+
+def test_agent_session_adapter_reads_assistant_only_after_prompt_settles() -> None:
+    from loushang.harness.scenario import AgentSessionWorkflowAdapter
+
+    class BlockingSession:
+        def __init__(self) -> None:
+            self.messages: list[object] = []
+            self.prompt_started = asyncio.Event()
+            self.release_prompt = asyncio.Event()
+
+        async def prompt(self, text: str) -> None:
+            self.messages.append(SimpleNamespace(role="user", content=text))
+            self.prompt_started.set()
+            await self.release_prompt.wait()
+            self.messages.append(
+                SimpleNamespace(role="assistant", content="settled response")
+            )
+
+        async def wait_for_idle(self) -> None:
+            raise AssertionError("prompt already owns idle settlement")
+
+    async def scenario() -> None:
+        session = BlockingSession()
+        adapter = AgentSessionWorkflowAdapter(session)
+
+        prompt_task = asyncio.create_task(adapter.run_prompt("hello"))
+        await session.prompt_started.wait()
+        await asyncio.sleep(0)
+
+        assert prompt_task.done() is False
+        assert [
+            message.content
+            for message in session.messages
+            if message.role == "assistant"
+        ] == []
+        assert [event.type for event in adapter.events()] == ["run.started"]
+
+        session.release_prompt.set()
+
+        assert await prompt_task == "settled response"
+        assert [event.type for event in adapter.events()] == [
+            "run.started",
+            "assistant.message",
+            "run.ended",
+        ]
+
+    asyncio.run(scenario())

--- a/tests/harness/session/operation_contract.py
+++ b/tests/harness/session/operation_contract.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import pytest
+
+from loushang.harness.session import (
+    SessionOperationAvailability,
+    SessionOperationCapability,
+    SessionOperationResolver,
+    SessionOperationUnavailableError,
+    SessionPromptRequest,
+)
+
+ResolverFactory = Callable[
+    ["CurrentSessionSlot", SessionOperationAvailability | None],
+    SessionOperationResolver,
+]
+
+
+class ContractControl:
+    """Minimal control whose observations define the shared operation contract."""
+
+    session_id = "contract-session"
+    session_name = "Contract"
+    pending_message_count = 0
+    is_retrying = False
+    is_compacting = False
+    auto_retry_enabled = True
+    auto_compaction_enabled = True
+
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.steering: list[str] = []
+        self.follow_ups: list[str] = []
+        self.abort_calls = 0
+        self.clear_calls = 0
+        self._idle = asyncio.Event()
+        self._idle.set()
+
+    async def prompt(self, text: str, images=None, **kwargs: object) -> None:
+        del images
+        self.events.append(f"prompt:{text}")
+        callback = kwargs.get("preflight_result")
+        if callable(callback):
+            callback(True)
+
+    async def wait_for_idle(self) -> None:
+        self.events.append("wait_for_idle")
+        await self._idle.wait()
+
+    def steer(self, text: str, images=None) -> None:
+        del images
+        self.steering.append(text)
+
+    def follow_up(self, text: str, images=None) -> None:
+        del images
+        self.follow_ups.append(text)
+
+    def get_steering_messages(self) -> list[str]:
+        return list(self.steering)
+
+    def get_follow_up_messages(self) -> list[str]:
+        return list(self.follow_ups)
+
+    def clear_queue(self) -> dict[str, list[str]]:
+        self.clear_calls += 1
+        return {"steering": [], "follow_up": []}
+
+    async def continue_run(self) -> None:
+        return None
+
+    def abort(self) -> bool:
+        self.abort_calls += 1
+        return True
+
+    async def set_session_name(self, name: str | None) -> None:
+        self.session_name = name
+
+    def abort_retry(self) -> None:
+        return None
+
+    async def wait_for_retry(self) -> None:
+        return None
+
+    def set_auto_retry_enabled(self, enabled: bool) -> None:
+        self.auto_retry_enabled = enabled
+
+    def set_auto_compaction_enabled(self, enabled: bool) -> None:
+        self.auto_compaction_enabled = enabled
+
+    async def compact(self, custom_instructions: str | None = None) -> object:
+        return {"instructions": custom_instructions}
+
+    def abort_compaction(self) -> None:
+        return None
+
+    async def refresh_resources(self) -> None:
+        return None
+
+    def request_resource_refresh(self) -> None:
+        return None
+
+    def subscribe_runtime_events(self, listener):
+        del listener
+        return lambda: None
+
+
+class CurrentSessionSlot:
+    def __init__(self, control: ContractControl) -> None:
+        self.current_session = SimpleNamespace(session_control=control)
+
+    def get_current_session(self) -> object:
+        return self.current_session
+
+    def replace(self, control: ContractControl) -> None:
+        self.current_session = SimpleNamespace(session_control=control)
+
+
+class SessionOperationContract:
+    """Reusable behavioral suite for every Product session-operation binding."""
+
+    resolver_factory: ResolverFactory
+
+    def _resolve(
+        self,
+        slot: CurrentSessionSlot,
+        availability: SessionOperationAvailability | None = None,
+    ) -> SessionOperationResolver:
+        return self.resolver_factory(slot, availability)
+
+    def test_prompt_is_a_settled_operation(self) -> None:
+        async def scenario() -> None:
+            control = ContractControl()
+            control._idle.clear()
+            resolve = self._resolve(CurrentSessionSlot(control))
+            preflight: list[bool] = []
+
+            pending = asyncio.create_task(
+                resolve().prompt(
+                    SessionPromptRequest("review", source="contract"),
+                    on_preflight=preflight.append,
+                )
+            )
+            await asyncio.sleep(0)
+
+            assert not pending.done()
+            assert control.events == ["prompt:review", "wait_for_idle"]
+            assert preflight == [True]
+
+            control._idle.set()
+            await pending
+
+        asyncio.run(scenario())
+
+    def test_queue_and_abort_primitives_remain_distinct(self) -> None:
+        control = ContractControl()
+        operations = self._resolve(CurrentSessionSlot(control))()
+
+        operations.steer("adjust")
+        operations.follow_up("later")
+        assert operations.abort_turn() is True
+
+        assert control.steering == ["adjust"]
+        assert control.follow_ups == ["later"]
+        assert control.abort_calls == 1
+        assert control.clear_calls == 0
+
+    def test_resolver_rebinds_after_current_session_changes(self) -> None:
+        first = ContractControl()
+        first.session_id = "first"
+        second = ContractControl()
+        second.session_id = "second"
+        slot = CurrentSessionSlot(first)
+        resolve = self._resolve(slot)
+
+        assert resolve().session_id == "first"
+        slot.replace(second)
+        assert resolve().session_id == "second"
+
+    def test_unavailable_capability_uses_the_typed_error(self) -> None:
+        resolve = self._resolve(
+            CurrentSessionSlot(ContractControl()),
+            SessionOperationAvailability.from_capabilities(
+                (SessionOperationCapability.IDENTITY,)
+            ),
+        )
+
+        with pytest.raises(SessionOperationUnavailableError, match="input"):
+            resolve().follow_up("later")
+
+    def test_product_errors_are_not_reclassified_as_unavailable(self) -> None:
+        class BrokenControl(ContractControl):
+            def steer(self, text: str, images=None) -> None:
+                del text, images
+                raise AttributeError("product steering bug")
+
+        operations = self._resolve(CurrentSessionSlot(BrokenControl()))()
+
+        with pytest.raises(AttributeError, match="product steering bug"):
+            operations.steer("adjust")
+
+
+__all__ = [
+    "CurrentSessionSlot",
+    "ResolverFactory",
+    "SessionOperationContract",
+]

--- a/tests/harness/session/test_operation_contract.py
+++ b/tests/harness/session/test_operation_contract.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from loushang.harness.session import (
+    SessionOperationAvailability,
+    current_session_operation_resolver,
+)
+from tests.harness.session.operation_contract import (
+    CurrentSessionSlot,
+    SessionOperationContract,
+)
+
+
+class TestHarnessSessionOperationContract(SessionOperationContract):
+    @staticmethod
+    def resolver_factory(
+        slot: CurrentSessionSlot,
+        availability: SessionOperationAvailability | None,
+    ):
+        return current_session_operation_resolver(
+            slot,
+            availability=availability,
+        )

--- a/tests/harnesstui/conversation/test_plain_prompt_host.py
+++ b/tests/harnesstui/conversation/test_plain_prompt_host.py
@@ -67,9 +67,6 @@ def test_plain_prompt_host_owns_turn_order_and_cleanup() -> None:
     async def submit(prompt: str, turn_index: int, turn_count: int) -> None:
         events.append(f"submit:{turn_index}/{turn_count}:{prompt}")
 
-    async def wait_for_idle() -> None:
-        events.append("wait")
-
     def capture_failure_state() -> int:
         events.append("capture")
         return 0
@@ -89,7 +86,6 @@ def test_plain_prompt_host_owns_turn_order_and_cleanup() -> None:
                     prepare=prepare,
                     subscribe=subscribe,
                     submit=submit,
-                    wait_for_idle=wait_for_idle,
                     capture_failure_state=capture_failure_state,
                     resolve_failure=resolve_failure,
                     render_user=lambda prompt: events.append(f"user:{prompt}"),
@@ -112,13 +108,11 @@ def test_plain_prompt_host_owns_turn_order_and_cleanup() -> None:
         "capture",
         "user:first",
         "submit:0/2:first",
-        "wait",
         "resolve:0",
         "worked:2.0",
         "capture",
         "user:second",
         "submit:1/2:second",
-        "wait",
         "resolve:0",
         "worked:5.0",
         "unsubscribe",
@@ -200,9 +194,6 @@ def test_plain_prompt_host_stops_after_product_reports_failure() -> None:
         if turn_index == 1:
             failure_version += 1
 
-    async def wait_for_idle() -> None:
-        return None
-
     async def dispose() -> None:
         events.append("dispose")
 
@@ -214,7 +205,6 @@ def test_plain_prompt_host_stops_after_product_reports_failure() -> None:
                     prepare=prepare,
                     subscribe=subscribe,
                     submit=submit,
-                    wait_for_idle=wait_for_idle,
                     capture_failure_state=lambda: failure_version,
                     resolve_failure=lambda previous: (
                         "product failure" if previous != failure_version else None
@@ -255,9 +245,6 @@ def test_plain_prompt_host_presents_run_exception_and_verbose_traceback() -> Non
     async def submit(_prompt: str, _turn_index: int, _turn_count: int) -> None:
         raise RuntimeError("prompt failed")
 
-    async def wait_for_idle() -> None:
-        raise AssertionError("wait must not run")
-
     async def dispose() -> None:
         events.append("dispose")
 
@@ -269,7 +256,6 @@ def test_plain_prompt_host_presents_run_exception_and_verbose_traceback() -> Non
                     prepare=prepare,
                     subscribe=subscribe,
                     submit=submit,
-                    wait_for_idle=wait_for_idle,
                     capture_failure_state=lambda: None,
                     resolve_failure=lambda _previous: None,
                     render_user=lambda prompt: events.append(f"user:{prompt}"),
@@ -303,9 +289,6 @@ def test_plain_prompt_host_presents_dispose_failure() -> None:
     async def submit(_prompt: str, _turn_index: int, _turn_count: int) -> None:
         return None
 
-    async def wait_for_idle() -> None:
-        return None
-
     async def dispose() -> None:
         raise RuntimeError("dispose failed")
 
@@ -317,7 +300,6 @@ def test_plain_prompt_host_presents_dispose_failure() -> None:
                     prepare=prepare,
                     subscribe=lambda: lambda: None,
                     submit=submit,
-                    wait_for_idle=wait_for_idle,
                     capture_failure_state=lambda: None,
                     resolve_failure=lambda _previous: None,
                     render_user=lambda _prompt: None,
@@ -350,9 +332,6 @@ def test_plain_prompt_host_preserves_unsubscribe_failure_boundary() -> None:
     async def submit(_prompt: str, _turn_index: int, _turn_count: int) -> None:
         return None
 
-    async def wait_for_idle() -> None:
-        return None
-
     async def dispose() -> None:
         nonlocal dispose_calls
         dispose_calls += 1
@@ -363,7 +342,6 @@ def test_plain_prompt_host_preserves_unsubscribe_failure_boundary() -> None:
             prepare=prepare,
             subscribe=subscribe,
             submit=submit,
-            wait_for_idle=wait_for_idle,
             capture_failure_state=lambda: None,
             resolve_failure=lambda _previous: None,
             render_user=lambda _prompt: None,

--- a/tests/harnesstui/conversation/test_ui_controller.py
+++ b/tests/harnesstui/conversation/test_ui_controller.py
@@ -4,7 +4,10 @@ import asyncio
 from types import SimpleNamespace
 
 from loushang.harness.host.types import HostActionResult
-from loushang.harness.session import SessionOperationRuntime
+from loushang.harness.session import (
+    SessionOperationAvailability,
+    SessionOperationRuntime,
+)
 from loushang.harnesstui.conversation.controller import (
     build_standard_conversation_ui_controller,
 )
@@ -40,6 +43,19 @@ def test_conversation_ui_controller_routes_actions_to_runtime_current_session() 
 
     assert prompts == [("current", "hello")]
     assert followups == [("current", "later")]
+
+
+def test_conversation_ui_controller_reports_explicitly_unavailable_input() -> None:
+    controller = build_standard_conversation_ui_controller(
+        get_operations=lambda: SessionOperationRuntime(
+            SimpleNamespace(),
+            availability=SessionOperationAvailability.from_capabilities(()),
+        ),
+    )
+
+    result = asyncio.run(controller.follow_up("later"))
+
+    assert result.error_message == "Follow-up is unavailable for this session."
 
 
 def test_conversation_ui_controller_resolves_session_command_on_current_session() -> (

--- a/tests/work/test_session.py
+++ b/tests/work/test_session.py
@@ -43,6 +43,9 @@ class _DesignSession:
     async def prompt(self, text: str) -> None:
         self.prompts.append(text)
 
+    async def wait_for_idle(self) -> None:
+        raise AssertionError("settled prompt must not be followed by a second wait")
+
 
 def test_session_work_runtime_accepts_product_vocabulary_as_a_profile() -> None:
     async def scenario() -> None:
@@ -147,3 +150,85 @@ def test_prepared_turn_projection_is_product_neutral() -> None:
             follow_up_messages=("Check contrast",),
         ),
     )
+
+
+def test_session_work_plan_waits_for_each_prompt_before_advancing() -> None:
+    class BlockingPlanSession:
+        def __init__(self) -> None:
+            self.prompts: list[str] = []
+            self.first_prompt_started = asyncio.Event()
+            self.release_first_prompt = asyncio.Event()
+
+        def subscribe_runtime_events(
+            self,
+            listener: Callable[[object], object],
+        ) -> Callable[[], None]:
+            del listener
+            return lambda: None
+
+        async def prompt(
+            self,
+            text: str,
+            *,
+            images: object = None,
+            streaming_behavior: str | None = None,
+            source: str | None = None,
+        ) -> None:
+            del images, streaming_behavior, source
+            self.prompts.append(text)
+            if len(self.prompts) == 1:
+                self.first_prompt_started.set()
+                await self.release_first_prompt.wait()
+
+        async def wait_for_idle(self) -> None:
+            raise AssertionError("prompt already owns idle settlement")
+
+    async def scenario() -> None:
+        session = BlockingPlanSession()
+        after_turns: list[str] = []
+        runtime = SessionWorkRuntime(
+            session=session,
+            event_log=InMemoryEventLogBackend(),
+            profile=SessionWorkProfile(
+                domain="design",
+                operation_kind="SubmitDesignTurn",
+            ),
+            project_event_facts=lambda _event: (),
+        )
+        turns = (
+            SessionWorkTurn(
+                text="first",
+                plan_id="plan-design",
+                step_id="first",
+                step_index=0,
+            ),
+            SessionWorkTurn(
+                text="second",
+                plan_id="plan-design",
+                step_id="second",
+                step_index=1,
+            ),
+        )
+
+        plan_task = asyncio.create_task(
+            runtime.submit_plan(
+                turns,
+                session_id="design-session",
+                after_turn=lambda turn, _index, _total: after_turns.append(turn.text),
+            )
+        )
+        await session.first_prompt_started.wait()
+        await asyncio.sleep(0)
+
+        assert plan_task.done() is False
+        assert session.prompts == ["first"]
+        assert after_turns == []
+
+        session.release_first_prompt.set()
+
+        run = await plan_task
+        assert run.status == "completed"
+        assert session.prompts == ["first", "second"]
+        assert after_turns == ["first", "second"]
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

- define one settled-return contract for shared session prompt operations and remove duplicate post-prompt idle waits from TUI, Scenario, and Work adapters
- add reusable Product-neutral session-operation contract coverage, including dynamic current-session rebinding and typed availability failures
- split the legacy RPC surface into focused command groups and add narrow private Protocols without changing the JSONL wire
- add the public `loushang.harness.host.rpc.testing` API for finite golden playback and staged concurrent playback
- specify and verify abort settlement: RPC acknowledges immediately while the prompt task owns one idle wait; TUI keeps its composite abort/clear/command behavior
- make explicit RPC disposal settle Product-owned prompt/bash tasks before transport teardown

## Playback coverage

- cross-group RPC success and validation-error golden traces
- dynamic session replacement and command resolution
- asynchronous prompt and Bash completion
- immediate abort acknowledgement followed by exactly-once prompt settlement
- disposal while a prompt remains outstanding

## Validation

- `uv --cache-dir .uv-cache run ruff check ...`: passed
- `uv --cache-dir .uv-cache run mypy --follow-imports=skip src/loushang/harness/host/rpc/runtime.py src/loushang/harness/host/rpc/testing.py`: passed
- focused RPC, Coding, HarnessTUI, and architecture tests: 293 passed
- `uv --cache-dir .uv-cache run pytest tests -q`: 6723 passed, 7 skipped
- `git diff --check`: passed
