### PR TITLE
refactor(harness): type resource discovery request

### DIFF
--- a/docs/internals/architecture/harness/current-owner-map.md
+++ b/docs/internals/architecture/harness/current-owner-map.md
@@ -127,7 +127,11 @@ policies. Context discovery, built-in discovery, temporary discovery,
 filesystem discovery, descriptor parsing, and package policy do not depend on
 discovery coordination, resolution, the pipeline, or the public loader facade.
 Loader option normalization and system-prompt source resolution remain with the
-public loader owner rather than discovery coordination.
+public loader owner rather than discovery coordination. The loader projects its
+normalized state into one immutable pipeline-owned discovery request. The
+pipeline owns candidate-source aggregation, including the single expression of
+temporary, built-in, external-package, user-global, and project-local candidate
+order; discovery diagnostic order remains an explicit, separate contract.
 Resolution never imports any discovery owner or package policy, live profile
 binding never imports profile resolution, and internal leaf modules never
 import their public facade. The tool execution host consumes a private

--- a/docs/internals/architecture/harness/platform-resource-layout-boundary.md
+++ b/docs/internals/architecture/harness/platform-resource-layout-boundary.md
@@ -124,8 +124,9 @@ The product-neutral runtime now lives under `loushang.harness.resources`:
   summaries;
 - `loader` is the stable public facade and owns loader state, runtime options,
   reload, queries, and the standard workspace resource-root mode;
-- `_loader_pipeline` owns discovery-to-resolution orchestration, diagnostic and
-  merge-decision aggregation, and `ResourceSnapshot` assembly;
+- `_loader_pipeline` owns the immutable loader-to-pipeline discovery request,
+  candidate-source ordering, discovery-to-resolution orchestration, diagnostic
+  and merge-decision aggregation, and `ResourceSnapshot` assembly;
 - `_loader_discovery_context` owns context-file ancestor traversal, descriptor
   construction, diagnostics, and nearest-context selection;
 - `_loader_descriptor_parsing` owns source-neutral prompt/skill frontmatter

--- a/src/loushang/harness/resources/_loader_discovery.py
+++ b/src/loushang/harness/resources/_loader_discovery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
 def _discover_user_global_resources(
     user_resource_roots: tuple[Path, ...],
     *,
-    explicit_roots: set[Path] | None = None,
+    explicit_roots: Collection[Path] | None = None,
 ) -> _SourceDiscovery:
     prompts: list[PromptFragmentDescriptor] = []
     skills: list[SkillDescriptor] = []
@@ -140,7 +141,7 @@ def _discover_project_resources(root: Path) -> _SourceDiscovery:
 def _discover_external_package_resources(
     package_roots: tuple[Path, ...],
     *,
-    package_source_filters: dict[Path, PackageSourceConfig] | None = None,
+    package_source_filters: Mapping[Path, PackageSourceConfig] | None = None,
 ) -> _SourceDiscovery:
     prompts: list[PromptFragmentDescriptor] = []
     skills: list[SkillDescriptor] = []

--- a/src/loushang/harness/resources/_loader_pipeline.py
+++ b/src/loushang/harness/resources/_loader_pipeline.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING
 
 from loushang.harness.diagnostics.types import DiagnosticDraft
@@ -26,49 +29,117 @@ from loushang.harness.resources._loader_resolution import (
     _resolve_extension_candidates,
     _resolve_strict_named_candidates,
 )
-from loushang.harness.resources._loader_types import DEFAULT_CONTEXT_FILE_NAMES
+from loushang.harness.resources._loader_types import (
+    DEFAULT_CONTEXT_FILE_NAMES,
+    _SourceDiscovery,
+)
 from loushang.harness.resources.types import (
+    ExtensionDescriptor,
     PromptFragmentDescriptor,
     ResourceSnapshot,
     ResourceSourceKind,
+    SkillDescriptor,
+    ThemeDescriptor,
 )
 
 if TYPE_CHECKING:
     from loushang.harness.resources.packages.source import PackageSourceConfig
 
 
-def _discover_snapshot(
-    cwd: Path,
-    *,
-    package_roots: tuple[Path, ...] = (),
-    package_source_filters: dict[Path, PackageSourceConfig] | None = None,
-    user_resource_roots: tuple[Path, ...] = (),
-    explicit_user_roots: set[Path] | None = None,
-    additional_extension_paths: tuple[Path, ...] = (),
-    additional_skill_paths: tuple[Path, ...] = (),
-    additional_prompt_template_paths: tuple[Path, ...] = (),
-    additional_theme_paths: tuple[Path, ...] = (),
-    no_extensions: bool = False,
-    no_skills: bool = False,
-    no_prompt_templates: bool = False,
-    no_themes: bool = False,
-    no_context_files: bool = False,
-    built_in_resource_packages: tuple[str, ...] = (),
-    context_file_names: tuple[str, ...] = DEFAULT_CONTEXT_FILE_NAMES,
-    project_resource_root: Path | None = None,
-) -> ResourceSnapshot:
-    target = Path(cwd)
+@dataclass(frozen=True)
+class _ResourceDiscoveryRequest:
+    cwd: Path
+    package_roots: tuple[Path, ...] = ()
+    package_source_filters: Mapping[Path, PackageSourceConfig] = field(
+        default_factory=dict
+    )
+    user_resource_roots: tuple[Path, ...] = ()
+    explicit_user_roots: frozenset[Path] = frozenset()
+    additional_extension_paths: tuple[Path, ...] = ()
+    additional_skill_paths: tuple[Path, ...] = ()
+    additional_prompt_template_paths: tuple[Path, ...] = ()
+    additional_theme_paths: tuple[Path, ...] = ()
+    no_extensions: bool = False
+    no_skills: bool = False
+    no_prompt_templates: bool = False
+    no_themes: bool = False
+    no_context_files: bool = False
+    built_in_resource_packages: tuple[str, ...] = ()
+    context_file_names: tuple[str, ...] = DEFAULT_CONTEXT_FILE_NAMES
+    project_resource_root: Path | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "package_source_filters",
+            MappingProxyType(dict(self.package_source_filters)),
+        )
+        object.__setattr__(
+            self,
+            "explicit_user_roots",
+            frozenset(self.explicit_user_roots),
+        )
+
+
+@dataclass(frozen=True)
+class _ResourceDiscoveries:
+    candidate_order: tuple[_SourceDiscovery, ...]
+    diagnostic_order: tuple[_SourceDiscovery, ...]
+
+    @property
+    def prompts(self) -> tuple[PromptFragmentDescriptor, ...]:
+        return tuple(
+            descriptor
+            for discovery in self.candidate_order
+            for descriptor in discovery.prompts
+        )
+
+    @property
+    def skills(self) -> tuple[SkillDescriptor, ...]:
+        return tuple(
+            descriptor
+            for discovery in self.candidate_order
+            for descriptor in discovery.skills
+        )
+
+    @property
+    def extensions(self) -> tuple[ExtensionDescriptor, ...]:
+        return tuple(
+            descriptor
+            for discovery in self.candidate_order
+            for descriptor in discovery.extensions
+        )
+
+    @property
+    def themes(self) -> tuple[ThemeDescriptor, ...]:
+        return tuple(
+            descriptor
+            for discovery in self.candidate_order
+            for descriptor in discovery.themes
+        )
+
+    @property
+    def diagnostics(self) -> tuple[DiagnosticDraft, ...]:
+        return tuple(
+            diagnostic
+            for discovery in self.diagnostic_order
+            for diagnostic in discovery.diagnostics
+        )
+
+
+def _discover_snapshot(request: _ResourceDiscoveryRequest) -> ResourceSnapshot:
+    target = Path(request.cwd)
     context_descriptors: list[PromptFragmentDescriptor]
     agents_descriptor: PromptFragmentDescriptor | None
     context_diagnostics: list[DiagnosticDraft]
-    if no_context_files:
+    if request.no_context_files:
         context_descriptors, agents_descriptor, context_diagnostics = [], None, []
     else:
         context_descriptors, agents_descriptor, context_diagnostics = (
             _discover_context_descriptors(
                 target,
-                user_resource_roots=user_resource_roots,
-                context_file_names=context_file_names,
+                user_resource_roots=request.user_resource_roots,
+                context_file_names=request.context_file_names,
             )
         )
     project_context_descriptors = [
@@ -81,103 +152,86 @@ def _discover_snapshot(
         if project_context_descriptors
         else (target if target.is_dir() else target.parent)
     )
-    if project_resource_root is not None:
-        project_root = project_resource_root
+    if request.project_resource_root is not None:
+        project_root = request.project_resource_root
 
     built_in = _apply_resource_switches(
-        _discover_built_in_resources(built_in_resource_packages),
-        no_prompts=no_prompt_templates,
-        no_skills=no_skills,
-        no_extensions=no_extensions,
-        no_themes=no_themes,
+        _discover_built_in_resources(request.built_in_resource_packages),
+        no_prompts=request.no_prompt_templates,
+        no_skills=request.no_skills,
+        no_extensions=request.no_extensions,
+        no_themes=request.no_themes,
     )
     external = _apply_resource_switches(
         _discover_external_package_resources(
-            package_roots, package_source_filters=package_source_filters
+            request.package_roots,
+            package_source_filters=request.package_source_filters,
         ),
-        no_prompts=no_prompt_templates,
-        no_skills=no_skills,
-        no_extensions=no_extensions,
-        no_themes=no_themes,
+        no_prompts=request.no_prompt_templates,
+        no_skills=request.no_skills,
+        no_extensions=request.no_extensions,
+        no_themes=request.no_themes,
     )
     user_global = _apply_resource_switches(
         _discover_user_global_resources(
-            user_resource_roots, explicit_roots=explicit_user_roots
+            request.user_resource_roots,
+            explicit_roots=request.explicit_user_roots,
         ),
-        no_prompts=no_prompt_templates,
-        no_skills=no_skills,
-        no_extensions=no_extensions,
-        no_themes=no_themes,
+        no_prompts=request.no_prompt_templates,
+        no_skills=request.no_skills,
+        no_extensions=request.no_extensions,
+        no_themes=request.no_themes,
     )
     project = _apply_resource_switches(
         _discover_project_resources(project_root),
-        no_prompts=no_prompt_templates,
-        no_skills=no_skills,
-        no_extensions=no_extensions,
-        no_themes=no_themes,
+        no_prompts=request.no_prompt_templates,
+        no_skills=request.no_skills,
+        no_extensions=request.no_extensions,
+        no_themes=request.no_themes,
     )
     temporary = _discover_temporary_resources(
         target,
-        extension_paths=additional_extension_paths,
-        skill_paths=additional_skill_paths,
-        prompt_paths=additional_prompt_template_paths,
-        theme_paths=additional_theme_paths,
+        extension_paths=request.additional_extension_paths,
+        skill_paths=request.additional_skill_paths,
+        prompt_paths=request.additional_prompt_template_paths,
+        theme_paths=request.additional_theme_paths,
     )
+
+    discoveries = _ResourceDiscoveries(
+        candidate_order=(temporary, built_in, external, user_global, project),
+        diagnostic_order=(built_in, external, user_global, project, temporary),
+    )
+    prompt_candidates = discoveries.prompts
+    skill_candidates = discoveries.skills
+    extension_candidates = discoveries.extensions
+    theme_candidates = discoveries.themes
 
     active_prompts, prompt_diagnostics, prompt_decisions = (
         _resolve_strict_named_candidates(
-            [
-                *temporary.prompts,
-                *built_in.prompts,
-                *external.prompts,
-                *user_global.prompts,
-                *project.prompts,
-            ],
+            prompt_candidates,
             resource_type="prompt",
         )
     )
     active_skills, skill_diagnostics, skill_decisions = (
         _resolve_strict_named_candidates(
-            [
-                *temporary.skills,
-                *built_in.skills,
-                *external.skills,
-                *user_global.skills,
-                *project.skills,
-            ],
+            skill_candidates,
             resource_type="skill",
         )
     )
     active_extensions, extension_diagnostics, extension_decisions = (
         _resolve_extension_candidates(
-            [
-                *temporary.extensions,
-                *built_in.extensions,
-                *external.extensions,
-                *user_global.extensions,
-                *project.extensions,
-            ],
+            extension_candidates,
             resource_type="extension",
         )
     )
     active_themes, theme_diagnostics, theme_decisions = _resolve_candidates(
-        [
-            *temporary.themes,
-            *built_in.themes,
-            *external.themes,
-            *user_global.themes,
-            *project.themes,
-        ],
+        theme_candidates,
         resource_type="theme",
     )
 
     diagnostics = [
         *context_diagnostics,
-        *built_in.diagnostics,
-        *external.diagnostics,
-        *user_global.diagnostics,
-        *project.diagnostics,
-        *temporary.diagnostics,
+        *discoveries.diagnostics,
         *prompt_diagnostics,
         *skill_diagnostics,
         *extension_diagnostics,
@@ -192,15 +246,15 @@ def _discover_snapshot(
     return ResourceSnapshot(
         cwd=target,
         source_kinds=_source_kinds_for(
-            package_roots,
-            user_resource_roots,
-            has_built_in=bool(built_in_resource_packages),
+            request.package_roots,
+            request.user_resource_roots,
+            has_built_in=bool(request.built_in_resource_packages),
             has_temporary=any(
                 (
-                    additional_extension_paths,
-                    additional_skill_paths,
-                    additional_prompt_template_paths,
-                    additional_theme_paths,
+                    request.additional_extension_paths,
+                    request.additional_skill_paths,
+                    request.additional_prompt_template_paths,
+                    request.additional_theme_paths,
                 )
             ),
         ),
@@ -208,45 +262,13 @@ def _discover_snapshot(
         active_context_descriptors=tuple(context_descriptors),
         candidate_agents_descriptors=tuple(context_descriptors),
         active_prompt_descriptors=tuple(active_prompts),
-        candidate_prompt_descriptors=tuple(
-            [
-                *temporary.prompts,
-                *built_in.prompts,
-                *external.prompts,
-                *user_global.prompts,
-                *project.prompts,
-            ]
-        ),
+        candidate_prompt_descriptors=prompt_candidates,
         active_skill_descriptors=tuple(active_skills),
-        candidate_skill_descriptors=tuple(
-            [
-                *temporary.skills,
-                *built_in.skills,
-                *external.skills,
-                *user_global.skills,
-                *project.skills,
-            ]
-        ),
+        candidate_skill_descriptors=skill_candidates,
         active_extension_descriptors=tuple(active_extensions),
-        candidate_extension_descriptors=tuple(
-            [
-                *temporary.extensions,
-                *built_in.extensions,
-                *external.extensions,
-                *user_global.extensions,
-                *project.extensions,
-            ]
-        ),
+        candidate_extension_descriptors=extension_candidates,
         active_theme_descriptors=tuple(active_themes),
-        candidate_theme_descriptors=tuple(
-            [
-                *temporary.themes,
-                *built_in.themes,
-                *external.themes,
-                *user_global.themes,
-                *project.themes,
-            ]
-        ),
+        candidate_theme_descriptors=theme_candidates,
         diagnostics=tuple(diagnostics),
         merge_decisions=tuple(merge_decisions),
     )

--- a/src/loushang/harness/resources/_loader_resolution.py
+++ b/src/loushang/harness/resources/_loader_resolution.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from loushang.harness.diagnostics.types import DiagnosticDraft
 from loushang.harness.resources._loader_precedence import (
     _candidate_sort_key,
@@ -19,7 +21,7 @@ from loushang.harness.resources.types import (
 
 
 def _resolve_candidates(
-    candidates: list[DescriptorT],
+    candidates: Sequence[DescriptorT],
     *,
     resource_type: str,
 ) -> tuple[list[DescriptorT], list[DiagnosticDraft], list[ResourceMergeDecision]]:
@@ -115,7 +117,7 @@ def _resolve_candidates(
 
 
 def _resolve_strict_named_candidates(
-    candidates: list[DescriptorT],
+    candidates: Sequence[DescriptorT],
     *,
     resource_type: str,
 ) -> tuple[list[DescriptorT], list[DiagnosticDraft], list[ResourceMergeDecision]]:
@@ -289,7 +291,7 @@ def _collision_path_metadata(
 
 
 def _resolve_extension_candidates(
-    candidates: list[ExtensionDescriptor],
+    candidates: Sequence[ExtensionDescriptor],
     *,
     resource_type: str,
 ) -> tuple[

--- a/src/loushang/harness/resources/loader.py
+++ b/src/loushang/harness/resources/loader.py
@@ -16,6 +16,7 @@ from loushang.harness.resources._loader_package_policy import (
 )
 from loushang.harness.resources._loader_pipeline import (
     _discover_snapshot,
+    _ResourceDiscoveryRequest,
     _source_kinds_for,
 )
 from loushang.harness.resources._loader_types import (
@@ -261,12 +262,12 @@ class ResourceLoader:
             if self._project_resource_mode == "standard"
             else None
         )
-        snapshot = _discover_snapshot(
-            target,
+        request = _ResourceDiscoveryRequest(
+            cwd=target,
             package_roots=self._package_roots,
             package_source_filters=self._package_source_filters,
             user_resource_roots=self._user_resource_roots,
-            explicit_user_roots=self._explicit_user_resource_roots,
+            explicit_user_roots=frozenset(self._explicit_user_resource_roots),
             additional_extension_paths=self._additional_extension_paths,
             additional_skill_paths=self._additional_skill_paths,
             additional_prompt_template_paths=self._additional_prompt_template_paths,
@@ -280,6 +281,7 @@ class ResourceLoader:
             context_file_names=self._context_file_names,
             project_resource_root=project_resource_root,
         )
+        snapshot = _discover_snapshot(request)
         self._snapshot = snapshot
         self._resolved_system_prompt = _resolve_prompt_input(
             self._system_prompt_source, cwd=Path(cwd)

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -3327,6 +3327,18 @@ def test_harness_split_internal_owners_have_one_way_dependencies() -> None:
         "loushang.harness.resources._loader_discovery_temporary"
         in _absolute_imports(resource_root / "_loader_pipeline.py")
     )
+    pipeline_text = (resource_root / "_loader_pipeline.py").read_text(
+        encoding="utf-8"
+    )
+    loader_text = (resource_root / "loader.py").read_text(encoding="utf-8")
+    assert "class _ResourceDiscoveryRequest:" in pipeline_text
+    assert "class _ResourceDiscoveries:" in pipeline_text
+    assert (
+        "def _discover_snapshot(request: _ResourceDiscoveryRequest)"
+        in pipeline_text
+    )
+    assert "class _ResourceDiscoveryRequest:" not in loader_text
+    assert "snapshot = _discover_snapshot(request)" in loader_text
     assert "def _discover_context_descriptors" not in (
         resource_root / "_loader_discovery.py"
     ).read_text(encoding="utf-8")

--- a/tests/harness/resources/test_loader_pipeline.py
+++ b/tests/harness/resources/test_loader_pipeline.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import MappingProxyType
+
+from loushang.harness.diagnostics.types import DiagnosticDraft
+from loushang.harness.resources._loader_pipeline import (
+    _ResourceDiscoveries,
+    _ResourceDiscoveryRequest,
+)
+from loushang.harness.resources._loader_types import _SourceDiscovery
+from loushang.harness.resources.loader import ResourceLoader
+from loushang.harness.resources.packages.source import PackageSourceConfig
+from loushang.harness.resources.types import (
+    ExtensionDescriptor,
+    PromptFragmentDescriptor,
+    ResourceSnapshot,
+    ResourceSourceKind,
+    SkillDescriptor,
+    ThemeDescriptor,
+)
+
+
+def _source_discovery(source_kind: ResourceSourceKind) -> _SourceDiscovery:
+    name = str(source_kind)
+    path = Path(f"/{name}")
+    return _SourceDiscovery(
+        prompts=[
+            PromptFragmentDescriptor(
+                name=name,
+                source_path=path / "prompt.md",
+                text=name,
+                source_kind=source_kind,
+            )
+        ],
+        skills=[
+            SkillDescriptor(
+                name=name,
+                source_path=path / "SKILL.md",
+                source_kind=source_kind,
+            )
+        ],
+        extensions=[
+            ExtensionDescriptor(
+                name=name,
+                source_path=path / "extension.py",
+                source_kind=source_kind,
+            )
+        ],
+        themes=[
+            ThemeDescriptor(
+                name=name,
+                source_path=path / "theme.json",
+                source_kind=source_kind,
+            )
+        ],
+        diagnostics=[DiagnosticDraft(code=name, message=name)],
+    )
+
+
+def test_resource_discoveries_centralize_candidate_and_diagnostic_order() -> None:
+    by_kind = {
+        source_kind: _source_discovery(source_kind)
+        for source_kind in (
+            "temporary",
+            "built_in",
+            "external_package",
+            "user_global",
+            "project_local",
+        )
+    }
+    candidate_order = (
+        "temporary",
+        "built_in",
+        "external_package",
+        "user_global",
+        "project_local",
+    )
+    diagnostic_order = (
+        "built_in",
+        "external_package",
+        "user_global",
+        "project_local",
+        "temporary",
+    )
+    discoveries = _ResourceDiscoveries(
+        candidate_order=tuple(by_kind[source_kind] for source_kind in candidate_order),
+        diagnostic_order=tuple(
+            by_kind[source_kind] for source_kind in diagnostic_order
+        ),
+    )
+
+    assert tuple(descriptor.name for descriptor in discoveries.prompts) == (
+        candidate_order
+    )
+    assert tuple(descriptor.name for descriptor in discoveries.skills) == (
+        candidate_order
+    )
+    assert tuple(descriptor.name for descriptor in discoveries.extensions) == (
+        candidate_order
+    )
+    assert tuple(descriptor.name for descriptor in discoveries.themes) == (
+        candidate_order
+    )
+    assert tuple(diagnostic.code for diagnostic in discoveries.diagnostics) == (
+        diagnostic_order
+    )
+
+
+def test_resource_loader_passes_one_immutable_discovery_request(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    import loushang.harness.resources.loader as loader_module
+
+    package_root = tmp_path / "package"
+    user_root = tmp_path / "user"
+    workspace = tmp_path / "workspace"
+    package_filter = PackageSourceConfig(
+        source=str(package_root),
+        prompts=("review.md",),
+    )
+    captured: list[_ResourceDiscoveryRequest] = []
+
+    def discover(request: _ResourceDiscoveryRequest) -> ResourceSnapshot:
+        captured.append(request)
+        return ResourceSnapshot(cwd=request.cwd)
+
+    monkeypatch.setattr(loader_module, "_discover_snapshot", discover)
+    loader = ResourceLoader(
+        package_roots=(package_root,),
+        package_source_filters={package_root: package_filter},
+        user_resource_roots=(user_root,),
+        additional_extension_paths=("review.py",),
+        additional_skill_paths=("review-skill",),
+        additional_prompt_template_paths=("review.md",),
+        additional_theme_paths=("dark.json",),
+        no_extensions=True,
+        no_skills=True,
+        no_prompt_templates=True,
+        no_themes=True,
+        no_context_files=True,
+        built_in_resource_packages=("loushang.builtin",),
+        context_file_names=("PROJECT.md",),
+        workspace_root=workspace,
+    )
+    loader.set_user_resource_roots((user_root,), explicit_roots=(user_root,))
+
+    loader.discover_resources(workspace)
+
+    assert len(captured) == 1
+    request = captured[0]
+    assert request.cwd == workspace
+    assert request.package_roots == (package_root.resolve(),)
+    assert request.package_source_filters == {
+        package_root.resolve(): package_filter
+    }
+    assert isinstance(request.package_source_filters, MappingProxyType)
+    assert request.user_resource_roots == (user_root.resolve(),)
+    assert request.explicit_user_roots == frozenset({user_root.resolve()})
+    assert request.additional_extension_paths == (Path("review.py"),)
+    assert request.additional_skill_paths == (Path("review-skill"),)
+    assert request.additional_prompt_template_paths == (Path("review.md"),)
+    assert request.additional_theme_paths == (Path("dark.json"),)
+    assert request.no_extensions is True
+    assert request.no_skills is True
+    assert request.no_prompt_templates is True
+    assert request.no_themes is True
+    assert request.no_context_files is True
+    assert request.built_in_resource_packages == ("loushang.builtin",)
+    assert request.context_file_names == ("PROJECT.md",)
+    assert request.project_resource_root == workspace.resolve() / ".loushang"


### PR DESCRIPTION
## Summary

- replace the loader-to-pipeline parameter fan-out with one immutable typed discovery request
- centralize prompt, skill, extension, and theme candidate source ordering in the pipeline
- preserve discovery diagnostic ordering as an explicit separate contract
- allow resolution owners to consume read-only descriptor sequences
- add request and ordering characterization tests, architecture gates, and owner documentation

## Why

The resource snapshot pipeline exposed cwd plus sixteen keyword parameters, mirroring loader state and making omissions or default drift easy. Candidate source lists were also repeated for every resource type and again during snapshot assembly. This change makes the private boundary explicit and gives source ordering one owner without changing public APIs or discovery behavior.

## Validation

- Harness tests: 1525 passed
- focused resource, Coding, and architecture suite: 199 passed
- Ruff: passed
- mypy Harness: passed
- internal dependency graph: 428 modules, 1443 edges, 0 cyclic SCCs
- git diff check: passed