### PR TITLE
refactor(harness): isolate context accounting and stage session composition

### DIFF
--- a/docs/internals/architecture/harness/agent-transcript-maintenance-boundary.md
+++ b/docs/internals/architecture/harness/agent-transcript-maintenance-boundary.md
@@ -18,8 +18,10 @@ around an open Agent transcript:
   failed-assistant removal, and common retry events.
 
 The implementation keeps these responsibilities physically cohesive:
-`transcript.maintenance` owns context accounting and compaction, while
-`transcript.retry_runtime` owns the Agent-message retry adapter. The public
+`transcript.context_usage` owns Agent-message and checkpoint-aware context
+accounting, `transcript.maintenance` owns compaction decisions and lifecycle,
+and `transcript.retry_runtime` owns the Agent-message retry adapter. Generic
+usage values and budget arithmetic remain in `harness.context`. The public
 `loushang.harness.transcript` exports remain the stable Product-facing API.
 
 This is an optional Agent/AI profile. `harness.conversation` and generic
@@ -80,8 +82,9 @@ projection, default settings, and TUI/RPC/HTML output projection.
 
 ## Dependency Rule
 
-`harness.transcript.maintenance` and `harness.transcript.retry_runtime` may
-import public Agent message aliases and stable `loushang.ai.types`. The adjacent optional
+`harness.transcript.context_usage`, `harness.transcript.maintenance`, and
+`harness.transcript.retry_runtime` may import public Agent message aliases and
+stable `loushang.ai.types`. The adjacent optional
 `harness.transcript.summarization` module may additionally use the
 public `loushang.ai` completion surface. None of these modules may import Coding, AI
 provider registries, provider implementations, authentication resolution,

--- a/docs/internals/architecture/harness/session-agent-session-boundary.md
+++ b/docs/internals/architecture/harness/session-agent-session-boundary.md
@@ -61,6 +61,14 @@ not aliases for already assembled runtimes. Context refresh, resource refresh,
 event projection, and serialization must use their existing runtime owners
 instead of adding pass-through callbacks to `SessionCompositionPorts`.
 
+The composition root is staged internally without expanding that port surface:
+foundation runtimes assemble diagnostics, tools, resources, navigation, and
+bash; maintenance runtimes assemble the selected compaction capability plus
+compaction and retry runtimes; Product bindings assemble model, identity,
+maintenance, inspection, and extension bindings after the core `SessionRuntime`
+exists. The private stage results are frozen containers of existing runtimes,
+not new bridges, coordinators, or callback owners.
+
 ## Deletion condition
 
 The old `AgentSession` implementation is reduced to a thin Product adapter.

--- a/src/loushang/harness/session/composition.py
+++ b/src/loushang/harness/session/composition.py
@@ -74,6 +74,7 @@ from loushang.harness.session.diagnostics import (
 )
 from loushang.harness.session.extension_bridge import AgentSessionExtensionBridge
 from loushang.harness.session.extension_composition import (
+    AgentSessionExtensionComposition,
     AgentSessionExtensionCompositionPorts,
     compose_agent_session_extensions,
 )
@@ -248,7 +249,9 @@ class SessionCompositionPorts:
     record_extension_runtime_diagnostic: Callable[[DiagnosticDraft], None]
     execute_compaction: ProductCompactionExecutor
     execute_branch_summary: BranchSummaryExecutor
-    before_compaction: Callable[[CompactionHookRequest], Awaitable[CompactionHookDecision | None]]
+    before_compaction: Callable[
+        [CompactionHookRequest], Awaitable[CompactionHookDecision | None]
+    ]
     after_compaction: Callable[[CompactionResult, str, bool], Awaitable[None]]
     before_agent_start_system_prompt_options: Callable[[], dict[str, object]]
     sleep_for_retry: Callable[[int, CancellationSignal], Awaitable[None]]
@@ -286,17 +289,152 @@ class SessionComposition:
     session_inspector: AgentSessionInspector
 
 
+@dataclass(frozen=True)
+class _FoundationRuntimes:
+    diagnostics_bridge: SessionDiagnosticsRuntime
+    tool_controller: SessionToolController
+    resource_refresh_runtime: SessionResourceRefreshRuntime
+    resource_watch_controller: ResourceChangeWatcher
+    navigation_runtime: AgentTranscriptNavigationRuntime
+    bash_runtime: BashExecutionRuntime
+
+
+@dataclass(frozen=True)
+class _MaintenanceRuntimes:
+    compaction_capability: AgentTranscriptCompactionCapability
+    compaction_runtime: AgentTranscriptCompactionRuntime
+    retry_runtime: AgentTranscriptRetryRuntime
+
+
+@dataclass(frozen=True)
+class _ProductBindings:
+    selection_runtime: AgentTranscriptSelectionRuntime
+    model_binding: SessionModelBinding
+    identity_binding: SessionIdentityBinding
+    maintenance_binding: SessionMaintenanceBinding
+    extension_composition: AgentSessionExtensionComposition
+    session_inspector: AgentSessionInspector
+
+
 def compose_session_runtime(ports: SessionCompositionPorts) -> SessionComposition:
     """Build the standard Agent session runtime from Product ports."""
 
     agent = ports.agent
     session = ports.session_manager
-    settings = ports.settings
-    capability_runtime = ports.capability_runtime
+    foundation = _build_foundation_runtimes(ports)
+    maintenance = _build_maintenance_runtimes(ports)
+    command_controller = ports.command_controller(foundation.diagnostics_bridge)
+    extension_event_sink = ExtensionAgentEventRuntime(
+        get_extension_runtime=lambda: ports.extension_runner,
+        get_cwd=session.get_cwd,
+    )
 
-    async def refresh_extension_runtime(reason: str) -> None:
-        await ports.extension_bridge.refresh(reason=reason)
+    async def check_auto_compaction(
+        message: AssistantMessage,
+    ) -> AutoCompactionOutcome:
+        return await maintenance.compaction_runtime.maybe_compact_after_turn(
+            message,
+            is_context_overflow_fn=is_context_overflow,
+        )
 
+    async def compact_before_prompt() -> AutoCompactionOutcome:
+        message = _last_assistant_message(agent.state.messages)
+        if message is None:
+            return AutoCompactionOutcome()
+        return await check_auto_compaction(message)
+
+    session_runtime = SessionRuntime(
+        agent=agent,
+        transcript=TranscriptRuntimePort(
+            session_id=session.get_header().conversation_id,
+            append_message=session.append_message,
+            commit_application_message=session.commit_application_message,
+            refresh_context=lambda: ports.apply_context(
+                session.build_session_context()
+            ),
+            set_commit_observer=session.set_commit_observer,
+        ),
+        turn_policy=TurnPolicyPort(
+            get_extension_runner=lambda: ports.extension_runner,
+            get_cwd=session.get_cwd,
+            extract_extension_command_invocation=(
+                command_controller.extract_extension_command_invocation
+            ),
+            execute_command_async=command_controller.execute_command_async,
+            preflight_user_input=command_controller.preflight_user_input,
+            reject_queued_extension_command=(
+                command_controller.raise_if_queued_extension_command
+            ),
+            preflight_user_input_async=command_controller.preflight_user_input_async,
+            before_agent_start_system_prompt_options=ports.before_agent_start_system_prompt_options,
+            sync_extension_diagnostics=(
+                foundation.diagnostics_bridge.sync_extension_diagnostics
+            ),
+            compact_before_prompt_async=compact_before_prompt,
+        ),
+        after_turn_policy=AfterTurnPolicyPort(
+            emit_extension_agent_event=extension_event_sink.emit_agent_event,
+            record_tool_execution_error=(
+                foundation.diagnostics_bridge.record_tool_execution_error
+            ),
+            retry_controller=maintenance.retry_runtime,
+            compaction_controller=maintenance.compaction_runtime,
+            sync_extension_diagnostics=(
+                foundation.diagnostics_bridge.sync_extension_diagnostics
+            ),
+            record_assistant_response_error=(
+                foundation.diagnostics_bridge.record_assistant_response_error
+            ),
+            check_auto_compaction=check_auto_compaction,
+        ),
+    )
+    bindings = _build_product_bindings(
+        ports,
+        foundation=foundation,
+        maintenance=maintenance,
+        command_controller=command_controller,
+        session_runtime=session_runtime,
+    )
+    return SessionComposition(
+        capability_runtime=ports.capability_runtime,
+        diagnostics_bridge=foundation.diagnostics_bridge,
+        tool_controller=foundation.tool_controller,
+        resource_refresh_runtime=foundation.resource_refresh_runtime,
+        resource_watch_controller=foundation.resource_watch_controller,
+        navigation_runtime=foundation.navigation_runtime,
+        compaction_capability=maintenance.compaction_capability,
+        compaction_runtime=maintenance.compaction_runtime,
+        bash_runtime=foundation.bash_runtime,
+        package_controller=ports.package_controller,
+        command_controller=command_controller,
+        extension_event_sink=extension_event_sink,
+        retry_runtime=maintenance.retry_runtime,
+        session_runtime=session_runtime,
+        extension_input_runtime=bindings.extension_composition.input_runtime,
+        extension_message_controller=bindings.extension_composition.message_controller,
+        extension_provider_controller=(
+            bindings.extension_composition.provider_controller
+        ),
+        extension_replacement_controller=(
+            bindings.extension_composition.replacement_controller
+        ),
+        extension_runtime_binding_factory=(
+            bindings.extension_composition.runtime_binding_factory
+        ),
+        extension_bridge=ports.extension_bridge,
+        selection_runtime=bindings.selection_runtime,
+        model_binding=bindings.model_binding,
+        identity_binding=bindings.identity_binding,
+        maintenance_binding=bindings.maintenance_binding,
+        extension_binding=bindings.extension_composition.binding,
+        session_inspector=bindings.session_inspector,
+    )
+
+
+def _build_foundation_runtimes(
+    ports: SessionCompositionPorts,
+) -> _FoundationRuntimes:
+    session = ports.session_manager
     diagnostics_bridge = SessionDiagnosticsRuntime(
         diagnostics_service=ports.diagnostics_service,
         get_scope=lambda: SessionDiagnosticScope(
@@ -310,7 +448,6 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
             else 0
         ),
     )
-
     tool_controller = _build_tool_controller(ports, diagnostics_bridge)
     resource_refresh_runtime = SessionResourceRefreshRuntime(
         get_resource_loader=lambda: ports.resource_loader,
@@ -319,7 +456,7 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         get_extension_runtime=lambda: ports.extension_runner,
         get_settings=lambda: cast(
             ResourceSettingsPort | None,
-            settings.get_settings_manager(),
+            ports.settings.get_settings_manager(),
         ),
         set_resource_bundle=ports.set_resource_bundle,
         rebuild_prompt_and_tools_view=ports.rebuild_prompt_and_tools_view,
@@ -329,11 +466,11 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
                 message=f"Extension resource refresh failed: {error}",
             )
         ),
-        sync_extension_diagnostics=lambda: diagnostics_bridge.sync_extension_diagnostics(
-            phase="resource_loading"
+        sync_extension_diagnostics=lambda: (
+            diagnostics_bridge.sync_extension_diagnostics(phase="resource_loading")
         ),
         prepare_resource_refresh=ports.prepare_resource_refresh,
-        skill_activation_runtime=capability_runtime.skill_activation,
+        skill_activation_runtime=ports.capability_runtime.skill_activation,
     )
     resource_watch_controller = ResourceChangeWatcher(
         get_paths=ports.get_resource_watch_paths,
@@ -351,13 +488,41 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
             code="branch_summary_failed", exc=error
         ),
     )
+    bash_runtime = BashExecutionRuntime(
+        BashExecutionPorts(
+            get_cwd=session.get_cwd,
+            get_definition=ports.get_bash_definition,
+            execute_definition=tool_controller.execute_tool_definition,
+            create_call_id=ports.create_bash_call_id,
+            append_record=session.append_message,
+            refresh_context=ports.refresh_agent_messages,
+            before_execute=ports.before_bash,
+            operations=(
+                ExecServiceBashOperations(ports.tool_exec_service)
+                if ports.tool_exec_service is not None
+                else None
+            ),
+        )
+    )
+    return _FoundationRuntimes(
+        diagnostics_bridge=diagnostics_bridge,
+        tool_controller=tool_controller,
+        resource_refresh_runtime=resource_refresh_runtime,
+        resource_watch_controller=resource_watch_controller,
+        navigation_runtime=navigation_runtime,
+        bash_runtime=bash_runtime,
+    )
+
+
+def _build_maintenance_runtimes(
+    ports: SessionCompositionPorts,
+) -> _MaintenanceRuntimes:
+    agent = ports.agent
+    session = ports.session_manager
     compaction_capability = _resolve_compaction_capability(session)
 
     def get_compaction_policy() -> TranscriptCompactionPolicy:
-        return _compaction_policy(
-            settings.get_compaction_policy_override(),
-            compaction_capability.policy,
-        )
+        return _current_compaction_policy(ports, compaction_capability)
 
     compaction_runtime = AgentTranscriptCompactionRuntime(
         transcript=session,
@@ -377,49 +542,11 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         before_compaction=ports.before_compaction,
         after_compaction=ports.after_compaction,
         record_runtime_exception=ports.record_runtime_exception,
-        product_id=capability_runtime.profile.product_id,
+        product_id=ports.capability_runtime.profile.product_id,
         session_id=session.get_header().conversation_id,
     )
-    bash_runtime = BashExecutionRuntime(
-        BashExecutionPorts(
-            get_cwd=session.get_cwd,
-            get_definition=ports.get_bash_definition,
-            execute_definition=tool_controller.execute_tool_definition,
-            create_call_id=ports.create_bash_call_id,
-            append_record=session.append_message,
-            refresh_context=ports.refresh_agent_messages,
-            before_execute=ports.before_bash,
-            operations=(
-                ExecServiceBashOperations(ports.tool_exec_service)
-                if ports.tool_exec_service is not None
-                else None
-            ),
-        )
-    )
-
-    package_controller = ports.package_controller
-    command_controller = ports.command_controller(diagnostics_bridge)
-    extension_event_sink = ExtensionAgentEventRuntime(
-        get_extension_runtime=lambda: ports.extension_runner,
-        get_cwd=session.get_cwd,
-    )
-
-    async def check_auto_compaction(
-        message: AssistantMessage,
-    ) -> AutoCompactionOutcome:
-        return await compaction_runtime.maybe_compact_after_turn(
-            message,
-            is_context_overflow_fn=is_context_overflow,
-        )
-
-    async def compact_before_prompt() -> AutoCompactionOutcome:
-        message = _last_assistant_message(agent.state.messages)
-        if message is None:
-            return AutoCompactionOutcome()
-        return await check_auto_compaction(message)
-
     retry_runtime = AgentTranscriptRetryRuntime(
-        get_policy=lambda: _retry_policy(settings.get_retry_settings()),
+        get_policy=lambda: _retry_policy(ports.settings.get_retry_settings()),
         get_messages=lambda: list(agent.state.messages),
         set_messages=agent.state.set_messages,
         get_context_window=lambda: agent.model.context_window,
@@ -428,41 +555,23 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         sleep_for_retry=ports.sleep_for_retry,
         is_context_overflow_fn=is_context_overflow,
     )
-    session_runtime = SessionRuntime(
-        agent=agent,
-        transcript=TranscriptRuntimePort(
-            session_id=session.get_header().conversation_id,
-            append_message=session.append_message,
-            commit_application_message=session.commit_application_message,
-            refresh_context=lambda: ports.apply_context(session.build_session_context()),
-            set_commit_observer=session.set_commit_observer,
-        ),
-        turn_policy=TurnPolicyPort(
-            get_extension_runner=lambda: ports.extension_runner,
-            get_cwd=session.get_cwd,
-            extract_extension_command_invocation=(
-                command_controller.extract_extension_command_invocation
-            ),
-            execute_command_async=command_controller.execute_command_async,
-            preflight_user_input=command_controller.preflight_user_input,
-            reject_queued_extension_command=(
-                command_controller.raise_if_queued_extension_command
-            ),
-            preflight_user_input_async=command_controller.preflight_user_input_async,
-            before_agent_start_system_prompt_options=ports.before_agent_start_system_prompt_options,
-            sync_extension_diagnostics=diagnostics_bridge.sync_extension_diagnostics,
-            compact_before_prompt_async=compact_before_prompt,
-        ),
-        after_turn_policy=AfterTurnPolicyPort(
-            emit_extension_agent_event=extension_event_sink.emit_agent_event,
-            record_tool_execution_error=diagnostics_bridge.record_tool_execution_error,
-            retry_controller=retry_runtime,
-            compaction_controller=compaction_runtime,
-            sync_extension_diagnostics=diagnostics_bridge.sync_extension_diagnostics,
-            record_assistant_response_error=diagnostics_bridge.record_assistant_response_error,
-            check_auto_compaction=check_auto_compaction,
-        ),
+    return _MaintenanceRuntimes(
+        compaction_capability=compaction_capability,
+        compaction_runtime=compaction_runtime,
+        retry_runtime=retry_runtime,
     )
+
+
+def _build_product_bindings(
+    ports: SessionCompositionPorts,
+    *,
+    foundation: _FoundationRuntimes,
+    maintenance: _MaintenanceRuntimes,
+    command_controller: SessionCommandController[Any],
+    session_runtime: SessionRuntime,
+) -> _ProductBindings:
+    agent = ports.agent
+    session = ports.session_manager
     selection_runtime = AgentTranscriptSelectionRuntime(
         session=session,
         get_model=lambda: agent.model,
@@ -471,6 +580,9 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         set_thinking_level_value=lambda level: setattr(agent, "thinking_level", level),
         get_model_catalog=lambda: ports.model_registry,
     )
+
+    async def refresh_extension_runtime(reason: str) -> None:
+        await ports.extension_bridge.refresh(reason=reason)
 
     async def apply_model_selection(
         selection: object,
@@ -482,7 +594,6 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
             selection,
             agent,
             ports.extension_runner,
-            resource_refresh_runtime,
             refresh_extension_runtime,
             session.get_cwd,
             source=source,
@@ -500,13 +611,13 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
             runtime_binding_factory=ports.extension_runtime_binding_factory,
             bridge=ports.extension_bridge,
             session_start_event=ports.session_start_event,
-            tool_controller=tool_controller,
+            tool_controller=foundation.tool_controller,
             command_controller=command_controller,
             selection_runtime=selection_runtime,
             session_runtime=session_runtime,
-            navigation_runtime=navigation_runtime,
-            resource_refresh_runtime=resource_refresh_runtime,
-            resource_watch_controller=resource_watch_controller,
+            navigation_runtime=foundation.navigation_runtime,
+            resource_refresh_runtime=foundation.resource_refresh_runtime,
+            resource_watch_controller=foundation.resource_watch_controller,
             footer_data_provider=ports.footer_data_provider,
             get_context_usage=ports.get_context_usage,
             set_model=apply_model_selection,
@@ -518,15 +629,19 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
             compact=partial(
                 _compact_manual,
                 session_runtime,
-                compaction_runtime,
+                maintenance.compaction_runtime,
             ),
             execute_branch_summary=ports.execute_branch_summary,
             record_runtime_diagnostic=ports.record_extension_runtime_diagnostic,
             sync_extension_diagnostics=(
-                diagnostics_bridge.sync_extension_diagnostics
+                foundation.diagnostics_bridge.sync_extension_diagnostics
             ),
         )
     )
+
+    def get_compaction_policy() -> TranscriptCompactionPolicy:
+        return _current_compaction_policy(ports, maintenance.compaction_capability)
+
     model_binding = SessionModelBinding(
         get_model_selection_callback=selection_runtime.get_model_selection,
         set_model_callback=apply_model_selection,
@@ -557,65 +672,49 @@ def compose_session_runtime(ports: SessionCompositionPorts) -> SessionCompositio
         ),
     )
     maintenance_binding = SessionMaintenanceBinding(
-        is_compacting_callback=lambda: compaction_runtime.is_compacting
-        or navigation_runtime.is_summarizing,
-        auto_retry_enabled_callback=lambda: settings.auto_retry_enabled,
+        is_compacting_callback=lambda: (
+            maintenance.compaction_runtime.is_compacting
+            or foundation.navigation_runtime.is_summarizing
+        ),
+        auto_retry_enabled_callback=lambda: ports.settings.auto_retry_enabled,
         auto_compaction_enabled_callback=lambda: get_compaction_policy().enabled,
-        set_auto_retry_enabled_callback=settings.set_auto_retry_enabled,
-        set_auto_compaction_enabled_callback=settings.set_auto_compaction_enabled,
+        set_auto_retry_enabled_callback=ports.settings.set_auto_retry_enabled,
+        set_auto_compaction_enabled_callback=(
+            ports.settings.set_auto_compaction_enabled
+        ),
         compact_callback=partial(
             _compact_manual,
             session_runtime,
-            compaction_runtime,
+            maintenance.compaction_runtime,
         ),
-        abort_compaction_callback=compaction_runtime.abort,
+        abort_compaction_callback=maintenance.compaction_runtime.abort,
     )
     session_inspector = AgentSessionInspector(
         agent=agent,
         session=session,
         get_session_id=lambda: session.get_session_record().session_id,
         get_session_name=lambda: session.get_session_record().metadata.name,
-        get_active_tool_names=tool_controller.get_active_tool_names,
-        is_retrying=lambda: retry_runtime.is_retrying,
-        is_compacting=lambda: compaction_runtime.is_compacting
-        or navigation_runtime.is_summarizing,
-        get_last_diagnostics=diagnostics_bridge.get_last_diagnostics,
+        get_active_tool_names=foundation.tool_controller.get_active_tool_names,
+        is_retrying=lambda: maintenance.retry_runtime.is_retrying,
+        is_compacting=lambda: (
+            maintenance.compaction_runtime.is_compacting
+            or foundation.navigation_runtime.is_summarizing
+        ),
+        get_last_diagnostics=foundation.diagnostics_bridge.get_last_diagnostics,
         get_model_selection=selection_runtime.get_model_selection,
         is_host_running=lambda: session_runtime.is_active,
         get_compaction_reserve_tokens=lambda: get_compaction_policy().reserve_tokens,
         get_compaction_compact_percent=lambda: get_compaction_policy().compact_percent,
-        get_compaction_keep_recent_tokens=lambda: get_compaction_policy().keep_recent_tokens,
+        get_compaction_keep_recent_tokens=lambda: (
+            get_compaction_policy().keep_recent_tokens
+        ),
     )
-    return SessionComposition(
-        capability_runtime=capability_runtime,
-        diagnostics_bridge=diagnostics_bridge,
-        tool_controller=tool_controller,
-        resource_refresh_runtime=resource_refresh_runtime,
-        resource_watch_controller=resource_watch_controller,
-        navigation_runtime=navigation_runtime,
-        compaction_capability=compaction_capability,
-        compaction_runtime=compaction_runtime,
-        bash_runtime=bash_runtime,
-        package_controller=package_controller,
-        command_controller=command_controller,
-        extension_event_sink=extension_event_sink,
-        retry_runtime=retry_runtime,
-        session_runtime=session_runtime,
-        extension_input_runtime=extension_composition.input_runtime,
-        extension_message_controller=extension_composition.message_controller,
-        extension_provider_controller=extension_composition.provider_controller,
-        extension_replacement_controller=(
-            extension_composition.replacement_controller
-        ),
-        extension_runtime_binding_factory=(
-            extension_composition.runtime_binding_factory
-        ),
-        extension_bridge=ports.extension_bridge,
+    return _ProductBindings(
         selection_runtime=selection_runtime,
         model_binding=model_binding,
         identity_binding=identity_binding,
         maintenance_binding=maintenance_binding,
-        extension_binding=extension_composition.binding,
+        extension_composition=extension_composition,
         session_inspector=session_inspector,
     )
 
@@ -636,8 +735,7 @@ def _build_tool_controller(
             else None
         ),
         initial_active_tool_names=list(
-            ports.active_tool_names
-            or [tool.name for tool in ports.agent.tools]
+            ports.active_tool_names or [tool.name for tool in ports.agent.tools]
         ),
         default_activate_new_tools=(
             ports.active_tool_names is None
@@ -690,6 +788,16 @@ def _retry_policy(settings: object) -> RetryPolicy:
         enabled=bool(getattr(settings, "enabled", False)),
         max_attempts=int(getattr(settings, "max_retries", 0)),
         base_delay_ms=int(getattr(settings, "base_delay_ms", 0)),
+    )
+
+
+def _current_compaction_policy(
+    ports: SessionCompositionPorts,
+    capability: AgentTranscriptCompactionCapability,
+) -> TranscriptCompactionPolicy:
+    return _compaction_policy(
+        ports.settings.get_compaction_policy_override(),
+        capability.policy,
     )
 
 
@@ -798,16 +906,15 @@ async def _set_model(
     selection: object,
     agent: Agent,
     extension_runner: ExtensionEventPort | None,
-    resource_refresh_runtime: SessionResourceRefreshRuntime,
     refresh_extension_runtime: Callable[[str], Awaitable[None]],
     get_cwd: Callable[[], str],
     source: str = "set",
 ) -> None:
-    resolved = selection_runtime.resolve_model(
-        cast(Model | ModelSelection, selection)
-    )
+    resolved = selection_runtime.resolve_model(cast(Model | ModelSelection, selection))
     previous = agent.model
-    endpoint_id = selection.endpoint_id if isinstance(selection, ModelSelection) else None
+    endpoint_id = (
+        selection.endpoint_id if isinstance(selection, ModelSelection) else None
+    )
     await selection_runtime.apply_model(resolved, endpoint_id=endpoint_id)
     await refresh_extension_runtime("model_selection_changed")
     if extension_runner is not None and previous != resolved:

--- a/src/loushang/harness/transcript/__init__.py
+++ b/src/loushang/harness/transcript/__init__.py
@@ -21,6 +21,17 @@ from loushang.harness.transcript.compaction import (
     plan_turn_aware_compaction,
     prepare_turn_aware_compaction,
 )
+from loushang.harness.transcript.context_usage import (
+    ContextUsageSnapshot,
+    build_context_usage_snapshot,
+    calculate_context_tokens,
+    current_context_usage,
+    estimate_context_tokens,
+    estimate_message_tokens,
+    has_post_compaction_usage,
+    latest_compaction_entry,
+    model_context_window,
+)
 from loushang.harness.transcript.directory import (
     AgentTranscriptDirectoryRuntime,
     IndexRefreshFailureRecorder,
@@ -99,18 +110,9 @@ from loushang.harness.transcript.maintenance import (
     CompactionPreparation,
     CompactionResult,
     CompactionStatus,
-    ContextUsageSnapshot,
     TranscriptCompactionPolicy,
-    build_context_usage_snapshot,
     build_threshold_compaction_decision,
-    calculate_context_tokens,
-    current_context_usage,
-    estimate_context_tokens,
-    estimate_message_tokens,
-    has_post_compaction_usage,
     is_compaction_aborted,
-    latest_compaction_entry,
-    model_context_window,
 )
 from loushang.harness.transcript.migration import (
     CURRENT_SESSION_VERSION,

--- a/src/loushang/harness/transcript/compaction.py
+++ b/src/loushang/harness/transcript/compaction.py
@@ -10,11 +10,11 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 from loushang.harness.context import ConversationCompactionPlanner
+from loushang.harness.transcript.context_usage import estimate_context_tokens
 from loushang.harness.transcript.maintenance import (
     CompactionPlan,
     CompactionPreparation,
     TranscriptCompactionPolicy,
-    estimate_context_tokens,
 )
 from loushang.harness.transcript.profile import AgentTranscriptProfile
 from loushang.harness.transcript.types import (

--- a/src/loushang/harness/transcript/context_usage.py
+++ b/src/loushang/harness/transcript/context_usage.py
@@ -1,0 +1,332 @@
+"""Context accounting for the optional Agent transcript profile.
+
+This module derives context-budget observations from stable Agent messages and
+transcript compaction checkpoints. Generic estimates and budget arithmetic
+remain in :mod:`loushang.harness.context`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from loushang.agent.types import AgentMessage
+from loushang.ai.types import AssistantMessage, ToolResultMessage, UserMessage
+from loushang.harness.context.budget import calculate_compaction_budget
+from loushang.harness.context.usage import ContextUsageEstimate
+from loushang.harness.conversation import ConversationRecord
+from loushang.harness.transcript.kinds import (
+    AGENT_MESSAGE_KIND,
+    CONTEXT_COMPACTION_CHECKPOINT_KIND,
+)
+
+ContextUsageSource = Literal[
+    "assistant_usage", "estimated_from_last_usage", "estimated", "unknown"
+]
+
+
+@dataclass(frozen=True)
+class ContextUsageSnapshot:
+    """One context-budget observation over an Agent transcript branch."""
+
+    tokens: int | None
+    context_window: int | None
+    reserve_tokens: int
+    compact_percent: float = 100.0
+    keep_recent_tokens: int | None = None
+    percent_threshold_tokens: int | None = None
+    reserve_threshold_tokens: int | None = None
+    threshold_tokens: int | None = None
+    threshold_reason: Literal["compact_percent", "reserve_tokens"] | None = None
+    percent: float | None = None
+    source: ContextUsageSource = "unknown"
+    last_usage_index: int | None = None
+    stale_after_compaction: bool = False
+    compactable: bool = False
+    reason: str | None = None
+
+
+def calculate_context_tokens(usage: object) -> int:
+    """Extract total tokens from stable AI usage values or their JSON form."""
+
+    total_tokens = _usage_value(usage, "totalTokens", "total_tokens")
+    if isinstance(total_tokens, int) and total_tokens > 0:
+        return total_tokens
+    return sum(
+        _integer_usage_value(_usage_value(usage, *keys))
+        for keys in (
+            ("input",),
+            ("output",),
+            ("cacheRead", "cache_read"),
+            ("cacheWrite", "cache_write"),
+        )
+    )
+
+
+def estimate_context_tokens(messages: Sequence[AgentMessage]) -> ContextUsageEstimate:
+    """Estimate current context using the latest completed assistant usage."""
+
+    sequence = list(messages)
+    last_usage = _last_assistant_usage_info(sequence)
+    if last_usage is None:
+        estimated = sum(estimate_message_tokens(message) for message in sequence)
+        return ContextUsageEstimate(
+            tokens=estimated,
+            usage_tokens=0,
+            trailing_tokens=estimated,
+            last_usage_index=None,
+        )
+
+    usage, usage_index = last_usage
+    usage_tokens = calculate_context_tokens(usage)
+    trailing_tokens = sum(
+        estimate_message_tokens(message) for message in sequence[usage_index + 1 :]
+    )
+    return ContextUsageEstimate(
+        tokens=usage_tokens + trailing_tokens,
+        usage_tokens=usage_tokens,
+        trailing_tokens=trailing_tokens,
+        last_usage_index=usage_index,
+    )
+
+
+def current_context_usage(
+    messages: Sequence[AgentMessage],
+    branch_entries: Sequence[object],
+    model: object | None,
+) -> tuple[int | None, int | None, float | None]:
+    snapshot = build_context_usage_snapshot(
+        messages, branch_entries, model, reserve_tokens=0
+    )
+    return snapshot.tokens, snapshot.context_window, snapshot.percent
+
+
+def build_context_usage_snapshot(
+    messages: Sequence[AgentMessage],
+    branch_entries: Sequence[object],
+    model: object | None,
+    *,
+    reserve_tokens: int,
+    compact_percent: float = 100.0,
+    keep_recent_tokens: int | None = None,
+) -> ContextUsageSnapshot:
+    context_window = model_context_window(model)
+    if context_window is None:
+        return ContextUsageSnapshot(
+            tokens=None,
+            context_window=None,
+            reserve_tokens=reserve_tokens,
+            compact_percent=compact_percent,
+            keep_recent_tokens=keep_recent_tokens,
+            threshold_tokens=None,
+            threshold_reason=None,
+            percent=None,
+            source="unknown",
+            last_usage_index=None,
+            stale_after_compaction=False,
+            compactable=False,
+            reason="unknown_context_window",
+        )
+
+    budget = calculate_compaction_budget(
+        context_window=context_window,
+        compact_percent=compact_percent,
+        reserve_tokens=reserve_tokens,
+    )
+    latest_compaction = latest_compaction_entry(branch_entries)
+    if latest_compaction is not None and not has_post_compaction_usage(
+        branch_entries, latest_compaction
+    ):
+        return ContextUsageSnapshot(
+            tokens=None,
+            context_window=context_window,
+            reserve_tokens=reserve_tokens,
+            compact_percent=budget.compact_percent,
+            keep_recent_tokens=keep_recent_tokens,
+            percent_threshold_tokens=budget.percent_threshold_tokens,
+            reserve_threshold_tokens=budget.reserve_threshold_tokens,
+            threshold_tokens=budget.threshold_tokens,
+            threshold_reason=budget.threshold_reason,
+            percent=None,
+            source="unknown",
+            last_usage_index=None,
+            stale_after_compaction=True,
+            compactable=False,
+            reason="stale_usage_after_compaction",
+        )
+
+    estimate = estimate_context_tokens(messages) if messages else None
+    tokens = estimate.tokens if estimate is not None else 0
+    last_usage_index = estimate.last_usage_index if estimate is not None else None
+    if estimate is None or last_usage_index is None:
+        source: ContextUsageSource = "estimated"
+    elif estimate.trailing_tokens > 0:
+        source = "estimated_from_last_usage"
+    else:
+        source = "assistant_usage"
+    compactable = tokens > budget.threshold_tokens
+    return ContextUsageSnapshot(
+        tokens=tokens,
+        context_window=context_window,
+        reserve_tokens=reserve_tokens,
+        compact_percent=budget.compact_percent,
+        keep_recent_tokens=keep_recent_tokens,
+        percent_threshold_tokens=budget.percent_threshold_tokens,
+        reserve_threshold_tokens=budget.reserve_threshold_tokens,
+        threshold_tokens=budget.threshold_tokens,
+        threshold_reason=budget.threshold_reason,
+        percent=(tokens / context_window) * 100,
+        source=source,
+        last_usage_index=last_usage_index,
+        stale_after_compaction=False,
+        compactable=compactable,
+        reason="threshold" if compactable else None,
+    )
+
+
+def model_context_window(model: object | None) -> int | None:
+    capabilities: object | None = getattr(model, "capabilities", None)
+    raw_context_window: object | None = getattr(capabilities, "context_window", None)
+    if raw_context_window is None:
+        raw_context_window = getattr(model, "context_window", None)
+    return _positive_int(raw_context_window)
+
+
+def latest_compaction_entry(
+    entries: Sequence[object],
+) -> ConversationRecord[object] | None:
+    for entry in reversed(entries):
+        if (
+            isinstance(entry, ConversationRecord)
+            and entry.kind == CONTEXT_COMPACTION_CHECKPOINT_KIND
+        ):
+            return entry
+    return None
+
+
+def has_post_compaction_usage(
+    entries: Sequence[object], compaction: ConversationRecord[object]
+) -> bool:
+    try:
+        compaction_index = list(entries).index(compaction)
+    except ValueError:
+        return False
+    for entry in reversed(entries[compaction_index + 1 :]):
+        if (
+            not isinstance(entry, ConversationRecord)
+            or entry.kind != AGENT_MESSAGE_KIND
+        ):
+            continue
+        message = entry.payload
+        if not isinstance(message, AssistantMessage):
+            continue
+        if message.stop_reason in {"aborted", "error"}:
+            return False
+        return calculate_context_tokens(message.usage) > 0
+    return False
+
+
+def estimate_message_tokens(message: AgentMessage) -> int:
+    chars = 0
+    if isinstance(message, UserMessage):
+        if isinstance(message.content, str):
+            chars = len(message.content)
+        else:
+            for block in message.content:
+                if getattr(block, "type", None) == "text":
+                    chars += len(str(getattr(block, "text", "")))
+                elif getattr(block, "type", None) == "image":
+                    chars += 4_800
+        return (chars + 3) // 4
+    if isinstance(message, AssistantMessage):
+        for assistant_block in message.content:
+            block_type = getattr(assistant_block, "type", None)
+            if block_type == "text":
+                chars += len(str(getattr(assistant_block, "text", "")))
+            elif block_type == "thinking":
+                chars += len(str(getattr(assistant_block, "thinking", "")))
+            elif block_type == "toolCall":
+                chars += len(str(getattr(assistant_block, "name", ""))) + len(
+                    str(getattr(assistant_block, "arguments", ""))
+                )
+            elif block_type == "image":
+                chars += 4_800
+        return (chars + 3) // 4
+    if isinstance(message, ToolResultMessage):
+        for block in message.content:
+            if getattr(block, "type", None) == "text":
+                chars += len(str(getattr(block, "text", "")))
+            elif getattr(block, "type", None) == "image":
+                chars += 4_800
+        return (chars + 3) // 4
+    return 0
+
+
+def _usage_value(usage: object, *keys: str) -> object | None:
+    if isinstance(usage, Mapping):
+        for key in keys:
+            value = usage.get(key)
+            if value is not None:
+                return value
+        return None
+    for key in keys:
+        if hasattr(usage, key):
+            value = getattr(usage, key)
+            if value is not None:
+                return value
+    return None
+
+
+def _integer_usage_value(value: object | None) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float | str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _positive_int(value: object | None) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float | str):
+        try:
+            parsed = int(value)
+        except ValueError:
+            return None
+        return parsed if parsed > 0 else None
+    return None
+
+
+def _last_assistant_usage_info(
+    messages: Sequence[AgentMessage],
+) -> tuple[object, int] | None:
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if isinstance(message, AssistantMessage) and message.stop_reason not in (
+            "aborted",
+            "error",
+        ):
+            return message.usage, index
+    return None
+
+
+__all__ = [
+    "ContextUsageSnapshot",
+    "ContextUsageSource",
+    "build_context_usage_snapshot",
+    "calculate_context_tokens",
+    "current_context_usage",
+    "estimate_context_tokens",
+    "estimate_message_tokens",
+    "has_post_compaction_usage",
+    "latest_compaction_entry",
+    "model_context_window",
+]

--- a/src/loushang/harness/transcript/maintenance.py
+++ b/src/loushang/harness/transcript/maintenance.py
@@ -1,8 +1,9 @@
-"""Maintenance primitives for the optional Agent transcript profile.
+"""Compaction lifecycle for the optional Agent transcript profile.
 
-The profile owns durable conversation facts. This module owns reusable context
-budget observations and compaction lifecycle mechanics around those facts.
-Product code supplies policy and presentation or diagnostic adapters.
+The profile owns durable conversation facts. Adjacent ``context_usage`` owns
+context-budget observations; this module owns compaction decisions and
+lifecycle mechanics around those facts. Product code supplies policy and
+presentation or diagnostic adapters.
 """
 
 from __future__ import annotations
@@ -15,10 +16,8 @@ from time import monotonic
 from typing import Any, Literal, Protocol
 
 from loushang.agent.types import AgentMessage
-from loushang.ai.types import AssistantMessage, ToolResultMessage, UserMessage
-from loushang.harness.context.budget import calculate_compaction_budget
+from loushang.ai.types import AssistantMessage
 from loushang.harness.context.compaction import CompactionCoordinator
-from loushang.harness.context.usage import ContextUsageEstimate
 from loushang.harness.conversation import ConversationRecord
 from loushang.harness.events import (
     CompactionReason,
@@ -26,36 +25,18 @@ from loushang.harness.events import (
     ContextCompactionStarted,
     SessionRuntimeEventPayload,
 )
-from loushang.harness.transcript.kinds import (
-    AGENT_MESSAGE_KIND,
-    CONTEXT_COMPACTION_CHECKPOINT_KIND,
+from loushang.harness.transcript.context_usage import (
+    ContextUsageSnapshot,
+    build_context_usage_snapshot,
+    calculate_context_tokens,
+    current_context_usage,
+    estimate_context_tokens,
+    estimate_message_tokens,
+    has_post_compaction_usage,
+    latest_compaction_entry,
+    model_context_window,
 )
 from loushang.harness.transcript.types import AgentTranscriptRecord
-
-ContextUsageSource = Literal[
-    "assistant_usage", "estimated_from_last_usage", "estimated", "unknown"
-]
-
-
-@dataclass(frozen=True)
-class ContextUsageSnapshot:
-    """One context-budget observation over an Agent transcript branch."""
-
-    tokens: int | None
-    context_window: int | None
-    reserve_tokens: int
-    compact_percent: float = 100.0
-    keep_recent_tokens: int | None = None
-    percent_threshold_tokens: int | None = None
-    reserve_threshold_tokens: int | None = None
-    threshold_tokens: int | None = None
-    threshold_reason: Literal["compact_percent", "reserve_tokens"] | None = None
-    percent: float | None = None
-    source: ContextUsageSource = "unknown"
-    last_usage_index: int | None = None
-    stale_after_compaction: bool = False
-    compactable: bool = False
-    reason: str | None = None
 
 
 @dataclass(frozen=True)
@@ -538,144 +519,6 @@ class AgentTranscriptCompactionRuntime:
         return result, record_id, from_hook
 
 
-def calculate_context_tokens(usage: object) -> int:
-    """Extract total tokens from stable AI usage values or their JSON form."""
-
-    total_tokens = _usage_value(usage, "totalTokens", "total_tokens")
-    if isinstance(total_tokens, int) and total_tokens > 0:
-        return total_tokens
-    return sum(
-        _integer_usage_value(_usage_value(usage, *keys))
-        for keys in (
-            ("input",),
-            ("output",),
-            ("cacheRead", "cache_read"),
-            ("cacheWrite", "cache_write"),
-        )
-    )
-
-
-def estimate_context_tokens(messages: Sequence[AgentMessage]) -> ContextUsageEstimate:
-    """Estimate current context using the latest completed assistant usage."""
-
-    sequence = list(messages)
-    last_usage = _last_assistant_usage_info(sequence)
-    if last_usage is None:
-        estimated = sum(estimate_message_tokens(message) for message in sequence)
-        return ContextUsageEstimate(
-            tokens=estimated,
-            usage_tokens=0,
-            trailing_tokens=estimated,
-            last_usage_index=None,
-        )
-
-    usage, usage_index = last_usage
-    usage_tokens = calculate_context_tokens(usage)
-    trailing_tokens = sum(
-        estimate_message_tokens(message) for message in sequence[usage_index + 1 :]
-    )
-    return ContextUsageEstimate(
-        tokens=usage_tokens + trailing_tokens,
-        usage_tokens=usage_tokens,
-        trailing_tokens=trailing_tokens,
-        last_usage_index=usage_index,
-    )
-
-
-def current_context_usage(
-    messages: Sequence[AgentMessage],
-    branch_entries: Sequence[object],
-    model: object | None,
-) -> tuple[int | None, int | None, float | None]:
-    snapshot = build_context_usage_snapshot(
-        messages, branch_entries, model, reserve_tokens=0
-    )
-    return snapshot.tokens, snapshot.context_window, snapshot.percent
-
-
-def build_context_usage_snapshot(
-    messages: Sequence[AgentMessage],
-    branch_entries: Sequence[object],
-    model: object | None,
-    *,
-    reserve_tokens: int,
-    compact_percent: float = 100.0,
-    keep_recent_tokens: int | None = None,
-) -> ContextUsageSnapshot:
-    context_window = model_context_window(model)
-    if context_window is None:
-        return ContextUsageSnapshot(
-            tokens=None,
-            context_window=None,
-            reserve_tokens=reserve_tokens,
-            compact_percent=compact_percent,
-            keep_recent_tokens=keep_recent_tokens,
-            threshold_tokens=None,
-            threshold_reason=None,
-            percent=None,
-            source="unknown",
-            last_usage_index=None,
-            stale_after_compaction=False,
-            compactable=False,
-            reason="unknown_context_window",
-        )
-
-    budget = calculate_compaction_budget(
-        context_window=context_window,
-        compact_percent=compact_percent,
-        reserve_tokens=reserve_tokens,
-    )
-    latest_compaction = latest_compaction_entry(branch_entries)
-    if latest_compaction is not None and not has_post_compaction_usage(
-        branch_entries, latest_compaction
-    ):
-        return ContextUsageSnapshot(
-            tokens=None,
-            context_window=context_window,
-            reserve_tokens=reserve_tokens,
-            compact_percent=budget.compact_percent,
-            keep_recent_tokens=keep_recent_tokens,
-            percent_threshold_tokens=budget.percent_threshold_tokens,
-            reserve_threshold_tokens=budget.reserve_threshold_tokens,
-            threshold_tokens=budget.threshold_tokens,
-            threshold_reason=budget.threshold_reason,
-            percent=None,
-            source="unknown",
-            last_usage_index=None,
-            stale_after_compaction=True,
-            compactable=False,
-            reason="stale_usage_after_compaction",
-        )
-
-    estimate = estimate_context_tokens(messages) if messages else None
-    tokens = estimate.tokens if estimate is not None else 0
-    last_usage_index = estimate.last_usage_index if estimate is not None else None
-    if estimate is None or last_usage_index is None:
-        source: ContextUsageSource = "estimated"
-    elif estimate.trailing_tokens > 0:
-        source = "estimated_from_last_usage"
-    else:
-        source = "assistant_usage"
-    compactable = tokens > budget.threshold_tokens
-    return ContextUsageSnapshot(
-        tokens=tokens,
-        context_window=context_window,
-        reserve_tokens=reserve_tokens,
-        compact_percent=budget.compact_percent,
-        keep_recent_tokens=keep_recent_tokens,
-        percent_threshold_tokens=budget.percent_threshold_tokens,
-        reserve_threshold_tokens=budget.reserve_threshold_tokens,
-        threshold_tokens=budget.threshold_tokens,
-        threshold_reason=budget.threshold_reason,
-        percent=(tokens / context_window) * 100,
-        source=source,
-        last_usage_index=last_usage_index,
-        stale_after_compaction=False,
-        compactable=compactable,
-        reason="threshold" if compactable else None,
-    )
-
-
 def build_threshold_compaction_decision(
     messages: Sequence[AgentMessage],
     branch_entries: Sequence[object],
@@ -709,50 +552,10 @@ def build_threshold_compaction_decision(
     )
 
 
-def model_context_window(model: object | None) -> int | None:
-    capabilities: object | None = getattr(model, "capabilities", None)
-    raw_context_window: object | None = getattr(capabilities, "context_window", None)
-    if raw_context_window is None:
-        raw_context_window = getattr(model, "context_window", None)
-    return _positive_int(raw_context_window)
-
-
-def latest_compaction_entry(
-    entries: Sequence[object],
-) -> ConversationRecord[object] | None:
-    for entry in reversed(entries):
-        if (
-            isinstance(entry, ConversationRecord)
-            and entry.kind == CONTEXT_COMPACTION_CHECKPOINT_KIND
-        ):
-            return entry
-    return None
-
-
-def has_post_compaction_usage(
-    entries: Sequence[object], compaction: ConversationRecord[object]
-) -> bool:
-    try:
-        compaction_index = list(entries).index(compaction)
-    except ValueError:
-        return False
-    for entry in reversed(entries[compaction_index + 1 :]):
-        if (
-            not isinstance(entry, ConversationRecord)
-            or entry.kind != AGENT_MESSAGE_KIND
-        ):
-            continue
-        message = entry.payload
-        if not isinstance(message, AssistantMessage):
-            continue
-        if message.stop_reason in {"aborted", "error"}:
-            return False
-        return calculate_context_tokens(message.usage) > 0
-    return False
-
-
 def is_compaction_aborted(exc: Exception) -> bool:
-    return isinstance(exc, CompactionAborted) or getattr(exc, "name", None) == "AbortError"
+    return (
+        isinstance(exc, CompactionAborted) or getattr(exc, "name", None) == "AbortError"
+    )
 
 
 def _message_is_before_or_at_entry(
@@ -803,97 +606,6 @@ def _merge_preparation_result_details(
     if result_details is not None:
         merged["resultDetails"] = result_details
     return merged
-
-
-def _usage_value(usage: object, *keys: str) -> object | None:
-    if isinstance(usage, Mapping):
-        for key in keys:
-            value = usage.get(key)
-            if value is not None:
-                return value
-        return None
-    for key in keys:
-        if hasattr(usage, key):
-            value = getattr(usage, key)
-            if value is not None:
-                return value
-    return None
-
-
-def _integer_usage_value(value: object | None) -> int:
-    if isinstance(value, bool):
-        return 0
-    if isinstance(value, int):
-        return value
-    if isinstance(value, float | str):
-        try:
-            return int(value)
-        except ValueError:
-            return 0
-    return 0
-
-
-def _positive_int(value: object | None) -> int | None:
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value if value > 0 else None
-    if isinstance(value, float | str):
-        try:
-            parsed = int(value)
-        except ValueError:
-            return None
-        return parsed if parsed > 0 else None
-    return None
-
-
-def _last_assistant_usage_info(
-    messages: Sequence[AgentMessage],
-) -> tuple[object, int] | None:
-    for index in range(len(messages) - 1, -1, -1):
-        message = messages[index]
-        if isinstance(message, AssistantMessage) and message.stop_reason not in (
-            "aborted",
-            "error",
-        ):
-            return message.usage, index
-    return None
-
-
-def estimate_message_tokens(message: AgentMessage) -> int:
-    chars = 0
-    if isinstance(message, UserMessage):
-        if isinstance(message.content, str):
-            chars = len(message.content)
-        else:
-            for block in message.content:
-                if getattr(block, "type", None) == "text":
-                    chars += len(str(getattr(block, "text", "")))
-                elif getattr(block, "type", None) == "image":
-                    chars += 4_800
-        return (chars + 3) // 4
-    if isinstance(message, AssistantMessage):
-        for assistant_block in message.content:
-            block_type = getattr(assistant_block, "type", None)
-            if block_type == "text":
-                chars += len(str(getattr(assistant_block, "text", "")))
-            elif block_type == "thinking":
-                chars += len(str(getattr(assistant_block, "thinking", "")))
-            elif block_type == "toolCall":
-                chars += len(str(getattr(assistant_block, "name", ""))) + len(
-                    str(getattr(assistant_block, "arguments", ""))
-                )
-            elif block_type == "image":
-                chars += 4_800
-        return (chars + 3) // 4
-    if isinstance(message, ToolResultMessage):
-        for block in message.content:
-            if getattr(block, "type", None) == "text":
-                chars += len(str(getattr(block, "text", "")))
-            elif getattr(block, "type", None) == "image":
-                chars += 4_800
-        return (chars + 3) // 4
-    return 0
 
 
 __all__ = [

--- a/src/loushang/harness/transcript/summarization.py
+++ b/src/loushang/harness/transcript/summarization.py
@@ -562,7 +562,7 @@ def serialize_agent_conversation(messages: Sequence[object]) -> str:
 def estimate_agent_message_tokens(message: AgentMessage) -> int:
     """Use the standard transcript estimator for one visible Agent message."""
 
-    from loushang.harness.transcript.maintenance import estimate_message_tokens
+    from loushang.harness.transcript.context_usage import estimate_message_tokens
 
     return estimate_message_tokens(message)
 

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -639,12 +639,15 @@ def test_agent_transcript_interaction_runtime_is_neutral_and_adopted() -> None:
 
 
 def test_agent_transcript_maintenance_runtime_is_neutral_and_adopted() -> None:
+    context_usage_source = Path(
+        "src/loushang/harness/transcript/context_usage.py"
+    ).read_text(encoding="utf-8")
     maintenance_source = Path(
         "src/loushang/harness/transcript/maintenance.py"
     ).read_text(encoding="utf-8")
-    retry_source = Path(
-        "src/loushang/harness/transcript/retry_runtime.py"
-    ).read_text(encoding="utf-8")
+    retry_source = Path("src/loushang/harness/transcript/retry_runtime.py").read_text(
+        encoding="utf-8"
+    )
     composition_source = Path("src/loushang/harness/session/composition.py").read_text(
         encoding="utf-8"
     )
@@ -652,8 +655,11 @@ def test_agent_transcript_maintenance_runtime_is_neutral_and_adopted() -> None:
         "docs/internals/architecture/harness/agent-transcript-maintenance-boundary.md"
     ).read_text(encoding="utf-8")
 
+    assert "loushang.coding" not in context_usage_source
     assert "loushang.coding" not in maintenance_source
     assert "loushang.coding" not in retry_source
+    assert "class ContextUsageSnapshot" in context_usage_source
+    assert "class ContextUsageSnapshot" not in maintenance_source
     assert "AgentTranscriptRetryRuntime" in retry_source
     assert "AutoRetryOutcome" in retry_source
     assert "AgentTranscriptCompactionRuntime" in composition_source

--- a/tests/harness/session/test_composition.py
+++ b/tests/harness/session/test_composition.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import inspect
 from dataclasses import fields
 from types import SimpleNamespace
 
+import loushang.harness.session.composition as composition_module
 from loushang.harness.config.agent import CompactionSettings
 from loushang.harness.session import ProductCompactionExecutor
 from loushang.harness.session.composition import (
@@ -47,6 +49,28 @@ def test_session_composition_ports_exclude_runtime_owned_forwarders() -> None:
             "continue_run",
         }
     )
+
+
+def test_session_composition_uses_private_staged_builders() -> None:
+    source = inspect.getsource(composition_module.compose_session_runtime)
+    builder_names = {
+        "_build_foundation_runtimes",
+        "_build_maintenance_runtimes",
+        "_build_product_bindings",
+    }
+
+    assert all(name in source for name in builder_names)
+    assert builder_names.isdisjoint(composition_module.__all__)
+    assert len(source.splitlines()) <= 150
+    assert "SessionDiagnosticsRuntime(" not in source
+    assert "AgentTranscriptCompactionRuntime(" not in source
+    assert "SessionModelBinding(" not in source
+    for container in (
+        composition_module._FoundationRuntimes,
+        composition_module._MaintenanceRuntimes,
+        composition_module._ProductBindings,
+    ):
+        assert all("callback" not in field.name for field in fields(container))
 
 
 def test_compaction_policy_uses_capability_without_product_override() -> None:

--- a/tests/harness/transcript/test_context_usage.py
+++ b/tests/harness/transcript/test_context_usage.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import loushang.harness.transcript.context_usage as context_usage
+import loushang.harness.transcript.maintenance as maintenance
+from loushang.harness.transcript import (
+    ContextUsageSnapshot,
+    build_context_usage_snapshot,
+    calculate_context_tokens,
+    current_context_usage,
+    estimate_context_tokens,
+    estimate_message_tokens,
+    has_post_compaction_usage,
+    latest_compaction_entry,
+    model_context_window,
+)
+
+
+def test_context_usage_public_exports_keep_their_stable_package_surface() -> None:
+    assert ContextUsageSnapshot is context_usage.ContextUsageSnapshot
+    assert maintenance.ContextUsageSnapshot is context_usage.ContextUsageSnapshot
+    assert build_context_usage_snapshot is context_usage.build_context_usage_snapshot
+    assert (
+        maintenance.build_context_usage_snapshot
+        is context_usage.build_context_usage_snapshot
+    )
+    assert calculate_context_tokens is context_usage.calculate_context_tokens
+    assert current_context_usage is context_usage.current_context_usage
+    assert estimate_context_tokens is context_usage.estimate_context_tokens
+    assert estimate_message_tokens is context_usage.estimate_message_tokens
+    assert has_post_compaction_usage is context_usage.has_post_compaction_usage
+    assert latest_compaction_entry is context_usage.latest_compaction_entry
+    assert model_context_window is context_usage.model_context_window


### PR DESCRIPTION
## Summary

- move Agent transcript context accounting into a dedicated transcript context_usage owner while preserving package and legacy maintenance imports
- stage Session composition into foundation, maintenance, and Product-binding builders
- keep SessionCompositionPorts and the public API unchanged

## Impact

Context accounting and compaction lifecycle now have separate physical owners. Session assembly exposes its dependency order directly, with no new bridge, coordinator, or callback forwarding contract.

## Validation

- Ruff format and lint
- mypy for 58 Harness Session source files and 28 Transcript source files
- 169 Harness Session tests
- 275 architecture, Context, and Transcript tests
- 65 focused Session and Coding compatibility tests
- git diff --check