### PR TITLE
test(tui): fail fast on stalled lifecycle gates

### DIFF
--- a/.github/workflows/harnesstui-quality.yml
+++ b/.github/workflows/harnesstui-quality.yml
@@ -6,9 +6,14 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   harnesstui-quality:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -21,5 +26,23 @@ jobs:
       - name: Install dependencies
         run: make bootstrap
 
+      - name: Create report directory
+        run: uv run python -c "from pathlib import Path; Path('.artifacts').mkdir(exist_ok=True)"
+
       - name: Harnesstui quality gate
+        env:
+          PYTEST_ADDOPTS: >-
+            -o faulthandler_timeout=60
+            --junitxml=.artifacts/harnesstui-quality.xml
         run: make check-harnesstui
+
+      - name: Reject empty, skipped, or failing report
+        run: uv run python scripts/dev/verify_pytest_xml.py .artifacts/harnesstui-quality.xml
+
+      - name: Upload pytest report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: harnesstui-quality-pytest-report
+          path: .artifacts/harnesstui-quality.xml
+          if-no-files-found: warn

--- a/.github/workflows/tui-render-contract.yml
+++ b/.github/workflows/tui-render-contract.yml
@@ -6,6 +6,13 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTEST_ADDOPTS: "-o faulthandler_timeout=60"
+
 jobs:
   deterministic-render:
     name: deterministic-render (${{ matrix.os }})
@@ -161,3 +168,33 @@ jobs:
 
       - name: Reject empty, skipped, or failing report
         run: uv run python scripts/dev/verify_pytest_xml.py .artifacts/tmux-scrollback.xml
+
+  tui-cross-platform-contracts:
+    name: tui-cross-platform-contracts
+    if: always()
+    needs:
+      - deterministic-render
+      - terminal-platform-unit
+      - native-terminal
+      - tmux-scrollback
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every cross-platform terminal contract
+        env:
+          DETERMINISTIC_RENDER: ${{ needs.deterministic-render.result }}
+          TERMINAL_PLATFORM_UNIT: ${{ needs.terminal-platform-unit.result }}
+          NATIVE_TERMINAL: ${{ needs.native-terminal.result }}
+          TMUX_SCROLLBACK: ${{ needs.tmux-scrollback.result }}
+        run: |
+          for result in \
+            "$DETERMINISTIC_RENDER" \
+            "$TERMINAL_PLATFORM_UNIT" \
+            "$NATIVE_TERMINAL" \
+            "$TMUX_SCROLLBACK"
+          do
+            if [ "$result" != "success" ]; then
+              echo "required TUI job did not succeed: $result" >&2
+              exit 1
+            fi
+          done

--- a/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
+++ b/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
@@ -145,6 +145,19 @@ separate fixed-Ubuntu required job. Each required job emits pytest XML and
 fails closed when the report is empty, skipped, failing, or records the wrong
 native backend.
 
+Both TUI workflows cancel superseded runs for the same ref. Every pytest job
+uses a bounded GitHub job timeout and `faulthandler_timeout=60`, so a stalled
+async lifecycle emits a Python stack before the runner deadline. The
+Harnesstui quality job also persists JUnit XML and passes it through the same
+fail-closed verifier. `tui-cross-platform-contracts` is the stable aggregate
+required-check context: it succeeds only after every Linux, Windows, native
+terminal, and tmux dependency succeeds.
+
+Deterministic screen-loop lifecycle recipes use `BlockingPromptController`
+for prompts that settle during abort. Its one-shot context requires the prompt
+to start, receive settlement from the abort callback, finish within a bounded
+deadline, and leave no active asyncio task when the recipe returns.
+
 ## Live Terminal Smoke Checklist
 
 Manual testing should focus on terminal behavior that is hard to assert

--- a/src/loushang/harnesstui/testing/scenarios/lifecycle.py
+++ b/src/loushang/harnesstui/testing/scenarios/lifecycle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from typing import Generic, Protocol, TypeVar
 
@@ -13,6 +12,7 @@ from loushang.harnesstui.testing.scenarios.factory import (
     ScenarioFrameContracts,
 )
 from loushang.harnesstui.testing.screen_loop_playback import (
+    BlockingPromptController,
     ConversationScreenLoopPlaybackResult,
 )
 from loushang.tui.playback_suite import PlaybackScenarioSpec
@@ -163,7 +163,7 @@ class _LifecycleRecipes(Generic[AppT]):
         scenario = self.factory.loop_scenario()
         prompts: list[str] = []
         steers: list[str] = []
-        abort_settled = asyncio.Event()
+        blocking_prompt = BlockingPromptController()
 
         async def handle_prompt(text: str) -> None:
             prompts.append(text)
@@ -172,27 +172,28 @@ class _LifecycleRecipes(Generic[AppT]):
                 scenario.app.append_assistant_chunk("fresh response")
                 return
             scenario.app.append_assistant_chunk("old response")
-            await abort_settled.wait()
+            await blocking_prompt.wait_until_settled()
 
         async def handle_steer(text: str) -> None:
             steers.append(text)
 
-        result = (
-            scenario.type_text("old")
-            .enter()
-            .wait(0.01)
-            .type_text("fresh")
-            .enter()
-            .wait(0.01)
-            .escape()
-            .wait(0.04)
-            .end_input()
-            .run(
-                handle_prompt=handle_prompt,
-                handle_steer=handle_steer,
-                on_abort=abort_settled.set,
+        with blocking_prompt:
+            result = (
+                scenario.type_text("old")
+                .enter()
+                .wait(0.01)
+                .type_text("fresh")
+                .enter()
+                .wait(0.01)
+                .escape()
+                .wait(0.04)
+                .end_input()
+                .run(
+                    handle_prompt=handle_prompt,
+                    handle_steer=handle_steer,
+                    on_abort=blocking_prompt.settle_on_abort,
+                )
             )
-        )
         result.assert_exit_code(0)
         result.assert_text_contains("old")
         result.assert_text_contains("fresh")
@@ -211,7 +212,7 @@ class _LifecycleRecipes(Generic[AppT]):
         scenario = self.factory.loop_scenario().with_pending_steers("prequeued")
         prompts: list[str] = []
         steers: list[str] = []
-        abort_settled = asyncio.Event()
+        blocking_prompt = BlockingPromptController()
 
         async def handle_prompt(text: str) -> None:
             if text == "prequeued":
@@ -219,27 +220,28 @@ class _LifecycleRecipes(Generic[AppT]):
                 return
             scenario.app.begin_assistant()
             scenario.app.append_assistant_chunk("working")
-            await abort_settled.wait()
+            await blocking_prompt.wait_until_settled()
 
         async def handle_steer(text: str) -> None:
             steers.append(text)
 
-        result = (
-            scenario.type_text("start")
-            .enter()
-            .wait(0.01)
-            .type_text("running steer")
-            .enter()
-            .wait(0.01)
-            .escape()
-            .wait(0.04)
-            .end_input()
-            .run(
-                handle_prompt=handle_prompt,
-                handle_steer=handle_steer,
-                on_abort=abort_settled.set,
+        with blocking_prompt:
+            result = (
+                scenario.type_text("start")
+                .enter()
+                .wait(0.01)
+                .type_text("running steer")
+                .enter()
+                .wait(0.01)
+                .escape()
+                .wait(0.04)
+                .end_input()
+                .run(
+                    handle_prompt=handle_prompt,
+                    handle_steer=handle_steer,
+                    on_abort=blocking_prompt.settle_on_abort,
+                )
             )
-        )
         result.assert_exit_code(0)
         assert steers == ["running steer"]
         assert prompts == ["prequeued"]
@@ -252,25 +254,29 @@ class _LifecycleRecipes(Generic[AppT]):
     ) -> ConversationScreenLoopPlaybackResult[AppT]:
         scenario = self.factory.loop_scenario().with_pending_steers("queued")
         prompts: list[str] = []
-        abort_settled = asyncio.Event()
+        blocking_prompt = BlockingPromptController()
 
         async def handle_prompt(text: str) -> None:
             if text == "queued":
                 prompts.append(text)
                 return
-            await abort_settled.wait()
+            await blocking_prompt.wait_until_settled()
 
-        result = (
-            scenario.type_text("start")
-            .enter()
-            .wait(0.01)
-            .type_text("draft")
-            .wait(0.01)
-            .escape()
-            .wait(0.04)
-            .end_input()
-            .run(handle_prompt=handle_prompt, on_abort=abort_settled.set)
-        )
+        with blocking_prompt:
+            result = (
+                scenario.type_text("start")
+                .enter()
+                .wait(0.01)
+                .type_text("draft")
+                .wait(0.01)
+                .escape()
+                .wait(0.04)
+                .end_input()
+                .run(
+                    handle_prompt=handle_prompt,
+                    on_abort=blocking_prompt.settle_on_abort,
+                )
+            )
         result.assert_exit_code(0)
         assert prompts == ["queued"]
         result.assert_composer_text("draft")
@@ -284,27 +290,28 @@ class _LifecycleRecipes(Generic[AppT]):
         scenario = self.factory.loop_scenario()
         prompts: list[str] = []
         aborts: list[str] = []
-        abort_settled = asyncio.Event()
+        blocking_prompt = BlockingPromptController()
 
         async def handle_prompt(text: str) -> None:
             prompts.append(text)
             scenario.app.begin_assistant()
             scenario.app.append_assistant_chunk("working before ctrl-c")
-            await abort_settled.wait()
+            await blocking_prompt.wait_until_settled()
 
         async def on_abort() -> None:
             aborts.append("abort")
-            abort_settled.set()
+            blocking_prompt.settle_on_abort()
 
-        result = (
-            scenario.type_text("long running")
-            .enter()
-            .wait(0.01)
-            .ctrl_c()
-            .wait(0.04)
-            .end_input()
-            .run(handle_prompt=handle_prompt, on_abort=on_abort)
-        )
+        with blocking_prompt:
+            result = (
+                scenario.type_text("long running")
+                .enter()
+                .wait(0.01)
+                .ctrl_c()
+                .wait(0.04)
+                .end_input()
+                .run(handle_prompt=handle_prompt, on_abort=on_abort)
+            )
         result.assert_exit_code(0)
         assert prompts == ["long running"]
         assert aborts == ["abort"]
@@ -357,5 +364,6 @@ class _LifecycleRecipes(Generic[AppT]):
         result.assert_no_clear_screen()
         result.assert_cursor_matches_diagnostics()
         self.contracts.assert_interaction(result)
+
 
 __all__ = ["LifecycleScenarioAppPort", "lifecycle_scenarios"]

--- a/src/loushang/harnesstui/testing/screen_loop_playback.py
+++ b/src/loushang/harnesstui/testing/screen_loop_playback.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 from collections.abc import Coroutine, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -109,6 +110,87 @@ class TimedInputChunkReader:
             await asyncio.sleep(delay)
         self._index += 1
         return chunk.data
+
+
+class BlockingPromptController:
+    """Bound one abort-settled prompt used by deterministic lifecycle tests.
+
+    The prompt handler awaits :meth:`wait_until_settled`, while the simulated
+    abort callback invokes :meth:`settle_on_abort`.  The context manager fails
+    closed unless the prompt started, the abort released it, and its task
+    finished before the scenario returned.
+    """
+
+    def __init__(self, *, timeout_seconds: float = 1.0) -> None:
+        if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+            raise ValueError("blocking prompt timeout must be finite and greater than zero")
+        self._timeout_seconds = timeout_seconds
+        self._started = False
+        self._settle_requested = False
+        self._finished = False
+        self._settled_event: asyncio.Event | None = None
+        self._waiter: asyncio.Task[object] | None = None
+
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    @property
+    def settled(self) -> bool:
+        return self._settle_requested and self._finished
+
+    async def wait_until_settled(self) -> None:
+        if self._started:
+            raise RuntimeError("blocking prompt controller supports one prompt")
+        waiter = asyncio.current_task()
+        if waiter is None:
+            raise RuntimeError("blocking prompt must run inside an asyncio task")
+        self._started = True
+        self._waiter = waiter
+        settled_event = asyncio.Event()
+        self._settled_event = settled_event
+        if self._settle_requested:
+            settled_event.set()
+        try:
+            await asyncio.wait_for(
+                settled_event.wait(),
+                timeout=self._timeout_seconds,
+            )
+        except TimeoutError as error:
+            raise AssertionError(
+                "blocking prompt was not settled by abort within "
+                f"{self._timeout_seconds:.3f}s"
+            ) from error
+        finally:
+            self._finished = True
+
+    def settle_on_abort(self) -> None:
+        self._settle_requested = True
+        if self._settled_event is not None:
+            self._settled_event.set()
+
+    def assert_finished(self) -> None:
+        if not self._started:
+            raise AssertionError("blocking prompt never started")
+        if not self._settle_requested:
+            raise AssertionError("blocking prompt abort never requested settlement")
+        if not self._finished:
+            raise AssertionError("blocking prompt did not finish")
+        if self._waiter is None or not self._waiter.done():
+            raise AssertionError("blocking prompt left a residual asyncio task")
+
+    def __enter__(self) -> BlockingPromptController:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: object,
+        _exc: object,
+        _traceback: object,
+    ) -> Literal[False]:
+        if exc_type is None:
+            self.assert_finished()
+        return False
 
 
 @dataclass(frozen=True, slots=True)
@@ -410,6 +492,7 @@ def _ignore_abort() -> None:
 
 
 __all__ = [
+    "BlockingPromptController",
     "ConversationScreenLoopArtifacts",
     "ConversationScreenLoopPlayback",
     "ConversationScreenLoopPlaybackResult",

--- a/tests/coding/test_screen_tui_playback_harness.py
+++ b/tests/coding/test_screen_tui_playback_harness.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-import asyncio
 import json
 
 import pytest
 
 from loushang.harnesstui.testing.performance import (
     build_synthetic_long_transcript_records,
+)
+from loushang.harnesstui.testing.screen_loop_playback import (
+    BlockingPromptController,
 )
 from loushang.tui import (
     PLAYBACK_ARTIFACTS_ENV,
@@ -343,7 +345,7 @@ def test_screen_tui_loop_playback_drives_running_steer_then_escape() -> None:
     scenario = ScreenTuiLoopScenario()
     prompts: list[str] = []
     steers: list[tuple[str, str]] = []
-    abort_settled = asyncio.Event()
+    blocking_prompt = BlockingPromptController()
 
     async def handle_prompt(text: str) -> None:
         prompts.append(text)
@@ -353,27 +355,28 @@ def test_screen_tui_loop_playback_drives_running_steer_then_escape() -> None:
             return
         scenario.app.begin_assistant()
         scenario.app.append_assistant_chunk("working")
-        await abort_settled.wait()
+        await blocking_prompt.wait_until_settled()
 
     async def handle_steer(text: str) -> None:
         steers.append(("queue" if scenario.app.state.running else "execute", text))
 
-    result = (
-        scenario.type_text("go")
-        .enter()
-        .wait(0.01)
-        .type_text("change")
-        .enter()
-        .wait(0.01)
-        .escape()
-        .wait(0.04)
-        .end_input()
-        .run(
-            handle_prompt=handle_prompt,
-            handle_steer=handle_steer,
-            on_abort=abort_settled.set,
+    with blocking_prompt:
+        result = (
+            scenario.type_text("go")
+            .enter()
+            .wait(0.01)
+            .type_text("change")
+            .enter()
+            .wait(0.01)
+            .escape()
+            .wait(0.04)
+            .end_input()
+            .run(
+                handle_prompt=handle_prompt,
+                handle_steer=handle_steer,
+                on_abort=blocking_prompt.settle_on_abort,
+            )
         )
-    )
 
     with result.write_artifacts_on_failure_from_env(
         basename="screen-loop-running-steer-escape"
@@ -490,7 +493,7 @@ def test_screen_tui_loop_scenario_drives_escape_pending_steer_flow() -> None:
     scenario = ScreenTuiLoopScenario()
     prompts: list[str] = []
     steers: list[str] = []
-    abort_settled = asyncio.Event()
+    blocking_prompt = BlockingPromptController()
 
     async def handle_prompt(text: str) -> None:
         prompts.append(text)
@@ -500,27 +503,28 @@ def test_screen_tui_loop_scenario_drives_escape_pending_steer_flow() -> None:
             return
         scenario.app.begin_assistant()
         scenario.app.append_assistant_chunk("old response")
-        await abort_settled.wait()
+        await blocking_prompt.wait_until_settled()
 
     async def handle_steer(text: str) -> None:
         steers.append(text)
 
-    result = (
-        scenario.type_text("old")
-        .enter()
-        .wait(0.01)
-        .type_text("fresh")
-        .enter()
-        .wait(0.01)
-        .escape()
-        .wait(0.04)
-        .end_input()
-        .run(
-            handle_prompt=handle_prompt,
-            handle_steer=handle_steer,
-            on_abort=abort_settled.set,
+    with blocking_prompt:
+        result = (
+            scenario.type_text("old")
+            .enter()
+            .wait(0.01)
+            .type_text("fresh")
+            .enter()
+            .wait(0.01)
+            .escape()
+            .wait(0.04)
+            .end_input()
+            .run(
+                handle_prompt=handle_prompt,
+                handle_steer=handle_steer,
+                on_abort=blocking_prompt.settle_on_abort,
+            )
         )
-    )
 
     with result.write_artifacts_on_failure_from_env(
         basename="screen-loop-escape-pending-steer"
@@ -542,7 +546,7 @@ def test_screen_tui_loop_scenario_keeps_pending_steer_fifo_on_escape() -> None:
     scenario = ScreenTuiLoopScenario().with_pending_steers("prequeued")
     prompts: list[str] = []
     steers: list[str] = []
-    abort_settled = asyncio.Event()
+    blocking_prompt = BlockingPromptController()
 
     async def handle_prompt(text: str) -> None:
         if text == "prequeued":
@@ -550,27 +554,28 @@ def test_screen_tui_loop_scenario_keeps_pending_steer_fifo_on_escape() -> None:
             return
         scenario.app.begin_assistant()
         scenario.app.append_assistant_chunk("working")
-        await abort_settled.wait()
+        await blocking_prompt.wait_until_settled()
 
     async def handle_steer(text: str) -> None:
         steers.append(text)
 
-    result = (
-        scenario.type_text("start")
-        .enter()
-        .wait(0.01)
-        .type_text("running steer")
-        .enter()
-        .wait(0.01)
-        .escape()
-        .wait(0.04)
-        .end_input()
-        .run(
-            handle_prompt=handle_prompt,
-            handle_steer=handle_steer,
-            on_abort=abort_settled.set,
+    with blocking_prompt:
+        result = (
+            scenario.type_text("start")
+            .enter()
+            .wait(0.01)
+            .type_text("running steer")
+            .enter()
+            .wait(0.01)
+            .escape()
+            .wait(0.04)
+            .end_input()
+            .run(
+                handle_prompt=handle_prompt,
+                handle_steer=handle_steer,
+                on_abort=blocking_prompt.settle_on_abort,
+            )
         )
-    )
 
     with result.write_artifacts_on_failure_from_env(
         basename="screen-loop-escape-pending-fifo"
@@ -586,25 +591,29 @@ def test_screen_tui_loop_scenario_preserves_composer_draft_when_escape_runs_pend
 ):
     scenario = ScreenTuiLoopScenario().with_pending_steers("queued")
     prompts: list[str] = []
-    abort_settled = asyncio.Event()
+    blocking_prompt = BlockingPromptController()
 
     async def handle_prompt(text: str) -> None:
         if text == "queued":
             prompts.append(text)
             return
-        await abort_settled.wait()
+        await blocking_prompt.wait_until_settled()
 
-    result = (
-        scenario.type_text("start")
-        .enter()
-        .wait(0.01)
-        .type_text("draft")
-        .wait(0.01)
-        .escape()
-        .wait(0.04)
-        .end_input()
-        .run(handle_prompt=handle_prompt, on_abort=abort_settled.set)
-    )
+    with blocking_prompt:
+        result = (
+            scenario.type_text("start")
+            .enter()
+            .wait(0.01)
+            .type_text("draft")
+            .wait(0.01)
+            .escape()
+            .wait(0.04)
+            .end_input()
+            .run(
+                handle_prompt=handle_prompt,
+                on_abort=blocking_prompt.settle_on_abort,
+            )
+        )
 
     with result.write_artifacts_on_failure_from_env(
         basename="screen-loop-escape-preserves-draft"

--- a/tests/harnesstui/testing/test_screen_loop_playback.py
+++ b/tests/harnesstui/testing/test_screen_loop_playback.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass, field
 
+import pytest
+
 from loushang.harnesstui.conversation.screen_state import ScreenConversationState
 from loushang.harnesstui.testing.screen_loop_playback import (
+    BlockingPromptController,
     ConversationScreenLoopPlayback,
     ConversationScreenLoopScenario,
     ScriptedInputChunk,
@@ -68,6 +72,40 @@ class _ScreenApp:
 
 def _app_factory(*, now):
     return _ScreenApp(clock=now)
+
+
+def test_blocking_prompt_controller_settles_without_residual_task() -> None:
+    controller = BlockingPromptController(timeout_seconds=0.1)
+
+    async def run() -> None:
+        with controller:
+            waiter = asyncio.create_task(controller.wait_until_settled())
+            await asyncio.sleep(0)
+            assert controller.started
+            controller.settle_on_abort()
+            await waiter
+
+    asyncio.run(run())
+    assert controller.settled
+
+
+def test_blocking_prompt_controller_fails_closed_on_missing_abort() -> None:
+    controller = BlockingPromptController(timeout_seconds=0.001)
+
+    with pytest.raises(AssertionError, match="not settled by abort"):
+        asyncio.run(controller.wait_until_settled())
+
+
+def test_blocking_prompt_controller_context_requires_completed_lifecycle() -> None:
+    with pytest.raises(AssertionError, match="never started"):
+        with BlockingPromptController():
+            pass
+
+
+@pytest.mark.parametrize("timeout", [0, float("inf"), float("nan")])
+def test_blocking_prompt_controller_rejects_unbounded_timeout(timeout: float) -> None:
+    with pytest.raises(ValueError, match="finite and greater than zero"):
+        BlockingPromptController(timeout_seconds=timeout)
 
 
 def test_screen_loop_playback_runs_scripted_chunks_through_shared_runner() -> None:

--- a/tests/tui/test_tui_testing_strategy_docs.py
+++ b/tests/tui/test_tui_testing_strategy_docs.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 
 def test_testing_docs_use_screen_tui_playback_name() -> None:
     assert Path("docs/internals/testing/screen-tui-playback.md").exists()
@@ -43,10 +45,7 @@ def test_testing_strategy_documents_composer_selection_manual_smoke() -> None:
     ).read_text(encoding="utf-8")
 
     assert "composer-selection-stress" in text
-    assert (
-        "scripts/run_tui_playback.py composer-selection-stress"
-        in text
-    )
+    assert "scripts/run_tui_playback.py composer-selection-stress" in text
     assert "Shift+Left" in text
     assert "Shift+Home" in text
     assert "Shift+End" in text
@@ -101,6 +100,32 @@ def test_testing_strategy_separates_native_terminal_and_tmux_evidence() -> None:
     assert "fails closed" in strategy
 
 
+@pytest.mark.tui_render_contract
+def test_required_terminal_workflows_fail_fast_and_publish_stable_gate() -> None:
+    strategy = Path(
+        "docs/internals/architecture/tui/native-terminal-core/testing-strategy.md"
+    ).read_text(encoding="utf-8")
+    harnesstui = Path(".github/workflows/harnesstui-quality.yml").read_text(
+        encoding="utf-8"
+    )
+    terminal = Path(".github/workflows/tui-render-contract.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "BlockingPromptController" in strategy
+    assert "`tui-cross-platform-contracts`" in strategy
+
+    for workflow in (harnesstui, terminal):
+        assert "cancel-in-progress: true" in workflow
+        assert "faulthandler_timeout=60" in workflow
+        assert "timeout-minutes:" in workflow
+
+    assert "--junitxml=.artifacts/harnesstui-quality.xml" in harnesstui
+    assert "verify_pytest_xml.py .artifacts/harnesstui-quality.xml" in harnesstui
+    assert "tui-cross-platform-contracts:" in terminal
+    assert "Require every cross-platform terminal contract" in terminal
+
+
 def test_theme_key_design_lists_editor_selection_token() -> None:
     text = Path(
         "docs/internals/architecture/tui/native-terminal-core/key-designs/KD-009-theme-resolution.md"
@@ -152,9 +177,7 @@ def test_public_tui_reference_documents_editing_foundation() -> None:
 
 
 def test_public_tui_reference_documents_runner_and_playback_examples() -> None:
-    english_runner = Path("docs/en/reference/tui-runner.md").read_text(
-        encoding="utf-8"
-    )
+    english_runner = Path("docs/en/reference/tui-runner.md").read_text(encoding="utf-8")
     chinese_runner = Path("docs/zh-CN/reference/tui-runner.md").read_text(
         encoding="utf-8"
     )


### PR DESCRIPTION
## What changed

- bounds Harnesstui/TUI CI with per-ref cancellation, job deadlines, and pytest faulthandler stacks
- makes Harnesstui emit JUnit XML, verifies it fail-closed, and uploads the report
- adds the stable `tui-cross-platform-contracts` aggregate check for repository rules
- introduces a one-shot `BlockingPromptController` that settles abort-driven prompt tests within a deadline and rejects residual tasks
- migrates lifecycle recipes and their product regressions away from raw unbounded events

## Validation

- `make test-tui`: 1274 passed
- `make check-harnesstui` with workflow-equivalent `PYTEST_ADDOPTS`: 1253 passed, 65 deselected
- JUnit verifier: tests=1253, skipped=0, failures=0, errors=0
- focused lifecycle/workflow regressions: 102 passed

Refs #445
