### PR TITLE
feat(coding): add TypeScript LSP compatibility preset

### DIFF
--- a/.github/workflows/coding-lsp-compatibility.yml
+++ b/.github/workflows/coding-lsp-compatibility.yml
@@ -13,6 +13,7 @@ on:
       - "src/loushang/harness/sandbox/**"
       - "src/loushang/harness/tools/process_hosting/**"
       - "tests/integration/coding/test_pyright_lsp_live.py"
+      - "tests/integration/coding/test_typescript_lsp_live.py"
   pull_request:
     paths:
       - ".github/workflows/coding-lsp-compatibility.yml"
@@ -23,6 +24,7 @@ on:
       - "src/loushang/harness/sandbox/**"
       - "src/loushang/harness/tools/process_hosting/**"
       - "tests/integration/coding/test_pyright_lsp_live.py"
+      - "tests/integration/coding/test_typescript_lsp_live.py"
   workflow_dispatch:
 
 jobs:
@@ -50,3 +52,34 @@ jobs:
 
       - name: Verify real Pyright LSP compatibility
         run: uv run pytest tests/integration/coding/test_pyright_lsp_live.py -q
+
+  typescript-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install Python dependencies
+        run: uv sync --locked --extra dev
+
+      - name: Install pinned TypeScript Server
+        run: >-
+          npm install --global
+          typescript-language-server@5.3.0
+          typescript@5.9.3
+
+      - name: Verify real TypeScript LSP compatibility
+        run: >-
+          uv run pytest
+          tests/integration/coding/test_typescript_lsp_live.py
+          -q

--- a/docs/en/user-guide/README.md
+++ b/docs/en/user-guide/README.md
@@ -93,6 +93,13 @@ availability, and never construct a Session, start a Server, or install one.
 Loushang probes installed Pyright, TypeScript Language Server, rust-analyzer,
 gopls, and clangd defaults.
 
+The TypeScript preset covers `.ts`, `.tsx`, `.js`, `.jsx`, and their standard
+module variants. It chooses the nearest `tsconfig.json`, `jsconfig.json`,
+`package.json`, or `.git` root. Install both `typescript-language-server` and a
+compatible `typescript` package yourself; when either usable server setup is
+absent, ordinary Coding tools continue to work and Loushang does not install
+packages automatically.
+
 Inside an interactive Coding Session, use the separate Session-local surface:
 
 ```text
@@ -119,6 +126,11 @@ Contributors with `pyright-langserver` already on `PATH` can run the optional
 real-server gate with `uv run pytest
 tests/integration/coding/test_pyright_lsp_live.py -q`; it skips when Pyright is
 absent and never installs it.
+
+The corresponding TypeScript gate is `uv run pytest
+tests/integration/coding/test_typescript_lsp_live.py -q`. It looks for
+`typescript-language-server` on `PATH` by default, or accepts an executable via
+`LOUSHANG_TEST_TYPESCRIPT_LANGSERVER`; it also never installs the Server.
 
 Declare a custom server in `~/.loushang/coding/lsp.json`:
 

--- a/docs/internals/architecture/coding/lsp/specification.md
+++ b/docs/internals/architecture/coding/lsp/specification.md
@@ -148,6 +148,13 @@ Rules:
 This conservative project rule is the P0 substitute for the future general
 workspace-trust gate.
 
+The built-in TypeScript Language Server preset recognizes JavaScript,
+JavaScript React, TypeScript, and TypeScript React as distinct language ids. It
+selects the nearest `tsconfig.json`, `jsconfig.json`, `package.json`, or `.git`
+root and starts `typescript-language-server --stdio` only after a semantic
+query. If the executable is absent, catalog discovery reports the preset as
+unavailable without installing or starting anything.
+
 ## 4. Core Data Contracts
 
 The exact dataclass organization may evolve, but these semantic records are
@@ -823,7 +830,9 @@ direct subprocess launcher as a temporary production bypass.
 - H4.1 bounded, version-aware passive diagnostic reception and lifecycle
   cleanup, without model delivery;
 - fake Server tests;
-- a path-scoped CI compatibility gate against a pinned real Pyright Server;
+- path-scoped CI compatibility gates against pinned real Pyright and
+  TypeScript Language Servers; the TypeScript gate pins the language-server
+  wrapper and its TypeScript runtime as a tested pair;
 - clean degradation when no Server exists.
 
 ### Deferred

--- a/docs/zh-CN/user-guide/README.md
+++ b/docs/zh-CN/user-guide/README.md
@@ -83,6 +83,11 @@ Server 仍只会在第一次语义查询时惰性启动。独立 CLI 的 `status
 Server。Loushang 会探测已安装的 Pyright、TypeScript Language Server、rust-analyzer、
 gopls 和 clangd。
 
+TypeScript 预设覆盖 `.ts`、`.tsx`、`.js`、`.jsx` 及其标准模块变体，并选择最近的
+`tsconfig.json`、`jsconfig.json`、`package.json` 或 `.git` 作为根。用户需要自行安装
+`typescript-language-server` 和兼容的 `typescript` 包；缺少可用 Server 时，普通 Coding
+工具仍可继续工作，Loushang 不会自动安装任何包。
+
 在交互式 Coding Session 内，使用独立的 Session 运行态表面：
 
 ```text
@@ -106,6 +111,11 @@ TUI 会直接执行同一个 Session 命令；RPC 客户端可以先用 `get_com
 已经把 `pyright-langserver` 放入 `PATH` 的贡献者可以运行可选真实 Server 门：
 `uv run pytest tests/integration/coding/test_pyright_lsp_live.py -q`。未安装 Pyright 时测试会
 跳过，测试自身不会安装它。
+
+TypeScript 的对应兼容性门是
+`uv run pytest tests/integration/coding/test_typescript_lsp_live.py -q`，默认从 `PATH`
+查找 `typescript-language-server`，也可通过 `LOUSHANG_TEST_TYPESCRIPT_LANGSERVER`
+指定可执行文件；测试同样不会安装 Server。
 
 自定义 Server 写入 `~/.loushang/coding/lsp.json`：
 

--- a/src/loushang/coding/lsp/discovery.py
+++ b/src/loushang/coding/lsp/discovery.py
@@ -150,9 +150,12 @@ def product_default_lsp_definitions() -> tuple[LspServerDefinition, ...]:
             id="typescript-language-server",
             command=("typescript-language-server", "--stdio"),
             language_extensions={
-                "javascript": (".js", ".jsx", ".mjs", ".cjs"),
-                "typescript": (".ts", ".tsx", ".mts", ".cts"),
+                "javascript": (".js", ".mjs", ".cjs"),
+                "javascriptreact": (".jsx",),
+                "typescript": (".ts", ".mts", ".cts"),
+                "typescriptreact": (".tsx",),
             },
+            root_markers=("tsconfig.json", "jsconfig.json", "package.json", ".git"),
             source="product-default",
         ),
         LspServerDefinition(

--- a/tests/coding/lsp/test_discovery.py
+++ b/tests/coding/lsp/test_discovery.py
@@ -5,9 +5,12 @@ from collections.abc import Mapping
 from pathlib import Path
 
 from loushang.coding.lsp import (
+    LspCatalog,
+    LspSelector,
     LspServerDefinition,
     default_lsp_environment,
     discover_lsp_catalog,
+    product_default_lsp_definitions,
 )
 
 
@@ -247,6 +250,92 @@ def test_product_defaults_report_unavailable_without_installing_or_starting(
         "typescript-language-server",
     ]
     assert {record.state for record in snapshot.records} == {"unavailable"}
+
+
+def test_typescript_product_preset_maps_languages_and_selects_nearest_root(
+    tmp_path: Path,
+) -> None:
+    definition = next(
+        item
+        for item in product_default_lsp_definitions()
+        if item.id == "typescript-language-server"
+    )
+    package_root = tmp_path / "packages" / "web"
+    source_root = package_root / "src"
+    source_root.mkdir(parents=True)
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    (package_root / "tsconfig.json").write_text("{}", encoding="utf-8")
+    selector = LspSelector(
+        workspace_root=tmp_path,
+        catalog=LspCatalog((definition,)),
+    )
+
+    assert definition.command == ("typescript-language-server", "--stdio")
+    assert definition.language_extensions == {
+        "javascript": (".js", ".mjs", ".cjs"),
+        "javascriptreact": (".jsx",),
+        "typescript": (".ts", ".mts", ".cts"),
+        "typescriptreact": (".tsx",),
+    }
+    assert definition.root_markers == (
+        "tsconfig.json",
+        "jsconfig.json",
+        "package.json",
+        ".git",
+    )
+    assert selector.select(source_root / "component.tsx").language_id == (
+        "typescriptreact"
+    )
+    assert selector.select(source_root / "component.jsx").language_id == (
+        "javascriptreact"
+    )
+    selection = selector.select(source_root / "main.ts")
+    assert selection.language_id == "typescript"
+    assert selection.workspace_root == package_root
+    assert selection.reason_code == "nearest_root"
+
+
+def test_typescript_product_preset_is_admitted_only_when_binary_exists(
+    tmp_path: Path,
+) -> None:
+    probes: list[str] = []
+
+    snapshot = discover_lsp_catalog(
+        workspace_root=tmp_path,
+        baseline_environment={"PATH": "/tools"},
+        global_config_path=False,
+        project_config_path=False,
+        executable_resolver=lambda command, _environment: (
+            probes.append(command)
+            or (
+                "/tools/typescript-language-server"
+                if command == "typescript-language-server"
+                else None
+            )
+        ),
+    )
+
+    assert [item.id for item in snapshot.definitions] == ["typescript-language-server"]
+    definition = snapshot.definitions[0]
+    assert definition.command == (
+        "/tools/typescript-language-server",
+        "--stdio",
+    )
+    record = next(
+        item
+        for item in snapshot.records
+        if item.definition_id == "typescript-language-server"
+    )
+    assert record.state == "admitted"
+    assert record.source == "product-default"
+    assert record.executable == "/tools/typescript-language-server"
+    assert probes == [
+        "clangd",
+        "gopls",
+        "pyright-langserver",
+        "rust-analyzer",
+        "typescript-language-server",
+    ]
 
 
 def test_default_environment_excludes_unrelated_secrets() -> None:

--- a/tests/coding/lsp/test_fake_launcher_vertical_slice.py
+++ b/tests/coding/lsp/test_fake_launcher_vertical_slice.py
@@ -22,6 +22,7 @@ from loushang.coding.lsp import (
     ProcessStderrTail,
     create_document_outline_tool_definition,
     create_inspect_symbol_tool_definition,
+    product_default_lsp_definitions,
 )
 from loushang.harness.tools import ToolContext
 from loushang.harness.tools.workspace.wrapper import wrap_tool_definition
@@ -1586,3 +1587,74 @@ def test_language_mapping_catalog_freeze_and_literal_root_markers(
                 "other": (".ts",),
             },
         )
+
+
+def test_python_and_typescript_servers_are_selected_independently_in_one_session(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        python_root = tmp_path / "python-service"
+        typescript_root = tmp_path / "web-app"
+        python_root.mkdir()
+        typescript_root.mkdir()
+        (python_root / "pyproject.toml").touch()
+        (typescript_root / "tsconfig.json").write_text("{}", encoding="utf-8")
+        python_source = python_root / "main.py"
+        typescript_source = typescript_root / "main.ts"
+        tsx_source = typescript_root / "component.tsx"
+        for source in (python_source, typescript_source, tsx_source):
+            source.touch()
+        files = {
+            python_source.resolve(): "value = 1\n",
+            typescript_source.resolve(): "export const value = 1;\n",
+            tsx_source.resolve(): "export const View = () => null;\n",
+        }
+        typescript_definition = next(
+            item
+            for item in product_default_lsp_definitions()
+            if item.id == "typescript-language-server"
+        )
+        launcher = FakeLauncher(definition_result=None, outline_result=None)
+        binding = CodingLspBinding(
+            workspace_root=tmp_path,
+            definitions=(_definition(), typescript_definition),
+            launcher=launcher,
+            read_text=lambda path: files[path],
+            baseline_environment={"PATH": "/admitted/bin"},
+        )
+
+        await binding.inspect_symbol(
+            path="python-service/main.py",
+            line=1,
+            character=1,
+            correlation_id="python-query",
+        )
+        await binding.inspect_symbol(
+            path="web-app/main.ts",
+            line=1,
+            character=14,
+            correlation_id="typescript-query",
+        )
+        await binding.document_outline(
+            path="web-app/component.tsx",
+            correlation_id="tsx-query",
+        )
+
+        assert [request.command for request in launcher.requests] == [
+            ("fake-language-server", "--stdio"),
+            ("typescript-language-server", "--stdio"),
+        ]
+        assert [request.cwd for request in launcher.requests] == [
+            str(python_root.resolve()),
+            str(typescript_root.resolve()),
+        ]
+        status_by_id = {
+            server.definition_id: server for server in binding.status().servers
+        }
+        assert status_by_id["fake-python"].runtime_id == 1
+        assert status_by_id["fake-python"].open_document_count == 1
+        assert status_by_id["typescript-language-server"].runtime_id == 2
+        assert status_by_id["typescript-language-server"].open_document_count == 2
+        await binding.dispose()
+
+    asyncio.run(scenario())

--- a/tests/integration/coding/test_typescript_lsp_live.py
+++ b/tests/integration/coding/test_typescript_lsp_live.py
@@ -1,0 +1,238 @@
+"""Optional compatibility gate for an already-installed TypeScript Server."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from loushang.coding.lsp import (
+    CodingLspRuntime,
+    LspServerRuntimeStatus,
+    bind_coding_lsp_runtime,
+    default_lsp_environment,
+    discover_lsp_catalog,
+)
+from loushang.coding.sandbox import (
+    bind_coding_sandbox_runtime,
+    coding_workspace_execution_profile,
+)
+from loushang.harness.sandbox import SandboxSettings
+from loushang.harness.tools.process_hosting import ProcessExecutionScope
+from loushang.harness.workspace.exec import ExecService
+
+
+def _resolve_typescript_language_server() -> str | None:
+    configured = os.environ.get("LOUSHANG_TEST_TYPESCRIPT_LANGSERVER")
+    if configured is None:
+        return shutil.which("typescript-language-server")
+    candidate = Path(configured).expanduser().resolve()
+    return str(candidate) if candidate.is_file() else None
+
+
+_TYPESCRIPT_LANGUAGE_SERVER = _resolve_typescript_language_server()
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.skipif(
+        _TYPESCRIPT_LANGUAGE_SERVER is None,
+        reason=(
+            "typescript-language-server is not installed; optional LSP "
+            "compatibility verification skipped"
+        ),
+    ),
+]
+
+
+class _NoApprovalResolver:
+    actor_id = "coding-lsp-typescript-live"
+
+    def resolve(self, request: object) -> object:
+        del request
+        raise AssertionError(
+            "an admitted TypeScript Server launch must not request approval"
+        )
+
+
+async def _wait_for_diagnostic_state(
+    runtime: CodingLspRuntime,
+    predicate: Callable[[LspServerRuntimeStatus], bool],
+    *,
+    timeout_seconds: float = 15,
+) -> LspServerRuntimeStatus:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    last_status: LspServerRuntimeStatus | None = None
+    while loop.time() < deadline:
+        status = runtime.status()
+        if status.servers:
+            last_status = status.servers[0]
+            if predicate(last_status):
+                return last_status
+        await asyncio.sleep(0.05)
+    raise AssertionError(
+        f"TypeScript diagnostic state did not converge; last status: {last_status!r}"
+    )
+
+
+def test_product_typescript_preset_semantics_diagnostics_and_shutdown(
+    tmp_path: Path,
+) -> None:
+    async def scenario() -> None:
+        assert _TYPESCRIPT_LANGUAGE_SERVER is not None
+        project = tmp_path / "web-app"
+        source_root = project / "src"
+        source_root.mkdir(parents=True)
+        (project / "package.json").write_text(
+            '{"name":"lsp-typescript-live","private":true}',
+            encoding="utf-8",
+        )
+        (project / "tsconfig.json").write_text(
+            "{"
+            '"compilerOptions":{'
+            '"target":"ES2022",'
+            '"module":"ESNext",'
+            '"moduleResolution":"Bundler",'
+            '"strict":true,'
+            '"noEmit":true'
+            "},"
+            '"include":["src/**/*.ts"]'
+            "}",
+            encoding="utf-8",
+        )
+        library = source_root / "lib.ts"
+        library.write_text(
+            "export function target(value: number): number {\n"
+            "  return value;\n"
+            "}\n\n"
+            'export const broken: number = "not a number";\n',
+            encoding="utf-8",
+        )
+        main_line = 'export const label = "😀"; export const result = target(1);'
+        main = source_root / "main.ts"
+        main.write_text(
+            'import { target } from "./lib";\n' + main_line + "\n",
+            encoding="utf-8",
+        )
+
+        catalog = discover_lsp_catalog(
+            workspace_root=project,
+            baseline_environment=default_lsp_environment(),
+            global_config_path=False,
+            project_config_path=False,
+            executable_resolver=lambda command, _environment: (
+                _TYPESCRIPT_LANGUAGE_SERVER
+                if command == "typescript-language-server"
+                else None
+            ),
+        )
+        assert [item.id for item in catalog.definitions] == [
+            "typescript-language-server"
+        ]
+        definition = catalog.definitions[0]
+        assert definition.source == "product-default"
+        assert definition.root_markers == (
+            "tsconfig.json",
+            "jsconfig.json",
+            "package.json",
+            ".git",
+        )
+
+        sandbox_runtime = bind_coding_sandbox_runtime(
+            workspace_root=project,
+            writable_workspace=True,
+            settings=SandboxSettings(enabled=False),
+            base_exec_service=ExecService(),
+        )
+        runtime = bind_coding_lsp_runtime(
+            workspace_root=project,
+            definitions=catalog.definitions,
+            process_launcher_binder=sandbox_runtime,
+            execution_scope=ProcessExecutionScope(
+                approval_resolver=_NoApprovalResolver(),
+                execution_profile_ceiling=coding_workspace_execution_profile(
+                    project,
+                    writable=True,
+                ),
+            ),
+            read_text=lambda path: path.read_text(encoding="utf-8"),
+            baseline_environment=default_lsp_environment(),
+        )
+        try:
+            # Public positions count Unicode code points; the Server receives UTF-16.
+            # A missing conversion would land on the space before ``target``.
+            target_character = main_line.index("target") + 1
+            definition_result = await runtime.inspect_symbol(
+                path="src/main.ts",
+                line=2,
+                character=target_character,
+                correlation_id="typescript-live-definition",
+            )
+            references = await runtime.inspect_symbol(
+                path="src/main.ts",
+                line=2,
+                character=target_character,
+                query="references",
+                correlation_id="typescript-live-references",
+            )
+            hover = await runtime.inspect_symbol(
+                path="src/main.ts",
+                line=2,
+                character=target_character,
+                query="hover",
+                correlation_id="typescript-live-hover",
+            )
+            outline = await runtime.document_outline(
+                path="src/lib.ts",
+                correlation_id="typescript-live-outline",
+            )
+
+            assert definition_result.server_id == "typescript-language-server"
+            assert definition_result.count >= 1
+            assert all(item.readable for item in definition_result.items)
+            assert references.count >= 2
+            assert hover.count >= 1
+            assert any(item.name == "target" for item in outline.items)
+            diagnosed = await _wait_for_diagnostic_state(
+                runtime,
+                lambda server: (
+                    server.accepted_diagnostic_publications >= 1
+                    and server.current_diagnostic_count >= 1
+                ),
+            )
+            assert diagnosed.workspace_root == str(project.resolve())
+            assert diagnosed.open_document_count == 2
+
+            library.write_text(
+                "export function target(value: number): number {\n"
+                "  return value;\n"
+                "}\n\n"
+                "export const broken: number = 1;\n",
+                encoding="utf-8",
+            )
+            await runtime.document_outline(
+                path="src/lib.ts",
+                correlation_id="typescript-live-diagnostic-fix",
+            )
+            cleared = await _wait_for_diagnostic_state(
+                runtime,
+                lambda server: (
+                    server.accepted_diagnostic_publications
+                    > diagnosed.accepted_diagnostic_publications
+                    and server.current_diagnostic_count == 0
+                ),
+            )
+            assert cleared.diagnostic_document_count == 0
+        finally:
+            await runtime.close()
+            await sandbox_runtime.close()
+
+        status = runtime.status()
+        assert status.disposed is True
+        assert status.servers[0].state == "stopped"
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary

- turn the built-in TypeScript Language Server declaration into a compatibility preset for JavaScript, JSX, TypeScript, and TSX
- select the nearest TypeScript/JavaScript project root while preserving clean unavailable-server degradation
- add fake multi-server coverage and a pinned real TypeScript Language Server compatibility gate
- document user-facing setup and the Coding-owned architecture contract

## User impact

Projects with an installed `typescript-language-server` and compatible `typescript` package can use the existing `inspect_symbol` and `document_outline` tools without custom server configuration. Loushang still starts servers lazily and never installs packages automatically.

## Validation

- `ruff format --check` and `ruff check` on changed Python files
- `46 passed` in `tests/coding/lsp`
- `2348 passed` in `tests/coding`
- `161 passed` in architecture boundary tests
- pinned real `typescript-language-server@5.3.0` + `typescript@5.9.3` compatibility test
- pinned real Pyright compatibility regression test
- `git diff --check`
