### PR TITLE
test(tui): verify native terminal contracts on Windows and Linux

### DIFF
--- a/.github/workflows/harnesstui-quality.yml
+++ b/.github/workflows/harnesstui-quality.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   harnesstui-quality:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tui-render-contract.yml
+++ b/.github/workflows/tui-render-contract.yml
@@ -83,6 +83,49 @@ jobs:
         if: runner.os == 'Linux'
         run: uv run python scripts/dev/verify_pytest_xml.py .artifacts/terminal-platform-posix.xml
 
+  native-terminal:
+    name: native-terminal (${{ matrix.backend }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            backend: posix-pty
+          - os: windows-2022
+            backend: conpty
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install locked dependencies
+        run: uv sync --locked --extra dev
+
+      - name: Create report directory
+        run: uv run python -c "from pathlib import Path; Path('.artifacts').mkdir(exist_ok=True)"
+
+      - name: Native backend conformance and shared CLI contract
+        env:
+          LOUSHANG_REQUIRED_TERMINAL_BACKEND: ${{ matrix.backend }}
+        run: >-
+          uv run pytest tests/tui/test_terminal_query_responder.py
+          tests/tui/test_terminal_process_backend.py
+          tests/coding/test_cli_terminal_contract.py
+          --strict-markers --strict-config
+          --junitxml=.artifacts/native-terminal.xml -q
+
+      - name: Reject empty, skipped, failing, or wrong-backend report
+        run: >-
+          uv run python scripts/dev/verify_pytest_xml.py
+          .artifacts/native-terminal.xml
+          --require-property terminal_backend=${{ matrix.backend }}
+
   tmux-scrollback:
     name: tmux-scrollback (ubuntu-24.04)
     runs-on: ubuntu-24.04

--- a/.github/workflows/tui-render-contract.yml
+++ b/.github/workflows/tui-render-contract.yml
@@ -1,4 +1,4 @@
-name: TUI Render Contract
+name: TUI Cross-platform Contracts
 
 on:
   push:
@@ -7,8 +7,14 @@ on:
   pull_request:
 
 jobs:
-  tui-render-contract:
-    runs-on: ubuntu-latest
+  deterministic-render:
+    name: deterministic-render (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022]
     steps:
       - uses: actions/checkout@v4
 
@@ -18,8 +24,97 @@ jobs:
 
       - uses: astral-sh/setup-uv@v5
 
-      - name: Install dependencies
-        run: make bootstrap
+      - name: Install locked dependencies
+        run: uv sync --locked --extra dev
 
-      - name: TUI render contract
-        run: make test-tui-render-contract
+      - name: Create report directory
+        run: uv run python -c "from pathlib import Path; Path('.artifacts').mkdir(exist_ok=True)"
+
+      - name: Deterministic render and playback contracts
+        run: >-
+          uv run pytest tests/tui tests/harnesstui tests/coding
+          -m tui_render_contract --strict-markers --strict-config
+          --junitxml=.artifacts/deterministic-render.xml -q
+
+      - name: Reject empty, skipped, or failing report
+        run: uv run python scripts/dev/verify_pytest_xml.py .artifacts/deterministic-render.xml
+
+  terminal-platform-unit:
+    name: terminal-platform-unit (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2022]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install locked dependencies
+        run: uv sync --locked --extra dev
+
+      - name: Create report directory
+        run: uv run python -c "from pathlib import Path; Path('.artifacts').mkdir(exist_ok=True)"
+
+      - name: Shared terminal platform units
+        run: >-
+          uv run pytest tests/tui/test_terminal_platform.py
+          tests/tui/test_terminal_session.py tests/tui/test_terminal_input.py
+          --strict-markers --strict-config
+          --junitxml=.artifacts/terminal-platform-shared.xml -q
+
+      - name: Reject empty, skipped, or failing shared report
+        run: uv run python scripts/dev/verify_pytest_xml.py .artifacts/terminal-platform-shared.xml
+
+      - name: POSIX terminal platform units
+        if: runner.os == 'Linux'
+        run: >-
+          uv run pytest tests/tui/test_terminal_input_posix.py
+          --strict-markers --strict-config
+          --junitxml=.artifacts/terminal-platform-posix.xml -q
+
+      - name: Reject empty, skipped, or failing POSIX report
+        if: runner.os == 'Linux'
+        run: uv run python scripts/dev/verify_pytest_xml.py .artifacts/terminal-platform-posix.xml
+
+  tmux-scrollback:
+    name: tmux-scrollback (ubuntu-24.04)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install tmux
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes tmux
+          tmux -V
+
+      - name: Install locked dependencies
+        run: uv sync --locked --extra dev
+
+      - name: Create report directory
+        run: uv run python -c "from pathlib import Path; Path('.artifacts').mkdir(exist_ok=True)"
+
+      - name: Required tmux pane and history contracts
+        env:
+          LOUSHANG_REQUIRE_TMUX: "1"
+        run: >-
+          uv run pytest tests/coding/test_screen_coding_tui_pty_smoke.py
+          -m tui_tmux_integration --strict-markers --strict-config
+          --junitxml=.artifacts/tmux-scrollback.xml -q
+
+      - name: Reject empty, skipped, or failing report
+        run: uv run python scripts/dev/verify_pytest_xml.py .artifacts/tmux-scrollback.xml

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ HARNESS_TEST_PATHS := \
 	tests/harness \
 	tests/architecture/test_import_boundaries.py
 
-.PHONY: bootstrap test test-ai check-ai test-tui test-tui-render-contract lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip
+.PHONY: bootstrap test test-ai check-ai test-tui test-tui-render-contract test-tui-terminal-platform test-tui-tmux lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip
 .PHONY: check-ai-catalog check-ai-examples check-ai-imports check-ai-coverage
 .PHONY: check-harness lint-harness typecheck-harness test-harness
 .PHONY: check-harnesstui lint-harnesstui typecheck-harnesstui test-harnesstui
@@ -163,10 +163,16 @@ test-harnesstui:
 	uv --cache-dir .uv-cache run --extra dev pytest $(HARNESSTUI_TEST_PATHS) $(CODING_TUI_PRODUCT_TEST_PATHS) -m "not tui_render_contract" -q
 
 test-tui:
-	. .venv/bin/activate && python -m pytest tests/tui -q
+	uv --cache-dir .uv-cache run --extra dev pytest tests/tui -q
 
 test-tui-render-contract:
 	uv --cache-dir .uv-cache run --extra dev pytest tests/tui tests/harnesstui tests/coding -m tui_render_contract -q
+
+test-tui-terminal-platform:
+	uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_terminal_platform.py tests/tui/test_terminal_session.py tests/tui/test_terminal_input.py tests/tui/test_terminal_input_posix.py --strict-markers --strict-config -q
+
+test-tui-tmux:
+	LOUSHANG_REQUIRE_TMUX=1 uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_screen_coding_tui_pty_smoke.py -m tui_tmux_integration --strict-markers --strict-config -q
 
 lane-status:
 	uv run python scripts/dev/lane_status.py

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ HARNESS_TEST_PATHS := \
 	tests/harness \
 	tests/architecture/test_import_boundaries.py
 
-.PHONY: bootstrap test test-ai check-ai test-tui test-tui-render-contract test-tui-terminal-platform test-tui-tmux lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip
+.PHONY: bootstrap test test-ai check-ai test-tui test-tui-render-contract test-tui-terminal-platform test-tui-native test-tui-tmux lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip
 .PHONY: check-ai-catalog check-ai-examples check-ai-imports check-ai-coverage
 .PHONY: check-harness lint-harness typecheck-harness test-harness
 .PHONY: check-harnesstui lint-harnesstui typecheck-harnesstui test-harnesstui
@@ -170,6 +170,9 @@ test-tui-render-contract:
 
 test-tui-terminal-platform:
 	uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_terminal_platform.py tests/tui/test_terminal_session.py tests/tui/test_terminal_input.py tests/tui/test_terminal_input_posix.py --strict-markers --strict-config -q
+
+test-tui-native:
+	uv --cache-dir .uv-cache run --extra dev pytest tests/tui/test_terminal_query_responder.py tests/tui/test_terminal_process_backend.py tests/coding/test_cli_terminal_contract.py --strict-markers --strict-config -q
 
 test-tui-tmux:
 	LOUSHANG_REQUIRE_TMUX=1 uv --cache-dir .uv-cache run --extra dev pytest tests/coding/test_screen_coding_tui_pty_smoke.py -m tui_tmux_integration --strict-markers --strict-config -q

--- a/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
+++ b/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
@@ -117,9 +117,13 @@ query response, bounded timeout, process-tree termination, and idempotent
 cleanup. They do not claim exact final screen state; FakeTerminal/playback owns
 that evidence.
 
-The Windows backend uses `pywinpty==3.0.5` through its low-level `winpty.PTY`
+The Windows backend uses `pywinpty==2.0.15` through its low-level `winpty.PTY`
 API and explicitly selects ConPTY. It does not permit an automatic WinPTY
-fallback. Both backends execute the shared real CLI `/quit` contract in
+fallback. Version 3.0.5 was rejected by the Windows lifecycle spike because its
+asynchronous backend could leave the final query response pending and lose the
+tail of large output at process exit. The selected version is x64-only; ARM64
+is not a supported native-test target until a candidate wheel passes the same
+contracts. Both backends execute the shared real CLI `/quit` contract in
 `tests/coding/test_cli_terminal_contract.py`.
 
 tmux is a separate terminal-implementation integration. Its marker only proves

--- a/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
+++ b/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
@@ -117,13 +117,13 @@ query response, bounded timeout, process-tree termination, and idempotent
 cleanup. They do not claim exact final screen state; FakeTerminal/playback owns
 that evidence.
 
-The Windows backend uses `pywinpty==2.0.15` through its low-level `winpty.PTY`
-API and explicitly selects ConPTY. It does not permit an automatic WinPTY
-fallback. Version 3.0.5 was rejected by the Windows lifecycle spike because its
-asynchronous backend could leave the final query response pending and lose the
-tail of large output at process exit. The selected version is x64-only; ARM64
-is not a supported native-test target until a candidate wheel passes the same
-contracts. Both backends execute the shared real CLI `/quit` contract in
+The Windows backend calls the system ConPTY API through a test-only `ctypes`
+wrapper, explicitly selects ConPTY, and owns its pipes, HPCON, process handle,
+and lifecycle threads. It has no WinPTY fallback or Windows package dependency.
+Pywinpty versions 3.0.5 and
+2.0.15 were both rejected by the Windows lifecycle spike for pending writes,
+lost or corrupted output, and incomplete teardown. Both backends execute the
+shared real CLI `/quit` contract in
 `tests/coding/test_cli_terminal_contract.py`.
 
 tmux is a separate terminal-implementation integration. Its marker only proves

--- a/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
+++ b/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
@@ -108,6 +108,39 @@ Examples:
 - extensions receive normalized input events rather than raw terminal bytes
 - v1 prompt_toolkit modules are not on the new public API path
 
+### 5. Native Terminal Transport Tests
+
+Run the same test-only terminal driver contract over a POSIX PTY on Linux and
+ConPTY on Windows. These tests prove structured argv, cwd/environment handling,
+Unicode and VT transport, resize, exit status, large output drain, terminal
+query response, bounded timeout, process-tree termination, and idempotent
+cleanup. They do not claim exact final screen state; FakeTerminal/playback owns
+that evidence.
+
+The Windows backend uses `pywinpty==3.0.5` through its low-level `winpty.PTY`
+API and explicitly selects ConPTY. It does not permit an automatic WinPTY
+fallback. Both backends execute the shared real CLI `/quit` contract in
+`tests/coding/test_cli_terminal_contract.py`.
+
+tmux is a separate terminal-implementation integration. Its marker only proves
+pane history and scrollback behavior and must not be used as the Windows
+equivalent of ConPTY.
+
+Run the local collections with:
+
+```bash
+make test-tui-render-contract
+make test-tui-terminal-platform
+make test-tui-native
+```
+
+CI runs deterministic and platform jobs on fixed Ubuntu 24.04 and Windows
+Server 2022 runners, runs the shared native contract with
+`LOUSHANG_REQUIRED_TERMINAL_BACKEND=posix-pty|conpty`, and runs tmux in a
+separate fixed-Ubuntu required job. Each required job emits pytest XML and
+fails closed when the report is empty, skipped, failing, or records the wrong
+native backend.
+
 ## Live Terminal Smoke Checklist
 
 Manual testing should focus on terminal behavior that is hard to assert

--- a/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
+++ b/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
@@ -225,7 +225,7 @@ ConPTY driver 使用自己拥有的同步匿名管道，必须：
 - 自己实现有 deadline 的 `read_until()` 与 `wait()`，不直接暴露 Win32 同步 I/O 的无界阻塞面。
 - Windows 超时清理使用从可信 `%SystemRoot%\System32` 解析的绝对路径 `taskkill.exe /PID <pid> /T /F` 作为同步进程树兜底，记录 stdout、stderr 和退出码；随后轮询 fixture 暴露的根/孙 PID 直到消失或 deadline。`taskkill` 非零但进程已不存在可记录为竞态成功，仍有残留则 required CI 失败。后续若产品引入 Job Object，可复用更强的树生命周期能力。
 - 关闭采用有总 deadline 的状态机，而不是固定的“先 join reader、再 close PTY”：reader 从 spawn 起持续运行；请求正常退出或同步树终止；在 reader 仍持续排空时启动经过 spike 验证的 PTY teardown（后端若支持则显式管理 output endpoint）；等待 teardown/EOF；必要时调用 `cancel_io()` 解除阻塞；最后有限 join reader 并确认 thread/handle 零残留。
-- 所有输入/输出 pipe、HPCON、process/thread handle 都有唯一所有者；正常退出、timeout 和异常路径都必须关闭。`ClosePseudoConsole` 在独立受 deadline 约束的线程执行，同时 reader 持续 drain；未通过零残留断言前不得以 Python 外层进程退出推定 ConPTY 已安全关闭。
+- 所有输入/输出 pipe、HPCON、process/thread handle 都有唯一所有者；传给 `CreatePseudoConsole` 的 server-side pipe handles 是借用关系，必须存活到 `ClosePseudoConsole` 返回后才能关闭。正常退出、timeout 和异常路径都必须关闭。`ClosePseudoConsole` 在独立受 deadline 约束的线程执行，同时 reader 持续 drain；未通过零残留断言前不得以 Python 外层进程退出推定 ConPTY 已安全关闭。
 
 ### Terminal query responder
 

--- a/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
+++ b/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
@@ -1,0 +1,432 @@
+# 跨平台原生终端与 TUI 测试设计
+
+状态：经三项独立只读评审、最终文本复核及一轮外部联合评审后修订，认可进入实施；跟踪 issue：[#445](https://github.com/zhnt/loushang/issues/445)。
+
+日期：2026-08-13
+
+## 结论
+
+Windows 不能因为缺少 Unix `pty` 或 `tmux` 而跳过 TUI 产品能力。正确做法也不是把 ConPTY 原始输出当作 Windows 版 `capture-pane`，而是建立一套按证据能力分层、按平台选择实现、在 CI 中 fail-closed 的跨平台终端验证栈：
+
+1. **共享确定性语义合同**：复用现有 `FakeScreen`、`FakeTerminalPort`、playback 和 screen-loop 测试，Linux 与 Windows 运行同一套渲染、历史、光标、压缩、恢复和退出清理断言。
+2. **原生伪终端进程合同**：同一个产品测试合同通过 POSIX PTY 或 Windows ConPTY 启动真实 CLI，验证 TTY 边界、输入输出、VT 生命周期、resize、退出码、有限 drain 和进程树清理。
+3. **终端实现专属合同**：tmux 继续验证它实际解释后的 pane、scrollback 和 `capture-pane` 语义；Windows 不运行 tmux，但必须运行前两层和 ConPTY 专属合同。
+
+这三类证据是现有 Native TUI 四层测试策略的纵向补充，不替代 `Pure Renderable -> Render Loop -> Terminal Playback -> Boundary` 分层。
+
+## 目标与非目标
+
+### 目标
+
+- 明确区分 API 最低兼容边界、自动化验证平台与正式支持平台，不用依赖 wheel 存在替代本仓库证据。
+- Linux 与 Windows 对相同用户可见不变量执行同一个 native terminal contract，而不是维护两套漂移的产品测试。
+- 平台差异被封装在 test-only driver 内，不污染 `loushang.tui` 产品 API。
+- required CI 中 backend 缺失、零测试、skip、挂起或清理失败都必须失败并给出结构化诊断。
+- ConPTY transport、确定性 screen model 和真实 terminal emulator 的证据边界清晰，不作过度声明。
+
+### 非目标
+
+- 首版不自研完整的 `CreatePseudoConsole` ctypes 封装。
+- 首版不把 pywinpty 加入产品运行依赖。
+- 首版不实现完整 VT emulator，也不声称 ConPTY 原始 VT 流等价于最终 Windows Terminal 屏幕。
+- 不要求 Windows 运行 tmux 专属功能；能力不适用不等于跳过 Windows 产品合同。
+- 首版正式验证范围收敛为 Windows x64、Python 3.11+；Windows ARM64 仅标记为依赖可安装/预期兼容，进入独立 runner 或发布验收矩阵后才升级为正式支持。
+- 不扩展到 Windows x86、早于 Windows 10 1809 的系统或所有 Python 版本组合。
+
+## 当前事实与缺口
+
+### 已有能力
+
+- `src/loushang/tui/terminal.py` 已有 `FakeScreen`、`FakeTerminalPort` 和 `ProcessTerminalPort`。
+- `src/loushang/tui/playback.py`、`src/loushang/harnesstui/testing/` 和 `tests/coding/tui_support/playback.py` 已形成确定性 playback 基础，不能重复建设。
+- `tests/coding/test_screen_coding_tui_terminal_playback.py` 已覆盖自动压缩后的历史/流式输出和退出清理最终屏幕。
+- `src/loushang/tui/terminal_platform.py` 与 `terminal_input.py` 已包含 Windows VT console mode 和 `msvcrt` 输入路径。
+- `tests/coding/test_screen_coding_tui_pty_smoke.py` 已有 POSIX `/quit` smoke 和 tmux scrollback 集成。
+
+### 现存缺口
+
+1. 测试模块顶层无条件 `import pty`。Python 的 `pty` 只支持 Unix，Windows 会在执行任何 `pytest.skip()` 之前收集失败。
+2. `/quit` PTY smoke 没有 `tui_render_contract` marker，也不在 `HARNESSTUI_TEST_PATHS` 中，当前两个 TUI workflow 实际都不执行它。
+3. `tui_render_contract` 同时承载确定性 playback 和外部 tmux 集成，marker 语义不纯。
+4. tmux 缺失时静默 skip；即使合同从未运行，CI 仍可能绿色。
+5. `tests/tui/test_terminal_platform.py`、`test_terminal_session.py` 和 `test_terminal_input.py` 未进入现有 TUI required gate。
+6. `TimedTtyChunkInput` 以 `os.pipe()` 模拟输入却声明 `isatty() == True`。Windows 下产品 reader 因而改走 `msvcrt` 并读取当前进程控制台，而不是 scripted pipe；共享 screen-loop playback 可能挂起或读取错误输入。
+7. tmux fixture 的 ready file 只证明子进程已写出，不证明 tmux 已消费完输出；随后立即 `capture-pane` 有竞态。
+8. auto-compaction tmux 用例混合策略、Session、持久化、恢复、投影、渲染和 scrollback，多数状态断言应属于共享确定性合同。
+
+本设计形成前的本地聚焦基线为 23 项通过。受限沙箱内 tmux 因 socket `Operation not permitted` 失败，沙箱外同一组测试全部通过；这也证明环境能力诊断与产品回归报告必须分开。
+
+## 证据架构
+
+| 证据层 | 回答的问题 | 公共机制 | 平台路由 |
+|---|---|---|---|
+| 共享确定性语义 | 逻辑历史、viewport、cursor、最终 screen 和清理语义是否正确 | 现有 FakeTerminal/playback/screen-loop | Linux、Windows 同一套 |
+| 原生伪终端 transport | 真实 CLI 是否识别 TTY、接受输入、输出 VT、退出并清理 | `TerminalProcessDriver` contract | POSIX PTY / ConPTY |
+| 终端实现集成 | 特定 emulator/multiplexer 如何解释 VT 并保存历史 | tmux `capture-pane`；未来可选 VT emulator | Ubuntu tmux；Windows 首版无等价 pane API |
+| 人工真实终端 | IME、候选窗、宿主快捷键及肉眼体验 | 发布前 smoke checklist | Windows Terminal、VS Code、WezTerm、Kitty 等 |
+
+### 证据边界
+
+- `strip_control_sequences(raw_output)` 只删除控制序列，不执行光标移动、清行、覆盖和 scrollback，因此不能证明最终屏幕状态。
+- “退出后最终 screen 没有 idle/running 状态栏”由 FakeTerminal playback 负责。
+- 原生 PTY/ConPTY 负责证明相应 cleanup/restore VT 序列确实穿过真实终端 transport、命令正常退出且没有残留进程。
+- tmux `capture-pane -S -` 负责证明 tmux 解释后的 pane/history；它不能被 ConPTY raw output 机械替代。
+
+## 共享确定性语义层
+
+### 复用而非重建
+
+继续使用以下所有权：
+
+- `loushang.tui`：render operation、FakeScreen、FakeTerminalPort 和基础 playback。
+- `loushang.harnesstui.testing`：产品中立 conversation/render/screen-loop 测试能力。
+- `tests/coding/tui_support`：Coding 专属 scenario、fixture 和产品绑定。
+
+不得新增第二套 FakeScreen、第二套 render playback 或独立的“Windows screen model”。
+
+### 修复 Windows fake-TTY 缺陷
+
+共享 screen-loop 测试不应使用 `os.pipe() + isatty=True` 假冒操作系统控制台。推荐为 screen-loop runner 注入明确的 input-chunk source/read function，使确定性测试消费 scripted bytes；原生 TTY reader 则由 PTY/ConPTY 合同单独覆盖。
+
+验收要求：
+
+- 相同 screen-loop suite 在 Ubuntu 和 Windows 上运行。
+- 测试输入永远不读取 CI runner 的真实 console。
+- decoded input、生命周期、压缩、history/resume、退出清理均无平台 skip。
+
+### auto-compaction 职责拆分
+
+- 把 `AgentSession 自动压缩 -> TUI projection -> persistence/resume` 及 JSON evidence 迁移为平台无关组合合同。
+- tmux 用例只保留需要真实 pane/history 的最小场景。
+- 手工 compact 和自动 compact 共享 scenario 数据，不各自维护一套 80/40 行魔法常量。
+
+## Test-only 原生终端驱动
+
+### 所有权与目录
+
+中立驱动放在：
+
+```text
+tests/tui/terminal_process_support/
+  __init__.py
+  contract.py
+  diagnostics.py
+  factory.py
+  posix_pty.py
+  windows_conpty.py
+```
+
+Coding 产品 smoke 放在：
+
+```text
+tests/coding/test_cli_terminal_contract.py
+```
+
+tmux 专属集成放在：
+
+```text
+tests/coding/test_tmux_scrollback_integration.py
+```
+
+这样 driver 仍为 test-only、可供任何 TUI 产品复用，又不会错误归属到 Coding 产品或 `harnesstui` conversation 层。
+
+### 统一接口
+
+```python
+class TerminalProcessDriver(Protocol):
+    @classmethod
+    def spawn(
+        cls,
+        args: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        columns: int,
+        rows: int,
+    ) -> Self: ...
+
+    def __enter__(self) -> Self: ...
+    def __exit__(self, exc_type, exc, traceback) -> Literal[False]: ...
+    def write(self, text: str) -> None: ...
+    def read_until(
+        self,
+        predicate: Callable[[str], bool],
+        *,
+        timeout: float,
+    ) -> str: ...
+    def resize(self, *, columns: int, rows: int) -> None: ...
+    def is_alive(self) -> bool: ...
+    def wait(self, *, timeout: float) -> int: ...
+    def terminate_tree(self, *, timeout: float) -> None: ...
+    def close(self, *, timeout: float) -> None: ...
+
+    @property
+    def raw_output(self) -> str: ...
+
+    @property
+    def diagnostics(self) -> TerminalProcessDiagnostics: ...
+```
+
+接口合同：
+
+- `args` 必须是结构化 argv，不允许 `shell=True`；不得用 `shlex.join()` 构造 Windows 命令行。
+- PTY 的 stdout/stderr 合并是显式合同。
+- driver 是 context manager，`__exit__()` 委托幂等 `close()` 并返回 `False`；断言失败、timeout 和异常路径都必须关闭 handle/FD、终止进程树。
+- 后台持续 drain，不能依赖 `readline()`；ANSI、无换行输出和跨 chunk Unicode 都必须工作。
+- POSIX 使用增量 UTF-8 decoder；ConPTY 若 library 返回 Unicode，也要保留原始文本边界和 reader error。
+- 输出使用有界 ring buffer；诊断保留 backend、PID、argv、cwd、尺寸、退出状态、reader error 和有限输出尾部。
+- 所有 timeout 使用 monotonic deadline。
+- 进程退出后采用“收到数据则重新计时”的有限 idle drain，避免丢失尾部恢复序列。
+- `close()` 和 `terminate_tree()` 幂等。
+
+### Driver conformance
+
+两个 backend 必须运行同一个 conformance suite：
+
+- argv、cwd、env，含空格和中文路径；
+- 中文、emoji、跨 chunk UTF-8；
+- CR、CRLF 和无换行输出；
+- VT 序列保持可观测；
+- 初始尺寸与 resize；
+- 退出码 0 和非 0；
+- 大于管道容量的输出后立即退出；
+- timeout/cancellation 后根进程和孙进程均无残留；
+- 输出管道 EOF/reader 完成、尾部 idle drain、重复 close；不把 POSIX Ctrl-D 与 Windows input-channel close 伪装成统一的输入 EOF 合同；
+- terminal query/response 不挂起。
+
+## POSIX PTY backend
+
+- 平台专属 `pty`、`select`、`termios`、`fcntl` 导入只存在于 `posix_pty.py`。
+- 子进程使用新 session/process group；timeout 后先温和终止，再按 deadline 强制杀整个组。
+- resize 使用 `TIOCSWINSZ` 并验证子进程能观察到新尺寸。
+- 把 PTY master 上的预期 EIO 识别为 EOF，不吞掉其他 OSError。
+- 读循环、有限 drain、输出上限和错误诊断必须与 ConPTY 后端语义一致。
+
+## Windows ConPTY backend
+
+### 支持边界与依赖
+
+ConPTY API 最低可用边界为 Windows 10 1809/build 17763 和 Windows Server 2019；这不等于每个最低版本都已有持续验证。首版自动化验证平台为 Windows Server 2022 x64/Python 3.11，正式桌面验收平台为 Windows 10 22H2 x64。pywinpty 同时提供 ARM64 wheel，但 ARM64 在本仓库增加独立证据前仅为预期兼容。
+
+`pywinpty` 仅加入开发依赖并锁定原生版本：
+
+```toml
+"pywinpty==3.0.5; sys_platform == 'win32'"
+```
+
+分发名为 `pywinpty`、导入名为 `winpty`。锁文件必须包含 Windows wheel；CI 使用 `uv sync --locked --extra dev`。版本升级通过独立依赖 PR 和 Windows 合同验证完成。
+
+### 强制 ConPTY
+
+- backend 必须显式选择 `ConPTY`，不能使用自动选择后静默回退 WinPTY。
+- required CI 中缺少依赖、系统版本过低、架构无 wheel、创建失败或实际 backend 不符都直接失败并打印诊断。
+- 不启用 `PSEUDOCONSOLE_INHERIT_CURSOR`。
+
+### 同步 I/O、drain 与关闭
+
+ConPTY 使用同步管道，driver 必须：
+
+- 用独立 reader thread 持续排空输出；测试主线程不得直接阻塞在 `PtyProcess.read()`。
+- writer 串行化，测试输入和 terminal responder 不并发写底层 PTY。
+- 自己实现有 deadline 的 `read_until()` 与 `wait()`，不直接暴露 pywinpty 的无界阻塞 API。
+- Windows 超时清理使用从可信 `%SystemRoot%\System32` 解析的绝对路径 `taskkill.exe /PID <pid> /T /F` 作为同步进程树兜底，记录 stdout、stderr 和退出码；随后轮询 fixture 暴露的根/孙 PID 直到消失或 deadline。`taskkill` 非零但进程已不存在可记录为竞态成功，仍有残留则 required CI 失败。后续若产品引入 Job Object，可复用更强的树生命周期能力。
+- 关闭采用有总 deadline 的状态机，而不是固定的“先 join reader、再 close PTY”：reader 从 spawn 起持续运行；请求正常退出或同步树终止；在 reader 仍持续排空时启动经过 spike 验证的 PTY teardown（后端若支持则显式管理 output endpoint）；等待 teardown/EOF；必要时调用 `cancel_io()` 解除阻塞；最后有限 join reader 并确认 thread/handle 零残留。
+- pywinpty `PtyProcess` 自身可能持有 native/daemon reader。P1 必须证明 `PtyProcess + cancel_io` 在目标 Windows 上可以完整退出；否则改用可显式控制 handle/pipe 生命周期的低层 `winpty.PTY` 或其他库层。未通过 spike 前不得以 Python 外层 reader 已退出推定 ConPTY 已安全关闭。
+
+### Terminal query responder
+
+headless ConPTY 不只是哑管道。当前源码审计显示产品主动发出两类 query：KeyboardProtocolController 的 `ESC[?u`（150ms 后回退 modify-other-keys）以及 capability-gated 的 `ESC[16t`；后者不会阻塞产品启动，若终端响应则输入层解析 `ESC[6;<height>;<width>t`。此外 ConPTY backend、依赖或专用 fixture 可能触发 DSR。P1 必须从产品源码、pywinpty/winpty-rs 行为和测试 fixture 重新生成“query -> 响应/无响应 -> fallback/deadline”清单，并把清单固化为 responder contract，不能仅依赖本设计中的静态枚举。
+
+最小 responder 必须跨 chunk 识别并响应：
+
+- `CSI 5 n` -> `CSI 0 n`；
+- `CSI 6 n` -> harness 明确配置的合法位置（首版默认 `ESC[1;1R`），仅作为 headless-test fallback 解阻塞。
+
+driver 不拥有 screen model，因此该固定 DSR 响应不代表真实最终 cursor，也不能用于验证 cursor correctness。若未来产品合同依赖真实 cursor truth，必须增加有限 VT cursor tracker，并对超出支持的控制序列 fail-closed。首版不伪装 Kitty keyboard protocol 支持；对 `ESC[?u` 保持无响应并验证产品按既有 150ms deadline 回退。hermetic 基线 profile 关闭 cell-size query；单独的 cell-size profile 对 `ESC[16t` 明确选择“无响应但产品继续运行”或返回受控的 `ESC[6;<height>;<width>t`，两条路径都需测试。主动 DSR fixture 必须验证跨 chunk query、响应格式及普通文本不被误识别；清单中任何可能阻塞且无已验证 fallback 的未知 query 都 fail-closed。
+
+### 原生 Windows 单元边界
+
+Windows CI 还必须实际执行 terminal platform/session/input 的共享及 Windows 专属集合；Ubuntu 执行共享及 POSIX 专属集合。P0 要把当前文件中依赖 `termios`/`tty` 或显式 Windows skip 的测试拆到精确集合，required job 不整文件运行后再容忍 runtime skip。
+
+相关现有文件包括：
+
+- `tests/tui/test_terminal_platform.py`；
+- `tests/tui/test_terminal_session.py`；
+- `tests/tui/test_terminal_input.py`。
+
+覆盖 VT input/output mode、Quick Edit 处理、`msvcrt` 输入、正常/异常/timeout 后 console mode 恢复。共享、POSIX-only、Windows-only 测试由 workflow 精确选择，required 集合内部不得保留 `importorskip` 或平台 skip。这些单元测试不能被 ConPTY smoke 取代。
+
+## 共享真实 CLI 产品合同
+
+POSIX PTY 与 Windows ConPTY 执行同一组断言：
+
+1. 用 `sys.executable -m loushang.coding.cli --tui` 启动结构化 argv。
+2. 等待明确的产品 readiness 条件，而不是绑定某个 `show cursor` 实现细节。
+3. 确认欢迎内容和所需 VT 生命周期序列到达 transport。
+4. 发送 `/quit\r`，在有界时间内以退出码 0 结束。
+5. 确认启用过的 cursor、paste、mouse/focus/keyboard 等终端模式有配对的恢复序列。
+6. 完成有限 tail drain，输出末尾不再追加 live `idle/running` 状态。
+7. timeout 或断言失败时无子孙进程、FD、handle 或 reader thread 残留。
+
+注意：第 5、6 项只断言 transport 中发出了清理/恢复事实；最终 screen 的精确状态仍由共享 FakeTerminal playback 证明。
+
+产品合同必须使用 hermetic terminal environment：从清洗后的宿主环境构造，明确设置 `TERM`/`COLORTERM`，清除 `TMUX`、`STY`、`WT_SESSION`、`TERM_PROGRAM`、Kitty/WezTerm/Ghostty、SSH/WSL 等会改变 capability detection 的身份变量。Windows 环境变量按大小写不敏感方式合并，避免 `PATH`/`Path` 重复。需要验证特定宿主时另建显式 profile，不能让 CI runner 的偶然环境改变共享断言。
+
+第二阶段增加：
+
+- 中文输入/输出；
+- resize 后继续输入并退出；
+- Ctrl-C、异常退出和强制 timeout 恢复；
+- 连续 10–20 次运行的稳定性检查。
+
+## tmux 专属合同
+
+- 独立 marker：`tui_tmux_integration`。
+- Ubuntu CI 显式安装并运行 `tmux -V`；required job 中缺失或 socket 启动失败直接失败。
+- 不再以 ready file 作为唯一完成条件；轮询 `capture-pane`，直到最终可见 sentinel/预期尾行出现或 monotonic deadline 到期。
+- 失败诊断包含 tmux server stderr、pane capture 和 fixture evidence。
+- 对关键 sentinel 在可行时断言恰好一次，避免 `rfind` 掩盖重复历史回放。
+- tmux 测试只保留 pane/history/scrollback 证据；自动压缩策略、持久化和 resume 状态移入共享组合合同。
+
+## Marker 与 CI 设计
+
+### Marker
+
+- `tui_render_contract`：纯 Python、确定性、平台无关，不依赖外部终端进程。
+- `tui_terminal_backend`：POSIX PTY/ConPTY driver conformance。
+- `tui_terminal_contract`：共享真实 CLI 产品合同。
+- `tui_tmux_integration`：tmux pane/history 专属集成。
+
+required marker 中不得使用平台 `skipif` 来表达实现路由。workflow/fixture 选择当前 backend，合同本身保持共享。
+
+### Required jobs
+
+| Job | Runner | 必须执行 |
+|---|---|---|
+| deterministic-render | `ubuntu-24.04` + `windows-2022` | 共享 render/playback/screen-loop；零平台 skip |
+| terminal-platform-unit | `ubuntu-24.04` + `windows-2022` | 共享集合 + 当前平台专属集合；required collection 零 skip |
+| native-terminal | `ubuntu-24.04` | POSIX PTY backend conformance + 共享 CLI contract |
+| native-terminal | `windows-2022` | 强制 ConPTY backend conformance + 同一 CLI contract |
+| tmux-scrollback | `ubuntu-24.04` | 显式安装 tmux，执行 pane/history 合同 |
+
+CI 公共规则：
+
+- 使用 Python 3.11，并固定 `ubuntu-24.04` 与 `windows-2022`，避免 `*-latest` 迁移操作系统版本；runner image 内部更新仍通过 job 日志与失败诊断记录。
+- Windows 直接运行 `uv sync --locked --extra dev` 与 `uv run pytest`，不依赖当前 POSIX Make recipe。
+- native job 设置 `LOUSHANG_REQUIRED_TERMINAL_BACKEND=posix-pty|conpty`；tmux job 设置 `LOUSHANG_REQUIRE_TMUX=1`。
+- 使用 `--strict-markers --strict-config`、job `timeout-minutes` 和 JUnit 输出。
+- 平台无关的 JUnit 校验器要求 required job 的测试数大于零、skipped 为零、failure/error 为零，并核对诊断中的实际 backend；该校验器属于 P0 交付物，不是只停留在 workflow 约定中的人工检查。
+- 不把“本机缺少可选能力”静默转为假绿；普通本地运行可以给出明确 capability unavailable 诊断，required CI 必须失败。
+- native 与 tmux job 必须显式选择 `tests/tui/terminal_process_support/` 及对应产品合同路径；driver 位于 `tests/tui/` 不代表现有白名单 gate 会自动收集它。
+
+GitHub hosted Windows Server 只证明 Windows API 与 ConPTY 路径。若 Windows 10 是正式支持平台，还必须保留 Windows 10 22H2/build 19045 实机或 self-hosted nightly/发布前验收。
+
+## 分阶段实施
+
+### P0：测试语义与 CI 止血
+
+- 创建/绑定跟踪 issue，并记录当前基线。
+- 首先在 `windows-2022` 运行 terminal platform/session/input 与共享 playback 的裸基线，记录通过、失败和现有 skip，再据此拆分共享/POSIX/Windows collection；不把未知基线直接算作产品回归。
+- 拆分顶层 Unix-only import，保证 Windows 能收集共享测试。
+- 修复 `TimedTtyChunkInput` 假 TTY；共享 screen-loop 改用注入的 scripted input source。
+- 纯化 marker，拆出共享、POSIX、Windows terminal platform/input 集合，确保 `/quit` smoke 与相应单元测试进入明确 gate。
+- marker 拆分与最小 Ubuntu tmux required job 原子落地：显式安装/预检 tmux，required collection 零 skip。若该 job 尚未就绪，不得先把现有 tmux 测试移出 render gate。
+- deterministic render/playback 在 Ubuntu 和 Windows 同时运行。
+- 增加平台无关的 JUnit 结果校验器并在每个 required job 调用：断言 tests > 0、skipped = 0、failures/errors = 0，并在 native job 校验实际 backend。
+- 更新 `pyproject.toml` marker 注册/说明、Native TUI testing strategy 及 `tests/tui/test_tui_testing_strategy_docs.py`，避免文档守护测试和 marker 语义漂移。
+- 把 `make test-tui` 改造为与新集合一致的跨平台本地入口，或以明确的新入口替代并删除；不得保留一个 CI 永不调用且只能在 POSIX `.venv/bin/activate` 下工作的权威名称。
+
+P0 风险清单必须点名 `src/loushang/harnesstui/testing/screen_loop_playback.py` 和当前 required gate 中使用本地 `_TimedTtyChunkInput` 的 `tests/coding/test_screen_coding_tui_loop.py`；input source 注入不得只修共享 helper 而遗漏产品侧同类假 TTY。
+
+交付门槛：Windows 共享合同不 skip、不读取 runner 真实 console；现有 Linux 确定性回归不降级。
+
+### P1：Windows ConPTY 生命周期技术选型 spike（不独立合并）
+
+在正式抽象前，用 `pywinpty==3.0.5`、强制 ConPTY 验证五个场景：
+
+1. 大输出并立即退出；
+2. 产品/依赖/fixture query 全集盘点，为每一类定义响应、无响应 fallback 与 deadline，并覆盖 DSR、Kitty 和 cell-size profile；
+3. 正常退出与尾部 drain；
+4. timeout 后孙进程清理；
+5. 重复 close/异常路径无挂起。
+
+Spike 结果必须固化为 backend conformance tests，不能只留下实验脚本。
+
+P1 是探索分支上的合并前门槛，不是可单独发布的切片。它同时比较 `PtyProcess`、必要时的低层 `winpty.PTY` 或替代封装，证明 teardown 能收掉 library 内部和外部 reader；选型证据通过后再进入 P2a/P2b。不得把临时依赖、无 required CI 的 spike 或无法验证 thread 零残留的实现合入主线。
+
+### P2a：中立协议、POSIX backend 与既有 smoke 迁移
+
+- 在 P1 已验证双平台可实现性的接口上落地 test-only driver protocol 与 POSIX PTY backend。
+- 固化 POSIX backend conformance，增加 Ubuntu native-terminal required job。
+- 迁移现有 `/quit` smoke 为同一产品合同。
+
+P2a 不宣称 Windows 原生 terminal contract 已完成，也不得关闭 P0 的 Windows deterministic/platform gates。共享合同与协议必须以 P1 已验证的 ConPTY 生命周期能力为约束，避免 POSIX 先行后把 Windows 实现逼入不兼容接口。
+
+### P2b：ConPTY 与 Windows native gate 原子启用
+
+- 落地强制 ConPTY backend，加入条件 dev dependency 和锁文件。
+- 增加 Windows native-terminal required job；显式选择 test support、backend conformance 和同一 `/quit` 产品合同路径。
+- 把 P1 的大输出、query matrix、Unicode、resize、退出码、timeout 子孙进程、输出 EOF/drain 和幂等 close 固化为双 backend conformance。
+
+P2b 不允许合并“Windows job 存在但全部 skip”“ConPTY backend 尚未受进程树清理保护”或“pywinpty teardown 尚未证明 reader/handle 零残留”的中间状态。P2a 与 P2b 可以分成小步提交，但 P2b 是 Windows 原生支持声明和本轮跨平台目标的发布阻断项，不能停在 P2a 宣称完成。
+
+### P3：tmux 与 auto-compaction 职责收敛
+
+- 自动压缩、投影、持久化、恢复迁移为共享组合合同。
+- tmux 用例瘦身为真实 pane/history 证据。
+- 在 P0 已有 required job 上继续完善 capture polling、完成 sentinel、有限 drain、重复检测和 fixture 诊断。
+- `kill-server` 必须有 timeout、退出诊断和清理后确认；清理失败不能被 finally 中的 `check=False` 静默吞掉。
+
+### P4：真实产品与宿主稳定性发布矩阵
+
+- 将 P2b 已在 backend conformance 覆盖的 Unicode、resize、Ctrl-C/timeout、异常退出、无换行和大输出进一步扩展到真实 CLI 产品场景。
+- PR 上做小规模重复，nightly 做 10–20 次稳定性检查。
+- Windows 10 22H2 实机/自托管验收 Windows Terminal、VS Code Terminal 和至少一个第三方宿主。
+- ARM64 若要升级为正式支持，必须在本阶段加入 Windows ARM64 自托管/native runner，实际运行依赖安装、ConPTY conformance 和共享 CLI contract；否则继续标记为预期兼容。
+- 只有在需要自动证明 Windows 最终屏幕解释时，再评估独立 VT emulator；它不是首版阻断项。
+
+## 发布验收矩阵
+
+| 不变量 | FakeTerminal | POSIX PTY | ConPTY | tmux |
+|---|---:|---:|---:|---:|
+| 精确 logical history/viewport/cursor | 必须 | 不声明 | 不声明 | pane 结果 |
+| 自动压缩与 persistence/resume | 必须 | 不绑定 | 不绑定 | 不再承担 |
+| 最终 screen 清除 live 状态栏 | 必须 | 不声明 | 不声明 | 可观察 |
+| 真实 CLI TTY 识别与 `/quit` | 不适用 | 必须 | 必须 | 非核心 |
+| VT cleanup/restore 穿过 transport | operation 级 | 必须 | 必须 | 可观察 |
+| resize/Unicode/退出码 | 语义级 | 必须 | 必须 | 非核心 |
+| timeout/进程树/handle 清理 | 不适用 | 必须 | 必须 | fixture 清理 |
+| pane scrollback/history | 模型级 | 不声明 | 不声明 | 必须 |
+
+最终完成标准：Ubuntu 与 Windows 共享 native contract 均实际执行且零 skip；Windows 诊断确认使用 ConPTY；tmux job 实际启动并零 skip；正常退出、异常和 timeout 三条路径均恢复终端且无残留；现有 deterministic render contract 不降级。
+
+## 三项独立评审与裁决
+
+本方案经架构边界、Windows/ConPTY、测试/CI 三个只读 Agent 独立评审，在正式文本落盘后完成第二轮逐条复核，并吸收一轮外部联合评审。共同认可三类证据分离、双 backend 共享产品合同、ConPTY 不等于 `capture-pane`、Windows required job 零 skip。已吸收的关键意见包括：
+
+- 先修 Windows fake-TTY playback 输入缺陷；
+- 新增独立 terminal/tmux marker，补齐现有 CI 覆盖空洞；
+- 区分 ConPTY API 最低边界、x64 正式验证范围和 ARM64 预期兼容，避免无证据的支持声明；
+- reader thread、可配置 terminal query responder、有限 drain、同步树终止和幂等 close；
+- 删除不可移植的统一输入 EOF 语义，并将 pywinpty teardown 能否零残留设为 P1 技术选型门槛；
+- 平台单元测试拆成共享/POSIX/Windows 精确集合，避免“零 skip”与现有 runtime skip 冲突；
+- auto-compaction 状态合同与 tmux pane 合同拆分；
+- tmux marker 与最小 required job 在 P0 原子落地，readiness 后续改为 capture polling，CI 中依赖缺失不允许 skip。
+- 外部联合评审进一步补充并已采纳：JUnit fail-closed 校验器归入 P0、产品 query 全集归入 P1、Ubuntu runner 固定、测试策略守护与本地入口同步、tmux teardown 诊断，以及 P2 拆为可审查的 P2a/P2b。
+
+对 driver 放置存在轻微分歧：一项评审建议放 Coding test support，另一项建议放 TUI test support。本方案选择中立的 `tests/tui/terminal_process_support/`，因为 driver 不包含 Coding 语义；Coding `/quit` contract 仍留在 `tests/coding/`，避免所有权混淆。
+
+## 可交给其他 Agent 的评审请求
+
+> 请对 `docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md` 做一次严格、只读的架构、Windows 与 CI 联合评审，不要修改文件。请对照 loushang 当前 `src/loushang/tui/`、`src/loushang/harnesstui/testing/`、`tests/tui/`、`tests/coding/test_screen_coding_tui_pty_smoke.py`、`tests/coding/test_screen_coding_tui_terminal_playback.py`、`tests/coding/tui_support/`、Makefile 和 `.github/workflows/` 核实事实；重点判断：现有 Native TUI 四层测试与新增三类终端证据是否职责清晰且不重复，`TimedTtyChunkInput` 的 Windows 假 TTY 缺陷是否被正确处理，test-only driver 的所有权和接口是否足以覆盖 argv/Unicode/resize/timeout/有限 drain/进程树/幂等关闭，pywinpty 强制 ConPTY、Windows API 最低边界与实际支持声明、同步 I/O、terminal query responder 与旧系统关闭死锁是否完整，ConPTY raw VT 与最终 screen/tmux capture-pane 是否严格区分，以及 required CI 的 marker、零 skip、测试数校验、Windows Server 2022 与 Windows 10 实机矩阵是否能防止假绿。请逐项列出认可项、阻断项、非阻断建议、不同意的决定和证据路径，并判断 P0/P1/P2a/P2b/P3/P4 每个切片或技术门槛是否保持跨平台正确性与 fail-closed。
+
+## 参考
+
+- Python `pty`：<https://docs.python.org/3/library/pty.html>
+- Microsoft `CreatePseudoConsole`：<https://learn.microsoft.com/en-us/windows/console/createpseudoconsole>
+- Microsoft 创建 pseudoconsole session：<https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session>
+- Microsoft `ClosePseudoConsole`：<https://learn.microsoft.com/en-us/windows/console/closepseudoconsole>
+- pywinpty：<https://pypi.org/project/pywinpty/>
+- pywinpty `PtyProcess`：<https://github.com/andfoy/pywinpty/blob/v3.0.5/winpty/ptyprocess.py>
+- winpty-rs terminal query 注意事项：<https://github.com/andfoy/winpty-rs#important-notes>
+- GitHub Actions runner image labels：<https://github.com/actions/runner-images>

--- a/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
+++ b/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
@@ -206,15 +206,15 @@ class TerminalProcessDriver(Protocol):
 
 ### 支持边界与依赖
 
-ConPTY API 最低可用边界为 Windows 10 1809/build 17763 和 Windows Server 2019；这不等于每个最低版本都已有持续验证。首版自动化验证平台为 Windows Server 2022 x64/Python 3.11，正式桌面验收平台为 Windows 10 22H2 x64。pywinpty 同时提供 ARM64 wheel，但 ARM64 在本仓库增加独立证据前仅为预期兼容。
+ConPTY API 最低可用边界为 Windows 10 1809/build 17763 和 Windows Server 2019；这不等于每个最低版本都已有持续验证。首版自动化验证平台为 Windows Server 2022 x64/Python 3.11，正式桌面验收平台为 Windows 10 22H2 x64。锁定的 pywinpty 版本没有 Windows ARM64 wheel，因此首版明确只支持 x64；ARM64 必须等依赖候选通过同一套原生合同并增加独立 CI 证据后再声明支持，不能从 ConPTY API 可用性推导兼容。
 
 `pywinpty` 仅加入开发依赖并锁定原生版本：
 
 ```toml
-"pywinpty==3.0.5; sys_platform == 'win32'"
+"pywinpty==2.0.15; sys_platform == 'win32'"
 ```
 
-分发名为 `pywinpty`、导入名为 `winpty`。锁文件必须包含 Windows wheel；CI 使用 `uv sync --locked --extra dev`。版本升级通过独立依赖 PR 和 Windows 合同验证完成。
+分发名为 `pywinpty`、导入名为 `winpty`。锁文件必须包含 Windows x64 wheel；CI 使用 `uv sync --locked --extra dev`。P1 在 Windows Server 2022 上实测拒绝了 `pywinpty==3.0.5`：其 `winpty-rs==1.0.6` 异步 ConPTY 写入可能把最后一次 terminal response 留在 pending 状态，异步 reader 也会在进程退出边界丢失大输出尾块。`2.0.15` 使用同步写入和独立读缓存，仍须通过本规范的 query、无换行大输出、退出码与零残留合同。版本升级通过独立依赖 PR 和 Windows 合同验证完成，不能只按版本号前进。
 
 ### 强制 ConPTY
 
@@ -342,7 +342,7 @@ P0 风险清单必须点名 `src/loushang/harnesstui/testing/screen_loop_playbac
 
 ### P1：Windows ConPTY 生命周期技术选型 spike（不独立合并）
 
-在正式抽象前，用 `pywinpty==3.0.5`、强制 ConPTY 验证五个场景：
+在正式抽象前，用锁定版本、强制 ConPTY 验证五个场景：
 
 1. 大输出并立即退出；
 2. 产品/依赖/fixture query 全集盘点，为每一类定义响应、无响应 fallback 与 deadline，并覆盖 DSR、Kitty 和 cell-size profile；
@@ -427,6 +427,6 @@ P2b 不允许合并“Windows job 存在但全部 skip”“ConPTY backend 尚�
 - Microsoft 创建 pseudoconsole session：<https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session>
 - Microsoft `ClosePseudoConsole`：<https://learn.microsoft.com/en-us/windows/console/closepseudoconsole>
 - pywinpty：<https://pypi.org/project/pywinpty/>
-- pywinpty `PtyProcess`：<https://github.com/andfoy/pywinpty/blob/v3.0.5/winpty/ptyprocess.py>
+- pywinpty `PtyProcess`：<https://github.com/andfoy/pywinpty/blob/v2.0.15/winpty/ptyprocess.py>
 - winpty-rs terminal query 注意事项：<https://github.com/andfoy/winpty-rs#important-notes>
 - GitHub Actions runner image labels：<https://github.com/actions/runner-images>

--- a/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
+++ b/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
@@ -338,7 +338,7 @@ P0 风险清单必须点名 `src/loushang/harnesstui/testing/screen_loop_playbac
 
 在正式抽象前，用锁定版本、强制 ConPTY 验证五个场景：
 
-1. 大输出并立即退出；
+1. 大于 64 KiB 的无换行输出与 backpressure，以及独立的立即退出尾部 drain；
 2. 产品/依赖/fixture query 全集盘点，为每一类定义响应、无响应 fallback 与 deadline，并覆盖 DSR、Kitty 和 cell-size profile；
 3. 正常退出与尾部 drain；
 4. timeout 后孙进程清理；
@@ -358,7 +358,7 @@ P2a 不宣称 Windows 原生 terminal contract 已完成，也不得关闭 P0 �
 
 ### P2b：ConPTY 与 Windows native gate 原子启用
 
-- 落地强制 ConPTY backend，加入条件 dev dependency 和锁文件。
+- 落地基于 Win32 API 的强制 ConPTY backend；保持测试栈零 Windows 条件依赖，Linux 与 Windows 均不安装 pywinpty。
 - 增加 Windows native-terminal required job；显式选择 test support、backend conformance 和同一 `/quit` 产品合同路径。
 - 把 P1 的大输出、query matrix、Unicode、resize、退出码、timeout 子孙进程、输出 EOF/drain 和幂等 close 固化为双 backend conformance。
 

--- a/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
+++ b/docs/internals/specs/2026-08-13-cross-platform-terminal-test-design.md
@@ -30,7 +30,7 @@ Windows 不能因为缺少 Unix `pty` 或 `tmux` 而跳过 TUI 产品能力。�
 - 首版不把 pywinpty 加入产品运行依赖。
 - 首版不实现完整 VT emulator，也不声称 ConPTY 原始 VT 流等价于最终 Windows Terminal 屏幕。
 - 不要求 Windows 运行 tmux 专属功能；能力不适用不等于跳过 Windows 产品合同。
-- 首版正式验证范围收敛为 Windows x64、Python 3.11+；Windows ARM64 仅标记为依赖可安装/预期兼容，进入独立 runner 或发布验收矩阵后才升级为正式支持。
+- 首版正式验证范围收敛为 Windows x64、Python 3.11+；Windows ARM64 仅标记为 API 层预期兼容，进入独立 runner 或发布验收矩阵后才升级为正式支持。
 - 不扩展到 Windows x86、早于 Windows 10 1809 的系统或所有 Python 版本组合。
 
 ## 当前事实与缺口
@@ -206,15 +206,9 @@ class TerminalProcessDriver(Protocol):
 
 ### 支持边界与依赖
 
-ConPTY API 最低可用边界为 Windows 10 1809/build 17763 和 Windows Server 2019；这不等于每个最低版本都已有持续验证。首版自动化验证平台为 Windows Server 2022 x64/Python 3.11，正式桌面验收平台为 Windows 10 22H2 x64。锁定的 pywinpty 版本没有 Windows ARM64 wheel，因此首版明确只支持 x64；ARM64 必须等依赖候选通过同一套原生合同并增加独立 CI 证据后再声明支持，不能从 ConPTY API 可用性推导兼容。
+ConPTY API 最低可用边界为 Windows 10 1809/build 17763 和 Windows Server 2019；这不等于每个最低版本都已有持续验证。首版自动化验证平台为 Windows Server 2022 x64/Python 3.11，正式桌面验收平台为 Windows 10 22H2 x64。测试后端通过 Python 标准库 `ctypes` 直接调用系统 ConPTY API，不下载 Windows 原生 wheel。ARM64 在 API 层预期兼容，但必须增加独立 CI 证据后才声明支持，不能从 API 可用性推导已验证兼容。
 
-`pywinpty` 仅加入开发依赖并锁定原生版本：
-
-```toml
-"pywinpty==2.0.15; sys_platform == 'win32'"
-```
-
-分发名为 `pywinpty`、导入名为 `winpty`。锁文件必须包含 Windows x64 wheel；CI 使用 `uv sync --locked --extra dev`。P1 在 Windows Server 2022 上实测拒绝了 `pywinpty==3.0.5`：其 `winpty-rs==1.0.6` 异步 ConPTY 写入可能把最后一次 terminal response 留在 pending 状态，异步 reader 也会在进程退出边界丢失大输出尾块。`2.0.15` 使用同步写入和独立读缓存，仍须通过本规范的 query、无换行大输出、退出码与零残留合同。版本升级通过独立依赖 PR 和 Windows 合同验证完成，不能只按版本号前进。
+P1 在 Windows Server 2022 上实测拒绝了两个 pywinpty 候选：`3.0.5`/`winpty-rs 1.0.6` 的异步写入可能把最后一次 terminal response 留在 pending 状态，异步 reader 也会在进程退出边界丢失大输出尾块；`2.0.15` 会在跨块 UTF-8 输出中产生替换字符，且真实 CLI 正常退出后 reader 不能在总 deadline 内关闭。首版因此不引入 pywinpty 开发依赖，而以测试专用薄封装显式拥有 pipe、HPCON、process handle 和线程生命周期。任何未来依赖替换都必须通过 query、无换行大输出、退出码、进程树与零残留合同，不能只按版本号前进。
 
 ### 强制 ConPTY
 
@@ -224,14 +218,14 @@ ConPTY API 最低可用边界为 Windows 10 1809/build 17763 和 Windows Server 
 
 ### 同步 I/O、drain 与关闭
 
-ConPTY 使用同步管道，driver 必须：
+ConPTY driver 使用自己拥有的同步匿名管道，必须：
 
 - 用独立 reader thread 持续排空输出；测试主线程不得直接阻塞在 `PtyProcess.read()`。
 - writer 串行化，测试输入和 terminal responder 不并发写底层 PTY。
-- 自己实现有 deadline 的 `read_until()` 与 `wait()`，不直接暴露 pywinpty 的无界阻塞 API。
+- 自己实现有 deadline 的 `read_until()` 与 `wait()`，不直接暴露 Win32 同步 I/O 的无界阻塞面。
 - Windows 超时清理使用从可信 `%SystemRoot%\System32` 解析的绝对路径 `taskkill.exe /PID <pid> /T /F` 作为同步进程树兜底，记录 stdout、stderr 和退出码；随后轮询 fixture 暴露的根/孙 PID 直到消失或 deadline。`taskkill` 非零但进程已不存在可记录为竞态成功，仍有残留则 required CI 失败。后续若产品引入 Job Object，可复用更强的树生命周期能力。
 - 关闭采用有总 deadline 的状态机，而不是固定的“先 join reader、再 close PTY”：reader 从 spawn 起持续运行；请求正常退出或同步树终止；在 reader 仍持续排空时启动经过 spike 验证的 PTY teardown（后端若支持则显式管理 output endpoint）；等待 teardown/EOF；必要时调用 `cancel_io()` 解除阻塞；最后有限 join reader 并确认 thread/handle 零残留。
-- pywinpty `PtyProcess` 自身可能持有 native/daemon reader。P1 必须证明 `PtyProcess + cancel_io` 在目标 Windows 上可以完整退出；否则改用可显式控制 handle/pipe 生命周期的低层 `winpty.PTY` 或其他库层。未通过 spike 前不得以 Python 外层 reader 已退出推定 ConPTY 已安全关闭。
+- 所有输入/输出 pipe、HPCON、process/thread handle 都有唯一所有者；正常退出、timeout 和异常路径都必须关闭。`ClosePseudoConsole` 在独立受 deadline 约束的线程执行，同时 reader 持续 drain；未通过零残留断言前不得以 Python 外层进程退出推定 ConPTY 已安全关闭。
 
 ### Terminal query responder
 
@@ -352,7 +346,7 @@ P0 风险清单必须点名 `src/loushang/harnesstui/testing/screen_loop_playbac
 
 Spike 结果必须固化为 backend conformance tests，不能只留下实验脚本。
 
-P1 是探索分支上的合并前门槛，不是可单独发布的切片。它同时比较 `PtyProcess`、必要时的低层 `winpty.PTY` 或替代封装，证明 teardown 能收掉 library 内部和外部 reader；选型证据通过后再进入 P2a/P2b。不得把临时依赖、无 required CI 的 spike 或无法验证 thread 零残留的实现合入主线。
+P1 是探索分支上的合并前门槛，不是可单独发布的切片。它比较 `PtyProcess`、低层 `winpty.PTY` 与显式所有权的测试薄封装，最终淘汰两个 pywinpty 候选并选择直接 Win32 ConPTY 路径；选型证据通过后再进入 P2a/P2b。不得把临时依赖、无 required CI 的 spike 或无法验证 thread/handle 零残留的实现合入主线。
 
 ### P2a：中立协议、POSIX backend 与既有 smoke 迁移
 
@@ -368,7 +362,7 @@ P2a 不宣称 Windows 原生 terminal contract 已完成，也不得关闭 P0 �
 - 增加 Windows native-terminal required job；显式选择 test support、backend conformance 和同一 `/quit` 产品合同路径。
 - 把 P1 的大输出、query matrix、Unicode、resize、退出码、timeout 子孙进程、输出 EOF/drain 和幂等 close 固化为双 backend conformance。
 
-P2b 不允许合并“Windows job 存在但全部 skip”“ConPTY backend 尚未受进程树清理保护”或“pywinpty teardown 尚未证明 reader/handle 零残留”的中间状态。P2a 与 P2b 可以分成小步提交，但 P2b 是 Windows 原生支持声明和本轮跨平台目标的发布阻断项，不能停在 P2a 宣称完成。
+P2b 不允许合并“Windows job 存在但全部 skip”“ConPTY backend 尚未受进程树清理保护”或“ConPTY teardown 尚未证明 reader/handle 零残留”的中间状态。P2a 与 P2b 可以分成小步提交，但 P2b 是 Windows 原生支持声明和本轮跨平台目标的发布阻断项，不能停在 P2a 宣称完成。
 
 ### P3：tmux 与 auto-compaction 职责收敛
 
@@ -408,7 +402,7 @@ P2b 不允许合并“Windows job 存在但全部 skip”“ConPTY backend 尚�
 - 新增独立 terminal/tmux marker，补齐现有 CI 覆盖空洞；
 - 区分 ConPTY API 最低边界、x64 正式验证范围和 ARM64 预期兼容，避免无证据的支持声明；
 - reader thread、可配置 terminal query responder、有限 drain、同步树终止和幂等 close；
-- 删除不可移植的统一输入 EOF 语义，并将 pywinpty teardown 能否零残留设为 P1 技术选型门槛；
+- 删除不可移植的统一输入 EOF 语义，并将 ConPTY teardown 能否零残留设为 P1 技术选型门槛；
 - 平台单元测试拆成共享/POSIX/Windows 精确集合，避免“零 skip”与现有 runtime skip 冲突；
 - auto-compaction 状态合同与 tmux pane 合同拆分；
 - tmux marker 与最小 required job 在 P0 原子落地，readiness 后续改为 capture polling，CI 中依赖缺失不允许 skip。
@@ -427,6 +421,6 @@ P2b 不允许合并“Windows job 存在但全部 skip”“ConPTY backend 尚�
 - Microsoft 创建 pseudoconsole session：<https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session>
 - Microsoft `ClosePseudoConsole`：<https://learn.microsoft.com/en-us/windows/console/closepseudoconsole>
 - pywinpty：<https://pypi.org/project/pywinpty/>
-- pywinpty `PtyProcess`：<https://github.com/andfoy/pywinpty/blob/v2.0.15/winpty/ptyprocess.py>
+- pywinpty（被 P1 spike 淘汰的候选）：<https://github.com/andfoy/pywinpty/>
 - winpty-rs terminal query 注意事项：<https://github.com/andfoy/winpty-rs#important-notes>
 - GitHub Actions runner image labels：<https://github.com/actions/runner-images>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ loushang-tui = "loushang.coding.ui.cli:main"
 
 [project.optional-dependencies]
 dev = [
-  "pywinpty==2.0.15; sys_platform == 'win32'",
   "pytest>=8,<9",
   "pytest-cov>=7,<8",
   "ruff>=0.11,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ loushang-tui = "loushang.coding.ui.cli:main"
 
 [project.optional-dependencies]
 dev = [
+  "pywinpty==3.0.5; sys_platform == 'win32'",
   "pytest>=8,<9",
   "pytest-cov>=7,<8",
   "ruff>=0.11,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ addopts = ["--import-mode=importlib"]
 markers = [
   "live: real provider verification that may require network access and credentials",
   "tui_render_contract: deterministic TUI render correctness, structural performance, and terminal-operation contract",
+  "tui_terminal_backend: native POSIX PTY or Windows ConPTY driver conformance",
+  "tui_terminal_contract: shared real CLI contract over the native terminal backend",
+  "tui_tmux_integration: tmux pane, history, and scrollback integration contract",
   "vendor_verification: vendor or endpoint compatibility verification cases",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ loushang-tui = "loushang.coding.ui.cli:main"
 
 [project.optional-dependencies]
 dev = [
-  "pywinpty==3.0.5; sys_platform == 'win32'",
+  "pywinpty==2.0.15; sys_platform == 'win32'",
   "pytest>=8,<9",
   "pytest-cov>=7,<8",
   "ruff>=0.11,<1",

--- a/scripts/dev/verify_pytest_xml.py
+++ b/scripts/dev/verify_pytest_xml.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Fail closed when a required pytest XML report is empty or non-passing."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path)
+    parser.add_argument(
+        "--require-property",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="require a testsuite property; repeat for multiple properties",
+    )
+    return parser
+
+
+def verify_report(report: Path, required_properties: tuple[str, ...] = ()) -> str:
+    try:
+        root = ET.parse(report).getroot()
+    except (OSError, ET.ParseError) as error:
+        raise ValueError(f"cannot read pytest XML report {report}: {error}") from error
+
+    suites = [root] if root.tag == "testsuite" else list(root.findall("testsuite"))
+    if not suites:
+        raise ValueError(f"pytest XML report {report} has no testsuite")
+
+    counts = {
+        key: sum(_integer_attribute(suite, key, report) for suite in suites)
+        for key in ("tests", "skipped", "failures", "errors")
+    }
+    problems: list[str] = []
+    if counts["tests"] <= 0:
+        problems.append("tests must be greater than zero")
+    for key in ("skipped", "failures", "errors"):
+        if counts[key] != 0:
+            problems.append(f"{key} must be zero, got {counts[key]}")
+
+    properties = {
+        (item.get("name") or ""): item.get("value") or ""
+        for suite in suites
+        for item in suite.findall("./properties/property")
+    }
+    for requirement in required_properties:
+        name, separator, expected = requirement.partition("=")
+        if not separator or not name:
+            problems.append(
+                f"invalid property requirement {requirement!r}; expected NAME=VALUE"
+            )
+        elif properties.get(name) != expected:
+            problems.append(
+                f"required property {name!r} must be {expected!r}, "
+                f"got {properties.get(name)!r}"
+            )
+
+    summary = ", ".join(f"{key}={value}" for key, value in counts.items())
+    if problems:
+        raise ValueError(f"required pytest report failed ({summary}): {'; '.join(problems)}")
+    return summary
+
+
+def _integer_attribute(suite: ET.Element, name: str, report: Path) -> int:
+    raw = suite.get(name, "0")
+    try:
+        return int(raw)
+    except ValueError as error:
+        raise ValueError(
+            f"pytest XML report {report} has invalid {name}={raw!r}"
+        ) from error
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        summary = verify_report(args.report, tuple(args.require_property))
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 1
+    print(f"required pytest report passed: {summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/loushang/harnesstui/conversation/host.py
+++ b/src/loushang/harnesstui/conversation/host.py
@@ -36,6 +36,7 @@ from loushang.harnesstui.conversation.screen_runner import (
     run_conversation_screen,
 )
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
+from loushang.tui.terminal_input import InputChunkReader
 
 IntentT = TypeVar("IntentT")
 OutcomeT = TypeVar("OutcomeT")
@@ -352,6 +353,7 @@ async def run_action_host_conversation_screen(
     keybindings: KeybindingManager | KeybindingConfig | None = None,
     terminal_mode_factory: TerminalModeFactory | None = None,
     terminal_size_provider: TerminalSizeProvider | None = None,
+    input_chunk_reader: InputChunkReader | None = None,
 ) -> int:
     """Run a screen by binding one neutral action host exactly once."""
 
@@ -371,6 +373,7 @@ async def run_action_host_conversation_screen(
         keybindings=keybindings,
         terminal_mode_factory=terminal_mode_factory,
         terminal_size_provider=terminal_size_provider,
+        input_chunk_reader=input_chunk_reader,
         input_router_factory=profile.input_router_factory,
         interruption_message=profile.interruption_message,
         cancellation_message=profile.cancellation_message,

--- a/src/loushang/harnesstui/conversation/screen_runner.py
+++ b/src/loushang/harnesstui/conversation/screen_runner.py
@@ -23,7 +23,10 @@ from loushang.tui.scheduler import RenderRequestKind
 from loushang.tui.terminal import ProcessTerminalPort, TerminalSize
 from loushang.tui.terminal_capabilities import TerminalRuntimeCapabilities
 from loushang.tui.terminal_diagnostics import format_terminal_diagnostics
-from loushang.tui.terminal_input import read_input_chunk_or_render_tick
+from loushang.tui.terminal_input import (
+    InputChunkReader,
+    read_input_chunk_or_render_tick,
+)
 from loushang.tui.terminal_session import TerminalSession
 
 HandlerResult = Awaitable[int | None] | int | None
@@ -152,6 +155,7 @@ async def run_conversation_screen(
     interruption_message: str,
     cancellation_message: str,
     input_router_factory: ConversationInputRouterFactoryPort | None = None,
+    input_chunk_reader: InputChunkReader | None = None,
 ) -> int:
     """Run one product-neutral interactive conversation screen.
 
@@ -243,6 +247,7 @@ async def run_conversation_screen(
                     stdin,
                     runtime=runtime,
                     active_task=active_task,
+                    input_chunk_reader=input_chunk_reader,
                     render_wakeup=render_wakeup,
                     pending_input_idle_ms=10 if reader.has_pending else None,
                     idle_wakeup_ms=_terminal_runtime_wakeup_ms(terminal_context),

--- a/src/loushang/harnesstui/testing/screen_loop_playback.py
+++ b/src/loushang/harnesstui/testing/screen_loop_playback.py
@@ -2,15 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import threading
-import time
 from collections.abc import Coroutine, Iterator, Mapping, Sequence
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from io import StringIO
 from pathlib import Path
-from typing import Generic, Literal, Protocol, Self, TextIO, TypeVar, cast
+from typing import Generic, Literal, Protocol, Self, TextIO, TypeVar
 
 from loushang.harnesstui.conversation.screen_runner import (
     AbortHandler,
@@ -36,6 +33,7 @@ from loushang.harnesstui.testing.ports import (
 from loushang.tui.cell_width import strip_control_sequences
 from loushang.tui.playback import playback_artifacts_directory_from_env
 from loushang.tui.terminal import TerminalOperation, TerminalSize
+from loushang.tui.terminal_input import InputChunkReader
 
 ScreenAppT = TypeVar("ScreenAppT", bound=ConversationScreenPort)
 
@@ -62,6 +60,7 @@ class ConversationScreenLoopRunnerPort(Protocol):
         interruption_message: str,
         cancellation_message: str,
         input_router_factory: ConversationInputRouterFactoryPort | None,
+        input_chunk_reader: InputChunkReader | None,
     ) -> Coroutine[object, object, int]: ...
 
 
@@ -87,67 +86,29 @@ class NoTerminalMode:
         return False
 
 
-class TimedTtyChunkInput:
-    """TTY-like pipe that emits scripted chunks from a background writer."""
+class TimedInputChunkReader:
+    """Async test input source that emits chunks relative to its first read."""
 
     def __init__(
         self,
         chunks: Sequence[ScriptedInputChunk],
-        *,
-        block_seconds: float = 0.002,
     ) -> None:
-        self._start = time.perf_counter()
-        self._block_seconds = max(0.0001, block_seconds)
-        self._read_fd, self._write_fd = os.pipe()
-        self._closed = threading.Event()
-        self._writer = threading.Thread(
-            target=self._write_chunks,
-            args=(tuple(chunks),),
-            daemon=True,
-        )
-        self._writer.start()
+        self._chunks = tuple(chunks)
+        self._index = 0
+        self._started_at: float | None = None
 
-    def fileno(self) -> int:
-        return self._read_fd
-
-    def isatty(self) -> bool:
-        return True
-
-    def read(self, _size: int = -1) -> str:
-        return ""
-
-    def close(self) -> None:
-        if self._closed.is_set():
-            return
-        self._closed.set()
-        with suppress(OSError):
-            os.close(self._read_fd)
-        self._writer.join(timeout=0.1)
-
-    def __enter__(self) -> Self:
-        return self
-
-    def __exit__(self, *_args: object) -> Literal[False]:
-        self.close()
-        return False
-
-    def _write_chunks(self, chunks: tuple[ScriptedInputChunk, ...]) -> None:
-        try:
-            for chunk in chunks:
-                while (
-                    remaining := chunk.at_seconds - (time.perf_counter() - self._start)
-                ) > 0:
-                    if self._closed.wait(min(self._block_seconds, remaining)):
-                        return
-                if self._closed.is_set():
-                    return
-                try:
-                    os.write(self._write_fd, chunk.data.encode())
-                except OSError:
-                    return
-        finally:
-            with suppress(OSError):
-                os.close(self._write_fd)
+    async def __call__(self, _stdin: TextIO) -> str:
+        if self._index >= len(self._chunks):
+            return ""
+        loop = asyncio.get_running_loop()
+        if self._started_at is None:
+            self._started_at = loop.time()
+        chunk = self._chunks[self._index]
+        delay = chunk.at_seconds - (loop.time() - self._started_at)
+        if delay > 0:
+            await asyncio.sleep(delay)
+        self._index += 1
+        return chunk.data
 
 
 @dataclass(frozen=True, slots=True)
@@ -304,41 +265,35 @@ class ConversationScreenLoopPlayback(Generic[ScreenAppT]):
     ) -> ConversationScreenLoopPlaybackResult[ScreenAppT]:
         scripted_chunks = tuple(_coerce_chunk(chunk) for chunk in chunks)
         stdout = StringIO()
-        stdin: TextIO
-        timed_input: TimedTtyChunkInput | None = None
-        if scripted_chunks:
-            timed_input = TimedTtyChunkInput(scripted_chunks)
-            stdin = cast(TextIO, timed_input)
-        else:
-            stdin = StringIO("")
-        try:
-            exit_code: int = asyncio.run(
-                self._runner(
-                    app=self.app,
-                    stdin=stdin,
-                    stdout=stdout,
-                    handle_prompt=handle_prompt or _ignore_text,
-                    handle_local=handle_local,
-                    handle_steer=handle_steer,
-                    handle_followup=handle_followup,
-                    handle_surface_intent=handle_surface_intent,
-                    on_abort=on_abort or _ignore_abort,
-                    should_exit=should_exit or (lambda _text: False),
-                    is_local_command=is_local_command,
-                    terminal_mode_factory=terminal_mode_factory
-                    or (lambda _stdin, _stdout: NoTerminalMode()),
-                    terminal_size_provider=lambda: TerminalSize(
-                        columns=self.width,
-                        rows=self.height,
-                    ),
-                    interruption_message=self.interruption_message,
-                    cancellation_message=self.cancellation_message,
-                    input_router_factory=self._input_router_factory,
-                )
+        stdin = StringIO("")
+        input_chunk_reader = (
+            TimedInputChunkReader(scripted_chunks) if scripted_chunks else None
+        )
+        exit_code: int = asyncio.run(
+            self._runner(
+                app=self.app,
+                stdin=stdin,
+                stdout=stdout,
+                handle_prompt=handle_prompt or _ignore_text,
+                handle_local=handle_local,
+                handle_steer=handle_steer,
+                handle_followup=handle_followup,
+                handle_surface_intent=handle_surface_intent,
+                on_abort=on_abort or _ignore_abort,
+                should_exit=should_exit or (lambda _text: False),
+                is_local_command=is_local_command,
+                terminal_mode_factory=terminal_mode_factory
+                or (lambda _stdin, _stdout: NoTerminalMode()),
+                terminal_size_provider=lambda: TerminalSize(
+                    columns=self.width,
+                    rows=self.height,
+                ),
+                interruption_message=self.interruption_message,
+                cancellation_message=self.cancellation_message,
+                input_router_factory=self._input_router_factory,
+                input_chunk_reader=input_chunk_reader,
             )
-        finally:
-            if timed_input is not None:
-                timed_input.close()
+        )
         state = dict(self._state_snapshot(self.app))
         payload = (
             dict(self._result_payload(exit_code, self.app))
@@ -462,5 +417,5 @@ __all__ = [
     "ConversationScreenLoopScenario",
     "NoTerminalMode",
     "ScriptedInputChunk",
-    "TimedTtyChunkInput",
+    "TimedInputChunkReader",
 ]

--- a/src/loushang/tui/runner.py
+++ b/src/loushang/tui/runner.py
@@ -26,7 +26,10 @@ from loushang.tui.terminal import (
     TerminalSize,
     terminal_size_from_environment,
 )
-from loushang.tui.terminal_input import read_input_chunk_or_render_tick
+from loushang.tui.terminal_input import (
+    InputChunkReader,
+    read_input_chunk_or_render_tick,
+)
 from loushang.tui.terminal_session import TerminalSession
 from loushang.tui.tui import Tui
 
@@ -83,6 +86,7 @@ class TuiRunner:
     stdout: TextIO | None = None
     terminal_size_provider: TerminalSizeProvider | None = None
     terminal_session_factory: TerminalSessionFactory | None = None
+    input_chunk_reader: InputChunkReader | None = None
     _running: bool = field(default=False, init=False, repr=False)
 
     async def run(
@@ -139,6 +143,7 @@ class TuiRunner:
                         stdin,
                         runtime=runtime,
                         active_task=None,
+                        input_chunk_reader=self.input_chunk_reader,
                         render_wakeup=render_wakeup,
                         pending_input_idle_ms=10 if reader.has_pending else None,
                         idle_wakeup_ms=terminal_runtime_wakeup_ms(terminal_context),

--- a/src/loushang/tui/terminal_input.py
+++ b/src/loushang/tui/terminal_input.py
@@ -5,11 +5,13 @@ import importlib
 import os
 import select
 import sys
+import threading
 import time
 import weakref
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass
+from functools import partial
 from io import StringIO
 from typing import Any, Literal, Protocol, TextIO
 
@@ -47,6 +49,9 @@ _WINDOWS_TTY_READ_FUTURES: weakref.WeakKeyDictionary[
 class RuntimeLike(Protocol):
     def request_next_animation_frame(self) -> Any: ...
     def render_now(self) -> Any: ...
+
+
+InputChunkReader = Callable[[TextIO], Awaitable[str]]
 
 
 @dataclass(slots=True)
@@ -203,11 +208,13 @@ async def read_input_chunk_or_render_tick(
     *,
     runtime: RuntimeLike,
     active_task: asyncio.Task[Any] | None,
+    input_chunk_reader: InputChunkReader | None = None,
     render_wakeup: asyncio.Event | None = None,
     pending_input_idle_ms: int | None = None,
     idle_wakeup_ms: int | None = None,
 ) -> str | None:
-    input_task = asyncio.create_task(read_input_chunk(stdin))
+    read_chunk = input_chunk_reader or read_input_chunk
+    input_task = asyncio.create_task(read_chunk(stdin))
     try:
         while True:
             await asyncio.sleep(0)
@@ -369,9 +376,13 @@ async def _read_windows_tty_input_chunk_from_module_async(msvcrt: Any) -> str:
     loop = asyncio.get_running_loop()
     future = _WINDOWS_TTY_READ_FUTURES.get(loop)
     if future is None:
-        future = loop.run_in_executor(
-            None, _read_windows_tty_input_chunk_from_module, msvcrt
-        )
+        future = loop.create_future()
+        threading.Thread(
+            target=_read_windows_tty_input_in_thread,
+            args=(loop, future, msvcrt),
+            name="loushang-windows-console-reader",
+            daemon=True,
+        ).start()
         _WINDOWS_TTY_READ_FUTURES[loop] = future
     try:
         result = await asyncio.shield(future)
@@ -382,6 +393,33 @@ async def _read_windows_tty_input_chunk_from_module_async(msvcrt: Any) -> str:
     if _WINDOWS_TTY_READ_FUTURES.get(loop) is future:
         del _WINDOWS_TTY_READ_FUTURES[loop]
     return result
+
+
+def _read_windows_tty_input_in_thread(
+    loop: asyncio.AbstractEventLoop,
+    future: asyncio.Future[str],
+    msvcrt: Any,
+) -> None:
+    try:
+        result = _read_windows_tty_input_chunk_from_module(msvcrt)
+    except BaseException as error:
+        callback = partial(_set_future_exception, future, error)
+    else:
+        callback = partial(_set_future_result, future, result)
+    with suppress(RuntimeError):
+        loop.call_soon_threadsafe(callback)
+
+
+def _set_future_result(future: asyncio.Future[str], result: str) -> None:
+    if not future.done():
+        future.set_result(result)
+
+
+def _set_future_exception(
+    future: asyncio.Future[str], error: BaseException
+) -> None:
+    if not future.done():
+        future.set_exception(error)
 
 
 def _read_windows_tty_input_chunk_from_module(msvcrt: Any) -> str:

--- a/tests/coding/test_cli_terminal_contract.py
+++ b/tests/coding/test_cli_terminal_contract.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from loushang.tui import strip_control_sequences
+from tests.tui.terminal_process_support import (
+    selected_backend_name,
+    spawn_terminal_process,
+    terminal_test_environment,
+)
+
+pytestmark = pytest.mark.tui_terminal_contract
+
+
+@pytest.fixture(autouse=True)
+def _record_backend(record_testsuite_property) -> None:
+    record_testsuite_property("terminal_backend", selected_backend_name())
+
+
+def test_real_cli_quit_restores_terminal_modes_and_cleans_live_footer() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    env = terminal_test_environment(repo_root)
+
+    with spawn_terminal_process(
+        [sys.executable, "-m", "loushang.coding.cli", "--tui"],
+        cwd=repo_root,
+        env=env,
+        columns=80,
+        rows=24,
+    ) as driver:
+        driver.read_until(
+            lambda output: "Welcome to Loushang CLI"
+            in strip_control_sequences(output),
+            timeout=15,
+        )
+        driver.write("/quit\r")
+        assert driver.wait(timeout=15) == 0
+        output = driver.raw_output
+
+    assert driver.diagnostics.backend == selected_backend_name()
+    assert driver.diagnostics.reader_alive is False
+    assert "Welcome to Loushang CLI" in strip_control_sequences(output)
+    assert "\x1b[?25l" in output
+    assert "\x1b[?2026h" in output
+    assert "\x1b[2K" in output
+    _assert_paired_mode(output, enable="\x1b[?2004h", disable="\x1b[?2004l")
+    _assert_paired_mode(output, enable="\x1b[?1004h", disable="\x1b[?1004l")
+    final_sync_end = output.rfind("\x1b[?2026l")
+    assert final_sync_end != -1
+    final_tail = strip_control_sequences(output[final_sync_end:])
+    assert " | idle" not in final_tail
+    assert " | running" not in final_tail
+
+
+def _assert_paired_mode(output: str, *, enable: str, disable: str) -> None:
+    enabled_at = output.find(enable)
+    disabled_at = output.rfind(disable)
+    assert enabled_at != -1
+    assert disabled_at > enabled_at

--- a/tests/coding/test_cli_terminal_contract.py
+++ b/tests/coding/test_cli_terminal_contract.py
@@ -45,7 +45,6 @@ def test_real_cli_quit_restores_terminal_modes_and_cleans_live_footer() -> None:
     assert "Welcome to Loushang CLI" in strip_control_sequences(output)
     assert "\x1b[?25l" in output
     assert "\x1b[?2026h" in output
-    assert "\x1b[2K" in output
     _assert_paired_mode(output, enable="\x1b[?2004h", disable="\x1b[?2004l")
     _assert_paired_mode(output, enable="\x1b[?1004h", disable="\x1b[?1004l")
     final_sync_end = output.rfind("\x1b[?2026l")

--- a/tests/coding/test_screen_coding_tui_loop.py
+++ b/tests/coding/test_screen_coding_tui_loop.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
-import threading
 import time
 from collections.abc import Awaitable, Callable
 from io import StringIO
@@ -14,6 +12,10 @@ from loushang.harnesstui.conversation.attachments import PromptImageAttachment
 from loushang.harnesstui.conversation.control import ConversationTextAction
 from loushang.harnesstui.testing.action_host import (
     CallbackConversationActionHost,
+)
+from loushang.harnesstui.testing.screen_loop_playback import (
+    ScriptedInputChunk,
+    TimedInputChunkReader,
 )
 from loushang.tui import strip_control_sequences
 from tests.coding.tui_support.scenario_binding import run_coding_test_screen
@@ -453,7 +455,10 @@ def test_screen_loop_escape_closes_model_surface_and_restores_prompt() -> None:
     result = asyncio.run(
         run_coding_test_screen(
             app=app,
-            stdin=_TimedTtyChunkInput((0.0, "/model\r"), (0.01, "\x1b")),
+            stdin=StringIO(""),
+            input_chunk_reader=_timed_input_reader(
+                (0.0, "/model\r"), (0.01, "\x1b")
+            ),
             stdout=stdout,
             action_host=_action_host(),
             handle_local=manager.handle_text,
@@ -712,7 +717,8 @@ def test_screen_loop_executes_queued_steer_after_running_escape_with_delay() -> 
     result = asyncio.run(
         run_coding_test_screen(
             app=app,
-            stdin=_TimedTtyChunkInput(
+            stdin=StringIO(""),
+            input_chunk_reader=_timed_input_reader(
                 (0.0, "start\r"),
                 (0.01, "follow\r"),
                 (0.02, "\x1b"),
@@ -755,7 +761,8 @@ def test_screen_loop_escape_runs_pending_steer_before_unsubmitted_composer_text(
     result = asyncio.run(
         run_coding_test_screen(
             app=app,
-            stdin=_TimedTtyChunkInput(
+            stdin=StringIO(""),
+            input_chunk_reader=_timed_input_reader(
                 (0.0, "start\r"),
                 (0.01, "draft"),
                 (0.02, "\x1b"),
@@ -802,7 +809,10 @@ def test_screen_loop_renders_pending_steer_stream_after_escape_interrupt() -> No
     result = asyncio.run(
         run_coding_test_screen(
             app=app,
-            stdin=_TimedTtyChunkInput((0.0, "start\r"), (0.01, "\x1b"), (0.2, "")),
+            stdin=StringIO(""),
+            input_chunk_reader=_timed_input_reader(
+                (0.0, "start\r"), (0.01, "\x1b"), (0.2, "")
+            ),
             stdout=stdout,
             action_host=_action_host(submit=handle_prompt),
             terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
@@ -844,7 +854,8 @@ def test_screen_loop_ignores_running_steer_duplicate_on_interrupt() -> None:
     result = asyncio.run(
         run_coding_test_screen(
             app=app,
-            stdin=_TimedTtyChunkInput(
+            stdin=StringIO(""),
+            input_chunk_reader=_timed_input_reader(
                 (0.0, "start\r"), (0.01, "follow\r"), (0.02, "\x1b")
             ),
             stdout=stdout,
@@ -888,7 +899,8 @@ def test_screen_loop_abort_uses_first_pending_steer_before_running_steer() -> No
     result = asyncio.run(
         run_coding_test_screen(
             app=app,
-            stdin=_TimedTtyChunkInput(
+            stdin=StringIO(""),
+            input_chunk_reader=_timed_input_reader(
                 (0.0, "start\r"), (0.01, "follow\r"), (0.02, "\x1b")
             ),
             stdout=stdout,
@@ -976,7 +988,7 @@ def test_screen_loop_renders_streaming_updates_without_waiting_for_keyboard() ->
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
     stdout = StringIO()
-    stdin = _TimedTtyChunkInput((0.0, "go\r"), (0.2, ""))
+    input_chunk_reader = _timed_input_reader((0.0, "go\r"), (0.2, ""))
     app = ScreenCodingTuiApp(
         model_label="kimi", cwd="/repo", branch="main", session_label="abcd"
     )
@@ -991,7 +1003,8 @@ def test_screen_loop_renders_streaming_updates_without_waiting_for_keyboard() ->
     result = asyncio.run(
         run_coding_test_screen(
             app=app,
-            stdin=stdin,
+            stdin=StringIO(""),
+            input_chunk_reader=input_chunk_reader,
             stdout=stdout,
             action_host=_action_host(submit=handle_prompt),
             terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
@@ -1009,7 +1022,7 @@ def test_screen_loop_wakes_stream_render_before_active_interval() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 
     stdout = StringIO()
-    stdin = _TimedTtyChunkInput((0.0, "go\r"), (0.1, ""))
+    input_chunk_reader = _timed_input_reader((0.0, "go\r"), (0.1, ""))
     app = ScreenCodingTuiApp(
         model_label="kimi", cwd="/repo", branch="main", session_label="abcd"
     )
@@ -1028,7 +1041,8 @@ def test_screen_loop_wakes_stream_render_before_active_interval() -> None:
     result = asyncio.run(
         run_coding_test_screen(
             app=app,
-            stdin=stdin,
+            stdin=StringIO(""),
+            input_chunk_reader=input_chunk_reader,
             stdout=stdout,
             action_host=_action_host(submit=handle_prompt),
             terminal_mode_factory=lambda _stdin, _stdout: _NoTerminalMode(),
@@ -1213,38 +1227,9 @@ class _OrderingTerminalMode:
         return False
 
 
-class _TimedTtyChunkInput:
-    def __init__(
-        self, *chunks: tuple[float, str], block_seconds: float = 0.002
-    ) -> None:
-        self._start = time.perf_counter()
-        self._chunks = list(chunks)
-        self._block_seconds = block_seconds
-        self._read_fd, write_fd = os.pipe()
-        self._closed = threading.Event()
-
-        def writer() -> None:
-            try:
-                for emit_at, chunk in self._chunks:
-                    while (
-                        remaining := emit_at - (time.perf_counter() - self._start)
-                    ) > 0:
-                        time.sleep(min(self._block_seconds, remaining))
-                    if self._closed.is_set():
-                        break
-                    os.write(write_fd, chunk.encode())
-            finally:
-                os.close(write_fd)
-
-        self._writer = threading.Thread(target=writer, daemon=True)
-        self._writer.start()
-
-    def fileno(self) -> int:
-        return self._read_fd
-
-    def isatty(self) -> bool:
-        return True
-
-    def read(self, _size: int) -> str:
-        # This stream is tty-like and read through the terminal reader path.
-        return ""
+def _timed_input_reader(
+    *chunks: tuple[float, str],
+) -> TimedInputChunkReader:
+    return TimedInputChunkReader(
+        tuple(ScriptedInputChunk(at_seconds=at, data=data) for at, data in chunks)
+    )

--- a/tests/coding/test_screen_coding_tui_pty_smoke.py
+++ b/tests/coding/test_screen_coding_tui_pty_smoke.py
@@ -7,35 +7,9 @@ import shutil
 import subprocess
 import sys
 import time
-from contextlib import suppress
 from pathlib import Path
 
 import pytest
-
-from loushang.tui import strip_control_sequences
-
-
-@pytest.mark.tui_terminal_contract
-def test_screen_tui_cli_pty_smoke_quit_cleans_bottom_frame() -> None:
-    if os.name == "nt":
-        pytest.skip("PTY smoke uses POSIX pty")
-
-    output, returncode = _run_pty_command(
-        [sys.executable, "-m", "loushang.coding.cli", "--tui"],
-        input_text="/quit\r",
-        cwd=_repo_root(),
-    )
-
-    assert returncode == 0
-    assert "Welcome to Loushang CLI" in strip_control_sequences(output)
-    assert "\x1b[?25l" in output
-    assert "\x1b[?2026h" in output
-    assert "\x1b[2K" in output
-    final_sync_end = output.rfind("\x1b[?2026l")
-    assert final_sync_end != -1
-    final_tail = strip_control_sequences(output[final_sync_end:])
-    assert " | idle" not in final_tail
-    assert " | running" not in final_tail
 
 
 @pytest.mark.tui_tmux_integration
@@ -262,97 +236,6 @@ def _capture_tmux(
         check=False,
     )
     return captured.stdout + captured.stderr
-
-
-def _run_pty_command(
-    args: list[str],
-    *,
-    input_text: str,
-    cwd: Path,
-    timeout_seconds: float = 12.0,
-) -> tuple[str, int]:
-    import pty
-    import select
-
-    master_fd, slave_fd = pty.openpty()
-    env = _subprocess_env(cwd)
-    process = subprocess.Popen(
-        args,
-        cwd=cwd,
-        stdin=slave_fd,
-        stdout=slave_fd,
-        stderr=slave_fd,
-        close_fds=True,
-        env=env,
-    )
-    os.close(slave_fd)
-    output = bytearray()
-    input_sent = False
-    deadline = time.monotonic() + timeout_seconds
-    try:
-        while time.monotonic() < deadline:
-            if not input_sent and b"\x1b[?25h" in output:
-                os.write(master_fd, input_text.encode())
-                input_sent = True
-            readable, _, _ = select.select([master_fd], [], [], 0.05)
-            if readable:
-                try:
-                    chunk = os.read(master_fd, 4096)
-                except OSError:
-                    break
-                if not chunk:
-                    break
-                output.extend(chunk)
-            if process.poll() is not None:
-                output.extend(_read_available(master_fd))
-                break
-        if process.poll() is None:
-            try:
-                process.wait(timeout=1.0)
-            except subprocess.TimeoutExpired:
-                process.terminate()
-                try:
-                    process.wait(timeout=1.0)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=1.0)
-                raise AssertionError(
-                    f"PTY command timed out; output:\n{output.decode(errors='replace')}"
-                )
-            else:
-                output.extend(_read_available(master_fd))
-        if process.returncode is None:
-            process.terminate()
-            try:
-                process.wait(timeout=1.0)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                process.wait(timeout=1.0)
-            raise AssertionError(
-                f"PTY command timed out; output:\n{output.decode(errors='replace')}"
-            )
-        return output.decode(errors="replace"), process.returncode
-    finally:
-        with suppress(OSError):
-            os.close(master_fd)
-
-
-def _read_available(fd: int) -> bytes:
-    import select
-
-    output = bytearray()
-    while True:
-        readable, _, _ = select.select([fd], [], [], 0)
-        if not readable:
-            break
-        try:
-            chunk = os.read(fd, 4096)
-        except OSError:
-            break
-        if not chunk:
-            break
-        output.extend(chunk)
-    return bytes(output)
 
 
 def _subprocess_env(repo_root: Path) -> dict[str, str]:

--- a/tests/coding/test_screen_coding_tui_pty_smoke.py
+++ b/tests/coding/test_screen_coding_tui_pty_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import pty
 import select
@@ -48,24 +49,117 @@ def test_screen_tui_tmux_pty_preserves_compact_history_and_streamed_tail(
     if tmux is None:
         pytest.skip("tmux is not installed")
 
+    captured = _run_tmux_fixture(
+        tmp_path=tmp_path,
+        tmux=tmux,
+        fixture_name="compact_pty_fixture.py",
+        ready_name="compact-playback.ready",
+        socket_name=f"loushang-compact-{os.getpid()}",
+        session_name="compact",
+    )
+
+    early_lines = tuple(f"PLAYBACK_EARLY_{index:03d}" for index in range(1, 81))
+    after_lines = tuple(f"AFTER_COMPACT_{index:03d}" for index in range(1, 41))
+    _assert_ordered_lines(captured, early_lines)
+    _assert_ordered_lines(captured, after_lines)
+    assert "Context compacted (500000 tokens before)" in captured
+    assert "hidden summary line one" not in captured
+    assert "hidden summary line two" not in captured
+
+
+@pytest.mark.tui_render_contract
+def test_screen_tui_tmux_pty_auto_compaction_preserves_history_and_resume(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("tmux PTY regression uses POSIX terminals")
+    tmux = shutil.which("tmux")
+    if tmux is None:
+        pytest.skip("tmux is not installed")
+
+    evidence_file = tmp_path / "auto-compact-evidence.json"
+    session_dir = tmp_path / "sessions"
+    captured = _run_tmux_fixture(
+        tmp_path=tmp_path,
+        tmux=tmux,
+        fixture_name="auto_compact_pty_fixture.py",
+        ready_name="auto-compact-playback.ready",
+        socket_name=f"loushang-auto-compact-{os.getpid()}",
+        session_name="auto-compact",
+        extra_args=(
+            "--evidence-file",
+            str(evidence_file),
+            "--session-dir",
+            str(session_dir),
+        ),
+        ready_timeout_seconds=30,
+    )
+
+    early_lines = tuple(f"AUTO_EARLY_{index:03d}" for index in range(1, 81))
+    after_lines = tuple(f"AUTO_AFTER_{index:03d}" for index in range(1, 41))
+    _assert_ordered_lines(captured, early_lines)
+    _assert_ordered_lines(captured, after_lines)
+    assert "Context compacted (" in captured
+    assert "AUTO_COMPACT_PRIVATE_SUMMARY" not in captured
+
+    evidence = json.loads(evidence_file.read_text(encoding="utf-8"))
+    assert evidence["entryCount"] == 5
+    assert evidence["checkpointCount"] == 1
+    assert evidence["compactionEventTypes"] == [
+        "compaction_start",
+        "compaction_end",
+    ]
+    assert evidence["compactionReasons"] == ["threshold", "threshold"]
+    assert evidence["compactionStages"] == ["started", "committed"]
+    assert evidence["fullHistoryHasEarly"] is True
+    assert evidence["fullHistoryHasAfter"] is True
+    assert evidence["resumeContextHasSummary"] is True
+    assert evidence["resumeContextHasAfter"] is True
+    assert evidence["resumeHistoryCheckpointCount"] == 1
+    assert evidence["resumeHistoryHasEarly"] is True
+    assert evidence["resumeHistoryHasAfter"] is True
+
+    session_file = Path(evidence["sessionFile"])
+    assert session_file.is_file()
+    jsonl = session_file.read_text(encoding="utf-8")
+    records = [json.loads(line) for line in jsonl.splitlines()]
+    assert (
+        sum(record.get("kind") == "context.compaction_checkpoint" for record in records)
+        == 1
+    )
+    assert early_lines[0] in jsonl
+    assert early_lines[-1] in jsonl
+    assert after_lines[0] in jsonl
+    assert after_lines[-1] in jsonl
+
+
+def _run_tmux_fixture(
+    *,
+    tmp_path: Path,
+    tmux: str,
+    fixture_name: str,
+    ready_name: str,
+    socket_name: str,
+    session_name: str,
+    extra_args: tuple[str, ...] = (),
+    ready_timeout_seconds: float = 15,
+) -> str:
     repo_root = _repo_root()
-    ready_file = tmp_path / "compact-playback.ready"
-    tmux_config = tmp_path / "tmux.conf"
+    ready_file = tmp_path / ready_name
+    tmux_config = tmp_path / f"{session_name}.tmux.conf"
     tmux_config.write_text("set-option -g history-limit 20000\n", encoding="utf-8")
-    socket_name = f"loushang-compact-{os.getpid()}"
     command = shlex.join(
         [
             sys.executable,
-            str(
-                repo_root
-                / "tests/coding/tui_support/compact_pty_fixture.py"
-            ),
+            str(repo_root / "tests/coding/tui_support" / fixture_name),
             "--ready-file",
             str(ready_file),
+            *extra_args,
         ]
     )
     env = _subprocess_env(repo_root)
     tmux_args = [tmux, "-f", str(tmux_config), "-L", socket_name]
+    target = f"{session_name}:0.0"
     try:
         started = subprocess.run(
             [
@@ -77,7 +171,7 @@ def test_screen_tui_tmux_pty_preserves_compact_history_and_streamed_tail(
                 "-y",
                 "18",
                 "-s",
-                "compact",
+                session_name,
                 command,
             ],
             cwd=repo_root,
@@ -88,38 +182,21 @@ def test_screen_tui_tmux_pty_preserves_compact_history_and_streamed_tail(
             check=False,
         )
         assert started.returncode == 0, started.stderr
-        deadline = time.monotonic() + 15
+        deadline = time.monotonic() + ready_timeout_seconds
         while time.monotonic() < deadline and not ready_file.exists():
             time.sleep(0.05)
-        assert ready_file.exists(), _capture_tmux(tmux_args, env=env, cwd=repo_root)
-
-        captured = _capture_tmux(tmux_args, env=env, cwd=repo_root)
-
-        early_lines = tuple(
-            f"PLAYBACK_EARLY_{index:03d}" for index in range(1, 81)
+        assert ready_file.exists(), _capture_tmux(
+            tmux_args,
+            env=env,
+            cwd=repo_root,
+            target=target,
         )
-        after_lines = tuple(
-            f"AFTER_COMPACT_{index:03d}" for index in range(1, 41)
+        return _capture_tmux(
+            tmux_args,
+            env=env,
+            cwd=repo_root,
+            target=target,
         )
-        early_counts = {line: captured.count(line) for line in early_lines}
-        after_counts = {line: captured.count(line) for line in after_lines}
-        assert all(count >= 1 for count in early_counts.values()), (
-            early_counts,
-            captured,
-        )
-        assert all(count >= 1 for count in after_counts.values()), (
-            after_counts,
-            captured,
-        )
-        assert [captured.rfind(line) for line in early_lines] == sorted(
-            captured.rfind(line) for line in early_lines
-        )
-        assert [captured.rfind(line) for line in after_lines] == sorted(
-            captured.rfind(line) for line in after_lines
-        )
-        assert "Context compacted (500000 tokens before)" in captured
-        assert "hidden summary line one" not in captured
-        assert "hidden summary line two" not in captured
     finally:
         subprocess.run(
             [*tmux_args, "kill-server"],
@@ -131,11 +208,19 @@ def test_screen_tui_tmux_pty_preserves_compact_history_and_streamed_tail(
         )
 
 
+def _assert_ordered_lines(captured: str, lines: tuple[str, ...]) -> None:
+    counts = {line: captured.count(line) for line in lines}
+    assert all(count >= 1 for count in counts.values()), (counts, captured)
+    positions = [captured.rfind(line) for line in lines]
+    assert positions == sorted(positions)
+
+
 def _capture_tmux(
     tmux_args: list[str],
     *,
     env: dict[str, str],
     cwd: Path,
+    target: str = "compact:0.0",
 ) -> str:
     captured = subprocess.run(
         [
@@ -146,7 +231,7 @@ def _capture_tmux(
             "-S",
             "-",
             "-t",
-            "compact:0.0",
+            target,
         ],
         cwd=cwd,
         env=env,
@@ -207,7 +292,9 @@ def _run_pty_command(
                 except subprocess.TimeoutExpired:
                     process.kill()
                     process.wait(timeout=1.0)
-                raise AssertionError(f"PTY command timed out; output:\n{output.decode(errors='replace')}")
+                raise AssertionError(
+                    f"PTY command timed out; output:\n{output.decode(errors='replace')}"
+                )
             else:
                 output.extend(_read_available(master_fd))
         if process.returncode is None:
@@ -217,7 +304,9 @@ def _run_pty_command(
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=1.0)
-            raise AssertionError(f"PTY command timed out; output:\n{output.decode(errors='replace')}")
+            raise AssertionError(
+                f"PTY command timed out; output:\n{output.decode(errors='replace')}"
+            )
         return output.decode(errors="replace"), process.returncode
     finally:
         with suppress(OSError):

--- a/tests/coding/test_screen_coding_tui_pty_smoke.py
+++ b/tests/coding/test_screen_coding_tui_pty_smoke.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import pty
-import select
 import shlex
 import shutil
 import subprocess
@@ -17,6 +15,7 @@ import pytest
 from loushang.tui import strip_control_sequences
 
 
+@pytest.mark.tui_terminal_contract
 def test_screen_tui_cli_pty_smoke_quit_cleans_bottom_frame() -> None:
     if os.name == "nt":
         pytest.skip("PTY smoke uses POSIX pty")
@@ -39,13 +38,15 @@ def test_screen_tui_cli_pty_smoke_quit_cleans_bottom_frame() -> None:
     assert " | running" not in final_tail
 
 
-@pytest.mark.tui_render_contract
+@pytest.mark.tui_tmux_integration
 def test_screen_tui_tmux_pty_preserves_compact_history_and_streamed_tail(
     tmp_path: Path,
 ) -> None:
     if os.name == "nt":
         pytest.skip("tmux PTY regression uses POSIX terminals")
     tmux = shutil.which("tmux")
+    if tmux is None and os.environ.get("LOUSHANG_REQUIRE_TMUX") == "1":
+        pytest.fail("required tmux executable was not found")
     if tmux is None:
         pytest.skip("tmux is not installed")
 
@@ -56,24 +57,28 @@ def test_screen_tui_tmux_pty_preserves_compact_history_and_streamed_tail(
         ready_name="compact-playback.ready",
         socket_name=f"loushang-compact-{os.getpid()}",
         session_name="compact",
+        visible_sentinel="AFTER_COMPACT_040",
     )
 
     early_lines = tuple(f"PLAYBACK_EARLY_{index:03d}" for index in range(1, 81))
     after_lines = tuple(f"AFTER_COMPACT_{index:03d}" for index in range(1, 41))
     _assert_ordered_lines(captured, early_lines)
     _assert_ordered_lines(captured, after_lines)
+    assert captured.count(after_lines[-1]) == 1
     assert "Context compacted (500000 tokens before)" in captured
     assert "hidden summary line one" not in captured
     assert "hidden summary line two" not in captured
 
 
-@pytest.mark.tui_render_contract
+@pytest.mark.tui_tmux_integration
 def test_screen_tui_tmux_pty_auto_compaction_preserves_history_and_resume(
     tmp_path: Path,
 ) -> None:
     if os.name == "nt":
         pytest.skip("tmux PTY regression uses POSIX terminals")
     tmux = shutil.which("tmux")
+    if tmux is None and os.environ.get("LOUSHANG_REQUIRE_TMUX") == "1":
+        pytest.fail("required tmux executable was not found")
     if tmux is None:
         pytest.skip("tmux is not installed")
 
@@ -93,12 +98,14 @@ def test_screen_tui_tmux_pty_auto_compaction_preserves_history_and_resume(
             str(session_dir),
         ),
         ready_timeout_seconds=30,
+        visible_sentinel="AUTO_AFTER_040",
     )
 
     early_lines = tuple(f"AUTO_EARLY_{index:03d}" for index in range(1, 81))
     after_lines = tuple(f"AUTO_AFTER_{index:03d}" for index in range(1, 41))
     _assert_ordered_lines(captured, early_lines)
     _assert_ordered_lines(captured, after_lines)
+    assert captured.count(after_lines[-1]) == 1
     assert "Context compacted (" in captured
     assert "AUTO_COMPACT_PRIVATE_SUMMARY" not in captured
 
@@ -143,6 +150,7 @@ def _run_tmux_fixture(
     session_name: str,
     extra_args: tuple[str, ...] = (),
     ready_timeout_seconds: float = 15,
+    visible_sentinel: str,
 ) -> str:
     repo_root = _repo_root()
     ready_file = tmp_path / ready_name
@@ -191,11 +199,24 @@ def _run_tmux_fixture(
             cwd=repo_root,
             target=target,
         )
-        return _capture_tmux(
+        captured = _capture_tmux(
             tmux_args,
             env=env,
             cwd=repo_root,
             target=target,
+        )
+        while time.monotonic() < deadline:
+            if visible_sentinel in captured:
+                return captured
+            time.sleep(0.05)
+            captured = _capture_tmux(
+                tmux_args,
+                env=env,
+                cwd=repo_root,
+                target=target,
+            )
+        raise AssertionError(
+            f"tmux pane did not show {visible_sentinel!r} before deadline:\n{captured}"
         )
     finally:
         subprocess.run(
@@ -211,7 +232,7 @@ def _run_tmux_fixture(
 def _assert_ordered_lines(captured: str, lines: tuple[str, ...]) -> None:
     counts = {line: captured.count(line) for line in lines}
     assert all(count >= 1 for count in counts.values()), (counts, captured)
-    positions = [captured.rfind(line) for line in lines]
+    positions = [captured.find(line) for line in lines]
     assert positions == sorted(positions)
 
 
@@ -250,6 +271,9 @@ def _run_pty_command(
     cwd: Path,
     timeout_seconds: float = 12.0,
 ) -> tuple[str, int]:
+    import pty
+    import select
+
     master_fd, slave_fd = pty.openpty()
     env = _subprocess_env(cwd)
     process = subprocess.Popen(
@@ -314,6 +338,8 @@ def _run_pty_command(
 
 
 def _read_available(fd: int) -> bytes:
+    import select
+
     output = bytearray()
     while True:
         readable, _, _ = select.select([fd], [], [], 0)

--- a/tests/coding/tui_support/auto_compact_pty_fixture.py
+++ b/tests/coding/tui_support/auto_compact_pty_fixture.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+from loushang.agent import AbortSignal, Agent
+from loushang.ai import AssistantMessage, TextPart, Usage, UserMessage
+from loushang.ai.model import Capabilities, Model
+from loushang.coding.control import CompactionSettings, ControlConfig, SettingsManager
+from loushang.coding.session import AgentSession
+from loushang.coding.session_manager import SessionManager
+from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+from loushang.harness.transcript import summarization as summary_module
+from loushang.harnesstui.conversation.agent_binding import (
+    agent_session_history_records,
+    build_agent_screen_conversation_projection,
+)
+from loushang.tui import (
+    AssistantMessageRecord,
+    ContextCompactionRecord,
+    ProcessTerminalPort,
+    RenderLoop,
+    TerminalSize,
+    TuiRuntime,
+)
+
+_PRIVATE_SUMMARY = "AUTO_COMPACT_PRIVATE_SUMMARY"
+
+
+def _usage(total_tokens: int) -> Usage:
+    return Usage(
+        input=total_tokens,
+        output=0,
+        cache_read=0,
+        cache_write=0,
+        total_tokens=total_tokens,
+        cost={},
+    )
+
+
+def _assistant(text: str, *, total_tokens: int) -> AssistantMessage:
+    return AssistantMessage(
+        endpoint="test-endpoint",
+        role="assistant",
+        content=[TextPart(type="text", text=text)] if text else [],
+        api="anthropic-messages",
+        provider="faux",
+        model="tiny-auto-compact",
+        response_id=None,
+        usage=_usage(total_tokens),
+        stop_reason="stop",
+        error_message=None,
+        timestamp=1.0,
+    )
+
+
+class _SummaryStream:
+    async def result(self) -> AssistantMessage:
+        return _assistant(_PRIVATE_SUMMARY, total_tokens=1)
+
+
+async def _fake_summary_stream(
+    model: object,
+    context: object,
+    options: object | None = None,
+) -> _SummaryStream:
+    del model, context, options
+    return _SummaryStream()
+
+
+def _message_text(message: object) -> str:
+    content = getattr(message, "content", ())
+    return "".join(part.text for part in content if isinstance(part, TextPart))
+
+
+async def _emit_assistant_turn(
+    *,
+    session: AgentSession,
+    runtime: TuiRuntime,
+    lines: tuple[str, ...],
+    total_tokens: int,
+) -> None:
+    signal = AbortSignal()
+    session_runtime = session._composition.session_runtime
+    await session_runtime.handle_agent_event(
+        {"type": "message_start", "message": _assistant("", total_tokens=0)},
+        signal,
+    )
+    text = ""
+    for index, line in enumerate(lines):
+        delta = f"{line}\n" if index < len(lines) - 1 else line
+        text += delta
+        await session_runtime.handle_agent_event(
+            {
+                "type": "message_update",
+                "message": _assistant(text, total_tokens=total_tokens),
+                "assistant_message_event": {
+                    "type": "text_delta",
+                    "delta": delta,
+                },
+            },
+            signal,
+        )
+        runtime.render_now()
+    assistant = _assistant(text, total_tokens=total_tokens)
+    await session_runtime.handle_agent_event(
+        {"type": "message_end", "message": assistant},
+        signal,
+    )
+    runtime.render_now()
+    await session_runtime.handle_agent_event(
+        {"type": "agent_end", "messages": [assistant]},
+        signal,
+    )
+    runtime.render_now()
+
+
+async def _render_auto_compact_playback(
+    *,
+    ready_file: Path,
+    evidence_file: Path,
+    session_dir: Path,
+) -> None:
+    app = ScreenCodingTuiApp(
+        model_label="faux/tiny-auto-compact",
+        cwd="/repo",
+        branch="main",
+        session_label="pty-auto-compact",
+        now=lambda: 3.0,
+    )
+    terminal = ProcessTerminalPort(
+        output=sys.stdout,
+        size_provider=lambda: TerminalSize(columns=80, rows=18),
+        track_screen=False,
+    )
+    runtime = TuiRuntime(render_loop=RenderLoop(app), terminal=terminal)
+    projector = build_agent_screen_conversation_projection(app)
+    manager = await SessionManager.new(
+        session_dir=session_dir,
+        cwd="/repo",
+        persist=True,
+    )
+    session = AgentSession(
+        agent=Agent(
+            initial_state={
+                "system_prompt": "",
+                "model": Model(
+                    id="tiny-auto-compact",
+                    name="Tiny Auto Compact",
+                    provider="faux",
+                    endpoint="anthropic-messages",
+                    capabilities=Capabilities(
+                        input=("text",),
+                        stream=True,
+                        context_window=100,
+                        max_tokens=32,
+                    ),
+                ),
+                "thinking_level": "off",
+            }
+        ),
+        session_manager=manager,
+        settings_manager=SettingsManager(
+            ControlConfig(
+                compaction=CompactionSettings(
+                    enabled=True,
+                    compact_percent=80,
+                    reserve_tokens=10,
+                    keep_recent_tokens=1,
+                )
+            )
+        ),
+    )
+    events: list[dict[str, object]] = []
+
+    def handle_event(event: dict[str, object]) -> None:
+        events.append(event)
+        projector.handle(event)
+
+    unsubscribe = session.subscribe(handle_event)
+    original_stream = summary_module.stream
+    summary_module.stream = _fake_summary_stream
+    early_lines = tuple(f"AUTO_EARLY_{index:03d}" for index in range(1, 81))
+    after_lines = tuple(f"AUTO_AFTER_{index:03d}" for index in range(1, 41))
+    try:
+        await manager.append_message(
+            UserMessage(
+                role="user",
+                content=[TextPart(type="text", text="trigger automatic compaction")],
+                timestamp=0.0,
+            )
+        )
+        app.start_prompt("trigger automatic compaction", started_at=0.0)
+        runtime.render_now()
+        await _emit_assistant_turn(
+            session=session,
+            runtime=runtime,
+            lines=early_lines,
+            total_tokens=95,
+        )
+
+        await manager.append_message(
+            UserMessage(
+                role="user",
+                content=[TextPart(type="text", text="continue after auto compact")],
+                timestamp=2.0,
+            )
+        )
+        app.start_prompt("continue after auto compact", started_at=2.0)
+        runtime.render_now()
+        await _emit_assistant_turn(
+            session=session,
+            runtime=runtime,
+            lines=after_lines,
+            total_tokens=10,
+        )
+    finally:
+        summary_module.stream = original_stream
+        unsubscribe()
+
+    session_file = manager.get_session_file()
+    if session_file is None:
+        raise AssertionError("persistent playback did not materialize a session file")
+    await manager.dispose_runtime_profile()
+
+    resumed = await SessionManager.load(session_file, persist=True)
+    try:
+        resumed_entries = resumed.get_entries()
+        resumed_context = resumed.build_session_context()
+        resumed_history = agent_session_history_records(resumed.get_branch())
+        full_history = "\n".join(
+            _message_text(entry.payload)
+            for entry in resumed_entries
+            if entry.kind == "agent.message"
+        )
+        context_text = "\n".join(
+            _message_text(message) for message in resumed_context.messages
+        )
+        rendered_history_text = "\n".join(
+            record.text
+            for record in resumed_history
+            if isinstance(record, AssistantMessageRecord)
+        )
+        compaction_events = [
+            event
+            for event in events
+            if event.get("type") in {"compaction_start", "compaction_end"}
+        ]
+        evidence = {
+            "sessionFile": str(session_file),
+            "entryCount": len(resumed_entries),
+            "checkpointCount": sum(
+                entry.kind == "context.compaction_checkpoint"
+                for entry in resumed_entries
+            ),
+            "compactionEventTypes": [
+                str(event.get("type")) for event in compaction_events
+            ],
+            "compactionReasons": [
+                str(event.get("reason")) for event in compaction_events
+            ],
+            "compactionStages": [
+                str(event.get("stage")) for event in compaction_events
+            ],
+            "fullHistoryHasEarly": early_lines[0] in full_history
+            and early_lines[-1] in full_history,
+            "fullHistoryHasAfter": after_lines[0] in full_history
+            and after_lines[-1] in full_history,
+            "resumeContextHasSummary": _PRIVATE_SUMMARY in context_text,
+            "resumeContextHasAfter": after_lines[0] in context_text
+            and after_lines[-1] in context_text,
+            "resumeHistoryCheckpointCount": sum(
+                isinstance(record, ContextCompactionRecord)
+                for record in resumed_history
+            ),
+            "resumeHistoryHasEarly": early_lines[0] in rendered_history_text
+            and early_lines[-1] in rendered_history_text,
+            "resumeHistoryHasAfter": after_lines[0] in rendered_history_text
+            and after_lines[-1] in rendered_history_text,
+        }
+    finally:
+        await resumed.dispose_runtime_profile()
+
+    evidence_file.write_text(
+        json.dumps(evidence, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    ready_file.touch()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ready-file", type=Path, required=True)
+    parser.add_argument("--evidence-file", type=Path, required=True)
+    parser.add_argument("--session-dir", type=Path, required=True)
+    args = parser.parse_args()
+    asyncio.run(
+        _render_auto_compact_playback(
+            ready_file=args.ready_file,
+            evidence_file=args.evidence_file,
+            session_dir=args.session_dir,
+        )
+    )
+    while True:
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/coding/tui_support/scenario_binding.py
+++ b/tests/coding/tui_support/scenario_binding.py
@@ -37,6 +37,7 @@ from loushang.harnesstui.testing.scenarios.factory import (
     ScenarioFrameContracts,
 )
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
+from loushang.tui.terminal_input import InputChunkReader
 from tests.coding.tui_support.scenarios.budgets import (
     INTERACTION_FRAME_BUDGET,
     LONG_TRANSCRIPT_FRAME_BUDGET,
@@ -78,6 +79,7 @@ async def run_coding_test_screen(
     keybindings: KeybindingManager | KeybindingConfig | None = None,
     terminal_mode_factory: TerminalModeFactory | None = None,
     terminal_size_provider: TerminalSizeProvider | None = None,
+    input_chunk_reader: InputChunkReader | None = None,
 ) -> int:
     """Bind the Coding test profile directly to canonical screen owners."""
 
@@ -94,6 +96,7 @@ async def run_coding_test_screen(
         keybindings=keybindings,
         terminal_mode_factory=terminal_mode_factory,
         terminal_size_provider=terminal_size_provider,
+        input_chunk_reader=input_chunk_reader,
     )
 
 
@@ -115,6 +118,7 @@ async def run_coding_scenario_screen_loop(
     interruption_message: str,
     cancellation_message: str,
     input_router_factory: ConversationInputRouterFactoryPort | None,
+    input_chunk_reader: InputChunkReader | None,
 ) -> int:
     del input_router_factory
     if (
@@ -138,6 +142,7 @@ async def run_coding_scenario_screen_loop(
         is_local_command=is_local_command,
         terminal_mode_factory=terminal_mode_factory,
         terminal_size_provider=terminal_size_provider,
+        input_chunk_reader=input_chunk_reader,
     )
 
 

--- a/tests/dev/test_verify_pytest_xml.py
+++ b/tests/dev/test_verify_pytest_xml.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_verifier_accepts_nonempty_passing_report_and_required_property(
+    tmp_path: Path,
+) -> None:
+    result = _run_verifier(
+        tmp_path,
+        '<testsuites><testsuite tests="2" skipped="0" failures="0" errors="0">'
+        '<properties><property name="terminal_backend" value="conpty"/>'
+        "</properties></testsuite></testsuites>",
+        "--require-property",
+        "terminal_backend=conpty",
+    )
+
+    assert result.returncode == 0
+    assert "tests=2" in result.stdout
+
+
+def test_verifier_rejects_empty_report(tmp_path: Path) -> None:
+    result = _run_verifier(
+        tmp_path,
+        '<testsuites><testsuite tests="0" skipped="0" failures="0" errors="0"/>'
+        "</testsuites>",
+    )
+
+    assert result.returncode == 1
+    assert "tests must be greater than zero" in result.stderr
+
+
+def test_verifier_rejects_skipped_failed_or_error_results(tmp_path: Path) -> None:
+    result = _run_verifier(
+        tmp_path,
+        '<testsuites><testsuite tests="4" skipped="1" failures="1" errors="1"/>'
+        "</testsuites>",
+    )
+
+    assert result.returncode == 1
+    assert "skipped must be zero" in result.stderr
+    assert "failures must be zero" in result.stderr
+    assert "errors must be zero" in result.stderr
+
+
+def test_verifier_rejects_wrong_required_property(tmp_path: Path) -> None:
+    result = _run_verifier(
+        tmp_path,
+        '<testsuites><testsuite tests="1" skipped="0" failures="0" errors="0">'
+        '<properties><property name="terminal_backend" value="posix-pty"/>'
+        "</properties></testsuite></testsuites>",
+        "--require-property",
+        "terminal_backend=conpty",
+    )
+
+    assert result.returncode == 1
+    assert "terminal_backend" in result.stderr
+
+
+def _run_verifier(
+    tmp_path: Path, xml: str, *args: str
+) -> subprocess.CompletedProcess[str]:
+    report = tmp_path / "pytest.xml"
+    report.write_text(xml, encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            "scripts/dev/verify_pytest_xml.py",
+            str(report),
+            *args,
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )

--- a/tests/harness/transcript/test_summarization.py
+++ b/tests/harness/transcript/test_summarization.py
@@ -28,6 +28,7 @@ def _model(*, supports_stream: bool) -> Model:
 
 def _message(text: str) -> AssistantMessage:
     return AssistantMessage(
+        endpoint="anthropic-messages",
         role="assistant",
         content=[TextPart(type="text", text=text)],
         api="anthropic-messages",

--- a/tests/tui/terminal_process_support/__init__.py
+++ b/tests/tui/terminal_process_support/__init__.py
@@ -1,0 +1,13 @@
+"""Cross-platform native terminal process drivers used only by tests."""
+
+from .environment import terminal_test_environment
+from .factory import selected_backend_name, spawn_terminal_process
+from .protocol import TerminalProcessDiagnostics, TerminalProcessDriver
+
+__all__ = [
+    "TerminalProcessDiagnostics",
+    "TerminalProcessDriver",
+    "selected_backend_name",
+    "spawn_terminal_process",
+    "terminal_test_environment",
+]

--- a/tests/tui/terminal_process_support/base.py
+++ b/tests/tui/terminal_process_support/base.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Literal
+
+from .protocol import TerminalProcessDiagnostics
+from .query_responder import TerminalQueryResponder
+
+
+class BufferedTerminalDriver:
+    backend_name = "unknown"
+    _output_limit = 1_000_000
+
+    def __init__(
+        self,
+        args: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        columns: int,
+        rows: int,
+    ) -> None:
+        self._args = tuple(str(arg) for arg in args)
+        self._cwd = cwd
+        self._env = dict(env)
+        self._columns = columns
+        self._rows = rows
+        self._condition = threading.Condition()
+        self._output = ""
+        self._last_output_at = time.monotonic()
+        self._reader_error: BaseException | None = None
+        self._reader_done = False
+        self._closed = False
+        self._close_lock = threading.Lock()
+        self._writer_lock = threading.Lock()
+        self._termination: str | None = None
+        self._responder = TerminalQueryResponder(
+            rows=rows,
+            columns=columns,
+            respond_to_cell_size=_env_flag(env, "LOUSHANG_TEST_RESPOND_CELL_SIZE"),
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(
+        self, exc_type: object, exc: object, traceback: object
+    ) -> Literal[False]:
+        del exc_type, exc, traceback
+        self.close()
+        return False
+
+    @property
+    def raw_output(self) -> str:
+        with self._condition:
+            return self._output
+
+    def read_until(
+        self, predicate: Callable[[str], bool], *, timeout: float
+    ) -> str:
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._condition:
+            while True:
+                output = self._output
+                self._raise_reader_or_query_error()
+                if predicate(output):
+                    return output
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        "terminal output predicate timed out:\n"
+                        f"{self.diagnostics}"
+                    )
+                self._condition.wait(min(0.05, remaining))
+
+    def _record_output(self, text: str) -> None:
+        if not text:
+            return
+        with self._condition:
+            self._output = (self._output + text)[-self._output_limit :]
+            self._last_output_at = time.monotonic()
+            self._condition.notify_all()
+        for response in self._responder.feed(text):
+            self.write(response)
+
+    def _record_reader_error(self, error: BaseException) -> None:
+        with self._condition:
+            self._reader_error = error
+            self._condition.notify_all()
+
+    def _record_reader_done(self) -> None:
+        with self._condition:
+            self._reader_done = True
+            self._condition.notify_all()
+
+    def _wait_for_idle_output(self, *, timeout: float, idle: float = 0.1) -> None:
+        deadline = time.monotonic() + max(0.0, timeout)
+        with self._condition:
+            while True:
+                self._raise_reader_or_query_error()
+                now = time.monotonic()
+                if self._reader_done or now - self._last_output_at >= idle:
+                    return
+                remaining = deadline - now
+                if remaining <= 0:
+                    raise TimeoutError(f"terminal tail drain timed out:\n{self.diagnostics}")
+                self._condition.wait(min(idle, remaining))
+
+    def _raise_reader_or_query_error(self) -> None:
+        if self._reader_error is not None:
+            raise RuntimeError("terminal reader failed") from self._reader_error
+        if self._responder.unknown_queries:
+            raise RuntimeError(
+                "unsupported blocking terminal query: "
+                + ", ".join(repr(item) for item in self._responder.unknown_queries)
+            )
+
+    def _base_diagnostics(
+        self,
+        *,
+        pid: int | None,
+        exit_status: int | None,
+        reader_alive: bool,
+    ) -> TerminalProcessDiagnostics:
+        return TerminalProcessDiagnostics(
+            backend=self.backend_name,
+            pid=pid,
+            argv=self._args,
+            cwd=self._cwd,
+            columns=self._columns,
+            rows=self._rows,
+            exit_status=exit_status,
+            reader_alive=reader_alive,
+            reader_error=(
+                None
+                if self._reader_error is None
+                else f"{type(self._reader_error).__name__}: {self._reader_error}"
+            ),
+            unknown_queries=tuple(self._responder.unknown_queries),
+            output_tail=self.raw_output[-4000:],
+            termination=self._termination,
+        )
+
+
+def _env_flag(env: Mapping[str, str], name: str) -> bool:
+    for key, value in env.items():
+        if key.casefold() == name.casefold():
+            return value == "1"
+    return False

--- a/tests/tui/terminal_process_support/environment.py
+++ b/tests/tui/terminal_process_support/environment.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+_IDENTITY_VARIABLES = {
+    "colorterm",
+    "ghostty_resources_dir",
+    "ghostty_bin_dir",
+    "kitty_listen_on",
+    "kitty_pid",
+    "ssh_client",
+    "ssh_connection",
+    "ssh_tty",
+    "sty",
+    "term_program",
+    "term_program_version",
+    "tmux",
+    "wezterm_executable",
+    "wezterm_pane",
+    "wsl_distro_name",
+    "wsl_interop",
+    "wt_profile_id",
+    "wt_session",
+}
+
+
+def terminal_test_environment(
+    repo_root: Path,
+    *,
+    base: Mapping[str, str] | None = None,
+    extra: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    source = dict(os.environ if base is None else base)
+    env = {
+        key: value
+        for key, value in source.items()
+        if key.casefold() not in _IDENTITY_VARIABLES
+    }
+    _set_case_insensitive(env, "TERM", "xterm-256color")
+    _set_case_insensitive(env, "COLORTERM", "truecolor")
+    _set_case_insensitive(env, "PYTHONUNBUFFERED", "1")
+    existing_pythonpath = _get_case_insensitive(env, "PYTHONPATH")
+    pythonpath = str(repo_root / "src")
+    if existing_pythonpath:
+        pythonpath = f"{pythonpath}{os.pathsep}{existing_pythonpath}"
+    _set_case_insensitive(env, "PYTHONPATH", pythonpath)
+    for key, value in (extra or {}).items():
+        _set_case_insensitive(env, key, value)
+    return env
+
+
+def _get_case_insensitive(env: Mapping[str, str], name: str) -> str | None:
+    return next(
+        (value for key, value in env.items() if key.casefold() == name.casefold()),
+        None,
+    )
+
+
+def _set_case_insensitive(env: dict[str, str], name: str, value: str) -> None:
+    for key in tuple(env):
+        if key.casefold() == name.casefold():
+            del env[key]
+    env[name] = value

--- a/tests/tui/terminal_process_support/factory.py
+++ b/tests/tui/terminal_process_support/factory.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+from .protocol import TerminalProcessDriver
+
+
+def selected_backend_name() -> str:
+    return "conpty" if os.name == "nt" else "posix-pty"
+
+
+def spawn_terminal_process(
+    args: Sequence[str],
+    *,
+    cwd: Path,
+    env: Mapping[str, str],
+    columns: int = 80,
+    rows: int = 24,
+) -> TerminalProcessDriver:
+    selected = selected_backend_name()
+    required = os.environ.get("LOUSHANG_REQUIRED_TERMINAL_BACKEND")
+    if required is not None and required != selected:
+        raise RuntimeError(
+            f"required terminal backend is {required!r}, selected {selected!r}"
+        )
+    if selected == "conpty":
+        from .windows_conpty import WindowsConPtyDriver
+
+        driver = WindowsConPtyDriver
+    else:
+        from .posix_pty import PosixPtyDriver
+
+        driver = PosixPtyDriver
+    return driver.spawn(
+        args,
+        cwd=cwd,
+        env=env,
+        columns=columns,
+        rows=rows,
+    )

--- a/tests/tui/terminal_process_support/fixture_child.py
+++ b/tests/tui/terminal_process_support/fixture_child.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="scenario", required=True)
+
+    metadata = subparsers.add_parser("metadata")
+    metadata.add_argument("--argument", required=True)
+    metadata.add_argument("--env-name", required=True)
+
+    subparsers.add_parser("resize")
+    subparsers.add_parser("query")
+
+    large = subparsers.add_parser("large")
+    large.add_argument("--size", type=int, default=200_000)
+    large.add_argument("--code", type=int, default=7)
+
+    tree = subparsers.add_parser("tree")
+    tree.add_argument("--pid-file", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.scenario == "metadata":
+        payload = {
+            "argument": args.argument,
+            "cwd": os.getcwd(),
+            "env": os.environ[args.env_name],
+            "size": list(os.get_terminal_size(sys.stdout.fileno())),
+        }
+        sys.stdout.write("META:" + json.dumps(payload, ensure_ascii=False) + "\r\n")
+        sys.stdout.write("UNICODE:中文🙂\r\n")
+        sys.stdout.write("VT:\x1b[31mred\x1b[0m:NO_NEWLINE")
+        sys.stdout.flush()
+        return 0
+    if args.scenario == "resize":
+        initial = os.get_terminal_size(sys.stdout.fileno())
+        print(f"INITIAL_SIZE:{initial.columns}x{initial.lines}", flush=True)
+        sys.stdin.readline()
+        resized = os.get_terminal_size(sys.stdout.fileno())
+        print(f"RESIZED_SIZE:{resized.columns}x{resized.lines}", flush=True)
+        return 0
+    if args.scenario == "query":
+        _enable_immediate_input()
+        sys.stdout.write("\x1b[")
+        sys.stdout.flush()
+        time.sleep(0.01)
+        sys.stdout.write("5n")
+        sys.stdout.flush()
+        status = _read_characters(4)
+        sys.stdout.write("\x1b[6")
+        sys.stdout.flush()
+        time.sleep(0.01)
+        sys.stdout.write("n")
+        sys.stdout.flush()
+        cursor = _read_characters(6)
+        print(f"QUERY_OK:{status.encode().hex()}:{cursor.encode().hex()}", flush=True)
+        return 0 if (status, cursor) == ("\x1b[0n", "\x1b[1;1R") else 9
+    if args.scenario == "large":
+        sys.stdout.write("LARGE_BEGIN" + ("界" * args.size) + "LARGE_END")
+        sys.stdout.flush()
+        return args.code
+    if args.scenario == "tree":
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        args.pid_file.write_text(
+            json.dumps({"root": os.getpid(), "child": child.pid}),
+            encoding="utf-8",
+        )
+        print(f"TREE_READY:{os.getpid()}:{child.pid}", flush=True)
+        time.sleep(60)
+        return 0
+    raise AssertionError(args.scenario)
+
+
+def _enable_immediate_input() -> None:
+    if os.name == "nt":
+        return
+    import termios
+    import tty
+
+    fd = sys.stdin.fileno()
+    tty.setcbreak(fd)
+    attrs = termios.tcgetattr(fd)
+    attrs[3] &= ~termios.ECHO
+    termios.tcsetattr(fd, termios.TCSANOW, attrs)
+
+
+def _read_characters(count: int) -> str:
+    if os.name == "nt":
+        import msvcrt
+
+        return "".join(msvcrt.getwch() for _ in range(count))
+    return sys.stdin.read(count)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tui/terminal_process_support/fixture_child.py
+++ b/tests/tui/terminal_process_support/fixture_child.py
@@ -58,12 +58,14 @@ def main(argv: list[str] | None = None) -> int:
         sys.stdout.write("5n")
         sys.stdout.flush()
         status = _read_characters(4)
+        print(f"STATUS_GOT:{status.encode().hex()}", flush=True)
         sys.stdout.write("\x1b[6")
         sys.stdout.flush()
         time.sleep(0.01)
         sys.stdout.write("n")
         sys.stdout.flush()
         cursor = _read_characters(6)
+        print(f"CURSOR_GOT:{cursor.encode().hex()}", flush=True)
         print(f"QUERY_OK:{status.encode().hex()}:{cursor.encode().hex()}", flush=True)
         return 0 if (status, cursor) == ("\x1b[0n", "\x1b[1;1R") else 9
     if args.scenario == "large":

--- a/tests/tui/terminal_process_support/fixture_child.py
+++ b/tests/tui/terminal_process_support/fixture_child.py
@@ -71,8 +71,7 @@ def main(argv: list[str] | None = None) -> int:
         cursor_is_valid = re.fullmatch(r"\x1b\[[1-9]\d*;[1-9]\d*R", cursor)
         return 0 if status == "\x1b[0n" and cursor_is_valid else 9
     if args.scenario == "large":
-        full_units, remainder = divmod(args.size, 1000)
-        payload = (("x" * 999 + "界") * full_units) + ("x" * remainder)
+        payload = "é" * args.size
         sys.stdout.write("LARGE_BEGIN" + payload + "LARGE_END")
         sys.stdout.flush()
         # Keep the console process alive until the client has observed the

--- a/tests/tui/terminal_process_support/fixture_child.py
+++ b/tests/tui/terminal_process_support/fixture_child.py
@@ -71,7 +71,7 @@ def main(argv: list[str] | None = None) -> int:
         cursor_is_valid = re.fullmatch(r"\x1b\[[1-9]\d*;[1-9]\d*R", cursor)
         return 0 if status == "\x1b[0n" and cursor_is_valid else 9
     if args.scenario == "large":
-        payload = "é" * args.size
+        payload = "界" * args.size
         sys.stdout.write("LARGE_BEGIN" + payload + "LARGE_END")
         sys.stdout.flush()
         # Keep the console process alive until the client has observed the

--- a/tests/tui/terminal_process_support/fixture_child.py
+++ b/tests/tui/terminal_process_support/fixture_child.py
@@ -75,6 +75,11 @@ def main(argv: list[str] | None = None) -> int:
         payload = (("x" * 999 + "界") * full_units) + ("x" * remainder)
         sys.stdout.write("LARGE_BEGIN" + payload + "LARGE_END")
         sys.stdout.flush()
+        # Keep the console process alive until the client has observed the
+        # complete rendered update. ConHost may coalesce/drop outstanding
+        # screen diffs when a producer exits immediately after a huge write;
+        # the separate metadata scenario covers immediate no-newline drain.
+        sys.stdin.readline()
         return args.code
     if args.scenario == "tree":
         child = subprocess.Popen(

--- a/tests/tui/terminal_process_support/fixture_child.py
+++ b/tests/tui/terminal_process_support/fixture_child.py
@@ -91,6 +91,21 @@ def main(argv: list[str] | None = None) -> int:
 
 def _enable_immediate_input() -> None:
     if os.name == "nt":
+        import ctypes
+        import msvcrt
+
+        # ConPTY delivers terminal responses as VT input only when the child
+        # console requests that mode. Disable cooked line/echo handling so a
+        # split DSR response is observable character-for-character.
+        handle = ctypes.c_void_p(msvcrt.get_osfhandle(sys.stdin.fileno()))
+        mode = ctypes.c_uint32()
+        if not ctypes.windll.kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            raise ctypes.WinError()
+        requested = (mode.value | 0x0080 | 0x0200) & ~(0x0002 | 0x0004 | 0x0040)
+        if not ctypes.windll.kernel32.SetConsoleMode(
+            handle, ctypes.c_uint32(requested)
+        ):
+            raise ctypes.WinError()
         return
     import termios
     import tty

--- a/tests/tui/terminal_process_support/fixture_child.py
+++ b/tests/tui/terminal_process_support/fixture_child.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -67,9 +68,12 @@ def main(argv: list[str] | None = None) -> int:
         cursor = _read_characters(6)
         print(f"CURSOR_GOT:{cursor.encode().hex()}", flush=True)
         print(f"QUERY_OK:{status.encode().hex()}:{cursor.encode().hex()}", flush=True)
-        return 0 if (status, cursor) == ("\x1b[0n", "\x1b[1;1R") else 9
+        cursor_is_valid = re.fullmatch(r"\x1b\[[1-9]\d*;[1-9]\d*R", cursor)
+        return 0 if status == "\x1b[0n" and cursor_is_valid else 9
     if args.scenario == "large":
-        sys.stdout.write("LARGE_BEGIN" + ("界" * args.size) + "LARGE_END")
+        full_units, remainder = divmod(args.size, 1000)
+        payload = (("x" * 999 + "界") * full_units) + ("x" * remainder)
+        sys.stdout.write("LARGE_BEGIN" + payload + "LARGE_END")
         sys.stdout.flush()
         return args.code
     if args.scenario == "tree":

--- a/tests/tui/terminal_process_support/fixture_child.py
+++ b/tests/tui/terminal_process_support/fixture_child.py
@@ -71,14 +71,18 @@ def main(argv: list[str] | None = None) -> int:
         cursor_is_valid = re.fullmatch(r"\x1b\[[1-9]\d*;[1-9]\d*R", cursor)
         return 0 if status == "\x1b[0n" and cursor_is_valid else 9
     if args.scenario == "large":
-        payload = "界" * args.size
-        sys.stdout.write("LARGE_BEGIN" + payload + "LARGE_END")
+        _enable_immediate_input()
+        sys.stdout.write("LARGE_BEGIN")
+        for index, offset in enumerate(range(0, args.size, 1000)):
+            chunk_size = min(1000, args.size - offset)
+            sys.stdout.write(("界" * chunk_size) + f"LARGE_CHUNK:{index}:")
+            sys.stdout.flush()
+            if _read_characters(1) != "c":
+                return 10
+        sys.stdout.write("LARGE_END")
         sys.stdout.flush()
-        # Keep the console process alive until the client has observed the
-        # complete rendered update. ConHost may coalesce/drop outstanding
-        # screen diffs when a producer exits immediately after a huge write;
-        # the separate metadata scenario covers immediate no-newline drain.
-        sys.stdin.readline()
+        if _read_characters(1) != "c":
+            return 10
         return args.code
     if args.scenario == "tree":
         child = subprocess.Popen(

--- a/tests/tui/terminal_process_support/posix_pty.py
+++ b/tests/tui/terminal_process_support/posix_pty.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import codecs
+import errno
+import fcntl
+import os
+import pty
+import select
+import signal
+import struct
+import subprocess
+import termios
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from pathlib import Path
+from typing import Self
+
+from .base import BufferedTerminalDriver
+from .protocol import TerminalProcessDiagnostics
+
+
+class PosixPtyDriver(BufferedTerminalDriver):
+    backend_name = "posix-pty"
+
+    def __init__(
+        self,
+        args: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        columns: int,
+        rows: int,
+        master_fd: int,
+        process: subprocess.Popen[bytes],
+    ) -> None:
+        super().__init__(
+            args, cwd=cwd, env=env, columns=columns, rows=rows
+        )
+        self._master_fd = master_fd
+        self._process = process
+        self._stop_reader = threading.Event()
+        self._reader = threading.Thread(
+            target=self._read_loop,
+            name=f"loushang-posix-pty-reader-{process.pid}",
+            daemon=True,
+        )
+        self._reader.start()
+
+    @classmethod
+    def spawn(
+        cls,
+        args: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        columns: int,
+        rows: int,
+    ) -> Self:
+        if not args:
+            raise ValueError("terminal argv must not be empty")
+        master_fd, slave_fd = pty.openpty()
+        try:
+            _set_window_size(slave_fd, columns=columns, rows=rows)
+            process = subprocess.Popen(
+                [str(arg) for arg in args],
+                cwd=cwd,
+                env=dict(env),
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                close_fds=True,
+                start_new_session=True,
+            )
+        except BaseException:
+            os.close(master_fd)
+            raise
+        finally:
+            os.close(slave_fd)
+        os.set_blocking(master_fd, False)
+        return cls(
+            args,
+            cwd=cwd,
+            env=env,
+            columns=columns,
+            rows=rows,
+            master_fd=master_fd,
+            process=process,
+        )
+
+    def write(self, text: str) -> None:
+        with self._writer_lock:
+            if self._closed:
+                raise RuntimeError("terminal driver is closed")
+            payload = text.encode("utf-8")
+            offset = 0
+            while offset < len(payload):
+                offset += os.write(self._master_fd, payload[offset:])
+
+    def resize(self, *, columns: int, rows: int) -> None:
+        _set_window_size(self._master_fd, columns=columns, rows=rows)
+        self._columns = columns
+        self._rows = rows
+        self._responder.columns = columns
+        self._responder.rows = rows
+        with _ignore_process_lookup():
+            os.killpg(self._process.pid, signal.SIGWINCH)
+
+    def is_alive(self) -> bool:
+        return self._process.poll() is None
+
+    def wait(self, *, timeout: float) -> int:
+        try:
+            status = self._process.wait(timeout=max(0.0, timeout))
+        except subprocess.TimeoutExpired as error:
+            raise TimeoutError(f"terminal process wait timed out:\n{self.diagnostics}") from error
+        self._wait_for_idle_output(timeout=min(1.0, max(0.1, timeout)))
+        return status
+
+    def terminate_tree(self, *, timeout: float) -> None:
+        deadline = time.monotonic() + max(0.0, timeout)
+        if not self.is_alive():
+            return
+        self._termination = "SIGTERM process group"
+        with _ignore_process_lookup():
+            os.killpg(self._process.pid, signal.SIGTERM)
+        graceful_deadline = min(deadline, time.monotonic() + 0.5)
+        while self.is_alive() and time.monotonic() < graceful_deadline:
+            time.sleep(0.01)
+        if self.is_alive():
+            self._termination = "SIGKILL process group"
+            with _ignore_process_lookup():
+                os.killpg(self._process.pid, signal.SIGKILL)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError(f"terminal process tree termination timed out:\n{self.diagnostics}")
+        try:
+            self._process.wait(timeout=remaining)
+        except subprocess.TimeoutExpired as error:
+            raise TimeoutError(
+                f"terminal process tree termination timed out:\n{self.diagnostics}"
+            ) from error
+
+    def close(self, *, timeout: float = 5.0) -> None:
+        with self._close_lock:
+            if self._closed:
+                return
+            deadline = time.monotonic() + max(0.0, timeout)
+            try:
+                if self.is_alive():
+                    self.terminate_tree(timeout=max(0.01, deadline - time.monotonic()))
+                self._wait_for_idle_output(
+                    timeout=max(0.01, min(0.5, deadline - time.monotonic()))
+                )
+            finally:
+                self._stop_reader.set()
+                with suppress(OSError):
+                    os.close(self._master_fd)
+                self._reader.join(timeout=max(0.0, deadline - time.monotonic()))
+                self._closed = True
+            if self._reader.is_alive():
+                raise TimeoutError(f"POSIX PTY reader did not stop:\n{self.diagnostics}")
+
+    @property
+    def diagnostics(self) -> TerminalProcessDiagnostics:
+        return self._base_diagnostics(
+            pid=self._process.pid,
+            exit_status=self._process.poll(),
+            reader_alive=self._reader.is_alive(),
+        )
+
+    def _read_loop(self) -> None:
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        try:
+            while not self._stop_reader.is_set():
+                readable, _, _ = select.select([self._master_fd], [], [], 0.05)
+                if not readable:
+                    continue
+                try:
+                    chunk = os.read(self._master_fd, 65_536)
+                except OSError as error:
+                    if error.errno == errno.EIO:
+                        break
+                    raise
+                if not chunk:
+                    break
+                self._record_output(decoder.decode(chunk))
+            tail = decoder.decode(b"", final=True)
+            if tail:
+                self._record_output(tail)
+        except OSError as error:
+            if not self._stop_reader.is_set() and error.errno not in {errno.EBADF}:
+                self._record_reader_error(error)
+        except BaseException as error:
+            self._record_reader_error(error)
+        finally:
+            self._record_reader_done()
+
+
+def _set_window_size(fd: int, *, columns: int, rows: int) -> None:
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, columns, 0, 0))
+
+
+class _ignore_process_lookup:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+        del traceback
+        return exc_type is ProcessLookupError and isinstance(exc, ProcessLookupError)

--- a/tests/tui/terminal_process_support/protocol.py
+++ b/tests/tui/terminal_process_support/protocol.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol, Self
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalProcessDiagnostics:
+    backend: str
+    pid: int | None
+    argv: tuple[str, ...]
+    cwd: Path
+    columns: int
+    rows: int
+    exit_status: int | None
+    reader_alive: bool
+    reader_error: str | None
+    unknown_queries: tuple[str, ...]
+    output_tail: str
+    termination: str | None = None
+
+
+class TerminalProcessDriver(Protocol):
+    backend_name: str
+
+    @classmethod
+    def spawn(
+        cls,
+        args: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        columns: int,
+        rows: int,
+    ) -> Self: ...
+
+    def __enter__(self) -> Self: ...
+
+    def __exit__(
+        self, exc_type: object, exc: object, traceback: object
+    ) -> Literal[False]: ...
+
+    def write(self, text: str) -> None: ...
+
+    def read_until(
+        self, predicate: Callable[[str], bool], *, timeout: float
+    ) -> str: ...
+
+    def resize(self, *, columns: int, rows: int) -> None: ...
+
+    def is_alive(self) -> bool: ...
+
+    def wait(self, *, timeout: float) -> int: ...
+
+    def terminate_tree(self, *, timeout: float) -> None: ...
+
+    def close(self, *, timeout: float = 5.0) -> None: ...
+
+    @property
+    def raw_output(self) -> str: ...
+
+    @property
+    def diagnostics(self) -> TerminalProcessDiagnostics: ...

--- a/tests/tui/terminal_process_support/query_responder.py
+++ b/tests/tui/terminal_process_support/query_responder.py
@@ -36,6 +36,8 @@ class TerminalQueryResponder:
         return tuple(responses)
 
     def _response_for(self, sequence: str) -> tuple[str, ...]:
+        if sequence in {"\x1b[c", "\x1b[0c"}:
+            return ("\x1b[?1;0c",)
         if sequence == "\x1b[5n":
             return ("\x1b[0n",)
         if sequence == "\x1b[6n":

--- a/tests/tui/terminal_process_support/query_responder.py
+++ b/tests/tui/terminal_process_support/query_responder.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class TerminalQueryResponder:
+    """Minimal incremental responder for blocking headless terminal queries."""
+
+    rows: int
+    columns: int
+    respond_to_cell_size: bool = False
+    unknown_queries: list[str] = field(default_factory=list)
+    _control: str = ""
+
+    def feed(self, text: str) -> tuple[str, ...]:
+        responses: list[str] = []
+        for character in text:
+            if not self._control:
+                if character == "\x1b":
+                    self._control = character
+                continue
+            self._control += character
+            if self._control == "\x1b" and character != "[":
+                self._control = "\x1b" if character == "\x1b" else ""
+                continue
+            if not self._control.startswith("\x1b["):
+                continue
+            if len(self._control) == 2:
+                continue
+            if "@" <= character <= "~":
+                responses.extend(self._response_for(self._control))
+                self._control = ""
+            elif len(self._control) > 64:
+                self._control = ""
+        return tuple(responses)
+
+    def _response_for(self, sequence: str) -> tuple[str, ...]:
+        if sequence == "\x1b[5n":
+            return ("\x1b[0n",)
+        if sequence == "\x1b[6n":
+            return ("\x1b[1;1R",)
+        if sequence == "\x1b[16t" and self.respond_to_cell_size:
+            return (f"\x1b[6;{self.rows};{self.columns}t",)
+        if sequence in {"\x1b[?u", "\x1b[16t"}:
+            return ()
+        if sequence.endswith("n"):
+            self.unknown_queries.append(sequence)
+        return ()

--- a/tests/tui/terminal_process_support/windows_conpty.py
+++ b/tests/tui/terminal_process_support/windows_conpty.py
@@ -63,7 +63,7 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
             from winpty.enums import Backend
         except ImportError as error:
             raise RuntimeError(
-                "required pywinpty==3.0.5 dependency is unavailable"
+                "required pywinpty==2.0.15 dependency is unavailable"
             ) from error
         if Backend.ConPTY != 0:
             raise RuntimeError(f"unexpected pywinpty ConPTY backend id: {Backend.ConPTY}")
@@ -186,7 +186,7 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
                 if pty_object is None:
                     break
                 try:
-                    data = pty_object.read(blocking=False)
+                    data = pty_object.read(32768, blocking=False)
                 except BaseException:
                     if pty_object.iseof() or not pty_object.isalive():
                         break

--- a/tests/tui/terminal_process_support/windows_conpty.py
+++ b/tests/tui/terminal_process_support/windows_conpty.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import gc
+import codecs
+import ctypes
 import os
 import shutil
 import subprocess
@@ -8,15 +9,71 @@ import threading
 import time
 from collections.abc import Mapping, Sequence
 from contextlib import suppress
+from ctypes import wintypes
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Self
 
 from .base import BufferedTerminalDriver
 from .protocol import TerminalProcessDiagnostics
 
+_CREATE_UNICODE_ENVIRONMENT = 0x00000400
+_EXTENDED_STARTUPINFO_PRESENT = 0x00080000
+_HANDLE_FLAG_INHERIT = 0x00000001
+_PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE = 0x00020016
+_STATUS_PENDING = 259
+_WAIT_OBJECT_0 = 0
+_WAIT_TIMEOUT = 258
+_ERROR_BROKEN_PIPE = 109
+_ERROR_OPERATION_ABORTED = 995
+_ERROR_NO_DATA = 232
+
+
+class _Coord(ctypes.Structure):
+    _fields_ = [("X", wintypes.SHORT), ("Y", wintypes.SHORT)]
+
+
+class _StartupInfo(ctypes.Structure):
+    _fields_ = [
+        ("cb", wintypes.DWORD),
+        ("lpReserved", wintypes.LPWSTR),
+        ("lpDesktop", wintypes.LPWSTR),
+        ("lpTitle", wintypes.LPWSTR),
+        ("dwX", wintypes.DWORD),
+        ("dwY", wintypes.DWORD),
+        ("dwXSize", wintypes.DWORD),
+        ("dwYSize", wintypes.DWORD),
+        ("dwXCountChars", wintypes.DWORD),
+        ("dwYCountChars", wintypes.DWORD),
+        ("dwFillAttribute", wintypes.DWORD),
+        ("dwFlags", wintypes.DWORD),
+        ("wShowWindow", wintypes.WORD),
+        ("cbReserved2", wintypes.WORD),
+        ("lpReserved2", ctypes.POINTER(wintypes.BYTE)),
+        ("hStdInput", wintypes.HANDLE),
+        ("hStdOutput", wintypes.HANDLE),
+        ("hStdError", wintypes.HANDLE),
+    ]
+
+
+class _StartupInfoEx(ctypes.Structure):
+    _fields_ = [
+        ("StartupInfo", _StartupInfo),
+        ("lpAttributeList", wintypes.LPVOID),
+    ]
+
+
+class _ProcessInformation(ctypes.Structure):
+    _fields_ = [
+        ("hProcess", wintypes.HANDLE),
+        ("hThread", wintypes.HANDLE),
+        ("dwProcessId", wintypes.DWORD),
+        ("dwThreadId", wintypes.DWORD),
+    ]
+
 
 class WindowsConPtyDriver(BufferedTerminalDriver):
-    """Low-level pywinpty driver with one explicitly owned reader thread."""
+    """Test-only ConPTY driver that owns every native handle and thread."""
 
     backend_name = "conpty"
 
@@ -28,18 +85,31 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
         env: Mapping[str, str],
         columns: int,
         rows: int,
-        pty_object: Any,
+        api: _WindowsApi,
+        pseudoconsole: wintypes.HANDLE,
+        input_write: wintypes.HANDLE,
+        output_read: wintypes.HANDLE,
+        process_handle: wintypes.HANDLE,
+        pid: int,
     ) -> None:
         super().__init__(
             args, cwd=cwd, env=env, columns=columns, rows=rows
         )
-        self._pty: Any | None = pty_object
-        self._pid = pty_object.pid
+        self._api = api
+        self._pseudoconsole: wintypes.HANDLE | None = pseudoconsole
+        self._input_write: wintypes.HANDLE | None = input_write
+        self._output_read: wintypes.HANDLE | None = output_read
+        self._process_handle: wintypes.HANDLE | None = process_handle
+        self._pid = pid
         self._exit_status: int | None = None
         self._stop_reader = threading.Event()
+        self._pseudoconsole_close_started = False
+        self._pseudoconsole_close_error: BaseException | None = None
+        self._pseudoconsole_close_thread: threading.Thread | None = None
+        self._transport_finalized = False
         self._reader = threading.Thread(
             target=self._read_loop,
-            name=f"loushang-conpty-reader-{self._pid}",
+            name=f"loushang-conpty-reader-{pid}",
             daemon=True,
         )
         self._reader.start()
@@ -58,69 +128,128 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
             raise RuntimeError("ConPTY is only available on Windows")
         if not args:
             raise ValueError("terminal argv must not be empty")
-        try:
-            from winpty import PTY
-            from winpty.enums import Backend
-        except ImportError as error:
-            raise RuntimeError(
-                "required pywinpty==2.0.15 dependency is unavailable"
-            ) from error
-        if Backend.ConPTY != 0:
-            raise RuntimeError(f"unexpected pywinpty ConPTY backend id: {Backend.ConPTY}")
+        if not cwd.is_dir():
+            raise FileNotFoundError(f"terminal cwd was not found: {cwd}")
+        if columns <= 0 or rows <= 0 or columns > 32767 or rows > 32767:
+            raise ValueError("ConPTY dimensions must be between 1 and 32767")
+
+        api = _WindowsApi()
         executable = _resolve_executable(str(args[0]), env)
-        pty_object = PTY(columns, rows, backend=Backend.ConPTY)
-        environment = "\0".join(f"{key}={value}" for key, value in env.items()) + "\0"
-        arguments = [str(arg) for arg in args[1:]]
-        command_line = None if not arguments else " " + subprocess.list2cmdline(arguments)
-        spawned = pty_object.spawn(
-            str(executable),
-            cmdline=command_line,
-            cwd=str(cwd),
-            env=environment,
-        )
-        if spawned is False or pty_object.pid is None:
-            raise RuntimeError("pywinpty failed to spawn a forced ConPTY process")
+        input_read, input_write = api.create_pipe()
+        output_read, output_write = api.create_pipe()
+        pseudoconsole = wintypes.HANDLE()
+        process_info = _ProcessInformation()
+        attribute_buffer: Any | None = None
+        attribute_list: wintypes.LPVOID | None = None
+        process_created = False
+        try:
+            api.create_pseudoconsole(
+                columns=columns,
+                rows=rows,
+                input_read=input_read,
+                output_write=output_write,
+                result=pseudoconsole,
+            )
+            attribute_buffer, attribute_list = api.create_attribute_list(
+                pseudoconsole
+            )
+            command_line = ctypes.create_unicode_buffer(
+                subprocess.list2cmdline(
+                    [str(executable), *(str(arg) for arg in args[1:])]
+                )
+            )
+            environment = ctypes.create_unicode_buffer(_environment_block(env))
+            startup = _StartupInfoEx()
+            startup.StartupInfo.cb = ctypes.sizeof(_StartupInfoEx)
+            startup.lpAttributeList = attribute_list
+            api.create_process(
+                executable=executable,
+                command_line=command_line,
+                cwd=cwd,
+                environment=environment,
+                startup=startup,
+                process_info=process_info,
+            )
+            process_created = True
+        finally:
+            if attribute_list is not None:
+                api.delete_attribute_list(attribute_list)
+            del attribute_buffer
+            api.close_handle(input_read)
+            api.close_handle(output_write)
+            if process_info.hThread:
+                api.close_handle(process_info.hThread)
+            if not process_created:
+                api.close_handle(input_write)
+                api.close_handle(output_read)
+                if pseudoconsole:
+                    api.close_pseudoconsole(pseudoconsole)
+                if process_info.hProcess:
+                    api.close_handle(process_info.hProcess)
+
         return cls(
             args,
             cwd=cwd,
             env=env,
             columns=columns,
             rows=rows,
-            pty_object=pty_object,
+            api=api,
+            pseudoconsole=pseudoconsole,
+            input_write=input_write,
+            output_read=output_read,
+            process_handle=process_info.hProcess,
+            pid=int(process_info.dwProcessId),
         )
 
     def write(self, text: str) -> None:
+        data = text.encode("utf-8")
         with self._writer_lock:
-            if self._closed or self._pty is None:
+            handle = self._input_write
+            if self._closed or handle is None:
                 raise RuntimeError("terminal driver is closed")
-            self._pty.write(text)
+            offset = 0
+            while offset < len(data):
+                offset += self._api.write_file(handle, data[offset:])
 
     def resize(self, *, columns: int, rows: int) -> None:
-        if self._pty is None:
+        pseudoconsole = self._pseudoconsole
+        if pseudoconsole is None or self._pseudoconsole_close_started:
             raise RuntimeError("terminal driver is closed")
-        self._pty.set_size(columns, rows)
+        self._api.resize_pseudoconsole(pseudoconsole, columns, rows)
         self._columns = columns
         self._rows = rows
         self._responder.columns = columns
         self._responder.rows = rows
 
     def is_alive(self) -> bool:
-        return bool(self._pty is not None and self._pty.isalive())
+        handle = self._process_handle
+        if handle is None:
+            return False
+        result = self._api.wait_for_single_object(handle, 0)
+        if result == _WAIT_TIMEOUT:
+            return True
+        if result == _WAIT_OBJECT_0:
+            return False
+        raise ctypes.WinError(ctypes.get_last_error())
 
     def wait(self, *, timeout: float) -> int:
         deadline = time.monotonic() + max(0.0, timeout)
-        while self.is_alive() and time.monotonic() < deadline:
+        while self.is_alive():
             self._raise_reader_or_query_error()
-            time.sleep(0.01)
-        if self.is_alive():
-            raise TimeoutError(f"ConPTY process wait timed out:\n{self.diagnostics}")
-        if self._pty is not None:
-            self._exit_status = self._pty.get_exitstatus()
-        self._wait_for_idle_output(timeout=max(0.01, deadline - time.monotonic()))
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"ConPTY process wait timed out:\n{self.diagnostics}")
+            handle = self._process_handle
+            assert handle is not None
+            self._api.wait_for_single_object(
+                handle, max(1, min(50, int(remaining * 1000)))
+            )
+        self._capture_exit_status()
+        self._finalize_transport(deadline=deadline)
         return 0 if self._exit_status is None else self._exit_status
 
     def terminate_tree(self, *, timeout: float) -> None:
-        if not self.is_alive() or self._pid is None:
+        if not self.is_alive():
             return
         deadline = time.monotonic() + max(0.0, timeout)
         taskkill = _trusted_taskkill_path(self._env)
@@ -144,64 +273,407 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
             time.sleep(0.01)
         if self.is_alive():
             raise TimeoutError(f"ConPTY process tree remained alive:\n{self.diagnostics}")
+        self._capture_exit_status()
 
     def close(self, *, timeout: float = 5.0) -> None:
         with self._close_lock:
             if self._closed:
                 return
             deadline = time.monotonic() + max(0.0, timeout)
+            failure: BaseException | None = None
             try:
                 if self.is_alive():
                     self.terminate_tree(timeout=max(0.01, deadline - time.monotonic()))
-                self._wait_for_idle_output(
-                    timeout=max(0.01, min(0.5, deadline - time.monotonic()))
-                )
+                self._capture_exit_status()
+                self._finalize_transport(deadline=deadline)
+            except BaseException as error:
+                failure = error
             finally:
-                pty_object, self._pty = self._pty, None
-                if pty_object is not None:
-                    with suppress(BaseException):
-                        self._exit_status = pty_object.get_exitstatus()
-                    with suppress(BaseException):
-                        pty_object.cancel_io()
                 self._stop_reader.set()
+                if self._output_read is not None:
+                    with suppress(BaseException):
+                        self._api.cancel_io(self._output_read)
                 self._reader.join(timeout=max(0.0, deadline - time.monotonic()))
-                del pty_object
-                gc.collect()
+                self._close_output_handle()
+                if self._process_handle is not None:
+                    self._api.close_handle(self._process_handle)
+                    self._process_handle = None
                 self._closed = True
+            if failure is not None:
+                raise failure
             if self._reader.is_alive():
                 raise TimeoutError(f"ConPTY reader did not stop:\n{self.diagnostics}")
 
     @property
     def diagnostics(self) -> TerminalProcessDiagnostics:
-        return self._base_diagnostics(
+        base = self._base_diagnostics(
             pid=self._pid,
             exit_status=self._exit_status,
             reader_alive=self._reader.is_alive(),
         )
+        close_error = self._pseudoconsole_close_error
+        if close_error is None:
+            return base
+        return replace(
+            base,
+            reader_error=(
+                f"ConPTY close {type(close_error).__name__}: {close_error}"
+            ),
+        )
 
     def _read_loop(self) -> None:
+        decoder = codecs.getincrementaldecoder("utf-8")("replace")
         try:
             while not self._stop_reader.is_set():
-                pty_object = self._pty
-                if pty_object is None:
+                handle = self._output_read
+                if handle is None:
                     break
-                try:
-                    data = pty_object.read(32768, blocking=False)
-                except BaseException:
-                    if pty_object.iseof() or not pty_object.isalive():
-                        break
-                    raise
-                if data:
-                    self._record_output(data)
-                if not data and pty_object.iseof():
-                    break
+                data = self._api.read_file(handle, 32768)
                 if not data:
-                    time.sleep(0.002)
+                    break
+                text = decoder.decode(data, final=False)
+                if text:
+                    self._record_output(text)
+            tail = decoder.decode(b"", final=True)
+            if tail:
+                self._record_output(tail)
         except BaseException as error:
             if not self._stop_reader.is_set():
                 self._record_reader_error(error)
         finally:
             self._record_reader_done()
+
+    def _capture_exit_status(self) -> None:
+        if self._exit_status is not None or self._process_handle is None:
+            return
+        status = self._api.get_exit_code(self._process_handle)
+        if status != _STATUS_PENDING:
+            self._exit_status = status
+
+    def _finalize_transport(self, *, deadline: float) -> None:
+        if self._transport_finalized:
+            return
+        self._close_input_handle()
+        self._start_pseudoconsole_close()
+        self._reader.join(timeout=max(0.0, deadline - time.monotonic()))
+        closer = self._pseudoconsole_close_thread
+        if closer is not None:
+            closer.join(timeout=max(0.0, deadline - time.monotonic()))
+        if self._reader.is_alive() or (closer is not None and closer.is_alive()):
+            raise TimeoutError(
+                "ConPTY output/close lifecycle exceeded its deadline:\n"
+                f"{self.diagnostics}"
+            )
+        if self._pseudoconsole_close_error is not None:
+            raise RuntimeError("ClosePseudoConsole failed") from self._pseudoconsole_close_error
+        self._close_output_handle()
+        self._transport_finalized = True
+
+    def _start_pseudoconsole_close(self) -> None:
+        if self._pseudoconsole_close_started:
+            return
+        self._pseudoconsole_close_started = True
+        pseudoconsole = self._pseudoconsole
+        if pseudoconsole is None:
+            return
+
+        def close_pseudoconsole() -> None:
+            try:
+                self._api.close_pseudoconsole(pseudoconsole)
+            except BaseException as error:
+                self._pseudoconsole_close_error = error
+            finally:
+                self._pseudoconsole = None
+
+        self._pseudoconsole_close_thread = threading.Thread(
+            target=close_pseudoconsole,
+            name=f"loushang-conpty-close-{self._pid}",
+            daemon=True,
+        )
+        self._pseudoconsole_close_thread.start()
+
+    def _close_input_handle(self) -> None:
+        with self._writer_lock:
+            if self._input_write is not None:
+                self._api.close_handle(self._input_write)
+                self._input_write = None
+
+    def _close_output_handle(self) -> None:
+        if self._output_read is not None:
+            self._api.close_handle(self._output_read)
+            self._output_read = None
+
+
+class _WindowsApi:
+    def __init__(self) -> None:
+        try:
+            kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+            self.CreatePseudoConsole = kernel32.CreatePseudoConsole
+            self.ResizePseudoConsole = kernel32.ResizePseudoConsole
+            self.ClosePseudoConsole = kernel32.ClosePseudoConsole
+        except (AttributeError, OSError) as error:
+            raise RuntimeError(
+                "ConPTY requires Windows 10 1809/build 17763 or newer"
+            ) from error
+        self.CreatePipe = kernel32.CreatePipe
+        self.SetHandleInformation = kernel32.SetHandleInformation
+        self.InitializeProcThreadAttributeList = (
+            kernel32.InitializeProcThreadAttributeList
+        )
+        self.UpdateProcThreadAttribute = kernel32.UpdateProcThreadAttribute
+        self.DeleteProcThreadAttributeList = kernel32.DeleteProcThreadAttributeList
+        self.CreateProcessW = kernel32.CreateProcessW
+        self.WaitForSingleObject = kernel32.WaitForSingleObject
+        self.GetExitCodeProcess = kernel32.GetExitCodeProcess
+        self.CloseHandle = kernel32.CloseHandle
+        self.ReadFile = kernel32.ReadFile
+        self.WriteFile = kernel32.WriteFile
+        self.CancelIoEx = kernel32.CancelIoEx
+        self._configure_signatures()
+
+    def _configure_signatures(self) -> None:
+        self.CreatePseudoConsole.argtypes = [
+            _Coord,
+            wintypes.HANDLE,
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.HANDLE),
+        ]
+        self.CreatePseudoConsole.restype = wintypes.LONG
+        self.ResizePseudoConsole.argtypes = [wintypes.HANDLE, _Coord]
+        self.ResizePseudoConsole.restype = wintypes.LONG
+        self.ClosePseudoConsole.argtypes = [wintypes.HANDLE]
+        self.ClosePseudoConsole.restype = None
+        self.CreatePipe.argtypes = [
+            ctypes.POINTER(wintypes.HANDLE),
+            ctypes.POINTER(wintypes.HANDLE),
+            wintypes.LPVOID,
+            wintypes.DWORD,
+        ]
+        self.CreatePipe.restype = wintypes.BOOL
+        self.SetHandleInformation.argtypes = [
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.DWORD,
+        ]
+        self.SetHandleInformation.restype = wintypes.BOOL
+        self.InitializeProcThreadAttributeList.argtypes = [
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(ctypes.c_size_t),
+        ]
+        self.InitializeProcThreadAttributeList.restype = wintypes.BOOL
+        self.UpdateProcThreadAttribute.argtypes = [
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.c_size_t,
+            wintypes.LPVOID,
+            ctypes.c_size_t,
+            wintypes.LPVOID,
+            ctypes.POINTER(ctypes.c_size_t),
+        ]
+        self.UpdateProcThreadAttribute.restype = wintypes.BOOL
+        self.DeleteProcThreadAttributeList.argtypes = [wintypes.LPVOID]
+        self.DeleteProcThreadAttributeList.restype = None
+        self.CreateProcessW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.LPWSTR,
+            wintypes.LPVOID,
+            wintypes.LPVOID,
+            wintypes.BOOL,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.LPCWSTR,
+            ctypes.POINTER(_StartupInfoEx),
+            ctypes.POINTER(_ProcessInformation),
+        ]
+        self.CreateProcessW.restype = wintypes.BOOL
+        self.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+        self.WaitForSingleObject.restype = wintypes.DWORD
+        self.GetExitCodeProcess.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self.GetExitCodeProcess.restype = wintypes.BOOL
+        self.CloseHandle.argtypes = [wintypes.HANDLE]
+        self.CloseHandle.restype = wintypes.BOOL
+        self.ReadFile.argtypes = [
+            wintypes.HANDLE,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            wintypes.LPVOID,
+        ]
+        self.ReadFile.restype = wintypes.BOOL
+        self.WriteFile.argtypes = self.ReadFile.argtypes
+        self.WriteFile.restype = wintypes.BOOL
+        self.CancelIoEx.argtypes = [wintypes.HANDLE, wintypes.LPVOID]
+        self.CancelIoEx.restype = wintypes.BOOL
+
+    def create_pipe(self) -> tuple[wintypes.HANDLE, wintypes.HANDLE]:
+        read_handle = wintypes.HANDLE()
+        write_handle = wintypes.HANDLE()
+        if not self.CreatePipe(
+            ctypes.byref(read_handle), ctypes.byref(write_handle), None, 0
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        try:
+            for handle in (read_handle, write_handle):
+                if not self.SetHandleInformation(handle, _HANDLE_FLAG_INHERIT, 0):
+                    raise ctypes.WinError(ctypes.get_last_error())
+        except BaseException:
+            self.close_handle(read_handle)
+            self.close_handle(write_handle)
+            raise
+        return read_handle, write_handle
+
+    def create_pseudoconsole(
+        self,
+        *,
+        columns: int,
+        rows: int,
+        input_read: wintypes.HANDLE,
+        output_write: wintypes.HANDLE,
+        result: wintypes.HANDLE,
+    ) -> None:
+        status = self.CreatePseudoConsole(
+            _Coord(columns, rows),
+            input_read,
+            output_write,
+            0,
+            ctypes.byref(result),
+        )
+        _raise_hresult(status, "CreatePseudoConsole")
+
+    def resize_pseudoconsole(
+        self, pseudoconsole: wintypes.HANDLE, columns: int, rows: int
+    ) -> None:
+        if columns <= 0 or rows <= 0 or columns > 32767 or rows > 32767:
+            raise ValueError("ConPTY dimensions must be between 1 and 32767")
+        _raise_hresult(
+            self.ResizePseudoConsole(pseudoconsole, _Coord(columns, rows)),
+            "ResizePseudoConsole",
+        )
+
+    def close_pseudoconsole(self, pseudoconsole: wintypes.HANDLE) -> None:
+        self.ClosePseudoConsole(pseudoconsole)
+
+    def create_attribute_list(
+        self, pseudoconsole: wintypes.HANDLE
+    ) -> tuple[Any, wintypes.LPVOID]:
+        size = ctypes.c_size_t()
+        self.InitializeProcThreadAttributeList(None, 1, 0, ctypes.byref(size))
+        buffer = ctypes.create_string_buffer(size.value)
+        attribute_list = ctypes.cast(buffer, wintypes.LPVOID)
+        if not self.InitializeProcThreadAttributeList(
+            attribute_list, 1, 0, ctypes.byref(size)
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        if not self.UpdateProcThreadAttribute(
+            attribute_list,
+            0,
+            _PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+            wintypes.LPVOID(pseudoconsole.value),
+            ctypes.sizeof(pseudoconsole),
+            None,
+            None,
+        ):
+            self.DeleteProcThreadAttributeList(attribute_list)
+            raise ctypes.WinError(ctypes.get_last_error())
+        return buffer, attribute_list
+
+    def delete_attribute_list(self, attribute_list: wintypes.LPVOID) -> None:
+        self.DeleteProcThreadAttributeList(attribute_list)
+
+    def create_process(
+        self,
+        *,
+        executable: Path,
+        command_line: Any,
+        cwd: Path,
+        environment: Any,
+        startup: _StartupInfoEx,
+        process_info: _ProcessInformation,
+    ) -> None:
+        if not self.CreateProcessW(
+            str(executable),
+            command_line,
+            None,
+            None,
+            False,
+            _EXTENDED_STARTUPINFO_PRESENT | _CREATE_UNICODE_ENVIRONMENT,
+            ctypes.cast(environment, wintypes.LPVOID),
+            str(cwd),
+            ctypes.byref(startup),
+            ctypes.byref(process_info),
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+
+    def wait_for_single_object(self, handle: wintypes.HANDLE, timeout_ms: int) -> int:
+        return int(self.WaitForSingleObject(handle, max(0, timeout_ms)))
+
+    def get_exit_code(self, handle: wintypes.HANDLE) -> int:
+        status = wintypes.DWORD()
+        if not self.GetExitCodeProcess(handle, ctypes.byref(status)):
+            raise ctypes.WinError(ctypes.get_last_error())
+        return int(status.value)
+
+    def read_file(self, handle: wintypes.HANDLE, size: int) -> bytes:
+        buffer = ctypes.create_string_buffer(size)
+        read = wintypes.DWORD()
+        if not self.ReadFile(handle, buffer, size, ctypes.byref(read), None):
+            error = ctypes.get_last_error()
+            if error in {_ERROR_BROKEN_PIPE, _ERROR_OPERATION_ABORTED, _ERROR_NO_DATA}:
+                return b""
+            raise ctypes.WinError(error)
+        return buffer.raw[: read.value]
+
+    def write_file(self, handle: wintypes.HANDLE, data: bytes) -> int:
+        if not data:
+            return 0
+        buffer = ctypes.create_string_buffer(data)
+        written = wintypes.DWORD()
+        if not self.WriteFile(
+            handle, buffer, len(data), ctypes.byref(written), None
+        ):
+            raise ctypes.WinError(ctypes.get_last_error())
+        if written.value == 0:
+            raise OSError("ConPTY input pipe accepted zero bytes")
+        return int(written.value)
+
+    def cancel_io(self, handle: wintypes.HANDLE) -> None:
+        if not self.CancelIoEx(handle, None):
+            error = ctypes.get_last_error()
+            if error != _ERROR_NOT_FOUND:
+                raise ctypes.WinError(error)
+
+    def close_handle(self, handle: wintypes.HANDLE) -> None:
+        if handle and not self.CloseHandle(handle):
+            raise ctypes.WinError(ctypes.get_last_error())
+
+
+_ERROR_NOT_FOUND = 1168
+
+
+def _raise_hresult(status: int, operation: str) -> None:
+    if status < 0:
+        unsigned = ctypes.c_uint32(status).value
+        raise OSError(f"{operation} failed with HRESULT 0x{unsigned:08X}")
+
+
+def _environment_block(env: Mapping[str, str]) -> str:
+    entries: list[str] = []
+    seen: set[str] = set()
+    for key, value in sorted(env.items(), key=lambda item: item[0].casefold()):
+        folded = key.casefold()
+        if folded in seen:
+            continue
+        if not key or "=" in key or "\0" in key or "\0" in value:
+            raise ValueError(f"invalid Windows environment entry: {key!r}")
+        seen.add(folded)
+        entries.append(f"{key}={value}")
+    return "\0".join(entries) + "\0\0"
 
 
 def _resolve_executable(command: str, env: Mapping[str, str]) -> Path:

--- a/tests/tui/terminal_process_support/windows_conpty.py
+++ b/tests/tui/terminal_process_support/windows_conpty.py
@@ -20,7 +20,9 @@ from .protocol import TerminalProcessDiagnostics
 _CREATE_UNICODE_ENVIRONMENT = 0x00000400
 _EXTENDED_STARTUPINFO_PRESENT = 0x00080000
 _HANDLE_FLAG_INHERIT = 0x00000001
+_STARTF_USESTDHANDLES = 0x00000100
 _PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE = 0x00020016
+_INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
 _STATUS_PENDING = 259
 _WAIT_OBJECT_0 = 0
 _WAIT_TIMEOUT = 258
@@ -87,6 +89,8 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
         rows: int,
         api: _WindowsApi,
         pseudoconsole: wintypes.HANDLE,
+        conpty_input_read: wintypes.HANDLE,
+        conpty_output_write: wintypes.HANDLE,
         input_write: wintypes.HANDLE,
         output_read: wintypes.HANDLE,
         process_handle: wintypes.HANDLE,
@@ -97,6 +101,10 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
         )
         self._api = api
         self._pseudoconsole: wintypes.HANDLE | None = pseudoconsole
+        # CreatePseudoConsole borrows its pipe handles until ClosePseudoConsole.
+        # They are distinct from the client-side handles used by write/read.
+        self._conpty_input_read: wintypes.HANDLE | None = conpty_input_read
+        self._conpty_output_write: wintypes.HANDLE | None = conpty_output_write
         self._input_write: wintypes.HANDLE | None = input_write
         self._output_read: wintypes.HANDLE | None = output_read
         self._process_handle: wintypes.HANDLE | None = process_handle
@@ -161,6 +169,14 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
             environment = ctypes.create_unicode_buffer(_environment_block(env))
             startup = _StartupInfoEx()
             startup.StartupInfo.cb = ctypes.sizeof(_StartupInfoEx)
+            # Windows 7+ may inherit the parent's standard handles even when
+            # bInheritHandles is false. Hosted CI redirects those handles to its
+            # own pipes, so explicitly invalidate them and let ConPTY supply the
+            # console endpoints to the child.
+            startup.StartupInfo.dwFlags = _STARTF_USESTDHANDLES
+            startup.StartupInfo.hStdInput = _INVALID_HANDLE_VALUE
+            startup.StartupInfo.hStdOutput = _INVALID_HANDLE_VALUE
+            startup.StartupInfo.hStdError = _INVALID_HANDLE_VALUE
             startup.lpAttributeList = attribute_list
             api.create_process(
                 executable=executable,
@@ -175,8 +191,6 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
             if attribute_list is not None:
                 api.delete_attribute_list(attribute_list)
             del attribute_buffer
-            api.close_handle(input_read)
-            api.close_handle(output_write)
             if process_info.hThread:
                 api.close_handle(process_info.hThread)
             if not process_created:
@@ -184,6 +198,8 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
                 api.close_handle(output_read)
                 if pseudoconsole:
                     api.close_pseudoconsole(pseudoconsole)
+                api.close_handle(input_read)
+                api.close_handle(output_write)
                 if process_info.hProcess:
                     api.close_handle(process_info.hProcess)
 
@@ -195,6 +211,8 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
             rows=rows,
             api=api,
             pseudoconsole=pseudoconsole,
+            conpty_input_read=input_read,
+            conpty_output_write=output_write,
             input_write=input_write,
             output_read=output_read,
             process_handle=process_info.hProcess,
@@ -384,6 +402,11 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
                 self._pseudoconsole_close_error = error
             finally:
                 self._pseudoconsole = None
+                try:
+                    self._close_conpty_pipe_handles()
+                except BaseException as error:
+                    if self._pseudoconsole_close_error is None:
+                        self._pseudoconsole_close_error = error
 
         self._pseudoconsole_close_thread = threading.Thread(
             target=close_pseudoconsole,
@@ -391,6 +414,24 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
             daemon=True,
         )
         self._pseudoconsole_close_thread.start()
+
+    def _close_conpty_pipe_handles(self) -> None:
+        first_error: BaseException | None = None
+        if self._conpty_input_read is not None:
+            try:
+                self._api.close_handle(self._conpty_input_read)
+            except BaseException as error:
+                first_error = error
+            self._conpty_input_read = None
+        if self._conpty_output_write is not None:
+            try:
+                self._api.close_handle(self._conpty_output_write)
+            except BaseException as error:
+                if first_error is None:
+                    first_error = error
+            self._conpty_output_write = None
+        if first_error is not None:
+            raise first_error
 
     def _close_input_handle(self) -> None:
         with self._writer_lock:
@@ -485,7 +526,7 @@ class _WindowsApi:
             wintypes.DWORD,
             wintypes.LPVOID,
             wintypes.LPCWSTR,
-            ctypes.POINTER(_StartupInfoEx),
+            ctypes.POINTER(_StartupInfo),
             ctypes.POINTER(_ProcessInformation),
         ]
         self.CreateProcessW.restype = wintypes.BOOL
@@ -605,7 +646,7 @@ class _WindowsApi:
             _EXTENDED_STARTUPINFO_PRESENT | _CREATE_UNICODE_ENVIRONMENT,
             ctypes.cast(environment, wintypes.LPVOID),
             str(cwd),
-            ctypes.byref(startup),
+            ctypes.byref(startup.StartupInfo),
             ctypes.byref(process_info),
         ):
             raise ctypes.WinError(ctypes.get_last_error())

--- a/tests/tui/terminal_process_support/windows_conpty.py
+++ b/tests/tui/terminal_process_support/windows_conpty.py
@@ -193,7 +193,7 @@ class WindowsConPtyDriver(BufferedTerminalDriver):
                     raise
                 if data:
                     self._record_output(data)
-                if pty_object.iseof():
+                if not data and pty_object.iseof():
                     break
                 if not data:
                     time.sleep(0.002)

--- a/tests/tui/terminal_process_support/windows_conpty.py
+++ b/tests/tui/terminal_process_support/windows_conpty.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import gc
+import os
+import shutil
+import subprocess
+import threading
+import time
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, Self
+
+from .base import BufferedTerminalDriver
+from .protocol import TerminalProcessDiagnostics
+
+
+class WindowsConPtyDriver(BufferedTerminalDriver):
+    """Low-level pywinpty driver with one explicitly owned reader thread."""
+
+    backend_name = "conpty"
+
+    def __init__(
+        self,
+        args: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        columns: int,
+        rows: int,
+        pty_object: Any,
+    ) -> None:
+        super().__init__(
+            args, cwd=cwd, env=env, columns=columns, rows=rows
+        )
+        self._pty: Any | None = pty_object
+        self._pid = pty_object.pid
+        self._exit_status: int | None = None
+        self._stop_reader = threading.Event()
+        self._reader = threading.Thread(
+            target=self._read_loop,
+            name=f"loushang-conpty-reader-{self._pid}",
+            daemon=True,
+        )
+        self._reader.start()
+
+    @classmethod
+    def spawn(
+        cls,
+        args: Sequence[str],
+        *,
+        cwd: Path,
+        env: Mapping[str, str],
+        columns: int,
+        rows: int,
+    ) -> Self:
+        if os.name != "nt":
+            raise RuntimeError("ConPTY is only available on Windows")
+        if not args:
+            raise ValueError("terminal argv must not be empty")
+        try:
+            from winpty import PTY
+            from winpty.enums import Backend
+        except ImportError as error:
+            raise RuntimeError(
+                "required pywinpty==3.0.5 dependency is unavailable"
+            ) from error
+        if Backend.ConPTY != 0:
+            raise RuntimeError(f"unexpected pywinpty ConPTY backend id: {Backend.ConPTY}")
+        executable = _resolve_executable(str(args[0]), env)
+        pty_object = PTY(columns, rows, backend=Backend.ConPTY)
+        environment = "\0".join(f"{key}={value}" for key, value in env.items()) + "\0"
+        arguments = [str(arg) for arg in args[1:]]
+        command_line = None if not arguments else " " + subprocess.list2cmdline(arguments)
+        spawned = pty_object.spawn(
+            str(executable),
+            cmdline=command_line,
+            cwd=str(cwd),
+            env=environment,
+        )
+        if spawned is False or pty_object.pid is None:
+            raise RuntimeError("pywinpty failed to spawn a forced ConPTY process")
+        return cls(
+            args,
+            cwd=cwd,
+            env=env,
+            columns=columns,
+            rows=rows,
+            pty_object=pty_object,
+        )
+
+    def write(self, text: str) -> None:
+        with self._writer_lock:
+            if self._closed or self._pty is None:
+                raise RuntimeError("terminal driver is closed")
+            self._pty.write(text)
+
+    def resize(self, *, columns: int, rows: int) -> None:
+        if self._pty is None:
+            raise RuntimeError("terminal driver is closed")
+        self._pty.set_size(columns, rows)
+        self._columns = columns
+        self._rows = rows
+        self._responder.columns = columns
+        self._responder.rows = rows
+
+    def is_alive(self) -> bool:
+        return bool(self._pty is not None and self._pty.isalive())
+
+    def wait(self, *, timeout: float) -> int:
+        deadline = time.monotonic() + max(0.0, timeout)
+        while self.is_alive() and time.monotonic() < deadline:
+            self._raise_reader_or_query_error()
+            time.sleep(0.01)
+        if self.is_alive():
+            raise TimeoutError(f"ConPTY process wait timed out:\n{self.diagnostics}")
+        if self._pty is not None:
+            self._exit_status = self._pty.get_exitstatus()
+        self._wait_for_idle_output(timeout=max(0.01, deadline - time.monotonic()))
+        return 0 if self._exit_status is None else self._exit_status
+
+    def terminate_tree(self, *, timeout: float) -> None:
+        if not self.is_alive() or self._pid is None:
+            return
+        deadline = time.monotonic() + max(0.0, timeout)
+        taskkill = _trusted_taskkill_path(self._env)
+        try:
+            completed = subprocess.run(
+                [str(taskkill), "/PID", str(self._pid), "/T", "/F"],
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                capture_output=True,
+                timeout=max(0.01, deadline - time.monotonic()),
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise TimeoutError(f"taskkill timed out:\n{self.diagnostics}") from error
+        self._termination = (
+            f"taskkill rc={completed.returncode}; "
+            f"stdout={completed.stdout[-500:]!r}; stderr={completed.stderr[-500:]!r}"
+        )
+        while self.is_alive() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        if self.is_alive():
+            raise TimeoutError(f"ConPTY process tree remained alive:\n{self.diagnostics}")
+
+    def close(self, *, timeout: float = 5.0) -> None:
+        with self._close_lock:
+            if self._closed:
+                return
+            deadline = time.monotonic() + max(0.0, timeout)
+            try:
+                if self.is_alive():
+                    self.terminate_tree(timeout=max(0.01, deadline - time.monotonic()))
+                self._wait_for_idle_output(
+                    timeout=max(0.01, min(0.5, deadline - time.monotonic()))
+                )
+            finally:
+                pty_object, self._pty = self._pty, None
+                if pty_object is not None:
+                    with suppress(BaseException):
+                        self._exit_status = pty_object.get_exitstatus()
+                    with suppress(BaseException):
+                        pty_object.cancel_io()
+                self._stop_reader.set()
+                self._reader.join(timeout=max(0.0, deadline - time.monotonic()))
+                del pty_object
+                gc.collect()
+                self._closed = True
+            if self._reader.is_alive():
+                raise TimeoutError(f"ConPTY reader did not stop:\n{self.diagnostics}")
+
+    @property
+    def diagnostics(self) -> TerminalProcessDiagnostics:
+        return self._base_diagnostics(
+            pid=self._pid,
+            exit_status=self._exit_status,
+            reader_alive=self._reader.is_alive(),
+        )
+
+    def _read_loop(self) -> None:
+        try:
+            while not self._stop_reader.is_set():
+                pty_object = self._pty
+                if pty_object is None:
+                    break
+                try:
+                    data = pty_object.read(blocking=False)
+                except BaseException:
+                    if pty_object.iseof() or not pty_object.isalive():
+                        break
+                    raise
+                if data:
+                    self._record_output(data)
+                if pty_object.iseof():
+                    break
+                if not data:
+                    time.sleep(0.002)
+        except BaseException as error:
+            if not self._stop_reader.is_set():
+                self._record_reader_error(error)
+        finally:
+            self._record_reader_done()
+
+
+def _resolve_executable(command: str, env: Mapping[str, str]) -> Path:
+    candidate = Path(command)
+    if candidate.is_absolute() and candidate.is_file():
+        return candidate
+    path = next(
+        (value for key, value in env.items() if key.casefold() == "path"),
+        None,
+    )
+    resolved = shutil.which(command, path=path)
+    if resolved is None:
+        raise FileNotFoundError(f"terminal executable was not found: {command}")
+    return Path(resolved).resolve()
+
+
+def _trusted_taskkill_path(env: Mapping[str, str]) -> Path:
+    system_root = next(
+        (value for key, value in env.items() if key.casefold() == "systemroot"),
+        os.environ.get("SystemRoot", r"C:\Windows"),
+    )
+    taskkill = Path(system_root) / "System32" / "taskkill.exe"
+    if not taskkill.is_file():
+        raise FileNotFoundError(f"trusted taskkill.exe was not found: {taskkill}")
+    return taskkill

--- a/tests/tui/test_runner.py
+++ b/tests/tui/test_runner.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from dataclasses import dataclass
 from io import StringIO
-from typing import Any
+from typing import Any, Literal
 
 from loushang.tui import (
     FakeTerminalPort,
@@ -155,10 +154,11 @@ def test_runner_context_request_render_wakes_input_wait() -> None:
 
         return await TuiRunner(
             tui,
-            stdin=_BlockingAfterFirstInput(first="x", block_seconds=0.03),
+            stdin=StringIO(""),
             stdout=stdout,
             terminal_session_factory=_recording_terminal_session_factory(),
             terminal_size_provider=lambda: TerminalSize(columns=20, rows=5),
+            input_chunk_reader=_AsyncAfterFirstInput(first="x", block_seconds=0.03),
         ).run(on_input=handle)
 
     assert asyncio.run(run()) == 0
@@ -202,10 +202,11 @@ def test_runner_rejects_reentrant_run_calls() -> None:
     tui = Tui()
     runner = TuiRunner(
         tui,
-        stdin=_BlockingAfterFirstInput(first="x", block_seconds=0.03),
+        stdin=StringIO(""),
         stdout=StringIO(),
         terminal_session_factory=_recording_terminal_session_factory(),
         terminal_size_provider=lambda: TerminalSize(columns=20, rows=5),
+        input_chunk_reader=_AsyncAfterFirstInput(first="x", block_seconds=0.03),
     )
     errors: list[str] = []
 
@@ -301,10 +302,11 @@ def test_runner_polls_terminal_runtime_fallback_on_idle_wakeup() -> None:
 
         return await TuiRunner(
             Tui(),
-            stdin=_BlockingAfterFirstInput(first="x", block_seconds=0.03),
+            stdin=StringIO(""),
             stdout=StringIO(),
             terminal_session_factory=lambda _stdin, _stdout: session,
             terminal_size_provider=lambda: TerminalSize(columns=20, rows=5),
+            input_chunk_reader=_AsyncAfterFirstInput(first="x", block_seconds=0.03),
         ).run(on_input=handle)
 
     assert asyncio.run(run()) == 0
@@ -347,7 +349,9 @@ class _RecordingTerminalSession:
         self.entered += 1
         return self
 
-    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+    def __exit__(
+        self, exc_type: object, exc: object, traceback: object
+    ) -> Literal[False]:
         self.exited += 1
         return False
 
@@ -378,18 +382,15 @@ def _recording_terminal_session_factory() -> Any:
     return lambda _stdin, _stdout: _RecordingTerminalSession()
 
 
-class _BlockingAfterFirstInput:
+class _AsyncAfterFirstInput:
     def __init__(self, *, first: str, block_seconds: float) -> None:
         self._first = first
         self._block_seconds = block_seconds
         self._calls = 0
 
-    def read(self, _size: int) -> str:
+    async def __call__(self, _stdin: Any) -> str:
         self._calls += 1
         if self._calls == 1:
             return self._first
-        time.sleep(self._block_seconds)
+        await asyncio.sleep(self._block_seconds)
         return ""
-
-    def isatty(self) -> bool:
-        return False

--- a/tests/tui/test_runner_smoke.py
+++ b/tests/tui/test_runner_smoke.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from dataclasses import dataclass
 from io import StringIO
-from typing import Any
+from typing import Any, Literal
 
 from loushang.tui import (
     InputEvent,
@@ -19,13 +18,15 @@ from loushang.tui import (
 )
 
 
-def test_runner_smoke_drives_input_async_render_control_event_and_exit_cleanup() -> None:
+def test_runner_smoke_drives_input_async_render_control_event_and_exit_cleanup() -> (
+    None
+):
     view = _SmokeView()
     tui = Tui()
     tui.add_child(view)
     stdout = StringIO()
     session = _RecordingTerminalSession()
-    stdin = _ScriptedInput(
+    input_chunk_reader = _ScriptedInput(
         (
             "a",
             "\x1b[6;18;9t",
@@ -58,10 +59,11 @@ def test_runner_smoke_drives_input_async_render_control_event_and_exit_cleanup()
 
         return await TuiRunner(
             tui,
-            stdin=stdin,
+            stdin=StringIO(""),
             stdout=stdout,
             terminal_session_factory=lambda _stdin, _stdout: session,
             terminal_size_provider=lambda: TerminalSize(columns=32, rows=8),
+            input_chunk_reader=input_chunk_reader,
         ).run(on_input=handle)
 
     assert asyncio.run(run()) == 0
@@ -82,7 +84,11 @@ def test_runner_smoke_drives_input_async_render_control_event_and_exit_cleanup()
         InputEvent(kind="text", text="q"),
     )
     assert session.control_events == [
-        (InputEvent(kind="signal", signal="cell_size", text="18;9", raw="\x1b[6;18;9t"),)
+        (
+            InputEvent(
+                kind="signal", signal="cell_size", text="18;9", raw="\x1b[6;18;9t"
+            ),
+        )
     ]
     assert session.entered == 1
     assert session.exited == 1
@@ -99,7 +105,10 @@ class _SmokeView:
             f"Count: {self.count}",
             f"Status: {self.status}",
         )
-        return RenderResult.from_lines([RenderLine(row[: constraints.width]) for row in rows], constraints=constraints)
+        return RenderResult.from_lines(
+            [RenderLine(row[: constraints.width]) for row in rows],
+            constraints=constraints,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,17 +121,14 @@ class _ScriptedInput:
     def __init__(self, chunks: tuple[str | _SleepThen, ...]) -> None:
         self._chunks = list(chunks)
 
-    def read(self, _size: int) -> str:
+    async def __call__(self, _stdin: Any) -> str:
         if not self._chunks:
             return ""
         chunk = self._chunks.pop(0)
         if isinstance(chunk, _SleepThen):
-            time.sleep(chunk.seconds)
+            await asyncio.sleep(chunk.seconds)
             return chunk.value
         return chunk
-
-    def isatty(self) -> bool:
-        return False
 
 
 class _RecordingTerminalSession:
@@ -135,7 +141,9 @@ class _RecordingTerminalSession:
         self.entered += 1
         return self
 
-    def __exit__(self, exc_type: object, exc: object, traceback: object) -> bool:
+    def __exit__(
+        self, exc_type: object, exc: object, traceback: object
+    ) -> Literal[False]:
         self.exited += 1
         return False
 

--- a/tests/tui/test_terminal_input.py
+++ b/tests/tui/test_terminal_input.py
@@ -182,17 +182,24 @@ def test_read_input_chunk_or_render_tick_wakes_for_deferred_render_request() -> 
     async def run() -> tuple[str | None, int, int]:
         runtime = _DeferredRuntime()
         render_wakeup = asyncio.Event()
+        release_input = asyncio.Event()
+
+        async def read_after_render(_stdin: object) -> str:
+            await release_input.wait()
+            return ""
 
         async def wake_later() -> None:
-            await asyncio.sleep(0.001)
             render_wakeup.set()
+            while runtime.rendered == 0:
+                await asyncio.sleep(0)
+            release_input.set()
 
         wake_task = asyncio.create_task(wake_later())
         result = await read_input_chunk_or_render_tick(
             StringIO(""),
             runtime=runtime,
             active_task=None,
-            input_chunk_reader=_DelayedInputReader(block_seconds=0.01),
+            input_chunk_reader=read_after_render,
             render_wakeup=render_wakeup,
         )
         await wake_task
@@ -230,31 +237,6 @@ def test_drain_input_consumes_buffered_stringio_text() -> None:
 
     assert drained == "leftover"
     assert stdin.read() == ""
-
-
-def test_drain_input_respects_max_duration_for_continuous_tty_input(
-    monkeypatch,
-) -> None:
-    calls: list[int] = []
-
-    def fake_select(
-        read_list: list[int], _write: list[Any], _error: list[Any], _timeout: float
-    ):
-        return read_list, [], []
-
-    def fake_read(_fd: int, size: int) -> bytes:
-        calls.append(size)
-        return b"x"
-
-    clock = _FloatClock(step=0.004)
-    monkeypatch.setattr("select.select", fake_select)
-    monkeypatch.setattr("os.read", fake_read)
-
-    drained = drain_input(
-        _TtyInput(), max_bytes=1_000, idle_timeout=0.01, max_duration=0.01, now=clock
-    )
-
-    assert 1 <= len(drained) < 1_000
 
 
 def test_input_batch_routes_kitty_protocol_response_as_control_event() -> None:
@@ -532,17 +514,6 @@ class _TtyInput:
 
     def isatty(self) -> bool:
         return True
-
-
-class _FloatClock:
-    def __init__(self, *, step: float) -> None:
-        self.value = 0.0
-        self.step = step
-
-    def __call__(self) -> float:
-        current = self.value
-        self.value += self.step
-        return current
 
 
 def _install_fake_msvcrt(

--- a/tests/tui/test_terminal_input.py
+++ b/tests/tui/test_terminal_input.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import os
 import sys
 import threading
 import time
@@ -11,18 +10,11 @@ from io import StringIO
 from types import SimpleNamespace
 from typing import Any
 
-import pytest
-
 from loushang.tui.input import (
     BRACKETED_PASTE_END,
     BRACKETED_PASTE_START,
     InputEvent,
     InputReader,
-)
-from loushang.tui.keyboard_protocol import (
-    KITTY_QUERY_SEQUENCE,
-    MODIFY_OTHER_KEYS_DISABLE_SEQUENCE,
-    MODIFY_OTHER_KEYS_ENABLE_SEQUENCE,
 )
 from loushang.tui.terminal_input import (
     TerminalInputMode,
@@ -39,76 +31,6 @@ def test_terminal_input_mode_does_not_write_modes_for_non_tty_streams() -> None:
         pass
 
     assert stdout.getvalue() == ""
-
-
-def test_terminal_input_mode_enables_and_restores_tty_modes(monkeypatch: Any) -> None:
-    termios = pytest.importorskip("termios")
-    pytest.importorskip("tty")
-    stdin = _TtyInput()
-    stdout = StringIO()
-    original_attrs = [
-        getattr(termios, "ICRNL", 0),
-        0,
-        0,
-        termios.ECHO
-        | termios.ICANON
-        | getattr(termios, "ISIG", 0)
-        | getattr(termios, "IEXTEN", 0),
-        0,
-        0,
-        [0] * 32,
-    ]
-    tcsetattr_calls: list[tuple[int, int, list[Any]]] = []
-
-    monkeypatch.setattr("termios.tcgetattr", lambda fd: original_attrs)
-    monkeypatch.setattr(
-        "termios.tcsetattr",
-        lambda fd, when, attrs: tcsetattr_calls.append((fd, when, attrs)),
-    )
-    monkeypatch.setattr("tty.setcbreak", lambda fd: None)
-    monkeypatch.setattr(
-        "loushang.tui.terminal_input.drain_input", lambda *args, **kwargs: ""
-    )
-
-    with TerminalInputMode(stdin=stdin, stdout=stdout):
-        pass
-
-    output = stdout.getvalue()
-    assert "\x1b[?2004h" in output
-    assert "\x1b[?1004h" in output
-    assert KITTY_QUERY_SEQUENCE in output
-    assert MODIFY_OTHER_KEYS_ENABLE_SEQUENCE in output
-    assert "\x1b[?2004l" in output
-    assert "\x1b[?1004l" in output
-    assert MODIFY_OTHER_KEYS_DISABLE_SEQUENCE in output
-    active_attrs = tcsetattr_calls[0][2]
-    assert active_attrs[3] & getattr(termios, "IEXTEN", 0) == 0
-    assert tcsetattr_calls[-1] == (stdin.fileno(), termios.TCSADRAIN, original_attrs)
-
-
-def test_terminal_input_mode_delivers_control_v() -> None:
-    if os.name == "nt":
-        pytest.skip("PTY input test uses POSIX termios")
-    pty = pytest.importorskip("pty")
-    select = pytest.importorskip("select")
-    master_fd, slave_fd = pty.openpty()
-    try:
-        with os.fdopen(slave_fd, "r", closefd=False) as stdin:
-            with TerminalInputMode(
-                stdin=stdin,
-                stdout=StringIO(),
-                bracketed_paste=False,
-                focus_events=False,
-                keyboard_protocols=False,
-                drain_on_exit=False,
-            ):
-                os.write(master_fd, b"\x16")
-                readable, _, _ = select.select([slave_fd], [], [], 1.0)
-                assert readable == [slave_fd]
-                assert os.read(slave_fd, 1) == b"\x16"
-    finally:
-        os.close(master_fd)
-        os.close(slave_fd)
 
 
 def test_terminal_input_mode_writes_control_modes_on_windows_without_posix_modules(
@@ -267,9 +189,10 @@ def test_read_input_chunk_or_render_tick_wakes_for_deferred_render_request() -> 
 
         wake_task = asyncio.create_task(wake_later())
         result = await read_input_chunk_or_render_tick(
-            _BlockingOnceInput(block_seconds=0.01),
+            StringIO(""),
             runtime=runtime,
             active_task=None,
+            input_chunk_reader=_DelayedInputReader(block_seconds=0.01),
             render_wakeup=render_wakeup,
         )
         await wake_task
@@ -286,9 +209,10 @@ def test_read_input_chunk_or_render_tick_wakes_for_terminal_runtime_deadline() -
     async def run() -> tuple[str | None, int]:
         runtime = _Runtime()
         result = await read_input_chunk_or_render_tick(
-            _BlockingOnceInput(block_seconds=0.01),
+            StringIO(""),
             runtime=runtime,
             active_task=None,
+            input_chunk_reader=_DelayedInputReader(block_seconds=0.01),
             idle_wakeup_ms=1,
         )
         return result, runtime.rendered
@@ -593,18 +517,13 @@ class _ImmediateDecision:
     delay_ms = 0
 
 
-class _BlockingOnceInput:
+class _DelayedInputReader:
     def __init__(self, *, block_seconds: float) -> None:
         self.block_seconds = block_seconds
 
-    def read(self, _size: int) -> str:
-        import time
-
-        time.sleep(self.block_seconds)
+    async def __call__(self, _stdin: object) -> str:
+        await asyncio.sleep(self.block_seconds)
         return ""
-
-    def isatty(self) -> bool:
-        return False
 
 
 class _TtyInput:
@@ -638,11 +557,7 @@ def _install_fake_msvcrt(
         kbhit=kbhit or (lambda: bool(pending)),
         getwch=getwch or (lambda: pending.pop(0)),
     )
-    original_import_module = importlib.import_module
-
-    def fake_import_module(name: str, package: str | None = None) -> object:
-        if name == "msvcrt":
-            return fake_msvcrt
-        return original_import_module(name, package)
-
-    monkeypatch.setattr("importlib.import_module", fake_import_module)
+    monkeypatch.setattr(
+        "loushang.tui.terminal_input._load_windows_console_module",
+        lambda: fake_msvcrt,
+    )

--- a/tests/tui/test_terminal_input_posix.py
+++ b/tests/tui/test_terminal_input_posix.py
@@ -9,7 +9,7 @@ from loushang.tui.keyboard_protocol import (
     MODIFY_OTHER_KEYS_DISABLE_SEQUENCE,
     MODIFY_OTHER_KEYS_ENABLE_SEQUENCE,
 )
-from loushang.tui.terminal_input import TerminalInputMode
+from loushang.tui.terminal_input import TerminalInputMode, drain_input
 
 
 def test_terminal_input_mode_enables_and_restores_tty_modes(monkeypatch: Any) -> None:
@@ -81,9 +81,45 @@ def test_terminal_input_mode_delivers_control_v() -> None:
         os.close(slave_fd)
 
 
+def test_drain_input_respects_max_duration_for_continuous_tty_input(
+    monkeypatch: Any,
+) -> None:
+    calls: list[int] = []
+
+    def fake_select(
+        read_list: list[int], _write: list[Any], _error: list[Any], _timeout: float
+    ) -> tuple[list[int], list[Any], list[Any]]:
+        return read_list, [], []
+
+    def fake_read(_fd: int, size: int) -> bytes:
+        calls.append(size)
+        return b"x"
+
+    clock = _FloatClock(step=0.004)
+    monkeypatch.setattr("select.select", fake_select)
+    monkeypatch.setattr("os.read", fake_read)
+
+    drained = drain_input(
+        _TtyInput(), max_bytes=1_000, idle_timeout=0.01, max_duration=0.01, now=clock
+    )
+
+    assert 1 <= len(drained) < 1_000
+
+
 class _TtyInput:
     def fileno(self) -> int:
         return 42
 
     def isatty(self) -> bool:
         return True
+
+
+class _FloatClock:
+    def __init__(self, *, step: float) -> None:
+        self.value = 0.0
+        self.step = step
+
+    def __call__(self) -> float:
+        current = self.value
+        self.value += self.step
+        return current

--- a/tests/tui/test_terminal_input_posix.py
+++ b/tests/tui/test_terminal_input_posix.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+from io import StringIO
+from typing import Any
+
+from loushang.tui.keyboard_protocol import (
+    KITTY_QUERY_SEQUENCE,
+    MODIFY_OTHER_KEYS_DISABLE_SEQUENCE,
+    MODIFY_OTHER_KEYS_ENABLE_SEQUENCE,
+)
+from loushang.tui.terminal_input import TerminalInputMode
+
+
+def test_terminal_input_mode_enables_and_restores_tty_modes(monkeypatch: Any) -> None:
+    import termios
+
+    stdin = _TtyInput()
+    stdout = StringIO()
+    original_attrs = [
+        getattr(termios, "ICRNL", 0),
+        0,
+        0,
+        termios.ECHO
+        | termios.ICANON
+        | getattr(termios, "ISIG", 0)
+        | getattr(termios, "IEXTEN", 0),
+        0,
+        0,
+        [0] * 32,
+    ]
+    tcsetattr_calls: list[tuple[int, int, list[Any]]] = []
+
+    monkeypatch.setattr("termios.tcgetattr", lambda fd: original_attrs)
+    monkeypatch.setattr(
+        "termios.tcsetattr",
+        lambda fd, when, attrs: tcsetattr_calls.append((fd, when, attrs)),
+    )
+    monkeypatch.setattr("tty.setcbreak", lambda fd: None)
+    monkeypatch.setattr(
+        "loushang.tui.terminal_input.drain_input", lambda *args, **kwargs: ""
+    )
+
+    with TerminalInputMode(stdin=stdin, stdout=stdout):
+        pass
+
+    output = stdout.getvalue()
+    assert "\x1b[?2004h" in output
+    assert "\x1b[?1004h" in output
+    assert KITTY_QUERY_SEQUENCE in output
+    assert MODIFY_OTHER_KEYS_ENABLE_SEQUENCE in output
+    assert "\x1b[?2004l" in output
+    assert "\x1b[?1004l" in output
+    assert MODIFY_OTHER_KEYS_DISABLE_SEQUENCE in output
+    active_attrs = tcsetattr_calls[0][2]
+    assert active_attrs[3] & getattr(termios, "IEXTEN", 0) == 0
+    assert tcsetattr_calls[-1] == (stdin.fileno(), termios.TCSADRAIN, original_attrs)
+
+
+def test_terminal_input_mode_delivers_control_v() -> None:
+    import pty
+    import select
+
+    master_fd, slave_fd = pty.openpty()
+    try:
+        with os.fdopen(slave_fd, "r", closefd=False) as stdin:
+            with TerminalInputMode(
+                stdin=stdin,
+                stdout=StringIO(),
+                bracketed_paste=False,
+                focus_events=False,
+                keyboard_protocols=False,
+                drain_on_exit=False,
+            ):
+                os.write(master_fd, b"\x16")
+                readable, _, _ = select.select([slave_fd], [], [], 1.0)
+                assert readable == [slave_fd]
+                assert os.read(slave_fd, 1) == b"\x16"
+    finally:
+        os.close(master_fd)
+        os.close(slave_fd)
+
+
+class _TtyInput:
+    def fileno(self) -> int:
+        return 42
+
+    def isatty(self) -> bool:
+        return True

--- a/tests/tui/test_terminal_process_backend.py
+++ b/tests/tui/test_terminal_process_backend.py
@@ -92,8 +92,11 @@ def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
         _fixture_args("large", "--size", "100000", "--code", "7"),
         cwd=tmp_path,
         env=_environment(),
-        columns=80,
-        rows=24,
+        # ConHost interprets and re-emits VT output. A narrow viewport turns a
+        # large double-width line into thousands of scroll/repaint operations,
+        # obscuring the transport/drain behavior this contract is testing.
+        columns=4096,
+        rows=64,
     ) as driver:
         driver.read_until(lambda text: "LARGE_END" in text, timeout=20)
         assert driver.wait(timeout=10) == 7
@@ -113,8 +116,9 @@ def test_terminal_backend_answers_split_dsr_queries(tmp_path: Path) -> None:
         rows=24,
     ) as driver:
         output = driver.read_until(lambda text: "QUERY_OK:" in text, timeout=10)
-        assert driver.wait(timeout=10) == 0
+        status = driver.wait(timeout=10)
 
+    assert status == 0, output
     assert "QUERY_OK:1b5b306e:1b5b313b3152" in output
 
 

--- a/tests/tui/test_terminal_process_backend.py
+++ b/tests/tui/test_terminal_process_backend.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.tui.terminal_process_support import (
+    selected_backend_name,
+    spawn_terminal_process,
+    terminal_test_environment,
+)
+
+pytestmark = pytest.mark.tui_terminal_backend
+
+
+@pytest.fixture(autouse=True)
+def _record_backend(record_testsuite_property) -> None:
+    record_testsuite_property("terminal_backend", selected_backend_name())
+
+
+def test_terminal_backend_preserves_argv_cwd_env_unicode_vt_and_initial_size(
+    tmp_path: Path,
+) -> None:
+    cwd = tmp_path / "目录 with space"
+    cwd.mkdir()
+    env = _environment(extra={"LOUSHANG_FIXTURE_VALUE": "环境 value"})
+    argument = "参数 with space"
+
+    with spawn_terminal_process(
+        _fixture_args(
+            "metadata",
+            "--argument",
+            argument,
+            "--env-name",
+            "LOUSHANG_FIXTURE_VALUE",
+        ),
+        cwd=cwd,
+        env=env,
+        columns=91,
+        rows=27,
+    ) as driver:
+        output = driver.read_until(lambda text: "NO_NEWLINE" in text, timeout=10)
+        status = driver.wait(timeout=10)
+
+    metadata_text = output.split("META:", 1)[1].splitlines()[0]
+    metadata = json.loads(metadata_text)
+    assert status == 0
+    assert metadata == {
+        "argument": argument,
+        "cwd": str(cwd),
+        "env": "环境 value",
+        "size": [91, 27],
+    }
+    assert "UNICODE:中文🙂" in output
+    assert "VT:\x1b[31mred\x1b[0m:NO_NEWLINE" in output
+    assert driver.diagnostics.reader_alive is False
+
+
+def test_terminal_backend_resize_is_visible_to_child(tmp_path: Path) -> None:
+    with spawn_terminal_process(
+        _fixture_args("resize"),
+        cwd=tmp_path,
+        env=_environment(),
+        columns=80,
+        rows=24,
+    ) as driver:
+        driver.read_until(lambda text: "INITIAL_SIZE:80x24" in text, timeout=10)
+        driver.resize(columns=103, rows=31)
+        driver.write("continue\r")
+        output = driver.read_until(
+            lambda text: "RESIZED_SIZE:103x31" in text, timeout=10
+        )
+        assert driver.wait(timeout=10) == 0
+
+    assert "RESIZED_SIZE:103x31" in output
+
+
+def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
+    tmp_path: Path,
+) -> None:
+    with spawn_terminal_process(
+        _fixture_args("large", "--size", "100000", "--code", "7"),
+        cwd=tmp_path,
+        env=_environment(),
+        columns=80,
+        rows=24,
+    ) as driver:
+        driver.read_until(lambda text: "LARGE_END" in text, timeout=20)
+        assert driver.wait(timeout=10) == 7
+        output = driver.raw_output
+
+    assert output.startswith("LARGE_BEGIN")
+    assert output.endswith("LARGE_END")
+    assert output.count("界") == 100_000
+
+
+def test_terminal_backend_answers_split_dsr_queries(tmp_path: Path) -> None:
+    with spawn_terminal_process(
+        _fixture_args("query"),
+        cwd=tmp_path,
+        env=_environment(),
+        columns=80,
+        rows=24,
+    ) as driver:
+        output = driver.read_until(lambda text: "QUERY_OK:" in text, timeout=10)
+        assert driver.wait(timeout=10) == 0
+
+    assert "QUERY_OK:1b5b306e:1b5b313b3152" in output
+
+
+def test_terminal_backend_timeout_terminates_root_and_descendant(
+    tmp_path: Path,
+) -> None:
+    pid_file = tmp_path / "tree-pids.json"
+    driver = spawn_terminal_process(
+        _fixture_args("tree", "--pid-file", str(pid_file)),
+        cwd=tmp_path,
+        env=_environment(),
+        columns=80,
+        rows=24,
+    )
+    try:
+        driver.read_until(lambda text: "TREE_READY:" in text, timeout=10)
+        pids = json.loads(pid_file.read_text(encoding="utf-8"))
+        driver.terminate_tree(timeout=10)
+        _wait_until_processes_exit(tuple(pids.values()), timeout=5)
+    finally:
+        driver.close(timeout=5)
+        driver.close(timeout=5)
+
+    assert driver.is_alive() is False
+    assert driver.diagnostics.reader_alive is False
+
+
+def test_terminal_backend_close_is_idempotent_after_normal_exit(tmp_path: Path) -> None:
+    driver = spawn_terminal_process(
+        _fixture_args("metadata", "--argument", "x", "--env-name", "PATH"),
+        cwd=tmp_path,
+        env=_environment(),
+        columns=80,
+        rows=24,
+    )
+    driver.read_until(lambda text: "NO_NEWLINE" in text, timeout=10)
+    assert driver.wait(timeout=10) == 0
+    driver.close(timeout=5)
+    driver.close(timeout=5)
+
+    assert driver.diagnostics.reader_alive is False
+
+
+def _fixture_args(*args: str) -> list[str]:
+    return [
+        sys.executable,
+        str(
+            Path(__file__).parent
+            / "terminal_process_support"
+            / "fixture_child.py"
+        ),
+        *args,
+    ]
+
+
+def _environment(*, extra: dict[str, str] | None = None) -> dict[str, str]:
+    return terminal_test_environment(_repo_root(), extra=extra)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _wait_until_processes_exit(pids: tuple[int, ...], *, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        alive = tuple(pid for pid in pids if _process_is_alive(pid))
+        if not alive:
+            return
+        time.sleep(0.02)
+    raise AssertionError(f"terminal process tree still alive: {alive}")
+
+
+def _process_is_alive(pid: int) -> bool:
+    if os.name == "nt":
+        import ctypes
+
+        process = ctypes.windll.kernel32.OpenProcess(0x1000, False, pid)
+        if not process:
+            return False
+        try:
+            exit_code = ctypes.c_ulong()
+            if not ctypes.windll.kernel32.GetExitCodeProcess(
+                process, ctypes.byref(exit_code)
+            ):
+                return False
+            return exit_code.value == 259
+        finally:
+            ctypes.windll.kernel32.CloseHandle(process)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True

--- a/tests/tui/test_terminal_process_backend.py
+++ b/tests/tui/test_terminal_process_backend.py
@@ -56,7 +56,13 @@ def test_terminal_backend_preserves_argv_cwd_env_unicode_vt_and_initial_size(
         "size": [91, 27],
     }
     assert "UNICODE:中文🙂" in output
-    assert "VT:\x1b[31mred\x1b[0m:NO_NEWLINE" in output
+    assert any(
+        sequence in output
+        for sequence in (
+            "VT:\x1b[31mred\x1b[0m:NO_NEWLINE",
+            "VT:\x1b[31mred\x1b[m:NO_NEWLINE",
+        )
+    )
     assert driver.diagnostics.reader_alive is False
 
 
@@ -93,8 +99,8 @@ def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
         assert driver.wait(timeout=10) == 7
         output = driver.raw_output
 
-    assert output.startswith("LARGE_BEGIN")
-    assert output.endswith("LARGE_END")
+    assert "LARGE_BEGIN" in output
+    assert "LARGE_END" in output
     assert output.count("界") == 100_000
 
 

--- a/tests/tui/test_terminal_process_backend.py
+++ b/tests/tui/test_terminal_process_backend.py
@@ -90,9 +90,9 @@ def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
     tmp_path: Path,
 ) -> None:
     with spawn_terminal_process(
-        # 40,000 two-byte UTF-8 code points keep the unbroken payload above
-        # 64 KiB while avoiding a ConHost font/render throughput benchmark.
-        _fixture_args("large", "--size", "40000", "--code", "7"),
+        # 22,000 three-byte UTF-8 code points keep the unbroken payload above
+        # 64 KiB while bounding the ConHost screen-render workload.
+        _fixture_args("large", "--size", "22000", "--code", "7"),
         cwd=tmp_path,
         env=_environment(),
         # ConHost interprets and re-emits VT output. A narrow viewport turns a
@@ -108,7 +108,7 @@ def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
 
     assert "LARGE_BEGIN" in output
     assert "LARGE_END" in output
-    assert output.count("é") == 40_000
+    assert output.count("界") == 22_000
 
 
 def test_terminal_backend_answers_split_dsr_queries(tmp_path: Path) -> None:

--- a/tests/tui/test_terminal_process_backend.py
+++ b/tests/tui/test_terminal_process_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import time
 from pathlib import Path
@@ -104,7 +105,8 @@ def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
 
     assert "LARGE_BEGIN" in output
     assert "LARGE_END" in output
-    assert output.count("界") == 100_000
+    assert output.count("界") == 100
+    assert output.count("x") == 99_900
 
 
 def test_terminal_backend_answers_split_dsr_queries(tmp_path: Path) -> None:
@@ -119,7 +121,11 @@ def test_terminal_backend_answers_split_dsr_queries(tmp_path: Path) -> None:
         status = driver.wait(timeout=10)
 
     assert status == 0, output
-    assert "QUERY_OK:1b5b306e:1b5b313b3152" in output
+    query = re.search(r"QUERY_OK:([0-9a-f]+):([0-9a-f]+)", output)
+    assert query is not None
+    assert bytes.fromhex(query.group(1)) == b"\x1b[0n"
+    cursor = bytes.fromhex(query.group(2)).decode("ascii")
+    assert re.fullmatch(r"\x1b\[[1-9]\d*;[1-9]\d*R", cursor)
 
 
 def test_terminal_backend_timeout_terminates_root_and_descendant(

--- a/tests/tui/test_terminal_process_backend.py
+++ b/tests/tui/test_terminal_process_backend.py
@@ -101,8 +101,15 @@ def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
         columns=4096,
         rows=64,
     ) as driver:
-        driver.read_until(lambda text: "LARGE_END" in text, timeout=20)
-        driver.write("continue\r")
+        for index in range(22):
+            marker = f"LARGE_CHUNK:{index}:"
+            driver.read_until(
+                lambda text, marker=marker: marker in text,
+                timeout=10,
+            )
+            driver.write("c")
+        driver.read_until(lambda text: "LARGE_END" in text, timeout=10)
+        driver.write("c")
         assert driver.wait(timeout=10) == 7
         output = driver.raw_output
 

--- a/tests/tui/test_terminal_process_backend.py
+++ b/tests/tui/test_terminal_process_backend.py
@@ -100,6 +100,7 @@ def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
         rows=64,
     ) as driver:
         driver.read_until(lambda text: "LARGE_END" in text, timeout=20)
+        driver.write("continue\r")
         assert driver.wait(timeout=10) == 7
         output = driver.raw_output
 

--- a/tests/tui/test_terminal_process_backend.py
+++ b/tests/tui/test_terminal_process_backend.py
@@ -90,7 +90,9 @@ def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
     tmp_path: Path,
 ) -> None:
     with spawn_terminal_process(
-        _fixture_args("large", "--size", "100000", "--code", "7"),
+        # 40,000 two-byte UTF-8 code points keep the unbroken payload above
+        # 64 KiB while avoiding a ConHost font/render throughput benchmark.
+        _fixture_args("large", "--size", "40000", "--code", "7"),
         cwd=tmp_path,
         env=_environment(),
         # ConHost interprets and re-emits VT output. A narrow viewport turns a
@@ -106,8 +108,7 @@ def test_terminal_backend_drains_large_no_newline_output_and_exit_status(
 
     assert "LARGE_BEGIN" in output
     assert "LARGE_END" in output
-    assert output.count("界") == 100
-    assert output.count("x") == 99_900
+    assert output.count("é") == 40_000
 
 
 def test_terminal_backend_answers_split_dsr_queries(tmp_path: Path) -> None:

--- a/tests/tui/test_terminal_query_responder.py
+++ b/tests/tui/test_terminal_query_responder.py
@@ -15,6 +15,12 @@ def test_responder_handles_split_dsr_and_ignores_ordinary_vt() -> None:
     assert responder.unknown_queries == []
 
 
+def test_responder_answers_conpty_device_attributes_query() -> None:
+    responder = TerminalQueryResponder(rows=24, columns=80)
+
+    assert responder.feed("\x1b[c") == ("\x1b[?1;0c",)
+
+
 def test_responder_does_not_claim_kitty_and_cell_size_has_explicit_profiles() -> None:
     baseline = TerminalQueryResponder(rows=31, columns=103)
     enabled = TerminalQueryResponder(

--- a/tests/tui/test_terminal_query_responder.py
+++ b/tests/tui/test_terminal_query_responder.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from tests.tui.terminal_process_support.query_responder import (
+    TerminalQueryResponder,
+)
+
+
+def test_responder_handles_split_dsr_and_ignores_ordinary_vt() -> None:
+    responder = TerminalQueryResponder(rows=24, columns=80)
+
+    assert responder.feed("ordinary\x1b[31m\x1b[") == ()
+    assert responder.feed("5n") == ("\x1b[0n",)
+    assert responder.feed("\x1b[6") == ()
+    assert responder.feed("n") == ("\x1b[1;1R",)
+    assert responder.unknown_queries == []
+
+
+def test_responder_does_not_claim_kitty_and_cell_size_has_explicit_profiles() -> None:
+    baseline = TerminalQueryResponder(rows=31, columns=103)
+    enabled = TerminalQueryResponder(
+        rows=31, columns=103, respond_to_cell_size=True
+    )
+
+    assert baseline.feed("\x1b[?u\x1b[16t") == ()
+    assert enabled.feed("\x1b[16t") == ("\x1b[6;31;103t",)
+
+
+def test_responder_records_unknown_blocking_query_for_fail_closed_driver() -> None:
+    responder = TerminalQueryResponder(rows=24, columns=80)
+
+    assert responder.feed("\x1b[99n") == ()
+    assert responder.unknown_queries == ["\x1b[99n"]

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -93,7 +93,7 @@ def test_testing_strategy_separates_native_terminal_and_tmux_evidence() -> None:
     ).read_text(encoding="utf-8")
 
     assert "Native Terminal Transport Tests" in strategy
-    assert "pywinpty==2.0.15" in strategy
+    assert "test-only `ctypes`" in strategy
     assert "explicitly selects ConPTY" in strategy
     assert "test_cli_terminal_contract.py" in strategy
     assert "tmux is a separate terminal-implementation integration" in strategy

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -87,6 +87,20 @@ def test_testing_strategy_documents_streaming_control_and_live_smoke() -> None:
     assert "Kitty, iTerm2, WezTerm, Ghostty, VS Code terminal" in strategy
 
 
+def test_testing_strategy_separates_native_terminal_and_tmux_evidence() -> None:
+    strategy = Path(
+        "docs/internals/architecture/tui/native-terminal-core/testing-strategy.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Native Terminal Transport Tests" in strategy
+    assert "pywinpty==3.0.5" in strategy
+    assert "explicitly selects ConPTY" in strategy
+    assert "test_cli_terminal_contract.py" in strategy
+    assert "tmux is a separate terminal-implementation integration" in strategy
+    assert "make test-tui-native" in strategy
+    assert "fails closed" in strategy
+
+
 def test_theme_key_design_lists_editor_selection_token() -> None:
     text = Path(
         "docs/internals/architecture/tui/native-terminal-core/key-designs/KD-009-theme-resolution.md"

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -93,7 +93,7 @@ def test_testing_strategy_separates_native_terminal_and_tmux_evidence() -> None:
     ).read_text(encoding="utf-8")
 
     assert "Native Terminal Transport Tests" in strategy
-    assert "pywinpty==3.0.5" in strategy
+    assert "pywinpty==2.0.15" in strategy
     assert "explicitly selects ConPTY" in strategy
     assert "test_cli_terminal_contract.py" in strategy
     assert "tmux is a separate terminal-implementation integration" in strategy

--- a/uv.lock
+++ b/uv.lock
@@ -584,6 +584,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "ruff" },
     { name = "types-pygments" },
 ]
@@ -601,6 +602,7 @@ requires-dist = [
     { name = "pygments", specifier = ">=2.19,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7,<8" },
+    { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'dev'", specifier = "==3.0.5" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11,<1" },
     { name = "types-pygments", marker = "extra == 'dev'", specifier = ">=2.19,<3" },
     { name = "wcwidth", specifier = "==0.8.2" },
@@ -978,6 +980,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/5c/31feb3dd82d1b33ae0bd09ca601edb993d9da1b7f0226b3336d4b4c39e1e/pywinpty-3.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:af7a8720c78776ddd6259b71dd567944f766a6cd67f8d2887fbc4973967bacda", size = 2092466, upload-time = "2026-06-10T23:44:24.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fe/fe23e2229ffec0c10190cef5964f5c9b2dba179d23b69ae537b7ea90bcab/pywinpty-3.0.5-cp311-cp311-win_arm64.whl", hash = "sha256:c2406f54f699eab75953fb75ce805f2ae55a33a957cd070890abd454fb4b7680", size = 818395, upload-time = "2026-06-10T23:41:56.93Z" },
+    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/f3cd1b1e5fc56517f54452c49f92049e7dd9ffc8a63de22a495581f50d04/pywinpty-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:03bb3c16d691d9242267201830bcd0e64a9b663170e9042bc84b210da9de15ac", size = 2090663, upload-time = "2026-06-10T23:43:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dd/96d6cbfc6d9ddab5c1c2f92c26545ae8997446a2ba7ee2024cd43c81f49b/pywinpty-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:89c5c6ef08997a3b4b277b214a35fe15cab4dd6d119f0140aa71df5b1168fdbc", size = 815700, upload-time = "2026-06-10T23:40:50.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/36/d98087bce0acaa4cce7f196103cfa7be3f63ce65f52473bb3e38784ae5d9/pywinpty-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7b566165e0c5fdd6abe167a5ac8b954be6a843eb55a85946576d6bc1dea03d6d", size = 2090093, upload-time = "2026-06-10T23:40:58.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fd/fe2b0db922ba052ce3976a08f3fc05d0c05047c8b4ebb6102e832b8ef563/pywinpty-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:24366280a8aa677323da87bec729cb3ea3b35367386cece0978bdc6e4695c690", size = 814517, upload-time = "2026-06-10T23:42:34.946Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -602,7 +602,7 @@ requires-dist = [
     { name = "pygments", specifier = ">=2.19,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7,<8" },
-    { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'dev'", specifier = "==3.0.5" },
+    { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'dev'", specifier = "==2.0.15" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11,<1" },
     { name = "types-pygments", marker = "extra == 'dev'", specifier = ">=2.19,<3" },
     { name = "wcwidth", specifier = "==0.8.2" },
@@ -984,22 +984,14 @@ wheels = [
 
 [[package]]
 name = "pywinpty"
-version = "3.0.5"
+version = "2.0.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/7c/917f9c4681bb8d34bfbe0b79d36bbcd902651aeab48790df3d30ba0202fb/pywinpty-2.0.15.tar.gz", hash = "sha256:312cf39153a8736c617d45ce8b6ad6cd2107de121df91c455b10ce6bba7a39b2", size = 29017, upload-time = "2025-02-03T21:53:23.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/5c/31feb3dd82d1b33ae0bd09ca601edb993d9da1b7f0226b3336d4b4c39e1e/pywinpty-3.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:af7a8720c78776ddd6259b71dd567944f766a6cd67f8d2887fbc4973967bacda", size = 2092466, upload-time = "2026-06-10T23:44:24.453Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/fe/fe23e2229ffec0c10190cef5964f5c9b2dba179d23b69ae537b7ea90bcab/pywinpty-3.0.5-cp311-cp311-win_arm64.whl", hash = "sha256:c2406f54f699eab75953fb75ce805f2ae55a33a957cd070890abd454fb4b7680", size = 818395, upload-time = "2026-06-10T23:41:56.93Z" },
-    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
-    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/23/f3cd1b1e5fc56517f54452c49f92049e7dd9ffc8a63de22a495581f50d04/pywinpty-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:03bb3c16d691d9242267201830bcd0e64a9b663170e9042bc84b210da9de15ac", size = 2090663, upload-time = "2026-06-10T23:43:59.845Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/dd/96d6cbfc6d9ddab5c1c2f92c26545ae8997446a2ba7ee2024cd43c81f49b/pywinpty-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:89c5c6ef08997a3b4b277b214a35fe15cab4dd6d119f0140aa71df5b1168fdbc", size = 815700, upload-time = "2026-06-10T23:40:50.001Z" },
-    { url = "https://files.pythonhosted.org/packages/30/36/d98087bce0acaa4cce7f196103cfa7be3f63ce65f52473bb3e38784ae5d9/pywinpty-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7b566165e0c5fdd6abe167a5ac8b954be6a843eb55a85946576d6bc1dea03d6d", size = 2090093, upload-time = "2026-06-10T23:40:58.933Z" },
-    { url = "https://files.pythonhosted.org/packages/57/fd/fe2b0db922ba052ce3976a08f3fc05d0c05047c8b4ebb6102e832b8ef563/pywinpty-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:24366280a8aa677323da87bec729cb3ea3b35367386cece0978bdc6e4695c690", size = 814517, upload-time = "2026-06-10T23:42:34.946Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ac/6884dcb7108af66ad53f73ef4dad096e768c9203a6e6ce5e6b0c4a46e238/pywinpty-2.0.15-cp311-cp311-win_amd64.whl", hash = "sha256:9a6bcec2df2707aaa9d08b86071970ee32c5026e10bcc3cc5f6f391d85baf7ca", size = 1405249, upload-time = "2025-02-03T21:55:47.114Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e5/9714def18c3a411809771a3fbcec70bffa764b9675afb00048a620fca604/pywinpty-2.0.15-cp312-cp312-win_amd64.whl", hash = "sha256:83a8f20b430bbc5d8957249f875341a60219a4e971580f2ba694fbfb54a45ebc", size = 1405243, upload-time = "2025-02-03T21:56:52.476Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/16/2ab7b3b7f55f3c6929e5f629e1a68362981e4e5fed592a2ed1cb4b4914a5/pywinpty-2.0.15-cp313-cp313-win_amd64.whl", hash = "sha256:ab5920877dd632c124b4ed17bc6dd6ef3b9f86cd492b963ffdb1a67b85b0f408", size = 1405020, upload-time = "2025-02-03T21:56:04.753Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/16/edef3515dd2030db2795dbfbe392232c7a0f3dc41b98e92b38b42ba497c7/pywinpty-2.0.15-cp313-cp313t-win_amd64.whl", hash = "sha256:a4560ad8c01e537708d2790dbe7da7d986791de805d89dd0d3697ca59e9e4901", size = 1404151, upload-time = "2025-02-03T21:55:53.628Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -584,7 +584,6 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "ruff" },
     { name = "types-pygments" },
 ]
@@ -602,7 +601,6 @@ requires-dist = [
     { name = "pygments", specifier = ">=2.19,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8,<9" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7,<8" },
-    { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'dev'", specifier = "==2.0.15" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11,<1" },
     { name = "types-pygments", marker = "extra == 'dev'", specifier = ">=2.19,<3" },
     { name = "wcwidth", specifier = "==0.8.2" },
@@ -980,18 +978,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
-]
-
-[[package]]
-name = "pywinpty"
-version = "2.0.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/7c/917f9c4681bb8d34bfbe0b79d36bbcd902651aeab48790df3d30ba0202fb/pywinpty-2.0.15.tar.gz", hash = "sha256:312cf39153a8736c617d45ce8b6ad6cd2107de121df91c455b10ce6bba7a39b2", size = 29017, upload-time = "2025-02-03T21:53:23.265Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/ac/6884dcb7108af66ad53f73ef4dad096e768c9203a6e6ce5e6b0c4a46e238/pywinpty-2.0.15-cp311-cp311-win_amd64.whl", hash = "sha256:9a6bcec2df2707aaa9d08b86071970ee32c5026e10bcc3cc5f6f391d85baf7ca", size = 1405249, upload-time = "2025-02-03T21:55:47.114Z" },
-    { url = "https://files.pythonhosted.org/packages/88/e5/9714def18c3a411809771a3fbcec70bffa764b9675afb00048a620fca604/pywinpty-2.0.15-cp312-cp312-win_amd64.whl", hash = "sha256:83a8f20b430bbc5d8957249f875341a60219a4e971580f2ba694fbfb54a45ebc", size = 1405243, upload-time = "2025-02-03T21:56:52.476Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/16/2ab7b3b7f55f3c6929e5f629e1a68362981e4e5fed592a2ed1cb4b4914a5/pywinpty-2.0.15-cp313-cp313-win_amd64.whl", hash = "sha256:ab5920877dd632c124b4ed17bc6dd6ef3b9f86cd492b963ffdb1a67b85b0f408", size = 1405020, upload-time = "2025-02-03T21:56:04.753Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/16/edef3515dd2030db2795dbfbe392232c7a0f3dc41b98e92b38b42ba497c7/pywinpty-2.0.15-cp313-cp313t-win_amd64.whl", hash = "sha256:a4560ad8c01e537708d2790dbe7da7d986791de805d89dd0d3697ca59e9e4901", size = 1404151, upload-time = "2025-02-03T21:55:53.628Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- defines the reviewed cross-platform terminal test design and tracks it in #445
- removes fake-TTY scripted input and adds fail-closed pytest XML gates
- separates deterministic, platform, native PTY/ConPTY, and tmux evidence
- adds one test-only terminal driver contract with POSIX PTY and direct Win32 ConPTY backends
- runs the same real CLI quit contract and backend conformance suite on Linux and Windows
- makes TuiRunner input reading injectable so deterministic tests never block a real console or executor thread

## Why

Windows previously could not collect or execute POSIX-only PTY tests, and scripted fake TTY input could read the runner console through msvcrt. The suite also lacked a required Windows ConPTY lifecycle gate and could silently pass with skips.

The final Windows backend uses the ConPTY Win32 APIs through ctypes. Both pywinpty candidates were rejected during the lifecycle spike, so this change adds no pywinpty dependency on either platform.

## Validation

- GitHub Windows Server 2022 native ConPTY gate passes output/backpressure, UTF-8, query response, resize, exit-code, timeout/process-tree, EOF drain, idempotent close, and the real CLI quit contract
- all 17 pull-request checks pass on the previously published revision, including all 7 TUI workflow jobs across Ubuntu, Windows, and tmux
- local full TUI suite: 1273 passed
- local Harnesstui gate: ruff and mypy pass; 1246 passed, 65 deselected
- required pytest XML gates reject zero-test, skipped, failed, and errored runs

The PR remains draft only for final review and the separate Windows 10 desktop-host release-validation step; hosted Windows ConPTY support is implemented and green.
