### PR TITLE
feat(coding): activate configurable LSP support

### DIFF
--- a/docs/en/user-guide/README.md
+++ b/docs/en/user-guide/README.md
@@ -75,6 +75,41 @@ loushang --tools bash,write -p "Inspect this project."
 loushang --no-tools -p "Explain the repository from context only."
 ```
 
+### LSP Semantic Tools
+
+`coding.lsp` is an optional, high-frequency Coding capability that provides
+`inspect_symbol` and `document_outline`. It defaults to `on_demand`; make the
+tools part of the agent's default tool set for one invocation with:
+
+```bash
+loushang --capability coding.lsp=always
+loushang lsp status
+loushang lsp doctor
+```
+
+Servers still start lazily on the first semantic query. `status` and `doctor`
+only inspect configuration and executable availability; they do not start or
+install a server. Loushang probes installed Pyright, TypeScript Language Server,
+rust-analyzer, gopls, and clangd defaults.
+
+Declare a custom server in `~/.loushang/coding/lsp.json`:
+
+```json
+{
+  "servers": [
+    {
+      "id": "python-custom",
+      "command": ["my-language-server", "--stdio"],
+      "language_extensions": {"python": [".py", ".pyi"]}
+    }
+  ]
+}
+```
+
+Project `.loushang/lsp.json` may tune a Product default or a server already
+declared by the user. Until the general workspace-trust mechanism exists, a
+repository config cannot introduce a new executable or environment override.
+
 ## Extensions
 
 Extensions are Python files that can register lifecycle hooks, tools, dynamic resources, commands, and flags. Start with the runnable extension examples in [examples/coding/extensions](../../../examples/coding/extensions/).

--- a/docs/internals/architecture/coding/component-interfaces/tools.md
+++ b/docs/internals/architecture/coding/component-interfaces/tools.md
@@ -74,6 +74,11 @@
 - 高频查询复用语言 provider 输出的版本化逐文件事实缓存，而不缓存 AST 或主观架构结论。CLI 默认在
   `LOUSHANG_HOME/cache/coding/arch` 使用磁盘缓存；长驻工具复用进程内缓存。内容指纹负责单文件失效，文件集合变化则使依赖
   模块索引的事实整体失效；缓存损坏或版本不兼容必须安全退化为重新分析。
+- `coding.lsp` 同样是 Coding Product Capability Bundle，而不是 Harness builtin。它通过
+  `coding.lsp.tools` 提供 `inspect_symbol` 与 `document_outline`；`on_demand` / `always` 只控制工具可见性，Server
+  始终在第一次语义查询时惰性启动。
+- Coding 拥有 `lsp.json` 的 Server 发现、优先级、可执行文件 admission 与结构化状态；Harness 只提供授权进程启动、
+  Sandbox、裸字节传输和 Session 兜底清理。`loushang lsp status|doctor` 只检查 catalog，不隐式启动或安装 Server。
 
 ## Reference Implementation Alignment
 

--- a/docs/internals/architecture/coding/lsp/specification.md
+++ b/docs/internals/architecture/coding/lsp/specification.md
@@ -89,16 +89,15 @@ runtime.
 ## 3. Configuration Contract
 
 Coding `ControlConfig.capabilities` continues to own the mount selection. LSP
-details belong to a Coding-owned config object. A representative JSON shape is:
+details stay out of Harness configuration and use a Coding-owned `lsp.json`.
+The user-level file is `~/.loushang/coding/lsp.json`; the project-level file is
+`.loushang/lsp.json`. The implemented shape is:
 
 ```json
 {
-  "capabilities": {
-    "coding.lsp": "on_demand"
-  },
-  "lsp": {
-    "servers": {
-      "pyright": {
+  "servers": [
+    {
+        "id": "pyright",
         "command": ["pyright-langserver", "--stdio"],
         "language_extensions": {
           "python": [".py", ".pyi"]
@@ -111,11 +110,14 @@ details belong to a Coding-owned config object. A representative JSON shape is:
         "startup_timeout_seconds": 20,
         "request_timeout_seconds": 15,
         "shutdown_timeout_seconds": 3
-      }
     }
-  }
+  ]
 }
 ```
+
+The mount remains in ordinary Coding settings, for example
+`{"capabilities": {"coding.lsp": "always"}}`, or can be overridden for one
+process with `--capability coding.lsp=always`.
 
 Rules:
 
@@ -134,8 +136,16 @@ Rules:
   interpreted.
 - P0 supports stdio only and has no `transport` field that promises an
   unimplemented socket mode.
+- Product defaults are admitted only when their executable is found; Loushang
+  never installs a language server implicitly.
+- Until a general workspace-trust runtime exists, project config may tune a
+  Product-default or user-admitted server only when its complete argv exactly
+  matches that trusted definition. It cannot introduce process-environment
+  overrides; the admitted user-level environment is inherited unchanged. A
+  custom command must first be declared in the user-level file.
 
-Project-local Server config is not evaluated until workspace trust succeeds.
+This conservative project rule is the P0 substitute for the future general
+workspace-trust gate.
 
 ## 4. Core Data Contracts
 

--- a/docs/zh-CN/user-guide/README.md
+++ b/docs/zh-CN/user-guide/README.md
@@ -67,6 +67,38 @@ loushang --tools bash,write -p "Inspect this project."
 loushang --no-tools -p "Explain the repository from context only."
 ```
 
+### LSP 语义工具
+
+`coding.lsp` 是可选的高频 Coding 能力，提供 `inspect_symbol` 和
+`document_outline`。默认是 `on_demand`；要让它们进入当前 agent 的默认工具集：
+
+```bash
+loushang --capability coding.lsp=always
+loushang lsp status
+loushang lsp doctor
+```
+
+Server 仍只会在第一次语义查询时惰性启动；`status` 和 `doctor` 只检查配置与可执行文件，
+不会启动或安装任何 Server。Loushang 会探测已安装的 Pyright、TypeScript Language
+Server、rust-analyzer、gopls 和 clangd。
+
+自定义 Server 写入 `~/.loushang/coding/lsp.json`：
+
+```json
+{
+  "servers": [
+    {
+      "id": "python-custom",
+      "command": ["my-language-server", "--stdio"],
+      "language_extensions": {"python": [".py", ".pyi"]}
+    }
+  ]
+}
+```
+
+项目的 `.loushang/lsp.json` 可以调整产品默认或用户已声明的 Server，但在通用 workspace
+trust 机制完成前，不能从仓库配置引入新的可执行文件或环境变量。
+
 ## 扩展
 
 扩展是可以注册生命周期 hooks、工具、动态资源、命令和 flags 的 Python 文件。可以先阅读 [examples/coding/extensions](../../../examples/coding/extensions/) 中的可运行扩展示例。

--- a/src/loushang/coding/bootstrap.py
+++ b/src/loushang/coding/bootstrap.py
@@ -18,6 +18,11 @@ from loushang.coding.control.settings_store import (
     default_project_settings_path,
 )
 from loushang.coding.diagnostics.profile import coding_runtime_identity
+from loushang.coding.lsp.discovery import (
+    coding_lsp_config_paths,
+    default_lsp_environment,
+    discover_lsp_catalog,
+)
 from loushang.coding.lsp.model import LspServerDefinition
 from loushang.coding.lsp.ports import WorkspaceTextReader
 from loushang.coding.lsp.runtime import (
@@ -240,22 +245,34 @@ def _create_agent_session(
                 "child approval actor must match its delegated execution profile"
             )
     services = services or create_services()
-    resolved_lsp_definitions = tuple(lsp_definitions)
-    if resolved_lsp_definitions and lsp_baseline_environment is None:
-        raise ValueError(
-            "lsp_baseline_environment is required when LSP definitions are supplied"
-        )
     lsp_mode = coding_capability_mount_mode(
         services.settings_manager,
         CODING_LSP_CAPABILITY,
     )
-    lsp_slot = (
-        DeferredCodingLspRuntime()
-        if resolved_lsp_definitions
-        and lsp_mode != "disabled"
-        and normalize_no_tools(no_tools) != "all"
-        else None
+    resolved_lsp_environment = (
+        dict(lsp_baseline_environment)
+        if lsp_baseline_environment is not None
+        else default_lsp_environment()
     )
+    lsp_enabled_for_session = (
+        lsp_mode != "disabled" and normalize_no_tools(no_tools) != "all"
+    )
+    global_lsp_config, project_lsp_config = coding_lsp_config_paths(
+        services.settings_manager,
+        workspace_root=session_manager.get_cwd(),
+    )
+    resolved_lsp_definitions = (
+        discover_lsp_catalog(
+            workspace_root=session_manager.get_cwd(),
+            baseline_environment=resolved_lsp_environment,
+            explicit_definitions=tuple(lsp_definitions),
+            global_config_path=global_lsp_config,
+            project_config_path=project_lsp_config,
+        ).definitions
+        if lsp_enabled_for_session
+        else ()
+    )
+    lsp_slot = DeferredCodingLspRuntime() if lsp_enabled_for_session else None
     # Restored sessions carry historical transcript.  A previous run may have
     # been interrupted between a tool call and its result, leaving an unpaired
     # toolCall in the transcript.  Force repair pairing for such sessions so
@@ -298,8 +315,14 @@ def _create_agent_session(
         and tool_registry is not None
         else tool_registry
     )
+    construction_tools = tools
     if lsp_slot is not None:
-        session_tool_registry = session_tool_registry or WorkspaceToolRegistry()
+        if session_tool_registry is None:
+            session_tool_registry = WorkspaceToolRegistry()
+            for definition in tools or ():
+                session_tool_registry.register_tool(definition)
+            if tools is not None:
+                construction_tools = None
         register_coding_lsp_tools(
             session_tool_registry,
             runtime=lsp_slot,
@@ -358,7 +381,7 @@ def _create_agent_session(
                     ),
                 ),
                 read_text=lsp_read_text or _read_lsp_workspace_text,
-                baseline_environment=dict(lsp_baseline_environment or {}),
+                baseline_environment=resolved_lsp_environment,
             )
             lsp_slot.bind(lsp_runtime)
         child_session = AgentSession(
@@ -403,7 +426,7 @@ def _create_agent_session(
         append_system_prompt=resolved_append_system_prompt,
         model=model,
         thinking_level=thinking_level,
-        tools=tools,
+        tools=construction_tools,
         tool_registry=session_tool_registry,
         allowed_tool_names=allowed_tool_names,
         active_tool_names=active_tool_names,

--- a/src/loushang/coding/cli/__main__.py
+++ b/src/loushang/coding/cli/__main__.py
@@ -25,6 +25,7 @@ from loushang.coding.capabilities import (
     coding_capability_mount_mode,
 )
 from loushang.coding.cli.args import CliArgs, ExtensionFlag, help_text, parse_args
+from loushang.coding.cli.lsp import extract_lsp_argv, run_coding_lsp_command
 from loushang.coding.cli.multiagent import run_coding_multiagent_command
 from loushang.coding.cli.workspace import (
     extract_workspace_argv,
@@ -289,6 +290,7 @@ async def run_cli(
     continuity_runner=run_continuity_picker,
     multiagent_runner=run_coding_multiagent_command,
     workspace_runner=run_coding_workspace_command,
+    lsp_runner=run_coding_lsp_command,
 ) -> int:
     raw_argv = tuple(argv or ())
     workspace_argv = extract_workspace_argv(raw_argv)
@@ -299,6 +301,17 @@ async def run_cli(
             stdout=stdout or sys.stdout,
             stderr=stderr or sys.stderr,
             cwd=cwd,
+        )
+    lsp_argv = extract_lsp_argv(raw_argv)
+    if lsp_argv is not None:
+        return await lsp_runner(
+            lsp_argv,
+            stdin=stdin or sys.stdin,
+            stdout=stdout or sys.stdout,
+            stderr=stderr or sys.stderr,
+            cwd=cwd,
+            services=services,
+            build_services=build_default_services,
         )
     multiagent_argv = extract_multiagent_argv(raw_argv)
     if multiagent_argv is not None:

--- a/src/loushang/coding/cli/lsp.py
+++ b/src/loushang/coding/cli/lsp.py
@@ -1,0 +1,193 @@
+"""Read-only Coding LSP catalog status and doctor commands."""
+
+from __future__ import annotations
+
+import json
+from argparse import ArgumentParser
+from collections.abc import Callable, Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Never, TextIO
+
+from loushang.coding.capabilities import (
+    CODING_LSP_CAPABILITY,
+    coding_capability_mount_mode,
+)
+from loushang.coding.lsp.discovery import (
+    LspCatalogSnapshot,
+    coding_lsp_config_paths,
+    default_lsp_environment,
+    discover_lsp_catalog,
+)
+
+
+class LspCliUsageError(ValueError):
+    def __init__(self, message: str, *, usage: str) -> None:
+        super().__init__(message)
+        self.usage = usage
+
+
+class _NoExitParser(ArgumentParser):
+    def error(self, message: str) -> Never:
+        raise LspCliUsageError(message, usage=self.format_usage())
+
+
+def extract_lsp_argv(argv: Sequence[str]) -> tuple[str, ...] | None:
+    values = list(argv)
+    if values and values[0] == "lsp":
+        return tuple(values[1:])
+    if len(values) >= 3 and values[0] == "--cwd" and values[2] == "lsp":
+        return ("--cwd", values[1], *values[3:])
+    if len(values) >= 2 and values[0].startswith("--cwd=") and values[1] == "lsp":
+        return (values[0], *values[2:])
+    return None
+
+
+async def run_coding_lsp_command(
+    argv: Sequence[str],
+    *,
+    stdin: TextIO,
+    stdout: TextIO,
+    stderr: TextIO,
+    cwd: str | Path | None = None,
+    services: Any | None = None,
+    build_services: Callable[[Path], Any],
+) -> int:
+    """Inspect Product configuration without constructing a session or process."""
+
+    del stdin
+    try:
+        namespace = _parser().parse_args(list(argv))
+    except LspCliUsageError as error:
+        stderr.write(error.usage)
+        stderr.write(f"Error: {error}\n")
+        return 2
+    if namespace.help or namespace.command is None:
+        stdout.write(_parser().format_help())
+        return 0
+
+    project_root = Path(namespace.cwd or cwd or Path.cwd()).expanduser().resolve()
+    if not project_root.is_dir():
+        stderr.write(f"Error: not a directory: {project_root}\n")
+        return 2
+    try:
+        resolved_services = services or build_services(project_root)
+        settings_manager = getattr(resolved_services, "settings_manager", None)
+        mode = coding_capability_mount_mode(
+            settings_manager,
+            CODING_LSP_CAPABILITY,
+        )
+        global_config, project_config = coding_lsp_config_paths(
+            settings_manager,
+            workspace_root=project_root,
+        )
+        snapshot = discover_lsp_catalog(
+            workspace_root=project_root,
+            baseline_environment=default_lsp_environment(),
+            global_config_path=global_config,
+            project_config_path=project_config,
+        )
+    except (OSError, UnicodeError, TypeError, ValueError) as error:
+        stderr.write(f"Error: {error}\n")
+        return 1
+
+    if namespace.output_format == "json":
+        _write_json(stdout, mode=mode, snapshot=snapshot)
+    else:
+        _write_text(
+            stdout,
+            mode=mode,
+            snapshot=snapshot,
+            doctor=namespace.command == "doctor",
+        )
+    if namespace.command == "doctor" and mode != "disabled":
+        return 0 if _doctor_ready(snapshot) else 1
+    return 0
+
+
+def _parser() -> _NoExitParser:
+    parser = _NoExitParser(
+        prog="loushang lsp",
+        add_help=False,
+        description="Inspect Coding LSP configuration without starting a server.",
+    )
+    parser.add_argument("--help", "-h", action="store_true", dest="help")
+    parser.add_argument("--cwd")
+    subparsers = parser.add_subparsers(dest="command")
+    for command in ("status", "doctor"):
+        command_parser = subparsers.add_parser(command, add_help=False)
+        command_parser.add_argument("--help", "-h", action="store_true", dest="help")
+        command_parser.add_argument(
+            "--format",
+            choices=("text", "json"),
+            default="text",
+            dest="output_format",
+        )
+    return parser
+
+
+def _write_json(
+    stdout: TextIO,
+    *,
+    mode: str,
+    snapshot: LspCatalogSnapshot,
+) -> None:
+    stdout.write(
+        json.dumps(
+            {
+                "capability": CODING_LSP_CAPABILITY,
+                "mount_mode": mode,
+                "catalog_generation": snapshot.generation,
+                "admitted_count": snapshot.admitted_count,
+                "process_start_attempted": False,
+                "servers": [asdict(record) for record in snapshot.records],
+            },
+            indent=2,
+        )
+    )
+    stdout.write("\n")
+
+
+def _write_text(
+    stdout: TextIO,
+    *,
+    mode: str,
+    snapshot: LspCatalogSnapshot,
+    doctor: bool,
+) -> None:
+    stdout.write(f"Capability: {CODING_LSP_CAPABILITY} ({mode})\n")
+    stdout.write(f"Catalog: {snapshot.generation}\n")
+    stdout.write(f"Admitted servers: {snapshot.admitted_count}\n")
+    stdout.write("Process start attempted: no\n")
+    if snapshot.records:
+        stdout.write("STATE\tSERVER\tSOURCE\tDETAIL\n")
+        for record in snapshot.records:
+            stdout.write(
+                f"{record.state}\t{record.definition_id}\t{record.source}\t"
+                f"{record.detail}\n"
+            )
+    if doctor:
+        if mode == "disabled":
+            stdout.write("Doctor: capability is disabled.\n")
+        elif _doctor_ready(snapshot):
+            stdout.write("Doctor: ready.\n")
+        elif snapshot.admitted_count:
+            stdout.write("Doctor: configuration errors require attention.\n")
+        else:
+            stdout.write(
+                "Doctor: no language server is available; install a Product "
+                "default or configure .loushang/lsp.json.\n"
+            )
+
+
+def _doctor_ready(snapshot: LspCatalogSnapshot) -> bool:
+    return snapshot.admitted_count > 0 and not any(
+        record.state == "rejected" for record in snapshot.records
+    )
+
+
+__all__ = [
+    "LspCliUsageError",
+    "extract_lsp_argv",
+    "run_coding_lsp_command",
+]

--- a/src/loushang/coding/lsp/__init__.py
+++ b/src/loushang/coding/lsp/__init__.py
@@ -3,12 +3,24 @@
 from loushang.coding.lsp.binding import CodingLspBinding
 from loushang.coding.lsp.catalog import LspCatalog
 from loushang.coding.lsp.client import LspClient
+from loushang.coding.lsp.discovery import (
+    LspAdmissionRecord,
+    LspCatalogSnapshot,
+    coding_lsp_config_paths,
+    default_global_lsp_config_path,
+    default_lsp_environment,
+    default_project_lsp_config_path,
+    discover_lsp_catalog,
+    product_default_lsp_definitions,
+)
 from loushang.coding.lsp.documents import DocumentSnapshot, LspDocumentManager
 from loushang.coding.lsp.model import (
     CodeLocation,
     CodePosition,
     CodeQueryResult,
     CodeRange,
+    CodeSymbol,
+    DocumentOutlineResult,
     LspError,
     LspInvalidInputError,
     LspProtocolError,
@@ -37,9 +49,13 @@ from loushang.coding.lsp.tool_pack import (
     register_coding_lsp_tools,
 )
 from loushang.coding.lsp.tools import (
+    DOCUMENT_OUTLINE_TOOL_NAME,
     INSPECT_SYMBOL_TOOL_NAME,
+    MAX_DOCUMENT_OUTLINE_DEPTH,
+    MAX_DOCUMENT_OUTLINE_RESULTS,
     MAX_INSPECT_SYMBOL_RESULTS,
     CodingLspTools,
+    create_document_outline_tool_definition,
     create_inspect_symbol_tool_definition,
 )
 
@@ -49,14 +65,19 @@ __all__ = [
     "CodePosition",
     "CodeQueryResult",
     "CodeRange",
+    "CodeSymbol",
     "CodingLspBinding",
     "CodingLspRuntime",
     "CodingLspTools",
     "CODING_LSP_TOOL_PACK",
     "DeferredCodingLspRuntime",
+    "DOCUMENT_OUTLINE_TOOL_NAME",
+    "DocumentOutlineResult",
     "DocumentSnapshot",
     "INSPECT_SYMBOL_TOOL_NAME",
     "LspCatalog",
+    "LspCatalogSnapshot",
+    "LspAdmissionRecord",
     "LspClient",
     "LspDocumentManager",
     "LspError",
@@ -70,12 +91,21 @@ __all__ = [
     "LspServerSupervisor",
     "LspUnavailableError",
     "MAX_INSPECT_SYMBOL_RESULTS",
+    "MAX_DOCUMENT_OUTLINE_DEPTH",
+    "MAX_DOCUMENT_OUTLINE_RESULTS",
     "ProcessExit",
     "ProcessHandle",
     "ProcessLauncherBinder",
     "ProcessLaunchRequest",
     "ProcessStderrTail",
     "bind_coding_lsp_runtime",
+    "coding_lsp_config_paths",
+    "create_document_outline_tool_definition",
     "create_inspect_symbol_tool_definition",
+    "default_global_lsp_config_path",
+    "default_lsp_environment",
+    "default_project_lsp_config_path",
+    "discover_lsp_catalog",
+    "product_default_lsp_definitions",
     "register_coding_lsp_tools",
 ]

--- a/src/loushang/coding/lsp/binding.py
+++ b/src/loushang/coding/lsp/binding.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 from loushang.coding.lsp.catalog import LspCatalog
 from loushang.coding.lsp.documents import LspDocumentManager
-from loushang.coding.lsp.model import CodeQueryResult, LspServerDefinition
+from loushang.coding.lsp.model import (
+    CodeQueryResult,
+    DocumentOutlineResult,
+    LspServerDefinition,
+)
 from loushang.coding.lsp.ports import (
     AuthorizedProcessLauncher,
     PathExists,
@@ -70,6 +74,23 @@ class CodingLspBinding:
             line=line,
             character=character,
             query=query,
+            limit=limit,
+            correlation_id=correlation_id,
+            signal=signal,
+        )
+
+    async def document_outline(
+        self,
+        *,
+        path: str,
+        depth: int = 4,
+        limit: int = 200,
+        correlation_id: str,
+        signal: object | None = None,
+    ) -> DocumentOutlineResult:
+        return await self._tools.document_outline(
+            path=path,
+            depth=depth,
             limit=limit,
             correlation_id=correlation_id,
             signal=signal,

--- a/src/loushang/coding/lsp/client.py
+++ b/src/loushang/coding/lsp/client.py
@@ -87,6 +87,10 @@ class LspClient:
                                 "didSave": False,
                             },
                             "definition": {"dynamicRegistration": False},
+                            "documentSymbol": {
+                                "dynamicRegistration": False,
+                                "hierarchicalDocumentSymbolSupport": True,
+                            },
                         },
                         "workspace": {
                             "configuration": True,

--- a/src/loushang/coding/lsp/discovery.py
+++ b/src/loushang/coding/lsp/discovery.py
@@ -1,0 +1,581 @@
+"""Coding-owned configuration, discovery, and admission for LSP servers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Literal
+
+from loushang.coding.lsp.model import LspServerDefinition
+
+LspAdmissionState = Literal["admitted", "disabled", "rejected", "unavailable"]
+ExecutableResolver = Callable[[str, Mapping[str, str]], str | None]
+ConfigPath = str | Path | Literal[False] | None
+
+_MAX_CONFIG_BYTES = 256 * 1024
+_MAX_SERVER_DECLARATIONS = 64
+_ALLOWED_SERVER_FIELDS = frozenset(
+    {
+        "id",
+        "enabled",
+        "command",
+        "language_extensions",
+        "root_markers",
+        "priority",
+        "environment",
+        "initialization_options",
+        "settings",
+        "startup_timeout_seconds",
+        "request_timeout_seconds",
+        "shutdown_timeout_seconds",
+    }
+)
+_BASELINE_ENVIRONMENT_NAMES = frozenset(
+    {
+        "CONDA_PREFIX",
+        "COMSPEC",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "LOGNAME",
+        "NODE_PATH",
+        "NVM_BIN",
+        "NVM_DIR",
+        "PATH",
+        "PATHEXT",
+        "PYENV_ROOT",
+        "SHELL",
+        "SYSTEMROOT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "USER",
+        "VIRTUAL_ENV",
+        "XDG_CACHE_HOME",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LspAdmissionRecord:
+    definition_id: str
+    source: str
+    state: LspAdmissionState
+    detail: str
+    executable: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LspCatalogSnapshot:
+    """One immutable Product catalog snapshot plus bounded admission facts."""
+
+    generation: str
+    definitions: tuple[LspServerDefinition, ...]
+    records: tuple[LspAdmissionRecord, ...]
+
+    @property
+    def admitted_count(self) -> int:
+        return len(self.definitions)
+
+
+@dataclass(frozen=True, slots=True)
+class _Declaration:
+    definition_id: str
+    source: str
+    definition: LspServerDefinition | None
+    enabled: bool = True
+    error: str | None = None
+
+
+def default_global_lsp_config_path() -> Path:
+    return Path.home() / ".loushang" / "coding" / "lsp.json"
+
+
+def default_project_lsp_config_path(workspace_root: str | Path) -> Path:
+    return Path(workspace_root).expanduser().resolve() / ".loushang" / "lsp.json"
+
+
+def coding_lsp_config_paths(
+    settings_manager: object | None,
+    *,
+    workspace_root: str | Path,
+) -> tuple[ConfigPath, ConfigPath]:
+    """Resolve Product config beside the active generic settings layers."""
+
+    global_base = getattr(settings_manager, "global_base_dir", None)
+    project_base = getattr(settings_manager, "project_base_dir", None)
+    global_path: ConfigPath = (
+        Path(global_base) / "lsp.json" if global_base is not None else False
+    )
+    project_path: ConfigPath = (
+        Path(project_base) / "lsp.json"
+        if project_base is not None
+        else default_project_lsp_config_path(workspace_root)
+    )
+    return global_path, project_path
+
+
+def default_lsp_environment(
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Project a stable, secret-averse environment for language servers."""
+
+    source = os.environ if environ is None else environ
+    return {
+        name: value
+        for name, value in source.items()
+        if name in _BASELINE_ENVIRONMENT_NAMES and isinstance(value, str)
+    }
+
+
+def product_default_lsp_definitions() -> tuple[LspServerDefinition, ...]:
+    """Return inert Product defaults; discovery admits only installed binaries."""
+
+    return (
+        LspServerDefinition(
+            id="pyright",
+            command=("pyright-langserver", "--stdio"),
+            language_extensions={"python": (".py", ".pyi")},
+            source="product-default",
+        ),
+        LspServerDefinition(
+            id="typescript-language-server",
+            command=("typescript-language-server", "--stdio"),
+            language_extensions={
+                "javascript": (".js", ".jsx", ".mjs", ".cjs"),
+                "typescript": (".ts", ".tsx", ".mts", ".cts"),
+            },
+            source="product-default",
+        ),
+        LspServerDefinition(
+            id="rust-analyzer",
+            command=("rust-analyzer",),
+            language_extensions={"rust": (".rs",)},
+            source="product-default",
+        ),
+        LspServerDefinition(
+            id="gopls",
+            command=("gopls", "serve"),
+            language_extensions={"go": (".go",)},
+            source="product-default",
+        ),
+        LspServerDefinition(
+            id="clangd",
+            command=("clangd",),
+            language_extensions={
+                "c": (".c", ".h"),
+                "cpp": (".cc", ".cpp", ".cxx", ".hh", ".hpp", ".hxx"),
+            },
+            source="product-default",
+        ),
+    )
+
+
+def discover_lsp_catalog(
+    *,
+    workspace_root: str | Path,
+    baseline_environment: Mapping[str, str],
+    explicit_definitions: Iterable[LspServerDefinition] = (),
+    global_config_path: ConfigPath = None,
+    project_config_path: ConfigPath = None,
+    executable_resolver: ExecutableResolver | None = None,
+    include_product_defaults: bool = True,
+) -> LspCatalogSnapshot:
+    """Build one catalog without launching or communicating with any server."""
+
+    root = Path(workspace_root).expanduser().resolve()
+    declarations: list[_Declaration] = []
+    if include_product_defaults:
+        declarations.extend(
+            _Declaration(item.id, item.source, item)
+            for item in product_default_lsp_definitions()
+        )
+    user_declarations = _load_optional_config(
+        global_config_path,
+        default=default_global_lsp_config_path(),
+        source="user-config",
+    )
+    project_declarations = _load_optional_config(
+        project_config_path,
+        default=default_project_lsp_config_path(root),
+        source="project-config",
+    )
+    declarations.extend(user_declarations)
+    declarations.extend(
+        _admit_project_declarations(
+            project_declarations,
+            user_declarations=user_declarations,
+        )
+    )
+    declarations.extend(
+        _Declaration(item.id, "session", item) for item in explicit_definitions
+    )
+
+    # Later sources have higher Product precedence. A disabled higher-precedence
+    # declaration intentionally masks the same lower-precedence definition.
+    selected: dict[str, _Declaration] = {}
+    malformed: list[_Declaration] = []
+    for declaration in declarations:
+        if declaration.error is not None and declaration.definition_id.startswith("<"):
+            malformed.append(declaration)
+            continue
+        selected[declaration.definition_id] = declaration
+
+    resolve = executable_resolver or _resolve_executable
+    admitted: list[LspServerDefinition] = []
+    records: list[LspAdmissionRecord] = []
+    for declaration in (*malformed, *(selected[key] for key in sorted(selected))):
+        if declaration.error is not None:
+            records.append(
+                LspAdmissionRecord(
+                    definition_id=declaration.definition_id,
+                    source=declaration.source,
+                    state="rejected",
+                    detail=declaration.error,
+                )
+            )
+            continue
+        if not declaration.enabled:
+            records.append(
+                LspAdmissionRecord(
+                    definition_id=declaration.definition_id,
+                    source=declaration.source,
+                    state="disabled",
+                    detail="disabled by higher-precedence Coding configuration",
+                )
+            )
+            continue
+        definition = declaration.definition
+        assert definition is not None
+        # Public SDK definitions are already-admitted session declarations. The
+        # production config/default paths are resolved here before publication.
+        effective_environment = dict(baseline_environment)
+        effective_environment.update(definition.environment)
+        executable = (
+            definition.command[0]
+            if declaration.source == "session"
+            else resolve(definition.command[0], effective_environment)
+        )
+        if executable is None:
+            records.append(
+                LspAdmissionRecord(
+                    definition_id=definition.id,
+                    source=declaration.source,
+                    state="unavailable",
+                    detail=f"executable not found: {definition.command[0]}",
+                )
+            )
+            continue
+        admitted_definition = (
+            definition
+            if declaration.source == "session"
+            else replace(
+                definition,
+                command=(executable, *definition.command[1:]),
+            )
+        )
+        admitted.append(admitted_definition)
+        records.append(
+            LspAdmissionRecord(
+                definition_id=definition.id,
+                source=declaration.source,
+                state="admitted",
+                detail="definition validated and executable is available",
+                executable=executable,
+            )
+        )
+
+    definitions = tuple(sorted(admitted, key=lambda item: item.id))
+    generation_input = json.dumps(
+        {
+            "definitions": [
+                _definition_generation_value(definition) for definition in definitions
+            ],
+            "records": [
+                {
+                    "id": item.definition_id,
+                    "source": item.source,
+                    "state": item.state,
+                    "detail": item.detail,
+                    "executable": item.executable,
+                }
+                for item in records
+            ],
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    generation = hashlib.sha256(generation_input).hexdigest()[:12]
+    return LspCatalogSnapshot(
+        generation=generation,
+        definitions=definitions,
+        records=tuple(records),
+    )
+
+
+def _load_config(path: Path, *, source: str) -> tuple[_Declaration, ...]:
+    if not path.is_file():
+        return ()
+    try:
+        if path.stat().st_size > _MAX_CONFIG_BYTES:
+            raise ValueError(f"config exceeds {_MAX_CONFIG_BYTES} bytes")
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, Mapping):
+            raise TypeError("config root must be an object")
+        unknown = set(raw) - {"servers"}
+        if unknown:
+            raise ValueError(f"unknown config fields: {', '.join(sorted(unknown))}")
+        servers = raw.get("servers", ())
+        if not isinstance(servers, list):
+            raise TypeError("servers must be an array")
+        if len(servers) > _MAX_SERVER_DECLARATIONS:
+            raise ValueError(
+                f"servers exceeds the {_MAX_SERVER_DECLARATIONS}-entry limit"
+            )
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        return (_Declaration("<config>", source, None, error=str(exc)),)
+
+    declarations: list[_Declaration] = []
+    for index, value in enumerate(servers):
+        try:
+            declarations.append(_parse_declaration(value, source=source))
+        except (TypeError, ValueError) as exc:
+            definition_id = (
+                value.get("id")
+                if isinstance(value, Mapping) and isinstance(value.get("id"), str)
+                else f"<server:{index}>"
+            )
+            declarations.append(
+                _Declaration(str(definition_id), source, None, error=str(exc))
+            )
+    return tuple(declarations)
+
+
+def _load_optional_config(
+    path: ConfigPath,
+    *,
+    default: Path,
+    source: str,
+) -> tuple[_Declaration, ...]:
+    if path is False:
+        return ()
+    return _load_config(Path(path) if path is not None else default, source=source)
+
+
+def _admit_project_declarations(
+    declarations: tuple[_Declaration, ...],
+    *,
+    user_declarations: tuple[_Declaration, ...],
+) -> tuple[_Declaration, ...]:
+    """Keep repository config from introducing a new executable identity.
+
+    A future workspace-trust runtime can replace this conservative P0 rule.
+    User-level config may establish a trusted custom server id; project config
+    can then tune that server but cannot replace its executable or environment.
+    """
+
+    trusted_definitions = {
+        definition.id: definition for definition in product_default_lsp_definitions()
+    }
+    for declaration in user_declarations:
+        if not declaration.enabled:
+            trusted_definitions.pop(declaration.definition_id, None)
+        elif declaration.definition is not None:
+            trusted_definitions[declaration.definition_id] = declaration.definition
+
+    admitted: list[_Declaration] = []
+    for declaration in declarations:
+        definition = declaration.definition
+        if not declaration.enabled or definition is None:
+            admitted.append(declaration)
+            continue
+        trusted_definition = trusted_definitions.get(declaration.definition_id)
+        if (
+            trusted_definition is None
+            or definition.command != trusted_definition.command
+        ):
+            admitted.append(
+                _Declaration(
+                    declaration.definition_id,
+                    declaration.source,
+                    None,
+                    error=(
+                        "project config cannot introduce or alter a process command; "
+                        "add the complete command to user-level Coding lsp.json first"
+                    ),
+                )
+            )
+            continue
+        if definition.environment:
+            admitted.append(
+                _Declaration(
+                    declaration.definition_id,
+                    declaration.source,
+                    None,
+                    error=(
+                        "project config cannot set process environment overrides; "
+                        "configure them in user-level Coding lsp.json"
+                    ),
+                )
+            )
+            continue
+        admitted.append(
+            replace(
+                declaration,
+                definition=replace(
+                    definition,
+                    command=trusted_definition.command,
+                    environment=trusted_definition.environment,
+                ),
+            )
+        )
+    return tuple(admitted)
+
+
+def _parse_declaration(value: object, *, source: str) -> _Declaration:
+    if not isinstance(value, Mapping):
+        raise TypeError("server declarations must be objects")
+    unknown = set(value) - _ALLOWED_SERVER_FIELDS
+    if unknown:
+        raise ValueError(f"unknown server fields: {', '.join(sorted(unknown))}")
+    raw_id = value.get("id")
+    if not isinstance(raw_id, str) or not raw_id.strip():
+        raise TypeError("server id must be a non-empty string")
+    definition_id = raw_id.strip()
+    enabled = value.get("enabled", True)
+    if not isinstance(enabled, bool):
+        raise TypeError("server enabled must be a boolean")
+    if not enabled:
+        return _Declaration(definition_id, source, None, enabled=False)
+
+    command = value.get("command")
+    if not isinstance(command, list) or not all(
+        isinstance(item, str) for item in command
+    ):
+        raise TypeError("server command must be a string array")
+    language_extensions = value.get("language_extensions")
+    if not isinstance(language_extensions, Mapping):
+        raise TypeError("server language_extensions must be an object")
+    normalized_languages: dict[str, tuple[str, ...]] = {}
+    for language, extensions in language_extensions.items():
+        if not isinstance(language, str) or not isinstance(extensions, list):
+            raise TypeError("language_extensions must map strings to string arrays")
+        if not all(isinstance(extension, str) for extension in extensions):
+            raise TypeError("language_extensions must map strings to string arrays")
+        normalized_languages[language] = tuple(extensions)
+
+    root_markers = value.get("root_markers", [])
+    if not isinstance(root_markers, list) or not all(
+        isinstance(marker, str) for marker in root_markers
+    ):
+        raise TypeError("server root_markers must be a string array")
+    environment = value.get("environment", {})
+    initialization_options = value.get("initialization_options", {})
+    settings = value.get("settings", {})
+    definition = LspServerDefinition(
+        id=definition_id,
+        command=tuple(command),
+        language_extensions=normalized_languages,
+        root_markers=tuple(root_markers),
+        priority=_integer_field(value, "priority", 0),
+        environment=_string_mapping(environment, "environment"),
+        initialization_options=_object_mapping(
+            initialization_options, "initialization_options"
+        ),
+        settings=_object_mapping(settings, "settings"),
+        startup_timeout_seconds=_number_field(value, "startup_timeout_seconds", 20.0),
+        request_timeout_seconds=_number_field(value, "request_timeout_seconds", 15.0),
+        shutdown_timeout_seconds=_number_field(value, "shutdown_timeout_seconds", 3.0),
+        source=source,
+    )
+    return _Declaration(definition_id, source, definition)
+
+
+def _integer_field(value: Mapping[object, object], name: str, default: int) -> int:
+    item = value.get(name, default)
+    if not isinstance(item, int) or isinstance(item, bool):
+        raise TypeError(f"server {name} must be an integer")
+    return item
+
+
+def _number_field(value: Mapping[object, object], name: str, default: float) -> float:
+    item = value.get(name, default)
+    if not isinstance(item, int | float) or isinstance(item, bool):
+        raise TypeError(f"server {name} must be a number")
+    return float(item)
+
+
+def _string_mapping(value: object, name: str) -> dict[str, str]:
+    if not isinstance(value, Mapping) or not all(
+        isinstance(key, str) and isinstance(item, str) for key, item in value.items()
+    ):
+        raise TypeError(f"server {name} must map strings to strings")
+    return dict(value)
+
+
+def _object_mapping(value: object, name: str) -> dict[str, object]:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise TypeError(f"server {name} must be an object")
+    return dict(value)
+
+
+def _resolve_executable(command: str, environment: Mapping[str, str]) -> str | None:
+    path = Path(command)
+    if path.is_absolute():
+        return (
+            str(path.resolve()) if path.is_file() and os.access(path, os.X_OK) else None
+        )
+    if len(path.parts) != 1:
+        return None
+    return shutil.which(command, path=environment.get("PATH"))
+
+
+def _definition_generation_value(
+    definition: LspServerDefinition,
+) -> dict[str, object]:
+    return {
+        "id": definition.id,
+        "command": definition.command,
+        "language_extensions": _json_generation_value(definition.language_extensions),
+        "root_markers": definition.root_markers,
+        "priority": definition.priority,
+        "environment": _json_generation_value(definition.environment),
+        "initialization_options": _json_generation_value(
+            definition.initialization_options
+        ),
+        "settings": _json_generation_value(definition.settings),
+        "startup_timeout_seconds": definition.startup_timeout_seconds,
+        "request_timeout_seconds": definition.request_timeout_seconds,
+        "shutdown_timeout_seconds": definition.shutdown_timeout_seconds,
+        "source": definition.source,
+    }
+
+
+def _json_generation_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(name): _json_generation_value(item) for name, item in value.items()}
+    if isinstance(value, tuple):
+        return [_json_generation_value(item) for item in value]
+    return value
+
+
+__all__ = [
+    "LspAdmissionRecord",
+    "LspAdmissionState",
+    "LspCatalogSnapshot",
+    "coding_lsp_config_paths",
+    "default_global_lsp_config_path",
+    "default_lsp_environment",
+    "default_project_lsp_config_path",
+    "discover_lsp_catalog",
+    "product_default_lsp_definitions",
+]

--- a/src/loushang/coding/lsp/model.py
+++ b/src/loushang/coding/lsp/model.py
@@ -175,6 +175,31 @@ class CodeQueryResult:
     warnings: tuple[str, ...] = ()
 
 
+@dataclass(frozen=True, slots=True)
+class CodeSymbol:
+    """One normalized document symbol with bounded nested children."""
+
+    name: str
+    kind: int
+    kind_name: str
+    range: CodeRange
+    selection_range: CodeRange
+    detail: str | None = None
+    container_name: str | None = None
+    children: tuple[CodeSymbol, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class DocumentOutlineResult:
+    items: tuple[CodeSymbol, ...]
+    count: int
+    truncated: bool
+    server_id: str
+    document_version: int | None
+    readiness: str = "ready"
+    warnings: tuple[str, ...] = ()
+
+
 def _normalize_extension(value: str) -> str:
     if not isinstance(value, str):
         raise TypeError("LSP server extensions must be strings")
@@ -246,6 +271,8 @@ __all__ = [
     "CodePosition",
     "CodeQueryResult",
     "CodeRange",
+    "CodeSymbol",
+    "DocumentOutlineResult",
     "LspError",
     "LspInvalidInputError",
     "LspProtocolError",

--- a/src/loushang/coding/lsp/runtime.py
+++ b/src/loushang/coding/lsp/runtime.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from typing import Protocol
 
 from loushang.coding.lsp.binding import CodingLspBinding
-from loushang.coding.lsp.model import CodeQueryResult, LspServerDefinition
+from loushang.coding.lsp.model import (
+    CodeQueryResult,
+    DocumentOutlineResult,
+    LspServerDefinition,
+)
 from loushang.coding.lsp.ports import WorkspaceTextReader
 from loushang.harness.tools.process_hosting import ProcessExecutionScope
 from loushang.harness.workspace.process import AuthorizedProcessLauncher
@@ -50,6 +54,23 @@ class CodingLspRuntime:
             signal=signal,
         )
 
+    async def document_outline(
+        self,
+        *,
+        path: str,
+        depth: int = 4,
+        limit: int = 200,
+        correlation_id: str,
+        signal: object | None = None,
+    ) -> DocumentOutlineResult:
+        return await self._binding.document_outline(
+            path=path,
+            depth=depth,
+            limit=limit,
+            correlation_id=correlation_id,
+            signal=signal,
+        )
+
     async def close(self) -> None:
         await self._binding.dispose()
 
@@ -84,6 +105,26 @@ class DeferredCodingLspRuntime:
             line=line,
             character=character,
             query=query,
+            limit=limit,
+            correlation_id=correlation_id,
+            signal=signal,
+        )
+
+    async def document_outline(
+        self,
+        *,
+        path: str,
+        depth: int = 4,
+        limit: int = 200,
+        correlation_id: str,
+        signal: object | None = None,
+    ) -> DocumentOutlineResult:
+        runtime = self._runtime
+        if runtime is None:
+            raise RuntimeError("Coding LSP runtime is not bound")
+        return await runtime.document_outline(
+            path=path,
+            depth=depth,
             limit=limit,
             correlation_id=correlation_id,
             signal=signal,

--- a/src/loushang/coding/lsp/tool_pack.py
+++ b/src/loushang/coding/lsp/tool_pack.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from loushang.coding.capabilities import CODING_LSP_CAPABILITY
 from loushang.coding.lsp.tools import (
+    DOCUMENT_OUTLINE_TOOL_NAME,
     INSPECT_SYMBOL_TOOL_NAME,
     InspectSymbolRuntime,
+    create_document_outline_tool_definition,
     create_inspect_symbol_tool_definition,
 )
 from loushang.harness.config.agent import CapabilityMountMode
@@ -18,7 +20,7 @@ from loushang.harness.tools.workspace.registry import WorkspaceToolRegistry
 
 CODING_LSP_TOOL_PACK = ToolPackDefinition(
     name="coding.lsp.tools",
-    tools=(INSPECT_SYMBOL_TOOL_NAME,),
+    tools=(INSPECT_SYMBOL_TOOL_NAME, DOCUMENT_OUTLINE_TOOL_NAME),
     metadata={"product_capability": CODING_LSP_CAPABILITY},
 )
 
@@ -36,7 +38,10 @@ def register_coding_lsp_tools(
     if mode not in {"on_demand", "always"}:
         raise ValueError(f"unsupported coding.lsp mount mode: {mode!r}")
     resolution = resolve_tool_contributions(
-        (ToolContribution(create_inspect_symbol_tool_definition(runtime)),),
+        (
+            ToolContribution(create_inspect_symbol_tool_definition(runtime)),
+            ToolContribution(create_document_outline_tool_definition(runtime)),
+        ),
         packs=(CODING_LSP_TOOL_PACK,),
         include_packs=(CODING_LSP_TOOL_PACK.name,),
     )

--- a/src/loushang/coding/lsp/tools.py
+++ b/src/loushang/coding/lsp/tools.py
@@ -14,6 +14,8 @@ from loushang.coding.lsp.model import (
     CodePosition,
     CodeQueryResult,
     CodeRange,
+    CodeSymbol,
+    DocumentOutlineResult,
     LspInvalidInputError,
     LspProtocolError,
 )
@@ -23,7 +25,40 @@ from loushang.harness.tools.authoring import ToolContext, direct_tool
 from loushang.harness.tools.core import ToolDefinition, tool
 
 INSPECT_SYMBOL_TOOL_NAME = "inspect_symbol"
+DOCUMENT_OUTLINE_TOOL_NAME = "document_outline"
 MAX_INSPECT_SYMBOL_RESULTS = 50
+MAX_DOCUMENT_OUTLINE_DEPTH = 8
+MAX_DOCUMENT_OUTLINE_RESULTS = 200
+_MAX_OUTLINE_PROTOCOL_SYMBOLS = 2_000
+
+_SYMBOL_KIND_NAMES = (
+    "file",
+    "module",
+    "namespace",
+    "package",
+    "class",
+    "method",
+    "property",
+    "field",
+    "constructor",
+    "enum",
+    "interface",
+    "function",
+    "variable",
+    "constant",
+    "string",
+    "number",
+    "boolean",
+    "array",
+    "object",
+    "key",
+    "null",
+    "enum_member",
+    "struct",
+    "event",
+    "operator",
+    "type_parameter",
+)
 
 
 class InspectSymbolRuntime(Protocol):
@@ -38,6 +73,16 @@ class InspectSymbolRuntime(Protocol):
         correlation_id: str,
         signal: object | None = None,
     ) -> CodeQueryResult: ...
+
+    async def document_outline(
+        self,
+        *,
+        path: str,
+        depth: int = 4,
+        limit: int = 200,
+        correlation_id: str,
+        signal: object | None = None,
+    ) -> DocumentOutlineResult: ...
 
 
 @dataclass(slots=True)
@@ -98,6 +143,47 @@ class CodingLspTools:
             server_id=selection.definition_id,
             document_version=document.version,
             warnings=warnings,
+        )
+
+    async def document_outline(
+        self,
+        *,
+        path: str,
+        depth: int = 4,
+        limit: int = 200,
+        correlation_id: str,
+        signal: object | None = None,
+    ) -> DocumentOutlineResult:
+        _validate_outline_input(depth=depth, limit=limit)
+        selection = self.selector.select(path)
+        runtime = await self.supervisor.ensure_runtime(
+            selection,
+            correlation_id=correlation_id,
+            signal=signal,
+        )
+        document = await self.documents.ensure_document(
+            runtime,
+            selection.file_path,
+            language_id=selection.language_id,
+        )
+        raw_result = await runtime.client.request(
+            "textDocument/documentSymbol",
+            {"textDocument": {"uri": document.uri}},
+        )
+        normalizer = _OutlineNormalizer(
+            content=document.content,
+            document_uri=document.uri,
+            depth=depth,
+            limit=limit,
+        )
+        items = normalizer.normalize(raw_result)
+        return DocumentOutlineResult(
+            items=items,
+            count=normalizer.count,
+            truncated=normalizer.truncated,
+            server_id=selection.definition_id,
+            document_version=document.version,
+            warnings=tuple(normalizer.warnings),
         )
 
     async def _normalize_locations(
@@ -245,6 +331,59 @@ def create_inspect_symbol_tool_definition(
     return direct_tool(inspect_symbol)
 
 
+def create_document_outline_tool_definition(
+    runtime: InspectSymbolRuntime,
+) -> ToolDefinition:
+    """Create the bounded, hierarchy-preserving document outline tool."""
+
+    @tool(
+        name=DOCUMENT_OUTLINE_TOOL_NAME,
+        label="Document Outline",
+        description=(
+            "Return a bounded semantic hierarchy of symbols in one workspace file "
+            "using its admitted language server."
+        ),
+        prompt_snippet=(
+            "- document_outline: Inspect the semantic symbol hierarchy of one "
+            "workspace file."
+        ),
+        prompt_guidelines=(
+            "Use document_outline to understand a file's classes, functions, and "
+            "nested members without reading the entire file.",
+        ),
+        schema_overrides={
+            "properties": {
+                "depth": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_DOCUMENT_OUTLINE_DEPTH,
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_DOCUMENT_OUTLINE_RESULTS,
+                },
+            }
+        },
+    )
+    async def document_outline(
+        ctx: ToolContext,
+        path: str,
+        depth: int = 4,
+        limit: int = 200,
+    ) -> dict[str, object]:
+        result = await runtime.document_outline(
+            path=path,
+            depth=depth,
+            limit=limit,
+            correlation_id=ctx.tool_call_id,
+            signal=ctx.signal,
+        )
+        return asdict(result)
+
+    return direct_tool(document_outline)
+
+
 def _validate_query_input(
     *,
     line: int,
@@ -266,6 +405,154 @@ def _validate_query_input(
     ):
         raise LspInvalidInputError(
             f"limit must be between 1 and {MAX_INSPECT_SYMBOL_RESULTS}"
+        )
+
+
+def _validate_outline_input(*, depth: int, limit: int) -> None:
+    if (
+        not isinstance(depth, int)
+        or isinstance(depth, bool)
+        or not 1 <= depth <= MAX_DOCUMENT_OUTLINE_DEPTH
+    ):
+        raise LspInvalidInputError(
+            f"depth must be between 1 and {MAX_DOCUMENT_OUTLINE_DEPTH}"
+        )
+    if (
+        not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or not 1 <= limit <= MAX_DOCUMENT_OUTLINE_RESULTS
+    ):
+        raise LspInvalidInputError(
+            f"limit must be between 1 and {MAX_DOCUMENT_OUTLINE_RESULTS}"
+        )
+
+
+class _OutlineNormalizer:
+    def __init__(
+        self,
+        *,
+        content: str,
+        document_uri: str,
+        depth: int,
+        limit: int,
+    ) -> None:
+        self._content = content
+        self._document_uri = document_uri
+        self._depth = depth
+        self._limit = limit
+        self.count = 0
+        self._emitted = 0
+        self.truncated = False
+        self.warnings: list[str] = []
+
+    def normalize(self, raw_result: object) -> tuple[CodeSymbol, ...]:
+        if raw_result is None:
+            return ()
+        if not isinstance(raw_result, list):
+            raise LspProtocolError("documentSymbol result must be an array or null")
+        return self._visit(raw_result, level=1)
+
+    def _visit(self, raw_items: list[object], *, level: int) -> tuple[CodeSymbol, ...]:
+        items: list[CodeSymbol] = []
+        for raw_item in raw_items:
+            if not self._reserve_protocol_item():
+                break
+            if not isinstance(raw_item, Mapping):
+                raise LspProtocolError("documentSymbol items must be objects")
+            raw_children = raw_item.get("children", ())
+            if not isinstance(raw_children, list | tuple):
+                raise LspProtocolError("documentSymbol children must be an array")
+            children_values = list(raw_children)
+            if level > self._depth or self._emitted >= self._limit:
+                self.truncated = True
+                self._count_omitted(children_values)
+                continue
+
+            self._emitted += 1
+            children: tuple[CodeSymbol, ...] = ()
+            if children_values:
+                if level == self._depth:
+                    self.truncated = True
+                    self._count_omitted(children_values)
+                else:
+                    children = self._visit(children_values, level=level + 1)
+            items.append(self._parse_symbol(raw_item, children=children))
+        return tuple(items)
+
+    def _reserve_protocol_item(self) -> bool:
+        if self.count >= _MAX_OUTLINE_PROTOCOL_SYMBOLS:
+            self.truncated = True
+            warning = "language server returned too many document symbols"
+            if warning not in self.warnings:
+                self.warnings.append(warning)
+            return False
+        self.count += 1
+        return True
+
+    def _count_omitted(self, raw_items: list[object]) -> None:
+        pending = list(reversed(raw_items))
+        while pending:
+            raw_item = pending.pop()
+            if not self._reserve_protocol_item():
+                return
+            if isinstance(raw_item, Mapping):
+                raw_children = raw_item.get("children", ())
+                if isinstance(raw_children, list | tuple):
+                    pending.extend(reversed(raw_children))
+
+    def _parse_symbol(
+        self,
+        raw_symbol: Mapping[str, object],
+        *,
+        children: tuple[CodeSymbol, ...],
+    ) -> CodeSymbol:
+        name = raw_symbol.get("name")
+        kind = raw_symbol.get("kind")
+        if not isinstance(name, str) or not name:
+            raise LspProtocolError("documentSymbol name must be a non-empty string")
+        if (
+            not isinstance(kind, int)
+            or isinstance(kind, bool)
+            or not 1 <= kind <= len(_SYMBOL_KIND_NAMES)
+        ):
+            raise LspProtocolError("documentSymbol kind is outside the LSP range")
+
+        raw_range = raw_symbol.get("range")
+        raw_selection_range = raw_symbol.get("selectionRange")
+        container_name = raw_symbol.get("containerName")
+        if raw_range is None:
+            raw_location = raw_symbol.get("location")
+            if not isinstance(raw_location, Mapping):
+                raise LspProtocolError(
+                    "documentSymbol item is missing range or location"
+                )
+            if raw_location.get("uri") != self._document_uri:
+                raise LspProtocolError(
+                    "documentSymbol location must refer to the requested document"
+                )
+            raw_range = raw_location.get("range")
+            raw_selection_range = raw_range
+        if not isinstance(raw_range, Mapping) or not isinstance(
+            raw_selection_range, Mapping
+        ):
+            raise LspProtocolError("documentSymbol ranges must be objects")
+        detail = raw_symbol.get("detail")
+        if detail is not None and not isinstance(detail, str):
+            raise LspProtocolError("documentSymbol detail must be a string")
+        if container_name is not None and not isinstance(container_name, str):
+            raise LspProtocolError("documentSymbol containerName must be a string")
+        return CodeSymbol(
+            name=name,
+            kind=kind,
+            kind_name=_SYMBOL_KIND_NAMES[kind - 1],
+            range=_to_public_range(self._content, _parse_lsp_range(raw_range)),
+            selection_range=_to_public_range(
+                self._content,
+                _parse_lsp_range(raw_selection_range),
+            ),
+            detail=detail,
+            container_name=container_name,
+            children=children,
         )
 
 
@@ -357,8 +644,12 @@ def _file_uri_path(uri: str) -> Path | None:
 
 __all__ = [
     "CodingLspTools",
+    "DOCUMENT_OUTLINE_TOOL_NAME",
     "INSPECT_SYMBOL_TOOL_NAME",
     "InspectSymbolRuntime",
+    "MAX_DOCUMENT_OUTLINE_DEPTH",
+    "MAX_DOCUMENT_OUTLINE_RESULTS",
     "MAX_INSPECT_SYMBOL_RESULTS",
+    "create_document_outline_tool_definition",
     "create_inspect_symbol_tool_definition",
 ]

--- a/tests/coding/lsp/fixtures/fake_lsp_server.py
+++ b/tests/coding/lsp/fixtures/fake_lsp_server.py
@@ -67,6 +67,23 @@ def _definition_result(message: Mapping[str, object]) -> dict[str, object]:
     }
 
 
+def _outline_result() -> list[dict[str, object]]:
+    return [
+        {
+            "name": "target",
+            "kind": 13,
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": 0, "character": 10},
+            },
+            "selectionRange": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": 0, "character": 6},
+            },
+        }
+    ]
+
+
 def main() -> int:
     while True:
         message = _read_message()
@@ -86,6 +103,7 @@ def main() -> int:
                         "capabilities": {
                             "positionEncoding": "utf-16",
                             "definitionProvider": True,
+                            "documentSymbolProvider": True,
                             "textDocumentSync": 2,
                         }
                     },
@@ -97,6 +115,14 @@ def main() -> int:
                     "jsonrpc": "2.0",
                     "id": request_id,
                     "result": _definition_result(message),
+                }
+            )
+        elif method == "textDocument/documentSymbol":
+            _write_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": _outline_result(),
                 }
             )
         elif method == "shutdown":

--- a/tests/coding/lsp/test_cli.py
+++ b/tests/coding/lsp/test_cli.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+from types import SimpleNamespace
+
+from loushang.ai.model import Capabilities, Model
+from loushang.coding.bootstrap import create_agent_session, create_services
+from loushang.coding.cli.__main__ import _run_coding_pre_runtime_operation, run_cli
+from loushang.coding.cli.args import parse_args
+from loushang.coding.cli.lsp import run_coding_lsp_command
+from loushang.coding.control import ControlConfig, SettingsManager
+from loushang.coding.lsp import (
+    DOCUMENT_OUTLINE_TOOL_NAME,
+    INSPECT_SYMBOL_TOOL_NAME,
+)
+from loushang.coding.session_manager import SessionManager
+from loushang.harness.cli import AgentCliStatePreparationContext
+
+
+def _model() -> Model:
+    return Model(
+        id="faux-model",
+        name="Faux",
+        provider="faux",
+        endpoint="anthropic-messages",
+        capabilities=Capabilities(
+            reasoning=True,
+            input=("text",),
+            context_window=128_000,
+            max_tokens=4_096,
+        ),
+    )
+
+
+def _configure_python_server(config_dir: Path) -> None:
+    config = config_dir / "lsp.json"
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        json.dumps(
+            {
+                "servers": [
+                    {
+                        "id": "configured-python",
+                        "command": [sys.executable, "-m", "configured_lsp"],
+                        "language_extensions": {"python": [".py"]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_status_and_doctor_inspect_catalog_without_starting_process(
+    tmp_path: Path,
+) -> None:
+    user_config_dir = tmp_path / "user-config"
+    _configure_python_server(user_config_dir)
+    services = create_services(
+        settings_manager=SettingsManager(
+            ControlConfig(capabilities={"coding.lsp": "always"}),
+            global_settings_path=user_config_dir / "settings.json",
+        )
+    )
+    stdout = StringIO()
+
+    exit_code = asyncio.run(
+        run_coding_lsp_command(
+            ("status", "--format", "json"),
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=services,
+            build_services=lambda _root: (_ for _ in ()).throw(
+                AssertionError("provided services must be reused")
+            ),
+        )
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert exit_code == 0
+    assert payload["mount_mode"] == "always"
+    assert payload["admitted_count"] >= 1
+    assert payload["process_start_attempted"] is False
+    configured = next(
+        item
+        for item in payload["servers"]
+        if item["definition_id"] == "configured-python"
+    )
+    assert configured["state"] == "admitted"
+
+
+def test_doctor_reports_missing_servers_without_attempting_install(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
+    services = create_services(
+        settings_manager=SettingsManager(
+            ControlConfig(capabilities={"coding.lsp": "always"})
+        )
+    )
+    stdout = StringIO()
+
+    exit_code = asyncio.run(
+        run_coding_lsp_command(
+            ("doctor",),
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=services,
+            build_services=lambda _root: services,
+        )
+    )
+
+    assert exit_code == 1
+    assert "Process start attempted: no" in stdout.getvalue()
+    assert "no language server is available" in stdout.getvalue()
+
+
+def test_doctor_fails_for_rejected_config_even_when_another_server_is_admitted(
+    tmp_path: Path,
+) -> None:
+    user_config_dir = tmp_path / "user-config"
+    _configure_python_server(user_config_dir)
+    config = user_config_dir / "lsp.json"
+    payload = json.loads(config.read_text(encoding="utf-8"))
+    payload["servers"].append(
+        {
+            "id": "broken",
+            "command": "not-an-array",
+            "language_extensions": {"python": [".py"]},
+        }
+    )
+    config.write_text(json.dumps(payload), encoding="utf-8")
+    services = create_services(
+        settings_manager=SettingsManager(
+            ControlConfig(capabilities={"coding.lsp": "always"}),
+            global_settings_path=user_config_dir / "settings.json",
+        )
+    )
+    stdout = StringIO()
+
+    exit_code = asyncio.run(
+        run_coding_lsp_command(
+            ("doctor",),
+            stdin=StringIO(),
+            stdout=stdout,
+            stderr=StringIO(),
+            cwd=tmp_path,
+            services=services,
+            build_services=lambda _root: services,
+        )
+    )
+
+    assert exit_code == 1
+    assert "configuration errors require attention" in stdout.getvalue()
+
+
+def test_top_level_lsp_command_short_circuits_session_runtime(tmp_path: Path) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def lsp_runner(argv, **kwargs):
+        del kwargs
+        calls.append(tuple(argv))
+        return 7
+
+    exit_code = asyncio.run(
+        run_cli(
+            ("lsp", "status"),
+            cwd=tmp_path,
+            stdin=StringIO(),
+            stdout=StringIO(),
+            stderr=StringIO(),
+            lsp_runner=lsp_runner,
+            runtime_builder=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("status must not construct a session runtime")
+            ),
+        )
+    )
+
+    assert exit_code == 7
+    assert calls == [("status",)]
+
+
+def test_generic_cli_capability_override_activates_coding_lsp() -> None:
+    manager = SettingsManager()
+    services = create_services(settings_manager=manager)
+    context = AgentCliStatePreparationContext(
+        args=parse_args(["--capability", "coding.lsp=always"]),
+        project_root=Path.cwd(),
+        session_dir=Path.cwd() / ".loushang" / "sessions",
+        services=services,
+        stdout=StringIO(),
+        stderr=StringIO(),
+    )
+
+    result = asyncio.run(
+        _run_coding_pre_runtime_operation(
+            context,
+            workflow_runner=SimpleNamespace(),
+        )
+    )
+
+    assert result is None
+    assert manager.get_settings().capabilities["coding.lsp"] == "always"
+
+
+def test_configured_lsp_is_available_to_ordinary_session_and_remains_lazy(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from loushang.coding.sandbox import SandboxExecutionRuntime
+
+    user_config_dir = tmp_path / "user-config"
+    _configure_python_server(user_config_dir)
+    starts: list[object] = []
+
+    class _NeverLauncher:
+        async def start(self, *args: object, **kwargs: object) -> object:
+            starts.append((args, kwargs))
+            raise AssertionError("session construction must not start an LSP server")
+
+    monkeypatch.setattr(
+        SandboxExecutionRuntime,
+        "bind_process_launcher",
+        lambda _runtime, _scope: _NeverLauncher(),
+    )
+    services = create_services(
+        settings_manager=SettingsManager(
+            ControlConfig(capabilities={"coding.lsp": "always"}),
+            global_settings_path=user_config_dir / "settings.json",
+        )
+    )
+    manager = asyncio.run(
+        SessionManager.new(
+            session_dir=tmp_path / "sessions",
+            cwd=str(tmp_path),
+            persist=False,
+        )
+    )
+
+    session = create_agent_session(
+        session_manager=manager,
+        services=services,
+        model=_model(),
+    )
+
+    assert {INSPECT_SYMBOL_TOOL_NAME, DOCUMENT_OUTLINE_TOOL_NAME}.issubset(
+        session.get_active_tool_names()
+    )
+    assert starts == []
+    asyncio.run(session.dispose())

--- a/tests/coding/lsp/test_discovery.py
+++ b/tests/coding/lsp/test_discovery.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+
+from loushang.coding.lsp import (
+    LspServerDefinition,
+    default_lsp_environment,
+    discover_lsp_catalog,
+)
+
+
+def _write_config(path: Path, servers: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"servers": servers}), encoding="utf-8")
+
+
+def test_catalog_merges_config_by_product_precedence_and_admits_available_server(
+    tmp_path: Path,
+) -> None:
+    user_config = tmp_path / "user-lsp.json"
+    project_config = tmp_path / "project-lsp.json"
+    _write_config(
+        user_config,
+        [
+            {
+                "id": "python-custom",
+                "command": ["custom-lsp", "--stdio"],
+                "language_extensions": {"python": [".py"]},
+                "environment": {"CUSTOM_LSP_HOME": "/trusted/home"},
+            },
+            {"id": "disabled-default", "enabled": False},
+        ],
+    )
+    _write_config(
+        project_config,
+        [
+            {
+                "id": "python-custom",
+                "command": ["custom-lsp", "--stdio"],
+                "language_extensions": {"python": ["py", "pyi"]},
+                "priority": 20,
+                "settings": {"analysis": {"strict": True}},
+            },
+            {"id": "broken", "command": "not-an-array"},
+        ],
+    )
+    probe_environments: list[dict[str, str]] = []
+
+    def resolve(command: str, environment: Mapping[str, str]) -> str | None:
+        resolved_environment = dict(environment)
+        probe_environments.append(resolved_environment)
+        return (
+            f"{resolved_environment['PATH']}/{command}"
+            if command == "custom-lsp"
+            else None
+        )
+
+    snapshot = discover_lsp_catalog(
+        workspace_root=tmp_path,
+        baseline_environment={"PATH": "/tools"},
+        global_config_path=user_config,
+        project_config_path=project_config,
+        executable_resolver=resolve,
+        include_product_defaults=False,
+    )
+
+    assert snapshot.admitted_count == 1
+    assert snapshot.definitions[0].command == ("/tools/custom-lsp", "--stdio")
+    assert snapshot.definitions[0].extensions == (".py", ".pyi")
+    assert snapshot.definitions[0].environment == {"CUSTOM_LSP_HOME": "/trusted/home"}
+    assert probe_environments == [
+        {"PATH": "/tools", "CUSTOM_LSP_HOME": "/trusted/home"}
+    ]
+    assert [
+        (record.definition_id, record.source, record.state)
+        for record in snapshot.records
+    ] == [
+        ("broken", "project-config", "rejected"),
+        ("disabled-default", "user-config", "disabled"),
+        ("python-custom", "project-config", "admitted"),
+    ]
+    assert snapshot.records[-1].executable == "/tools/custom-lsp"
+    assert len(snapshot.generation) == 12
+
+    _write_config(
+        project_config,
+        [
+            {
+                "id": "python-custom",
+                "command": ["custom-lsp", "--stdio"],
+                "language_extensions": {"python": [".py"]},
+                "settings": {"analysis": {"strict": False}},
+            }
+        ],
+    )
+    changed = discover_lsp_catalog(
+        workspace_root=tmp_path,
+        baseline_environment={"PATH": "/tools"},
+        global_config_path=user_config,
+        project_config_path=project_config,
+        executable_resolver=lambda command, _environment: f"/tools/{command}",
+        include_product_defaults=False,
+    )
+    assert changed.generation != snapshot.generation
+
+
+def test_project_config_cannot_alter_arguments_of_trusted_command(
+    tmp_path: Path,
+) -> None:
+    user_config = tmp_path / "user-lsp.json"
+    project_config = tmp_path / "project-lsp.json"
+    _write_config(
+        user_config,
+        [
+            {
+                "id": "python-custom",
+                "command": ["python", "-m", "trusted_lsp"],
+                "language_extensions": {"python": [".py"]},
+            }
+        ],
+    )
+    _write_config(
+        project_config,
+        [
+            {
+                "id": "python-custom",
+                "command": ["python", "-c", "run_untrusted_code()"],
+                "language_extensions": {"python": [".py"]},
+            }
+        ],
+    )
+
+    snapshot = discover_lsp_catalog(
+        workspace_root=tmp_path,
+        baseline_environment={"PATH": "/tools"},
+        global_config_path=user_config,
+        project_config_path=project_config,
+        executable_resolver=lambda command, _environment: f"/tools/{command}",
+        include_product_defaults=False,
+    )
+
+    assert snapshot.admitted_count == 0
+    assert snapshot.records[0].state == "rejected"
+    assert "complete command" in snapshot.records[0].detail
+
+
+def test_explicit_sdk_definition_is_already_admitted_without_binary_probe(
+    tmp_path: Path,
+) -> None:
+    probes: list[str] = []
+    definition = LspServerDefinition(
+        id="sdk-fake",
+        command=("not-installed-in-this-test", "--stdio"),
+        language_extensions={"python": (".py",)},
+    )
+
+    snapshot = discover_lsp_catalog(
+        workspace_root=tmp_path,
+        baseline_environment={},
+        explicit_definitions=(definition,),
+        global_config_path=tmp_path / "missing-user.json",
+        project_config_path=tmp_path / "missing-project.json",
+        executable_resolver=lambda command, _environment: probes.append(command),
+        include_product_defaults=False,
+    )
+
+    assert snapshot.definitions == (definition,)
+    assert snapshot.records[0].state == "admitted"
+    assert probes == []
+
+
+def test_project_config_cannot_introduce_untrusted_executable(tmp_path: Path) -> None:
+    project_config = tmp_path / "project-lsp.json"
+    _write_config(
+        project_config,
+        [
+            {
+                "id": "repository-command",
+                "command": ["run-anything", "--stdio"],
+                "language_extensions": {"python": [".py"]},
+            }
+        ],
+    )
+
+    snapshot = discover_lsp_catalog(
+        workspace_root=tmp_path,
+        baseline_environment={"PATH": "/tools"},
+        global_config_path=False,
+        project_config_path=project_config,
+        executable_resolver=lambda command, _environment: f"/tools/{command}",
+        include_product_defaults=False,
+    )
+
+    assert snapshot.admitted_count == 0
+    assert snapshot.records[0].state == "rejected"
+    assert "user-level" in snapshot.records[0].detail
+
+
+def test_product_defaults_report_unavailable_without_installing_or_starting(
+    tmp_path: Path,
+) -> None:
+    probes: list[str] = []
+
+    snapshot = discover_lsp_catalog(
+        workspace_root=tmp_path,
+        baseline_environment={"PATH": "/empty"},
+        global_config_path=tmp_path / "missing-user.json",
+        project_config_path=tmp_path / "missing-project.json",
+        executable_resolver=lambda command, _environment: probes.append(command),
+    )
+
+    assert snapshot.admitted_count == 0
+    assert probes == [
+        "clangd",
+        "gopls",
+        "pyright-langserver",
+        "rust-analyzer",
+        "typescript-language-server",
+    ]
+    assert {record.state for record in snapshot.records} == {"unavailable"}
+
+
+def test_default_environment_excludes_unrelated_secrets() -> None:
+    environment = default_lsp_environment(
+        {
+            "PATH": "/bin",
+            "HOME": "/home/example",
+            "LANG": "C.UTF-8",
+            "API_TOKEN": "secret",
+            "AWS_SECRET_ACCESS_KEY": "secret",
+        }
+    )
+
+    assert environment == {
+        "PATH": "/bin",
+        "HOME": "/home/example",
+        "LANG": "C.UTF-8",
+    }

--- a/tests/coding/lsp/test_fake_launcher_vertical_slice.py
+++ b/tests/coding/lsp/test_fake_launcher_vertical_slice.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from loushang.coding.lsp import (
+    DOCUMENT_OUTLINE_TOOL_NAME,
     CodingLspBinding,
     LspCatalog,
     LspClient,
@@ -18,6 +19,7 @@ from loushang.coding.lsp import (
     ProcessExit,
     ProcessLaunchRequest,
     ProcessStderrTail,
+    create_document_outline_tool_definition,
     create_inspect_symbol_tool_definition,
 )
 from loushang.harness.tools import ToolContext
@@ -81,6 +83,7 @@ class FakeLspServer:
         self,
         *,
         definition_result: object,
+        outline_result: object,
         initialize_gate: asyncio.Event | None,
         definition_gate: asyncio.Event | None,
         shutdown_gate: asyncio.Event | None,
@@ -91,6 +94,7 @@ class FakeLspServer:
         self.stdin: asyncio.Queue[bytes | None] = asyncio.Queue()
         self.stdout: asyncio.Queue[bytes | None] = asyncio.Queue()
         self.definition_result = definition_result
+        self.outline_result = outline_result
         self.initialize_gate = initialize_gate
         self.definition_gate = definition_gate
         self.shutdown_gate = shutdown_gate
@@ -155,6 +159,17 @@ class FakeLspServer:
                                 "jsonrpc": "2.0",
                                 "id": request_id,
                                 "result": self.definition_result,
+                            }
+                        ),
+                    )
+                elif method == "textDocument/documentSymbol":
+                    self._schedule_response(
+                        None,
+                        _frame(
+                            {
+                                "jsonrpc": "2.0",
+                                "id": request_id,
+                                "result": self.outline_result,
                             }
                         ),
                     )
@@ -240,6 +255,7 @@ class FakeLauncher:
         self,
         *,
         definition_result: object,
+        outline_result: object = None,
         initialize_gate: asyncio.Event | None = None,
         definition_gate: asyncio.Event | None = None,
         shutdown_gate: asyncio.Event | None = None,
@@ -248,6 +264,7 @@ class FakeLauncher:
         ignore_exit: bool = False,
     ) -> None:
         self.definition_result = definition_result
+        self.outline_result = outline_result
         self.initialize_gate = initialize_gate
         self.definition_gate = definition_gate
         self.shutdown_gate = shutdown_gate
@@ -270,6 +287,7 @@ class FakeLauncher:
         self.correlation_ids.append(correlation_id)
         server = FakeLspServer(
             definition_result=self.definition_result,
+            outline_result=self.outline_result,
             initialize_gate=self.initialize_gate,
             definition_gate=self.definition_gate,
             shutdown_gate=self.shutdown_gate,
@@ -427,6 +445,109 @@ def test_fake_launcher_drives_tool_to_definition_and_ordered_sync(
         await binding.dispose()
         assert launcher.handles[0].close_calls == 1
         assert server.methods()[-2:] == ["shutdown", "exit"]
+
+    asyncio.run(scenario())
+
+
+def test_document_outline_preserves_hierarchy_and_enforces_depth(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "pyproject.toml").touch()
+        source = project / "main.py"
+        source.touch()
+        content = "class Greeter:\n    def hello(self):\n        pass\n\ndef main():\n    pass\n"
+        files = {source.resolve(): content}
+        outline = [
+            {
+                "name": "Greeter",
+                "detail": "class Greeter",
+                "kind": 5,
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": 2, "character": 12},
+                },
+                "selectionRange": {
+                    "start": {"line": 0, "character": 6},
+                    "end": {"line": 0, "character": 13},
+                },
+                "children": [
+                    {
+                        "name": "hello",
+                        "kind": 6,
+                        "range": {
+                            "start": {"line": 1, "character": 4},
+                            "end": {"line": 2, "character": 12},
+                        },
+                        "selectionRange": {
+                            "start": {"line": 1, "character": 8},
+                            "end": {"line": 1, "character": 13},
+                        },
+                    }
+                ],
+            },
+            {
+                "name": "main",
+                "kind": 12,
+                "range": {
+                    "start": {"line": 4, "character": 0},
+                    "end": {"line": 5, "character": 8},
+                },
+                "selectionRange": {
+                    "start": {"line": 4, "character": 4},
+                    "end": {"line": 4, "character": 8},
+                },
+            },
+        ]
+        launcher = FakeLauncher(definition_result=None, outline_result=outline)
+        binding = _binding(tmp_path, launcher, files)
+
+        result = await binding.document_outline(
+            path="project/main.py",
+            depth=2,
+            correlation_id="outline-1",
+        )
+        shallow = await binding.document_outline(
+            path="project/main.py",
+            depth=1,
+            correlation_id="outline-2",
+        )
+        limited = await binding.document_outline(
+            path="project/main.py",
+            limit=1,
+            correlation_id="outline-3",
+        )
+
+        assert result.count == 3
+        assert result.truncated is False
+        assert [item.name for item in result.items] == ["Greeter", "main"]
+        assert result.items[0].kind_name == "class"
+        assert result.items[0].children[0].name == "hello"
+        assert result.items[0].children[0].range.start.line == 2
+        assert shallow.count == 3
+        assert shallow.truncated is True
+        assert shallow.items[0].children == ()
+        assert limited.count == 3
+        assert limited.truncated is True
+        assert [item.name for item in limited.items] == ["Greeter"]
+        assert launcher.correlation_ids == ["outline-1"]
+        assert (
+            launcher.handles[0].server.methods().count("textDocument/documentSymbol")
+            == 3
+        )
+
+        with pytest.raises(LspInvalidInputError, match="depth"):
+            await binding.document_outline(
+                path="project/main.py",
+                depth=0,
+                correlation_id="invalid-outline",
+            )
+
+        definition = create_document_outline_tool_definition(binding)
+        assert definition.name == DOCUMENT_OUTLINE_TOOL_NAME
+        await binding.dispose()
 
     asyncio.run(scenario())
 

--- a/tests/coding/lsp/test_harness_launcher_vertical_slice.py
+++ b/tests/coding/lsp/test_harness_launcher_vertical_slice.py
@@ -46,6 +46,7 @@ def test_real_harness_launcher_drives_lsp_query_and_graceful_cleanup(
         )
         lsp_runtime = None
         result = None
+        outline = None
         try:
             lsp_runtime = bind_coding_lsp_runtime(
                 workspace_root=project,
@@ -82,6 +83,10 @@ def test_real_harness_launcher_drives_lsp_query_and_graceful_cleanup(
                 character=7,
                 correlation_id="real-lsp-query-1",
             )
+            outline = await lsp_runtime.document_outline(
+                path="main.py",
+                correlation_id="real-lsp-query-2",
+            )
         finally:
             if lsp_runtime is not None:
                 await lsp_runtime.close()
@@ -93,11 +98,16 @@ def test_real_harness_launcher_drives_lsp_query_and_graceful_cleanup(
         assert result.items[0].path == "main.py"
         assert result.items[0].range.start.line == 1
         assert result.items[0].range.start.character == 1
+        assert outline is not None
+        assert outline.count == 1
+        assert outline.items[0].name == "target"
+        assert outline.items[0].kind_name == "variable"
         assert method_log.read_text(encoding="utf-8").splitlines() == [
             "initialize",
             "initialized",
             "textDocument/didOpen",
             "textDocument/definition",
+            "textDocument/documentSymbol",
             "shutdown",
             "exit",
         ]

--- a/tests/coding/lsp/test_runtime.py
+++ b/tests/coding/lsp/test_runtime.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from loushang.coding.lsp import (
+    DOCUMENT_OUTLINE_TOOL_NAME,
     INSPECT_SYMBOL_TOOL_NAME,
     CodingLspRuntime,
     DeferredCodingLspRuntime,
@@ -71,14 +72,16 @@ def test_deferred_runtime_and_tool_pack_preserve_mount_policy() -> None:
     register_coding_lsp_tools(on_demand, runtime=slot, mode="on_demand")
 
     assert [item.name for item in on_demand.list_definitions()] == [
-        INSPECT_SYMBOL_TOOL_NAME
+        INSPECT_SYMBOL_TOOL_NAME,
+        DOCUMENT_OUTLINE_TOOL_NAME,
     ]
     assert on_demand.list_enabled_definitions() == []
 
     always = WorkspaceToolRegistry()
     register_coding_lsp_tools(always, runtime=slot, mode="always")
     assert [item.name for item in always.list_enabled_definitions()] == [
-        INSPECT_SYMBOL_TOOL_NAME
+        INSPECT_SYMBOL_TOOL_NAME,
+        DOCUMENT_OUTLINE_TOOL_NAME,
     ]
 
     with pytest.raises(RuntimeError, match="not bound"):
@@ -87,6 +90,14 @@ def test_deferred_runtime_and_tool_pack_preserve_mount_policy() -> None:
                 path="main.py",
                 line=1,
                 character=1,
+                correlation_id="before-session",
+            )
+        )
+
+    with pytest.raises(RuntimeError, match="not bound"):
+        asyncio.run(
+            slot.document_outline(
+                path="main.py",
                 correlation_id="before-session",
             )
         )

--- a/tests/coding/test_bootstrap.py
+++ b/tests/coding/test_bootstrap.py
@@ -287,11 +287,9 @@ def test_create_agent_session_binds_always_on_lsp_to_sandbox_scope(
     asyncio.run(session.dispose())
 
 
-def test_create_agent_session_requires_explicit_lsp_environment(tmp_path) -> None:
-    import pytest
-
+def test_create_agent_session_projects_default_lsp_environment(tmp_path) -> None:
     from loushang.coding.bootstrap import create_agent_session
-    from loushang.coding.lsp import LspServerDefinition
+    from loushang.coding.lsp import INSPECT_SYMBOL_TOOL_NAME, LspServerDefinition
     from loushang.coding.session_manager import SessionManager
 
     manager = asyncio.run(
@@ -302,18 +300,78 @@ def test_create_agent_session_requires_explicit_lsp_environment(tmp_path) -> Non
         )
     )
 
-    with pytest.raises(ValueError, match="lsp_baseline_environment"):
-        create_agent_session(
-            session_manager=manager,
-            model=_model(),
-            lsp_definitions=(
-                LspServerDefinition(
-                    id="python-test",
-                    command=("python-language-server", "--stdio"),
-                    language_extensions={"python": (".py",)},
-                ),
+    session = create_agent_session(
+        session_manager=manager,
+        model=_model(),
+        lsp_definitions=(
+            LspServerDefinition(
+                id="python-test",
+                command=("python-language-server", "--stdio"),
+                language_extensions={"python": (".py",)},
             ),
+        ),
+    )
+
+    assert INSPECT_SYMBOL_TOOL_NAME in {
+        definition.name for definition in session.get_all_tools()
+    }
+    asyncio.run(session.dispose())
+
+
+def test_on_demand_lsp_discovers_installed_product_defaults(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import loushang.coding.bootstrap as coding_bootstrap
+    from loushang.coding.bootstrap import create_agent_session, create_services
+    from loushang.coding.control import ControlConfig, SettingsManager
+    from loushang.coding.lsp import LspServerDefinition
+    from loushang.coding.session_manager import SessionManager
+
+    executable_dir = tmp_path / "bin"
+    executable_dir.mkdir()
+    executable = executable_dir / "pyright-langserver"
+    executable.write_text("#!/bin/sh\n", encoding="utf-8")
+    executable.chmod(0o755)
+    project = tmp_path / "project"
+    project.mkdir()
+    captured_definitions: list[LspServerDefinition] = []
+    bind_runtime = coding_bootstrap.bind_coding_lsp_runtime
+
+    def capture_definitions(**kwargs):
+        captured_definitions.extend(kwargs["definitions"])
+        return bind_runtime(**kwargs)
+
+    monkeypatch.setattr(
+        coding_bootstrap,
+        "bind_coding_lsp_runtime",
+        capture_definitions,
+    )
+    services = create_services(
+        settings_manager=SettingsManager(
+            ControlConfig(capabilities={"coding.lsp": "on_demand"}),
+            global_settings_path=tmp_path / "config" / "settings.json",
+            project_settings_path=project / ".loushang" / "settings.json",
         )
+    )
+    manager = asyncio.run(
+        SessionManager.new(
+            session_dir=tmp_path / "sessions",
+            cwd=str(project),
+            persist=False,
+        )
+    )
+
+    session = create_agent_session(
+        session_manager=manager,
+        model=_model(),
+        services=services,
+        lsp_baseline_environment={"PATH": str(executable_dir)},
+    )
+
+    assert [definition.id for definition in captured_definitions] == ["pyright"]
+    assert captured_definitions[0].command == (str(executable.resolve()), "--stdio")
+    asyncio.run(session.dispose())
 
 
 def test_create_agent_session_result_returns_sdk_creation_snapshot(tmp_path) -> None:
@@ -1531,6 +1589,8 @@ def test_create_agent_session_synthesizes_definitions_from_legacy_tools(
         "grep",
         "write",
         "edit",
+        "inspect_symbol",
+        "document_outline",
     ]
     assert "Available tools:" in session.agent.system_prompt
 
@@ -1600,6 +1660,8 @@ def test_create_agent_session_defaults_custom_tools_active_without_defaulting_al
         "write",
         "edit",
         "custom_tool",
+        "inspect_symbol",
+        "document_outline",
     ]
     assert "- custom_tool:" not in session.agent.system_prompt
     assert "- grep:" in session.agent.system_prompt
@@ -2182,8 +2244,15 @@ def test_create_agent_session_merges_extension_resources_and_tools(tmp_path) -> 
         in session.agent.system_prompt
     )
     assert session.get_active_tool_names() == ["ext_tool"]
-    assert [definition.name for definition in session.get_all_tools()] == ["ext_tool"]
-    assert session.get_all_tool_infos()[0]["sourceInfo"] == {
+    assert [definition.name for definition in session.get_all_tools()] == [
+        "inspect_symbol",
+        "document_outline",
+        "ext_tool",
+    ]
+    extension_info = next(
+        info for info in session.get_all_tool_infos() if info["name"] == "ext_tool"
+    )
+    assert extension_info["sourceInfo"] == {
         "path": "/tmp/extensions/demo",
         "source": "filesystem",
         "scope": "project",

--- a/tests/coding/test_sdk_surface.py
+++ b/tests/coding/test_sdk_surface.py
@@ -40,10 +40,10 @@ def test_coding_top_level_exports_stable_sdk_surface() -> None:
         "BootstrapServices",
         "CreateAgentSessionResult",
         "CwdBoundServicesAudit",
-            "CwdBoundServicesAuditIssue",
-            "ExtensionFlagValues",
-            "HeadlessApprovalMode",
-            "SdkSurfaceCompatibilityReport",
+        "CwdBoundServicesAuditIssue",
+        "ExtensionFlagValues",
+        "HeadlessApprovalMode",
+        "SdkSurfaceCompatibilityReport",
         "SdkSurfaceSnapshot",
         "SessionManager",
         "check_sdk_surface_compatibility",
@@ -92,6 +92,9 @@ def test_coding_top_level_exposes_sdk_surface_snapshot() -> None:
         "approval_resolver",
         "tool_policy_evaluator",
         "enable_multiagent",
+        "lsp_definitions",
+        "lsp_baseline_environment",
+        "lsp_read_text",
     )
     assert snapshot.to_dict()["missing_exports"] == []
 
@@ -182,6 +185,9 @@ def test_coding_top_level_sdk_entry_signatures_are_stable() -> None:
         "approval_resolver",
         "tool_policy_evaluator",
         "enable_multiagent",
+        "lsp_definitions",
+        "lsp_baseline_environment",
+        "lsp_read_text",
     )
     assert tuple(
         inspect.signature(coding.create_agent_session_result).parameters
@@ -207,6 +213,9 @@ def test_coding_top_level_sdk_entry_signatures_are_stable() -> None:
         "approval_resolver",
         "tool_policy_evaluator",
         "enable_multiagent",
+        "lsp_definitions",
+        "lsp_baseline_environment",
+        "lsp_read_text",
     )
     assert tuple(inspect.signature(coding.create_agent_session_runtime).parameters) == (
         "session_dir",
@@ -227,6 +236,9 @@ def test_coding_top_level_sdk_entry_signatures_are_stable() -> None:
         "approval_resolver",
         "tool_policy_evaluator",
         "enable_multiagent",
+        "lsp_definitions",
+        "lsp_baseline_environment",
+        "lsp_read_text",
     )
 
 


### PR DESCRIPTION
## Summary
- activate Coding-owned LSP discovery, user/project configuration, status/doctor CLI, and lazy session binding
- add document outline alongside symbol inspection and preserve sandbox-owned process hosting
- harden P0 admission with complete-argv trust, inherited trusted environment, merged executable probes, frozen absolute executables, and full catalog generation hashing
- document Product defaults, mount modes, configuration, and user-facing commands

## Verification
- `.venv/bin/python -m pytest tests/coding/lsp tests/coding/test_bootstrap.py tests/coding/test_sdk_surface.py -k 'not sdk_smoke' -q` (88 passed, 1 deselected)
- `.venv/bin/mypy src/loushang/coding/lsp src/loushang/coding/cli/lsp.py src/loushang/coding/bootstrap.py`
- `.venv/bin/ruff check` and `.venv/bin/ruff format --check` on all changed Python files
- `.venv/bin/python -m pytest tests/architecture/test_import_boundaries.py::test_coding_lsp_h3_consumes_only_public_process_hosting_ports -q`