### PR TITLE
fix(harness): integrate compact streaming and transcript UI

### DIFF
--- a/src/loushang/harness/session/commands/projection.py
+++ b/src/loushang/harness/session/commands/projection.py
@@ -28,7 +28,11 @@ def project_standard_session_command_result(
             session = result.value
             if isinstance(session, Mapping):
                 session = dict(session)
-            return _ok_command_result(command, session=session)
+            return _ok_command_result(
+                command,
+                session=session,
+                message=_session_message(session),
+            )
         case StandardSessionCommandId.RENAME:
             name = result.value
             return _ok_command_result(
@@ -197,6 +201,23 @@ def _standard_argument_error(result: StandardSessionCommandResult) -> str:
             return "Usage: /tree <entry-id> [--summarize] [--label <label>]"
         case _:
             return f"Invalid arguments for /{result.command_id.value}"
+
+
+def _session_message(session: object) -> str:
+    if not isinstance(session, Mapping):
+        return "Session information available."
+
+    fields = (
+        ("Session", session.get("session_id")),
+        ("Name", session.get("session_name")),
+        ("CWD", session.get("cwd")),
+    )
+    parts = [
+        f"{label}: {value}"
+        for label, value in fields
+        if isinstance(value, str) and value
+    ]
+    return " | ".join(parts) or "Session information available."
 
 
 def _ok_command_result(command: str, **fields: object) -> dict[str, object]:

--- a/src/loushang/harness/transcript/summarization.py
+++ b/src/loushang/harness/transcript/summarization.py
@@ -14,7 +14,7 @@ from types import MappingProxyType
 from typing import cast
 
 from loushang.agent.types import AgentMessage
-from loushang.ai import ApiKeyAuth, CallOptions, Context, Model, complete
+from loushang.ai import ApiKeyAuth, CallOptions, Context, Model, complete, stream
 from loushang.ai.types import AssistantMessage, TextPart, UserMessage
 from loushang.foundation.json import JSONValue, require_json_value
 from loushang.harness.context import (
@@ -212,7 +212,7 @@ def default_summary_completer(
     context: Context,
     options: CallOptions | None = None,
 ) -> Awaitable[str]:
-    """Call the stable AI completion surface and return assistant text."""
+    """Use the model's declared completion mode and return assistant text."""
 
     return _complete_text(model, context, options)
 
@@ -493,7 +493,12 @@ async def _complete_text(
     context: Context,
     options: CallOptions | None,
 ) -> str:
-    message = await complete(cast(Model, model), context, options)
+    typed_model = cast(Model, model)
+    if typed_model.supports_stream:
+        event_stream = await stream(typed_model, context, options)
+        message = await event_stream.result()
+    else:
+        message = await complete(typed_model, context, options)
     return "".join(
         part.text
         for part in getattr(message, "content", ())

--- a/src/loushang/harnesstui/conversation/screen_app.py
+++ b/src/loushang/harnesstui/conversation/screen_app.py
@@ -284,9 +284,8 @@ class ScreenConversationApp:
         *,
         summary: str = "",
         tokens_before: int | None = None,
-        max_records: int = 80,
     ) -> None:
-        """Append a compaction fact and bound the active record window."""
+        """Append a compaction fact without changing the active transcript window."""
 
         self.state.records.append(
             ContextCompactionRecord(
@@ -295,11 +294,6 @@ class ScreenConversationApp:
             )
         )
         self.state.mark_records_changed()
-        evicted = self.state.trim_transcript_prefix(max_records=max_records)
-        if evicted:
-            self._render_baseline_reset_reason = (
-                "transcript_window_trimmed:context_compaction"
-            )
 
     def trim_active_transcript_window(self) -> None:
         """Apply the configured logical-line budget to the active window."""

--- a/src/loushang/tui/transcript.py
+++ b/src/loushang/tui/transcript.py
@@ -576,9 +576,6 @@ def _render_thinking(record: ThinkingRecord, *, width: int) -> list[str]:
 
 def _context_compaction_line(record: ContextCompactionRecord) -> str:
     line = "* Context compacted"
-    summary = record.summary.strip()
-    if summary:
-        line += f": {summary}"
     if record.tokens_before is not None:
         line += f" ({record.tokens_before} tokens before)"
     return line

--- a/tests/coding/test_agent_session_compaction.py
+++ b/tests/coding/test_agent_session_compaction.py
@@ -790,6 +790,113 @@ def test_agent_session_auto_compacts_after_agent_end_when_threshold_exceeded(
     assert compaction_end["will_retry"] is False
 
 
+def test_agent_session_auto_compaction_uses_default_streaming_summarizer(
+    tmp_path, monkeypatch
+) -> None:
+    from loushang.agent import AbortSignal, Agent
+    from loushang.coding.control import (
+        CompactionSettings,
+        ControlConfig,
+        SettingsManager,
+    )
+    from loushang.coding.session import AgentSession
+    from loushang.coding.session_manager import SessionManager
+    from loushang.harness.transcript import summarization as summary_module
+
+    manager = asyncio.run(
+        SessionManager.new(session_dir=tmp_path, cwd="/tmp/project", persist=False)
+    )
+    asyncio.run(
+        manager.append_message(
+            UserMessage(
+                role="user",
+                content=[TextPart(type="text", text="older context")],
+                timestamp=0.0,
+            )
+        )
+    )
+    model = Model(
+        id="tiny-stream-model",
+        name="Tiny Stream",
+        provider="faux",
+        endpoint="anthropic-messages",
+        capabilities=Capabilities(
+            reasoning=True,
+            stream=True,
+            input=("text",),
+            context_window=100,
+            max_tokens=64,
+        ),
+    )
+    session = AgentSession(
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": model,
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=manager,
+        settings_manager=SettingsManager(
+            ControlConfig(
+                compaction=CompactionSettings(
+                    enabled=True, reserve_tokens=10, keep_recent_tokens=1
+                )
+            )
+        ),
+    )
+    events: list[object] = []
+    session.subscribe(events.append)
+    stream_calls: list[tuple[object, object, object | None]] = []
+    summary_message = _assistant_message("threshold stream summary")
+
+    class FakeEventStream:
+        async def result(self):
+            return summary_message
+
+    async def fake_stream(model, context, options=None):
+        stream_calls.append((model, context, options))
+        return FakeEventStream()
+
+    monkeypatch.setattr(summary_module, "stream", fake_stream)
+    assistant = _assistant_message(
+        "recent reply",
+        usage=Usage(
+            input=90,
+            output=5,
+            cache_read=0,
+            cache_write=0,
+            total_tokens=95,
+            cost={},
+        ),
+        timestamp=1.0,
+    )
+
+    async def scenario() -> None:
+        await session._composition.session_runtime.handle_agent_event(
+            {"type": "message_end", "message": assistant}, AbortSignal()
+        )
+        await session._composition.session_runtime.handle_agent_event(
+            {"type": "agent_end", "messages": [assistant]}, AbortSignal()
+        )
+
+    asyncio.run(scenario())
+
+    assert len(stream_calls) == 1
+    assert all(call[0] is model for call in stream_calls)
+    checkpoint = next(
+        entry
+        for entry in manager.get_entries()
+        if entry.kind == "context.compaction_checkpoint"
+    )
+    assert "threshold stream summary" in checkpoint.payload.summary
+    compaction_end = next(
+        event for event in events if event["type"] == "compaction_end"
+    )
+    assert compaction_end["reason"] == "threshold"
+    assert compaction_end["stage"] == "committed"
+
+
 def test_agent_session_auto_compaction_uses_compact_percent_threshold(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/coding/test_compaction_core.py
+++ b/tests/coding/test_compaction_core.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from loushang.ai import ApiKeyAuth, CallOptions
+from loushang.ai.model import Capabilities, Model
 from loushang.ai.types import (
     AssistantMessage,
     TextPart,
@@ -39,46 +40,121 @@ from loushang.harness.transcript import (
 
 
 @pytest.mark.anyio
-async def test_complete_text_calls_root_complete_with_options(monkeypatch) -> None:
+async def test_complete_text_aggregates_root_stream_with_options(monkeypatch) -> None:
     from loushang.ai import Context
     from loushang.harness.transcript import summarization as summary_module
 
     captured: dict[str, object] = {}
 
-    async def fake_complete(model, context, options=None):
+    message = AssistantMessage(
+        role="assistant",
+        content=[TextPart(type="text", text="summary text")],
+        api="faux",
+        provider="faux",
+        model="faux-model",
+        response_id=None,
+        usage=Usage(
+            input=0,
+            output=0,
+            cache_read=0,
+            cache_write=0,
+            total_tokens=0,
+            cost=None,
+        ),
+        stop_reason="stop",
+        error_message=None,
+        timestamp=0.0,
+    )
+
+    class FakeEventStream:
+        async def result(self):
+            captured["result_called"] = True
+            return message
+
+    async def fake_stream(model, context, options=None):
         captured["model"] = model
         captured["context"] = context
         captured["options"] = options
-        return AssistantMessage(
-            role="assistant",
-            content=[TextPart(type="text", text="summary text")],
-            api="faux",
-            provider="faux",
-            model="faux-model",
-            response_id=None,
-            usage=Usage(
-                input=0,
-                output=0,
-                cache_read=0,
-                cache_write=0,
-                total_tokens=0,
-                cost=None,
-            ),
-            stop_reason="stop",
-            error_message=None,
-            timestamp=0.0,
-        )
+        return FakeEventStream()
 
-    monkeypatch.setattr(summary_module, "complete", fake_complete)
+    monkeypatch.setattr(summary_module, "stream", fake_stream)
     options = CallOptions(auth=ApiKeyAuth("key"), headers={"x-test": "1"})
     context = Context(
         messages=[UserMessage(role="user", content="summarize", timestamp=0.0)]
     )
+    model = Model(
+        id="stream-model",
+        name="Stream Model",
+        provider="faux",
+        endpoint="anthropic-messages",
+        capabilities=Capabilities(stream=True),
+    )
 
-    result = await summary_module._complete_text("model", context, options)
+    result = await summary_module._complete_text(model, context, options)
 
     assert result == "summary text"
-    assert captured == {"model": "model", "context": context, "options": options}
+    assert captured == {
+        "model": model,
+        "context": context,
+        "options": options,
+        "result_called": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_complete_text_uses_complete_for_non_stream_model(monkeypatch) -> None:
+    from loushang.ai import Context
+    from loushang.harness.transcript import summarization as summary_module
+
+    captured: dict[str, object] = {}
+    message = AssistantMessage(
+        role="assistant",
+        content=[TextPart(type="text", text="non-stream summary")],
+        api="faux",
+        provider="faux",
+        model="faux-model",
+        response_id=None,
+        usage=Usage(
+            input=0,
+            output=0,
+            cache_read=0,
+            cache_write=0,
+            total_tokens=0,
+            cost=None,
+        ),
+        stop_reason="stop",
+        error_message=None,
+        timestamp=0.0,
+    )
+
+    async def fake_complete(model, context, options=None):
+        captured["model"] = model
+        captured["context"] = context
+        captured["options"] = options
+        return message
+
+    async def unexpected_stream(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("stream() must not be used without stream capability")
+
+    monkeypatch.setattr(summary_module, "complete", fake_complete)
+    monkeypatch.setattr(summary_module, "stream", unexpected_stream)
+    options = CallOptions(auth=ApiKeyAuth("key"), headers={"x-test": "1"})
+    context = Context(
+        messages=[UserMessage(role="user", content="summarize", timestamp=0.0)]
+    )
+    model = Model(
+        id="complete-model",
+        name="Complete Model",
+        provider="faux",
+        endpoint="anthropic-messages",
+        capabilities=Capabilities(stream=False),
+    )
+
+    result = await summary_module._complete_text(model, context, options)
+
+    assert result == "non-stream summary"
+    assert captured == {"model": model, "context": context, "options": options}
 
 
 def test_compaction_package_exports_product_symbols() -> None:

--- a/tests/coding/test_screen_coding_tui_events.py
+++ b/tests/coding/test_screen_coding_tui_events.py
@@ -640,7 +640,7 @@ def test_screen_event_projector_renders_same_text_queued_message_after_initial_e
     assert app.state.records == [UserPromptRecord("same"), UserPromptRecord("same")]
 
 
-def test_screen_event_projector_appends_compaction_record_and_tracks_baseline_reset() -> (
+def test_screen_event_projector_appends_compaction_record_without_trimming_history() -> (
     None
 ):
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
@@ -675,19 +675,14 @@ def test_screen_event_projector_appends_compaction_record_and_tracks_baseline_re
         }
     )
 
-    assert app.state.evicted_prefix_record_count > 0
+    assert len(app.state.records) == 122
+    assert app.state.evicted_prefix_record_count == 0
     assert isinstance(app.state.records[-1], ContextCompactionRecord)
     assert app.state.records[-1].summary == "condensed summary"
     assert app.state.records[-1].tokens_before == 500_000
-    assert all(
-        not getattr(record, "text", "").startswith("old prompt 0")
-        for record in app.state.records
-    )
+    assert app.state.records[0] == UserPromptRecord("old prompt 0")
     assert UserPromptRecord("recent prompt") in app.state.records
-    assert (
-        app.consume_render_baseline_reset_reason()
-        == "transcript_window_trimmed:context_compaction"
-    )
+    assert app.consume_render_baseline_reset_reason() is None
 
 
 def test_screen_event_projector_does_not_reset_baseline_without_compaction_eviction() -> (

--- a/tests/coding/test_screen_coding_tui_terminal_playback.py
+++ b/tests/coding/test_screen_coding_tui_terminal_playback.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from io import StringIO
+from types import SimpleNamespace
 
 import pytest
 
+from loushang.ai import TextPart
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 from loushang.coding.ui.screen_input import build_screen_input_router
 from loushang.harnesstui.testing.performance import (
@@ -27,6 +29,138 @@ from loushang.tui.transcript import ToolExecutionRecord
 from tests.coding.tui_support.playback import ScreenTuiScenario
 
 pytestmark = pytest.mark.tui_render_contract
+
+
+def _assistant(text: str = "") -> SimpleNamespace:
+    return SimpleNamespace(
+        role="assistant",
+        content=[TextPart(type="text", text=text)] if text else [],
+        stop_reason="stop",
+        error_message=None,
+    )
+
+
+def test_screen_coding_tui_playback_preserves_history_across_auto_compaction_and_streaming() -> None:
+    from loushang.harnesstui.conversation.agent_binding import (
+        build_agent_screen_conversation_projection,
+    )
+
+    app = _app()
+    runtime, port = _runtime(app, width=80, height=18)
+    projector = build_agent_screen_conversation_projection(app)
+
+    app.start_prompt("earlier prompt", started_at=0.0)
+    runtime.render_now()
+    app.begin_assistant()
+    for index in range(80):
+        app.append_assistant_chunk(f"earlier line {index}\n")
+        runtime.render_now()
+    app.end_assistant()
+    app.complete_run(elapsed_seconds=1.0)
+    runtime.render_now()
+
+    projector.handle({"type": "compaction_start", "reason": "threshold"})
+    runtime.render_now()
+    projector.handle(
+        {
+            "type": "compaction_end",
+            "reason": "threshold",
+            "result": {
+                "summary": "first summary line\nsecond summary line",
+                "first_kept_entry_id": "entry-100",
+                "tokens_before": 500_000,
+            },
+        }
+    )
+    compact_step = runtime.render_now()
+
+    app.start_prompt("continue", started_at=0.0)
+    runtime.render_now()
+    projector.handle({"type": "message_start", "message": _assistant()})
+    streaming_steps = []
+    streamed_text = ""
+    expected_after_lines = tuple(
+        f"AFTER_COMPACT_{index:03d}" for index in range(1, 41)
+    )
+    line_index = 0
+    batch_index = 0
+    batch_sizes = (1, 3, 2, 4)
+    while line_index < len(expected_after_lines):
+        batch_size = batch_sizes[batch_index % len(batch_sizes)]
+        batch_end = min(line_index + batch_size, len(expected_after_lines))
+        batch = "\n".join(expected_after_lines[line_index:batch_end])
+        if batch_end < len(expected_after_lines):
+            batch += "\n"
+
+        # Provider deltas do not align with rendered lines, while stream render
+        # requests may be coalesced. Split each batch mid-line and render only
+        # after the full batch to exercise multi-row viewport advances.
+        split_at = min(7, len(batch))
+        for chunk in (batch[:split_at], batch[split_at:]):
+            if not chunk:
+                continue
+            streamed_text += chunk
+            projector.handle(
+                {
+                    "type": "message_update",
+                    "message": _assistant(streamed_text),
+                    "assistant_message_event": {
+                        "type": "text_delta",
+                        "delta": chunk,
+                    },
+                }
+            )
+        streaming_steps.append(runtime.render_now())
+        line_index = batch_end
+        batch_index += 1
+    projector.handle(
+        {"type": "message_end", "message": _assistant(streamed_text)}
+    )
+    commit_step = runtime.render_now()
+
+    terminal_text = strip_control_sequences(
+        "\n".join((*port.screen.scrollback_lines, *port.screen.visible_lines))
+    )
+    compact_lines = tuple(
+        strip_control_sequences(line)
+        for line in compact_step.diagnostics.current_logical_lines
+    )
+    final_step = streaming_steps[-1]
+
+    assert sum(
+        "Context compacted (500000 tokens before)" in line
+        for line in compact_lines
+    ) == 1
+    assert "earlier prompt" in terminal_text
+    assert "earlier line 0" in terminal_text
+    assert "earlier line 79" in terminal_text
+    assert terminal_text.count("Context compacted (500000 tokens before)") == 1
+    assert all(terminal_text.count(line) == 1 for line in expected_after_lines)
+    assert [terminal_text.index(line) for line in expected_after_lines] == sorted(
+        terminal_text.index(line) for line in expected_after_lines
+    )
+    assert "first summary line" not in terminal_text
+    assert "second summary line" not in terminal_text
+    assert all(
+        step.diagnostics.operation_class != "recovery_repaint"
+        for step in (*streaming_steps, commit_step)
+    )
+    assert any(
+        current.diagnostics.viewport_top - previous.diagnostics.viewport_top > 1
+        for previous, current in zip(streaming_steps, streaming_steps[1:])
+    )
+    assert final_step.frame is not None
+    expected_physical_cursor_row = (
+        final_step.diagnostics.hardware_cursor_row
+        - final_step.diagnostics.viewport_top
+    )
+    assert final_step.frame.screen_after.cursor_row == expected_physical_cursor_row
+    assert (
+        final_step.frame.screen_after.cursor_column
+        == final_step.diagnostics.hardware_cursor_column
+    )
+    assert port.screen.cursor_row == expected_physical_cursor_row
+    assert port.screen.cursor_column == final_step.diagnostics.hardware_cursor_column
 
 
 def test_screen_coding_tui_streaming_uses_differential_updates_without_clearing_screen() -> None:

--- a/tests/coding/test_session_command_controller.py
+++ b/tests/coding/test_session_command_controller.py
@@ -333,6 +333,7 @@ def test_command_controller_executes_builtin_rename_session_and_unsupported_comm
         "command": "session",
         "status": "ok",
         "session": {"session_id": "session-1", "cwd": "/tmp/project"},
+        "message": "Session: session-1 | CWD: /tmp/project",
     }
     assert controller.extract_builtin_command_invocation("/model") is None
 

--- a/tests/harnesstui/conversation/test_screen_app.py
+++ b/tests/harnesstui/conversation/test_screen_app.py
@@ -104,24 +104,23 @@ def test_screen_conversation_app_owns_compaction_window_mechanics() -> None:
     )
 
 
-def test_screen_conversation_app_appends_compaction_fact_and_trims_records() -> None:
+def test_screen_conversation_app_appends_compaction_fact_without_trimming_records() -> None:
     app = _app()
     app.state.records.extend(UserPromptRecord(str(index)) for index in range(3))
 
     app.append_context_compaction_record(
         summary="condensed",
         tokens_before=42,
-        max_records=2,
     )
 
     assert app.state.records == [
+        UserPromptRecord("0"),
+        UserPromptRecord("1"),
         UserPromptRecord("2"),
         ContextCompactionRecord(summary="condensed", tokens_before=42),
     ]
-    assert app.state.evicted_prefix_record_count == 2
-    assert app.consume_render_baseline_reset_reason() == (
-        "transcript_window_trimmed:context_compaction"
-    )
+    assert app.state.evicted_prefix_record_count == 0
+    assert app.consume_render_baseline_reset_reason() is None
 
 
 def test_screen_conversation_app_applies_active_logical_line_budget() -> None:

--- a/tests/tui/test_transcript_records.py
+++ b/tests/tui/test_transcript_records.py
@@ -88,9 +88,19 @@ def test_worked_divider_commits_as_stable_transcript_record() -> None:
 
 
 def test_context_compaction_record_renders_as_single_stable_transcript_line() -> None:
-    view = TranscriptView([ContextCompactionRecord(summary="older context summarized", tokens_before=500_000)])
+    view = TranscriptView(
+        [
+            ContextCompactionRecord(
+                summary="older context\nsummarized",
+                tokens_before=500_000,
+            )
+        ]
+    )
 
-    assert rendered_text(view, width=80) == ("* Context compacted: older context summarized (500000 tokens before)",)
+    lines = rendered_text(view, width=80)
+
+    assert lines == ("* Context compacted (500000 tokens before)",)
+    assert all("\n" not in line and "\r" not in line for line in lines)
 
 
 def test_status_record_renders_message_without_thinking_prefix() -> None:


### PR DESCRIPTION
## Summary

Integrate the compact streaming and transcript UI fix from `lane/harness` into `main`.

- use streaming aggregation for compaction summaries when supported by the model
- preserve the live TUI transcript and keep compaction markers terminal-safe
- add fragmented/coalesced terminal playback coverage
- show useful session identity details from `/session`

## Validation

- manual Kimi K3 `/compact` verification passed
- focused changed-file tests: 124 passed
- TUI render-contract suite: 167 passed
- HarnessTUI quality: lint and mypy passed; 1245 tests passed
- Harness lint and mypy passed across 437 source files
- all checks on source PR #440 passed
