### PR TITLE
fix(tui): stop Windows VT escape sequences leaking as literal text

### DIFF
--- a/src/loushang/harnesstui/conversation/screen_runner.py
+++ b/src/loushang/harnesstui/conversation/screen_runner.py
@@ -25,6 +25,7 @@ from loushang.tui.terminal_capabilities import TerminalRuntimeCapabilities
 from loushang.tui.terminal_diagnostics import format_terminal_diagnostics
 from loushang.tui.terminal_input import (
     InputChunkReader,
+    default_pending_input_idle_ms,
     read_input_chunk_or_render_tick,
 )
 from loushang.tui.terminal_session import TerminalSession
@@ -249,7 +250,9 @@ async def run_conversation_screen(
                     active_task=active_task,
                     input_chunk_reader=input_chunk_reader,
                     render_wakeup=render_wakeup,
-                    pending_input_idle_ms=10 if reader.has_pending else None,
+                    pending_input_idle_ms=(
+                        default_pending_input_idle_ms() if reader.has_pending else None
+                    ),
                     idle_wakeup_ms=_terminal_runtime_wakeup_ms(terminal_context),
                 )
                 input_events: tuple[Any, ...]

--- a/src/loushang/tui/runner.py
+++ b/src/loushang/tui/runner.py
@@ -28,6 +28,7 @@ from loushang.tui.terminal import (
 )
 from loushang.tui.terminal_input import (
     InputChunkReader,
+    default_pending_input_idle_ms,
     read_input_chunk_or_render_tick,
 )
 from loushang.tui.terminal_session import TerminalSession
@@ -145,7 +146,11 @@ class TuiRunner:
                         active_task=None,
                         input_chunk_reader=self.input_chunk_reader,
                         render_wakeup=render_wakeup,
-                        pending_input_idle_ms=10 if reader.has_pending else None,
+                        pending_input_idle_ms=(
+                            default_pending_input_idle_ms()
+                            if reader.has_pending
+                            else None
+                        ),
                         idle_wakeup_ms=terminal_runtime_wakeup_ms(terminal_context),
                     )
                     if data is None:

--- a/src/loushang/tui/terminal_input.py
+++ b/src/loushang/tui/terminal_input.py
@@ -41,6 +41,13 @@ _WINDOWS_EXTENDED_KEY_SEQUENCES = {
     "E": "\x1b[23~",
     "F": "\x1b[24~",
 }
+PENDING_INPUT_IDLE_MS = 10
+WINDOWS_PENDING_INPUT_IDLE_MS = 50
+# Cap on chars drained into one Windows chunk so flood/paste streams cannot
+# starve the render loop; undrained chars stay in the console input buffer
+# and are returned by the next chunk read.
+_WINDOWS_MAX_CHUNK_CHARS = 4096
+
 _WINDOWS_TTY_READ_FUTURES: weakref.WeakKeyDictionary[
     asyncio.AbstractEventLoop, asyncio.Future[str]
 ] = weakref.WeakKeyDictionary()
@@ -423,11 +430,43 @@ def _set_future_exception(
 
 
 def _read_windows_tty_input_chunk_from_module(msvcrt: Any) -> str:
-    char = msvcrt.getwch()
-    if char in {"\x00", "\xe0"}:
-        extended = msvcrt.getwch()
-        return _WINDOWS_EXTENDED_KEY_SEQUENCES.get(extended, char + extended)
-    return char
+    first = msvcrt.getwch()
+    if first in {"\x00", "\xe0"}:
+        return _read_windows_extended_key_sequence(msvcrt, first)
+    chars = [first]
+    size = len(first)
+    while size < _WINDOWS_MAX_CHUNK_CHARS:
+        try:
+            has_input = bool(msvcrt.kbhit())
+        except (OSError, ValueError):
+            break
+        if not has_input:
+            break
+        char = msvcrt.getwch()
+        if char in {"\x00", "\xe0"}:
+            sequence = _read_windows_extended_key_sequence(msvcrt, char)
+            chars.append(sequence)
+            size += len(sequence)
+            continue
+        chars.append(char)
+        size += 1
+    return "".join(chars)
+
+
+def _read_windows_extended_key_sequence(msvcrt: Any, char: str) -> str:
+    extended = msvcrt.getwch()
+    return _WINDOWS_EXTENDED_KEY_SEQUENCES.get(extended, char + extended)
+
+
+def default_pending_input_idle_ms() -> int:
+    """Idle window before a pending partial escape sequence is force-flushed.
+
+    Windows console reads deliver VT sequences one character per chunk, so a
+    split sequence needs a wider window than the reader's own 10 ms poll.
+    """
+    if _is_windows_console_platform():
+        return WINDOWS_PENDING_INPUT_IDLE_MS
+    return PENDING_INPUT_IDLE_MS
 
 
 def _drain_windows_tty_input(
@@ -484,7 +523,10 @@ def _load_windows_console_module() -> Any | None:
 
 
 __all__ = [
+    "PENDING_INPUT_IDLE_MS",
     "TerminalInputMode",
+    "WINDOWS_PENDING_INPUT_IDLE_MS",
+    "default_pending_input_idle_ms",
     "drain_input",
     "read_input_chunk",
     "read_input_chunk_or_render_tick",

--- a/tests/tui/test_runner.py
+++ b/tests/tui/test_runner.py
@@ -244,6 +244,46 @@ def test_runner_context_stop_returns_exit_code() -> None:
     assert asyncio.run(run()) == 12
 
 
+def test_runner_uses_platform_pending_input_idle_window(monkeypatch: Any) -> None:
+    sentinel = 777
+    monkeypatch.setattr(
+        "loushang.tui.runner.default_pending_input_idle_ms", lambda: sentinel
+    )
+    observed: list[int | None] = []
+
+    async def fake_read_tick(_stdin: object, **kwargs: Any) -> str:
+        observed.append(kwargs["pending_input_idle_ms"])
+        return "\x1b" if len(observed) == 1 else ""
+
+    monkeypatch.setattr(
+        "loushang.tui.runner.read_input_chunk_or_render_tick", fake_read_tick
+    )
+
+    async def run() -> int:
+        return await TuiRunner(
+            Tui(),
+            stdin=StringIO(""),
+            stdout=StringIO(),
+            terminal_session_factory=_recording_terminal_session_factory(),
+            terminal_size_provider=lambda: TerminalSize(columns=20, rows=5),
+        ).run()
+
+    assert asyncio.run(run()) == 0
+    # First read has no pending input; the second observes the pending ESC and
+    # must receive the platform-aware idle window; the third exits on EOF.
+    assert observed == [None, sentinel, None]
+
+
+def test_screen_runner_uses_platform_pending_input_idle_window() -> None:
+    import inspect
+
+    from loushang.harnesstui.conversation import screen_runner
+
+    source = inspect.getsource(screen_runner.run_conversation_screen)
+
+    assert "default_pending_input_idle_ms()" in source
+
+
 def test_runner_passes_streams_to_terminal_session_factory() -> None:
     stdin = StringIO("")
     stdout = StringIO()

--- a/tests/tui/test_terminal_input.py
+++ b/tests/tui/test_terminal_input.py
@@ -17,7 +17,12 @@ from loushang.tui.input import (
     InputReader,
 )
 from loushang.tui.terminal_input import (
+    _WINDOWS_MAX_CHUNK_CHARS,
+    PENDING_INPUT_IDLE_MS,
+    WINDOWS_PENDING_INPUT_IDLE_MS,
     TerminalInputMode,
+    _read_windows_tty_input_chunk_from_module,
+    default_pending_input_idle_ms,
     drain_input,
     read_input_chunk,
     read_input_chunk_or_render_tick,
@@ -76,6 +81,92 @@ def test_read_input_chunk_reads_windows_tty_key(monkeypatch: Any) -> None:
     result = asyncio.run(read_input_chunk(_TtyInput()))
 
     assert result == "x"
+
+
+def test_read_input_chunk_drains_split_windows_vt_sequence_atomically(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    _install_fake_msvcrt(monkeypatch, chars=["\x1b", "[", "B"])
+
+    result = asyncio.run(read_input_chunk(_TtyInput()))
+
+    assert result == "\x1b[B"
+
+
+def test_windows_chunk_reader_maps_extended_key_first_char(monkeypatch: Any) -> None:
+    fake_msvcrt = _install_fake_msvcrt(monkeypatch, chars=["\xe0", "H"])
+
+    result = _read_windows_tty_input_chunk_from_module(fake_msvcrt)
+
+    assert result == "\x1b[A"
+
+
+def test_windows_chunk_reader_reads_extended_scancode_without_kbhit(
+    monkeypatch: Any,
+) -> None:
+    fake_msvcrt = _install_fake_msvcrt(
+        monkeypatch, chars=["\xe0", "H"], kbhit=lambda: False
+    )
+
+    result = _read_windows_tty_input_chunk_from_module(fake_msvcrt)
+
+    assert result == "\x1b[A"
+
+
+def test_windows_chunk_reader_maps_extended_key_in_drained_tail(
+    monkeypatch: Any,
+) -> None:
+    fake_msvcrt = _install_fake_msvcrt(monkeypatch, chars=["a", "\xe0", "P", "b"])
+
+    result = _read_windows_tty_input_chunk_from_module(fake_msvcrt)
+
+    assert result == "a\x1b[Bb"
+
+
+def test_windows_chunk_reader_caps_drain_and_leaves_rest_for_next_chunk(
+    monkeypatch: Any,
+) -> None:
+    fake_msvcrt = _install_fake_msvcrt(
+        monkeypatch, chars=["x"] * (_WINDOWS_MAX_CHUNK_CHARS + 10)
+    )
+
+    first = _read_windows_tty_input_chunk_from_module(fake_msvcrt)
+    second = _read_windows_tty_input_chunk_from_module(fake_msvcrt)
+
+    assert first == "x" * _WINDOWS_MAX_CHUNK_CHARS
+    assert second == "x" * 10
+
+
+def test_default_pending_input_idle_ms_is_wider_on_windows(monkeypatch: Any) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    assert default_pending_input_idle_ms() == WINDOWS_PENDING_INPUT_IDLE_MS
+    assert WINDOWS_PENDING_INPUT_IDLE_MS > PENDING_INPUT_IDLE_MS
+
+
+def test_default_pending_input_idle_ms_stays_short_off_windows(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    assert default_pending_input_idle_ms() == PENDING_INPUT_IDLE_MS
+    assert PENDING_INPUT_IDLE_MS == 10
+
+
+def test_input_batch_joins_split_arrow_chunks_into_one_key_event() -> None:
+    reader = InputReader()
+
+    first = reader.feed_batch("\x1b")
+    second = reader.feed_batch("[")
+    third = reader.feed_batch("B")
+
+    assert first.app_events == ()
+    assert first.has_pending
+    assert second.app_events == ()
+    assert second.has_pending
+    assert third.app_events == (InputEvent(kind="key", key="down", raw="\x1b[B"),)
+    assert not third.has_pending
 
 
 def test_windows_blocking_key_read_does_not_block_render_wakeup(monkeypatch: Any) -> None:
@@ -150,7 +241,9 @@ def test_windows_canceled_key_read_is_reused_by_next_reader(monkeypatch: Any) ->
 
     assert result == "h"
     assert calls == ["start", "end"]
-    assert kbhit_calls == 1
+    # One gate poll for the canceled read, one drain poll after its char
+    # arrived; the reused read adds no further polls.
+    assert kbhit_calls == 2
 
 
 def test_read_input_chunk_or_render_tick_reads_raw_stringio_escape_without_tail_joining() -> (
@@ -522,7 +615,7 @@ def _install_fake_msvcrt(
     chars: list[str] | None = None,
     kbhit: object | None = None,
     getwch: object | None = None,
-) -> None:
+) -> Any:
     pending = list(chars or ())
     fake_msvcrt = SimpleNamespace(
         kbhit=kbhit or (lambda: bool(pending)),
@@ -532,3 +625,4 @@ def _install_fake_msvcrt(
         "loushang.tui.terminal_input._load_windows_console_module",
         lambda: fake_msvcrt,
     )
+    return fake_msvcrt


### PR DESCRIPTION
## 问题

Windows 上启动 TUI 后，按方向键、移动鼠标会在输入框漏出 `[B` 之类的原始转义序列字符。

根因：开启 VT 输入后控制台把方向键以 `ESC [ B` 文本送达，而 Windows 读取器（`msvcrt.getwch()`）每次只取 1 个字符；转义序列 pending 缓冲只等 10ms 空闲就被强制 flush（`runner.py` / `screen_runner.py`），而读取器自身 `kbhit()` 轮询间隔就是 10ms——只要 `[` 比 `ESC` 晚到 10ms 以上，`ESC` 被 flush 成 Escape 键，剩下的 `[B` 按字面文本插入输入框。鼠标 SGR 序列（6+ 个单字符 chunk）同理。

## 修复

- **排干式读取**：Windows 读取器拿到首字符后循环 `kbhit()/getwch()` 把当前可用字符攒成一个原子 chunk（上限 4096 防粘贴/鼠标洪流），`ESC[B` 整体到达；`\x00`/`\xe0` 扩展键扫描码配对对首字符和排干尾部都完整保留；POSIX 路径零改动。
- **平台感知 flush 窗口**：Windows 50ms / 其他平台 10ms，两处 runner 共用 `default_pending_input_idle_ms()`（顺带修复单独按 Escape 键的响应延迟代价仅 +40ms）。

## 测试

新增 9 个测试：拆分序列原子排干、扩展键三种场景（首字符/无 kbhit 直读扫描码/排干尾部）、chunk 上限翻转、平台窗口值、runner 接线、拆分 chunk 端到端解析。目标套件 390 passed，harnesstui 会话层 251 passed，全量沙箱套件 0 新增失败，ruff 全过；经独立 code review（approve-with-nits，nit 已落实）。

## ⚠️ 合并前

代码层验证充分，但**尚无 Windows 真机验证**（开发机为 macOS）。请在 Windows（cmd / Windows Terminal）上 checkout 本分支，启动 TUI 按方向键、动鼠标确认不再漏字符后再合并。