### PR TITLE
refactor(harness): harden compaction lifecycle

### DIFF
--- a/docs/internals/architecture/harness/agent-transcript-maintenance-boundary.md
+++ b/docs/internals/architecture/harness/agent-transcript-maintenance-boundary.md
@@ -27,6 +27,8 @@ Harness provides:
 ```text
 ContextUsageSnapshot / CompactionDecision
 CompactionPlan / CompactionPreparation / CompactionResult / CompactionStatus
+AutoCompactionOutcome
+CompactionAborted
 AgentTranscriptCompactionRuntime
 AgentTranscriptRetryRuntime
 ```
@@ -34,7 +36,10 @@ AgentTranscriptRetryRuntime
 The compaction runtime operates through the existing `AgentTranscriptSession`:
 it reads the active branch, receives a Product-selected preparation strategy and
 summary binding, appends the standard compaction checkpoint only after
-successful execution, refreshes context, and publishes common lifecycle events.
+successful execution, refreshes context before invoking best-effort Product
+post-commit observers, and publishes common lifecycle events. Automatic checks
+return an explicit outcome; the Session runtime, not the transcript runtime,
+owns continuation scheduling.
 `harness.transcript.summarization` owns the reusable model-call and
 message-serialization mechanism; it accepts Product prompt profiles,
 completion selection, and JSON-safe summary decoration. It does not own prompt
@@ -75,6 +80,17 @@ provider registries, provider implementations, authentication resolution,
 Product configuration, or UI/RPC types. Product-specific prompt/profile,
 completion selection, artifact decoration, and overflow classification are
 injected through explicit values or callbacks.
+
+Hook cancellation raises the typed `CompactionAborted` exception; ordinary
+exceptions with similar text are failures, not cancellation. Compaction start
+and end events expose the lifecycle stage, Product and session identifiers,
+elapsed milliseconds, known before/after token counts, and the committed
+checkpoint record ID. Unknown post-checkpoint token usage remains `None` rather
+than being estimated as an observed value.
+
+The resolved runtime capability configuration remains authoritative per field.
+Product compaction settings use `None` to inherit capability values, while
+concrete live settings override only their corresponding fields.
 
 ## Verification
 

--- a/docs/internals/architecture/harness/product-runtime-injection/02-context-compaction-binding.md
+++ b/docs/internals/architecture/harness/product-runtime-injection/02-context-compaction-binding.md
@@ -77,6 +77,11 @@ The Product supplies three bounded bindings:
 2. an optional pre-compaction adapter, such as a Product extension hook;
 3. an optional post-commit projection adapter.
 
+The executor callable is the public
+`loushang.harness.session.ProductCompactionExecutor` contract. Product adapters
+depend on that narrow callable shape; the internal positional executor used by
+the transcript mechanism remains an implementation detail of composition.
+
 The Harness executor may call the stable AI completion surface, but it cannot
 choose a different cut point or append a transcript record. Only Harness
 commits the checkpoint. Coding therefore retains its code-change/file-operation
@@ -99,8 +104,10 @@ existing checkpoints; it must fail rather than cancelling or replacing an
 active compaction.
 
 The selected JSON configuration supplies the mechanism policy. Coding's
-explicit `CompactionSettings` are a higher-priority Product override; when no
-such override is present, an OEM-selected configuration applies directly.
+`CompactionSettings` are higher-priority, field-level Product overrides:
+`None` inherits the selected capability value, while a concrete value overrides
+that field. Changing enablement therefore does not freeze unrelated capability
+thresholds into Product settings.
 
 The resolved runtime profile is persisted as session metadata. It records only
 the mechanism ID, version, and JSON configuration; it never serializes prompt
@@ -123,8 +130,8 @@ generic code-execution injection point.
 
 - Cancellation, executor failure, invalid preparation, and hook cancellation
   leave the transcript and current context projection unchanged.
-- A successful executor result is appended once as a checkpoint before the
-  context projection is refreshed or post-commit adapters run.
+- A successful executor result is appended once as a checkpoint and the context
+  projection is refreshed before post-commit adapters run.
 - A failed post-commit adapter is reported as a Product diagnostic and must not
   retry the append.
 - Overflow recovery performs at most one compact-and-retry attempt per run.

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 
 from loushang.agent import Agent
 from loushang.ai.api_registry import ApiProviderRegistry
 from loushang.coding.compaction.adapter import (
     execute_coding_branch_summary,
-    execute_coding_compaction,
+)
+from loushang.coding.compaction.adapter import (
+    execute_coding_compaction as _execute_coding_compaction,
 )
 from loushang.coding.product_plan import CODING_CAPABILITY_PROFILE
 from loushang.coding.resource_runtime import (
@@ -39,7 +41,11 @@ from loushang.harness.session.cwd_audit import CwdBoundServicesAudit
 from loushang.harness.session.event_types import AgentSessionEvent
 from loushang.harness.session.footer import FooterDataProvider
 from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
-from loushang.harness.transcript import BranchSummaryOutput
+from loushang.harness.transcript import (
+    BranchSummaryOutput,
+    CompactionPreparation,
+    CompactionResult,
+)
 from loushang.harness.workspace.exec import ExecService
 
 SessionEventListener = Callable[[AgentSessionEvent], Awaitable[None] | None]
@@ -53,18 +59,38 @@ def _copy_to_clipboard(text: str) -> object:
     return copy_to_clipboard(text)
 
 
-async def _execute_coding_compaction(**kwargs: object) -> object:
-    return await execute_coding_compaction(**kwargs)
-
-
-async def _execute_coding_compaction_runtime(**kwargs: object) -> object:
-    return await _execute_coding_compaction(**kwargs)
+async def _execute_coding_compaction_runtime(
+    *,
+    preparation: CompactionPreparation,
+    model: object,
+    headers: Mapping[str, str] | None,
+    signal: object | None,
+    custom_instructions: str | None = None,
+) -> CompactionResult:
+    return await _execute_coding_compaction(
+        preparation=preparation,
+        model=model,
+        headers=headers,
+        signal=signal,
+        custom_instructions=custom_instructions,
+    )
 
 
 async def _execute_coding_branch_summary(
-    entries: Sequence[object], **kwargs: object
+    entries: Sequence[object],
+    *,
+    model: object,
+    signal: object | None,
+    custom_instructions: str | None = None,
+    replace_instructions: bool = False,
 ) -> BranchSummaryOutput:
-    return await execute_coding_branch_summary(entries, **kwargs)
+    return await execute_coding_branch_summary(
+        entries,
+        model=model,
+        signal=signal,
+        custom_instructions=custom_instructions,
+        replace_instructions=replace_instructions,
+    )
 
 
 class AgentSession(AgentProductSession):

--- a/src/loushang/harness/config/agent/types.py
+++ b/src/loushang/harness/config/agent/types.py
@@ -29,10 +29,18 @@ class ThinkingBudgetMap(TypedDict, total=False):
 
 @dataclass(frozen=True)
 class CompactionSettings:
-    enabled: bool = True
-    compact_percent: float = 80.0
-    reserve_tokens: int = 8_192
-    keep_recent_tokens: int = 32_768
+    """Product overrides for the capability-selected compaction policy.
+
+    ``None`` means that the corresponding value is inherited from the active
+    runtime capability.  Concrete values remain compatible with existing
+    settings files and allow each Product or session to override fields
+    independently.
+    """
+
+    enabled: bool | None = None
+    compact_percent: float | None = None
+    reserve_tokens: int | None = None
+    keep_recent_tokens: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/loushang/harness/context/compaction.py
+++ b/src/loushang/harness/context/compaction.py
@@ -84,6 +84,8 @@ class CompactionCoordinator(Generic[R]):
             self._finish()
 
     def abort(self) -> None:
+        if not self._is_compacting:
+            return
         self._aborted = True
         if self._abort_driver is not None:
             self._abort_driver()

--- a/src/loushang/harness/events/__init__.py
+++ b/src/loushang/harness/events/__init__.py
@@ -9,6 +9,7 @@ _EXPORT_MODULES = {
     "BranchSummaryCompleted": "loushang.harness.events.session",
     "BranchSummaryStarted": "loushang.harness.events.session",
     "CompactionReason": "loushang.harness.events.session",
+    "CompactionStage": "loushang.harness.events.session",
     "ContextCompactionCompleted": "loushang.harness.events.session",
     "ContextCompactionStarted": "loushang.harness.events.session",
     "ConversationMetadataChanged": "loushang.harness.events.session",

--- a/src/loushang/harness/events/runtime_projection.py
+++ b/src/loushang/harness/events/runtime_projection.py
@@ -49,6 +49,10 @@ def project_session_runtime_event(
         }
         if payload.usage is not None:
             result["usage"] = payload.usage
+        for name in ("stage", "product_id", "session_id", "tokens_before"):
+            value = getattr(payload, name)
+            if value is not None:
+                result[name] = value
         return result
     if isinstance(payload, ContextCompactionCompleted):
         result = {
@@ -64,6 +68,18 @@ def project_session_runtime_event(
             result["usage_before"] = payload.usage_before
         if payload.usage_after is not None:
             result["usage_after"] = payload.usage_after
+        for name in (
+            "stage",
+            "product_id",
+            "session_id",
+            "duration_ms",
+            "tokens_before",
+            "tokens_after",
+            "checkpoint_record_id",
+        ):
+            value = getattr(payload, name)
+            if value is not None:
+                result[name] = value
         return result
     if isinstance(payload, RetryStarted):
         attempt = payload.attempt

--- a/src/loushang/harness/events/session.py
+++ b/src/loushang/harness/events/session.py
@@ -7,6 +7,13 @@ from typing import Literal, TypeAlias
 from loushang.harness.permissions import PermissionProfileId, PermissionProfileScope
 
 CompactionReason: TypeAlias = Literal["manual", "threshold", "overflow"]
+CompactionStage: TypeAlias = Literal[
+    "started",
+    "aborted",
+    "failed",
+    "committed",
+    "post_hook_failed",
+]
 PackageProgressType: TypeAlias = Literal["start", "progress", "complete", "error"]
 PackageProgressAction: TypeAlias = Literal[
     "install", "update", "remove", "check", "resolve"
@@ -61,6 +68,10 @@ class QueueChanged:
 class ContextCompactionStarted:
     reason: CompactionReason
     usage: Mapping[str, object] | None = None
+    stage: CompactionStage | None = None
+    product_id: str | None = None
+    session_id: str | None = None
+    tokens_before: int | None = None
 
 
 @dataclass(frozen=True)
@@ -72,6 +83,13 @@ class ContextCompactionCompleted:
     error_message: str | None = None
     usage_before: Mapping[str, object] | None = None
     usage_after: Mapping[str, object] | None = None
+    stage: CompactionStage | None = None
+    product_id: str | None = None
+    session_id: str | None = None
+    duration_ms: float | None = None
+    tokens_before: int | None = None
+    tokens_after: int | None = None
+    checkpoint_record_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -175,6 +193,7 @@ __all__ = [
     "BranchSummaryCompleted",
     "BranchSummaryStarted",
     "CompactionReason",
+    "CompactionStage",
     "ContextCompactionCompleted",
     "ContextCompactionStarted",
     "ConversationMetadataChanged",

--- a/src/loushang/harness/session/__init__.py
+++ b/src/loushang/harness/session/__init__.py
@@ -134,6 +134,7 @@ from loushang.harness.session.commands.execution import (
 from loushang.harness.session.commands.projection import (
     project_standard_session_command_result,
 )
+from loushang.harness.session.composition import ProductCompactionExecutor
 from loushang.harness.session.cwd_audit import (
     CwdBoundServicesAudit,
     CwdBoundServicesAuditIssue,
@@ -451,6 +452,7 @@ __all__ = [
     "ModelSelectionApplyResult",
     "PromptController",
     "ProductSessionRuntime",
+    "ProductCompactionExecutor",
     "ProductSessionRuntimePorts",
     "ProductTranscriptSessionLifecyclePorts",
     "ProductTranscriptSessionLifecycleStore",

--- a/src/loushang/harness/session/agent_adapter.py
+++ b/src/loushang/harness/session/agent_adapter.py
@@ -12,7 +12,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
-from loushang.agent import Agent, AgentEvent, ThinkingLevel
+from loushang.agent import Agent, ThinkingLevel
 from loushang.ai.model import Model, ModelSelection
 from loushang.ai.types import AssistantMessage
 from loushang.harness.approval import (
@@ -23,7 +23,6 @@ from loushang.harness.capabilities import CapabilityCompositionRuntime
 from loushang.harness.diagnostics.service import DiagnosticsService
 from loushang.harness.diagnostics.types import DiagnosticDraft, DiagnosticPhase
 from loushang.harness.events import (
-    CompactionReason,
     PackageProgressChanged,
     project_session_runtime_event,
 )
@@ -40,7 +39,6 @@ from loushang.harness.extensions.context import (
     SessionBeforeTreeEvent,
     SessionShutdownEvent,
 )
-from loushang.harness.extensions.types import ResolvedCommand
 from loushang.harness.permissions import (
     PermissionProfileSnapshot,
 )
@@ -110,7 +108,6 @@ from loushang.harness.transcript import (
     AgentTranscriptRetryRuntime,
     AgentTranscriptSelectionRuntime,
     BranchSummaryOutput,
-    CompactionPreparation,
     CompactionResult,
     CompactionStatus,
     ProductTranscriptSession,
@@ -195,9 +192,6 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
         return self._create_replaced_session_context(
             self if session is None else session
         )
-
-    def _get_registered_provider(self, name: str):
-        return self._extension_provider_controller.get_registered_provider(name)
 
     async def set_active_tools(self, tool_names: list[str]) -> None:
         await self._operations.set_active_tools(tool_names, emit_refresh=True)
@@ -335,24 +329,11 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
             operations=_bash_operations_from_extension_result(event_result)
         )
 
-    def _execute_resource_command(self, invocation_name: str, args: str):
-        return self._command_controller.execute_resource_command(invocation_name, args)
-
-    def _record_command_not_found(self, invocation_name: str, args: str) -> None:
-        self._command_controller.record_command_not_found(invocation_name, args)
-
     async def get_command_argument_completions(
         self, invocation_name: str, prefix: str
     ) -> list[object] | None:
         return await self._command_controller.get_command_argument_completions(
             invocation_name, prefix
-        )
-
-    def _record_extension_command_error(
-        self, *, command: ResolvedCommand, exc: BaseException
-    ) -> None:
-        self._command_controller.record_extension_command_error(
-            command=command, exc=exc
         )
 
     def get_context_usage(self):
@@ -386,25 +367,8 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
     async def _reload_from_extension(self) -> None:
         await self._extension_bridge.bind(reason="reload")
 
-    async def _set_model_internal(
-        self, model: object, *, emit_refresh: bool, source: str = "set"
-    ) -> None:
-        await self._operations.set_model(
-            model, emit_refresh=emit_refresh, source=source
-        )
-
     def _apply_active_tools(self, tool_names: list[str]) -> None:
         self._operations.apply_active_tools(tool_names)
-
-    async def _set_active_tools_internal(
-        self, tool_names: list[str], *, emit_refresh: bool
-    ) -> None:
-        await self._operations.set_active_tools(tool_names, emit_refresh=emit_refresh)
-
-    async def _compact_manual(
-        self, custom_instructions: str | None = None
-    ) -> CompactionResult:
-        return await self._operations.compact_manual(custom_instructions)
 
     async def maybe_compact_after_turn(
         self, assistant_message: AssistantMessage
@@ -527,11 +491,6 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
     def _refresh_resources_for_extension_runtime(self) -> None:
         self._resource_refresh_runtime.refresh()
 
-    async def _reload_resources_from_watch(self) -> None:
-        await self._resource_refresh_runtime.refresh_async(reason="watch")
-        if self._extension_runner is not None:
-            await self._extension_bridge.refresh(reason="resource_watch")
-
     def _resource_watch_paths(self) -> list[Path]:
         cwd = Path(self.session_manager.get_cwd())
         paths: set[Path] = {
@@ -566,17 +525,6 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
         if settings_manager is not None:
             settings_manager.reload()
         self._configure_package_resource_roots()
-
-    def _refresh_package_resources(self) -> None:
-        self._package_controller.refresh_package_resources()
-
-    async def _prepare_configured_remote_package_records(self) -> None:
-        await self._package_controller.prepare_configured_remote_package_records()
-
-    def _record_package_update_check_diagnostics(
-        self, updates: list[dict[str, object]]
-    ) -> None:
-        self._package_controller.record_package_update_check_diagnostics(updates)
 
     def _configure_package_resource_roots(self) -> None:
         self._package_controller.configure_package_resource_roots()
@@ -718,44 +666,6 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
     ) -> None:
         await self._operations.dispatch_event(event, source_record_id=source_record_id)
 
-    def _get_compaction_settings(self) -> object:
-        return self._settings_controller.get_compaction_settings()
-
-    def _get_retry_settings(self) -> object:
-        return self._settings_controller.get_retry_settings()
-
-    async def _check_auto_compaction(
-        self, assistant_message: AssistantMessage
-    ) -> CompactionResult | None:
-        return await self._operations.check_auto_compaction(assistant_message)
-
-    async def _compact_before_prompt(self) -> CompactionResult | None:
-        return await self._operations.compact_before_prompt()
-
-    async def _compact_internal(
-        self,
-        *,
-        reason: CompactionReason,
-        will_retry: bool,
-        raise_on_error: bool,
-        custom_instructions: str | None = None,
-    ) -> CompactionResult | None:
-        return await self._operations.compact_internal(
-            reason=reason,
-            will_retry=will_retry,
-            raise_on_error=raise_on_error,
-            custom_instructions=custom_instructions,
-        )
-
-    async def _execute_selected_compaction(
-        self,
-        preparation: CompactionPreparation,
-        custom_instructions: str | None,
-    ) -> CompactionResult:
-        return await self._operations.execute_selected_compaction(
-            preparation, custom_instructions
-        )
-
     def _preflight_user_input(
         self, user_input: str, *, allow_extension_commands: bool = True
     ):
@@ -770,19 +680,6 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
             user_input, allow_extension_commands=allow_extension_commands
         )
 
-    def _extract_extension_command_invocation(
-        self, user_input: str
-    ) -> tuple[str, str] | None:
-        return self._command_controller.extract_extension_command_invocation(user_input)
-
-    def _raise_if_queued_extension_command(self, user_input: str) -> None:
-        self._command_controller.raise_if_queued_extension_command(user_input)
-
-    def _record_preflight_diagnostics(
-        self, diagnostics: tuple[DiagnosticDraft, ...]
-    ) -> None:
-        self._command_controller.record_preflight_diagnostics(diagnostics)
-
     def _sync_extension_diagnostics(
         self,
         *,
@@ -792,14 +689,6 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
 
     def _record_runtime_exception(self, *, code: str, exc: Exception | str) -> None:
         self._diagnostics_bridge.record_runtime_exception(code=code, exc=exc)
-
-    def _record_assistant_response_error(
-        self, assistant_message: AssistantMessage
-    ) -> None:
-        self._diagnostics_bridge.record_assistant_response_error(assistant_message)
-
-    def _record_tool_execution_error(self, event: AgentEvent) -> None:
-        self._diagnostics_bridge.record_tool_execution_error(event)
 
     def _record_extension_runtime_diagnostic(self, diagnostic: DiagnosticDraft) -> None:
         self._diagnostics_bridge.record_extension_runtime_diagnostic(diagnostic)

--- a/src/loushang/harness/session/agent_event_router.py
+++ b/src/loushang/harness/session/agent_event_router.py
@@ -6,6 +6,7 @@ from typing import Protocol
 
 from loushang.agent import AbortSignal, AgentEvent
 from loushang.ai.types import AssistantMessage
+from loushang.harness.transcript import CompactionResult
 
 AppendMessage = Callable[[object], Awaitable[str]]
 EventDispatcher = Callable[..., Awaitable[None]]
@@ -13,7 +14,9 @@ ExtensionEventEmitter = Callable[[AgentEvent], Awaitable[None]]
 ToolExecutionErrorRecorder = Callable[[AgentEvent], None]
 ExtensionDiagnosticsSync = Callable[..., None]
 AssistantResponseErrorRecorder = Callable[[AssistantMessage], None]
-AutoCompactionChecker = Callable[[AssistantMessage], Awaitable[object | None]]
+AutoCompactionChecker = Callable[
+    [AssistantMessage], Awaitable[CompactionResult | None]
+]
 QueuedMessageConsumer = Callable[[object], bool]
 
 

--- a/src/loushang/harness/session/agent_product.py
+++ b/src/loushang/harness/session/agent_product.py
@@ -57,6 +57,7 @@ from loushang.harness.session.command_controller import (
 )
 from loushang.harness.session.commands.execution import StandardSessionCommandPorts
 from loushang.harness.session.composition import (
+    ProductCompactionExecutor,
     SessionCompositionPorts,
     SessionExtensionCompositionPort,
     SessionModelCatalogPort,
@@ -82,7 +83,6 @@ from loushang.harness.transcript import (
 )
 from loushang.harness.workspace.exec import ExecService
 
-CompactionExecutor = Callable[..., Awaitable[CompactionResult]]
 BranchSummaryExecutor = Callable[..., Awaitable[BranchSummaryOutput]]
 ChangelogProvider = Callable[[str, str], object]
 ClipboardWriter = Callable[[str], object]
@@ -113,7 +113,7 @@ class AgentProductSession(AgentSessionAdapterMixin):
         agent: Agent,
         session_manager: ProductTranscriptSession[Any, Any],
         capability_runtime: CapabilityCompositionRuntime,
-        execute_compaction: CompactionExecutor,
+        execute_compaction: ProductCompactionExecutor,
         execute_branch_summary: BranchSummaryExecutor,
         get_changelog: ChangelogProvider,
         copy_to_clipboard: ClipboardWriter,
@@ -276,17 +276,13 @@ class AgentProductSession(AgentSessionAdapterMixin):
                 agent=self.agent,
                 session_manager=self.session_manager,
                 extension_runner=self._extension_runner,
-                execute_compaction=self._execute_product_compaction,
                 execute_branch_summary=self._execute_product_branch_summary,
                 before_tree=self._apply_before_tree_hook,
-                before_compaction=self._before_product_compaction,
-                after_compaction=self._after_product_compaction,
                 dispose_runtime_profile=self._dispose_session_runtime_profile,
                 finalize_shutdown=self._finalize_after_session_shutdown,
                 invalidate_extension_contexts=self._invalidate_extension_contexts,
                 sync_extension_diagnostics=self._sync_extension_diagnostics,
                 close_approvals=self._close_session_approvals,
-                continue_run=composition.session_runtime.schedule_continue_run,
             ),
             settings=self._settings_controller,
             session_manager=self.session_manager,
@@ -392,12 +388,7 @@ class AgentProductSession(AgentSessionAdapterMixin):
             before_compaction=self._before_product_compaction,
             after_compaction=self._after_product_compaction,
             before_agent_start_system_prompt_options=self._before_agent_start_system_prompt_options,
-            compact_before_prompt=self._compact_before_prompt,
             sleep_for_retry=self._retry_sleep,
-            continue_run=lambda: self._session_runtime.schedule_continue_run(),
-            # Resolve at call time so Product overrides and test/runtime
-            # replacements remain observable after composition.
-            compact_internal=lambda **kwargs: self._compact_internal(**kwargs),
         )
 
     def get_context_usage(self):

--- a/src/loushang/harness/session/composition.py
+++ b/src/loushang/harness/session/composition.py
@@ -9,7 +9,7 @@ compaction, tools, resources, extensions, and command runtimes.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 from loushang.agent import Agent
 from loushang.ai.api_registry import ApiProviderRegistry
 from loushang.ai.model import Model, ModelSelection
+from loushang.ai.types import AssistantMessage
 from loushang.ai.utils import is_context_overflow
 from loushang.harness.approval import ApprovalResolver
 from loushang.harness.capabilities import CapabilityCompositionRuntime
@@ -117,9 +118,21 @@ if TYPE_CHECKING:
 
 AsyncEvent = Callable[[object], Awaitable[None]]
 EventDispatcher = Callable[..., Awaitable[None]]
-CompactionExecutor = Callable[..., Awaitable[CompactionResult]]
-CompactionRunner = Callable[..., Awaitable[CompactionResult | None]]
 BranchSummaryExecutor = Callable[..., Awaitable[BranchSummaryOutput]]
+
+
+class ProductCompactionExecutor(Protocol):
+    """Live Product binding for the standard Harness compaction mechanism."""
+
+    async def __call__(
+        self,
+        *,
+        preparation: CompactionPreparation,
+        model: object,
+        headers: Mapping[str, str] | None,
+        signal: object | None,
+        custom_instructions: str | None = None,
+    ) -> CompactionResult: ...
 
 
 class ModelDetailRegistryPort(Protocol):
@@ -232,15 +245,12 @@ class SessionCompositionPorts:
     rebuild_prompt_and_tools_view: Callable[[], None]
     set_resource_bundle: Callable[[ResourceBundle], None]
     record_extension_runtime_diagnostic: Callable[[DiagnosticDraft], None]
-    execute_compaction: CompactionExecutor
+    execute_compaction: ProductCompactionExecutor
     execute_branch_summary: BranchSummaryExecutor
     before_compaction: Callable[[CompactionHookRequest], Awaitable[CompactionHookDecision | None]]
     after_compaction: Callable[[CompactionResult, str, bool], Awaitable[None]]
     before_agent_start_system_prompt_options: Callable[[], dict[str, object]]
-    compact_before_prompt: Callable[[], Awaitable[object | None]]
     sleep_for_retry: Callable[[int, CancellationSignal], Awaitable[None]]
-    continue_run: Callable[[], Awaitable[None]]
-    compact_internal: CompactionRunner
 
 
 @dataclass
@@ -341,11 +351,16 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         ),
     )
     compaction_capability = _resolve_compaction_capability(session)
+
+    def get_compaction_policy() -> TranscriptCompactionPolicy:
+        return _compaction_policy(
+            settings.get_compaction_policy_override(),
+            compaction_capability.policy,
+        )
+
     compaction_runtime = AgentTranscriptCompactionRuntime(
         transcript=session,
-        get_policy=lambda: _compaction_policy(
-            settings.get_compaction_settings(), compaction_capability.policy
-        ),
+        get_policy=get_compaction_policy,
         get_model=lambda: agent.model,
         get_context_messages=lambda: list(session.build_session_context().messages),
         refresh_context=ports.refresh_agent_messages,
@@ -361,6 +376,8 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         before_compaction=ports.before_compaction,
         after_compaction=ports.after_compaction,
         record_runtime_exception=ports.record_runtime_exception,
+        product_id=capability_runtime.profile.product_id,
+        session_id=session.get_header().conversation_id,
     )
     bash_runtime = BashExecutionRuntime(
         BashExecutionPorts(
@@ -385,13 +402,34 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         get_extension_runtime=lambda: ports.extension_runner,
         get_cwd=session.get_cwd,
     )
+
+    async def continue_session_run() -> None:
+        await session_runtime.schedule_continue_run()
+
+    async def check_auto_compaction(
+        message: AssistantMessage,
+    ) -> CompactionResult | None:
+        outcome = await compaction_runtime.maybe_compact_after_turn(
+            message,
+            is_context_overflow_fn=is_context_overflow,
+        )
+        if outcome.should_continue:
+            session_runtime.schedule_continue_run()
+        return outcome.result
+
+    async def compact_before_prompt() -> CompactionResult | None:
+        message = _last_assistant_message(agent.state.messages)
+        if message is None:
+            return None
+        return await check_auto_compaction(message)
+
     retry_runtime = AgentTranscriptRetryRuntime(
         get_policy=lambda: _retry_policy(settings.get_retry_settings()),
         get_messages=lambda: list(agent.state.messages),
         set_messages=agent.state.set_messages,
         get_context_window=lambda: agent.model.context_window,
         dispatch_event=ports.dispatch_event,
-        continue_run=ports.continue_run,
+        continue_run=continue_session_run,
         record_runtime_exception=ports.record_runtime_exception,
         sleep_for_retry=ports.sleep_for_retry,
         is_context_overflow_fn=is_context_overflow,
@@ -420,7 +458,7 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
             preflight_user_input_async=command_controller.preflight_user_input_async,
             before_agent_start_system_prompt_options=ports.before_agent_start_system_prompt_options,
             sync_extension_diagnostics=diagnostics_bridge.sync_extension_diagnostics,
-            compact_before_prompt_async=ports.compact_before_prompt,
+            compact_before_prompt_async=compact_before_prompt,
         ),
         after_turn_policy=AfterTurnPolicyPort(
             emit_extension_agent_event=extension_event_sink.emit_agent_event,
@@ -429,12 +467,7 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
             compaction_controller=compaction_runtime,
             sync_extension_diagnostics=diagnostics_bridge.sync_extension_diagnostics,
             record_assistant_response_error=diagnostics_bridge.record_assistant_response_error,
-            check_auto_compaction=lambda message: compaction_runtime.maybe_compact_after_turn(
-                message,
-                compact_internal_fn=ports.compact_internal,
-                continue_run_fn=ports.continue_run,
-                is_context_overflow_fn=is_context_overflow,
-            ),
+            check_auto_compaction=check_auto_compaction,
         ),
     )
     # The retry and turn policies close over ``session_runtime`` above.  Their
@@ -537,7 +570,7 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         is_compacting_callback=lambda: compaction_runtime.is_compacting
         or navigation_runtime.is_summarizing,
         auto_retry_enabled_callback=lambda: settings.auto_retry_enabled,
-        auto_compaction_enabled_callback=lambda: settings.auto_compaction_enabled,
+        auto_compaction_enabled_callback=lambda: get_compaction_policy().enabled,
         set_auto_retry_enabled_callback=settings.set_auto_retry_enabled,
         set_auto_compaction_enabled_callback=settings.set_auto_compaction_enabled,
         compact_callback=partial(
@@ -545,7 +578,7 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
             session_runtime,
             compaction_runtime,
         ),
-        abort_compaction_callback=lambda: _abort_session(session_runtime),
+        abort_compaction_callback=compaction_runtime.abort,
     )
     session_inspector = AgentSessionInspector(
         agent=agent,
@@ -559,18 +592,9 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         get_last_diagnostics=diagnostics_bridge.get_last_diagnostics,
         get_model_selection=selection_runtime.get_model_selection,
         is_host_running=lambda: session_runtime.is_active,
-        get_compaction_reserve_tokens=lambda: _compaction_policy(
-            settings.get_compaction_settings(),
-            compaction_capability.policy,
-        ).reserve_tokens,
-        get_compaction_compact_percent=lambda: _compaction_policy(
-            settings.get_compaction_settings(),
-            compaction_capability.policy,
-        ).compact_percent,
-        get_compaction_keep_recent_tokens=lambda: _compaction_policy(
-            settings.get_compaction_settings(),
-            compaction_capability.policy,
-        ).keep_recent_tokens,
+        get_compaction_reserve_tokens=lambda: get_compaction_policy().reserve_tokens,
+        get_compaction_compact_percent=lambda: get_compaction_policy().compact_percent,
+        get_compaction_keep_recent_tokens=lambda: get_compaction_policy().keep_recent_tokens,
     )
     return SessionComposition(
         capability_runtime=capability_runtime,
@@ -679,14 +703,18 @@ def _retry_policy(settings: object) -> RetryPolicy:
     )
 
 
-def _compaction_policy(settings: object, capability: TranscriptCompactionPolicy):
-    if not getattr(settings, "enabled", False) and not any(
-        hasattr(settings, field)
-        for field in ("reserve_tokens", "compact_percent", "keep_recent_tokens")
-    ):
+def _compaction_policy(
+    settings: object | None,
+    capability: TranscriptCompactionPolicy,
+) -> TranscriptCompactionPolicy:
+    if settings is None:
         return capability
     return TranscriptCompactionPolicy(
-        enabled=bool(getattr(settings, "enabled", capability.enabled)),
+        enabled=_bool_setting(
+            settings,
+            "enabled",
+            capability.enabled,
+        ),
         reserve_tokens=_int_setting(
             settings,
             "reserve_tokens",
@@ -710,6 +738,11 @@ def _int_setting(settings: object, name: str, fallback: int) -> int:
     return fallback if value is None else int(value)
 
 
+def _bool_setting(settings: object, name: str, fallback: bool) -> bool:
+    value = getattr(settings, name, fallback)
+    return fallback if value is None else bool(value)
+
+
 def _float_setting(settings: object, name: str, fallback: float) -> float:
     value = getattr(settings, name, fallback)
     return fallback if value is None else float(value)
@@ -721,7 +754,7 @@ def _optional_int_setting(
     fallback: int | None,
 ) -> int | None:
     value = getattr(settings, name, fallback)
-    return None if value is None else int(value)
+    return fallback if value is None else int(value)
 
 
 async def sleep_for_retry(delay_ms: int, signal: CancellationSignal) -> None:
@@ -739,20 +772,18 @@ async def sleep_for_retry(delay_ms: int, signal: CancellationSignal) -> None:
 
 
 async def _execute_compaction(
-    executor: CompactionExecutor,
+    executor: ProductCompactionExecutor,
     agent: Agent,
     preparation: CompactionPreparation,
     custom_instructions: str | None,
 ) -> CompactionResult:
-    kwargs: dict[str, object] = {
-        "preparation": preparation,
-        "model": agent.model,
-        "headers": None,
-        "signal": agent.signal,
-    }
-    if custom_instructions is not None:
-        kwargs["custom_instructions"] = custom_instructions
-    return await executor(**kwargs)
+    return await executor(
+        preparation=preparation,
+        model=agent.model,
+        headers=None,
+        signal=agent.signal,
+        custom_instructions=custom_instructions,
+    )
 
 
 async def _compact_manual(
@@ -770,10 +801,6 @@ async def _compact_manual(
     )
     assert result is not None
     return result
-
-
-def _abort_session(session_runtime: SessionRuntime) -> None:
-    session_runtime.abort()
 
 
 async def _set_model(
@@ -827,7 +854,17 @@ async def _reload_resources_from_watch(
         await refresh_async()
 
 
+def _last_assistant_message(
+    messages: Sequence[object],
+) -> AssistantMessage | None:
+    for message in reversed(messages):
+        if isinstance(message, AssistantMessage):
+            return message
+    return None
+
+
 __all__ = [
+    "ProductCompactionExecutor",
     "SessionComposition",
     "SessionCompositionPorts",
     "compose_session_runtime",

--- a/src/loushang/harness/session/event_serialization.py
+++ b/src/loushang/harness/session/event_serialization.py
@@ -114,6 +114,9 @@ def _serialize_session_event(event: Mapping[str, object]) -> dict[str, Any]:
             compaction_payload["usage"] = serialize_context_usage_payload(
                 event["usage"]
             )
+        for name in ("stage", "product_id", "session_id", "tokens_before"):
+            if name in event:
+                compaction_payload[name] = event[name]
         return compaction_payload
     if event_type == "compaction_end":
         from loushang.harness.context import serialize_context_usage_payload
@@ -138,6 +141,17 @@ def _serialize_session_event(event: Mapping[str, object]) -> dict[str, Any]:
             )
         if "error_message" in event:
             compaction_end_payload["error_message"] = event["error_message"]
+        for name in (
+            "stage",
+            "product_id",
+            "session_id",
+            "duration_ms",
+            "tokens_before",
+            "tokens_after",
+            "checkpoint_record_id",
+        ):
+            if name in event:
+                compaction_end_payload[name] = event[name]
         return compaction_end_payload
     if event_type == "auto_retry_start":
         return {

--- a/src/loushang/harness/session/event_types.py
+++ b/src/loushang/harness/session/event_types.py
@@ -7,6 +7,7 @@ from typing import Literal, NotRequired, TypeAlias, TypedDict
 from loushang.agent.types import AgentEvent
 from loushang.harness.events.session import (
     CompactionReason,
+    CompactionStage,
     PackageProgressAction,
     PackageProgressType,
 )
@@ -22,6 +23,10 @@ class CompactionStartEvent(TypedDict):
     type: Literal["compaction_start"]
     reason: CompactionReason
     usage: NotRequired[object]
+    stage: NotRequired[CompactionStage]
+    product_id: NotRequired[str]
+    session_id: NotRequired[str]
+    tokens_before: NotRequired[int]
 
 
 class CompactionEndEvent(TypedDict):
@@ -33,6 +38,13 @@ class CompactionEndEvent(TypedDict):
     error_message: NotRequired[str]
     usage_before: NotRequired[object]
     usage_after: NotRequired[object]
+    stage: NotRequired[CompactionStage]
+    product_id: NotRequired[str]
+    session_id: NotRequired[str]
+    duration_ms: NotRequired[float]
+    tokens_before: NotRequired[int]
+    tokens_after: NotRequired[int]
+    checkpoint_record_id: NotRequired[str]
 
 
 class AutoRetryStartEvent(TypedDict):

--- a/src/loushang/harness/session/operations_runtime.py
+++ b/src/loushang/harness/session/operations_runtime.py
@@ -16,8 +16,6 @@ from typing import Any, TypeAlias, cast
 from loushang.agent import Agent
 from loushang.ai.model import Model, ModelSelection
 from loushang.ai.types import AssistantMessage
-from loushang.ai.utils import is_context_overflow
-from loushang.harness.events import CompactionReason
 from loushang.harness.extensions.context import (
     SessionBeforeTreeResult,
     SessionShutdownEvent,
@@ -29,9 +27,6 @@ from loushang.harness.session.composition import (
 )
 from loushang.harness.transcript import (
     BranchSummaryOutput,
-    CompactionHookDecision,
-    CompactionHookRequest,
-    CompactionPreparation,
     CompactionResult,
     CompactionStatus,
     ProductTranscriptSession,
@@ -55,19 +50,13 @@ class SessionOperationsPorts:
     agent: Agent
     session_manager: ProductTranscriptSession[Any, Any]
     extension_runner: SessionExtensionCompositionPort | None
-    execute_compaction: Callable[..., Awaitable[CompactionResult]]
     execute_branch_summary: Callable[..., Awaitable[BranchSummaryOutput]]
     before_tree: Callable[..., Awaitable[BeforeTreeHookResult]]
-    before_compaction: Callable[
-        [CompactionHookRequest], Awaitable[CompactionHookDecision | None]
-    ]
-    after_compaction: Callable[[CompactionResult, str, bool], Awaitable[None]]
     dispose_runtime_profile: Callable[[], object | None]
     finalize_shutdown: Callable[[], None]
     invalidate_extension_contexts: Callable[[str], None]
     sync_extension_diagnostics: Callable[..., None]
     close_approvals: Callable[[], None]
-    continue_run: Callable[[], Awaitable[None]]
 
 
 class SessionOperations:
@@ -124,22 +113,13 @@ class SessionOperations:
                 cwd=self.ports.session_manager.get_cwd(),
             )
 
-    async def compact_manual(self, custom_instructions: str | None = None) -> CompactionResult:
-        self.composition.session_runtime.abort()
-        await self.composition.session_runtime.wait_for_idle()
-        result = await self.composition.compaction_runtime.compact(
-            reason="manual",
-            will_retry=False,
-            raise_on_error=True,
-            custom_instructions=custom_instructions,
-        )
-        assert result is not None
-        return result
-
     async def maybe_compact_after_turn(
         self, assistant_message: AssistantMessage
     ) -> CompactionResult | None:
-        return await self._check_auto_compaction(assistant_message)
+        result = await self.composition.session_runtime.check_auto_compaction(
+            assistant_message
+        )
+        return result
 
     def get_compaction_status(self) -> CompactionStatus:
         return CompactionStatus(
@@ -234,69 +214,6 @@ class SessionOperations:
                 self.composition.capability_runtime.dispose()
                 self.ports.finalize_shutdown()
 
-    async def check_auto_compaction(
-        self, assistant_message: AssistantMessage
-    ) -> CompactionResult | None:
-        return await self._check_auto_compaction(assistant_message)
-
-    async def compact_before_prompt(self) -> CompactionResult | None:
-        assistant_message = self._last_assistant_message()
-        if assistant_message is None:
-            return None
-        return await self._check_auto_compaction(assistant_message)
-
-    async def compact_internal(
-        self,
-        *,
-        reason: CompactionReason,
-        will_retry: bool,
-        raise_on_error: bool,
-        custom_instructions: str | None = None,
-    ) -> CompactionResult | None:
-        return await self.composition.compaction_runtime.compact(
-            reason=reason,
-            will_retry=will_retry,
-            raise_on_error=raise_on_error,
-            custom_instructions=custom_instructions,
-        )
-
-    async def execute_selected_compaction(
-        self,
-        preparation: CompactionPreparation,
-        custom_instructions: str | None,
-    ) -> CompactionResult:
-        result = await self._execute_compaction_with(
-            preparation,
-            custom_instructions,
-        )
-        assert isinstance(result, CompactionResult)
-        return result
-
-    async def _execute_compaction_with(
-        self,
-        preparation: CompactionPreparation,
-        custom_instructions: str | None,
-    ) -> CompactionResult:
-        kwargs: dict[str, object] = {
-            "preparation": preparation,
-            "model": self.ports.agent.model,
-            "headers": None,
-            "signal": self.ports.agent.signal,
-        }
-        if custom_instructions is not None:
-            kwargs["custom_instructions"] = custom_instructions
-        return await self.ports.execute_compaction(**kwargs)
-
-    async def _check_auto_compaction(
-        self, assistant_message: AssistantMessage
-    ) -> CompactionResult | None:
-        return await self.composition.compaction_runtime.maybe_compact_after_turn(
-            assistant_message,
-            compact_internal_fn=self.compact_internal,
-            continue_run_fn=self.ports.continue_run,
-            is_context_overflow_fn=is_context_overflow,
-        )
-
     async def _apply_before_tree_hook(
         self,
         plan: TranscriptNavigationPlan,
@@ -354,13 +271,6 @@ class SessionOperations:
             )
 
         return run
-
-    def _last_assistant_message(self) -> AssistantMessage | None:
-        for message in reversed(self.ports.agent.state.messages):
-            if isinstance(message, AssistantMessage):
-                return message
-        return None
-
 
 def _is_model_selection(value: object) -> bool:
     return value.__class__.__name__ == "ModelSelection"

--- a/src/loushang/harness/session/prompt_controller.py
+++ b/src/loushang/harness/session/prompt_controller.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 
 from loushang.ai.types import ImagePart, TextPart, UserMessage
 from loushang.harness.runtime.turn import TurnInput, TurnOrchestrator
-from loushang.harness.transcript import ApplicationMessage
+from loushang.harness.transcript import ApplicationMessage, CompactionResult
 
 CommandExtractor = Callable[[str], tuple[str, str] | None]
 CommandExecutor = Callable[[str, str], Awaitable[object | None]]
@@ -17,7 +17,7 @@ CwdProvider = Callable[[], str]
 Preflight = Callable[..., Awaitable[Any]]
 BeforeAgentStartOptions = Callable[[], dict[str, object]]
 ExtensionDiagnosticsSync = Callable[..., None]
-PrePromptCompaction = Callable[[], Awaitable[object | None]]
+PrePromptCompaction = Callable[[], Awaitable[CompactionResult | None]]
 RunPrompt = Callable[[list[object]], Awaitable[None]]
 
 

--- a/src/loushang/harness/session/runtime.py
+++ b/src/loushang/harness/session/runtime.py
@@ -36,7 +36,11 @@ from loushang.harness.session.agent_event_router import (
 from loushang.harness.session.application_input import ApplicationInputRuntime
 from loushang.harness.session.prompt_controller import AgentPort, PromptController
 from loushang.harness.session.queue_controller import AgentQueuePort, QueueController
-from loushang.harness.transcript import ApplicationMessage, CommitResult
+from loushang.harness.transcript import (
+    ApplicationMessage,
+    CommitResult,
+    CompactionResult,
+)
 
 AppendMessage = Callable[[object], Awaitable[str]]
 CommitApplicationMessage = Callable[[ApplicationMessage], Awaitable[CommitResult]]
@@ -48,10 +52,12 @@ PreflightUserInput = Callable[..., Awaitable[object]]
 SynchronousPreflightUserInput = Callable[[str], object]
 RejectQueuedExtensionCommand = Callable[[str], None]
 BeforeAgentStartOptions = Callable[[], dict[str, object]]
-PrePromptCompaction = Callable[[], Awaitable[object | None]]
+PrePromptCompaction = Callable[[], Awaitable[CompactionResult | None]]
 ToolExecutionErrorRecorder = Callable[[AgentEvent], None]
 AssistantResponseErrorRecorder = Callable[[AssistantMessage], None]
-AutoCompactionChecker = Callable[[AssistantMessage], Awaitable[object | None]]
+AutoCompactionChecker = Callable[
+    [AssistantMessage], Awaitable[CompactionResult | None]
+]
 RuntimeEventListener = Callable[[RuntimeEvent[object]], Awaitable[None] | None]
 AgentEventListener = Callable[[AgentEvent, AbortSignal], Awaitable[None] | None]
 
@@ -254,6 +260,14 @@ class SessionRuntime:
         return self._host_runtime.defer_run(
             self.agent.continue_run,
             key="agent-continue",
+        )
+
+    async def check_auto_compaction(
+        self,
+        assistant_message: AssistantMessage,
+    ) -> CompactionResult | None:
+        return await self.after_turn_policy.check_auto_compaction(
+            assistant_message
         )
 
     def abort(self) -> bool:

--- a/src/loushang/harness/session/settings.py
+++ b/src/loushang/harness/session/settings.py
@@ -50,6 +50,18 @@ class SessionSettingsBinding:
             return self.default_compaction()
         return getattr(self.settings_manager.get_settings(), "compaction")
 
+    def get_compaction_policy_override(self) -> object | None:
+        """Return the bound Product's field-level policy overrides.
+
+        Compaction setting fields use ``None`` to inherit from the runtime
+        capability, so a default settings manager does not shadow Product or
+        OEM policy values.
+        """
+
+        if self.settings_manager is None:
+            return None
+        return getattr(self.settings_manager.get_settings(), "compaction")
+
     def get_retry_settings(self) -> object:
         if self.settings_manager is None:
             return self.default_retry()
@@ -102,16 +114,13 @@ class SessionSettingsBinding:
     def set_auto_retry_enabled(self, enabled: bool) -> None:
         getattr(self.ensure_settings_manager(), "set_retry_enabled")(enabled)
 
-    @property
-    def auto_compaction_enabled(self) -> bool:
-        return bool(getattr(self.get_compaction_settings(), "enabled", False))
-
     def set_auto_compaction_enabled(self, enabled: bool) -> None:
         manager = self.ensure_settings_manager()
+        current = self.get_compaction_settings()
         getattr(manager, "update_settings")(
             scope="session",
             compaction=replace(
-                cast(Any, self.get_compaction_settings()),
+                cast(Any, current),
                 enabled=enabled,
             ),
         )

--- a/src/loushang/harness/transcript/__init__.py
+++ b/src/loushang/harness/transcript/__init__.py
@@ -91,6 +91,8 @@ from loushang.harness.transcript.lifecycle import (
 from loushang.harness.transcript.maintenance import (
     AgentTranscriptCompactionRuntime,
     AgentTranscriptRetryRuntime,
+    AutoCompactionOutcome,
+    CompactionAborted,
     CompactionDecision,
     CompactionHookDecision,
     CompactionHookRequest,
@@ -228,6 +230,7 @@ from loushang.harness.transcript.writer import (
 )
 
 __all__ = [
+    "AutoCompactionOutcome",
     "AGENT_MESSAGE_KIND",
     "APPLICATION_MESSAGE_KIND",
     "COMMAND_EXECUTION_KIND",
@@ -291,6 +294,7 @@ __all__ = [
     "CompactionDecision",
     "CompactionHookDecision",
     "CompactionHookRequest",
+    "CompactionAborted",
     "CompactionPlan",
     "CompactionPreparation",
     "CompactionResult",

--- a/src/loushang/harness/transcript/maintenance.py
+++ b/src/loushang/harness/transcript/maintenance.py
@@ -14,6 +14,7 @@ import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
+from time import monotonic
 from typing import Any, Literal, Protocol
 
 from loushang.agent.types import AgentMessage
@@ -84,6 +85,18 @@ class CompactionResult:
     first_kept_entry_id: str
     tokens_before: int
     details: object | None = None
+
+
+class CompactionAborted(RuntimeError):
+    """A Product hook deliberately stopped compaction before commit."""
+
+
+@dataclass(frozen=True)
+class AutoCompactionOutcome:
+    """Explicit control result for one automatic-compaction check."""
+
+    result: CompactionResult | None = None
+    should_continue: bool = False
 
 
 @dataclass(frozen=True)
@@ -378,7 +391,6 @@ CompactionHook = Callable[
     [CompactionHookRequest], Awaitable[CompactionHookDecision | None]
 ]
 CompactionCommitObserver = Callable[[CompactionResult, str, bool], Awaitable[None]]
-CompactionRunner = Callable[..., Awaitable[CompactionResult | None]]
 HasQueuedMessages = Callable[[], bool]
 
 
@@ -404,6 +416,8 @@ class AgentTranscriptCompactionRuntime:
         before_compaction: CompactionHook | None = None,
         after_compaction: CompactionCommitObserver | None = None,
         record_runtime_exception: RuntimeExceptionRecorder = _noop_record_runtime_exception,
+        product_id: str | None = None,
+        session_id: str | None = None,
     ) -> None:
         self._transcript = transcript
         self._get_policy = get_policy
@@ -417,6 +431,8 @@ class AgentTranscriptCompactionRuntime:
         self._before_compaction = before_compaction
         self._after_compaction = after_compaction
         self._record_runtime_exception = record_runtime_exception
+        self._product_id = product_id
+        self._session_id = session_id
         self._lifecycle: CompactionCoordinator[CompactionResult] = (
             CompactionCoordinator()
         )
@@ -446,24 +462,21 @@ class AgentTranscriptCompactionRuntime:
         self,
         assistant_message: AssistantMessage,
         *,
-        compact_internal_fn: CompactionRunner | None = None,
-        continue_run_fn: ContinueRun | None = None,
         is_context_overflow_fn: ContextOverflowPredicate | None = None,
-    ) -> CompactionResult | None:
+    ) -> AutoCompactionOutcome:
         policy = self._get_policy()
         if not policy.enabled:
-            return None
+            return AutoCompactionOutcome()
         context_window = model_context_window(self._get_model()) or 0
         if context_window <= 0:
-            return None
+            return AutoCompactionOutcome()
         branch = self._transcript.get_branch()
         latest_compaction = latest_compaction_entry(branch)
         if latest_compaction is not None and _message_is_before_or_at_entry(
             assistant_message, latest_compaction
         ):
-            return None
+            return AutoCompactionOutcome()
 
-        run_compact = compact_internal_fn or self.compact
         if is_context_overflow_fn is not None and is_context_overflow_fn(
             assistant_message, context_window
         ):
@@ -482,16 +495,23 @@ class AgentTranscriptCompactionRuntime:
                         error_message=message,
                         usage_before=usage,
                         usage_after=usage,
+                        stage="failed",
+                        product_id=self._product_id,
+                        session_id=self._session_id,
+                        duration_ms=0.0,
+                        tokens_before=_usage_tokens(usage),
+                        tokens_after=_usage_tokens(usage),
                     )
                 )
-                return None
+                return AutoCompactionOutcome()
             self._overflow_recovery_attempted = True
-            result = await run_compact(
+            result = await self.compact(
                 reason="overflow", will_retry=True, raise_on_error=False
             )
-            if result is not None and continue_run_fn is not None:
-                asyncio.ensure_future(continue_run_fn())
-            return result
+            return AutoCompactionOutcome(
+                result=result,
+                should_continue=result is not None,
+            )
 
         context_messages = self._get_context_messages()
         if not any(message is assistant_message for message in context_messages):
@@ -506,17 +526,14 @@ class AgentTranscriptCompactionRuntime:
             keep_recent_tokens=policy.keep_recent_tokens,
         )
         if decision.usage.tokens is None or decision.action != "threshold":
-            return None
-        result = await run_compact(
+            return AutoCompactionOutcome()
+        result = await self.compact(
             reason="threshold", will_retry=False, raise_on_error=False
         )
-        if (
-            result is not None
-            and continue_run_fn is not None
-            and self._has_queued_messages()
-        ):
-            asyncio.ensure_future(continue_run_fn())
-        return result
+        return AutoCompactionOutcome(
+            result=result,
+            should_continue=result is not None and self._has_queued_messages(),
+        )
 
     async def compact(
         self,
@@ -528,52 +545,146 @@ class AgentTranscriptCompactionRuntime:
         execute_compaction: CompactionExecutor | None = None,
         prepare_compaction: PreparationProvider | None = None,
     ) -> CompactionResult | None:
+        started_at = monotonic()
         policy = self._get_policy()
         usage_before = _snapshot_payload(self.build_usage_snapshot(policy))
         await self._dispatch_event(
-            ContextCompactionStarted(reason=reason, usage=usage_before)
+            ContextCompactionStarted(
+                reason=reason,
+                usage=usage_before,
+                stage="started",
+                product_id=self._product_id,
+                session_id=self._session_id,
+                tokens_before=_usage_tokens(usage_before),
+            )
         )
+        committed: tuple[CompactionResult, str, bool] | None = None
+
+        async def execute_transaction() -> CompactionResult:
+            nonlocal committed
+            result, record_id, from_hook = await self._execute(
+                reason=reason,
+                custom_instructions=custom_instructions,
+                prepare_compaction=prepare_compaction or self._prepare_compaction,
+                execute_compaction=execute_compaction or self._execute_compaction,
+                policy=policy,
+            )
+            # A successful append is the commit point.  Refresh synchronously
+            # before yielding to Product observers so live context cannot lag
+            # behind a durable checkpoint.
+            self._refresh_context()
+            committed = (result, record_id, from_hook)
+            return result
+
+        task = asyncio.current_task()
+        abort_driver: Callable[[], None] | None = None
+        if task is not None:
+
+            def abort_task() -> None:
+                task.cancel()
+
+            abort_driver = abort_task
         try:
             result = await self._lifecycle.run(
-                lambda: self._execute(
-                    reason=reason,
-                    custom_instructions=custom_instructions,
-                    prepare_compaction=prepare_compaction or self._prepare_compaction,
-                    execute_compaction=execute_compaction or self._execute_compaction,
-                    policy=policy,
-                ),
+                execute_transaction,
                 reason=reason,
+                abort_driver=abort_driver,
             )
+        except asyncio.CancelledError:
+            await self._dispatch_compaction_completed(
+                reason=reason,
+                result=None,
+                aborted=True,
+                will_retry=will_retry,
+                policy=policy,
+                usage_before=usage_before,
+                started_at=started_at,
+                stage="aborted",
+            )
+            if raise_on_error:
+                raise
+            return None
         except Exception as exc:
             aborted = is_compaction_aborted(exc)
             if not aborted:
                 self._record_runtime_exception(code="compaction_failed", exc=exc)
-            await self._dispatch_event(
-                ContextCompactionCompleted(
-                    reason=reason,
-                    result=None,
-                    aborted=aborted,
-                    will_retry=will_retry,
-                    usage_before=usage_before,
-                    usage_after=_snapshot_payload(self.build_usage_snapshot(policy)),
-                    error_message=None if aborted else f"Compaction failed: {exc}",
-                )
+            await self._dispatch_compaction_completed(
+                reason=reason,
+                result=None,
+                aborted=aborted,
+                will_retry=will_retry,
+                policy=policy,
+                usage_before=usage_before,
+                started_at=started_at,
+                stage="aborted" if aborted else "failed",
+                error_message=None if aborted else f"Compaction failed: {exc}",
             )
             if raise_on_error:
                 raise
             return None
 
+        post_commit_failed = False
+        if committed is not None and self._after_compaction is not None:
+            committed_result, record_id, from_hook = committed
+            try:
+                await self._after_compaction(
+                    committed_result,
+                    record_id,
+                    from_hook,
+                )
+            except Exception as exc:
+                post_commit_failed = True
+                self._record_runtime_exception(
+                    code="compaction_post_commit_failed",
+                    exc=exc,
+                )
+
+        await self._dispatch_compaction_completed(
+            reason=reason,
+            result=asdict(result),
+            aborted=False,
+            will_retry=will_retry,
+            policy=policy,
+            usage_before=usage_before,
+            started_at=started_at,
+            stage="post_hook_failed" if post_commit_failed else "committed",
+            checkpoint_record_id=committed[1] if committed is not None else None,
+        )
+        return result
+
+    async def _dispatch_compaction_completed(
+        self,
+        *,
+        reason: CompactionReason,
+        result: object | None,
+        aborted: bool,
+        will_retry: bool,
+        policy: TranscriptCompactionPolicy,
+        usage_before: Mapping[str, object],
+        started_at: float,
+        stage: Literal["aborted", "failed", "committed", "post_hook_failed"],
+        error_message: str | None = None,
+        checkpoint_record_id: str | None = None,
+    ) -> None:
+        usage_after = _snapshot_payload(self.build_usage_snapshot(policy))
         await self._dispatch_event(
             ContextCompactionCompleted(
                 reason=reason,
-                result=asdict(result),
-                aborted=False,
+                result=result,
+                aborted=aborted,
                 will_retry=will_retry,
+                error_message=error_message,
                 usage_before=usage_before,
-                usage_after=_snapshot_payload(self.build_usage_snapshot(policy)),
+                usage_after=usage_after,
+                stage=stage,
+                product_id=self._product_id,
+                session_id=self._session_id,
+                duration_ms=round(max(monotonic() - started_at, 0.0) * 1_000, 3),
+                tokens_before=_usage_tokens(usage_before),
+                tokens_after=_usage_tokens(usage_after),
+                checkpoint_record_id=checkpoint_record_id,
             )
         )
-        return result
 
     def build_usage_snapshot(
         self, policy: TranscriptCompactionPolicy | None = None
@@ -596,7 +707,7 @@ class AgentTranscriptCompactionRuntime:
         prepare_compaction: PreparationProvider,
         execute_compaction: CompactionExecutor,
         policy: TranscriptCompactionPolicy,
-    ) -> CompactionResult:
+    ) -> tuple[CompactionResult, str, bool]:
         preparation = prepare_compaction(
             self._transcript.get_branch(),
             policy.keep_recent_tokens or 0,
@@ -617,7 +728,7 @@ class AgentTranscriptCompactionRuntime:
                 )
             )
             if decision is not None and decision.cancel:
-                raise RuntimeError("Compaction cancelled")
+                raise CompactionAborted("Compaction cancelled")
             if decision is not None and decision.result is not None:
                 result = decision.result
                 from_hook = True
@@ -632,10 +743,7 @@ class AgentTranscriptCompactionRuntime:
             details=result.details,
             from_hook=from_hook,
         )
-        if self._after_compaction is not None:
-            await self._after_compaction(result, record_id, from_hook)
-        self._refresh_context()
-        return result
+        return result, record_id, from_hook
 
 
 def calculate_context_tokens(usage: object) -> int:
@@ -852,9 +960,7 @@ def has_post_compaction_usage(
 
 
 def is_compaction_aborted(exc: Exception) -> bool:
-    return (
-        str(exc) == "Compaction cancelled" or getattr(exc, "name", None) == "AbortError"
-    )
+    return isinstance(exc, CompactionAborted) or getattr(exc, "name", None) == "AbortError"
 
 
 def _message_is_before_or_at_entry(
@@ -875,6 +981,11 @@ def _entry_timestamp_ms(timestamp: str) -> float | None:
 
 def _snapshot_payload(snapshot: ContextUsageSnapshot) -> dict[str, Any]:
     return asdict(snapshot)
+
+
+def _usage_tokens(usage: Mapping[str, object]) -> int | None:
+    tokens = usage.get("tokens")
+    return tokens if isinstance(tokens, int) and not isinstance(tokens, bool) else None
 
 
 def _with_preparation_details(
@@ -1014,10 +1125,12 @@ def estimate_message_tokens(message: AgentMessage) -> int:
 
 
 __all__ = [
+    "AutoCompactionOutcome",
     "AgentTranscriptCompactionRuntime",
     "AgentTranscriptRetryRuntime",
     "CompactionHookDecision",
     "CompactionHookRequest",
+    "CompactionAborted",
     "CompactionDecision",
     "CompactionPlan",
     "CompactionPreparation",

--- a/tests/coding/test_agent_session_compaction.py
+++ b/tests/coding/test_agent_session_compaction.py
@@ -195,6 +195,9 @@ def test_agent_session_compact_appends_compaction_and_rebuilds_context(
 
     assert events[0]["type"] == "compaction_start"
     assert events[0]["reason"] == "manual"
+    assert events[0]["stage"] == "started"
+    assert events[0]["product_id"] == "coding"
+    assert events[0]["session_id"] == session.session_id
     assert events[0]["usage"]["reserve_tokens"] == 8192
     assert events[0]["usage"]["keep_recent_tokens"] == 1
     assert events[-1]["type"] == "compaction_end"
@@ -207,6 +210,11 @@ def test_agent_session_compact_appends_compaction_and_rebuilds_context(
     }
     assert events[-1]["aborted"] is False
     assert events[-1]["will_retry"] is False
+    assert events[-1]["stage"] == "committed"
+    assert events[-1]["product_id"] == "coding"
+    assert events[-1]["session_id"] == session.session_id
+    assert events[-1]["duration_ms"] >= 0
+    assert events[-1]["checkpoint_record_id"] == compaction_entry.record_id
     assert events[-1]["usage_before"] == events[0]["usage"]
     assert events[-1]["usage_after"]["stale_after_compaction"] is True
 
@@ -278,6 +286,82 @@ def test_agent_session_exposes_compaction_service_surface(
     assert result.summary == "public surface summary"
     assert result.first_kept_entry_id == assistant_id
     assert session.get_compaction_status().is_compacting is False
+
+
+def test_agent_session_abort_compaction_cancels_public_manual_operation(
+    tmp_path, monkeypatch
+) -> None:
+    from loushang.agent import Agent
+    from loushang.coding.control import (
+        CompactionSettings,
+        ControlConfig,
+        SettingsManager,
+    )
+    from loushang.coding.session import AgentSession
+    from loushang.coding.session_manager import SessionManager
+
+    manager = asyncio.run(
+        SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    )
+    asyncio.run(
+        manager.append_message(
+            UserMessage(role="user", content="older context", timestamp=0.0)
+        )
+    )
+    asyncio.run(manager.append_message(_assistant_text_message("recent reply")))
+    session = AgentSession(
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": _model(),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=manager,
+        settings_manager=SettingsManager(
+            ControlConfig(
+                compaction=CompactionSettings(
+                    enabled=True,
+                    reserve_tokens=8_192,
+                    keep_recent_tokens=1,
+                )
+            )
+        ),
+    )
+    started = asyncio.Event()
+    events: list[object] = []
+
+    async def _blocking_compact(**kwargs):
+        del kwargs
+        started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(
+        "loushang.coding.session.agent_session._execute_coding_compaction",
+        _blocking_compact,
+    )
+    session.subscribe(events.append)
+
+    async def scenario() -> None:
+        task = asyncio.create_task(session.compact())
+        await started.wait()
+        session.abort_compaction()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(scenario())
+
+    assert all(
+        entry.kind != "context.compaction_checkpoint"
+        for entry in manager.get_entries()
+    )
+    assert session.get_compaction_status().is_compacting is False
+    compaction_end = next(
+        event for event in events if event["type"] == "compaction_end"
+    )
+    assert compaction_end["aborted"] is True
+    assert compaction_end["result"] is None
 
 
 def test_agent_session_compact_emits_error_event_on_failure(
@@ -364,12 +448,19 @@ def test_agent_session_compact_emits_error_event_on_failure(
     ]
     assert events[0]["type"] == "compaction_start"
     assert events[0]["reason"] == "manual"
+    assert events[0]["stage"] == "started"
+    assert events[0]["product_id"] == "coding"
+    assert events[0]["session_id"] == session.session_id
     assert events[0]["usage"]["reserve_tokens"] == 8192
     assert events[-1]["type"] == "compaction_end"
     assert events[-1]["reason"] == "manual"
     assert events[-1]["result"] is None
     assert events[-1]["aborted"] is False
     assert events[-1]["will_retry"] is False
+    assert events[-1]["stage"] == "failed"
+    assert events[-1]["product_id"] == "coding"
+    assert events[-1]["session_id"] == session.session_id
+    assert events[-1]["duration_ms"] >= 0
     assert events[-1]["usage_before"] == events[0]["usage"]
     assert events[-1]["usage_after"]["tokens"] == events[0]["usage"]["tokens"]
     assert events[-1]["error_message"] == "Compaction failed: boom"
@@ -449,7 +540,9 @@ def test_agent_session_compact_respects_extension_before_compact_cancellation(
     )
     session.subscribe(events.append)
 
-    with pytest.raises(RuntimeError, match="Compaction cancelled"):
+    from loushang.harness.transcript import CompactionAborted
+
+    with pytest.raises(CompactionAborted, match="Compaction cancelled"):
         asyncio.run(session.compact())
 
     assert [entry.kind for entry in manager.get_entries()] == [
@@ -1238,9 +1331,10 @@ def test_agent_session_threshold_auto_compaction_resumes_agent_level_queue(
             tokens_before=preparation.tokens_before,
         )
 
-    async def _continue_run() -> None:
+    def _continue_run() -> asyncio.Task[None]:
         nonlocal continue_runs
         continue_runs += 1
+        return asyncio.create_task(asyncio.sleep(0))
 
     monkeypatch.setattr(
         "loushang.coding.session.agent_session._execute_coding_compaction",
@@ -1345,9 +1439,10 @@ def test_agent_session_overflow_recovery_emits_compaction_with_retry_flag(
     )
     continue_runs = 0
 
-    async def _continue_run() -> None:
+    def _continue_run() -> asyncio.Task[None]:
         nonlocal continue_runs
         continue_runs += 1
+        return asyncio.create_task(asyncio.sleep(0))
 
     monkeypatch.setattr(
         session._session_runtime, "schedule_continue_run", _continue_run
@@ -1456,9 +1551,10 @@ def test_agent_session_overflow_recovery_is_limited_to_one_attempt(
 
     continue_runs = 0
 
-    async def _continue_run() -> None:
+    def _continue_run() -> asyncio.Task[None]:
         nonlocal continue_runs
         continue_runs += 1
+        return asyncio.create_task(asyncio.sleep(0))
 
     monkeypatch.setattr(
         "loushang.coding.session.agent_session._execute_coding_compaction",

--- a/tests/coding/test_agent_session_retry.py
+++ b/tests/coding/test_agent_session_retry.py
@@ -532,7 +532,11 @@ def test_agent_session_overflow_routes_to_compaction_instead_of_retry(
     async def _fake_continue_run():
         raise AssertionError("overflow should not trigger retry continue_run")
 
-    monkeypatch.setattr(session, "_compact_internal", _fake_compact_internal)
+    monkeypatch.setattr(
+        session._compaction_runtime,
+        "compact",
+        _fake_compact_internal,
+    )
     monkeypatch.setattr(
         session._session_runtime, "schedule_continue_run", _fake_continue_run
     )

--- a/tests/coding/test_session_settings_controller.py
+++ b/tests/coding/test_session_settings_controller.py
@@ -14,7 +14,6 @@ def test_session_settings_controller_returns_defaults_without_manager() -> None:
     assert controller.get_compaction_settings() == CompactionSettings()
     assert controller.get_retry_settings() == RetrySettings()
     assert controller.auto_retry_enabled is controller.get_retry_settings().enabled
-    assert controller.auto_compaction_enabled is controller.get_compaction_settings().enabled
 
 
 def test_session_settings_controller_lazily_creates_manager_for_auto_flags() -> None:

--- a/tests/harness/context/test_compaction.py
+++ b/tests/harness/context/test_compaction.py
@@ -165,6 +165,8 @@ def test_compaction_lifecycle_is_single_flight_and_abortable() -> None:
 
     async def scenario() -> None:
         coordinator = CompactionCoordinator[str]()
+        coordinator.abort()
+        assert coordinator.get_status().aborted is False
         started = asyncio.Event()
         release = asyncio.Event()
         aborted: list[bool] = []

--- a/tests/harness/session/test_composition.py
+++ b/tests/harness/session/test_composition.py
@@ -1,15 +1,27 @@
 from __future__ import annotations
 
 from dataclasses import fields
+from types import SimpleNamespace
 
+from loushang.harness.config.agent import CompactionSettings
+from loushang.harness.session import ProductCompactionExecutor
+from loushang.harness.session.composition import (
+    ProductCompactionExecutor as CompositionProductCompactionExecutor,
+)
 from loushang.harness.session.composition import (
     SessionCompositionPorts,
+    _compaction_policy,
     _resolve_compaction_capability,
 )
 from loushang.harness.transcript import (
     TURN_AWARE_SUMMARY_IMPLEMENTATION,
     TURN_AWARE_SUMMARY_VERSION,
+    TranscriptCompactionPolicy,
 )
+
+
+def test_product_compaction_executor_is_a_public_session_contract() -> None:
+    assert ProductCompactionExecutor is CompositionProductCompactionExecutor
 
 
 def test_compaction_capability_fallback_uses_supported_integer_version() -> None:
@@ -30,5 +42,70 @@ def test_session_composition_ports_exclude_runtime_owned_forwarders() -> None:
             "refresh_resources_for_extension_runtime",
             "refresh_resources_for_extension_runtime_async",
             "serialize_context_usage",
+            "compact_before_prompt",
+            "compact_internal",
+            "continue_run",
         }
+    )
+
+
+def test_compaction_policy_uses_capability_without_product_override() -> None:
+    capability = TranscriptCompactionPolicy(
+        enabled=False,
+        reserve_tokens=1_234,
+        compact_percent=67,
+        keep_recent_tokens=456,
+    )
+
+    assert _compaction_policy(None, capability) is capability
+
+
+def test_compaction_policy_uses_capability_with_default_product_settings() -> None:
+    capability = TranscriptCompactionPolicy(
+        enabled=False,
+        reserve_tokens=1_234,
+        compact_percent=67,
+        keep_recent_tokens=456,
+    )
+
+    assert _compaction_policy(CompactionSettings(), capability) == capability
+
+
+def test_compaction_policy_applies_only_explicit_product_fields() -> None:
+    capability = TranscriptCompactionPolicy(
+        enabled=True,
+        reserve_tokens=1_234,
+        compact_percent=67,
+        keep_recent_tokens=456,
+    )
+
+    assert _compaction_policy(
+        CompactionSettings(enabled=False), capability
+    ) == TranscriptCompactionPolicy(
+        enabled=False,
+        reserve_tokens=1_234,
+        compact_percent=67,
+        keep_recent_tokens=456,
+    )
+
+
+def test_compaction_policy_applies_explicit_product_override() -> None:
+    capability = TranscriptCompactionPolicy(
+        enabled=False,
+        reserve_tokens=1_234,
+        compact_percent=67,
+        keep_recent_tokens=456,
+    )
+    override = SimpleNamespace(
+        enabled=True,
+        reserve_tokens=8_192,
+        compact_percent=80,
+        keep_recent_tokens=32_768,
+    )
+
+    assert _compaction_policy(override, capability) == TranscriptCompactionPolicy(
+        enabled=True,
+        reserve_tokens=8_192,
+        compact_percent=80,
+        keep_recent_tokens=32_768,
     )

--- a/tests/harness/session/test_settings.py
+++ b/tests/harness/session/test_settings.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loushang.harness.config.agent import CompactionSettings
+from loushang.harness.session.settings import SessionSettingsBinding
+
+
+@dataclass
+class _Snapshot:
+    compaction: CompactionSettings
+
+
+class _SettingsManager:
+    def __init__(self) -> None:
+        self.snapshot = _Snapshot(compaction=CompactionSettings())
+
+    def get_settings(self) -> _Snapshot:
+        return self.snapshot
+
+    def get_retry_settings(self) -> object:
+        return object()
+
+    def update_settings(self, *, scope: str, compaction: CompactionSettings) -> None:
+        assert scope == "session"
+        self.snapshot = _Snapshot(compaction=compaction)
+
+
+def test_settings_binding_materializes_only_the_changed_policy_field() -> None:
+    manager = _SettingsManager()
+    binding = SessionSettingsBinding(
+        create_settings_manager=lambda: manager,
+        default_compaction=CompactionSettings,
+    )
+
+    assert binding.get_compaction_policy_override() is None
+
+    binding.set_auto_compaction_enabled(False)
+
+    assert binding.get_compaction_policy_override() == CompactionSettings(
+        enabled=False,
+    )

--- a/tests/harness/test_runtime_event_projection.py
+++ b/tests/harness/test_runtime_event_projection.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from loushang.ai.types import AssistantMessage, Usage
 from loushang.harness.events import (
     BranchSummaryCompleted,
+    ContextCompactionCompleted,
     ContextCompactionStarted,
     PackageProgressChanged,
     QueueChanged,
@@ -70,6 +71,41 @@ def test_runtime_projection_converts_common_session_payloads() -> None:
         "type": "compaction_start",
         "reason": "threshold",
         "usage": {"tokens": 90},
+    }
+    assert project_session_runtime_event(
+        _event(
+            "session.compaction_end",
+            ContextCompactionCompleted(
+                "manual",
+                {"summary": "done"},
+                False,
+                False,
+                usage_before={"tokens": 90},
+                usage_after={"tokens": 30},
+                stage="committed",
+                product_id="research",
+                session_id="s1",
+                duration_ms=12.5,
+                tokens_before=90,
+                tokens_after=30,
+                checkpoint_record_id="checkpoint-1",
+            ),
+        )
+    ) == {
+        "type": "compaction_end",
+        "reason": "manual",
+        "result": {"summary": "done"},
+        "aborted": False,
+        "will_retry": False,
+        "usage_before": {"tokens": 90},
+        "usage_after": {"tokens": 30},
+        "stage": "committed",
+        "product_id": "research",
+        "session_id": "s1",
+        "duration_ms": 12.5,
+        "tokens_before": 90,
+        "tokens_after": 30,
+        "checkpoint_record_id": "checkpoint-1",
     }
     assert project_session_runtime_event(
         _event(

--- a/tests/harness/transcript/test_maintenance.py
+++ b/tests/harness/transcript/test_maintenance.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 from loushang.ai.model import Capabilities, Model
 from loushang.ai.types import AssistantMessage, TextPart, Usage, UserMessage
 from loushang.harness.conversation import (
@@ -9,7 +11,11 @@ from loushang.harness.conversation import (
     ConversationKey,
     MemoryConversationStore,
 )
-from loushang.harness.events import ContextCompactionCompleted, RetryCompleted
+from loushang.harness.events import (
+    ContextCompactionCompleted,
+    ContextCompactionStarted,
+    RetryCompleted,
+)
 from loushang.harness.runtime.retry import RetryPolicy
 from loushang.harness.transcript import (
     AgentTranscriptCompactionRuntime,
@@ -17,10 +23,12 @@ from loushang.harness.transcript import (
     AgentTranscriptRetryRuntime,
     AgentTranscriptSession,
     AgentTranscriptUnitOfWork,
+    CompactionAborted,
     CompactionPreparation,
     CompactionResult,
     TranscriptCompactionPolicy,
     build_context_usage_snapshot,
+    is_compaction_aborted,
 )
 
 
@@ -46,6 +54,11 @@ def _usage(total_tokens: int = 0) -> Usage:
         total_tokens=total_tokens,
         cost=None,
     )
+
+
+def test_compaction_abort_classification_is_type_based() -> None:
+    assert is_compaction_aborted(CompactionAborted("Compaction cancelled")) is True
+    assert is_compaction_aborted(RuntimeError("Compaction cancelled")) is False
 
 
 def _assistant(
@@ -172,7 +185,12 @@ def test_compaction_runtime_commits_checkpoint_and_publishes_common_events() -> 
         assert result is not None
         assert session.get_entries()[-1].kind == "context.compaction_checkpoint"
         assert refreshed == [True]
+        assert isinstance(events[0], ContextCompactionStarted)
+        assert events[0].stage == "started"
+        assert events[0].tokens_before == 20
         assert isinstance(events[-1], ContextCompactionCompleted)
+        assert events[-1].stage == "committed"
+        assert events[-1].checkpoint_record_id == session.get_entries()[-1].record_id
         assert events[-1].result == {
             "summary": "summary",
             "first_kept_entry_id": assistant_id,
@@ -225,13 +243,297 @@ def test_compaction_runtime_counts_the_completed_message_before_context_refresh(
             has_queued_messages=lambda: False,
         )
 
-        result = await runtime.maybe_compact_after_turn(
+        outcome = await runtime.maybe_compact_after_turn(
             completed,
             is_context_overflow_fn=lambda message, context_window: False,
         )
 
-        assert result is not None
+        assert outcome.result is not None
+        assert outcome.should_continue is False
         assert session.get_entries()[-1].kind == "context.compaction_checkpoint"
+
+    asyncio.run(scenario())
+
+
+def test_compaction_runtimes_keep_product_bindings_and_state_isolated() -> None:
+    async def scenario() -> None:
+        research = await _session()
+        design = await _session()
+        calls: list[tuple[str, str]] = []
+
+        async def build_runtime(label: str, session: AgentTranscriptSession):
+            await session.append_message(
+                UserMessage(role="user", content=f"{label} prompt", timestamp=0.0)
+            )
+            assistant_id = await session.append_message(_assistant(total_tokens=20))
+
+            def prepare(entries, keep_recent_tokens):
+                assert keep_recent_tokens == (4 if label == "research" else 8)
+                return CompactionPreparation(
+                    first_kept_entry_id=assistant_id,
+                    messages_to_summarize=[session.build_context().messages[0]],
+                    turn_prefix_messages=[],
+                    is_split_turn=False,
+                    tokens_before=20,
+                )
+
+            async def execute(preparation, instructions):
+                calls.append((label, "execute"))
+                return CompactionResult(
+                    summary=f"{label} summary",
+                    first_kept_entry_id=preparation.first_kept_entry_id,
+                    tokens_before=preparation.tokens_before,
+                )
+
+            async def before(request):
+                calls.append((label, f"before:{request.reason}"))
+                return None
+
+            async def after(result, record_id, from_hook):
+                del result, record_id, from_hook
+                calls.append((label, "after"))
+
+            return AgentTranscriptCompactionRuntime(
+                transcript=session,
+                get_policy=lambda: TranscriptCompactionPolicy(
+                    enabled=True,
+                    reserve_tokens=10,
+                    keep_recent_tokens=4 if label == "research" else 8,
+                ),
+                get_model=_model,
+                get_context_messages=lambda: list(session.build_context().messages),
+                refresh_context=lambda: calls.append((label, "refresh")),
+                prepare_compaction=prepare,
+                execute_compaction=execute,
+                dispatch_event=lambda event: _append([], event),
+                has_queued_messages=lambda: False,
+                before_compaction=before,
+                after_compaction=after,
+            )
+
+        research_runtime = await build_runtime("research", research)
+        design_runtime = await build_runtime("design", design)
+
+        await research_runtime.compact(reason="manual", will_retry=False)
+        await design_runtime.compact(reason="manual", will_retry=False)
+
+        assert research.get_entries()[-1].payload.summary == "research summary"
+        assert design.get_entries()[-1].payload.summary == "design summary"
+        assert calls == [
+            ("research", "before:manual"),
+            ("research", "execute"),
+            ("research", "refresh"),
+            ("research", "after"),
+            ("design", "before:manual"),
+            ("design", "execute"),
+            ("design", "refresh"),
+            ("design", "after"),
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_compaction_abort_cancels_executor_without_committing_checkpoint() -> None:
+    async def scenario() -> None:
+        session = await _session()
+        user_id = await session.append_message(
+            UserMessage(role="user", content="older", timestamp=0.0)
+        )
+        assistant_id = await session.append_message(_assistant(total_tokens=20))
+        started = asyncio.Event()
+        events: list[object] = []
+
+        def prepare(entries, keep_recent_tokens):
+            del entries, keep_recent_tokens
+            return CompactionPreparation(
+                first_kept_entry_id=assistant_id,
+                messages_to_summarize=[session.build_context().messages[0]],
+                turn_prefix_messages=[],
+                is_split_turn=False,
+                tokens_before=20,
+            )
+
+        async def execute(preparation, instructions):
+            del preparation, instructions
+            started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        runtime = AgentTranscriptCompactionRuntime(
+            transcript=session,
+            get_policy=lambda: TranscriptCompactionPolicy(
+                enabled=True,
+                reserve_tokens=10,
+            ),
+            get_model=_model,
+            get_context_messages=lambda: list(session.build_context().messages),
+            refresh_context=lambda: None,
+            prepare_compaction=prepare,
+            execute_compaction=execute,
+            dispatch_event=lambda event: _append(events, event),
+            has_queued_messages=lambda: False,
+        )
+
+        task = asyncio.create_task(
+            runtime.compact(reason="manual", will_retry=False)
+        )
+        await started.wait()
+        runtime.abort()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert [entry.record_id for entry in session.get_entries()] == [
+            user_id,
+            assistant_id,
+        ]
+        assert isinstance(events[-1], ContextCompactionCompleted)
+        assert events[-1].aborted is True
+        assert events[-1].stage == "aborted"
+        assert events[-1].duration_ms is not None
+        assert runtime.get_status().is_compacting is False
+        assert runtime.get_status().aborted is True
+
+    asyncio.run(scenario())
+
+
+def test_post_commit_failure_keeps_success_and_refreshed_context() -> None:
+    async def scenario() -> None:
+        session = await _session()
+        await session.append_message(
+            UserMessage(role="user", content="older", timestamp=0.0)
+        )
+        assistant_id = await session.append_message(_assistant(total_tokens=20))
+        order: list[str] = []
+        diagnostics: list[str] = []
+
+        def prepare(entries, keep_recent_tokens):
+            del entries, keep_recent_tokens
+            return CompactionPreparation(
+                first_kept_entry_id=assistant_id,
+                messages_to_summarize=[session.build_context().messages[0]],
+                turn_prefix_messages=[],
+                is_split_turn=False,
+                tokens_before=20,
+            )
+
+        async def execute(preparation, instructions):
+            del instructions
+            return CompactionResult(
+                summary="committed",
+                first_kept_entry_id=preparation.first_kept_entry_id,
+                tokens_before=preparation.tokens_before,
+            )
+
+        async def after(result, record_id, from_hook):
+            del result, record_id, from_hook
+            order.append("after")
+            raise RuntimeError("observer failed")
+
+        events: list[object] = []
+        runtime = AgentTranscriptCompactionRuntime(
+            transcript=session,
+            get_policy=lambda: TranscriptCompactionPolicy(
+                enabled=True,
+                reserve_tokens=10,
+            ),
+            get_model=_model,
+            get_context_messages=lambda: list(session.build_context().messages),
+            refresh_context=lambda: order.append("refresh"),
+            prepare_compaction=prepare,
+            execute_compaction=execute,
+            dispatch_event=lambda event: _append(events, event),
+            has_queued_messages=lambda: False,
+            after_compaction=after,
+            record_runtime_exception=lambda *, code, exc: diagnostics.append(
+                f"{code}:{exc}"
+            ),
+            product_id="research",
+            session_id="session-research",
+        )
+
+        result = await runtime.compact(reason="manual", will_retry=False)
+
+        assert result is not None
+        assert result.summary == "committed"
+        assert order == ["refresh", "after"]
+        assert diagnostics == ["compaction_post_commit_failed:observer failed"]
+        assert session.get_entries()[-1].kind == "context.compaction_checkpoint"
+        completed = events[-1]
+        assert isinstance(completed, ContextCompactionCompleted)
+        assert completed.stage == "post_hook_failed"
+        assert completed.product_id == "research"
+        assert completed.session_id == "session-research"
+        assert completed.duration_ms is not None
+        assert completed.duration_ms >= 0
+        assert completed.tokens_before is not None
+        assert completed.tokens_after is None
+        assert completed.checkpoint_record_id == session.get_entries()[-1].record_id
+
+    asyncio.run(scenario())
+
+
+def test_abort_after_commit_does_not_cancel_post_commit_observer() -> None:
+    async def scenario() -> None:
+        session = await _session()
+        await session.append_message(
+            UserMessage(role="user", content="older", timestamp=0.0)
+        )
+        assistant_id = await session.append_message(_assistant(total_tokens=20))
+        observer_started = asyncio.Event()
+        release_observer = asyncio.Event()
+
+        def prepare(entries, keep_recent_tokens):
+            del entries, keep_recent_tokens
+            return CompactionPreparation(
+                first_kept_entry_id=assistant_id,
+                messages_to_summarize=[session.build_context().messages[0]],
+                turn_prefix_messages=[],
+                is_split_turn=False,
+                tokens_before=20,
+            )
+
+        async def execute(preparation, instructions):
+            del instructions
+            return CompactionResult(
+                summary="committed",
+                first_kept_entry_id=preparation.first_kept_entry_id,
+                tokens_before=preparation.tokens_before,
+            )
+
+        async def after(result, record_id, from_hook):
+            del result, record_id, from_hook
+            observer_started.set()
+            await release_observer.wait()
+
+        runtime = AgentTranscriptCompactionRuntime(
+            transcript=session,
+            get_policy=lambda: TranscriptCompactionPolicy(
+                enabled=True,
+                reserve_tokens=10,
+            ),
+            get_model=_model,
+            get_context_messages=lambda: list(session.build_context().messages),
+            refresh_context=lambda: None,
+            prepare_compaction=prepare,
+            execute_compaction=execute,
+            dispatch_event=lambda event: _append([], event),
+            has_queued_messages=lambda: False,
+            after_compaction=after,
+        )
+
+        task = asyncio.create_task(
+            runtime.compact(reason="manual", will_retry=False)
+        )
+        await observer_started.wait()
+        assert runtime.is_compacting is False
+        runtime.abort()
+        release_observer.set()
+
+        result = await task
+        assert result is not None
+        assert result.summary == "committed"
+        assert runtime.get_status().aborted is False
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary

- make Product compaction settings field-level overrides of the selected runtime capability
- give compaction cancellation, checkpoint commit, context refresh, post-hook handling, and continuation explicit ownership
- publish the Product compaction executor contract and remove redundant session adapter forwarding
- add lifecycle observability for stage, Product/session identity, duration, token counts, and checkpoint identity

## Root cause

The composed session routed compaction through several callbacks, treated a default settings object as a complete override, and aborted the whole Agent run instead of the active compaction. Continuation and post-commit behavior were also implicit, which obscured lifecycle boundaries for additional Products.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests -q -k 'not test_legacy_command_modules_are_absent'` — 6771 passed, 7 skipped, 2 deselected
- architecture dependency tests — 152 passed
- `uv --cache-dir .uv-cache run --extra dev mypy src/loushang/harness src/loushang/coding/session/agent_session.py`
- `uv --cache-dir .uv-cache run --extra dev ruff check src tests`
- `git diff --check`

The two deselected parameterized cases are the pre-existing contradiction between the checked-in `loushang.harness.capabilities.commands` module and the legacy-module-absence assertion.
