### PR TITLE
feat(harness): execute session commands over RPC

### DIFF
--- a/docs/en/user-guide/README.md
+++ b/docs/en/user-guide/README.md
@@ -105,8 +105,15 @@ open-document, request, timeout, replacement, and discarded-publication counts.
 It is read-only and does not start a Server. `/lsp stop` gracefully shuts down
 the exact Session-owned Server; the next semantic query may start a replacement.
 Embedding code can use `session.get_lsp_status()` and
-`await session.stop_lsp_server(...)` over the same bounded snapshot. The Session
-command is discoverable through the normal TUI and RPC command catalogs.
+`await session.stop_lsp_server(...)` over the same bounded snapshot. The TUI
+executes the same Session command directly. RPC clients can discover it with
+`get_commands` and execute it without a model turn:
+
+```json
+{"id":"lsp-status","type":"execute_command","command":"lsp","args":"status"}
+```
+
+The response carries the command's structured result under `data.result`.
 
 Contributors with `pyright-langserver` already on `PATH` can run the optional
 real-server gate with `uv run pytest

--- a/docs/internals/architecture/coding/lsp/component-boundaries.md
+++ b/docs/internals/architecture/coding/lsp/component-boundaries.md
@@ -442,7 +442,8 @@ Read-only snapshots from `catalog`, `supervisor`, `documents`, and
 
 Richer restart controls are follow-on Product operations. The current Session
 command is contributed by Coding through the shared command catalog; Harness
-does not acquire an LSP command identifier.
+does not acquire an LSP command identifier. Remote clients execute it through
+Harness's Product-neutral `execute_command` RPC route.
 
 ### Queries
 

--- a/docs/internals/architecture/coding/lsp/specification.md
+++ b/docs/internals/architecture/coding/lsp/specification.md
@@ -716,7 +716,9 @@ await session.stop_lsp_server(...)      # SDK, explicit mutation
 
 The independent CLI never constructs a Session and therefore cannot claim to
 inspect a live child process. Session commands use the normal Product command
-catalog so TUI and RPC discovery do not need an LSP-specific Harness route.
+catalog: TUI dispatches that catalog locally, while RPC uses the generic
+`execute_command` route after discovery. Neither surface needs an LSP-specific
+Harness route.
 These are Product operations, not model tools. A richer explicit restart
 command may be added after the replacement policy is measured; in P0, stop plus
 the next demand is sufficient.

--- a/docs/internals/architecture/harness/session-rpc-operation-boundary.md
+++ b/docs/internals/architecture/harness/session-rpc-operation-boundary.md
@@ -51,7 +51,8 @@ The command groups are:
 - `session_lifecycle`: listing, create/restore/fork/clone, naming, and rebinding;
 - `model_settings`: model, thinking, queue, tool, retry, and compaction settings;
 - `transcript`: transcript queries and export;
-- `command_catalog`: command inventory and completion;
+- `command_catalog`: command inventory, completion, and direct execution through
+  the current Product Session's admitted command dispatcher;
 - `diagnostics`: diagnostic and error-report queries;
 - `packages`: package inventory and lifecycle; and
 - `bash_maintenance`: Bash execution and maintenance controls.
@@ -65,6 +66,12 @@ uses the same pattern for session event subscription, extension-UI binding,
 and tool-rendering context. These adapters resolve the current session on each
 invocation or are rebuilt after lifecycle rebinding, so they do not capture a
 stale Session.
+
+`execute_command` accepts only a command name and string arguments. It invokes
+the current Session's existing `execute_command_async` port and returns its
+strict-JSON result; it does not interpret Product command names, invoke a model
+turn, execute a shell command, or create a second command registry. Missing
+commands and non-serializable results are explicit RPC errors.
 
 ## Prompt And Abort Semantics
 

--- a/docs/zh-CN/user-guide/README.md
+++ b/docs/zh-CN/user-guide/README.md
@@ -93,8 +93,15 @@ gopls 和 clangd。
 `/lsp status` 只报告当前 Session 已知的 Server，包括生命周期、打开文档数、请求、超时、
 替换次数和已丢弃诊断发布数；查询本身不会启动 Server。`/lsp stop` 优雅关闭精确匹配的
 Session Server，下一次语义查询可以按需启动替代实例。嵌入方可使用
-`session.get_lsp_status()` 和 `await session.stop_lsp_server(...)` 取得同一份有界状态；
-普通 TUI 与 RPC 命令目录都能发现该 Session 命令。
+`session.get_lsp_status()` 和 `await session.stop_lsp_server(...)` 取得同一份有界状态。
+TUI 会直接执行同一个 Session 命令；RPC 客户端可以先用 `get_commands` 发现命令，再在不经过
+模型回合的情况下执行：
+
+```json
+{"id":"lsp-status","type":"execute_command","command":"lsp","args":"status"}
+```
+
+响应会把命令的结构化结果放在 `data.result`。
 
 已经把 `pyright-langserver` 放入 `PATH` 的贡献者可以运行可选真实 Server 门：
 `uv run pytest tests/integration/coding/test_pyright_lsp_live.py -q`。未安装 Pyright 时测试会

--- a/src/loushang/harness/host/rpc/commands/command_catalog.py
+++ b/src/loushang/harness/host/rpc/commands/command_catalog.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, Protocol
 
-from loushang.harness.commands import complete_slash_commands
+from loushang.harness.commands import complete_slash_commands, normalize_command_name
+from loushang.harness.host.json_projection import (
+    HostJsonProjectionError,
+    project_host_value,
+)
 from loushang.harness.host.rpc.output import RpcOutput
 from loushang.harness.host.rpc.routing import LegacyRpcHandler
 from loushang.harness.host.rpc.wire import project_command_descriptor
@@ -21,6 +26,12 @@ class _CommandCatalogSession(Protocol):
         command: str,
         prefix: str,
     ) -> Awaitable[Sequence[object] | None]: ...
+
+    def execute_command_async(
+        self,
+        invocation_name: str,
+        args: str,
+    ) -> Awaitable[object | None]: ...
 
 
 class RpcCommandCatalogCommands:
@@ -39,6 +50,100 @@ class RpcCommandCatalogCommands:
         return (
             ("get_commands", self.get_commands),
             ("get_command_completions", self.get_command_completions),
+            ("execute_command", self.execute_command),
+        )
+
+    async def execute_command(
+        self,
+        command_id: str | None,
+        payload: dict[str, Any],
+    ) -> None:
+        command_name = payload.get("command")
+        if not isinstance(command_name, str):
+            self._error(
+                command_id,
+                "execute_command",
+                "execute_command requires a non-empty string command.",
+                code="invalid_request",
+            )
+            return
+        invocation_name = normalize_command_name(command_name)
+        if not invocation_name:
+            self._error(
+                command_id,
+                "execute_command",
+                "execute_command requires a non-empty string command.",
+                code="invalid_request",
+            )
+            return
+        args = payload.get("args", "")
+        if not isinstance(args, str):
+            self._error(
+                command_id,
+                "execute_command",
+                "execute_command args must be a string.",
+                code="invalid_request",
+            )
+            return
+        executor = getattr(self._get_session(), "execute_command_async", None)
+        if not callable(executor):
+            self._error(
+                command_id,
+                "execute_command",
+                "Command execution is not available.",
+                code="command_execution_unavailable",
+            )
+            return
+        try:
+            execution = executor(invocation_name, args)
+            if inspect.isawaitable(execution):
+                execution = await execution
+        except Exception as error:
+            self._error(
+                command_id,
+                "execute_command",
+                f"Failed to execute command {invocation_name!r}: {error}",
+                code="command_execution_failed",
+            )
+            return
+        if execution is None:
+            self._error(
+                command_id,
+                "execute_command",
+                f"Command not found: {invocation_name}",
+                code="command_not_found",
+            )
+            return
+        result = getattr(execution, "result", execution)
+        projected_invocation_name = getattr(
+            execution,
+            "invocation_name",
+            invocation_name,
+        )
+        if not isinstance(projected_invocation_name, str):
+            projected_invocation_name = invocation_name
+        try:
+            projected_result = project_host_value(
+                result,
+                name="command_result",
+                surface="RPC command",
+            )
+        except HostJsonProjectionError:
+            self._error(
+                command_id,
+                "execute_command",
+                f"Command result is not serializable: {invocation_name}",
+                code="command_result_not_serializable",
+            )
+            return
+        self._output.success(
+            request_id=command_id,
+            command="execute_command",
+            data={
+                "invocationName": projected_invocation_name,
+                "args": args,
+                "result": projected_result,
+            },
         )
 
     def get_commands(

--- a/tests/coding/test_rpc_projection_errors.py
+++ b/tests/coding/test_rpc_projection_errors.py
@@ -111,6 +111,7 @@ def test_rpc_mode_command_catalog_preserves_the_complete_legacy_surface() -> Non
             "compact",
             "cycle_model",
             "cycle_thinking_level",
+            "execute_command",
             "export_html",
             "extension_ui_response",
             "follow_up",

--- a/tests/coding/test_rpc_resources.py
+++ b/tests/coding/test_rpc_resources.py
@@ -680,6 +680,69 @@ def test_rpc_mode_discovers_coding_lsp_session_command() -> None:
     assert command["argumentHint"] == "[status | stop <server-id> <root>]"
 
 
+def test_rpc_mode_executes_coding_lsp_session_command() -> None:
+    from loushang.coding.lsp.commands import (
+        execute_lsp_session_command,
+        lsp_session_command_descriptor,
+    )
+    from loushang.harness.host.rpc import RpcHost as RpcMode
+
+    class LspCommandSession(FakeSession):
+        def list_commands(self):
+            return [lsp_session_command_descriptor()]
+
+        async def execute_command_async(self, invocation_name: str, args: str):
+            assert invocation_name == "lsp"
+            return await execute_lsp_session_command(None, args)
+
+    session = LspCommandSession(session_id="session-a", cwd="/tmp/project")
+    runtime = FakeRuntime(session)
+    stdin = StringIO(
+        json.dumps(
+            {
+                "id": "lsp-status",
+                "type": "execute_command",
+                "command": "lsp",
+                "args": "status",
+            }
+        )
+        + "\n"
+    )
+    stdout = StringIO()
+
+    async def scenario() -> None:
+        mode = RpcMode(runtime=runtime, stdin=stdin, stdout=stdout)
+        assert await mode.run() == 0
+
+    asyncio.run(scenario())
+
+    assert _parse_jsonl(stdout) == [
+        {
+            "id": "lsp-status",
+            "type": "response",
+            "command": "execute_command",
+            "success": True,
+            "data": {
+                "invocationName": "lsp",
+                "args": "status",
+                "result": {
+                    "source": "builtin",
+                    "command": "lsp",
+                    "status": "ok",
+                    "scope": "session",
+                    "enabled": False,
+                    "disposed": False,
+                    "servers": [],
+                    "starting_count": 0,
+                    "ready_count": 0,
+                    "failed_count": 0,
+                    "display": "LSP session capability: disabled",
+                },
+            },
+        }
+    ]
+
+
 def test_rpc_mode_get_commands_projects_session_command_descriptors() -> None:
     from loushang.harness.host.rpc import RpcHost as RpcMode
 

--- a/tests/harness/host/test_rpc_components.py
+++ b/tests/harness/host/test_rpc_components.py
@@ -28,6 +28,7 @@ from loushang.harness.host.rpc.projections import (
     STANDARD_RPC_DIAGNOSTICS_PROJECTION,
 )
 from loushang.harness.host.rpc.routing import legacy_rpc_routes
+from loushang.harness.session import CommandExecutionResult
 
 
 def test_rpc_package_keeps_the_stable_host_exports() -> None:
@@ -199,7 +200,110 @@ def test_rpc_command_groups_declare_their_complete_legacy_bindings() -> None:
     assert tuple(command for command, _handler in command_catalog.bindings()) == (
         "get_commands",
         "get_command_completions",
+        "execute_command",
     )
+
+
+def test_rpc_command_execution_returns_the_current_session_result() -> None:
+    class _Session:
+        def __init__(self, value: str) -> None:
+            self.value = value
+            self.calls: list[tuple[str, str]] = []
+
+        async def execute_command_async(
+            self,
+            invocation_name: str,
+            args: str,
+        ) -> CommandExecutionResult:
+            self.calls.append((invocation_name, args))
+            return CommandExecutionResult(
+                invocation_name=invocation_name,
+                result={"value": self.value},
+            )
+
+    stdout = StringIO()
+    current = [_Session("before")]
+    commands = RpcCommandCatalogCommands(
+        get_session=lambda: current[0],
+        output=RpcOutput(stdout),
+    )
+    selected = _Session("after")
+    current[0] = selected
+
+    asyncio.run(
+        commands.execute_command(
+            "execute",
+            {"command": "/status", "args": "verbose"},
+        )
+    )
+
+    assert selected.calls == [("status", "verbose")]
+    assert json.loads(stdout.getvalue()) == {
+        "id": "execute",
+        "type": "response",
+        "command": "execute_command",
+        "success": True,
+        "data": {
+            "invocationName": "status",
+            "args": "verbose",
+            "result": {"value": "after"},
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("payload", "error_code"),
+    [
+        ({"command": ""}, "invalid_request"),
+        ({"command": "status", "args": []}, "invalid_request"),
+    ],
+)
+def test_rpc_command_execution_rejects_invalid_input(
+    payload: dict[str, object],
+    error_code: str,
+) -> None:
+    stdout = StringIO()
+    commands = RpcCommandCatalogCommands(
+        get_session=object,
+        output=RpcOutput(stdout),
+    )
+
+    asyncio.run(commands.execute_command("execute", payload))
+
+    response = json.loads(stdout.getvalue())
+    assert response["success"] is False
+    assert response["errorCode"] == error_code
+
+
+def test_rpc_command_execution_reports_unknown_and_unserializable_results() -> None:
+    class _Session:
+        def __init__(self) -> None:
+            self.result: object | None = None
+
+        async def execute_command_async(
+            self,
+            invocation_name: str,
+            args: str,
+        ) -> object | None:
+            del invocation_name, args
+            return self.result
+
+    session = _Session()
+    stdout = StringIO()
+    commands = RpcCommandCatalogCommands(
+        get_session=lambda: session,
+        output=RpcOutput(stdout),
+    )
+
+    asyncio.run(commands.execute_command("missing", {"command": "missing"}))
+    session.result = object()
+    asyncio.run(commands.execute_command("unsafe", {"command": "unsafe"}))
+
+    responses = [json.loads(line) for line in stdout.getvalue().splitlines()]
+    assert [response["errorCode"] for response in responses] == [
+        "command_not_found",
+        "command_result_not_serializable",
+    ]
 
 
 def test_rpc_package_commands_resolve_the_current_rebound_session() -> None:


### PR DESCRIPTION
## Summary

- add a Product-neutral `execute_command` request to the existing Harness RPC command-catalog group
- dispatch through the current Session's admitted `execute_command_async` port without a model turn or Product-specific route
- strictly project structured results and return explicit invalid, missing, unavailable, execution, and serialization errors
- exercise `/lsp status` end to end and document the generic RPC request

## Why

RPC clients could discover Session commands but could not execute them and receive their structured result. Coding therefore exposed `/lsp` in TUI and SDK while RPC remained discovery-only. This closes the generic command feedback loop without teaching Harness about LSP.

## Validation

- Harness Ruff: passed
- Harness mypy: 437 source files, no issues
- Harness and import-boundary tests: 1734 passed
- Coding tests: 2338 passed
- architecture import-boundary tests: 157 passed
- focused RPC tests: 50 passed
- `git diff --check`
