### PR TITLE
refactor(session): centralize composed runtime state

### DIFF
--- a/docs/internals/architecture/harness/session-agent-session-boundary.md
+++ b/docs/internals/architecture/harness/session-agent-session-boundary.md
@@ -69,6 +69,13 @@ maintenance, inspection, and extension bindings after the core `SessionRuntime`
 exists. The private stage results are frozen containers of existing runtimes,
 not new bridges, coordinators, or callback owners.
 
+`SessionComposition` is also a frozen assembly result. After installation, the
+Agent Product adapter keeps that result as its single source for assembled
+runtimes and bindings instead of copying each component into another private
+attribute. Product objects that must exist before composition, such as package
+and extension controllers, may retain their construction-time references; the
+adapter must not create post-assembly runtime mirrors for convenience.
+
 ## Deletion condition
 
 The old `AgentSession` implementation is reduced to a thin Product adapter.

--- a/src/loushang/harness/session/agent_adapter.py
+++ b/src/loushang/harness/session/agent_adapter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import Any, Protocol, cast
 
 from loushang.agent import Agent, ThinkingLevel
 from loushang.ai.model import Model, ModelSelection
@@ -27,12 +27,7 @@ from loushang.harness.events import (
     project_session_runtime_event,
 )
 from loushang.harness.extensions import ExtensionProviderRuntime
-from loushang.harness.extensions.agent import (
-    ExtensionAgentEventRuntime,
-    ExtensionAgentHookRuntime,
-    ExtensionInputRuntime,
-)
-from loushang.harness.extensions.agent.input_adapter import ExtensionInputAdapter
+from loushang.harness.extensions.agent import ExtensionAgentHookRuntime
 from loushang.harness.extensions.agent.replacement import ExtensionReplacementRuntime
 from loushang.harness.extensions.context import (
     ReplacedSessionContext,
@@ -49,7 +44,6 @@ from loushang.harness.resources.packages.materializer import (
 )
 from loushang.harness.resources.packages.session import SessionPackageController
 from loushang.harness.resources.types import ResourceBundle
-from loushang.harness.resources.watcher import ResourceChangeWatcher
 from loushang.harness.session.agent_product_runtime import (
     AgentProductSessionRuntime as AgentProductSessionRuntime,
 )
@@ -61,24 +55,12 @@ from loushang.harness.session.agent_product_runtime import (
 from loushang.harness.session.approval_interaction import (
     AgentSessionApprovalRuntime,
 )
-from loushang.harness.session.bash import (
-    BashExecutionRuntime,
-    UserBashHookResult,
-    UserBashRequest,
-)
-from loushang.harness.session.bindings import (
-    SessionExtensionBinding,
-    SessionIdentityBinding,
-    SessionMaintenanceBinding,
-    SessionModelBinding,
-)
-from loushang.harness.session.command_controller import SessionCommandController
+from loushang.harness.session.bash import UserBashHookResult, UserBashRequest
 from loushang.harness.session.composition import (
     SessionComposition,
     SessionExtensionCompositionPort,
     SessionModelCatalogPort,
 )
-from loushang.harness.session.diagnostics import SessionDiagnosticsRuntime
 from loushang.harness.session.export import (
     export_session_to_html,
     export_session_to_jsonl,
@@ -87,13 +69,10 @@ from loushang.harness.session.extension_bridge import AgentSessionExtensionBridg
 from loushang.harness.session.facade import (
     SessionFacade,
 )
-from loushang.harness.session.inspection import AgentSessionInspector
 from loushang.harness.session.operations_runtime import (
     SessionOperations,
     SessionOperationsPorts,
 )
-from loushang.harness.session.resource_refresh import SessionResourceRefreshRuntime
-from loushang.harness.session.runtime import SessionRuntime
 from loushang.harness.session.settings import SessionSettingsBinding
 from loushang.harness.tools.core import ToolDefinition
 from loushang.harness.tools.workspace.protocol import (
@@ -101,12 +80,7 @@ from loushang.harness.tools.workspace.protocol import (
 )
 from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
 from loushang.harness.transcript import (
-    AgentTranscriptCompactionCapability,
-    AgentTranscriptCompactionRuntime,
     AgentTranscriptContext,
-    AgentTranscriptNavigationRuntime,
-    AgentTranscriptRetryRuntime,
-    AgentTranscriptSelectionRuntime,
     BranchSummaryOutput,
     CompactionResult,
     CompactionStatus,
@@ -122,8 +96,6 @@ from loushang.harness.workspace.exec import (
     ExecUpdateCallback,
 )
 
-if TYPE_CHECKING:
-    from loushang.harness.session.tool_controller import SessionToolController
 
 class _ReloadableSettings(Protocol):
     def reload(self) -> None: ...
@@ -137,38 +109,19 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
     model_registry: SessionModelCatalogPort | None
     diagnostics_service: DiagnosticsService | None
     _approval_runtime: AgentSessionApprovalRuntime
-    _bash_runtime: BashExecutionRuntime
     _capability_runtime: CapabilityCompositionRuntime | None
-    _command_controller: SessionCommandController[Any]
-    _compaction_capability: AgentTranscriptCompactionCapability
-    _compaction_runtime: AgentTranscriptCompactionRuntime
-    _diagnostics_bridge: SessionDiagnosticsRuntime
+    _composition: SessionComposition
     _exec_service: ExecService
-    _extension_binding: SessionExtensionBinding
-    _extension_event_sink: ExtensionAgentEventRuntime
-    _extension_input_runtime: ExtensionInputRuntime
-    _extension_message_controller: ExtensionInputAdapter
     _extension_provider_controller: ExtensionProviderRuntime
     _extension_replacement_controller: ExtensionReplacementRuntime
     _extension_runner: SessionExtensionCompositionPort | None
     _extension_bridge: AgentSessionExtensionBridge
-    _identity_binding: SessionIdentityBinding
-    _maintenance_binding: SessionMaintenanceBinding
-    _model_binding: SessionModelBinding
-    _navigation_runtime: AgentTranscriptNavigationRuntime
     _operations: SessionOperations
     _package_controller: SessionPackageController
     _package_materializer: PackageMaterializer | None
     _resource_loader: ResourceLoader | None
-    _resource_refresh_runtime: SessionResourceRefreshRuntime
-    _resource_watch_controller: ResourceChangeWatcher
-    _retry_runtime: AgentTranscriptRetryRuntime
-    _selection_runtime: AgentTranscriptSelectionRuntime
     _session_default_model: Model
-    _session_inspector: AgentSessionInspector
-    _session_runtime: SessionRuntime
     _settings_controller: SessionSettingsBinding
-    _tool_controller: SessionToolController
     _tool_registry: WorkspaceToolRegistry | None
     resource_bundle: ResourceBundle | None
 
@@ -206,15 +159,15 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
         """Register live-bound tools without exposing composition internals."""
 
         definitions = tuple(
-            self._tool_controller.register_runtime_tool(
+            self._composition.tool_controller.register_runtime_tool(
                 tool,
                 source_info=source_info,
             )
             for tool in tools
         )
         if activate:
-            active = self._tool_controller.get_active_tool_names()
-            self._tool_controller.apply_active_tools(
+            active = self._composition.tool_controller.get_active_tool_names()
+            self._composition.tool_controller.apply_active_tools(
                 [
                     *active,
                     *(
@@ -332,8 +285,10 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
     async def get_command_argument_completions(
         self, invocation_name: str, prefix: str
     ) -> list[object] | None:
-        return await self._command_controller.get_command_argument_completions(
-            invocation_name, prefix
+        return (
+            await self._composition.command_controller.get_command_argument_completions(
+                invocation_name, prefix
+            )
         )
 
     def get_context_usage(self):
@@ -347,7 +302,7 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
 
     def _get_builtin_session_info(self) -> dict[str, object]:
         record = self.session_manager.get_session_record()
-        stats = self._session_inspector.build_session_stats()
+        stats = self._composition.session_inspector.build_session_stats()
         session_file = record.session_file
         return {
             "session_id": record.session_id,
@@ -459,21 +414,21 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
                 await result
 
     def _default_active_tool_names(self) -> list[str]:
-        return self._tool_controller.default_active_tool_names()
+        return self._composition.tool_controller.default_active_tool_names()
 
     def _register_extension_runtime_tool(
         self, tool: object, source_info: object | None = None
     ) -> None:
-        definition = self._tool_controller.register_runtime_tool(
+        definition = self._composition.tool_controller.register_runtime_tool(
             tool, source_info=source_info
         )
         if self._tool_registry is None:
-            self._tool_registry = self._tool_controller.tool_registry
+            self._tool_registry = self._composition.tool_controller.tool_registry
         if definition.name in self.get_active_tool_names():
             self._extension_bridge.refresh_bindings()
 
     def _rebuild_prompt_and_tools_view(self) -> None:
-        self._tool_controller.rebuild_prompt_and_tools_view()
+        self._composition.tool_controller.rebuild_prompt_and_tools_view()
 
     def _before_agent_start_system_prompt_options(self) -> dict[str, object]:
         return {
@@ -489,7 +444,7 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
         self.resource_bundle = resource_bundle
 
     def _refresh_resources_for_extension_runtime(self) -> None:
-        self._resource_refresh_runtime.refresh()
+        self._composition.resource_refresh_runtime.refresh()
 
     def _resource_watch_paths(self) -> list[Path]:
         cwd = Path(self.session_manager.get_cwd())
@@ -553,12 +508,16 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
     async def _send_message_from_extension(
         self, message: object, options: object | None = None
     ) -> None:
-        await self._extension_message_controller.send_message(message, options)
+        await self._composition.extension_message_controller.send_message(
+            message, options
+        )
 
     async def _send_user_message_from_extension_async(
         self, content: object, options: object | None = None
     ) -> None:
-        await self._extension_message_controller.send_user_message(content, options)
+        await self._composition.extension_message_controller.send_user_message(
+            content, options
+        )
 
     async def _compact_from_extension(
         self, custom_instructions: str | None = None
@@ -654,9 +613,9 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
             else None,
         )
         try:
-            self._session_runtime.schedule_event_dispatch(event)
+            self._composition.session_runtime.schedule_event_dispatch(event)
         except RuntimeError:
-            self._session_runtime.dispatch_event_without_loop(event)
+            self._composition.session_runtime.dispatch_event_without_loop(event)
 
     async def _dispatch_event(
         self,
@@ -669,14 +628,14 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
     def _preflight_user_input(
         self, user_input: str, *, allow_extension_commands: bool = True
     ):
-        return self._command_controller.preflight_user_input(
+        return self._composition.command_controller.preflight_user_input(
             user_input, allow_extension_commands=allow_extension_commands
         )
 
     async def _preflight_user_input_async(
         self, user_input: str, *, allow_extension_commands: bool = True
     ):
-        return await self._command_controller.preflight_user_input_async(
+        return await self._composition.command_controller.preflight_user_input_async(
             user_input, allow_extension_commands=allow_extension_commands
         )
 
@@ -685,13 +644,17 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
         *,
         phase: DiagnosticPhase,
     ) -> None:
-        self._diagnostics_bridge.sync_extension_diagnostics(phase=phase)
+        self._composition.diagnostics_bridge.sync_extension_diagnostics(phase=phase)
 
     def _record_runtime_exception(self, *, code: str, exc: Exception | str) -> None:
-        self._diagnostics_bridge.record_runtime_exception(code=code, exc=exc)
+        self._composition.diagnostics_bridge.record_runtime_exception(
+            code=code, exc=exc
+        )
 
     def _record_extension_runtime_diagnostic(self, diagnostic: DiagnosticDraft) -> None:
-        self._diagnostics_bridge.record_extension_runtime_diagnostic(diagnostic)
+        self._composition.diagnostics_bridge.record_extension_runtime_diagnostic(
+            diagnostic
+        )
 
     def _wire_extension_hooks(self) -> None:
         if self._extension_runner is not None:
@@ -700,6 +663,7 @@ class AgentSessionAdapterMixin(SessionFacade[Any, Any, Any, Any, Any, Any, Any])
                 extension_runtime=self._extension_runner,
                 get_cwd=self.session_manager.get_cwd,
             ).install()
+
 
 def initialize_composed_session(
     session: AgentSessionAdapterMixin,
@@ -716,36 +680,20 @@ def initialize_composed_session(
 ) -> None:
     """Install an assembled composition on a Product Session adapter."""
 
-    session._capability_runtime = composition.capability_runtime
-    session._diagnostics_bridge = composition.diagnostics_bridge
-    session._tool_controller = composition.tool_controller
-    session._resource_refresh_runtime = composition.resource_refresh_runtime
-    session._resource_watch_controller = composition.resource_watch_controller
-    session._navigation_runtime = composition.navigation_runtime
-    session._compaction_capability = composition.compaction_capability
-    session._compaction_runtime = composition.compaction_runtime
-    session._bash_runtime = composition.bash_runtime
+    if operations_ports.composition is not composition:
+        raise ValueError("Session operations must use the installed composition.")
     package_controller = composition.package_controller
     if package_controller is None:
         raise RuntimeError("Agent Product sessions require package operations.")
+
+    session._composition = composition
+    session._capability_runtime = composition.capability_runtime
     session._package_controller = package_controller
-    session._command_controller = composition.command_controller
-    session._extension_event_sink = composition.extension_event_sink
-    session._retry_runtime = composition.retry_runtime
-    session._session_runtime = composition.session_runtime
-    session._extension_input_runtime = composition.extension_input_runtime
-    session._extension_message_controller = composition.extension_message_controller
     session._extension_provider_controller = composition.extension_provider_controller
     session._extension_replacement_controller = (
         composition.extension_replacement_controller
     )
     session._extension_bridge = composition.extension_bridge
-    session._selection_runtime = composition.selection_runtime
-    session._model_binding = composition.model_binding
-    session._identity_binding = composition.identity_binding
-    session._maintenance_binding = composition.maintenance_binding
-    session._extension_binding = composition.extension_binding
-    session._session_inspector = composition.session_inspector
     session._operations = SessionOperations(operations_ports)
     SessionFacade.__init__(
         session,
@@ -784,7 +732,7 @@ def initialize_composed_session(
         session._rebuild_prompt_and_tools_view()
     if session._extension_runner is not None:
         session._wire_extension_hooks()
-        session._extension_bridge.bind_bindings()
+        composition.extension_bridge.bind_bindings()
     sync_footer()
 
 

--- a/src/loushang/harness/session/agent_product.py
+++ b/src/loushang/harness/session/agent_product.py
@@ -21,7 +21,6 @@ from loushang.harness.config.agent import (
 from loushang.harness.context import serialize_context_usage_payload
 from loushang.harness.diagnostics.service import DiagnosticsService
 from loushang.harness.extensions import ExtensionProviderRuntime
-from loushang.harness.extensions.agent.input_adapter import ExtensionInputAdapter
 from loushang.harness.extensions.agent.replacement import ExtensionReplacementRuntime
 from loushang.harness.extensions.context import (
     ReplacedSessionContext,
@@ -66,7 +65,6 @@ from loushang.harness.session.composition import (
 from loushang.harness.session.diagnostics import SessionDiagnosticsRuntime
 from loushang.harness.session.extension_bridge import AgentSessionExtensionBridge
 from loushang.harness.session.operations_runtime import SessionOperationsPorts
-from loushang.harness.session.runtime import SessionRuntime
 from loushang.harness.session.settings import SessionSettingsBinding
 from loushang.harness.session.side_question import (
     SIDE_QUESTION_BOUNDARY_PROMPT,
@@ -74,7 +72,6 @@ from loushang.harness.session.side_question import (
 )
 from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
 from loushang.harness.transcript import (
-    AgentTranscriptSelectionRuntime,
     BranchSummaryOutput,
     CompactionHookDecision,
     CompactionHookRequest,
@@ -103,9 +100,6 @@ class AgentProductSession(AgentSessionAdapterMixin):
     """Bind Product callbacks to the existing standard session runtimes."""
 
     resource_bundle: ResourceBundle | None
-    _extension_message_controller: ExtensionInputAdapter
-    _session_runtime: SessionRuntime
-    _selection_runtime: AgentTranscriptSelectionRuntime
 
     def __init__(
         self,
@@ -450,7 +444,7 @@ class AgentProductSession(AgentSessionAdapterMixin):
     def _sync_footer_available_provider_count(self) -> None:
         providers = {
             selection.provider
-            for selection in self._selection_runtime.get_available_models()
+            for selection in self._composition.selection_runtime.get_available_models()
             if isinstance(selection.provider, str)
         }
         self.footer_data_provider.set_available_provider_count(len(providers))

--- a/src/loushang/harness/session/composition.py
+++ b/src/loushang/harness/session/composition.py
@@ -257,7 +257,7 @@ class SessionCompositionPorts:
     sleep_for_retry: Callable[[int, CancellationSignal], Awaitable[None]]
 
 
-@dataclass
+@dataclass(frozen=True)
 class SessionComposition:
     """All standard runtime objects assembled for one Product session."""
 

--- a/src/loushang/harness/session/export.py
+++ b/src/loushang/harness/session/export.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from loushang.harness.presentation import RenderableToolDefinition
-from loushang.harness.session.inspection import AgentSessionInspector
+from loushang.harness.session.composition import SessionComposition
 from loushang.harness.tools.core import ToolDefinition
 from loushang.harness.transcript import (
     AgentTranscriptContext,
@@ -29,7 +29,9 @@ class ExportAgentPort(Protocol):
 
 class SessionExportPort(Protocol):
     session_manager: ProductTranscriptSession[Any, Any]
-    _session_inspector: AgentSessionInspector
+
+    @property
+    def _composition(self) -> SessionComposition: ...
 
     @property
     def agent(self) -> ExportAgentPort: ...
@@ -84,7 +86,7 @@ def export_session_to_html(
 
 
 def _build_export_request(session: SessionExportPort) -> TranscriptExportRequest:
-    stats = session._session_inspector.build_session_stats()
+    stats = session._composition.session_inspector.build_session_stats()
     context_usage = stats.context_usage
     entries = session.session_manager.get_entries()
     tools = tuple(

--- a/tests/coding/test_agent_session.py
+++ b/tests/coding/test_agent_session.py
@@ -850,17 +850,17 @@ def test_agent_session_forwards_agent_lifecycle_events_to_extensions(tmp_path) -
             timestamp=0.0,
         )
 
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_start"}, session.agent.signal
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "turn_start"}, session.agent.signal
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "turn_end", "message": assistant, "tool_results": [tool_result]},
             session.agent.signal,
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [assistant]}, session.agent.signal
         )
 
@@ -930,10 +930,10 @@ def test_agent_session_forwards_message_and_tool_execution_events_to_extensions(
             content=[TextPart(type="text", text="ok")], details={}
         )
 
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_start", "message": assistant}, session.agent.signal
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {
                 "type": "tool_execution_end",
                 "tool_call_id": "tc1",
@@ -971,7 +971,7 @@ def test_agent_session_records_tool_execution_error_diagnostic_with_correlation(
             agent=Agent(), session_manager=manager, diagnostics_service=diagnostics
         )
 
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {
                 "type": "tool_execution_end",
                 "tool_call_id": "tc1",
@@ -2391,7 +2391,7 @@ def test_agent_session_removes_visible_queue_when_queued_user_message_starts(
     session.steer("queued")
 
     asyncio.run(
-        session._session_runtime.handle_agent_event(
+        session._composition.session_runtime.handle_agent_event(
             {
                 "type": "message_start",
                 "message": UserMessage(
@@ -2422,9 +2422,9 @@ def test_agent_session_follow_up_and_state_snapshot(tmp_path) -> None:
     session = AgentSession(agent=agent, session_manager=manager)
 
     session.follow_up("later")
-    session._retry_runtime.retry_future = object()  # type: ignore[assignment]
+    session._composition.retry_runtime.retry_future = object()  # type: ignore[assignment]
     state = session.get_state()
-    session._retry_runtime.retry_future = None
+    session._composition.retry_runtime.retry_future = None
 
     assert state.run == RunState(status="idle")
     assert state.follow_up == ["later"]
@@ -3387,7 +3387,7 @@ def test_agent_session_disposal_closes_approval_before_waiting_for_host(
             )
 
         active_run = asyncio.create_task(
-            session._session_runtime.host_runtime.run(wait_for_approval)
+            session._composition.session_runtime.host_runtime.run(wait_for_approval)
         )
         await presented.wait()
         await asyncio.wait_for(getattr(session, dispose_method)(), timeout=0.2)
@@ -3722,7 +3722,7 @@ def test_agent_session_disposal_finalizes_when_host_dispose_fails(tmp_path) -> N
             ),
             approval_resolver=resolver,
         )
-        session._session_runtime._host_runtime = FailingHostRuntime()  # type: ignore[assignment]
+        session._composition.session_runtime._host_runtime = FailingHostRuntime()  # type: ignore[assignment]
         pending = asyncio.create_task(
             resolver.resolve(ApprovalRequest(tool_name="write", arguments={}))
         )

--- a/tests/coding/test_agent_session_compaction.py
+++ b/tests/coding/test_agent_session_compaction.py
@@ -770,10 +770,10 @@ def test_agent_session_auto_compacts_after_agent_end_when_threshold_exceeded(
     session.subscribe(events.append)
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": assistant}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [assistant]}, AbortSignal()
         )
         await asyncio.sleep(0)
@@ -884,10 +884,10 @@ def test_agent_session_auto_compaction_uses_compact_percent_threshold(
     session.subscribe(events.append)
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": assistant}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [assistant]}, AbortSignal()
         )
         await asyncio.sleep(0)
@@ -1343,10 +1343,10 @@ def test_agent_session_threshold_auto_compaction_resumes_agent_level_queue(
     monkeypatch.setattr(session.agent, "continue_run", _continue_run)
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": assistant}, session.agent.signal
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [assistant]}, session.agent.signal
         )
         await asyncio.sleep(0)
@@ -1445,15 +1445,15 @@ def test_agent_session_overflow_recovery_emits_compaction_with_retry_flag(
         return asyncio.create_task(asyncio.sleep(0))
 
     monkeypatch.setattr(
-        session._session_runtime, "schedule_continue_run", _continue_run
+        session._composition.session_runtime, "schedule_continue_run", _continue_run
     )
     session.subscribe(events.append)
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": assistant}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [assistant]}, AbortSignal()
         )
         await asyncio.sleep(0)
@@ -1561,19 +1561,19 @@ def test_agent_session_overflow_recovery_is_limited_to_one_attempt(
         _fake_compact,
     )
     monkeypatch.setattr(
-        session._session_runtime, "schedule_continue_run", _continue_run
+        session._composition.session_runtime, "schedule_continue_run", _continue_run
     )
     session.subscribe(events.append)
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": assistant}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [assistant]}, AbortSignal()
         )
         await asyncio.sleep(0)
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [assistant]}, AbortSignal()
         )
 

--- a/tests/coding/test_agent_session_retry.py
+++ b/tests/coding/test_agent_session_retry.py
@@ -107,15 +107,17 @@ def test_agent_session_retryable_error_starts_retry_and_removes_error_message(
         "loushang.coding.session.agent_session.sleep_for_retry", _instant_sleep
     )
     monkeypatch.setattr(
-        session._session_runtime, "schedule_continue_run", _fake_continue_run
+        session._composition.session_runtime,
+        "schedule_continue_run",
+        _fake_continue_run,
     )
     session.subscribe(events.append)
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": error_message}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [error_message]}, AbortSignal()
         )
         await asyncio.sleep(0)
@@ -177,22 +179,24 @@ def test_agent_session_retry_success_emits_end_event_and_resolves_waiter(
         "loushang.coding.session.agent_session.sleep_for_retry", _instant_sleep
     )
     monkeypatch.setattr(
-        session._session_runtime, "schedule_continue_run", _fake_continue_run
+        session._composition.session_runtime,
+        "schedule_continue_run",
+        _fake_continue_run,
     )
     session.subscribe(events.append)
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": error_message}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [error_message]}, AbortSignal()
         )
         await asyncio.sleep(0)
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": success_message}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [success_message]}, AbortSignal()
         )
         await session.wait_for_retry()
@@ -252,17 +256,19 @@ def test_agent_session_retry_preserves_queued_messages_until_retry_continues(
         "loushang.coding.session.agent_session.sleep_for_retry", _instant_sleep
     )
     monkeypatch.setattr(
-        session._session_runtime, "schedule_continue_run", _fake_continue_run
+        session._composition.session_runtime,
+        "schedule_continue_run",
+        _fake_continue_run,
     )
     session.subscribe(events.append)
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": error_message}, AbortSignal()
         )
         session.steer("queued steer")
         session.follow_up("queued follow")
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [error_message]}, AbortSignal()
         )
         await asyncio.sleep(0)
@@ -325,16 +331,18 @@ def test_agent_session_abort_retry_ends_retry_with_failure(
         "loushang.coding.session.agent_session.sleep_for_retry", _blocking_sleep
     )
     monkeypatch.setattr(
-        session._session_runtime, "schedule_continue_run", _fake_continue_run
+        session._composition.session_runtime,
+        "schedule_continue_run",
+        _fake_continue_run,
     )
     session.subscribe(events.append)
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": error_message}, AbortSignal()
         )
         retry_task = asyncio.create_task(
-            session._session_runtime.handle_agent_event(
+            session._composition.session_runtime.handle_agent_event(
                 {"type": "agent_end", "messages": [error_message]}, AbortSignal()
             )
         )
@@ -398,23 +406,25 @@ def test_agent_session_retry_max_retries_emits_final_failure(
         "loushang.coding.session.agent_session.sleep_for_retry", _instant_sleep
     )
     monkeypatch.setattr(
-        session._session_runtime, "schedule_continue_run", _fake_continue_run
+        session._composition.session_runtime,
+        "schedule_continue_run",
+        _fake_continue_run,
     )
 
     async def scenario() -> None:
         session.agent.state.messages.append(error_message)
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": error_message}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [error_message]}, AbortSignal()
         )
         await asyncio.sleep(0)
         session.agent.state.messages.append(error_message)
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": error_message}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [error_message]}, AbortSignal()
         )
 
@@ -473,10 +483,10 @@ def test_agent_session_records_non_retryable_assistant_error_as_provider_diagnos
     error_message = _assistant_error_message("provider quota exhausted")
 
     async def scenario() -> None:
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": error_message}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [error_message]}, AbortSignal()
         )
 
@@ -533,21 +543,23 @@ def test_agent_session_overflow_routes_to_compaction_instead_of_retry(
         raise AssertionError("overflow should not trigger retry continue_run")
 
     monkeypatch.setattr(
-        session._compaction_runtime,
+        session._composition.compaction_runtime,
         "compact",
         _fake_compact_internal,
     )
     monkeypatch.setattr(
-        session._session_runtime, "schedule_continue_run", _fake_continue_run
+        session._composition.session_runtime,
+        "schedule_continue_run",
+        _fake_continue_run,
     )
     session.subscribe(events.append)
 
     async def scenario() -> None:
         session.agent.state.messages.append(overflow_message)
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "message_end", "message": overflow_message}, AbortSignal()
         )
-        await session._session_runtime.handle_agent_event(
+        await session._composition.session_runtime.handle_agent_event(
             {"type": "agent_end", "messages": [overflow_message]}, AbortSignal()
         )
 

--- a/tests/coding/test_agent_session_runtime.py
+++ b/tests/coding/test_agent_session_runtime.py
@@ -253,12 +253,16 @@ async def test_runtime_listener_failure_does_not_duplicate_agent_message(
     event = {"type": "message_end", "message": message}
 
     try:
-        await session._session_runtime.handle_agent_event(event, session.agent.signal)
+        await session._composition.session_runtime.handle_agent_event(
+            event, session.agent.signal
+        )
     except RuntimeError as exc:
         assert str(exc) == "message projection failed"
     else:
         raise AssertionError("message projection failure must propagate")
-    await session._session_runtime.handle_agent_event(event, session.agent.signal)
+    await session._composition.session_runtime.handle_agent_event(
+        event, session.agent.signal
+    )
 
     assert commit_events == 1
     assert failed_message_events == 1

--- a/tests/coding/test_application_input_runtime_contract.py
+++ b/tests/coding/test_application_input_runtime_contract.py
@@ -29,8 +29,12 @@ def test_agent_session_direct_application_input_reuses_one_commit_and_projection
             delivery_mode="direct",
         )
 
-        first = await session._session_runtime.application_inputs.deliver(message)
-        second = await session._session_runtime.application_inputs.deliver(message)
+        first = await session._composition.session_runtime.application_inputs.deliver(
+            message
+        )
+        second = await session._composition.session_runtime.application_inputs.deliver(
+            message
+        )
         await asyncio.sleep(0)
 
         assert first.disposition == "committed"

--- a/tests/coding/test_host_runtime_core_compatibility.py
+++ b/tests/coding/test_host_runtime_core_compatibility.py
@@ -68,7 +68,7 @@ def test_agent_session_coordinates_public_lifecycle_through_host_runtime(
                 persist=False,
             ),
         )
-        runtime = session._session_runtime
+        runtime = session._composition.session_runtime
         assert isinstance(runtime, SessionRuntime)
         assert isinstance(runtime.queue, QueueController)
         assert isinstance(runtime.prompt_controller, PromptController)

--- a/tests/coding/test_runtime_profile.py
+++ b/tests/coding/test_runtime_profile.py
@@ -245,15 +245,41 @@ def test_agent_session_uses_and_disposes_selected_compaction_runtime(tmp_path) -
         session = create_agent_session(session_manager=manager, model=_model())
         capability_runtime = session._capability_runtime
 
-        assert session._compaction_capability is compaction_capability
-        assert session._compaction_runtime._get_policy() == compaction_capability.policy
+        mirrored_runtime_names = {
+            "_bash_runtime",
+            "_command_controller",
+            "_compaction_capability",
+            "_compaction_runtime",
+            "_diagnostics_bridge",
+            "_extension_binding",
+            "_extension_event_sink",
+            "_extension_input_runtime",
+            "_extension_message_controller",
+            "_identity_binding",
+            "_maintenance_binding",
+            "_model_binding",
+            "_navigation_runtime",
+            "_resource_refresh_runtime",
+            "_resource_watch_controller",
+            "_retry_runtime",
+            "_selection_runtime",
+            "_session_inspector",
+            "_session_runtime",
+            "_tool_controller",
+        }
+        assert mirrored_runtime_names.isdisjoint(vars(session))
+        assert session._composition.compaction_capability is compaction_capability
+        assert (
+            session._composition.compaction_runtime._get_policy()
+            == compaction_capability.policy
+        )
         assert capability_runtime is not None
         assert (
-            session._tool_controller.prompt_section_composer
+            session._composition.tool_controller.prompt_section_composer
             is capability_runtime.prompt_section_composer
         )
         assert (
-            session._command_controller.pack_composer
+            session._composition.command_controller.pack_composer
             is capability_runtime.command_pack_composer
         )
 

--- a/tests/coding/test_session_introspection.py
+++ b/tests/coding/test_session_introspection.py
@@ -149,7 +149,7 @@ def _model() -> Model:
 def test_build_context_usage_counts_messages_and_tools(tmp_path) -> None:
     usage = _build_session_with_tool_turn(
         tmp_path
-    )._session_inspector.get_context_usage()
+    )._composition.session_inspector.get_context_usage()
     assert usage is not None
     assert usage.message_count >= 3
     assert usage.tool_call_count == 1
@@ -159,7 +159,7 @@ def test_build_context_usage_counts_messages_and_tools(tmp_path) -> None:
 def test_build_context_usage_uses_best_effort_token_estimate(tmp_path) -> None:
     usage = _build_session_with_tool_turn(
         tmp_path
-    )._session_inspector.get_context_usage()
+    )._composition.session_inspector.get_context_usage()
     assert usage is not None
     assert usage.estimated_context_tokens is not None
 
@@ -202,7 +202,7 @@ def test_build_context_usage_uses_session_compaction_settings(tmp_path) -> None:
         ),
     )
 
-    usage = session._session_inspector.get_context_usage()
+    usage = session._composition.session_inspector.get_context_usage()
 
     assert usage is not None
     assert usage.compact_percent == 80
@@ -218,7 +218,7 @@ def test_build_session_stats_includes_context_usage_and_session_metadata(
     tmp_path,
 ) -> None:
     session = _build_session_with_tool_turn(tmp_path)
-    stats = session._session_inspector.build_session_stats()
+    stats = session._composition.session_inspector.build_session_stats()
     assert stats.session_id == session.session_id
     assert stats.context_usage is not None
 
@@ -335,7 +335,7 @@ def test_build_session_stats_reports_token_totals_after_compaction(tmp_path) -> 
     agent.state.set_messages(manager.build_session_context().messages)
     session = coding_session.AgentSession(agent=agent, session_manager=manager)
 
-    stats = session._session_inspector.build_session_stats()
+    stats = session._composition.session_inspector.build_session_stats()
 
     assert stats.tokens.total == 220_000
     assert stats.tokens.input == 220_000
@@ -377,6 +377,6 @@ def test_build_session_stats_tracks_active_tools_and_diagnostics(tmp_path) -> No
         diagnostics_service=diagnostics,
     )
 
-    stats = session._session_inspector.build_session_stats()
+    stats = session._composition.session_inspector.build_session_stats()
     assert stats.active_tool_count == len(session.get_active_tool_names())
     assert stats.has_diagnostics is True

--- a/tests/coding/test_session_resource_watcher.py
+++ b/tests/coding/test_session_resource_watcher.py
@@ -79,9 +79,9 @@ def test_agent_session_dispose_stops_resource_watcher(tmp_path) -> None:
 
     async def scenario() -> None:
         session.start_resource_watcher(interval_seconds=60)
-        assert session._resource_watch_controller.is_running is True
+        assert session._composition.resource_watch_controller.is_running is True
         await session.dispose()
 
     asyncio.run(scenario())
 
-    assert session._resource_watch_controller.is_running is False
+    assert session._composition.resource_watch_controller.is_running is False

--- a/tests/harness/session/test_composition.py
+++ b/tests/harness/session/test_composition.py
@@ -11,6 +11,7 @@ from loushang.harness.session.composition import (
     ProductCompactionExecutor as CompositionProductCompactionExecutor,
 )
 from loushang.harness.session.composition import (
+    SessionComposition,
     SessionCompositionPorts,
     _compaction_policy,
     _resolve_compaction_capability,
@@ -49,6 +50,10 @@ def test_session_composition_ports_exclude_runtime_owned_forwarders() -> None:
             "continue_run",
         }
     )
+
+
+def test_session_composition_is_a_frozen_assembly_result() -> None:
+    assert SessionComposition.__dataclass_params__.frozen is True
 
 
 def test_session_composition_uses_private_staged_builders() -> None:


### PR DESCRIPTION
## Summary

- make `SessionComposition` a frozen assembly result
- keep composed runtimes and bindings behind `AgentSessionAdapterMixin._composition` instead of duplicating them across private fields
- validate composition identity during installation and update export/Product consumers
- add architecture guards and migrate internal tests away from removed mirrors

## Why

The adapter copied roughly twenty assembled runtime references into a second set of private attributes. That created two representations of the same session wiring and made later composition changes harder to reason about.

## Impact

Public `SessionComposition` fields and Product behavior remain unchanged. Product-owned objects needed before assembly continue to retain their construction-time references.

## Validation

- `make check-harnesstui`
- `uv --cache-dir .uv-cache run --extra dev mypy --follow-imports=silent src/loushang/harness/session src/loushang/coding/session src/loushang/coding/bootstrap.py`
- `uv --cache-dir .uv-cache run --extra dev pytest tests/harness/session tests/coding -q`
- `uv --cache-dir .uv-cache run --extra dev pytest tests/harness/session tests/architecture/test_import_boundaries.py -q`
- targeted Ruff checks and `git diff --check`
