### PR TITLE
Test Coding LSP through real process hosting

### DIFF
--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -337,6 +337,7 @@ def _create_agent_session(
         lsp_runtime: CodingLspRuntime | None = None
         lsp_session: AgentSession | None = None
         if lsp_slot is not None:
+
             async def emit_lsp_audit_event(event: Mapping[str, object]) -> None:
                 if lsp_session is None:
                     raise RuntimeError("Coding LSP session is not yet bound")
@@ -709,9 +710,7 @@ def _create_agent_session_runtime(
     fixed_services = services if services is not None else create_services()
     fixed_lsp_definitions = tuple(lsp_definitions)
     fixed_lsp_environment = (
-        dict(lsp_baseline_environment)
-        if lsp_baseline_environment is not None
-        else None
+        dict(lsp_baseline_environment) if lsp_baseline_environment is not None else None
     )
     return build_agent_product_session_runtime(
         session_dir=Path(session_dir),

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -213,8 +213,7 @@ class AgentSession(AgentProductSession):
                     primary_error = cleanup_error
                 else:
                     primary_error.add_note(
-                        "process host or sandbox cleanup also failed: "
-                        f"{cleanup_error}"
+                        f"process host or sandbox cleanup also failed: {cleanup_error}"
                     )
         if primary_error is not None:
             raise primary_error

--- a/tests/coding/lsp/fixtures/fake_lsp_server.py
+++ b/tests/coding/lsp/fixtures/fake_lsp_server.py
@@ -1,0 +1,117 @@
+"""Minimal stdio LSP server used by the real Process Hosting integration test."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+
+def _read_message() -> dict[str, object] | None:
+    headers: dict[str, str] = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        if line in {b"\n", b"\r\n"}:
+            break
+        name, separator, value = line.decode("ascii").partition(":")
+        if not separator:
+            raise RuntimeError("malformed LSP header")
+        headers[name.strip().lower()] = value.strip()
+    content_length = int(headers["content-length"])
+    payload = sys.stdin.buffer.read(content_length)
+    if len(payload) != content_length:
+        raise RuntimeError("LSP request ended mid-frame")
+    message = json.loads(payload)
+    if not isinstance(message, dict):
+        raise RuntimeError("LSP message must be an object")
+    return message
+
+
+def _write_message(message: Mapping[str, object]) -> None:
+    body = json.dumps(
+        dict(message),
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode("ascii"))
+    sys.stdout.buffer.write(body)
+    sys.stdout.buffer.flush()
+
+
+def _record_method(method: str) -> None:
+    log_path = os.environ.get("LOUSHANG_FAKE_LSP_LOG")
+    if log_path is None:
+        return
+    with Path(log_path).open("a", encoding="utf-8") as stream:
+        stream.write(f"{method}\n")
+
+
+def _definition_result(message: Mapping[str, object]) -> dict[str, object]:
+    params = message.get("params", {})
+    text_document = (
+        params.get("textDocument", {}) if isinstance(params, Mapping) else {}
+    )
+    uri = text_document.get("uri") if isinstance(text_document, Mapping) else None
+    if not isinstance(uri, str):
+        raise RuntimeError("definition request is missing a document URI")
+    return {
+        "uri": uri,
+        "range": {
+            "start": {"line": 0, "character": 0},
+            "end": {"line": 0, "character": 6},
+        },
+    }
+
+
+def main() -> int:
+    while True:
+        message = _read_message()
+        if message is None:
+            return 0
+        method = message.get("method")
+        if isinstance(method, str):
+            _record_method(method)
+
+        request_id = message.get("id")
+        if method == "initialize":
+            _write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "capabilities": {
+                            "positionEncoding": "utf-16",
+                            "definitionProvider": True,
+                            "textDocumentSync": 2,
+                        }
+                    },
+                }
+            )
+        elif method == "textDocument/definition":
+            _write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": _definition_result(message),
+                }
+            )
+        elif method == "shutdown":
+            _write_message({"jsonrpc": "2.0", "id": request_id, "result": None})
+        elif method == "exit":
+            return 0
+        elif request_id is not None:
+            _write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {"code": -32601, "message": "Method not found"},
+                }
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/coding/lsp/test_harness_launcher_vertical_slice.py
+++ b/tests/coding/lsp/test_harness_launcher_vertical_slice.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from loushang.coding.lsp import LspServerDefinition, bind_coding_lsp_runtime
+from loushang.coding.sandbox import (
+    bind_coding_sandbox_runtime,
+    coding_workspace_execution_profile,
+)
+from loushang.harness.sandbox import SandboxSettings
+from loushang.harness.tools.process_hosting import ProcessExecutionScope
+from loushang.harness.workspace.exec import ExecService
+
+_FAKE_LSP_SERVER = Path(__file__).parent / "fixtures" / "fake_lsp_server.py"
+
+
+class _NoApprovalResolver:
+    actor_id = "coding-lsp-integration"
+
+    def resolve(self, request: object) -> object:
+        del request
+        raise AssertionError("an admitted Coding LSP launch must not request approval")
+
+
+def test_real_harness_launcher_drives_lsp_query_and_graceful_cleanup(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "pyproject.toml").touch()
+        source = project / "main.py"
+        source.write_text("target = 1\nprint(target)\n", encoding="utf-8")
+        method_log = project / "lsp-methods.log"
+        secret = "must-not-appear-in-audit"
+        audit_events: list[dict[str, object]] = []
+
+        sandbox_runtime = bind_coding_sandbox_runtime(
+            workspace_root=project,
+            writable_workspace=True,
+            settings=SandboxSettings(enabled=False),
+            base_exec_service=ExecService(),
+        )
+        lsp_runtime = None
+        result = None
+        try:
+            lsp_runtime = bind_coding_lsp_runtime(
+                workspace_root=project,
+                definitions=(
+                    LspServerDefinition(
+                        id="repository-fake-python",
+                        command=(sys.executable, str(_FAKE_LSP_SERVER)),
+                        language_extensions={"python": (".py",)},
+                        root_markers=("pyproject.toml",),
+                        environment={
+                            "LOUSHANG_FAKE_LSP_LOG": str(method_log),
+                            "LOUSHANG_FAKE_LSP_SECRET": secret,
+                        },
+                        startup_timeout_seconds=3,
+                        request_timeout_seconds=3,
+                        shutdown_timeout_seconds=3,
+                    ),
+                ),
+                process_launcher_binder=sandbox_runtime,
+                execution_scope=ProcessExecutionScope(
+                    approval_resolver=_NoApprovalResolver(),
+                    audit_sink=audit_events.append,
+                    execution_profile_ceiling=coding_workspace_execution_profile(
+                        project,
+                        writable=True,
+                    ),
+                ),
+                read_text=lambda path: path.read_text(encoding="utf-8"),
+                baseline_environment={},
+            )
+            result = await lsp_runtime.inspect_symbol(
+                path="main.py",
+                line=2,
+                character=7,
+                correlation_id="real-lsp-query-1",
+            )
+        finally:
+            if lsp_runtime is not None:
+                await lsp_runtime.close()
+            await sandbox_runtime.close()
+
+        assert result is not None
+        assert result.server_id == "repository-fake-python"
+        assert result.count == 1
+        assert result.items[0].path == "main.py"
+        assert result.items[0].range.start.line == 1
+        assert result.items[0].range.start.character == 1
+        assert method_log.read_text(encoding="utf-8").splitlines() == [
+            "initialize",
+            "initialized",
+            "textDocument/didOpen",
+            "textDocument/definition",
+            "shutdown",
+            "exit",
+        ]
+
+        assert not any(
+            event.get("type") == "tool_approval_requested" for event in audit_events
+        )
+        frozen = [
+            event for event in audit_events if event.get("type") == "tool_action_frozen"
+        ]
+        assert len(frozen) == 1
+        assert frozen[0]["tool_call_id"] == "real-lsp-query-1"
+        assert frozen[0]["actor_id"] == "coding-lsp-integration"
+        assert secret not in json.dumps(audit_events, sort_keys=True)
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

- add a repository-owned minimal stdio LSP fixture
- drive one real definition query through Coding LSP, the scope-bound Harness launcher, ProcessHost, and an actual child process
- verify lazy admitted launch needs no approval, preserves correlation/actor audit data, keeps environment values out of audit, and performs `shutdown` then `exit`
- retain an explicit empty environment baseline; the two test-only values are supplied by the admitted server definition

## Validation

- `.venv/bin/python -m pytest tests/coding/lsp/test_harness_launcher_vertical_slice.py -q` — 1 passed
- Ruff passes for the fixture, integration test, and mechanically formatted touched source files
- `git diff --check` passes
