### PR TITLE
refactor(harness): own filesystem resource discovery

### DIFF
--- a/docs/internals/architecture/harness/current-owner-map.md
+++ b/docs/internals/architecture/harness/current-owner-map.md
@@ -80,9 +80,13 @@ split internally. The implemented dependency direction is:
 
 ```text
 resource loader facade -> package policy
-resource loader facade -> snapshot pipeline -> context discovery
-                                            -> other source discovery -> package policy
-                                            -> resolution -> precedence policy
+resource loader facade -> snapshot pipeline
+                            -> context discovery
+                            -> other source coordinator
+                                 -> filesystem discovery -> descriptor parsing
+                                 -> descriptor parsing
+                                 -> package policy
+                            -> resolution -> precedence policy
 
 runtime profile facade -> types + admission + resolution + binding + standard slots
 admission / resolution / binding / standard slots -> profile types
@@ -92,6 +96,9 @@ typed settings patch -> settings schema codec field rules
 settings schema codec / typed settings patch -> Agent settings types
 
 workspace read tool + Host prompt input -> workspace image payload owner
+
+tool definition owner -> execution bindings
+session execution scope -> tool execution host -> structural definition port
 ```
 
 Context-file ancestor traversal, configured filename precedence, descriptor
@@ -99,14 +106,25 @@ construction, and nearest-context selection belong to
 `harness.resources._loader_discovery_context`. Package-root and filter
 normalization, descriptor-selection patterns, root diagnostics, and per-root
 resource accounting belong to `harness.resources._loader_package_policy`.
-Filesystem, external-package scanning, temporary, and built-in source discovery
-remain in `_loader_discovery`; external-package scanning consumes the package
-policy without moving the shared filesystem scanners. The snapshot pipeline
-calls both discovery paths but does not depend directly on package policy.
-Context discovery and package policy do not depend on discovery coordination,
-resolution, the pipeline, or the public loader facade. Resolution never imports
-either discovery owner or package policy, live profile binding never imports
-profile resolution, and internal leaf modules never import their public facade.
+Source-neutral prompt/skill frontmatter projection, descriptor construction,
+and skill metadata validation belong to
+`harness.resources._loader_descriptor_parsing`; it performs no filesystem or
+package-resource I/O.
+Filesystem directory traversal and reads, recursive skill discovery and ignore
+rules, extension entry lookup, and theme JSON validation belong to
+`harness.resources._loader_discovery_filesystem`. External-package,
+temporary-path, and built-in package coordination remain in
+`_loader_discovery`; the coordinator consumes filesystem discovery,
+descriptor parsing, and package policy. The snapshot pipeline calls the source
+coordinator and context discovery but does not depend directly on those leaf
+owners. Context discovery, filesystem discovery, descriptor parsing, and
+package policy do not depend on discovery coordination, resolution, the
+pipeline, or the public loader facade.
+Resolution never imports any discovery owner or package policy, live profile
+binding never imports profile resolution, and internal leaf modules never
+import their public facade. The tool execution host consumes a private
+structural definition port; `harness.tools.execution` does not import the
+`ToolDefinition` owner in `harness.tools.core`.
 The Agent settings manager depends only on the explicit codec/patch ports
 enforced by the architecture tests, not on field-level serializer helpers.
 Image MIME validation, header dimensions, base64 encoding, inline limits, and
@@ -123,9 +141,10 @@ policy remains with Host prompt input and the read tool.
 - no Session-module import from the Session public barrel;
 - one-way Harness, Work, and Channel dependencies;
 - explicit Agent/AI import allowlists for optional profiles;
-- one-way resource loader, context discovery, package policy, runtime profile,
-  and Agent settings internals with an exact manager-to-codec/patch import
-  allowlist;
+- one-way resource loader, context discovery, descriptor parsing, package
+  policy, runtime profile, and Agent settings internals with an exact
+  manager-to-codec/patch import allowlist;
+- one-way tool-definition-to-execution dependencies;
 - one shared workspace image-payload owner consumed by Host prompt input and
   the read tool;
 - Product-neutral Harnesstui and shared runtime owners.

--- a/docs/internals/architecture/harness/platform-resource-layout-boundary.md
+++ b/docs/internals/architecture/harness/platform-resource-layout-boundary.md
@@ -126,8 +126,16 @@ The product-neutral runtime now lives under `loushang.harness.resources`:
   reload, queries, and the standard workspace resource-root mode;
 - `_loader_pipeline` owns discovery-to-resolution orchestration, diagnostic and
   merge-decision aggregation, and `ResourceSnapshot` assembly;
-- `_loader_discovery` owns filesystem, package, built-in, context, and temporary
-  candidate discovery plus source-specific filtering;
+- `_loader_discovery_context` owns context-file ancestor traversal, descriptor
+  construction, diagnostics, and nearest-context selection;
+- `_loader_descriptor_parsing` owns source-neutral prompt/skill frontmatter
+  projection, descriptor construction, and skill validation without I/O;
+- `_loader_discovery_filesystem` owns filesystem directory traversal and reads,
+  skill ignore rules, extension entry lookup, and theme JSON validation;
+- `_loader_discovery` owns external-package, built-in, and temporary source
+  coordination plus source-specific filtering;
+- `_loader_package_policy` owns external-package root/filter normalization,
+  root diagnostics, filtering, and per-root resource accounting;
 - `_loader_resolution` owns collision handling and winner/active-candidate
   decisions without importing discovery;
 - `_loader_precedence` is the single owner of the source priority table, rank,

--- a/docs/internals/architecture/harness/tool-execution-binding-boundary.md
+++ b/docs/internals/architecture/harness/tool-execution-binding-boundary.md
@@ -379,6 +379,7 @@ harness.tools.core
 
 harness.tools.execution
   ToolExecutionHost
+  private structural definition port (name + execution binding)
   DirectExecution
   AuthorizedExecution
   PreparedToolAction
@@ -408,6 +409,11 @@ Product
   supplies Product-specific action facts when required
   does not own Policy, Approval, or Gateway dispatch
 ```
+
+The dependency is deliberately one-way: `harness.tools.core` imports the
+execution binding types stored by `ToolDefinition`, while
+`harness.tools.execution` dispatches through its private structural port and
+does not import `ToolDefinition`, including under `TYPE_CHECKING`.
 
 `ToolRegistry` stores definitions and may be bound to a host supplied by its
 execution scope. It does not select Policy, retain Approval, construct a

--- a/src/loushang/harness/resources/_loader_descriptor_parsing.py
+++ b/src/loushang/harness/resources/_loader_descriptor_parsing.py
@@ -1,0 +1,240 @@
+"""Source-neutral descriptor parsing for discovered resource content."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loushang.harness.diagnostics.types import DiagnosticDraft
+from loushang.harness.resources.diagnostics import resource_diagnostic
+from loushang.harness.resources.frontmatter import (
+    FrontmatterParseError,
+    parse_frontmatter,
+)
+from loushang.harness.resources.types import (
+    PromptFragmentDescriptor,
+    ResourceSourceKind,
+    ResourceSourceScope,
+    SkillDescriptor,
+)
+
+_MAX_SKILL_NAME_LENGTH = 64
+
+_MAX_SKILL_DESCRIPTION_LENGTH = 1024
+
+
+def _prompt_descriptor_from_text(
+    *,
+    name: str,
+    source_path: Path,
+    text: str,
+    canonical_name: str,
+    source_kind: ResourceSourceKind,
+    source_scope: ResourceSourceScope,
+    source: str,
+    source_root: Path,
+    source_root_order: int = 0,
+) -> tuple[PromptFragmentDescriptor | None, list[DiagnosticDraft]]:
+    try:
+        parsed = parse_frontmatter(text)
+    except FrontmatterParseError as exc:
+        return None, [
+            _invalid_frontmatter_diagnostic(
+                exc,
+                source_path=source_path,
+                resource_type="prompt",
+                source_kind=source_kind,
+            )
+        ]
+    frontmatter = parsed.frontmatter
+    body = parsed.body
+    description = _frontmatter_string(frontmatter.get("description"))
+    argument_hint = _frontmatter_string(frontmatter.get("argument-hint"))
+    return (
+        PromptFragmentDescriptor(
+            name=name,
+            source_path=source_path,
+            text=text,
+            description=description,
+            argument_hint=argument_hint,
+            metadata={
+                "frontmatter": frontmatter,
+                "body": body,
+            },
+            canonical_name=canonical_name,
+            source_kind=source_kind,
+            source_scope=source_scope,
+            source=source,
+            source_root=source_root,
+            source_root_order=source_root_order,
+        ),
+        [],
+    )
+
+
+def _skill_descriptor_from_text(
+    *,
+    parent_name: str,
+    source_path: Path,
+    content: str,
+    canonical_name: str,
+    source_kind: ResourceSourceKind,
+    source_scope: ResourceSourceScope,
+    source: str,
+    source_root: Path,
+    source_root_order: int = 0,
+) -> tuple[SkillDescriptor | None, list[DiagnosticDraft]]:
+    try:
+        parsed = parse_frontmatter(content)
+    except FrontmatterParseError as exc:
+        return None, [
+            _invalid_frontmatter_diagnostic(
+                exc,
+                source_path=source_path,
+                resource_type="skill",
+                source_kind=source_kind,
+            )
+        ]
+    frontmatter = parsed.frontmatter
+    body = parsed.body
+    skill_name = _frontmatter_string(frontmatter.get("name")) or parent_name
+    description = _frontmatter_string(frontmatter.get("description"))
+    diagnostics = _skill_frontmatter_diagnostics(
+        frontmatter=frontmatter,
+        skill_name=skill_name,
+        parent_name=parent_name,
+        source_path=source_path,
+        source_kind=source_kind,
+    )
+    return (
+        SkillDescriptor(
+            name=skill_name,
+            source_path=source_path,
+            content=content,
+            description=description,
+            disable_model_invocation=frontmatter.get("disable-model-invocation")
+            is True,
+            metadata={
+                "frontmatter": frontmatter,
+                "body": body,
+            },
+            canonical_name=canonical_name,
+            source_kind=source_kind,
+            source_scope=source_scope,
+            source=source,
+            source_root=source_root,
+            source_root_order=source_root_order,
+        ),
+        diagnostics,
+    )
+
+
+def _invalid_frontmatter_diagnostic(
+    error: FrontmatterParseError,
+    *,
+    source_path: Path,
+    resource_type: str,
+    source_kind: ResourceSourceKind,
+) -> DiagnosticDraft:
+    return resource_diagnostic(
+        code=f"invalid_{resource_type}_frontmatter",
+        message=str(error),
+        source_path=source_path,
+        resource_type=resource_type,
+        source_kind=source_kind,
+    )
+
+
+def _skill_frontmatter_diagnostics(
+    *,
+    frontmatter: dict[str, object],
+    skill_name: str,
+    parent_name: str,
+    source_path: Path,
+    source_kind: ResourceSourceKind,
+) -> list[DiagnosticDraft]:
+    if not frontmatter:
+        return []
+    diagnostics: list[DiagnosticDraft] = []
+    description = _frontmatter_string(frontmatter.get("description"))
+    if description is None:
+        diagnostics.append(
+            _skill_validation_diagnostic(
+                code="invalid_skill_description",
+                message="Skill frontmatter description is required.",
+                source_path=source_path,
+                source_kind=source_kind,
+                field="description",
+            )
+        )
+    elif len(description) > _MAX_SKILL_DESCRIPTION_LENGTH:
+        diagnostics.append(
+            _skill_validation_diagnostic(
+                code="invalid_skill_description",
+                message=f"Skill frontmatter description exceeds {_MAX_SKILL_DESCRIPTION_LENGTH} characters.",
+                source_path=source_path,
+                source_kind=source_kind,
+                field="description",
+            )
+        )
+    if skill_name != parent_name:
+        diagnostics.append(
+            _skill_validation_diagnostic(
+                code="invalid_skill_name",
+                message=f'Skill frontmatter name "{skill_name}" does not match parent directory "{parent_name}".',
+                source_path=source_path,
+                source_kind=source_kind,
+                field="name",
+            )
+        )
+    if len(skill_name) > _MAX_SKILL_NAME_LENGTH:
+        diagnostics.append(
+            _skill_validation_diagnostic(
+                code="invalid_skill_name",
+                message=f"Skill frontmatter name exceeds {_MAX_SKILL_NAME_LENGTH} characters.",
+                source_path=source_path,
+                source_kind=source_kind,
+                field="name",
+            )
+        )
+    if not _is_valid_skill_name(skill_name):
+        diagnostics.append(
+            _skill_validation_diagnostic(
+                code="invalid_skill_name",
+                message="Skill frontmatter name must contain lowercase letters, numbers, and hyphens only.",
+                source_path=source_path,
+                source_kind=source_kind,
+                field="name",
+            )
+        )
+    return diagnostics
+
+
+def _skill_validation_diagnostic(
+    *,
+    code: str,
+    message: str,
+    source_path: Path,
+    source_kind: ResourceSourceKind,
+    field: str,
+) -> DiagnosticDraft:
+    return resource_diagnostic(
+        code=code,
+        message=message,
+        source_path=source_path,
+        resource_type="skill",
+        source_kind=source_kind,
+        metadata={"field": field},
+    )
+
+
+def _is_valid_skill_name(name: str) -> bool:
+    if not name or name.startswith("-") or name.endswith("-") or "--" in name:
+        return False
+    return all(char.islower() or char.isdigit() or char == "-" for char in name)
+
+
+def _frontmatter_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None

--- a/src/loushang/harness/resources/_loader_discovery.py
+++ b/src/loushang/harness/resources/_loader_discovery.py
@@ -2,36 +2,36 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
-from fnmatch import fnmatch
 from importlib import resources
 from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from loushang.harness.diagnostics.types import DiagnosticDraft
+from loushang.harness.resources._loader_descriptor_parsing import (
+    _prompt_descriptor_from_text,
+    _skill_descriptor_from_text,
+)
+from loushang.harness.resources._loader_discovery_filesystem import (
+    _discover_extensions_from_dir,
+    _discover_prompts_from_dir,
+    _discover_skills_from_dir,
+    _discover_themes_from_dir,
+    _find_extension_entry,
+    _read_text_file,
+    _skill_descriptor_from_file,
+    _theme_json_diagnostic,
+)
 from loushang.harness.resources._loader_package_policy import (
     _filter_package_descriptors,
     _package_root_diagnostic,
 )
-from loushang.harness.resources._loader_types import (
-    _IGNORE_FILE_NAMES,
-    _MAX_SKILL_DESCRIPTION_LENGTH,
-    _MAX_SKILL_NAME_LENGTH,
-    _SOURCE_LABEL,
-    _SourceDiscovery,
-)
+from loushang.harness.resources._loader_types import _SOURCE_LABEL, _SourceDiscovery
 from loushang.harness.resources.diagnostics import resource_diagnostic
-from loushang.harness.resources.frontmatter import (
-    FrontmatterParseError,
-    parse_frontmatter,
-)
 from loushang.harness.resources.types import (
     ExtensionDescriptor,
     PromptFragmentDescriptor,
-    ResourceSourceKind,
-    ResourceSourceScope,
     SkillDescriptor,
     ThemeDescriptor,
 )
@@ -614,465 +614,6 @@ def _discover_themes(
     )
 
 
-def _discover_prompts_from_dir(
-    prompts_dir: Path,
-    *,
-    source_kind: ResourceSourceKind,
-    source_scope: ResourceSourceScope,
-    source_label: str,
-    source_root_order: int = 0,
-) -> tuple[list[PromptFragmentDescriptor], list[DiagnosticDraft]]:
-    if not prompts_dir.is_dir():
-        return [], []
-
-    descriptors: list[PromptFragmentDescriptor] = []
-    diagnostics: list[DiagnosticDraft] = []
-    for entry in sorted(prompts_dir.iterdir(), key=lambda path: path.name):
-        if entry.is_file() and entry.suffix == ".md":
-            text, read_diagnostics = _read_text_file(
-                entry,
-                diagnostic_code="unreadable_prompt_entry",
-                message_prefix="Failed to read prompt entry",
-            )
-            diagnostics.extend(read_diagnostics)
-            if text is None:
-                continue
-            descriptor, frontmatter_diagnostics = _prompt_descriptor_from_text(
-                name=entry.stem,
-                source_path=entry,
-                text=text,
-                canonical_name=entry.name,
-                source_kind=source_kind,
-                source_scope=source_scope,
-                source=source_label,
-                source_root=prompts_dir,
-                source_root_order=source_root_order,
-            )
-            diagnostics.extend(frontmatter_diagnostics)
-            if descriptor is not None:
-                descriptors.append(descriptor)
-            continue
-        diagnostics.append(
-            resource_diagnostic(
-                code="unsupported_prompt_entry",
-                message="Prompt entries must be .md files.",
-                source_path=entry,
-                resource_type="prompt",
-                source_kind=source_kind,
-            )
-        )
-    return descriptors, diagnostics
-
-
-def _prompt_descriptor_from_text(
-    *,
-    name: str,
-    source_path: Path,
-    text: str,
-    canonical_name: str,
-    source_kind: ResourceSourceKind,
-    source_scope: ResourceSourceScope,
-    source: str,
-    source_root: Path,
-    source_root_order: int = 0,
-) -> tuple[PromptFragmentDescriptor | None, list[DiagnosticDraft]]:
-    try:
-        parsed = parse_frontmatter(text)
-    except FrontmatterParseError as exc:
-        return None, [
-            _invalid_frontmatter_diagnostic(
-                exc,
-                source_path=source_path,
-                resource_type="prompt",
-                source_kind=source_kind,
-            )
-        ]
-    frontmatter = parsed.frontmatter
-    body = parsed.body
-    description = _frontmatter_string(frontmatter.get("description"))
-    argument_hint = _frontmatter_string(frontmatter.get("argument-hint"))
-    return (
-        PromptFragmentDescriptor(
-            name=name,
-            source_path=source_path,
-            text=text,
-            description=description,
-            argument_hint=argument_hint,
-            metadata={
-                "frontmatter": frontmatter,
-                "body": body,
-            },
-            canonical_name=canonical_name,
-            source_kind=source_kind,
-            source_scope=source_scope,
-            source=source,
-            source_root=source_root,
-            source_root_order=source_root_order,
-        ),
-        [],
-    )
-
-
-def _discover_skills_from_dir(
-    skills_dir: Path,
-    *,
-    source_kind: ResourceSourceKind,
-    source_scope: ResourceSourceScope,
-    source_label: str,
-    source_root_order: int = 0,
-) -> tuple[list[SkillDescriptor], list[DiagnosticDraft]]:
-    if not skills_dir.is_dir():
-        return [], []
-
-    return _discover_skills_recursive(
-        skills_dir,
-        root_dir=skills_dir,
-        ignore_patterns=(),
-        source_kind=source_kind,
-        source_scope=source_scope,
-        source_label=source_label,
-        source_root_order=source_root_order,
-    )
-
-
-def _discover_skills_recursive(
-    current_dir: Path,
-    *,
-    root_dir: Path,
-    ignore_patterns: tuple[str, ...],
-    source_kind: ResourceSourceKind,
-    source_scope: ResourceSourceScope,
-    source_label: str,
-    source_root_order: int = 0,
-) -> tuple[list[SkillDescriptor], list[DiagnosticDraft]]:
-    descriptors: list[SkillDescriptor] = []
-    diagnostics: list[DiagnosticDraft] = []
-    active_ignore_patterns = (
-        *ignore_patterns,
-        *_read_skill_ignore_patterns(current_dir, root_dir),
-    )
-    skill_file = current_dir / "SKILL.md"
-    if skill_file.is_file():
-        descriptor, skill_diagnostics = _skill_descriptor_from_file(
-            skill_file,
-            root_dir=root_dir,
-            parent_name=current_dir.name,
-            source_kind=source_kind,
-            source_scope=source_scope,
-            source_label=source_label,
-            source_root_order=source_root_order,
-        )
-        diagnostics.extend(skill_diagnostics)
-        return ([descriptor] if descriptor is not None else []), diagnostics
-
-    for entry in sorted(current_dir.iterdir(), key=lambda path: path.name):
-        if entry.name == "SKILL.md":
-            continue
-        if entry.is_file():
-            if current_dir == root_dir and entry.name not in _IGNORE_FILE_NAMES:
-                diagnostics.append(
-                    resource_diagnostic(
-                        code="unsupported_skill_entry",
-                        message="Skill entries must be directories.",
-                        source_path=entry,
-                        resource_type="skill",
-                        source_kind=source_kind,
-                    )
-                )
-            continue
-        if not entry.is_dir() or _skip_skill_directory(entry):
-            continue
-        if _is_skill_path_ignored(
-            entry, root_dir=root_dir, patterns=active_ignore_patterns
-        ):
-            continue
-        child_descriptors, child_diagnostics = _discover_skills_recursive(
-            entry,
-            root_dir=root_dir,
-            ignore_patterns=active_ignore_patterns,
-            source_kind=source_kind,
-            source_scope=source_scope,
-            source_label=source_label,
-            source_root_order=source_root_order,
-        )
-        descriptors.extend(child_descriptors)
-        diagnostics.extend(child_diagnostics)
-    return descriptors, diagnostics
-
-
-def _skill_descriptor_from_file(
-    skill_file: Path,
-    *,
-    root_dir: Path,
-    parent_name: str,
-    source_kind: ResourceSourceKind,
-    source_scope: ResourceSourceScope,
-    source_label: str,
-    source_root_order: int,
-) -> tuple[SkillDescriptor | None, list[DiagnosticDraft]]:
-    content, diagnostics = _read_text_file(
-        skill_file,
-        diagnostic_code="unreadable_skill_entry",
-        message_prefix="Failed to read skill entry",
-    )
-    if content is None:
-        return None, diagnostics
-
-    try:
-        parsed = parse_frontmatter(content)
-    except FrontmatterParseError as exc:
-        diagnostics.append(
-            _invalid_frontmatter_diagnostic(
-                exc,
-                source_path=skill_file,
-                resource_type="skill",
-                source_kind=source_kind,
-            )
-        )
-        return None, diagnostics
-    frontmatter = parsed.frontmatter
-    body = parsed.body
-    skill_name = _frontmatter_string(frontmatter.get("name")) or parent_name
-    description = _frontmatter_string(frontmatter.get("description"))
-    diagnostics.extend(
-        _skill_frontmatter_diagnostics(
-            frontmatter=frontmatter,
-            skill_name=skill_name,
-            parent_name=parent_name,
-            source_path=skill_file,
-            source_kind=source_kind,
-        )
-    )
-    canonical_name = skill_file.relative_to(root_dir).as_posix()
-    return (
-        SkillDescriptor(
-            name=skill_name,
-            source_path=skill_file,
-            content=content,
-            description=description,
-            disable_model_invocation=frontmatter.get("disable-model-invocation")
-            is True,
-            metadata={
-                "frontmatter": frontmatter,
-                "body": body,
-            },
-            canonical_name=canonical_name,
-            source_kind=source_kind,
-            source_scope=source_scope,
-            source=source_label,
-            source_root=root_dir,
-            source_root_order=source_root_order,
-        ),
-        diagnostics,
-    )
-
-
-def _skip_skill_directory(path: Path) -> bool:
-    return path.name.startswith(".") or path.name == "node_modules"
-
-
-def _read_skill_ignore_patterns(current_dir: Path, root_dir: Path) -> tuple[str, ...]:
-    patterns: list[str] = []
-    relative_prefix = current_dir.relative_to(root_dir).as_posix()
-    prefix = "" if relative_prefix == "." else relative_prefix
-    for filename in _IGNORE_FILE_NAMES:
-        ignore_file = current_dir / filename
-        if not ignore_file.is_file():
-            continue
-        try:
-            lines = ignore_file.read_text(encoding="utf-8").splitlines()
-        except OSError:
-            continue
-        for raw_line in lines:
-            pattern = _normalize_skill_ignore_pattern(raw_line, prefix=prefix)
-            if pattern is not None:
-                patterns.append(pattern)
-    return tuple(patterns)
-
-
-def _normalize_skill_ignore_pattern(raw_line: str, *, prefix: str) -> str | None:
-    line = raw_line.strip()
-    if not line or line.startswith("#") or line.startswith("!"):
-        return None
-    if line.startswith("\\#") or line.startswith("\\!"):
-        line = line[1:]
-    if line.startswith("/"):
-        line = line[1:]
-    if prefix and "/" not in line.rstrip("/"):
-        line = f"{prefix}/{line}"
-    elif prefix:
-        line = f"{prefix}/{line}"
-    return line
-
-
-def _is_skill_path_ignored(
-    path: Path, *, root_dir: Path, patterns: tuple[str, ...]
-) -> bool:
-    if not patterns:
-        return False
-    relative_path = path.relative_to(root_dir).as_posix()
-    directory_path = f"{relative_path}/"
-    for pattern in patterns:
-        normalized = pattern.rstrip("/")
-        if pattern.endswith("/") and (
-            relative_path == normalized or directory_path.startswith(pattern)
-        ):
-            return True
-        if relative_path == normalized or relative_path.startswith(f"{normalized}/"):
-            return True
-        if fnmatch(relative_path, normalized) or fnmatch(directory_path, pattern):
-            return True
-    return False
-
-
-def _discover_extensions_from_dir(
-    extensions_dir: Path,
-    *,
-    source_kind: ResourceSourceKind,
-    source_scope: ResourceSourceScope,
-    source_label: str,
-    source_root_order: int = 0,
-) -> tuple[list[ExtensionDescriptor], list[DiagnosticDraft]]:
-    if not extensions_dir.is_dir():
-        return [], []
-
-    descriptors: list[ExtensionDescriptor] = []
-    diagnostics: list[DiagnosticDraft] = []
-    for entry in sorted(
-        extensions_dir.iterdir(),
-        key=lambda path: (0 if path.is_dir() else 1, path.name),
-    ):
-        if entry.is_file() and entry.suffix == ".py":
-            descriptors.append(
-                ExtensionDescriptor(
-                    name=entry.stem,
-                    source_path=entry,
-                    entry_path=entry,
-                    canonical_name=entry.name,
-                    source_kind=source_kind,
-                    source_scope=source_scope,
-                    source=source_label,
-                    source_root=extensions_dir,
-                    source_root_order=source_root_order,
-                )
-            )
-            continue
-        if entry.is_dir():
-            entry_path = _find_extension_entry(entry)
-            if entry_path is None:
-                diagnostics.append(
-                    resource_diagnostic(
-                        code="missing_extension_entry",
-                        message="Extension directories must contain extension.py or __init__.py.",
-                        source_path=entry,
-                        resource_type="extension",
-                        source_kind=source_kind,
-                    )
-                )
-                continue
-            descriptors.append(
-                ExtensionDescriptor(
-                    name=entry.name,
-                    source_path=entry,
-                    entry_path=entry_path,
-                    canonical_name=entry.name,
-                    source_kind=source_kind,
-                    source_scope=source_scope,
-                    source=source_label,
-                    source_root=extensions_dir,
-                    source_root_order=source_root_order,
-                )
-            )
-            continue
-        diagnostics.append(
-            resource_diagnostic(
-                code="unsupported_extension_entry",
-                message="Extension entries must be .py files or directories.",
-                source_path=entry,
-                resource_type="extension",
-                source_kind=source_kind,
-            )
-        )
-    return descriptors, diagnostics
-
-
-def _discover_themes_from_dir(
-    themes_dir: Path,
-    *,
-    source_kind: ResourceSourceKind,
-    source_scope: ResourceSourceScope,
-    source_label: str,
-    source_root_order: int = 0,
-) -> tuple[list[ThemeDescriptor], list[DiagnosticDraft]]:
-    if not themes_dir.is_dir():
-        return [], []
-
-    descriptors: list[ThemeDescriptor] = []
-    diagnostics: list[DiagnosticDraft] = []
-    for entry in sorted(themes_dir.iterdir(), key=lambda path: path.name):
-        if entry.is_file() and not entry.name.endswith(".json"):
-            diagnostics.append(
-                resource_diagnostic(
-                    code="unsupported_theme_entry",
-                    message="Theme file entries must be .json files.",
-                    source_path=entry,
-                    resource_type="theme",
-                    source_kind=source_kind,
-                )
-            )
-            continue
-        if entry.is_file():
-            diagnostic = _theme_json_diagnostic(entry, source_kind=source_kind)
-            if diagnostic is not None:
-                diagnostics.append(diagnostic)
-                continue
-        descriptors.append(
-            ThemeDescriptor(
-                name=entry.stem if entry.is_file() else entry.name,
-                source_path=entry,
-                canonical_name=entry.name,
-                source_kind=source_kind,
-                source_scope=source_scope,
-                source=source_label,
-                source_root=themes_dir,
-                source_root_order=source_root_order,
-            )
-        )
-    return descriptors, diagnostics
-
-
-def _theme_json_diagnostic(
-    path: Path, *, source_kind: ResourceSourceKind
-) -> DiagnosticDraft | None:
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        return resource_diagnostic(
-            code="invalid_theme_json",
-            message=f"Theme JSON is invalid: {exc.msg}",
-            source_path=path,
-            resource_type="theme",
-            source_kind=source_kind,
-        )
-    except Exception as exc:
-        return resource_diagnostic(
-            code="unreadable_theme_entry",
-            message=f"Failed to read theme entry: {exc}",
-            source_path=path,
-            resource_type="theme",
-            source_kind=source_kind,
-        )
-    if not isinstance(payload, dict):
-        return resource_diagnostic(
-            code="invalid_theme_schema",
-            message="Theme JSON must be an object.",
-            source_path=path,
-            resource_type="theme",
-            source_kind=source_kind,
-        )
-    return None
-
-
 def _discover_built_in_prompts(
     resource_package: str,
     *,
@@ -1178,58 +719,23 @@ def _discover_built_in_skills(
         diagnostics.extend(read_diagnostics)
         if content is None:
             continue
-
-        try:
-            parsed = parse_frontmatter(content)
-        except FrontmatterParseError as exc:
-            diagnostics.append(
-                _invalid_frontmatter_diagnostic(
-                    exc,
-                    source_path=_package_resource_path(
-                        resource_package, f"skills/{entry.name}/SKILL.md"
-                    ),
-                    resource_type="skill",
-                    source_kind="built_in",
-                )
-            )
-            continue
-        frontmatter = parsed.frontmatter
-        body = parsed.body
-        skill_name = _frontmatter_string(frontmatter.get("name")) or entry.name
-        description = _frontmatter_string(frontmatter.get("description"))
-        diagnostics.extend(
-            _skill_frontmatter_diagnostics(
-                frontmatter=frontmatter,
-                skill_name=skill_name,
-                parent_name=entry.name,
-                source_path=_package_resource_path(
-                    resource_package, f"skills/{entry.name}/SKILL.md"
-                ),
-                source_kind="built_in",
-            )
+        source_path = _package_resource_path(
+            resource_package, f"skills/{entry.name}/SKILL.md"
         )
-        descriptors.append(
-            SkillDescriptor(
-                name=skill_name,
-                source_path=_package_resource_path(
-                    resource_package, f"skills/{entry.name}/SKILL.md"
-                ),
-                content=content,
-                description=description,
-                disable_model_invocation=frontmatter.get("disable-model-invocation")
-                is True,
-                metadata={
-                    "frontmatter": frontmatter,
-                    "body": body,
-                },
-                canonical_name=f"{entry.name}/SKILL.md",
-                source_kind="built_in",
-                source_scope="builtin",
-                source="package_resource",
-                source_root=_package_source_root_path(resource_package, "skills"),
-                source_root_order=source_root_order,
-            )
+        descriptor, parsing_diagnostics = _skill_descriptor_from_text(
+            parent_name=entry.name,
+            source_path=source_path,
+            content=content,
+            canonical_name=f"{entry.name}/SKILL.md",
+            source_kind="built_in",
+            source_scope="builtin",
+            source="package_resource",
+            source_root=_package_source_root_path(resource_package, "skills"),
+            source_root_order=source_root_order,
         )
+        diagnostics.extend(parsing_diagnostics)
+        if descriptor is not None:
+            descriptors.append(descriptor)
     return descriptors, diagnostics
 
 
@@ -1362,153 +868,12 @@ def _built_in_category_root(resource_package: str, category: str) -> Traversable
     return category_root
 
 
-def _find_extension_entry(entry: Path) -> Path | None:
-    for filename in ("extension.py", "__init__.py"):
-        candidate = entry / filename
-        if candidate.is_file():
-            return candidate
-    return None
-
-
 def _find_extension_entry_name(entry: Traversable) -> str | None:
     for filename in ("extension.py", "__init__.py"):
         candidate = entry / filename
         if candidate.is_file():
             return filename
     return None
-
-
-def _read_text_file(
-    path: Path,
-    *,
-    diagnostic_code: str,
-    message_prefix: str,
-) -> tuple[str | None, list[DiagnosticDraft]]:
-    try:
-        return path.read_text(encoding="utf-8").strip(), []
-    except OSError as exc:
-        return (
-            None,
-            [
-                resource_diagnostic(
-                    code=diagnostic_code,
-                    message=f"{message_prefix}: {exc}",
-                    source_path=path,
-                )
-            ],
-        )
-
-
-def _invalid_frontmatter_diagnostic(
-    error: FrontmatterParseError,
-    *,
-    source_path: Path,
-    resource_type: str,
-    source_kind: ResourceSourceKind,
-) -> DiagnosticDraft:
-    return resource_diagnostic(
-        code=f"invalid_{resource_type}_frontmatter",
-        message=str(error),
-        source_path=source_path,
-        resource_type=resource_type,
-        source_kind=source_kind,
-    )
-
-
-def _skill_frontmatter_diagnostics(
-    *,
-    frontmatter: dict[str, object],
-    skill_name: str,
-    parent_name: str,
-    source_path: Path,
-    source_kind: ResourceSourceKind,
-) -> list[DiagnosticDraft]:
-    if not frontmatter:
-        return []
-    diagnostics: list[DiagnosticDraft] = []
-    description = _frontmatter_string(frontmatter.get("description"))
-    if description is None:
-        diagnostics.append(
-            _skill_validation_diagnostic(
-                code="invalid_skill_description",
-                message="Skill frontmatter description is required.",
-                source_path=source_path,
-                source_kind=source_kind,
-                field="description",
-            )
-        )
-    elif len(description) > _MAX_SKILL_DESCRIPTION_LENGTH:
-        diagnostics.append(
-            _skill_validation_diagnostic(
-                code="invalid_skill_description",
-                message=f"Skill frontmatter description exceeds {_MAX_SKILL_DESCRIPTION_LENGTH} characters.",
-                source_path=source_path,
-                source_kind=source_kind,
-                field="description",
-            )
-        )
-    if skill_name != parent_name:
-        diagnostics.append(
-            _skill_validation_diagnostic(
-                code="invalid_skill_name",
-                message=f'Skill frontmatter name "{skill_name}" does not match parent directory "{parent_name}".',
-                source_path=source_path,
-                source_kind=source_kind,
-                field="name",
-            )
-        )
-    if len(skill_name) > _MAX_SKILL_NAME_LENGTH:
-        diagnostics.append(
-            _skill_validation_diagnostic(
-                code="invalid_skill_name",
-                message=f"Skill frontmatter name exceeds {_MAX_SKILL_NAME_LENGTH} characters.",
-                source_path=source_path,
-                source_kind=source_kind,
-                field="name",
-            )
-        )
-    if not _is_valid_skill_name(skill_name):
-        diagnostics.append(
-            _skill_validation_diagnostic(
-                code="invalid_skill_name",
-                message="Skill frontmatter name must contain lowercase letters, numbers, and hyphens only.",
-                source_path=source_path,
-                source_kind=source_kind,
-                field="name",
-            )
-        )
-    return diagnostics
-
-
-def _skill_validation_diagnostic(
-    *,
-    code: str,
-    message: str,
-    source_path: Path,
-    source_kind: ResourceSourceKind,
-    field: str,
-) -> DiagnosticDraft:
-    return resource_diagnostic(
-        code=code,
-        message=message,
-        source_path=source_path,
-        resource_type="skill",
-        source_kind=source_kind,
-        metadata={"field": field},
-    )
-
-
-def _is_valid_skill_name(name: str) -> bool:
-    if not name or name.startswith("-") or name.endswith("-") or "--" in name:
-        return False
-    return all(char.islower() or char.isdigit() or char == "-" for char in name)
-
-
-def _frontmatter_string(value: object) -> str | None:
-    if not isinstance(value, str):
-        return None
-    normalized = value.strip()
-    return normalized or None
 
 
 def _read_text_resource(

--- a/src/loushang/harness/resources/_loader_discovery_filesystem.py
+++ b/src/loushang/harness/resources/_loader_discovery_filesystem.py
@@ -1,0 +1,425 @@
+"""Filesystem-backed resource discovery and validation."""
+
+from __future__ import annotations
+
+import json
+from fnmatch import fnmatch
+from pathlib import Path
+
+from loushang.harness.diagnostics.types import DiagnosticDraft
+from loushang.harness.resources._loader_descriptor_parsing import (
+    _prompt_descriptor_from_text,
+    _skill_descriptor_from_text,
+)
+from loushang.harness.resources._loader_types import _IGNORE_FILE_NAMES
+from loushang.harness.resources.diagnostics import resource_diagnostic
+from loushang.harness.resources.types import (
+    ExtensionDescriptor,
+    PromptFragmentDescriptor,
+    ResourceSourceKind,
+    ResourceSourceScope,
+    SkillDescriptor,
+    ThemeDescriptor,
+)
+
+
+def _discover_prompts_from_dir(
+    prompts_dir: Path,
+    *,
+    source_kind: ResourceSourceKind,
+    source_scope: ResourceSourceScope,
+    source_label: str,
+    source_root_order: int = 0,
+) -> tuple[list[PromptFragmentDescriptor], list[DiagnosticDraft]]:
+    if not prompts_dir.is_dir():
+        return [], []
+
+    descriptors: list[PromptFragmentDescriptor] = []
+    diagnostics: list[DiagnosticDraft] = []
+    for entry in sorted(prompts_dir.iterdir(), key=lambda path: path.name):
+        if entry.is_file() and entry.suffix == ".md":
+            text, read_diagnostics = _read_text_file(
+                entry,
+                diagnostic_code="unreadable_prompt_entry",
+                message_prefix="Failed to read prompt entry",
+            )
+            diagnostics.extend(read_diagnostics)
+            if text is None:
+                continue
+            descriptor, frontmatter_diagnostics = _prompt_descriptor_from_text(
+                name=entry.stem,
+                source_path=entry,
+                text=text,
+                canonical_name=entry.name,
+                source_kind=source_kind,
+                source_scope=source_scope,
+                source=source_label,
+                source_root=prompts_dir,
+                source_root_order=source_root_order,
+            )
+            diagnostics.extend(frontmatter_diagnostics)
+            if descriptor is not None:
+                descriptors.append(descriptor)
+            continue
+        diagnostics.append(
+            resource_diagnostic(
+                code="unsupported_prompt_entry",
+                message="Prompt entries must be .md files.",
+                source_path=entry,
+                resource_type="prompt",
+                source_kind=source_kind,
+            )
+        )
+    return descriptors, diagnostics
+
+
+def _discover_skills_from_dir(
+    skills_dir: Path,
+    *,
+    source_kind: ResourceSourceKind,
+    source_scope: ResourceSourceScope,
+    source_label: str,
+    source_root_order: int = 0,
+) -> tuple[list[SkillDescriptor], list[DiagnosticDraft]]:
+    if not skills_dir.is_dir():
+        return [], []
+
+    return _discover_skills_recursive(
+        skills_dir,
+        root_dir=skills_dir,
+        ignore_patterns=(),
+        source_kind=source_kind,
+        source_scope=source_scope,
+        source_label=source_label,
+        source_root_order=source_root_order,
+    )
+
+
+def _discover_skills_recursive(
+    current_dir: Path,
+    *,
+    root_dir: Path,
+    ignore_patterns: tuple[str, ...],
+    source_kind: ResourceSourceKind,
+    source_scope: ResourceSourceScope,
+    source_label: str,
+    source_root_order: int = 0,
+) -> tuple[list[SkillDescriptor], list[DiagnosticDraft]]:
+    descriptors: list[SkillDescriptor] = []
+    diagnostics: list[DiagnosticDraft] = []
+    active_ignore_patterns = (
+        *ignore_patterns,
+        *_read_skill_ignore_patterns(current_dir, root_dir),
+    )
+    skill_file = current_dir / "SKILL.md"
+    if skill_file.is_file():
+        descriptor, skill_diagnostics = _skill_descriptor_from_file(
+            skill_file,
+            root_dir=root_dir,
+            parent_name=current_dir.name,
+            source_kind=source_kind,
+            source_scope=source_scope,
+            source_label=source_label,
+            source_root_order=source_root_order,
+        )
+        diagnostics.extend(skill_diagnostics)
+        return ([descriptor] if descriptor is not None else []), diagnostics
+
+    for entry in sorted(current_dir.iterdir(), key=lambda path: path.name):
+        if entry.name == "SKILL.md":
+            continue
+        if entry.is_file():
+            if current_dir == root_dir and entry.name not in _IGNORE_FILE_NAMES:
+                diagnostics.append(
+                    resource_diagnostic(
+                        code="unsupported_skill_entry",
+                        message="Skill entries must be directories.",
+                        source_path=entry,
+                        resource_type="skill",
+                        source_kind=source_kind,
+                    )
+                )
+            continue
+        if not entry.is_dir() or _skip_skill_directory(entry):
+            continue
+        if _is_skill_path_ignored(
+            entry, root_dir=root_dir, patterns=active_ignore_patterns
+        ):
+            continue
+        child_descriptors, child_diagnostics = _discover_skills_recursive(
+            entry,
+            root_dir=root_dir,
+            ignore_patterns=active_ignore_patterns,
+            source_kind=source_kind,
+            source_scope=source_scope,
+            source_label=source_label,
+            source_root_order=source_root_order,
+        )
+        descriptors.extend(child_descriptors)
+        diagnostics.extend(child_diagnostics)
+    return descriptors, diagnostics
+
+
+def _skill_descriptor_from_file(
+    skill_file: Path,
+    *,
+    root_dir: Path,
+    parent_name: str,
+    source_kind: ResourceSourceKind,
+    source_scope: ResourceSourceScope,
+    source_label: str,
+    source_root_order: int,
+) -> tuple[SkillDescriptor | None, list[DiagnosticDraft]]:
+    content, diagnostics = _read_text_file(
+        skill_file,
+        diagnostic_code="unreadable_skill_entry",
+        message_prefix="Failed to read skill entry",
+    )
+    if content is None:
+        return None, diagnostics
+    descriptor, parsing_diagnostics = _skill_descriptor_from_text(
+        parent_name=parent_name,
+        source_path=skill_file,
+        content=content,
+        canonical_name=skill_file.relative_to(root_dir).as_posix(),
+        source_kind=source_kind,
+        source_scope=source_scope,
+        source=source_label,
+        source_root=root_dir,
+        source_root_order=source_root_order,
+    )
+    diagnostics.extend(parsing_diagnostics)
+    return descriptor, diagnostics
+
+
+def _skip_skill_directory(path: Path) -> bool:
+    return path.name.startswith(".") or path.name == "node_modules"
+
+
+def _read_skill_ignore_patterns(current_dir: Path, root_dir: Path) -> tuple[str, ...]:
+    patterns: list[str] = []
+    relative_prefix = current_dir.relative_to(root_dir).as_posix()
+    prefix = "" if relative_prefix == "." else relative_prefix
+    for filename in _IGNORE_FILE_NAMES:
+        ignore_file = current_dir / filename
+        if not ignore_file.is_file():
+            continue
+        try:
+            lines = ignore_file.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for raw_line in lines:
+            pattern = _normalize_skill_ignore_pattern(raw_line, prefix=prefix)
+            if pattern is not None:
+                patterns.append(pattern)
+    return tuple(patterns)
+
+
+def _normalize_skill_ignore_pattern(raw_line: str, *, prefix: str) -> str | None:
+    line = raw_line.strip()
+    if not line or line.startswith("#") or line.startswith("!"):
+        return None
+    if line.startswith("\\#") or line.startswith("\\!"):
+        line = line[1:]
+    if line.startswith("/"):
+        line = line[1:]
+    if prefix:
+        line = f"{prefix}/{line}"
+    return line
+
+
+def _is_skill_path_ignored(
+    path: Path, *, root_dir: Path, patterns: tuple[str, ...]
+) -> bool:
+    if not patterns:
+        return False
+    relative_path = path.relative_to(root_dir).as_posix()
+    directory_path = f"{relative_path}/"
+    for pattern in patterns:
+        normalized = pattern.rstrip("/")
+        if pattern.endswith("/") and (
+            relative_path == normalized or directory_path.startswith(pattern)
+        ):
+            return True
+        if relative_path == normalized or relative_path.startswith(f"{normalized}/"):
+            return True
+        if fnmatch(relative_path, normalized) or fnmatch(directory_path, pattern):
+            return True
+    return False
+
+
+def _discover_extensions_from_dir(
+    extensions_dir: Path,
+    *,
+    source_kind: ResourceSourceKind,
+    source_scope: ResourceSourceScope,
+    source_label: str,
+    source_root_order: int = 0,
+) -> tuple[list[ExtensionDescriptor], list[DiagnosticDraft]]:
+    if not extensions_dir.is_dir():
+        return [], []
+
+    descriptors: list[ExtensionDescriptor] = []
+    diagnostics: list[DiagnosticDraft] = []
+    for entry in sorted(
+        extensions_dir.iterdir(),
+        key=lambda path: (0 if path.is_dir() else 1, path.name),
+    ):
+        if entry.is_file() and entry.suffix == ".py":
+            descriptors.append(
+                ExtensionDescriptor(
+                    name=entry.stem,
+                    source_path=entry,
+                    entry_path=entry,
+                    canonical_name=entry.name,
+                    source_kind=source_kind,
+                    source_scope=source_scope,
+                    source=source_label,
+                    source_root=extensions_dir,
+                    source_root_order=source_root_order,
+                )
+            )
+            continue
+        if entry.is_dir():
+            entry_path = _find_extension_entry(entry)
+            if entry_path is None:
+                diagnostics.append(
+                    resource_diagnostic(
+                        code="missing_extension_entry",
+                        message="Extension directories must contain extension.py or __init__.py.",
+                        source_path=entry,
+                        resource_type="extension",
+                        source_kind=source_kind,
+                    )
+                )
+                continue
+            descriptors.append(
+                ExtensionDescriptor(
+                    name=entry.name,
+                    source_path=entry,
+                    entry_path=entry_path,
+                    canonical_name=entry.name,
+                    source_kind=source_kind,
+                    source_scope=source_scope,
+                    source=source_label,
+                    source_root=extensions_dir,
+                    source_root_order=source_root_order,
+                )
+            )
+            continue
+        diagnostics.append(
+            resource_diagnostic(
+                code="unsupported_extension_entry",
+                message="Extension entries must be .py files or directories.",
+                source_path=entry,
+                resource_type="extension",
+                source_kind=source_kind,
+            )
+        )
+    return descriptors, diagnostics
+
+
+def _discover_themes_from_dir(
+    themes_dir: Path,
+    *,
+    source_kind: ResourceSourceKind,
+    source_scope: ResourceSourceScope,
+    source_label: str,
+    source_root_order: int = 0,
+) -> tuple[list[ThemeDescriptor], list[DiagnosticDraft]]:
+    if not themes_dir.is_dir():
+        return [], []
+
+    descriptors: list[ThemeDescriptor] = []
+    diagnostics: list[DiagnosticDraft] = []
+    for entry in sorted(themes_dir.iterdir(), key=lambda path: path.name):
+        if entry.is_file() and not entry.name.endswith(".json"):
+            diagnostics.append(
+                resource_diagnostic(
+                    code="unsupported_theme_entry",
+                    message="Theme file entries must be .json files.",
+                    source_path=entry,
+                    resource_type="theme",
+                    source_kind=source_kind,
+                )
+            )
+            continue
+        if entry.is_file():
+            diagnostic = _theme_json_diagnostic(entry, source_kind=source_kind)
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+                continue
+        descriptors.append(
+            ThemeDescriptor(
+                name=entry.stem if entry.is_file() else entry.name,
+                source_path=entry,
+                canonical_name=entry.name,
+                source_kind=source_kind,
+                source_scope=source_scope,
+                source=source_label,
+                source_root=themes_dir,
+                source_root_order=source_root_order,
+            )
+        )
+    return descriptors, diagnostics
+
+
+def _theme_json_diagnostic(
+    path: Path, *, source_kind: ResourceSourceKind
+) -> DiagnosticDraft | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return resource_diagnostic(
+            code="invalid_theme_json",
+            message=f"Theme JSON is invalid: {exc.msg}",
+            source_path=path,
+            resource_type="theme",
+            source_kind=source_kind,
+        )
+    except Exception as exc:
+        return resource_diagnostic(
+            code="unreadable_theme_entry",
+            message=f"Failed to read theme entry: {exc}",
+            source_path=path,
+            resource_type="theme",
+            source_kind=source_kind,
+        )
+    if not isinstance(payload, dict):
+        return resource_diagnostic(
+            code="invalid_theme_schema",
+            message="Theme JSON must be an object.",
+            source_path=path,
+            resource_type="theme",
+            source_kind=source_kind,
+        )
+    return None
+
+
+def _find_extension_entry(entry: Path) -> Path | None:
+    for filename in ("extension.py", "__init__.py"):
+        candidate = entry / filename
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _read_text_file(
+    path: Path,
+    *,
+    diagnostic_code: str,
+    message_prefix: str,
+) -> tuple[str | None, list[DiagnosticDraft]]:
+    try:
+        return path.read_text(encoding="utf-8").strip(), []
+    except OSError as exc:
+        return (
+            None,
+            [
+                resource_diagnostic(
+                    code=diagnostic_code,
+                    message=f"{message_prefix}: {exc}",
+                    source_path=path,
+                )
+            ],
+        )

--- a/src/loushang/harness/resources/_loader_types.py
+++ b/src/loushang/harness/resources/_loader_types.py
@@ -15,10 +15,6 @@ from loushang.harness.resources.types import (
     ThemeDescriptor,
 )
 
-_MAX_SKILL_NAME_LENGTH = 64
-
-_MAX_SKILL_DESCRIPTION_LENGTH = 1024
-
 _IGNORE_FILE_NAMES = (".gitignore", ".ignore", ".fdignore")
 
 DEFAULT_CONTEXT_FILE_NAMES = ("AGENTS.md", "AGENTS.MD")

--- a/src/loushang/harness/tools/execution.py
+++ b/src/loushang/harness/tools/execution.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import Any, Protocol
 
 from loushang.agent.types import AgentToolResult
 from loushang.ai.types import ToolCall
 from loushang.harness.authorization import EffectiveExecutionProfile
 from loushang.harness.effects import ToolEffect
 from loushang.harness.policy import ToolPolicySubject
-
-if TYPE_CHECKING:
-    from loushang.harness.tools.core import ToolDefinition
 
 ToolUpdateCallback = Callable[[object], Awaitable[None] | None]
 
@@ -202,6 +199,16 @@ class AuthorizedExecution:
 ExecutionBinding = DirectExecution | AuthorizedExecution
 
 
+class _ExecutableToolDefinition(Protocol):
+    """Structural port consumed by the execution host."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def execution(self) -> ExecutionBinding: ...
+
+
 class ToolAuthorizationGateway(Protocol):
     async def execute(
         self,
@@ -219,7 +226,7 @@ class ToolExecutionHost:
 
     async def dispatch(
         self,
-        definition: ToolDefinition,
+        definition: _ExecutableToolDefinition,
         call: ToolCall,
         context: ToolCallContext,
     ) -> AgentToolResult[Any]:

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3096,8 +3096,10 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         runtime_root / "_profile_binding.py",
         runtime_root / "_profile_resolution.py",
         runtime_root / "_profile_types.py",
+        resource_root / "_loader_descriptor_parsing.py",
         resource_root / "_loader_discovery.py",
         resource_root / "_loader_discovery_context.py",
+        resource_root / "_loader_discovery_filesystem.py",
         resource_root / "_loader_package_policy.py",
         resource_root / "_loader_pipeline.py",
         resource_root / "_loader_precedence.py",
@@ -3134,10 +3136,22 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
             "loushang.harness.runtime._profile_resolution",
         ),
         resource_root / "_loader_precedence.py": (
+            "loushang.harness.resources._loader_descriptor_parsing",
             "loushang.harness.resources._loader_discovery",
             "loushang.harness.resources._loader_discovery_context",
+            "loushang.harness.resources._loader_discovery_filesystem",
             "loushang.harness.resources._loader_package_policy",
             "loushang.harness.resources._loader_pipeline",
+            "loushang.harness.resources._loader_resolution",
+            "loushang.harness.resources.loader",
+        ),
+        resource_root / "_loader_descriptor_parsing.py": (
+            "loushang.harness.resources._loader_discovery",
+            "loushang.harness.resources._loader_discovery_context",
+            "loushang.harness.resources._loader_discovery_filesystem",
+            "loushang.harness.resources._loader_package_policy",
+            "loushang.harness.resources._loader_pipeline",
+            "loushang.harness.resources._loader_precedence",
             "loushang.harness.resources._loader_resolution",
             "loushang.harness.resources.loader",
         ),
@@ -3149,7 +3163,18 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
             "loushang.harness.resources.loader",
         ),
         resource_root / "_loader_discovery_context.py": (
+            "loushang.harness.resources._loader_descriptor_parsing",
             "loushang.harness.resources._loader_discovery",
+            "loushang.harness.resources._loader_discovery_filesystem",
+            "loushang.harness.resources._loader_package_policy",
+            "loushang.harness.resources._loader_pipeline",
+            "loushang.harness.resources._loader_precedence",
+            "loushang.harness.resources._loader_resolution",
+            "loushang.harness.resources.loader",
+        ),
+        resource_root / "_loader_discovery_filesystem.py": (
+            "loushang.harness.resources._loader_discovery",
+            "loushang.harness.resources._loader_discovery_context",
             "loushang.harness.resources._loader_package_policy",
             "loushang.harness.resources._loader_pipeline",
             "loushang.harness.resources._loader_precedence",
@@ -3157,21 +3182,27 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
             "loushang.harness.resources.loader",
         ),
         resource_root / "_loader_package_policy.py": (
+            "loushang.harness.resources._loader_descriptor_parsing",
             "loushang.harness.resources._loader_discovery",
             "loushang.harness.resources._loader_discovery_context",
+            "loushang.harness.resources._loader_discovery_filesystem",
             "loushang.harness.resources._loader_pipeline",
             "loushang.harness.resources._loader_precedence",
             "loushang.harness.resources._loader_resolution",
             "loushang.harness.resources.loader",
         ),
         resource_root / "_loader_resolution.py": (
+            "loushang.harness.resources._loader_descriptor_parsing",
             "loushang.harness.resources._loader_discovery",
             "loushang.harness.resources._loader_discovery_context",
+            "loushang.harness.resources._loader_discovery_filesystem",
             "loushang.harness.resources._loader_package_policy",
             "loushang.harness.resources._loader_pipeline",
             "loushang.harness.resources.loader",
         ),
         resource_root / "_loader_pipeline.py": (
+            "loushang.harness.resources._loader_descriptor_parsing",
+            "loushang.harness.resources._loader_discovery_filesystem",
             "loushang.harness.resources._loader_package_policy",
             "loushang.harness.resources.loader",
         ),
@@ -3231,6 +3262,14 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         resource_root / "_loader_discovery.py"
     )
     assert (
+        "loushang.harness.resources._loader_descriptor_parsing"
+        in _absolute_imports(resource_root / "_loader_discovery.py")
+    )
+    assert (
+        "loushang.harness.resources._loader_discovery_filesystem"
+        in _absolute_imports(resource_root / "_loader_discovery.py")
+    )
+    assert (
         "loushang.harness.resources._loader_discovery_context"
         in _absolute_imports(resource_root / "_loader_pipeline.py")
     )
@@ -3252,10 +3291,39 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
     assert "def _filter_package_descriptors" in (
         resource_root / "_loader_package_policy.py"
     ).read_text(encoding="utf-8")
+    assert "def _prompt_descriptor_from_text" not in (
+        resource_root / "_loader_discovery.py"
+    ).read_text(encoding="utf-8")
+    assert "def _skill_descriptor_from_text" in (
+        resource_root / "_loader_descriptor_parsing.py"
+    ).read_text(encoding="utf-8")
+    assert "def _discover_skills_from_dir" not in (
+        resource_root / "_loader_discovery.py"
+    ).read_text(encoding="utf-8")
+    assert "def _discover_skills_from_dir" in (
+        resource_root / "_loader_discovery_filesystem.py"
+    ).read_text(encoding="utf-8")
+    assert (
+        "loushang.harness.resources._loader_descriptor_parsing"
+        not in _absolute_imports(resource_root / "loader.py")
+    )
+    assert (
+        "loushang.harness.resources._loader_discovery_filesystem"
+        not in _absolute_imports(resource_root / "loader.py")
+    )
     assert "loushang.harness.resources._loader_precedence" in _absolute_imports(
         resource_root / "_loader_resolution.py"
     )
     assert patch_module in _absolute_imports(manager_path)
+
+
+def test_harness_tool_execution_does_not_import_tool_definition_owner() -> None:
+    tool_root = Path("src/loushang/harness/tools")
+    core_module = "loushang.harness.tools.core"
+    execution_module = "loushang.harness.tools.execution"
+
+    assert execution_module in _absolute_imports(tool_root / "core.py")
+    assert core_module not in _absolute_imports(tool_root / "execution.py")
 
 
 def test_harness_conversation_runtime_core_is_documented_and_adopted() -> None:

--- a/tests/harness/resources/test_loader_descriptor_parsing.py
+++ b/tests/harness/resources/test_loader_descriptor_parsing.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loushang.harness.resources._loader_descriptor_parsing import (
+    _prompt_descriptor_from_text,
+    _skill_descriptor_from_text,
+)
+
+
+def test_prompt_descriptor_parsing_owns_frontmatter_projection() -> None:
+    source_path = Path("resources/prompts/review.md")
+
+    descriptor, diagnostics = _prompt_descriptor_from_text(
+        name="review",
+        source_path=source_path,
+        text=(
+            "---\n"
+            "description: Review pull requests\n"
+            'argument-hint: "<PR-URL>"\n'
+            "---\n\n"
+            "Review $1 and summarize risks."
+        ),
+        canonical_name="review.md",
+        source_kind="built_in",
+        source_scope="builtin",
+        source="package_resource",
+        source_root=Path("resources/prompts"),
+    )
+
+    assert diagnostics == []
+    assert descriptor is not None
+    assert descriptor.description == "Review pull requests"
+    assert descriptor.argument_hint == "<PR-URL>"
+    assert descriptor.metadata["body"] == "Review $1 and summarize risks."
+    assert descriptor.source_kind == "built_in"
+
+
+def test_skill_descriptor_parsing_owns_validation_and_projection() -> None:
+    source_path = Path("resources/skills/Debugging/SKILL.md")
+
+    descriptor, diagnostics = _skill_descriptor_from_text(
+        parent_name="Debugging",
+        source_path=source_path,
+        content="---\nname: Bad_Name\n---\n\nTrace the narrowest failure.",
+        canonical_name="Debugging/SKILL.md",
+        source_kind="project_local",
+        source_scope="project",
+        source="filesystem",
+        source_root=Path("resources/skills"),
+    )
+
+    assert descriptor is not None
+    assert descriptor.name == "Bad_Name"
+    assert descriptor.metadata["body"] == "Trace the narrowest failure."
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "invalid_skill_description",
+        "invalid_skill_name",
+        "invalid_skill_name",
+    ]
+    assert {
+        diagnostic.details["metadata"]["field"] for diagnostic in diagnostics
+    } == {"description", "name"}
+
+
+def test_descriptor_parsing_rejects_invalid_frontmatter_without_io() -> None:
+    descriptor, diagnostics = _skill_descriptor_from_text(
+        parent_name="broken",
+        source_path=Path("resources/skills/broken/SKILL.md"),
+        content="---\ndescription: [broken\n---\n\nBroken body.",
+        canonical_name="broken/SKILL.md",
+        source_kind="external_package",
+        source_scope="package",
+        source="package_resource",
+        source_root=Path("resources/skills"),
+    )
+
+    assert descriptor is None
+    assert [diagnostic.code for diagnostic in diagnostics] == [
+        "invalid_skill_frontmatter"
+    ]
+    assert diagnostics[0].details["source_kind"] == "external_package"

--- a/tests/harness/resources/test_loader_discovery_filesystem.py
+++ b/tests/harness/resources/test_loader_discovery_filesystem.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loushang.harness.resources._loader_discovery_filesystem import (
+    _discover_extensions_from_dir,
+    _discover_prompts_from_dir,
+    _discover_skills_from_dir,
+    _discover_themes_from_dir,
+)
+
+
+def test_filesystem_discovery_scans_each_standard_resource_category(
+    tmp_path: Path,
+) -> None:
+    prompts_dir = tmp_path / "prompts"
+    skill_dir = tmp_path / "skills" / "review"
+    extension_dir = tmp_path / "extensions" / "review"
+    themes_dir = tmp_path / "themes"
+    prompts_dir.mkdir()
+    skill_dir.mkdir(parents=True)
+    extension_dir.mkdir(parents=True)
+    themes_dir.mkdir()
+    (prompts_dir / "review.md").write_text(
+        "---\ndescription: Review changes\n---\n\nReview carefully.",
+        encoding="utf-8",
+    )
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: review\ndescription: Review changes.\n---\n\nReview carefully.",
+        encoding="utf-8",
+    )
+    (extension_dir / "extension.py").write_text("", encoding="utf-8")
+    (themes_dir / "dark.json").write_text("{}", encoding="utf-8")
+
+    common = {
+        "source_kind": "project_local",
+        "source_scope": "project",
+        "source_label": "filesystem",
+    }
+    prompts, prompt_diagnostics = _discover_prompts_from_dir(prompts_dir, **common)
+    skills, skill_diagnostics = _discover_skills_from_dir(
+        tmp_path / "skills", **common
+    )
+    extensions, extension_diagnostics = _discover_extensions_from_dir(
+        tmp_path / "extensions", **common
+    )
+    themes, theme_diagnostics = _discover_themes_from_dir(themes_dir, **common)
+
+    assert [descriptor.canonical_name for descriptor in prompts] == ["review.md"]
+    assert [descriptor.canonical_name for descriptor in skills] == [
+        "review/SKILL.md"
+    ]
+    assert [descriptor.canonical_name for descriptor in extensions] == ["review"]
+    assert [descriptor.canonical_name for descriptor in themes] == ["dark.json"]
+    assert [
+        *prompt_diagnostics,
+        *skill_diagnostics,
+        *extension_diagnostics,
+        *theme_diagnostics,
+    ] == []
+
+
+def test_filesystem_discovery_owns_skill_ignore_and_theme_validation(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    ignored_skill = skills_dir / "ignored"
+    active_skill = skills_dir / "active"
+    themes_dir = tmp_path / "themes"
+    ignored_skill.mkdir(parents=True)
+    active_skill.mkdir()
+    themes_dir.mkdir()
+    (skills_dir / ".gitignore").write_text("ignored/\n", encoding="utf-8")
+    (ignored_skill / "SKILL.md").write_text("Ignored", encoding="utf-8")
+    (active_skill / "SKILL.md").write_text("Active", encoding="utf-8")
+    (themes_dir / "broken.json").write_text("[]", encoding="utf-8")
+
+    common = {
+        "source_kind": "external_package",
+        "source_scope": "package",
+        "source_label": "package_resource",
+    }
+    skills, skill_diagnostics = _discover_skills_from_dir(skills_dir, **common)
+    themes, theme_diagnostics = _discover_themes_from_dir(themes_dir, **common)
+
+    assert [descriptor.name for descriptor in skills] == ["active"]
+    assert skill_diagnostics == []
+    assert themes == []
+    assert [diagnostic.code for diagnostic in theme_diagnostics] == [
+        "invalid_theme_schema"
+    ]


### PR DESCRIPTION
## What changed

- remove the `harness.tools.core` / `harness.tools.execution` type dependency cycle by dispatching through an execution-owned structural port
- add a source-neutral resource descriptor parsing owner for prompt and skill frontmatter projection and validation
- add a filesystem discovery owner for directory traversal, skill ignore rules, extension entry lookup, file reads, and theme validation
- reduce the general resource discovery coordinator from 1,583 lines to 950 lines
- update architecture gates and authoritative owner documentation

## Why

Resource discovery still mixed source coordination, filesystem mechanics, and descriptor semantics in one large module. The split establishes leaf-first dependencies that let filesystem and built-in discovery share parsing rules without importing the coordinator. The tool execution change removes the remaining type-only Harness SCC.

## Impact

Public resource and tool APIs are unchanged. Diagnostic codes and messages, resource ordering, filtering, temporary paths, built-in resources, and execution behavior remain compatible.

## Validation

- `make check-harness` Ruff and mypy stages passed; mypy checked 426 source files
- `pytest tests/harness -vv`: 1517 passed
- `pytest` focused resource, Coding loader, and architecture suites: 193 passed
- `pytest tests/coding/test_resource_loader.py -vv`: 35 passed
- static Harness dependency graph: 426 modules, 1256 edges, 0 cycles
- `git diff --check`
