### PR TITLE
feat(harness): add bounded process hosting core

### DIFF
--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -116,6 +116,9 @@ description.
   disabled-by-default process containment service, its cross-platform
   Protocols, centralized host detection and backend selection, existing
   `ExecService` integration, and session/child lifecycle.
+- [Process Hosting Boundary](process-hosting-boundary.md) defines the narrow
+  session-owned long-lived child-process substrate, fixed lifecycle limits,
+  public contract restraint, and the deferred authorization/Sandbox binding.
 - [Context Budget And Accounting Boundary](context-budget-accounting-boundary.md)
   defines deterministic compaction-budget and usage-estimate record ownership
   while keeping message estimation and compaction policy in product adapters.

--- a/docs/internals/architecture/harness/current-owner-map.md
+++ b/docs/internals/architecture/harness/current-owner-map.md
@@ -31,7 +31,7 @@ depend on `loushang.coding`, `loushang.work`, `loushang.method`,
 | `tools` / `approval` / `policy` / `sandbox` | tool authoring and hosted execution mechanics, action policy evaluation, approval lifecycle, effects and containment ports | Product risk defaults, Product approval wording, arbitrary Product commands |
 | `resources` / `extensions` / `capabilities` | resource discovery and precedence, package materialization mechanics, extension runtime, capability composition | Product-owned built-in content, trust decisions, activation policy |
 | `host` / `cli` / `events` / `presentation` | Product-neutral host lifecycle, RPC/JSON projection, runtime event contracts and reusable presentation | AppService tenancy, Channel protocol, Product grammar or final UI composition |
-| `diagnostics` / `continuity` / `workspace` | shared diagnostic records/export, continuity provider composition, workspace and execution primitives | Product-specific recovery UX, business audit retention, Product artifact semantics |
+| `diagnostics` / `continuity` / `workspace` | shared diagnostic records/export, continuity provider composition, one-shot execution, and bounded session-owned process primitives | Product-specific recovery UX, business audit retention, protocol/server selection, Product artifact semantics |
 
 ## Dependency Direction
 

--- a/docs/internals/architecture/harness/process-hosting-boundary.md
+++ b/docs/internals/architecture/harness/process-hosting-boundary.md
@@ -1,0 +1,116 @@
+# Harness Process Hosting Boundary
+
+## Status
+
+Status: accepted for `lane/harness`.
+
+This document defines the Product-neutral substrate for session-owned,
+long-lived child processes. It does not make LSP a Harness concern.
+
+## Decision
+
+Harness owns the mechanics required to keep a bounded child process alive:
+
+- a frozen, shell-free launch request;
+- a raw byte stdin/stdout handle and a bounded stderr tail;
+- fixed Host-owned process, read, write, stderr, and termination limits;
+- pending-start reservations and atomic handle publication;
+- process-group termination with kill fallback;
+- natural-exit, failed-start, cancellation, and Session-fallback cleanup.
+
+Products own executable admission, selection, protocol behavior, document
+state, semantic tools, restart policy, and user-facing diagnostics. Coding LSP
+therefore remains under `loushang.coding`; it consumes this substrate through a
+narrow launcher binding.
+
+## Public Surface
+
+`loushang.harness.workspace.process` exports only:
+
+- `AuthorizedProcessLauncher`;
+- `ProcessLaunchRequest`;
+- `ProcessHandle`;
+- `ProcessExit`;
+- `ProcessStderrTail`.
+
+`ProcessHost`, the local transport, the spawner seam, reservations, process
+identifiers, and OS signaling remain Harness internals. There is no public
+`ProcessBackend`, transport API, process event family, Host snapshot, daemon,
+or RPC service. H1 publishes `AuthorizedProcessLauncher` only as the consumer
+port; the concrete execution-scope binding remains an H2 concern.
+
+The launch request contains only the complete executable argv, an absolute
+cwd, and a frozen effective environment. It cannot carry caller-selected
+resource limits, shell text, LSP methods, restart settings, or approval policy.
+Environment values are execution state and must not be projected into normal
+status, audit, transcript, or approval text.
+
+## Lifecycle Invariants
+
+`ProcessHost` has `open -> closing -> closed` lifecycle semantics.
+
+- A start reserves capacity before any asynchronous spawn work. Pending and
+  published children consume the same fixed quota.
+- `close()` rejects new reservations, cancels in-flight starts, reclaims any
+  attached but unpublished child, and closes every published handle.
+- A child that exits before publication cannot leave a phantom registration.
+- Natural exit, `wait()`, `terminate()`, `close()`, and the internal finalizer
+  share one exit result and one registration release.
+- Host cleanup continues through terminate, kill, stream draining, and child
+  settlement before caller cancellation is propagated.
+- Close failures do not skip other children and leave the Host in `closed`
+  state before an aggregate Host error is reported.
+
+These are correctness requirements, not optional Product policy.
+
+## Authorization And Sandbox Boundary
+
+Process Hosting itself does not display or request approval. Interactive
+approval is not an intrinsic cost of a Coding LSP launch. A later
+execution-scope-bound launcher will apply the effective execution profile and
+Sandbox decision before delegating to `ProcessHost`; a Product may configure
+catalog-admitted built-in language servers for automatic authorization within
+that ceiling.
+
+The later binding must not let a Product call `ProcessHost` directly. It must
+freeze executable, argv, cwd, and effective environment once, resolve the current
+execution/Sandbox profile in Harness, and fail before OS spawn when
+required containment is unavailable. Harness does not validate Coding catalog
+admission and must not import Coding to do so.
+
+Long-lived Sandbox ownership is intentionally not claimed by the H1 core. Its
+private H2 seam must produce wrapped spawn material plus an owned cleanup and
+must close that scope on natural exit, failed publication, launch cancellation,
+Host close, and Sandbox-runtime fallback.
+
+## Relationship To One-Shot Exec
+
+`ExecService` remains a one-shot request/result service. Hosted processes do
+not add `keep_alive` to `ExecRequest` and do not expose an `ExecService` handle.
+
+The two paths share only local OS mechanics: shell-free spawn, a new process
+session, and process-group termination. Their ownership and cancellation
+contracts remain separate.
+
+## Delivery State
+
+H1 provides the neutral records, internal `ProcessHost`, local spawner, shared
+OS helpers, private containment lifecycle seam, Fake Spawner tests, and a real
+raw-stdio smoke test.
+
+Deferred to H2:
+
+- the execution-scope-bound authorized launcher;
+- long-lived Sandbox containment planning and scope ownership;
+- shared one-shot/hosted Bubblewrap command planning;
+- Host-before-Sandbox runtime disposal with delayed cancellation;
+- audit correlation and a private complete-launch fingerprint;
+- Coding adapter cleanup that preserves the primary Product disposal error.
+
+Deferred to Coding:
+
+- binding the production launcher into the H3 LSP capability;
+- LSP framing and protocol handlers;
+- server definitions, admission, selection, and instance supervision;
+- document synchronization and semantic tools;
+- any restart, idle eviction, diagnostics inbox, or cross-Session pooling.

--- a/docs/internals/architecture/harness/shared-capability-boundaries.md
+++ b/docs/internals/architecture/harness/shared-capability-boundaries.md
@@ -152,6 +152,7 @@ Harness may own neutral workspace mechanics:
 - file operation request/result shapes;
 - process execution request/result shapes;
 - stream event records;
+- bounded session-owned process launch/handle records and lifecycle mechanics;
 - workspace tool protocols;
 - reusable concrete workspace tool definitions and their neutral renderers.
 

--- a/src/loushang/harness/workspace/_local_process.py
+++ b/src/loushang/harness/workspace/_local_process.py
@@ -1,0 +1,73 @@
+"""Shared local OS mechanics for one-shot and hosted workspace processes."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal as signal_module
+from collections.abc import Mapping
+
+
+async def spawn_local_process(
+    *,
+    command: tuple[str, ...],
+    cwd: str,
+    environment: Mapping[str, str],
+    pipe_stdin: bool,
+) -> asyncio.subprocess.Process:
+    return await asyncio.create_subprocess_exec(
+        *command,
+        cwd=cwd,
+        env=dict(environment),
+        start_new_session=True,
+        stdin=asyncio.subprocess.PIPE if pipe_stdin else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+
+def terminate_local_process(process: object) -> None:
+    _signal_process_group(
+        process,
+        group_signal=signal_module.SIGTERM,
+        fallback_method="terminate",
+    )
+
+
+def kill_local_process(process: object) -> None:
+    _signal_process_group(
+        process,
+        group_signal=signal_module.SIGKILL,
+        fallback_method="kill",
+    )
+
+
+def _signal_process_group(
+    process: object,
+    *,
+    group_signal: signal_module.Signals,
+    fallback_method: str,
+) -> None:
+    pid = getattr(process, "pid", None)
+    try:
+        if isinstance(pid, int) and pid > 0 and hasattr(os, "killpg"):
+            os.killpg(pid, group_signal)
+            return
+    except ProcessLookupError:
+        return
+    except OSError:
+        pass
+    fallback = getattr(process, fallback_method, None)
+    if not callable(fallback):
+        return
+    try:
+        fallback()
+    except ProcessLookupError:
+        return
+
+
+__all__ = [
+    "kill_local_process",
+    "spawn_local_process",
+    "terminate_local_process",
+]

--- a/src/loushang/harness/workspace/exec/service.py
+++ b/src/loushang/harness/workspace/exec/service.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
-import signal as signal_module
 import tempfile
 from collections.abc import Awaitable
 from contextlib import suppress
@@ -11,6 +10,10 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Literal, Protocol, TextIO
 
+from loushang.harness.workspace._local_process import (
+    kill_local_process,
+    spawn_local_process,
+)
 from loushang.harness.workspace.truncation import truncate_tail
 
 from .types import (
@@ -71,16 +74,14 @@ class LocalExecBackend:
         on_update: ExecUpdateCallback | None = None,
     ) -> ExecResult:
         assert request.effective_environment is not None
+        assert request.cwd is not None
         env = dict(request.effective_environment)
 
-        process = await asyncio.create_subprocess_exec(
-            *request.command,
+        process = await spawn_local_process(
+            command=request.command,
             cwd=request.cwd,
-            env=env,
-            start_new_session=True,
-            stdin=asyncio.subprocess.PIPE if request.stdin is not None else None,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            environment=env,
+            pipe_stdin=request.stdin is not None,
         )
 
         stdout_capture = _StreamCapture(
@@ -356,18 +357,7 @@ class _OutputCapture:
 
 
 def _kill_process(process: asyncio.subprocess.Process) -> None:
-    try:
-        if process.pid is not None:
-            os.killpg(process.pid, signal_module.SIGKILL)
-        else:
-            process.kill()
-    except ProcessLookupError:
-        return
-    except OSError:
-        try:
-            process.kill()
-        except ProcessLookupError:
-            return
+    kill_local_process(process)
 
 
 async def _wait_for_abort(signal: object | None) -> None:

--- a/src/loushang/harness/workspace/process/__init__.py
+++ b/src/loushang/harness/workspace/process/__init__.py
@@ -1,0 +1,17 @@
+"""Hosted-process contracts for long-lived workspace capabilities."""
+
+from .types import (
+    AuthorizedProcessLauncher,
+    ProcessExit,
+    ProcessHandle,
+    ProcessLaunchRequest,
+    ProcessStderrTail,
+)
+
+__all__ = [
+    "AuthorizedProcessLauncher",
+    "ProcessExit",
+    "ProcessHandle",
+    "ProcessLaunchRequest",
+    "ProcessStderrTail",
+]

--- a/src/loushang/harness/workspace/process/host.py
+++ b/src/loushang/harness/workspace/process/host.py
@@ -1,0 +1,568 @@
+"""Session-owned process host with fixed limits and exactly-once cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from dataclasses import dataclass
+
+from loushang.harness.workspace._local_process import (
+    kill_local_process,
+    terminate_local_process,
+)
+
+from .local import (
+    LocalProcessSpawner,
+    ProcessContainmentPlan,
+    ProcessContainmentPlanner,
+    ProcessSpawner,
+    ProcessTransport,
+)
+from .types import ProcessExit, ProcessHandle, ProcessLaunchRequest, ProcessStderrTail
+
+
+class ProcessHostError(RuntimeError):
+    pass
+
+
+class ProcessHostClosedError(ProcessHostError):
+    pass
+
+
+class ProcessHostCapacityError(ProcessHostError):
+    pass
+
+
+class ProcessWriteLimitError(ProcessHostError):
+    pass
+
+
+@dataclass(slots=True)
+class _Reservation:
+    reservation_id: int
+    owner: asyncio.Task[object]
+    transport: ProcessTransport | None = None
+    containment: ProcessContainmentPlan | None = None
+    cleanup_error: BaseException | None = None
+
+    def attach(self, transport: ProcessTransport) -> None:
+        if self.transport is not None and self.transport is not transport:
+            raise RuntimeError("process reservation already owns a transport")
+        self.transport = transport
+
+    def attach_containment(self, containment: ProcessContainmentPlan) -> None:
+        if self.containment is not None and self.containment is not containment:
+            raise RuntimeError("process reservation already owns containment")
+        self.containment = containment
+
+
+class _BoundedByteTail:
+    def __init__(self, max_bytes: int) -> None:
+        self._max_bytes = max_bytes
+        self._content = bytearray()
+        self._truncated = False
+
+    def append(self, chunk: bytes) -> None:
+        if not chunk:
+            return
+        self._content.extend(chunk)
+        overflow = len(self._content) - self._max_bytes
+        if overflow > 0:
+            del self._content[:overflow]
+            self._truncated = True
+
+    def snapshot(self) -> ProcessStderrTail:
+        return ProcessStderrTail(
+            content=bytes(self._content),
+            truncated=self._truncated,
+        )
+
+
+class _HostedProcess(ProcessHandle):
+    def __init__(
+        self,
+        transport: ProcessTransport,
+        *,
+        max_read_bytes: int,
+        max_write_bytes: int,
+        stderr_max_bytes: int,
+        termination_grace_seconds: float,
+        containment: ProcessContainmentPlan | None,
+        on_exit: Callable[[_HostedProcess], Awaitable[None]],
+    ) -> None:
+        self._transport = transport
+        self._max_read_bytes = max_read_bytes
+        self._max_write_bytes = max_write_bytes
+        self._termination_grace_seconds = termination_grace_seconds
+        self._containment = containment
+        self._on_exit = on_exit
+        self._stderr_tail = _BoundedByteTail(stderr_max_bytes)
+        self._stdin_lock = asyncio.Lock()
+        self._lifecycle_lock = asyncio.Lock()
+        self._stdin_closed = False
+        self._closing = False
+        self._exit: asyncio.Future[ProcessExit] = (
+            asyncio.get_running_loop().create_future()
+        )
+        self._termination_task: asyncio.Task[ProcessExit] | None = None
+        self._close_task: asyncio.Task[None] | None = None
+        self._stderr_task = asyncio.create_task(
+            self._drain_stderr(),
+            name="harness-hosted-process-stderr",
+        )
+        self._finalizer_task = asyncio.create_task(
+            self._finalize(),
+            name="harness-hosted-process-finalizer",
+        )
+
+    async def read_stdout(self, max_bytes: int = 64 * 1024) -> bytes:
+        if (
+            not isinstance(max_bytes, int)
+            or isinstance(max_bytes, bool)
+            or max_bytes < 1
+            or max_bytes > self._max_read_bytes
+        ):
+            raise ValueError(f"max_bytes must be between 1 and {self._max_read_bytes}")
+        stream = self._transport.stdout
+        if stream is None:
+            return b""
+        return await stream.read(max_bytes)
+
+    async def write_stdin(self, data: bytes) -> None:
+        if not isinstance(data, bytes):
+            raise TypeError("hosted process stdin writes must be bytes")
+        if len(data) > self._max_write_bytes:
+            raise ProcessWriteLimitError(
+                f"stdin write exceeds fixed {self._max_write_bytes}-byte limit"
+            )
+        async with self._stdin_lock:
+            if self._closing or self._exit.done() or self._stdin_closed:
+                raise ProcessHostClosedError("hosted process stdin is closed")
+            stream = self._transport.stdin
+            if stream is None:
+                raise ProcessHostClosedError("hosted process has no stdin pipe")
+            try:
+                stream.write(data)
+                await stream.drain()
+            except (BrokenPipeError, ConnectionResetError) as exc:
+                raise ProcessHostClosedError("hosted process stdin is closed") from exc
+
+    async def close_stdin(self) -> None:
+        async with self._stdin_lock:
+            if self._stdin_closed:
+                return
+            self._stdin_closed = True
+            stream = self._transport.stdin
+            if stream is None:
+                return
+            stream.close()
+            with suppress(BrokenPipeError, ConnectionResetError):
+                await stream.wait_closed()
+
+    async def wait(self) -> ProcessExit:
+        return await asyncio.shield(self._exit)
+
+    async def terminate(self) -> ProcessExit:
+        async with self._lifecycle_lock:
+            task = self._termination_task
+            if task is None:
+                self._closing = True
+                task = asyncio.create_task(
+                    self._terminate_owned(),
+                    name="harness-hosted-process-terminate",
+                )
+                self._termination_task = task
+        return await asyncio.shield(task)
+
+    async def close(self) -> None:
+        async with self._lifecycle_lock:
+            task = self._close_task
+            if task is None:
+                self._closing = True
+                task = asyncio.create_task(
+                    self._close_owned(),
+                    name="harness-hosted-process-close",
+                )
+                self._close_task = task
+        await asyncio.shield(task)
+
+    def stderr_tail(self) -> ProcessStderrTail:
+        return self._stderr_tail.snapshot()
+
+    def _is_settled(self) -> bool:
+        return self._exit.done()
+
+    async def _drain_stderr(self) -> None:
+        stream = self._transport.stderr
+        if stream is None:
+            return
+        while True:
+            chunk = await stream.read(64 * 1024)
+            if not chunk:
+                return
+            self._stderr_tail.append(chunk)
+
+    async def _finalize(self) -> None:
+        primary_error: BaseException | None = None
+        return_code: int | None = None
+        try:
+            try:
+                return_code = await self._transport.wait()
+            except BaseException as exc:
+                primary_error = exc
+            try:
+                await self._stderr_task
+            except BaseException as exc:
+                if primary_error is None:
+                    primary_error = exc
+                else:
+                    primary_error.add_note(f"stderr cleanup also failed: {exc}")
+            if self._containment is not None:
+                try:
+                    await self._containment.close()
+                except BaseException as exc:
+                    if primary_error is None:
+                        primary_error = exc
+                    else:
+                        primary_error.add_note(
+                            f"containment cleanup also failed: {exc}"
+                        )
+            if not self._exit.done():
+                if primary_error is not None:
+                    self._exit.set_exception(primary_error)
+                else:
+                    assert return_code is not None
+                    self._exit.set_result(ProcessExit(return_code=return_code))
+        finally:
+            self._closing = True
+            await self._on_exit(self)
+
+    async def _terminate_owned(self) -> ProcessExit:
+        if self._exit.done():
+            return await asyncio.shield(self._exit)
+        stdin_error: BaseException | None = None
+        try:
+            await self.close_stdin()
+        except BaseException as exc:
+            stdin_error = exc
+        terminate_local_process(self._transport)
+        try:
+            try:
+                result = await asyncio.wait_for(
+                    asyncio.shield(self._exit),
+                    self._termination_grace_seconds,
+                )
+            except TimeoutError:
+                kill_local_process(self._transport)
+                result = await asyncio.shield(self._exit)
+        except BaseException as settlement_error:
+            if stdin_error is not None:
+                stdin_error.add_note(
+                    f"process settlement also failed: {settlement_error}"
+                )
+                raise stdin_error from settlement_error
+            raise
+        if stdin_error is not None:
+            raise stdin_error
+        return result
+
+    async def _close_owned(self) -> None:
+        primary_error: BaseException | None = None
+        try:
+            await self.close_stdin()
+        except BaseException as exc:
+            primary_error = exc
+        try:
+            await self.terminate()
+        except BaseException as exc:
+            primary_error = _record_cleanup_error(
+                primary_error,
+                exc,
+                context="process termination also failed",
+            )
+        try:
+            await self._finalizer_task
+        except BaseException as exc:
+            primary_error = _record_cleanup_error(
+                primary_error,
+                exc,
+                context="process finalization also failed",
+            )
+        if primary_error is not None:
+            raise primary_error
+
+
+class ProcessHost:
+    """Internal owner for a bounded set of long-lived child processes."""
+
+    def __init__(
+        self,
+        *,
+        spawner: ProcessSpawner | None = None,
+        max_processes: int = 4,
+        max_read_bytes: int = 64 * 1024,
+        max_write_bytes: int = 1024 * 1024,
+        stderr_max_bytes: int = 64 * 1024,
+        termination_grace_seconds: float = 1.0,
+    ) -> None:
+        for name, value in (
+            ("max_processes", max_processes),
+            ("max_read_bytes", max_read_bytes),
+            ("max_write_bytes", max_write_bytes),
+            ("stderr_max_bytes", stderr_max_bytes),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"{name} must be a positive integer")
+        if termination_grace_seconds <= 0:
+            raise ValueError("termination_grace_seconds must be positive")
+        self._spawner = spawner or LocalProcessSpawner()
+        self._max_processes = max_processes
+        self._max_read_bytes = max_read_bytes
+        self._max_write_bytes = max_write_bytes
+        self._stderr_max_bytes = stderr_max_bytes
+        self._termination_grace_seconds = termination_grace_seconds
+        self._state = "open"
+        self._lock = asyncio.Lock()
+        self._next_reservation_id = 1
+        self._reservations: dict[int, _Reservation] = {}
+        self._registrations: set[_HostedProcess] = set()
+        self._close_task: asyncio.Task[None] | None = None
+
+    async def start(
+        self,
+        request: ProcessLaunchRequest,
+        *,
+        containment_planner: ProcessContainmentPlanner | None = None,
+    ) -> ProcessHandle:
+        if not isinstance(request, ProcessLaunchRequest):
+            raise TypeError("ProcessHost.start requires ProcessLaunchRequest")
+        owner = asyncio.current_task()
+        if owner is None:
+            raise RuntimeError("ProcessHost.start requires an asyncio task")
+        async with self._lock:
+            if self._state != "open":
+                raise ProcessHostClosedError("process host is closing")
+            if (
+                len(self._reservations) + len(self._registrations)
+                >= self._max_processes
+            ):
+                raise ProcessHostCapacityError("process host capacity is exhausted")
+            reservation = _Reservation(self._next_reservation_id, owner)
+            self._next_reservation_id += 1
+            self._reservations[reservation.reservation_id] = reservation
+
+        handle: _HostedProcess | None = None
+        published = False
+        primary_error: BaseException | None = None
+        try:
+            launch_request = request
+            if containment_planner is not None:
+                containment = await containment_planner(request)
+                if not isinstance(containment, ProcessContainmentPlan):
+                    raise TypeError(
+                        "process containment planner must return ProcessContainmentPlan"
+                    )
+                reservation.attach_containment(containment)
+                launch_request = containment.request
+            transport = await self._spawner(
+                launch_request,
+                on_spawn=reservation.attach,
+            )
+            reservation.attach(transport)
+            handle = _HostedProcess(
+                transport,
+                max_read_bytes=self._max_read_bytes,
+                max_write_bytes=self._max_write_bytes,
+                stderr_max_bytes=self._stderr_max_bytes,
+                termination_grace_seconds=self._termination_grace_seconds,
+                containment=reservation.containment,
+                on_exit=self._release,
+            )
+            async with self._lock:
+                if (
+                    self._state != "open"
+                    or self._reservations.get(reservation.reservation_id)
+                    is not reservation
+                ):
+                    raise ProcessHostClosedError("process host closed during start")
+                self._reservations.pop(reservation.reservation_id, None)
+                self._registrations.add(handle)
+                # The child can exit before publication. Its finalizer may have
+                # attempted release before registration, so make publication
+                # itself close that race without retaining a phantom quota.
+                if handle._is_settled():
+                    self._registrations.discard(handle)
+                published = True
+            return handle
+        except BaseException as exc:
+            primary_error = exc
+            raise
+        finally:
+            if not published:
+                rollback_task = asyncio.create_task(
+                    self._rollback_start(reservation, handle),
+                    name="harness-process-host-start-rollback",
+                )
+                try:
+                    await _await_cleanup_before_propagating_cancellation(rollback_task)
+                except BaseException as cleanup_error:
+                    if primary_error is not None:
+                        primary_error.add_note(
+                            f"process start rollback also failed: {cleanup_error}"
+                        )
+                        raise primary_error from cleanup_error
+                    raise
+
+    async def close(self) -> None:
+        async with self._lock:
+            task = self._close_task
+            if task is None:
+                self._state = "closing"
+                task = asyncio.create_task(
+                    self._close_owned(),
+                    name="harness-process-host-close",
+                )
+                self._close_task = task
+        await _await_cleanup_before_propagating_cancellation(task)
+
+    async def _close_owned(self) -> None:
+        async with self._lock:
+            reservations = tuple(self._reservations.values())
+            reservation_tasks = tuple(
+                reservation.owner for reservation in reservations
+            )
+        for task in reservation_tasks:
+            if task is not asyncio.current_task():
+                task.cancel()
+        if reservation_tasks:
+            await asyncio.gather(*reservation_tasks, return_exceptions=True)
+
+        async with self._lock:
+            registrations = tuple(self._registrations)
+        close_errors = tuple(
+            reservation.cleanup_error
+            for reservation in reservations
+            if reservation.cleanup_error is not None
+        )
+        if registrations:
+            results = await asyncio.gather(
+                *(registration.close() for registration in registrations),
+                return_exceptions=True,
+            )
+            close_errors = (
+                *close_errors,
+                *(
+                    result
+                    for result in results
+                    if isinstance(result, BaseException)
+                ),
+            )
+        async with self._lock:
+            self._state = "closed"
+        if close_errors:
+            raise ProcessHostError(
+                "one or more hosted processes failed to close"
+            ) from (close_errors[0])
+
+    async def _release(self, handle: _HostedProcess) -> None:
+        async with self._lock:
+            self._registrations.discard(handle)
+
+    async def _rollback_start(
+        self,
+        reservation: _Reservation,
+        handle: _HostedProcess | None,
+    ) -> None:
+        try:
+            async with self._lock:
+                self._reservations.pop(reservation.reservation_id, None)
+            if handle is not None:
+                await handle.close()
+            else:
+                try:
+                    if reservation.transport is not None:
+                        await _close_unpublished_transport(
+                            reservation.transport,
+                            grace_seconds=self._termination_grace_seconds,
+                        )
+                finally:
+                    if reservation.containment is not None:
+                        await reservation.containment.close()
+        except BaseException as exc:
+            reservation.cleanup_error = exc
+            raise
+
+
+async def _close_unpublished_transport(
+    transport: ProcessTransport,
+    *,
+    grace_seconds: float,
+) -> None:
+    primary_error: BaseException | None = None
+    stream = transport.stdin
+    if stream is not None:
+        try:
+            stream.close()
+            with suppress(BrokenPipeError, ConnectionResetError):
+                await stream.wait_closed()
+        except BaseException as exc:
+            primary_error = exc
+    terminate_local_process(transport)
+    try:
+        try:
+            await asyncio.wait_for(transport.wait(), grace_seconds)
+        except TimeoutError:
+            kill_local_process(transport)
+            await transport.wait()
+    except BaseException as exc:
+        primary_error = _record_cleanup_error(
+            primary_error,
+            exc,
+            context="unpublished process settlement also failed",
+        )
+    if primary_error is not None:
+        raise primary_error
+
+
+def _record_cleanup_error(
+    primary: BaseException | None,
+    error: BaseException,
+    *,
+    context: str,
+) -> BaseException:
+    if primary is None:
+        return error
+    if error is not primary:
+        primary.add_note(f"{context}: {error}")
+    return primary
+
+
+async def _await_cleanup_before_propagating_cancellation(
+    task: asyncio.Task[None],
+) -> None:
+    cancellation: asyncio.CancelledError | None = None
+    while True:
+        try:
+            await asyncio.shield(task)
+            break
+        except asyncio.CancelledError as exc:
+            if task.cancelled():
+                raise
+            if cancellation is None:
+                cancellation = exc
+        except BaseException as exc:
+            if cancellation is not None:
+                raise cancellation from exc
+            raise
+    if cancellation is not None:
+        raise cancellation
+
+
+__all__ = [
+    "ProcessHost",
+    "ProcessHostCapacityError",
+    "ProcessHostClosedError",
+    "ProcessHostError",
+    "ProcessWriteLimitError",
+]

--- a/src/loushang/harness/workspace/process/local.py
+++ b/src/loushang/harness/workspace/process/local.py
@@ -1,0 +1,211 @@
+"""Internal local transport and spawn seam for Process Hosting."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from typing import NoReturn, Protocol, cast
+
+from loushang.harness.workspace._local_process import (
+    kill_local_process,
+    spawn_local_process,
+)
+
+from .types import ProcessLaunchRequest
+
+
+class ProcessReader(Protocol):
+    async def read(self, max_bytes: int = -1) -> bytes: ...
+
+
+class ProcessWriter(Protocol):
+    def write(self, data: bytes) -> None: ...
+
+    async def drain(self) -> None: ...
+
+    def close(self) -> None: ...
+
+    async def wait_closed(self) -> None: ...
+
+
+class ProcessTransport(Protocol):
+    @property
+    def pid(self) -> int | None: ...
+
+    @property
+    def returncode(self) -> int | None: ...
+
+    @property
+    def stdin(self) -> ProcessWriter | None: ...
+
+    @property
+    def stdout(self) -> ProcessReader | None: ...
+
+    @property
+    def stderr(self) -> ProcessReader | None: ...
+
+    async def wait(self) -> int: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
+
+
+SpawnAttachment = Callable[[ProcessTransport], None]
+ContainmentClose = Callable[[], Awaitable[None] | None]
+
+
+class ProcessContainmentPlan:
+    """Internal spawn material plus one idempotent lifetime cleanup."""
+
+    def __init__(
+        self,
+        request: ProcessLaunchRequest,
+        *,
+        close: ContainmentClose | None = None,
+    ) -> None:
+        if not isinstance(request, ProcessLaunchRequest):
+            raise TypeError("containment plan requires ProcessLaunchRequest")
+        if close is not None and not callable(close):
+            raise TypeError("containment plan close callback must be callable")
+        self.request = request
+        self._close_callback = close
+        self._close_lock = asyncio.Lock()
+        self._close_task: asyncio.Task[None] | None = None
+
+    async def close(self) -> None:
+        async with self._close_lock:
+            task = self._close_task
+            if task is None:
+                task = asyncio.create_task(
+                    self._close_owned(),
+                    name="harness-process-containment-close",
+                )
+                self._close_task = task
+        await asyncio.shield(task)
+
+    async def _close_owned(self) -> None:
+        if self._close_callback is None:
+            return
+        result = self._close_callback()
+        if inspect.isawaitable(result):
+            await result
+
+
+class ProcessContainmentPlanner(Protocol):
+    async def __call__(
+        self,
+        request: ProcessLaunchRequest,
+    ) -> ProcessContainmentPlan: ...
+
+
+class ProcessSpawner(Protocol):
+    async def __call__(
+        self,
+        request: ProcessLaunchRequest,
+        *,
+        on_spawn: SpawnAttachment,
+    ) -> ProcessTransport: ...
+
+
+class LocalProcessSpawner:
+    """Spawn locally while making cancellation after OS creation recoverable."""
+
+    async def __call__(
+        self,
+        request: ProcessLaunchRequest,
+        *,
+        on_spawn: SpawnAttachment,
+    ) -> ProcessTransport:
+        spawn_task = cast(
+            "asyncio.Task[ProcessTransport]",
+            asyncio.create_task(
+                spawn_local_process(
+                    command=request.command,
+                    cwd=request.cwd,
+                    environment=dict(request.effective_environment),
+                    pipe_stdin=True,
+                ),
+                name="harness-local-process-spawn",
+            ),
+        )
+        try:
+            process = await asyncio.shield(spawn_task)
+        except asyncio.CancelledError as cancelled:
+            await _reclaim_spawn_before_propagating_cancellation(
+                spawn_task,
+                on_spawn=on_spawn,
+                cancellation=cancelled,
+            )
+        try:
+            on_spawn(process)
+        except BaseException:
+            kill_local_process(process)
+            await process.wait()
+            raise
+        return process
+
+
+async def _reclaim_spawn_before_propagating_cancellation(
+    spawn_task: asyncio.Task[ProcessTransport],
+    *,
+    on_spawn: SpawnAttachment,
+    cancellation: asyncio.CancelledError,
+) -> NoReturn:
+    while True:
+        try:
+            process = await asyncio.shield(spawn_task)
+            break
+        except asyncio.CancelledError:
+            if not spawn_task.done():
+                continue
+            try:
+                process = spawn_task.result()
+            except BaseException as exc:
+                raise cancellation from exc
+            break
+        except BaseException as exc:
+            raise cancellation from exc
+
+    try:
+        on_spawn(process)
+    except BaseException as exc:
+        attachment_error: BaseException | None = exc
+    else:
+        attachment_error = None
+
+    kill_local_process(process)
+    wait_task = asyncio.create_task(
+        process.wait(),
+        name="harness-cancelled-local-process-wait",
+    )
+    while True:
+        try:
+            await asyncio.shield(wait_task)
+            break
+        except asyncio.CancelledError:
+            if not wait_task.done():
+                continue
+            try:
+                wait_task.result()
+            except BaseException as exc:
+                raise cancellation from exc
+            break
+        except BaseException as exc:
+            raise cancellation from exc
+    if attachment_error is not None:
+        raise cancellation from attachment_error
+    raise cancellation
+
+
+__all__ = [
+    "LocalProcessSpawner",
+    "ProcessContainmentPlan",
+    "ProcessContainmentPlanner",
+    "ProcessReader",
+    "ProcessSpawner",
+    "ProcessTransport",
+    "ProcessWriter",
+    "SpawnAttachment",
+]

--- a/src/loushang/harness/workspace/process/types.py
+++ b/src/loushang/harness/workspace/process/types.py
@@ -1,0 +1,116 @@
+"""Public, Product-neutral contracts for hosted workspace processes."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+
+def _string_tuple(value: object, *, field_name: str) -> tuple[str, ...]:
+    if isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string sequence, not a shell string")
+    try:
+        normalized: tuple[object, ...] = tuple(value)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise TypeError(f"{field_name} must be a string sequence") from exc
+    if not normalized or any(
+        not isinstance(item, str) or not item for item in normalized
+    ):
+        raise ValueError(f"{field_name} must be a non-empty string sequence")
+    return tuple(item for item in normalized if isinstance(item, str))
+
+
+def _environment_tuple(value: object) -> tuple[tuple[str, str], ...]:
+    if isinstance(value, str):
+        raise TypeError("effective_environment must contain string pairs")
+    try:
+        items: tuple[object, ...] = tuple(value)  # type: ignore[arg-type]
+    except TypeError as exc:
+        raise TypeError("effective_environment must contain string pairs") from exc
+    normalized: list[tuple[str, str]] = []
+    for item in items:
+        if isinstance(item, str) or not isinstance(item, Iterable):
+            raise TypeError("effective_environment must contain string pairs")
+        pair: tuple[object, ...] = tuple(item)
+        if (
+            len(pair) != 2
+            or not isinstance(pair[0], str)
+            or not pair[0]
+            or not isinstance(pair[1], str)
+        ):
+            raise TypeError("effective_environment must contain string pairs")
+        normalized.append((pair[0], pair[1]))
+    names = tuple(name for name, _ in normalized)
+    if len(set(names)) != len(names):
+        raise ValueError("effective_environment names must be unique")
+    return tuple(normalized)
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessLaunchRequest:
+    """One fully materialized, shell-free process launch request."""
+
+    command: tuple[str, ...]
+    cwd: str
+    effective_environment: tuple[tuple[str, str], ...] = field(repr=False)
+
+    def __post_init__(self) -> None:
+        command = _string_tuple(self.command, field_name="command")
+        requested_cwd = Path(self.cwd).expanduser()
+        if not requested_cwd.is_absolute():
+            raise ValueError("process cwd must be an absolute path")
+        object.__setattr__(self, "command", command)
+        object.__setattr__(self, "cwd", str(requested_cwd.resolve()))
+        object.__setattr__(
+            self,
+            "effective_environment",
+            _environment_tuple(self.effective_environment),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessExit:
+    return_code: int
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessStderrTail:
+    content: bytes = b""
+    truncated: bool = False
+
+
+class ProcessHandle(Protocol):
+    async def read_stdout(self, max_bytes: int = 64 * 1024) -> bytes: ...
+
+    async def write_stdin(self, data: bytes) -> None: ...
+
+    async def close_stdin(self) -> None: ...
+
+    async def wait(self) -> ProcessExit: ...
+
+    async def terminate(self) -> ProcessExit: ...
+
+    async def close(self) -> None: ...
+
+    def stderr_tail(self) -> ProcessStderrTail: ...
+
+
+class AuthorizedProcessLauncher(Protocol):
+    async def start(
+        self,
+        request: ProcessLaunchRequest,
+        *,
+        correlation_id: str,
+        signal: object | None = None,
+    ) -> ProcessHandle: ...
+
+
+__all__ = [
+    "AuthorizedProcessLauncher",
+    "ProcessExit",
+    "ProcessHandle",
+    "ProcessLaunchRequest",
+    "ProcessStderrTail",
+]

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -5389,6 +5389,40 @@ def test_harness_workspace_execution_boundary_is_documented() -> None:
     assert "`loushang.harness.workspace.truncation`" in inventory_text
     assert "workspace execution implementation complete" in inventory_text
 
+
+def test_process_hosting_h1_keeps_product_and_h2_bindings_outside_workspace() -> None:
+    process_root = Path("src/loushang/harness/workspace/process")
+    forbidden_prefixes = (
+        "loushang.coding",
+        "loushang.harness.sandbox",
+        "loushang.harness.tools",
+        "loushang.harnesstui",
+    )
+    offenders: list[str] = []
+    for path in sorted(process_root.rglob("*.py")):
+        for imported in _absolute_imports(path):
+            if _matches_any(imported, forbidden_prefixes):
+                offenders.append(f"{path.as_posix()} imports {imported}")
+
+    assert offenders == []
+
+    design_path = Path(
+        "docs/internals/architecture/harness/process-hosting-boundary.md"
+    )
+    design_text = " ".join(design_path.read_text(encoding="utf-8").split())
+    required_phrases = {
+        "Harness Process Hosting Boundary",
+        "Long-lived Sandbox ownership is intentionally not claimed by the H1 core",
+        "Deferred to H2",
+        "There is no public `ProcessBackend`",
+    }
+    assert (
+        sorted(
+            phrase for phrase in required_phrases if phrase not in design_text
+        )
+        == []
+    )
+
     coding_exec_text = Path(
         "docs/internals/architecture/coding/component-interfaces/exec.md"
     ).read_text(encoding="utf-8")

--- a/tests/harness/workspace/process/test_host.py
+++ b/tests/harness/workspace/process/test_host.py
@@ -1,0 +1,517 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from loushang.harness.workspace.process import ProcessLaunchRequest
+from loushang.harness.workspace.process import local as local_process
+from loushang.harness.workspace.process.host import (
+    ProcessHost,
+    ProcessHostCapacityError,
+    ProcessHostClosedError,
+    ProcessHostError,
+    ProcessWriteLimitError,
+)
+from loushang.harness.workspace.process.local import (
+    ProcessContainmentPlan,
+    ProcessTransport,
+    SpawnAttachment,
+)
+
+
+class _FakeReader:
+    def __init__(self) -> None:
+        self._chunks: asyncio.Queue[bytes | None] = asyncio.Queue()
+        self._remainder = b""
+
+    def feed(self, content: bytes) -> None:
+        self._chunks.put_nowait(content)
+
+    def close(self) -> None:
+        self._chunks.put_nowait(None)
+
+    async def read(self, max_bytes: int = -1) -> bytes:
+        if not self._remainder:
+            chunk = await self._chunks.get()
+            if chunk is None:
+                return b""
+            self._remainder = chunk
+        if max_bytes < 0:
+            content, self._remainder = self._remainder, b""
+            return content
+        content, self._remainder = (
+            self._remainder[:max_bytes],
+            self._remainder[max_bytes:],
+        )
+        return content
+
+
+class _FailingReader:
+    def close(self) -> None:
+        return None
+
+    async def read(self, max_bytes: int = -1) -> bytes:
+        del max_bytes
+        raise OSError("synthetic stderr failure")
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.writes: list[bytes] = []
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        if self.closed:
+            raise BrokenPipeError
+        self.writes.append(data)
+
+    async def drain(self) -> None:
+        await asyncio.sleep(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        await asyncio.sleep(0)
+
+
+class _FailingCloseWriter(_FakeWriter):
+    async def wait_closed(self) -> None:
+        raise OSError("synthetic stdin close failure")
+
+
+class _FakeTransport:
+    pid = None
+
+    def __init__(self, *, terminate_immediately: bool = True) -> None:
+        self.returncode: int | None = None
+        self.stdin = _FakeWriter()
+        self.stdout = _FakeReader()
+        self.stderr = _FakeReader()
+        self.terminate_immediately = terminate_immediately
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self._exit: asyncio.Future[int] = asyncio.get_running_loop().create_future()
+
+    async def wait(self) -> int:
+        return await asyncio.shield(self._exit)
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        if self.terminate_immediately:
+            self.finish(-15)
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.finish(-9)
+
+    def finish(self, return_code: int, *, stderr: bytes = b"") -> None:
+        if self._exit.done():
+            return
+        self.returncode = return_code
+        if stderr:
+            self.stderr.feed(stderr)
+        self.stdout.close()
+        self.stderr.close()
+        self._exit.set_result(return_code)
+
+
+class _FakeSpawner:
+    def __init__(
+        self,
+        *,
+        pause_before_create: bool = False,
+        pause_after_attach: bool = False,
+        transport_factory: Callable[[], _FakeTransport] = _FakeTransport,
+    ) -> None:
+        self.pause_before_create = pause_before_create
+        self.pause_after_attach = pause_after_attach
+        self.transport_factory = transport_factory
+        self.entered = asyncio.Event()
+        self.allow_create = asyncio.Event()
+        self.attached = asyncio.Event()
+        self.allow_return = asyncio.Event()
+        self.transports: list[_FakeTransport] = []
+        if not pause_before_create:
+            self.allow_create.set()
+        if not pause_after_attach:
+            self.allow_return.set()
+
+    async def __call__(
+        self,
+        request: ProcessLaunchRequest,
+        *,
+        on_spawn: SpawnAttachment,
+    ) -> ProcessTransport:
+        del request
+        self.entered.set()
+        await self.allow_create.wait()
+        transport = self.transport_factory()
+        self.transports.append(transport)
+        on_spawn(transport)
+        self.attached.set()
+        await self.allow_return.wait()
+        return transport
+
+
+class _FailOnceSpawner(_FakeSpawner):
+    def __init__(self) -> None:
+        super().__init__()
+        self._failed = False
+
+    async def __call__(
+        self,
+        request: ProcessLaunchRequest,
+        *,
+        on_spawn: SpawnAttachment,
+    ) -> ProcessTransport:
+        if not self._failed:
+            self._failed = True
+            raise OSError("synthetic spawn failure")
+        return await super().__call__(request, on_spawn=on_spawn)
+
+
+def _request(tmp_path: Path) -> ProcessLaunchRequest:
+    return ProcessLaunchRequest(
+        command=("language-server", "--stdio"),
+        cwd=str(tmp_path),
+        effective_environment=(),
+    )
+
+
+def test_pending_start_reserves_capacity_and_close_rejects_new_work(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        spawner = _FakeSpawner(pause_before_create=True)
+        host = ProcessHost(spawner=spawner, max_processes=1)
+        start_task = asyncio.create_task(host.start(_request(tmp_path)))
+        await spawner.entered.wait()
+
+        with pytest.raises(ProcessHostCapacityError):
+            await host.start(_request(tmp_path))
+
+        await host.close()
+        with pytest.raises(asyncio.CancelledError):
+            await start_task
+        assert spawner.transports == []
+        with pytest.raises(ProcessHostClosedError):
+            await host.start(_request(tmp_path))
+
+    asyncio.run(scenario())
+
+
+def test_close_racing_attached_start_reclaims_unpublished_child(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        spawner = _FakeSpawner(pause_after_attach=True)
+        host = ProcessHost(spawner=spawner, max_processes=1)
+        start_task = asyncio.create_task(host.start(_request(tmp_path)))
+        await spawner.attached.wait()
+
+        await host.close()
+
+        with pytest.raises(asyncio.CancelledError):
+            await start_task
+        transport = spawner.transports[0]
+        assert transport.stdin.closed is True
+        assert transport.terminate_calls == 1
+        assert transport.returncode == -15
+
+    asyncio.run(scenario())
+
+
+def test_close_racing_spawn_reclaims_attached_containment(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        spawner = _FakeSpawner(pause_before_create=True)
+        close_count = 0
+
+        async def close_containment() -> None:
+            nonlocal close_count
+            close_count += 1
+
+        async def plan(request: ProcessLaunchRequest) -> ProcessContainmentPlan:
+            return ProcessContainmentPlan(request, close=close_containment)
+
+        host = ProcessHost(spawner=spawner)
+        start_task = asyncio.create_task(
+            host.start(_request(tmp_path), containment_planner=plan)
+        )
+        await spawner.entered.wait()
+
+        await host.close()
+
+        with pytest.raises(asyncio.CancelledError):
+            await start_task
+        assert close_count == 1
+
+    asyncio.run(scenario())
+
+
+def test_natural_exit_releases_capacity_and_preserves_bounded_stderr(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        spawner = _FakeSpawner()
+        host = ProcessHost(spawner=spawner, max_processes=1, stderr_max_bytes=4)
+        first = await host.start(_request(tmp_path))
+        transport = spawner.transports[0]
+        transport.stdout.feed(b"a")
+        transport.stdout.feed(b"bc")
+
+        assert await first.read_stdout(2) == b"a"
+        assert await first.read_stdout(2) == b"bc"
+        with pytest.raises(ProcessHostCapacityError):
+            await host.start(_request(tmp_path))
+
+        transport.finish(7, stderr=b"abcdef")
+        first_exit, second_exit = await asyncio.gather(first.wait(), first.wait())
+        assert first_exit is second_exit
+        assert first_exit.return_code == 7
+        assert first.stderr_tail().content == b"cdef"
+        assert first.stderr_tail().truncated is True
+
+        second = await host.start(_request(tmp_path))
+        await second.close()
+        await host.close()
+
+    asyncio.run(scenario())
+
+
+def test_natural_exit_closes_containment_exactly_once(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        spawner = _FakeSpawner()
+        close_count = 0
+
+        async def close_containment() -> None:
+            nonlocal close_count
+            close_count += 1
+
+        async def plan(request: ProcessLaunchRequest) -> ProcessContainmentPlan:
+            return ProcessContainmentPlan(request, close=close_containment)
+
+        host = ProcessHost(spawner=spawner)
+        handle = await host.start(_request(tmp_path), containment_planner=plan)
+        spawner.transports[0].finish(0)
+
+        assert (await handle.wait()).return_code == 0
+        await handle.close()
+        await host.close()
+        assert close_count == 1
+
+    asyncio.run(scenario())
+
+
+def test_stderr_failure_does_not_skip_containment_or_registration_release(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        def failing_transport() -> _FakeTransport:
+            transport = _FakeTransport()
+            transport.stderr = _FailingReader()
+            return transport
+
+        spawner = _FakeSpawner(transport_factory=failing_transport)
+        close_count = 0
+
+        async def close_containment() -> None:
+            nonlocal close_count
+            close_count += 1
+
+        async def plan(request: ProcessLaunchRequest) -> ProcessContainmentPlan:
+            return ProcessContainmentPlan(request, close=close_containment)
+
+        host = ProcessHost(spawner=spawner, max_processes=1)
+        handle = await host.start(_request(tmp_path), containment_planner=plan)
+        spawner.transports[0].finish(0)
+
+        with pytest.raises(OSError, match="synthetic stderr failure"):
+            await handle.wait()
+        assert close_count == 1
+        await host.close()
+
+    asyncio.run(scenario())
+
+
+def test_write_limit_and_terminate_close_race_settle_once(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        spawner = _FakeSpawner()
+        host = ProcessHost(spawner=spawner, max_write_bytes=3)
+        handle = await host.start(_request(tmp_path))
+
+        with pytest.raises(ProcessWriteLimitError):
+            await handle.write_stdin(b"four")
+        await handle.write_stdin(b"abc")
+        assert spawner.transports[0].stdin.writes == [b"abc"]
+
+        termination, _ = await asyncio.gather(handle.terminate(), handle.close())
+        assert termination.return_code == -15
+        assert spawner.transports[0].terminate_calls == 1
+        assert (await handle.wait()) is termination
+        await host.close()
+
+    asyncio.run(scenario())
+
+
+def test_published_close_reports_stdin_failure_after_process_settlement(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        def failing_transport() -> _FakeTransport:
+            transport = _FakeTransport()
+            transport.stdin = _FailingCloseWriter()
+            return transport
+
+        spawner = _FakeSpawner(transport_factory=failing_transport)
+        host = ProcessHost(spawner=spawner)
+        handle = await host.start(_request(tmp_path))
+
+        with pytest.raises(OSError, match="synthetic stdin close failure"):
+            await handle.close()
+        transport = spawner.transports[0]
+        assert transport.terminate_calls == 1
+        assert transport.returncode == -15
+        assert (await handle.wait()).return_code == -15
+        await host.close()
+
+    asyncio.run(scenario())
+
+
+def test_unpublished_close_reports_cleanup_failure_without_leaking_child(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        def failing_transport() -> _FakeTransport:
+            transport = _FakeTransport()
+            transport.stdin = _FailingCloseWriter()
+            return transport
+
+        spawner = _FakeSpawner(
+            pause_after_attach=True,
+            transport_factory=failing_transport,
+        )
+        host = ProcessHost(spawner=spawner)
+        start_task = asyncio.create_task(host.start(_request(tmp_path)))
+        await spawner.attached.wait()
+
+        with pytest.raises(ProcessHostError, match="failed to close"):
+            await host.close()
+        with pytest.raises(asyncio.CancelledError):
+            await start_task
+        transport = spawner.transports[0]
+        assert transport.terminate_calls == 1
+        assert transport.returncode == -15
+
+    asyncio.run(scenario())
+
+
+def test_spawn_failure_rolls_back_reserved_capacity(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        spawner = _FailOnceSpawner()
+        host = ProcessHost(spawner=spawner, max_processes=1)
+
+        with pytest.raises(OSError, match="synthetic spawn failure"):
+            await host.start(_request(tmp_path))
+
+        handle = await host.start(_request(tmp_path))
+        await handle.close()
+        await host.close()
+
+    asyncio.run(scenario())
+
+
+def test_local_spawner_reclaims_child_before_repeated_cancellation_propagates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def scenario() -> None:
+        spawn_entered = asyncio.Event()
+        allow_spawn = asyncio.Event()
+        transport = _FakeTransport(terminate_immediately=False)
+
+        async def delayed_spawn(**kwargs: object) -> _FakeTransport:
+            del kwargs
+            spawn_entered.set()
+            await allow_spawn.wait()
+            return transport
+
+        monkeypatch.setattr(local_process, "spawn_local_process", delayed_spawn)
+        attached: list[ProcessTransport] = []
+        spawn_task = asyncio.create_task(
+            local_process.LocalProcessSpawner()(
+                _request(tmp_path),
+                on_spawn=attached.append,
+            )
+        )
+        await spawn_entered.wait()
+
+        spawn_task.cancel()
+        await asyncio.sleep(0)
+        spawn_task.cancel()
+        allow_spawn.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await spawn_task
+        assert attached == [transport]
+        assert transport.kill_calls == 1
+        assert transport.returncode == -9
+
+    asyncio.run(scenario())
+
+
+def test_host_close_continues_after_caller_cancellation(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        spawner = _FakeSpawner(
+            transport_factory=lambda: _FakeTransport(terminate_immediately=False)
+        )
+        host = ProcessHost(spawner=spawner, termination_grace_seconds=0.01)
+        await host.start(_request(tmp_path))
+
+        interrupted_close = asyncio.create_task(host.close())
+        await asyncio.sleep(0)
+        interrupted_close.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await interrupted_close
+
+        transport = spawner.transports[0]
+        assert transport.terminate_calls == 1
+        assert transport.kill_calls == 1
+        await host.close()
+
+    asyncio.run(scenario())
+
+
+def test_local_host_preserves_raw_stdio_and_bounded_stderr(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        host = ProcessHost(stderr_max_bytes=4)
+        request = ProcessLaunchRequest(
+            command=(
+                sys.executable,
+                "-c",
+                (
+                    "import sys; data=sys.stdin.buffer.read(); "
+                    "sys.stdout.buffer.write(b'A'+data+b'B'); "
+                    "sys.stderr.buffer.write(b'0123456789')"
+                ),
+            ),
+            cwd=str(tmp_path),
+            effective_environment=tuple(os.environ.items()),
+        )
+        handle = await host.start(request)
+        await handle.write_stdin(b"xyz")
+        await handle.close_stdin()
+
+        output = bytearray()
+        while chunk := await handle.read_stdout(2):
+            output.extend(chunk)
+        assert bytes(output) == b"AxyzB"
+        assert (await handle.wait()).return_code == 0
+        assert handle.stderr_tail().content == b"6789"
+        assert handle.stderr_tail().truncated is True
+        await host.close()
+
+    asyncio.run(scenario())

--- a/tests/harness/workspace/process/test_types.py
+++ b/tests/harness/workspace/process/test_types.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+import loushang.harness.workspace.process as process_contracts
+from loushang.harness.workspace.process import ProcessLaunchRequest
+
+
+def test_launch_request_freezes_shell_free_process_state(tmp_path: Path) -> None:
+    command = ["server", "--stdio"]
+    environment = [["TOKEN", "secret"], ["MODE", "test"]]
+
+    request = ProcessLaunchRequest(
+        command=command,
+        cwd=str(tmp_path),
+        effective_environment=environment,
+    )
+    command.append("--mutated")
+    environment[0][1] = "changed"
+
+    assert request.command == ("server", "--stdio")
+    assert request.cwd == str(tmp_path.resolve())
+    assert request.effective_environment == (("TOKEN", "secret"), ("MODE", "test"))
+    assert "secret" not in repr(request)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "error", "message"),
+    [
+        (
+            {
+                "command": "server --stdio",
+                "cwd": "/tmp",
+                "effective_environment": (),
+            },
+            TypeError,
+            "shell string",
+        ),
+        (
+            {"command": ("server",), "cwd": "relative", "effective_environment": ()},
+            ValueError,
+            "absolute path",
+        ),
+        (
+            {
+                "command": ("server",),
+                "cwd": "/tmp",
+                "effective_environment": (("A", "1"), ("A", "2")),
+            },
+            ValueError,
+            "unique",
+        ),
+    ],
+)
+def test_launch_request_rejects_ambiguous_process_state(
+    kwargs: dict[str, object],
+    error: type[Exception],
+    message: str,
+) -> None:
+    with pytest.raises(error, match=message):
+        ProcessLaunchRequest(**kwargs)  # type: ignore[arg-type]
+
+
+def test_public_contract_does_not_expose_host_or_caller_controlled_limits() -> None:
+    assert "ProcessHost" not in process_contracts.__all__
+    assert not hasattr(process_contracts, "ProcessHost")
+    assert "ProcessExecutionScope" not in process_contracts.__all__
+    assert not hasattr(process_contracts, "ProcessExecutionScope")
+    assert {field.name for field in fields(ProcessLaunchRequest)} == {
+        "command",
+        "cwd",
+        "effective_environment",
+    }


### PR DESCRIPTION
## What changed

- add a bounded, product-neutral Process Hosting core under `loushang.harness.workspace.process`
- expose only the consumer-facing launch protocol and process value objects; keep the concrete host, local transport, spawner, and containment seams internal
- share low-level local process spawn/termination mechanics with `ExecService` without merging their ownership or lifecycle semantics
- define and document capacity reservation, start/close races, termination, bounded stderr, containment cleanup, and host shutdown invariants
- harden rollback and cleanup so stdin failures do not skip child settlement, capacity release, or containment cleanup

## Why

Long-lived language servers and similar Harness capabilities need process ownership beyond one-shot `ExecService` calls. This H1 change establishes the smallest reusable substrate while preserving the architecture boundary: authorization policy, Sandbox binding, Coding/LSP integration, and tool exposure remain deferred to H2.

## Impact

Harness consumers can target the narrow `AuthorizedProcessLauncher` protocol without depending on a product, CLI, Sandbox backend, or concrete process implementation. Existing `ExecService` behavior is retained while its duplicated local OS mechanics move behind the shared private helper.

## Scope guardrails

- no public `ProcessBackend` abstraction
- no `coding`, `harnesstui`, `harness.tools`, or `harness.sandbox` dependency from the H1 package
- no keep-alive switch added to `ExecService`
- H2 authorization/Sandbox/Coding bindings are intentionally excluded from this PR

## Validation

- `ruff` on affected source and tests
- `mypy` on `harness.workspace.exec`, `harness.workspace.process`, and `_local_process.py`
- 1,955 architecture, Harness, agent-invocation, and Coding CLI tests passed
- `git diff --check origin/lane/harness...HEAD`
