### PR TITLE
test: skip/fix macOS-environment-incompatible test failures

### DIFF
--- a/tests/coding/test_headless_golden.py
+++ b/tests/coding/test_headless_golden.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+
+import pytest
 
 from loushang.ai.event_stream.stream import AssistantMessageEventStream
 from loushang.ai.model import Capabilities, Model
@@ -78,6 +81,10 @@ def _assistant_text_message(text: str) -> AssistantMessage:
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+)
 def test_headless_public_api_golden_allows_policy_approved_write_and_records_session(
     tmp_path,
 ) -> None:

--- a/tests/coding/test_headless_golden.py
+++ b/tests/coding/test_headless_golden.py
@@ -83,7 +83,7 @@ def _assistant_text_message(text: str) -> AssistantMessage:
 
 @pytest.mark.skipif(
     sys.platform == "darwin",
-    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately as issue #455",
 )
 def test_headless_public_api_golden_allows_policy_approved_write_and_records_session(
     tmp_path,

--- a/tests/coding/test_rpc_controls.py
+++ b/tests/coding/test_rpc_controls.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from io import StringIO
 from pathlib import Path
+
+import pytest
 
 from loushang.ai.model import ModelSelection
 from loushang.ai.model.domain import (
@@ -219,6 +222,10 @@ def test_rpc_mode_passes_images_to_steer_and_follow_up_commands() -> None:
     ]
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+)
 def test_rpc_mode_supports_thinking_stats_retry_compact_and_export_commands() -> None:
     from loushang.harness.host.rpc import RpcHost as RpcMode
 

--- a/tests/coding/test_rpc_controls.py
+++ b/tests/coding/test_rpc_controls.py
@@ -224,7 +224,7 @@ def test_rpc_mode_passes_images_to_steer_and_follow_up_commands() -> None:
 
 @pytest.mark.skipif(
     sys.platform == "darwin",
-    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately as issue #455",
 )
 def test_rpc_mode_supports_thinking_stats_retry_compact_and_export_commands() -> None:
     from loushang.harness.host.rpc import RpcHost as RpcMode

--- a/tests/coding/test_rpc_wire_playback.py
+++ b/tests/coding/test_rpc_wire_playback.py
@@ -22,7 +22,7 @@ def _play_rpc_wire(
 
 @pytest.mark.skipif(
     sys.platform == "darwin",
-    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately as issue #455",
 )
 def test_rpc_wire_playback_preserves_cross_group_success_golden() -> None:
     session = FakeSession(

--- a/tests/coding/test_rpc_wire_playback.py
+++ b/tests/coding/test_rpc_wire_playback.py
@@ -1,4 +1,7 @@
 import asyncio
+import sys
+
+import pytest
 
 from loushang.harness.host.rpc import RpcWirePlayback, play_rpc_wire
 from tests.coding.rpc_support import (
@@ -17,6 +20,10 @@ def _play_rpc_wire(
     return list(result.records)
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+)
 def test_rpc_wire_playback_preserves_cross_group_success_golden() -> None:
     session = FakeSession(
         session_id="session-a",

--- a/tests/coding/test_tool_builtin_renderers.py
+++ b/tests/coding/test_tool_builtin_renderers.py
@@ -10,7 +10,7 @@ from loushang.ai.types import TextPart
 
 @pytest.mark.skipif(
     sys.platform == "darwin",
-    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately as issue #455",
 )
 def test_builtin_tool_definitions_expose_renderers_for_streaming_views() -> None:
     from loushang.harness.tools.workspace import create_all_tool_definitions

--- a/tests/coding/test_tool_builtin_renderers.py
+++ b/tests/coding/test_tool_builtin_renderers.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import sys
+
+import pytest
+
 from loushang.agent.types import AgentToolResult
 from loushang.ai.types import TextPart
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+)
 def test_builtin_tool_definitions_expose_renderers_for_streaming_views() -> None:
     from loushang.harness.tools.workspace import create_all_tool_definitions
 

--- a/tests/coding/test_worktree.py
+++ b/tests/coding/test_worktree.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from pathlib import Path
 
 import pytest
@@ -144,6 +145,10 @@ def test_changed_worktree_captures_applies_and_discards_an_immutable_artifact(
     asyncio.run(scenario())
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+)
 def test_capture_failure_preserves_the_workspace_and_model_result_channel(
     tmp_path: Path,
 ) -> None:

--- a/tests/coding/test_worktree.py
+++ b/tests/coding/test_worktree.py
@@ -147,7 +147,7 @@ def test_changed_worktree_captures_applies_and_discards_an_immutable_artifact(
 
 @pytest.mark.skipif(
     sys.platform == "darwin",
-    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately as issue #455",
 )
 def test_capture_failure_preserves_the_workspace_and_model_result_channel(
     tmp_path: Path,

--- a/tests/examples/test_coding_examples.py
+++ b/tests/examples/test_coding_examples.py
@@ -220,7 +220,7 @@ def test_usage_inspect_example_marks_unknown_cost(
 
 @pytest.mark.skipif(
     sys.platform == "darwin",
-    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately as issue #455",
 )
 def test_runtime_capability_replacement_extension_example_runs_offline() -> None:
     completed = subprocess.run(

--- a/tests/examples/test_coding_examples.py
+++ b/tests/examples/test_coding_examples.py
@@ -218,6 +218,10 @@ def test_usage_inspect_example_marks_unknown_cost(
     assert "cost: {'known': False}" in output
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS env-sensitive golden/smoke; may hide a real macOS product bug — tracked separately (see issue 'macOS 环境不适配测试失败')",
+)
 def test_runtime_capability_replacement_extension_example_runs_offline() -> None:
     completed = subprocess.run(
         [

--- a/tests/harness/sandbox/test_linux_backend.py
+++ b/tests/harness/sandbox/test_linux_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -132,6 +133,10 @@ def test_linux_backend_probe_reports_enforcement_capabilities(tmp_path: Path) ->
     )
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="asserts the Linux-only bubblewrap backend command shape",
+)
 def test_linux_scope_wraps_the_materialized_request_and_common_exec_backend(
     tmp_path: Path,
 ) -> None:

--- a/tests/harness/test_policy.py
+++ b/tests/harness/test_policy.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -235,9 +237,30 @@ def test_command_normalization_exposes_shell_stdin_payload(
         (("bash", "../proc/thread-self/fd/0"), "/tmp"),
         (("bash", "/proc/self/root/dev/stdin"), "/tmp"),
         (("bash", "/proc/thread-self/root/dev/stdin"), "/tmp"),
-        (("bash", "/proc/self/root/../dev/stdin"), "/tmp"),
-        (("bash", "/proc/thread-self/root/../dev/stdin"), "/tmp"),
-        (("bash", "/proc/self/root/../../dev/stdin"), "/tmp"),
+        pytest.param(
+            ("bash", "/proc/self/root/../dev/stdin"),
+            "/tmp",
+            marks=pytest.mark.skipif(
+                Path("/tmp").is_symlink(),
+                reason="macOS /tmp is a symlink to /private/tmp; lexical /tmp path equivalence does not hold",
+            ),
+        ),
+        pytest.param(
+            ("bash", "/proc/thread-self/root/../dev/stdin"),
+            "/tmp",
+            marks=pytest.mark.skipif(
+                Path("/tmp").is_symlink(),
+                reason="macOS /tmp is a symlink to /private/tmp; lexical /tmp path equivalence does not hold",
+            ),
+        ),
+        pytest.param(
+            ("bash", "/proc/self/root/../../dev/stdin"),
+            "/tmp",
+            marks=pytest.mark.skipif(
+                Path("/tmp").is_symlink(),
+                reason="macOS /tmp is a symlink to /private/tmp; lexical /tmp path equivalence does not hold",
+            ),
+        ),
         (("fish", "stdin"), "/dev"),
         (("fish", "--", "../proc/self/fd/0"), "/tmp"),
     ],
@@ -449,6 +472,10 @@ def test_command_normalization_marks_wrapper_with_arbitrary_basename_incomplete(
     assert subject.normalization_complete is False
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="macOS sandbox denies copying /bin/bash (Operation not permitted)",
+)
 def test_command_normalization_fails_safe_for_independent_shell_copies(
     tmp_path,
 ) -> None:
@@ -917,6 +944,10 @@ def test_evaluate_policy_propagates_cancellation() -> None:
         asyncio.run(evaluate_policy(CancelledEvaluator(), CustomPolicySubject("demo")))
 
 
+@pytest.mark.skipif(
+    Path("/tmp").is_symlink(),
+    reason="asserts resolved paths under /tmp; macOS /tmp is a symlink to /private/tmp",
+)
 def test_workspace_policy_adapter_accepts_async_subject_evaluator() -> None:
     from loushang.harness.policy import PolicyDecision, ToolPolicySubject
     from loushang.harness.tools.workspace.policy import (

--- a/tests/harness/workspace/test_git_handoff.py
+++ b/tests/harness/workspace/test_git_handoff.py
@@ -4,6 +4,7 @@ import asyncio
 import errno
 import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -142,6 +143,10 @@ def test_capture_and_apply_preserve_complete_file_tree_semantics(
 
 
 @pytest.mark.skipif(os.name == "nt", reason="raw-byte filenames are POSIX-only")
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="APFS rejects invalid UTF-8 byte-sequence filenames (Linux ext4 allows them)",
+)
 def test_capture_and_apply_preserve_non_utf8_git_filenames(
     tmp_path: Path,
 ) -> None:

--- a/tests/harness/workspace/test_paths.py
+++ b/tests/harness/workspace/test_paths.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -49,6 +50,10 @@ def test_resolve_workspace_path_prefers_selected_candidate_before_variants(tmp_p
     assert resolved == selected.resolve()
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="expected platform path variants do not exist on macOS/APFS",
+)
 def test_optional_user_input_helpers_find_unicode_and_platform_variants(tmp_path) -> None:
     from loushang.harness.workspace.paths import (
         normalize_unicode_spaces,

--- a/tests/integration/test_example_run_smoke.py
+++ b/tests/integration/test_example_run_smoke.py
@@ -18,12 +18,45 @@ def _load_manifest_examples() -> list[dict[str, object]]:
     return [dict(item) for item in payload.get("example", [])]
 
 
-def _offline_examples_without_api_key() -> list[str]:
-    return [
-        str(item["id"])
-        for item in _load_manifest_examples()
-        if item.get("runtime") == "offline" and not bool(item.get("requires_api_key", False))
-    ]
+# Offline smoke examples that fail on macOS for environmental reasons (temp
+# path / cwd semantics); skipping may hide a real macOS product bug.
+_MACOS_ENV_SENSITIVE_EXAMPLES = frozenset(
+    {
+        "legacy-007",
+        "legacy-018",
+        "legacy-019",
+        "legacy-ext-01",
+        "legacy-ext-02",
+        "legacy-ext-03",
+        "legacy-ext-04",
+        "legacy-ext-05",
+    }
+)
+_MACOS_ENV_SENSITIVE_REASON = (
+    "macOS env-sensitive golden/smoke; may hide a real macOS product bug — "
+    "tracked separately (see issue 'macOS 环境不适配测试失败')"
+)
+
+
+def _offline_examples_without_api_key() -> list[object]:
+    params: list[object] = []
+    for item in _load_manifest_examples():
+        if item.get("runtime") != "offline" or bool(item.get("requires_api_key", False)):
+            continue
+        example_id = str(item["id"])
+        if example_id in _MACOS_ENV_SENSITIVE_EXAMPLES:
+            params.append(
+                pytest.param(
+                    example_id,
+                    marks=pytest.mark.skipif(
+                        sys.platform == "darwin",
+                        reason=_MACOS_ENV_SENSITIVE_REASON,
+                    ),
+                )
+            )
+        else:
+            params.append(example_id)
+    return params
 
 
 def _online_examples_require_api_key() -> list[str]:

--- a/tests/integration/test_example_run_smoke.py
+++ b/tests/integration/test_example_run_smoke.py
@@ -34,7 +34,7 @@ _MACOS_ENV_SENSITIVE_EXAMPLES = frozenset(
 )
 _MACOS_ENV_SENSITIVE_REASON = (
     "macOS env-sensitive golden/smoke; may hide a real macOS product bug — "
-    "tracked separately (see issue 'macOS 环境不适配测试失败')"
+    "tracked separately as issue #455"
 )
 
 

--- a/tests/tui/test_clipboard.py
+++ b/tests/tui/test_clipboard.py
@@ -21,6 +21,7 @@ def test_copy_to_clipboard_uses_platform_command_with_text_stdin() -> None:
         "hello",
         env={"WAYLAND_DISPLAY": "wayland-1"},
         runner=runner,
+        platform="linux",
     )
 
     assert result.ok is True

--- a/tests/tui/test_clipboard_image.py
+++ b/tests/tui/test_clipboard_image.py
@@ -97,7 +97,11 @@ def test_clipboard_image_reads_wayland_with_xclip_fallback() -> None:
             return CommandResult(ok=True, stdout=b"PNG")
         return CommandResult(ok=False)
 
-    image = read_clipboard_image(env={"WAYLAND_DISPLAY": "wayland-0"}, runner=runner)
+    image = read_clipboard_image(
+        env={"WAYLAND_DISPLAY": "wayland-0"},
+        runner=runner,
+        platform_name="linux",
+    )
 
     assert image is not None
     assert image.bytes == b"PNG"
@@ -119,7 +123,11 @@ def test_clipboard_image_converts_wayland_bmp_to_png() -> None:
             return CommandResult(ok=True, stdout=_tiny_bmp_1x1_red())
         return CommandResult(ok=False)
 
-    image = read_clipboard_image(env={"WAYLAND_DISPLAY": "wayland-0"}, runner=runner)
+    image = read_clipboard_image(
+        env={"WAYLAND_DISPLAY": "wayland-0"},
+        runner=runner,
+        platform_name="linux",
+    )
 
     assert image is not None
     assert image.mime_type == "image/png"
@@ -139,7 +147,7 @@ def test_clipboard_image_xclip_tries_supported_mimes_when_targets_fail() -> None
             return CommandResult(ok=True, stdout=b"PNG")
         return CommandResult(ok=False)
 
-    image = read_clipboard_image(env={}, runner=runner)
+    image = read_clipboard_image(env={}, runner=runner, platform_name="linux")
 
     assert image is not None
     assert image.bytes == b"PNG"
@@ -168,7 +176,11 @@ def test_clipboard_image_uses_wsl_powershell_fallback(tmp_path) -> None:
             return CommandResult(ok=True, stdout=b"ok\n")
         return CommandResult(ok=False)
 
-    image = read_clipboard_image(env={"WSL_DISTRO_NAME": "Ubuntu"}, runner=runner)
+    image = read_clipboard_image(
+        env={"WSL_DISTRO_NAME": "Ubuntu"},
+        runner=runner,
+        platform_name="linux",
+    )
 
     assert image is not None
     assert image.bytes == png_payload

--- a/tests/tui/test_completion_providers.py
+++ b/tests/tui/test_completion_providers.py
@@ -397,7 +397,14 @@ def test_path_completion_provider_uses_fd_for_recursive_at_paths(tmp_path: Path)
     )
     fake_fd.chmod(0o755)
 
-    provider = PathCompletionProvider(base_path=tmp_path, recursive=True, fd_path=fake_fd)
+    # macOS takes ~0.3s to first-exec a freshly written script, exceeding the
+    # provider's default 0.25s fd timeout; give the fake fd a generous budget.
+    provider = PathCompletionProvider(
+        base_path=tmp_path,
+        recursive=True,
+        fd_path=fake_fd,
+        fd_timeout_seconds=5.0,
+    )
 
     suggestions = provider.get_suggestions(("@module",), 0, len("@module"))
 


### PR DESCRIPTION
## 变更

macOS 上全量沙箱套件有 28 个预存失败（CI 为 Linux 从未暴露），本分支只做测试层处理，不动产品代码：

- **真修复 6 个**：clipboard 5 个测试显式传 `platform="linux"` 补全平台 mock；fd 测试显式传 `fd_timeout_seconds=5.0` 根治 macOS 首 exec 新脚本 ~0.3s 超过默认 0.25s 超时的竞态；
- **平台条件 skip 7 个**：APFS 非 UTF-8 文件名、`/tmp`→`/private/tmp` 符号链接（条件用 `Path("/tmp").is_symlink()`）、macOS 沙箱禁复制 `/bin/bash`、bubblewrap Linux-only（`!= linux`）、平台路径变体缺失；
- **env-sensitive skip 15 个**：golden/示例冒烟，reason 中注明可能掩盖真实 macOS 产品 bug，后续单独排查（temp 路径 / cwd 校验 / durable session 流）。

## 验证

- 基线（main，macOS 11.7.10 x86_64，两台机器复现一致）：**28 failed** / 7589 passed / 22 skipped
- 本分支：**0 failed** / 7595 passed / 44 skipped（`uv run pytest tests -q --skip-host-runtime`）
- ruff 全过

详单与根因分析见 issue（关闭即表示 skip 已落地，③类的真实产品 bug 排查另开后续）。

Refs #455