### PR TITLE
Extract context resource discovery owner

### DIFF
--- a/docs/internals/architecture/harness/current-owner-map.md
+++ b/docs/internals/architecture/harness/current-owner-map.md
@@ -79,7 +79,8 @@ Compatibility facades remain stable while large implementation pipelines are
 split internally. The implemented dependency direction is:
 
 ```text
-resource loader facade -> snapshot pipeline -> discovery + resolution
+resource loader facade -> snapshot pipeline -> context discovery
+                                            -> other source discovery + resolution
                                             -> precedence policy
 
 runtime profile facade -> types + admission + resolution + binding + standard slots
@@ -92,10 +93,16 @@ settings schema codec / typed settings patch -> Agent settings types
 workspace read tool + Host prompt input -> workspace image payload owner
 ```
 
-Resolution never imports discovery, live profile binding never imports profile
-resolution, and internal leaf modules never import their public facade. The
-Agent settings manager depends only on the explicit codec/patch ports enforced
-by the architecture tests, not on field-level serializer helpers.
+Context-file ancestor traversal, configured filename precedence, descriptor
+construction, and nearest-context selection belong to
+`harness.resources._loader_discovery_context`. Filesystem, package, temporary,
+and built-in source discovery remain in `_loader_discovery`; both discovery
+owners are called by the snapshot pipeline and do not depend on one another.
+Resolution never imports either discovery owner, live profile binding never
+imports profile resolution, and internal leaf modules never import their public
+facade. The Agent settings manager depends only on the explicit codec/patch
+ports enforced by the architecture tests, not on field-level serializer
+helpers.
 Image MIME validation, header dimensions, base64 encoding, inline limits, and
 resize preparation belong to `harness.tools.workspace.image_payload`; neither
 prompt input nor the read tool owns a second copy of those rules or the
@@ -110,8 +117,8 @@ policy remains with Host prompt input and the read tool.
 - no Session-module import from the Session public barrel;
 - one-way Harness, Work, and Channel dependencies;
 - explicit Agent/AI import allowlists for optional profiles;
-- one-way resource loader, runtime profile, and Agent settings internals with
-  an exact manager-to-codec/patch import allowlist;
+- one-way resource loader, context discovery, runtime profile, and Agent
+  settings internals with an exact manager-to-codec/patch import allowlist;
 - one shared workspace image-payload owner consumed by Host prompt input and
   the read tool;
 - Product-neutral Harnesstui and shared runtime owners.

--- a/src/loushang/harness/resources/_loader_discovery.py
+++ b/src/loushang/harness/resources/_loader_discovery.py
@@ -16,7 +16,6 @@ from loushang.harness.resources._loader_types import (
     _MAX_SKILL_DESCRIPTION_LENGTH,
     _MAX_SKILL_NAME_LENGTH,
     _SOURCE_LABEL,
-    _SOURCE_SCOPE,
     DescriptorT,
     _SourceDiscovery,
 )
@@ -566,123 +565,6 @@ def _discover_built_in_resources(
         themes=themes,
         diagnostics=diagnostics,
     )
-
-
-def _discover_context_descriptors(
-    start: Path,
-    *,
-    user_resource_roots: tuple[Path, ...],
-    context_file_names: tuple[str, ...],
-) -> tuple[
-    list[PromptFragmentDescriptor],
-    PromptFragmentDescriptor | None,
-    list[DiagnosticDraft],
-]:
-    descriptors: list[PromptFragmentDescriptor] = []
-    diagnostics: list[DiagnosticDraft] = []
-
-    for index, root in enumerate(user_resource_roots):
-        if not root.is_dir():
-            continue
-        descriptor, read_diagnostics = _discover_context_descriptor_from_dir(
-            root,
-            source_kind="user_global",
-            source_root_order=index,
-            context_file_names=context_file_names,
-        )
-        diagnostics.extend(read_diagnostics)
-        if descriptor is not None:
-            descriptors.append(descriptor)
-
-    project_descriptors: list[PromptFragmentDescriptor] = []
-    for index, current in enumerate(reversed(_ancestor_dirs(start))):
-        descriptor, read_diagnostics = _discover_context_descriptor_from_dir(
-            current,
-            source_kind="project_local",
-            source_root_order=index,
-            context_file_names=context_file_names,
-        )
-        diagnostics.extend(read_diagnostics)
-        if descriptor is not None:
-            project_descriptors.append(descriptor)
-    descriptors.extend(project_descriptors)
-    return descriptors, _nearest_context_descriptor(descriptors), diagnostics
-
-
-def _ancestor_dirs(start: Path) -> list[Path]:
-    current = start if start.is_dir() else start.parent
-    dirs: list[Path] = []
-    while True:
-        dirs.append(current)
-        if current.parent == current:
-            return dirs
-        current = current.parent
-
-
-def _discover_context_descriptor_from_dir(
-    root: Path,
-    *,
-    source_kind: ResourceSourceKind,
-    source_root_order: int,
-    context_file_names: tuple[str, ...],
-) -> tuple[PromptFragmentDescriptor | None, list[DiagnosticDraft]]:
-    for filename in context_file_names:
-        candidate = root / filename
-        if not candidate.is_file():
-            continue
-        text, diagnostics = _read_text_file(
-            candidate,
-            diagnostic_code=_context_read_diagnostic_code(candidate.name),
-            message_prefix=f"Failed to read {candidate.name}",
-        )
-        if text is None:
-            return None, diagnostics
-        return (
-            PromptFragmentDescriptor(
-                name=candidate.name,
-                source_path=candidate,
-                text=text,
-                id=_context_descriptor_id(candidate.name, source_kind),
-                canonical_name=candidate.name,
-                prompt_kind=_context_prompt_kind(candidate.name),
-                source_kind=source_kind,
-                source_scope=_SOURCE_SCOPE[source_kind],
-                source=_SOURCE_LABEL[source_kind],
-                source_root=root,
-                source_root_order=source_root_order,
-            ),
-            diagnostics,
-        )
-    return None, []
-
-
-def _context_prompt_kind(filename: str) -> str:
-    return "agents_md" if filename.upper() == "AGENTS.MD" else "claude_md"
-
-
-def _context_descriptor_id(filename: str, source_kind: ResourceSourceKind) -> str:
-    source_prefix = "user" if source_kind == "user_global" else "project"
-    context_name = (
-        "agents" if _context_prompt_kind(filename) == "agents_md" else "claude"
-    )
-    return f"{source_prefix}.{context_name}"
-
-
-def _context_read_diagnostic_code(filename: str) -> str:
-    return (
-        "unreadable_agents_file"
-        if _context_prompt_kind(filename) == "agents_md"
-        else "unreadable_claude_file"
-    )
-
-
-def _nearest_context_descriptor(
-    descriptors: list[PromptFragmentDescriptor],
-) -> PromptFragmentDescriptor | None:
-    for descriptor in reversed(descriptors):
-        if descriptor.source_kind == "project_local":
-            return descriptor
-    return descriptors[-1] if descriptors else None
 
 
 def _discover_prompts(

--- a/src/loushang/harness/resources/_loader_discovery_context.py
+++ b/src/loushang/harness/resources/_loader_discovery_context.py
@@ -1,0 +1,142 @@
+"""Context-file discovery for the resource loader pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loushang.harness.diagnostics.types import DiagnosticDraft
+from loushang.harness.resources._loader_types import _SOURCE_LABEL, _SOURCE_SCOPE
+from loushang.harness.resources.diagnostics import resource_diagnostic
+from loushang.harness.resources.types import (
+    PromptFragmentDescriptor,
+    ResourceSourceKind,
+)
+
+
+def _discover_context_descriptors(
+    start: Path,
+    *,
+    user_resource_roots: tuple[Path, ...],
+    context_file_names: tuple[str, ...],
+) -> tuple[
+    list[PromptFragmentDescriptor],
+    PromptFragmentDescriptor | None,
+    list[DiagnosticDraft],
+]:
+    descriptors: list[PromptFragmentDescriptor] = []
+    diagnostics: list[DiagnosticDraft] = []
+
+    for index, root in enumerate(user_resource_roots):
+        if not root.is_dir():
+            continue
+        descriptor, read_diagnostics = _discover_context_descriptor_from_dir(
+            root,
+            source_kind="user_global",
+            source_root_order=index,
+            context_file_names=context_file_names,
+        )
+        diagnostics.extend(read_diagnostics)
+        if descriptor is not None:
+            descriptors.append(descriptor)
+
+    project_descriptors: list[PromptFragmentDescriptor] = []
+    for index, current in enumerate(reversed(_ancestor_dirs(start))):
+        descriptor, read_diagnostics = _discover_context_descriptor_from_dir(
+            current,
+            source_kind="project_local",
+            source_root_order=index,
+            context_file_names=context_file_names,
+        )
+        diagnostics.extend(read_diagnostics)
+        if descriptor is not None:
+            project_descriptors.append(descriptor)
+    descriptors.extend(project_descriptors)
+    return descriptors, _nearest_context_descriptor(descriptors), diagnostics
+
+
+def _ancestor_dirs(start: Path) -> list[Path]:
+    current = start if start.is_dir() else start.parent
+    dirs: list[Path] = []
+    while True:
+        dirs.append(current)
+        if current.parent == current:
+            return dirs
+        current = current.parent
+
+
+def _discover_context_descriptor_from_dir(
+    root: Path,
+    *,
+    source_kind: ResourceSourceKind,
+    source_root_order: int,
+    context_file_names: tuple[str, ...],
+) -> tuple[PromptFragmentDescriptor | None, list[DiagnosticDraft]]:
+    for filename in context_file_names:
+        candidate = root / filename
+        if not candidate.is_file():
+            continue
+        text, diagnostics = _read_context_file(candidate)
+        if text is None:
+            return None, diagnostics
+        return (
+            PromptFragmentDescriptor(
+                name=candidate.name,
+                source_path=candidate,
+                text=text,
+                id=_context_descriptor_id(candidate.name, source_kind),
+                canonical_name=candidate.name,
+                prompt_kind=_context_prompt_kind(candidate.name),
+                source_kind=source_kind,
+                source_scope=_SOURCE_SCOPE[source_kind],
+                source=_SOURCE_LABEL[source_kind],
+                source_root=root,
+                source_root_order=source_root_order,
+            ),
+            diagnostics,
+        )
+    return None, []
+
+
+def _read_context_file(path: Path) -> tuple[str | None, list[DiagnosticDraft]]:
+    try:
+        return path.read_text(encoding="utf-8").strip(), []
+    except OSError as exc:
+        return (
+            None,
+            [
+                resource_diagnostic(
+                    code=_context_read_diagnostic_code(path.name),
+                    message=f"Failed to read {path.name}: {exc}",
+                    source_path=path,
+                )
+            ],
+        )
+
+
+def _context_prompt_kind(filename: str) -> str:
+    return "agents_md" if filename.upper() == "AGENTS.MD" else "claude_md"
+
+
+def _context_descriptor_id(filename: str, source_kind: ResourceSourceKind) -> str:
+    source_prefix = "user" if source_kind == "user_global" else "project"
+    context_name = (
+        "agents" if _context_prompt_kind(filename) == "agents_md" else "claude"
+    )
+    return f"{source_prefix}.{context_name}"
+
+
+def _context_read_diagnostic_code(filename: str) -> str:
+    return (
+        "unreadable_agents_file"
+        if _context_prompt_kind(filename) == "agents_md"
+        else "unreadable_claude_file"
+    )
+
+
+def _nearest_context_descriptor(
+    descriptors: list[PromptFragmentDescriptor],
+) -> PromptFragmentDescriptor | None:
+    for descriptor in reversed(descriptors):
+        if descriptor.source_kind == "project_local":
+            return descriptor
+    return descriptors[-1] if descriptors else None

--- a/src/loushang/harness/resources/_loader_pipeline.py
+++ b/src/loushang/harness/resources/_loader_pipeline.py
@@ -9,11 +9,13 @@ from loushang.harness.diagnostics.types import DiagnosticDraft
 from loushang.harness.resources._loader_discovery import (
     _apply_resource_switches,
     _discover_built_in_resources,
-    _discover_context_descriptors,
     _discover_external_package_resources,
     _discover_project_resources,
     _discover_temporary_resources,
     _discover_user_global_resources,
+)
+from loushang.harness.resources._loader_discovery_context import (
+    _discover_context_descriptors,
 )
 from loushang.harness.resources._loader_resolution import (
     _resolve_candidates,

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3097,6 +3097,7 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         runtime_root / "_profile_resolution.py",
         runtime_root / "_profile_types.py",
         resource_root / "_loader_discovery.py",
+        resource_root / "_loader_discovery_context.py",
         resource_root / "_loader_pipeline.py",
         resource_root / "_loader_precedence.py",
         resource_root / "_loader_resolution.py",
@@ -3133,11 +3134,20 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         ),
         resource_root / "_loader_precedence.py": (
             "loushang.harness.resources._loader_discovery",
+            "loushang.harness.resources._loader_discovery_context",
             "loushang.harness.resources._loader_pipeline",
             "loushang.harness.resources._loader_resolution",
             "loushang.harness.resources.loader",
         ),
         resource_root / "_loader_discovery.py": (
+            "loushang.harness.resources._loader_discovery_context",
+            "loushang.harness.resources._loader_pipeline",
+            "loushang.harness.resources._loader_precedence",
+            "loushang.harness.resources._loader_resolution",
+            "loushang.harness.resources.loader",
+        ),
+        resource_root / "_loader_discovery_context.py": (
+            "loushang.harness.resources._loader_discovery",
             "loushang.harness.resources._loader_pipeline",
             "loushang.harness.resources._loader_precedence",
             "loushang.harness.resources._loader_resolution",
@@ -3145,6 +3155,7 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         ),
         resource_root / "_loader_resolution.py": (
             "loushang.harness.resources._loader_discovery",
+            "loushang.harness.resources._loader_discovery_context",
             "loushang.harness.resources._loader_pipeline",
             "loushang.harness.resources.loader",
         ),
@@ -3200,6 +3211,16 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
     assert "loushang.harness.resources._loader_pipeline" in _absolute_imports(
         resource_root / "loader.py"
     )
+    assert (
+        "loushang.harness.resources._loader_discovery_context"
+        in _absolute_imports(resource_root / "_loader_pipeline.py")
+    )
+    assert "def _discover_context_descriptors" not in (
+        resource_root / "_loader_discovery.py"
+    ).read_text(encoding="utf-8")
+    assert "def _discover_context_descriptors" in (
+        resource_root / "_loader_discovery_context.py"
+    ).read_text(encoding="utf-8")
     assert "loushang.harness.resources._loader_precedence" in _absolute_imports(
         resource_root / "_loader_resolution.py"
     )

--- a/tests/harness/resources/test_loader_discovery_context.py
+++ b/tests/harness/resources/test_loader_discovery_context.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loushang.harness.resources._loader_discovery_context import (
+    _discover_context_descriptors,
+)
+
+
+def test_context_discovery_stacks_user_and_ancestor_descriptors(tmp_path: Path) -> None:
+    user_root = tmp_path / "user"
+    workspace_root = tmp_path / "workspace"
+    project_root = workspace_root / "project"
+    nested = project_root / "src" / "feature"
+    user_root.mkdir()
+    nested.mkdir(parents=True)
+    user_context = user_root / "AGENTS.md"
+    workspace_context = workspace_root / "AGENTS.md"
+    project_context = project_root / "CLAUDE.md"
+    user_context.write_text("Global guidance", encoding="utf-8")
+    workspace_context.write_text("Workspace guidance", encoding="utf-8")
+    project_context.write_text("Project guidance", encoding="utf-8")
+
+    descriptors, nearest, diagnostics = _discover_context_descriptors(
+        nested,
+        user_resource_roots=(user_root,),
+        context_file_names=("AGENTS.md", "CLAUDE.md"),
+    )
+
+    assert diagnostics == []
+    assert [descriptor.source_path for descriptor in descriptors] == [
+        user_context,
+        workspace_context,
+        project_context,
+    ]
+    assert [descriptor.text for descriptor in descriptors] == [
+        "Global guidance",
+        "Workspace guidance",
+        "Project guidance",
+    ]
+    assert [descriptor.source_kind for descriptor in descriptors] == [
+        "user_global",
+        "project_local",
+        "project_local",
+    ]
+    assert [descriptor.source_scope for descriptor in descriptors] == [
+        "user",
+        "project",
+        "project",
+    ]
+    assert [descriptor.id for descriptor in descriptors] == [
+        "user.agents",
+        "project.agents",
+        "project.claude",
+    ]
+    assert [descriptor.prompt_kind for descriptor in descriptors] == [
+        "agents_md",
+        "agents_md",
+        "claude_md",
+    ]
+    assert [descriptor.source_root_order for descriptor in descriptors] == [
+        0,
+        len(workspace_root.parents),
+        len(project_root.parents),
+    ]
+    assert nearest is descriptors[-1]
+
+
+def test_context_discovery_uses_configured_filename_precedence(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    nested_file = project_root / "src" / "module.py"
+    nested_file.parent.mkdir(parents=True)
+    nested_file.touch()
+    agents_context = project_root / "AGENTS.md"
+    claude_context = project_root / "CLAUDE.md"
+    agents_context.write_text("Agent guidance", encoding="utf-8")
+    claude_context.write_text("Compatibility guidance", encoding="utf-8")
+
+    descriptors, nearest, diagnostics = _discover_context_descriptors(
+        nested_file,
+        user_resource_roots=(),
+        context_file_names=("CLAUDE.md", "AGENTS.md"),
+    )
+
+    assert diagnostics == []
+    assert [descriptor.source_path for descriptor in descriptors] == [claude_context]
+    assert descriptors[0].canonical_name == "CLAUDE.md"
+    assert descriptors[0].prompt_kind == "claude_md"
+    assert nearest is descriptors[0]
+
+
+def test_context_discovery_falls_back_to_last_user_root(tmp_path: Path) -> None:
+    first_root = tmp_path / "first"
+    second_root = tmp_path / "second"
+    project_root = tmp_path / "project"
+    first_root.mkdir()
+    second_root.mkdir()
+    project_root.mkdir()
+    first_context = first_root / "AGENTS.md"
+    second_context = second_root / "AGENTS.md"
+    first_context.write_text("First", encoding="utf-8")
+    second_context.write_text("Second", encoding="utf-8")
+
+    descriptors, nearest, diagnostics = _discover_context_descriptors(
+        project_root,
+        user_resource_roots=(first_root, second_root),
+        context_file_names=("AGENTS.md",),
+    )
+
+    assert diagnostics == []
+    assert [descriptor.source_path for descriptor in descriptors] == [
+        first_context,
+        second_context,
+    ]
+    assert nearest is descriptors[-1]
+
+
+def test_context_discovery_reports_unreadable_context_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    context_path = project_root / "AGENTS.md"
+    context_path.write_text("Unreadable", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def fail_context_read(path: Path, *args, **kwargs):
+        if path == context_path:
+            raise OSError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fail_context_read)
+
+    descriptors, nearest, diagnostics = _discover_context_descriptors(
+        project_root,
+        user_resource_roots=(),
+        context_file_names=("AGENTS.md",),
+    )
+
+    assert descriptors == []
+    assert nearest is None
+    assert len(diagnostics) == 1
+    assert diagnostics[0].code == "unreadable_agents_file"
+    assert diagnostics[0].source_path == context_path
+    assert diagnostics[0].message.startswith("Failed to read AGENTS.md: ")


### PR DESCRIPTION
## What changed

- extract context-file discovery from the shared resource discovery module into `_loader_discovery_context.py`
- make the snapshot pipeline call context discovery and other source discovery as independent sibling owners
- preserve ancestor traversal, configured filename precedence, descriptor identity, user-root fallback, nearest-context selection, and read diagnostics
- add characterization tests and architecture gates for the one-way dependency boundary
- update the authoritative Harness owner map

## Why

`_loader_discovery.py` combined context ancestry and selection policy with filesystem, package, temporary, and built-in source scanners. Context discovery is a distinct change axis and can be separated without changing resource resolution or public APIs.

## Impact

Resource loading behavior and public contracts are unchanged. The context-file owner is now independently testable, the snapshot pipeline remains the only coordinator, and resolution cannot depend on either discovery implementation.

## Validation

- `make lint-harness`
- `make typecheck-harness` — 423 source files clean
- `uv --cache-dir .uv-cache run --extra dev pytest tests/harness tests/architecture/test_import_boundaries.py -q` — 1661 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_resource_loader.py -q` — 35 passed
