### PR TITLE
docs(architecture): align product capability boundaries

### DIFF
--- a/docs/internals/architecture/coding/component-interfaces/domain.md
+++ b/docs/internals/architecture/coding/component-interfaces/domain.md
@@ -1,5 +1,9 @@
 # `domain`
 
+This note describes the current compatibility boundary. `CodingDomainApp` is a
+thin Coding profile over the canonical `loushang.method.MethodDomainRuntime`;
+it is not the independent DomainApp runtime used by older architecture drafts.
+
 ## Role
 
 - coding domain app integration boundary
@@ -104,6 +108,20 @@ parameters; it does not redefine their semantics.
 - `--method` is rejected in TUI and RPC paths until ARD-006 preconditions are met.
 - `--work-log` is supported for one-shot text/print/json prompts and rejected in TUI/RPC paths.
 - Fixed linear `MethodPlan` execution is represented as one prepared coding turn per step.
+
+## V3 Target Direction
+
+- Coding is the domain-specific Product. The target architecture does not add a
+  second `CodingDomainApp` runtime inside that Product.
+- The Coding Product Session binding owns lightweight conversation preparation;
+  its Work Preparer and Product Work Executor own structured Method/Work
+  preparation and execution binding.
+- The current `CodingDomainApp` facade may remain while CLI callers still use
+  `prepare_turns(...)`, but it must not acquire new Product routing, capability
+  activation, tool-policy, or Work lifecycle responsibilities.
+- Product capability requirements from a Method projection are resolved by the
+  Coding Product binding and enforced through Harness. They are not executed by
+  this compatibility facade.
 
 ## Reference Implementation Alignment
 

--- a/docs/internals/architecture/coding/component-interfaces/method.md
+++ b/docs/internals/architecture/coding/component-interfaces/method.md
@@ -17,6 +17,10 @@
 
 The full boundary is documented in [domain.md](domain.md).
 
+This is a current compatibility surface. In the v3 target, Coding remains the
+domain-specific Product and its Product Session/Work bindings absorb this thin
+bridge; no independent `CodingDomainApp` runtime is added.
+
 ## Related Architecture Decisions
 
 - [Method Facts Contract](../method-facts-contract.md)

--- a/docs/internals/architecture/coding/component-interfaces/tools.md
+++ b/docs/internals/architecture/coding/component-interfaces/tools.md
@@ -50,6 +50,20 @@
 - approval UI 与用户交互
 - mode / RPC / export 的 rendered event projection
 
+## Optional Capability Packs
+
+- `coding.arch` 定位为标准安装、高频可用、默认按需激活，并允许用户通过 CLI 或 Coding 配置设为常驻的架构能力包。
+- `coding.arch` 不属于 `CODING_BUILTIN_TOOL_PACK`；安装表示工具定义可用，`disabled` / `on_demand` / `always`
+  激活策略决定当前 session 是否允许和默认激活该工具集合。
+- `coding.arch` 是包含 Architecture Skill、工具能力和相关资源的 Coding Product Capability Bundle id，也是 Skill 或
+  Method 使用的 opaque Product capability requirement。Coding Product binding 再将它解析为 family-specific Capability
+  Packs；具体 tool-family pack 使用独立限定 id（例如 `coding.arch.tools`）并由 `CODING_ARCH_TOOL_PACK` 描述。Method
+  资产不直接依赖 Harness ToolPack 类型或取得执行权限。
+- 架构 Skill 负责匹配架构分析、架构设计和重构规划任务；具体工具保持事实导向和窄接口，通过命名 ToolPack 组合，不使用泛化的
+  “分析架构”工具替代可验证的结构化查询。
+- CLI 或 Coding 配置的显式常驻选择应增量加入默认工具集合，不得替换 builtin tools，也不得绕过 `--no-tools`、session
+  allowlist、delegated execution profile、policy 或 approval 边界。
+
 ## Reference Implementation Alignment
 
 - 语义上对齐 `reference CLI` 的 built-in tool registry / tool definition layer

--- a/docs/internals/architecture/coding/loushang-coding-system-context.md
+++ b/docs/internals/architecture/coding/loushang-coding-system-context.md
@@ -111,7 +111,9 @@
 - guidance
 - work product 模板
 
-`method` 不直接承担 coding runtime，而是为 `coding` 提供方法层资产、编译与投影。`coding` 通过 `CodingDomainApp` 把 method plan/prepared turn 应用到 coding turn。
+`method` 不直接承担 coding runtime，而是为 `coding` 提供方法层资产、编译与投影。当前兼容路径通过薄的
+`CodingDomainApp` facade 把 method plan/prepared turn 应用到 coding turn；v3 目标由 Coding Product 的 Work
+Preparer 和 Product Work Executor 吸收该职责，不保留独立的 DomainApp runtime。
 
 ### loushang-work
 

--- a/docs/internals/architecture/drafts/future-loushang-architecture-v3.md
+++ b/docs/internals/architecture/drafts/future-loushang-architecture-v3.md
@@ -295,6 +295,34 @@ Agent owns the execution loop and calls AI. Harness and Agent coordinate tool
 execution through admitted tools and sandbox policy; the AI layer remains
 independent of Harness and Product code.
 
+### Product capability requirements and scoped activation
+
+Method and Skill resources may declare opaque Product capability requirements,
+such as `coding.arch`. They do not name Harness `ToolPackDefinition` values,
+register executable handlers, or grant themselves execution authority. For
+structured work, the Product work preparer carries the requirement into the
+run-specific Work contract and the Product executor resolves it through the
+Product's admitted capability catalog. For a lightweight Session turn, the
+Product conversation binding performs the equivalent resolution without
+creating a Work run.
+
+A Product capability may resolve to an admitted Product Capability Bundle and
+one or more family-specific Capability Packs, including a named tool pack. The
+Product retains the mapping, mount defaults, and policy; Harness retains
+contribution resolution, allow-list enforcement, live tool rebinding, sandbox
+and approval integration, and scoped activation mechanics. A Product may expose
+`disabled`, `on_demand`, and `always` mount modes, but no mode may override host
+admission, delegated execution restrictions, Session allow-lists, or tool
+policy.
+
+Scoped activation is additive and owner-aware. Manual selection, Product
+defaults, a Skill invocation, and a Method/Work step may independently request
+the same capability. Releasing one activation removes only that owner's request;
+completion, failure, cancellation, and runtime disposal must all release their
+owned activation idempotently. This capability activation scope is distinct
+from the AppService control lease that selects which attached client may mutate
+a Session.
+
 ### Method visibility in clients
 
 V3 does not add `MethodPlanStatus` or `MethodStepStatus` to the base App

--- a/docs/internals/architecture/method/README.md
+++ b/docs/internals/architecture/method/README.md
@@ -51,9 +51,13 @@ Work   = Business intent enactment and authoritative runtime facts
 - work log persistence
 - Native TUI rendering or playback
 
-Coding-specific method usage is bridged through `loushang.coding.domain`.
-When a method is enacted, `loushang.work` owns the resulting run, plan, step,
-outcome, event-log, replay, artifact-reference, and deviation facts.
+Current Coding-specific method usage is bridged through
+`loushang.coding.domain`. This is a compatibility facade over the shared Method
+runtime, not a separate long-term DomainApp execution layer. In the v3 target,
+the Coding Product work preparer consumes the Method plan and its Product work
+executor binds each admitted step to Harness. When a method is enacted,
+`loushang.work` owns the resulting run, plan, step, outcome, event-log, replay,
+artifact-reference, and deviation facts.
 
 ## Relation To Agent Harness And Products
 
@@ -84,6 +88,19 @@ artifact types, content, loading, rendering, validation, and materialization.
 
 Therefore the shared work layer should prefer a lightweight `ArtifactRef` over a
 shared abstract `Artifact` base class.
+
+## Capability Boundary
+
+Method resources may describe an opaque Product capability requirement, but
+they do not select a Harness tool pack, register executable tools, or grant
+runtime authority. A Product work preparer interprets the requirement in its
+domain and carries it into the run-specific Work contract; the Product executor
+then resolves it through admitted Product capabilities before invoking Harness.
+
+`MethodApplicability.capabilities` remains an applicability and matching fact.
+It must not silently become a runtime authorization or ToolPack activation
+field. A stable execution-requirement schema should be added only with the
+Product/Work projection that consumes it.
 
 ## Field Mapping
 

--- a/docs/internals/architecture/subsystem.md
+++ b/docs/internals/architecture/subsystem.md
@@ -271,8 +271,9 @@ Artifact 分层规则：
 - 通用边界协议定义
 - 通用 terminal UI primitives
 
-`coding` 可以直接依赖 `loushang.harness` 和 `work` 处理普通 coding turn；只有
-结构化 / guided 工作需要通过 `method`。
+`coding` 可以直接依赖 `loushang.harness` 处理轻量 coding turn；只有被受理为持久
+业务承诺的工作才进入 `work`，其中需要结构化 / guided 方法的工作再选择性消费
+`method`。
 
 ## Layer Relationship
 
@@ -307,19 +308,29 @@ loushang.agent
 跨产品工作抽象链路为：
 
 ```text
-loushang.work
-  <- loushang.coding / loushang.design / loushang.research / loushang.ppt / loushang.cowork
+loushang.method
+  -> Product Work Preparer, only for structured work
+  -> loushang.work
 
-loushang.work
-  <- loushang.method
-  <- product adapters, only for structured work
+loushang.coding / loushang.design / loushang.research / loushang.ppt / loushang.cowork
+  -> Product Work Preparer
+  -> loushang.work
 ```
 
 长期目标边界为：
 
 ```text
-external host/client -> loushang.channel -> loushang.work -> domain app
+external host/client
+  -> embedded host or AppService
+      -> Product Session binding -> loushang.harness
+      -> Product Work Preparer -> loushang.work
+           -> Product Work Executor -> loushang.harness
 ```
+
+轻量 Session turn 与受理后的 structured Work 是显式不同的路径；并非所有
+Product turn 都必须经过 `channel`、`work` 或 `method`。`channel` 是可选的
+operation/event 边界，不是 Product runtime 的统一入口。Product 本身承担领域
+语义，长期目标不再引入独立的 `DomainApp` runtime。
 
 其中：
 
@@ -329,7 +340,8 @@ external host/client -> loushang.channel -> loushang.work -> domain app
   adapter / command substrate
 - `harnesstui` 提供跨产品的 Harness/TUI conversation interaction 与
   presentation composition；可依赖 `harness` 和 `tui`，不可依赖 `coding`
-- `channel` 提供目标边界通信和已注入 Product host 的 transport runtime
+- `channel` 提供选定的 operation/event、订阅、关联和回放边界，不承担通用
+  Product 路由或 transport/runtime 总线职责
 - `tui` 提供通用终端交互原语
 - `method` 提供可选的方法组织与 plan/projection
 - `work` 提供业务 work acceptance、运行终态、事件、日志与 projection
@@ -358,12 +370,11 @@ product packages -> harness
 product packages -> agent
   # only through stable agent primitives when bypassing harness is justified
 
-method -> work
 product packages -> work
 channel -> work
 
 product packages -> method
-  # optional and only for structured work
+  # optional and only for structured work; Product binds Method output to Work
 
 product TUI adapters -> tui
 

--- a/docs/internals/architecture/work/README.md
+++ b/docs/internals/architecture/work/README.md
@@ -87,6 +87,12 @@ plan identity 之前，调用方不得跨 run 复用会产生歧义的 `plan_id`
 | `WorkOutcome` | 可结构化验证的业务结果、失败或取消结论 |
 | `WorkPlanRevision` | 保留原始计划与证据链的显式计划修订，而不是静默改写历史 |
 
+Target `WorkPlanSpec` may carry opaque Product capability requirement facts that
+were bound by the Product work preparer. Work preserves and correlates those
+facts with the run/step but does not resolve Product Capability Bundles,
+Capability Packs, tool definitions, or authorization. The Product executor
+performs that resolution before invoking Harness.
+
 目标语义关系是：
 
 ```text

--- a/docs/internals/glossary/loushang-product.md
+++ b/docs/internals/glossary/loushang-product.md
@@ -268,6 +268,14 @@ A named runtime or domain concern, such as a conversation store, memory
 provider, compaction planner, tool definition, command descriptor, deck
 renderer, or artifact handler.
 
+### Product Capability Requirement
+
+An opaque Product-level request for a named capability, declared by an admitted
+Skill, Method, Work plan, Session operation, or Product default. A requirement
+does not name executable handlers, select a Harness implementation, grant
+authority, or imply activation. The Active Product resolves it through its
+admitted capability catalog and policy.
+
 ### Capability Slot
 
 A Product-declared location at which one or more implementations of a
@@ -303,6 +311,11 @@ is required, use the PPT Product and an explicit Product Handoff.
 
 The Product-owned activation of an admitted Product Capability Bundle or
 Capability Pack for a specific runtime scope.
+
+A Product may define `disabled`, `on_demand`, or `always` mount policy. Scoped
+mounts from Product defaults, manual selection, Skills, and Method/Work steps are
+additive and independently owned; releasing one scope must not remove another
+scope's request. A Capability Mount is unrelated to an AppService control lease.
 
 For example, Coding may mount `ppt-authoring` while remaining the Active
 Product. The Product Session should snapshot continuity-critical mounted


### PR DESCRIPTION
## Summary

- align the v3 target around Product Session and Work bindings instead of a long-term DomainApp runtime
- define opaque Product capability requirements, capability mounts, and scoped activation ownership
- position `coding.arch` as a Product Capability Bundle that resolves to a separately identified tool-family pack
- preserve `CodingDomainApp` as a current compatibility facade without assigning it new target responsibilities

## Why

The existing long-term subsystem documentation still routed structured work through a DomainApp and implied a direct Method-to-Work dependency. That conflicted with the v3 Product Work Preparer and Product Work Executor boundary. The capability documentation also needed to distinguish Product requirements and bundles from Harness ToolPack implementations and runtime authority.

## Impact

This is documentation-only. It clarifies the target ownership and dependency direction for future `coding.arch`, Method/Work integration, and Skill-triggered capability activation without changing the current runtime surface.

## Validation

- `git diff --cached --check`
- `git diff --check`
