### PR TITLE
fix(harness): reduce routine PowerShell approval noise

### DIFF
--- a/src/loushang/harness/policy/effects_detection.py
+++ b/src/loushang/harness/policy/effects_detection.py
@@ -177,6 +177,78 @@ _POWERSHELL_GIT_UNSAFE_SWITCH_OPTIONS = frozenset(
     {"--discard-changes", "--force", "-f"}
 )
 _POWERSHELL_GIT_EXTERNAL_DIFF_OPTIONS = frozenset({"--ext-diff", "--textconv"})
+_POWERSHELL_ROUTINE_LITERAL_COMMANDS = frozenset(
+    {
+        "echo",
+        "cat",
+        "dir",
+        "get-childitem",
+        "get-command",
+        "get-content",
+        "get-date",
+        "get-location",
+        "get-process",
+        "gci",
+        "gc",
+        "gi",
+        "gl",
+        "get-item",
+        "ls",
+        "pwd",
+        "resolve-path",
+        "select-string",
+        "sls",
+        "test-path",
+        "type",
+        "write-output",
+    }
+)
+_POWERSHELL_PATH_READ_COMMANDS = frozenset(
+    {
+        "cat",
+        "dir",
+        "gc",
+        "gci",
+        "get-childitem",
+        "get-content",
+        "get-item",
+        "gi",
+        "ls",
+        "resolve-path",
+        "select-string",
+        "sls",
+        "test-path",
+        "type",
+    }
+)
+_POWERSHELL_CONTENT_READ_COMMANDS = frozenset(
+    {"cat", "gc", "get-content", "select-string", "sls", "type"}
+)
+_POWERSHELL_ROUTINE_EXTERNAL_COMMANDS = frozenset(
+    {
+        "mypy",
+        "mypy.exe",
+        "pytest",
+        "pytest.exe",
+        "rg",
+        "rg.exe",
+        "ruff",
+        "ruff.exe",
+        "where.exe",
+    }
+)
+_POWERSHELL_PYTHON_COMMANDS = frozenset({"py", "py.exe", "python", "python.exe"})
+_POWERSHELL_SAFE_PYTHON_MODULES = frozenset({"mypy", "pytest", "ruff"})
+_POWERSHELL_UV_COMMANDS = frozenset({"uv", "uv.exe"})
+_POWERSHELL_UV_GLOBAL_VALUE_OPTIONS = frozenset({"--cache-dir"})
+_POWERSHELL_UV_GLOBAL_FLAG_OPTIONS = frozenset(
+    {"--no-cache", "--offline", "--quiet", "-q"}
+)
+_POWERSHELL_UV_RUN_VALUE_OPTIONS = frozenset({"--extra", "--group"})
+_POWERSHELL_UV_RUN_FLAG_OPTIONS = frozenset(
+    {"--frozen", "--locked", "--no-dev", "--no-sync", "--offline"}
+)
+_POWERSHELL_PROVIDER_PATH = re.compile(r"^([A-Za-z][A-Za-z0-9_.-]*):")
 
 
 @dataclass(frozen=True, slots=True)
@@ -336,6 +408,7 @@ def _detect_powershell_effects(
     if invocation is not None:
         invocation_effect_count = len(effects)
         _detect_invocation_effects(invocation, effects)
+        _detect_powershell_sensitive_read_effects(invocation, effects)
         if len(effects) != invocation_effect_count:
             return
         if _is_classified_powershell_invocation(invocation):
@@ -346,14 +419,29 @@ def _detect_powershell_effects(
 def _powershell_invocation(tokens: tuple[str, ...] | None) -> _Invocation | None:
     if not tokens:
         return None
-    executable = tokens[0].casefold()
+    executable = tokens[0].replace("\\", "/").rsplit("/", 1)[-1].casefold()
     if executable == "git.exe":
         executable = "git"
     return _Invocation(executable, tuple(tokens[1:]))
 
 
 def _is_classified_powershell_invocation(invocation: _Invocation) -> bool:
-    if invocation.executable != "git":
+    executable = invocation.executable
+    if executable in _POWERSHELL_ROUTINE_LITERAL_COMMANDS:
+        return _powershell_literal_arguments_are_safe(invocation)
+    if executable in _POWERSHELL_ROUTINE_EXTERNAL_COMMANDS:
+        return not (
+            executable in {"rg", "rg.exe"}
+            and any(
+                argument == "--pre" or argument.startswith("--pre=")
+                for argument in invocation.arguments
+            )
+        )
+    if executable in _POWERSHELL_PYTHON_COMMANDS:
+        return _is_classified_python_check(invocation.arguments)
+    if executable in _POWERSHELL_UV_COMMANDS:
+        return _is_classified_uv_run(invocation.arguments)
+    if executable != "git":
         return False
     operation_and_arguments = _powershell_git_operation(invocation.arguments)
     if operation_and_arguments is None:
@@ -375,6 +463,135 @@ def _is_classified_powershell_invocation(invocation: _Invocation) -> bool:
     ):
         return False
     return True
+
+
+def _powershell_literal_arguments_are_safe(invocation: _Invocation) -> bool:
+    if any(
+        len(argument) > 1
+        and argument.startswith("/")
+        and argument[1].isalpha()
+        for argument in invocation.arguments
+    ):
+        return False
+    if invocation.executable not in _POWERSHELL_PATH_READ_COMMANDS:
+        return True
+    for argument in invocation.arguments:
+        for path_value in _powershell_path_values(argument):
+            if _powershell_provider_name(path_value) is not None:
+                return False
+            if (
+                invocation.executable in _POWERSHELL_CONTENT_READ_COMMANDS
+                and any(marker in path_value for marker in ("*", "?"))
+            ):
+                return False
+    return True
+
+
+def _is_classified_python_check(arguments: tuple[str, ...]) -> bool:
+    if arguments in {("--version",), ("-V",), ("-VV",)}:
+        return True
+    return (
+        len(arguments) >= 2
+        and arguments[0] == "-m"
+        and arguments[1].casefold() in _POWERSHELL_SAFE_PYTHON_MODULES
+    )
+
+
+def _is_classified_uv_run(arguments: tuple[str, ...]) -> bool:
+    remaining = _consume_powershell_options(
+        arguments,
+        value_options=_POWERSHELL_UV_GLOBAL_VALUE_OPTIONS,
+        flag_options=_POWERSHELL_UV_GLOBAL_FLAG_OPTIONS,
+    )
+    if remaining is None or not remaining or remaining[0] != "run":
+        return False
+    remaining = _consume_powershell_options(
+        remaining[1:],
+        value_options=_POWERSHELL_UV_RUN_VALUE_OPTIONS,
+        flag_options=_POWERSHELL_UV_RUN_FLAG_OPTIONS,
+    )
+    if remaining is None:
+        return False
+    nested = _powershell_invocation(remaining)
+    if nested is None:
+        return False
+    if nested.executable in _POWERSHELL_ROUTINE_EXTERNAL_COMMANDS:
+        return True
+    if nested.executable in _POWERSHELL_PYTHON_COMMANDS:
+        return _is_classified_python_check(nested.arguments)
+    return False
+
+
+def _consume_powershell_options(
+    arguments: tuple[str, ...],
+    *,
+    value_options: frozenset[str],
+    flag_options: frozenset[str],
+) -> tuple[str, ...] | None:
+    values = list(arguments)
+    while values and values[0].startswith("-"):
+        value = values.pop(0)
+        option, separator, _ = value.partition("=")
+        if option in flag_options and not separator:
+            continue
+        if option not in value_options:
+            return None
+        if not separator:
+            if not values:
+                return None
+            values.pop(0)
+    return tuple(values)
+
+
+def _detect_powershell_sensitive_read_effects(
+    invocation: _Invocation,
+    effects: list[DetectedPolicyEffect],
+) -> None:
+    if invocation.executable not in _POWERSHELL_PATH_READ_COMMANDS:
+        return
+    for argument in invocation.arguments:
+        for path_value in _powershell_path_values(argument):
+            provider = _powershell_provider_name(path_value)
+            if provider == "env":
+                _append_effect(
+                    effects,
+                    DetectedPolicyEffect(
+                        "secret_access",
+                        "secret_environment",
+                        "Process environment secrets could be exposed",
+                    ),
+                )
+                return
+            if _looks_like_secret_path(path_value):
+                _append_effect(
+                    effects,
+                    DetectedPolicyEffect(
+                        "secret_access",
+                        "secret_access",
+                        "A credential or secret-bearing file would be read",
+                    ),
+                )
+                return
+
+
+def _powershell_path_values(argument: str) -> tuple[str, ...]:
+    if not argument.startswith("-"):
+        return (argument,)
+    for separator in (":", "="):
+        _, found, value = argument.partition(separator)
+        if found and value:
+            return (value,)
+    return ()
+
+
+def _powershell_provider_name(value: str) -> str | None:
+    match = _POWERSHELL_PROVIDER_PATH.match(value)
+    if match is None:
+        return None
+    name = match.group(1).casefold()
+    # A single-letter prefix is a Windows filesystem drive, not a PowerShell
+    # provider such as Env:, Variable:, Cert:, HKCU:, or HKLM:.
+    return None if len(name) == 1 else name
 
 
 def _powershell_git_operation(

--- a/src/loushang/harness/tools/workspace/shell.py
+++ b/src/loushang/harness/tools/workspace/shell.py
@@ -325,6 +325,7 @@ def create_shell_tool_definition(
             (
                 "Use PowerShell cmdlets and PowerShell pipelines; do not emit Bash syntax such as export, test -f, or $(...).",
                 "Keep scripts compatible with Windows PowerShell 5.1 unless PowerShell 7-only syntax is required and known to be available.",
+                "Prefer one literal command per tool call for routine inspection and checks; compound scripts, pipelines, redirects, and dynamic expressions may require approval.",
                 "Prefer read, grep, find, ls, write, and edit for file operations when those tools are more precise.",
             )
             if is_windows

--- a/tests/harness/test_policy_engine.py
+++ b/tests/harness/test_policy_engine.py
@@ -159,24 +159,82 @@ def _evaluate_powershell(engine: PolicyEngine, script: str):
     )
 
 
-def test_powershell_policy_allows_only_constrained_read_only_forms() -> None:
+@pytest.mark.parametrize(
+    "script",
+    (
+        "Get-Location",
+        "Get-Process -Id 42",
+        "Get-ChildItem -Force -Name",
+        "Get-ChildItem src -Recurse -File",
+        "dir src",
+        "ls -Force",
+        "Get-Content README.md -TotalCount 80",
+        "Get-Content -Path:README.md",
+        "cat README.md",
+        "Select-String TODO README.md",
+        "Test-Path pyproject.toml",
+        "Resolve-Path .",
+        "Get-Command git",
+        "Write-Output 'hello'",
+        "echo hello",
+        "rg TODO src tests",
+        "where.exe git",
+        r".venv\Scripts\python.exe -m pytest tests -q",
+        "uv run pytest tests -q",
+        "uv run --extra dev pytest tests -q",
+        "uv --cache-dir .uv-cache run --extra=dev ruff check src tests",
+        "ruff check src tests",
+        "mypy src/loushang/ai",
+    ),
+)
+def test_powershell_policy_allows_routine_literal_commands(script: str) -> None:
     engine = PolicyEngine()
 
-    assert _evaluate_powershell(engine, "Get-Location").disposition == "allow"
-    assert (
-        _evaluate_powershell(engine, "Get-Process -Id 42").disposition == "allow"
-    )
-    assert (
-        _evaluate_powershell(engine, "Get-ChildItem -Force -Name").disposition
-        == "allow"
-    )
+    assert _evaluate_powershell(engine, script).disposition == "allow"
 
 
-def test_powershell_policy_asks_for_unclassified_script() -> None:
-    decision = _evaluate_powershell(PolicyEngine(), "Write-Output 'hello'")
+@pytest.mark.parametrize(
+    "script",
+    (
+        "Write-Output $env:API_TOKEN",
+        "Get-Content *",
+        "Get-ItemProperty HKCU:\\Software\\Example",
+        "Set-Content output.txt hello",
+        "python -c \"open('output.txt', 'w').write('hello')\"",
+        "uv tool install example-package",
+        "uv run --with example-package pytest tests -q",
+        "rg --pre 'python helper.py' TODO .",
+        "where git",
+        "rg TODO src > report.txt",
+        "Get-ChildItem src | Select-Object -First 1",
+    ),
+)
+def test_powershell_policy_asks_for_unclassified_script(script: str) -> None:
+    decision = _evaluate_powershell(PolicyEngine(), script)
 
     assert decision.disposition == "ask"
     assert decision.code == "unclassified_powershell_command"
+
+
+@pytest.mark.parametrize(
+    ("script", "expected_code"),
+    (
+        ("Get-Content .env", "secret_access"),
+        ("Get-Content -Path:.env", "secret_access"),
+        ("cat .env", "secret_access"),
+        ("Select-String TOKEN .env", "secret_access"),
+        ("Get-Content Env:API_TOKEN", "secret_environment"),
+        ("Get-Content -LiteralPath:Env:API_TOKEN", "secret_environment"),
+    ),
+)
+def test_powershell_routine_reads_still_protect_secrets(
+    script: str,
+    expected_code: str,
+) -> None:
+    decision = _evaluate_powershell(PolicyEngine(), script)
+
+    assert decision.disposition == "ask"
+    assert decision.code == expected_code
 
 
 @pytest.mark.parametrize(

--- a/tests/harness/tools/test_shell_tool.py
+++ b/tests/harness/tools/test_shell_tool.py
@@ -132,11 +132,9 @@ def test_windows_shell_tool_authorizes_plaintext_and_executes_encoded_transport(
     }
 
 
-def test_windows_shell_tool_fails_closed_before_execution_for_unknown_script(
+def test_windows_shell_tool_runs_literal_output_without_approval(
     tmp_path: Path,
 ) -> None:
-    from loushang.harness.tools.workspace import PolicyEnforcementError
-
     operations = _RecordingOperations()
     tool = wrap_tool_definition(
         create_shell_tool_definition(
@@ -148,13 +146,12 @@ def test_windows_shell_tool_fails_closed_before_execution_for_unknown_script(
         policy_evaluator=PolicyEngine(),
     )
 
-    with pytest.raises(PolicyEnforcementError) as raised:
-        asyncio.run(tool.execute("shell-2", {"command": "Write-Output hello"}))
-
-    assert raised.value.tool_result_details["policy_code"] == (
-        "unclassified_powershell_command"
+    result = asyncio.run(
+        tool.execute("shell-2", {"command": "Write-Output hello"})
     )
-    assert operations.requests == []
+
+    assert result.content[0].text == "ok\n"
+    assert len(operations.requests) == 1
 
 
 def test_windows_shell_tool_runs_classified_git_status_without_approval(
@@ -225,6 +222,20 @@ def test_windows_shell_tool_schema_and_runtime_reject_argv_input() -> None:
         asyncio.run(tool.execute("shell-3", {"command": ["cmd.exe", "/c", "dir"]}))
 
 
+def test_windows_shell_tool_guides_routine_commands_away_from_compound_scripts() -> (
+    None
+):
+    definition = create_shell_tool_definition(
+        environment=_windows(),
+        resolver_factory=_resolver_factory,
+    )
+
+    assert any(
+        "one literal command per tool call" in guideline
+        for guideline in definition.prompt_guidelines
+    )
+
+
 def test_windows_shell_tool_audit_records_safe_resolution_metadata(
     tmp_path: Path,
 ) -> None:
@@ -283,14 +294,12 @@ def test_native_windows_shell_tool_runs_without_bash_installation(
 
 @pytest.mark.skipif(os.name != "nt", reason="requires a native Windows host")
 def test_native_windows_shell_tool_preserves_echo_output(tmp_path: Path) -> None:
-    approvals = _RecordingApprovalResolver()
     tool = wrap_tool_definition(
         create_shell_tool_definition(
             environment=LocalHostEnvironmentProbe().detect(),
         ),
         context_provider=_context(tmp_path),
         policy_evaluator=PolicyEngine(),
-        approval_resolver=approvals,
     )
 
     result = asyncio.run(tool.execute("shell-native-echo", {"command": "echo hello"}))
@@ -301,7 +310,6 @@ def test_native_windows_shell_tool_preserves_echo_output(tmp_path: Path) -> None
     assert result.details["stdio_drain_reason"] is None
     assert result.content[0].text.strip() == "hello"
     assert transcript_result.content[0].text == result.content[0].text
-    assert len(approvals.requests) == 1
 
 
 @pytest.mark.skipif(os.name != "nt", reason="requires a native Windows host")


### PR DESCRIPTION
## What changed

- classify common literal PowerShell inspection and local-check commands as routine
- preserve approval for secrets, dynamic expressions, compound scripts, redirects, package installation, and other unclassified effects
- guide agents toward one literal command per tool call on Windows
- make the native Windows `echo hello` contract run without an approval resolver

## Why

The first fail-closed Windows PowerShell policy allowed only a very small set of commands. Routine work such as `echo`, source reads, searches, and test commands therefore requested approval repeatedly even though the same workflow is uninterrupted on POSIX hosts.

## Impact

Windows users can run ordinary inspection, search, Git, and test commands with substantially fewer prompts. The change is scoped to the PowerShell dialect; POSIX and Cmd policy paths are unchanged.

## Validation

- `make check-harness`
- 1881 passed, 4 skipped
- Ruff passed
- mypy passed

Refs #444
