### PR TITLE
fix(ai): default pairing to repair so interrupted transcripts recover

### DIFF
--- a/src/loushang/ai/README.md
+++ b/src/loushang/ai/README.md
@@ -142,8 +142,10 @@ register_api_provider(custom_adapter)
 `timeout_seconds` 是一次 attempt 的完整 deadline，覆盖请求创建、首包和完整消费。
 `idle_timeout_seconds` 只约束流式 raw part 之间的空闲时间。
 
-`pairing_mode` 默认是 `strict`。只有调用方显式选择 `repair` 时，归一化层才修复
-历史 tool-call/tool-result transcript。
+`pairing_mode` 默认是 `repair`。默认修复历史 tool-call/tool-result transcript 中
+缺失的结果（例如一次运行在工具调用后、结果写回前被中断），补入 synthetic
+error result 并继续，而不是让整个请求失败。需要严格校验（例如新会话的
+消息流）时，调用方可显式选择 `strict`。
 
 `cache_key` 是不透明协议缓存键，不代表 Loushang session。当前只有声明支持的 adapter
 消费它；`cache_retention="none"` 会移除该键。

--- a/src/loushang/ai/api/streaming.py
+++ b/src/loushang/ai/api/streaming.py
@@ -204,8 +204,8 @@ def _supports_structured_output_mapping(adapter: object) -> bool:
 
 def _resolve_pairing_mode(options) -> PairingMode:
     if options is None:
-        return "strict"
-    pairing_mode = getattr(options, "pairing_mode", "strict")
+        return "repair"
+    pairing_mode = getattr(options, "pairing_mode", "repair")
     if pairing_mode == "repair":
         return "repair"
     return "strict"

--- a/src/loushang/ai/options.py
+++ b/src/loushang/ai/options.py
@@ -90,7 +90,11 @@ class CallOptions:
     idle_timeout_seconds: float | int | None = None
     retry: RetryOptions | None = None
     trace: object | None = None
-    pairing_mode: PairingMode = "strict"
+    # Default to repair so interrupted/partial transcripts (e.g. a run killed
+    # mid-tool-call) recover automatically instead of failing the whole request.
+    # Callers that need strict validation (e.g. new-session message flow) can
+    # set pairing_mode="strict" explicitly.
+    pairing_mode: PairingMode = "repair"
     reasoning: ReasoningOptions | None = None
     tool_choice: ToolChoice | None = None
     output: StructuredOutputOptions | None = None

--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from dataclasses import replace
 from functools import partial
 from pathlib import Path
 from typing import Literal, cast
@@ -223,6 +224,28 @@ def _create_agent_session(
                 "child approval actor must match its delegated execution profile"
             )
     services = services or create_services()
+    # Restored sessions carry historical transcript.  A previous run may have
+    # been interrupted between a tool call and its result, leaving an unpaired
+    # toolCall in the transcript.  Force repair pairing for such sessions so
+    # resume recovers automatically instead of raising
+    # "Missing tool results before next message".  New sessions have no
+    # history and stay on the (global) default.
+    if len(session_manager.get_entries()) > 0:
+        base_factory = agent_factory
+
+        def _resume_agent_factory(**kwargs: object) -> Agent:
+            from loushang.ai.options import CallOptions
+
+            call_options = kwargs.get("call_options")
+            if call_options is None:
+                kwargs["call_options"] = CallOptions(pairing_mode="repair")
+            else:
+                kwargs["call_options"] = replace(
+                    call_options, pairing_mode="repair"
+                )
+            return base_factory(**kwargs)
+
+        agent_factory = _resume_agent_factory
     multiagent_types = None
     resolved_append_system_prompt = tuple(append_system_prompt or ())
     if enable_multiagent:

--- a/tests/ai/test_api_streaming.py
+++ b/tests/ai/test_api_streaming.py
@@ -244,9 +244,14 @@ def test_public_stream_suppresses_cache_key_when_retention_is_none() -> None:
     assert provider.request.options.cache_key is None
 
 
-def test_stream_defaults_to_strict_pairing_and_exposes_repair_option(
+def test_stream_defaults_to_repair_pairing_and_exposes_strict_option(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Default pairing repairs missing tool results; strict remains opt-in.
+
+    The default changed from strict to repair so restored/interrupted
+    transcripts recover automatically instead of failing the whole request.
+    """
     _patch_resolved_request(monkeypatch)
     monkeypatch.setattr("loushang.ai.messages.resolve_model_api", lambda _model: "faux")
     monkeypatch.setattr(
@@ -276,20 +281,7 @@ def test_stream_defaults_to_strict_pairing_and_exposes_repair_option(
         timestamp=0.0,
     )
 
-    with pytest.raises(ValueError, match="Missing tool results before next message"):
-        asyncio.run(
-            stream(
-                _Model(),
-                {
-                    "messages": [
-                        assistant,
-                        UserMessage(role="user", content="next", timestamp=0.0),
-                    ]
-                },
-                CallOptions(),
-            )
-        )
-
+    # Default (CallOptions()) now repairs the missing tool result.
     asyncio.run(
         stream(
             _Model(),
@@ -299,7 +291,7 @@ def test_stream_defaults_to_strict_pairing_and_exposes_repair_option(
                     UserMessage(role="user", content="next", timestamp=0.0),
                 ]
             },
-            CallOptions(pairing_mode="repair"),
+            CallOptions(),
         )
     )
 
@@ -313,6 +305,21 @@ def test_stream_defaults_to_strict_pairing_and_exposes_repair_option(
     assert isinstance(synthetic, ToolResultMessage)
     assert synthetic.tool_call_id == "call_1"
     assert synthetic.is_error is True
+
+    # Explicit strict still rejects the malformed transcript.
+    with pytest.raises(ValueError, match="Missing tool results before next message"):
+        asyncio.run(
+            stream(
+                _Model(),
+                {
+                    "messages": [
+                        assistant,
+                        UserMessage(role="user", content="next", timestamp=0.0),
+                    ]
+                },
+                CallOptions(pairing_mode="strict"),
+            )
+        )
 
 
 def test_complete_raises_typed_error_for_stream_error(


### PR DESCRIPTION
## Problem

A run interrupted between a tool call and its result leaves an unpaired toolCall in the transcript. With the previous `strict` pairing default, any resume of such a session failed with `Missing tool results before next message` before the first model request — making the session permanently unresumable.

## Root Cause

- `CallOptions.pairing_mode` defaulted to `strict`, which raises on any historical unpaired toolCall.
- `transform.py` already implements repair (synthesizes an error tool result + `missing_tool_result` diagnostic), but it was never the default.
- Coding resume path did not opt in to repair.

## Fix

1. **AI layer (global default)**: `CallOptions.pairing_mode` and `_resolve_pairing_mode` now default to `repair`. Interrupted/partial transcripts recover automatically; explicit `pairing_mode="strict"` remains available for callers needing strict validation.
2. **Coding resume (defense-in-depth)**: `_create_agent_session` wraps `agent_factory` for restored sessions (history present) to force `pairing_mode="repair"`, so resume stays safe even if the global default changes back to strict.
3. **Docs & tests**: README updated; `test_stream_defaults_to_strict_pairing_and_exposes_repair_option` rewritten to assert the new default repairs while explicit strict still rejects.

## Validation

- `pytest tests/ai/`: 647 passed, 7 skipped.
- `pytest tests/coding/`: 2278 passed; 8 pre-existing macOS path/Unicode failures unrelated to this change.
- `ruff check`: clean.
- End-to-end: malformed transcript (toolCall without result) + default options now normalizes successfully (synthetic error toolResult inserted).