### PR TITLE
test(foundation): freeze phase zero contracts

### DIFF
--- a/docs/internals/architecture/drafts/README.md
+++ b/docs/internals/architecture/drafts/README.md
@@ -27,6 +27,7 @@ Current live references:
 ## Documents
 
 - [Foundation Refactor Plan](foundation-refactor-plan.md)
+- [Foundation Phase 0 Inventory](foundation-phase-0-inventory.md)
 - [Loushang Future Target Architecture v3](future-loushang-architecture-v3.md)
 - [Application Service Refactor](application-service-refactor.md)
 - [Loushang Runtime Architecture](loushang-runtime-architecture.md)

--- a/docs/internals/architecture/drafts/foundation-phase-0-inventory.md
+++ b/docs/internals/architecture/drafts/foundation-phase-0-inventory.md
@@ -1,0 +1,127 @@
+# Foundation Phase 0 Inventory
+
+## Status
+
+Recorded baseline for the proposed Foundation refactor. The inventory was
+captured from commit `3b01a233` for issue #426. It describes current ownership
+and compatibility obligations; it does not make the target package accepted
+architecture.
+
+## Current Package Inventory
+
+`loushang.protocol` contains:
+
+```text
+__init__.py
+json_value.py
+```
+
+Its root public surface is:
+
+```text
+JSONPrimitive
+JSONValue
+JsonValueError
+dump_json_value
+require_json_mapping
+require_json_value
+```
+
+`loushang.observability` contains:
+
+```text
+__init__.py
+_time.py
+context.py
+debug_log.py
+logger.py
+problem.py
+problem_text.py
+runtime.py
+runtime_identity.py
+sinks.py
+trace.py
+```
+
+Its root public surface is frozen by
+`tests/observability/test_public_api.py`. The current root exports 35 names,
+including records, logger/context APIs, router configuration, concrete sinks,
+runtime binding, runtime identity, and Problem text helpers. The target
+Foundation surface may be narrower, but the old root must continue forwarding
+all of these names during compatibility.
+
+## Production Consumer Counts
+
+The scan covers Python files below `src/loushang`, excluding the current
+packages' relative internal imports.
+
+| Subsystem | Protocol | Observability |
+|---|---:|---:|
+| Agent | 4 | 1 |
+| AI | 2 | 7 |
+| Channel | 2 | 0 |
+| Coding | 1 | 4 |
+| Harness | 30 | 5 |
+| HarnessTUI | 1 | 0 |
+| HarnessWork | 2 | 0 |
+| Ontology | 1 | 0 |
+| TUI | 0 | 1 |
+| Total | 43 | 18 |
+
+`src/loushang/agent/agent_loop.py` is the only file importing both packages,
+so the union is 60 production files.
+
+## Direct Submodule Imports
+
+All 43 Protocol consumers import from `loushang.protocol`; no production file
+directly imports `loushang.protocol.json_value`. The submodule remains a
+compatibility path because it is importable today.
+
+The following production files bypass the Observability root:
+
+| Import path | Production consumers |
+|---|---|
+| `loushang.observability.problem` | `ai/errors.py`, `ai/auth/support.py`, `ai/event_stream/raw_parts.py`, `ai/provider/errors.py`, `ai/structured.py`, `ai/trace.py` |
+| `loushang.observability.problem_text` | `coding/diagnostics/debug_status.py` |
+
+Repository tests also directly exercise these compatibility paths:
+
+```text
+loushang.observability.debug_log
+loushang.observability.problem
+loushang.observability.runtime_identity
+loushang.observability.trace
+```
+
+All current non-private Observability modules are included in the
+forwarding-path contract even when no production caller currently bypasses the
+root. The private `_time` module is not a compatibility path. This prevents a
+mechanical package move from breaking an importable repository-local module
+without promoting a private helper to public API.
+
+No Python file under `examples/` directly imports either package. Documentation
+mentions both ownership paths, primarily in the live architecture overview,
+subsystem description, Channel/Harness boundary documents, and the Foundation
+refactor plan. External downstream imports cannot be inferred from the
+repository and therefore remain a compatibility-release concern.
+
+## Frozen Behavior
+
+The Phase 0 characterization suite records:
+
+- strict JSON copying, exact-container policy, path reporting, cycle rejection,
+  finite floats, valid UTF-8 strings, integer encoder bounds, mapping validation,
+  and deterministic dumping;
+- diagnostic projection of tuples and general `Mapping` implementations,
+  rejection of unknown objects and non-finite floats, and the current scalar
+  subclass and invalid-surrogate behavior;
+- exact `ProblemRecord` and `DebugEventRecord` dictionary shapes;
+- exact Problem/debug text output and Trace JSONL fallback/output shape;
+- ContextVar nesting, restoration, and copied-context isolation;
+- scope filtering, best-effort sink failure isolation, configuration
+  capture/restore/reset, and ProblemStore identity; and
+- current root exports and direct submodule importability.
+
+These tests freeze behavior for the ownership move. They do not promote every
+edge behavior into a permanent API promise; semantic tightening remains a
+separate change after the compatibility migration.

--- a/docs/internals/architecture/drafts/foundation-refactor-plan.md
+++ b/docs/internals/architecture/drafts/foundation-refactor-plan.md
@@ -64,8 +64,8 @@ position inconsistently:
   which makes ownership unclear even though callers should see one JSON value
   type.
 
-At the time of this draft, 59 production files directly import one or both
-current packages: 43 import `loushang.protocol` and 17 import
+At the Phase 0 baseline, 60 production files directly import one or both
+current packages: 43 import `loushang.protocol` and 18 import
 `loushang.observability`, with one file importing both. This breadth requires
 a compatibility-first migration rather than a repository-wide rename in one
 change.
@@ -671,7 +671,7 @@ compatibility deletion in one commit.
 | strict and diagnostic JSON behavior accidentally merged | one type owner, separately named policies, characterization tests |
 | import cycles from a broad root facade | minimal Foundation root; direct leaf imports; router inversion |
 | trace output silently changes | preserve private fallback initially; exact output tests |
-| large 59-file consumer churn hides regressions | compatibility-first migration in small subsystem batches |
+| large 60-file consumer churn hides regressions | compatibility-first migration in small subsystem batches |
 | old direct submodule imports break | provide forwarding modules for the complete observed path inventory |
 | Foundation becomes a dumping ground | admission rule and standard-library-only/import-direction gates |
 | `runtime.py` absorbs Product policy | retain only Observability lifecycle; audit helpers after mechanical move |

--- a/tests/observability/test_context.py
+++ b/tests/observability/test_context.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from contextvars import copy_context
+
 from loushang.observability import current_context, log_context
 
 
@@ -23,6 +25,19 @@ def test_log_context_binds_nested_values_and_restores_previous_context() -> None
         restored = current_context()
         assert restored.session_id == "s1"
         assert restored.run_id == 4
+
+    assert current_context().session_id is None
+    assert current_context().run_id is None
+
+
+def test_log_context_isolated_copy_retains_its_captured_value() -> None:
+    with log_context(session_id="captured", run_id=1):
+        captured = copy_context()
+
+    with log_context(session_id="current", run_id=2):
+        assert current_context().session_id == "current"
+        assert captured.run(current_context).session_id == "captured"
+        assert captured.run(current_context).run_id == 1
 
     assert current_context().session_id is None
     assert current_context().run_id is None

--- a/tests/observability/test_problem.py
+++ b/tests/observability/test_problem.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import UserDict
+from enum import IntEnum, StrEnum
 from pathlib import Path
 
 import pytest
@@ -9,6 +11,10 @@ from loushang.observability import (
     get_problem_store,
     log_context,
     reset_observability,
+)
+from loushang.observability.problem import (
+    ensure_json_safe_mapping,
+    ensure_json_safe_value,
 )
 
 
@@ -67,3 +73,59 @@ def test_problem_rejects_non_json_safe_details() -> None:
 
     with pytest.raises(TypeError, match="JSON-safe"):
         log.problem("bad_details", details={"path": Path("tmp/file.txt")})
+
+
+def test_diagnostic_projection_converts_tuples_and_mapping_implementations() -> None:
+    source = UserDict(
+        {
+            "items": (1, UserDict({"ok": True})),
+            "nested": [UserDict({"name": "alpha"})],
+        }
+    )
+
+    projected = ensure_json_safe_mapping(source, name="details")
+
+    assert projected == {
+        "items": [1, {"ok": True}],
+        "nested": [{"name": "alpha"}],
+    }
+    assert type(projected) is dict
+    assert type(projected["items"]) is list
+    assert projected is not source
+    assert projected["nested"] is not source["nested"]
+
+
+def test_diagnostic_projection_preserves_current_scalar_subclass_policy() -> None:
+    class Count(IntEnum):
+        ONE = 1
+
+    class Label(StrEnum):
+        ONE = "one"
+
+    assert ensure_json_safe_value(Count.ONE) is Count.ONE
+    assert ensure_json_safe_value(Label.ONE) is Label.ONE
+    assert ensure_json_safe_value("\ud800") == "\ud800"
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        (Path("tmp/file.txt"), "value must be JSON-safe: got PosixPath"),
+        (float("nan"), "value must be JSON-safe: non-finite float"),
+        (float("inf"), "value must be JSON-safe: non-finite float"),
+    ],
+)
+def test_diagnostic_projection_rejects_unknown_and_non_finite_values(
+    value: object,
+    message: str,
+) -> None:
+    with pytest.raises(TypeError, match=message):
+        ensure_json_safe_value(value)
+
+
+def test_diagnostic_projection_rejects_non_string_mapping_keys() -> None:
+    with pytest.raises(
+        TypeError,
+        match="details must be JSON-safe: keys must be strings",
+    ):
+        ensure_json_safe_mapping({1: "value"})  # type: ignore[arg-type]

--- a/tests/observability/test_public_api.py
+++ b/tests/observability/test_public_api.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib
+
+import loushang.observability as observability
+
+
+def test_observability_public_surface_is_frozen_for_compatibility() -> None:
+    assert set(observability.__all__) == {
+        "DebugEventRecord",
+        "DebugLogSink",
+        "InMemoryProblemStore",
+        "JSONValue",
+        "LogContext",
+        "ObservabilityLog",
+        "ProblemRecord",
+        "ProblemRecordReader",
+        "ProblemSeverity",
+        "RuntimeIdentityProfile",
+        "TraceJSONLSink",
+        "capture_observability",
+        "collect_profiled_runtime_identity",
+        "collect_runtime_identity",
+        "configure_debug_logging",
+        "configure_observability",
+        "current_context",
+        "disable_debug_file",
+        "enable_debug_file",
+        "format_problem_summary",
+        "format_profiled_runtime_identity_text",
+        "format_runtime_identity_text",
+        "get_log",
+        "get_problem_store",
+        "is_debug_event_enabled",
+        "is_problem_log_line",
+        "log_context",
+        "observability_runtime_context",
+        "parse_scopes",
+        "path_from_args_or_env",
+        "recent_problem_store_lines",
+        "reset_observability",
+        "restore_observability",
+        "session_log_label",
+        "value_from_args_or_env",
+    }
+    assert all(hasattr(observability, name) for name in observability.__all__)
+
+
+def test_observability_direct_submodule_paths_remain_importable() -> None:
+    submodules = {
+        "context",
+        "debug_log",
+        "logger",
+        "problem",
+        "problem_text",
+        "runtime",
+        "runtime_identity",
+        "sinks",
+        "trace",
+    }
+
+    assert {
+        importlib.import_module(f"loushang.observability.{name}").__name__
+        for name in submodules
+    } == {f"loushang.observability.{name}" for name in submodules}

--- a/tests/observability/test_sinks.py
+++ b/tests/observability/test_sinks.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from loushang.observability import (
     DebugEventRecord,
     InMemoryProblemStore,
+    ProblemRecord,
+    capture_observability,
     configure_debug_logging,
     configure_observability,
     current_context,
@@ -13,6 +16,7 @@ from loushang.observability import (
     is_debug_event_enabled,
     log_context,
     reset_observability,
+    restore_observability,
 )
 from loushang.observability.debug_log import DebugLogSink
 from loushang.observability.trace import TraceJSONLSink
@@ -345,3 +349,177 @@ def test_trace_sink_stringifies_non_finite_floats(tmp_path) -> None:
     assert "Infinity" not in raw_text
     assert record["data"]["nan_value"] == "nan"
     assert record["data"]["inf_value"] == "inf"
+
+
+def test_records_preserve_exact_dictionary_shapes() -> None:
+    problem = ProblemRecord(
+        code="provider_failed",
+        severity="warning",
+        source="provider",
+        message="retrying",
+        recoverable=True,
+        details={"attempt": 2},
+        exception_type="RuntimeError",
+        exception_message="temporary",
+        time="2026-08-08T12:00:00Z",
+        monotonic_ms=42,
+        module="loushang.tests.provider",
+        component="Provider",
+        session_id="session-1",
+        run_id=3,
+        cwd="/repo",
+        mode="tui",
+    )
+    debug_event = DebugEventRecord(
+        scope="provider",
+        name="retry",
+        data={"attempt": 2},
+        time="2026-08-08T12:00:01Z",
+        monotonic_ms=43,
+        module="loushang.tests.provider",
+        component="Provider",
+        session_id="session-1",
+        run_id=3,
+        cwd="/repo",
+        mode="tui",
+    )
+
+    assert problem.to_dict() == {
+        "code": "provider_failed",
+        "severity": "warning",
+        "source": "provider",
+        "message": "retrying",
+        "recoverable": True,
+        "details": {"attempt": 2},
+        "exception_type": "RuntimeError",
+        "exception_message": "temporary",
+        "time": "2026-08-08T12:00:00Z",
+        "monotonic_ms": 42,
+        "module": "loushang.tests.provider",
+        "component": "Provider",
+        "session_id": "session-1",
+        "run_id": 3,
+        "cwd": "/repo",
+        "mode": "tui",
+    }
+    assert debug_event.to_dict() == {
+        "scope": "provider",
+        "name": "retry",
+        "data": {"attempt": 2},
+        "time": "2026-08-08T12:00:01Z",
+        "monotonic_ms": 43,
+        "module": "loushang.tests.provider",
+        "component": "Provider",
+        "session_id": "session-1",
+        "run_id": 3,
+        "cwd": "/repo",
+        "mode": "tui",
+    }
+
+
+def test_debug_sink_preserves_exact_problem_and_debug_event_text(tmp_path) -> None:
+    debug_path = tmp_path / "debug.log"
+    sink = DebugLogSink(debug_path)
+
+    sink.write_problem(
+        ProblemRecord(
+            code="provider_failed",
+            severity="warning",
+            source="provider",
+            message="line one\nline two",
+            recoverable=True,
+            details={"attempt": 2, "payload": {"ok": False}},
+            time="2026-08-08T12:00:00Z",
+            module="loushang.tests.provider",
+            component="Provider",
+            session_id="session-1",
+            run_id=3,
+        )
+    )
+    sink.write_debug_event(
+        DebugEventRecord(
+            scope="provider",
+            name="retry",
+            data={"attempt": 2, "reason": "temporary"},
+            time="2026-08-08T12:00:01Z",
+            module="loushang.tests.provider",
+            component="Provider",
+            session_id="session-1",
+            run_id=3,
+        )
+    )
+
+    assert debug_path.read_text(encoding="utf-8") == (
+        "2026-08-08T12:00:00Z PROBLEM warning provider_failed "
+        "source=provider module=loushang.tests.provider component=Provider "
+        "session=session-1 run=3 recoverable=True line one\\nline two "
+        'attempt=2 payload={"ok":false}\n'
+        "2026-08-08T12:00:01Z DEBUG_EVENT provider retry "
+        "module=loushang.tests.provider component=Provider session=session-1 "
+        "run=3 attempt=2 reason=temporary\n"
+    )
+
+
+def test_trace_sink_preserves_exact_fallback_and_jsonl_shape(tmp_path) -> None:
+    trace_path = tmp_path / "trace.jsonl"
+    sink = TraceJSONLSink(trace_path)
+
+    sink.write_debug_event(
+        DebugEventRecord(
+            scope="provider",
+            name="usage",
+            data={
+                "location": Path("notes.txt"),
+                "numbers": (1, 2),
+                "not_finite": float("nan"),
+                "mapping": {1: "one"},
+            },
+            time="2026-08-08T12:00:00Z",
+            monotonic_ms=42,
+            module="loushang.tests.provider",
+            component="Provider",
+            session_id="session-1",
+            run_id=3,
+            cwd="/repo",
+            mode="tui",
+        )
+    )
+
+    assert trace_path.read_text(encoding="utf-8") == (
+        '{"component": "Provider", "cwd": "/repo", '
+        '"data": {"location": "notes.txt", "mapping": {"1": "one"}, '
+        '"not_finite": "nan", "numbers": [1, 2]}, '
+        '"kind": "debug_event", "mode": "tui", "module": '
+        '"loushang.tests.provider", "monotonic_ms": 42, "name": "usage", '
+        '"run_id": 3, "scope": "provider", "session_id": "session-1", '
+        '"time": "2026-08-08T12:00:00Z"}\n'
+    )
+
+
+def test_capture_restore_and_reset_preserve_router_state_identity(tmp_path) -> None:
+    first_path = tmp_path / "first.log"
+    second_path = tmp_path / "second.log"
+    first_store = InMemoryProblemStore()
+    second_store = InMemoryProblemStore()
+
+    configure_observability(
+        problem_sink=first_store,
+        debug_sink=DebugLogSink(first_path),
+        debug_scopes={"provider"},
+    )
+    snapshot = capture_observability()
+    configure_observability(
+        problem_sink=second_store,
+        debug_sink=DebugLogSink(second_path),
+        debug_scopes={"tui"},
+    )
+
+    restore_observability(snapshot)
+    assert get_problem_store() is first_store
+    get_log("loushang.tests.provider").debug_event("provider", "restored")
+    assert "restored" in first_path.read_text(encoding="utf-8")
+    assert not second_path.exists()
+
+    reset_observability()
+    assert get_problem_store() is not first_store
+    assert not is_debug_event_enabled("provider")

--- a/tests/protocol/test_public_api.py
+++ b/tests/protocol/test_public_api.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import importlib
+
+import loushang.protocol as protocol
+
+
+def test_protocol_public_surface_is_frozen_for_compatibility() -> None:
+    assert set(protocol.__all__) == {
+        "JSONPrimitive",
+        "JSONValue",
+        "JsonValueError",
+        "dump_json_value",
+        "require_json_mapping",
+        "require_json_value",
+    }
+    assert all(hasattr(protocol, name) for name in protocol.__all__)
+
+
+def test_protocol_json_value_submodule_remains_importable() -> None:
+    module = importlib.import_module("loushang.protocol.json_value")
+
+    assert module.__name__ == "loushang.protocol.json_value"


### PR DESCRIPTION
## Summary

- freeze the current Protocol and Observability public surfaces and direct submodule paths
- characterize strict JSON, diagnostic projection, record shapes, sink output, ContextVar isolation, and router state
- record the Phase 0 consumer/import inventory for the compatibility-first Foundation migration
- correct the production consumer baseline to 43 Protocol files, 18 Observability files, and 60 unique files

## Why

The Foundation ownership move crosses several level-two subsystems. These tests and the inventory make the current behavior and compatibility obligations explicit before production modules move.

This PR does not add `loushang.foundation`, move production code, change JSON semantics, or remove compatibility packages.

## Validation

- `214 passed` — Protocol, Observability, and architecture import-boundary suites
- `ruff check .` passed
- `git diff --check` passed
- three sandbox-restricted OAuth/JSON-index tests passed in the smallest non-sandbox scope
- three sandbox-restricted real-subprocess Coding tests passed in the smallest non-sandbox scope
- one sandbox-restricted persisted-session roundtrip test passed in the smallest non-sandbox scope
- full non-live run was attempted in the sandbox; it encountered only loopback-bind and process/file-index sandbox restrictions, with no behavioral assertion mismatch; the full suite was not moved outside the sandbox

Refs #426
