### PR TITLE
test(coding): fix macOS platform-specific test assertions

### DIFF
--- a/tests/coding/test_bootstrap.py
+++ b/tests/coding/test_bootstrap.py
@@ -1797,6 +1797,8 @@ def test_create_agent_session_marks_failing_mutation_builtin_tool_result_as_erro
 def test_create_agent_session_passes_resource_loader_into_agent_session(
     tmp_path,
 ) -> None:
+    from pathlib import Path
+
     from loushang.coding.bootstrap import create_agent_session, create_services
     from loushang.coding.resource_runtime import (
         CodingResourceLoader as DefaultResourceLoader,
@@ -1824,7 +1826,8 @@ def test_create_agent_session_passes_resource_loader_into_agent_session(
     )
 
     assert session._resource_loader is loader
-    assert loader.discover_calls == ["/tmp/project"]
+    # /tmp is a symlink to /private/tmp on macOS; assert the resolved form.
+    assert loader.discover_calls == [str(Path("/tmp/project").resolve())]
 
 
 def test_runtime_tool_failures_still_surface_as_tool_result_errors(tmp_path) -> None:

--- a/tests/coding/test_control_services.py
+++ b/tests/coding/test_control_services.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import date
+from pathlib import Path
 
 from loushang.ai.model import Capabilities, Model
 
@@ -151,7 +152,7 @@ def test_create_services_provides_settings_and_model_resolution_for_sessions(
     )
     assert (
         session.agent.system_prompt
-        == f"Be precise.\n\n{_runtime_footer('/tmp/project')}"
+        == f"Be precise.\n\n{_runtime_footer(str(Path('/tmp/project').resolve()))}"
     )
     assert session.agent.thinking_level == "high"
 

--- a/tests/coding/test_policy_engine.py
+++ b/tests/coding/test_policy_engine.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 
 def _bash_tool(
     *,
@@ -450,7 +452,9 @@ def test_policy_engine_compatibility_paths_use_last_execution_path(tmp_path) -> 
     (tmp_path / "cat").symlink_to("/bin/bash")
     engine = PolicyEngine()
     dangerous_env = (("PATH", "/usr/bin"), ("PATH", str(tmp_path)))
-    safe_env = tuple(reversed(dangerous_env))
+    # /usr/bin/cat does not exist on macOS (cat lives in /bin); include /bin so
+    # the "safe" PATH resolves a real cat on every platform.
+    safe_env = (("PATH", str(tmp_path)), ("PATH", "/usr/bin:/bin"))
 
     action = _evaluate_action(
         engine,
@@ -780,7 +784,7 @@ def test_bash_policy_evaluates_configured_shell_path(tmp_path) -> None:
 
 def test_bash_policy_blocks_destructive_shell_stdin_before_execution(tmp_path) -> None:
     import asyncio
-    from shutil import copy2
+    from shutil import copyfile
 
     import pytest
 
@@ -804,7 +808,9 @@ def test_bash_policy_blocks_destructive_shell_stdin_before_execution(tmp_path) -
     (tmp_path / "runner").symlink_to("/usr/bin/env")
     copied_shell_dir = tmp_path / "copied-shell"
     copied_shell_dir.mkdir()
-    copy2("/bin/bash", copied_shell_dir / "bash")
+    # copyfile (not copy2) avoids copying platform file flags; on macOS copy2
+    # triggers chflags PermissionError when reproducing /bin/bash attributes.
+    copyfile("/bin/bash", copied_shell_dir / "bash")
 
     for index, (command, cwd) in enumerate(
         (
@@ -816,9 +822,6 @@ def test_bash_policy_blocks_destructive_shell_stdin_before_execution(tmp_path) -
             (["bash", "/proc/thread-self/fd/0"], str(tmp_path)),
             (["bash", "/proc/self/root/dev/stdin"], str(tmp_path)),
             (["bash", "/proc/thread-self/root/dev/stdin"], str(tmp_path)),
-            (["bash", "/proc/self/root/../dev/stdin"], str(tmp_path)),
-            (["bash", "/proc/thread-self/root/../dev/stdin"], str(tmp_path)),
-            (["bash", "/proc/self/root/../../dev/stdin"], str(tmp_path)),
             (["bash", "../dev/stdin"], "/tmp"),
             (["bash", "../dev/fd/0"], "/tmp"),
             (["bash", "../proc/self/fd/0"], "/tmp"),
@@ -853,6 +856,17 @@ def test_bash_policy_blocks_destructive_shell_stdin_before_execution(tmp_path) -
                 ["/bin/busybox", "ash", "-c", "rm -rf /tmp/demo"],
                 str(tmp_path),
             ),
+        )
+        + (
+            # /proc/self/root/.. paths only exist on Linux; on macOS /proc does
+            # not exist, so these resolve to a missing path and are not stdin.
+            (
+                (["bash", "/proc/self/root/../dev/stdin"], str(tmp_path)),
+                (["bash", "/proc/thread-self/root/../dev/stdin"], str(tmp_path)),
+                (["bash", "/proc/self/root/../../dev/stdin"], str(tmp_path)),
+            )
+            if sys.platform.startswith("linux")
+            else ()
         )
     ):
         with pytest.raises(PermissionError):

--- a/tests/coding/test_source_info.py
+++ b/tests/coding/test_source_info.py
@@ -15,7 +15,9 @@ def test_executable_source_identity_projects_stable_runtime_details(
 
     details = coding_runtime_identity(cwd=tmp_path)
 
-    assert details["entrypoint"] == "/tmp/bin/loushang"
+    # entrypoint is resolved (symlinks expanded, e.g. /tmp -> /private/tmp on macOS);
+    # python_executable and argv0 keep the caller-supplied form.
+    assert details["entrypoint"] == str(Path("/tmp/bin/loushang").resolve())
     assert details["python_executable"] == "/tmp/python"
     assert details["argv0"] == "/tmp/bin/loushang"
     assert details["cwd"] == str(tmp_path)

--- a/tests/coding/test_tool_path_utils.py
+++ b/tests/coding/test_tool_path_utils.py
@@ -88,12 +88,16 @@ def test_resolve_tool_path_finds_existing_macos_screenshot_lowercase_am_pm_varia
 
 
 def test_resolve_tool_path_finds_existing_nfd_unicode_variant(tmp_path: Path) -> None:
+    import os
+
     target = tmp_path / "file\u0065\u0301.txt"
     target.write_text("accented payload", encoding="utf-8")
 
     resolved = resolve_tool_path("file\u00e9.txt", cwd=str(tmp_path))
 
-    assert resolved == target.resolve()
+    # macOS APFS treats NFC/NFD as the same file, so string equality on the
+    # normalization form is not portable; compare by file identity.
+    assert os.path.samefile(resolved, target)
 
 
 def test_resolve_tool_path_finds_existing_curly_quote_variant(tmp_path: Path) -> None:
@@ -108,12 +112,14 @@ def test_resolve_tool_path_finds_existing_curly_quote_variant(tmp_path: Path) ->
 def test_resolve_tool_path_finds_existing_combined_nfd_and_curly_quote_variant(
     tmp_path: Path,
 ) -> None:
+    import os
+
     target = tmp_path / "Capture d\u2019e\u0301cran.txt"
     target.write_text("combined payload", encoding="utf-8")
 
     resolved = resolve_tool_path("Capture d'\u00e9cran.txt", cwd=str(tmp_path))
 
-    assert resolved == target.resolve()
+    assert os.path.samefile(resolved, target)
 
 
 def test_resolve_tool_path_rejects_empty_string() -> None:


### PR DESCRIPTION
## Problem

Seven `tests/coding/` tests failed on macOS while passing on Linux. The product code is correct; the test assertions assumed non-macOS platform semantics.

## Root Causes & Fixes

| Category | Tests | Fix |
|---|---|---|
| `/tmp` → `/private/tmp` symlink (macOS) | `test_source_info`, `test_bootstrap`, `test_control_services` | Assert on `Path(...).resolve()` instead of the literal `/tmp` path |
| macOS APFS treats NFC/NFD as the same file | `test_tool_path_utils` (2 tests) | Compare with `os.path.samefile()` (file identity) instead of string equality on normalization form |
| `/usr/bin/cat` missing on macOS (cat in `/bin`) | `test_policy_engine` compatibility paths | Include `/bin` in the test PATH so the safe branch resolves a real cat on every platform |
| `copy2` chflags `PermissionError` on macOS; `/proc` Linux-only | `test_policy_engine` destructive stdin | `copy2` → `copyfile`; gate `/proc/self/root/..` cases with `sys.platform.startswith("linux")` |

## Cross-platform safety

- Linux: `/tmp` is `/tmp`, `/usr/bin/cat` exists, filesystem distinguishes NFC/NFD → all fixes preserve original behavior.
- macOS: fixes account for `/private/tmp`, `/bin/cat`, APFS normalization-insensitivity, chflags.
- `os.path.samefile`, `Path.resolve`, `sys.platform` guards are portable.

## Validation

- `pytest tests/coding/` → **2286 passed, 0 failed** (previously 8 failed including the empty `coding/tools` dir cleanup)
- `ruff check` → clean

Product code unchanged.