### PR TITLE
docs(harness): align capability and extension terminology

### DIFF
--- a/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
+++ b/docs/internals/architecture/agent/agent-harness-module-ownership-inventory.md
@@ -2,17 +2,12 @@
 
 ## Status
 
-Ownership inventory for
-[ARD-001: Agent Harness and Product Adapter Boundaries](ARD-001-agent-harness-and-product-adapters.md).
-Updated direction:
+Superseded as the current ownership inventory by the
+[Harness Current Owner Map](../harness/current-owner-map.md). This document is
+retained as the historical ownership input for
+[ARD-001: Agent Harness and Product Adapter Boundaries](ARD-001-agent-harness-and-product-adapters.md)
+and
 [ARD-002: Harness Product Adapter Substrate](ARD-002-harness-product-adapter-substrate.md).
-
-This document records module ownership for the prepared agent run contract. It is
-intentionally an inventory, not an implementation plan.
-It remains accurate for the current thin facade; future host/adapter substrate
-migration is tracked by the follow-up
-[Coding To Harness Migration Inventory](../harness/coding-to-harness-migration-inventory.md)
-before code moves.
 
 ## Scope
 
@@ -122,7 +117,7 @@ not harness candidates.
 | `policy` | Coding tool permission and approval policy | Product adapter | Do not move. |
 | `prompt` | Coding prompt assembly, preflight, templates | Product adapter | Do not move. |
 | `loader` / `resources` / `skill` | Resource discovery and Coding injection | Harness mechanism plus Product adapter | Move platform roots/layout, standard conventions, descriptors, discovery, merge, and reload to Harness. Keep content, activation, trust, and projection in Coding. |
-| `package` / `plugin` | Package/plugin lifecycle and materialization | Harness mechanism plus Product adapter | Move source/manifest/materialization and generic registry/resolver mechanics to Harness. Keep product policy, settings, and presentation in Coding. |
+| `package` / `plugin` | Resource Package lifecycle/materialization plus separate Plugin identity/source/enablement | Harness mechanism plus Product adapter | Move source/manifest/materialization and generic registry/resolver mechanics to Harness. Keep Product policy, settings, and presentation in Coding. |
 | `extensions` | Coding extension API, runner, policy, contributions | Product adapter | Do not move to agent. |
 | `domain` | Method-to-coding prepared turn bridge | Product adapter | Keep as product bridge. |
 | `control` | Settings, model controls, auth integration | Product adapter | Do not move. |

--- a/docs/internals/architecture/coding/ARD-004-package-plugin-boundary.md
+++ b/docs/internals/architecture/coding/ARD-004-package-plugin-boundary.md
@@ -8,8 +8,10 @@ The package/plugin distinction and CLI/RPC wire semantics remain valid, but
 the former `coding.package.*` and `coding.plugin.*` paths were removed. Generic
 package and plugin APIs, including catalog/materialization projections, are now
 imported from `loushang.harness.resources`; Coding binds product defaults in
-`coding.resource_runtime` and retains only discovery/materializer wiring in
-`coding.package_projection`.
+`coding.resource_runtime` and retains no Package or Plugin facade. Canonical
+terminology and current ownership are defined by the
+[Product And OEM Glossary](../../glossary/loushang-product.md) and
+[Harness Platform Resource Layout Boundary](../harness/platform-resource-layout-boundary.md).
 
 ## Context
 

--- a/docs/internals/architecture/coding/component-interfaces/README.md
+++ b/docs/internals/architecture/coding/component-interfaces/README.md
@@ -1,5 +1,14 @@
 # Loushang Coding Component Interface Notes
 
+## Status
+
+The directory is retained as design history for the original Coding component
+decomposition. It is no longer the current shared-owner map. Use the
+[Harness Current Owner Map](../../harness/current-owner-map.md) for ownership,
+the [Product And OEM Glossary](../../../glossary/loushang-product.md) for
+terminology, and current focused Product documents for the remaining Coding
+adapters.
+
 ## Purpose
 
 本目录用于放置 `loushang-coding` 各组件的单独接口说明。
@@ -58,7 +67,7 @@
 
 - [_template.md](_template.md)
 
-## Current Notes
+## Retained Component Notes
 
 - [bootstrap.md](bootstrap.md)
 - [sdk.md](sdk.md)

--- a/docs/internals/architecture/coding/component-interfaces/extensions.md
+++ b/docs/internals/architecture/coding/component-interfaces/extensions.md
@@ -1,5 +1,13 @@
 # `extensions`
 
+## Status
+
+Superseded as a Coding-owned shared runtime. Product-neutral Extension loading,
+routing, and lifecycle composition now belong to the
+[Harness Extension Runtime Core](../../harness/extension-runtime-core-boundary.md).
+The Product-specific semantics described below are retained as historical
+adapter requirements.
+
 ## Role
 
 - coding 扩展执行侧协调组件，以及可选的扩展发现/装载边界

--- a/docs/internals/architecture/coding/component-interfaces/package.md
+++ b/docs/internals/architecture/coding/component-interfaces/package.md
@@ -1,8 +1,16 @@
 # `package`
 
+## Status
+
+Superseded as a Coding-owned component. Product-neutral Resource Package
+materialization and lifecycle now belong to
+[Harness Platform Resource Layout](../../harness/platform-resource-layout-boundary.md).
+The definitions below are retained for compatibility history.
+
 ## Role
 
-- package/plugin lifecycle and source management boundary
+- Resource Package lifecycle and source-materialization boundary; Plugin
+  identity, registration, and enablement are separate
 - resource distribution unit bridge for local, remote, and Python package sources
 
 ## Owns

--- a/docs/internals/architecture/coding/component-interfaces/plugin.md
+++ b/docs/internals/architecture/coding/component-interfaces/plugin.md
@@ -1,5 +1,12 @@
 # `plugin`
 
+## Status
+
+Superseded as a Coding-owned component. Product-neutral Plugin identity,
+manifest, source, registry, resolver, and manager mechanics now belong to
+[Harness Platform Resource Layout](../../harness/platform-resource-layout-boundary.md).
+The definitions below are retained for compatibility history.
+
 ## Role
 
 - manifest-backed plugin source management component
@@ -84,8 +91,8 @@ package lifecycle facade：
 ## Reference Implementation Alignment
 
 - 对齐 `reference CLI` 中 package / package-manager / resource-plane 的总体方向
-- `plugin` 更接近 `reference packages` 的分发与资源声明语义，不等同于 `ExtensionAPI` 本身
-- `ExtensionAPI` 继续承担作者编程面；`plugin` 负责把 bundle 展开为 resources
+- `plugin` 对齐 manifest/source 声明与可选激活语义，但不拥有 Package 分发，也不等同于 `ExtensionAPI`
+- `ExtensionAPI` 继续承担作者编程面；`plugin` 把已解析的 package root 投影为 resources
 - `package` / `plugin` 在 loushang 中不再视为同义词：package 是资源分发单位，plugin 是 manifest-backed source view。
 - Headless MVP 已覆盖本地 plugin source 管理、enabled state、resource 展开与 package list UX；`--list-packages --list-packages-format json` 会标记同名多版本 package/plugin 的 `versionConflict` / `conflictVersions`。
 - Offline catalog projection is covered through CLI `--package-catalog <json>`; catalog entries are read locally and projected alongside installed/local packages without performing network install/update.

--- a/docs/internals/architecture/coding/loushang-coding-candidate-components.md
+++ b/docs/internals/architecture/coding/loushang-coding-candidate-components.md
@@ -1,5 +1,13 @@
 # Loushang Coding Candidate Components
 
+## Status
+
+Superseded as the current ownership topology by the
+[Harness Current Owner Map](../harness/current-owner-map.md). This document is
+retained as design history for the original Coding decomposition. Canonical
+Product, Capability, Resource Package, Plugin, and Extension terms come from
+the [Product And OEM Glossary](../../glossary/loushang-product.md).
+
 ## Scope
 
 本文档给出 `loushang-coding` 的候选组件列表，用于设计阶段对齐 `reference coding agent`。
@@ -263,11 +271,12 @@ coding resource descriptors 与加载结果边界。
 备注：
 
 - `extensions` 是 runtime 扩展面
-- `plugin` 是上层 package / distribution 形态，不取代 `extensions`
+- `plugin` 是 manifest-backed 可选贡献源的身份与启停边界，不取代
+  `extensions`，也不是 Package 分发边界
 
 ### `plugin`
 
-plugin bundle 管理与资源展开层。
+plugin identity、source、启停与资源根解析层。
 
 负责：
 
@@ -278,7 +287,8 @@ plugin bundle 管理与资源展开层。
 
 ### `package`
 
-package/plugin lifecycle 与 source 管理层。
+Resource Package lifecycle、source 与物化管理层；Plugin identity 和启停状态
+是独立边界。
 
 负责：
 

--- a/docs/internals/architecture/coding/loushang-coding-component-dependencies.md
+++ b/docs/internals/architecture/coding/loushang-coding-component-dependencies.md
@@ -1,5 +1,13 @@
 # Loushang Coding Component Dependencies
 
+## Status
+
+Superseded as the current dependency topology by the
+[Harness Current Owner Map](../harness/current-owner-map.md) and its import
+boundaries. The diagrams below describe the original Coding decomposition and
+are retained as design history, not as current Package/Plugin/Extension
+ownership.
+
 ## Scope
 
 本文档描述 `loushang-coding` 的组件依赖关系。

--- a/docs/internals/architecture/coding/loushang-coding-component-interfaces.md
+++ b/docs/internals/architecture/coding/loushang-coding-component-interfaces.md
@@ -1,5 +1,12 @@
 # Loushang Coding Component Interfaces
 
+## Status
+
+Superseded as the current cross-component interface map by the
+[Harness Current Owner Map](../harness/current-owner-map.md). Feature-local
+Coding contracts remain useful historical inputs, but shared resource,
+Package, Plugin, and Extension contracts are owned by Harness.
+
 ## Scope
 
 本文档作为 `loushang-coding` 组件接口设计的总入口。

--- a/docs/internals/architecture/coding/loushang-coding-component-inventory.md
+++ b/docs/internals/architecture/coding/loushang-coding-component-inventory.md
@@ -1,5 +1,13 @@
 # Loushang Coding Component Inventory
 
+## Status
+
+Superseded as the current ownership inventory by the
+[Harness Current Owner Map](../harness/current-owner-map.md). It is retained to
+explain the original Coding decomposition and must not be used to infer current
+module ownership. Canonical terminology is defined by the
+[Product And OEM Glossary](../../glossary/loushang-product.md).
+
 ## Scope
 
 本文档给出 `loushang-coding` 的组件清单总表。
@@ -45,8 +53,8 @@
 | `loader` | resource | 资源发现与加载 |
 | `resources` | resource | coding resource descriptors 与加载结果 |
 | `extensions` | resource | 扩展 hook 运行层 |
-| `plugin` | resource | plugin bundle 管理与资源展开 |
-| `package` | resource | package/plugin lifecycle 与 source 管理 |
+| `plugin` | resource | manifest-backed contribution source identity、启停与资源根解析（通用 owner 已迁入 Harness） |
+| `package` | resource | Resource Package lifecycle、source 与物化；不拥有 Plugin identity（通用 owner 已迁入 Harness） |
 | `domain` | resource | coding domain request、method policy 与 prepared turn bridge |
 | `control` | support | settings / model 控制平面 |
 | `policy` | support | 权限与审批策略 |

--- a/docs/internals/architecture/coding/loushang-coding-component-structure-and-responsibilities.md
+++ b/docs/internals/architecture/coding/loushang-coding-component-structure-and-responsibilities.md
@@ -1,5 +1,14 @@
 # Loushang Coding Component Structure And Responsibilities
 
+## Status
+
+Superseded as the current ownership topology by the
+[Harness Current Owner Map](../harness/current-owner-map.md). The original
+component analysis remains design history; current Package, Plugin, and
+Extension ownership is defined by the
+[Platform Resource Layout Boundary](../harness/platform-resource-layout-boundary.md)
+and [Extension Runtime Core Boundary](../harness/extension-runtime-core-boundary.md).
+
 ## Scope
 
 本文档描述 `loushang-coding` 的内部候选组件结构关系与职责边界。
@@ -124,7 +133,8 @@
 
 它们的共同特点是：
 
-- 提供 coding-specific 的资源注入、扩展能力、package/plugin lifecycle 与 method bridge
+- 提供 coding-specific 的资源注入、扩展能力、Resource Package lifecycle、
+  Plugin source/activation 与 method bridge
 - 更多负责“装什么”和“从哪里装”，而不是直接推进 run loop
 - 其中 `prompt` 是桥接组件：
   - 上接 `loader` / `resources` / `skill` / `domain`
@@ -453,13 +463,14 @@ flowchart TD
 备注：
 
 - `extensions` 是 runtime 扩展面
-- `plugin` 是上层 bundle / distribution 组件，不取代 `extensions`
+- `plugin` 是 manifest-backed 可选贡献源的身份与启停边界，不取代
+  `extensions`，也不是 Package 分发组件
 
 ### `plugin`
 
 角色：
 
-- plugin bundle 管理与资源展开层
+- plugin identity、source、启停与资源根解析层
 
 职责：
 
@@ -471,13 +482,14 @@ flowchart TD
 
 角色：
 
-- package/plugin lifecycle 与 source 管理层
+- Resource Package lifecycle、source 与物化管理层；Plugin identity 和启停
+  状态保持独立
 
 职责：
 
 - 管理 package catalog/source
 - 安装、更新、移除 package
-- 将 package materialize 为 plugin/resource 可消费形态
+- 将 Resource Package materialize 为资源加载器可消费的 package root
 
 ### `domain`
 

--- a/docs/internals/architecture/harness/README.md
+++ b/docs/internals/architecture/harness/README.md
@@ -6,7 +6,7 @@ prepare and run agent work without depending on another product package.
 It is intentionally narrower than a product framework and broader than the
 initial prepared-run facade. Harness owns product-neutral contracts, helper
 engines, registries, and lifecycle shapes that `coding`, `design`, `research`,
-`ppt`, `cowork`, and OEM products can share.
+`ppt`, `cowork`, and Products supplied or configured by OEMs can share.
 
 Harness may provide explicitly overridable cross-product platform defaults. It
 does not own domain content/defaults, product stores, product UI state, method
@@ -31,8 +31,14 @@ description.
 ## Boundary And Migration Document Catalog
 
 - [Product And OEM Glossary](../../glossary/loushang-product.md) defines the
-  canonical Product, OEM, Product Package, Capability Pack, Product Capability
-  Bundle, Plugin, and multi-Product launch vocabulary used by these boundaries.
+  canonical Product, OEM, Capability, Harness Capability, Package, Plugin,
+  Extension, Product Capability Bundle, and multi-Product launch vocabulary
+  used by these boundaries.
+- [Capability Variation And Replacement Boundary](capability-variation-and-replacement-boundary.md)
+  defines aggregate contribution, ordered interception and decoration,
+  exclusive replacement, protocol injection, composition-root ownership, and
+  the invariant enforcement layer that Product and Plugin variation cannot
+  bypass.
 - [Refactoring Principles](refactoring-principles.md) defines what may move
   into harness and how migration slices should be shaped.
 - [Shared Capability Boundaries](shared-capability-boundaries.md) maps tools,

--- a/docs/internals/architecture/harness/bootstrap-tool-contribution-boundary.md
+++ b/docs/internals/architecture/harness/bootstrap-tool-contribution-boundary.md
@@ -33,8 +33,9 @@ transition.
 Coding adapts its existing `ExtensionRunner`, `ResourceBundle`, and
 `DiagnosticDraft` values through a thin `_register_extension_tools` wrapper. It
 retains only the Coding diagnostic code/message and existing pack identifiers.
-Research, Design, PPT, and OEM Products can bind different extension runtimes,
-bundles, and diagnostic records without copying the contribution algorithm.
+Research, Design, PPT, and OEM-defined Products can bind different Extension
+runtimes, bundles, and diagnostic records without copying the contribution
+algorithm.
 
 ## Verification
 

--- a/docs/internals/architecture/harness/capability-domain-presentation-continuity-architecture.md
+++ b/docs/internals/architecture/harness/capability-domain-presentation-continuity-architecture.md
@@ -40,9 +40,9 @@ shared picker:
   already active Coding runtime.
 
 Moving those assumptions into Harness would make PPT, Design, Research, and
-mixed OEM products pretend to be Coding. Moving the whole picker into Coding
-would duplicate search, pagination, focus, preview, and activation mechanics in
-every product.
+Products composed by a mixed OEM Profile pretend to be Coding. Moving the whole
+picker into Coding would duplicate search, pagination, focus, preview, and
+activation mechanics in every product.
 
 The design therefore needs to answer a broader question:
 

--- a/docs/internals/architecture/harness/capability-variation-and-replacement-boundary.md
+++ b/docs/internals/architecture/harness/capability-variation-and-replacement-boundary.md
@@ -1,0 +1,202 @@
+# Harness Capability Variation And Replacement Boundary
+
+## Status
+
+Accepted architecture decision. Implementation remains boundary-specific: this
+decision does not make every described provider, backend, or lifecycle seam a
+public API.
+
+Canonical terms are defined in the
+[Product And OEM Glossary](../../glossary/loushang-product.md). This document
+defines when those variation semantics apply and how they preserve dependency,
+authority, and lifecycle boundaries.
+
+## Decision
+
+Loushang separates runtime-profile binding shape from behavioral variation
+semantics. They are orthogonal contracts and must not be collapsed into one
+enum or resolution rule.
+
+Every `RuntimeCapabilitySlot` declares one binding shape, allowed contribution
+sources, lifecycle scope, refresh boundary, and selection-conflict behavior:
+
+| Binding shape | Selection rule |
+| --- | --- |
+| `single` | retain at most one final admitted selection; refresh follows the slot's declared boundary |
+| `exclusive` | retain at most one final admitted selection and require a sealed refresh boundary |
+| `ordered` | retain distinct implementation/version identities in deterministic order, replacing an earlier selection of the same identity |
+| `append_only` | retain every admitted selection, including repeated identities, in deterministic order |
+
+An executable variation surface separately declares how its resolved values
+interact. A Product-only sealed slot need not expose an external variation
+surface. `Override` is only an umbrella term; it is never a sufficient
+resolution rule.
+
+The three executable composition semantics are:
+
+| Semantic | Cardinality | Resolution rule | Typical use |
+| --- | --- | --- | --- |
+| Aggregate Contribution | zero or more | admit every compatible entry and combine deterministically | tools, commands, server definitions, independent hooks |
+| Ordered Interception | zero or more around one operation or provider | build an explicit ordered chain with a declared error policy | policy interceptors, tracing, metrics, caching |
+| Exclusive Replacement | zero or one active provider per slot | select explicitly; reject unresolved ambiguity | approval resolver, model provider, storage or channel adapter |
+
+Decoration is the restricted case of Ordered Interception that wraps an
+already resolved capability without acquiring its selection, authority, or
+lifecycle ownership. Resource Overlay is a separate data-merge semantic: it
+may shadow a same-identity resource according to a documented precedence
+order, but it is not executable provider replacement.
+
+There is no one-to-one mapping between the two axes. An `ordered` slot may bind
+an Aggregate Contribution composer or an Ordered Interception pipeline. A
+`single` or `exclusive` slot may bind one provider, but admission and the
+surface contract decide whether Product, OEM, Extension, or session sources
+may replace it. An Extension may be carried by a Plugin, but Plugin identity is
+not a runtime-profile source. `append_only` is a selection-retention rule, not
+permission to execute every retained contribution.
+
+## Contract Ownership And Dependency Direction
+
+The layer that can state a contract without importing upstream domain
+vocabulary owns that contract:
+
+- Product-semantic ports remain Product-owned. For example, Coding owns a
+  future `LanguageServiceProvider` because language-server behavior, document
+  synchronization, and semantic operations are Coding concerns.
+- Product-neutral mechanism ports remain Harness-owned. For example,
+  `AuthorizedProcessLauncher` is a Harness capability that a Product may
+  consume.
+- The outer Product or Platform composition root selects concrete providers
+  and injects the narrow capabilities required to bind them.
+
+The resulting source dependency remains one-way:
+
+```text
+Product provider -> Product port and Harness public capabilities
+Harness          -X-> Product package or Product vocabulary
+```
+
+Harness may invoke an injected object at runtime without creating a reverse
+source dependency. It must not discover a Product implementation by deriving
+an import path, inspect Product-only types, branch on Product identity, or
+require a Product registry to interpret the injected contract.
+
+## Composition Lifecycle
+
+Replaceable capabilities follow a staged lifecycle:
+
+```text
+discover -> admit -> resolve -> bind -> dispose
+```
+
+- **Discover** reads descriptors and compatibility metadata without creating
+  live services or acquiring execution authority.
+- **Admit** applies Product, OEM, trust, version, and execution policy.
+- **Resolve** produces one deterministic and explainable selection or ordered
+  composition. Continuity-critical choices belong in the Resolved Runtime
+  Profile or its durable snapshot.
+- **Bind** constructs scoped live objects from a narrow immutable context. It
+  must not hand a Plugin the complete runtime as a service locator.
+- **Dispose** releases providers in the reverse of successful binding order.
+  Process-, Product-, Session-, workspace-, and document-scoped ownership must
+  be explicit.
+
+Discovery order is not selection policy. Priority may order admitted aggregate
+or interceptor entries where a boundary defines that behavior, but priority
+must not silently choose between ambiguous exclusive providers.
+
+## Safe Replacement Sandwich
+
+Product variation and Plugin-carried contributions are composed outside
+non-bypassable Harness invariants:
+
+```text
+Product-selected provider
+  -> Harness public capability
+     -> authorization / approval / sandbox / limit / cleanup enforcement
+        -> private mechanism
+```
+
+An allowed replacement may change Product behavior or policy within the
+declared execution-profile ceiling. It may add stricter checks. It cannot
+remove authorization, bypass approval coordination, disable required
+containment, enlarge Host-owned limits, or take cleanup ownership away from
+the Harness lifecycle.
+
+An approval resolver can therefore be an admitted Exclusive Replacement while
+the authorization gateway, immutable execution scope, revalidation, and
+cleanup invariants remain non-replaceable. Similarly, a trusted Platform may
+substitute a backend only where the owning boundary explicitly exposes that
+trusted seam. Backend substitution is not an ordinary Plugin right.
+
+## Registration And Conflict Rules
+
+Every replaceable or composable surface declares:
+
+- a stable capability or slot identifier;
+- its Runtime Capability Shape when it is profile-bound;
+- its behavioral composition semantic when variation is exposed;
+- compatible contract version;
+- allowed Product, OEM, Platform, Extension, or session sources and any
+  required Plugin provenance;
+- lifecycle scope and refresh boundary;
+- deterministic ordering where ordering is meaningful;
+- duplicate, ambiguity, failure, and fallback behavior.
+
+Registries must reject duplicate identities that the owning semantic cannot
+combine. Exclusive replacements require explicit Product, OEM, or Platform
+selection. They do not use last-write-wins or import order. Fallback providers
+are selected by the slot owner and are visible in the resolved profile and
+diagnostics.
+
+## Application To Coding Language Services
+
+A future Coding H3 language-service design should apply the decision as
+follows; this is an ownership example, not a claim that H3 is implemented:
+
+| Surface | Contract owner | Admitted sources | Semantic |
+| --- | --- | --- | --- |
+| `LanguageServiceProvider` | Coding | Product, plus explicitly admitted OEM or Extension layers if opened later | Exclusive Replacement when alternative complete providers are supported |
+| language-server definitions | Coding | Product and Extensions carried by admitted Coding Plugins | Aggregate Contribution with duplicate server identities rejected |
+| tracing, metrics, or cache wrappers | owning Coding/Harness integration boundary | Product/OEM/Extension as declared, with Plugin provenance where applicable | Decoration without authority widening |
+| `AuthorizedProcessLauncher` | Harness | execution-scope binding from Harness | injected public capability, not a Coding replacement slot |
+| authorization, required sandbox, limits, and process cleanup | Harness | Harness only | invariant enforcement, not replaceable by a Coding Plugin |
+
+The Coding composition root binds the chosen language provider with an
+execution-scope-bound `AuthorizedProcessLauncher`. Harness never imports the
+provider or interprets LSP methods.
+
+The current Process Hosting boundary deliberately exposes no public
+`ProcessBackend`, transport API, or concrete Host. This decision must not be
+used to infer such an extension point. A later backend seam requires its own
+boundary decision and trust model.
+
+## Validation
+
+Each implemented variation point requires focused contract tests that prove:
+
+- deterministic aggregate order or exclusive selection;
+- duplicate and ambiguous-provider rejection;
+- admission before construction and no discovery side effects;
+- narrow scope binding and reverse-order disposal;
+- failure and cancellation do not skip owned cleanup;
+- decorators preserve authority and lifecycle contracts;
+- Product adapters consume only Harness public APIs;
+- Harness tests use Product-neutral fixtures and Harness does not import a
+  Product package.
+
+Import-boundary gates enforce source dependency direction. Runtime tests prove
+that injected providers can be replaced without weakening the invariant
+enforcement layer.
+
+## Consequences And Non-Goals
+
+- Products can replace semantic providers without forking Harness mechanisms.
+- Plugin-carried contributions can participate or decorate only through
+  Product/OEM-admitted surfaces.
+- Resolution is diagnosable because the semantic, owner, selected source, and
+  fallback are explicit.
+- Security-sensitive mechanisms stay centrally enforced even when policy or
+  provider implementations vary.
+- This decision does not create a universal Plugin base class, global service
+  locator, public process backend, cross-Session provider pool, or implicit
+  dynamic-import convention.

--- a/docs/internals/architecture/harness/contribution-inventory-boundary.md
+++ b/docs/internals/architecture/harness/contribution-inventory-boundary.md
@@ -44,19 +44,20 @@ manifest/runtime projection live in
 `loushang.coding.extensions.contributions` module is removed; Coding imports
 the Harness owner directly.
 
-## Compatibility
+## Canonical Imports And Compatibility
 
-The Coding extension package may expose selected Harness values as part of its
-product API, but shared implementations are imported from their owners:
+The removed Coding Extension package does not expose compatibility aliases.
+Consumers import the Harness owner directly:
 
 ```python
-from loushang.coding.extensions import ExtensionInventory
-from loushang.coding.extensions import ExtensionSurfaceDescriptor
-from loushang.harness.extensions.contributions import ContributionRegistry
+from loushang.harness.contributions import ExtensionInventory
+from loushang.harness.contributions import ExtensionSurfaceDescriptor
+from loushang.harness.contributions import ContributionRegistry
 ```
 
-Harness-owned classes keep their harness `__module__`; Coding does not define a
-second implementation or a legacy submodule import path.
+The generic contribution names and Extension-shaped names refer to the same
+Harness-owned classes. They keep their Harness `__module__`; no Product defines
+a second implementation or legacy submodule import path.
 
 Existing constructor fields, registry methods, insertion ordering, duplicate
 visibility, exception attributes, and error text remain unchanged. No broad
@@ -101,7 +102,7 @@ The migration must prove:
 - descriptor values and frozen-record behavior remain unchanged;
 - registry insertion order and all indexes remain unchanged;
 - duplicate keys remain visible and `get()` preserves its exception contract;
-- accepted Coding paths share Harness class identity;
+- generic and Extension-shaped Harness names share class identity;
 - `LoadedExtension` projection produces Harness-owned records;
 - Coding internal consumers import the Harness owner directly;
 - extension runtime behavior and focused Coding tests remain unchanged;

--- a/docs/internals/architecture/harness/development-workflow.md
+++ b/docs/internals/architecture/harness/development-workflow.md
@@ -107,4 +107,4 @@ Harness task PRs should be reviewed for:
 
 The review question is not only whether a slice works. It is whether the slice
 keeps `harness` product-neutral while making future `design`, `research`,
-`ppt`, `cowork`, and OEM products easier to build.
+`ppt`, `cowork`, and OEM-defined Products easier to build.

--- a/docs/internals/architecture/harness/diagnostics-export-boundary.md
+++ b/docs/internals/architecture/harness/diagnostics-export-boundary.md
@@ -33,8 +33,8 @@ writer; it must not fall back to an unrestricted `repr()` in the archive.
 `.loushang/diagnostics` output default, `loushang-diag-*` name, README,
 camelCase manifest, latest debug/trace/session artifacts, and standard
 diagnostic serialization. These are shared Loushang host contracts rather than
-Coding semantics. Research, Design, PPT, OEM products, and extensions can use
-the default profile or inject another `DiagnosticBundleProfile`.
+Coding semantics. Research, Design, PPT, OEM-configured Products, and Extensions
+can use the default profile or inject another `DiagnosticBundleProfile`.
 
 The removed `loushang.coding.diag_export` facade is not retained. Coding CLI
 calls the Harness operation directly, preserving the existing archive schema.

--- a/docs/internals/architecture/harness/extension-runtime-core-boundary.md
+++ b/docs/internals/architecture/harness/extension-runtime-core-boundary.md
@@ -6,8 +6,17 @@ Status: implementation complete, including the follow-on control-plane routing
 closure, for integration into `lane/harness`.
 
 This boundary moves the product-neutral extension runtime core into
-`loushang.harness.extensions`. Coding remains a product adapter and preserves
-accepted import paths without maintaining a second implementation.
+`loushang.harness.extensions`. Coding remains Product composition; the
+zero-compatibility cutover preserves Product behavior without retaining Coding
+Extension import paths or a second implementation.
+
+Canonical Package, Plugin, and Extension terms are defined by the
+[Product And OEM Glossary](../../glossary/loushang-product.md). This runtime
+owns Extension loading and composition after discovery and Product/OEM
+admission. It does not own Resource Package distribution or Plugin identity,
+source registration, enablement, and package-root resolution; those mechanics
+belong to the
+[Platform Resource Layout Boundary](platform-resource-layout-boundary.md).
 
 ## Harness Ownership
 

--- a/docs/internals/architecture/harness/jsonl-command-host-boundary.md
+++ b/docs/internals/architecture/harness/jsonl-command-host-boundary.md
@@ -112,7 +112,8 @@ own a distinct, versioned command schema.
 
 The Harness Host helpers may depend on `loushang.protocol` and the Python
 standard library. They must not import AI, Agent runtime, Channel, Coding,
-Method, Work, TUI, or a Product extension package.
+Method, Work, TUI, a Product Package, or a Product-specific Extension
+implementation.
 
 This boundary does not add a common RPC response envelope, command registry,
 Work-operation mapping, sockets, HTTP/WebSocket transport, durable delivery,

--- a/docs/internals/architecture/harness/multiagent/technical-runtime-and-tools.md
+++ b/docs/internals/architecture/harness/multiagent/technical-runtime-and-tools.md
@@ -190,9 +190,9 @@ rules remain in `harness.multiagent.context`.
 
 Harness defines the `SessionSubagentFactory` contract but intentionally does
 not provide a factory that creates an arbitrary Product child. Coding, PPT,
-Design, and OEM Products must explicitly bind their own factory because only
-the Product knows how to construct its transcript/session, select its model and
-tools, route approvals, and interpret its workspace. A disabled or absent
+Design, and OEM-defined Products must explicitly bind their own factory because
+only the Product knows how to construct its transcript/session, select its model
+and tools, route approvals, and interpret its workspace. A disabled or absent
 binding therefore fails closed. A shared callback-driven factory may be
 extracted only after at least two Product implementations demonstrate the same
 stable construction seam.

--- a/docs/internals/architecture/harness/oem-extension-architecture.md
+++ b/docs/internals/architecture/harness/oem-extension-architecture.md
@@ -16,6 +16,7 @@ synonym for every OEM Package or OEM Profile.
 Accepted boundary decisions that inform this document:
 
 - [Shared Capability Boundaries](shared-capability-boundaries.md)
+- [Capability Variation And Replacement Boundary](capability-variation-and-replacement-boundary.md)
 - [Extension Runtime Core Boundary](extension-runtime-core-boundary.md)
 - [Contribution Inventory Boundary](contribution-inventory-boundary.md)
 - [Refactoring Principles](refactoring-principles.md)
@@ -30,8 +31,10 @@ A simple rule governs the OEM relationship:
 If the extension framework only supports registering tools and injecting
 resource roots, OEMs can only ship custom tools and override skill/prompt
 content. If the framework supports policy injection and channel adapter
-registration, OEMs can ship a complete product fork with custom permissions,
-custom models, and a custom delivery surface.
+registration, OEMs can ship a deeply customized Product configuration with
+custom permissions, models, and delivery surfaces without forking Product
+source. A distinct Product identity still requires the Product Package
+registration contract described below.
 
 This is not a theoretical concern. Every surface type and injection protocol
 that an OEM needs but cannot express through an extension becomes a reason for
@@ -100,9 +103,10 @@ layout conventions and loader merge algorithms are stable.
 ### 3. Extension Registration
 
 OEMs ship extensions that declare `ExtensionSurfaceDescriptor` records.
-Extensions are the packaging vehicle for tools, commands, hooks, model
-providers, channel adapters, and (when the surface types exist) policy and
-approval implementations.
+Extensions are executable or declarative contributions for tools, commands,
+hooks, model providers, channel adapters, and (when the surface types exist)
+policy and approval implementations. Plugins or Resource Packages carry those
+contributions; the Extension itself is not the packaging boundary.
 
 ```python
 # OEM extension shipped as a plugin
@@ -137,7 +141,15 @@ This categorisation is important because OEMs typically need all three:
 | --- | --- | --- |
 | **Contribution** (aggregate) | All declarations run independently; failure is isolated | Ship custom tools, commands, methods, skills |
 | **Interceptor** (pipeline) | Handlers form a pipeline; each sees previous output; failure governed by `on_error` | Ship custom hooks and policy evaluators |
-| **Replacement** (exclusive) | Only one active per slot; failure propagates to the Product-selected fallback | Ship approval resolvers, custom model providers, channel adapters, storage backends |
+| **Replacement** (one active provider) | Only one provider is active for the surface; failure propagates to the Product-selected fallback | Ship approval resolvers, custom model providers, channel adapters, storage backends |
+
+These are applications of the canonical Aggregate Contribution, Ordered
+Interception, and Exclusive Replacement semantics. A decorator is a restricted
+interceptor that preserves the selected provider's authority and lifecycle;
+`override` alone is not a conflict-resolution rule. The
+[Capability Variation And Replacement Boundary](capability-variation-and-replacement-boundary.md)
+is authoritative for admission, resolution, binding, disposal, and invariant
+enforcement.
 
 Harness extension dispatch now provides stable dependency-aware observer,
 interceptor, reducer, and first-match routing. Policy contributions use the
@@ -199,14 +211,15 @@ oem_extension_loading  — an OEM plugin with tool/hook surfaces still loads and
 These tests assert the harness boundary. Product-specific integration tests
 are separate and remain in product packages.
 
-## OEM Plugin Packaging
+## OEM Package And Plugin Contributions
 
-An OEM product is a directory that bundles all three override mechanisms
-under one plugin manifest:
+An OEM Package is the installable distribution boundary. It may bundle OEM
+Profile configuration, resource overlays, and one or more manifest-backed
+Plugins that carry optional Extension contributions:
 
 ```text
 oem-foocorp/
-  loushang-plugin.json           # plugin identity and capability declarations
+  loushang-plugin.json           # optional Plugin contribution identity
   models/
     foocorp-models.json           # model registry overlay
   skills/
@@ -225,15 +238,19 @@ oem-foocorp/
     overrides.yaml                # OEM configuration defaults
 ```
 
-A single `loushang-plugin.json` manifest declares the plugin identity and
-capabilities. `PluginResolver` reads the manifest, `PluginManager` manages
-activation, and the resource loader discovers the standard directories.
-No code in the OEM plugin needs to import harness internals.
+`loushang-plugin.json` declares only the Plugin identity and contributions.
+It does not define the OEM identity, replace the OEM Profile, or register a
+Product. `PluginResolver` reads the manifest, `PluginManager` manages Plugin
+activation, and the resource loader discovers the standard directories. No
+code in an OEM-carried Plugin needs to import Harness internals.
 
 ## Relationship To Product Kernel
 
-An OEM product is not a second-class citizen. It has the same relationship
-to harness as Coding:
+An OEM Package may additionally distribute an OEM-defined Product. That
+Product is first-class only when it supplies a distinct Product Kernel,
+`product_id`, Product Descriptor, Product Factory, and Product Adapter through
+the Product Package registration contract. It then has the same relationship
+to Harness as Coding:
 
 ```text
 product adapter
@@ -242,20 +259,28 @@ product adapter
   -> owns domain tools, prompts, and artifact semantics
 ```
 
-The only difference is that Coding ships with the main repository and an
-OEM product ships as an external plugin. The architecture does not
-distinguish between them at the harness boundary.
+The distribution difference is that Coding currently ships with the main
+repository while an OEM-defined Product may ship in an external Product
+Package. It is not registered merely because an OEM Plugin is installed. The
+Harness Product boundary otherwise treats admitted Product Packages uniformly.
 
-An OEM may choose to fork an existing product adapter (e.g. start from
-Coding and override its tool activation and permissions) or write a
-completely new product adapter for a domain that Coding does not cover.
+An OEM Profile that only rebrands, configures, or overlays Coding remains an
+OEM-configured Coding Product. It does not create a new Product identity.
+
+When only tool activation, permissions, resources, models, branding, or
+delivery surfaces differ, the OEM should use Profile overlays and admitted
+Plugin contributions. When the OEM defines a distinct Product Kernel or domain,
+it may derive or write a Product Adapter and distribute it through a Product
+Package with a distinct Product identity.
 
 ## Non-Goals
 
 This document does not:
 
-- Define a marketplace protocol for OEM plugin distribution.
-- Specify a signing or trust model for OEM plugins.
+- Define a marketplace protocol for OEM Package distribution or Resource
+  Packages that carry Plugin manifests.
+- Specify a signing or distribution-trust model for OEM Packages or Resource
+  Packages carrying Plugins.
 - Describe multi-tenant OEM hosting where one deployment serves multiple
   OEM configurations.
 - Cover OEM-specific licensing or commercial terms.

--- a/docs/internals/architecture/harness/platform-resource-layout-boundary.md
+++ b/docs/internals/architecture/harness/platform-resource-layout-boundary.md
@@ -88,6 +88,32 @@ example, Coding may register `loushang.coding.resources`; Design may register
 `loushang.design.resources`. The package slot and loading machinery are shared,
 while the prompt, skill, theme, and extension content remains product-owned.
 
+## Package, Plugin, And Extension Roles
+
+Canonical terminology comes from the
+[Product And OEM Glossary](../../glossary/loushang-product.md). Within the
+resource runtime, the three concepts remain separate:
+
+- a **Resource Package** is the distribution or materialization root for
+  resources;
+- a **Plugin** is a manifest-backed optional identity and activation view that
+  may resolve to a package root;
+- an **Extension** is executable or declarative behavior described by a
+  resource descriptor and admitted into an extension surface.
+
+The standard projection is:
+
+```text
+plugin source -> plugin manifest -> resource package root -> resource descriptors
+                                                        -> extension descriptors
+```
+
+A configured package root does not require a Plugin manifest. A Plugin may
+contain only prompts, Skills, themes, or assets and therefore no Extension.
+Package installation, Plugin enablement, descriptor discovery, Extension
+admission, and Extension activation are distinct state transitions. None of
+the first three grants execution authority.
+
 ## Responsibility Split
 
 Harness owns:

--- a/docs/internals/architecture/harness/process-hosting-boundary.md
+++ b/docs/internals/architecture/harness/process-hosting-boundary.md
@@ -23,6 +23,14 @@ state, semantic tools, restart policy, and user-facing diagnostics. Coding LSP
 therefore remains under `loushang.coding`; it consumes this substrate through a
 narrow launcher binding.
 
+This binding follows the
+[Capability Variation And Replacement Boundary](capability-variation-and-replacement-boundary.md):
+Coding may replace a Product-owned language-service provider and aggregate
+server definitions, while Harness injects the authorized process capability.
+Authorization, required containment, fixed Host limits, and cleanup remain an
+invariant enforcement layer that a Coding provider or Plugin cannot replace or
+bypass.
+
 ## Public Surface
 
 `loushang.harness.workspace.process` exports only:

--- a/docs/internals/architecture/harness/product-capability-composition-core.md
+++ b/docs/internals/architecture/harness/product-capability-composition-core.md
@@ -27,6 +27,24 @@ Coding is the compatibility adapter. Product-neutral Harness fixtures using
 research and design vocabulary provide the independent contract probe; a
 second production Product is not required by the neutrality evidence gate.
 
+## Bound Behavior Semantics
+
+The values bound through Capability Slots use the behavioral semantics from the
+[Capability Variation And Replacement Boundary](capability-variation-and-replacement-boundary.md):
+
+- command and tool packs are Aggregate Contributions after Product admission;
+- prompt sections are an ordered aggregate whose ordering is supplied by the
+  Product and recorded in the prepared result;
+- injected prompt parsing, expansion, activation, and callback behavior is
+  Protocol Injection at the Product composition root;
+- same-name resource or tool behavior follows the owning catalog's documented
+  precedence and conflict contract; it is not a general last-write-wins rule.
+
+This core does not publish a universal exclusive-provider registry. A Product
+that exposes Exclusive Replacement behavior must declare its Runtime
+Capability Shape, selection, fallback, lifecycle, and diagnostic behavior
+explicitly.
+
 ## Harness Ownership
 
 ### Commands

--- a/docs/internals/architecture/harness/product-runtime-injection/00-requirements.md
+++ b/docs/internals/architecture/harness/product-runtime-injection/00-requirements.md
@@ -20,6 +20,11 @@ facts, deterministic replay, permissions, or compatibility.
 
 ## Terms
 
+Canonical Capability and composition vocabulary comes from the
+[Product And OEM Glossary](../../../glossary/loushang-product.md). The
+[Capability Variation And Replacement Boundary](../capability-variation-and-replacement-boundary.md)
+is authoritative for executable composition semantics.
+
 | Term | Meaning |
 | --- | --- |
 | Capability | A named runtime concern, such as a conversation store, memory provider, compaction planner, or tool pack. |
@@ -41,9 +46,13 @@ store, artifact, approval, model, or presentation defaults.
 
 ### PDRI-002: Explicit Slot Semantics
 
-Every injectable capability must declare whether it is a single selection, an
-ordered composition, an exclusive replacement, or an append-only contribution.
-It must also declare its binding scope and mutability.
+Every injectable capability must declare a `single`, `exclusive`, `ordered`,
+or `append_only` Runtime Capability Shape, plus its binding scope and
+mutability. When the resolved behavior is externally composable or
+replaceable, its detailed boundary must separately declare Aggregate
+Contribution, Ordered Interception/Decoration, or Exclusive Replacement
+semantics. A data-resource surface may instead declare Resource Overlay
+semantics with explicit identity and precedence rules.
 
 ### PDRI-003: Controlled Sources
 
@@ -140,7 +149,8 @@ This wave does not:
 ## Acceptance Criteria For Detailed Designs
 
 Each component design must trace its requirements by identifier, specify its
-slot semantics and lifecycle, and define Product, OEM, extension, and session
-override authority. A detailed design is not implementation-ready until it
+slot shape, lifecycle, and any behavioral variation semantic, and define
+Product, OEM, extension, and session override authority. A detailed design is
+not implementation-ready until it
 also defines its runtime snapshot, failure behavior, diagnostics, and contract
 tests.

--- a/docs/internals/architecture/harness/product-runtime-injection/03-resource-packs-binding.md
+++ b/docs/internals/architecture/harness/product-runtime-injection/03-resource-packs-binding.md
@@ -12,8 +12,8 @@ trust policy, and executable adapters.
 The five capability-composition slots already describe how a Product selects
 resource activation and capability-pack mechanics. This binding removes the
 remaining Coding-private registry and wrapper around those neutral mechanisms
-so Research, PPT, Design, Cowork, and OEM Products can bind the same runtime
-without copying factory or validation logic.
+so Research, PPT, Design, Cowork, and OEM-defined Products can bind the same
+runtime without copying factory or validation logic.
 
 This is not a new resource discovery system, extension container, or global
 service locator. Resource discovery, package materialization, manifest trust,

--- a/docs/internals/architecture/harness/product-runtime-injection/README.md
+++ b/docs/internals/architecture/harness/product-runtime-injection/README.md
@@ -80,6 +80,7 @@ Every implementation wave that introduces a new injectable capability must:
 
 ## Related Boundaries
 
+- [Capability Variation And Replacement Boundary](../capability-variation-and-replacement-boundary.md)
 - [Shared Capability Boundaries](../shared-capability-boundaries.md)
 - [Product Runtime Core Boundary](../product-runtime-core-boundary.md)
 - [Product Configuration Runtime Boundary](../product-configuration-runtime-boundary.md)

--- a/docs/internals/architecture/harness/product-transcript-session-boundary.md
+++ b/docs/internals/architecture/harness/product-transcript-session-boundary.md
@@ -9,7 +9,7 @@ Implemented on `harness/session-adapter-collapse`.
 `loushang.harness.transcript.ProductTranscriptSession` is the reusable
 Product-facing wrapper around a bound `AgentTranscriptLifecycleSession`. It
 owns the repetitive session surface shared by Coding, Research, Design, PPT,
-and OEM Products:
+and OEM-defined Products:
 
 - create, open, load, recent-resume, in-memory, and selected-path fork;
 - current transcript metadata, records, context, tree, labels, diagnostics,

--- a/docs/internals/architecture/harness/shared-capability-boundaries.md
+++ b/docs/internals/architecture/harness/shared-capability-boundaries.md
@@ -11,8 +11,35 @@ The guiding rule is:
 harness provides mechanism
 product adapter provides defaults and semantics
 OEM layer overrides product policy
-extensions contribute optional capabilities
+extensions contribute optional providers or capability items through declared surfaces
 ```
+
+Canonical Product, OEM, Capability, Package, Plugin, and Extension terms are
+defined in the
+[Product And OEM Glossary](../../glossary/loushang-product.md).
+
+## Harness Capability Meaning
+
+A **Harness Capability** is a Product-neutral Capability whose public contract,
+reusable mechanism, or explicitly overridable platform default is owned by
+Harness. `Shared capability` describes cross-Product reuse; it does not define
+a Plugin surface, installation unit, global singleton, mandatory activation,
+or common Product configuration.
+
+Ownership and binding remain separate:
+
+```text
+Harness owns a Product-neutral capability contract or mechanism
+  -> Product declares whether and how its runtime consumes it
+     -> OEM may vary only Product-declared overlay points
+        -> admitted Plugins may contribute only through declared surfaces
+```
+
+A Product-owned Capability can consume Harness Capabilities without moving its
+domain semantics into Harness. An Extension can contribute a provider or item
+to an admitted Capability Slot without owning that Capability, Product, or
+lifecycle. The composition rules for those slots are defined by the
+[Capability Variation And Replacement Boundary](capability-variation-and-replacement-boundary.md).
 
 ## Layer Model
 
@@ -60,7 +87,7 @@ are explicitly overridable. It must not choose domain content, activation,
 trust, or projection policy on a product's behalf.
 
 This product kernel is what differentiates `coding`, `design`, `research`,
-`ppt`, `cowork`, and OEM products. Product bootstrap and wiring should become
+`ppt`, `cowork`, and OEM-defined Products. Product bootstrap and wiring should become
 small as Harness grows, but these semantics must not migrate merely to reduce
 the number of lines in a product package.
 
@@ -71,7 +98,7 @@ Harness may own:
 - tool definition value types that are not product-specific;
 - schema inference and normalization helpers;
 - registry/resolution interfaces;
-- contribution records from packages or extensions;
+- contribution records from Resource Packages or Extensions;
 - availability metadata and diagnostics;
 - wrapper engines that adapt neutral tool call inputs to `loushang.agent`
   tool primitives;
@@ -389,15 +416,23 @@ remediation, session projection, and UI behavior.
 
 ## OEM Override Model
 
-OEMs override product behaviour through three mechanisms, plus the packaging
-boundary that makes them distributable as a single unit:
+The canonical composition rules are defined by the
+[Capability Variation And Replacement Boundary](capability-variation-and-replacement-boundary.md).
+In particular, `override` is an umbrella term: every surface must declare
+Aggregate Contribution, Ordered Interception/Decoration, Resource Overlay, or
+Exclusive Replacement semantics. Product and OEM variation cannot bypass a
+Harness invariant enforcement layer.
+
+OEMs vary Product behavior through three mechanisms. An OEM Package is the
+separate distribution boundary that may carry the corresponding Profile,
+overlays, and Plugins:
 
 | Mechanism | How it works | Examples |
 | --- | --- | --- |
 | Protocol injection | OEM supplies an implementation of a Harness-defined protocol; Harness calls it without knowing the product or OEM identity | `PolicyEvaluator`, `ApprovalResolver`, `ExtensionPolicyResolver` |
 | Resource overlay | OEM directories are discovered alongside built-in and product directories; same-key files shadow lower-precedence layers | `skills/*/SKILL.md`, `methods/*/METHOD.md`, `prompts/*.md`, `themes/*.json` |
 | Extension registration | OEM ships extensions that declare `ExtensionSurfaceDescriptor` records; product/OEM policy gates activation | tools, commands, model providers, channel adapters, hooks |
-| Plugin packaging | An OEM plugin manifest (`loushang-plugin.json`) bundles resource roots, extensions, and configuration overrides into one distributable unit | `PluginManager → PluginResolver → ResourceDescriptors` |
+| OEM Package with Plugin contributions | The OEM Package distributes OEM Profile/configuration and resource roots; optional `loushang-plugin.json` manifests identify independently activated Plugin contributions | OEM Package → `PluginManager → PluginResolver → ResourceDescriptors` |
 
 ### Override Layer Order
 
@@ -412,8 +447,8 @@ harness provides mechanism
 A mechanism belongs to Harness and cannot be overridden by OEM (e.g. the
 agent loop, the channel envelope protocol, the contribution inventory index).
 An OEM may override product defaults, product resource content, and product
-activation policy. An OEM may add new capabilities through extensions. An OEM
-must not replace Harness mechanisms.
+activation policy. An OEM may contribute optional providers or capability items
+through admitted Extensions. An OEM must not replace Harness mechanisms.
 
 ### Dimensions OEMs Can Override
 
@@ -422,7 +457,7 @@ others — they are orthogonal replaceability points:
 
 | Dimension | Override method | Harness stability contract |
 | --- | --- | --- |
-| Product (coding / ppt / research / …) | Ship an OEM product adapter that reuses the shared harness | Product adapters depend on Harness protocols, not internals |
+| Product (coding / ppt / research / …) | Ship an OEM-defined Product Adapter with a distinct Product identity that reuses Harness | Product adapters depend on Harness protocols, not internals |
 | Channel (TUI / WebUI / SDK / bot / …) | Register an OEM channel adapter | `ChannelEnvelope(WorkOperation/WorkEvent/RuntimeEventView)` schema, additive evolution |
 | Method (bugfix / tdd / review / …) | Override method resources in OEM directories | `methods/*/METHOD.md` format and loader mechanics |
 | Skill (debugging / refactoring / …) | Override skill resources | `skills/*/SKILL.md` format and activation settings |
@@ -447,7 +482,7 @@ others — they are orthogonal replaceability points:
 The shared contribution flow should be:
 
 ```text
-extension/package contributes neutral records
+Extension or Resource Package contributes neutral records
   -> harness validates and normalizes contribution shape
   -> product adapter decides applicability
   -> OEM layer may override activation/policy

--- a/docs/internals/glossary/loushang-product-zh.md
+++ b/docs/internals/glossary/loushang-product-zh.md
@@ -23,6 +23,39 @@
 Harness 提供产品中立机制；Product 提供领域语义、默认值与策略；OEM 选择并
 覆盖多个 Product；Plugin 只能在 Product 和 OEM 准入后贡献可选资源或行为。
 
+## 核心概念所在维度
+
+这些术语分别回答不同问题，不能互相替代：
+
+| 英文术语 | 所在维度 | 核心问题 |
+| --- | --- | --- |
+| Product | 领域身份 | 哪个完整领域体验拥有当前 Session？ |
+| OEM | 平台选择与覆盖 | 当前发行选择哪些 Product、默认值、策略、资源与品牌？ |
+| Capability | 运行时组合 | 运行时需要绑定什么具名能力？ |
+| Harness Capability | 共享机制 owner | 哪些产品中立契约或机制由 Harness 拥有？ |
+| Package | 分发与物化 | 软件或资源如何交付？ |
+| Plugin | 可选身份与激活 | 哪个 manifest-backed 贡献源可以被独立准入和启停？ |
+| Extension | 可执行或声明式贡献 | 什么可选行为进入一个明确的扩展面？ |
+
+运行时关系是：
+
+```text
+OEM 选择并覆盖 Products
+  → Product 声明并绑定 Capability Slots
+     → Harness 提供产品中立的 Harness Capabilities
+     → 已准入 Plugin 贡献资源或 Extensions
+```
+
+分发关系是另一条独立轴：
+
+```text
+Product Package  → 注册 Product
+OEM Package      → 提供 OEM Profile、覆盖和可选 Plugins
+Resource Package → 分发资源和可选 Extensions
+Plugin           → 为贡献源提供可选身份与激活边界
+Extension        → 向已准入运行时扩展面贡献行为
+```
+
 ## 平台与启动模型
 
 | 英文术语 | 中文术语 | 中文简介 |
@@ -75,13 +108,33 @@ OEM 通常不是 Product。一个 OEM Package 可以启用 `coding`、`ppt` 和
 
 ## 能力组合模型
 
+本节只定义术语。绑定、冲突、依赖、权限与生命周期规则见
+[Harness Capability Variation And Replacement Boundary](../architecture/harness/capability-variation-and-replacement-boundary.md)。
+
 | 英文术语 | 中文术语 | 中文简介 |
 | --- | --- | --- |
 | Capability | 能力 | 可命名的运行时或领域关注点，如 Store、Memory、Tool、Command、Deck Renderer 或 Artifact Handler。 |
+| Harness Capability | Harness 能力／共享能力 | 由 Harness 拥有公共契约、可复用机制或可覆盖平台默认值的产品中立 Capability；“共享”不表示全局单例、强制启用或 Plugin 类型。 |
 | Capability Slot | 能力槽 | Product 声明的能力绑定位置，定义组合形态、生命周期范围、刷新边界和允许来源。 |
+| Runtime Capability Shape | 运行时能力形态 | `RuntimeCapabilitySlot` 的选择保留和绑定规则：`single`、`exclusive`、`ordered` 或 `append_only`；它与 provider/extension surface 的行为组合语义正交。 |
+| Capability Provider | 能力提供者 | 经过发现、准入和解析后，可绑定到 Capability Slot 的工厂、适配器或运行时实现；被安装或发现本身不授予权限。 |
+| Override | 覆盖／变体 | 对 Product 或 Platform 缺省行为的泛称；它本身不规定冲突规则，必须进一步说明使用哪一种组合语义。 |
+| Aggregate Contribution | 聚合贡献 | 所有获准贡献都保持有效，并由所属 Product 或 Harness 机制确定性合并。 |
+| Ordered Interception | 有序拦截 | 获准处理器组成顺序明确的处理链，并按照声明的错误策略委托、观察或转换结果。 |
+| Decoration | 装饰 | 有序拦截的受限形式；包装已经解析的能力，但不接管选择权，也不能削弱授权、沙箱或生命周期不变量。 |
+| Exclusive Replacement | 独占替换 | 一个声明的变体 surface 最终只有一个获准 provider 生效；选择必须显式且可解释，Runtime Capability Shape 另行决定选择保留和刷新。 |
+| Protocol Injection | 协议注入 | Composition Root 通过稳定 Protocol 或公共能力契约注入实现；运行时调用注入对象不构成源码反向依赖。 |
+| Composition Root | 组合根 | 发现、准入、解析、构造、绑定并释放运行时对象图的最外层生命周期 owner。 |
+| Invariant Enforcement Layer | 不变量执行层 | 围绕可替换 provider 或私有机制强制授权、审批、沙箱、资源限制、校验和清理保证的不可绕过包装层。 |
+| Trusted Backend Substitution | 可信后端替换 | 仅在 owner 明确公开相应 seam 时，由可信 Platform 组合替换私有机制；它不是普通 Plugin 权利。 |
 | Capability Pack | 能力包 | 运行时准入后，针对单一能力项类型的有序贡献组；对应代码中的 `CapabilityPack[T]`。 |
 | Product Capability Bundle | Product 能力组合包 | 面向装配或分发、包含多种能力与资源类型的组合，如 `ppt-authoring`。 |
 | Capability Mount | 能力挂载 | Product 在特定运行时范围内激活已准入 Capability Pack 或 Product Capability Bundle 的动作。 |
+
+Runtime Capability Shape 与行为组合语义不是同一维度：`ordered` shape
+既可以承载 Aggregate Contribution，也可以承载 Ordered Interception；
+`single`／`exclusive` 只说明最终绑定一个选择，并不自动授予任意来源替换权，
+其中 `exclusive` 还要求 sealed refresh boundary。
 
 `CapabilityPack[T]` 不是安装包。它只组合一种 `T`，例如 Tool 或 Command。
 `ppt-authoring` 如果同时包含 Skill、Prompt、Tool、Command、Deck Asset、
@@ -96,12 +149,24 @@ Product。
 | 英文术语 | 中文术语 | 中文简介 |
 | --- | --- | --- |
 | Package | 包（需加限定词） | 架构文档中必须写成 Product Package、OEM Package 或 Resource Package。 |
+| Python package | Python 包 | Python 导入或软件分发概念；不自动表示 Loushang Resource Package、Plugin 或 Product Package。 |
 | Resource Package | 资源包 | 可安装或物化的 Skill、Prompt、Theme、Extension 和 Product Asset 集合。 |
 | Plugin | 插件 | 可选、可独立启停的资源根或 Extension 贡献来源；受 Product/OEM 信任与激活策略控制。 |
 | Extension | 扩展 | 通过约定扩展面贡献的可执行或声明式行为，如 Tool、Command、Hook、Policy、Renderer 或 Channel Adapter。 |
 | Skill | 技能／Skill | 教给模型专业工作流、领域约定或 Tool 使用方式的指令资源，不代表执行权限。 |
 | Product Asset | Product 素材／产品素材 | 由 Product 解释的领域文件，如模板、布局、品牌包、图片或设计素材。 |
 | Deck Asset | Deck 素材／演示文稿素材 | PPT 领域的 Product Asset，如演示模板、Slide Layout、Master、Theme、Brand Kit 或媒体。 |
+
+三者关系应写成：
+
+```text
+plugin source → plugin manifest → resource package root → resource descriptors
+                                                       → extension descriptors
+```
+
+- Resource Package 是分发／物化边界；不一定带有 Plugin manifest。
+- Plugin 是 manifest-backed 身份、准入和启停边界；可以只贡献 Skill、Prompt、Theme 或素材。
+- Extension 是运行时行为贡献；被发现不等于已获准执行，也不会因此成为 Product。
 
 Deck Asset 可以来自 PPT Product、OEM 覆盖或 Product Capability Bundle，但不应
 为了复用相对文件路径而被建模成 Skill。

--- a/docs/internals/glossary/loushang-product.md
+++ b/docs/internals/glossary/loushang-product.md
@@ -33,6 +33,40 @@ Harness supplies product-neutral mechanisms. A Product supplies domain
 semantics, defaults, and policy. An OEM selects and overlays Products. Plugins
 contribute optional resources or behavior only after Product and OEM admission.
 
+## Concept Dimensions
+
+The core terms name different architectural dimensions and must not be used as
+substitutes for one another:
+
+| Term | Dimension | Governing question |
+| --- | --- | --- |
+| Product | domain identity | What coherent domain experience owns this Session? |
+| OEM | platform selection and overlay | Which Products, defaults, policy, resources, and branding does this distribution select? |
+| Capability | runtime composition | What named ability must the runtime bind? |
+| Harness Capability | shared mechanism ownership | Which Product-neutral contract or mechanism does Harness own? |
+| Package | distribution and materialization | How are software or resources delivered? |
+| Plugin | optional identity and activation | Which manifest-backed contribution source can be admitted and enabled independently? |
+| Extension | executable or declarative contribution | What optional behavior enters a defined extension surface? |
+
+The runtime relationship is:
+
+```text
+OEM selects and overlays Products
+  -> Product declares and binds Capability Slots
+     -> Harness supplies Product-neutral Harness Capabilities
+     -> admitted Plugins contribute resources or Extensions
+```
+
+Distribution is an orthogonal relationship:
+
+```text
+Product Package  -> registers a Product
+OEM Package      -> provides an OEM Profile and optional overlays or Plugins
+Resource Package -> distributes resources and optional Extensions
+Plugin           -> gives optional identity and activation to a contribution source
+Extension        -> contributes behavior to an admitted runtime surface
+```
+
 ## Platform And Launch Model
 
 ### Platform
@@ -262,11 +296,30 @@ Coding launch, or a Product with OEM overlays.
 
 ## Capability Composition
 
+This section defines vocabulary. The binding, conflict, dependency, authority,
+and lifecycle rules are defined by the
+[Harness Capability Variation And Replacement Boundary](../architecture/harness/capability-variation-and-replacement-boundary.md).
+
 ### Capability
 
 A named runtime or domain concern, such as a conversation store, memory
 provider, compaction planner, tool definition, command descriptor, deck
 renderer, or artifact handler.
+
+### Harness Capability
+
+A Product-neutral Capability whose public contract, reusable mechanism, or
+explicitly overridable platform default is owned by Harness. Examples include
+authorized process launching, workspace operations, resource discovery,
+approval coordination, runtime-profile resolution, and shared lifecycle
+mechanics.
+
+`Harness Capability` is the canonical owner-oriented term. `Shared capability`
+may describe its cross-Product reuse, but it is not a Plugin manifest kind or a
+separate activation object. Shared does not mean global singleton, mandatory
+for every Product, or identically configured by every Product. Products still
+own domain defaults, admission, activation, policy, and presentation unless a
+specific boundary says otherwise.
 
 ### Product Capability Requirement
 
@@ -281,6 +334,96 @@ admitted capability catalog and policy.
 A Product-declared location at which one or more implementations of a
 Capability may bind. The slot defines composition shape, lifecycle scope,
 refresh boundary, and allowed contribution sources.
+
+### Runtime Capability Shape
+
+The profile-resolution cardinality and identity rule declared by a
+`RuntimeCapabilitySlot`: `single`, `exclusive`, `ordered`, or `append_only`.
+Shape answers how selections are retained and bound; it is separate from the
+behavioral variation semantic applied by the resolved provider or extension
+surface.
+
+An `ordered` shape can feed either Aggregate Contribution or Ordered
+Interception. A `single` or `exclusive` shape can supply one provider without
+implying that every source is allowed to replace it. `exclusive` additionally
+requires a sealed refresh boundary. `append_only` retains repeated selections
+where the owning aggregate contract permits them.
+
+### Capability Provider
+
+A factory, adapter, or live implementation that can satisfy a Capability Slot
+after discovery, admission, and resolution. A provider does not acquire
+authority merely by being installed or discovered.
+
+### Override
+
+An umbrella term for an allowed variation of a Product or platform default.
+`Override` does not define a conflict rule. Architecture documents must name
+the applicable Aggregate Contribution, Ordered Interception, Resource Overlay,
+or Exclusive Replacement semantic instead of relying on unspecified
+last-write-wins behavior.
+
+Runtime Capability Shape and variation semantics are orthogonal. Architecture
+documents must record both when a runtime-profile slot binds replaceable or
+composable behavior.
+
+### Aggregate Contribution
+
+A composition semantic in which every admitted contribution remains active
+and the owning Product or Harness mechanism combines them deterministically.
+Tools, commands, hooks, and server-definition catalogs may use this semantic
+when their owning boundary permits multiple entries.
+
+### Ordered Interception
+
+A composition semantic in which admitted handlers form an explicit ordered
+pipeline. Each handler delegates to, observes, or transforms the next result
+under a declared error policy. Ordering is part of the resolved contract and
+must not depend on incidental discovery order.
+
+### Decoration
+
+A restricted form of Ordered Interception that wraps an already resolved
+capability without taking ownership of its selection. Tracing, metrics, and
+caching are typical decorators. A decorator must preserve the underlying
+authority and lifecycle contract and cannot weaken an invariant enforcement
+layer.
+
+### Exclusive Replacement
+
+A composition semantic in which exactly one admitted provider is active for a
+declared variation surface. Selection is explicit and explainable; ambiguous
+candidates are rejected instead of being resolved by silent last-write-wins
+behavior. When profile-bound, Runtime Capability Shape independently governs
+selection retention and refresh. Any fallback is selected by the owning
+Product or Platform policy.
+
+### Protocol Injection
+
+Composition-root wiring of an implementation through a stable Protocol or
+public capability contract. Runtime invocation of the injected object does not
+create a reverse source dependency: Harness must not import or interpret a
+Product implementation that was injected through a neutral contract.
+
+### Composition Root
+
+The outer lifecycle owner that discovers, admits, resolves, constructs, binds,
+and disposes a runtime object graph. A composition root may know concrete
+implementations from multiple layers; the composed layers must continue to
+depend only on their public inward-facing contracts.
+
+### Invariant Enforcement Layer
+
+A non-bypassable wrapper that preserves authority, approval, sandbox,
+resource-limit, validation, or cleanup guarantees around a replaceable
+provider or private mechanism. Product and Plugin variation may tighten these
+guarantees but cannot replace or weaken the enforcement layer.
+
+### Trusted Backend Substitution
+
+Replacement of a private mechanism by an explicitly trusted Platform
+composition point. This is not an ordinary Plugin right and exists only where
+the owning boundary deliberately publishes such a seam.
 
 ### Capability Pack
 
@@ -330,7 +473,9 @@ documents.
 
 Use Product Package for an installable Product, OEM Package for an installable
 OEM configuration, and Resource Package for an installable resource
-collection. Do not use unqualified Package when ownership matters.
+collection. Use Python package only for the Python import/distribution concept;
+it does not imply a Loushang Resource Package, Plugin, or Product Package. Do
+not use unqualified Package when ownership matters.
 
 ### Resource Package
 
@@ -348,7 +493,8 @@ roots and, where supported, extension contributions.
 
 A Plugin runs under Product and OEM activation and trust policy. It does not own
 the Product lifecycle, select the Active Product, or acquire execution authority
-merely by being installed.
+merely by being installed. A Plugin is the manifest-backed identity and
+activation boundary, not the installed bytes or materialized directory itself.
 
 ### Extension
 
@@ -357,7 +503,22 @@ extension surface, such as a Tool, command, hook, policy interceptor, approval
 replacement, renderer, or channel adapter.
 
 An Extension is one possible contribution carried by a Plugin or Resource
-Package. Product or OEM policy decides whether it is admitted and active.
+Package. Product or OEM policy decides whether it is admitted and active. An
+Extension does not become a Product or acquire execution authority merely
+because its descriptor was discovered.
+
+The canonical resource relationship is:
+
+```text
+plugin source -> plugin manifest -> resource package root -> resource descriptors
+                                                        -> extension descriptors
+```
+
+Not every Resource Package is a Plugin: a configured package root can be
+consumed directly. Not every Plugin carries an Extension: it may provide only
+Skills, prompts, themes, or assets. Not every Extension needs a dedicated
+Package: built-in Product resources may contribute one through their existing
+Product Package.
 
 ### Skill
 


### PR DESCRIPTION
## Summary

- define canonical Product, OEM, Capability, Harness Capability, Package, Plugin, and Extension dimensions in the English and Chinese glossaries
- add an accepted Harness decision separating runtime capability shapes from aggregate, interception, replacement, and resource-overlay semantics
- align OEM, resource, extension, and legacy Coding architecture documents with the current Harness owner boundaries

## Why

Architecture documents used overlapping meanings for package, plugin, extension, product, and override. This made dependency injection and replaceability rules ambiguous and left older Coding inventories in conflict with current Harness ownership.

## Impact

Documentation and architecture contracts only. No runtime code or public API behavior changes.

## Validation

- `uv --cache-dir .uv-cache run --extra dev pytest tests/architecture -q` — 161 passed
- checked 32 changed Markdown files and 255 local links — all resolve
- `git diff --check origin/main...HEAD`
