### PR TITLE
docs(architecture): clarify stable substrate and playback boundaries

### DIFF
--- a/docs/internals/architecture/README.md
+++ b/docs/internals/architecture/README.md
@@ -14,19 +14,21 @@ architecture material. Not every file here has the same authority.
 Read in this order for current implementation decisions:
 
 1. [Architecture Overview](architecture-overview.md)
-2. [Subsystems](subsystem.md)
-3. Accepted ARDs under subsystem directories, especially
+2. [Cross-Layer Architecture Principles](loushang-architecture-principles.md)
+3. [Subsystems](subsystem.md)
+4. Accepted ARDs under subsystem directories, especially
    [agent harness boundaries](agent/ARD-001-agent-harness-and-product-adapters.md),
    [harness product adapter substrate](agent/ARD-002-harness-product-adapter-substrate.md), and
    [coding](coding/ARD-001-coding-product-boundaries.md)
-4. Component interfaces and core data object notes for the subsystem being edited
-5. Draft/history/reference material only when extra rationale is needed
+5. Component interfaces and core data object notes for the subsystem being edited
+6. Draft/history/reference material only when extra rationale is needed
 
 When files conflict, prefer current code/tests and accepted ARDs over drafts,
 history, experimental notes, or legacy documents.
 
 ## Live Architecture Areas
 
+- [Cross-Layer Architecture Principles](loushang-architecture-principles.md)
 - [AI](ai/README.md)
 - [Agent](agent/README.md)
 - [Channel](channel/README.md)
@@ -34,7 +36,12 @@ history, experimental notes, or legacy documents.
 - [Method](method/README.md)
 - [Work](work/README.md)
 - [TUI](tui/README.md)
+- [Harness TUI](harnesstui/README.md)
 - [Monorepo Conventions](loushang-monorepo-conventions.md)
+
+For terminal architecture evaluation, read the TUI overview together with
+[KD-010: Terminal Playback Harness](tui/native-terminal-core/key-designs/KD-010-terminal-playback-harness.md)
+and [HarnessTUI Conversation Playback Testing](harnesstui/README.md#conversation-playback-testing).
 
 ## Non-Live Reference Areas
 
@@ -42,5 +49,5 @@ history, experimental notes, or legacy documents.
 - [TUI History](tui/history/README.md)
 
 Historical terminology and old paths may be preserved in non-live areas. Do not
-rewrite those files just to match current package names unless a live migration
-plan explicitly asks for it.
+rewrite those files just to match current Python package names unless a live
+migration plan explicitly asks for it.

--- a/docs/internals/architecture/architecture-overview.md
+++ b/docs/internals/architecture/architecture-overview.md
@@ -11,9 +11,56 @@
 
 `loushang` 以内核承载语义，以协议连接边界，以适配器触达环境，以扩展点驱动演化。
 
+## Architecture Evaluation Lens
+
+评估 Loushang 时，应区分“当前开箱即用的 Agent 功能数量”和“系统长期需要
+保持稳定的语义 substrate”。Loushang 有意不把某一代模型需要的 planner、
+reflection、todo reminder、通用 verifier prompt 或工具选择启发式固化进
+Agent 内循环。模型能力可以吞噬这些认知脚手架，但不应吞噬权限、副作用控制、
+证据、持久化、协调和 Work truth。
+
+以下是理解当前架构价值的主要视角：
+
+| 设计 | 架构价值 | 不应误读为 |
+|---|---|---|
+| `ai` 与小型 `agent` 执行内核 | Provider 变化和模型能力升级不要求重写 Product/Work 语义 | Agent Loop 应内置 planner、verifier 或产品 workflow |
+| Product -> Harness -> Agent -> AI 的单向依赖 | 跨产品机制复用，同时阻止 Coding 语义污染底层 | Harness 是第二套 Agent Loop |
+| Conversation、Transcript、Runtime Event、Work Event 分层 | 区分交互记录、执行事实与业务权威事实 | 一份 checkpoint 或消息日志可以替代全部状态 |
+| Method 与 Work 分离 | Method 规定什么必须成立；模型决定怎样达到；Work 记录本次实际履约 | MethodPlan、模型 todo 和一次 Agent invocation 是同一对象 |
+| Policy、Approval、Enforcement 分离 | 同一 action model 支撑决策、同意、强制执行和审计，委派权限只能收窄 | 提示模型“不要越权”就是安全边界 |
+| TUI、HarnessTUI 与 Product presentation 分离 | 终端机制、对话交互和产品语义可独立演进、测试和复用 | TUI 必须理解 Agent/AI/Coding 对象 |
+| terminal playback | 将输入、streaming、resize、surface、光标和终端操作序列变成可执行回归契约 | 只对最终屏幕文本做 snapshot，或等同于 Session transcript replay |
+
+这些优点不意味着当前能力面已经完整。通用图执行、远端 multi-agent、持久
+审批和 managed runtime 仍有明确缺口。架构评价应同时报告“能力是否已实现”
+和“该能力应由哪个 owner 实现”，不能因为某个可选认知脚手架尚未内置，就把
+它错误记为 Agent 内循环缺陷。
+
+### Playback 是 TUI 的可执行规范
+
+Loushang TUI playback 不等同于重放历史消息。它把脚本化输入和运行事件送入
+真实的输入解码、路由、render planning 与 terminal-operation 边界，并逐步记录
+逻辑行、changed range、viewport、光标、repaint 原因、scrollback policy、
+终端操作和可选 frame。更高层的 HarnessTUI playback 还记录 neutral action
+result、conversation state，并可用 scripted TTY chunks 运行真实 screen loop。
+
+因此 playback 能验证普通 final-screen golden 难以发现的问题：中间帧闪烁、
+重复 transcript、resize/reflow 漂移、错误清屏、scrollback 破坏、光标错位、
+streaming 每 token 产生一个 block、surface focus 顺序、steer/follow-up/abort
+路由以及跨 feature 交互回归。它也能输出 JSONL trace、screen、terminal 和 state
+artifact，并对操作数、输出字节、changed lines、同步 frame 和长 transcript
+性能设置预算。
+
+这是一项对模型和 Product 都相对稳定的能力：模型输出策略可以变化，不同
+Product 可以复用相同机制，而终端交互和渲染不变量仍能通过同一套
+Product-neutral playback substrate 验证。详细设计见
+[TUI Architecture](./tui/README.md)、
+[Terminal Playback Harness](./tui/native-terminal-core/key-designs/KD-010-terminal-playback-harness.md)
+和 [HarnessTUI](./harnesstui/README.md#conversation-playback-testing)。
+
 ## Monorepo Subsystem Map
 
-`loushang` 采用 monorepo 组织。当前阶段按统一根 Python project 组织各子系统源码，而不是先拆成多个独立 package。
+`loushang` 采用 monorepo 组织。当前阶段按统一根 Python project 组织各子系统源码，而不是先拆成多个独立 Python packages。
 
 当前已经落到 Python 包级源码的主要子系统包括：
 
@@ -22,6 +69,7 @@
 - `loushang.channel`
 - `loushang.coding`
 - `loushang.harness`
+- `loushang.harnesstui`
 - `loushang.method`
 - `loushang.tui`
 - `loushang.work`
@@ -48,6 +96,7 @@ loushang/
       channel/
       coding/
       harness/
+      harnesstui/
       method/
       tui/
       work/
@@ -68,6 +117,8 @@ loushang/
 跨层架构判断准则请参见 [Loushang Architecture Principles](./loushang-architecture-principles.md)。
 文档分层与阅读规则请参见 [Loushang Documentation Model](./loushang-documentation-model.md)。
 `loushang-tui` 子系统文档请参见 [Loushang-TUI Architecture](./tui/README.md)。
+`loushang-harnesstui` 的中性 conversation composition 与 playback testing
+边界请参见 [Loushang Harness TUI](./harnesstui/README.md)。
 `loushang-harness` 的产品适配器 substrate 方向请参见
 [ARD-002: Harness Product Adapter Substrate](./agent/ARD-002-harness-product-adapter-substrate.md)。
 `loushang-work` 的业务工作与方法履约边界请参见
@@ -79,10 +130,11 @@ loushang/
 
 ```text
 CLI / TUI
-  -> loushang.coding bootstrap / runtime / session
-  -> loushang.agent loop
-  -> loushang.ai provider adapters
-  -> tools / events / store / diagnostics / modes
+  -> loushang.coding Product composition
+  -> loushang.harness Session / prepared run
+       -> loushang.agent loop
+            -> loushang.ai provider adapters
+       -> tools / policy / approval / sandbox / events
 ```
 
 相邻能力层：
@@ -136,4 +188,4 @@ CLI / TUI
 1. `loushang.work` 的 run-bound plan binding、动态输入与 outcome 验证
 2. channel capability negotiation and interaction request/response contracts
 3. TUI method status layer 与 `WorkEvent` / `WorkPlanRun` projection
-4. public CLI reference 对 method/work/package surface 的补齐
+4. public CLI reference 对 Method、Work 与 Resource Package surfaces 的补齐

--- a/docs/internals/architecture/drafts/future-loushang-architecture-v3.md
+++ b/docs/internals/architecture/drafts/future-loushang-architecture-v3.md
@@ -8,9 +8,10 @@
 Status: proposed target architecture.
 
 This document explains the decisions and invariants shown in the v3 diagram.
-It is not a description of the current package surface and does not authorize
-creating AppService, a daemon, WebSocket transport, a relay, or distributed
-state synchronization ahead of an accepted delivery requirement.
+It is not a description of the current Python package or public API surface and
+does not authorize creating AppService, a daemon, WebSocket transport, a relay,
+or distributed state synchronization ahead of an accepted delivery
+requirement.
 
 Current code, tests, and accepted ARDs remain authoritative. When this document
 conflicts with them, the live source wins until a later ARD explicitly accepts
@@ -111,7 +112,7 @@ not a synonym for every message, turn, Agent invocation, or in-process task.
 A hosted Product runtime binding contains narrow capabilities rather than one
 universal Product interface:
 
-- Conversation capability: prompts, tool profile, policy, and Session
+- Conversation capability: prompts, admitted tool selection, policy, and Session
   operations;
 - Work preparer: Product intent to `WorkOperation`, current `WorkRunSpec`, and a
   future frozen `WorkPlanSpec`;
@@ -156,13 +157,17 @@ local Agent
   -> remote capability service
 ```
 
-The first collaboration implementation chooses one backend for a Session or
-capability profile: either the current local `SessionMultiAgentRuntime` or one
-remote collaboration service behind the same tool façade. It does not require
-per-child mixing of local, plugin, and remote placement in one logical tree.
-That simpler choice keeps the remote service free to own its child tree and
-mailbox while the local Host retains capability admission, authority, bounded
-result projection, and Product interaction routing.
+The first collaboration implementation binds one explicitly selected provider
+for a Session-scoped collaboration Capability: either the current local
+`SessionMultiAgentRuntime` or one remote collaboration service behind the same
+tool façade. If alternative providers are admitted, this is an Exclusive
+Replacement surface: Plugin identity and discovery order are not selection
+policy, although a Plugin may carry an admitted Extension provider. The first
+implementation does not require per-child mixing of multiple local and remote
+providers in one logical tree. That simpler choice keeps the remote service
+free to own its child tree and mailbox while the local Host retains Capability
+admission, authority, bounded result projection, and Product interaction
+routing.
 
 An internal `AgentExecutionPort` is optional and deferred. It is justified only
 when the Host must transparently mix physical backends inside one logical tree
@@ -183,6 +188,81 @@ The implemented local CLI P0 is documented in
 [One-Shot Agent Invocation Tool Boundary](../harness/agent-invocation-tool-boundary.md):
 it proves the admitted-tool path without introducing an execution provider,
 job lifecycle, or new multi-agent runtime abstraction.
+
+### 5. Keep model-contingent cognition outside the stable substrate
+
+Model capability may absorb more planning, decomposition, reflection, context
+selection, generic verifier prompting, and tool-selection heuristics over time.
+Those features are model-contingent cognitive scaffolds, not durable system
+authority. V3 therefore does not grow the Agent loop or AppService around the
+current limitations of a particular model generation.
+
+The stable Loushang substrate owns invariants that remain necessary even when a
+model becomes substantially more capable:
+
+- authority, Policy, Approval, sandboxing, and least privilege;
+- effectful tool execution, idempotency, cancellation, retry, and failure
+  convergence;
+- Conversation, transcript, Session, event ordering, persistence, and recovery;
+- Product-owned Capability admission, tenant/workspace isolation, and secret
+  boundaries;
+- multi-agent communication, concurrency, and cross-process coordination
+  contracts; and
+- Work admission, authoritative events, artifacts, evidence, acceptance, and
+  terminal outcome.
+
+The low-level Agent loop remains a mechanical model/tool protocol engine. It
+may expose narrow seams for context transformation, tool preflight, result
+projection, events, and cancellation, but it does not own a planner, verifier,
+plan mode, todo policy, memory policy, or Product semantics. Model-contingent
+features belong in Product-owned strategies behind declared Capability Slots,
+admitted Extensions or Skills, or explicitly selected Runtime Profile
+bindings.
+
+Planning and verification each have a durable and a disposable form:
+
+```text
+plan as cognitive aid
+  -> replaceable model strategy
+
+plan as coordination / approval / resume / audit contract
+  -> Product binding and Work-owned fact after acceptance
+
+self-verification prompt or fixed verdict format
+  -> replaceable model strategy
+
+compiler / test / scanner / independent-environment evidence
+  -> Product-interpreted evidence correlated by Work
+```
+
+At the Method boundary, the durable rule is: **Method specifies what must hold;
+the model decides how to achieve it.** Method owns reusable roles,
+constraints, gates, expected artifacts, acceptance conditions, and evidence
+requirements. Within that envelope the model may change its decomposition,
+tool order, reasoning strategy, or use of subagents as model capability evolves.
+When a plan must coordinate people or agents, gate approval, survive restart,
+or support audit, the Product binds it into a run-specific contract and Work
+accepts it as an authoritative fact. See [Method Architecture](../method/README.md).
+
+Presentation invariants are also part of the stable substrate. Native TUI
+playback scripts input, streaming, resize, surface, and control-flow events
+through render planning and terminal-operation boundaries, while HarnessTUI
+playback adds neutral conversation routing, state snapshots, and real
+screen-loop fixtures. This playback is not a second transcript or Work replay
+engine: it is an executable client contract proving that snapshots and events
+produce bounded, cursor-safe, scrollback-safe, deterministic terminal effects.
+The same playback substrate remains useful for embedded and AppClient-backed
+profiles and across different Products. See [TUI Architecture](../tui/README.md)
+and [Terminal Playback Harness](../tui/native-terminal-core/key-designs/KD-010-terminal-playback-harness.md).
+
+An architectural feature should not become kernel ownership or an
+irreversible persistent schema merely because today's models need it. A useful
+test is: if a future model with materially stronger native reasoning could
+remove the feature without weakening authority, evidence, persistence, or
+coordination, the feature stays outside the stable substrate.
+
+Model capability may swallow Agent cognition; it must not swallow authority,
+effect control, evidence, persistence, coordination, or Work truth.
 
 ## Client And Process Profiles
 
@@ -316,7 +396,8 @@ At composition time AppService receives an explicit `ProductResolver` plus
 host-owned providers for admitted Session, Work, and optional Channel ports.
 The exact provider protocols remain part of the first vertical slice; the
 invariant is that AppService never consults a global registry, imports a
-Product package, or performs provider discovery while dispatching a request.
+Product implementation Python package, or performs provider discovery while
+dispatching a request.
 
 The host maintains a live Session routing table, not a filesystem directory or
 persistent Session catalog.
@@ -348,32 +429,33 @@ Likewise, an Agent turn does not own a Work run.
 
 Harness owns reusable Session, transcript, context, tools, approval integration,
 retry, compaction, workspace, and sandbox mechanisms. Harness does not import
-Work or a Product package. The Product executor is the adapter that connects a
-Work step to Harness without reversing that dependency.
+`loushang.work` or a Product implementation Python package. The Product executor
+is the adapter that connects a Work step to Harness without reversing that
+dependency.
 
 Agent owns the execution loop and calls AI. Harness and Agent coordinate tool
 execution through admitted tools and sandbox policy; the AI layer remains
 independent of Harness and Product code.
 
-### Product capability requirements and scoped activation
+### Product Capability Requirement resolution and scoped activation
 
-Method and Skill resources may declare opaque Product capability requirements,
-such as `coding.arch`. They do not name Harness `ToolPackDefinition` values,
-register executable handlers, or grant themselves execution authority. For
-structured work, the Product work preparer carries the requirement into the
+Method and Skill resources may declare opaque Product Capability Requirement
+values, such as `coding.arch`. They do not name Harness `ToolPackDefinition`
+values, register executable handlers, or grant themselves execution authority.
+For structured work, the Product work preparer carries the requirement into the
 run-specific Work contract and the Product executor resolves it through the
-Product's admitted capability catalog. For a lightweight Session turn, the
+Product's admitted Capability catalog. For a lightweight Session turn, the
 Product conversation binding performs the equivalent resolution without
 creating a Work run.
 
-A Product capability may resolve to an admitted Product Capability Bundle and
-one or more family-specific Capability Packs, including a named tool pack. The
-Product retains the mapping, mount defaults, and policy; Harness retains
-contribution resolution, allow-list enforcement, live tool rebinding, sandbox
-and approval integration, and scoped activation mechanics. A Product may expose
-`disabled`, `on_demand`, and `always` mount modes, but no mode may override host
-admission, delegated execution restrictions, Session allow-lists, or tool
-policy.
+A Product Capability Requirement may resolve to an admitted Product Capability
+Bundle and one or more family-specific Capability Packs, including a named tool
+pack. The Product retains the mapping, mount defaults, and policy; Harness
+retains contribution resolution, allow-list enforcement, live tool rebinding,
+sandbox and approval integration, and scoped activation mechanics. A Product
+may expose `disabled`, `on_demand`, and `always` mount modes, but no mode may
+bypass or widen host admission, delegated execution restrictions, Session
+allow-lists, or tool policy.
 
 Scoped activation is additive and owner-aware. Manual selection, Product
 defaults, a Skill invocation, and a Method/Work step may independently request
@@ -389,7 +471,7 @@ V3 does not add `MethodPlanStatus` or `MethodStepStatus` to the base App
 protocol. When a Product first needs to render method progress, its projection
 may derive a Product-facing application view from Method identity and
 Work-owned plan/step facts. Harnesstui consumes that view without importing the
-Method package.
+`loushang.method` Python package.
 
 A stable Method editing, steering, or inspection protocol is added only after a
 Product surface requires it and defines its compatibility needs. The target
@@ -494,14 +576,14 @@ The v3 target does not require:
 - turning Channel into the universal App protocol;
 - sharing mutable runtime instances across processes;
 - automatic Embedded-to-Daemon transcript merge;
-- AppService-owned approval or extension-interaction futures;
+- AppService-owned approval or Extension-interaction futures;
 - a public P2P relay in the first AppService release;
 - a base App protocol for MethodPlan/MethodStep state before a Product needs to
   render, inspect, or steer it;
 - treating every remote Agent call as a stateful collaboration Session;
 - one universal remote-Agent interface or a mandatory `AgentExecutionPort`;
 - Product imports inside AppService; or
-- one generic Product profile capable of arbitrary runtime injection.
+- one universal Product runtime binding capable of arbitrary injection.
 
 ## Staged Delivery
 
@@ -551,6 +633,7 @@ interaction.
 - [Application Service Refactor](application-service-refactor.md)
 - [Agent, Harness, And Product Adapters](../agent/ARD-001-agent-harness-and-product-adapters.md)
 - [Harness Product Runtime Core Boundary](../harness/product-runtime-core-boundary.md)
+- [Capability Variation And Replacement Boundary](../harness/capability-variation-and-replacement-boundary.md)
 - [Session Facade Boundary](../harness/session-facade-boundary.md)
 - [Channel Architecture](../channel/README.md)
 - [Work Architecture](../work/README.md)

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -18,9 +18,9 @@ direction is:
 
 The reverse dependencies are forbidden. In particular, `loushang.harnesstui`
 must not import `loushang.coding`, `loushang.agent`, AI message/model/provider
-packages, or product-specific policy. `loushang.harness` and `loushang.tui` are
-independent peers: Harnesstui may depend on both, but neither peer may depend on
-Harnesstui or on the other peer.
+Python packages, or product-specific policy. `loushang.harness` and
+`loushang.tui` are independent peers: Harnesstui may depend on both, but neither
+peer may depend on Harnesstui or on the other peer.
 
 ## Responsibilities
 
@@ -84,7 +84,7 @@ caller-supplied descriptors and choices.
 The explicit module paths `loushang.harnesstui.commands.source`,
 `loushang.harnesstui.commands.interaction`, and
 `loushang.harnesstui.selection.interaction` are the stable entrypoints for
-these workflows. Package initializers do not add convenience re-exports.
+these workflows. Python package initializers do not add convenience re-exports.
 
 ## Settings and Prepared Surfaces
 
@@ -123,8 +123,8 @@ hard-code a Coding workspace layout.
 
 The explicit module path
 `loushang.harnesstui.conversation.attachments` is the stable entrypoint for this
-capability. The conversation package initializer does not add a convenience
-re-export.
+capability. The conversation Python package initializer does not add a
+convenience re-export.
 
 ## Conversation State, Queue, and Reader
 
@@ -171,8 +171,8 @@ The stable imports introduced by this slice are the explicit module paths
 `loushang.harnesstui.conversation.window_budget`,
 `loushang.harnesstui.conversation.queue`,
 `loushang.harnesstui.conversation.reader` and
-`loushang.harnesstui.conversation.source`. The conversation package does not
-yet expose a broader convenience API.
+`loushang.harnesstui.conversation.source`. The conversation Python package does
+not yet expose a broader convenience API.
 
 ## Tool Transcript and Status Profile
 
@@ -234,8 +234,8 @@ projection over presentation-ready status values. Coding continues to own live
 Session reads, the concrete settings store, scope choice, and provider update
 timing. Removed Coding status modules are not compatibility re-exported.
 
-These explicit module paths are the stable imports for this slice. The package
-initializers do not need to provide convenience re-exports.
+These explicit module paths are the stable imports for this slice. The Python
+package initializers do not need to provide convenience re-exports.
 
 ## Conversation Event Projection
 
@@ -279,8 +279,8 @@ test exercises the complete adapter-to-projector-to-target delta path, so the
 existing `make test-tui-render-contract` gate covers this new boundary.
 
 The explicit `projection`, `plain_target`, and `screen_target` module paths
-above are the stable imports for this capability. The package initializer does
-not provide convenience re-exports.
+above are the stable imports for this capability. The Python package initializer
+does not provide convenience re-exports.
 
 ## Conversation Screen Composition
 
@@ -301,7 +301,7 @@ composer prompts, frame copy, theme, welcome panel, transcript presentation,
 320-line budget, compaction wording, path compaction, and tool-output preview
 policy. The shared app does not import Coding, AI, Agent, or raw product events.
 The explicit `screen_frame` and `screen_app` module paths are stable; the
-conversation package initializer does not re-export them.
+conversation Python package initializer does not re-export them.
 
 ## Conversation Transcript Styling
 
@@ -318,7 +318,7 @@ does not participate in segmentation, cache invalidation, frame planning, or
 terminal writes; its module-level regular expressions, span ordering, and
 per-line call shape remain part of the frozen render-performance contract.
 The explicit module path above is stable and is not re-exported by the
-conversation package initializer.
+conversation Python package initializer.
 
 ## Conversation Interaction Control
 
@@ -362,7 +362,7 @@ The screen runner coordinates existing rendering calls but does not move or
 replace transcript segmentation, invalidation, render caches, frame
 composition, or terminal writes. Those hot-path responsibilities and the
 independent render-performance contract remain unchanged. The conversation
-package initializer intentionally does not re-export these entrypoints.
+Python package initializer intentionally does not re-export these entrypoints.
 
 `AgentScreenConversationApplicationBinding` and
 `AgentPlainConversationApplicationBinding` compose these existing ports for
@@ -389,12 +389,46 @@ policy, surface presentation, and fallback copy supplied to the binding.
 product-neutral interaction ports above. Its dependency direction is
 `tests/coding/tui_support` -> `loushang.harnesstui.testing` ->
 `loushang.harnesstui` / `loushang.tui`. The reverse direction is forbidden:
-production Harnesstui must never import its testing package, and the generic
-TUI remains independent of both Harnesstui layers.
+production Harnesstui must never import its testing Python package, and the
+generic TUI remains independent of both Harnesstui layers.
 
-The shared testing package must not import Coding, AI, Agent, or Harness
-runtime packages. It owns only reusable terminal test mechanics over neutral
-ports:
+Playback is an architectural boundary test, not only UI snapshot convenience.
+It proves that a Product can bind neutral Harness conversation facts into the
+shared TUI without creating Product-specific input, routing, rendering, or
+screen-loop semantics. The production dependency remains one-way even though
+the testing layer can drive the same public ports with deterministic fixtures.
+
+Three playback forms cover different failure classes:
+
+| Playback form | Real boundaries exercised | Evidence captured |
+|---|---|---|
+| Direct render scenario | prepared app state -> render planning -> fake terminal | logical/visible frames, terminal operations, repaint diagnostics |
+| Decoded-input playback | raw chunks -> `InputReader` -> keybindings -> conversation router -> render loop | routed actions, per-step state, frames and terminal trace |
+| Screen-loop playback | timed TTY-like chunks -> reusable async screen runner -> Product callbacks | raw terminal output, normalized text, exit/result facts and final state |
+
+This layering detects sequence bugs that isolated widget tests and final-screen
+goldens cannot: an intermediate wrong focus owner, duplicate optimistic user
+echo, stale pending queue, abort/steer/follow-up misrouting, transient cursor
+movement, unnecessary repaint, accidental clear-screen, or state that looks
+correct only after a later frame repairs it.
+
+The testing contracts are intentionally Product-neutral. Coding supplies its
+app factory, scenario catalog, policy, copy, and Product-only assertions, while
+future Research, PPT, or Cowork products can reuse the same input, render, and
+screen-loop drivers. This makes playback evidence useful when extracting shared
+behavior: reuse is demonstrated through explicit ports rather than inferred by
+copying Coding fixtures into HarnessTUI.
+
+Playback artifacts also separate semantic and physical evidence. Neutral action
+results and conversation state explain what the router decided; logical frames
+explain what the renderer intended; serialized terminal output explains what
+the host would receive. Keeping all three prevents a passing high-level state
+assertion from hiding a terminal regression, and prevents a visual golden from
+hiding incorrect conversation control flow.
+
+The shared testing Python package must not import Coding, AI, Agent, or Harness
+runtime Python packages. It owns only reusable terminal test mechanics over
+neutral ports:
 
 - `loushang.harnesstui.testing.ports` defines the application, router,
   snapshot, result, and factory protocols used by playback drivers;
@@ -416,18 +450,18 @@ ports:
   under `loushang.harnesstui.testing.scenarios` provide reusable recipe
   builders. They do not construct a product catalog at import time.
 
-These explicit modules are the stable testing entrypoints. The testing package
-initializer intentionally does not re-export them. `ConversationRenderScenario`,
-the input and screen-loop drivers, and the scenario factory own the reusable
-fixture mechanics; `loushang.tui.playback_suite.run_playback_cli` owns catalog
-selection and reporting. Repository-local support in `tests/coding/tui_support`
-only binds those facilities into a concrete Coding catalog and retains
-product-only scenarios, fakes, copy, fixture volumes, and render-performance
-budgets. The repository manual runner is `scripts/run_tui_playback.py`;
-none of this product test support is part of the installed Coding package. The
-temporary
+These explicit modules are the stable testing entrypoints. The testing Python
+package initializer intentionally does not re-export them.
+`ConversationRenderScenario`, the input and screen-loop drivers, and the
+scenario factory own the reusable fixture mechanics;
+`loushang.tui.playback_suite.run_playback_cli` owns catalog selection and
+reporting. Repository-local support in `tests/coding/tui_support` only binds
+those facilities into a concrete Coding catalog and retains product-only
+scenarios, fakes, copy, fixture volumes, and render-performance budgets. The
+repository manual runner is `scripts/run_tui_playback.py`; none of this product
+test support is part of the installed Coding Python package. The temporary
 `loushang.coding.ui.playback*` and `loushang.coding.ui.perf_probe` compatibility
-paths were retired after their consumers moved to the canonical testing
+paths were retired after their consumers moved to the canonical testing Python
 packages. Persisted Coding Session materialization remains in
 `loushang.coding.presentation.tui.history`.
 
@@ -509,8 +543,8 @@ renderer and `loushang.tui`.
 
 The stable imports are the explicit module paths
 `loushang.harnesstui.plain.renderer` and
-`loushang.harnesstui.conversation.plain_target`; their package initializers do
-not provide convenience re-exports.
+`loushang.harnesstui.conversation.plain_target`; their Python package
+initializers do not provide convenience re-exports.
 
 ## Settings, Selection, and Surface Composition
 
@@ -568,7 +602,8 @@ persisted; Harnesstui never calls a Session or settings manager.
 
 The explicit module paths above are the stable imports. Coding binds prepared
 product data and callbacks directly, without subclassing or re-exporting these
-shared implementations; package initializers do not add convenience exports.
+shared implementations; Python package initializers do not add convenience
+exports.
 
 ## Quality Gate
 

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -18,9 +18,9 @@ direction is:
 
 The reverse dependencies are forbidden. In particular, `loushang.harnesstui`
 must not import `loushang.coding`, `loushang.agent`, AI message/model/provider
-Python packages, or product-specific policy. `loushang.harness` and
-`loushang.tui` are independent peers: Harnesstui may depend on both, but neither
-peer may depend on Harnesstui or on the other peer.
+Python packages, or product-specific policy. `loushang.harness` and `loushang.tui` are
+independent peers: Harnesstui may depend on both, but neither peer may depend on
+Harnesstui or on the other peer.
 
 ## Responsibilities
 

--- a/docs/internals/architecture/loushang-architecture-principles.md
+++ b/docs/internals/architecture/loushang-architecture-principles.md
@@ -26,8 +26,12 @@
 
 关系如下：
 
-- [Architecture Overview](/home/dev/workspace/loushang/docs/architecture/architecture-overview.md)
+- [Architecture Overview](./architecture-overview.md)
   - 定义整体分层与子系统地图
+- [Product And OEM Glossary](../glossary/loushang-product.md)
+  - 定义 Product、OEM、Capability、Package、Plugin 与 Extension 等跨层术语
+- [Capability Variation And Replacement Boundary](./harness/capability-variation-and-replacement-boundary.md)
+  - 定义 Runtime Capability Shape、贡献、拦截、替换与 overlay 语义
 - 本文
   - 定义跨层通用的架构判断准则
 - 子系统文档
@@ -58,7 +62,7 @@
 - 把当前模型能力硬编码进 harness
 - 把状态混杂在 prompt 与临时上下文里
 - 把权限控制退化为提示词约束
-- 把规划、执行、评估混成一个不可验证的 agent
+- 把业务承诺、执行权限和完成判定混成一个不可追溯的 agent 黑箱
 - 把产品装配写成对底层内核的侵入式定制
 
 本文档的目标，是为后续架构设计提供一组稳定的高阶判断标准。
@@ -153,7 +157,33 @@
 
 ---
 
-### 2. Externalized State Before Context Accumulation
+### 2. Stable Substrate Before Model-Contingent Cognition
+
+模型能力会持续增强，并逐步吸收任务分解、临时规划、反思、上下文选择、
+通用 verifier prompt 和工具选择启发式。Loushang 不应把这些当前代际的
+认知脚手架固化为 Agent 内循环、核心所有权或不可迁移的持久状态。
+
+应长期稳定的是模型无法替代的系统不变量：
+
+- authority、Policy、Approval、sandbox 和最小权限；
+- 副作用执行、幂等、取消、重试和失败收敛；
+- Conversation、Transcript、Session、事件顺序、持久化和恢复；
+- capability admission、租户与 workspace 隔离；
+- multi-agent 通信、并发与跨进程协调契约；
+- Work admission、权威事件、artifact、evidence、acceptance 和终态；
+- 输入、呈现和终端副作用等可执行交互不变量。
+
+todo、planner、reflection、verifier agent、plan mode、completion reminder、
+渐进工具 UX、模型路由和 prompt-based memory policy 应保持为可替换的
+Product-owned Capability Provider、admitted Extension、Skill 或显式选择的
+Runtime Profile binding。
+
+判断标准是：如果模型能力增强十倍后某组件可以删除，而权限、证据、持久化、
+协调和业务终态没有变弱，那么该组件不应进入稳定内核。
+
+---
+
+### 3. Externalized State Before Context Accumulation
 
 长时任务的核心问题不是“如何塞进更多上下文”，而是“如何维护可恢复、可查询、可审计的外部状态”。
 
@@ -178,7 +208,7 @@
 
 ---
 
-### 3. Capability Governance Before Fixed Invocation Paths
+### 4. Capability Governance Before Fixed Invocation Paths
 
 能力治理是授权问题，调用路径只是实现问题。
 
@@ -209,7 +239,7 @@
 
 ---
 
-### 4. Structural Security Before Instructional Safety
+### 5. Structural Security Before Instructional Safety
 
 安全边界应尽量通过系统结构保证，而不是依赖提示词、约定或“模型应该听话”。
 
@@ -234,9 +264,11 @@
 
 ---
 
-### 5. Verification And Traceability Are First-Class Capabilities
+### 6. Verification And Traceability Are First-Class Capabilities
 
-`loushang` 不应把验证视为“执行之后的补充动作”，而应把它视为系统的一等能力。
+`loushang` 不应把验证视为“执行之后的补充动作”，而应把可验证目标、外部
+证据和 traceability 视为系统的一等能力。这里的一等能力不是指在 Agent
+内循环中内置一个通用 verifier。
 
 这意味着：
 
@@ -260,34 +292,50 @@
 - validation note
 - provenance / trace
 
----
+需要区分：
 
-### 6. Separate Planning, Execution, And Evaluation Responsibilities
+```text
+提示模型“请自我验证”或强制固定 verdict 格式
+  -> 可替换的模型策略
 
-自主系统可以协同，但不应把规划、执行、评估无差别混合成一个黑箱。
+编译、测试、扫描、领域校验和独立执行环境产生的 evidence
+  -> Product 解释、Work 关联的外部事实
+```
 
-这条准则并不强制要求一定采用多个 agent 实例，而是要求职责显式可分。
-
-推荐保持分离的职责包括：
-
-- 规划
-- 执行
-- 评估
-- 审批
-- 记忆与状态整理
-
-对 `loushang` 的含义是：
-
-- 方法层不应只生成一个“计划文本”
-- 规划结果应成为可执行契约
-- 评估不应只是执行后的附带自评
-- 运行时应允许引入独立 evaluator / critic / reviewer 角色
-
-当系统无法说明“谁在规划、谁在执行、谁在判定完成”时，通常说明职责边界仍不清楚。
+独立 evaluator / reviewer 可以用于高风险或职责隔离场景，但不应成为所有
+普通 turn 的固定成本。验证机制应由 Product、Method、Work 和可选
+multi-agent 组合拥有；低层 Agent Loop 只执行准备好的调用和工具。
 
 ---
 
-### 7. Default For Long-Horizon Recovery And Evolution
+### 7. Keep Responsibilities Explicit Without Freezing Cognitive Choreography
+
+自主系统不能把业务承诺、执行权限和完成判定混成一个不可追溯的黑箱，但这
+不要求每个任务都经过独立 planner、executor 和 evaluator Agent。
+
+核心原则是：**Method 规定“什么必须成立”，模型决定“怎样达到”。**
+
+Method 稳定表达角色责任、约束、gates、预期 artifact、acceptance 和 evidence；
+模型可以在这个 envelope 内改变分解、工具顺序、推理方式、临时 plan 和
+subagent 使用策略。更强模型可以吸收这些局部认知步骤，而不改变 Method
+contract 或 Work truth。
+
+只有当计划或评估需要承担外部责任时，才必须显式物化：
+
+- 计划需要协调人或 agent、控制预算、等待审批、跨重启恢复或接受审计；
+- 验证需要独立权限、不同执行环境或客观 evidence；
+- 完成判定需要形成可查询、可回放的 Work outcome。
+
+在这些场景中，Product 把 Method 或用户意图绑定为 run-specific Work
+contract，Work 拥有接受、revision、deviation、evidence 和终态；Harness
+multi-agent 可以提供独立 reviewer 的技术执行，但不拥有业务验收。
+
+因此，职责必须可说明，认知 choreography 必须可替换。不要把“可分离”误写成
+“必须由多个 Agent 固定串联”，也不要把模型的临时 todo 自动提升为权威计划。
+
+---
+
+### 8. Default For Long-Horizon Recovery And Evolution
 
 `loushang` 应默认把长时任务视为常态，而不是异常情况。
 
@@ -313,9 +361,9 @@
 
 ---
 
-### 8. Product Assembly Must Preserve Kernel Consistency
+### 9. Product Assembly Must Preserve Kernel Consistency
 
-`loushang-coding`、`tui`、`methods` 等上层产品装配可以有强场景化选择，但不应破坏内核一致性。
+`loushang.coding`、`loushang.tui`、`loushang.method` 等上层产品与能力装配可以有强场景化选择，但不应破坏内核一致性。
 
 这意味着：
 
@@ -366,9 +414,12 @@
 
 ### Responsibility Separation vs Runtime Cost
 
-规划、执行、评估分离会带来更多运行步骤与协调成本。
+把计划和评估物化为独立 Agent 或外部阶段会带来更多运行步骤与协调成本。
 
-但在复杂任务中，缺少职责分离往往会造成更高的返工与验证成本。
+普通低风险 turn 可以让同一模型在明确边界内自主完成局部规划、执行和自检。
+只有当协调、权限、客观证据、恢复或审计要求足以证明其价值时，才引入独立
+planner、reviewer 或 verifier。职责的外部可追溯性必须稳定，具体认知步骤不必
+固定。
 
 ---
 
@@ -376,12 +427,13 @@
 
 结合当前 `loushang` 的分层设计，近期最应优先落实的方向包括：
 
-1. 明确 `session`、`event`、`artifact`、`capability` 的统一建模
-2. 把 `channel` 设计为可承载恢复、审计与查询的边界层，而不只是消息搬运层
-3. 在 `methods` 层把计划、阶段、验收条件与 work product 变成可运行对象
-4. 在 `agent` 层显式支持规划、执行、评估等职责分离
+1. 明确 Conversation、Session、event、artifact、capability 和 Work 的权威 owner
+2. 保持 `channel` 为 transport-safe operation/event boundary；恢复、审计和业务 truth 仍由 Harness、Work 或未来 AppService 的对应 owner 承担
+3. 在 `method` 层稳定表达目标、约束、gates、预期 artifact、acceptance 和 evidence，而不是冻结模型推理 choreography
+4. 保持 `agent` 为机械模型/工具执行内核；由 Harness、Product、Method、Work 和 multi-agent 在需要时组合 planner 或 verifier
 5. 在工具体系中区分能力模型、执行路径与凭据中介，避免混为一谈
 6. 在产品层坚持“场景装配建立在通用内核之上”，而不是反向侵入底层
+7. 把 TUI playback 作为输入、渲染和终端副作用的可执行契约，持续验证 resize、streaming、cursor、scrollback 和跨 feature 路由不变量
 
 ---
 
@@ -392,6 +444,8 @@
 - 所有工具都必须通过 proxy
 - 所有 sandbox 都完全不可接触任何受控资源
 - 任何场景都必须使用多 agent
+- 任何任务都必须显式生成计划或经过独立 verifier
+- planner、reflection 或 verifier 应进入 Agent 内循环
 - 任何状态都必须持久化到复杂基础设施
 - 为了追求抽象纯度而牺牲当前实现推进
 
@@ -400,7 +454,8 @@
 - 能力模型应先于调用路径争论
 - 结构性边界应先于提示词约束
 - 可恢复状态应先于上下文堆积
-- 可验证职责应先于黑箱式自主
+- 外部 evidence 和职责可追溯性应先于黑箱式自主
+- 稳定 substrate 应先于当前模型需要的认知脚手架
 
 ---
 
@@ -413,7 +468,7 @@
 - 哪些语义必须稳定
 - 哪些状态必须可恢复
 - 哪些能力必须被治理
-- 哪些职责必须被分离
+- 哪些职责必须对外显式，哪些认知步骤可以交给模型自主完成
 - 哪些产品装配不能破坏内核一致性
 
 这些准则构成 `loushang` 后续子系统设计、方法层设计与产品化装配的共同约束。

--- a/docs/internals/architecture/method/README.md
+++ b/docs/internals/architecture/method/README.md
@@ -31,6 +31,46 @@ Policy = Permission and approval boundary
 Work   = Business intent enactment and authoritative runtime facts
 ```
 
+## Model Autonomy Boundary
+
+**Method 规定“什么必须成立”，模型决定“怎样达到”。**
+
+Method 应稳定表达一类工作的目标、适用条件、角色责任、约束、audit
+points、gates、预期产物、验收条件和证据要求。它不应把某一代模型需要的
+认知脚手架固化成长期流程，例如：
+
+- 强制每个普通任务先生成 todo；
+- 固定的逐步推理、反思或 self-critique 模板；
+- 每隔若干工具调用注入一次进度提醒；
+- 仅靠 prompt 约束的通用 verifier 流程；
+- 静态模型路由或工具选择启发式。
+
+在 Method 的约束和 Product/Harness 授权边界内，模型可以自主选择任务分解、
+工具顺序、局部推理策略、是否使用子 agent，以及是否维护临时计划。模型能力
+增强时，这些内部策略可以减少、替换或消失，而不要求修改 Method contract。
+
+需要区分两种计划：
+
+```text
+帮助模型思考的临时 plan
+  -> model- or Product-owned strategy, admitted Extension, or Skill
+
+供人、团队和系统共同遵守的 plan
+  -> Product binding -> Work acceptance -> Work-owned fact
+```
+
+当计划涉及跨 agent 协作、人工审批、预算、恢复、审计或验收时，它不再只是
+模型的认知辅助。Product 必须把它绑定成 run-specific Work contract，由 Work
+接受、排序和记录；执行中的改变应成为显式 revision 或 deviation，而不是模型
+静默改写历史。
+
+同样，Method 可以规定“必须提供哪些验证证据”，但不应默认规定模型必须使用
+某个通用 verifier prompt。Product 解释编译、测试、扫描、领域校验和独立执行
+环境产生的证据，Work 记录这些证据及其对 outcome 的影响。
+
+这个边界使更强的模型获得更大的局部自主性，同时保持 Method 的组织约束、
+Work 的权威事实以及 Loushang substrate 的权限、证据、持久化和协调边界稳定。
+
 ## Current Boundary
 
 `loushang.method` owns:
@@ -63,10 +103,10 @@ artifact-reference, and deviation facts.
 
 `loushang.method` is optional for product execution.
 
-Product packages such as `loushang.coding`, and future `loushang.research`,
-`loushang.ppt`, and `loushang.cowork`, may call `loushang.harness` directly for
-lightweight turns. They may also write or project through
-`loushang.work` directly.
+Product implementation Python packages such as `loushang.coding`, and future
+`loushang.research`, `loushang.ppt`, and `loushang.cowork`, may call
+`loushang.harness` directly for lightweight turns. They may also write or
+project through `loushang.work` directly.
 
 Use `method` when the product needs structured work: planning, staged execution,
 review gates, method-specific constraints, or acceptance criteria. Do not route
@@ -83,19 +123,20 @@ should produce.
 `loushang.work` records actual artifact references: what was produced, where it
 is, which run or step produced it, and how it relates to the expected artifact.
 
-Product packages such as `coding`, `research`, `ppt`, and `cowork` own concrete
-artifact types, content, loading, rendering, validation, and materialization.
+Products such as Coding, Research, PPT, and Cowork own concrete artifact types,
+content, loading, rendering, validation, and materialization.
 
 Therefore the shared work layer should prefer a lightweight `ArtifactRef` over a
 shared abstract `Artifact` base class.
 
 ## Capability Boundary
 
-Method resources may describe an opaque Product capability requirement, but
+Method resources may describe an opaque Product Capability Requirement, but
 they do not select a Harness tool pack, register executable tools, or grant
 runtime authority. A Product work preparer interprets the requirement in its
 domain and carries it into the run-specific Work contract; the Product executor
-then resolves it through admitted Product capabilities before invoking Harness.
+then resolves it through the Product's admitted Capability catalog before
+invoking Harness.
 
 `MethodApplicability.capabilities` remains an applicability and matching fact.
 It must not silently become a runtime authorization or ToolPack activation
@@ -180,6 +221,8 @@ These fields are not yet closed enums. The experimental methodology documents re
 - Store and project method metadata before enforcing it.
 - Treat `MethodApplicability` shape as stable, but do not freeze the final ontology too early.
 - Bind skills step-locally in the future instead of globally injecting all method-related skills.
+- Define durable outcomes, constraints, artifacts, gates, and evidence; keep
+  model-contingent planning, reflection, and verifier choreography replaceable.
 
 ## Related Documents
 

--- a/docs/internals/architecture/subsystem.md
+++ b/docs/internals/architecture/subsystem.md
@@ -11,7 +11,9 @@
 
 - `loushang.ai`
 - `loushang.agent`
+- `loushang.channel`
 - `loushang.harness`
+- `loushang.harnesstui`
 - `loushang.coding`
 - `loushang.method`
 - `loushang.tui`
@@ -21,6 +23,7 @@
 
 - `loushang.observability`
 - `loushang.ontology`
+- `loushang.protocol`
 
 `loushang.runtime` 不再作为子系统保留。若某个 worktree 中仍存在
 `src/loushang/runtime`，它只是待删除的旧 command/effect 临时路径；迁移目标是
@@ -35,9 +38,9 @@ command substrate 的目标归属是 `loushang.harness`，见
 - `loushang.ppt`
 - `loushang.cowork`
 
-目标架构仍保留 `loushang.channel`，但当前没有 package-level
-implementation。现有 RPC mode 是 coding-local transitional adapter，不等于
-长期 channel surface。
+`loushang.channel` 已有对应 Python package implementation。现有
+`loushang.coding.mode.RpcMode` 仍是 Coding-local transitional adapter；它的
+命令表与 UI payload 不属于长期 Channel core。
 
 ## Subsystem Responsibilities
 
@@ -87,9 +90,11 @@ agent 运行内核。
 
 ### loushang-harness
 
-跨产品的 product-adapter substrate。当前已落地的核心是 prepared agent run
-contract，后续 product-neutral host / adapter / command / lifecycle /
-diagnostics 合同也归属这里。
+跨产品的 product-adapter substrate。它在唯一 prepared agent run contract
+之上组合 Product-neutral runtime、Session、Conversation、Transcript、Context、
+Tools、Policy、Approval、Sandbox、Capability、Host、Events、Continuity 和
+Workspace 机制。完整当前 owner 以
+[Harness Current Owner Map](./harness/current-owner-map.md) 为准。
 
 负责：
 
@@ -97,10 +102,13 @@ diagnostics 合同也归属这里。
 - `AgentRunResult`
 - `run_agent()`
 - headless agent run 编排
-- product-neutral adapter / prepared-turn / adapter-result contracts
-- product-neutral host lifecycle contracts
+- runtime cancellation、retry/scheduling、Runtime Profile resolution 与 binding
+- Session lifecycle、conversation repository、transcript、context packing 与 replay
+- tool authoring/hosting、Policy、Approval、Sandbox 和 execution-profile mechanics
+- resources、extensions、capabilities 与 scoped activation
+- product-neutral adapter、host、CLI、events、presentation、diagnostics、continuity
+  和 workspace contracts
 - command/effect value objects, such as `loushang.harness.commands`
-- generic diagnostics / status records
 
 不负责：
 
@@ -129,17 +137,17 @@ prepared-run contract，不引入第二套 `HarnessRunSpec`。原
 边界协议与 transport 层。该源码包已落地，并保持为由 Product host ports
 注入业务操作的 transport-first 层。
 
-负责：
+当前负责：
 
-- operation / event protocol
+- `WorkOperation` / `WorkEvent` 和已投影 `RuntimeEventView` 的边界值契约
+- JSONL envelope/framing 与严格 wire values
 - request / response correlation
-- notification / subscription
-- transport adapters, such as in-process, stdio/JSONL, HTTP, WebSocket
-- capability negotiation
-- delivery policy, such as immediate / coalesce / final-only
-- replay / resume
-- channel audit trail
-- multi-client access to the same work run
+- accepted ACK 与随后到达的 event delivery
+- 当前 `rpc_jsonl` adapter
+
+目标扩展包括 capability negotiation、interaction request/response、subscription
+cursor/resume，以及按需求增加的 in-process、IPC、HTTP/WebSocket 等 adapter。
+这些目标能力不能当作当前已实现事实。
 
 不负责：
 
@@ -149,11 +157,10 @@ prepared-run contract，不引入第二套 `HarnessRunSpec`。原
 - coding / design / research / ppt / cowork 产品内部 session
 - 产品 adapter 注册之外的业务执行
 
-`channel` 面向多客户端和多 UI：TUI、WebUI、AppUI、SDK host、RPC client
-都应通过 channel 发送 operation、订阅 event、恢复和回放状态。channel core
-承载 `WorkOperation` / `WorkEvent` 的边界传输语义；具体产品 adapter 由
-host 装配，不由 channel core 直接 import。对于 Host/Session 的瞬态观察，
-channel 还可承载已完成产品投影的 `RuntimeEventView`；它不解释或产生该 view。
+`channel` 可以服务 TUI、WebUI、AppUI、SDK host 和 RPC client，但不是所有
+Session/App 操作的强制总线。它承载选定的 `WorkOperation` / `WorkEvent` 和
+已完成产品投影的 `RuntimeEventView`；具体 Product adapter 由 host 装配，
+Channel 不解释或产生该 view，也不拥有 Work/Session truth。
 
 ### loushang-tui
 
@@ -165,6 +172,8 @@ channel 还可承载已完成产品投影的 `RuntimeEventView`；它不解释�
 - keybinding / history / TTY fallback 等终端交互能力
 - 真实 terminal scrollback 与 transient composer 的协调
 - 为产品适配层提供可复用的终端 UI primitives
+- render planning、terminal operations、diagnostics 和性能预算
+- product-neutral terminal playback、scenario suite 和 artifact mechanics
 
 不负责：
 
@@ -177,6 +186,33 @@ channel 还可承载已完成产品投影的 `RuntimeEventView`；它不解释�
 相关文档：
 
 - [Loushang-TUI Architecture](./tui/README.md)
+- [Terminal Playback Harness](./tui/native-terminal-core/key-designs/KD-010-terminal-playback-harness.md)
+
+### loushang-harnesstui
+
+Harness conversation contract 与通用 TUI 之间的 product-neutral composition
+层。它可以同时依赖 `loushang.harness` 和 `loushang.tui`，但二者都不反向依赖
+它；它也不得依赖 `loushang.coding`、AI provider 或 Product policy。
+
+负责：
+
+- neutral conversation snapshot/event 到 TUI records、surfaces 和 status 的投影
+- conversation input、queue、abort/steer/follow-up 和 approval presentation routing
+- transcript reader、tool transcript、settings/selection/surface 等共享交互
+- Agent-free neutral conversation ports，以及可选 Agent binding profile
+- 基于 neutral ports 的 direct render、decoded-input 和 screen-loop playback
+- playback conversation state、routed action 和 terminal artifact 的组合证据
+
+不负责：
+
+- terminal decoding/render-loop/terminal-write 内核
+- Harness Session、Conversation 或 Work 的权威状态
+- Coding intent、prompt、tool policy、模型选择策略或最终 Product copy
+- 第二套 Agent loop、conversation persistence 或 transcript renderer
+
+相关文档：
+
+- [Loushang Harness TUI](./harnesstui/README.md)
 
 ### loushang-method
 
@@ -281,6 +317,7 @@ Artifact 分层规则：
 
 ```text
 loushang.coding
+  -> loushang.harness
   -> loushang.agent
   -> loushang.ai
 ```
@@ -339,10 +376,13 @@ operation/event 边界，不是 Product runtime 的统一入口。Product 本身
 - `harness` 提供跨产品 prepared-run contract 以及 product-neutral host /
   adapter / command substrate
 - `harnesstui` 提供跨产品的 Harness/TUI conversation interaction 与
-  presentation composition；可依赖 `harness` 和 `tui`，不可依赖 `coding`
+  presentation composition，以及基于中性 ports 的 conversation input、
+  render 和 screen-loop playback testing；可依赖 `harness` 和 `tui`，不可依赖
+  `coding`
 - `channel` 提供选定的 operation/event、订阅、关联和回放边界，不承担通用
   Product 路由或 transport/runtime 总线职责
-- `tui` 提供通用终端交互原语
+- `tui` 提供通用终端交互原语、render/terminal diagnostics 与确定性 playback
+  substrate
 - `method` 提供可选的方法组织与 plan/projection
 - `work` 提供业务 work acceptance、运行终态、事件、日志与 projection
 - `coding` 提供 coding 产品装配；feature-local adapter 解释 Coding 语义，
@@ -356,24 +396,24 @@ operation/event 边界，不是 Product runtime 的统一入口。Product 本身
 目标二级组件依赖关系。本节中 `A -> B` 表示 `A` 可以依赖 / 调用 `B`。
 
 ```text
-all packages -> observability
+all Python packages -> observability
 
-method / work / product packages -> ontology
+method / work / Product implementation Python packages -> ontology
   # only when semantic typing is needed
 
 agent -> ai
-product packages -> ai
+Product implementation Python packages -> ai
   # only for product-level helper AI calls
 
 harness -> agent
-product packages -> harness
-product packages -> agent
+Product implementation Python packages -> harness
+Product implementation Python packages -> agent
   # only through stable agent primitives when bypassing harness is justified
 
-product packages -> work
+Product implementation Python packages -> work
 channel -> work
 
-product packages -> method
+Product implementation Python packages -> method
   # optional and only for structured work; Product binds Method output to Work
 
 product TUI adapters -> tui
@@ -381,7 +421,7 @@ product TUI adapters -> tui
 UI clients / SDK hosts / RPC clients -> channel
 ```
 
-Product packages are peers:
+Product implementation Python packages are peers:
 
 ```text
 coding
@@ -391,9 +431,9 @@ ppt
 cowork
 ```
 
-Product packages should not depend on each other directly. Cross-product
-coordination should go through explicit adapters, `work` events, `channel`
-protocol, or a future host-level orchestration layer.
+Product implementation Python packages should not depend on each other
+directly. Cross-Product coordination should go through explicit adapters,
+`work` events, `channel` protocol, or a future host-level orchestration layer.
 
 Multi-UI target shape:
 
@@ -421,11 +461,18 @@ or own product execution internals.
 | Product-run loop | `loushang.harness` plus product adapter | prepared run handoff, product-neutral host/adapter/lifecycle contracts, shared engines | second agent loop, product defaults, provider behavior |
 | Work/method loop | `loushang.work` and optional `loushang.method` | durable operations/events/projections, method plan/step guidance | model streaming, product UI, harness execution mechanics |
 | Channel loop | `loushang.channel` | external operation/event transport, subscription, replay, correlation | local UI widgets, product internals, agent state machine |
-| TUI render loop | `loushang.tui` plus product UI adapter | terminal input/render primitives and product-specific terminal wiring | agent loop, provider behavior, harness policy |
+| TUI render loop | `loushang.tui` plus product UI adapter | terminal input/render planning, terminal operations, and product-specific final wiring | agent loop, provider behavior, harness policy, durable transcript truth |
 
 This split lets `harness`, `tui`, `agent`, and `ai` develop in parallel. A
 harness change should affect those lanes only when it intentionally changes a
 stable cross-boundary contract. Otherwise:
+
+TUI playback is not another runtime loop or a second conversation replay
+engine. It drives the existing input, render, terminal, and optional
+HarnessTUI screen-loop boundaries with scripted events, then records semantic
+state and physical terminal evidence. Its value is precisely that it tests the
+cross-boundary sequence without taking ownership away from Conversation,
+Session, Work, Product presentation, or the live render loop.
 
 - TUI changes stay in `loushang.tui` or product-owned UI adapters.
 - Agent changes stay in `loushang.agent`.

--- a/docs/internals/architecture/tui/README.md
+++ b/docs/internals/architecture/tui/README.md
@@ -68,14 +68,14 @@ screen app and surfaces, plain/screen runner bindings, settings-page builder,
 input/clipboard policy, run/event context, completion, startup, and hotkey
 presentation. Raw intents, action control, model/settings facts, tool/event/
 history projection, approval binding, resume discovery, and Session-facing
-projection adapters live in their Coding feature packages instead.
+projection adapters live in their Coding feature Python packages instead.
 
-The package has a 2,200-line upper-budget gate. This is not an instruction to
-move `screen_app.py` into a shared layer: that file deliberately owns Coding's
-long-lived transcript presentation, cwd cache token, glyph/theme mapping, path
-compaction, tool-output preview, 320-line active-window policy, and render
-baseline reset reasons. Those contracts remain covered by the independent
-render-performance gate.
+The `loushang.tui` Python package has a 2,200-line upper-budget gate. This is not
+an instruction to move `screen_app.py` into a shared layer: that file
+deliberately owns Coding's long-lived transcript presentation, cwd cache token,
+glyph/theme mapping, path compaction, tool-output preview, 320-line active-window
+policy, and render baseline reset reasons. Those contracts remain covered by
+the independent render-performance gate.
 
 Generic terminal diagnostics aggregation lives in
 `loushang.tui.terminal_diagnostics`. It combines terminal environment,
@@ -85,7 +85,87 @@ result. Products decide when and where to expose the formatted text.
 Generic playback-suite orchestration lives in `loushang.tui.playback_suite`.
 It owns neutral scenario specifications and results, scenario selection,
 timing, and artifact dispatch. Product scenario catalogs, command-line runners,
-and product-specific playback hosts remain in their product adapter packages.
+and product-specific playback hosts remain in their Product Adapter Python
+packages.
+
+## Why Playback Is An Architectural Capability
+
+TUI playback is an executable specification of terminal behavior, not merely a
+test helper and not a synonym for replaying persisted conversation records.
+
+| Mechanism | Question answered |
+|---|---|
+| Conversation/transcript replay | What durable conversation state should be reconstructed? |
+| Render snapshot | What logical content should one render state contain? |
+| Terminal playback | Which logical frames and terminal operations occur across an interaction sequence? |
+| Screen-loop playback | Does scripted TTY input traverse the real async input/router/screen lifecycle correctly? |
+
+The distinction matters because the final visible screen cannot reveal many
+terminal regressions. A UI may end with the expected text while having flickered,
+cleared scrollback, moved the cursor through transcript content, emitted an
+unbounded number of bytes, duplicated streaming blocks, or briefly routed input
+to the wrong surface.
+
+### Playback fidelity layers
+
+The current architecture provides complementary levels rather than one giant
+end-to-end fixture:
+
+1. `loushang.tui.playback` drives scripted events through render planning and a
+   `FakeTerminalPort`. Every step can capture logical lines, changed ranges,
+   viewport and cursor coordinates, terminal operations, repaint kind/reason,
+   clear-scrollback behavior, cache reuse, materialization counts, and the
+   flushed terminal frame.
+2. `loushang.harnesstui.testing.input_playback` adds the real `InputReader`,
+   keybindings, conversation router, overlay host, neutral routed action
+   results, and per-step conversation-state snapshots.
+3. `loushang.harnesstui.testing.screen_loop_playback` drives the reusable async
+   conversation screen loop with timed TTY-like chunks, then captures raw
+   output, control-sequence-free text, exit state, Product-supplied result facts,
+   and state artifacts.
+4. `loushang.tui.playback_suite` supplies product-neutral scenario selection,
+   tag filtering, timing, budgets, failure capture, and artifact dispatch.
+   Products own only their scenario catalogs, fakes, copy, and policy.
+
+This split keeps tests close to the owner of each invariant. Pure rendering
+does not require a Product, conversation routing does not require Agent/AI
+objects, and Product scenarios do not fork the generic playback engine.
+
+### What playback proves
+
+Playback assertions cover both semantic output and physical terminal effects:
+
+- visible and scrollback text;
+- operation classes and exact terminal frames;
+- maximum operations, serialized bytes, and changed visible lines per step;
+- cursor agreement, stable screen anchors, synchronized frames, and clear-screen
+  policy;
+- resize/reflow and recovery repaint behavior;
+- streaming draft promotion, transcript block reuse, and bounded hot-path work;
+- paste, completion, selection, surface focus, queue, abort, steer, and follow-up
+  ordering; and
+- long-transcript rendering budgets and failure artifacts.
+
+This is stronger than relying only on golden final frames or manual smoke tests:
+the trace explains *how* the terminal reached a state and preserves intermediate
+evidence for a failure. JSONL traces and optional frame/screen/terminal/state
+artifacts also make regressions reviewable without reproducing the original
+interactive terminal session.
+
+### Why the capability remains valuable as models improve
+
+Playback validates the UI substrate rather than a particular model's prose or
+reasoning strategy. More capable models may change response shape, tool choice,
+or streaming cadence, but the invariants around input routing, terminal effects,
+cursor safety, resize, bounded rendering, cancellation, and queue semantics
+remain. Product-neutral playback therefore protects a stable part of Loushang
+that stronger models do not absorb.
+
+The accepted low-level design is [KD-010: Terminal Playback Harness](./native-terminal-core/key-designs/KD-010-terminal-playback-harness.md),
+with test layering and live-smoke obligations in
+[Testing Strategy](./native-terminal-core/testing-strategy.md). Harness-oriented
+composition is documented in
+[HarnessTUI Conversation Playback Testing](../harnesstui/README.md#conversation-playback-testing).
 
 ## Screen Transcript Region
 


### PR DESCRIPTION
## Summary

- define a cross-layer evaluation principle that keeps model-contingent planning, reflection, and verifier choreography outside the stable substrate
- clarify Method, Work, Product, Harness, Channel, TUI, and HarnessTUI ownership using the canonical Product/OEM/Capability/Package/Plugin/Extension vocabulary
- document terminal and conversation playback as executable architecture contracts with explicit evidence and dependency boundaries
- update the subsystem map and v3 target architecture to match current implementations without claiming unimplemented Channel or AppService capabilities

## Why

The architecture documentation mixed durable authority, evidence, persistence, and lifecycle concerns with cognitive scaffolding that stronger models may replace. It also under-described current HarnessTUI playback and used several ambiguous package, capability, profile, and provider-replacement terms.

## Impact

Documentation and architecture contracts only. No runtime code or public API behavior changes.

## Validation

- `uv --cache-dir /tmp/uv-cache run --extra dev pytest tests/architecture -q` — 161 passed
- checked 8 changed Markdown files and 90 local links — all resolve
- `git diff --check origin/main...HEAD`
