### PR TITLE
docs(harness): close coding migration ledger

### DIFF
--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -47,7 +47,8 @@ description.
   mandatory rebaseline ledger, revised six delivery waves, and closure gates
   for turning Coding into a declarative Product adapter.
 - [Coding Shared-Layer Migration Ledger](coding-shared-layer-migration-ledger.md)
-  records the concrete source-to-owner cutover scope for each delivery wave.
+  is the closed historical record of the concrete source-to-owner cutover
+  completed through Wave 7, Slice Z.
 - [CLI Product Host Collapse](cli-product-host-collapse.md) defines ordered
   standard CLI operation dispatch and shared session/resource/package host
   operations while Products retain grammar, policy, and mode selection.

--- a/docs/internals/architecture/harness/coding-shared-layer-migration-ledger.md
+++ b/docs/internals/architecture/harness/coding-shared-layer-migration-ledger.md
@@ -11,6 +11,17 @@ is the Wave R evidence for this ledger. It distinguishes shared mechanisms that
 are already adopted from actual Coding duplicates; only the latter may support a
 future migration LOC claim.
 
+## Closure Status
+
+Status: complete through Wave 7, Slice Z as of 2026-08-03.
+
+This ledger is now a closed historical delivery record for the current
+Coding-to-Harness migration. The implemented ownership map is maintained in
+[Harness Current Owner Map](current-owner-map.md); source and architecture
+gates remain authoritative over both documents. New ownership work requires a
+new accepted boundary or migration record rather than reopening the completed
+wave sequence in this ledger.
+
 ## Ownership Rules
 
 Move an implementation out of `loushang.coding` when it implements a mechanism,
@@ -332,7 +343,7 @@ do not import Coding, and no RPC/CLI wire fields changed in this wave. The
 lifecycle contract is verified with independent Harness/Channel fakes plus the
 existing Coding settings and CLI regressions.
 
-### Wave 6, Slice B: Generic Product CLI Surfaces (In Progress)
+### Wave 6, Slice B: Generic Product CLI Surfaces (Complete)
 
 The detailed boundary is [Product CLI Lifecycle Boundary](product-cli-lifecycle-boundary.md).
 This slice extracts only object-shape and lifecycle mechanisms. It does not move

--- a/docs/internals/architecture/harness/control-plane-runtime-boundary.md
+++ b/docs/internals/architecture/harness/control-plane-runtime-boundary.md
@@ -2,7 +2,8 @@
 
 ## Status
 
-Status: implemented on `harness/control-plane-runtime`; integration pending.
+Status: implemented and integrated. The original implementation branch was
+`harness/control-plane-runtime`.
 
 The extension-routing portions of this document remain current. Its
 tool-shaped Policy and boolean Approval target is superseded by


### PR DESCRIPTION
## What changed

- Mark the Coding-to-Harness migration ledger closed through Wave 7, Slice Z.
- Correct the completed Wave 6 CLI slice and integrated Control Plane status.
- Clarify in the Harness architecture index that the ledger is a historical delivery record and the current owner map is authoritative.

## Why

The implementation and ownership gates were already integrated, but two historical status labels still reported in-progress or pending work. That mismatch could make contributors treat migration records as current architecture authority.

## Impact

Documentation only. Runtime behavior, public APIs, wire contracts, and dependency gates are unchanged.

## Validation

- Harness architecture links validated.
- Architecture import-boundary suite: 152 passed.
- `git diff --check` passed.
- Status scan found no remaining Harness migration `integration pending` or `In Progress` marker.
