### PR TITLE
feat(harness): declare runtime capability variation semantics

### DIFF
--- a/docs/internals/architecture/harness/capability-variation-and-replacement-boundary.md
+++ b/docs/internals/architecture/harness/capability-variation-and-replacement-boundary.md
@@ -38,7 +38,7 @@ The three executable composition semantics are:
 | --- | --- | --- | --- |
 | Aggregate Contribution | zero or more | admit every compatible entry and combine deterministically | tools, commands, server definitions, independent hooks |
 | Ordered Interception | zero or more around one operation or provider | build an explicit ordered chain with a declared error policy | policy interceptors, tracing, metrics, caching |
-| Exclusive Replacement | zero or one active provider per slot | select explicitly; reject unresolved ambiguity | approval resolver, model provider, storage or channel adapter |
+| Exclusive Replacement | zero or one active provider per slot | apply the owning surface's explicit deterministic selection rule; reject only unresolved ambiguity | approval resolver, model provider, storage or channel adapter |
 
 Decoration is the restricted case of Ordered Interception that wraps an
 already resolved capability without acquiring its selection, authority, or
@@ -143,10 +143,58 @@ Every replaceable or composable surface declares:
 - duplicate, ambiguity, failure, and fallback behavior.
 
 Registries must reject duplicate identities that the owning semantic cannot
-combine. Exclusive replacements require explicit Product, OEM, or Platform
-selection. They do not use last-write-wins or import order. Fallback providers
-are selected by the slot owner and are visible in the resolved profile and
-diagnostics.
+combine. Exclusive replacements require an explicit Product, OEM, or Platform
+selection rule. A runtime-profile `single` slot may use its declared
+source/layer/selection precedence; another surface may require a named provider
+or reject competing candidates. These policies do not use incidental import or
+discovery order. Fallback providers are selected by the slot owner and are
+visible in the resolved profile and diagnostics.
+
+## Standard Runtime Capability Semantic Inventory
+
+This inventory applies the canonical glossary terms to the standard Harness
+runtime slots. It is not a second glossary: term definitions remain in the
+[Product And OEM Glossary](../../glossary/loushang-product.md), while
+`src/loushang/harness/runtime/_profile_standard.py` remains the code authority
+for current slot keys, shapes, scopes, refresh boundaries, and source ceilings.
+
+The **slot semantic** describes how alternative bound implementations interact.
+The **nested semantic** describes values subsequently consumed by the selected
+implementation. Keeping these columns separate prevents an ordered collection
+of prompt sections or capability packs from being mistaken for permission to
+bind multiple composer implementations.
+
+| Standard slot | Owner boundary | Current profile contract | Slot semantic | Nested semantic | Alignment status |
+| --- | --- | --- | --- | --- | --- |
+| `conversation.store` | Harness Conversation and transcript runtime | `single`; Session; sealed; Product/OEM | Exclusive Replacement | None | Executable: profile precedence selects one store implementation. |
+| `agent.transcript_profile` | Harness transcript runtime | `single`; Session; sealed; Product/OEM | Exclusive Replacement | None | Executable: profile precedence selects one transcript profile. |
+| `context.compaction` | Harness Context and transcript runtime | `single`; Session; turn; Product/OEM/Extension/session | Exclusive Replacement | None | Executable: profile precedence selects one turn-refreshable implementation. |
+| `resource.runtime` | Harness Resources | `single`; workspace; sealed; Product/OEM | Exclusive Replacement of the activation runtime | Resource Overlay inside the admitted `ResourceBundle` | Executable; the provider and data-overlay axes remain separate. |
+| `prompt.sections` | Product prompt policy with Harness composition mechanics | `single`; Session; turn; Product/OEM/Extension/session | Exclusive Replacement of the composer | Aggregate Contribution of admitted `PromptSection` values | Aligned: exactly one composer binds, while its input sections remain an ordered aggregate. |
+| `skill.activation` | Product activation policy with Harness resource mechanics | `single`; Session; turn; Product/OEM/Extension/session | Exclusive Replacement | One selected policy transforms the admitted resource bundle | Executable: exactly one activation runtime binds. |
+| `tool.packs` | Product tool policy with Harness pack composition | `single`; Session; turn; Product/OEM/Extension | Exclusive Replacement of the composer | Aggregate Contribution of admitted `CapabilityPack` values | Aligned: exactly one composer binds, while admitted packs remain an ordered aggregate. |
+| `command.packs` | Product command policy with Harness pack composition | `single`; Session; turn; Product/OEM/Extension | Exclusive Replacement of the composer | Aggregate Contribution of admitted `CapabilityPack` values | Aligned: exactly one composer binds, while admitted packs remain an ordered aggregate. |
+| `interaction.side_question` | Product interaction port with Harness Session binding | optional `single`; Session; sealed; Product/OEM/Extension | Exclusive Replacement | None | Executable: profile precedence selects zero or one provider factory. |
+| `continuity.provider_packs` | Harness Continuity composition | optional `ordered`; Process; sealed; Product/OEM | Aggregate Contribution | Each pack contributes one or more continuity providers | Executable: all resolved packs compose in profile order and duplicate provider identities are rejected. |
+
+No current standard runtime slot is classified as Ordered Interception.
+Extension-routing interceptor chains are a separate executable surface and must
+retain their own ordering, error, and delegation contract rather than borrowing
+the semantics of an `ordered` runtime slot.
+
+`RuntimeCapabilitySlot.variation_semantic` is the executable code authority for
+this classification. Slots that admit non-Product sources or retain multiple
+values must declare it. Shape/semantic compatibility is validated when the
+slot is constructed, and the semantic is retained in new runtime-profile
+snapshots. Legacy schema-v1 snapshots without the additive field remain
+readable and are normalized against the current Product contract during
+resume validation.
+
+No standard slot declares automatic provider fallback. A Product default is
+the baseline selection; a higher-precedence admitted Exclusive Replacement may
+replace it, but a binding failure does not silently retry the baseline.
+Introducing such fallback requires a separately declared failure policy,
+durable provenance, and lifecycle tests.
 
 ## Application To Coding Language Services
 

--- a/docs/internals/architecture/harness/product-capability-composition-core.md
+++ b/docs/internals/architecture/harness/product-capability-composition-core.md
@@ -32,9 +32,11 @@ second production Product is not required by the neutrality evidence gate.
 The values bound through Capability Slots use the behavioral semantics from the
 [Capability Variation And Replacement Boundary](capability-variation-and-replacement-boundary.md):
 
-- command and tool packs are Aggregate Contributions after Product admission;
-- prompt sections are an ordered aggregate whose ordering is supplied by the
-  Product and recorded in the prepared result;
+- command and tool pack composers use Exclusive Replacement, while the
+  admitted packs passed to the selected composer are Aggregate Contributions;
+- the prompt-section composer uses Exclusive Replacement, while its admitted
+  sections are an ordered aggregate whose ordering is supplied by the Product
+  and recorded in the prepared result;
 - injected prompt parsing, expansion, activation, and callback behavior is
   Protocol Injection at the Product composition root;
 - same-name resource or tool behavior follows the owning catalog's documented

--- a/docs/internals/architecture/harness/product-runtime-injection/03-resource-packs-binding.md
+++ b/docs/internals/architecture/harness/product-runtime-injection/03-resource-packs-binding.md
@@ -45,8 +45,8 @@ behavior is fixed. `prompt.sections` requires exactly `separator` and
 `stripSections`. Resource roots, disabled selectors, conflict policy, and the
 actual pack values are Product inputs to the bound operations, not hidden
 Harness configuration. The standard runtime binds one composition mechanism
-per slot; an ordered slot's multiple admitted content packs are passed to that
-mechanism and retain their own provenance.
+per slot; multiple admitted prompt sections or content packs are passed to the
+selected mechanism and retain their own provenance.
 
 ## Product Policy And Admission
 
@@ -65,8 +65,9 @@ authority.
 ## Durable And Refresh Rules
 
 The Product persists the pure resolved capability-profile snapshot separately
-from its conversation/runtime profile. The snapshot contains only selected
-implementation IDs, versions, JSON config, and provenance.
+from its conversation/runtime profile. The snapshot contains only the declared
+variation semantic, selected implementation IDs, versions, JSON config, and
+provenance.
 
 `resource.runtime` stays sealed for the session. Prompt, skill, tool-pack, and
 command-pack slots retain their declared turn refresh boundary, but a Product

--- a/docs/internals/architecture/harness/product-runtime-injection/components/capability-composition-binding.md
+++ b/docs/internals/architecture/harness/product-runtime-injection/components/capability-composition-binding.md
@@ -18,18 +18,18 @@ It satisfies PDRI-001, PDRI-004, PDRI-008, PDRI-009, PDRI-010, and PDRI-011.
 
 ## Standard Slots
 
-| Slot | Shape / lifecycle | Sources | Meaning |
+| Slot | Shape / semantic / lifecycle | Sources | Meaning |
 | --- | --- | --- | --- |
-| `resource.runtime` | single, workspace, sealed | Product, OEM | Resource discovery/materialization implementation. Content may refresh; the backend cannot hot-swap inside a Session. |
-| `prompt.sections` | ordered, session, turn-refreshable | Product, OEM, approved extension, session | Prepared prompt section providers. |
-| `skill.activation` | single, session, turn-refreshable | Product, OEM, approved extension, session | The policy that decides which discovered skills are active and model-visible. |
-| `tool.packs` | ordered, session, turn-refreshable | Product, OEM, approved extension | Definitions/materializers to contribute; a session cannot inject an executable handler. |
-| `command.packs` | ordered, session, turn-refreshable | Product, OEM, approved extension | Command descriptors and handlers; a session cannot inject an executable handler. |
+| `resource.runtime` | single, Exclusive Replacement, workspace, sealed | Product, OEM | Resource discovery/materialization implementation. Content may refresh; the backend cannot hot-swap inside a Session. |
+| `prompt.sections` | single, Exclusive Replacement, session, turn-refreshable | Product, OEM, approved extension, session | One prepared-prompt composer; its admitted section inputs are Aggregate Contributions. |
+| `skill.activation` | single, Exclusive Replacement, session, turn-refreshable | Product, OEM, approved extension, session | The policy that decides which discovered skills are active and model-visible. |
+| `tool.packs` | single, Exclusive Replacement, session, turn-refreshable | Product, OEM, approved extension | One pack composer; its admitted tool-pack inputs are Aggregate Contributions. |
+| `command.packs` | single, Exclusive Replacement, session, turn-refreshable | Product, OEM, approved extension | One pack composer; its admitted command-pack inputs are Aggregate Contributions. |
 
-An ordered slot retains contributor order after source/layer/selection ordering;
-the concrete pack runtime owns duplicate-name conflict rules. `tool.packs` and
-`command.packs` deliberately exclude session selection because a session
-setting must not acquire executable authority.
+The selected prompt or pack composer retains its input contribution order and
+owns its duplicate-name conflict rules. `tool.packs` and `command.packs`
+deliberately exclude session selection because a session setting must not
+acquire executable authority.
 
 ## Admission
 
@@ -88,9 +88,9 @@ defines its resume contract.
 
 ## Durable And Refresh Rules
 
-The resolved profile snapshot records implementation ID, version, JSON
-configuration, and layer provenance. It never records live factories, handler
-callables, credentials, or arbitrary extension objects.
+The resolved profile snapshot records variation semantic, implementation ID,
+version, JSON configuration, and layer provenance. It never records live
+factories, handler callables, credentials, or arbitrary extension objects.
 
 `resource.runtime` is sealed for the Session. Refreshing resources must keep
 the selected backend and atomically retain the last valid materialized bundle

--- a/docs/internals/architecture/harness/product-runtime-injection/components/runtime-profile-resolution.md
+++ b/docs/internals/architecture/harness/product-runtime-injection/components/runtime-profile-resolution.md
@@ -67,11 +67,11 @@ provider instance, or a Product object.
 The first shared vocabulary is deliberately limited to these neutral slot
 identifiers:
 
-| Slot | Shape | Refresh | Intended contract owner |
-| --- | --- | --- | --- |
-| `conversation.store` | single | sealed | `harness.storage` |
-| `agent.transcript_profile` | single | sealed | `harness.transcript` |
-| `context.compaction` | single | turn | `harness.context` |
+| Slot | Shape | Variation semantic | Refresh | Intended contract owner |
+| --- | --- | --- | --- | --- |
+| `conversation.store` | single | Exclusive Replacement | sealed | `harness.storage` |
+| `agent.transcript_profile` | single | Exclusive Replacement | sealed | `harness.transcript` |
+| `context.compaction` | single | Exclusive Replacement | turn | `harness.context` |
 
 The vocabulary does not import or prescribe an implementation. A Product can
 bind a memory, file, database, or OEM store factory only when its plan and
@@ -92,7 +92,10 @@ sort by priority, implementation key, version, and canonical JSON
 configuration. The resolver never uses discovery order or factory side
 effects.
 
-- A `single` or `exclusive` slot chooses the final authorized selection.
+- A `single` or `exclusive` slot retains only the final authorized selection
+  under the declared source/layer/selection precedence. When its variation
+  semantic is Exclusive Replacement, that selected implementation is the only
+  active provider.
 - An `ordered` slot replaces an earlier selection with the same
   `(implementation, version)` identity while retaining a deterministic
   sequence for distinct identities.
@@ -100,7 +103,14 @@ effects.
   identities, in deterministic order.
 - An undeclared slot, forbidden source, duplicate source/layer identity, or
   ambiguous single selection fails with `RuntimeProfileDiagnostic` values.
-- Missing required slots fail rather than falling back implicitly.
+- Missing required slots and failed bindings fail rather than falling back
+  implicitly.
+
+`RuntimeCapabilitySlot.variation_semantic` separately declares
+`aggregate_contribution`, `ordered_interception`, or `exclusive_replacement`.
+Non-Product or multi-value surfaces must provide it, and the slot constructor
+rejects shape/semantic combinations that cannot be executed by the generic
+resolver and binder.
 
 The resolver accepts `RuntimeProfileLayer` data; it does not decide whether a
 particular extension is trusted. Extension manifests, permissions, dependency
@@ -111,9 +121,12 @@ to the resolver (PDRI-003, PDRI-009).
 
 `ResolvedRuntimeProfile.snapshot()` produces `RuntimeProfileSnapshot` schema
 version 1. The JSON form records the Product, slot shape/scope/refresh boundary,
-selected implementation key/version/configuration, and source-layer
-provenance. `RuntimeProfileSnapshot.from_json()` validates that the entire
-payload is strict JSON and rejects boolean or malformed version values.
+variation semantic, selected implementation key/version/configuration, and
+source-layer provenance. The variation field is an additive schema-v1 field:
+legacy snapshots without it remain readable and Product resume validation
+normalizes them against the current declared slot contract.
+`RuntimeProfileSnapshot.from_json()` validates that the payload is strict JSON
+and rejects boolean or malformed version values.
 
 The snapshot is evidence of what a current Loushang session used; it is not a
 factory registry and is not an implicit compatibility importer. Native load

--- a/docs/internals/glossary/loushang-product.md
+++ b/docs/internals/glossary/loushang-product.md
@@ -333,7 +333,9 @@ admitted capability catalog and policy.
 
 A Product-declared location at which one or more implementations of a
 Capability may bind. The slot defines composition shape, lifecycle scope,
-refresh boundary, and allowed contribution sources.
+refresh boundary, and allowed contribution sources. When the slot exposes
+replaceable or composable behavior, `variation_semantic` separately records
+Aggregate Contribution, Ordered Interception, or Exclusive Replacement.
 
 ### Runtime Capability Shape
 
@@ -392,11 +394,12 @@ layer.
 ### Exclusive Replacement
 
 A composition semantic in which exactly one admitted provider is active for a
-declared variation surface. Selection is explicit and explainable; ambiguous
-candidates are rejected instead of being resolved by silent last-write-wins
-behavior. When profile-bound, Runtime Capability Shape independently governs
-selection retention and refresh. Any fallback is selected by the owning
-Product or Platform policy.
+declared variation surface. Selection is explicit and explainable: the owning
+surface may define deterministic precedence, require a named provider, or
+reject candidates that its policy cannot disambiguate. It must not rely on
+incidental last-write or discovery order. When profile-bound, Runtime
+Capability Shape independently governs selection retention and refresh. Any
+fallback is selected by the owning Product or Platform policy.
 
 ### Protocol Injection
 

--- a/src/loushang/coding/session_manager.py
+++ b/src/loushang/coding/session_manager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 from loushang.coding.product_plan import (
     CODING_CAPABILITY_PROFILE,
     CODING_CAPABILITY_PROFILE_METADATA_KEY,
@@ -60,8 +62,12 @@ def _validate_coding_restored_header(
         )
     current_capability_snapshot = CODING_CAPABILITY_PROFILE.snapshot()
     if persist and _selected_capabilities(
-        capability_snapshot
-    ) != _selected_capabilities(current_capability_snapshot):
+        capability_snapshot,
+        current=current_capability_snapshot,
+    ) != _selected_capabilities(
+        current_capability_snapshot,
+        current=current_capability_snapshot,
+    ):
         raise ValueError(
             "Coding cannot resume a session with an unsupported capability profile"
         )
@@ -69,11 +75,25 @@ def _validate_coding_restored_header(
 
 def _selected_capabilities(
     snapshot: RuntimeProfileSnapshot,
+    *,
+    current: RuntimeProfileSnapshot,
 ) -> tuple[RuntimeProfileSnapshotCapability, ...]:
     """Compare continuity-critical slots; auxiliary interaction is additive."""
 
+    current_capabilities = {
+        capability.slot: capability for capability in current.capabilities
+    }
     return tuple(
-        capability
+        replace(
+            capability,
+            shape=current_capabilities[capability.slot].shape,
+            variation_semantic=current_capabilities[
+                capability.slot
+            ].variation_semantic,
+        )
+        if capability.variation_semantic is None
+        and capability.slot in current_capabilities
+        else capability
         for capability in snapshot.capabilities
         if capability.selections
         and capability.slot != SIDE_QUESTION_PROVIDER_SLOT.key

--- a/src/loushang/harness/runtime/__init__.py
+++ b/src/loushang/harness/runtime/__init__.py
@@ -41,6 +41,7 @@ from loushang.harness.runtime.profile import (
     RuntimeCapabilitySelection,
     RuntimeCapabilityShape,
     RuntimeCapabilitySlot,
+    RuntimeCapabilityVariationSemantic,
     RuntimeProfileAdmission,
     RuntimeProfileAdmissionPolicy,
     RuntimeProfileBinder,
@@ -59,6 +60,7 @@ from loushang.harness.runtime.profile import (
     SealedRuntimeCapabilityError,
     standard_agent_session_slots,
     standard_capability_composition_slots,
+    standard_runtime_capability_slots,
 )
 from loushang.harness.runtime.retry import RetryCoordinator, RetryPolicy
 from loushang.harness.runtime.scheduling import CoalescingScheduler
@@ -129,6 +131,7 @@ __all__ = [
     "RuntimeCapabilitySelection",
     "RuntimeCapabilityShape",
     "RuntimeCapabilitySlot",
+    "RuntimeCapabilityVariationSemantic",
     "RuntimeProfileBinder",
     "RuntimeProfileBinding",
     "RuntimeProfileBindings",
@@ -177,4 +180,5 @@ __all__ = [
     "stage_file_import",
     "standard_agent_session_slots",
     "standard_capability_composition_slots",
+    "standard_runtime_capability_slots",
 ]

--- a/src/loushang/harness/runtime/_profile_standard.py
+++ b/src/loushang/harness/runtime/_profile_standard.py
@@ -9,6 +9,7 @@ from loushang.harness.runtime._profile_types import (
 CONVERSATION_STORE_SLOT = RuntimeCapabilitySlot(
     key="conversation.store",
     shape="single",
+    variation_semantic="exclusive_replacement",
     scope="session",
     refresh_boundary="sealed",
     allowed_sources=frozenset({"product", "oem"}),
@@ -16,6 +17,7 @@ CONVERSATION_STORE_SLOT = RuntimeCapabilitySlot(
 AGENT_TRANSCRIPT_PROFILE_SLOT = RuntimeCapabilitySlot(
     key="agent.transcript_profile",
     shape="single",
+    variation_semantic="exclusive_replacement",
     scope="session",
     refresh_boundary="sealed",
     allowed_sources=frozenset({"product", "oem"}),
@@ -23,6 +25,7 @@ AGENT_TRANSCRIPT_PROFILE_SLOT = RuntimeCapabilitySlot(
 CONTEXT_COMPACTION_SLOT = RuntimeCapabilitySlot(
     key="context.compaction",
     shape="single",
+    variation_semantic="exclusive_replacement",
     scope="session",
     refresh_boundary="turn",
     allowed_sources=frozenset({"product", "oem", "extension", "session"}),
@@ -30,13 +33,15 @@ CONTEXT_COMPACTION_SLOT = RuntimeCapabilitySlot(
 RESOURCE_RUNTIME_SLOT = RuntimeCapabilitySlot(
     key="resource.runtime",
     shape="single",
+    variation_semantic="exclusive_replacement",
     scope="workspace",
     refresh_boundary="sealed",
     allowed_sources=frozenset({"product", "oem"}),
 )
 PROMPT_SECTIONS_SLOT = RuntimeCapabilitySlot(
     key="prompt.sections",
-    shape="ordered",
+    shape="single",
+    variation_semantic="exclusive_replacement",
     scope="session",
     refresh_boundary="turn",
     allowed_sources=frozenset({"product", "oem", "extension", "session"}),
@@ -44,20 +49,23 @@ PROMPT_SECTIONS_SLOT = RuntimeCapabilitySlot(
 SKILL_ACTIVATION_SLOT = RuntimeCapabilitySlot(
     key="skill.activation",
     shape="single",
+    variation_semantic="exclusive_replacement",
     scope="session",
     refresh_boundary="turn",
     allowed_sources=frozenset({"product", "oem", "extension", "session"}),
 )
 TOOL_PACKS_SLOT = RuntimeCapabilitySlot(
     key="tool.packs",
-    shape="ordered",
+    shape="single",
+    variation_semantic="exclusive_replacement",
     scope="session",
     refresh_boundary="turn",
     allowed_sources=frozenset({"product", "oem", "extension"}),
 )
 COMMAND_PACKS_SLOT = RuntimeCapabilitySlot(
     key="command.packs",
-    shape="ordered",
+    shape="single",
+    variation_semantic="exclusive_replacement",
     scope="session",
     refresh_boundary="turn",
     allowed_sources=frozenset({"product", "oem", "extension"}),
@@ -65,6 +73,7 @@ COMMAND_PACKS_SLOT = RuntimeCapabilitySlot(
 SIDE_QUESTION_PROVIDER_SLOT = RuntimeCapabilitySlot(
     key="interaction.side_question",
     shape="single",
+    variation_semantic="exclusive_replacement",
     scope="session",
     refresh_boundary="sealed",
     allowed_sources=frozenset({"product", "oem", "extension"}),
@@ -73,6 +82,7 @@ SIDE_QUESTION_PROVIDER_SLOT = RuntimeCapabilitySlot(
 CONTINUITY_PROVIDER_PACKS_SLOT = RuntimeCapabilitySlot(
     key="continuity.provider_packs",
     shape="ordered",
+    variation_semantic="aggregate_contribution",
     scope="process",
     refresh_boundary="sealed",
     allowed_sources=frozenset({"product", "oem"}),
@@ -102,3 +112,9 @@ def standard_capability_composition_slots() -> tuple[RuntimeCapabilitySlot, ...]
         SIDE_QUESTION_PROVIDER_SLOT,
         CONTINUITY_PROVIDER_PACKS_SLOT,
     )
+
+
+def standard_runtime_capability_slots() -> tuple[RuntimeCapabilitySlot, ...]:
+    """Return the complete standard Runtime Capability semantic inventory."""
+
+    return standard_agent_session_slots() + standard_capability_composition_slots()

--- a/src/loushang/harness/runtime/_profile_types.py
+++ b/src/loushang/harness/runtime/_profile_types.py
@@ -10,6 +10,11 @@ from loushang.protocol import JSONValue, require_json_mapping
 
 RuntimeProfileSource = Literal["product", "oem", "extension", "session"]
 RuntimeCapabilityShape = Literal["single", "ordered", "exclusive", "append_only"]
+RuntimeCapabilityVariationSemantic = Literal[
+    "aggregate_contribution",
+    "ordered_interception",
+    "exclusive_replacement",
+]
 RuntimeCapabilityScope = Literal[
     "process", "tenant", "workspace", "session", "turn", "channel"
 ]
@@ -21,10 +26,19 @@ _SOURCES: frozenset[RuntimeProfileSource] = frozenset(
 _SHAPES: frozenset[RuntimeCapabilityShape] = frozenset(
     {"single", "ordered", "exclusive", "append_only"}
 )
+_VARIATION_SEMANTICS: frozenset[RuntimeCapabilityVariationSemantic] = frozenset(
+    {
+        "aggregate_contribution",
+        "ordered_interception",
+        "exclusive_replacement",
+    }
+)
 _SCOPES: frozenset[RuntimeCapabilityScope] = frozenset(
     {"process", "tenant", "workspace", "session", "turn", "channel"}
 )
 _REFRESH_BOUNDARIES: frozenset[RuntimeRefreshBoundary] = frozenset({"sealed", "turn"})
+
+
 def _require_nonempty_string(value: object, *, name: str) -> str:
     if not isinstance(value, str) or not value:
         raise ValueError(f"{name} must be a non-empty string")
@@ -65,6 +79,7 @@ class RuntimeCapabilitySlot:
     refresh_boundary: RuntimeRefreshBoundary
     allowed_sources: frozenset[RuntimeProfileSource]
     required: bool = True
+    variation_semantic: RuntimeCapabilityVariationSemantic | None = None
 
     def __post_init__(self) -> None:
         _require_nonempty_string(self.key, name="slot key")
@@ -84,6 +99,36 @@ class RuntimeCapabilitySlot:
             _require_choice(source, name="slot allowed source", choices=_SOURCES)
         if self.shape == "exclusive" and self.refresh_boundary != "sealed":
             raise ValueError("exclusive slots must use the sealed refresh boundary")
+        if self.variation_semantic is not None:
+            _require_choice(
+                self.variation_semantic,
+                name="slot variation semantic",
+                choices=_VARIATION_SEMANTICS,
+            )
+        if (
+            sources != frozenset({"product"})
+            or self.shape in {"ordered", "append_only"}
+        ) and self.variation_semantic is None:
+            raise ValueError(
+                "externally variable or multi-value slots must declare a variation "
+                "semantic"
+            )
+        if (
+            self.variation_semantic == "exclusive_replacement"
+            and self.shape not in {"single", "exclusive"}
+        ):
+            raise ValueError(
+                "exclusive replacement requires a single or exclusive slot shape"
+            )
+        if (
+            self.variation_semantic
+            in {"aggregate_contribution", "ordered_interception"}
+            and self.shape not in {"ordered", "append_only"}
+        ):
+            raise ValueError(
+                "aggregate contribution and ordered interception require an "
+                "ordered or append_only slot shape"
+            )
         object.__setattr__(self, "allowed_sources", sources)
 
 
@@ -319,6 +364,7 @@ class RuntimeProfileSnapshotCapability:
     scope: RuntimeCapabilityScope
     refresh_boundary: RuntimeRefreshBoundary
     selections: tuple[RuntimeProfileSnapshotSelection, ...]
+    variation_semantic: RuntimeCapabilityVariationSemantic | None = None
 
     def __post_init__(self) -> None:
         _require_nonempty_string(self.slot, name="snapshot slot")
@@ -329,6 +375,12 @@ class RuntimeProfileSnapshotCapability:
             name="snapshot refresh boundary",
             choices=_REFRESH_BOUNDARIES,
         )
+        if self.variation_semantic is not None:
+            _require_choice(
+                self.variation_semantic,
+                name="snapshot variation semantic",
+                choices=_VARIATION_SEMANTICS,
+            )
         selections = tuple(self.selections)
         if any(
             not isinstance(selection, RuntimeProfileSnapshotSelection)
@@ -358,6 +410,15 @@ class RuntimeProfileSnapshotCapability:
                 name=f"{name}.refreshBoundary",
                 choices=_REFRESH_BOUNDARIES,
             ),
+            variation_semantic=(
+                _require_choice(
+                    mapping.get("variationSemantic"),
+                    name=f"{name}.variationSemantic",
+                    choices=_VARIATION_SEMANTICS,
+                )
+                if mapping.get("variationSemantic") is not None
+                else None
+            ),
             selections=tuple(
                 RuntimeProfileSnapshotSelection.from_json(
                     selection, name=f"{name}.selections[{index}]"
@@ -367,13 +428,16 @@ class RuntimeProfileSnapshotCapability:
         )
 
     def to_json(self) -> dict[str, JSONValue]:
-        return {
+        result: dict[str, JSONValue] = {
             "slot": self.slot,
             "shape": self.shape,
             "scope": self.scope,
             "refreshBoundary": self.refresh_boundary,
             "selections": [selection.to_json() for selection in self.selections],
         }
+        if self.variation_semantic is not None:
+            result["variationSemantic"] = self.variation_semantic
+        return result
 
 
 @dataclass(frozen=True)
@@ -483,6 +547,7 @@ class ResolvedRuntimeProfile:
                     shape=capability.slot.shape,
                     scope=capability.slot.scope,
                     refresh_boundary=capability.slot.refresh_boundary,
+                    variation_semantic=capability.slot.variation_semantic,
                     selections=tuple(
                         RuntimeProfileSnapshotSelection(
                             implementation=resolved.selection.implementation,

--- a/src/loushang/harness/runtime/profile.py
+++ b/src/loushang/harness/runtime/profile.py
@@ -32,6 +32,7 @@ from loushang.harness.runtime._profile_standard import (
     TOOL_PACKS_SLOT,
     standard_agent_session_slots,
     standard_capability_composition_slots,
+    standard_runtime_capability_slots,
 )
 from loushang.harness.runtime._profile_types import (
     ProductRuntimePlan,
@@ -42,6 +43,7 @@ from loushang.harness.runtime._profile_types import (
     RuntimeCapabilitySelection,
     RuntimeCapabilityShape,
     RuntimeCapabilitySlot,
+    RuntimeCapabilityVariationSemantic,
     RuntimeProfileDiagnostic,
     RuntimeProfileLayer,
     RuntimeProfileResolutionError,
@@ -70,6 +72,7 @@ __all__ = [
     "RuntimeCapabilitySelection",
     "RuntimeCapabilityShape",
     "RuntimeCapabilitySlot",
+    "RuntimeCapabilityVariationSemantic",
     "RuntimeProfileBinder",
     "RuntimeProfileBinding",
     "RuntimeProfileBindings",
@@ -92,4 +95,5 @@ __all__ = [
     "TOOL_PACKS_SLOT",
     "standard_agent_session_slots",
     "standard_capability_composition_slots",
+    "standard_runtime_capability_slots",
 ]

--- a/src/loushang/harness/transcript/runtime_profile.py
+++ b/src/loushang/harness/transcript/runtime_profile.py
@@ -182,11 +182,12 @@ class AgentTranscriptProfileRuntime:
         require_current: bool,
     ) -> RuntimeProfileSnapshot | None:
         snapshot = self.read_snapshot(metadata)
+        current_snapshot = profile.snapshot()
         if (
             require_current
             and snapshot is not None
-            and self._normalize_snapshot(snapshot)
-            != self._normalize_snapshot(profile.snapshot())
+            and self._normalize_snapshot(snapshot, current=current_snapshot)
+            != self._normalize_snapshot(current_snapshot, current=current_snapshot)
         ):
             raise ValueError(
                 f"{self.spec.product_name} cannot resume a session with an "
@@ -197,11 +198,25 @@ class AgentTranscriptProfileRuntime:
     def _normalize_snapshot(
         self,
         snapshot: RuntimeProfileSnapshot,
+        *,
+        current: RuntimeProfileSnapshot,
     ) -> RuntimeProfileSnapshot:
         """Canonicalize pre-release aliases without weakening profile checks."""
 
+        current_capabilities = {
+            capability.slot: capability for capability in current.capabilities
+        }
         capabilities = []
         for capability in snapshot.capabilities:
+            current_capability = current_capabilities.get(capability.slot)
+            if (
+                capability.variation_semantic is None
+                and current_capability is not None
+            ):
+                capability = replace(
+                    capability,
+                    variation_semantic=current_capability.variation_semantic,
+                )
             if capability.slot != _TRANSCRIPT_SLOT:
                 capabilities.append(capability)
                 continue

--- a/tests/coding/test_runtime_profile.py
+++ b/tests/coding/test_runtime_profile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from copy import deepcopy
 from dataclasses import replace
 
 import pytest
@@ -157,6 +158,47 @@ def test_persistent_session_accepts_snapshot_without_auxiliary_side_question(
                 CODING_CAPABILITY_PROFILE_METADATA_KEY: capability_snapshot,
             },
         )
+        write_session_file(manager.session_file, header, manager.get_entries())
+        await manager.dispose_runtime_profile()
+
+        resumed = await SessionManager.load(manager.session_file, persist=True)
+        await resumed.dispose_runtime_profile()
+
+    asyncio.run(scenario())
+
+
+def test_persistent_session_accepts_legacy_capability_semantic_snapshot(
+    tmp_path,
+) -> None:
+    async def scenario() -> None:
+        manager = await SessionManager.new(
+            session_dir=tmp_path,
+            cwd="/tmp/project",
+            persist=True,
+        )
+        assert manager.session_file is not None
+        await manager.append_message(
+            UserMessage(role="user", content="materialize", timestamp=0.0)
+        )
+        metadata = deepcopy(dict(manager.header.metadata))
+        for metadata_key in (
+            CODING_RUNTIME_PROFILE_METADATA_KEY,
+            CODING_CAPABILITY_PROFILE_METADATA_KEY,
+        ):
+            snapshot = metadata[metadata_key]
+            assert isinstance(snapshot, dict)
+            capabilities = snapshot["capabilities"]
+            assert isinstance(capabilities, list)
+            for capability in capabilities:
+                assert isinstance(capability, dict)
+                capability.pop("variationSemantic")
+                if capability["slot"] in {
+                    "prompt.sections",
+                    "tool.packs",
+                    "command.packs",
+                }:
+                    capability["shape"] = "ordered"
+        header = replace(manager.header, metadata=metadata)
         write_session_file(manager.session_file, header, manager.get_entries())
         await manager.dispose_runtime_profile()
 

--- a/tests/harness/runtime/test_profile.py
+++ b/tests/harness/runtime/test_profile.py
@@ -30,6 +30,7 @@ from loushang.harness.runtime import (
     RuntimeProfileSnapshot,
     SealedRuntimeCapabilityError,
     standard_capability_composition_slots,
+    standard_runtime_capability_slots,
 )
 
 
@@ -150,6 +151,41 @@ def test_resolver_rejects_undeclared_and_unauthorized_layers_with_diagnostics() 
     }
 
 
+def test_exclusive_replacement_uses_runtime_profile_precedence() -> None:
+    profile = RuntimeProfileResolver().resolve(
+        _agent_plan(),
+        layers=(
+            RuntimeProfileLayer(
+                source="session",
+                layer_id="session:compact",
+                selections=(
+                    RuntimeCapabilitySelection(
+                        slot="context.compaction",
+                        implementation="session-compact",
+                        implementation_version=1,
+                    ),
+                ),
+            ),
+            RuntimeProfileLayer(
+                source="extension",
+                layer_id="extension:compact",
+                selections=(
+                    RuntimeCapabilitySelection(
+                        slot="context.compaction",
+                        implementation="extension-compact",
+                        implementation_version=1,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    selected = profile.capability("context.compaction").selections
+    assert len(selected) == 1
+    assert selected[0].selection.implementation == "session-compact"
+    assert selected[0].source == "session"
+
+
 def test_ordered_replaces_same_identity_while_append_only_keeps_every_contribution() -> (
     None
 ):
@@ -159,6 +195,7 @@ def test_ordered_replaces_same_identity_while_append_only_keeps_every_contributi
         scope="session",
         refresh_boundary="sealed",
         allowed_sources=frozenset({"product", "extension"}),
+        variation_semantic="aggregate_contribution",
     )
     append_slot = RuntimeCapabilitySlot(
         key="audit.observers",
@@ -166,10 +203,19 @@ def test_ordered_replaces_same_identity_while_append_only_keeps_every_contributi
         scope="session",
         refresh_boundary="sealed",
         allowed_sources=frozenset({"product", "extension"}),
+        variation_semantic="aggregate_contribution",
+    )
+    interceptor_slot = RuntimeCapabilitySlot(
+        key="policy.interceptors",
+        shape="ordered",
+        scope="session",
+        refresh_boundary="sealed",
+        allowed_sources=frozenset({"product", "extension"}),
+        variation_semantic="ordered_interception",
     )
     plan = ProductRuntimePlan(
         product_id="research",
-        slots=(ordered_slot, append_slot),
+        slots=(ordered_slot, append_slot, interceptor_slot),
         defaults=(
             RuntimeCapabilitySelection(
                 slot="prompt.sections",
@@ -180,6 +226,11 @@ def test_ordered_replaces_same_identity_while_append_only_keeps_every_contributi
             RuntimeCapabilitySelection(
                 slot="audit.observers",
                 implementation="history",
+                implementation_version=1,
+            ),
+            RuntimeCapabilitySelection(
+                slot="policy.interceptors",
+                implementation="authorization",
                 implementation_version=1,
             ),
         ),
@@ -203,6 +254,11 @@ def test_ordered_replaces_same_identity_while_append_only_keeps_every_contributi
                         implementation="history",
                         implementation_version=1,
                     ),
+                    RuntimeCapabilitySelection(
+                        slot="policy.interceptors",
+                        implementation="tracing",
+                        implementation_version=1,
+                    ),
                 ),
             ),
         ),
@@ -212,6 +268,68 @@ def test_ordered_replaces_same_identity_while_append_only_keeps_every_contributi
         "title": "Cited sources"
     }
     assert len(profile.capability("audit.observers").selections) == 2
+    assert [
+        selection.selection.implementation
+        for selection in profile.capability("policy.interceptors").selections
+    ] == ["authorization", "tracing"]
+
+
+def test_failed_external_replacement_does_not_implicitly_bind_product_baseline() -> (
+    None
+):
+    created: list[str] = []
+
+    def create_product(
+        selection: RuntimeCapabilitySelection,
+        context: object | None,
+    ) -> str:
+        del context
+        created.append(selection.implementation)
+        return selection.implementation
+
+    plan = ProductRuntimePlan(
+        product_id="research",
+        slots=(CONVERSATION_STORE_SLOT,),
+        defaults=(
+            RuntimeCapabilitySelection(
+                slot="conversation.store",
+                implementation="product-store",
+                implementation_version=1,
+            ),
+        ),
+    )
+    profile = RuntimeProfileResolver().resolve(
+        plan,
+        layers=(
+            RuntimeProfileLayer(
+                source="oem",
+                layer_id="oem:store",
+                selections=(
+                    RuntimeCapabilitySelection(
+                        slot="conversation.store",
+                        implementation="oem-store",
+                        implementation_version=1,
+                    ),
+                ),
+            ),
+        ),
+    )
+    binder = RuntimeProfileBinder(
+        RuntimeCapabilityRegistry(
+            (
+                RuntimeCapabilityImplementation(
+                    slot="conversation.store",
+                    implementation="product-store",
+                    implementation_version=1,
+                    create=create_product,
+                ),
+            )
+        )
+    )
+
+    with pytest.raises(RuntimeCapabilityBindingError, match="oem-store"):
+        binder.bind_sync(profile)
+    assert created == []
 
 
 def test_binder_refreshes_turn_safe_slots_and_invalidates_prior_leases() -> None:
@@ -460,6 +578,60 @@ def test_snapshot_rejects_boolean_versions_instead_of_treating_them_as_integers(
         )
 
 
+def test_snapshot_records_variation_semantics_and_reads_legacy_capabilities() -> None:
+    profile_snapshot = RuntimeProfileResolver().resolve(_agent_plan()).snapshot()
+    payload = profile_snapshot.to_json()
+
+    capabilities = payload["capabilities"]
+    assert isinstance(capabilities, list)
+    assert isinstance(capabilities[0], dict)
+    assert capabilities[0]["variationSemantic"] == "exclusive_replacement"
+    assert RuntimeProfileSnapshot.from_json(payload) == profile_snapshot
+
+    legacy_payload = profile_snapshot.to_json()
+    legacy_capabilities = legacy_payload["capabilities"]
+    assert isinstance(legacy_capabilities, list)
+    for capability in legacy_capabilities:
+        assert isinstance(capability, dict)
+        capability.pop("variationSemantic")
+    legacy_snapshot = RuntimeProfileSnapshot.from_json(legacy_payload)
+    assert all(
+        capability.variation_semantic is None
+        for capability in legacy_snapshot.capabilities
+    )
+
+
+def test_variable_slots_require_shape_compatible_variation_semantics() -> None:
+    with pytest.raises(ValueError, match="must declare a variation semantic"):
+        RuntimeCapabilitySlot(
+            key="replaceable",
+            shape="single",
+            scope="session",
+            refresh_boundary="sealed",
+            allowed_sources=frozenset({"product", "oem"}),
+        )
+
+    with pytest.raises(ValueError, match="single or exclusive"):
+        RuntimeCapabilitySlot(
+            key="invalid-replacement",
+            shape="ordered",
+            scope="session",
+            refresh_boundary="sealed",
+            allowed_sources=frozenset({"product"}),
+            variation_semantic="exclusive_replacement",
+        )
+
+    with pytest.raises(ValueError, match="ordered or append_only"):
+        RuntimeCapabilitySlot(
+            key="invalid-aggregate",
+            shape="single",
+            scope="session",
+            refresh_boundary="sealed",
+            allowed_sources=frozenset({"product"}),
+            variation_semantic="aggregate_contribution",
+        )
+
+
 def test_sync_binder_rejects_async_factories_without_creating_an_event_loop() -> None:
     slot = RuntimeCapabilitySlot(
         key="pure",
@@ -544,6 +716,28 @@ def test_capability_composition_slots_have_deliberate_source_boundaries() -> Non
     assert slots["continuity.provider_packs"].allowed_sources == frozenset(
         {"product", "oem"}
     )
+    assert slots["prompt.sections"].shape == "single"
+    assert slots["tool.packs"].shape == "single"
+    assert slots["command.packs"].shape == "single"
+
+
+def test_standard_slots_have_one_explicit_variation_semantic() -> None:
+    slots = {slot.key: slot for slot in standard_runtime_capability_slots()}
+
+    assert {
+        key: slot.variation_semantic for key, slot in slots.items()
+    } == {
+        "conversation.store": "exclusive_replacement",
+        "agent.transcript_profile": "exclusive_replacement",
+        "context.compaction": "exclusive_replacement",
+        "resource.runtime": "exclusive_replacement",
+        "prompt.sections": "exclusive_replacement",
+        "skill.activation": "exclusive_replacement",
+        "tool.packs": "exclusive_replacement",
+        "command.packs": "exclusive_replacement",
+        "interaction.side_question": "exclusive_replacement",
+        "continuity.provider_packs": "aggregate_contribution",
+    }
 
 
 def test_admission_requires_an_explicit_grant_and_slot_permission() -> None:

--- a/tests/harness/transcript/test_runtime_profile.py
+++ b/tests/harness/transcript/test_runtime_profile.py
@@ -96,6 +96,27 @@ def test_product_runtime_accepts_pre_release_current_format_alias() -> None:
     )
 
 
+def test_product_runtime_accepts_legacy_snapshot_without_variation_semantics() -> None:
+    runtime = _runtime()
+    profile = runtime.resolve(persist=True)
+    metadata = runtime.snapshot_metadata(profile)
+    persisted = metadata["runtimeProfile"]
+    assert isinstance(persisted, dict)
+    capabilities = persisted["capabilities"]
+    assert isinstance(capabilities, list)
+    for capability in capabilities:
+        assert isinstance(capability, dict)
+        capability.pop("variationSemantic")
+
+    restored = runtime.validate_snapshot(metadata, profile, require_current=True)
+
+    assert restored is not None
+    assert all(
+        capability.variation_semantic is None
+        for capability in restored.capabilities
+    )
+
+
 def test_product_runtime_rejects_another_products_snapshot() -> None:
     research = _runtime("research")
     design = _runtime("design")


### PR DESCRIPTION
## Summary

- add explicit Runtime Capability variation semantics for aggregate contribution, ordered interception, and exclusive replacement
- align the standard prompt/tool/command composer slots with their single-implementation consumers while preserving nested contribution aggregation
- persist variation semantics in runtime-profile snapshots and normalize legacy snapshots during Transcript and Coding resume
- update the canonical glossary and Harness architecture documents with the executable standard-slot inventory

## Why

Runtime Capability Shape describes how selections are retained, while variation semantics describe how the resolved behavior interacts. Those axes were documented but not represented independently in the runtime contract, and three composer slots were declared as multi-value even though their consumers required one implementation.

Exclusive Replacement remains independent from candidate conflict policy: `single` and `exclusive` slots continue to use the existing deterministic source/layer/selection precedence. This change does not reject multiple external layers merely because the final behavior is an exclusive replacement, and it does not add implicit binding fallback.

## Validation

- Ruff checks passed
- mypy passed for 438 Harness and Coding source files
- 42 focused Runtime, Capabilities, Continuity, Transcript, Coding, and snapshot compatibility tests passed
- `git diff --check` passed
