### PR TITLE
Extract resource package policy owner

### DIFF
--- a/docs/internals/architecture/harness/current-owner-map.md
+++ b/docs/internals/architecture/harness/current-owner-map.md
@@ -79,9 +79,10 @@ Compatibility facades remain stable while large implementation pipelines are
 split internally. The implemented dependency direction is:
 
 ```text
+resource loader facade -> package policy
 resource loader facade -> snapshot pipeline -> context discovery
-                                            -> other source discovery + resolution
-                                            -> precedence policy
+                                            -> other source discovery -> package policy
+                                            -> resolution -> precedence policy
 
 runtime profile facade -> types + admission + resolution + binding + standard slots
 admission / resolution / binding / standard slots -> profile types
@@ -95,14 +96,19 @@ workspace read tool + Host prompt input -> workspace image payload owner
 
 Context-file ancestor traversal, configured filename precedence, descriptor
 construction, and nearest-context selection belong to
-`harness.resources._loader_discovery_context`. Filesystem, package, temporary,
-and built-in source discovery remain in `_loader_discovery`; both discovery
-owners are called by the snapshot pipeline and do not depend on one another.
-Resolution never imports either discovery owner, live profile binding never
-imports profile resolution, and internal leaf modules never import their public
-facade. The Agent settings manager depends only on the explicit codec/patch
-ports enforced by the architecture tests, not on field-level serializer
-helpers.
+`harness.resources._loader_discovery_context`. Package-root and filter
+normalization, descriptor-selection patterns, root diagnostics, and per-root
+resource accounting belong to `harness.resources._loader_package_policy`.
+Filesystem, external-package scanning, temporary, and built-in source discovery
+remain in `_loader_discovery`; external-package scanning consumes the package
+policy without moving the shared filesystem scanners. The snapshot pipeline
+calls both discovery paths but does not depend directly on package policy.
+Context discovery and package policy do not depend on discovery coordination,
+resolution, the pipeline, or the public loader facade. Resolution never imports
+either discovery owner or package policy, live profile binding never imports
+profile resolution, and internal leaf modules never import their public facade.
+The Agent settings manager depends only on the explicit codec/patch ports
+enforced by the architecture tests, not on field-level serializer helpers.
 Image MIME validation, header dimensions, base64 encoding, inline limits, and
 resize preparation belong to `harness.tools.workspace.image_payload`; neither
 prompt input nor the read tool owns a second copy of those rules or the
@@ -117,8 +123,9 @@ policy remains with Host prompt input and the read tool.
 - no Session-module import from the Session public barrel;
 - one-way Harness, Work, and Channel dependencies;
 - explicit Agent/AI import allowlists for optional profiles;
-- one-way resource loader, context discovery, runtime profile, and Agent
-  settings internals with an exact manager-to-codec/patch import allowlist;
+- one-way resource loader, context discovery, package policy, runtime profile,
+  and Agent settings internals with an exact manager-to-codec/patch import
+  allowlist;
 - one shared workspace image-payload owner consumed by Host prompt input and
   the read tool;
 - Product-neutral Harnesstui and shared runtime owners.

--- a/src/loushang/harness/resources/_loader_discovery.py
+++ b/src/loushang/harness/resources/_loader_discovery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from fnmatch import fnmatch
 from importlib import resources
 from importlib.resources.abc import Traversable
@@ -11,12 +11,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loushang.harness.diagnostics.types import DiagnosticDraft
+from loushang.harness.resources._loader_package_policy import (
+    _filter_package_descriptors,
+    _package_root_diagnostic,
+)
 from loushang.harness.resources._loader_types import (
     _IGNORE_FILE_NAMES,
     _MAX_SKILL_DESCRIPTION_LENGTH,
     _MAX_SKILL_NAME_LENGTH,
     _SOURCE_LABEL,
-    DescriptorT,
     _SourceDiscovery,
 )
 from loushang.harness.resources.diagnostics import resource_diagnostic
@@ -1539,145 +1542,6 @@ def _package_resource_path(resource_package: str, relative_path: str) -> Path:
 
 def _package_source_root_path(resource_package: str, category: str) -> Path:
     return Path(resource_package.replace(".", "/")) / category
-
-
-def _normalize_package_roots(
-    package_roots: Sequence[str | Path] | None,
-) -> tuple[Path, ...]:
-    if not package_roots:
-        return ()
-    return tuple(Path(root).expanduser().resolve() for root in package_roots)
-
-
-def _normalize_package_source_filters(
-    package_source_filters: Mapping[str | Path, PackageSourceConfig] | None,
-) -> dict[Path, PackageSourceConfig]:
-    if not package_source_filters:
-        return {}
-    return {
-        Path(root).expanduser().resolve(): config
-        for root, config in package_source_filters.items()
-    }
-
-
-def _filter_package_descriptors(
-    descriptors: list[DescriptorT],
-    *,
-    root: Path,
-    patterns: tuple[str, ...] | None,
-) -> list[DescriptorT]:
-    if patterns is None:
-        return descriptors
-    if not patterns:
-        return []
-    includes = [pattern for pattern in patterns if not _is_override_pattern(pattern)]
-    excludes = [pattern[1:] for pattern in patterns if pattern.startswith("!")]
-    force_includes = [pattern[1:] for pattern in patterns if pattern.startswith("+")]
-    force_excludes = [pattern[1:] for pattern in patterns if pattern.startswith("-")]
-    filtered: list[DescriptorT] = []
-    for descriptor in descriptors:
-        enabled = (
-            True
-            if not includes
-            else _descriptor_matches_patterns(
-                descriptor, root=root, patterns=tuple(includes)
-            )
-        )
-        if excludes and _descriptor_matches_patterns(
-            descriptor, root=root, patterns=tuple(excludes)
-        ):
-            enabled = False
-        if force_includes and _descriptor_matches_patterns(
-            descriptor, root=root, patterns=tuple(force_includes), exact=True
-        ):
-            enabled = True
-        if force_excludes and _descriptor_matches_patterns(
-            descriptor, root=root, patterns=tuple(force_excludes), exact=True
-        ):
-            enabled = False
-        if enabled:
-            filtered.append(descriptor)
-    return filtered
-
-
-def _is_override_pattern(pattern: str) -> bool:
-    return pattern.startswith(("!", "+", "-"))
-
-
-def _descriptor_matches_patterns(
-    descriptor: DescriptorT,
-    *,
-    root: Path,
-    patterns: tuple[str, ...],
-    exact: bool = False,
-) -> bool:
-    values = _descriptor_match_values(descriptor, root=root)
-    if exact:
-        return any(
-            value == pattern.lstrip("./") for pattern in patterns for value in values
-        )
-    return any(fnmatch(value, pattern) for pattern in patterns for value in values)
-
-
-def _descriptor_match_values(descriptor: DescriptorT, *, root: Path) -> tuple[str, ...]:
-    values = {
-        descriptor.name,
-        descriptor.id or "",
-        descriptor.canonical_name or "",
-        descriptor.source_path.name,
-        descriptor.source_path.parent.name,
-    }
-    try:
-        relative_path = descriptor.source_path.resolve().relative_to(root).as_posix()
-    except ValueError:
-        relative_path = descriptor.source_path.as_posix()
-    values.add(relative_path)
-    return tuple(value for value in values if value)
-
-
-def _package_root_diagnostic(code: str, message: str, root: Path) -> DiagnosticDraft:
-    return resource_diagnostic(
-        code=code,
-        message=message,
-        source_path=root,
-        resource_type="package",
-        source_kind="external_package",
-        metadata={"package_root": str(root)},
-    )
-
-
-def _count_package_descriptors(descriptors: tuple[DescriptorT, ...], root: Path) -> int:
-    return sum(
-        1
-        for descriptor in descriptors
-        if _path_belongs_to_root(descriptor.source_path, root)
-    )
-
-
-def _count_package_diagnostics(
-    diagnostics: tuple[DiagnosticDraft, ...], root: Path
-) -> int:
-    return sum(
-        1 for diagnostic in diagnostics if _diagnostic_belongs_to_root(diagnostic, root)
-    )
-
-
-def _diagnostic_belongs_to_root(diagnostic: DiagnosticDraft, root: Path) -> bool:
-    metadata = diagnostic.details.get("metadata")
-    package_root = metadata.get("package_root") if isinstance(metadata, dict) else None
-    if package_root == str(root):
-        return True
-    if diagnostic.source_path is None:
-        return False
-    return _path_belongs_to_root(diagnostic.source_path, root)
-
-
-def _path_belongs_to_root(path: Path, root: Path) -> bool:
-    try:
-        path.resolve().relative_to(root)
-    except ValueError:
-        return False
-    return True
 
 
 def _normalize_user_resource_roots(

--- a/src/loushang/harness/resources/_loader_package_policy.py
+++ b/src/loushang/harness/resources/_loader_package_policy.py
@@ -1,0 +1,154 @@
+"""Package-root normalization, filtering, diagnostics, and accounting policy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loushang.harness.diagnostics.types import DiagnosticDraft
+from loushang.harness.resources._loader_types import DescriptorT
+from loushang.harness.resources.diagnostics import resource_diagnostic
+
+if TYPE_CHECKING:
+    from loushang.harness.resources.packages.source import PackageSourceConfig
+
+
+def _normalize_package_roots(
+    package_roots: Sequence[str | Path] | None,
+) -> tuple[Path, ...]:
+    if not package_roots:
+        return ()
+    return tuple(Path(root).expanduser().resolve() for root in package_roots)
+
+
+def _normalize_package_source_filters(
+    package_source_filters: Mapping[str | Path, PackageSourceConfig] | None,
+) -> dict[Path, PackageSourceConfig]:
+    if not package_source_filters:
+        return {}
+    return {
+        Path(root).expanduser().resolve(): config
+        for root, config in package_source_filters.items()
+    }
+
+
+def _filter_package_descriptors(
+    descriptors: list[DescriptorT],
+    *,
+    root: Path,
+    patterns: tuple[str, ...] | None,
+) -> list[DescriptorT]:
+    if patterns is None:
+        return descriptors
+    if not patterns:
+        return []
+    includes = [pattern for pattern in patterns if not _is_override_pattern(pattern)]
+    excludes = [pattern[1:] for pattern in patterns if pattern.startswith("!")]
+    force_includes = [pattern[1:] for pattern in patterns if pattern.startswith("+")]
+    force_excludes = [pattern[1:] for pattern in patterns if pattern.startswith("-")]
+    filtered: list[DescriptorT] = []
+    for descriptor in descriptors:
+        enabled = (
+            True
+            if not includes
+            else _descriptor_matches_patterns(
+                descriptor, root=root, patterns=tuple(includes)
+            )
+        )
+        if excludes and _descriptor_matches_patterns(
+            descriptor, root=root, patterns=tuple(excludes)
+        ):
+            enabled = False
+        if force_includes and _descriptor_matches_patterns(
+            descriptor, root=root, patterns=tuple(force_includes), exact=True
+        ):
+            enabled = True
+        if force_excludes and _descriptor_matches_patterns(
+            descriptor, root=root, patterns=tuple(force_excludes), exact=True
+        ):
+            enabled = False
+        if enabled:
+            filtered.append(descriptor)
+    return filtered
+
+
+def _is_override_pattern(pattern: str) -> bool:
+    return pattern.startswith(("!", "+", "-"))
+
+
+def _descriptor_matches_patterns(
+    descriptor: DescriptorT,
+    *,
+    root: Path,
+    patterns: tuple[str, ...],
+    exact: bool = False,
+) -> bool:
+    values = _descriptor_match_values(descriptor, root=root)
+    if exact:
+        return any(
+            value == pattern.lstrip("./") for pattern in patterns for value in values
+        )
+    return any(fnmatch(value, pattern) for pattern in patterns for value in values)
+
+
+def _descriptor_match_values(descriptor: DescriptorT, *, root: Path) -> tuple[str, ...]:
+    values = {
+        descriptor.name,
+        descriptor.id or "",
+        descriptor.canonical_name or "",
+        descriptor.source_path.name,
+        descriptor.source_path.parent.name,
+    }
+    try:
+        relative_path = descriptor.source_path.resolve().relative_to(root).as_posix()
+    except ValueError:
+        relative_path = descriptor.source_path.as_posix()
+    values.add(relative_path)
+    return tuple(value for value in values if value)
+
+
+def _package_root_diagnostic(code: str, message: str, root: Path) -> DiagnosticDraft:
+    return resource_diagnostic(
+        code=code,
+        message=message,
+        source_path=root,
+        resource_type="package",
+        source_kind="external_package",
+        metadata={"package_root": str(root)},
+    )
+
+
+def _count_package_descriptors(descriptors: tuple[DescriptorT, ...], root: Path) -> int:
+    return sum(
+        1
+        for descriptor in descriptors
+        if _path_belongs_to_root(descriptor.source_path, root)
+    )
+
+
+def _count_package_diagnostics(
+    diagnostics: tuple[DiagnosticDraft, ...], root: Path
+) -> int:
+    return sum(
+        1 for diagnostic in diagnostics if _diagnostic_belongs_to_root(diagnostic, root)
+    )
+
+
+def _diagnostic_belongs_to_root(diagnostic: DiagnosticDraft, root: Path) -> bool:
+    metadata = diagnostic.details.get("metadata")
+    package_root = metadata.get("package_root") if isinstance(metadata, dict) else None
+    if package_root == str(root):
+        return True
+    if diagnostic.source_path is None:
+        return False
+    return _path_belongs_to_root(diagnostic.source_path, root)
+
+
+def _path_belongs_to_root(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root)
+    except ValueError:
+        return False
+    return True

--- a/src/loushang/harness/resources/loader.py
+++ b/src/loushang/harness/resources/loader.py
@@ -9,13 +9,15 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from loushang.harness.diagnostics.types import DiagnosticDraft
 from loushang.harness.resources._loader_discovery import (
+    _normalize_runtime_paths,
+    _normalize_user_resource_roots,
+    _resolve_prompt_input,
+)
+from loushang.harness.resources._loader_package_policy import (
     _count_package_descriptors,
     _count_package_diagnostics,
     _normalize_package_roots,
     _normalize_package_source_filters,
-    _normalize_runtime_paths,
-    _normalize_user_resource_roots,
-    _resolve_prompt_input,
 )
 from loushang.harness.resources._loader_pipeline import (
     _discover_snapshot,

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3098,6 +3098,7 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         runtime_root / "_profile_types.py",
         resource_root / "_loader_discovery.py",
         resource_root / "_loader_discovery_context.py",
+        resource_root / "_loader_package_policy.py",
         resource_root / "_loader_pipeline.py",
         resource_root / "_loader_precedence.py",
         resource_root / "_loader_resolution.py",
@@ -3135,6 +3136,7 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         resource_root / "_loader_precedence.py": (
             "loushang.harness.resources._loader_discovery",
             "loushang.harness.resources._loader_discovery_context",
+            "loushang.harness.resources._loader_package_policy",
             "loushang.harness.resources._loader_pipeline",
             "loushang.harness.resources._loader_resolution",
             "loushang.harness.resources.loader",
@@ -3148,6 +3150,15 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         ),
         resource_root / "_loader_discovery_context.py": (
             "loushang.harness.resources._loader_discovery",
+            "loushang.harness.resources._loader_package_policy",
+            "loushang.harness.resources._loader_pipeline",
+            "loushang.harness.resources._loader_precedence",
+            "loushang.harness.resources._loader_resolution",
+            "loushang.harness.resources.loader",
+        ),
+        resource_root / "_loader_package_policy.py": (
+            "loushang.harness.resources._loader_discovery",
+            "loushang.harness.resources._loader_discovery_context",
             "loushang.harness.resources._loader_pipeline",
             "loushang.harness.resources._loader_precedence",
             "loushang.harness.resources._loader_resolution",
@@ -3156,10 +3167,12 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         resource_root / "_loader_resolution.py": (
             "loushang.harness.resources._loader_discovery",
             "loushang.harness.resources._loader_discovery_context",
+            "loushang.harness.resources._loader_package_policy",
             "loushang.harness.resources._loader_pipeline",
             "loushang.harness.resources.loader",
         ),
         resource_root / "_loader_pipeline.py": (
+            "loushang.harness.resources._loader_package_policy",
             "loushang.harness.resources.loader",
         ),
         settings_root / "types.py": (
@@ -3211,6 +3224,12 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
     assert "loushang.harness.resources._loader_pipeline" in _absolute_imports(
         resource_root / "loader.py"
     )
+    assert "loushang.harness.resources._loader_package_policy" in _absolute_imports(
+        resource_root / "loader.py"
+    )
+    assert "loushang.harness.resources._loader_package_policy" in _absolute_imports(
+        resource_root / "_loader_discovery.py"
+    )
     assert (
         "loushang.harness.resources._loader_discovery_context"
         in _absolute_imports(resource_root / "_loader_pipeline.py")
@@ -3220,6 +3239,18 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
     ).read_text(encoding="utf-8")
     assert "def _discover_context_descriptors" in (
         resource_root / "_loader_discovery_context.py"
+    ).read_text(encoding="utf-8")
+    assert "def _normalize_package_roots" not in (
+        resource_root / "_loader_discovery.py"
+    ).read_text(encoding="utf-8")
+    assert "def _normalize_package_roots" in (
+        resource_root / "_loader_package_policy.py"
+    ).read_text(encoding="utf-8")
+    assert "def _filter_package_descriptors" not in (
+        resource_root / "_loader_discovery.py"
+    ).read_text(encoding="utf-8")
+    assert "def _filter_package_descriptors" in (
+        resource_root / "_loader_package_policy.py"
     ).read_text(encoding="utf-8")
     assert "loushang.harness.resources._loader_precedence" in _absolute_imports(
         resource_root / "_loader_resolution.py"

--- a/tests/harness/resources/test_loader_package_policy.py
+++ b/tests/harness/resources/test_loader_package_policy.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loushang.harness.diagnostics.types import DiagnosticDraft
+from loushang.harness.resources._loader_package_policy import (
+    _count_package_descriptors,
+    _count_package_diagnostics,
+    _filter_package_descriptors,
+    _normalize_package_roots,
+    _normalize_package_source_filters,
+    _package_root_diagnostic,
+)
+from loushang.harness.resources.packages.source import PackageSourceConfig
+from loushang.harness.resources.types import PromptFragmentDescriptor
+
+
+def _prompt(root: Path, filename: str) -> PromptFragmentDescriptor:
+    return PromptFragmentDescriptor(
+        name=Path(filename).stem,
+        source_path=root / "prompts" / filename,
+        text=filename,
+        id=filename,
+        canonical_name=filename,
+        source_kind="external_package",
+        source_scope="package",
+        source_root=root,
+    )
+
+
+def test_package_policy_normalizes_roots_and_filter_keys(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    config = PackageSourceConfig(source="packages/review")
+
+    roots = _normalize_package_roots(("packages/review", Path("packages/debug")))
+    filters = _normalize_package_source_filters({"packages/review": config})
+
+    assert roots == (
+        (tmp_path / "packages" / "review").resolve(),
+        (tmp_path / "packages" / "debug").resolve(),
+    )
+    assert filters == {(tmp_path / "packages" / "review").resolve(): config}
+    assert _normalize_package_roots(None) == ()
+    assert _normalize_package_source_filters(None) == {}
+
+
+def test_package_policy_applies_include_and_override_patterns(tmp_path: Path) -> None:
+    root = tmp_path / "review-pack"
+    review = _prompt(root, "review.md")
+    debug = _prompt(root, "debug.md")
+    descriptors = [review, debug]
+
+    assert _filter_package_descriptors(
+        descriptors,
+        root=root,
+        patterns=("prompts/*.md",),
+    ) == descriptors
+    assert _filter_package_descriptors(
+        descriptors,
+        root=root,
+        patterns=("*.md", "!debug.md", "+debug.md", "-review.md"),
+    ) == [debug]
+    assert _filter_package_descriptors(
+        descriptors,
+        root=root,
+        patterns=(),
+    ) == []
+    assert _filter_package_descriptors(
+        descriptors,
+        root=root,
+        patterns=None,
+    ) == descriptors
+
+
+def test_package_policy_counts_only_owned_descriptors_and_diagnostics(
+    tmp_path: Path,
+) -> None:
+    root = (tmp_path / "review-pack").resolve()
+    inside = _prompt(root, "review.md")
+    outside = _prompt(tmp_path / "other-pack", "debug.md")
+    inside_diagnostic = DiagnosticDraft(
+        code="inside",
+        message="inside",
+        source_path=root / "extensions" / "README.txt",
+    )
+    root_diagnostic = _package_root_diagnostic(
+        "empty_package_root",
+        "Package root contains no loadable resources.",
+        root,
+    )
+    outside_diagnostic = DiagnosticDraft(
+        code="outside",
+        message="outside",
+        source_path=tmp_path / "other-pack" / "README.txt",
+    )
+    unscoped_diagnostic = DiagnosticDraft(code="unscoped", message="unscoped")
+
+    assert _count_package_descriptors((inside, outside), root) == 1
+    assert (
+        _count_package_diagnostics(
+            (
+                inside_diagnostic,
+                root_diagnostic,
+                outside_diagnostic,
+                unscoped_diagnostic,
+            ),
+            root,
+        )
+        == 2
+    )
+    assert root_diagnostic.source_path == root
+    assert root_diagnostic.details == {
+        "resource_type": "package",
+        "source_kind": "external_package",
+        "metadata": {"package_root": str(root)},
+    }


### PR DESCRIPTION
## What changed

- extract package-root normalization, source-filter normalization, descriptor matching, package-root diagnostics, and per-root accounting into `_loader_package_policy.py`
- make the public resource loader use the owner for input normalization and package summaries
- make external-package discovery consume only the filtering and diagnostic policy while retaining the shared filesystem scanners
- add package-policy characterization tests, one-way dependency gates, and owner-map documentation

## Why

The public loader and external-package discovery both depended on package-specific policy buried inside the large general discovery module. Moving the entire external-package scanner would create a reverse dependency on shared filesystem scanners, so this slice separates only the stable package policy boundary.

## Impact

Resource discovery behavior and public contracts are unchanged. Package input and summary mechanics now have a focused owner, the snapshot pipeline does not depend directly on that policy, and package policy cannot import discovery, resolution, the pipeline, or the public facade.

## Validation

- `make lint-harness`
- `make typecheck-harness` — 424 source files clean
- `uv --cache-dir .uv-cache run --extra dev pytest tests/harness tests/architecture/test_import_boundaries.py -q` — 1664 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_resource_loader.py -q` — 35 passed
