### PR TITLE
feat(coding): add bounded LSP diagnostic inbox

### DIFF
--- a/.github/workflows/coding-lsp-compatibility.yml
+++ b/.github/workflows/coding-lsp-compatibility.yml
@@ -1,0 +1,52 @@
+name: Coding LSP Compatibility
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/coding-lsp-compatibility.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/loushang/coding/lsp/**"
+      - "src/loushang/coding/sandbox/**"
+      - "src/loushang/harness/sandbox/**"
+      - "src/loushang/harness/tools/process_hosting/**"
+      - "tests/integration/coding/test_pyright_lsp_live.py"
+  pull_request:
+    paths:
+      - ".github/workflows/coding-lsp-compatibility.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/loushang/coding/lsp/**"
+      - "src/loushang/coding/sandbox/**"
+      - "src/loushang/harness/sandbox/**"
+      - "src/loushang/harness/tools/process_hosting/**"
+      - "tests/integration/coding/test_pyright_lsp_live.py"
+  workflow_dispatch:
+
+jobs:
+  pyright-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install Python dependencies
+        run: uv sync --locked --extra dev
+
+      - name: Install pinned Pyright
+        run: npm install --global pyright@1.1.411
+
+      - name: Verify real Pyright LSP compatibility
+        run: uv run pytest tests/integration/coding/test_pyright_lsp_live.py -q

--- a/docs/internals/architecture/coding/lsp/candidate-components.md
+++ b/docs/internals/architecture/coding/lsp/candidate-components.md
@@ -79,13 +79,13 @@ also translates committed workspace mutations into `didOpen`, `didChange`,
 
 ### `diagnostics`
 
-H4 consumes diagnostic publications, validates source runtime and version,
-replaces the current set for a document, computes bounded deltas, deduplicates
-delivery, and expires stale state. It owns `CodeDiagnostic`, not Harness
-operational diagnostic records.
+H4.1 consumes diagnostic publications, validates source runtime and version,
+and replaces the bounded current set for a document. H4.2 computes delivery
+deltas, deduplicates delivery, and expires pending state. The component owns
+`CodeDiagnostic`, not Harness operational diagnostic records.
 
-P0 does not instantiate this component; its client recognizes and discards
-`publishDiagnostics` without retaining the payload.
+The ordinary H4.1 binding instantiates this component. It does not expose a
+diagnostic query tool or inject model context.
 
 ### `tools`
 

--- a/docs/internals/architecture/coding/lsp/component-boundaries.md
+++ b/docs/internals/architecture/coding/lsp/component-boundaries.md
@@ -174,8 +174,9 @@ Own one initialized JSON-RPC/LSP connection to one process.
 Events are delivered through injected callbacks or an event sink. The client
 does not import higher-level components.
 
-In P0, `publishDiagnostics` is recognized and discarded without payload
-retention. The H4 binding routes it to `diagnostics`.
+H4.1 routes `publishDiagnostics` through a bounded synchronous callback to
+`diagnostics`. Client closure also invokes a non-blocking lifecycle callback so
+runtime-local diagnostic state is released on graceful exit or failure.
 
 ### Out Of Scope
 
@@ -283,15 +284,15 @@ parsing language syntax, and presenting diagnostics.
 
 ### Role
 
-Maintain current code-diagnostic state and bounded model-delivery deltas.
+Maintain bounded current code-diagnostic state. H4.2 adds model-delivery deltas.
 
 ### Owns
 
 - replacement sets keyed by runtime, canonical document, and accepted version;
 - normalization, deduplication, severity mapping, and stale rejection;
-- per-document, per-turn, and total-memory limits;
-- pending-delivery markers and bounded expiry;
-- distinction between current state and newly deliverable delta.
+- per-document and total-memory limits;
+- H4.2 pending-delivery markers, per-turn limits, and bounded expiry;
+- H4.2 distinction between current state and newly deliverable delta.
 
 ### Depends On
 
@@ -303,13 +304,13 @@ Maintain current code-diagnostic state and bounded model-delivery deltas.
 
 - `replace_publication(runtime, uri, version, diagnostics)`
 - `clear_runtime(key)`
-- `mark_delivered(delivery_id)`
-- `expire(now)`
+- H4.2 `mark_delivered(delivery_id)`
+- H4.2 `expire(now)`
 
 ### Queries
 
 - `current(path=None)`
-- `pending_delta(budget) -> DiagnosticDelivery`
+- H4.2 `pending_delta(budget) -> DiagnosticDelivery`
 - `snapshot()`
 
 ### Events

--- a/docs/internals/architecture/coding/lsp/harness-foundation.md
+++ b/docs/internals/architecture/coding/lsp/harness-foundation.md
@@ -600,9 +600,13 @@ Only H1-H2 are Harness prerequisites for active production LSP.
 - ship bounded active semantic tools and read-only status/doctor;
 - on crash, fail current requests and allow the next demand to reauthorize and
   start a replacement;
-- do not add warm-up, idle eviction, automatic backoff or passive diagnostics.
+- do not add warm-up, idle eviction, automatic backoff or model-visible passive
+  diagnostic delivery.
 
 ### H4. Passive diagnostic feedback
+
+H4.1 is Coding-only bounded reception and lifecycle cleanup; it needs no new
+Harness contract. H4.2 completes the feedback loop:
 
 - add the minimal mutation fact/source/sink over `OrderedEventBus`;
 - integrate successful Harness write/edit commits;

--- a/docs/internals/architecture/coding/lsp/requirements.md
+++ b/docs/internals/architecture/coding/lsp/requirements.md
@@ -194,20 +194,23 @@ target document with disk state and resynchronize if necessary. This preserves
 correctness for shell commands, external editors, or mutation sources not yet
 covered by the event path.
 
-### R12. Passive diagnostics (H4, deferred from active P0)
+### R12. Passive diagnostics (H4.1 reception; H4.2 delivery)
 
 The capability must be able to receive `publishDiagnostics`, retain the latest
 diagnostic set per Server/document, recognize empty sets as clearing previous
 diagnostics, and project only new, relevant diagnostics to the model.
 
-Diagnostic delivery must be version-aware where the Server supplies a version,
-bounded per file and per turn, severity ordered, deduplicated across turns, and
-capable of marking unversioned or stale information.
+Diagnostic reception must be version-aware where the Server supplies a version,
+bounded per document and session, severity ordered, and capable of recognizing
+unversioned or stale information. Diagnostic delivery must additionally be
+bounded per turn and deduplicated across turns.
 
-P0 recognizes and discards `publishDiagnostics` without retaining payloads or
-injecting context. This keeps ordinary Servers protocol-safe before H4 exists.
+H4.1 retains normalized current replacement sets for already-open documents and
+clears them on empty publication, document advance, runtime retirement, crash,
+or session disposal. It does not inject model context. H4.2 adds committed
+mutation consumption and bounded model delivery.
 
-### R13. Separate code diagnostics (H4 data; P0 operational failures only)
+### R13. Separate code diagnostics (H4.1 data)
 
 LSP diagnostics must use Coding-owned `CodeDiagnostic` records. They must not be
 stored as Harness operational `DiagnosticRecord` values, which represent

--- a/docs/internals/architecture/coding/lsp/specification.md
+++ b/docs/internals/architecture/coding/lsp/specification.md
@@ -419,10 +419,11 @@ P0 handlers:
 | `window/showMessageRequest` | reject or select no action |
 | unknown request | JSON-RPC method-not-found/error response |
 
-P0 also recognizes `textDocument/publishDiagnostics` notifications and discards
-them after validating only the bounded envelope needed to identify the method.
-It retains no diagnostic payload, injects no model context, and logs no source
-content. H4 replaces this discard handler with the bounded diagnostic Inbox.
+H4.1 routes `textDocument/publishDiagnostics` notifications synchronously to a
+bounded session-local Inbox. The handler accepts only already-open documents,
+normalizes at most a fixed number of items, and never performs I/O or awaits a
+consumer on the protocol reader. Rejected publications increment a bounded
+status counter. No diagnostic payload is injected into model context or logged.
 Unknown notifications are ignored with at most bounded metadata diagnostics.
 
 Client capabilities must disable dynamic features that the client does not
@@ -588,7 +589,7 @@ not the primary bounding mechanism.
 
 ## 10. Passive Diagnostic Feedback
 
-### 10.1 Authoritative current set
+### 10.1 Authoritative current set (H4.1 implemented)
 
 LSP diagnostics are published as a complete set for a Server/document. The
 Inbox replaces the current set for that key, including replacement by an empty
@@ -604,7 +605,14 @@ If a version is present:
 If no version is present, records are marked unversioned and tied to the latest
 observed document state without claiming exact version authority.
 
-### 10.2 Pending delivery
+The initial implementation scans at most 512 raw items per publication, retains
+at most 100 normalized diagnostics per document, 128 documents, 2,048 total
+diagnostics, and a 256K-character diagnostic accounting budget per session. It
+also bounds individual message, code, source, and tag values. The Inbox evicts
+the least-recently-replaced document set when a total limit is exceeded and
+records omission, truncation, malformed, version-anomaly, and eviction counters.
+
+### 10.2 Pending delivery (H4.2 deferred)
 
 The Inbox derives a delta against delivered keys. A diagnostic key includes
 Server, URI, version class, range, severity, code, source, and message.
@@ -622,7 +630,7 @@ priority: error -> warning -> information -> hint
 Measured H4 implementation work selects the exact Coding Product defaults. The
 projection reports how many diagnostics were omitted.
 
-### 10.3 Delivery point
+### 10.3 Delivery point (H4.2 deferred)
 
 Pending diagnostics are attached after a completed tool batch or before the
 next model turn, not injected while a model response is streaming. A debounce
@@ -687,7 +695,7 @@ granted by Server capability negotiation alone.
 
 ## 12. Status And Operational Diagnostics
 
-The status surface returns bounded records for:
+The target status surface returns bounded records for:
 
 - catalog generation and definition provenance;
 - admitted/rejected/unavailable definitions;
@@ -698,6 +706,10 @@ The status surface returns bounded records for:
 - open document count;
 - current/pending diagnostic counts;
 - result and diagnostic truncation counts.
+
+H4.1 exposes accepted/rejected publication counts and current diagnostic
+document/item counts per live runtime. Detailed Inbox omission and truncation
+counters remain internal until H4.2 defines their stable SDK/TUI projection.
 
 Source text, request payload contents, inherited environment, and unrestricted
 stderr are excluded. Stderr is kept in a bounded operational buffer or artifact
@@ -808,12 +820,15 @@ direct subprocess launcher as a temporary production bypass.
 - status/doctor;
 - explicit stop; after a crash or stop, the next demand may reauthorize and
   start a replacement;
+- H4.1 bounded, version-aware passive diagnostic reception and lifecycle
+  cleanup, without model delivery;
 - fake Server tests;
+- a path-scoped CI compatibility gate against a pinned real Pyright Server;
 - clean degradation when no Server exists.
 
 ### Deferred
 
-- committed workspace mutation event and passive diagnostics;
+- committed workspace mutation event and H4.2 diagnostic delivery;
 - workspace warm-up and idle eviction;
 - automatic restart budgets and exponential backoff;
 - live catalog-generation migration;

--- a/src/loushang/coding/lsp/__init__.py
+++ b/src/loushang/coding/lsp/__init__.py
@@ -15,6 +15,7 @@ from loushang.coding.lsp.discovery import (
 )
 from loushang.coding.lsp.documents import DocumentSnapshot, LspDocumentManager
 from loushang.coding.lsp.model import (
+    CodeDiagnostic,
     CodeHover,
     CodeLocation,
     CodePosition,
@@ -69,6 +70,7 @@ from loushang.coding.lsp.tools import (
 
 __all__ = [
     "AuthorizedProcessLauncher",
+    "CodeDiagnostic",
     "CodeHover",
     "CodeLocation",
     "CodePosition",

--- a/src/loushang/coding/lsp/binding.py
+++ b/src/loushang/coding/lsp/binding.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 from loushang.coding.lsp.catalog import LspCatalog
+from loushang.coding.lsp.diagnostics import DiagnosticInbox
 from loushang.coding.lsp.documents import LspDocumentManager
 from loushang.coding.lsp.model import (
     CodeQueryResult,
@@ -49,15 +50,21 @@ class CodingLspBinding:
             workspace_root=root,
             read_text=read_text,
         )
+        diagnostics = DiagnosticInbox(
+            workspace_root=root,
+            document_lookup=documents.snapshot_for_uri,
+        )
         supervisor = LspServerSupervisor(
             catalog=catalog,
             launcher=launcher,
             baseline_environment=baseline_environment,
             open_document_count=documents.open_document_count,
             release_runtime_documents=documents.release_runtime,
+            diagnostics=diagnostics,
         )
         self._workspace_root = root
         self._catalog = catalog
+        self._diagnostics = diagnostics
         self._supervisor = supervisor
         self._tools = CodingLspTools(
             selector=selector,

--- a/src/loushang/coding/lsp/client.py
+++ b/src/loushang/coding/lsp/client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from types import MappingProxyType
 
@@ -16,6 +16,9 @@ _MAX_HEADER_BYTES = 16 * 1024
 _MAX_MESSAGE_BYTES = 4 * 1024 * 1024
 _MAX_PENDING_REQUESTS = 128
 _MAX_CONFIGURATION_ITEMS = 64
+
+DiagnosticPublicationHandler = Callable[[Mapping[str, object]], bool]
+ConnectionClosedHandler = Callable[[], None]
 
 
 class LspClient:
@@ -28,11 +31,15 @@ class LspClient:
         request_timeout_seconds: float,
         shutdown_timeout_seconds: float,
         settings: Mapping[str, object] | None = None,
+        on_publish_diagnostics: DiagnosticPublicationHandler | None = None,
+        on_close: ConnectionClosedHandler | None = None,
     ) -> None:
         self._handle = handle
         self._request_timeout_seconds = request_timeout_seconds
         self._shutdown_timeout_seconds = shutdown_timeout_seconds
         self._settings = dict(settings or {})
+        self._on_publish_diagnostics = on_publish_diagnostics
+        self._on_close = on_close
         self._buffer = bytearray()
         self._write_lock = asyncio.Lock()
         self._lifecycle_lock = asyncio.Lock()
@@ -43,6 +50,7 @@ class LspClient:
         self._state = "open"
         self._position_encoding = "utf-16"
         self._server_capabilities: Mapping[str, object] = MappingProxyType({})
+        self._accepted_diagnostic_publications = 0
         self._discarded_diagnostic_publications = 0
         self._request_count = 0
         self._timeout_count = 0
@@ -66,6 +74,10 @@ class LspClient:
     @property
     def discarded_diagnostic_publications(self) -> int:
         return self._discarded_diagnostic_publications
+
+    @property
+    def accepted_diagnostic_publications(self) -> int:
+        return self._accepted_diagnostic_publications
 
     @property
     def request_count(self) -> int:
@@ -123,6 +135,11 @@ class LspClient:
                             "documentSymbol": {
                                 "dynamicRegistration": False,
                                 "hierarchicalDocumentSymbolSupport": True,
+                            },
+                            "publishDiagnostics": {
+                                "relatedInformation": False,
+                                "tagSupport": {"valueSet": [1, 2]},
+                                "versionSupport": True,
                             },
                         },
                         "workspace": {
@@ -213,7 +230,7 @@ class LspClient:
                         "$/cancelRequest",
                         {"id": request_id},
                         allow_closing=allow_closing,
-                )
+                    )
                 raise
             except BaseException:
                 self._last_error = "request_failed"
@@ -360,6 +377,9 @@ class LspClient:
                     error = LspProtocolError(f"LSP reader failed: {error}")
                 self._last_error = "connection_closed"
                 self._fail_pending(error)
+            if self._on_close is not None:
+                with suppress(Exception):
+                    self._on_close()
 
     async def _read_message(self) -> Mapping[str, object]:
         while b"\r\n\r\n" not in self._buffer:
@@ -408,7 +428,20 @@ class LspClient:
             if "id" in message:
                 await self._handle_server_request(message, method)
             elif method == "textDocument/publishDiagnostics":
-                self._discarded_diagnostic_publications += 1
+                accepted = False
+                params = message.get("params")
+                if (
+                    isinstance(params, Mapping)
+                    and self._on_publish_diagnostics is not None
+                ):
+                    try:
+                        accepted = self._on_publish_diagnostics(params) is True
+                    except Exception:
+                        accepted = False
+                if not accepted:
+                    self._discarded_diagnostic_publications += 1
+                else:
+                    self._accepted_diagnostic_publications += 1
             return
 
         response_id = message.get("id")
@@ -463,4 +496,8 @@ def _thaw_json(value: object) -> object:
     return value
 
 
-__all__ = ["LspClient"]
+__all__ = [
+    "ConnectionClosedHandler",
+    "DiagnosticPublicationHandler",
+    "LspClient",
+]

--- a/src/loushang/coding/lsp/commands.py
+++ b/src/loushang/coding/lsp/commands.py
@@ -56,7 +56,9 @@ async def execute_lsp_session_command(
     if action == "status":
         if len(values) != 1 and values:
             return _usage_error()
-        status = runtime.status() if runtime is not None else disabled_lsp_session_status()
+        status = (
+            runtime.status() if runtime is not None else disabled_lsp_session_status()
+        )
         return _status_result(status)
     if action != "stop" or len(values) != 3:
         return _usage_error()
@@ -134,6 +136,7 @@ def _status_display(status: LspSessionStatus) -> str:
         lines.append(
             f"{server.state}\t{server.definition_id}\t{server.workspace_root}\t"
             f"documents={server.open_document_count}\t"
+            f"diagnostics={server.current_diagnostic_count}\t"
             f"requests={server.request_count}\ttimeouts={server.timeout_count}\t"
             f"replacements={server.replacement_count}"
         )

--- a/src/loushang/coding/lsp/diagnostics.py
+++ b/src/loushang/coding/lsp/diagnostics.py
@@ -1,0 +1,456 @@
+"""Bounded, version-aware passive diagnostic state for one Coding session."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from time import time
+from typing import Protocol
+
+from loushang.coding.lsp.model import CodeDiagnostic, LspProtocolError
+from loushang.coding.lsp.positions import parse_lsp_range, to_public_range
+
+DEFAULT_MAX_DIAGNOSTIC_DOCUMENTS = 128
+DEFAULT_MAX_DIAGNOSTICS_PER_DOCUMENT = 100
+DEFAULT_MAX_TOTAL_DIAGNOSTICS = 2_048
+DEFAULT_MAX_DIAGNOSTIC_CHARACTERS = 256 * 1024
+DEFAULT_MAX_RAW_DIAGNOSTICS_PER_PUBLICATION = 512
+MAX_DIAGNOSTIC_MESSAGE_CHARACTERS = 2_000
+MAX_DIAGNOSTIC_CODE_CHARACTERS = 256
+MAX_DIAGNOSTIC_SOURCE_CHARACTERS = 128
+
+_SEVERITIES = {
+    1: "error",
+    2: "warning",
+    3: "information",
+    4: "hint",
+}
+_SEVERITY_ORDER = {
+    "error": 0,
+    "warning": 1,
+    "information": 2,
+    "hint": 3,
+    "unknown": 4,
+}
+_TAGS = {1: "unnecessary", 2: "deprecated"}
+
+
+class DiagnosticDocumentState(Protocol):
+    path: Path
+    uri: str
+    version: int
+    content: str
+
+
+DiagnosticDocumentLookup = Callable[
+    [int, str],
+    DiagnosticDocumentState | None,
+]
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticInboxSnapshot:
+    document_count: int
+    diagnostic_count: int
+    total_characters: int
+    publication_count: int
+    malformed_publication_count: int
+    unknown_document_publication_count: int
+    stale_publication_count: int
+    future_publication_count: int
+    omitted_diagnostic_count: int
+    truncated_value_count: int
+    evicted_document_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class _DiagnosticPublication:
+    runtime_id: int
+    uri: str
+    document_version: int
+    diagnostics: tuple[CodeDiagnostic, ...]
+    characters: int
+
+
+class DiagnosticInbox:
+    """Retain only current, bounded diagnostic replacement sets."""
+
+    def __init__(
+        self,
+        *,
+        workspace_root: Path,
+        document_lookup: DiagnosticDocumentLookup,
+        max_documents: int = DEFAULT_MAX_DIAGNOSTIC_DOCUMENTS,
+        max_diagnostics_per_document: int = DEFAULT_MAX_DIAGNOSTICS_PER_DOCUMENT,
+        max_total_diagnostics: int = DEFAULT_MAX_TOTAL_DIAGNOSTICS,
+        max_total_characters: int = DEFAULT_MAX_DIAGNOSTIC_CHARACTERS,
+        max_raw_diagnostics_per_publication: int = (
+            DEFAULT_MAX_RAW_DIAGNOSTICS_PER_PUBLICATION
+        ),
+        clock: Callable[[], float] = time,
+    ) -> None:
+        limits = {
+            "max_documents": max_documents,
+            "max_diagnostics_per_document": max_diagnostics_per_document,
+            "max_total_diagnostics": max_total_diagnostics,
+            "max_total_characters": max_total_characters,
+            "max_raw_diagnostics_per_publication": (
+                max_raw_diagnostics_per_publication
+            ),
+        }
+        for name, value in limits.items():
+            if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+                raise ValueError(f"{name} must be a positive integer")
+        self._workspace_root = workspace_root.resolve()
+        self._document_lookup = document_lookup
+        self._max_documents = max_documents
+        self._max_diagnostics_per_document = max_diagnostics_per_document
+        self._max_total_diagnostics = max_total_diagnostics
+        self._max_total_characters = max_total_characters
+        self._max_raw_diagnostics_per_publication = max_raw_diagnostics_per_publication
+        self._clock = clock
+        self._entries: OrderedDict[
+            tuple[int, str],
+            _DiagnosticPublication,
+        ] = OrderedDict()
+        self._diagnostic_count = 0
+        self._total_characters = 0
+        self._publication_count = 0
+        self._malformed_publication_count = 0
+        self._unknown_document_publication_count = 0
+        self._stale_publication_count = 0
+        self._future_publication_count = 0
+        self._omitted_diagnostic_count = 0
+        self._truncated_value_count = 0
+        self._evicted_document_count = 0
+
+    def replace_publication(
+        self,
+        *,
+        runtime_id: int,
+        server_id: str,
+        uri: object,
+        version: object,
+        diagnostics: object,
+    ) -> bool:
+        """Replace one complete Server/document set; return whether it was accepted."""
+
+        self._publication_count += 1
+        if (
+            not isinstance(runtime_id, int)
+            or isinstance(runtime_id, bool)
+            or runtime_id < 1
+            or not isinstance(server_id, str)
+            or not server_id
+            or not isinstance(uri, str)
+            or not uri
+            or not isinstance(diagnostics, list)
+        ):
+            self._malformed_publication_count += 1
+            return False
+        if version is not None and (
+            not isinstance(version, int) or isinstance(version, bool) or version < 0
+        ):
+            self._malformed_publication_count += 1
+            return False
+
+        document = self._document_lookup(runtime_id, uri)
+        if document is None or document.uri != uri:
+            self._unknown_document_publication_count += 1
+            return False
+        key = (runtime_id, uri)
+        previous = self._entries.get(key)
+        if previous is not None and previous.document_version != document.version:
+            self._remove(key)
+        if isinstance(version, int):
+            if version < document.version:
+                self._stale_publication_count += 1
+                return False
+            if version > document.version:
+                self._future_publication_count += 1
+                return False
+
+        raw_items = diagnostics[: self._max_raw_diagnostics_per_publication]
+        self._omitted_diagnostic_count += max(len(diagnostics) - len(raw_items), 0)
+        received_at = self._clock()
+        normalized: dict[tuple[object, ...], CodeDiagnostic] = {}
+        for item in raw_items:
+            diagnostic, truncated_values = self._normalize_diagnostic(
+                item,
+                server_id=server_id,
+                document=document,
+                version=version,
+                received_at=received_at,
+            )
+            self._truncated_value_count += truncated_values
+            if diagnostic is None:
+                self._omitted_diagnostic_count += 1
+                continue
+            normalized.setdefault(_diagnostic_key(diagnostic), diagnostic)
+
+        candidates = sorted(normalized.values(), key=_diagnostic_sort_key)
+        retained: list[CodeDiagnostic] = []
+        path = _workspace_relative_path(document.path, self._workspace_root)
+        characters = len(uri) + (len(path) if path is not None else 0)
+        item_limit = min(
+            self._max_diagnostics_per_document,
+            self._max_total_diagnostics,
+        )
+        for diagnostic in candidates:
+            item_characters = _diagnostic_characters(diagnostic)
+            if (
+                len(retained) >= item_limit
+                or characters + item_characters > self._max_total_characters
+            ):
+                self._omitted_diagnostic_count += 1
+                continue
+            retained.append(diagnostic)
+            characters += item_characters
+
+        self._remove(key)
+        if retained:
+            publication = _DiagnosticPublication(
+                runtime_id=runtime_id,
+                uri=uri,
+                document_version=document.version,
+                diagnostics=tuple(retained),
+                characters=characters,
+            )
+            self._entries[key] = publication
+            self._diagnostic_count += len(publication.diagnostics)
+            self._total_characters += publication.characters
+            self._enforce_total_limits()
+        return True
+
+    def current(self, *, runtime_id: int | None = None) -> tuple[CodeDiagnostic, ...]:
+        self._prune_obsolete(runtime_id)
+        return tuple(
+            diagnostic
+            for publication in self._entries.values()
+            if runtime_id is None or publication.runtime_id == runtime_id
+            for diagnostic in publication.diagnostics
+        )
+
+    def counts(self, runtime_id: int) -> tuple[int, int]:
+        self._prune_obsolete(runtime_id)
+        publications = tuple(
+            publication
+            for publication in self._entries.values()
+            if publication.runtime_id == runtime_id
+        )
+        return len(publications), sum(
+            len(publication.diagnostics) for publication in publications
+        )
+
+    def release_runtime(self, runtime_id: int) -> None:
+        for key in tuple(self._entries):
+            if key[0] == runtime_id:
+                self._remove(key)
+
+    def snapshot(self) -> DiagnosticInboxSnapshot:
+        self._prune_obsolete()
+        return DiagnosticInboxSnapshot(
+            document_count=len(self._entries),
+            diagnostic_count=self._diagnostic_count,
+            total_characters=self._total_characters,
+            publication_count=self._publication_count,
+            malformed_publication_count=self._malformed_publication_count,
+            unknown_document_publication_count=(
+                self._unknown_document_publication_count
+            ),
+            stale_publication_count=self._stale_publication_count,
+            future_publication_count=self._future_publication_count,
+            omitted_diagnostic_count=self._omitted_diagnostic_count,
+            truncated_value_count=self._truncated_value_count,
+            evicted_document_count=self._evicted_document_count,
+        )
+
+    def _normalize_diagnostic(
+        self,
+        value: object,
+        *,
+        server_id: str,
+        document: DiagnosticDocumentState,
+        version: int | None,
+        received_at: float,
+    ) -> tuple[CodeDiagnostic | None, int]:
+        if not isinstance(value, Mapping):
+            return None, 0
+        raw_message = value.get("message")
+        raw_range = value.get("range")
+        if (
+            not isinstance(raw_message, str)
+            or not raw_message.strip()
+            or not isinstance(raw_range, Mapping)
+        ):
+            return None, 0
+        try:
+            code_range = to_public_range(
+                document.content,
+                parse_lsp_range(raw_range),
+            )
+        except LspProtocolError:
+            return None, 0
+
+        message, message_truncated = _bounded_text(
+            raw_message.strip(),
+            MAX_DIAGNOSTIC_MESSAGE_CHARACTERS,
+        )
+        code = value.get("code")
+        if isinstance(code, int) and not isinstance(code, bool):
+            code = str(code)
+        if not isinstance(code, str):
+            code = None
+        code, code_truncated = _bounded_optional_text(
+            code,
+            MAX_DIAGNOSTIC_CODE_CHARACTERS,
+        )
+        source, source_truncated = _bounded_optional_text(
+            value.get("source") if isinstance(value.get("source"), str) else None,
+            MAX_DIAGNOSTIC_SOURCE_CHARACTERS,
+        )
+        raw_tags = value.get("tags")
+        tags_truncated = isinstance(raw_tags, list) and len(raw_tags) > 8
+        tags = (
+            tuple(
+                tag
+                for item in raw_tags[:8]
+                if isinstance(item, int)
+                and not isinstance(item, bool)
+                and (tag := _TAGS.get(item)) is not None
+            )
+            if isinstance(raw_tags, list)
+            else ()
+        )
+        severity_value = value.get("severity")
+        severity = (
+            _SEVERITIES.get(severity_value, "unknown")
+            if isinstance(severity_value, int) and not isinstance(severity_value, bool)
+            else "unknown"
+        )
+        return (
+            CodeDiagnostic(
+                server_id=server_id,
+                uri=document.uri,
+                path=_workspace_relative_path(document.path, self._workspace_root),
+                version=version,
+                severity=severity,
+                message=message,
+                range=code_range,
+                code=code,
+                source=source,
+                tags=tags,
+                received_at=received_at,
+            ),
+            sum(
+                (
+                    message_truncated,
+                    code_truncated,
+                    source_truncated,
+                    tags_truncated,
+                )
+            ),
+        )
+
+    def _enforce_total_limits(self) -> None:
+        while (
+            len(self._entries) > self._max_documents
+            or self._diagnostic_count > self._max_total_diagnostics
+            or self._total_characters > self._max_total_characters
+        ):
+            _key, publication = self._entries.popitem(last=False)
+            self._diagnostic_count -= len(publication.diagnostics)
+            self._total_characters -= publication.characters
+            self._omitted_diagnostic_count += len(publication.diagnostics)
+            self._evicted_document_count += 1
+
+    def _remove(self, key: tuple[int, str]) -> None:
+        publication = self._entries.pop(key, None)
+        if publication is None:
+            return
+        self._diagnostic_count -= len(publication.diagnostics)
+        self._total_characters -= publication.characters
+
+    def _prune_obsolete(self, runtime_id: int | None = None) -> None:
+        for key, publication in tuple(self._entries.items()):
+            if runtime_id is not None and publication.runtime_id != runtime_id:
+                continue
+            document = self._document_lookup(publication.runtime_id, publication.uri)
+            if document is None or document.version != publication.document_version:
+                self._remove(key)
+
+
+def _workspace_relative_path(path: Path, workspace_root: Path) -> str | None:
+    try:
+        return path.resolve().relative_to(workspace_root).as_posix()
+    except (OSError, ValueError):
+        return None
+
+
+def _bounded_text(value: str, limit: int) -> tuple[str, bool]:
+    return (value, False) if len(value) <= limit else (value[:limit], True)
+
+
+def _bounded_optional_text(
+    value: str | None,
+    limit: int,
+) -> tuple[str | None, bool]:
+    if value is None:
+        return None, False
+    bounded, truncated = _bounded_text(value, limit)
+    return bounded, truncated
+
+
+def _diagnostic_key(diagnostic: CodeDiagnostic) -> tuple[object, ...]:
+    return (
+        diagnostic.range.start.line,
+        diagnostic.range.start.character,
+        diagnostic.range.end.line,
+        diagnostic.range.end.character,
+        diagnostic.severity,
+        diagnostic.code,
+        diagnostic.source,
+        diagnostic.message,
+        diagnostic.tags,
+    )
+
+
+def _diagnostic_sort_key(diagnostic: CodeDiagnostic) -> tuple[object, ...]:
+    return (
+        _SEVERITY_ORDER[diagnostic.severity],
+        diagnostic.range.start.line,
+        diagnostic.range.start.character,
+        diagnostic.message,
+        diagnostic.code or "",
+    )
+
+
+def _diagnostic_characters(diagnostic: CodeDiagnostic) -> int:
+    return (
+        len(diagnostic.server_id)
+        + len(diagnostic.uri)
+        + len(diagnostic.path or "")
+        + len(diagnostic.message)
+        + len(diagnostic.code or "")
+        + len(diagnostic.source or "")
+        + sum(len(tag) for tag in diagnostic.tags)
+        + 64
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_DIAGNOSTIC_CHARACTERS",
+    "DEFAULT_MAX_DIAGNOSTIC_DOCUMENTS",
+    "DEFAULT_MAX_DIAGNOSTICS_PER_DOCUMENT",
+    "DEFAULT_MAX_RAW_DIAGNOSTICS_PER_PUBLICATION",
+    "DEFAULT_MAX_TOTAL_DIAGNOSTICS",
+    "DiagnosticDocumentLookup",
+    "DiagnosticDocumentState",
+    "DiagnosticInbox",
+    "DiagnosticInboxSnapshot",
+    "MAX_DIAGNOSTIC_CODE_CHARACTERS",
+    "MAX_DIAGNOSTIC_MESSAGE_CHARACTERS",
+    "MAX_DIAGNOSTIC_SOURCE_CHARACTERS",
+]

--- a/src/loushang/coding/lsp/documents.py
+++ b/src/loushang/coding/lsp/documents.py
@@ -63,18 +63,23 @@ class LspDocumentManager:
                     content=content,
                     content_hash=content_hash,
                 )
-                await runtime.client.notify(
-                    "textDocument/didOpen",
-                    {
-                        "textDocument": {
-                            "uri": uri,
-                            "languageId": language_id,
-                            "version": 1,
-                            "text": content,
-                        }
-                    },
-                )
                 self._snapshots[key] = snapshot
+                try:
+                    await runtime.client.notify(
+                        "textDocument/didOpen",
+                        {
+                            "textDocument": {
+                                "uri": uri,
+                                "languageId": language_id,
+                                "version": 1,
+                                "text": content,
+                            }
+                        },
+                    )
+                except BaseException:
+                    if self._snapshots.get(key) is snapshot:
+                        self._snapshots.pop(key, None)
+                    raise
                 return snapshot
             if current.content_hash == content_hash:
                 return current
@@ -87,17 +92,22 @@ class LspDocumentManager:
                 content=content,
                 content_hash=content_hash,
             )
-            await runtime.client.notify(
-                "textDocument/didChange",
-                {
-                    "textDocument": {
-                        "uri": uri,
-                        "version": snapshot.version,
-                    },
-                    "contentChanges": [{"text": content}],
-                },
-            )
             self._snapshots[key] = snapshot
+            try:
+                await runtime.client.notify(
+                    "textDocument/didChange",
+                    {
+                        "textDocument": {
+                            "uri": uri,
+                            "version": snapshot.version,
+                        },
+                        "contentChanges": [{"text": content}],
+                    },
+                )
+            except BaseException:
+                if self._snapshots.get(key) is snapshot:
+                    self._snapshots[key] = current
+                raise
             return snapshot
 
     def canonical_path(self, path: str | Path) -> Path:
@@ -125,6 +135,15 @@ class LspDocumentManager:
         if runtime_id is None:
             return len(self._snapshots)
         return sum(key[0] == runtime_id for key in self._snapshots)
+
+    def snapshot_for_uri(
+        self,
+        runtime_id: int,
+        uri: str,
+    ) -> DocumentSnapshot | None:
+        """Return the current runtime-local snapshot without opening a document."""
+
+        return self._snapshots.get((runtime_id, uri))
 
     def release_runtime(self, runtime_id: int) -> None:
         snapshot_keys = [key for key in self._snapshots if key[0] == runtime_id]

--- a/src/loushang/coding/lsp/model.py
+++ b/src/loushang/coding/lsp/model.py
@@ -174,6 +174,24 @@ class CodeHover:
 
 
 @dataclass(frozen=True, slots=True)
+class CodeDiagnostic:
+    """One normalized code diagnostic, distinct from Harness operations."""
+
+    server_id: str
+    uri: str
+    path: str | None
+    version: int | None
+    severity: str
+    message: str
+    range: CodeRange
+    code: str | None = None
+    source: str | None = None
+    tags: tuple[str, ...] = ()
+    received_at: float = 0.0
+    stale: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class CodeQueryResult:
     items: tuple[CodeLocation | CodeHover, ...]
     count: int
@@ -276,6 +294,7 @@ def _freeze_json_value(value: object) -> object:
 
 
 __all__ = [
+    "CodeDiagnostic",
     "CodeHover",
     "CodeLocation",
     "CodePosition",

--- a/src/loushang/coding/lsp/positions.py
+++ b/src/loushang/coding/lsp/positions.py
@@ -1,0 +1,104 @@
+"""Shared UTF-16/LSP and public code-point position conversion."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from loushang.coding.lsp.model import (
+    CodePosition,
+    CodeRange,
+    LspInvalidInputError,
+    LspProtocolError,
+)
+
+
+def to_lsp_position(content: str, position: CodePosition) -> dict[str, int]:
+    lines = content.split("\n")
+    if position.line > len(lines):
+        raise LspInvalidInputError("line is outside the current document")
+    line = lines[position.line - 1]
+    if line.endswith("\r"):
+        line = line[:-1]
+    offset = position.character - 1
+    if offset > len(line):
+        raise LspInvalidInputError("character is outside the current line")
+    utf16_character = len(line[:offset].encode("utf-16-le")) // 2
+    return {"line": position.line - 1, "character": utf16_character}
+
+
+def parse_lsp_range(
+    raw_range: Mapping[str, object],
+) -> tuple[tuple[int, int], tuple[int, int]]:
+    def position(name: str) -> tuple[int, int]:
+        raw = raw_range.get(name)
+        if not isinstance(raw, Mapping):
+            raise LspProtocolError(f"LSP range {name!r} must be an object")
+        line = raw.get("line")
+        character = raw.get("character")
+        if (
+            not isinstance(line, int)
+            or isinstance(line, bool)
+            or line < 0
+            or not isinstance(character, int)
+            or isinstance(character, bool)
+            or character < 0
+        ):
+            raise LspProtocolError("LSP positions must be non-negative integers")
+        return line, character
+
+    start = position("start")
+    end = position("end")
+    if end < start:
+        raise LspProtocolError("LSP range end precedes its start")
+    return start, end
+
+
+def to_public_range(
+    content: str,
+    value: tuple[tuple[int, int], tuple[int, int]],
+) -> CodeRange:
+    return CodeRange(
+        start=to_public_position(content, value[0]),
+        end=to_public_position(content, value[1]),
+    )
+
+
+def to_public_position(content: str, value: tuple[int, int]) -> CodePosition:
+    line_number, utf16_character = value
+    lines = content.split("\n")
+    if line_number >= len(lines):
+        raise LspProtocolError("LSP result line is outside the target document")
+    line = lines[line_number]
+    if line.endswith("\r"):
+        line = line[:-1]
+    consumed = 0
+    code_points = 0
+    for character in line:
+        if consumed == utf16_character:
+            break
+        width = len(character.encode("utf-16-le")) // 2
+        if consumed + width > utf16_character:
+            raise LspProtocolError("LSP position splits a UTF-16 surrogate pair")
+        consumed += width
+        code_points += 1
+    if consumed != utf16_character:
+        raise LspProtocolError("LSP result character is outside the target line")
+    return CodePosition(line=line_number + 1, character=code_points + 1)
+
+
+def fallback_public_range(
+    value: tuple[tuple[int, int], tuple[int, int]],
+) -> CodeRange:
+    return CodeRange(
+        start=CodePosition(line=value[0][0] + 1, character=value[0][1] + 1),
+        end=CodePosition(line=value[1][0] + 1, character=value[1][1] + 1),
+    )
+
+
+__all__ = [
+    "fallback_public_range",
+    "parse_lsp_range",
+    "to_lsp_position",
+    "to_public_position",
+    "to_public_range",
+]

--- a/src/loushang/coding/lsp/status.py
+++ b/src/loushang/coding/lsp/status.py
@@ -20,7 +20,10 @@ class LspServerRuntimeStatus:
     request_count: int = 0
     timeout_count: int = 0
     replacement_count: int = 0
+    accepted_diagnostic_publications: int = 0
     discarded_diagnostic_publications: int = 0
+    diagnostic_document_count: int = 0
+    current_diagnostic_count: int = 0
     last_request_duration_ms: float | None = None
     last_error: str | None = None
 

--- a/src/loushang/coding/lsp/supervisor.py
+++ b/src/loushang/coding/lsp/supervisor.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 
 from loushang.coding.lsp.catalog import LspCatalog
 from loushang.coding.lsp.client import LspClient
+from loushang.coding.lsp.diagnostics import DiagnosticInbox
 from loushang.coding.lsp.model import (
     LspProtocolError,
     LspServerKey,
@@ -46,6 +47,7 @@ class LspServerSupervisor:
         baseline_environment: Mapping[str, str],
         open_document_count: Callable[[int], int] | None = None,
         release_runtime_documents: Callable[[int], None] | None = None,
+        diagnostics: DiagnosticInbox | None = None,
     ) -> None:
         self._catalog = catalog
         self._launcher = launcher
@@ -62,12 +64,14 @@ class LspServerSupervisor:
         self._start_counts: dict[LspServerKey, int] = {}
         self._request_counts: dict[LspServerKey, int] = {}
         self._timeout_counts: dict[LspServerKey, int] = {}
+        self._accepted_diagnostic_counts: dict[LspServerKey, int] = {}
         self._diagnostic_counts: dict[LspServerKey, int] = {}
         self._last_request_durations: dict[LspServerKey, float] = {}
         self._open_document_count = open_document_count or (lambda _runtime_id: 0)
-        self._release_runtime_documents = (
-            release_runtime_documents or (lambda _runtime_id: None)
+        self._release_runtime_documents = release_runtime_documents or (
+            lambda _runtime_id: None
         )
+        self._diagnostics = diagnostics
 
     async def ensure_runtime(
         self,
@@ -165,14 +169,27 @@ class LspServerSupervisor:
             client = runtime.client if runtime is not None else None
             request_count = self._request_counts.get(key, 0)
             timeout_count = self._timeout_counts.get(key, 0)
+            accepted_diagnostic_count = self._accepted_diagnostic_counts.get(key, 0)
             diagnostic_count = self._diagnostic_counts.get(key, 0)
             last_duration = self._last_request_durations.get(key)
             if client is not None:
                 request_count += client.request_count
                 timeout_count += client.timeout_count
+                accepted_diagnostic_count += client.accepted_diagnostic_publications
                 diagnostic_count += client.discarded_diagnostic_publications
                 if client.last_request_duration_ms is not None:
                     last_duration = client.last_request_duration_ms
+            diagnostic_document_count = 0
+            current_diagnostic_count = 0
+            if (
+                runtime is not None
+                and state == "ready"
+                and self._diagnostics is not None
+            ):
+                (
+                    diagnostic_document_count,
+                    current_diagnostic_count,
+                ) = self._diagnostics.counts(runtime.runtime_id)
             last_error = self._last_errors.get(key)
             if state == "failed" and last_error is None:
                 last_error = (
@@ -196,7 +213,10 @@ class LspServerSupervisor:
                     request_count=request_count,
                     timeout_count=timeout_count,
                     replacement_count=max(self._start_counts.get(key, 0) - 1, 0),
+                    accepted_diagnostic_publications=accepted_diagnostic_count,
                     discarded_diagnostic_publications=diagnostic_count,
+                    diagnostic_document_count=diagnostic_document_count,
+                    current_diagnostic_count=current_diagnostic_count,
                     last_request_duration_ms=last_duration,
                     last_error=last_error,
                 )
@@ -286,6 +306,17 @@ class LspServerSupervisor:
                 request_timeout_seconds=definition.request_timeout_seconds,
                 shutdown_timeout_seconds=definition.shutdown_timeout_seconds,
                 settings=definition.settings,
+                on_publish_diagnostics=(
+                    lambda params: (
+                        self._diagnostics is not None
+                        and self._replace_diagnostics(
+                            runtime_id=runtime_id,
+                            server_id=key.definition_id,
+                            params=params,
+                        )
+                    )
+                ),
+                on_close=lambda: self._release_diagnostics(runtime_id),
             )
             await client.initialize(
                 root_uri=key.workspace_root.as_uri(),
@@ -313,6 +344,8 @@ class LspServerSupervisor:
             if client is not None:
                 self._accumulate_client(key, client)
                 self._release_runtime_documents(runtime_id)
+            if self._diagnostics is not None:
+                self._diagnostics.release_runtime(runtime_id)
             async with self._lock:
                 if self._states.get(key) == "starting":
                     if isinstance(exc, asyncio.CancelledError) or self._disposed:
@@ -330,14 +363,46 @@ class LspServerSupervisor:
 
     def _retire_runtime(self, runtime: LspRuntimeHandle) -> None:
         self._accumulate_client(runtime.key, runtime.client)
+        if self._diagnostics is not None:
+            self._diagnostics.release_runtime(runtime.runtime_id)
         self._release_runtime_documents(runtime.runtime_id)
 
+    def _replace_diagnostics(
+        self,
+        *,
+        runtime_id: int,
+        server_id: str,
+        params: Mapping[str, object],
+    ) -> bool:
+        diagnostics = self._diagnostics
+        if diagnostics is None:
+            return False
+        return diagnostics.replace_publication(
+            runtime_id=runtime_id,
+            server_id=server_id,
+            uri=params.get("uri"),
+            version=params.get("version"),
+            diagnostics=params.get("diagnostics"),
+        )
+
+    def _release_diagnostics(self, runtime_id: int) -> None:
+        if self._diagnostics is not None:
+            self._diagnostics.release_runtime(runtime_id)
+
     def _accumulate_client(self, key: LspServerKey, client: LspClient) -> None:
-        self._request_counts[key] = self._request_counts.get(key, 0) + client.request_count
-        self._timeout_counts[key] = self._timeout_counts.get(key, 0) + client.timeout_count
+        self._request_counts[key] = (
+            self._request_counts.get(key, 0) + client.request_count
+        )
+        self._timeout_counts[key] = (
+            self._timeout_counts.get(key, 0) + client.timeout_count
+        )
         self._diagnostic_counts[key] = (
             self._diagnostic_counts.get(key, 0)
             + client.discarded_diagnostic_publications
+        )
+        self._accepted_diagnostic_counts[key] = (
+            self._accepted_diagnostic_counts.get(key, 0)
+            + client.accepted_diagnostic_publications
         )
         if client.last_request_duration_ms is not None:
             self._last_request_durations[key] = client.last_request_duration_ms
@@ -368,6 +433,7 @@ class LspServerSupervisor:
             self._start_counts.pop(candidate, None)
             self._request_counts.pop(candidate, None)
             self._timeout_counts.pop(candidate, None)
+            self._accepted_diagnostic_counts.pop(candidate, None)
             self._diagnostic_counts.pop(candidate, None)
             self._last_request_durations.pop(candidate, None)
 

--- a/src/loushang/coding/lsp/tools.py
+++ b/src/loushang/coding/lsp/tools.py
@@ -14,12 +14,17 @@ from loushang.coding.lsp.model import (
     CodeLocation,
     CodePosition,
     CodeQueryResult,
-    CodeRange,
     CodeSymbol,
     DocumentOutlineResult,
     LspInvalidInputError,
     LspProtocolError,
 )
+from loushang.coding.lsp.positions import (
+    fallback_public_range as _fallback_public_range,
+)
+from loushang.coding.lsp.positions import parse_lsp_range as _parse_lsp_range
+from loushang.coding.lsp.positions import to_lsp_position as _to_lsp_position
+from loushang.coding.lsp.positions import to_public_range as _to_public_range
 from loushang.coding.lsp.selector import LspSelector
 from loushang.coding.lsp.supervisor import LspRuntimeHandle, LspServerSupervisor
 from loushang.harness.tools.authoring import ToolContext, direct_tool
@@ -724,85 +729,6 @@ class _OutlineNormalizer:
             container_name=container_name,
             children=children,
         )
-
-
-def _to_lsp_position(content: str, position: CodePosition) -> dict[str, int]:
-    lines = content.split("\n")
-    if position.line > len(lines):
-        raise LspInvalidInputError("line is outside the current document")
-    line = lines[position.line - 1]
-    if line.endswith("\r"):
-        line = line[:-1]
-    offset = position.character - 1
-    if offset > len(line):
-        raise LspInvalidInputError("character is outside the current line")
-    utf16_character = len(line[:offset].encode("utf-16-le")) // 2
-    return {"line": position.line - 1, "character": utf16_character}
-
-
-def _parse_lsp_range(
-    raw_range: Mapping[str, object],
-) -> tuple[tuple[int, int], tuple[int, int]]:
-    def position(name: str) -> tuple[int, int]:
-        raw = raw_range.get(name)
-        if not isinstance(raw, Mapping):
-            raise LspProtocolError(f"LSP range {name!r} must be an object")
-        line = raw.get("line")
-        character = raw.get("character")
-        if (
-            not isinstance(line, int)
-            or isinstance(line, bool)
-            or line < 0
-            or not isinstance(character, int)
-            or isinstance(character, bool)
-            or character < 0
-        ):
-            raise LspProtocolError("LSP positions must be non-negative integers")
-        return line, character
-
-    return position("start"), position("end")
-
-
-def _to_public_range(
-    content: str,
-    value: tuple[tuple[int, int], tuple[int, int]],
-) -> CodeRange:
-    return CodeRange(
-        start=_to_public_position(content, value[0]),
-        end=_to_public_position(content, value[1]),
-    )
-
-
-def _to_public_position(content: str, value: tuple[int, int]) -> CodePosition:
-    line_number, utf16_character = value
-    lines = content.split("\n")
-    if line_number >= len(lines):
-        raise LspProtocolError("LSP result line is outside the target document")
-    line = lines[line_number]
-    if line.endswith("\r"):
-        line = line[:-1]
-    consumed = 0
-    code_points = 0
-    for character in line:
-        if consumed == utf16_character:
-            break
-        width = len(character.encode("utf-16-le")) // 2
-        if consumed + width > utf16_character:
-            raise LspProtocolError("LSP position splits a UTF-16 surrogate pair")
-        consumed += width
-        code_points += 1
-    if consumed != utf16_character:
-        raise LspProtocolError("LSP result character is outside the target line")
-    return CodePosition(line=line_number + 1, character=code_points + 1)
-
-
-def _fallback_public_range(
-    value: tuple[tuple[int, int], tuple[int, int]],
-) -> CodeRange:
-    return CodeRange(
-        start=CodePosition(line=value[0][0] + 1, character=value[0][1] + 1),
-        end=CodePosition(line=value[1][0] + 1, character=value[1][1] + 1),
-    )
 
 
 def _file_uri_path(uri: str) -> Path | None:

--- a/tests/coding/lsp/test_commands.py
+++ b/tests/coding/lsp/test_commands.py
@@ -24,6 +24,7 @@ class _Runtime:
                     workspace_root=str(self.root),
                     state="stopped" if self.stopped else "ready",
                     open_document_count=0 if self.stopped else 1,
+                    current_diagnostic_count=0 if self.stopped else 2,
                     request_count=3,
                 ),
             )
@@ -54,6 +55,7 @@ def test_lsp_session_command_projects_status_and_explicit_stop(tmp_path: Path) -
     assert status.result["scope"] == "session"
     assert status.result["ready_count"] == 1
     assert "pyright" in status.result["display"]
+    assert "diagnostics=2" in status.result["display"]
     assert runtime.stop_calls == [("pyright", str(tmp_path))]
     assert stopped.result["action"] == "stop"
     assert stopped.result["stopped"] is True

--- a/tests/coding/lsp/test_diagnostics.py
+++ b/tests/coding/lsp/test_diagnostics.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from loushang.coding.lsp.diagnostics import (
+    MAX_DIAGNOSTIC_MESSAGE_CHARACTERS,
+    DiagnosticInbox,
+)
+from loushang.coding.lsp.documents import DocumentSnapshot
+from loushang.coding.lsp.model import CodePosition, CodeRange
+
+
+def _snapshot(
+    path: Path, *, version: int = 1, content: str = "value = 1\n"
+) -> DocumentSnapshot:
+    return DocumentSnapshot(
+        path=path,
+        uri=path.as_uri(),
+        language_id="python",
+        version=version,
+        content=content,
+        content_hash=f"hash-{version}",
+    )
+
+
+def _raw_diagnostic(
+    message: str,
+    *,
+    severity: int = 1,
+    start: int = 0,
+    end: int = 1,
+) -> dict[str, object]:
+    return {
+        "range": {
+            "start": {"line": 0, "character": start},
+            "end": {"line": 0, "character": end},
+        },
+        "severity": severity,
+        "message": message,
+        "code": 42,
+        "source": "fake",
+        "tags": [1, 2, 99],
+    }
+
+
+def test_diagnostic_inbox_normalizes_replaces_and_clears_current_set(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "main.py"
+    document = _snapshot(source, version=3, content="a😀b\n")
+    documents = {(7, document.uri): document}
+    inbox = DiagnosticInbox(
+        workspace_root=tmp_path,
+        document_lookup=lambda runtime_id, uri: documents.get((runtime_id, uri)),
+        clock=lambda: 12.5,
+    )
+
+    accepted = inbox.replace_publication(
+        runtime_id=7,
+        server_id="fake-python",
+        uri=document.uri,
+        version=3,
+        diagnostics=[
+            _raw_diagnostic("hint", severity=4, start=0, end=1),
+            _raw_diagnostic("emoji", severity=1, start=1, end=3),
+            _raw_diagnostic("emoji", severity=1, start=1, end=3),
+            {"message": "missing range"},
+        ],
+    )
+
+    assert accepted is True
+    assert inbox.counts(7) == (1, 2)
+    diagnostics = inbox.current(runtime_id=7)
+    assert [item.message for item in diagnostics] == ["emoji", "hint"]
+    assert diagnostics[0].server_id == "fake-python"
+    assert diagnostics[0].path == "main.py"
+    assert diagnostics[0].version == 3
+    assert diagnostics[0].severity == "error"
+    assert diagnostics[0].range == CodeRange(
+        start=CodePosition(line=1, character=2),
+        end=CodePosition(line=1, character=3),
+    )
+    assert diagnostics[0].code == "42"
+    assert diagnostics[0].source == "fake"
+    assert diagnostics[0].tags == ("unnecessary", "deprecated")
+    assert diagnostics[0].received_at == 12.5
+    assert diagnostics[0].stale is False
+    assert inbox.snapshot().omitted_diagnostic_count == 1
+
+    assert inbox.replace_publication(
+        runtime_id=7,
+        server_id="fake-python",
+        uri=document.uri,
+        version=None,
+        diagnostics=[],
+    )
+    assert inbox.current(runtime_id=7) == ()
+    assert inbox.counts(7) == (0, 0)
+
+
+def test_diagnostic_inbox_rejects_wrong_version_unknown_and_malformed_sets(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "main.py"
+    document = _snapshot(source, version=4)
+    documents = {(2, document.uri): document}
+    inbox = DiagnosticInbox(
+        workspace_root=tmp_path,
+        document_lookup=lambda runtime_id, uri: documents.get((runtime_id, uri)),
+    )
+    assert inbox.replace_publication(
+        runtime_id=2,
+        server_id="fake-python",
+        uri=document.uri,
+        version=4,
+        diagnostics=[_raw_diagnostic("current")],
+    )
+
+    assert not inbox.replace_publication(
+        runtime_id=2,
+        server_id="fake-python",
+        uri=document.uri,
+        version=3,
+        diagnostics=[],
+    )
+    assert not inbox.replace_publication(
+        runtime_id=2,
+        server_id="fake-python",
+        uri=document.uri,
+        version=5,
+        diagnostics=[],
+    )
+    assert not inbox.replace_publication(
+        runtime_id=2,
+        server_id="fake-python",
+        uri=(tmp_path / "unknown.py").as_uri(),
+        version=4,
+        diagnostics=[],
+    )
+    assert not inbox.replace_publication(
+        runtime_id=2,
+        server_id="fake-python",
+        uri=document.uri,
+        version="4",
+        diagnostics=[],
+    )
+
+    assert [item.message for item in inbox.current(runtime_id=2)] == ["current"]
+    snapshot = inbox.snapshot()
+    assert snapshot.publication_count == 5
+    assert snapshot.stale_publication_count == 1
+    assert snapshot.future_publication_count == 1
+    assert snapshot.unknown_document_publication_count == 1
+    assert snapshot.malformed_publication_count == 1
+
+
+def test_diagnostic_inbox_enforces_limits_and_releases_runtime(tmp_path: Path) -> None:
+    paths = [tmp_path / f"file_{index}.py" for index in range(3)]
+    documents = {(9, path.as_uri()): _snapshot(path) for path in paths}
+    inbox = DiagnosticInbox(
+        workspace_root=tmp_path,
+        document_lookup=lambda runtime_id, uri: documents.get((runtime_id, uri)),
+        max_documents=2,
+        max_diagnostics_per_document=1,
+        max_total_diagnostics=2,
+        max_total_characters=16_000,
+        max_raw_diagnostics_per_publication=2,
+    )
+
+    for path in paths:
+        assert inbox.replace_publication(
+            runtime_id=9,
+            server_id="fake-python",
+            uri=path.as_uri(),
+            version=1,
+            diagnostics=[
+                _raw_diagnostic("warning", severity=2),
+                _raw_diagnostic("error", severity=1),
+                _raw_diagnostic("not scanned", severity=3),
+            ],
+        )
+
+    assert inbox.counts(9) == (2, 2)
+    assert [item.path for item in inbox.current(runtime_id=9)] == [
+        "file_1.py",
+        "file_2.py",
+    ]
+    assert all(item.message == "error" for item in inbox.current(runtime_id=9))
+    snapshot = inbox.snapshot()
+    assert snapshot.evicted_document_count == 1
+    assert snapshot.omitted_diagnostic_count == 7
+
+    inbox.release_runtime(9)
+    assert inbox.counts(9) == (0, 0)
+
+
+def test_diagnostic_inbox_bounds_large_values(tmp_path: Path) -> None:
+    source = tmp_path / "main.py"
+    document = _snapshot(source)
+    inbox = DiagnosticInbox(
+        workspace_root=tmp_path,
+        document_lookup=lambda runtime_id, uri: (
+            document if (runtime_id, uri) == (1, document.uri) else None
+        ),
+    )
+
+    assert inbox.replace_publication(
+        runtime_id=1,
+        server_id="fake-python",
+        uri=document.uri,
+        version=None,
+        diagnostics=[_raw_diagnostic("x" * (MAX_DIAGNOSTIC_MESSAGE_CHARACTERS + 50))],
+    )
+
+    diagnostic = inbox.current(runtime_id=1)[0]
+    assert diagnostic.version is None
+    assert len(diagnostic.message) == MAX_DIAGNOSTIC_MESSAGE_CHARACTERS
+    assert inbox.snapshot().truncated_value_count == 1

--- a/tests/coding/lsp/test_documents.py
+++ b/tests/coding/lsp/test_documents.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from loushang.coding.lsp.documents import LspDocumentManager
+
+
+class _ObservingClient:
+    def __init__(self, uri: str) -> None:
+        self.manager: LspDocumentManager | None = None
+        self.runtime_id = 3
+        self.uri = uri
+        self.observed_versions: list[int] = []
+        self.fail_next = False
+
+    async def notify(self, method: str, params: object) -> None:
+        del method, params
+        assert self.manager is not None
+        snapshot = self.manager.snapshot_for_uri(self.runtime_id, self.uri)
+        assert snapshot is not None
+        self.observed_versions.append(snapshot.version)
+        if self.fail_next:
+            self.fail_next = False
+            raise RuntimeError("notify failed")
+
+
+def test_document_snapshot_is_visible_during_notify_and_rolls_back_on_failure(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        source = tmp_path / "main.py"
+        source.touch()
+        contents = {source.resolve(): "value = 1\n"}
+        client = _ObservingClient(source.resolve().as_uri())
+        manager = LspDocumentManager(
+            workspace_root=tmp_path,
+            read_text=lambda path: contents[path],
+        )
+        client.manager = manager
+        runtime = SimpleNamespace(runtime_id=client.runtime_id, client=client)
+
+        opened = await manager.ensure_document(runtime, source, language_id="python")
+        assert opened.version == 1
+        assert client.observed_versions == [1]
+
+        contents[source.resolve()] = "value = 2\n"
+        client.fail_next = True
+        with pytest.raises(RuntimeError, match="notify failed"):
+            await manager.ensure_document(runtime, source, language_id="python")
+        assert client.observed_versions == [1, 2]
+        assert manager.snapshot_for_uri(client.runtime_id, source.as_uri()) == opened
+
+    asyncio.run(scenario())

--- a/tests/coding/lsp/test_fake_launcher_vertical_slice.py
+++ b/tests/coding/lsp/test_fake_launcher_vertical_slice.py
@@ -245,6 +245,29 @@ class FakeLspServer:
         self._response_tasks.add(task)
         task.add_done_callback(self._response_tasks.discard)
 
+    async def publish_diagnostics(
+        self,
+        *,
+        uri: str,
+        diagnostics: list[object],
+        version: int | None = None,
+    ) -> None:
+        params: dict[str, object] = {
+            "uri": uri,
+            "diagnostics": diagnostics,
+        }
+        if version is not None:
+            params["version"] = version
+        await self.stdout.put(
+            _frame(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "textDocument/publishDiagnostics",
+                    "params": params,
+                }
+            )
+        )
+
     def methods(self) -> list[str]:
         return [
             method
@@ -1062,6 +1085,7 @@ def test_runtime_status_is_read_only_and_explicit_stop_allows_replacement(
         assert ready_server.request_count == 2
         assert ready_server.timeout_count == 0
         assert ready_server.replacement_count == 0
+        assert ready_server.accepted_diagnostic_publications == 0
         assert ready_server.discarded_diagnostic_publications == 1
         assert ready_server.last_request_duration_ms is not None
         assert ready_server.last_error is None
@@ -1105,6 +1129,167 @@ def test_runtime_status_is_read_only_and_explicit_stop_allows_replacement(
         disposed = binding.status()
         assert disposed.disposed is True
         assert disposed.servers[0].state == "stopped"
+
+    asyncio.run(scenario())
+
+
+def test_passive_diagnostics_are_versioned_replaced_bounded_and_released(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        (tmp_path / "pyproject.toml").touch()
+        source = tmp_path / "main.py"
+        source.touch()
+        files = {source.resolve(): "value = 1\n"}
+        launcher = FakeLauncher(definition_result=None)
+        binding = _binding(tmp_path, launcher, files)
+
+        await binding.inspect_symbol(
+            path="main.py",
+            line=1,
+            character=1,
+            correlation_id="diagnostic-open",
+        )
+        server = launcher.handles[0].server
+        diagnostic = {
+            "range": {
+                "start": {"line": 0, "character": 0},
+                "end": {"line": 0, "character": 5},
+            },
+            "severity": 1,
+            "message": "invalid value",
+            "source": "fake",
+        }
+
+        await server.publish_diagnostics(
+            uri=source.resolve().as_uri(),
+            version=1,
+            diagnostics=[diagnostic],
+        )
+        for _ in range(100):
+            if binding.status().servers[0].current_diagnostic_count == 1:
+                break
+            await asyncio.sleep(0)
+        ready = binding.status().servers[0]
+        assert ready.diagnostic_document_count == 1
+        assert ready.current_diagnostic_count == 1
+        assert ready.accepted_diagnostic_publications == 1
+        assert ready.discarded_diagnostic_publications == 1
+
+        await server.publish_diagnostics(
+            uri=source.resolve().as_uri(),
+            version=0,
+            diagnostics=[],
+        )
+        for _ in range(100):
+            if binding.status().servers[0].discarded_diagnostic_publications == 2:
+                break
+            await asyncio.sleep(0)
+        stale = binding.status().servers[0]
+        assert stale.current_diagnostic_count == 1
+        assert stale.accepted_diagnostic_publications == 1
+        assert stale.discarded_diagnostic_publications == 2
+
+        files[source.resolve()] = "value = 2\n"
+        changed = await binding.inspect_symbol(
+            path="main.py",
+            line=1,
+            character=1,
+            correlation_id="diagnostic-change",
+        )
+        assert changed.document_version == 2
+        assert binding.status().servers[0].current_diagnostic_count == 0
+
+        await server.publish_diagnostics(
+            uri=source.resolve().as_uri(),
+            version=2,
+            diagnostics=[diagnostic, {**diagnostic, "message": "second"}],
+        )
+        for _ in range(100):
+            if binding.status().servers[0].current_diagnostic_count == 2:
+                break
+            await asyncio.sleep(0)
+        assert binding.status().servers[0].current_diagnostic_count == 2
+        assert binding.status().servers[0].accepted_diagnostic_publications == 2
+
+        await server.publish_diagnostics(
+            uri=source.resolve().as_uri(),
+            version=2,
+            diagnostics=[],
+        )
+        for _ in range(100):
+            if binding.status().servers[0].current_diagnostic_count == 0:
+                break
+            await asyncio.sleep(0)
+        assert binding.status().servers[0].diagnostic_document_count == 0
+        assert binding.status().servers[0].accepted_diagnostic_publications == 3
+
+        await server.publish_diagnostics(
+            uri=source.resolve().as_uri(),
+            diagnostics=[diagnostic],
+        )
+        for _ in range(100):
+            if binding.status().servers[0].current_diagnostic_count == 1:
+                break
+            await asyncio.sleep(0)
+        assert await binding.stop(
+            definition_id="fake-python",
+            workspace_root=tmp_path,
+        )
+        stopped = binding.status().servers[0]
+        assert stopped.diagnostic_document_count == 0
+        assert stopped.current_diagnostic_count == 0
+        await binding.dispose()
+
+    asyncio.run(scenario())
+
+
+def test_passive_diagnostics_are_released_when_server_stdout_closes(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        (tmp_path / "pyproject.toml").touch()
+        source = tmp_path / "main.py"
+        source.touch()
+        launcher = FakeLauncher(definition_result=None)
+        binding = _binding(tmp_path, launcher, {source.resolve(): "value = 1\n"})
+        await binding.inspect_symbol(
+            path="main.py",
+            line=1,
+            character=1,
+            correlation_id="diagnostic-before-crash",
+        )
+        server = launcher.handles[0].server
+        await server.publish_diagnostics(
+            uri=source.resolve().as_uri(),
+            version=1,
+            diagnostics=[
+                {
+                    "range": {
+                        "start": {"line": 0, "character": 0},
+                        "end": {"line": 0, "character": 1},
+                    },
+                    "message": "before crash",
+                }
+            ],
+        )
+        for _ in range(100):
+            if binding.status().servers[0].current_diagnostic_count == 1:
+                break
+            await asyncio.sleep(0)
+        assert binding.status().servers[0].current_diagnostic_count == 1
+
+        await server.stdout.put(None)
+        for _ in range(100):
+            status = binding.status().servers[0]
+            if status.state == "failed":
+                break
+            await asyncio.sleep(0)
+        failed = binding.status().servers[0]
+        assert failed.state == "failed"
+        assert failed.diagnostic_document_count == 0
+        assert failed.current_diagnostic_count == 0
+        await binding.dispose()
 
     asyncio.run(scenario())
 

--- a/tests/integration/coding/test_pyright_lsp_live.py
+++ b/tests/integration/coding/test_pyright_lsp_live.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import shutil
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
 
 from loushang.coding.lsp import (
+    CodingLspRuntime,
     LspServerDefinition,
+    LspServerRuntimeStatus,
     bind_coding_lsp_runtime,
     default_lsp_environment,
 )
@@ -21,7 +25,16 @@ from loushang.harness.sandbox import SandboxSettings
 from loushang.harness.tools.process_hosting import ProcessExecutionScope
 from loushang.harness.workspace.exec import ExecService
 
-_PYRIGHT = shutil.which("pyright-langserver")
+
+def _resolve_pyright() -> str | None:
+    configured = os.environ.get("LOUSHANG_TEST_PYRIGHT_LANGSERVER")
+    if configured is None:
+        return shutil.which("pyright-langserver")
+    candidate = Path(configured).expanduser().resolve()
+    return str(candidate) if candidate.is_file() else None
+
+
+_PYRIGHT = _resolve_pyright()
 
 pytestmark = [
     pytest.mark.live,
@@ -43,20 +56,42 @@ class _NoApprovalResolver:
         raise AssertionError("an admitted Pyright launch must not request approval")
 
 
-def test_installed_pyright_definition_outline_and_shutdown(tmp_path: Path) -> None:
+async def _wait_for_diagnostic_state(
+    runtime: CodingLspRuntime,
+    predicate: Callable[[LspServerRuntimeStatus], bool],
+    *,
+    timeout_seconds: float = 15,
+) -> LspServerRuntimeStatus:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    last_status: LspServerRuntimeStatus | None = None
+    while loop.time() < deadline:
+        status = runtime.status()
+        if status.servers:
+            last_status = status.servers[0]
+            if predicate(last_status):
+                return last_status
+        await asyncio.sleep(0.05)
+    raise AssertionError(
+        f"Pyright diagnostic state did not converge; last status: {last_status!r}"
+    )
+
+
+def test_installed_pyright_semantics_diagnostics_and_shutdown(tmp_path: Path) -> None:
     async def scenario() -> None:
         assert _PYRIGHT is not None
         project = tmp_path / "project"
         project.mkdir()
         (project / "pyproject.toml").write_text(
-            "[project]\nname = \"lsp-live-smoke\"\nversion = \"0.0.0\"\n",
+            '[project]\nname = "lsp-live-smoke"\nversion = "0.0.0"\n',
             encoding="utf-8",
         )
         source = project / "main.py"
         source.write_text(
             "def target(value: int) -> int:\n"
             "    return value\n\n"
-            "result = target(1)\n",
+            "result = target(1)\n"
+            'broken: int = "not an int"\n',
             encoding="utf-8",
         )
         sandbox_runtime = bind_coding_sandbox_runtime(
@@ -105,9 +140,36 @@ def test_installed_pyright_definition_outline_and_shutdown(tmp_path: Path) -> No
             assert definition.count >= 1
             assert any(item.path == "main.py" for item in definition.items)
             assert any(item.name == "target" for item in outline.items)
-            status = runtime.status()
-            assert status.ready_count == 1
-            assert status.servers[0].open_document_count == 1
+            diagnosed = await _wait_for_diagnostic_state(
+                runtime,
+                lambda server: (
+                    server.accepted_diagnostic_publications >= 1
+                    and server.current_diagnostic_count >= 1
+                ),
+            )
+            assert diagnosed.diagnostic_document_count == 1
+            assert diagnosed.open_document_count == 1
+
+            source.write_text(
+                "def target(value: int) -> int:\n"
+                "    return value\n\n"
+                "result = target(1)\n"
+                "broken: int = 1\n",
+                encoding="utf-8",
+            )
+            await runtime.document_outline(
+                path="main.py",
+                correlation_id="pyright-live-diagnostic-fix",
+            )
+            cleared = await _wait_for_diagnostic_state(
+                runtime,
+                lambda server: (
+                    server.accepted_diagnostic_publications
+                    > diagnosed.accepted_diagnostic_publications
+                    and server.current_diagnostic_count == 0
+                ),
+            )
+            assert cleared.diagnostic_document_count == 0
         finally:
             await runtime.close()
             await sandbox_runtime.close()


### PR DESCRIPTION
## Summary

- add a bounded, version-aware session-local LSP diagnostic inbox
- route `publishDiagnostics` through the Coding LSP client and clean state on document/runtime lifecycle changes
- expose bounded publication/count status without adding diagnostic commands or model delivery
- add Fake Server coverage and a pinned Pyright compatibility gate
- align the Coding LSP architecture documents with the H4.1/H4.2 split

## Validation

- `uv --cache-dir .uv-cache run --extra dev ruff check src/loushang/coding/lsp tests/coding/lsp tests/integration/coding/test_pyright_lsp_live.py`
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding/lsp -q` — 43 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/coding -q` — 2345 passed
- `uv --cache-dir .uv-cache run --extra dev pytest tests/architecture/test_import_boundaries.py -q` — 157 passed
- real `pyright@1.1.411` compatibility test — 1 passed
- `git diff --check`
