### PR TITLE
fix(cli): drop unsupported kwargs in resume mode dispatch

### DIFF
--- a/src/loushang/harness/cli/agent_host.py
+++ b/src/loushang/harness/cli/agent_host.py
@@ -407,8 +407,6 @@ async def run_agent_cli_host(
             "stdin": request.stdin,
             "stdout": request.stdout,
             "stderr": request.stderr,
-            "output_mode": output_mode,
-            "render_tool_events": request.launch_plan.render_tool_events,
             "work_event_log": request.work_event_log,
             "work_port": request.plain_work_port,
         },


### PR DESCRIPTION
## 背景

`run_agent_mode()` 的签名没有 `output_mode` 和 `render_tool_events` 参数，但 `agent_host.py` 在 `runners.mode` 分支的 `fixed_arguments` 中把这两个参数传了进去，导致 `--resume <session> <消息>` 路径直接崩溃：

```
TypeError: run_agent_mode() got an unexpected keyword argument 'output_mode'
```

（`render_tool_events` 已包含在 `ModeConfig` 中，重复传入同样多余。）

## 改动

- `src/loushang/harness/cli/agent_host.py`：删除传给 `run_agent_mode` 的多余参数 `output_mode` 与 `render_tool_events`（2 行删除）。

## 验证

- `ruff check`、`mypy` 通过。
- `tests/coding` + `tests/harness/cli`：2438 个测试全部通过。
- 源码环境与新构建二进制实测：resume 卡死会话后发送消息正常落盘（此前直接 TypeError 崩溃）。

## 说明

该修复随本次二进制重构（含 `9eb21b44` pairing repair 修复）一起构建进新二进制，并已安装到 `~/.local/bin/loushang`。