### PR TITLE
docs(harness): align capability graph current status

### DIFF
--- a/docs/internals/architecture/README.md
+++ b/docs/internals/architecture/README.md
@@ -132,8 +132,8 @@ drift guards.
 - [Harness Current Owner Map](harness/current-owner-map.md) is the descriptive
   owner-map pattern.
 - [Harness Capability Dependency And Mount Lifecycle](harness/capability-dependency-and-mount-lifecycle.md)
-  is an accepted Target that explicitly distinguishes unimplemented graph
-  owners.
+  is an accepted Target whose graph owners are implemented while accepted
+  Capability IDs may still differ from production-mounted coverage.
 - [TUI Traceability Matrix](tui/native-terminal-core/traceability-matrix.md)
   demonstrates requirements-to-design-to-test traceability.
 - [Coding LSP](coding/lsp/README.md) demonstrates a nested Product Capability

--- a/docs/internals/architecture/harness/product-runtime-injection/components/capability-composition-binding.md
+++ b/docs/internals/architecture/harness/product-runtime-injection/components/capability-composition-binding.md
@@ -15,8 +15,10 @@ ordering, lifecycle, and diagnostics. Products retain their domain content,
 default selections, executable handlers, and policy.
 
 It satisfies PDRI-001, PDRI-004, PDRI-008, PDRI-009, PDRI-010, and PDRI-011.
-PDRI-013 through PDRI-015 define an accepted follow-on graph/finalization
-target that is not yet implemented by this component.
+PDRI-013 through PDRI-015 led to the implemented graph Planner, Binder,
+Runtime, and Projector owners under `loushang.harness.capabilities`; those
+owners are adjacent to this facet-composition component rather than hidden
+inside it.
 
 The standard slots below are internal Binding Facets rather than one public
 Capability dependency node per slot. Resource, prompt, skill, Tool-pack, and

--- a/docs/internals/architecture/harness/product-runtime-injection/components/runtime-profile-resolution.md
+++ b/docs/internals/architecture/harness/product-runtime-injection/components/runtime-profile-resolution.md
@@ -15,9 +15,10 @@ This component turns an explicitly declared Product runtime plan into a
 deterministic, inspectable, session-scoped set of live bindings. It satisfies
 the common mechanics in PDRI-001 through PDRI-012, with capability-specific
 policy remaining in each Product and its later component document.
-PDRI-013 through PDRI-015 define the accepted next-stage top-level Capability
-graph and incremental Mount finalization; those mechanics are not yet part of
-`loushang.harness.runtime.profile`.
+PDRI-013 through PDRI-015 are implemented by the adjacent top-level Capability
+graph Planner, Binder, Runtime, and Projector under
+`loushang.harness.capabilities`; they are intentionally not folded into the
+finer-grained `loushang.harness.runtime.profile` resolver.
 
 Harness owns resolution, strict data validation, lifecycle sequencing, stale
 lease invalidation, and diagnostics. A Product owns its slots, baseline
@@ -287,10 +288,12 @@ factory, Coding derives an explicit grant from its effective policy, the
 runtime profile selects one deterministic winner, only that factory binds, and
 Session shutdown cancels the active Provider before disposing the factory.
 
-PDRI-013 through PDRI-015 additionally require future neutral tests for
-dependency closure, full cycle paths, scope/phase inversion, unchanged-node
-reuse, failure/cancellation rollback with shielded cleanup, and reverse-
-topological disposal before the Mount-graph target may be marked implemented.
+The PDRI-013 through PDRI-015 graph evidence now lives in
+`tests/harness/capabilities/test_graph_planning.py`,
+`test_graph_binding.py`, and `test_graph_projection.py`, with owner and import
+gates under `tests/architecture/`. The separate `stable_reference` refresh
+binding still fails closed and is not implied by the implemented direct-
+dependency Mount runtime.
 
 ## Non-Goals
 

--- a/docs/internals/architecture/harness/shared-capability-boundaries.md
+++ b/docs/internals/architecture/harness/shared-capability-boundaries.md
@@ -43,10 +43,15 @@ lifecycle. The composition rules for those slots are defined by the
 Top-level Capability dependency and Mount lifecycle rules are defined by
 [Capability Dependency And Mount Lifecycle](capability-dependency-and-mount-lifecycle.md).
 
-## Accepted Target Top-Level Harness Capability IDs
+## Top-Level Harness Capability IDs
 
-The accepted target Harness Capability IDs are deliberately coarse. The
-top-level planner and live Mount graph are not yet implemented:
+The accepted Harness Capability IDs are deliberately coarse. The pure Planner,
+transactional Binder, live per-graph Runtime, and read-only Projector are now
+implemented under `loushang.harness.capabilities`. Role completeness and
+production mounting still vary by Capability; the
+[Harness Capability Catalog](capability-catalog.md) and
+[Current Owner Map](current-owner-map.md) are authoritative for that Current
+coverage.
 
 | Capability ID | Product-neutral boundary |
 | --- | --- |
@@ -54,8 +59,10 @@ top-level planner and live Mount graph are not yet implemented:
 | `harness.resources` | resource discovery, activation, and prompt/skill/tool/command contribution composition |
 | `harness.session` | Session, transcript, context, interaction, and continuity mechanics |
 
-These identities are the accepted dependency and observation budget, not a
-current public runtime API and not a limit on focused Harness Python modules.
+These identities are the accepted dependency and observation budget and the
+node vocabulary of the implemented Mount runtime. They are not a claim that
+every accepted ID is production-mounted, not a general public runtime API, and
+not a limit on focused Harness Python modules.
 Read, write, edit, process launch, prompt sections, Tool packs, compaction, and
 side-question providers remain facets or contributions inside the owning
 Capability; they do not become top-level nodes merely because their

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -4590,7 +4590,7 @@ def test_capability_docs_define_exact_top_level_id_budgets() -> None:
     assert (
         _markdown_table_first_column_after(
             shared_text,
-            "The accepted target Harness Capability IDs are deliberately coarse.",
+            "The accepted Harness Capability IDs are deliberately coarse.",
         )
         == expected_harness_ids
     )


### PR DESCRIPTION
## Summary

- update current Harness architecture docs to reflect the implemented Capability graph Planner, Binder, Runtime, and Projector
- retain the real remaining stable-reference refresh gap
- leave historical baselines and migration inventories unchanged

## Validation

- make check-architecture-docs
- focused Capability graph and architecture tests: 34 passed
- git diff --check