### PR TITLE
feat(coding): add optional arch analysis tool pack

### DIFF
--- a/docs/internals/architecture/coding/component-interfaces/tools.md
+++ b/docs/internals/architecture/coding/component-interfaces/tools.md
@@ -63,6 +63,14 @@
   “分析架构”工具替代可验证的结构化查询。
 - CLI 或 Coding 配置的显式常驻选择应增量加入默认工具集合，不得替换 builtin tools，也不得绕过 `--no-tools`、session
   allowlist、delegated execution profile、policy 或 approval 边界。
+- Coding CLI 使用通用 `--capability CAPABILITY=MODE` 形式覆盖当前进程，例如
+  `--capability coding.arch=always`；配置文件使用 `capabilities` 映射，例如
+  `{"capabilities": {"coding.arch": "always"}}`。CLI 覆盖只写入 session 配置层，不持久化修改 project/global
+  配置；未配置 `coding.arch` 时默认值为 `on_demand`。
+- `on_demand` 表示工具定义已 admission、可由 `/tools` 或等价 Session API 手动激活，但不进入默认 Agent tools/prompt；
+  `always` 表示增量加入默认激活集合；`disabled` 表示不向该 Session registry 注册该能力的工具定义。
+- `inspect_import_graph` 只接受当前 Coding workspace 内的 root（包括解析 symlink 后的 canonical path），所有 query
+  都受硬上限约束；工具返回 analyzer/cache 的可验证事实，不输出主观架构判断。
 - 高频查询复用语言 provider 输出的版本化逐文件事实缓存，而不缓存 AST 或主观架构结论。CLI 默认在
   `LOUSHANG_HOME/cache/coding/arch` 使用磁盘缓存；长驻工具复用进程内缓存。内容指纹负责单文件失效，文件集合变化则使依赖
   模块索引的事实整体失效；缓存损坏或版本不兼容必须安全退化为重新分析。

--- a/docs/internals/architecture/coding/core-data-objects/control-configs.md
+++ b/docs/internals/architecture/coding/core-data-objects/control-configs.md
@@ -39,6 +39,8 @@
 - 运行控制项
 - `compaction_settings`
 - `branch_summary_settings`
+- `capabilities: {ProductCapabilityId: disabled | on_demand | always}`，表达 Product capability 的默认挂载策略；
+  具体 capability id、默认值和 capability-to-pack 映射仍由 Coding Product 解释，配置层只校验通用挂载值。
 
 ### `CompactionSettings`
 

--- a/src/loushang/coding/__init__.py
+++ b/src/loushang/coding/__init__.py
@@ -1,4 +1,11 @@
 from loushang.ai.model import ModelSelection
+from loushang.coding.arch import (
+    CODING_ARCH_TOOL_PACK,
+    INSPECT_IMPORT_GRAPH_TOOL_NAME,
+    ImportGraphToolRuntime,
+    create_inspect_import_graph_tool_definition,
+    register_coding_arch_tools,
+)
 from loushang.coding.bootstrap import (
     AgentSessionServices,
     BootstrapServices,
@@ -13,6 +20,7 @@ from loushang.coding.bootstrap import (
     create_agent_session_services,
     create_services,
 )
+from loushang.coding.capabilities import CODING_ARCH_CAPABILITY
 from loushang.coding.prompt import assemble_system_prompt
 from loushang.coding.resource_runtime import (
     CodingResourceLoader as DefaultResourceLoader,
@@ -45,6 +53,7 @@ from loushang.coding.tool_pack import (
     register_coding_builtin_tools,
 )
 from loushang.harness.config.agent import (
+    CapabilityMountMode,
     ControlConfig,
     HeadlessApprovalMode,
     SettingsManager,
@@ -58,7 +67,10 @@ __all__ = [
     "BootstrapServices",
     "CODING_BUILTIN_TOOL_NAMES",
     "CODING_BUILTIN_TOOL_PACK",
+    "CODING_ARCH_CAPABILITY",
+    "CODING_ARCH_TOOL_PACK",
     "CODING_TOOL_NAMES",
+    "CapabilityMountMode",
     "CompactionDecision",
     "ContextUsage",
     "ContextUsageSnapshot",
@@ -69,6 +81,8 @@ __all__ = [
     "DefaultResourceLoader",
     "ExtensionFlagValues",
     "HeadlessApprovalMode",
+    "INSPECT_IMPORT_GRAPH_TOOL_NAME",
+    "ImportGraphToolRuntime",
     "ModelSelection",
     "ToolSettings",
     "TreeNavigationResult",
@@ -87,9 +101,11 @@ __all__ = [
     "create_coding_tool_definition",
     "create_coding_tool_definitions",
     "create_coding_tools",
+    "create_inspect_import_graph_tool_definition",
     "create_agent_session_runtime",
     "create_services",
     "check_sdk_surface_compatibility",
     "get_sdk_surface_snapshot",
     "register_coding_builtin_tools",
+    "register_coding_arch_tools",
 ]

--- a/src/loushang/coding/arch/__init__.py
+++ b/src/loushang/coding/arch/__init__.py
@@ -33,12 +33,25 @@ from loushang.coding.arch.providers import (
     ImportGraphProvider,
     PythonImportGraphProvider,
 )
+from loushang.coding.arch.tool import (
+    INSPECT_IMPORT_GRAPH_TOOL_NAME,
+    MAX_INSPECT_IMPORT_GRAPH_LIMIT,
+    ImportGraphToolRuntime,
+    create_inspect_import_graph_tool_definition,
+)
+from loushang.coding.arch.tool_pack import (
+    CODING_ARCH_TOOL_PACK,
+    register_coding_arch_tools,
+)
 
 __all__ = [
     "IMPORT_GRAPH_SCHEMA_VERSION",
     "IMPORT_FACT_CACHE_SCHEMA_VERSION",
     "PYTHON_IMPORT_PROVIDER_VERSION",
     "ArchitectureDiagnostic",
+    "CODING_ARCH_TOOL_PACK",
+    "INSPECT_IMPORT_GRAPH_TOOL_NAME",
+    "MAX_INSPECT_IMPORT_GRAPH_LIMIT",
     "BoundaryRule",
     "ImportCategory",
     "ImportCacheStats",
@@ -49,6 +62,7 @@ __all__ = [
     "ImportGraphEdge",
     "ImportGraphNode",
     "ImportGraphProvider",
+    "ImportGraphToolRuntime",
     "ImportGraphQuery",
     "ImportKind",
     "ImportModuleFact",
@@ -58,6 +72,8 @@ __all__ = [
     "PythonImportGraphProvider",
     "SourceEvidence",
     "analyze_import_graph",
+    "create_inspect_import_graph_tool_definition",
     "default_import_fact_cache_path",
     "query_import_graph",
+    "register_coding_arch_tools",
 ]

--- a/src/loushang/coding/arch/tool.py
+++ b/src/loushang/coding/arch/tool.py
@@ -1,0 +1,311 @@
+"""Model-facing import-graph tool over the deterministic analyzer."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import NotRequired, TypedDict, cast
+
+from loushang.coding.arch.import_graph import (
+    ImportGraphAnalyzer,
+    query_import_graph,
+)
+from loushang.coding.arch.model import (
+    BoundaryRule,
+    ImportGranularity,
+    ImportGraphQuery,
+    ImportSelection,
+)
+from loushang.harness.tools.authoring import (
+    FilesystemActionAdapter,
+    ToolContext,
+    authorized_tool,
+)
+from loushang.harness.tools.core import ToolDefinition, tool
+
+INSPECT_IMPORT_GRAPH_TOOL_NAME = "inspect_import_graph"
+MAX_INSPECT_IMPORT_GRAPH_LIMIT = 200
+MAX_INSPECT_IMPORT_GRAPH_EXCLUDES = 100
+MAX_INSPECT_IMPORT_GRAPH_BOUNDARY_RULES = 100
+
+
+class BoundaryRuleInput(TypedDict):
+    source: str
+    target: str
+    rule_id: NotRequired[str]
+
+
+@dataclass
+class ImportGraphToolRuntime:
+    """Keep one analyzer and its versioned per-file fact cache warm."""
+
+    analyzer: ImportGraphAnalyzer = field(default_factory=ImportGraphAnalyzer)
+
+    def inspect(
+        self,
+        *,
+        workspace: str | Path,
+        root: str = ".",
+        package_prefix: str | None = None,
+        language: str = "auto",
+        granularity: str = "module",
+        imports: str = "eager",
+        query: str = "summary",
+        source: str | None = None,
+        target: str | None = None,
+        limit: int = 100,
+        excludes: list[str] | None = None,
+        boundary_rules: list[BoundaryRuleInput] | None = None,
+        refresh_cache: bool = False,
+    ) -> dict[str, object]:
+        resolved_root = _resolve_workspace_root(workspace, root)
+        _validate_request(
+            granularity=granularity,
+            imports=imports,
+            query=query,
+            limit=limit,
+            excludes=excludes,
+            boundary_rules=boundary_rules,
+        )
+        graph = self.analyzer.analyze(
+            resolved_root,
+            package_prefix=package_prefix,
+            language=language,
+            granularity=cast(ImportGranularity, granularity),
+            imports=cast(ImportSelection, imports),
+            excludes=tuple(excludes or ()),
+            refresh_cache=refresh_cache,
+        )
+        result = query_import_graph(
+            graph,
+            cast(ImportGraphQuery, query),
+            source=source,
+            target=target,
+            limit=limit,
+            boundary_rules=_boundary_rules(boundary_rules or []),
+        )
+        _bound_tool_payload(result, query=cast(ImportGraphQuery, query), limit=limit)
+        result["cache"] = asdict(graph.cache_stats)
+        return result
+
+
+def create_inspect_import_graph_tool_definition(
+    *,
+    runtime: ImportGraphToolRuntime | None = None,
+) -> ToolDefinition:
+    """Create the optional Coding architecture tool definition."""
+
+    shared_runtime = runtime or ImportGraphToolRuntime()
+
+    @tool(
+        name=INSPECT_IMPORT_GRAPH_TOOL_NAME,
+        label="Inspect Import Graph",
+        description=(
+            "Inspect a bounded, deterministic import dependency view within the "
+            "current coding workspace. Query summaries, cycles, edges, paths, "
+            "hotspots, or boundary violations without returning the full graph."
+        ),
+        prompt_snippet=(
+            "- inspect_import_graph: Query architecture dependency facts for a "
+            "workspace source tree; prefer summary first and narrow follow-up queries."
+        ),
+        prompt_guidelines=(
+            "Use inspect_import_graph for verifiable import dependencies, cycles, "
+            "paths, hotspots, and boundary violations.",
+            "Start with query=summary, then use bounded focused queries instead of "
+            "requesting a complete dependency graph.",
+        ),
+        schema_overrides={
+            "properties": {
+                "root": {
+                    "type": "string",
+                    "description": (
+                        "Workspace-relative source root, or an absolute path contained "
+                        "by the current coding workspace."
+                    ),
+                },
+                "language": {
+                    "type": "string",
+                    "description": "Language provider id, or auto to detect one.",
+                },
+                "granularity": {"type": "string", "enum": ["module", "subsystem"]},
+                "imports": {"type": "string", "enum": ["eager", "all"]},
+                "query": {
+                    "type": "string",
+                    "enum": [
+                        "summary",
+                        "cycles",
+                        "edges",
+                        "path",
+                        "hotspots",
+                        "boundaries",
+                    ],
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_INSPECT_IMPORT_GRAPH_LIMIT,
+                },
+            }
+        },
+    )
+    def inspect_import_graph(
+        ctx: ToolContext,
+        root: str,
+        package_prefix: str | None = None,
+        language: str = "auto",
+        granularity: str = "module",
+        imports: str = "eager",
+        query: str = "summary",
+        source: str | None = None,
+        target: str | None = None,
+        limit: int = 100,
+        excludes: list[str] | None = None,
+        boundary_rules: list[BoundaryRuleInput] | None = None,
+        refresh_cache: bool = False,
+    ) -> dict[str, object]:
+        if ctx.cwd is None:
+            raise RuntimeError("inspect_import_graph requires a coding workspace")
+        return shared_runtime.inspect(
+            workspace=ctx.cwd,
+            root=root,
+            package_prefix=package_prefix,
+            language=language,
+            granularity=granularity,
+            imports=imports,
+            query=query,
+            source=source,
+            target=target,
+            limit=limit,
+            excludes=excludes,
+            boundary_rules=boundary_rules,
+            refresh_cache=refresh_cache,
+        )
+
+    definition = authorized_tool(
+        inspect_import_graph,
+        action=FilesystemActionAdapter(
+            operation="read",
+            path_argument="root",
+            default_path=".",
+        ),
+    )
+    return replace(definition, execution_mode="sequential")
+
+
+def _resolve_workspace_root(workspace: str | Path, root: str) -> Path:
+    if not isinstance(root, str) or not root.strip():
+        raise ValueError("import graph root must be a non-empty path")
+    workspace_root = Path(workspace).expanduser().resolve()
+    candidate = Path(root).expanduser()
+    if not candidate.is_absolute():
+        candidate = workspace_root / candidate
+    resolved = candidate.resolve()
+    if not resolved.is_relative_to(workspace_root):
+        raise PermissionError("import graph root must stay within the coding workspace")
+    return resolved
+
+
+def _validate_request(
+    *,
+    granularity: str,
+    imports: str,
+    query: str,
+    limit: int,
+    excludes: list[str] | None,
+    boundary_rules: list[BoundaryRuleInput] | None,
+) -> None:
+    if granularity not in {"module", "subsystem"}:
+        raise ValueError(f"unsupported import graph granularity: {granularity!r}")
+    if imports not in {"eager", "all"}:
+        raise ValueError(f"unsupported import selection: {imports!r}")
+    if query not in {"summary", "cycles", "edges", "path", "hotspots", "boundaries"}:
+        raise ValueError(f"unsupported import graph query: {query!r}")
+    if not isinstance(limit, int) or isinstance(limit, bool):
+        raise TypeError("query limit must be an integer")
+    if not 1 <= limit <= MAX_INSPECT_IMPORT_GRAPH_LIMIT:
+        raise ValueError(
+            f"query limit must be between 1 and {MAX_INSPECT_IMPORT_GRAPH_LIMIT}"
+        )
+    if excludes is not None and len(excludes) > MAX_INSPECT_IMPORT_GRAPH_EXCLUDES:
+        raise ValueError(
+            f"too many exclude patterns; maximum is {MAX_INSPECT_IMPORT_GRAPH_EXCLUDES}"
+        )
+    if excludes is not None and any(not isinstance(value, str) for value in excludes):
+        raise TypeError("exclude patterns must be strings")
+    if (
+        boundary_rules is not None
+        and len(boundary_rules) > MAX_INSPECT_IMPORT_GRAPH_BOUNDARY_RULES
+    ):
+        raise ValueError(
+            "too many boundary rules; maximum is "
+            f"{MAX_INSPECT_IMPORT_GRAPH_BOUNDARY_RULES}"
+        )
+
+
+def _boundary_rules(values: list[BoundaryRuleInput]) -> tuple[BoundaryRule, ...]:
+    rules: list[BoundaryRule] = []
+    for value in values:
+        if not isinstance(value, dict):
+            raise TypeError("boundary rules must be objects")
+        source = value.get("source")
+        target = value.get("target")
+        rule_id = value.get("rule_id", "")
+        if not isinstance(source, str) or not isinstance(target, str):
+            raise TypeError("boundary rule source and target must be strings")
+        if not isinstance(rule_id, str):
+            raise TypeError("boundary rule id must be a string")
+        rules.append(BoundaryRule(source=source, target=target, rule_id=rule_id))
+    return tuple(rules)
+
+
+def _bound_tool_payload(
+    payload: dict[str, object],
+    *,
+    query: ImportGraphQuery,
+    limit: int,
+) -> None:
+    cycle_member_limit = min(limit, 20)
+    if query == "summary":
+        members_truncated = False
+        for key in ("cycles", "eager_cycles", "typing_cycles"):
+            cycles = payload.get(key)
+            if not isinstance(cycles, list):
+                continue
+            for index, cycle in enumerate(cycles):
+                if not isinstance(cycle, list):
+                    continue
+                members_truncated = members_truncated or len(cycle) > cycle_member_limit
+                cycles[index] = cycle[:cycle_member_limit]
+        payload["cycle_members_truncated"] = members_truncated
+        return
+    if query == "cycles":
+        cycles = payload.get("cycles")
+        if not isinstance(cycles, list):
+            return
+        for cycle in cycles:
+            if not isinstance(cycle, dict):
+                continue
+            nodes = cycle.get("nodes")
+            if not isinstance(nodes, list):
+                continue
+            cycle["nodes"] = nodes[:cycle_member_limit]
+            cycle["nodes_truncated"] = len(nodes) > cycle_member_limit
+        return
+    if query == "path":
+        nodes = payload.get("nodes")
+        edges = payload.get("edges")
+        if not isinstance(nodes, list) or not isinstance(edges, list):
+            return
+        payload["nodes"] = nodes[:limit]
+        payload["edges"] = edges[: max(0, limit - 1)]
+        payload["truncated"] = len(nodes) > limit
+
+
+__all__ = [
+    "INSPECT_IMPORT_GRAPH_TOOL_NAME",
+    "MAX_INSPECT_IMPORT_GRAPH_LIMIT",
+    "BoundaryRuleInput",
+    "ImportGraphToolRuntime",
+    "create_inspect_import_graph_tool_definition",
+]

--- a/src/loushang/coding/arch/tool_pack.py
+++ b/src/loushang/coding/arch/tool_pack.py
@@ -1,0 +1,49 @@
+"""Optional architecture tool pack selected by the Coding product."""
+
+from __future__ import annotations
+
+from loushang.coding.arch.tool import (
+    INSPECT_IMPORT_GRAPH_TOOL_NAME,
+    ImportGraphToolRuntime,
+    create_inspect_import_graph_tool_definition,
+)
+from loushang.coding.capabilities import CODING_ARCH_CAPABILITY
+from loushang.harness.config.agent import CapabilityMountMode
+from loushang.harness.tools.contribution import (
+    ToolContribution,
+    ToolPackDefinition,
+    resolve_tool_contributions,
+)
+from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
+
+CODING_ARCH_TOOL_PACK = ToolPackDefinition(
+    name="coding.arch.tools",
+    tools=(INSPECT_IMPORT_GRAPH_TOOL_NAME,),
+    metadata={"product_capability": CODING_ARCH_CAPABILITY},
+)
+
+
+def register_coding_arch_tools(
+    registry: WorkspaceToolRegistry,
+    *,
+    mode: CapabilityMountMode = "on_demand",
+    runtime: ImportGraphToolRuntime | None = None,
+) -> WorkspaceToolRegistry:
+    """Admit arch tools according to Coding's Product mount policy."""
+
+    if mode == "disabled":
+        return registry
+    if mode not in {"on_demand", "always"}:
+        raise ValueError(f"unsupported coding.arch mount mode: {mode!r}")
+    definition = create_inspect_import_graph_tool_definition(runtime=runtime)
+    resolution = resolve_tool_contributions(
+        (ToolContribution(definition),),
+        packs=(CODING_ARCH_TOOL_PACK,),
+        include_packs=(CODING_ARCH_TOOL_PACK.name,),
+    )
+    for selected in resolution.definitions:
+        registry.register_tool(selected, enabled=mode == "always")
+    return registry
+
+
+__all__ = ["CODING_ARCH_TOOL_PACK", "register_coding_arch_tools"]

--- a/src/loushang/coding/capabilities.py
+++ b/src/loushang/coding/capabilities.py
@@ -1,0 +1,53 @@
+"""Coding-owned Product capability identities and mount policy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import cast
+
+from loushang.harness.config.agent import CapabilityMountMode
+
+CODING_ARCH_CAPABILITY = "coding.arch"
+
+_CODING_CAPABILITY_DEFAULTS: Mapping[str, CapabilityMountMode] = {
+    CODING_ARCH_CAPABILITY: "on_demand",
+}
+
+
+def coding_capability_mount_mode(
+    settings_manager: object | None,
+    capability: str,
+) -> CapabilityMountMode:
+    """Resolve one Coding capability without leaking Product ids into Harness."""
+
+    default = _CODING_CAPABILITY_DEFAULTS.get(capability, "disabled")
+    if settings_manager is None:
+        return default
+    get_settings = getattr(settings_manager, "get_settings", None)
+    if not callable(get_settings):
+        return default
+    configured = getattr(get_settings(), "capabilities", {})
+    if not isinstance(configured, Mapping):
+        return default
+    mode = configured.get(capability, default)
+    return mode if mode in {"disabled", "on_demand", "always"} else default
+
+
+def parse_capability_mount(value: str) -> tuple[str, CapabilityMountMode]:
+    """Parse the generic ``CAPABILITY=MODE`` Coding CLI form."""
+
+    capability, separator, mode = value.partition("=")
+    capability = capability.strip()
+    mode = mode.strip()
+    if not separator or not capability:
+        raise ValueError("expected CAPABILITY=disabled|on_demand|always")
+    if mode not in {"disabled", "on_demand", "always"}:
+        raise ValueError("mount mode must be disabled, on_demand, or always")
+    return capability, cast(CapabilityMountMode, mode)
+
+
+__all__ = [
+    "CODING_ARCH_CAPABILITY",
+    "coding_capability_mount_mode",
+    "parse_capability_mount",
+]

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -11,11 +11,17 @@ from loushang.ai.model import (
     parse_model_selection_reference,
 )
 from loushang.ai.model.registry import get_default_model_registry
+from loushang.coding.arch.tool import INSPECT_IMPORT_GRAPH_TOOL_NAME
+from loushang.coding.arch.tool_pack import register_coding_arch_tools
 from loushang.coding.bootstrap import (
     BootstrapServices,
     create_agent_session_runtime,
     create_agent_session_services,
     create_services,
+)
+from loushang.coding.capabilities import (
+    CODING_ARCH_CAPABILITY,
+    coding_capability_mount_mode,
 )
 from loushang.coding.cli.args import CliArgs, ExtensionFlag, help_text, parse_args
 from loushang.coding.cli.multiagent import run_coding_multiagent_command
@@ -192,6 +198,13 @@ def build_builtin_tool_registry(
         if callable(get_external_tool_policy)
         else None,
     )
+    register_coding_arch_tools(
+        registry,
+        mode=coding_capability_mount_mode(
+            settings_manager,
+            CODING_ARCH_CAPABILITY,
+        ),
+    )
     return registry
 
 
@@ -205,6 +218,17 @@ def default_runtime_builder(
     approval_resolver: InteractiveApprovalResolver | None = None,
     tool_policy_evaluator: object | None = None,
 ):
+    if not any(
+        definition.name == INSPECT_IMPORT_GRAPH_TOOL_NAME
+        for definition in tool_registry.list_definitions()
+    ):
+        register_coding_arch_tools(
+            tool_registry,
+            mode=coding_capability_mount_mode(
+                getattr(services, "settings_manager", None),
+                CODING_ARCH_CAPABILITY,
+            ),
+        )
     allowed_tool_names, active_tool_names = agent_tool_selection(args)
     resource_loader_options = configure_agent_resource_loader(
         services.resource_loader,
@@ -498,6 +522,11 @@ async def _run_coding_pre_runtime_operation(
     workflow_runner: Any,
 ) -> int | None:
     args = context.args
+    if args.capability_modes:
+        settings_manager = getattr(context.services, "settings_manager", None)
+        apply_overrides = getattr(settings_manager, "apply_overrides", None)
+        if callable(apply_overrides):
+            apply_overrides({"capabilities": dict(args.capability_modes)})
     diagnostics_result = run_diagnostics_export_operation(
         requested=args.diag_export,
         project_root=context.project_root,

--- a/src/loushang/coding/cli/args.py
+++ b/src/loushang/coding/cli/args.py
@@ -19,6 +19,7 @@ from loushang.harness.cli.agent_args import (
     agent_cli_argument_values,
     normalize_agent_cli_argv,
 )
+from loushang.harness.config.agent import CapabilityMountMode
 from loushang.harness.extensions.types import RegisteredFlag, ResolvedFlag
 
 MethodListFormat = Literal["tsv", "json"]
@@ -33,6 +34,7 @@ _BUILTIN_FLAG_NAMES = CODING_CLI_PROFILE.option_names
 class CliArgs(AgentCliArgs):
     """Standard Agent CLI values plus Coding's Method/Work additions."""
 
+    capability_modes: tuple[tuple[str, CapabilityMountMode], ...]
     method: str | None
     no_method: bool
     prompt_steps: str | None
@@ -93,6 +95,7 @@ def parse_args(
             unknown_flags=unknown_flags,
             extension_flag_values=extension_flag_values,
         ),
+        capability_modes=tuple(namespace.capability),
         method=namespace.method,
         no_method=namespace.no_method,
         prompt_steps=namespace.prompt_steps,

--- a/src/loushang/coding/cli/profile.py
+++ b/src/loushang/coding/cli/profile.py
@@ -7,11 +7,23 @@ owned by the Coding application.
 
 from __future__ import annotations
 
+from loushang.coding.capabilities import parse_capability_mount
 from loushang.harness.cli import STANDARD_CLI_PROFILE, CliArgumentSpec, CliProfile
 
 CODING_CLI_PROFILE: CliProfile = STANDARD_CLI_PROFILE.augment(
     profile_id="coding",
     root_arguments=(
+        CliArgumentSpec(
+            "coding.capability",
+            ("--capability",),
+            "capability",
+            owner="product",
+            action="append",
+            type=parse_capability_mount,
+            default=[],
+            metavar="CAPABILITY=MODE",
+            help=("Set a Product capability mount to disabled, on_demand, or always."),
+        ),
         CliArgumentSpec(
             "coding.method",
             ("--method",),

--- a/src/loushang/coding/control/__init__.py
+++ b/src/loushang/coding/control/__init__.py
@@ -1,5 +1,6 @@
 from loushang.harness.config.agent import (
     BranchSummarySettings,
+    CapabilityMountMode,
     CompactionSettings,
     ControlConfig,
     HeadlessApprovalMode,
@@ -19,6 +20,7 @@ from loushang.harness.config.agent import (
 
 __all__ = [
     "BranchSummarySettings",
+    "CapabilityMountMode",
     "CompactionSettings",
     "ControlConfig",
     "HeadlessApprovalMode",

--- a/src/loushang/harness/cli/types.py
+++ b/src/loushang/harness/cli/types.py
@@ -77,7 +77,7 @@ class CliArgumentSpec:
         """Return the argparse keyword arguments for this declarative spec."""
 
         kwargs: dict[str, object] = {"dest": self.dest, "action": self.action}
-        if self.action == "store" and self.type is not None:
+        if self.action in {"store", "append"} and self.type is not None:
             kwargs["type"] = self.type
         if self.nargs is not None:
             kwargs["nargs"] = self.nargs

--- a/src/loushang/harness/config/agent/__init__.py
+++ b/src/loushang/harness/config/agent/__init__.py
@@ -8,6 +8,7 @@ from loushang.harness.config.agent.manager import (
 )
 from loushang.harness.config.agent.types import (
     BranchSummarySettings,
+    CapabilityMountMode,
     CompactionSettings,
     ControlConfig,
     DoubleEscapeAction,
@@ -34,6 +35,7 @@ from loushang.harness.config.agent.types import (
 
 __all__ = [
     "BranchSummarySettings",
+    "CapabilityMountMode",
     "CompactionSettings",
     "ControlConfig",
     "DoubleEscapeAction",

--- a/src/loushang/harness/config/agent/_settings_codec.py
+++ b/src/loushang/harness/config/agent/_settings_codec.py
@@ -14,6 +14,7 @@ from loushang.harness.config import (
     encode_dataclass_diff,
 )
 from loushang.harness.config.agent.types import (
+    CapabilityMountMode,
     ControlConfig,
     DoubleEscapeAction,
     ExternalToolPolicy,
@@ -170,6 +171,37 @@ def _deserialize_headless_approval_mode(value: object) -> HeadlessApprovalMode |
     if value not in {"allow", "deny"}:
         raise ValueError("approval_mode must be 'allow', 'deny', or null")
     return cast(HeadlessApprovalMode, value)
+
+
+def _deserialize_capability_mounts(
+    value: object,
+) -> dict[str, CapabilityMountMode]:
+    if not isinstance(value, Mapping):
+        raise TypeError("capabilities must be a JSON object")
+    normalized: dict[str, CapabilityMountMode] = {}
+    for capability, mode in value.items():
+        if not isinstance(capability, str) or not capability.strip():
+            raise TypeError("capability ids must be non-empty strings")
+        if mode not in {"disabled", "on_demand", "always"}:
+            raise ValueError(
+                f"capabilities.{capability} must be 'disabled', "
+                "'on_demand', or 'always'"
+            )
+        normalized[capability.strip()] = cast(CapabilityMountMode, mode)
+    return normalized
+
+
+def _decode_capability_mount_overlay(
+    value: object,
+    current: object,
+) -> dict[str, CapabilityMountMode]:
+    existing = (
+        dict(cast(Mapping[str, CapabilityMountMode], current))
+        if isinstance(current, Mapping)
+        else {}
+    )
+    existing.update(_deserialize_capability_mounts(value))
+    return existing
 
 
 def _deserialize_permission_profile(value: object) -> PermissionProfileId:
@@ -620,6 +652,13 @@ CONTROL_CONFIG_CODEC = SchemaConfigCodec(
             decode=_decode_keybinding_overlay,
             encode=lambda current, default: _serialize_keybindings(
                 cast(Mapping[str, KeybindingValue], current)
+            ),
+        ),
+        ConfigFieldSpec(
+            "capabilities",
+            decode=_decode_capability_mount_overlay,
+            encode=lambda current, default: dict(
+                cast(Mapping[str, CapabilityMountMode], current)
             ),
         ),
         ConfigFieldSpec(

--- a/src/loushang/harness/config/agent/_settings_patch.py
+++ b/src/loushang/harness/config/agent/_settings_patch.py
@@ -12,6 +12,7 @@ from loushang.harness.config.agent._settings_codec import (
     _REMOVED_SETTING_MESSAGES,
     _bool_value,
     _bounded_int,
+    _deserialize_capability_mounts,
     _deserialize_double_escape_action,
     _deserialize_keybindings,
     _deserialize_queue_mode,
@@ -31,6 +32,7 @@ from loushang.harness.config.agent._settings_codec import (
 )
 from loushang.harness.config.agent.types import (
     BranchSummarySettings,
+    CapabilityMountMode,
     CompactionSettings,
     DoubleEscapeAction,
     ImageSettings,
@@ -84,6 +86,7 @@ class AgentSettingsUpdate:
     editor_padding_x: float | int | Unset = UNSET
     autocomplete_max_visible: float | int | Unset = UNSET
     keybindings: Mapping[str, object] | Unset = UNSET
+    capabilities: Mapping[str, CapabilityMountMode] | Unset = UNSET
     thinking_budgets: ThinkingBudgetMap | None | Unset = UNSET
     compaction: CompactionSettings | Unset = UNSET
     branch_summary: BranchSummarySettings | Unset = UNSET
@@ -197,6 +200,8 @@ def build_settings_patch(update: AgentSettingsUpdate) -> dict[str, Any]:
         patch["keybindings"] = _serialize_keybindings(
             _deserialize_keybindings(update.keybindings)
         )
+    if update.capabilities is not UNSET:
+        patch["capabilities"] = _deserialize_capability_mounts(update.capabilities)
     if update.thinking_budgets is not UNSET:
         patch["thinking_budgets"] = _thinking_budgets(update.thinking_budgets)
     if update.compaction is not UNSET:

--- a/src/loushang/harness/config/agent/manager.py
+++ b/src/loushang/harness/config/agent/manager.py
@@ -28,6 +28,7 @@ from loushang.harness.config.agent._settings_patch import (
 )
 from loushang.harness.config.agent.types import (
     BranchSummarySettings,
+    CapabilityMountMode,
     CompactionSettings,
     ControlConfig,
     DoubleEscapeAction,
@@ -180,6 +181,7 @@ class SettingsManager:
         editor_padding_x: float | int | Unset = UNSET,
         autocomplete_max_visible: float | int | Unset = UNSET,
         keybindings: Mapping[str, object] | Unset = UNSET,
+        capabilities: Mapping[str, CapabilityMountMode] | Unset = UNSET,
         thinking_budgets: ThinkingBudgetMap | None | Unset = UNSET,
         compaction: CompactionSettings | Unset = UNSET,
         branch_summary: BranchSummarySettings | Unset = UNSET,
@@ -225,6 +227,7 @@ class SettingsManager:
                 editor_padding_x=editor_padding_x,
                 autocomplete_max_visible=autocomplete_max_visible,
                 keybindings=keybindings,
+                capabilities=capabilities,
                 thinking_budgets=thinking_budgets,
                 compaction=compaction,
                 branch_summary=branch_summary,

--- a/src/loushang/harness/config/agent/types.py
+++ b/src/loushang/harness/config/agent/types.py
@@ -13,6 +13,7 @@ QueueMode = Literal["all", "one-at-a-time"]
 DoubleEscapeAction = Literal["fork", "tree", "none"]
 TreeFilterMode = Literal["default", "no-tools", "user-only", "labeled-only", "all"]
 ExternalToolPolicy = Literal["never", "auto", "required"]
+CapabilityMountMode = Literal["disabled", "on_demand", "always"]
 HeadlessApprovalMode = Literal["allow", "deny"]
 StatusLineAutoValue = Literal["auto", "true", "false"]
 StatusLineSeparator = Literal["pipe", "dot"]
@@ -149,6 +150,7 @@ class ControlConfig:
     editor_padding_x: int = 0
     autocomplete_max_visible: int = 5
     keybindings: dict[str, KeybindingValue] = field(default_factory=dict)
+    capabilities: dict[str, CapabilityMountMode] = field(default_factory=dict)
     thinking_budgets: ThinkingBudgetMap | None = None
     compaction: CompactionSettings = field(default_factory=CompactionSettings)
     branch_summary: BranchSummarySettings = field(default_factory=BranchSummarySettings)
@@ -176,6 +178,7 @@ class ControlConfig:
 __all__ = [
     "BranchSummarySettings",
     "CompactionSettings",
+    "CapabilityMountMode",
     "ControlConfig",
     "DoubleEscapeAction",
     "ExternalToolPolicy",

--- a/tests/coding/arch/test_activation.py
+++ b/tests/coding/arch/test_activation.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from loushang.coding.arch import INSPECT_IMPORT_GRAPH_TOOL_NAME
+from loushang.coding.bootstrap import create_services
+from loushang.coding.cli.__main__ import (
+    _run_coding_pre_runtime_operation,
+    build_builtin_tool_registry,
+    default_runtime_builder,
+)
+from loushang.coding.cli.args import parse_args
+from loushang.harness.cli import AgentCliStatePreparationContext
+from loushang.harness.config.agent import (
+    CapabilityMountMode,
+    ControlConfig,
+    SettingsManager,
+)
+from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
+
+
+def _runtime_args(*, no_tools: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(no_tools=no_tools, tools=(), no_session=True)
+
+
+def _create_cli_session(
+    tmp_path: Path,
+    *,
+    mode: CapabilityMountMode,
+    no_tools: bool = False,
+):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    settings = SettingsManager(ControlConfig(capabilities={"coding.arch": mode}))
+    services = create_services(settings_manager=settings)
+    registry = build_builtin_tool_registry(settings_manager=settings)
+    runtime = default_runtime_builder(
+        args=_runtime_args(no_tools=no_tools),
+        cwd=tmp_path,
+        session_dir=tmp_path / "sessions",
+        services=services,
+        tool_registry=registry,
+    )
+    return asyncio.run(runtime.create_session(cwd=str(tmp_path)))
+
+
+def test_cli_parses_generic_capability_mount_overrides() -> None:
+    args = parse_args(
+        [
+            "--capability",
+            "coding.arch=always",
+            "--capability",
+            "coding.review=disabled",
+        ]
+    )
+
+    assert args.capability_modes == (
+        ("coding.arch", "always"),
+        ("coding.review", "disabled"),
+    )
+
+    with pytest.raises(SystemExit):
+        parse_args(["--capability", "coding.arch=sometimes"])
+
+
+def test_project_config_decodes_capability_mounts(tmp_path: Path) -> None:
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "capabilities": {
+                    "coding.arch": "always",
+                    "coding.review": "on_demand",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = SettingsManager(project_settings_path=settings_path)
+
+    assert manager.get_settings().capabilities == {
+        "coding.arch": "always",
+        "coding.review": "on_demand",
+    }
+    assert manager.drain_errors() == []
+
+
+def test_cli_capability_mount_is_applied_as_session_config_overlay(
+    tmp_path: Path,
+) -> None:
+    manager = SettingsManager(
+        ControlConfig(capabilities={"coding.review": "on_demand"})
+    )
+    services = create_services(settings_manager=manager)
+    args = parse_args(["--capability", "coding.arch=always"])
+    context = AgentCliStatePreparationContext(
+        args=args,
+        project_root=tmp_path,
+        session_dir=tmp_path / "sessions",
+        services=services,
+        stdout=StringIO(),
+        stderr=StringIO(),
+    )
+
+    result = asyncio.run(
+        _run_coding_pre_runtime_operation(context, workflow_runner=None)
+    )
+
+    assert result is None
+    assert manager.get_settings().capabilities == {
+        "coding.review": "on_demand",
+        "coding.arch": "always",
+    }
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME in {
+        definition.name
+        for definition in build_builtin_tool_registry(
+            settings_manager=manager
+        ).list_enabled_definitions()
+    }
+
+
+def test_capability_overrides_merge_with_configured_mounts() -> None:
+    manager = SettingsManager(ControlConfig(capabilities={"coding.review": "always"}))
+
+    manager.apply_overrides({"capabilities": {"coding.arch": "disabled"}})
+
+    assert manager.get_settings().capabilities == {
+        "coding.review": "always",
+        "coding.arch": "disabled",
+    }
+
+
+def test_coding_config_controls_default_arch_tool_activation(tmp_path: Path) -> None:
+    on_demand = _create_cli_session(tmp_path / "on-demand", mode="on_demand")
+    always = _create_cli_session(tmp_path / "always", mode="always")
+    disabled = _create_cli_session(tmp_path / "disabled", mode="disabled")
+
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME not in on_demand.get_active_tool_names()
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME in {
+        definition.name for definition in on_demand.get_all_tools()
+    }
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME in always.get_active_tool_names()
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME not in {
+        definition.name for definition in disabled.get_all_tools()
+    }
+
+
+def test_no_tools_overrides_always_capability_mount(tmp_path: Path) -> None:
+    session = _create_cli_session(tmp_path, mode="always", no_tools=True)
+
+    assert session.get_active_tool_names() == []
+    assert session.get_all_tools() == []
+    assert session.agent.tools == []
+
+
+def test_arch_pack_remains_available_without_builtin_tools(tmp_path: Path) -> None:
+    settings = SettingsManager(ControlConfig(capabilities={"coding.arch": "always"}))
+    services = create_services(settings_manager=settings)
+    runtime = default_runtime_builder(
+        args=_runtime_args(),
+        cwd=tmp_path,
+        session_dir=tmp_path / "sessions",
+        services=services,
+        tool_registry=WorkspaceToolRegistry(),
+    )
+
+    session = asyncio.run(runtime.create_session(cwd=str(tmp_path)))
+
+    active = set(session.get_active_tool_names())
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME in active
+    assert not {"bash", "read", "ls", "find", "grep", "write", "edit"}.intersection(
+        active
+    )

--- a/tests/coding/arch/test_tool.py
+++ b/tests/coding/arch/test_tool.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from time import monotonic
+
+import pytest
+
+from loushang.agent import Agent
+from loushang.ai.model import Capabilities, Model
+from loushang.coding.arch import (
+    CODING_ARCH_TOOL_PACK,
+    INSPECT_IMPORT_GRAPH_TOOL_NAME,
+    ImportGraphToolRuntime,
+    create_inspect_import_graph_tool_definition,
+    register_coding_arch_tools,
+)
+from loushang.coding.session import AgentSession
+from loushang.coding.session_manager import SessionManager
+from loushang.harness.config.agent import CapabilityMountMode
+from loushang.harness.policy import PolicyEvaluator
+from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
+
+
+def _write_package(root: Path) -> Path:
+    package = root / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("from . import api\n", encoding="utf-8")
+    (package / "api.py").write_text("from pkg import core\n", encoding="utf-8")
+    (package / "core.py").write_text("from pkg import api\n", encoding="utf-8")
+    return package
+
+
+def _model() -> Model:
+    return Model(
+        id="faux-model",
+        name="Faux",
+        provider="faux",
+        endpoint="anthropic-messages",
+        capabilities=Capabilities(
+            reasoning=True,
+            input=("text",),
+            context_window=128000,
+            max_tokens=4096,
+        ),
+    )
+
+
+def _session(
+    workspace: Path,
+    *,
+    mode: CapabilityMountMode,
+    allowed_tool_names: list[str] | None = None,
+    tool_policy_evaluator: PolicyEvaluator | None = None,
+) -> AgentSession:
+    manager = asyncio.run(
+        SessionManager.new(
+            session_dir=workspace / ".sessions",
+            cwd=str(workspace),
+            persist=False,
+        )
+    )
+    registry = WorkspaceToolRegistry()
+    register_coding_arch_tools(registry, mode=mode)
+    agent = Agent(
+        initial_state={
+            "system_prompt": "Coding base prompt",
+            "model": _model(),
+            "thinking_level": "off",
+            "tools": [],
+        },
+        convert_to_llm=lambda messages: [],
+    )
+    return AgentSession(
+        agent=agent,
+        session_manager=manager,
+        tool_registry=registry,
+        allowed_tool_names=allowed_tool_names,
+        base_prompt="Coding base prompt",
+        tool_policy_evaluator=tool_policy_evaluator,
+    )
+
+
+def test_arch_tool_pack_is_separate_and_schema_is_bounded() -> None:
+    from loushang.coding.tool_pack import CODING_BUILTIN_TOOL_PACK
+
+    definition = create_inspect_import_graph_tool_definition()
+
+    assert CODING_ARCH_TOOL_PACK.name == "coding.arch.tools"
+    assert CODING_ARCH_TOOL_PACK.tools == (INSPECT_IMPORT_GRAPH_TOOL_NAME,)
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME not in CODING_BUILTIN_TOOL_PACK.tools
+    assert definition.execution_mode == "sequential"
+    assert "root" in definition.parameters["required"]
+    assert definition.parameters["properties"]["query"]["enum"] == [
+        "summary",
+        "cycles",
+        "edges",
+        "path",
+        "hotspots",
+        "boundaries",
+    ]
+    assert definition.parameters["properties"]["limit"]["maximum"] == 200
+
+
+def test_arch_mount_modes_and_live_agent_rebinding(tmp_path: Path) -> None:
+    _write_package(tmp_path)
+
+    on_demand = _session(tmp_path, mode="on_demand")
+    assert on_demand.get_active_tool_names() == []
+    assert [tool.name for tool in on_demand.get_all_tools()] == [
+        INSPECT_IMPORT_GRAPH_TOOL_NAME
+    ]
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME not in on_demand.agent.system_prompt
+
+    asyncio.run(on_demand.set_active_tools([INSPECT_IMPORT_GRAPH_TOOL_NAME]))
+    assert on_demand.get_active_tool_names() == [INSPECT_IMPORT_GRAPH_TOOL_NAME]
+    assert [tool.name for tool in on_demand.agent.tools] == [
+        INSPECT_IMPORT_GRAPH_TOOL_NAME
+    ]
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME in on_demand.agent.system_prompt
+
+    always = _session(tmp_path, mode="always")
+    assert always.get_active_tool_names() == [INSPECT_IMPORT_GRAPH_TOOL_NAME]
+    assert INSPECT_IMPORT_GRAPH_TOOL_NAME in always.agent.system_prompt
+
+    disabled = _session(tmp_path, mode="disabled")
+    assert disabled.get_all_tools() == []
+    assert disabled.get_active_tool_names() == []
+
+
+def test_arch_always_does_not_bypass_session_allowlist(tmp_path: Path) -> None:
+    _write_package(tmp_path)
+
+    session = _session(tmp_path, mode="always", allowed_tool_names=[])
+
+    assert session.get_all_tools() == []
+    assert session.get_active_tool_names() == []
+    assert session.agent.tools == []
+
+
+def test_inspect_import_graph_reuses_warm_cache_and_bounds_results(
+    tmp_path: Path,
+) -> None:
+    package = _write_package(tmp_path)
+    runtime = ImportGraphToolRuntime()
+
+    first = runtime.inspect(
+        workspace=tmp_path,
+        root="pkg",
+        package_prefix="pkg",
+        imports="all",
+        query="edges",
+        limit=1,
+    )
+    started = monotonic()
+    second = runtime.inspect(
+        workspace=tmp_path,
+        root="pkg",
+        package_prefix="pkg",
+        imports="all",
+        query="edges",
+        limit=1,
+    )
+    elapsed = monotonic() - started
+
+    assert first["cache"]["misses"] == 3
+    assert second["cache"]["hits"] == 3
+    assert len(second["results"]) == 1
+    assert second["truncated"] is True
+    assert elapsed < 1.0
+    assert Path(second["root"]) == package.resolve()
+
+    with pytest.raises(ValueError, match="between 1 and 200"):
+        runtime.inspect(workspace=tmp_path, limit=201)
+
+
+def test_inspect_import_graph_restricts_roots_to_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_package(workspace)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "external.py").write_text("VALUE = 1\n", encoding="utf-8")
+
+    runtime = ImportGraphToolRuntime()
+
+    with pytest.raises(PermissionError, match="within the coding workspace"):
+        runtime.inspect(workspace=workspace, root=str(outside))
+
+    symlink = workspace / "escaped"
+    try:
+        symlink.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        return
+    with pytest.raises(PermissionError, match="within the coding workspace"):
+        runtime.inspect(workspace=workspace, root="escaped")
+
+
+def test_materialized_arch_tool_runs_through_session_gateway(tmp_path: Path) -> None:
+    _write_package(tmp_path)
+    session = _session(tmp_path, mode="always")
+
+    result = asyncio.run(
+        session.agent.tools[0].execute(
+            "arch-call",
+            {
+                "root": "pkg",
+                "package_prefix": "pkg",
+                "imports": "all",
+                "query": "summary",
+                "limit": 10,
+            },
+        )
+    )
+
+    assert result.details["nodes"] == 3
+    assert result.details["edges"] == 3
+    assert result.details["cache"]["enabled"] is True
+
+
+def test_arch_tool_honors_session_tool_policy(tmp_path: Path) -> None:
+    from loushang.harness.policy_engine import PolicyEngine
+
+    _write_package(tmp_path)
+    session = _session(
+        tmp_path,
+        mode="always",
+        tool_policy_evaluator=PolicyEngine(
+            blocked_tools=[INSPECT_IMPORT_GRAPH_TOOL_NAME]
+        ),
+    )
+
+    with pytest.raises(PermissionError, match=INSPECT_IMPORT_GRAPH_TOOL_NAME):
+        asyncio.run(
+            session.agent.tools[0].execute(
+                "blocked-arch-call",
+                {"root": "pkg", "package_prefix": "pkg"},
+            )
+        )

--- a/tests/harness/cli/test_profile.py
+++ b/tests/harness/cli/test_profile.py
@@ -41,6 +41,27 @@ def test_product_additions_keep_standard_values_separate() -> None:
     assert invocation.positionals == ("draft",)
 
 
+def test_append_arguments_apply_their_declared_value_parser() -> None:
+    profile = STANDARD_CLI_PROFILE.augment(
+        profile_id="typed-append",
+        root_arguments=(
+            CliArgumentSpec(
+                "example.number",
+                ("--number",),
+                "numbers",
+                owner="product",
+                action="append",
+                type=int,
+                default=[],
+            ),
+        ),
+    )
+
+    invocation = parse_args(["--number", "1", "--number", "2"], profile)
+
+    assert invocation.product_values["numbers"] == [1, 2]
+
+
 def test_product_commands_and_command_arguments_are_additive() -> None:
     design = STANDARD_CLI_PROFILE.augment(
         profile_id="design",


### PR DESCRIPTION
## Summary

- add a bounded `inspect_import_graph` tool backed by a shared warm analyzer cache
- publish `coding.arch.tools` as an optional tool pack with `disabled`, `on_demand`, and `always` mount modes
- add generic CLI/config capability selection with session activation and precedence coverage

## Validation

- `uv run pytest tests/coding -q`: 2286 passed
- focused architecture, config, CLI, and public API tests: 309 passed, 1 deselected
- Ruff checks passed for all affected Python files
- mypy passed for 18 affected source modules
- warm-cache benchmark: 828/828 hits, max 0.578 seconds

## Note

- architecture checks: 151 passed; 5 existing failures are caused by ignored legacy `__pycache__` directories making retired package paths appear present
