### PR TITLE
feat(coding): add session-local LSP runtime operations

### DIFF
--- a/docs/en/user-guide/README.md
+++ b/docs/en/user-guide/README.md
@@ -88,9 +88,30 @@ loushang lsp doctor
 ```
 
 Servers still start lazily on the first semantic query. `status` and `doctor`
-only inspect configuration and executable availability; they do not start or
-install a server. Loushang probes installed Pyright, TypeScript Language Server,
-rust-analyzer, gopls, and clangd defaults.
+have `scope=catalog`: they only inspect configuration and executable
+availability, and never construct a Session, start a Server, or install one.
+Loushang probes installed Pyright, TypeScript Language Server, rust-analyzer,
+gopls, and clangd defaults.
+
+Inside an interactive Coding Session, use the separate Session-local surface:
+
+```text
+/lsp status
+/lsp stop <server-id> <root>
+```
+
+`/lsp status` reports only Servers known to that Session, including lifecycle,
+open-document, request, timeout, replacement, and discarded-publication counts.
+It is read-only and does not start a Server. `/lsp stop` gracefully shuts down
+the exact Session-owned Server; the next semantic query may start a replacement.
+Embedding code can use `session.get_lsp_status()` and
+`await session.stop_lsp_server(...)` over the same bounded snapshot. The Session
+command is discoverable through the normal TUI and RPC command catalogs.
+
+Contributors with `pyright-langserver` already on `PATH` can run the optional
+real-server gate with `uv run pytest
+tests/integration/coding/test_pyright_lsp_live.py -q`; it skips when Pyright is
+absent and never installs it.
 
 Declare a custom server in `~/.loushang/coding/lsp.json`:
 

--- a/docs/internals/architecture/coding/lsp/candidate-components.md
+++ b/docs/internals/architecture/coding/lsp/candidate-components.md
@@ -156,14 +156,16 @@ src/loushang/coding/lsp/
   tools.py
   tool_pack.py
   binding.py
+  commands.py
   status.py
 ```
 
 This is a target mapping, not a requirement to create every module in the first
 commit. Small adjacent records may begin together and split only when the
 component boundary has independent behavior or state. `tool_pack.py` is a
-physical declaration owned by the logical `tools` component, not an eleventh
-component.
+physical declaration owned by the logical `tools` component; `commands.py` is
+the Coding Session projection of logical `status`, not an additional runtime
+owner.
 
 ## Rejected Candidate Components
 

--- a/docs/internals/architecture/coding/lsp/component-boundaries.md
+++ b/docs/internals/architecture/coding/lsp/component-boundaries.md
@@ -436,8 +436,13 @@ Read-only snapshots from `catalog`, `supervisor`, `documents`, and
 
 ### Commands
 
-None. P0 CLI stop calls `binding` or `supervisor` explicitly after status
-inspection. Richer restart controls are follow-on Product operations.
+- Session `/lsp status` projects the current runtime snapshot without mutation;
+- Session `/lsp stop <server-id> <root>` calls `binding`/`supervisor` explicitly;
+- the independent `loushang lsp status|doctor` commands remain Catalog-only.
+
+Richer restart controls are follow-on Product operations. The current Session
+command is contributed by Coding through the shared command catalog; Harness
+does not acquire an LSP command identifier.
 
 ### Queries
 

--- a/docs/internals/architecture/coding/lsp/specification.md
+++ b/docs/internals/architecture/coding/lsp/specification.md
@@ -34,6 +34,7 @@ src/loushang/coding/lsp/
 ├── tools.py
 ├── tool_pack.py
 ├── binding.py
+├── commands.py
 └── status.py
 ```
 
@@ -705,14 +706,20 @@ with existing policy.
 Recommended non-model commands/queries are:
 
 ```text
-lsp status
-lsp doctor
-lsp stop <server-id> [root]
+loushang lsp status                     # offline Catalog scope
+loushang lsp doctor                     # offline Catalog scope
+/lsp status                             # current Session runtime scope
+/lsp stop <server-id> <root>            # current Session runtime scope
+session.get_lsp_status()                # SDK, read-only
+await session.stop_lsp_server(...)      # SDK, explicit mutation
 ```
 
-Exact CLI syntax belongs to Coding CLI design; these are Product operations,
-not model tools. A richer explicit restart command may be added after the
-replacement policy is measured; in P0, stop plus the next demand is sufficient.
+The independent CLI never constructs a Session and therefore cannot claim to
+inspect a live child process. Session commands use the normal Product command
+catalog so TUI and RPC discovery do not need an LSP-specific Harness route.
+These are Product operations, not model tools. A richer explicit restart
+command may be added after the replacement policy is measured; in P0, stop plus
+the next demand is sufficient.
 
 ## 13. Package And Extension Contributions
 

--- a/docs/zh-CN/user-guide/README.md
+++ b/docs/zh-CN/user-guide/README.md
@@ -78,9 +78,27 @@ loushang lsp status
 loushang lsp doctor
 ```
 
-Server 仍只会在第一次语义查询时惰性启动；`status` 和 `doctor` 只检查配置与可执行文件，
-不会启动或安装任何 Server。Loushang 会探测已安装的 Pyright、TypeScript Language
-Server、rust-analyzer、gopls 和 clangd。
+Server 仍只会在第一次语义查询时惰性启动。独立 CLI 的 `status` 和 `doctor` 标记为
+`scope=catalog`：它们只检查配置与可执行文件，不构造 Session，也不会启动或安装任何
+Server。Loushang 会探测已安装的 Pyright、TypeScript Language Server、rust-analyzer、
+gopls 和 clangd。
+
+在交互式 Coding Session 内，使用独立的 Session 运行态表面：
+
+```text
+/lsp status
+/lsp stop <server-id> <root>
+```
+
+`/lsp status` 只报告当前 Session 已知的 Server，包括生命周期、打开文档数、请求、超时、
+替换次数和已丢弃诊断发布数；查询本身不会启动 Server。`/lsp stop` 优雅关闭精确匹配的
+Session Server，下一次语义查询可以按需启动替代实例。嵌入方可使用
+`session.get_lsp_status()` 和 `await session.stop_lsp_server(...)` 取得同一份有界状态；
+普通 TUI 与 RPC 命令目录都能发现该 Session 命令。
+
+已经把 `pyright-langserver` 放入 `PATH` 的贡献者可以运行可选真实 Server 门：
+`uv run pytest tests/integration/coding/test_pyright_lsp_live.py -q`。未安装 Pyright 时测试会
+跳过，测试自身不会安装它。
 
 自定义 Server 写入 `~/.loushang/coding/lsp.json`：
 

--- a/src/loushang/coding/cli/lsp.py
+++ b/src/loushang/coding/cli/lsp.py
@@ -135,6 +135,7 @@ def _write_json(
     stdout.write(
         json.dumps(
             {
+                "scope": "catalog",
                 "capability": CODING_LSP_CAPABILITY,
                 "mount_mode": mode,
                 "catalog_generation": snapshot.generation,
@@ -155,6 +156,7 @@ def _write_text(
     snapshot: LspCatalogSnapshot,
     doctor: bool,
 ) -> None:
+    stdout.write("Scope: catalog (offline)\n")
     stdout.write(f"Capability: {CODING_LSP_CAPABILITY} ({mode})\n")
     stdout.write(f"Catalog: {snapshot.generation}\n")
     stdout.write(f"Admitted servers: {snapshot.admitted_count}\n")

--- a/src/loushang/coding/lsp/__init__.py
+++ b/src/loushang/coding/lsp/__init__.py
@@ -44,6 +44,12 @@ from loushang.coding.lsp.runtime import (
     bind_coding_lsp_runtime,
 )
 from loushang.coding.lsp.selector import LspSelector
+from loushang.coding.lsp.status import (
+    LspServerRuntimeState,
+    LspServerRuntimeStatus,
+    LspSessionStatus,
+    disabled_lsp_session_status,
+)
 from loushang.coding.lsp.supervisor import LspRuntimeHandle, LspServerSupervisor
 from loushang.coding.lsp.tool_pack import (
     CODING_LSP_TOOL_PACK,
@@ -92,6 +98,9 @@ __all__ = [
     "LspServerKey",
     "LspServerSelection",
     "LspServerSupervisor",
+    "LspServerRuntimeState",
+    "LspServerRuntimeStatus",
+    "LspSessionStatus",
     "LspUnavailableError",
     "MAX_INSPECT_SYMBOL_RESULTS",
     "MAX_HOVER_CONTENT_CHARACTERS",
@@ -109,6 +118,7 @@ __all__ = [
     "default_global_lsp_config_path",
     "default_lsp_environment",
     "default_project_lsp_config_path",
+    "disabled_lsp_session_status",
     "discover_lsp_catalog",
     "product_default_lsp_definitions",
     "register_coding_lsp_tools",

--- a/src/loushang/coding/lsp/binding.py
+++ b/src/loushang/coding/lsp/binding.py
@@ -10,7 +10,9 @@ from loushang.coding.lsp.documents import LspDocumentManager
 from loushang.coding.lsp.model import (
     CodeQueryResult,
     DocumentOutlineResult,
+    LspInvalidInputError,
     LspServerDefinition,
+    LspServerKey,
 )
 from loushang.coding.lsp.ports import (
     AuthorizedProcessLauncher,
@@ -18,6 +20,7 @@ from loushang.coding.lsp.ports import (
     WorkspaceTextReader,
 )
 from loushang.coding.lsp.selector import LspSelector
+from loushang.coding.lsp.status import LspSessionStatus
 from loushang.coding.lsp.supervisor import LspServerSupervisor
 from loushang.coding.lsp.tools import CodingLspTools
 
@@ -42,15 +45,19 @@ class CodingLspBinding:
             catalog=catalog,
             path_exists=path_exists,
         )
-        supervisor = LspServerSupervisor(
-            catalog=catalog,
-            launcher=launcher,
-            baseline_environment=baseline_environment,
-        )
         documents = LspDocumentManager(
             workspace_root=root,
             read_text=read_text,
         )
+        supervisor = LspServerSupervisor(
+            catalog=catalog,
+            launcher=launcher,
+            baseline_environment=baseline_environment,
+            open_document_count=documents.open_document_count,
+            release_runtime_documents=documents.release_runtime,
+        )
+        self._workspace_root = root
+        self._catalog = catalog
         self._supervisor = supervisor
         self._tools = CodingLspTools(
             selector=selector,
@@ -97,6 +104,31 @@ class CodingLspBinding:
             correlation_id=correlation_id,
             signal=signal,
         )
+
+    def status(self) -> LspSessionStatus:
+        return self._supervisor.status()
+
+    async def stop(
+        self,
+        *,
+        definition_id: str,
+        workspace_root: str | Path,
+    ) -> bool:
+        try:
+            self._catalog.definition(definition_id)
+        except KeyError as exc:
+            raise LspInvalidInputError(
+                f"unknown LSP server definition: {definition_id!r}"
+            ) from exc
+        root = Path(workspace_root).expanduser()
+        if not root.is_absolute():
+            root = self._workspace_root / root
+        root = root.resolve()
+        if not root.is_relative_to(self._workspace_root):
+            raise LspInvalidInputError(
+                "LSP Server root must stay within the Coding workspace"
+            )
+        return await self._supervisor.stop(LspServerKey(definition_id, root))
 
     async def dispose(self) -> None:
         await self._supervisor.dispose()

--- a/src/loushang/coding/lsp/client.py
+++ b/src/loushang/coding/lsp/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from collections.abc import Mapping
 from contextlib import suppress
 from types import MappingProxyType
@@ -43,6 +44,10 @@ class LspClient:
         self._position_encoding = "utf-16"
         self._server_capabilities: Mapping[str, object] = MappingProxyType({})
         self._discarded_diagnostic_publications = 0
+        self._request_count = 0
+        self._timeout_count = 0
+        self._last_request_duration_ms: float | None = None
+        self._last_error: str | None = None
 
     @property
     def position_encoding(self) -> str:
@@ -61,6 +66,22 @@ class LspClient:
     @property
     def discarded_diagnostic_publications(self) -> int:
         return self._discarded_diagnostic_publications
+
+    @property
+    def request_count(self) -> int:
+        return self._request_count
+
+    @property
+    def timeout_count(self) -> int:
+        return self._timeout_count
+
+    @property
+    def last_request_duration_ms(self) -> float | None:
+        return self._last_request_duration_ms
+
+    @property
+    def last_error(self) -> str | None:
+        return self._last_error
 
     async def initialize(
         self,
@@ -156,6 +177,8 @@ class LspClient:
             raise LspProtocolError("too many pending LSP requests")
         request_id = self._next_request_id
         self._next_request_id += 1
+        self._request_count += 1
+        started_at = time.monotonic()
         future: asyncio.Future[object] = asyncio.get_running_loop().create_future()
         self._pending[request_id] = future
         try:
@@ -171,6 +194,8 @@ class LspClient:
             try:
                 return await asyncio.wait_for(asyncio.shield(future), timeout)
             except TimeoutError:
+                self._timeout_count += 1
+                self._last_error = "request_timeout"
                 future.cancel()
                 with suppress(LspProtocolError):
                     await self._notify(
@@ -188,9 +213,16 @@ class LspClient:
                         "$/cancelRequest",
                         {"id": request_id},
                         allow_closing=allow_closing,
-                    )
+                )
+                raise
+            except BaseException:
+                self._last_error = "request_failed"
                 raise
         finally:
+            self._last_request_duration_ms = round(
+                (time.monotonic() - started_at) * 1000,
+                3,
+            )
             self._pending.pop(request_id, None)
 
     async def notify(self, method: str, params: Mapping[str, object]) -> None:
@@ -326,6 +358,7 @@ class LspClient:
                     error = LspProtocolError("language server closed stdout")
                 elif not isinstance(error, LspProtocolError):
                     error = LspProtocolError(f"LSP reader failed: {error}")
+                self._last_error = "connection_closed"
                 self._fail_pending(error)
 
     async def _read_message(self) -> Mapping[str, object]:
@@ -386,6 +419,7 @@ class LspClient:
             return
         error = message.get("error")
         if error is not None:
+            self._last_error = "request_failed"
             future.set_exception(LspProtocolError(f"LSP response error: {error!r}"))
         else:
             future.set_result(message.get("result"))

--- a/src/loushang/coding/lsp/commands.py
+++ b/src/loushang/coding/lsp/commands.py
@@ -1,0 +1,167 @@
+"""Coding-owned Session command projection for live LSP state."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import asdict
+from pathlib import Path
+from typing import Protocol
+
+from loushang.coding.lsp.status import (
+    LspSessionStatus,
+    disabled_lsp_session_status,
+)
+from loushang.harness.commands import SessionCommandDescriptor
+from loushang.harness.resources.source import create_source_info
+from loushang.harness.session import CommandExecutionResult
+
+LSP_SESSION_COMMAND_NAME = "lsp"
+
+
+class LspSessionRuntime(Protocol):
+    def status(self) -> LspSessionStatus: ...
+
+    async def stop(
+        self,
+        *,
+        definition_id: str,
+        workspace_root: str | Path,
+    ) -> bool: ...
+
+
+def lsp_session_command_descriptor() -> SessionCommandDescriptor:
+    return SessionCommandDescriptor(
+        name=LSP_SESSION_COMMAND_NAME,
+        description="Show or stop language servers owned by this session",
+        source="builtin",
+        source_info=create_source_info(
+            "<builtin>",
+            source="builtin",
+            scope="project",
+            origin="top-level",
+        ),
+        argument_hint="[status | stop <server-id> <root>]",
+    )
+
+
+async def execute_lsp_session_command(
+    runtime: LspSessionRuntime | None,
+    args: str,
+) -> CommandExecutionResult:
+    try:
+        values = shlex.split(args)
+    except ValueError as exc:
+        return _result(status="error", message=f"Invalid /lsp arguments: {exc}")
+    action = values[0] if values else "status"
+    if action == "status":
+        if len(values) != 1 and values:
+            return _usage_error()
+        status = runtime.status() if runtime is not None else disabled_lsp_session_status()
+        return _status_result(status)
+    if action != "stop" or len(values) != 3:
+        return _usage_error()
+    if runtime is None:
+        return _result(
+            status="error",
+            message="Coding LSP is disabled for this session.",
+        )
+    definition_id, workspace_root = values[1:]
+    try:
+        stopped = await runtime.stop(
+            definition_id=definition_id,
+            workspace_root=workspace_root,
+        )
+    except (KeyError, OSError, ValueError) as exc:
+        return _result(status="error", message=str(exc))
+    except Exception:
+        return _result(
+            status="error",
+            message=f"Failed to stop LSP Server {definition_id}.",
+        )
+    status = runtime.status()
+    projected = _status_payload(status)
+    projected.update(
+        {
+            "action": "stop",
+            "stopped": stopped,
+            "message": (
+                f"Stopped LSP Server {definition_id}."
+                if stopped
+                else f"No matching running LSP Server: {definition_id}."
+            ),
+        }
+    )
+    return CommandExecutionResult(
+        invocation_name=LSP_SESSION_COMMAND_NAME,
+        result=projected,
+    )
+
+
+def _status_result(status: LspSessionStatus) -> CommandExecutionResult:
+    payload = _status_payload(status)
+    payload["display"] = _status_display(status)
+    return CommandExecutionResult(
+        invocation_name=LSP_SESSION_COMMAND_NAME,
+        result=payload,
+    )
+
+
+def _status_payload(status: LspSessionStatus) -> dict[str, object]:
+    value = asdict(status)
+    value["servers"] = list(value["servers"])
+    return {
+        "source": "builtin",
+        "command": LSP_SESSION_COMMAND_NAME,
+        "status": "ok",
+        **value,
+        "starting_count": status.starting_count,
+        "ready_count": status.ready_count,
+        "failed_count": status.failed_count,
+    }
+
+
+def _status_display(status: LspSessionStatus) -> str:
+    if not status.enabled:
+        return "LSP session capability: disabled"
+    lines = [
+        "LSP session runtime: "
+        f"{status.ready_count} ready, {status.starting_count} starting, "
+        f"{status.failed_count} failed"
+    ]
+    if not status.servers:
+        lines.append("No language server has been started in this session.")
+    for server in status.servers:
+        lines.append(
+            f"{server.state}\t{server.definition_id}\t{server.workspace_root}\t"
+            f"documents={server.open_document_count}\t"
+            f"requests={server.request_count}\ttimeouts={server.timeout_count}\t"
+            f"replacements={server.replacement_count}"
+        )
+    return "\n".join(lines)
+
+
+def _usage_error() -> CommandExecutionResult:
+    return _result(
+        status="error",
+        message="Usage: /lsp [status | stop <server-id> <root>]",
+    )
+
+
+def _result(*, status: str, message: str) -> CommandExecutionResult:
+    return CommandExecutionResult(
+        invocation_name=LSP_SESSION_COMMAND_NAME,
+        result={
+            "source": "builtin",
+            "command": LSP_SESSION_COMMAND_NAME,
+            "status": status,
+            "message": message,
+        },
+    )
+
+
+__all__ = [
+    "LSP_SESSION_COMMAND_NAME",
+    "LspSessionRuntime",
+    "execute_lsp_session_command",
+    "lsp_session_command_descriptor",
+]

--- a/src/loushang/coding/lsp/documents.py
+++ b/src/loushang/coding/lsp/documents.py
@@ -121,5 +121,18 @@ class LspDocumentManager:
             )
         return content
 
+    def open_document_count(self, runtime_id: int | None = None) -> int:
+        if runtime_id is None:
+            return len(self._snapshots)
+        return sum(key[0] == runtime_id for key in self._snapshots)
+
+    def release_runtime(self, runtime_id: int) -> None:
+        snapshot_keys = [key for key in self._snapshots if key[0] == runtime_id]
+        for key in snapshot_keys:
+            self._snapshots.pop(key, None)
+        lock_keys = [key for key in self._locks if key[0] == runtime_id]
+        for key in lock_keys:
+            self._locks.pop(key, None)
+
 
 __all__ = ["DocumentSnapshot", "LspDocumentManager"]

--- a/src/loushang/coding/lsp/runtime.py
+++ b/src/loushang/coding/lsp/runtime.py
@@ -14,6 +14,7 @@ from loushang.coding.lsp.model import (
     LspServerDefinition,
 )
 from loushang.coding.lsp.ports import WorkspaceTextReader
+from loushang.coding.lsp.status import LspSessionStatus
 from loushang.harness.tools.process_hosting import ProcessExecutionScope
 from loushang.harness.workspace.process import AuthorizedProcessLauncher
 
@@ -71,6 +72,20 @@ class CodingLspRuntime:
             limit=limit,
             correlation_id=correlation_id,
             signal=signal,
+        )
+
+    def status(self) -> LspSessionStatus:
+        return self._binding.status()
+
+    async def stop(
+        self,
+        *,
+        definition_id: str,
+        workspace_root: str | Path,
+    ) -> bool:
+        return await self._binding.stop(
+            definition_id=definition_id,
+            workspace_root=workspace_root,
         )
 
     async def close(self) -> None:

--- a/src/loushang/coding/lsp/status.py
+++ b/src/loushang/coding/lsp/status.py
@@ -1,0 +1,59 @@
+"""Bounded, source-free status values for one Coding LSP session."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+LspServerRuntimeState = Literal["starting", "ready", "failed", "stopped"]
+
+
+@dataclass(frozen=True, slots=True)
+class LspServerRuntimeStatus:
+    """One known session-local Server runtime without process or source data."""
+
+    definition_id: str
+    workspace_root: str
+    state: LspServerRuntimeState
+    runtime_id: int | None = None
+    open_document_count: int = 0
+    request_count: int = 0
+    timeout_count: int = 0
+    replacement_count: int = 0
+    discarded_diagnostic_publications: int = 0
+    last_request_duration_ms: float | None = None
+    last_error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LspSessionStatus:
+    """Read-only status for the LSP capability bound to one Coding session."""
+
+    scope: Literal["session"] = "session"
+    enabled: bool = True
+    disposed: bool = False
+    servers: tuple[LspServerRuntimeStatus, ...] = ()
+
+    @property
+    def starting_count(self) -> int:
+        return sum(server.state == "starting" for server in self.servers)
+
+    @property
+    def ready_count(self) -> int:
+        return sum(server.state == "ready" for server in self.servers)
+
+    @property
+    def failed_count(self) -> int:
+        return sum(server.state == "failed" for server in self.servers)
+
+
+def disabled_lsp_session_status() -> LspSessionStatus:
+    return LspSessionStatus(enabled=False)
+
+
+__all__ = [
+    "LspServerRuntimeState",
+    "LspServerRuntimeStatus",
+    "LspSessionStatus",
+    "disabled_lsp_session_status",
+]

--- a/src/loushang/coding/lsp/supervisor.py
+++ b/src/loushang/coding/lsp/supervisor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 
@@ -19,6 +19,13 @@ from loushang.coding.lsp.ports import (
     ProcessHandle,
     ProcessLaunchRequest,
 )
+from loushang.coding.lsp.status import (
+    LspServerRuntimeState,
+    LspServerRuntimeStatus,
+    LspSessionStatus,
+)
+
+_MAX_RUNTIME_STATUS_RECORDS = 128
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,16 +44,30 @@ class LspServerSupervisor:
         catalog: LspCatalog,
         launcher: AuthorizedProcessLauncher,
         baseline_environment: Mapping[str, str],
+        open_document_count: Callable[[int], int] | None = None,
+        release_runtime_documents: Callable[[int], None] | None = None,
     ) -> None:
         self._catalog = catalog
         self._launcher = launcher
         self._baseline_environment = dict(baseline_environment)
         self._runtimes: dict[LspServerKey, LspRuntimeHandle] = {}
         self._starts: dict[LspServerKey, asyncio.Task[LspRuntimeHandle]] = {}
+        self._stops: dict[LspServerKey, asyncio.Task[None]] = {}
         self._lock = asyncio.Lock()
         self._next_runtime_id = 1
         self._disposed = False
         self._dispose_task: asyncio.Task[None] | None = None
+        self._states: dict[LspServerKey, LspServerRuntimeState] = {}
+        self._last_errors: dict[LspServerKey, str] = {}
+        self._start_counts: dict[LspServerKey, int] = {}
+        self._request_counts: dict[LspServerKey, int] = {}
+        self._timeout_counts: dict[LspServerKey, int] = {}
+        self._diagnostic_counts: dict[LspServerKey, int] = {}
+        self._last_request_durations: dict[LspServerKey, float] = {}
+        self._open_document_count = open_document_count or (lambda _runtime_id: 0)
+        self._release_runtime_documents = (
+            release_runtime_documents or (lambda _runtime_id: None)
+        )
 
     async def ensure_runtime(
         self,
@@ -64,10 +85,15 @@ class LspServerSupervisor:
                 return current
             if current is not None:
                 self._runtimes.pop(key, None)
+                self._retire_runtime(current)
+                self._remember_state(key, "failed")
+                self._last_errors[key] = "connection_closed"
             task = self._starts.get(key)
             if task is None:
                 runtime_id = self._next_runtime_id
                 self._next_runtime_id += 1
+                self._start_counts[key] = self._start_counts.get(key, 0) + 1
+                self._remember_state(key, "starting")
                 task = asyncio.create_task(
                     self._start_runtime(
                         key,
@@ -87,15 +113,95 @@ class LspServerSupervisor:
                     if self._starts.get(key) is task:
                         self._starts.pop(key, None)
 
-    async def stop(self, key: LspServerKey) -> None:
+    async def stop(self, key: LspServerKey) -> bool:
         async with self._lock:
-            runtime = self._runtimes.pop(key, None)
-            start = self._starts.pop(key, None)
-        if start is not None:
-            start.cancel()
-            await asyncio.gather(start, return_exceptions=True)
-        if runtime is not None:
-            await runtime.client.shutdown()
+            if self._disposed:
+                return False
+            existing_stop = self._stops.get(key)
+            if existing_stop is not None:
+                stop_task = existing_stop
+                stopped = True
+            else:
+                runtime = self._runtimes.pop(key, None)
+                start = self._starts.pop(key, None)
+                stopped = runtime is not None or start is not None
+                if not stopped:
+                    if key in self._states:
+                        self._remember_state(key, "stopped")
+                        self._last_errors.pop(key, None)
+                    return False
+                self._remember_state(key, "stopped")
+                self._last_errors.pop(key, None)
+                stop_task = asyncio.create_task(
+                    self._stop_owned_runtime(
+                        key,
+                        start=start,
+                        runtime=runtime,
+                    ),
+                    name=f"coding-lsp-stop:{key.definition_id}",
+                )
+                self._stops[key] = stop_task
+        await asyncio.shield(stop_task)
+        return stopped
+
+    def status(self) -> LspSessionStatus:
+        """Return one read-only snapshot without starting or stopping a Server."""
+
+        keys = set(self._states) | set(self._starts) | set(self._runtimes)
+        servers: list[LspServerRuntimeStatus] = []
+        for key in sorted(
+            keys,
+            key=lambda item: (item.definition_id, str(item.workspace_root)),
+        ):
+            runtime = self._runtimes.get(key)
+            if key in self._starts:
+                state: LspServerRuntimeState = "starting"
+            elif runtime is not None and runtime.client.is_closed:
+                state = "failed"
+            elif runtime is not None:
+                state = "ready"
+            else:
+                state = self._states.get(key, "stopped")
+            client = runtime.client if runtime is not None else None
+            request_count = self._request_counts.get(key, 0)
+            timeout_count = self._timeout_counts.get(key, 0)
+            diagnostic_count = self._diagnostic_counts.get(key, 0)
+            last_duration = self._last_request_durations.get(key)
+            if client is not None:
+                request_count += client.request_count
+                timeout_count += client.timeout_count
+                diagnostic_count += client.discarded_diagnostic_publications
+                if client.last_request_duration_ms is not None:
+                    last_duration = client.last_request_duration_ms
+            last_error = self._last_errors.get(key)
+            if state == "failed" and last_error is None:
+                last_error = (
+                    "connection_closed"
+                    if client is not None and client.is_closed
+                    else client.last_error
+                    if client is not None
+                    else "runtime_failed"
+                )
+            servers.append(
+                LspServerRuntimeStatus(
+                    definition_id=key.definition_id,
+                    workspace_root=str(key.workspace_root),
+                    state=state,
+                    runtime_id=runtime.runtime_id if runtime is not None else None,
+                    open_document_count=(
+                        self._open_document_count(runtime.runtime_id)
+                        if runtime is not None and state == "ready"
+                        else 0
+                    ),
+                    request_count=request_count,
+                    timeout_count=timeout_count,
+                    replacement_count=max(self._start_counts.get(key, 0) - 1, 0),
+                    discarded_diagnostic_publications=diagnostic_count,
+                    last_request_duration_ms=last_duration,
+                    last_error=last_error,
+                )
+            )
+        return LspSessionStatus(disposed=self._disposed, servers=tuple(servers))
 
     async def dispose(self) -> None:
         async with self._lock:
@@ -112,18 +218,45 @@ class LspServerSupervisor:
     async def _dispose_all(self) -> None:
         async with self._lock:
             starts = tuple(self._starts.values())
+            stops = tuple(self._stops.values())
             runtimes = tuple(self._runtimes.values())
+            for key in set(self._states) | set(self._starts) | set(self._runtimes):
+                self._remember_state(key, "stopped")
+                self._last_errors.pop(key, None)
             self._starts.clear()
+            self._stops.clear()
             self._runtimes.clear()
         for task in starts:
             task.cancel()
         if starts:
             await asyncio.gather(*starts, return_exceptions=True)
-        if runtimes:
-            await asyncio.gather(
-                *(runtime.client.shutdown() for runtime in runtimes),
-                return_exceptions=False,
+        if stops or runtimes:
+            results = await asyncio.gather(
+                *stops,
+                *(self._shutdown_runtime(runtime) for runtime in runtimes),
+                return_exceptions=True,
             )
+            for result in results:
+                if isinstance(result, BaseException):
+                    raise result
+
+    async def _stop_owned_runtime(
+        self,
+        key: LspServerKey,
+        *,
+        start: asyncio.Task[LspRuntimeHandle] | None,
+        runtime: LspRuntimeHandle | None,
+    ) -> None:
+        try:
+            if start is not None:
+                start.cancel()
+                await asyncio.gather(start, return_exceptions=True)
+            if runtime is not None:
+                await self._shutdown_runtime(runtime)
+        finally:
+            async with self._lock:
+                if self._stops.get(key) is asyncio.current_task():
+                    self._stops.pop(key, None)
 
     async def _start_runtime(
         self,
@@ -168,14 +301,75 @@ class LspServerSupervisor:
                 if self._disposed:
                     raise LspProtocolError("LSP supervisor was disposed during startup")
                 self._runtimes[key] = runtime
+                self._remember_state(key, "ready")
+                self._last_errors.pop(key, None)
             return runtime
-        except BaseException:
+        except BaseException as exc:
             with suppress(BaseException):
                 if client is not None:
                     await client.abort()
                 elif handle is not None:
                     await handle.close()
+            if client is not None:
+                self._accumulate_client(key, client)
+                self._release_runtime_documents(runtime_id)
+            async with self._lock:
+                if self._states.get(key) == "starting":
+                    if isinstance(exc, asyncio.CancelledError) or self._disposed:
+                        self._remember_state(key, "stopped")
+                    else:
+                        self._remember_state(key, "failed")
+                        self._last_errors[key] = "initialization_failed"
             raise
+
+    async def _shutdown_runtime(self, runtime: LspRuntimeHandle) -> None:
+        try:
+            await runtime.client.shutdown()
+        finally:
+            self._retire_runtime(runtime)
+
+    def _retire_runtime(self, runtime: LspRuntimeHandle) -> None:
+        self._accumulate_client(runtime.key, runtime.client)
+        self._release_runtime_documents(runtime.runtime_id)
+
+    def _accumulate_client(self, key: LspServerKey, client: LspClient) -> None:
+        self._request_counts[key] = self._request_counts.get(key, 0) + client.request_count
+        self._timeout_counts[key] = self._timeout_counts.get(key, 0) + client.timeout_count
+        self._diagnostic_counts[key] = (
+            self._diagnostic_counts.get(key, 0)
+            + client.discarded_diagnostic_publications
+        )
+        if client.last_request_duration_ms is not None:
+            self._last_request_durations[key] = client.last_request_duration_ms
+
+    def _remember_state(
+        self,
+        key: LspServerKey,
+        state: LspServerRuntimeState,
+    ) -> None:
+        self._states.pop(key, None)
+        self._states[key] = state
+        while len(self._states) > _MAX_RUNTIME_STATUS_RECORDS:
+            candidate = next(
+                (
+                    item
+                    for item in self._states
+                    if item != key
+                    and item not in self._starts
+                    and item not in self._stops
+                    and item not in self._runtimes
+                ),
+                None,
+            )
+            if candidate is None:
+                break
+            self._states.pop(candidate, None)
+            self._last_errors.pop(candidate, None)
+            self._start_counts.pop(candidate, None)
+            self._request_counts.pop(candidate, None)
+            self._timeout_counts.pop(candidate, None)
+            self._diagnostic_counts.pop(candidate, None)
+            self._last_request_durations.pop(candidate, None)
 
 
 __all__ = ["LspRuntimeHandle", "LspServerSupervisor"]

--- a/src/loushang/coding/session/agent_session.py
+++ b/src/loushang/coding/session/agent_session.py
@@ -10,7 +10,13 @@ from loushang.coding.compaction.adapter import (
 from loushang.coding.compaction.adapter import (
     execute_coding_compaction as _execute_coding_compaction,
 )
+from loushang.coding.lsp.commands import (
+    LSP_SESSION_COMMAND_NAME,
+    execute_lsp_session_command,
+    lsp_session_command_descriptor,
+)
 from loushang.coding.lsp.runtime import CodingLspRuntime
+from loushang.coding.lsp.status import LspSessionStatus, disabled_lsp_session_status
 from loushang.coding.product_plan import CODING_CAPABILITY_PROFILE
 from loushang.coding.resource_runtime import (
     CodingPackageMaterializer as PackageMaterializer,
@@ -25,6 +31,7 @@ from loushang.harness.capabilities import (
     CapabilityCompositionRuntime,
     bind_capability_composition_runtime,
 )
+from loushang.harness.commands import normalize_command_name
 from loushang.harness.config.agent import SettingsManager
 from loushang.harness.diagnostics.service import DiagnosticsService
 from loushang.harness.events import RuntimeEvent
@@ -179,6 +186,42 @@ class AgentSession(AgentProductSession):
         if self._sandbox_runtime is None:
             return SandboxStatus(state="disabled")
         return self._sandbox_runtime.status()
+
+    def get_lsp_status(self) -> LspSessionStatus:
+        if self._lsp_runtime is None:
+            return disabled_lsp_session_status()
+        return self._lsp_runtime.status()
+
+    async def stop_lsp_server(
+        self,
+        *,
+        definition_id: str,
+        workspace_root: str,
+    ) -> bool:
+        if self._lsp_runtime is None:
+            return False
+        return await self._lsp_runtime.stop(
+            definition_id=definition_id,
+            workspace_root=workspace_root,
+        )
+
+    def list_commands(self) -> list[object]:
+        commands = list(super().list_commands())
+        if not any(
+            getattr(command, "name", None) == LSP_SESSION_COMMAND_NAME
+            for command in commands
+        ):
+            commands.append(lsp_session_command_descriptor())
+        return commands
+
+    async def execute_command_async(
+        self,
+        invocation_name: str,
+        args: str,
+    ) -> object | None:
+        if normalize_command_name(invocation_name) == LSP_SESSION_COMMAND_NAME:
+            return await execute_lsp_session_command(self._lsp_runtime, args)
+        return await super().execute_command_async(invocation_name, args)
 
     async def emit_product_tool_audit_event(
         self,

--- a/tests/coding/lsp/test_cli.py
+++ b/tests/coding/lsp/test_cli.py
@@ -84,6 +84,7 @@ def test_status_and_doctor_inspect_catalog_without_starting_process(
 
     payload = json.loads(stdout.getvalue())
     assert exit_code == 0
+    assert payload["scope"] == "catalog"
     assert payload["mount_mode"] == "always"
     assert payload["admitted_count"] >= 1
     assert payload["process_start_attempted"] is False
@@ -120,6 +121,7 @@ def test_doctor_reports_missing_servers_without_attempting_install(
     )
 
     assert exit_code == 1
+    assert "Scope: catalog (offline)" in stdout.getvalue()
     assert "Process start attempted: no" in stdout.getvalue()
     assert "no language server is available" in stdout.getvalue()
 
@@ -255,5 +257,11 @@ def test_configured_lsp_is_available_to_ordinary_session_and_remains_lazy(
     assert {INSPECT_SYMBOL_TOOL_NAME, DOCUMENT_OUTLINE_TOOL_NAME}.issubset(
         session.get_active_tool_names()
     )
+    assert "lsp" in {command.name for command in session.list_commands()}
+    command_result = asyncio.run(session.execute_command_async("lsp", "status"))
+    assert command_result is not None
+    assert command_result.result["scope"] == "session"
+    assert command_result.result["servers"] == []
+    assert "No language server has been started" in command_result.result["display"]
     assert starts == []
     asyncio.run(session.dispose())

--- a/tests/coding/lsp/test_commands.py
+++ b/tests/coding/lsp/test_commands.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from loushang.coding.lsp.commands import execute_lsp_session_command
+from loushang.coding.lsp.status import (
+    LspServerRuntimeStatus,
+    LspSessionStatus,
+)
+
+
+class _Runtime:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.stop_calls: list[tuple[str, str]] = []
+        self.stopped = False
+
+    def status(self) -> LspSessionStatus:
+        return LspSessionStatus(
+            servers=(
+                LspServerRuntimeStatus(
+                    definition_id="pyright",
+                    workspace_root=str(self.root),
+                    state="stopped" if self.stopped else "ready",
+                    open_document_count=0 if self.stopped else 1,
+                    request_count=3,
+                ),
+            )
+        )
+
+    async def stop(
+        self,
+        *,
+        definition_id: str,
+        workspace_root: str | Path,
+    ) -> bool:
+        self.stop_calls.append((definition_id, str(workspace_root)))
+        self.stopped = True
+        return True
+
+
+def test_lsp_session_command_projects_status_and_explicit_stop(tmp_path: Path) -> None:
+    runtime = _Runtime(tmp_path)
+
+    status = asyncio.run(execute_lsp_session_command(runtime, "status"))
+    stopped = asyncio.run(
+        execute_lsp_session_command(
+            runtime,
+            f'stop pyright "{tmp_path}"',
+        )
+    )
+
+    assert status.result["scope"] == "session"
+    assert status.result["ready_count"] == 1
+    assert "pyright" in status.result["display"]
+    assert runtime.stop_calls == [("pyright", str(tmp_path))]
+    assert stopped.result["action"] == "stop"
+    assert stopped.result["stopped"] is True
+    assert stopped.result["servers"][0]["state"] == "stopped"
+
+
+def test_lsp_session_command_reports_disabled_and_invalid_usage() -> None:
+    disabled = asyncio.run(execute_lsp_session_command(None, "status"))
+    invalid = asyncio.run(execute_lsp_session_command(None, "stop pyright"))
+
+    assert disabled.result["enabled"] is False
+    assert disabled.result["display"] == "LSP session capability: disabled"
+    assert invalid.result["status"] == "error"
+    assert invalid.result["message"].startswith("Usage: /lsp")

--- a/tests/coding/lsp/test_fake_launcher_vertical_slice.py
+++ b/tests/coding/lsp/test_fake_launcher_vertical_slice.py
@@ -884,6 +884,11 @@ def test_initialize_failure_closes_fake_process_and_publishes_no_runtime(
 
         assert len(launcher.handles) == 1
         assert launcher.handles[0].close_calls == 1
+        failed = binding.status().servers[0]
+        assert failed.state == "failed"
+        assert failed.runtime_id is None
+        assert failed.request_count == 1
+        assert failed.last_error == "initialization_failed"
         await binding.dispose()
 
     asyncio.run(scenario())
@@ -1003,6 +1008,10 @@ def test_request_timeout_sends_protocol_cancel_and_keeps_runtime(
             )
         server = launcher.handles[0].server
         await _wait_for_method(server, "$/cancelRequest")
+        timed_out_status = binding.status().servers[0]
+        assert timed_out_status.state == "ready"
+        assert timed_out_status.timeout_count == 1
+        assert timed_out_status.last_error is None
 
         gate.set()
         result = await binding.inspect_symbol(
@@ -1013,6 +1022,127 @@ def test_request_timeout_sends_protocol_cancel_and_keeps_runtime(
         )
         assert result.count == 0
         assert len(launcher.requests) == 1
+        await binding.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_runtime_status_is_read_only_and_explicit_stop_allows_replacement(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        (tmp_path / "pyproject.toml").touch()
+        source = tmp_path / "main.py"
+        source.touch()
+        launcher = FakeLauncher(definition_result=None)
+        binding = _binding(tmp_path, launcher, {source.resolve(): "value = 1\n"})
+
+        initial = binding.status()
+        assert initial.scope == "session"
+        assert initial.enabled is True
+        assert initial.servers == ()
+        assert launcher.requests == []
+
+        await binding.inspect_symbol(
+            path="main.py",
+            line=1,
+            character=1,
+            correlation_id="status-query",
+        )
+        ready = binding.status()
+        assert ready.ready_count == 1
+        assert ready.starting_count == 0
+        assert len(launcher.requests) == 1
+        ready_server = ready.servers[0]
+        assert ready_server.definition_id == "fake-python"
+        assert ready_server.workspace_root == str(tmp_path.resolve())
+        assert ready_server.state == "ready"
+        assert ready_server.runtime_id == 1
+        assert ready_server.open_document_count == 1
+        assert ready_server.request_count == 2
+        assert ready_server.timeout_count == 0
+        assert ready_server.replacement_count == 0
+        assert ready_server.discarded_diagnostic_publications == 1
+        assert ready_server.last_request_duration_ms is not None
+        assert ready_server.last_error is None
+
+        with pytest.raises(LspInvalidInputError, match="unknown LSP server"):
+            await binding.stop(
+                definition_id="unknown",
+                workspace_root=tmp_path,
+            )
+        with pytest.raises(LspInvalidInputError, match="must stay within"):
+            await binding.stop(
+                definition_id="fake-python",
+                workspace_root=tmp_path.parent,
+            )
+
+        stopped = await binding.stop(
+            definition_id="fake-python",
+            workspace_root=tmp_path,
+        )
+        assert stopped is True
+        stopped_server = binding.status().servers[0]
+        assert stopped_server.state == "stopped"
+        assert stopped_server.runtime_id is None
+        assert stopped_server.open_document_count == 0
+        assert launcher.handles[0].server.methods()[-2:] == ["shutdown", "exit"]
+
+        await binding.inspect_symbol(
+            path="main.py",
+            line=1,
+            character=1,
+            correlation_id="replacement-query",
+        )
+        replacement = binding.status().servers[0]
+        assert replacement.state == "ready"
+        assert replacement.runtime_id == 2
+        assert replacement.replacement_count == 1
+        assert replacement.request_count >= 5
+        assert len(launcher.requests) == 2
+
+        await binding.dispose()
+        disposed = binding.status()
+        assert disposed.disposed is True
+        assert disposed.servers[0].state == "stopped"
+
+    asyncio.run(scenario())
+
+
+def test_runtime_status_observes_pending_start_without_starting_another_server(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        (tmp_path / "pyproject.toml").touch()
+        source = tmp_path / "main.py"
+        source.touch()
+        gate = asyncio.Event()
+        launcher = FakeLauncher(definition_result=None, initialize_gate=gate)
+        binding = _binding(tmp_path, launcher, {source.resolve(): "value = 1\n"})
+
+        query = asyncio.create_task(
+            binding.inspect_symbol(
+                path="main.py",
+                line=1,
+                character=1,
+                correlation_id="pending-start",
+            )
+        )
+        for _ in range(100):
+            if launcher.handles:
+                break
+            await asyncio.sleep(0)
+        assert launcher.handles
+
+        pending = binding.status()
+        assert pending.starting_count == 1
+        assert pending.servers[0].state == "starting"
+        assert pending.servers[0].open_document_count == 0
+        assert len(launcher.requests) == 1
+
+        gate.set()
+        await query
+        assert binding.status().servers[0].state == "ready"
         await binding.dispose()
 
     asyncio.run(scenario())
@@ -1138,6 +1268,57 @@ def test_cancelled_binding_dispose_keeps_one_shared_close_running(
     asyncio.run(scenario())
 
 
+def test_concurrent_stop_and_dispose_share_one_server_shutdown(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        (tmp_path / "pyproject.toml").touch()
+        source = tmp_path / "main.py"
+        source.touch()
+        shutdown_gate = asyncio.Event()
+        launcher = FakeLauncher(
+            definition_result=None,
+            shutdown_gate=shutdown_gate,
+        )
+        binding = _binding(tmp_path, launcher, {source.resolve(): "value = 1\n"})
+        await binding.inspect_symbol(
+            path="main.py",
+            line=1,
+            character=1,
+            correlation_id="open-before-stop",
+        )
+
+        first_stop = asyncio.create_task(
+            binding.stop(
+                definition_id="fake-python",
+                workspace_root=tmp_path,
+            )
+        )
+        await _wait_for_method(launcher.handles[0].server, "shutdown")
+        second_stop = asyncio.create_task(
+            binding.stop(
+                definition_id="fake-python",
+                workspace_root=tmp_path,
+            )
+        )
+        disposing = asyncio.create_task(binding.dispose())
+        await asyncio.sleep(0)
+        assert not first_stop.done()
+        assert not second_stop.done()
+        assert not disposing.done()
+
+        shutdown_gate.set()
+        assert await first_stop is True
+        assert await second_stop is True
+        await disposing
+
+        methods = launcher.handles[0].server.methods()
+        assert methods.count("shutdown") == 1
+        assert methods.count("exit") == 1
+        assert launcher.handles[0].close_calls == 1
+        assert binding.status().disposed is True
+
+    asyncio.run(scenario())
+
+
 def test_server_crash_restarts_on_demand_and_reopens_document(tmp_path: Path) -> None:
     async def scenario() -> None:
         (tmp_path / "pyproject.toml").touch()
@@ -1156,6 +1337,9 @@ def test_server_crash_restarts_on_demand_and_reopens_document(tmp_path: Path) ->
                 character=1,
                 correlation_id="crashed-query",
             )
+        crashed = binding.status().servers[0]
+        assert crashed.state == "failed"
+        assert crashed.last_error == "connection_closed"
         result = await binding.inspect_symbol(
             path="main.py",
             line=1,
@@ -1165,6 +1349,9 @@ def test_server_crash_restarts_on_demand_and_reopens_document(tmp_path: Path) ->
 
         assert result.count == 0
         assert len(launcher.requests) == 2
+        replacement = binding.status().servers[0]
+        assert replacement.state == "ready"
+        assert replacement.replacement_count == 1
         assert [
             handle.server.methods().count("textDocument/didOpen")
             for handle in launcher.handles

--- a/tests/coding/lsp/test_runtime.py
+++ b/tests/coding/lsp/test_runtime.py
@@ -63,7 +63,9 @@ def test_runtime_binds_the_harness_contract_without_starting_a_process(
     assert isinstance(runtime, CodingLspRuntime)
     assert binder.scope is scope
     assert ProcessLaunchRequest is HarnessProcessLaunchRequest
+    assert runtime.status().servers == ()
     asyncio.run(runtime.close())
+    assert runtime.status().disposed is True
 
 
 def test_deferred_runtime_and_tool_pack_preserve_mount_policy() -> None:

--- a/tests/coding/test_rpc_resources.py
+++ b/tests/coding/test_rpc_resources.py
@@ -655,6 +655,31 @@ def test_rpc_mode_get_commands_prefers_session_command_descriptors() -> None:
     ]
 
 
+def test_rpc_mode_discovers_coding_lsp_session_command() -> None:
+    from loushang.coding.lsp.commands import lsp_session_command_descriptor
+    from loushang.harness.host.rpc import RpcHost as RpcMode
+
+    class LspCommandSession(FakeSession):
+        def list_commands(self):
+            return [lsp_session_command_descriptor()]
+
+    session = LspCommandSession(session_id="session-a", cwd="/tmp/project")
+    runtime = FakeRuntime(session)
+    stdin = StringIO(json.dumps({"id": "commands", "type": "get_commands"}) + "\n")
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        mode = RpcMode(runtime=runtime, stdin=stdin, stdout=stdout)
+        assert await mode.run() == 0
+
+    asyncio.run(scenario())
+
+    command = _parse_jsonl(stdout)[0]["data"]["commands"][0]
+    assert command["name"] == "lsp"
+    assert command["source"] == "builtin"
+    assert command["argumentHint"] == "[status | stop <server-id> <root>]"
+
+
 def test_rpc_mode_get_commands_projects_session_command_descriptors() -> None:
     from loushang.harness.host.rpc import RpcHost as RpcMode
 

--- a/tests/coding/test_sdk_surface.py
+++ b/tests/coding/test_sdk_surface.py
@@ -289,6 +289,11 @@ def test_coding_top_level_sdk_smoke_covers_session_runtime_tools_and_diagnostics
             standalone_sessions.append(direct_session)
             assert isinstance(direct_session, coding.AgentSession)
             assert direct_session.session_manager is session_manager
+            assert direct_session.get_lsp_status().scope == "session"
+            assert direct_session.get_lsp_status().servers == ()
+            assert "lsp" in {
+                command.name for command in direct_session.list_commands()
+            }
 
             agent_services = coding.create_agent_session_services(
                 cwd=project_root,

--- a/tests/coding/test_ui_controller.py
+++ b/tests/coding/test_ui_controller.py
@@ -268,6 +268,32 @@ def test_controller_prefers_session_command_display_text_for_status() -> None:
     )
 
 
+def test_controller_dispatches_coding_lsp_session_status_without_model_prompt() -> None:
+    from loushang.coding.lsp.commands import (
+        execute_lsp_session_command,
+        lsp_session_command_descriptor,
+    )
+    from loushang.coding.ui.product_binding import build_coding_ui_controller
+    from loushang.harnesstui.conversation.intents import PromptIntent
+
+    class LspCommandSession(_Session):
+        def list_commands(self) -> list[object]:
+            return [lsp_session_command_descriptor()]
+
+        async def execute_command_async(self, invocation_name: str, args: str) -> object:
+            assert invocation_name == "lsp"
+            return await execute_lsp_session_command(None, args)
+
+    session = LspCommandSession()
+    controller = build_coding_ui_controller(session=session)
+
+    result = asyncio.run(controller.dispatch(PromptIntent(text="/lsp status")))
+
+    assert result.error_message is None
+    assert result.status_message == "LSP session capability: disabled"
+    assert session.prompts == []
+
+
 def test_controller_leaves_prompt_resource_commands_on_prompt_path() -> None:
     from loushang.coding.ui.product_binding import build_coding_ui_controller
     from loushang.harnesstui.conversation.intents import PromptIntent

--- a/tests/integration/coding/test_pyright_lsp_live.py
+++ b/tests/integration/coding/test_pyright_lsp_live.py
@@ -1,0 +1,119 @@
+"""Optional compatibility gate for an already-installed Pyright Server."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+
+import pytest
+
+from loushang.coding.lsp import (
+    LspServerDefinition,
+    bind_coding_lsp_runtime,
+    default_lsp_environment,
+)
+from loushang.coding.sandbox import (
+    bind_coding_sandbox_runtime,
+    coding_workspace_execution_profile,
+)
+from loushang.harness.sandbox import SandboxSettings
+from loushang.harness.tools.process_hosting import ProcessExecutionScope
+from loushang.harness.workspace.exec import ExecService
+
+_PYRIGHT = shutil.which("pyright-langserver")
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        _PYRIGHT is None,
+        reason=(
+            "pyright-langserver is not installed; optional LSP compatibility "
+            "verification skipped"
+        ),
+    ),
+]
+
+
+class _NoApprovalResolver:
+    actor_id = "coding-lsp-pyright-live"
+
+    def resolve(self, request: object) -> object:
+        del request
+        raise AssertionError("an admitted Pyright launch must not request approval")
+
+
+def test_installed_pyright_definition_outline_and_shutdown(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        assert _PYRIGHT is not None
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "pyproject.toml").write_text(
+            "[project]\nname = \"lsp-live-smoke\"\nversion = \"0.0.0\"\n",
+            encoding="utf-8",
+        )
+        source = project / "main.py"
+        source.write_text(
+            "def target(value: int) -> int:\n"
+            "    return value\n\n"
+            "result = target(1)\n",
+            encoding="utf-8",
+        )
+        sandbox_runtime = bind_coding_sandbox_runtime(
+            workspace_root=project,
+            writable_workspace=True,
+            settings=SandboxSettings(enabled=False),
+            base_exec_service=ExecService(),
+        )
+        runtime = bind_coding_lsp_runtime(
+            workspace_root=project,
+            definitions=(
+                LspServerDefinition(
+                    id="pyright-live",
+                    command=(_PYRIGHT, "--stdio"),
+                    language_extensions={"python": (".py",)},
+                    root_markers=("pyproject.toml",),
+                    startup_timeout_seconds=15,
+                    request_timeout_seconds=15,
+                    shutdown_timeout_seconds=5,
+                ),
+            ),
+            process_launcher_binder=sandbox_runtime,
+            execution_scope=ProcessExecutionScope(
+                approval_resolver=_NoApprovalResolver(),
+                execution_profile_ceiling=coding_workspace_execution_profile(
+                    project,
+                    writable=True,
+                ),
+            ),
+            read_text=lambda path: path.read_text(encoding="utf-8"),
+            baseline_environment=default_lsp_environment(),
+        )
+        try:
+            assert runtime.status().servers == ()
+            definition = await runtime.inspect_symbol(
+                path="main.py",
+                line=4,
+                character=10,
+                correlation_id="pyright-live-definition",
+            )
+            outline = await runtime.document_outline(
+                path="main.py",
+                correlation_id="pyright-live-outline",
+            )
+
+            assert definition.count >= 1
+            assert any(item.path == "main.py" for item in definition.items)
+            assert any(item.name == "target" for item in outline.items)
+            status = runtime.status()
+            assert status.ready_count == 1
+            assert status.servers[0].open_document_count == 1
+        finally:
+            await runtime.close()
+            await sandbox_runtime.close()
+
+        status = runtime.status()
+        assert status.disposed is True
+        assert status.servers[0].state == "stopped"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

- add bounded, read-only Session-local LSP runtime status and explicit stop operations
- expose the runtime surface through the Coding SDK and `/lsp` command while keeping standalone CLI status catalog-only
- cover lifecycle, counters, concurrent stop/dispose, TUI/RPC discovery, and an optional real-Pyright compatibility gate

## Why

The semantic LSP tools were usable after injection, but ordinary users had no safe way to inspect or stop the Session-owned language servers. This completes that operational surface without moving LSP semantics into Harness or making status calls start processes.

## Validation

- `uv --cache-dir .uv-cache run --extra dev ruff check ...`
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding -q` — 2337 passed
- focused Coding LSP, Harness process-hosting/sandbox, SDK, RPC and TUI tests — 219 passed
- optional Pyright live gate skips when `pyright-langserver` is absent
- `git diff --check`
