### PR TITLE
refactor(transcript): isolate retry runtime

### DIFF
--- a/docs/internals/architecture/harness/agent-transcript-maintenance-boundary.md
+++ b/docs/internals/architecture/harness/agent-transcript-maintenance-boundary.md
@@ -17,6 +17,11 @@ around an open Agent transcript:
 - retry classification, retry/backoff/cancellation/waiter lifecycle, live
   failed-assistant removal, and common retry events.
 
+The implementation keeps these responsibilities physically cohesive:
+`transcript.maintenance` owns context accounting and compaction, while
+`transcript.retry_runtime` owns the Agent-message retry adapter. The public
+`loushang.harness.transcript` exports remain the stable Product-facing API.
+
 This is an optional Agent/AI profile. `harness.conversation` and generic
 `harness.context` stay independent of Agent and AI message types.
 
@@ -75,10 +80,10 @@ projection, default settings, and TUI/RPC/HTML output projection.
 
 ## Dependency Rule
 
-`harness.transcript.maintenance` may import public Agent message aliases
-and stable `loushang.ai.types`. The adjacent optional
+`harness.transcript.maintenance` and `harness.transcript.retry_runtime` may
+import public Agent message aliases and stable `loushang.ai.types`. The adjacent optional
 `harness.transcript.summarization` module may additionally use the
-public `loushang.ai` completion surface. Neither module may import Coding, AI
+public `loushang.ai` completion surface. None of these modules may import Coding, AI
 provider registries, provider implementations, authentication resolution,
 Product configuration, or UI/RPC types. Product-specific prompt/profile,
 completion selection, artifact decoration, and overflow classification are
@@ -103,5 +108,5 @@ concrete live settings override only their corresponding fields.
   prompt-independent cancellation, and JSON-safe output without Coding.
 - Coding session tests preserve Coding prompt/profile, file-detail decoration,
   extension-hook, retry-policy, session-state, and display behavior.
-- Architecture tests prohibit a Coding import from maintenance and require the
-  Coding session binding to consume the Harness runtimes directly.
+- Architecture tests prohibit a Coding import from maintenance/retry modules
+  and require the Coding session binding to consume the Harness runtimes directly.

--- a/src/loushang/harness/transcript/__init__.py
+++ b/src/loushang/harness/transcript/__init__.py
@@ -90,9 +90,7 @@ from loushang.harness.transcript.lifecycle import (
 )
 from loushang.harness.transcript.maintenance import (
     AgentTranscriptCompactionRuntime,
-    AgentTranscriptRetryRuntime,
     AutoCompactionOutcome,
-    AutoRetryOutcome,
     CompactionAborted,
     CompactionDecision,
     CompactionHookDecision,
@@ -111,7 +109,6 @@ from loushang.harness.transcript.maintenance import (
     estimate_message_tokens,
     has_post_compaction_usage,
     is_compaction_aborted,
-    is_retryable_assistant_error,
     latest_compaction_entry,
     model_context_window,
 )
@@ -141,6 +138,11 @@ from loushang.harness.transcript.profile import (
     record_is_visible,
     record_role,
     record_to_context_item,
+)
+from loushang.harness.transcript.retry_runtime import (
+    AgentTranscriptRetryRuntime,
+    AutoRetryOutcome,
+    is_retryable_assistant_error,
 )
 from loushang.harness.transcript.runtime_profile import (
     AgentTranscriptProfileRuntime,

--- a/src/loushang/harness/transcript/maintenance.py
+++ b/src/loushang/harness/transcript/maintenance.py
@@ -1,16 +1,13 @@
 """Maintenance primitives for the optional Agent transcript profile.
 
-The profile owns durable conversation facts.  This module owns the reusable
-runtime calculations around those facts: context-budget observations and
-automatic retry lifecycle.  Product code supplies settings and presentation or
-diagnostic adapters; the session runtime owns continuation scheduling, and no
-Product needs to reimplement the state machines.
+The profile owns durable conversation facts. This module owns reusable context
+budget observations and compaction lifecycle mechanics around those facts.
+Product code supplies policy and presentation or diagnostic adapters.
 """
 
 from __future__ import annotations
 
 import asyncio
-import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime
@@ -27,14 +24,8 @@ from loushang.harness.events import (
     CompactionReason,
     ContextCompactionCompleted,
     ContextCompactionStarted,
-    RetryAttempt,
-    RetryCompleted,
-    RetryOutcome,
-    RetryStarted,
     SessionRuntimeEventPayload,
 )
-from loushang.harness.runtime import CancellationController, CancellationSignal
-from loushang.harness.runtime.retry import RetryCoordinator, RetryPolicy
 from loushang.harness.transcript.kinds import (
     AGENT_MESSAGE_KIND,
     CONTEXT_COMPACTION_CHECKPOINT_KIND,
@@ -100,13 +91,6 @@ class AutoCompactionOutcome:
 
 
 @dataclass(frozen=True)
-class AutoRetryOutcome:
-    """Explicit control result for one automatic-retry check."""
-
-    should_continue: bool = False
-
-
-@dataclass(frozen=True)
 class CompactionStatus:
     is_compacting: bool
     is_branch_summarizing: bool = False
@@ -151,210 +135,9 @@ class TranscriptCompactionPolicy:
     keep_recent_tokens: int | None = None
 
 
-_NON_RETRYABLE_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
-    re.compile(pattern, re.IGNORECASE)
-    for pattern in (
-        r"requires an api key",
-        r"\bapi[-_ ]?key\b",
-        r"authorization",
-        r"authentication",
-        r"\bunauthorized\b",
-        r"\bforbidden\b",
-        r"\b401\b",
-        r"\b403\b",
-        r"access[_ -]?terminated",
-        r"access.?denied",
-        r"permission.?denied",
-        r"currently only available",
-    )
-)
-
-_RETRYABLE_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
-    re.compile(pattern, re.IGNORECASE)
-    for pattern in (
-        r"overloaded",
-        r"provider.?returned.?error",
-        r"rate.?limit",
-        r"too many requests",
-        r"\b429\b",
-        r"\b500\b",
-        r"\b502\b",
-        r"\b503\b",
-        r"\b504\b",
-        r"service.?unavailable",
-        r"server.?error",
-        r"internal.?error",
-        r"network.?error",
-        r"network.*connection.*lost",
-        r"connection.?error",
-        r"connection.?refused",
-        r"connection.*lost",
-        r"fetch failed",
-        r"upstream.?connect",
-        r"socket hang up",
-        r"ended without",
-        r"timed? out",
-        r"timeout",
-        r"terminated",
-        r"retry delay",
-    )
-)
-
-RetrySettingsProvider = Callable[[], RetryPolicy]
 EventDispatcher = Callable[[SessionRuntimeEventPayload], Awaitable[None]]
-ContinueRun = Callable[[], Awaitable[None]]
 RuntimeExceptionRecorder = Callable[..., None]
-RetrySleeper = Callable[[int, CancellationSignal], Awaitable[None]]
-MessageProvider = Callable[[], list[AgentMessage]]
-MessageSetter = Callable[[list[AgentMessage]], None]
-ContextWindowProvider = Callable[[], int | None]
 ContextOverflowPredicate = Callable[[AssistantMessage, int], bool]
-
-
-class AgentTranscriptRetryRuntime:
-    """Run retry policy against one Agent transcript's live message state."""
-
-    def __init__(
-        self,
-        *,
-        get_policy: RetrySettingsProvider,
-        get_messages: MessageProvider,
-        set_messages: MessageSetter,
-        get_context_window: ContextWindowProvider,
-        dispatch_event: EventDispatcher,
-        record_runtime_exception: RuntimeExceptionRecorder,
-        sleep_for_retry: RetrySleeper,
-        is_context_overflow_fn: ContextOverflowPredicate,
-    ) -> None:
-        self._get_policy = get_policy
-        self._get_messages = get_messages
-        self._set_messages = set_messages
-        self._get_context_window = get_context_window
-        self._dispatch_event = dispatch_event
-        self._record_runtime_exception = record_runtime_exception
-        self._is_context_overflow = is_context_overflow_fn
-        self._coordinator = RetryCoordinator(
-            create_cancel_handle=CancellationController,
-            cancel=lambda controller: controller.abort(),
-            delay=lambda delay_ms, controller: sleep_for_retry(
-                delay_ms, controller.signal
-            ),
-            on_started=self._on_started,
-            on_finished=self._on_finished,
-        )
-
-    @property
-    def attempt(self) -> int:
-        return self._coordinator.attempt
-
-    @attempt.setter
-    def attempt(self, value: int) -> None:
-        self._coordinator.attempt = value
-
-    @property
-    def retry_future(self) -> asyncio.Future[None] | object | None:
-        return self._coordinator.future
-
-    @retry_future.setter
-    def retry_future(self, value: asyncio.Future[None] | object | None) -> None:
-        self._coordinator.future = value
-
-    @property
-    def is_retrying(self) -> bool:
-        return self._coordinator.is_retrying
-
-    @property
-    def cancel_handle(self) -> CancellationController | None:
-        return self._coordinator.cancel_handle
-
-    @cancel_handle.setter
-    def cancel_handle(self, value: CancellationController | None) -> None:
-        self._coordinator.cancel_handle = value
-
-    def abort(self) -> None:
-        self._coordinator.abort()
-
-    async def wait(self) -> None:
-        await self._coordinator.wait()
-
-    def ensure_future(self) -> asyncio.Future[None]:
-        return self._coordinator.ensure_waiter()
-
-    async def finish(
-        self,
-        *,
-        success: bool,
-        attempt: int,
-        final_error: str | None = None,
-    ) -> None:
-        await self._coordinator.finish(
-            RetryOutcome(
-                success=success,
-                attempt=attempt,
-                error=final_error,
-                cancelled=final_error == "Retry cancelled",
-            )
-        )
-
-    async def finish_success_if_needed(
-        self, assistant_message: AssistantMessage
-    ) -> None:
-        if assistant_message.stop_reason != "error" and self.attempt > 0:
-            await self.finish(success=True, attempt=self.attempt)
-
-    def should_prepare_retry(self, assistant_message: AssistantMessage) -> bool:
-        return self._get_policy().enabled and self.is_retryable_error(assistant_message)
-
-    def is_retryable_error(self, assistant_message: AssistantMessage) -> bool:
-        return is_retryable_assistant_error(
-            assistant_message,
-            context_window=self._get_context_window() or 0,
-            is_context_overflow_fn=self._is_context_overflow,
-        )
-
-    async def handle_retryable_error(
-        self,
-        assistant_message: AssistantMessage,
-    ) -> AutoRetryOutcome:
-        should_continue = await self._coordinator.retry(
-            assistant_message.error_message or "",
-            policy=self._get_policy(),
-            before_retry=self._remove_failed_assistant,
-        )
-        return AutoRetryOutcome(should_continue=should_continue)
-
-    def continue_retry(self, continue_run: ContinueRun) -> None:
-        self._coordinator.continue_retry(continue_run)
-
-    async def _on_started(self, attempt: RetryAttempt) -> None:
-        await self._dispatch_event(RetryStarted(attempt=attempt))
-
-    async def _on_finished(self, outcome: RetryOutcome) -> None:
-        final_error = (
-            ("Retry cancelled" if outcome.cancelled else outcome.error)
-            if not outcome.success
-            else None
-        )
-        if final_error is not None:
-            self._record_runtime_exception(
-                code="retry_cancelled" if outcome.cancelled else "retry_failed",
-                exc=final_error,
-            )
-        await self._dispatch_event(
-            RetryCompleted(
-                outcome=RetryOutcome(
-                    success=outcome.success,
-                    attempt=outcome.attempt,
-                    error=final_error,
-                    cancelled=outcome.cancelled,
-                )
-            )
-        )
-
-    def _remove_failed_assistant(self) -> None:
-        messages = self._get_messages()
-        if messages and getattr(messages[-1], "role", None) == "assistant":
-            self._set_messages(messages[:-1])
 
 
 class TranscriptCompactionStore(Protocol):
@@ -1022,26 +805,6 @@ def _merge_preparation_result_details(
     return merged
 
 
-def is_retryable_assistant_error(
-    message: AssistantMessage,
-    *,
-    context_window: int,
-    is_context_overflow_fn: ContextOverflowPredicate,
-) -> bool:
-    if message.stop_reason != "error" or not message.error_message:
-        return False
-    if is_context_overflow_fn(message, context_window):
-        return False
-    if any(
-        pattern.search(message.error_message)
-        for pattern in _NON_RETRYABLE_ERROR_PATTERNS
-    ):
-        return False
-    return any(
-        pattern.search(message.error_message) for pattern in _RETRYABLE_ERROR_PATTERNS
-    )
-
-
 def _usage_value(usage: object, *keys: str) -> object | None:
     if isinstance(usage, Mapping):
         for key in keys:
@@ -1135,9 +898,7 @@ def estimate_message_tokens(message: AgentMessage) -> int:
 
 __all__ = [
     "AutoCompactionOutcome",
-    "AutoRetryOutcome",
     "AgentTranscriptCompactionRuntime",
-    "AgentTranscriptRetryRuntime",
     "CompactionHookDecision",
     "CompactionHookRequest",
     "CompactionAborted",
@@ -1156,7 +917,6 @@ __all__ = [
     "estimate_context_tokens",
     "estimate_message_tokens",
     "has_post_compaction_usage",
-    "is_retryable_assistant_error",
     "is_compaction_aborted",
     "latest_compaction_entry",
     "model_context_window",

--- a/src/loushang/harness/transcript/retry_runtime.py
+++ b/src/loushang/harness/transcript/retry_runtime.py
@@ -1,0 +1,265 @@
+"""Automatic retry runtime for the optional Agent transcript profile.
+
+The generic runtime layer owns retry timing and lifecycle state. This module
+adapts that mechanism to live Agent messages and common session events while
+leaving continuation scheduling with the session runtime.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from loushang.agent.types import AgentMessage
+from loushang.ai.types import AssistantMessage
+from loushang.harness.events import (
+    RetryAttempt,
+    RetryCompleted,
+    RetryOutcome,
+    RetryStarted,
+    SessionRuntimeEventPayload,
+)
+from loushang.harness.runtime import CancellationController, CancellationSignal
+from loushang.harness.runtime.retry import RetryCoordinator, RetryPolicy
+
+
+@dataclass(frozen=True)
+class AutoRetryOutcome:
+    """Explicit control result for one automatic-retry check."""
+
+    should_continue: bool = False
+
+
+_NON_RETRYABLE_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"requires an api key",
+        r"\bapi[-_ ]?key\b",
+        r"authorization",
+        r"authentication",
+        r"\bunauthorized\b",
+        r"\bforbidden\b",
+        r"\b401\b",
+        r"\b403\b",
+        r"access[_ -]?terminated",
+        r"access.?denied",
+        r"permission.?denied",
+        r"currently only available",
+    )
+)
+
+_RETRYABLE_ERROR_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"overloaded",
+        r"provider.?returned.?error",
+        r"rate.?limit",
+        r"too many requests",
+        r"\b429\b",
+        r"\b500\b",
+        r"\b502\b",
+        r"\b503\b",
+        r"\b504\b",
+        r"service.?unavailable",
+        r"server.?error",
+        r"internal.?error",
+        r"network.?error",
+        r"network.*connection.*lost",
+        r"connection.?error",
+        r"connection.?refused",
+        r"connection.*lost",
+        r"fetch failed",
+        r"upstream.?connect",
+        r"socket hang up",
+        r"ended without",
+        r"timed? out",
+        r"timeout",
+        r"terminated",
+        r"retry delay",
+    )
+)
+
+RetrySettingsProvider = Callable[[], RetryPolicy]
+EventDispatcher = Callable[[SessionRuntimeEventPayload], Awaitable[None]]
+ContinueRun = Callable[[], Awaitable[None]]
+RuntimeExceptionRecorder = Callable[..., None]
+RetrySleeper = Callable[[int, CancellationSignal], Awaitable[None]]
+MessageProvider = Callable[[], list[AgentMessage]]
+MessageSetter = Callable[[list[AgentMessage]], None]
+ContextWindowProvider = Callable[[], int | None]
+ContextOverflowPredicate = Callable[[AssistantMessage, int], bool]
+
+
+class AgentTranscriptRetryRuntime:
+    """Run retry policy against one Agent transcript's live message state."""
+
+    def __init__(
+        self,
+        *,
+        get_policy: RetrySettingsProvider,
+        get_messages: MessageProvider,
+        set_messages: MessageSetter,
+        get_context_window: ContextWindowProvider,
+        dispatch_event: EventDispatcher,
+        record_runtime_exception: RuntimeExceptionRecorder,
+        sleep_for_retry: RetrySleeper,
+        is_context_overflow_fn: ContextOverflowPredicate,
+    ) -> None:
+        self._get_policy = get_policy
+        self._get_messages = get_messages
+        self._set_messages = set_messages
+        self._get_context_window = get_context_window
+        self._dispatch_event = dispatch_event
+        self._record_runtime_exception = record_runtime_exception
+        self._is_context_overflow = is_context_overflow_fn
+        self._coordinator = RetryCoordinator(
+            create_cancel_handle=CancellationController,
+            cancel=lambda controller: controller.abort(),
+            delay=lambda delay_ms, controller: sleep_for_retry(
+                delay_ms, controller.signal
+            ),
+            on_started=self._on_started,
+            on_finished=self._on_finished,
+        )
+
+    @property
+    def attempt(self) -> int:
+        return self._coordinator.attempt
+
+    @attempt.setter
+    def attempt(self, value: int) -> None:
+        self._coordinator.attempt = value
+
+    @property
+    def retry_future(self) -> asyncio.Future[None] | object | None:
+        return self._coordinator.future
+
+    @retry_future.setter
+    def retry_future(self, value: asyncio.Future[None] | object | None) -> None:
+        self._coordinator.future = value
+
+    @property
+    def is_retrying(self) -> bool:
+        return self._coordinator.is_retrying
+
+    @property
+    def cancel_handle(self) -> CancellationController | None:
+        return self._coordinator.cancel_handle
+
+    @cancel_handle.setter
+    def cancel_handle(self, value: CancellationController | None) -> None:
+        self._coordinator.cancel_handle = value
+
+    def abort(self) -> None:
+        self._coordinator.abort()
+
+    async def wait(self) -> None:
+        await self._coordinator.wait()
+
+    def ensure_future(self) -> asyncio.Future[None]:
+        return self._coordinator.ensure_waiter()
+
+    async def finish(
+        self,
+        *,
+        success: bool,
+        attempt: int,
+        final_error: str | None = None,
+    ) -> None:
+        await self._coordinator.finish(
+            RetryOutcome(
+                success=success,
+                attempt=attempt,
+                error=final_error,
+                cancelled=final_error == "Retry cancelled",
+            )
+        )
+
+    async def finish_success_if_needed(
+        self, assistant_message: AssistantMessage
+    ) -> None:
+        if assistant_message.stop_reason != "error" and self.attempt > 0:
+            await self.finish(success=True, attempt=self.attempt)
+
+    def should_prepare_retry(self, assistant_message: AssistantMessage) -> bool:
+        return self._get_policy().enabled and self.is_retryable_error(assistant_message)
+
+    def is_retryable_error(self, assistant_message: AssistantMessage) -> bool:
+        return is_retryable_assistant_error(
+            assistant_message,
+            context_window=self._get_context_window() or 0,
+            is_context_overflow_fn=self._is_context_overflow,
+        )
+
+    async def handle_retryable_error(
+        self,
+        assistant_message: AssistantMessage,
+    ) -> AutoRetryOutcome:
+        should_continue = await self._coordinator.retry(
+            assistant_message.error_message or "",
+            policy=self._get_policy(),
+            before_retry=self._remove_failed_assistant,
+        )
+        return AutoRetryOutcome(should_continue=should_continue)
+
+    def continue_retry(self, continue_run: ContinueRun) -> None:
+        self._coordinator.continue_retry(continue_run)
+
+    async def _on_started(self, attempt: RetryAttempt) -> None:
+        await self._dispatch_event(RetryStarted(attempt=attempt))
+
+    async def _on_finished(self, outcome: RetryOutcome) -> None:
+        final_error = (
+            ("Retry cancelled" if outcome.cancelled else outcome.error)
+            if not outcome.success
+            else None
+        )
+        if final_error is not None:
+            self._record_runtime_exception(
+                code="retry_cancelled" if outcome.cancelled else "retry_failed",
+                exc=final_error,
+            )
+        await self._dispatch_event(
+            RetryCompleted(
+                outcome=RetryOutcome(
+                    success=outcome.success,
+                    attempt=outcome.attempt,
+                    error=final_error,
+                    cancelled=outcome.cancelled,
+                )
+            )
+        )
+
+    def _remove_failed_assistant(self) -> None:
+        messages = self._get_messages()
+        if messages and getattr(messages[-1], "role", None) == "assistant":
+            self._set_messages(messages[:-1])
+
+
+def is_retryable_assistant_error(
+    message: AssistantMessage,
+    *,
+    context_window: int,
+    is_context_overflow_fn: ContextOverflowPredicate,
+) -> bool:
+    if message.stop_reason != "error" or not message.error_message:
+        return False
+    if is_context_overflow_fn(message, context_window):
+        return False
+    if any(
+        pattern.search(message.error_message)
+        for pattern in _NON_RETRYABLE_ERROR_PATTERNS
+    ):
+        return False
+    return any(
+        pattern.search(message.error_message) for pattern in _RETRYABLE_ERROR_PATTERNS
+    )
+
+
+__all__ = [
+    "AgentTranscriptRetryRuntime",
+    "AutoRetryOutcome",
+    "is_retryable_assistant_error",
+]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -642,6 +642,9 @@ def test_agent_transcript_maintenance_runtime_is_neutral_and_adopted() -> None:
     maintenance_source = Path(
         "src/loushang/harness/transcript/maintenance.py"
     ).read_text(encoding="utf-8")
+    retry_source = Path(
+        "src/loushang/harness/transcript/retry_runtime.py"
+    ).read_text(encoding="utf-8")
     composition_source = Path("src/loushang/harness/session/composition.py").read_text(
         encoding="utf-8"
     )
@@ -650,6 +653,9 @@ def test_agent_transcript_maintenance_runtime_is_neutral_and_adopted() -> None:
     ).read_text(encoding="utf-8")
 
     assert "loushang.coding" not in maintenance_source
+    assert "loushang.coding" not in retry_source
+    assert "AgentTranscriptRetryRuntime" in retry_source
+    assert "AutoRetryOutcome" in retry_source
     assert "AgentTranscriptCompactionRuntime" in composition_source
     assert "AgentTranscriptRetryRuntime" in composition_source
     assert not Path("src/loushang/coding/session/compaction_controller.py").exists()

--- a/tests/harness/transcript/test_maintenance.py
+++ b/tests/harness/transcript/test_maintenance.py
@@ -14,13 +14,10 @@ from loushang.harness.conversation import (
 from loushang.harness.events import (
     ContextCompactionCompleted,
     ContextCompactionStarted,
-    RetryCompleted,
 )
-from loushang.harness.runtime.retry import RetryPolicy
 from loushang.harness.transcript import (
     AgentTranscriptCompactionRuntime,
     AgentTranscriptRecord,
-    AgentTranscriptRetryRuntime,
     AgentTranscriptSession,
     AgentTranscriptUnitOfWork,
     CompactionAborted,
@@ -538,51 +535,5 @@ def test_abort_after_commit_does_not_cancel_post_commit_observer() -> None:
     asyncio.run(scenario())
 
 
-def test_retry_runtime_owns_identity_free_retry_lifecycle() -> None:
-    async def scenario() -> None:
-        messages = [
-            _assistant(
-                stop_reason="error",
-                error_message="503 service unavailable",
-            )
-        ]
-        events: list[object] = []
-        continued: list[bool] = []
-        runtime = AgentTranscriptRetryRuntime(
-            get_policy=lambda: RetryPolicy(
-                enabled=True,
-                max_attempts=2,
-                base_delay_ms=0,
-            ),
-            get_messages=lambda: list(messages),
-            set_messages=lambda updated: _replace(messages, updated),
-            get_context_window=lambda: 100,
-            dispatch_event=lambda event: _append(events, event),
-            record_runtime_exception=lambda **kwargs: None,
-            sleep_for_retry=lambda delay_ms, signal: _sleep(delay_ms, signal),
-            is_context_overflow_fn=lambda message, context_window: False,
-        )
-
-        outcome = await runtime.handle_retryable_error(messages[0])
-        assert outcome.should_continue is True
-        runtime.continue_retry(lambda: _append(continued, True))
-        await asyncio.sleep(0)
-        assert messages == []
-        assert continued == [True]
-        await runtime.finish(success=True, attempt=1)
-        assert isinstance(events[-1], RetryCompleted)
-        assert runtime.is_retrying is False
-
-    asyncio.run(scenario())
-
-
 async def _append(values: list[object], value: object) -> None:
     values.append(value)
-
-
-def _replace(target: list[object], replacement: list[object]) -> None:
-    target[:] = replacement
-
-
-async def _sleep(delay_ms: int, signal: object) -> None:
-    del delay_ms, signal

--- a/tests/harness/transcript/test_retry_runtime.py
+++ b/tests/harness/transcript/test_retry_runtime.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+
+from loushang.ai.types import AssistantMessage, TextPart, Usage
+from loushang.harness.events import RetryCompleted
+from loushang.harness.runtime.retry import RetryPolicy
+from loushang.harness.transcript import AgentTranscriptRetryRuntime
+
+
+def test_retry_runtime_owns_identity_free_retry_lifecycle() -> None:
+    async def scenario() -> None:
+        messages = [
+            _assistant_error("503 service unavailable"),
+        ]
+        events: list[object] = []
+        continued: list[bool] = []
+        runtime = AgentTranscriptRetryRuntime(
+            get_policy=lambda: RetryPolicy(
+                enabled=True,
+                max_attempts=2,
+                base_delay_ms=0,
+            ),
+            get_messages=lambda: list(messages),
+            set_messages=lambda updated: _replace(messages, updated),
+            get_context_window=lambda: 100,
+            dispatch_event=lambda event: _append(events, event),
+            record_runtime_exception=lambda **kwargs: None,
+            sleep_for_retry=lambda delay_ms, signal: _sleep(delay_ms, signal),
+            is_context_overflow_fn=lambda message, context_window: False,
+        )
+
+        outcome = await runtime.handle_retryable_error(messages[0])
+        assert outcome.should_continue is True
+        runtime.continue_retry(lambda: _append(continued, True))
+        await asyncio.sleep(0)
+        assert messages == []
+        assert continued == [True]
+        await runtime.finish(success=True, attempt=1)
+        assert isinstance(events[-1], RetryCompleted)
+        assert runtime.is_retrying is False
+
+    asyncio.run(scenario())
+
+
+def _assistant_error(error_message: str) -> AssistantMessage:
+    return AssistantMessage(
+        role="assistant",
+        content=[TextPart(type="text", text="error")],
+        api="responses",
+        provider="test",
+        model="test-model",
+        response_id=None,
+        usage=Usage(
+            input=0,
+            output=0,
+            cache_read=0,
+            cache_write=0,
+            total_tokens=0,
+            cost=None,
+        ),
+        stop_reason="error",
+        error_message=error_message,
+        timestamp=0.0,
+    )
+
+
+async def _append(values: list[object], value: object) -> None:
+    values.append(value)
+
+
+def _replace(target: list[object], replacement: list[object]) -> None:
+    target[:] = replacement
+
+
+async def _sleep(delay_ms: int, signal: object) -> None:
+    del delay_ms, signal


### PR DESCRIPTION
## Summary

- extract the Agent transcript retry adapter into `transcript.retry_runtime`
- keep context accounting and compaction mechanics in `transcript.maintenance`
- preserve the existing `loushang.harness.transcript` public exports
- move retry-focused tests to the matching test module
- document and enforce the neutral dependency boundary for both modules

## Why

`transcript.maintenance` combined context accounting, compaction lifecycle, retry classification, and the Agent retry adapter in one 1,163-line module. Retry already depended only on Agent messages, common retry events, cancellation, and the generic retry coordinator, so it formed a clean independent responsibility.

This extraction improves physical cohesion without changing runtime behavior or Product-facing APIs.

## Validation

- focused cross-layer tests: `192 passed`
- Harness and related Coding tests: `1501 passed`
- Harness Ruff: passed
- Harness mypy: 407 source files passed
- `make check-harnesstui`: Ruff and mypy passed; `1230 passed, 63 deselected`
- `git diff --check`
