### PR TITLE
fix(coding): harden LSP capability handling

### DIFF
--- a/src/loushang/coding/lsp/discovery.py
+++ b/src/loushang/coding/lsp/discovery.py
@@ -348,7 +348,7 @@ def _load_config(path: Path, *, source: str) -> tuple[_Declaration, ...]:
     for index, value in enumerate(servers):
         try:
             declarations.append(_parse_declaration(value, source=source))
-        except (TypeError, ValueError) as exc:
+        except (OverflowError, TypeError, ValueError) as exc:
             definition_id = (
                 value.get("id")
                 if isinstance(value, Mapping) and isinstance(value.get("id"), str)

--- a/src/loushang/coding/lsp/tools.py
+++ b/src/loushang/coding/lsp/tools.py
@@ -206,6 +206,21 @@ class CodingLspTools:
             correlation_id=correlation_id,
             signal=signal,
         )
+        if not _supports_capability(
+            runtime.client.server_capabilities,
+            "documentSymbolProvider",
+        ):
+            return DocumentOutlineResult(
+                items=(),
+                count=0,
+                truncated=False,
+                server_id=selection.definition_id,
+                document_version=None,
+                readiness="unsupported",
+                warnings=(
+                    "language server does not advertise document symbol support",
+                ),
+            )
         document = await self.documents.ensure_document(
             runtime,
             selection.file_path,

--- a/tests/coding/lsp/test_discovery.py
+++ b/tests/coding/lsp/test_discovery.py
@@ -198,6 +198,33 @@ def test_project_config_cannot_introduce_untrusted_executable(tmp_path: Path) ->
     assert "user-level" in snapshot.records[0].detail
 
 
+def test_config_rejects_timeout_too_large_to_convert(tmp_path: Path) -> None:
+    user_config = tmp_path / "user-lsp.json"
+    _write_config(
+        user_config,
+        [
+            {
+                "id": "overflowing-timeout",
+                "command": ["custom-lsp"],
+                "language_extensions": {"python": [".py"]},
+                "startup_timeout_seconds": 10**400,
+            }
+        ],
+    )
+
+    snapshot = discover_lsp_catalog(
+        workspace_root=tmp_path,
+        baseline_environment={"PATH": "/tools"},
+        global_config_path=user_config,
+        project_config_path=False,
+        include_product_defaults=False,
+    )
+
+    assert snapshot.admitted_count == 0
+    assert snapshot.records[0].definition_id == "overflowing-timeout"
+    assert snapshot.records[0].state == "rejected"
+
+
 def test_product_defaults_report_unavailable_without_installing_or_starting(
     tmp_path: Path,
 ) -> None:

--- a/tests/coding/lsp/test_fake_launcher_vertical_slice.py
+++ b/tests/coding/lsp/test_fake_launcher_vertical_slice.py
@@ -783,6 +783,38 @@ def test_document_outline_preserves_hierarchy_and_enforces_depth(
     asyncio.run(scenario())
 
 
+def test_document_outline_skips_unsupported_server_capability(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        (tmp_path / "pyproject.toml").touch()
+        source = tmp_path / "main.py"
+        source.touch()
+        files = {source.resolve(): "value = 1\n"}
+        launcher = FakeLauncher(
+            definition_result=None,
+            server_capabilities={"definitionProvider": True},
+        )
+        binding = _binding(tmp_path, launcher, files)
+
+        result = await binding.document_outline(
+            path="main.py",
+            correlation_id="unsupported-outline",
+        )
+
+        assert result.items == ()
+        assert result.count == 0
+        assert result.readiness == "unsupported"
+        assert result.document_version is None
+        assert result.warnings == (
+            "language server does not advertise document symbol support",
+        )
+        assert "textDocument/documentSymbol" not in launcher.handles[0].server.methods()
+        await binding.dispose()
+
+    asyncio.run(scenario())
+
+
 def test_concurrent_first_queries_single_flight_launch_and_document_open(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- return a bounded unsupported result when a server does not advertise document symbols
- reject overflowing timeout values as invalid LSP configuration
- preserve the existing lazy startup and optional capability boundaries

## Validation

- Ruff checks passed
- 2329 Coding tests passed