### PR TITLE
feat(harness): add authorized one-shot agent delegation

### DIFF
--- a/docs/internals/architecture/drafts/future-loushang-architecture-v3.md
+++ b/docs/internals/architecture/drafts/future-loushang-architecture-v3.md
@@ -179,6 +179,10 @@ business commitment. A2A may be one adapter for an independent external Agent;
 a Loushang-controlled service may use a smaller worker protocol without
 changing the tool contract. See
 [Remote Agent Capability Boundary](../harness/multiagent/remote-agent-capability-boundary.md).
+The implemented local CLI P0 is documented in
+[One-Shot Agent Invocation Tool Boundary](../harness/agent-invocation-tool-boundary.md):
+it proves the admitted-tool path without introducing an execution provider,
+job lifecycle, or new multi-agent runtime abstraction.
 
 ## Client And Process Profiles
 
@@ -552,3 +556,4 @@ interaction.
 - [Work Architecture](../work/README.md)
 - [Method Architecture](../method/README.md)
 - [Remote Agent Capability Boundary](../harness/multiagent/remote-agent-capability-boundary.md)
+- [One-Shot Agent Invocation Tool Boundary](../harness/agent-invocation-tool-boundary.md)

--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -106,6 +106,10 @@ description.
   authorized bindings, typed common effects, a session-owned authorization
   gateway, and the migration that removes raw tool execution bypasses without
   changing permission behavior.
+- [One-Shot Agent Invocation Tool Boundary](agent-invocation-tool-boundary.md)
+  records the implemented `delegate_agent` P0: a finite authorized subprocess
+  tool, Coding-owned CLI semantics, non-widening child tools, bounded output,
+  and the evidence gates before jobs or multi-agent semantics are introduced.
 - [Harness Tool Authoring](tool-authoring-guide.md) is the short developer guide
   for pure tools, common filesystem actions, and custom action adapters.
 - [Sandbox Runtime Boundary](sandbox-runtime-boundary.md) defines the optional,

--- a/docs/internals/architecture/harness/agent-invocation-tool-boundary.md
+++ b/docs/internals/architecture/harness/agent-invocation-tool-boundary.md
@@ -60,9 +60,12 @@ Coding 不自行执行或绕过 Harness Gateway。
    `--no-prompt-templates`。子进程没有交互式审批通道，外层 Session 的
    Policy、Approval、Sandbox 和取消信号仍然有效。
 6. timeout 与输出上限由 Product 固定，模型不能修改；返回值是有界 plain
-   output，不解析或依赖 TUI JSONL 事件。
+   output，不解析或依赖 TUI JSONL 事件。滚动捕获产生的临时 artifact 由
+   `ExecService` 在投影完成前删除，既不向模型暴露，也不遗留在宿主文件系统。
 7. 可选 `cwd` 必须解析到当前 Session workspace 内；动态 Session cwd 是
    默认根，不能被 runtime builder 的初始目录错误固化。
+8. Coding 默认不注册该工具；只有用户通过显式 `--tools delegate_agent,...`
+   选择时才装配和激活，避免在缺少独立预算控制的 P0 中产生隐含成本与延迟。
 
 `ProcessEffect` 是必要但不充分的保护。真正的不放大来自外层执行授权、Sandbox
 ceiling 和子工具非扩张三者同时成立。
@@ -93,4 +96,5 @@ P0 不提供：
 - Gateway execution profile 和取消信号传到同一请求；
 - cwd 不越界，工具集不放大且不能递归派生；
 - timeout、cancel、非零退出、空输出和截断具有稳定语义；
-- 默认 Coding 装配提供该工具，显式 `--tools` 仍具有最终决定权。
+- 默认 Coding 装配不提供该工具，只有显式 `--tools delegate_agent,...` 才注册；
+- 大输出的滚动捕获不会遗留临时 artifact。

--- a/docs/internals/architecture/harness/agent-invocation-tool-boundary.md
+++ b/docs/internals/architecture/harness/agent-invocation-tool-boundary.md
@@ -1,0 +1,96 @@
+# One-Shot Agent Invocation Tool Boundary
+
+Status: P0 implemented (2026-08-04)
+
+## Decision
+
+`delegate_agent` 是一个有限、同步、一次性的 admitted tool，不是
+`harness.multiagent` 中的 child actor，也不是 Session、Work 或异步 job。
+第一版只允许 Coding 的只读 agent type，并复用当前 Session 的
+`ExecService` 启动一个 `loushang --mode print` 子进程：
+
+```text
+model tool call
+  -> AgentDelegateToolPack                         Harness
+  -> prepare complete immutable subprocess plan   Coding adapter
+  -> AuthorizedExecution + ProcessEffect          Harness Gateway
+  -> current Session ExecService / sandbox
+  -> bounded opaque stdout                        Coding adapter
+  -> AgentToolResult                              Harness
+```
+
+这个边界有意不复用 `spawn_agent` 的树、mailbox、round、follow-up、approval
+bubbling 和 child registry 语义。子进程退出后调用即结束。
+
+## Ownership
+
+Harness 拥有：
+
+- `AgentInvocationRequest`、`PreparedAgentInvocation` 和
+  `AgentInvocationResult` 三个冻结值对象；
+- `AgentInvocationAdapter` 这一窄 Product seam；
+- `AgentDelegateToolPack`、schema、顺序执行语义，以及
+  `AuthorizedExecution + ProcessEffect`；
+- prepare / authorize / execute / project 的不可绕过顺序。
+
+Coding 拥有：
+
+- agent type 准入、角色 system prompt 和每类工具集合；
+- `loushang` CLI argv、`--mode print` 输出含义、模型引用和 cwd 规则；
+- 子进程安全默认值与最终输出/错误投影；
+- 在 Product bootstrap 中把适配器注入 Harness tool pack。
+
+Harness 不认识 `loushang` CLI flag、Coding 角色或 plain-mode 事件 schema；
+Coding 不自行执行或绕过 Harness Gateway。
+
+## P0 Security Contract
+
+1. Product 先生成完整的 `ExecRequest`，再交给 Policy/Approval；授权对象包含
+   精确 argv、cwd、timeout、模型引用、工具白名单以及 task/environment 摘要。
+2. task 正文只通过 stdin 传入，不出现在 argv、`ProcessEffect`、Policy subject
+   或审计 arguments 中。完整继承环境同样不进入审计，只以摘要绑定冻结计划。
+3. handler 在执行前重新计算并核对上述授权事实；执行时把 Gateway 产生的
+   `EffectiveExecutionProfile` 绑定到同一个冻结请求。
+4. 子工具集合是“父会话允许的工具 ∩ Coding 只读角色工具”。无论父集合为何，
+   都删除 `delegate_agent`、整个 multi-agent tool pack 以及 `bash/write/edit`。
+   因而 P0 既不能跨进程递归派生，也不把提示词层面的“只读”误当成权限边界。
+   只有只读 execution profile 或等价的可验证策略传递落地后，才重新评估给
+   subprocess explorer 开放 shell。
+5. 子 CLI 强制 `--no-session`、`--no-extensions`、`--no-skills` 和
+   `--no-prompt-templates`。子进程没有交互式审批通道，外层 Session 的
+   Policy、Approval、Sandbox 和取消信号仍然有效。
+6. timeout 与输出上限由 Product 固定，模型不能修改；返回值是有界 plain
+   output，不解析或依赖 TUI JSONL 事件。
+7. 可选 `cwd` 必须解析到当前 Session workspace 内；动态 Session cwd 是
+   默认根，不能被 runtime builder 的初始目录错误固化。
+
+`ProcessEffect` 是必要但不充分的保护。真正的不放大来自外层执行授权、Sandbox
+ceiling 和子工具非扩张三者同时成立。
+
+## Explicit Non-Goals
+
+P0 不提供：
+
+- 写入型 implementation worker；
+- follow-up、steering、list、attach、resume 或持久 Session；
+- job id、后台轮询、跨调用取消或恢复；
+- JSONL event parsing、流式 child event 投影或远端 wire protocol；
+- 通用 `AgentRuntimeProvider`、`AgentExecutionPort` 或独立
+  `harness.agent_invocation` 子系统。
+
+只有出现第二个非工具消费者、第二个真实 backend、稳定异步 job，或需要版本化
+输出协议时，才重新评估是否从 `harness.tools.agent_delegate` 提炼独立 substrate。
+只有需要持续寻址、follow-up、审批冒泡、共享跨进程配额或恢复 Session 时，才把
+相应 backend 接到 `harness.multiagent`。
+
+## Verification
+
+架构与回归测试必须持续证明：
+
+- tool definition 使用 `AuthorizedExecution` 并声明 `ProcessEffect`；
+- Policy deny 时不会调用 exec service；
+- task/凭据不进入 authorization arguments；
+- Gateway execution profile 和取消信号传到同一请求；
+- cwd 不越界，工具集不放大且不能递归派生；
+- timeout、cancel、非零退出、空输出和截断具有稳定语义；
+- 默认 Coding 装配提供该工具，显式 `--tools` 仍具有最终决定权。

--- a/docs/internals/architecture/harness/multiagent/remote-agent-capability-boundary.md
+++ b/docs/internals/architecture/harness/multiagent/remote-agent-capability-boundary.md
@@ -4,6 +4,11 @@
 > 本文限定远程 Agent 能力如何进入 Harness；它不改变当前已实现的
 > session-owned in-process multiagent 语义。
 
+> Implementation note (2026-08-04): 本地 CLI subprocess 形态的 P0 已按
+> [One-Shot Agent Invocation Tool Boundary](../agent-invocation-tool-boundary.md)
+> 落地。它验证的是普通 admitted tool 的授权、非扩张工具集、取消和有界输出
+> 边界，不代表远端 wire protocol、异步 job 或 collaboration backend 已实现。
+
 ## Decision
 
 “远程”只描述部署位置，不决定交互生命周期。远端 Agent 可以是一次性
@@ -123,8 +128,9 @@ backend，不足以证明需要 `AgentExecutionPort`。它只在 Host 必须透�
 
 ## Delivery Order
 
-1. 先把一次性远端 Agent 作为普通 admitted capability 实现并验证输出、
-   artifact、授权、超时和错误投影。
+1. 先用已实现的本地 CLI subprocess P0 验证普通 admitted capability 的输出、
+   授权、非扩张工具集、超时和错误投影；接入远端时复用 tool 语义，但另行定义
+   client/wire 适配器与远端身份、传输和 artifact 契约。
 2. 任务确实会超出一次 tool call 生命周期时，再增加 `submit / await /
    cancel` 与 `RunRef`；不自动增加 mailbox 或 attach。
 3. 只有需要 steering / follow-up 时，才增加 remote collaboration adapter，

--- a/docs/internals/architecture/harness/workspace-execution-boundary.md
+++ b/docs/internals/architecture/harness/workspace-execution-boundary.md
@@ -67,6 +67,13 @@ The request capture fields remain caller-supplied neutral configuration. Their
 current defaults are preserved for compatibility; harness does not decide which
 commands a product may run.
 
+`retain_output_artifacts` defaults to `True`, preserving the diagnostic artifact
+contract for existing callers. A finite consumer that never publishes artifact
+paths may set it to `False`; the execution backend must then return bounded
+preview metadata without retaining capture files. Artifact creation and cleanup
+remain backend-owned mechanics rather than a tool-specific `unlink()` escape
+hatch.
+
 `materialize_exec_request()` freezes inherited cwd and the complete merged
 environment before a request crosses an asynchronous policy or execution
 boundary. `ExecRequest.env` remains the caller-visible override set;

--- a/src/loushang/coding/agent_invocation.py
+++ b/src/loushang/coding/agent_invocation.py
@@ -1,0 +1,280 @@
+"""Coding's CLI semantics for the Harness one-shot agent invocation tool."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+from loushang.ai.model import model_selection_ref, normalize_model_selection
+from loushang.coding.multiagent import (
+    coding_agent_type_system_prompt,
+    coding_read_only_agent_types,
+)
+from loushang.harness.multiagent import AgentTypeRegistry, AgentTypeSpec
+from loushang.harness.tools.agent_delegate import (
+    AGENT_DELEGATE_TOOL_NAME,
+    AgentDelegateToolPack,
+    AgentInvocationRequest,
+    AgentInvocationResult,
+    PreparedAgentInvocation,
+)
+from loushang.harness.tools.multiagent import MULTIAGENT_TOOL_NAMES
+from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
+from loushang.harness.workspace.exec import (
+    ExecRequest,
+    ExecResult,
+    materialize_exec_request,
+)
+from loushang.harness.workspace.truncation import truncate_tail
+
+DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS = 300.0
+DEFAULT_AGENT_INVOCATION_PREVIEW_BYTES = 64 * 1024
+DEFAULT_AGENT_INVOCATION_PREVIEW_LINES = 1_000
+DEFAULT_AGENT_INVOCATION_ROLLING_BYTES = 128 * 1024
+_SUBPROCESS_FORBIDDEN_TOOL_NAMES = frozenset(
+    {
+        AGENT_DELEGATE_TOOL_NAME,
+        *MULTIAGENT_TOOL_NAMES,
+        "bash",
+        "write",
+        "edit",
+    }
+)
+_ONE_SHOT_READ_ONLY_PROMPT = (
+    "This one-shot subprocess exposes only the listed read/search tools. "
+    "Bash and mutation tools are intentionally unavailable; do not attempt "
+    "to modify the workspace or spawn another agent."
+)
+
+
+class CodingCliAgentInvocationAdapter:
+    """Compile a finite Coding role into a hardened ``loushang`` subprocess."""
+
+    def __init__(
+        self,
+        *,
+        workspace_root: str | Path | None = None,
+        parent_allowed_tools: Iterable[str],
+        executable: str | Path | None = None,
+        environment: Mapping[str, str] | None = None,
+        agent_types: AgentTypeRegistry | None = None,
+        timeout_seconds: float = DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS,
+        preview_max_bytes: int = DEFAULT_AGENT_INVOCATION_PREVIEW_BYTES,
+        preview_max_lines: int = DEFAULT_AGENT_INVOCATION_PREVIEW_LINES,
+        rolling_max_bytes: int = DEFAULT_AGENT_INVOCATION_ROLLING_BYTES,
+    ) -> None:
+        root = (
+            Path(workspace_root).expanduser().resolve(strict=False)
+            if workspace_root is not None
+            else None
+        )
+        if root is not None and not root.is_dir():
+            raise NotADirectoryError(20, "Not a directory", str(root))
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        if preview_max_bytes < 1 or preview_max_lines < 1:
+            raise ValueError("preview limits must be positive")
+        if rolling_max_bytes < preview_max_bytes:
+            raise ValueError("rolling_max_bytes must be at least preview_max_bytes")
+
+        parent_tools = tuple(parent_allowed_tools)
+        if any(not isinstance(name, str) or not name for name in parent_tools):
+            raise ValueError("parent_allowed_tools must contain non-empty names")
+        self._workspace_root = root
+        self._parent_allowed_tools = frozenset(parent_tools)
+        self._executable = str(executable) if executable is not None else None
+        self._environment = dict(environment) if environment is not None else None
+        self._agent_types = agent_types or coding_read_only_agent_types()
+        self._timeout_seconds = float(timeout_seconds)
+        self._preview_max_bytes = preview_max_bytes
+        self._preview_max_lines = preview_max_lines
+        self._rolling_max_bytes = rolling_max_bytes
+
+    @property
+    def admitted_agent_types(self) -> tuple[str, ...]:
+        return tuple(spec.name for spec in self._agent_types.values())
+
+    def prepare(
+        self,
+        request: AgentInvocationRequest,
+        *,
+        default_cwd: str | None,
+        model: object | None,
+    ) -> PreparedAgentInvocation:
+        spec = self._resolve_agent_type(request.agent_type)
+        cwd = self._resolve_cwd(request.cwd, default_cwd=default_cwd)
+        allowed_tools = self._resolve_allowed_tools(spec)
+        resolved_model = spec.default_model or _model_ref(model)
+        command = [
+            self._resolve_executable(),
+            "--mode",
+            "print",
+            "--no-session",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+            "--system-prompt",
+            (
+                f"{coding_agent_type_system_prompt(spec.name)}\n\n"
+                f"{_ONE_SHOT_READ_ONLY_PROMPT}"
+            ),
+            "--tools",
+            ",".join(allowed_tools),
+            "--cwd",
+            str(cwd),
+        ]
+        if resolved_model is not None:
+            command.extend(("--model", resolved_model))
+        exec_request = materialize_exec_request(
+            ExecRequest(
+                command=tuple(command),
+                cwd=str(cwd),
+                timeout_seconds=self._timeout_seconds,
+                stdin=request.task,
+                preview_max_lines=self._preview_max_lines,
+                preview_max_bytes=self._preview_max_bytes,
+                capture_full_output=False,
+                rolling_max_bytes=self._rolling_max_bytes,
+            ),
+            environ=self._environment,
+        )
+        return PreparedAgentInvocation(
+            request=request,
+            exec_request=exec_request,
+            allowed_tools=allowed_tools,
+            model_ref=resolved_model,
+        )
+
+    def project(
+        self,
+        prepared: PreparedAgentInvocation,
+        result: ExecResult,
+    ) -> AgentInvocationResult:
+        del prepared
+        if result.exit_code == 0 and not result.timed_out and not result.cancelled:
+            raw_output = result.stdout_preview or result.stdout
+            truncated = result.stdout_truncated
+        else:
+            raw_output = (
+                result.stderr_preview
+                or result.stderr
+                or result.stdout_preview
+                or result.stdout
+            )
+            truncated = result.stderr_truncated or result.stdout_truncated
+        bounded = truncate_tail(
+            raw_output,
+            max_lines=self._preview_max_lines,
+            max_bytes=self._preview_max_bytes,
+        )
+        return AgentInvocationResult(
+            output_text=bounded.content,
+            exit_code=result.exit_code,
+            timed_out=result.timed_out,
+            cancelled=result.cancelled,
+            truncated=truncated or bounded.truncated,
+        )
+
+    def _resolve_agent_type(self, name: str) -> AgentTypeSpec:
+        spec = self._agent_types.resolve(name)
+        if spec is None:
+            raise ValueError(f"unknown or non-read-only Coding agent type: {name!r}")
+        return spec
+
+    def _resolve_allowed_tools(self, spec: AgentTypeSpec) -> tuple[str, ...]:
+        allowed = tuple(
+            name
+            for name in spec.allowed_tools
+            if name in self._parent_allowed_tools
+            and name not in _SUBPROCESS_FORBIDDEN_TOOL_NAMES
+        )
+        if not allowed:
+            raise PermissionError(
+                f"parent grants no admitted tools to Coding agent type {spec.name!r}"
+            )
+        return allowed
+
+    def _resolve_cwd(
+        self,
+        requested_cwd: str | None,
+        *,
+        default_cwd: str | None,
+    ) -> Path:
+        if default_cwd is None and self._workspace_root is None:
+            raise ValueError("delegated agent invocation requires a workspace cwd")
+        workspace_root = (
+            self._workspace_root
+            if self._workspace_root is not None
+            else Path(default_cwd or "").expanduser().resolve(strict=False)
+        )
+        base = (
+            Path(default_cwd).expanduser()
+            if default_cwd is not None
+            else workspace_root
+        )
+        candidate = Path(requested_cwd).expanduser() if requested_cwd else base
+        if not candidate.is_absolute():
+            candidate = base / candidate
+        resolved = candidate.resolve(strict=False)
+        if not resolved.is_relative_to(workspace_root):
+            raise PermissionError(
+                f"delegated agent cwd is outside the Coding workspace: {resolved}"
+            )
+        if not resolved.is_dir():
+            raise NotADirectoryError(20, "Not a directory", str(resolved))
+        return resolved
+
+    def _resolve_executable(self) -> str:
+        if self._executable is not None:
+            return _require_executable(self._executable)
+        adjacent = Path(sys.executable).resolve(strict=False).parent / "loushang"
+        if adjacent.is_file() and os.access(adjacent, os.X_OK):
+            return str(adjacent)
+        discovered = shutil.which("loushang")
+        if discovered is None:
+            raise FileNotFoundError(
+                "cannot locate the loushang CLI for delegated agent invocation"
+            )
+        return _require_executable(discovered)
+
+
+def register_coding_agent_delegate_tool(
+    registry: WorkspaceToolRegistry,
+    *,
+    workspace_root: str | Path | None = None,
+    parent_allowed_tools: Iterable[str],
+    executable: str | Path | None = None,
+    environment: Mapping[str, str] | None = None,
+) -> WorkspaceToolRegistry:
+    adapter = CodingCliAgentInvocationAdapter(
+        workspace_root=workspace_root,
+        parent_allowed_tools=parent_allowed_tools,
+        executable=executable,
+        environment=environment,
+    )
+    return AgentDelegateToolPack(adapter=adapter).register(registry)
+
+
+def _model_ref(model: object | None) -> str | None:
+    selection = normalize_model_selection(model)
+    return model_selection_ref(selection) if selection is not None else None
+
+
+def _require_executable(value: str | Path) -> str:
+    path = Path(value).expanduser().resolve(strict=False)
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise FileNotFoundError(f"loushang CLI is not executable: {path}")
+    return str(path)
+
+
+__all__ = [
+    "DEFAULT_AGENT_INVOCATION_PREVIEW_BYTES",
+    "DEFAULT_AGENT_INVOCATION_PREVIEW_LINES",
+    "DEFAULT_AGENT_INVOCATION_ROLLING_BYTES",
+    "DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS",
+    "CodingCliAgentInvocationAdapter",
+    "register_coding_agent_delegate_tool",
+]

--- a/src/loushang/coding/agent_invocation.py
+++ b/src/loushang/coding/agent_invocation.py
@@ -137,6 +137,7 @@ class CodingCliAgentInvocationAdapter:
                 preview_max_lines=self._preview_max_lines,
                 preview_max_bytes=self._preview_max_bytes,
                 capture_full_output=False,
+                retain_output_artifacts=False,
                 rolling_max_bytes=self._rolling_max_bytes,
             ),
             environ=self._environment,

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -11,6 +11,7 @@ from loushang.ai.model import (
     parse_model_selection_reference,
 )
 from loushang.ai.model.registry import get_default_model_registry
+from loushang.coding.agent_invocation import register_coding_agent_delegate_tool
 from loushang.coding.arch.tool import INSPECT_IMPORT_GRAPH_TOOL_NAME
 from loushang.coding.arch.tool_pack import register_coding_arch_tools
 from loushang.coding.bootstrap import (
@@ -230,6 +231,17 @@ def default_runtime_builder(
             ),
         )
     allowed_tool_names, active_tool_names = agent_tool_selection(args)
+    runtime_tool_registry = tool_registry.copy()
+    if not getattr(args, "no_builtin_tools", False):
+        registered_parent_tools = tuple(
+            definition.name
+            for definition in runtime_tool_registry.list_enabled_definitions()
+            if allowed_tool_names is None or definition.name in allowed_tool_names
+        )
+        register_coding_agent_delegate_tool(
+            runtime_tool_registry,
+            parent_allowed_tools=registered_parent_tools,
+        )
     resource_loader_options = configure_agent_resource_loader(
         services.resource_loader,
         args,
@@ -243,7 +255,7 @@ def default_runtime_builder(
         session_dir=session_dir,
         services=services,
         services_factory=services_factory,
-        tool_registry=tool_registry,
+        tool_registry=runtime_tool_registry,
         allowed_tool_names=allowed_tool_names,
         active_tool_names=active_tool_names,
         persist=not args.no_session,

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -129,6 +129,7 @@ from loushang.harness.resources.packages import (
 from loushang.harness.resources.packages.security import PackageSecurityPolicy
 from loushang.harness.resources.plugins import is_remote_plugin_source
 from loushang.harness.scenario import run_fake_workflow_cli
+from loushang.harness.tools.agent_delegate import AGENT_DELEGATE_TOOL_NAME
 from loushang.harness.tools.workspace import (
     WorkspaceToolRuntimeSettings,
     workspace_tool_runtime_settings,
@@ -232,7 +233,11 @@ def default_runtime_builder(
         )
     allowed_tool_names, active_tool_names = agent_tool_selection(args)
     runtime_tool_registry = tool_registry.copy()
-    if not getattr(args, "no_builtin_tools", False):
+    if (
+        not getattr(args, "no_builtin_tools", False)
+        and allowed_tool_names is not None
+        and AGENT_DELEGATE_TOOL_NAME in allowed_tool_names
+    ):
         registered_parent_tools = tuple(
             definition.name
             for definition in runtime_tool_registry.list_enabled_definitions()

--- a/src/loushang/coding/multiagent.py
+++ b/src/loushang/coding/multiagent.py
@@ -563,11 +563,17 @@ def _resolve_system_prompt(request: SessionSubagentRequest) -> str:
     return _coding_role_system_prompt(request.agent_type.name)
 
 
-def _coding_role_system_prompt(agent_type: str) -> str:
+def coding_agent_type_system_prompt(agent_type: str) -> str:
+    """Return Coding's complete system prompt for one admitted agent type."""
+
     role_prompt = _ROLE_PROMPTS.get(agent_type)
     if role_prompt is None:
         raise ValueError(f"Coding has no system prompt for agent type {agent_type!r}")
     return f"{DEFAULT_CODING_SYSTEM_PROMPT}\n\n{role_prompt}"
+
+
+def _coding_role_system_prompt(agent_type: str) -> str:
+    return coding_agent_type_system_prompt(agent_type)
 
 
 def _resolve_allowed_tools(request: SessionSubagentRequest) -> tuple[str, ...]:
@@ -599,6 +605,7 @@ def _select_tool_registry(
 
 __all__ = [
     "CodingSubagentFactory",
+    "coding_agent_type_system_prompt",
     "coding_multiagent_system_prompt",
     "coding_recipe_context_plan",
     "coding_read_only_agent_types",

--- a/src/loushang/harness/tools/__init__.py
+++ b/src/loushang/harness/tools/__init__.py
@@ -1,5 +1,14 @@
 """Product-neutral tool authoring and hosted-execution contracts."""
 
+from .agent_delegate import (
+    AGENT_DELEGATE_TOOL_NAME,
+    AGENT_DELEGATE_TOOL_PACK,
+    AgentDelegateToolPack,
+    AgentInvocationAdapter,
+    AgentInvocationRequest,
+    AgentInvocationResult,
+    PreparedAgentInvocation,
+)
 from .authoring import (
     FilesystemActionAdapter,
     NetworkActionAdapter,
@@ -16,10 +25,17 @@ from .core import ToolDefinition, ToolRegistry
 from .execution import ToolExecutionHost
 
 __all__ = [
+    "AGENT_DELEGATE_TOOL_NAME",
+    "AGENT_DELEGATE_TOOL_PACK",
+    "AgentDelegateToolPack",
+    "AgentInvocationAdapter",
+    "AgentInvocationRequest",
+    "AgentInvocationResult",
     "FilesystemActionAdapter",
     "NetworkActionAdapter",
     "ProcessActionAdapter",
     "PublicationActionAdapter",
+    "PreparedAgentInvocation",
     "ToolContext",
     "ToolContextProvider",
     "ToolDefinition",

--- a/src/loushang/harness/tools/agent_delegate.py
+++ b/src/loushang/harness/tools/agent_delegate.py
@@ -1,0 +1,418 @@
+"""Authorized one-shot agent invocation exposed as a model-visible tool."""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import os
+from dataclasses import dataclass, field, replace
+from typing import Any, Protocol
+
+from loushang.agent.types import AgentToolResult, TextPart
+from loushang.ai.types import ToolCall
+from loushang.harness.effects import ProcessEffect
+from loushang.harness.policy import (
+    build_tool_policy_subject,
+    executable_search_path_from_env,
+    normalize_command_subject,
+)
+from loushang.harness.tools.contribution import ToolPackDefinition
+from loushang.harness.tools.core import ToolDefinition
+from loushang.harness.tools.execution import (
+    AuthorizedExecution,
+    AuthorizedToolAction,
+    AuthorizedToolContext,
+    PreparedToolAction,
+    ToolCallContext,
+)
+from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
+from loushang.harness.workspace.exec import ExecRequest, ExecResult
+
+AGENT_DELEGATE_TOOL_NAME = "delegate_agent"
+AGENT_DELEGATE_TOOL_PACK = ToolPackDefinition(
+    name="harness.agent_delegate",
+    tools=(AGENT_DELEGATE_TOOL_NAME,),
+)
+MAX_AGENT_DELEGATE_TASK_CHARS = 100_000
+
+
+@dataclass(frozen=True, slots=True)
+class AgentInvocationRequest:
+    """Model-requested, Product-neutral input for one finite invocation."""
+
+    agent_type: str
+    task: str = field(repr=False)
+    cwd: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.agent_type, str) or not self.agent_type.strip():
+            raise ValueError("agent_type must be a non-empty string")
+        if not isinstance(self.task, str) or not self.task.strip():
+            raise ValueError("task must be a non-empty string")
+        if len(self.task) > MAX_AGENT_DELEGATE_TASK_CHARS:
+            raise ValueError(
+                "task exceeds the delegate_agent input limit of "
+                f"{MAX_AGENT_DELEGATE_TASK_CHARS} characters"
+            )
+        if self.cwd is not None and (
+            not isinstance(self.cwd, str) or not self.cwd.strip()
+        ):
+            raise ValueError("cwd must be a non-empty string when provided")
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedAgentInvocation:
+    """Complete subprocess plan frozen before Policy and Approval."""
+
+    request: AgentInvocationRequest
+    exec_request: ExecRequest = field(repr=False)
+    allowed_tools: tuple[str, ...]
+    model_ref: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request, AgentInvocationRequest):
+            raise TypeError("request must be an AgentInvocationRequest")
+        if not isinstance(self.exec_request, ExecRequest):
+            raise TypeError("exec_request must be an ExecRequest")
+        tools = tuple(self.allowed_tools)
+        if not tools or any(not isinstance(tool, str) or not tool for tool in tools):
+            raise ValueError("allowed_tools must contain non-empty tool names")
+        if len(set(tools)) != len(tools):
+            raise ValueError("allowed_tools must not contain duplicates")
+        if self.model_ref is not None and (
+            not isinstance(self.model_ref, str) or not self.model_ref
+        ):
+            raise ValueError("model_ref must be non-empty when provided")
+        if not self.exec_request.command:
+            raise ValueError("agent invocation command must not be empty")
+        if self.exec_request.cwd is None:
+            raise ValueError("agent invocation cwd must be materialized")
+        if self.exec_request.effective_environment is None:
+            raise ValueError("agent invocation environment must be materialized")
+        if self.exec_request.stdin != self.request.task:
+            raise ValueError("agent invocation task must be carried through stdin")
+        object.__setattr__(self, "allowed_tools", tools)
+
+    @property
+    def task_digest(self) -> str:
+        return _text_digest(self.request.task)
+
+    @property
+    def environment_digest(self) -> str:
+        environment = self.exec_request.effective_environment
+        assert environment is not None
+        serialized = json.dumps(
+            sorted(environment),
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        return _text_digest(serialized)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentInvocationResult:
+    """Bounded child-process projection returned to the invoking model."""
+
+    output_text: str = field(repr=False)
+    exit_code: int
+    timed_out: bool = False
+    cancelled: bool = False
+    truncated: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.output_text, str):
+            raise TypeError("output_text must be a string")
+        if type(self.exit_code) is not int:
+            raise TypeError("exit_code must be an integer")
+        for name, value in (
+            ("timed_out", self.timed_out),
+            ("cancelled", self.cancelled),
+            ("truncated", self.truncated),
+        ):
+            if type(value) is not bool:
+                raise TypeError(f"{name} must be a boolean")
+
+
+class AgentInvocationAdapter(Protocol):
+    """Product-owned compiler/projector around the neutral process boundary."""
+
+    @property
+    def admitted_agent_types(self) -> tuple[str, ...]: ...
+
+    def prepare(
+        self,
+        request: AgentInvocationRequest,
+        *,
+        default_cwd: str | None,
+        model: object | None,
+    ) -> PreparedAgentInvocation: ...
+
+    def project(
+        self,
+        prepared: PreparedAgentInvocation,
+        result: ExecResult,
+    ) -> AgentInvocationResult: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _AgentDelegateActionAdapter:
+    adapter: AgentInvocationAdapter
+
+    def prepare(
+        self,
+        call: ToolCall,
+        context: ToolCallContext,
+    ) -> PreparedToolAction:
+        arguments = dict(call.arguments)
+        request = AgentInvocationRequest(
+            agent_type=_required_string(arguments.get("agent_type"), "agent_type"),
+            task=_required_string(arguments.get("task"), "task"),
+            cwd=_optional_string(arguments.get("cwd"), "cwd"),
+        )
+        if request.agent_type not in self.adapter.admitted_agent_types:
+            raise ValueError(
+                f"agent type {request.agent_type!r} is not admitted for "
+                f"{AGENT_DELEGATE_TOOL_NAME}"
+            )
+        prepared = self.adapter.prepare(
+            request,
+            default_cwd=context.cwd,
+            model=context.model,
+        )
+        _validate_adapter_output(request, prepared)
+        exec_request = prepared.exec_request
+        environment = exec_request.effective_environment
+        assert environment is not None
+        effect = ProcessEffect(exec_request.command)
+        authorization_arguments = _authorization_arguments(prepared)
+        command_subject = normalize_command_subject(
+            exec_request.command,
+            cwd=exec_request.cwd,
+            stdin=None,
+            executable_search_path=executable_search_path_from_env(
+                environment,
+                default=os.defpath,
+            ),
+            environment_overrides=environment,
+            environment_is_complete=True,
+        )
+        return PreparedToolAction(
+            tool_name=AGENT_DELEGATE_TOOL_NAME,
+            authorization_arguments=authorization_arguments,
+            execution_arguments={"prepared_invocation": prepared},
+            cwd=exec_request.cwd,
+            effects=(effect,),
+            policy_subject=build_tool_policy_subject(
+                tool_name=AGENT_DELEGATE_TOOL_NAME,
+                arguments=authorization_arguments,
+                cwd=exec_request.cwd,
+                command=command_subject,
+                effects=(effect,),
+            ),
+            execution_environment=environment,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _AgentDelegateAuthorizedHandler:
+    adapter: AgentInvocationAdapter
+
+    async def __call__(
+        self,
+        action: AuthorizedToolAction,
+        context: AuthorizedToolContext,
+    ) -> AgentToolResult[dict[str, Any]]:
+        prepared = action.execution_arguments.get("prepared_invocation")
+        if not isinstance(prepared, PreparedAgentInvocation):
+            raise TypeError(
+                "authorized delegate_agent action requires a "
+                "PreparedAgentInvocation"
+            )
+        if dict(action.authorization_arguments) != _authorization_arguments(prepared):
+            raise RuntimeError("authorized delegate_agent plan no longer matches")
+        execute = getattr(context.exec_service, "execute", None)
+        if not callable(execute):
+            raise RuntimeError("delegate_agent requires an authorized exec service")
+
+        exec_request = (
+            replace(
+                prepared.exec_request,
+                execution_profile=action.execution_profile,
+            )
+            if action.execution_profile is not None
+            else prepared.exec_request
+        )
+        result = execute(exec_request, signal=context.signal)
+        if inspect.isawaitable(result):
+            result = await result
+        if not isinstance(result, ExecResult):
+            raise TypeError("delegate_agent exec service must return ExecResult")
+
+        projected = self.adapter.project(prepared, result)
+        if not isinstance(projected, AgentInvocationResult):
+            raise TypeError(
+                "agent invocation adapter must return AgentInvocationResult"
+            )
+        if (
+            projected.exit_code != result.exit_code
+            or projected.timed_out != result.timed_out
+            or projected.cancelled != result.cancelled
+        ):
+            raise RuntimeError(
+                "agent invocation adapter changed subprocess status semantics"
+            )
+        if projected.timed_out:
+            raise TimeoutError(_failure_message(projected, "Delegated agent timed out"))
+        if projected.cancelled:
+            raise RuntimeError(_failure_message(projected, "Delegated agent aborted"))
+        if projected.exit_code != 0:
+            raise RuntimeError(
+                _failure_message(
+                    projected,
+                    f"Delegated agent exited with code {projected.exit_code}",
+                )
+            )
+        if not projected.output_text.strip():
+            raise RuntimeError("Delegated agent returned no output")
+        return AgentToolResult(
+            content=[TextPart(type="text", text=projected.output_text)],
+            details={
+                "agent_type": prepared.request.agent_type,
+                "exit_code": projected.exit_code,
+                "timed_out": projected.timed_out,
+                "cancelled": projected.cancelled,
+                "truncated": projected.truncated,
+                "allowed_tools": list(prepared.allowed_tools),
+                "model": prepared.model_ref,
+            },
+        )
+
+
+class AgentDelegateToolPack:
+    """Bind one Product adapter to the shared authorized tool definition."""
+
+    def __init__(self, *, adapter: AgentInvocationAdapter) -> None:
+        admitted = tuple(adapter.admitted_agent_types)
+        if not admitted or any(
+            not isinstance(agent_type, str) or not agent_type
+            for agent_type in admitted
+        ):
+            raise ValueError("delegate_agent requires admitted agent types")
+        if len(set(admitted)) != len(admitted):
+            raise ValueError("admitted agent types must not contain duplicates")
+        self._adapter = adapter
+        self._admitted_agent_types = admitted
+
+    def definitions(self) -> tuple[ToolDefinition, ...]:
+        return (self.definition(),)
+
+    def definition(self) -> ToolDefinition:
+        return ToolDefinition(
+            name=AGENT_DELEGATE_TOOL_NAME,
+            label="Delegate agent",
+            description=(
+                "Run one admitted read-only agent as a finite subprocess and "
+                "return its bounded output. The child has no session, follow-up, "
+                "interactive approval, or further agent-delegation capability."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "agent_type": {
+                        "type": "string",
+                        "enum": list(self._admitted_agent_types),
+                    },
+                    "task": {
+                        "type": "string",
+                        "maxLength": MAX_AGENT_DELEGATE_TASK_CHARS,
+                    },
+                    "cwd": {"type": "string"},
+                },
+                "required": ["agent_type", "task"],
+                "additionalProperties": False,
+            },
+            execution=AuthorizedExecution(
+                action_adapter=_AgentDelegateActionAdapter(self._adapter),
+                handler=_AgentDelegateAuthorizedHandler(self._adapter),
+            ),
+            execution_mode="sequential",
+            prompt_snippet=(
+                "- delegate_agent: Run one bounded read-only agent task in a "
+                "subprocess and wait for its output."
+            ),
+            prompt_guidelines=(
+                "Use delegate_agent only for a focused task that can finish in one response.",
+                "Do not expect follow-up, steering, persisted state, or interactive approval from the child.",
+            ),
+        )
+
+    def register(
+        self,
+        registry: WorkspaceToolRegistry,
+        *,
+        enabled: bool = True,
+    ) -> WorkspaceToolRegistry:
+        registry.register_tool(self.definition(), enabled=enabled)
+        return registry
+
+
+def _authorization_arguments(
+    prepared: PreparedAgentInvocation,
+) -> dict[str, object]:
+    request = prepared.exec_request
+    return {
+        "agent_type": prepared.request.agent_type,
+        "cwd": request.cwd,
+        "command": request.command,
+        "allowed_tools": prepared.allowed_tools,
+        "model": prepared.model_ref,
+        "task_sha256": prepared.task_digest,
+        "environment_sha256": prepared.environment_digest,
+        "timeout_seconds": request.timeout_seconds,
+    }
+
+
+def _validate_adapter_output(
+    request: AgentInvocationRequest,
+    prepared: PreparedAgentInvocation,
+) -> None:
+    if not isinstance(prepared, PreparedAgentInvocation):
+        raise TypeError(
+            "agent invocation adapter must return PreparedAgentInvocation"
+        )
+    if prepared.request != request:
+        raise ValueError("agent invocation adapter changed the invocation request")
+
+
+def _required_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise TypeError(f"{field_name} must be a non-empty string")
+    return value
+
+
+def _optional_string(value: object, field_name: str) -> str | None:
+    if value is None:
+        return None
+    return _required_string(value, field_name)
+
+
+def _text_digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8", errors="surrogatepass")).hexdigest()
+
+
+def _failure_message(result: AgentInvocationResult, prefix: str) -> str:
+    output = result.output_text.strip()
+    return f"{prefix}: {output}" if output else prefix
+
+
+__all__ = [
+    "AGENT_DELEGATE_TOOL_NAME",
+    "AGENT_DELEGATE_TOOL_PACK",
+    "MAX_AGENT_DELEGATE_TASK_CHARS",
+    "AgentDelegateToolPack",
+    "AgentInvocationAdapter",
+    "AgentInvocationRequest",
+    "AgentInvocationResult",
+    "PreparedAgentInvocation",
+]

--- a/src/loushang/harness/workspace/exec/service.py
+++ b/src/loushang/harness/workspace/exec/service.py
@@ -86,12 +86,14 @@ class LocalExecBackend:
         stdout_capture = _StreamCapture(
             stream_name="stdout",
             capture_full_output=request.capture_full_output,
+            retain_output_artifact=request.retain_output_artifacts,
             rolling_max_bytes=request.rolling_max_bytes,
             artifact_dir=request.artifact_dir,
         )
         stderr_capture = _StreamCapture(
             stream_name="stderr",
             capture_full_output=request.capture_full_output,
+            retain_output_artifact=request.retain_output_artifacts,
             rolling_max_bytes=request.rolling_max_bytes,
             artifact_dir=request.artifact_dir,
         )
@@ -226,6 +228,7 @@ class LocalExecBackend:
 class _StreamCapture:
     stream_name: str
     capture_full_output: bool
+    retain_output_artifact: bool
     rolling_max_bytes: int
     artifact_dir: str | None
     chunks: list[str] = field(default_factory=list)
@@ -274,6 +277,8 @@ class _StreamCapture:
         if self._artifact_handle is not None:
             self._artifact_handle.close()
             self._artifact_handle = None
+        if not self.retain_output_artifact:
+            self.discard_artifact()
 
     def discard_artifact(self) -> None:
         if self._artifact_path is None:
@@ -394,6 +399,15 @@ def _build_preview_from_capture(
     max_bytes: int,
 ):
     if capture.capture_full_output:
+        if not capture.retain_output_artifact:
+            return (
+                truncate_tail(
+                    capture.content,
+                    max_lines=max_lines,
+                    max_bytes=max_bytes,
+                ),
+                None,
+            )
         return _build_preview(
             capture.content,
             max_lines=max_lines,

--- a/src/loushang/harness/workspace/exec/types.py
+++ b/src/loushang/harness/workspace/exec/types.py
@@ -65,6 +65,7 @@ class ExecRequest:
     artifact_dir: str | None = None
     capture_full_output: bool = True
     rolling_max_bytes: int = 100 * 1024
+    retain_output_artifacts: bool = True
     effective_environment: tuple[tuple[str, str], ...] | None = field(
         default=None,
         repr=False,

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -2154,6 +2154,48 @@ def test_harness_slice1_symbols_are_not_top_level_exports() -> None:
     assert slice1_symbols.isdisjoint(set(harness.__all__))
 
 
+def test_agent_delegate_declares_authorized_process_execution() -> None:
+    from loushang.ai.types import ToolCall
+    from loushang.harness.effects import ProcessEffect
+    from loushang.harness.tools.agent_delegate import AgentDelegateToolPack
+    from loushang.harness.tools.execution import AuthorizedExecution, ToolCallContext
+
+    class Adapter:
+        admitted_agent_types = ("reviewer",)
+
+        def prepare(self, request, *, default_cwd, model):
+            from loushang.harness.tools.agent_delegate import PreparedAgentInvocation
+            from loushang.harness.workspace.exec import ExecRequest
+
+            del model
+            return PreparedAgentInvocation(
+                request=request,
+                exec_request=ExecRequest(
+                    command=("/usr/bin/loushang", "--mode", "print"),
+                    cwd=default_cwd,
+                    stdin=request.task,
+                    effective_environment=(("PATH", "/usr/bin"),),
+                ),
+                allowed_tools=("read",),
+            )
+
+        def project(self, prepared, result):
+            raise AssertionError("not used")
+
+    definition = AgentDelegateToolPack(adapter=Adapter()).definition()
+    assert isinstance(definition.execution, AuthorizedExecution)
+    prepared = definition.execution.action_adapter.prepare(
+        ToolCall(
+            type="toolCall",
+            id="call-1",
+            name="delegate_agent",
+            arguments={"agent_type": "reviewer", "task": "review"},
+        ),
+        ToolCallContext(tool_call_id="call-1", cwd="/workspace"),
+    )
+    assert isinstance(prepared.effects[0], ProcessEffect)
+
+
 def test_harness_workspace_symbols_are_not_top_level_exports() -> None:
     import loushang.harness as harness
 

--- a/tests/coding/test_agent_invocation.py
+++ b/tests/coding/test_agent_invocation.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from loushang.agent import AbortController
 from loushang.ai.types import ToolCall
 from loushang.coding.agent_invocation import CodingCliAgentInvocationAdapter
 from loushang.coding.cli.args import parse_args
@@ -65,6 +67,7 @@ def test_coding_cli_invocation_compiles_a_hardened_non_widening_command(
     assert task not in request.command
     assert request.timeout_seconds == 45
     assert request.capture_full_output is False
+    assert request.retain_output_artifacts is False
     assert request.effective_environment == (
         ("PATH", "/usr/bin"),
         ("PROVIDER_TOKEN", "secret"),
@@ -208,7 +211,7 @@ def test_coding_delegate_runs_through_the_real_exec_service(tmp_path: Path) -> N
     workspace.mkdir()
     executable = tmp_path / "loushang"
     executable.write_text(
-        "#!/bin/sh\nIFS= read -r task\nprintf 'child:%s\\n' \"$task\"\n",
+        "#!/bin/sh\ntask=$(cat)\nprintf 'child:%s\\n' \"$task\"\n",
         encoding="utf-8",
     )
     executable.chmod(0o755)
@@ -220,6 +223,7 @@ def test_coding_delegate_runs_through_the_real_exec_service(tmp_path: Path) -> N
     )
     definition = AgentDelegateToolPack(adapter=adapter).definition()
 
+    task = "检查 parser\nreport ✓"
     result = asyncio.run(
         create_workspace_tool_execution_host(policy_evaluator=None).dispatch(
             definition,
@@ -227,7 +231,7 @@ def test_coding_delegate_runs_through_the_real_exec_service(tmp_path: Path) -> N
                 type="toolCall",
                 id="delegate-1",
                 name="delegate_agent",
-                arguments={"agent_type": "reviewer", "task": "inspect parser"},
+                arguments={"agent_type": "reviewer", "task": task},
             ),
             ToolCallContext(
                 tool_call_id="delegate-1",
@@ -237,8 +241,95 @@ def test_coding_delegate_runs_through_the_real_exec_service(tmp_path: Path) -> N
         )
     )
 
-    assert result.content[0].text == "child:inspect parser\n"
+    assert result.content[0].text == f"child:{task}\n"
     assert result.details["exit_code"] == 0
+
+
+def test_coding_delegate_cancels_the_real_subprocess(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = tmp_path / "loushang"
+    executable.write_text("#!/bin/sh\nsleep 30\nprintf never\n", encoding="utf-8")
+    executable.chmod(0o755)
+    adapter = CodingCliAgentInvocationAdapter(
+        workspace_root=workspace,
+        parent_allowed_tools=("read",),
+        executable=executable,
+        environment={"PATH": "/usr/bin:/bin"},
+        timeout_seconds=5,
+    )
+    definition = AgentDelegateToolPack(adapter=adapter).definition()
+    controller = AbortController()
+
+    async def scenario() -> None:
+        async def abort_soon() -> None:
+            await asyncio.sleep(0.05)
+            controller.abort()
+
+        abort_task = asyncio.create_task(abort_soon())
+        with pytest.raises(RuntimeError, match="Delegated agent aborted"):
+            await create_workspace_tool_execution_host(
+                policy_evaluator=None
+            ).dispatch(
+                definition,
+                ToolCall(
+                    type="toolCall",
+                    id="delegate-cancel",
+                    name="delegate_agent",
+                    arguments={"agent_type": "reviewer", "task": "wait"},
+                ),
+                ToolCallContext(
+                    tool_call_id="delegate-cancel",
+                    cwd=str(workspace),
+                    signal=controller.signal,
+                    exec_service=ExecService(),
+                ),
+            )
+        await abort_task
+
+    asyncio.run(scenario())
+
+
+def test_coding_invocation_bounds_large_output_without_leaking_artifacts(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    artifact_dir = tmp_path / "artifacts"
+    workspace.mkdir()
+    artifact_dir.mkdir()
+    executable = tmp_path / "loushang"
+    executable.write_text(
+        "#!/bin/sh\ni=0\nwhile [ $i -lt 400 ]; do "
+        "printf 'line-%04d\\n' \"$i\"; i=$((i + 1)); done\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    adapter = CodingCliAgentInvocationAdapter(
+        workspace_root=workspace,
+        parent_allowed_tools=("read",),
+        executable=executable,
+        environment={"PATH": "/usr/bin:/bin"},
+        preview_max_bytes=1024,
+        preview_max_lines=2,
+        rolling_max_bytes=1024,
+    )
+    prepared = adapter.prepare(
+        AgentInvocationRequest(agent_type="reviewer", task="inspect"),
+        default_cwd=str(workspace),
+        model=None,
+    )
+
+    exec_result = asyncio.run(
+        ExecService().execute(
+            replace(prepared.exec_request, artifact_dir=str(artifact_dir))
+        )
+    )
+    projected = adapter.project(prepared, exec_result)
+
+    assert projected.output_text == "line-0398\nline-0399\n"
+    assert projected.truncated is True
+    assert exec_result.stdout_artifact_path is None
+    assert list(artifact_dir.iterdir()) == []
 
 
 def _flag_value(command: tuple[str, ...], flag: str) -> str:

--- a/tests/coding/test_agent_invocation.py
+++ b/tests/coding/test_agent_invocation.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from loushang.ai.types import ToolCall
+from loushang.coding.agent_invocation import CodingCliAgentInvocationAdapter
+from loushang.coding.cli.args import parse_args
+from loushang.harness.tools.agent_delegate import (
+    AgentDelegateToolPack,
+    AgentInvocationRequest,
+)
+from loushang.harness.tools.execution import ToolCallContext
+from loushang.harness.tools.workspace.authorization import (
+    create_workspace_tool_execution_host,
+)
+from loushang.harness.workspace.exec import ExecResult, ExecService
+
+
+def _executable(tmp_path: Path) -> Path:
+    executable = tmp_path / "loushang"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+    return executable
+
+
+def test_coding_cli_invocation_compiles_a_hardened_non_widening_command(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    nested = workspace / "src"
+    nested.mkdir(parents=True)
+    executable = _executable(tmp_path)
+    adapter = CodingCliAgentInvocationAdapter(
+        workspace_root=workspace,
+        parent_allowed_tools=(
+            "delegate_agent",
+            "spawn_agent",
+            "bash",
+            "read",
+            "grep",
+        ),
+        executable=executable,
+        environment={"PATH": "/usr/bin", "PROVIDER_TOKEN": "secret"},
+        timeout_seconds=45,
+    )
+    task = "inspect the parser without changing files"
+
+    prepared = adapter.prepare(
+        AgentInvocationRequest(
+            agent_type="explorer",
+            task=task,
+            cwd="src",
+        ),
+        default_cwd=str(workspace),
+        model=SimpleNamespace(provider_id="openai", id="gpt-test"),
+    )
+
+    request = prepared.exec_request
+    assert request.cwd == str(nested)
+    assert request.stdin == task
+    assert task not in request.command
+    assert request.timeout_seconds == 45
+    assert request.capture_full_output is False
+    assert request.effective_environment == (
+        ("PATH", "/usr/bin"),
+        ("PROVIDER_TOKEN", "secret"),
+    )
+    assert prepared.allowed_tools == ("read", "grep")
+    assert prepared.model_ref == "openai/gpt-test"
+    assert request.command[0] == str(executable.resolve())
+    assert _flag_value(request.command, "--mode") == "print"
+    assert _flag_value(request.command, "--tools") == "read,grep"
+    assert _flag_value(request.command, "--cwd") == str(nested)
+    assert _flag_value(request.command, "--model") == "openai/gpt-test"
+    assert _flag_value(request.command, "--system-prompt")
+    assert {
+        "--no-session",
+        "--no-extensions",
+        "--no-skills",
+        "--no-prompt-templates",
+    }.issubset(request.command)
+    assert "delegate_agent" not in _flag_value(request.command, "--tools")
+    assert "spawn_agent" not in _flag_value(request.command, "--tools")
+    assert "bash" not in _flag_value(request.command, "--tools")
+    child_args = parse_args(list(request.command[1:]))
+    assert child_args.mode == "print"
+    assert child_args.no_session is True
+    assert child_args.no_extensions is True
+    assert child_args.no_skills is True
+    assert child_args.no_prompt_templates is True
+    assert child_args.tools == ("read", "grep")
+
+
+def test_coding_cli_invocation_uses_the_live_session_cwd_as_dynamic_root(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    adapter = CodingCliAgentInvocationAdapter(
+        parent_allowed_tools=("read",),
+        executable=_executable(tmp_path),
+    )
+
+    prepared = adapter.prepare(
+        AgentInvocationRequest(agent_type="reviewer", task="review"),
+        default_cwd=str(second),
+        model=None,
+    )
+
+    assert prepared.exec_request.cwd == str(second)
+
+
+def test_coding_cli_invocation_rejects_cwd_escape_and_non_read_only_roles(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    adapter = CodingCliAgentInvocationAdapter(
+        workspace_root=workspace,
+        parent_allowed_tools=("read",),
+        executable=_executable(tmp_path),
+    )
+
+    with pytest.raises(PermissionError, match="outside"):
+        adapter.prepare(
+            AgentInvocationRequest(
+                agent_type="reviewer",
+                task="review",
+                cwd=str(outside),
+            ),
+            default_cwd=str(workspace),
+            model=None,
+        )
+    with pytest.raises(ValueError, match="non-read-only"):
+        adapter.prepare(
+            AgentInvocationRequest(
+                agent_type="implementation_worker",
+                task="edit",
+            ),
+            default_cwd=str(workspace),
+            model=None,
+        )
+
+
+def test_coding_cli_invocation_rejects_when_parent_grants_no_role_tools(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    adapter = CodingCliAgentInvocationAdapter(
+        workspace_root=workspace,
+        parent_allowed_tools=("delegate_agent", "spawn_agent"),
+        executable=_executable(tmp_path),
+    )
+
+    with pytest.raises(PermissionError, match="grants no admitted tools"):
+        adapter.prepare(
+            AgentInvocationRequest(agent_type="reviewer", task="review"),
+            default_cwd=str(workspace),
+            model=None,
+        )
+
+
+def test_coding_cli_invocation_projects_bounded_stdout_and_errors(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    adapter = CodingCliAgentInvocationAdapter(
+        workspace_root=workspace,
+        parent_allowed_tools=("read",),
+        executable=_executable(tmp_path),
+        preview_max_bytes=16,
+        preview_max_lines=2,
+        rolling_max_bytes=32,
+    )
+    prepared = adapter.prepare(
+        AgentInvocationRequest(agent_type="reviewer", task="review"),
+        default_cwd=str(workspace),
+        model=None,
+    )
+
+    success = adapter.project(
+        prepared,
+        ExecResult(exit_code=0, stdout="one\ntwo\nthree\n"),
+    )
+    failure = adapter.project(
+        prepared,
+        ExecResult(exit_code=2, stdout="ignored", stderr="safe failure"),
+    )
+
+    assert success.output_text == "two\nthree\n"
+    assert success.truncated is True
+    assert failure.output_text == "safe failure"
+    assert failure.exit_code == 2
+
+
+def test_coding_delegate_runs_through_the_real_exec_service(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    executable = tmp_path / "loushang"
+    executable.write_text(
+        "#!/bin/sh\nIFS= read -r task\nprintf 'child:%s\\n' \"$task\"\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    adapter = CodingCliAgentInvocationAdapter(
+        workspace_root=workspace,
+        parent_allowed_tools=("read",),
+        executable=executable,
+        environment={"PATH": "/usr/bin:/bin"},
+    )
+    definition = AgentDelegateToolPack(adapter=adapter).definition()
+
+    result = asyncio.run(
+        create_workspace_tool_execution_host(policy_evaluator=None).dispatch(
+            definition,
+            ToolCall(
+                type="toolCall",
+                id="delegate-1",
+                name="delegate_agent",
+                arguments={"agent_type": "reviewer", "task": "inspect parser"},
+            ),
+            ToolCallContext(
+                tool_call_id="delegate-1",
+                cwd=str(workspace),
+                exec_service=ExecService(),
+            ),
+        )
+    )
+
+    assert result.content[0].text == "child:inspect parser\n"
+    assert result.details["exit_code"] == 0
+
+
+def _flag_value(command: tuple[str, ...], flag: str) -> str:
+    index = command.index(flag)
+    return command[index + 1]

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -1031,6 +1031,43 @@ def test_default_runtime_builder_maps_no_tools_to_empty_allowed_tools(tmp_path) 
     assert session.multiagent_runtime is not None
 
 
+def test_default_runtime_builder_registers_delegate_only_when_explicitly_selected(
+    tmp_path,
+) -> None:
+    from loushang.coding.bootstrap import create_services
+    from loushang.coding.cli.__main__ import default_runtime_builder
+    from loushang.coding.tool_pack import (
+        register_coding_builtin_tools as register_builtin_tools,
+    )
+    from loushang.harness.tools.agent_delegate import AGENT_DELEGATE_TOOL_NAME
+    from loushang.harness.tools.workspace.registry import (
+        WorkspaceToolRegistry as ToolRegistry,
+    )
+
+    registry = ToolRegistry()
+    register_builtin_tools(registry)
+    runtime = default_runtime_builder(
+        args=SimpleNamespace(
+            no_tools=False,
+            tools=(AGENT_DELEGATE_TOOL_NAME, "read"),
+            no_builtin_tools=False,
+            no_session=True,
+        ),
+        cwd=tmp_path,
+        session_dir=tmp_path / "sessions",
+        services=create_services(),
+        tool_registry=registry,
+    )
+
+    session = asyncio.run(runtime.create_session(cwd=str(tmp_path)))
+
+    assert session.get_active_tool_names() == [AGENT_DELEGATE_TOOL_NAME, "read"]
+    assert {definition.name for definition in session.get_all_tools()} == {
+        AGENT_DELEGATE_TOOL_NAME,
+        "read",
+    }
+
+
 def test_default_runtime_builder_does_not_restore_delegate_when_builtins_disabled(
     tmp_path,
 ) -> None:
@@ -1160,7 +1197,7 @@ def test_default_runtime_builder_rebuilds_project_bound_services_for_session_cwd
     assert second.cwd_bound_services_audit.ok is True
     assert "Project B guidance" in second.agent.system_prompt
     assert "## Multi-agent collaboration" in second.agent.system_prompt
-    assert AGENT_DELEGATE_TOOL_NAME in second.get_active_tool_names()
+    assert AGENT_DELEGATE_TOOL_NAME not in second.get_active_tool_names()
     assert set(MULTIAGENT_TOOL_NAMES).issubset(second.get_active_tool_names())
     assert not set(MULTIAGENT_TOOL_NAMES).intersection(
         definition.name for definition in registry.list_definitions()

--- a/tests/coding/test_cli.py
+++ b/tests/coding/test_cli.py
@@ -1031,6 +1031,36 @@ def test_default_runtime_builder_maps_no_tools_to_empty_allowed_tools(tmp_path) 
     assert session.multiagent_runtime is not None
 
 
+def test_default_runtime_builder_does_not_restore_delegate_when_builtins_disabled(
+    tmp_path,
+) -> None:
+    from loushang.coding.bootstrap import create_services
+    from loushang.coding.cli.__main__ import default_runtime_builder
+    from loushang.harness.tools.agent_delegate import AGENT_DELEGATE_TOOL_NAME
+    from loushang.harness.tools.workspace.registry import (
+        WorkspaceToolRegistry as ToolRegistry,
+    )
+
+    runtime = default_runtime_builder(
+        args=SimpleNamespace(
+            no_tools=False,
+            tools=(),
+            no_builtin_tools=True,
+            no_session=True,
+        ),
+        cwd=tmp_path,
+        session_dir=tmp_path / "sessions",
+        services=create_services(),
+        tool_registry=ToolRegistry(),
+    )
+
+    session = asyncio.run(runtime.create_session(cwd=str(tmp_path)))
+
+    assert AGENT_DELEGATE_TOOL_NAME not in {
+        definition.name for definition in session.get_all_tools()
+    }
+
+
 def test_default_runtime_builder_applies_resource_and_prompt_options(tmp_path) -> None:
     from loushang.coding.bootstrap import create_services
     from loushang.coding.cli.__main__ import default_runtime_builder
@@ -1099,6 +1129,7 @@ def test_default_runtime_builder_rebuilds_project_bound_services_for_session_cwd
     from loushang.coding.tool_pack import (
         register_coding_builtin_tools as register_builtin_tools,
     )
+    from loushang.harness.tools.agent_delegate import AGENT_DELEGATE_TOOL_NAME
     from loushang.harness.tools.multiagent import MULTIAGENT_TOOL_NAMES
     from loushang.harness.tools.workspace.registry import (
         WorkspaceToolRegistry as ToolRegistry,
@@ -1129,10 +1160,14 @@ def test_default_runtime_builder_rebuilds_project_bound_services_for_session_cwd
     assert second.cwd_bound_services_audit.ok is True
     assert "Project B guidance" in second.agent.system_prompt
     assert "## Multi-agent collaboration" in second.agent.system_prompt
+    assert AGENT_DELEGATE_TOOL_NAME in second.get_active_tool_names()
     assert set(MULTIAGENT_TOOL_NAMES).issubset(second.get_active_tool_names())
     assert not set(MULTIAGENT_TOOL_NAMES).intersection(
         definition.name for definition in registry.list_definitions()
     )
+    assert AGENT_DELEGATE_TOOL_NAME not in {
+        definition.name for definition in registry.list_definitions()
+    }
     first_tools = {definition.name: definition for definition in first.get_all_tools()}
     second_tools = {
         definition.name: definition for definition in second.get_all_tools()

--- a/tests/harness/tools/test_agent_delegate.py
+++ b/tests/harness/tools/test_agent_delegate.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+import pytest
+
+from loushang.ai.types import ToolCall
+from loushang.harness.effects import ProcessEffect
+from loushang.harness.policy import PolicyDecision
+from loushang.harness.tools.agent_delegate import (
+    AGENT_DELEGATE_TOOL_NAME,
+    AgentDelegateToolPack,
+    AgentInvocationResult,
+    PreparedAgentInvocation,
+)
+from loushang.harness.tools.execution import (
+    AuthorizedExecution,
+    AuthorizedToolAction,
+    AuthorizedToolContext,
+    PreparedToolAction,
+    ToolCallContext,
+    ToolExecutionHost,
+)
+from loushang.harness.tools.workspace.authorization import (
+    create_workspace_tool_execution_host,
+)
+from loushang.harness.tools.workspace.policy import PolicyEnforcementError
+from loushang.harness.workspace.exec import ExecRequest, ExecResult
+
+
+@dataclass
+class _Adapter:
+    result: AgentInvocationResult = AgentInvocationResult("review complete", 0)
+
+    @property
+    def admitted_agent_types(self) -> tuple[str, ...]:
+        return ("reviewer",)
+
+    def prepare(self, request, *, default_cwd, model):
+        del model
+        return PreparedAgentInvocation(
+            request=request,
+            exec_request=ExecRequest(
+                command=("/workspace/.venv/bin/loushang", "--mode", "print"),
+                cwd=default_cwd,
+                stdin=request.task,
+                timeout_seconds=30,
+                capture_full_output=False,
+                effective_environment=(("PATH", "/usr/bin"), ("TOKEN", "secret")),
+            ),
+            allowed_tools=("read",),
+            model_ref="provider/model",
+        )
+
+    def project(self, prepared, result):
+        del prepared, result
+        return self.result
+
+
+class _ExecService:
+    def __init__(self, result: ExecResult | None = None) -> None:
+        self.requests: list[ExecRequest] = []
+        self.signals: list[object | None] = []
+        self.result = result or ExecResult(exit_code=0, stdout="review complete")
+
+    async def execute(self, request: ExecRequest, *, signal=None) -> ExecResult:
+        self.requests.append(request)
+        self.signals.append(signal)
+        return self.result
+
+
+class _Gateway:
+    def __init__(self, *, execution_profile: object | None = None) -> None:
+        self.prepared: PreparedToolAction | None = None
+        self.execution_profile = execution_profile
+
+    async def execute(self, prepared, handler, context: AuthorizedToolContext):
+        self.prepared = prepared
+        return await handler(
+            AuthorizedToolAction(
+                tool_name=prepared.tool_name,
+                authorization_arguments=prepared.authorization_arguments,
+                execution_arguments=prepared.execution_arguments,
+                cwd=prepared.cwd,
+                fingerprint="authorized",
+                effects=prepared.effects,
+                execution_profile=self.execution_profile,
+            ),
+            context,
+        )
+
+
+def _call(**arguments: object) -> ToolCall:
+    return ToolCall(
+        type="toolCall",
+        id="delegate-1",
+        name=AGENT_DELEGATE_TOOL_NAME,
+        arguments=arguments,
+    )
+
+
+def test_delegate_agent_is_sequential_and_uses_authorized_process_execution() -> None:
+    definition = AgentDelegateToolPack(adapter=_Adapter()).definition()
+    binding = definition.execution
+
+    assert definition.execution_mode == "sequential"
+    assert definition.parameters["properties"]["agent_type"]["enum"] == [
+        "reviewer"
+    ]
+    assert isinstance(binding, AuthorizedExecution)
+
+    prepared = binding.action_adapter.prepare(
+        _call(agent_type="reviewer", task="find the bug"),
+        ToolCallContext(tool_call_id="delegate-1", cwd="/workspace"),
+    )
+
+    assert prepared.tool_name == AGENT_DELEGATE_TOOL_NAME
+    assert prepared.effects == (
+        ProcessEffect(("/workspace/.venv/bin/loushang", "--mode", "print")),
+    )
+    assert prepared.policy_subject is not None
+    assert prepared.policy_subject.command is not None
+    assert "find the bug" not in repr(prepared.authorization_arguments)
+    assert "find the bug" not in repr(prepared.effects)
+    assert prepared.authorization_arguments["task_sha256"]
+    assert prepared.authorization_arguments["environment_sha256"]
+    assert "secret" not in repr(prepared.authorization_arguments)
+
+
+def test_delegate_agent_executes_the_frozen_request_through_the_scoped_service() -> None:
+    adapter = _Adapter()
+    definition = AgentDelegateToolPack(adapter=adapter).definition()
+    execution_profile = object()
+    gateway = _Gateway(execution_profile=execution_profile)
+    exec_service = _ExecService()
+    signal = object()
+
+    result = asyncio.run(
+        ToolExecutionHost(gateway).dispatch(
+            definition,
+            _call(agent_type="reviewer", task="review this"),
+            ToolCallContext(
+                tool_call_id="delegate-1",
+                cwd="/workspace",
+                signal=signal,
+                exec_service=exec_service,
+            ),
+        )
+    )
+
+    assert result.content[0].text == "review complete"
+    assert result.details == {
+        "agent_type": "reviewer",
+        "exit_code": 0,
+        "timed_out": False,
+        "cancelled": False,
+        "truncated": False,
+        "allowed_tools": ["read"],
+        "model": "provider/model",
+    }
+    assert len(exec_service.requests) == 1
+    assert exec_service.requests[0].stdin == "review this"
+    assert exec_service.requests[0].execution_profile is execution_profile
+    assert exec_service.signals == [signal]
+
+
+def test_delegate_agent_policy_denial_prevents_process_execution() -> None:
+    subjects: list[object] = []
+
+    class DenyPolicy:
+        def evaluate(self, subject):
+            subjects.append(subject)
+            return PolicyDecision.deny("subprocess denied", code="deny_delegate")
+
+    exec_service = _ExecService()
+    definition = AgentDelegateToolPack(adapter=_Adapter()).definition()
+
+    with pytest.raises(PolicyEnforcementError, match="subprocess denied"):
+        asyncio.run(
+            create_workspace_tool_execution_host(
+                policy_evaluator=DenyPolicy(),
+            ).dispatch(
+                definition,
+                _call(agent_type="reviewer", task="private review task"),
+                ToolCallContext(
+                    tool_call_id="delegate-1",
+                    cwd="/workspace",
+                    exec_service=exec_service,
+                ),
+            )
+        )
+
+    assert len(subjects) == 1
+    assert "private review task" not in repr(subjects[0])
+    assert exec_service.requests == []
+
+
+def test_delegate_agent_revalidates_the_authorized_plan_before_execution() -> None:
+    adapter = _Adapter()
+    binding = AgentDelegateToolPack(adapter=adapter).definition().execution
+    assert isinstance(binding, AuthorizedExecution)
+    prepared = binding.action_adapter.prepare(
+        _call(agent_type="reviewer", task="review this"),
+        ToolCallContext(tool_call_id="delegate-1", cwd="/workspace"),
+    )
+    action = AuthorizedToolAction(
+        tool_name=prepared.tool_name,
+        authorization_arguments={**prepared.authorization_arguments, "cwd": "/other"},
+        execution_arguments=prepared.execution_arguments,
+        cwd=prepared.cwd,
+        fingerprint="authorized",
+        effects=prepared.effects,
+    )
+
+    with pytest.raises(RuntimeError, match="no longer matches"):
+        asyncio.run(
+            binding.handler(
+                action,
+                AuthorizedToolContext(
+                    tool_call_id="delegate-1",
+                    exec_service=_ExecService(),
+                ),
+            )
+        )
+
+
+def test_delegate_agent_does_not_let_product_projection_change_process_status() -> None:
+    adapter = _Adapter(result=AgentInvocationResult("pretend success", 0))
+    definition = AgentDelegateToolPack(adapter=adapter).definition()
+
+    with pytest.raises(RuntimeError, match="changed subprocess status"):
+        asyncio.run(
+            ToolExecutionHost(_Gateway()).dispatch(
+                definition,
+                _call(agent_type="reviewer", task="review this"),
+                ToolCallContext(
+                    tool_call_id="delegate-1",
+                    cwd="/workspace",
+                    exec_service=_ExecService(ExecResult(exit_code=2)),
+                ),
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("projected", "error", "message"),
+    (
+        (AgentInvocationResult("late", -9, timed_out=True), TimeoutError, "timed out"),
+        (AgentInvocationResult("stopped", -9, cancelled=True), RuntimeError, "aborted"),
+        (AgentInvocationResult("failure", 2), RuntimeError, "exited with code 2"),
+        (AgentInvocationResult("", 0), RuntimeError, "returned no output"),
+    ),
+)
+def test_delegate_agent_projects_stable_failure_semantics(
+    projected: AgentInvocationResult,
+    error: type[Exception],
+    message: str,
+) -> None:
+    adapter = _Adapter(result=projected)
+    definition = AgentDelegateToolPack(adapter=adapter).definition()
+    exec_service = _ExecService(
+        ExecResult(
+            exit_code=projected.exit_code,
+            timed_out=projected.timed_out,
+            cancelled=projected.cancelled,
+        )
+    )
+
+    with pytest.raises(error, match=message):
+        asyncio.run(
+            ToolExecutionHost(_Gateway()).dispatch(
+                definition,
+                _call(agent_type="reviewer", task="review this"),
+                ToolCallContext(
+                    tool_call_id="delegate-1",
+                    cwd="/workspace",
+                    exec_service=exec_service,
+                ),
+            )
+        )
+
+
+def test_delegate_agent_rejects_unadmitted_types_before_process_execution() -> None:
+    binding = AgentDelegateToolPack(adapter=_Adapter()).definition().execution
+    assert isinstance(binding, AuthorizedExecution)
+
+    with pytest.raises(ValueError, match="not admitted"):
+        binding.action_adapter.prepare(
+            _call(agent_type="implementation_worker", task="edit files"),
+            ToolCallContext(tool_call_id="delegate-1", cwd="/workspace"),
+        )

--- a/tests/harness/workspace/test_exec.py
+++ b/tests/harness/workspace/test_exec.py
@@ -290,6 +290,42 @@ def test_exec_service_rolls_capture_without_losing_artifact(tmp_path: Path) -> N
     asyncio.run(scenario())
 
 
+@pytest.mark.parametrize("capture_full_output", [True, False])
+def test_exec_service_discards_unretained_output_artifacts(
+    tmp_path: Path,
+    capture_full_output: bool,
+) -> None:
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+
+    async def scenario() -> None:
+        result = await ExecService().execute(
+            ExecRequest(
+                command=[
+                    "/usr/bin/env",
+                    "python3",
+                    "-c",
+                    "for i in range(400): print(f'line-{i:04d}')",
+                ],
+                cwd=str(tmp_path),
+                preview_max_lines=2,
+                preview_max_bytes=1024,
+                artifact_dir=str(artifact_dir),
+                capture_full_output=capture_full_output,
+                retain_output_artifacts=False,
+                rolling_max_bytes=512,
+            )
+        )
+
+        assert result.stdout_preview == "line-0398\nline-0399\n"
+        assert result.stdout_truncated is True
+        assert result.stdout_artifact_path is None
+        assert result.stderr_artifact_path is None
+        assert list(artifact_dir.iterdir()) == []
+
+    asyncio.run(scenario())
+
+
 def test_exec_service_marks_timeout_and_cancellation(tmp_path: Path) -> None:
     async def scenario() -> None:
         timed_out = await ExecService().execute(


### PR DESCRIPTION
## What changed

- add a Harness-owned `delegate_agent` tool using `AuthorizedExecution` and `ProcessEffect`
- add the Coding CLI adapter that compiles admitted read-only roles into a finite `loushang --mode print` subprocess
- bind task input through stdin, freeze authorization digests, preserve the Session execution profile and cancellation signal, and return bounded output
- register and activate the tool only when `--tools` explicitly includes `delegate_agent`; the P0 default stays off until independent cost controls exist
- add a neutral `ExecRequest.retain_output_artifacts` policy so finite consumers can discard rolling-capture files without tool-specific filesystem cleanup
- document the one-shot invocation boundary and its relationship to remote-agent and V3 architecture

## Why

A finite subprocess agent is useful without introducing multi-agent actor, job, session, follow-up, or remote-runtime semantics. The implementation keeps Harness responsible for the protected process and capture boundary while Coding owns CLI flags, role prompts, model selection, and result projection.

## Security defaults

- child tools are the intersection of parent-admitted tools and the selected read-only role
- `bash`, `write`, `edit`, `delegate_agent`, and all multi-agent control tools are always removed in P0
- task text is carried only through stdin and does not enter argv, effects, policy subjects, or audit arguments
- child sessions, extensions, skills, and prompt templates are disabled
- timeout and output limits are Product-controlled
- private rolling-output artifacts are deleted by the execution backend and never projected to the model
- Policy denial prevents process launch; subprocess status cannot be rewritten by the Product projector

## Validation

- focused Harness/Coding regression: 263 passed
- architecture, full Harness, and affected Coding regression: 1936 passed
- Ruff passed for affected source and tests
- Mypy passed for the five affected typed core modules
- `git diff --check` passed

Refs #405
