### PR TITLE
feat(coding): add language-extensible arch import graph analyzer

### DIFF
--- a/docs/internals/architecture/coding/component-interfaces/tools.md
+++ b/docs/internals/architecture/coding/component-interfaces/tools.md
@@ -63,6 +63,9 @@
   “分析架构”工具替代可验证的结构化查询。
 - CLI 或 Coding 配置的显式常驻选择应增量加入默认工具集合，不得替换 builtin tools，也不得绕过 `--no-tools`、session
   allowlist、delegated execution profile、policy 或 approval 边界。
+- 高频查询复用语言 provider 输出的版本化逐文件事实缓存，而不缓存 AST 或主观架构结论。CLI 默认在
+  `LOUSHANG_HOME/cache/coding/arch` 使用磁盘缓存；长驻工具复用进程内缓存。内容指纹负责单文件失效，文件集合变化则使依赖
+  模块索引的事实整体失效；缓存损坏或版本不兼容必须安全退化为重新分析。
 
 ## Reference Implementation Alignment
 

--- a/examples/coding/README.md
+++ b/examples/coding/README.md
@@ -62,7 +62,11 @@ uv run python examples/coding/21_switch_model_route.py
 uv run python examples/coding/22_usage_inspect.py --endpoint kimi-code-anthropic --strict
 uv run python examples/coding/25_render_tool_events_contract.py
 uv run python examples/coding/extensions/01_lifecycle.py
+uv run python examples/coding/arch/01_import_graph.py
 ```
+
+架构分析示例直接使用公共 `loushang.coding.arch` API；更多说明见
+[`arch/README.md`](arch/README.md)。仓库自动化使用的 `scripts/arch` 入口不作为用户示例。
 
 如果已经激活本仓库虚拟环境，也可以直接用 `python`：
 

--- a/examples/coding/arch/01_import_graph.py
+++ b/examples/coding/arch/01_import_graph.py
@@ -1,0 +1,39 @@
+"""Analyze a small Python package without loading or executing it."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from loushang.coding.arch import analyze_import_graph, query_import_graph
+
+
+def main() -> None:
+    with TemporaryDirectory(prefix="loushang-arch-example-") as temporary:
+        package = Path(temporary) / "sample"
+        package.mkdir()
+        (package / "__init__.py").write_text(
+            "from . import api\n",
+            encoding="utf-8",
+        )
+        (package / "api.py").write_text(
+            "from sample import core\n",
+            encoding="utf-8",
+        )
+        (package / "core.py").write_text(
+            "from sample import api\n",
+            encoding="utf-8",
+        )
+
+        graph = analyze_import_graph(
+            package,
+            package_prefix="sample",
+            imports="all",
+        )
+        result = query_import_graph(graph, "summary", limit=10)
+        print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/coding/arch/README.md
+++ b/examples/coding/arch/README.md
@@ -1,0 +1,53 @@
+## Architecture Analysis Example
+
+`01_import_graph.py` 使用公共 `loushang.coding.arch` API 构造并分析一个临时 Python package，不需要模型或网络凭据：
+
+```bash
+uv run python examples/coding/arch/01_import_graph.py
+```
+
+正式的模块 CLI 也可以直接分析现有源码树：
+
+```bash
+uv run python -m loushang.coding.arch \
+  src/loushang \
+  --package-prefix loushang \
+  --granularity subsystem \
+  --imports all \
+  --query summary \
+  --pretty
+```
+
+模块 CLI 默认把按文件归一化事实缓存到
+`$LOUSHANG_HOME/cache/coding/arch/`（默认 `~/.loushang/cache/coding/arch/`）。
+可用 `--no-cache` 禁用、`--refresh-cache` 强制重建，或用 `--cache-info`
+把易变的缓存命中统计加入 JSON；默认查询 JSON 不含这些运行时统计，因此冷、热查询保持一致。
+
+在长期运行的 tool/session 进程中应复用一个 `ImportGraphAnalyzer` 实例。它默认持有内存事实缓存；第二次及后续扫描只为文件计算内容指纹，单文件内容变化只重解析该文件。需要跨进程复用时，可给构造器传入带路径的 `ImportFactCache`。
+
+`scripts/arch/analyze_import_graph.py` 是供仓库 CI 和维护脚本使用的薄适配器，不是首选的用户示例入口。
+
+维护者可以用同进程性能 gate 验证高频调用路径；它先强制冷扫描，再要求每次未修改的热扫描全部命中缓存，默认最大延迟为 1 秒：
+
+```bash
+uv run python scripts/arch/benchmark_import_graph.py \
+  src/loushang \
+  --package-prefix loushang \
+  --pretty
+```
+
+CLI 默认使用位于 `LOUSHANG_HOME/cache/coding/arch` 的版本化逐文件事实缓存；可用
+`--refresh-cache` 强制重建，或用 `--no-cache` 禁用。维护者可以单独运行可重复性能门槛：
+
+```bash
+uv run python scripts/arch/benchmark_import_graph.py \
+  src/loushang \
+  --package-prefix loushang \
+  --max-warm-seconds 1 \
+  --max-reload-seconds 1 \
+  --max-query-seconds 0.1 \
+  --pretty
+```
+
+计时从依赖导入完成后开始，分别报告冷扫描、同进程热扫描、磁盘缓存重新加载和纯查询，
+因此不会把 Python 进程启动时间误算为分析器延迟。

--- a/scripts/arch/analyze_import_graph.py
+++ b/scripts/arch/analyze_import_graph.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Run Coding's deterministic import graph analyzer."""
+
+from __future__ import annotations
+
+from loushang.coding.arch.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/arch/benchmark_import_graph.py
+++ b/scripts/arch/benchmark_import_graph.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Gate warm import-graph latency for a long-lived Coding process."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from statistics import median
+from time import perf_counter
+
+from loushang.coding.arch import (
+    ImportFactCache,
+    ImportGraphAnalyzer,
+    query_import_graph,
+)
+
+BENCHMARK_SCHEMA_VERSION = 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark repeated import-graph analysis in one long-lived process."
+        )
+    )
+    parser.add_argument("root", type=Path, help="Language source root to scan.")
+    parser.add_argument("--package-prefix")
+    parser.add_argument("--language", default="auto")
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument(
+        "--warm-max-seconds",
+        type=float,
+        default=1.0,
+        help="Fail when any unchanged warm analysis exceeds this latency.",
+    )
+    parser.add_argument(
+        "--cache-file",
+        type=Path,
+        help="Exercise atomic disk persistence in addition to the memory cache.",
+    )
+    parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.runs < 1:
+        parser.error("--runs must be at least 1")
+    if args.warm_max_seconds <= 0:
+        parser.error("--warm-max-seconds must be greater than 0")
+
+    cache = ImportFactCache(args.cache_file)
+    analyzer = ImportGraphAnalyzer(cache=cache)
+    analyze_arguments = {
+        "package_prefix": args.package_prefix,
+        "language": args.language,
+        "imports": "all",
+    }
+
+    cold_started = perf_counter()
+    cold_graph = analyzer.analyze(
+        args.root,
+        refresh_cache=True,
+        **analyze_arguments,
+    )
+    expected = query_import_graph(cold_graph, "summary")
+    cold_seconds = perf_counter() - cold_started
+
+    warm_seconds: list[float] = []
+    warm_hits: list[int] = []
+    for _ in range(args.runs):
+        started = perf_counter()
+        graph = analyzer.analyze(args.root, **analyze_arguments)
+        actual = query_import_graph(graph, "summary")
+        elapsed = perf_counter() - started
+        if actual != expected:
+            raise RuntimeError("warm import-graph result differs from cold result")
+        if (
+            graph.cache_stats.misses
+            or graph.cache_stats.hits != graph.cache_stats.entries
+        ):
+            raise RuntimeError("warm import-graph analysis did not fully hit the cache")
+        warm_seconds.append(elapsed)
+        warm_hits.append(graph.cache_stats.hits)
+
+    warm_max = max(warm_seconds)
+    passed = warm_max <= args.warm_max_seconds
+    result = {
+        "schema_version": BENCHMARK_SCHEMA_VERSION,
+        "root": str(args.root.expanduser().resolve()),
+        "language": cold_graph.language,
+        "modules": len(cold_graph.nodes),
+        "edges": len(cold_graph.edges),
+        "cache_entries": cold_graph.cache_stats.entries,
+        "cold_seconds": round(cold_seconds, 6),
+        "warm_runs": args.runs,
+        "warm_seconds": {
+            "min": round(min(warm_seconds), 6),
+            "median": round(median(warm_seconds), 6),
+            "max": round(warm_max, 6),
+        },
+        "warm_cache_hits": min(warm_hits),
+        "warm_max_seconds": args.warm_max_seconds,
+        "passed": passed,
+    }
+    print(json.dumps(result, indent=2 if args.pretty else None, sort_keys=True))
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["BENCHMARK_SCHEMA_VERSION", "build_parser", "main"]

--- a/src/loushang/coding/arch/__init__.py
+++ b/src/loushang/coding/arch/__init__.py
@@ -1,0 +1,63 @@
+"""Deterministic, language-extensible architecture analysis for Coding."""
+
+from loushang.coding.arch.cache import (
+    IMPORT_FACT_CACHE_SCHEMA_VERSION,
+    ImportFactCache,
+    default_import_fact_cache_path,
+)
+from loushang.coding.arch.import_graph import (
+    IMPORT_GRAPH_SCHEMA_VERSION,
+    ImportGraphAnalyzer,
+    analyze_import_graph,
+    query_import_graph,
+)
+from loushang.coding.arch.model import (
+    ArchitectureDiagnostic,
+    BoundaryRule,
+    ImportCacheStats,
+    ImportCategory,
+    ImportDependencyFact,
+    ImportGranularity,
+    ImportGraph,
+    ImportGraphEdge,
+    ImportGraphNode,
+    ImportGraphQuery,
+    ImportKind,
+    ImportModuleFact,
+    ImportProviderScan,
+    ImportSelection,
+    SourceEvidence,
+)
+from loushang.coding.arch.providers import (
+    PYTHON_IMPORT_PROVIDER_VERSION,
+    ImportGraphProvider,
+    PythonImportGraphProvider,
+)
+
+__all__ = [
+    "IMPORT_GRAPH_SCHEMA_VERSION",
+    "IMPORT_FACT_CACHE_SCHEMA_VERSION",
+    "PYTHON_IMPORT_PROVIDER_VERSION",
+    "ArchitectureDiagnostic",
+    "BoundaryRule",
+    "ImportCategory",
+    "ImportCacheStats",
+    "ImportDependencyFact",
+    "ImportGranularity",
+    "ImportGraph",
+    "ImportGraphAnalyzer",
+    "ImportGraphEdge",
+    "ImportGraphNode",
+    "ImportGraphProvider",
+    "ImportGraphQuery",
+    "ImportKind",
+    "ImportModuleFact",
+    "ImportProviderScan",
+    "ImportFactCache",
+    "ImportSelection",
+    "PythonImportGraphProvider",
+    "SourceEvidence",
+    "analyze_import_graph",
+    "default_import_fact_cache_path",
+    "query_import_graph",
+]

--- a/src/loushang/coding/arch/__main__.py
+++ b/src/loushang/coding/arch/__main__.py
@@ -1,0 +1,8 @@
+"""Run the Coding architecture analyzer as a Python module."""
+
+from __future__ import annotations
+
+from loushang.coding.arch.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/loushang/coding/arch/cache.py
+++ b/src/loushang/coding/arch/cache.py
@@ -1,0 +1,381 @@
+"""Versioned, rebuildable cache for normalized per-file import facts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from loushang.coding.arch.model import (
+    ArchitectureDiagnostic,
+    DiagnosticSeverity,
+    ImportCategory,
+    ImportDependencyFact,
+    ImportKind,
+    ImportModuleFact,
+    SourceEvidence,
+)
+from loushang.harness.resources.layout import resolve_platform_home
+
+IMPORT_FACT_CACHE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ImportFactCacheNamespace:
+    root_id: str
+    language: str
+    provider_version: int
+    package_prefix: str | None
+    configuration_key: str = ""
+
+
+@dataclass(frozen=True)
+class ImportFileFingerprint:
+    sha256: str
+    size: int
+
+
+@dataclass(frozen=True)
+class CachedImportFile:
+    fingerprint: ImportFileFingerprint
+    module: ImportModuleFact | None
+    dependencies: tuple[ImportDependencyFact, ...] = ()
+    diagnostics: tuple[ArchitectureDiagnostic, ...] = ()
+
+
+@dataclass(frozen=True)
+class ImportFactCacheSnapshot:
+    namespace: ImportFactCacheNamespace
+    module_index: tuple[tuple[str, str | None], ...]
+    entries: tuple[tuple[str, CachedImportFile], ...]
+
+    def entry_map(self) -> dict[str, CachedImportFile]:
+        return dict(self.entries)
+
+
+class ImportFactCache:
+    """In-memory fact cache with optional atomic JSON persistence."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path).expanduser() if path is not None else None
+        self._snapshots: dict[ImportFactCacheNamespace, ImportFactCacheSnapshot] = {}
+        self._disk_loaded = False
+        self._persisted_snapshot: ImportFactCacheSnapshot | None = None
+        self.last_error: str | None = None
+
+    def load(
+        self, namespace: ImportFactCacheNamespace
+    ) -> ImportFactCacheSnapshot | None:
+        self._load_disk_once()
+        return self._snapshots.get(namespace)
+
+    def replace(self, snapshot: ImportFactCacheSnapshot) -> None:
+        if (
+            self._snapshots.get(snapshot.namespace) == snapshot
+            and self.last_error is None
+        ):
+            return
+        self._snapshots[snapshot.namespace] = snapshot
+        if self.path is None:
+            return
+        if self._persisted_snapshot == snapshot:
+            self.last_error = None
+            return
+        try:
+            _write_snapshot(self.path, snapshot)
+        except OSError as exc:
+            self.last_error = str(exc)
+        else:
+            self._persisted_snapshot = snapshot
+            self.last_error = None
+
+    def _load_disk_once(self) -> None:
+        if self._disk_loaded:
+            return
+        self._disk_loaded = True
+        if self.path is None or not self.path.is_file():
+            return
+        try:
+            snapshot = _read_snapshot(self.path)
+        except (OSError, TypeError, ValueError) as exc:
+            self.last_error = str(exc)
+            return
+        self._snapshots[snapshot.namespace] = snapshot
+        self._persisted_snapshot = snapshot
+
+
+def import_cache_root_id(root: str | Path) -> str:
+    canonical = os.path.normcase(str(Path(root).expanduser().resolve()))
+    return hashlib.sha256(os.fsencode(canonical)).hexdigest()[:24]
+
+
+def default_import_fact_cache_path(
+    root: str | Path,
+    *,
+    language: str,
+    provider_version: int,
+    cache_root: str | Path | None = None,
+) -> Path:
+    normalized_language = _cache_path_segment(language, "language")
+    if provider_version < 1:
+        raise ValueError("provider_version must be at least 1")
+    base = (
+        resolve_platform_home() / "cache" / "coding" / "arch"
+        if cache_root is None
+        else Path(cache_root).expanduser()
+    )
+    root_id = import_cache_root_id(root)
+    filename = f"{normalized_language}-facts-v{provider_version}.json"
+    return base.resolve(strict=False) / root_id / filename
+
+
+def fingerprint_source(content: bytes) -> ImportFileFingerprint:
+    return ImportFileFingerprint(
+        sha256=hashlib.sha256(content).hexdigest(),
+        size=len(content),
+    )
+
+
+def _write_snapshot(path: Path, snapshot: ImportFactCacheSnapshot) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = _snapshot_payload(snapshot)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            temporary_path = Path(stream.name)
+            json.dump(payload, stream, sort_keys=True, separators=(",", ":"))
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            with suppress(FileNotFoundError):
+                temporary_path.unlink()
+
+
+def _read_snapshot(path: Path) -> ImportFactCacheSnapshot:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("import fact cache must contain a JSON object")
+    if payload.get("schema_version") != IMPORT_FACT_CACHE_SCHEMA_VERSION:
+        raise ValueError("unsupported import fact cache schema version")
+    namespace = _decode_namespace(payload.get("namespace"))
+    raw_module_index = _require_mapping(payload.get("module_index"), "module_index")
+    module_index = tuple(
+        sorted(
+            (
+                _require_string(path, "module_index path"),
+                _optional_string(module, "module_index module"),
+            )
+            for path, module in raw_module_index.items()
+        )
+    )
+    raw_entries = _require_mapping(payload.get("entries"), "entries")
+    entries = tuple(
+        sorted(
+            (
+                _require_string(relative_path, "entry path"),
+                _decode_cached_file(value),
+            )
+            for relative_path, value in raw_entries.items()
+        )
+    )
+    return ImportFactCacheSnapshot(
+        namespace=namespace,
+        module_index=module_index,
+        entries=entries,
+    )
+
+
+def _snapshot_payload(snapshot: ImportFactCacheSnapshot) -> dict[str, object]:
+    return {
+        "schema_version": IMPORT_FACT_CACHE_SCHEMA_VERSION,
+        "namespace": asdict(snapshot.namespace),
+        "module_index": dict(snapshot.module_index),
+        "entries": {
+            path: _cached_file_payload(entry) for path, entry in snapshot.entries
+        },
+    }
+
+
+def _cached_file_payload(entry: CachedImportFile) -> dict[str, object]:
+    return {
+        "fingerprint": asdict(entry.fingerprint),
+        "module": asdict(entry.module) if entry.module is not None else None,
+        "dependencies": [
+            {
+                **asdict(dependency),
+                "evidence": asdict(dependency.evidence),
+            }
+            for dependency in entry.dependencies
+        ],
+        "diagnostics": [asdict(diagnostic) for diagnostic in entry.diagnostics],
+    }
+
+
+def _decode_namespace(value: object) -> ImportFactCacheNamespace:
+    raw = _require_mapping(value, "namespace")
+    return ImportFactCacheNamespace(
+        root_id=_require_string(raw.get("root_id"), "namespace.root_id"),
+        language=_require_string(raw.get("language"), "namespace.language"),
+        provider_version=_require_integer(
+            raw.get("provider_version"), "namespace.provider_version"
+        ),
+        package_prefix=_optional_string(
+            raw.get("package_prefix"), "namespace.package_prefix"
+        ),
+        configuration_key=_require_string(
+            raw.get("configuration_key"),
+            "namespace.configuration_key",
+            allow_empty=True,
+        ),
+    )
+
+
+def _decode_cached_file(value: object) -> CachedImportFile:
+    raw = _require_mapping(value, "cache entry")
+    fingerprint_raw = _require_mapping(raw.get("fingerprint"), "fingerprint")
+    fingerprint = ImportFileFingerprint(
+        sha256=_require_string(fingerprint_raw.get("sha256"), "fingerprint.sha256"),
+        size=_require_integer(fingerprint_raw.get("size"), "fingerprint.size"),
+    )
+    module_raw = raw.get("module")
+    module = None if module_raw is None else _decode_module(module_raw)
+    dependencies_raw = _require_list(raw.get("dependencies"), "dependencies")
+    diagnostics_raw = _require_list(raw.get("diagnostics"), "diagnostics")
+    return CachedImportFile(
+        fingerprint=fingerprint,
+        module=module,
+        dependencies=tuple(_decode_dependency(item) for item in dependencies_raw),
+        diagnostics=tuple(_decode_diagnostic(item) for item in diagnostics_raw),
+    )
+
+
+def _decode_module(value: object) -> ImportModuleFact:
+    raw = _require_mapping(value, "module")
+    return ImportModuleFact(
+        module=_require_string(raw.get("module"), "module.module"),
+        path=_require_string(raw.get("path"), "module.path"),
+        language=_require_string(raw.get("language"), "module.language"),
+        is_package=_require_boolean(raw.get("is_package"), "module.is_package"),
+    )
+
+
+def _decode_dependency(value: object) -> ImportDependencyFact:
+    raw = _require_mapping(value, "dependency")
+    evidence_raw = _require_mapping(raw.get("evidence"), "dependency.evidence")
+    category = _require_string(raw.get("category"), "dependency.category")
+    if category not in {"eager", "typing", "deferred", "lazy_export"}:
+        raise ValueError(f"unsupported cached import category: {category!r}")
+    kind = _require_string(raw.get("kind"), "dependency.kind")
+    if kind not in {"import", "from_import", "dynamic_import"}:
+        raise ValueError(f"unsupported cached import kind: {kind!r}")
+    return ImportDependencyFact(
+        source=_require_string(raw.get("source"), "dependency.source"),
+        target=_require_string(raw.get("target"), "dependency.target"),
+        category=cast(ImportCategory, category),
+        kind=cast(ImportKind, kind),
+        evidence=SourceEvidence(
+            path=_require_string(evidence_raw.get("path"), "evidence.path"),
+            line=_require_integer(evidence_raw.get("line"), "evidence.line"),
+            column=_require_integer(evidence_raw.get("column"), "evidence.column"),
+            statement=_require_string(
+                evidence_raw.get("statement"), "evidence.statement", allow_empty=True
+            ),
+        ),
+        is_reexport=_require_boolean(raw.get("is_reexport"), "dependency.is_reexport"),
+    )
+
+
+def _decode_diagnostic(value: object) -> ArchitectureDiagnostic:
+    raw = _require_mapping(value, "diagnostic")
+    severity = _require_string(raw.get("severity"), "diagnostic.severity")
+    if severity not in {"error", "warning"}:
+        raise ValueError(f"unsupported cached diagnostic severity: {severity!r}")
+    line = raw.get("line")
+    return ArchitectureDiagnostic(
+        code=_require_string(raw.get("code"), "diagnostic.code"),
+        message=_require_string(raw.get("message"), "diagnostic.message"),
+        severity=cast(DiagnosticSeverity, severity),
+        path=_optional_string(raw.get("path"), "diagnostic.path"),
+        line=None if line is None else _require_integer(line, "diagnostic.line"),
+    )
+
+
+def _require_mapping(value: object, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{field_name} must be an object")
+    if any(not isinstance(key, str) for key in value):
+        raise TypeError(f"{field_name} keys must be strings")
+    return value
+
+
+def _require_list(value: object, field_name: str) -> list[object]:
+    if not isinstance(value, list):
+        raise TypeError(f"{field_name} must be an array")
+    return value
+
+
+def _require_string(
+    value: object, field_name: str, *, allow_empty: bool = False
+) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        raise TypeError(f"{field_name} must be a string")
+    return value
+
+
+def _optional_string(value: object, field_name: str) -> str | None:
+    if value is None:
+        return None
+    return _require_string(value, field_name)
+
+
+def _require_integer(value: object, field_name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{field_name} must be an integer")
+    return value
+
+
+def _require_boolean(value: object, field_name: str) -> bool:
+    if type(value) is not bool:
+        raise TypeError(f"{field_name} must be a boolean")
+    return value
+
+
+def _cache_path_segment(value: str, field_name: str) -> str:
+    normalized = value.strip()
+    if (
+        not normalized
+        or normalized in {".", ".."}
+        or "/" in normalized
+        or "\\" in normalized
+    ):
+        raise ValueError(f"{field_name} must be a non-empty path segment")
+    return normalized
+
+
+__all__ = [
+    "IMPORT_FACT_CACHE_SCHEMA_VERSION",
+    "CachedImportFile",
+    "ImportFactCache",
+    "ImportFactCacheNamespace",
+    "ImportFactCacheSnapshot",
+    "ImportFileFingerprint",
+    "default_import_fact_cache_path",
+    "fingerprint_source",
+    "import_cache_root_id",
+]

--- a/src/loushang/coding/arch/cli.py
+++ b/src/loushang/coding/arch/cli.py
@@ -1,0 +1,193 @@
+"""Command-line adapter for deterministic import graph analysis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict
+from pathlib import Path
+
+from loushang.coding.arch.cache import (
+    ImportFactCache,
+    default_import_fact_cache_path,
+)
+from loushang.coding.arch.import_graph import (
+    ImportGraphAnalyzer,
+    query_import_graph,
+)
+from loushang.coding.arch.model import BoundaryRule
+from loushang.coding.arch.providers.python import PYTHON_IMPORT_PROVIDER_VERSION
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Inspect a source tree's deterministic import graph.",
+    )
+    parser.add_argument("root", help="Language source root to scan.")
+    parser.add_argument(
+        "--package-prefix",
+        help="Package name represented by the source root, for example loushang.",
+    )
+    parser.add_argument(
+        "--language",
+        default="auto",
+        help="Language provider id; defaults to automatic detection.",
+    )
+    parser.add_argument(
+        "--granularity",
+        choices=("module", "subsystem"),
+        default="module",
+    )
+    parser.add_argument(
+        "--imports",
+        choices=("eager", "all"),
+        default="eager",
+        help="Include eager imports only or every classified import.",
+    )
+    parser.add_argument(
+        "--query",
+        choices=("summary", "cycles", "edges", "path", "hotspots", "boundaries"),
+        default="summary",
+    )
+    parser.add_argument("--source", help="Source node for edges or path queries.")
+    parser.add_argument("--target", help="Target node for edges or path queries.")
+    parser.add_argument("--limit", type=int, default=100)
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="GLOB",
+        help="Exclude a source-relative path glob; may be repeated.",
+    )
+    parser.add_argument(
+        "--deny",
+        action="append",
+        default=[],
+        metavar="SOURCE=TARGET",
+        help="Report imports from SOURCE prefix to TARGET prefix as violations.",
+    )
+    parser.add_argument(
+        "--fail-on-violations",
+        action="store_true",
+        help="Exit with status 1 when a supplied boundary rule is violated.",
+    )
+    cache_group = parser.add_mutually_exclusive_group()
+    cache_group.add_argument(
+        "--no-cache",
+        action="store_true",
+        help="Disable the versioned per-file fact cache.",
+    )
+    cache_group.add_argument(
+        "--cache-dir",
+        type=Path,
+        help="Store the fact cache below this directory instead of LOUSHANG_HOME.",
+    )
+    parser.add_argument(
+        "--refresh-cache",
+        action="store_true",
+        help="Ignore reusable facts and rebuild the cache for this scan.",
+    )
+    parser.add_argument(
+        "--cache-info",
+        action="store_true",
+        help="Include non-deterministic cache telemetry in the JSON response.",
+    )
+    parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        rules = tuple(_parse_boundary_rule(value) for value in args.deny)
+        cache = _build_cache(args.root, args.no_cache, args.cache_dir)
+        graph = ImportGraphAnalyzer(
+            cache=cache,
+            cache_enabled=cache is not None,
+        ).analyze(
+            args.root,
+            package_prefix=args.package_prefix,
+            language=args.language,
+            granularity=args.granularity,
+            imports=args.imports,
+            excludes=args.exclude,
+            refresh_cache=args.refresh_cache,
+        )
+        result = query_import_graph(
+            graph,
+            args.query,
+            source=args.source,
+            target=args.target,
+            limit=args.limit,
+            boundary_rules=rules,
+        )
+        if args.cache_info:
+            result["cache"] = asdict(graph.cache_stats)
+    except (OSError, ValueError) as exc:
+        print(json.dumps({"error": str(exc)}, sort_keys=True), file=sys.stderr)
+        return 2
+
+    print(
+        json.dumps(
+            result,
+            indent=2 if args.pretty else None,
+            sort_keys=True,
+        )
+    )
+    if args.fail_on_violations and rules:
+        gate = query_import_graph(
+            graph,
+            "boundaries",
+            limit=1,
+            boundary_rules=rules,
+        )
+        if _has_boundary_violations(gate):
+            return 1
+    return 0
+
+
+def _build_cache(
+    root: str,
+    disabled: bool,
+    cache_dir: Path | None,
+) -> ImportFactCache | None:
+    if disabled:
+        return None
+    path = default_import_fact_cache_path(
+        root,
+        language="python",
+        provider_version=PYTHON_IMPORT_PROVIDER_VERSION,
+        cache_root=cache_dir,
+    )
+    return ImportFactCache(path)
+
+
+def _parse_boundary_rule(value: str) -> BoundaryRule:
+    source, separator, target = value.partition("=")
+    if not separator or not source.strip() or not target.strip():
+        raise ValueError(f"invalid boundary rule {value!r}; expected SOURCE=TARGET")
+    normalized_source = source.strip()
+    normalized_target = target.strip()
+    return BoundaryRule(
+        source=normalized_source,
+        target=normalized_target,
+        rule_id=f"deny:{normalized_source}={normalized_target}",
+    )
+
+
+def _has_boundary_violations(result: dict[str, object]) -> bool:
+    direct = result.get("results")
+    if isinstance(direct, list) and direct:
+        return result.get("query") == "boundaries"
+    summary = result.get("boundary_violations")
+    return isinstance(summary, list) and bool(summary)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = ["build_parser", "main"]

--- a/src/loushang/coding/arch/import_graph.py
+++ b/src/loushang/coding/arch/import_graph.py
@@ -1,0 +1,646 @@
+"""Deterministic import graph construction and query operations."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import cast
+
+from loushang.coding.arch.cache import ImportFactCache
+from loushang.coding.arch.model import (
+    ArchitectureDiagnostic,
+    BoundaryRule,
+    ImportCategory,
+    ImportGranularity,
+    ImportGraph,
+    ImportGraphEdge,
+    ImportGraphNode,
+    ImportGraphQuery,
+    ImportKind,
+    ImportProviderScan,
+    ImportSelection,
+    SourceEvidence,
+)
+from loushang.coding.arch.providers.base import ImportGraphProvider
+from loushang.coding.arch.providers.python import PythonImportGraphProvider
+
+IMPORT_GRAPH_SCHEMA_VERSION = 1
+
+
+class ImportGraphAnalyzer:
+    """Select a language provider and project its facts into a stable graph."""
+
+    def __init__(
+        self,
+        providers: Iterable[ImportGraphProvider] | None = None,
+        *,
+        cache: ImportFactCache | None = None,
+        cache_enabled: bool = True,
+    ) -> None:
+        supplied = (
+            (PythonImportGraphProvider(),) if providers is None else tuple(providers)
+        )
+        if not supplied:
+            raise ValueError("at least one import graph provider is required")
+        languages = [provider.language for provider in supplied]
+        if any(
+            not isinstance(language, str) or not language.strip()
+            for language in languages
+        ):
+            raise ValueError(
+                "import graph provider languages must be non-empty strings"
+            )
+        if len(languages) != len(set(languages)):
+            raise ValueError("import graph provider languages must be unique")
+        if not cache_enabled and cache is not None:
+            raise ValueError("cache cannot be supplied when caching is disabled")
+        self._providers = supplied
+        self._cache = (
+            cache if cache is not None else ImportFactCache() if cache_enabled else None
+        )
+
+    @property
+    def languages(self) -> tuple[str, ...]:
+        return tuple(provider.language for provider in self._providers)
+
+    def analyze(
+        self,
+        root: str | Path,
+        *,
+        package_prefix: str | None = None,
+        language: str = "auto",
+        granularity: ImportGranularity = "module",
+        imports: ImportSelection = "eager",
+        excludes: Iterable[str] = (),
+        refresh_cache: bool = False,
+    ) -> ImportGraph:
+        resolved_root = Path(root).expanduser().resolve()
+        if not resolved_root.is_dir():
+            raise ValueError(f"import graph root is not a directory: {root}")
+        if granularity not in {"module", "subsystem"}:
+            raise ValueError(f"unsupported import graph granularity: {granularity!r}")
+        if imports not in {"eager", "all"}:
+            raise ValueError(f"unsupported import selection: {imports!r}")
+        provider = self._select_provider(resolved_root, language)
+        scan = provider.scan(
+            resolved_root,
+            package_prefix=package_prefix,
+            excludes=tuple(excludes),
+            cache=self._cache,
+            refresh_cache=refresh_cache,
+        )
+        _validate_scan(scan, provider_language=provider.language)
+        return _project_scan(
+            scan,
+            root=resolved_root,
+            package_prefix=package_prefix,
+            granularity=granularity,
+            imports=imports,
+        )
+
+    def _select_provider(self, root: Path, language: str) -> ImportGraphProvider:
+        if language != "auto":
+            for provider in self._providers:
+                if provider.language == language:
+                    return provider
+            available = ", ".join(self.languages)
+            raise ValueError(
+                f"unsupported import graph language {language!r}; "
+                f"available providers: {available}"
+            )
+        for provider in self._providers:
+            if provider.supports(root):
+                return provider
+        raise ValueError(f"no import graph provider supports root: {root}")
+
+
+def analyze_import_graph(
+    root: str | Path,
+    *,
+    package_prefix: str | None = None,
+    language: str = "auto",
+    granularity: ImportGranularity = "module",
+    imports: ImportSelection = "eager",
+    excludes: Iterable[str] = (),
+    providers: Iterable[ImportGraphProvider] | None = None,
+    cache: ImportFactCache | None = None,
+    cache_enabled: bool = True,
+    refresh_cache: bool = False,
+) -> ImportGraph:
+    """Analyze one source root using a built-in or caller-supplied provider."""
+
+    return ImportGraphAnalyzer(
+        providers,
+        cache=cache,
+        cache_enabled=cache_enabled,
+    ).analyze(
+        root,
+        package_prefix=package_prefix,
+        language=language,
+        granularity=granularity,
+        imports=imports,
+        excludes=excludes,
+        refresh_cache=refresh_cache,
+    )
+
+
+def query_import_graph(
+    graph: ImportGraph,
+    query: ImportGraphQuery = "summary",
+    *,
+    source: str | None = None,
+    target: str | None = None,
+    limit: int = 100,
+    boundary_rules: Iterable[BoundaryRule] = (),
+) -> dict[str, object]:
+    """Return one bounded, JSON-compatible view of an import graph."""
+
+    if query not in {
+        "summary",
+        "cycles",
+        "edges",
+        "path",
+        "hotspots",
+        "boundaries",
+    }:
+        raise ValueError(f"unsupported import graph query: {query!r}")
+    if limit < 1:
+        raise ValueError("query limit must be at least 1")
+    rules = tuple(boundary_rules)
+    payload = _base_payload(graph, query)
+
+    if query == "summary":
+        cycles = _cycles(graph.nodes, graph.edges)
+        eager_edges = tuple(edge for edge in graph.edges if edge.category == "eager")
+        eager_cycles = _cycles(graph.nodes, eager_edges)
+        typing_edges = tuple(edge for edge in graph.edges if edge.category == "typing")
+        typing_cycles = _cycles(graph.nodes, typing_edges)
+        violations = _boundary_violations(graph.edges, rules)
+        payload.update(
+            {
+                "cycles": [list(cycle) for cycle in cycles[:limit]],
+                "cycles_truncated": len(cycles) > limit,
+                "eager_cycles": [list(cycle) for cycle in eager_cycles[:limit]],
+                "eager_cycles_truncated": len(eager_cycles) > limit,
+                "typing_cycles": [list(cycle) for cycle in typing_cycles[:limit]],
+                "typing_cycles_truncated": len(typing_cycles) > limit,
+                "hotspots": _hotspots(graph.nodes, graph.edges, limit=min(limit, 20)),
+                "boundary_violations": violations[:limit],
+                "boundary_violations_truncated": len(violations) > limit,
+                "external_dependency_count": len(graph.external_dependencies),
+                "categories": _category_counts(graph.edges),
+                "diagnostics": [
+                    asdict(diagnostic) for diagnostic in graph.diagnostics[:limit]
+                ],
+                "diagnostics_truncated": len(graph.diagnostics) > limit,
+            }
+        )
+        return payload
+
+    if query == "cycles":
+        cycles = _cycles(graph.nodes, graph.edges)
+        payload.update(
+            {
+                "cycles": [
+                    _cycle_payload(cycle, graph.edges) for cycle in cycles[:limit]
+                ],
+                "truncated": len(cycles) > limit,
+            }
+        )
+        return payload
+
+    if query == "edges":
+        edges = tuple(
+            edge
+            for edge in graph.edges
+            if (source is None or edge.source == source)
+            and (target is None or edge.target == target)
+        )
+        payload.update(
+            {
+                "results": [_edge_payload(edge) for edge in edges[:limit]],
+                "truncated": len(edges) > limit,
+            }
+        )
+        return payload
+
+    if query == "path":
+        if not source or not target:
+            raise ValueError("path query requires source and target")
+        payload.update(_path_payload(graph, source=source, target=target))
+        return payload
+
+    if query == "hotspots":
+        hotspots = _hotspots(graph.nodes, graph.edges, limit=limit)
+        payload.update({"results": hotspots, "truncated": len(graph.nodes) > limit})
+        return payload
+
+    violations = _boundary_violations(graph.edges, rules)
+    payload.update(
+        {
+            "results": violations[:limit],
+            "truncated": len(violations) > limit,
+        }
+    )
+    return payload
+
+
+def _project_scan(
+    scan: ImportProviderScan,
+    *,
+    root: Path,
+    package_prefix: str | None,
+    granularity: ImportGranularity,
+    imports: ImportSelection,
+) -> ImportGraph:
+    modules_by_name = {module.module: module for module in scan.modules}
+    resolved_prefix = _resolved_package_prefix(scan, package_prefix)
+    node_ids = {
+        module: _project_node_id(module, resolved_prefix, granularity)
+        for module in modules_by_name
+    }
+    grouped_nodes: dict[str, list[str]] = {}
+    for module, node_id in node_ids.items():
+        grouped_nodes.setdefault(node_id, []).append(module)
+    nodes = tuple(
+        ImportGraphNode(
+            id=node_id,
+            modules=tuple(sorted(modules)),
+            paths=tuple(sorted({modules_by_name[module].path for module in modules})),
+        )
+        for node_id, modules in sorted(grouped_nodes.items())
+    )
+
+    selected_dependencies = tuple(
+        dependency
+        for dependency in scan.dependencies
+        if imports == "all" or dependency.category == "eager"
+    )
+    external_dependencies = tuple(
+        sorted(
+            {
+                dependency.target
+                for dependency in selected_dependencies
+                if dependency.target not in modules_by_name
+            }
+        )
+    )
+    grouped_edges: dict[
+        tuple[str, str, ImportCategory, ImportKind, bool], set[SourceEvidence]
+    ] = {}
+    for dependency in selected_dependencies:
+        if dependency.target not in modules_by_name:
+            continue
+        source = node_ids[dependency.source]
+        target = node_ids[dependency.target]
+        if granularity == "subsystem" and source == target:
+            continue
+        key = (
+            source,
+            target,
+            dependency.category,
+            dependency.kind,
+            dependency.is_reexport,
+        )
+        grouped_edges.setdefault(key, set()).add(dependency.evidence)
+    edges = tuple(
+        ImportGraphEdge(
+            source=source,
+            target=target,
+            category=category,
+            kind=kind,
+            is_reexport=is_reexport,
+            evidence=tuple(sorted(evidence)),
+        )
+        for (
+            source,
+            target,
+            category,
+            kind,
+            is_reexport,
+        ), evidence in sorted(grouped_edges.items())
+    )
+    return ImportGraph(
+        schema_version=IMPORT_GRAPH_SCHEMA_VERSION,
+        root=str(root),
+        language=scan.language,
+        package_prefix=resolved_prefix,
+        granularity=granularity,
+        imports=imports,
+        nodes=nodes,
+        edges=edges,
+        external_dependencies=external_dependencies,
+        diagnostics=tuple(sorted(scan.diagnostics, key=_diagnostic_sort_key)),
+        cache_stats=scan.cache_stats,
+    )
+
+
+def _resolved_package_prefix(
+    scan: ImportProviderScan, requested: str | None
+) -> str | None:
+    if requested:
+        return requested.strip().strip(".") or None
+    return scan.package_prefix
+
+
+def _project_node_id(
+    module: str,
+    package_prefix: str | None,
+    granularity: ImportGranularity,
+) -> str:
+    if granularity == "module":
+        return module
+    prefix = package_prefix.strip().strip(".") if package_prefix else ""
+    if prefix and (module == prefix or module.startswith(f"{prefix}.")):
+        remainder = module[len(prefix) :].lstrip(".")
+        return prefix if not remainder else f"{prefix}.{remainder.split('.', 1)[0]}"
+    return module.split(".", 1)[0]
+
+
+def _base_payload(graph: ImportGraph, query: ImportGraphQuery) -> dict[str, object]:
+    return {
+        "schema_version": graph.schema_version,
+        "query": query,
+        "language": graph.language,
+        "root": graph.root,
+        "package_prefix": graph.package_prefix,
+        "granularity": graph.granularity,
+        "imports": graph.imports,
+        "nodes": len(graph.nodes),
+        "edges": len(graph.edges),
+    }
+
+
+def _edge_payload(edge: ImportGraphEdge) -> dict[str, object]:
+    return {
+        "source": edge.source,
+        "target": edge.target,
+        "category": edge.category,
+        "kind": edge.kind,
+        "is_reexport": edge.is_reexport,
+        **_evidence_payload(edge.evidence),
+    }
+
+
+def _category_counts(edges: Sequence[ImportGraphEdge]) -> dict[str, int]:
+    counts: dict[str, int] = {category: 0 for category in _import_categories()}
+    for edge in edges:
+        counts[edge.category] += 1
+    return counts
+
+
+def _import_categories() -> tuple[ImportCategory, ...]:
+    return "eager", "typing", "deferred", "lazy_export"
+
+
+def _cycles(
+    nodes: Sequence[ImportGraphNode],
+    edges: Sequence[ImportGraphEdge],
+) -> tuple[tuple[str, ...], ...]:
+    node_names = tuple(node.id for node in nodes)
+    adjacency = _adjacency(node_names, edges)
+    reverse: dict[str, list[str]] = {node: [] for node in node_names}
+    for source, targets in adjacency.items():
+        for target in targets:
+            reverse[target].append(source)
+    for sources in reverse.values():
+        sources.sort()
+
+    visited: set[str] = set()
+    finish_order: list[str] = []
+    for start in node_names:
+        if start in visited:
+            continue
+        visited.add(start)
+        stack: list[tuple[str, int]] = [(start, 0)]
+        while stack:
+            node, offset = stack[-1]
+            targets = adjacency[node]
+            if offset < len(targets):
+                candidate = targets[offset]
+                stack[-1] = (node, offset + 1)
+                if candidate not in visited:
+                    visited.add(candidate)
+                    stack.append((candidate, 0))
+                continue
+            finish_order.append(node)
+            stack.pop()
+
+    components: list[tuple[str, ...]] = []
+    visited.clear()
+    for start in reversed(finish_order):
+        if start in visited:
+            continue
+        component: list[str] = []
+        pending = [start]
+        visited.add(start)
+        while pending:
+            node = pending.pop()
+            component.append(node)
+            for candidate in reversed(reverse[node]):
+                if candidate in visited:
+                    continue
+                visited.add(candidate)
+                pending.append(candidate)
+        normalized = tuple(sorted(component))
+        if len(normalized) > 1 or start in adjacency[start]:
+            components.append(normalized)
+    return tuple(sorted(components))
+
+
+def _adjacency(
+    nodes: Sequence[str], edges: Sequence[ImportGraphEdge]
+) -> dict[str, tuple[str, ...]]:
+    targets: dict[str, set[str]] = {node: set() for node in nodes}
+    for edge in edges:
+        targets.setdefault(edge.source, set()).add(edge.target)
+    return {node: tuple(sorted(values)) for node, values in targets.items()}
+
+
+def _cycle_payload(
+    cycle: tuple[str, ...], edges: Sequence[ImportGraphEdge]
+) -> dict[str, object]:
+    members = set(cycle)
+    cycle_edges = tuple(
+        edge for edge in edges if edge.source in members and edge.target in members
+    )
+    return {
+        "nodes": list(cycle),
+        "edge_count": len(cycle_edges),
+        "categories": _category_counts(cycle_edges),
+    }
+
+
+def _hotspots(
+    nodes: Sequence[ImportGraphNode],
+    edges: Sequence[ImportGraphEdge],
+    *,
+    limit: int,
+) -> list[dict[str, object]]:
+    incoming: dict[str, set[str]] = {node.id: set() for node in nodes}
+    outgoing: dict[str, set[str]] = {node.id: set() for node in nodes}
+    for edge in edges:
+        outgoing[edge.source].add(edge.target)
+        incoming[edge.target].add(edge.source)
+    ranked = sorted(
+        (
+            {
+                "node": node.id,
+                "fan_in": len(incoming[node.id]),
+                "fan_out": len(outgoing[node.id]),
+                "total": len(incoming[node.id]) + len(outgoing[node.id]),
+            }
+            for node in nodes
+        ),
+        key=lambda item: (
+            -cast(int, item["total"]),
+            -cast(int, item["fan_in"]),
+            -cast(int, item["fan_out"]),
+            cast(str, item["node"]),
+        ),
+    )
+    return ranked[:limit]
+
+
+def _path_payload(
+    graph: ImportGraph,
+    *,
+    source: str,
+    target: str,
+) -> dict[str, object]:
+    node_names = {node.id for node in graph.nodes}
+    if source not in node_names:
+        raise ValueError(f"unknown path source: {source!r}")
+    if target not in node_names:
+        raise ValueError(f"unknown path target: {target!r}")
+    adjacency = _adjacency(tuple(sorted(node_names)), graph.edges)
+    parents: dict[str, str | None] = {source: None}
+    queue: deque[str] = deque((source,))
+    while queue and target not in parents:
+        node = queue.popleft()
+        for candidate in adjacency[node]:
+            if candidate in parents:
+                continue
+            parents[candidate] = node
+            queue.append(candidate)
+    if target not in parents:
+        return {"found": False, "nodes": [], "edges": []}
+    path = [target]
+    while parents[path[-1]] is not None:
+        path.append(cast(str, parents[path[-1]]))
+    path.reverse()
+    selected_edges: list[dict[str, object]] = []
+    for edge_source, edge_target in zip(path, path[1:]):
+        matches = [
+            edge
+            for edge in graph.edges
+            if edge.source == edge_source and edge.target == edge_target
+        ]
+        selected_edges.append(_edge_payload(matches[0]))
+    return {"found": True, "nodes": path, "edges": selected_edges}
+
+
+def _boundary_violations(
+    edges: Sequence[ImportGraphEdge], rules: Sequence[BoundaryRule]
+) -> list[dict[str, object]]:
+    violations: list[dict[str, object]] = []
+    for rule in rules:
+        for edge in edges:
+            if not _prefix_matches(edge.source, rule.source):
+                continue
+            if not _prefix_matches(edge.target, rule.target):
+                continue
+            violations.append(
+                {
+                    "rule_id": rule.rule_id
+                    or f"{rule.source} must not import {rule.target}",
+                    "source": edge.source,
+                    "target": edge.target,
+                    "category": edge.category,
+                    **_evidence_payload(edge.evidence),
+                }
+            )
+    return sorted(
+        violations,
+        key=lambda item: (
+            cast(str, item["rule_id"]),
+            cast(str, item["source"]),
+            cast(str, item["target"]),
+            cast(str, item["category"]),
+        ),
+    )
+
+
+def _prefix_matches(value: str, prefix: str) -> bool:
+    normalized = prefix.strip()
+    if normalized == "*":
+        return True
+    if normalized.endswith(".*"):
+        normalized = normalized[:-2]
+    normalized = normalized.rstrip(".")
+    return value == normalized or value.startswith(f"{normalized}.")
+
+
+def _evidence_payload(
+    evidence: Sequence[SourceEvidence], *, limit: int = 20
+) -> dict[str, object]:
+    return {
+        "evidence": [asdict(item) for item in evidence[:limit]],
+        "evidence_truncated": len(evidence) > limit,
+    }
+
+
+def _validate_scan(scan: ImportProviderScan, *, provider_language: str) -> None:
+    if scan.language != provider_language:
+        raise ValueError(
+            f"provider {provider_language!r} returned language {scan.language!r}"
+        )
+    module_names = [module.module for module in scan.modules]
+    if any(not module for module in module_names):
+        raise ValueError("import graph providers must return non-empty module ids")
+    if len(module_names) != len(set(module_names)):
+        raise ValueError("import graph providers must return unique module ids")
+    foreign_modules = sorted(
+        module.module for module in scan.modules if module.language != scan.language
+    )
+    if foreign_modules:
+        raise ValueError(
+            "import graph modules use a different language than their provider: "
+            + ", ".join(foreign_modules)
+        )
+    known_modules = set(module_names)
+    missing_sources = sorted(
+        {
+            dependency.source
+            for dependency in scan.dependencies
+            if dependency.source not in known_modules
+        }
+    )
+    if missing_sources:
+        raise ValueError(
+            "import graph dependencies reference unknown source modules: "
+            + ", ".join(missing_sources)
+        )
+    if any(not dependency.target for dependency in scan.dependencies):
+        raise ValueError("import graph dependencies must have non-empty targets")
+
+
+def _diagnostic_sort_key(
+    diagnostic: ArchitectureDiagnostic,
+) -> tuple[object, ...]:
+    return (
+        diagnostic.path or "",
+        diagnostic.line or 0,
+        diagnostic.code,
+        diagnostic.message,
+    )
+
+
+__all__ = [
+    "IMPORT_GRAPH_SCHEMA_VERSION",
+    "ImportGraphAnalyzer",
+    "analyze_import_graph",
+    "query_import_graph",
+]

--- a/src/loushang/coding/arch/model.py
+++ b/src/loushang/coding/arch/model.py
@@ -1,0 +1,148 @@
+"""Language-neutral facts and results for Coding architecture analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+ImportCategory = Literal["eager", "typing", "deferred", "lazy_export"]
+ImportKind = Literal["import", "from_import", "dynamic_import"]
+ImportGranularity = Literal["module", "subsystem"]
+ImportSelection = Literal["eager", "all"]
+ImportGraphQuery = Literal[
+    "summary",
+    "cycles",
+    "edges",
+    "path",
+    "hotspots",
+    "boundaries",
+]
+DiagnosticSeverity = Literal["error", "warning"]
+
+
+@dataclass(frozen=True, order=True)
+class SourceEvidence:
+    """One source location supporting a dependency fact."""
+
+    path: str
+    line: int
+    column: int
+    statement: str = ""
+
+
+@dataclass(frozen=True)
+class ArchitectureDiagnostic:
+    code: str
+    message: str
+    severity: DiagnosticSeverity = "warning"
+    path: str | None = None
+    line: int | None = None
+
+
+@dataclass(frozen=True)
+class ImportModuleFact:
+    """One importable source module discovered by a language provider."""
+
+    module: str
+    path: str
+    language: str
+    is_package: bool = False
+
+
+@dataclass(frozen=True)
+class ImportDependencyFact:
+    """One provider-normalized import relation before graph projection."""
+
+    source: str
+    target: str
+    category: ImportCategory
+    kind: ImportKind
+    evidence: SourceEvidence
+    is_reexport: bool = False
+
+
+@dataclass(frozen=True)
+class ImportCacheStats:
+    enabled: bool = False
+    hits: int = 0
+    misses: int = 0
+    invalidated: int = 0
+    entries: int = 0
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class ImportProviderScan:
+    """Deterministic output returned by an import-graph language provider."""
+
+    language: str
+    modules: tuple[ImportModuleFact, ...]
+    dependencies: tuple[ImportDependencyFact, ...]
+    package_prefix: str | None = None
+    diagnostics: tuple[ArchitectureDiagnostic, ...] = ()
+    cache_stats: ImportCacheStats = field(default_factory=ImportCacheStats)
+
+
+@dataclass(frozen=True)
+class ImportGraphNode:
+    id: str
+    modules: tuple[str, ...]
+    paths: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ImportGraphEdge:
+    source: str
+    target: str
+    category: ImportCategory
+    kind: ImportKind
+    evidence: tuple[SourceEvidence, ...]
+    is_reexport: bool = False
+
+
+@dataclass(frozen=True)
+class ImportGraph:
+    schema_version: int
+    root: str
+    language: str
+    package_prefix: str | None
+    granularity: ImportGranularity
+    imports: ImportSelection
+    nodes: tuple[ImportGraphNode, ...]
+    edges: tuple[ImportGraphEdge, ...]
+    external_dependencies: tuple[str, ...] = ()
+    diagnostics: tuple[ArchitectureDiagnostic, ...] = ()
+    cache_stats: ImportCacheStats = field(default_factory=ImportCacheStats)
+
+
+@dataclass(frozen=True)
+class BoundaryRule:
+    """A deterministic deny rule over module or subsystem prefixes."""
+
+    source: str
+    target: str
+    rule_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.source.strip() or not self.target.strip():
+            raise ValueError("boundary source and target must be non-empty")
+
+
+__all__ = [
+    "ArchitectureDiagnostic",
+    "BoundaryRule",
+    "DiagnosticSeverity",
+    "ImportCategory",
+    "ImportCacheStats",
+    "ImportDependencyFact",
+    "ImportGranularity",
+    "ImportGraph",
+    "ImportGraphEdge",
+    "ImportGraphNode",
+    "ImportGraphQuery",
+    "ImportKind",
+    "ImportModuleFact",
+    "ImportProviderScan",
+    "ImportSelection",
+    "SourceEvidence",
+]

--- a/src/loushang/coding/arch/providers/__init__.py
+++ b/src/loushang/coding/arch/providers/__init__.py
@@ -1,0 +1,13 @@
+"""Built-in language providers for Coding architecture analysis."""
+
+from loushang.coding.arch.providers.base import ImportGraphProvider
+from loushang.coding.arch.providers.python import (
+    PYTHON_IMPORT_PROVIDER_VERSION,
+    PythonImportGraphProvider,
+)
+
+__all__ = [
+    "PYTHON_IMPORT_PROVIDER_VERSION",
+    "ImportGraphProvider",
+    "PythonImportGraphProvider",
+]

--- a/src/loushang/coding/arch/providers/base.py
+++ b/src/loushang/coding/arch/providers/base.py
@@ -1,0 +1,31 @@
+"""Provider contract for language-extensible import graph extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from loushang.coding.arch.cache import ImportFactCache
+from loushang.coding.arch.model import ImportProviderScan
+
+
+class ImportGraphProvider(Protocol):
+    """Extract normalized import facts for one programming language."""
+
+    @property
+    def language(self) -> str: ...
+
+    def supports(self, root: Path) -> bool: ...
+
+    def scan(
+        self,
+        root: Path,
+        *,
+        package_prefix: str | None = None,
+        excludes: tuple[str, ...] = (),
+        cache: ImportFactCache | None = None,
+        refresh_cache: bool = False,
+    ) -> ImportProviderScan: ...
+
+
+__all__ = ["ImportGraphProvider"]

--- a/src/loushang/coding/arch/providers/python.py
+++ b/src/loushang/coding/arch/providers/python.py
@@ -1,0 +1,631 @@
+"""Python AST provider for the language-neutral import graph contract."""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import io
+import os
+import tokenize
+from dataclasses import dataclass
+from pathlib import Path
+
+from loushang.coding.arch.cache import (
+    CachedImportFile,
+    ImportFactCache,
+    ImportFactCacheNamespace,
+    ImportFactCacheSnapshot,
+    ImportFileFingerprint,
+    fingerprint_source,
+    import_cache_root_id,
+)
+from loushang.coding.arch.model import (
+    ArchitectureDiagnostic,
+    ImportCacheStats,
+    ImportCategory,
+    ImportDependencyFact,
+    ImportKind,
+    ImportModuleFact,
+    ImportProviderScan,
+    SourceEvidence,
+)
+
+PYTHON_IMPORT_PROVIDER_VERSION = 1
+
+_DEFAULT_EXCLUDED_DIRECTORIES = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        "node_modules",
+        "venv",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _PythonSourceFile:
+    path: Path
+    relative_path: str
+    module: str
+    is_package: bool
+
+
+class PythonImportGraphProvider:
+    """Extract Python import dependencies without importing project code."""
+
+    language = "python"
+
+    def supports(self, root: Path) -> bool:
+        if not root.is_dir():
+            return False
+        return any(_iter_python_files(root, ()))
+
+    def scan(
+        self,
+        root: Path,
+        *,
+        package_prefix: str | None = None,
+        excludes: tuple[str, ...] = (),
+        cache: ImportFactCache | None = None,
+        refresh_cache: bool = False,
+    ) -> ImportProviderScan:
+        resolved_root = root.resolve()
+        if not resolved_root.is_dir():
+            raise ValueError(f"import graph root is not a directory: {root}")
+        prefix = _normalize_package_prefix(resolved_root, package_prefix)
+        discovery_diagnostics: list[ArchitectureDiagnostic] = []
+        module_index: list[tuple[str, str | None]] = []
+        sources_by_module: dict[str, _PythonSourceFile] = {}
+
+        for path in _iter_python_files(resolved_root, excludes):
+            relative_path = path.relative_to(resolved_root).as_posix()
+            module = _module_name(relative_path, prefix)
+            module_index.append((relative_path, module))
+            if module is None:
+                discovery_diagnostics.append(
+                    ArchitectureDiagnostic(
+                        code="invalid_python_module_path",
+                        message="Python source path cannot be represented as a module name.",
+                        path=relative_path,
+                    )
+                )
+                continue
+            candidate = _PythonSourceFile(
+                path=path,
+                relative_path=relative_path,
+                module=module,
+                is_package=path.name == "__init__.py",
+            )
+            existing = sources_by_module.get(module)
+            if existing is not None:
+                discovery_diagnostics.append(
+                    _duplicate_module_diagnostic(existing, candidate)
+                )
+                continue
+            sources_by_module[module] = candidate
+
+        normalized_module_index = tuple(sorted(module_index))
+        namespace = ImportFactCacheNamespace(
+            root_id=import_cache_root_id(resolved_root),
+            language=self.language,
+            provider_version=PYTHON_IMPORT_PROVIDER_VERSION,
+            package_prefix=prefix,
+        )
+        cached_snapshot = cache.load(namespace) if cache is not None else None
+        cache_error = cache.last_error if cache is not None else None
+        cached_entries = (
+            {}
+            if refresh_cache
+            or cached_snapshot is None
+            or cached_snapshot.module_index != normalized_module_index
+            else cached_snapshot.entry_map()
+        )
+        invalidated = (
+            len(cached_snapshot.entries)
+            if cached_snapshot is not None and not cached_entries
+            else 0
+        )
+
+        module_names = frozenset(sources_by_module)
+        current_entries: dict[str, CachedImportFile] = {}
+        hits = 0
+        misses = 0
+        for module in sorted(sources_by_module):
+            source_file = sources_by_module[module]
+            try:
+                content = source_file.path.read_bytes()
+            except OSError as exc:
+                misses += 1
+                discovery_diagnostics.append(
+                    ArchitectureDiagnostic(
+                        code="unreadable_python_source",
+                        message=str(exc),
+                        severity="error",
+                        path=source_file.relative_path,
+                    )
+                )
+                continue
+            fingerprint = fingerprint_source(content)
+            cached = cached_entries.get(source_file.relative_path)
+            if cached is not None and _cached_entry_matches(
+                cached,
+                source_file=source_file,
+                fingerprint=fingerprint,
+            ):
+                entry = cached
+                hits += 1
+            else:
+                if cached is not None:
+                    invalidated += 1
+                entry = _analyze_python_file(
+                    source_file,
+                    content=content,
+                    fingerprint=fingerprint,
+                    module_names=module_names,
+                )
+                misses += 1
+            current_entries[source_file.relative_path] = entry
+
+        if cache is not None:
+            cache.replace(
+                ImportFactCacheSnapshot(
+                    namespace=namespace,
+                    module_index=normalized_module_index,
+                    entries=tuple(sorted(current_entries.items())),
+                )
+            )
+            cache_error = cache.last_error or cache_error
+
+        modules: list[ImportModuleFact] = []
+        dependencies: list[ImportDependencyFact] = []
+        diagnostics = discovery_diagnostics
+        for entry in current_entries.values():
+            if entry.module is not None:
+                modules.append(entry.module)
+            dependencies.extend(entry.dependencies)
+            diagnostics.extend(entry.diagnostics)
+
+        return ImportProviderScan(
+            language=self.language,
+            modules=tuple(sorted(modules, key=lambda item: item.module)),
+            dependencies=tuple(sorted(dependencies, key=_dependency_sort_key)),
+            package_prefix=prefix,
+            diagnostics=tuple(sorted(diagnostics, key=_diagnostic_sort_key)),
+            cache_stats=ImportCacheStats(
+                enabled=cache is not None,
+                hits=hits,
+                misses=misses,
+                invalidated=invalidated,
+                entries=len(current_entries) if cache is not None else 0,
+                error=cache_error,
+            ),
+        )
+
+
+def _analyze_python_file(
+    source_file: _PythonSourceFile,
+    *,
+    content: bytes,
+    fingerprint: ImportFileFingerprint,
+    module_names: frozenset[str],
+) -> CachedImportFile:
+    fact = ImportModuleFact(
+        module=source_file.module,
+        path=source_file.relative_path,
+        language="python",
+        is_package=source_file.is_package,
+    )
+    try:
+        buffer = io.BytesIO(content)
+        encoding, _ = tokenize.detect_encoding(buffer.readline)
+        source = content.decode(encoding)
+    except (LookupError, SyntaxError, UnicodeError) as exc:
+        return CachedImportFile(
+            fingerprint=fingerprint,
+            module=None,
+            diagnostics=(
+                ArchitectureDiagnostic(
+                    code="unreadable_python_source",
+                    message=str(exc),
+                    severity="error",
+                    path=source_file.relative_path,
+                ),
+            ),
+        )
+
+    try:
+        tree = ast.parse(source, filename=source_file.relative_path)
+    except SyntaxError as exc:
+        return CachedImportFile(
+            fingerprint=fingerprint,
+            module=fact,
+            diagnostics=(
+                ArchitectureDiagnostic(
+                    code="python_syntax_error",
+                    message=exc.msg,
+                    severity="error",
+                    path=source_file.relative_path,
+                    line=exc.lineno,
+                ),
+            ),
+        )
+
+    visitor = _PythonImportVisitor(
+        module=fact,
+        module_names=module_names,
+        source=source,
+    )
+    visitor.visit(tree)
+    return CachedImportFile(
+        fingerprint=fingerprint,
+        module=fact,
+        dependencies=tuple(sorted(visitor.dependencies, key=_dependency_sort_key)),
+        diagnostics=tuple(sorted(visitor.diagnostics, key=_diagnostic_sort_key)),
+    )
+
+
+def _cached_entry_matches(
+    entry: CachedImportFile,
+    *,
+    source_file: _PythonSourceFile,
+    fingerprint: ImportFileFingerprint,
+) -> bool:
+    if entry.fingerprint != fingerprint:
+        return False
+    if entry.module is None:
+        return (
+            not entry.dependencies
+            and bool(entry.diagnostics)
+            and all(
+                diagnostic.code == "unreadable_python_source"
+                and diagnostic.severity == "error"
+                and diagnostic.path == source_file.relative_path
+                for diagnostic in entry.diagnostics
+            )
+        )
+    expected_module = ImportModuleFact(
+        module=source_file.module,
+        path=source_file.relative_path,
+        language="python",
+        is_package=source_file.is_package,
+    )
+    return (
+        entry.module == expected_module
+        and all(
+            dependency.source == source_file.module
+            and dependency.evidence.path == source_file.relative_path
+            for dependency in entry.dependencies
+        )
+        and all(
+            diagnostic.path in {None, source_file.relative_path}
+            for diagnostic in entry.diagnostics
+        )
+    )
+
+
+class _PythonImportVisitor(ast.NodeVisitor):
+    def __init__(
+        self,
+        *,
+        module: ImportModuleFact,
+        module_names: frozenset[str],
+        source: str,
+    ) -> None:
+        self.module = module
+        self.module_names = module_names
+        self.source = source
+        self._source_lines = source.splitlines(keepends=True)
+        self.dependencies: list[ImportDependencyFact] = []
+        self.diagnostics: list[ArchitectureDiagnostic] = []
+        self._function_depth = 0
+        self._typing_depth = 0
+        self._lazy_export_depth = 0
+
+    def visit_Import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            self._record(alias.name, node=node, kind="import")
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        base = self._resolve_from_base(node)
+        if base is None:
+            return
+        for alias in node.names:
+            target = base
+            if alias.name != "*":
+                candidate = f"{base}.{alias.name}" if base else alias.name
+                if candidate in self.module_names:
+                    target = candidate
+            if target:
+                self._record(target, node=node, kind="from_import")
+
+    def visit_If(self, node: ast.If) -> None:
+        self.visit(node.test)
+        if _is_type_checking_test(node.test):
+            self._typing_depth += 1
+            for statement in node.body:
+                self.visit(statement)
+            self._typing_depth -= 1
+            for statement in node.orelse:
+                self.visit(statement)
+            return
+        for statement in node.body:
+            self.visit(statement)
+        for statement in node.orelse:
+            self.visit(statement)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        target = _dynamic_import_target(node)
+        if target:
+            resolved = self._resolve_dynamic_target(target)
+            if resolved:
+                self._record(resolved, node=node, kind="dynamic_import")
+        self.generic_visit(node)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        self.visit(node.args)
+        if node.returns is not None:
+            self.visit(node.returns)
+        for type_parameter in getattr(node, "type_params", ()):
+            self.visit(type_parameter)
+
+        is_lazy_export = self._function_depth == 0 and node.name == "__getattr__"
+        self._function_depth += 1
+        if is_lazy_export:
+            self._lazy_export_depth += 1
+        for statement in node.body:
+            self.visit(statement)
+        if is_lazy_export:
+            self._lazy_export_depth -= 1
+        self._function_depth -= 1
+
+    def _resolve_from_base(self, node: ast.ImportFrom) -> str | None:
+        if node.level == 0:
+            return node.module or ""
+        package = (
+            self.module.module
+            if self.module.is_package
+            else self.module.module.rpartition(".")[0]
+        )
+        parts = package.split(".") if package else []
+        parents_to_remove = node.level - 1
+        if parents_to_remove and parents_to_remove >= len(parts):
+            self.diagnostics.append(
+                ArchitectureDiagnostic(
+                    code="invalid_relative_import",
+                    message="Relative import escapes the discovered package root.",
+                    path=self.module.path,
+                    line=node.lineno,
+                )
+            )
+            return None
+        base_parts = parts[: len(parts) - parents_to_remove]
+        if node.module:
+            base_parts.extend(node.module.split("."))
+        return ".".join(base_parts)
+
+    def _resolve_dynamic_target(self, target: str) -> str | None:
+        if not target.startswith("."):
+            return target
+        level = len(target) - len(target.lstrip("."))
+        remainder = target[level:]
+        package = (
+            self.module.module
+            if self.module.is_package
+            else self.module.module.rpartition(".")[0]
+        )
+        parts = package.split(".") if package else []
+        parents_to_remove = level - 1
+        if parents_to_remove and parents_to_remove >= len(parts):
+            return None
+        resolved = parts[: len(parts) - parents_to_remove]
+        if remainder:
+            resolved.extend(remainder.split("."))
+        return ".".join(resolved)
+
+    def _record(
+        self,
+        target: str,
+        *,
+        node: ast.AST,
+        kind: ImportKind,
+    ) -> None:
+        category = self._category()
+        is_reexport = category == "lazy_export" or (
+            self.module.is_package and target.startswith(f"{self.module.module}.")
+        )
+        statement = self._source_segment(node)
+        self.dependencies.append(
+            ImportDependencyFact(
+                source=self.module.module,
+                target=target,
+                category=category,
+                kind=kind,
+                evidence=SourceEvidence(
+                    path=self.module.path,
+                    line=getattr(node, "lineno", 1),
+                    column=getattr(node, "col_offset", 0) + 1,
+                    statement=" ".join(statement.split()),
+                ),
+                is_reexport=is_reexport,
+            )
+        )
+
+    def _source_segment(self, node: ast.AST) -> str:
+        start_line = getattr(node, "lineno", 0)
+        end_line = getattr(node, "end_lineno", start_line)
+        if start_line < 1 or end_line < start_line:
+            return ""
+        if end_line > len(self._source_lines):
+            return ""
+        start_column = getattr(node, "col_offset", 0)
+        end_column = getattr(node, "end_col_offset", None)
+        selected = self._source_lines[start_line - 1 : end_line]
+        if not selected:
+            return ""
+        selected[0] = _slice_utf8(selected[0], start_column, None)
+        if end_column is not None:
+            selected[-1] = _slice_utf8(selected[-1], 0, end_column)
+        return "".join(selected)
+
+    def _category(self) -> ImportCategory:
+        if self._typing_depth:
+            return "typing"
+        if self._lazy_export_depth:
+            return "lazy_export"
+        if self._function_depth:
+            return "deferred"
+        return "eager"
+
+
+def _duplicate_module_diagnostic(
+    existing: _PythonSourceFile,
+    candidate: _PythonSourceFile,
+) -> ArchitectureDiagnostic:
+    return ArchitectureDiagnostic(
+        code="duplicate_python_module",
+        message=(
+            f"Module {candidate.module!r} is provided by both "
+            f"{existing.relative_path!r} and {candidate.relative_path!r}; "
+            "the first path was retained."
+        ),
+        severity="error",
+        path=candidate.relative_path,
+    )
+
+
+def _iter_python_files(root: Path, excludes: tuple[str, ...]):
+    for directory, names, filenames in os.walk(root, followlinks=False):
+        current = Path(directory)
+        relative_directory = current.relative_to(root)
+        names[:] = sorted(
+            name
+            for name in names
+            if not (current / name).is_symlink()
+            and not _is_excluded((relative_directory / name).as_posix(), name, excludes)
+        )
+        for filename in sorted(filenames):
+            if not filename.endswith(".py"):
+                continue
+            candidate = current / filename
+            if candidate.is_symlink():
+                continue
+            relative = (relative_directory / filename).as_posix()
+            if _matches_exclude(relative, excludes):
+                continue
+            yield candidate
+
+
+def _is_excluded(relative: str, name: str, excludes: tuple[str, ...]) -> bool:
+    return name in _DEFAULT_EXCLUDED_DIRECTORIES or _matches_exclude(relative, excludes)
+
+
+def _matches_exclude(relative: str, excludes: tuple[str, ...]) -> bool:
+    normalized = relative.removeprefix("./")
+    return any(
+        fnmatch.fnmatchcase(normalized, pattern.removeprefix("./"))
+        or fnmatch.fnmatchcase(f"{normalized}/", pattern.removeprefix("./"))
+        for pattern in excludes
+        if pattern
+    )
+
+
+def _normalize_package_prefix(root: Path, value: str | None) -> str | None:
+    if value is None:
+        value = root.name if (root / "__init__.py").is_file() else None
+    if value is None:
+        return None
+    normalized = value.strip().strip(".")
+    if not normalized:
+        return None
+    if any(not part.isidentifier() for part in normalized.split(".")):
+        raise ValueError(f"invalid Python package prefix: {value!r}")
+    return normalized
+
+
+def _module_name(relative_path: str, prefix: str | None) -> str | None:
+    parts = list(Path(relative_path).with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts.pop()
+    if any(not part.isidentifier() for part in parts):
+        return None
+    if prefix:
+        parts = [*prefix.split("."), *parts]
+    if not parts:
+        return prefix
+    return ".".join(parts)
+
+
+def _is_type_checking_test(node: ast.AST) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id == "TYPE_CHECKING"
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "TYPE_CHECKING"
+        and isinstance(node.value, ast.Name)
+        and node.value.id in {"typing", "typing_extensions"}
+    )
+
+
+def _dynamic_import_target(node: ast.Call) -> str | None:
+    is_builtin_import = isinstance(node.func, ast.Name) and node.func.id == "__import__"
+    is_importlib_call = (
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == "import_module"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "importlib"
+    )
+    if not (is_builtin_import or is_importlib_call) or not node.args:
+        return None
+    value = node.args[0]
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return value.value
+    return None
+
+
+def _slice_utf8(value: str, start: int, end: int | None) -> str:
+    return value.encode("utf-8")[start:end].decode("utf-8", errors="replace")
+
+
+def _dependency_sort_key(
+    dependency: ImportDependencyFact,
+) -> tuple[object, ...]:
+    evidence = dependency.evidence
+    return (
+        dependency.source,
+        dependency.target,
+        dependency.category,
+        dependency.kind,
+        evidence.path,
+        evidence.line,
+        evidence.column,
+    )
+
+
+def _diagnostic_sort_key(
+    diagnostic: ArchitectureDiagnostic,
+) -> tuple[object, ...]:
+    return (
+        diagnostic.path or "",
+        diagnostic.line or 0,
+        diagnostic.code,
+        diagnostic.message,
+    )
+
+
+__all__ = ["PYTHON_IMPORT_PROVIDER_VERSION", "PythonImportGraphProvider"]

--- a/tests/coding/arch/test_benchmark.py
+++ b/tests/coding/arch/test_benchmark.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import runpy
+from collections.abc import Callable
+from pathlib import Path
+
+
+def test_warm_latency_benchmark_checks_full_cache_hits(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("from . import module_0\n", encoding="utf-8")
+    for index in range(40):
+        target = (index + 1) % 40
+        (package / f"module_{index}.py").write_text(
+            f"import pkg.module_{target}\n",
+            encoding="utf-8",
+        )
+    namespace = runpy.run_path("scripts/arch/benchmark_import_graph.py")
+    main = namespace["main"]
+    assert isinstance(main, Callable)
+
+    exit_code = main(
+        (
+            str(package),
+            "--package-prefix",
+            "pkg",
+            "--runs",
+            "2",
+            "--warm-max-seconds",
+            "10",
+        )
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["passed"] is True
+    assert payload["cache_entries"] == 41
+    assert payload["warm_cache_hits"] == 41
+    assert payload["warm_runs"] == 2

--- a/tests/coding/arch/test_cache.py
+++ b/tests/coding/arch/test_cache.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from loushang.coding.arch import (
+    IMPORT_FACT_CACHE_SCHEMA_VERSION,
+    PYTHON_IMPORT_PROVIDER_VERSION,
+    ImportFactCache,
+    ImportGraphAnalyzer,
+    query_import_graph,
+)
+
+
+def _write(root: Path, relative: str, source: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def _package(tmp_path: Path) -> Path:
+    package = tmp_path / "pkg"
+    _write(package, "__init__.py", "from . import api\n")
+    _write(package, "api.py", "import pkg.core\n")
+    _write(package, "core.py", "VALUE = 1\n")
+    return package
+
+
+def _analyzer(cache: ImportFactCache) -> ImportGraphAnalyzer:
+    return ImportGraphAnalyzer(cache=cache)
+
+
+def test_unchanged_scan_reuses_every_file_and_preserves_query_output(
+    tmp_path: Path,
+) -> None:
+    package = _package(tmp_path)
+    analyzer = ImportGraphAnalyzer()
+
+    cold = analyzer.analyze(package, package_prefix="pkg", imports="all")
+    warm = analyzer.analyze(package, package_prefix="pkg", imports="all")
+
+    assert cold.cache_stats.hits == 0
+    assert cold.cache_stats.misses == 3
+    assert warm.cache_stats.hits == 3
+    assert warm.cache_stats.misses == 0
+    assert warm.cache_stats.invalidated == 0
+    assert replace(cold, cache_stats=warm.cache_stats) == warm
+    assert query_import_graph(cold) == query_import_graph(warm)
+
+
+def test_same_size_file_change_only_reparses_changed_file(tmp_path: Path) -> None:
+    package = _package(tmp_path)
+    _write(package, "other.py", "VALUE = 2\n")
+    cache = ImportFactCache()
+    analyzer = _analyzer(cache)
+    analyzer.analyze(package, package_prefix="pkg", imports="all")
+
+    original = (package / "api.py").read_bytes()
+    _write(package, "api.py", "import pkg.othe\n")
+    assert len((package / "api.py").read_bytes()) == len(original)
+    changed = analyzer.analyze(package, package_prefix="pkg", imports="all")
+
+    assert changed.cache_stats.hits == 3
+    assert changed.cache_stats.misses == 1
+    assert changed.cache_stats.invalidated == 1
+    assert (
+        any(
+            edge.source == "pkg.api" and edge.target == "pkg.othe"
+            for edge in changed.edges
+        )
+        is False
+    )
+    assert "pkg.othe" in changed.external_dependencies
+
+
+def test_deletion_and_rename_invalidate_module_sensitive_facts(
+    tmp_path: Path,
+) -> None:
+    package = _package(tmp_path)
+    analyzer = _analyzer(ImportFactCache())
+    analyzer.analyze(package, package_prefix="pkg", imports="all")
+
+    (package / "core.py").unlink()
+    after_delete = analyzer.analyze(package, package_prefix="pkg", imports="all")
+
+    assert after_delete.cache_stats.invalidated == 3
+    assert after_delete.cache_stats.hits == 0
+    assert after_delete.cache_stats.misses == 2
+    assert {node.id for node in after_delete.nodes} == {"pkg", "pkg.api"}
+    assert "pkg.core" in after_delete.external_dependencies
+
+    (package / "api.py").rename(package / "service.py")
+    after_rename = analyzer.analyze(package, package_prefix="pkg", imports="all")
+
+    assert after_rename.cache_stats.invalidated == 2
+    assert after_rename.cache_stats.hits == 0
+    assert after_rename.cache_stats.misses == 2
+    assert {node.id for node in after_rename.nodes} == {"pkg", "pkg.service"}
+
+
+def test_syntax_error_is_cached_and_fixed_source_invalidates_it(tmp_path: Path) -> None:
+    package = _package(tmp_path)
+    _write(package, "broken.py", "def broken(:\n")
+    analyzer = _analyzer(ImportFactCache())
+
+    broken = analyzer.analyze(package, package_prefix="pkg", imports="all")
+    warm_broken = analyzer.analyze(package, package_prefix="pkg", imports="all")
+    _write(package, "broken.py", "VALUE = 3\n")
+    fixed = analyzer.analyze(package, package_prefix="pkg", imports="all")
+
+    assert any(item.code == "python_syntax_error" for item in broken.diagnostics)
+    assert warm_broken.cache_stats.hits == 4
+    assert fixed.cache_stats.hits == 3
+    assert fixed.cache_stats.misses == 1
+    assert fixed.cache_stats.invalidated == 1
+    assert all(item.code != "python_syntax_error" for item in fixed.diagnostics)
+
+
+def test_disk_cache_is_reused_across_analyzer_instances(tmp_path: Path) -> None:
+    package = _package(tmp_path)
+    cache_path = tmp_path / "cache" / "facts.json"
+
+    cold = _analyzer(ImportFactCache(cache_path)).analyze(
+        package,
+        package_prefix="pkg",
+        imports="all",
+    )
+    preserved_mtime_ns = 1_000_000_000
+    os.utime(cache_path, ns=(preserved_mtime_ns, preserved_mtime_ns))
+    warm = _analyzer(ImportFactCache(cache_path)).analyze(
+        package,
+        package_prefix="pkg",
+        imports="all",
+    )
+
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    assert cold.cache_stats.misses == 3
+    assert warm.cache_stats.hits == 3
+    assert warm.cache_stats.misses == 0
+    assert cache_path.stat().st_mtime_ns == preserved_mtime_ns
+    assert payload["schema_version"] == IMPORT_FACT_CACHE_SCHEMA_VERSION
+    assert payload["namespace"]["provider_version"] == PYTHON_IMPORT_PROVIDER_VERSION
+    assert str(package.resolve()) not in cache_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("version_field", ["schema_version", "provider_version"])
+def test_incompatible_disk_cache_is_rebuilt(
+    tmp_path: Path,
+    version_field: str,
+) -> None:
+    package = _package(tmp_path)
+    cache_path = tmp_path / "cache" / "facts.json"
+    _analyzer(ImportFactCache(cache_path)).analyze(package, package_prefix="pkg")
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    if version_field == "schema_version":
+        payload[version_field] = 999
+    else:
+        payload["namespace"][version_field] = 999
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    rebuilt = _analyzer(ImportFactCache(cache_path)).analyze(
+        package,
+        package_prefix="pkg",
+    )
+    rewritten = json.loads(cache_path.read_text(encoding="utf-8"))
+
+    assert rebuilt.cache_stats.hits == 0
+    assert rebuilt.cache_stats.misses == 3
+    assert rewritten["schema_version"] == IMPORT_FACT_CACHE_SCHEMA_VERSION
+    assert rewritten["namespace"]["provider_version"] == PYTHON_IMPORT_PROVIDER_VERSION
+
+
+def test_corrupt_disk_cache_degrades_to_a_rebuild(tmp_path: Path) -> None:
+    package = _package(tmp_path)
+    cache_path = tmp_path / "cache" / "facts.json"
+    cache_path.parent.mkdir(parents=True)
+    cache_path.write_text("not-json", encoding="utf-8")
+
+    rebuilt = _analyzer(ImportFactCache(cache_path)).analyze(
+        package,
+        package_prefix="pkg",
+    )
+
+    assert rebuilt.cache_stats.misses == 3
+    assert rebuilt.cache_stats.error is not None
+    assert json.loads(cache_path.read_text(encoding="utf-8"))["schema_version"] == 1
+
+
+def test_refresh_cache_reparses_every_file(tmp_path: Path) -> None:
+    package = _package(tmp_path)
+    analyzer = _analyzer(ImportFactCache())
+    analyzer.analyze(package, package_prefix="pkg")
+
+    refreshed = analyzer.analyze(
+        package,
+        package_prefix="pkg",
+        refresh_cache=True,
+    )
+
+    assert refreshed.cache_stats.hits == 0
+    assert refreshed.cache_stats.misses == 3
+    assert refreshed.cache_stats.invalidated == 3

--- a/tests/coding/arch/test_cli.py
+++ b/tests/coding/arch/test_cli.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loushang.coding.arch.cli import main
+
+
+def _package(tmp_path: Path) -> Path:
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("from . import api\n", encoding="utf-8")
+    (package / "api.py").write_text("from pkg import core\n", encoding="utf-8")
+    (package / "core.py").write_text("VALUE = 1\n", encoding="utf-8")
+    return package
+
+
+def test_cli_prints_bounded_json_query(tmp_path: Path, capsys) -> None:
+    package = _package(tmp_path)
+
+    exit_code = main(
+        (
+            str(package),
+            "--package-prefix",
+            "pkg",
+            "--query",
+            "edges",
+            "--source",
+            "pkg.api",
+            "--limit",
+            "1",
+            "--cache-dir",
+            str(tmp_path / "cache"),
+        )
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert captured.err == ""
+    assert payload["query"] == "edges"
+    assert payload["results"][0]["target"] == "pkg.core"
+
+
+def test_cli_can_fail_a_boundary_gate(tmp_path: Path, capsys) -> None:
+    package = _package(tmp_path)
+
+    exit_code = main(
+        (
+            str(package),
+            "--package-prefix",
+            "pkg",
+            "--query",
+            "boundaries",
+            "--deny",
+            "pkg.api=pkg.core",
+            "--fail-on-violations",
+            "--cache-dir",
+            str(tmp_path / "cache"),
+        )
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert payload["results"][0]["rule_id"] == "deny:pkg.api=pkg.core"
+
+
+def test_cli_reports_invalid_query_input_as_json(tmp_path: Path, capsys) -> None:
+    package = _package(tmp_path)
+
+    exit_code = main(
+        (
+            str(package),
+            "--query",
+            "path",
+            "--cache-dir",
+            str(tmp_path / "cache"),
+        )
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert json.loads(captured.err) == {
+        "error": "path query requires source and target"
+    }
+
+
+def test_cli_uses_disk_cache_by_default_and_opt_in_telemetry_is_separate(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    package = _package(tmp_path)
+    cache_dir = tmp_path / "cache"
+    arguments = (
+        str(package),
+        "--package-prefix",
+        "pkg",
+        "--cache-dir",
+        str(cache_dir),
+        "--cache-info",
+    )
+
+    assert main(arguments) == 0
+    cold = json.loads(capsys.readouterr().out)
+    assert main(arguments) == 0
+    warm = json.loads(capsys.readouterr().out)
+
+    assert cold["cache"]["misses"] == 3
+    assert warm["cache"]["hits"] == 3
+    cold.pop("cache")
+    warm.pop("cache")
+    assert cold == warm
+
+
+def test_cli_can_disable_cache(tmp_path: Path, capsys) -> None:
+    package = _package(tmp_path)
+
+    assert main((str(package), "--no-cache", "--cache-info")) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cache"] == {
+        "enabled": False,
+        "entries": 0,
+        "error": None,
+        "hits": 0,
+        "invalidated": 0,
+        "misses": 3,
+    }

--- a/tests/coding/arch/test_example.py
+++ b/tests/coding/arch/test_example.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import json
+import runpy
+from collections.abc import Callable
+
+
+def test_import_graph_example_uses_public_api(capsys) -> None:
+    namespace = runpy.run_path("examples/coding/arch/01_import_graph.py")
+    main = namespace["main"]
+    assert isinstance(main, Callable)
+
+    main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["language"] == "python"
+    assert payload["nodes"] == 3
+    assert payload["eager_cycles"] == [["sample.api", "sample.core"]]

--- a/tests/coding/arch/test_import_graph.py
+++ b/tests/coding/arch/test_import_graph.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from loushang.coding.arch import (
+    BoundaryRule,
+    ImportDependencyFact,
+    ImportGraphAnalyzer,
+    ImportModuleFact,
+    ImportProviderScan,
+    SourceEvidence,
+    analyze_import_graph,
+    query_import_graph,
+)
+from loushang.coding.arch.cache import ImportFactCache
+
+
+def _write(root: Path, relative: str, source: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(source).strip() + "\n", encoding="utf-8")
+
+
+def _python_package(root: Path) -> Path:
+    package = root / "pkg"
+    _write(
+        package,
+        "__init__.py",
+        """
+        from . import api
+
+        def __getattr__(name):
+            from . import lazy
+            return lazy
+        """,
+    )
+    _write(
+        package,
+        "api.py",
+        """
+        from typing import TYPE_CHECKING
+        from pkg import core
+
+        if TYPE_CHECKING:
+            from pkg import types
+
+        def load():
+            from pkg import lazy
+            return lazy
+        """,
+    )
+    _write(package, "core.py", "from pkg import api")
+    _write(
+        package,
+        "types.py",
+        """
+        import typing
+
+        if typing.TYPE_CHECKING:
+            from pkg import api
+        """,
+    )
+    _write(package, "lazy.py", "import pkg.core")
+    _write(package, "dynamic.py", "VALUE = 1")
+    _write(
+        package,
+        "loader.py",
+        """
+        import importlib
+
+        def load():
+            return importlib.import_module(".dynamic", __package__)
+        """,
+    )
+    return package
+
+
+def test_python_provider_classifies_imports_and_resolves_relative_modules(
+    tmp_path: Path,
+) -> None:
+    package = _python_package(tmp_path)
+
+    graph = analyze_import_graph(
+        package,
+        package_prefix="pkg",
+        imports="all",
+    )
+
+    edges = {
+        (edge.source, edge.target, edge.category, edge.kind): edge
+        for edge in graph.edges
+    }
+    assert ("pkg", "pkg.api", "eager", "from_import") in edges
+    assert edges[("pkg", "pkg.api", "eager", "from_import")].is_reexport
+    assert ("pkg.api", "pkg.core", "eager", "from_import") in edges
+    assert ("pkg.api", "pkg.types", "typing", "from_import") in edges
+    assert ("pkg.api", "pkg.lazy", "deferred", "from_import") in edges
+    assert ("pkg", "pkg.lazy", "lazy_export", "from_import") in edges
+    assert (
+        "pkg.loader",
+        "pkg.dynamic",
+        "deferred",
+        "dynamic_import",
+    ) in edges
+    assert (
+        edges[("pkg.api", "pkg.core", "eager", "from_import")].evidence[0].statement
+        == "from pkg import core"
+    )
+
+
+def test_eager_selection_excludes_typing_deferred_and_lazy_export_edges(
+    tmp_path: Path,
+) -> None:
+    package = _python_package(tmp_path)
+
+    graph = analyze_import_graph(package, package_prefix="pkg")
+
+    assert graph.imports == "eager"
+    assert graph.edges
+    assert {edge.category for edge in graph.edges} == {"eager"}
+    assert ("pkg.api", "pkg.types") not in {
+        (edge.source, edge.target) for edge in graph.edges
+    }
+
+
+def test_queries_report_cycles_paths_hotspots_and_boundaries(tmp_path: Path) -> None:
+    package = _python_package(tmp_path)
+    graph = analyze_import_graph(
+        package,
+        package_prefix="pkg",
+        imports="all",
+    )
+
+    summary = query_import_graph(
+        graph,
+        "summary",
+        boundary_rules=(BoundaryRule("pkg.api", "pkg.core", "api-to-core"),),
+    )
+    assert {"pkg.api", "pkg.core"}.issubset(summary["cycles"][0])
+    assert summary["eager_cycles"] == [["pkg.api", "pkg.core"]]
+    assert ["pkg.api", "pkg.types"] in summary["typing_cycles"]
+    assert summary["boundary_violations"][0]["rule_id"] == "api-to-core"
+    assert summary["categories"] == {
+        "eager": 4,
+        "typing": 2,
+        "deferred": 2,
+        "lazy_export": 1,
+    }
+
+    path = query_import_graph(
+        graph,
+        "path",
+        source="pkg",
+        target="pkg.core",
+    )
+    assert path["found"] is True
+    assert path["nodes"] == ["pkg", "pkg.api", "pkg.core"]
+
+    hotspots = query_import_graph(graph, "hotspots", limit=2)
+    assert len(hotspots["results"]) == 2
+    assert hotspots["results"][0]["node"] == "pkg.api"
+
+
+def test_subsystem_projection_collapses_modules_and_internal_edges(
+    tmp_path: Path,
+) -> None:
+    package = tmp_path / "pkg"
+    _write(package, "__init__.py", "")
+    _write(package, "alpha/__init__.py", "")
+    _write(package, "alpha/one.py", "from pkg.alpha import two\nfrom pkg import beta")
+    _write(package, "alpha/two.py", "VALUE = 1")
+    _write(package, "beta.py", "from pkg.alpha import one")
+
+    graph = analyze_import_graph(
+        package,
+        package_prefix="pkg",
+        granularity="subsystem",
+    )
+
+    assert [node.id for node in graph.nodes] == ["pkg", "pkg.alpha", "pkg.beta"]
+    assert {(edge.source, edge.target) for edge in graph.edges} == {
+        ("pkg.alpha", "pkg.beta"),
+        ("pkg.beta", "pkg.alpha"),
+    }
+
+
+def test_package_prefix_is_inferred_for_subsystem_projection(tmp_path: Path) -> None:
+    package = tmp_path / "pkg"
+    _write(package, "__init__.py", "")
+    _write(package, "alpha/one.py", "from pkg import beta")
+    _write(package, "beta.py", "VALUE = 1")
+
+    graph = analyze_import_graph(package, granularity="subsystem")
+
+    assert graph.package_prefix == "pkg"
+    assert [node.id for node in graph.nodes] == ["pkg", "pkg.alpha", "pkg.beta"]
+
+
+def test_provider_is_replaceable_without_changing_graph_queries(tmp_path: Path) -> None:
+    class ExampleProvider:
+        language = "example"
+
+        def supports(self, root: Path) -> bool:
+            return root.is_dir()
+
+        def scan(
+            self,
+            root: Path,
+            *,
+            package_prefix: str | None = None,
+            excludes: tuple[str, ...] = (),
+            cache: ImportFactCache | None = None,
+            refresh_cache: bool = False,
+        ) -> ImportProviderScan:
+            del root, package_prefix, excludes, cache, refresh_cache
+            return ImportProviderScan(
+                language=self.language,
+                modules=(
+                    ImportModuleFact("alpha", "alpha.src", self.language),
+                    ImportModuleFact("beta", "beta.src", self.language),
+                ),
+                dependencies=(
+                    ImportDependencyFact(
+                        source="alpha",
+                        target="beta",
+                        category="eager",
+                        kind="import",
+                        evidence=SourceEvidence("alpha.src", 1, 1, "use beta"),
+                    ),
+                ),
+            )
+
+    graph = ImportGraphAnalyzer((ExampleProvider(),)).analyze(
+        tmp_path,
+        language="example",
+    )
+
+    assert graph.language == "example"
+    assert query_import_graph(graph, "edges")["results"][0]["target"] == "beta"
+
+
+def test_cycle_query_handles_graphs_deeper_than_python_recursion_limit(
+    tmp_path: Path,
+) -> None:
+    module_names = tuple(f"module_{index:04d}" for index in range(1_100))
+
+    class LargeProvider:
+        language = "large"
+
+        def supports(self, root: Path) -> bool:
+            return root.is_dir()
+
+        def scan(
+            self,
+            root: Path,
+            *,
+            package_prefix: str | None = None,
+            excludes: tuple[str, ...] = (),
+            cache: ImportFactCache | None = None,
+            refresh_cache: bool = False,
+        ) -> ImportProviderScan:
+            del root, package_prefix, excludes, cache, refresh_cache
+            return ImportProviderScan(
+                language=self.language,
+                modules=tuple(
+                    ImportModuleFact(name, f"{name}.src", self.language)
+                    for name in module_names
+                ),
+                dependencies=tuple(
+                    ImportDependencyFact(
+                        source=name,
+                        target=module_names[(index + 1) % len(module_names)],
+                        category="eager",
+                        kind="import",
+                        evidence=SourceEvidence(f"{name}.src", 1, 1),
+                    )
+                    for index, name in enumerate(module_names)
+                ),
+            )
+
+    graph = ImportGraphAnalyzer((LargeProvider(),)).analyze(tmp_path)
+    result = query_import_graph(graph, "cycles")
+
+    assert len(result["cycles"]) == 1
+    assert result["cycles"][0]["nodes"] == list(module_names)
+
+
+def test_edge_query_bounds_repeated_source_evidence(tmp_path: Path) -> None:
+    package = tmp_path / "pkg"
+    _write(package, "__init__.py", "")
+    _write(package, "core.py", "VALUE = 1")
+    _write(package, "api.py", "\n".join(["import pkg.core"] * 25))
+
+    graph = analyze_import_graph(package, package_prefix="pkg")
+    result = query_import_graph(graph, "edges", source="pkg.api")
+
+    assert len(result["results"][0]["evidence"]) == 20
+    assert result["results"][0]["evidence_truncated"] is True
+
+
+def test_scan_reports_syntax_errors_and_honors_excludes(tmp_path: Path) -> None:
+    package = tmp_path / "pkg"
+    _write(package, "__init__.py", "")
+    _write(package, "broken.py", "def broken(")
+    _write(package, "generated/ignored.py", "import pkg.broken")
+
+    graph = analyze_import_graph(
+        package,
+        package_prefix="pkg",
+        excludes=("generated/*",),
+    )
+
+    assert {node.id for node in graph.nodes} == {"pkg", "pkg.broken"}
+    assert graph.diagnostics[0].code == "python_syntax_error"
+    assert graph.diagnostics[0].path == "broken.py"
+
+
+def test_scan_does_not_follow_source_symlinks(tmp_path: Path) -> None:
+    package = tmp_path / "pkg"
+    _write(package, "__init__.py", "")
+    outside = tmp_path / "outside.py"
+    outside.write_text("VALUE = 1\n", encoding="utf-8")
+    (package / "linked.py").symlink_to(outside)
+
+    graph = analyze_import_graph(package, package_prefix="pkg")
+
+    assert [node.id for node in graph.nodes] == ["pkg"]


### PR DESCRIPTION
## What changed

- add the language-neutral `loushang.coding.arch` graph model, provider protocol, graph queries, CLI, and Python AST provider
- classify eager, typing-only, deferred, lazy-export, relative, dynamic, and re-export imports without importing project code
- add versioned per-file fact caching with content-based invalidation, atomic disk persistence, safe rebuilds, and deterministic query output
- add an executable warm-latency benchmark, public example, automation adapter, documentation, and focused tests

## Why

Architecture inspection needs to be a reusable Coding product capability rather than a one-off CI script. The normalized provider contract lets additional languages participate without changing graph queries, while the incremental cache makes repeated tool/session queries practical.

## Impact

- `ImportGraphAnalyzer` reuses an in-memory cache by default in long-lived processes.
- `python -m loushang.coding.arch` uses a persistent cache below `LOUSHANG_HOME/cache/coding/arch` by default; `--no-cache`, `--refresh-cache`, and opt-in `--cache-info` are available.
- A single content change reparses only that file. File additions, deletions, or renames invalidate module-index-sensitive facts.
- Cache schema/provider incompatibility or corruption safely falls back to rebuilding facts.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/arch -q` — 26 passed
- `uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/arch tests/coding/arch scripts/arch examples/coding/arch`
- `uv --cache-dir .uv-cache run --extra dev mypy src/loushang/coding/arch`
- repository benchmark over 825 cached Python modules: 5/5 full cache hits, median 0.298 s, max 0.394 s
- full Coding regression: 2271 passed; the sole local failure was caused by an ignored retired-package `__pycache__` directory and passed when that cache was isolated
