### PR TITLE
docs(tui): define input ownership boundary

### DIFF
--- a/docs/superpowers/plans/2026-08-22-tui-harnesstui-input-ownership-refactor.md
+++ b/docs/superpowers/plans/2026-08-22-tui-harnesstui-input-ownership-refactor.md
@@ -1,0 +1,811 @@
+# TUI And HarnessTUI Input Ownership Refactor Plan
+
+> Implementation plan for the reviewed design in
+> `docs/superpowers/specs/2026-08-22-tui-harnesstui-input-ownership-boundary-design.md`.
+> Execute tasks in order and stop after the semantic ownership cut. Do not add
+> route deduplication or keybinding-catalog migration to this plan.
+
+**Goal:** Remove Harness conversation semantics from generic
+`loushang.tui.InputRouter` while preserving all HarnessTUI and Coding
+conversation behavior.
+
+**Architecture:** `loushang.tui` owns terminal and prompt-editor mechanics plus
+generic submit/cancel signals. `loushang.harnesstui` remains the sole owner of
+idle/running prompt, steer, follow-up, queue, and abort interpretation. This
+plan deliberately keeps the current HarnessTUI routing order and its partial
+mechanical duplication.
+
+**Tech stack:** Python 3.11+, dataclasses, typing `Literal`/`Protocol`, pytest,
+Ruff, existing TUI input playback and screen-loop playback.
+
+---
+
+## Scope Guard
+
+Allowed production edits:
+
+- `src/loushang/tui/input.py`
+- the generic stateful demo adapter in
+  `examples/tui/29_composer_bottom_frame.py`
+
+Allowed contract/documentation edits:
+
+- focused tests under `tests/tui/`
+- focused HarnessTUI/Coding characterization tests only when a missing invariant
+  is demonstrated
+- TUI and HarnessTUI architecture/input documentation
+- English and Chinese TUI editing/user guides
+
+Not allowed under this plan:
+
+- behavior changes in `src/loushang/harnesstui/conversation/input.py`
+- production changes under `src/loushang/coding/` or `src/loushang/harness/`
+- `ConversationInputResult` redesign
+- global keybinding catalog movement
+- broad `InputIntentKind` cleanup, including removal of existing
+  `steer`/`follow_up` envelope members; this tranche only adds the new generic
+  prompt cancel result
+- shared whole-router extraction or route-order deduplication
+
+If implementation requires a file outside this guard to make production
+behavior work, stop and return to design review.
+
+## Target Contract
+
+After this plan:
+
+```text
+loushang.tui.InputRouter
+  input: InputEvent + PromptInputTarget
+  state: editor/surface/jump/viewport only
+  output: submit | prompt_cancel | invalidate_render | generic surface intents
+
+loushang.harnesstui.ConversationInputRouter
+  input: InputEvent + conversation UI state
+  output: prompt | local | steer | follow-up | abort | surface result | exit
+```
+
+Generic `InputRouter` must not:
+
+- read `running`;
+- inspect steering support;
+- produce steer/follow-up;
+- downgrade steer to follow-up;
+- restore or request queued conversation messages;
+- map cancel to active-run abort.
+
+## PR Sequence
+
+### PR 1: Freeze The Boundary
+
+Reviewed design/plan/review artifacts and passing current-behavior
+characterization tests only. No production behavior change, current
+architecture-doc rewrite, target-contract red test, or future-state source
+gate.
+
+### PR 2: Migrate The Stateful Example
+
+Change only the application adapter in
+`examples/tui/29_composer_bottom_frame.py`. Stop passing conversation state to
+generic `InputRouter` and stop consuming its conversation-specific outputs,
+while the old router contract still exists. Verify the interactive event loop,
+not only snapshot rendering.
+
+### PR 3: Cut Generic Conversation Semantics
+
+Target-contract red tests, package-level source ownership gates, generic TUI
+implementation, durable/public documentation, and final verification. Red
+tests are not committed separately; they land green with the implementation.
+
+Do not combine any PR with later route deduplication.
+
+Rollback is dependency-ordered: revert PR 3 before PR 2, then PR 1 if desired.
+PR 2 is independently mergeable against the old Router, but it is not safe to
+revert PR 2 while PR 3 remains because that would restore a `running=` caller
+against the narrowed constructor. Record the PR 2 head/base SHA in PR 3 so the
+zero-example-diff and rollback order are mechanically reviewable.
+
+---
+
+## Task 0: Establish The High-Risk Work Lane
+
+**Files:** none
+
+- [ ] Create or identify a GitHub tracking issue for the TUI/HarnessTUI input
+  ownership cut.
+- [ ] Use the long-lived TUI worktree without deleting or repurposing it.
+- [ ] Confirm the worktree is clean before switching branches.
+- [ ] Create a task branch from the latest local `main`, for example:
+
+```bash
+git switch -c tui/input-ownership-boundary main
+```
+
+- [ ] Record the baseline commit in the tracking issue or PR notes.
+- [ ] Run the focused baseline:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/tui/test_input_routing.py \
+  tests/harnesstui/conversation/test_input.py \
+  tests/harnesstui/conversation/test_clipboard_input.py \
+  tests/coding/test_screen_coding_tui_input.py \
+  --skip-host-runtime \
+  -q
+```
+
+Expected current baseline: 110 tests pass. If the count changes on the eventual
+base commit, record the new passing count rather than forcing 110.
+
+- [ ] Run the playback baseline:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/tui/test_import_boundaries.py \
+  tests/harnesstui/testing/test_import_boundaries.py \
+  tests/harnesstui/testing/test_input_playback.py \
+  tests/harnesstui/testing/test_screen_loop_playback.py \
+  --skip-host-runtime \
+  -q
+```
+
+Expected current boundary/playback baseline: 21 tests pass. Record the actual
+count on the eventual base commit if it changes.
+
+- [ ] Run the Coding conversation playback/loop baseline:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/coding/test_screen_tui_playback_harness.py \
+  tests/coding/test_screen_coding_tui_loop.py \
+  --skip-host-runtime \
+  -q
+```
+
+Expected current Coding playback/loop baseline: 46 tests pass. Record the
+actual count on the eventual base commit if it changes.
+
+- [ ] Stop if either baseline is red for reasons unrelated to this plan.
+
+## Task 1: Freeze Current Conversation Behavior
+
+**Files:**
+
+- Modify only if a listed invariant is missing:
+  `tests/harnesstui/conversation/test_input.py`
+- Modify only if a listed invariant is missing:
+  `tests/coding/test_screen_coding_tui_input.py`
+- Verify: `tests/tui/test_input_routing.py`
+
+### Step 1: Inventory Existing Conversation Regressions
+
+- [ ] Confirm existing HarnessTUI/Coding tests cover:
+  - idle Enter starts a prompt;
+  - running Enter produces steer;
+  - running Alt+Enter produces follow-up;
+  - completion cancel wins before abort;
+  - idle cancel handles pending steer before draft clear;
+  - Alt+Up restores pending steer/follow-up text;
+  - Ctrl+O and clipboard-image routing remain HarnessTUI/Coding behavior.
+- [ ] Add only missing characterization. Do not rewrite already adequate tests.
+
+### Step 2: Run Passing Characterization
+
+Run the focused baseline from Task 0. PR 1 is mergeable only when every added
+test passes against unchanged production code.
+
+Do not add the future-state generic boundary tests or source ownership gate in
+PR 1. They belong to Task 3 because they are expected to fail before the
+implementation changes.
+
+## Task 2: Migrate The Generic Stateful Example First
+
+**Files:**
+
+- Modify: `examples/tui/29_composer_bottom_frame.py`
+
+This task is PR 2. It must remain independently mergeable while the current
+conversation-aware `InputRouter` implementation still exists.
+
+### Step 1: Record The Current Interactive Behavior
+
+Before editing, run the example with a deterministic fake duration:
+
+```bash
+.venv/bin/python examples/tui/29_composer_bottom_frame.py \
+  --min-run-seconds 20 \
+  --max-run-seconds 20
+```
+
+Record the observed state after idle Enter, running Enter, `/steer ...` Enter,
+Alt+Up, idle Ctrl+C, and running Escape/Ctrl+C. The example has no completion
+provider/items, so completion cancel is not a reachable example gate. This is a
+manual/PTY acceptance record, not a new example unit test. Also record idle
+`/quit` and running `/quit`; the latter must cancel the active fake task before
+exit.
+
+### Step 2: Remove Conversation Arguments And Outputs
+
+Construct generic `InputRouter` without `running=`:
+
+```python
+router = InputRouter(
+    composer=app.composer,
+    width=runtime.terminal.size().columns,
+)
+```
+
+The demo/application adapter must own these rules:
+
+- compute configured `is_cancel` with `KeybindingManager.matches()` and compute
+  normalized Ctrl+C identity without comparing the raw `"ctrl_c"` alias;
+- record `had_completions`, then call the generic router exactly once;
+- if cancel started with completions, treat it as editor-consumed;
+- otherwise map both the old Router's empty cancel result and the future
+  Router's `prompt_cancel` result into one application cancel decision;
+- idle Ctrl+C intentionally fixes the existing alias bug and exits the demo;
+- running Escape/Ctrl+C aborts the demo task exactly once;
+- idle Escape remains a no-op;
+- Alt+Up restores only the last pending follow-up before generic routing; it
+  does not restore or reorder pending steer;
+- `/q`, `/quit`, and `/exit` are classified before idle/running submit policy;
+  running exit cancels `active_task` before exiting;
+- generic `submit` starts work while idle;
+- generic `submit` queues a follow-up while running, except the existing
+  `/steer ` convention queues steer text.
+
+Remove demo dependence on these generic output forms:
+
+- `intent.kind == "follow_up"`;
+- `intent.kind == "abort"` from `InputRouter`;
+- `intent.note == "edit_last_queued_prompt"`.
+
+Do not add HarnessTUI imports to a generic TUI example. The application policy
+may use local helpers, app state, normalized key ids, and configured input
+actions. PR 3 must consume future `prompt_cancel` without changing this PR 2
+example code or executing cancel policy twice.
+
+### Step 3: Prove The Example Is Decoupled
+
+The following source inventory must return no conversation dependency in the
+interactive adapter:
+
+```bash
+rg -n \
+  'running=|intent\.kind == "follow_up"|intent\.kind == "abort"|edit_last_queued_prompt' \
+  examples/tui/29_composer_bottom_frame.py
+```
+
+Review any match before proceeding; unrelated display copy is not sufficient
+reason to weaken the check.
+
+### Step 4: Run Static And Non-Interactive Smoke
+
+```bash
+.venv/bin/python -m ruff check examples/tui/29_composer_bottom_frame.py
+.venv/bin/python examples/tui/29_composer_bottom_frame.py --snapshot --width 100 --height 28
+.venv/bin/python examples/tui/29_composer_bottom_frame.py --scripted --width 100 --height 28
+```
+
+Snapshot and scripted modes prove import/render health only; they do not close
+the interactive gate.
+
+### Step 5: Repeat The Interactive Acceptance Sequence
+
+Repeat Step 1 after the change and record:
+
+| Input | Required observation |
+| --- | --- |
+| text + Enter while idle | fake run starts and composer clears |
+| text + Enter while running | follow-up appears in the pending area |
+| `/steer focus logs` + Enter while running | steer item appears distinctly |
+| Alt+Up with steer and follow-up pending | last follow-up returns; steer remains pending |
+| Ctrl+C while idle | demo exits through the intentional alias bug fix |
+| Escape/Ctrl+C while running without completion | fake run aborts |
+| `/quit` + Enter while idle | demo exits without starting a fake run |
+| `/quit` + Enter while running | active fake task is cancelled, then demo exits |
+
+Do not merge PR 2 if only snapshot/scripted output was checked.
+
+## Task 3: Make Generic `InputRouter` Conversation-Neutral
+
+**Files:**
+
+- Modify: `src/loushang/tui/input.py`
+- Modify: `tests/tui/test_input_routing.py`
+- Modify or create package ownership coverage under `tests/tui/`
+
+This task begins PR 3. PR 2 must already be green so the generic router no
+longer has a stateful in-repository example consumer.
+
+### Step 1: Add Desired Generic Boundary Tests
+
+Add focused tests that express the target generic contract. These are expected
+to be red before the implementation in this task:
+
+```python
+def test_input_router_submit_is_conversation_neutral() -> None:
+    composer = Composer(prompt="> ")
+    composer.insert_text("later")
+    router = InputRouter(composer=composer)
+
+    assert router.route(InputEvent(kind="key", key="enter")) == (
+        InputIntent(kind="submit", text="later"),
+    )
+
+
+def test_input_router_unconsumed_cancel_emits_prompt_cancel() -> None:
+    composer = Composer(prompt="> ")
+    router = InputRouter(composer=composer)
+
+    assert router.route(InputEvent(kind="key", key="escape")) == (
+        InputIntent(kind="prompt_cancel"),
+    )
+
+
+def test_input_router_does_not_own_conversation_queue_editing() -> None:
+    composer = Composer(prompt="> ")
+    router = InputRouter(composer=composer)
+
+    assert router.route(InputEvent(kind="key", key="alt+up")) == ()
+```
+
+Also add regressions for the cancel priority matrix:
+
+- Escape and Ctrl+C each terminate a pending jump without producing
+  `prompt_cancel`;
+- an active surface still receives cancel when a jump is pending;
+- a focused editor still blocks prompt cancel when a jump is pending;
+- active completion still consumes cancel when a jump is pending;
+- Escape and Ctrl+C produce `prompt_cancel` only when truly unconsumed.
+- with a custom `jumpForward=escape` overlap, surface, focused editor, and
+  completion still win before jump cancel is swallowed.
+- with `jumpForward=escape` and no pending jump or higher-priority consumer,
+  Escape emits `prompt_cancel`; later text inserts normally instead of being
+  consumed as a jump target.
+
+Add public contract tests using dataclass/runtime/signature inspection:
+
+- constructor fields exclude `running` and `steering_supported`;
+- `inspect.signature(InputRouter)` is exactly `composer`, `surface_host`, then
+  keyword-only `width`, `height`, `keybindings`, and `target`;
+- `_jump_mode` is `init=False` and absent from the public constructor;
+- `InputRouter(composer, None, True)` raises `TypeError` rather than silently
+  rebinding `True` to `width`;
+- `submit()` accepts no `mode` argument;
+- a non-empty zero-argument `submit()` produces only generic `submit`.
+
+### Step 2: Add Package-Level Source Ownership Gates
+
+Add architecture tests that use runtime/dataclass inspection to verify:
+
+- `running` is absent;
+- `steering_supported` is absent;
+- generic `input.py` has no `SubmitMode` definition.
+
+Add an AST producer gate over every Python file under
+`src/loushang/tui/**/*.py`. Reject direct constant construction in both
+positional and keyword forms:
+
+- `InputIntent("steer", ...)`;
+- `InputIntent(kind="steer", ...)`;
+- `InputIntent("follow_up", ...)`;
+- `InputIntent(kind="follow_up", ...)`;
+- `InputIntent("command", ..., "edit_last_queued_prompt")`;
+- `InputIntent(kind="command", note="edit_last_queued_prompt")`.
+
+The AST gate must not reject retained `InputIntentKind` literal declarations,
+string values in migration documentation, or unrelated generic
+`InputIntent(kind="abort")` producers used by cancellable widgets. Existing
+structural dynamic-envelope forwarders such as configurable selection/dialog
+result kinds are explicitly outside this direct-constant guarantee. Add checker
+self-tests with small parsed snippets for every rejected positional/keyword
+form and for the allowed dynamic/abort forms. Recognize both
+`ast.Name(id="InputIntent")` and `ast.Attribute(attr="InputIntent")` call
+targets so module-qualified construction cannot bypass the gate. Do not use a
+brittle whole-tree substring assertion.
+
+### Step 3: Run The New Tests And Confirm RED
+
+Run only the new generic boundary tests.
+
+Expected failures:
+
+- `prompt_cancel` is not yet an accepted intent kind/route;
+- Alt+Up still emits the queued-edit command;
+- the current class still exposes conversation-state fields and branches.
+
+Do not commit red tests alone. Continue within this task and commit the tests
+with the green implementation.
+
+### Step 4: Narrow Generic Intent Vocabulary
+
+In `InputIntentKind`:
+
+- [ ] Add `prompt_cancel`.
+- [ ] Retain `follow_up` and `steer` as legacy members of the shared surface
+  intent envelope; generic `InputRouter` must stop constructing them.
+- [ ] Keep `abort`; other generic components already use it and broad intent
+  cleanup is outside scope.
+
+Remove:
+
+```python
+SubmitMode = Literal["submit", "follow_up", "steer"]
+```
+
+Do not touch unrelated approval, dialog, selection, settings, or command intent
+kinds.
+
+### Step 5: Remove Conversation State From The Router
+
+Remove these dataclass fields:
+
+```python
+running: bool = False
+steering_supported: bool = False
+```
+
+Add a keyword-only boundary and hide internal jump state from construction:
+
+```python
+_: KW_ONLY
+width: int = 80
+height: int = 24
+keybindings: KeybindingManager | None = None
+target: InitVar[PromptInputTarget | None] = None
+_jump_mode: Literal["forward", "backward"] | None = field(
+    default=None,
+    init=False,
+)
+```
+
+Keep `composer` and `surface_host` as the only positional parameters. This is a
+loud-failure boundary for old third/fourth positional calls, not a compatibility
+shim.
+
+### Step 6: Replace Cancel Routing Without Leaking Jump Cancel
+
+Compute `is_cancel` before evaluating pending jump state. Preserve these
+priorities:
+
+1. a pending jump is cleared, while recording whether this key is cancel; a
+   repeated jump binding returns early only when `not is_cancel`;
+2. active surface receives the key first;
+3. focused editor target still blocks prompt-only actions;
+4. active completion closes before generic cancel;
+5. cancel that already terminated pending jump returns no intent;
+6. only a truly unconsumed cancel emits `prompt_cancel`.
+
+Conceptually, the final decision is:
+
+```python
+if keybindings.matches(event.key, "tui.select.cancel"):
+    if cancelled_pending_jump:
+        return ()
+    return (InputIntent(kind="prompt_cancel"),)
+```
+
+Do not return immediately when the jump is first cleared: that would skip the
+existing surface/focused-editor/completion priority. Do not clear the prompt and
+do not emit `abort` here. Add the custom `jumpForward=escape` overlap
+regressions rather than broadening keybinding conflict validation in this PR.
+
+### Step 7: Remove Conversation Queue Routing
+
+Delete the `tui.queue.editLast` branch from generic `InputRouter`:
+
+```python
+if keybindings.matches(event.key, "tui.queue.editLast"):
+    return (InputIntent(kind="command", note="edit_last_queued_prompt"),)
+```
+
+Do not remove the keybinding definition in this plan; HarnessTUI still consumes
+the action id. The generic router simply stops assigning it conversation
+meaning.
+
+### Step 8: Simplify Submit
+
+Change:
+
+```python
+def submit(self, *, mode: SubmitMode = "submit") -> tuple[InputIntent, ...]:
+```
+
+to:
+
+```python
+def submit(self) -> tuple[InputIntent, ...]:
+```
+
+Keep the existing generic sequence:
+
+1. read target text;
+2. ignore empty text;
+3. add to target history;
+4. clear the target;
+5. return one generic submit intent.
+
+Delete all running, steer-support, downgrade, follow-up, and note branches.
+
+### Step 9: Update Existing Generic Tests
+
+- [ ] Remove construction with `running=` or `steering_supported=`.
+- [ ] Delete/replace tests whose only contract is generic running steer or
+  follow-up behavior.
+- [ ] Preserve surface-before-cancel and completion-before-cancel tests, changing
+  only the final generic result where necessary.
+- [ ] Expand jump cancellation coverage to Escape and Ctrl+C plus active
+  surface, focused editor, and completion combinations.
+- [ ] Preserve all editor, target, selection, completion, history, paste, jump,
+  page, resize, and keybinding override tests.
+- [ ] Verify that tests do not recreate conversation interpretation inside
+  `tests/tui`.
+
+### Step 10: Run Focused TUI Tests
+
+```bash
+.venv/bin/python -m pytest \
+  tests/tui/test_input_routing.py \
+  --skip-host-runtime \
+  -q
+```
+
+Expected: PASS.
+
+### Step 11: Run HarnessTUI And Coding Behavior Tests
+
+```bash
+.venv/bin/python -m pytest \
+  tests/harnesstui/conversation/test_input.py \
+  tests/harnesstui/conversation/test_clipboard_input.py \
+  tests/coding/test_screen_coding_tui_input.py \
+  --skip-host-runtime \
+  -q
+```
+
+Expected: all existing behavior remains green without production edits under
+`src/loushang/harnesstui` or `src/loushang/coding`.
+
+## Task 4: Update Durable And Public Documentation
+
+**Files:**
+
+- Modify:
+  `docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md`
+- Modify:
+  `docs/internals/architecture/tui/native-terminal-core/key-designs/KD-003-abort-steer-follow-up-sequence.md`
+- Modify: `docs/internals/architecture/harnesstui/README.md`
+- Modify: `docs/en/reference/tui-editing.md`
+- Modify: `docs/zh-CN/reference/tui-editing.md`
+- Modify if necessary: `docs/en/user-guide/tui.md`
+- Modify if necessary: `docs/zh-CN/user-guide/tui.md`
+- Modify status note:
+  `docs/superpowers/specs/2026-06-09-tui-input-router-decouple-design.md`
+
+### Step 1: Correct KD-002 Ownership
+
+Replace claims that generic `InputRouter` owns running abort or
+steer/follow-up semantics with:
+
+- generic TUI owns editor and prompt intent mechanics;
+- HarnessTUI owns conversation run-state interpretation;
+- Product adapters may define final command and action policy.
+
+Keep surface-first, focused-editor, completion, paste, and editor-state
+requirements unchanged.
+
+### Step 2: Correct KD-003 And Clarify HarnessTUI Ownership
+
+Correct KD-003 before updating the HarnessTUI README:
+
+- HarnessTUI conversation adapters interpret idle/running Enter,
+  follow-up/steer alternatives, queue restore, and conversation abort;
+- capability and downgrade policy stays above generic TUI;
+- current Coding uses HarnessTUI's default `running_submit_mode="steer"` and
+  does not yet inject an explicit capability policy;
+- explicit Coding policy injection remains deferred, while Coding continues to
+  supply slash-command classification, final actions, and copy;
+- generic TUI emits neutral prompt/editor signals only.
+
+Then document `ConversationInputRouter` as the sole Harness conversation input
+semantic owner. State that it reuses TUI editing targets/helpers without using
+generic `InputRouter` as a second conversation state machine.
+
+### Step 3: Update Public TUI Guidance
+
+Explain that generic `InputRouter` emits `submit` and `prompt_cancel`; an
+application adapter decides run-state meaning. Point Harness-backed conversation
+applications to HarnessTUI.
+
+Add a durable, searchable **Pre-1.0 InputRouter migration** section to the
+English and Chinese reference guides. It must identify the breaking removals
+and show both replacement paths:
+
+| Old API | Harness-backed replacement | Generic application replacement |
+| --- | --- | --- |
+| `InputRouter(running=...)` | `ConversationInputRouter` state projection | interpret generic `submit` from app state |
+| `steering_supported=...` | choose `running_submit_mode="steer"` when supported, otherwise `"follow_up"` | app-owned capability decision |
+| `submit(mode=...)` | HarnessTUI running-submit route | zero-argument `submit()` plus app policy |
+| third/fourth positional state arguments | use explicit HarnessTUI configuration | replace with keyword-only generic configuration and app state |
+
+State explicitly that only `composer` and `surface_host` remain positional.
+All later constructor configuration is keyword-only, and legacy calls such as
+`InputRouter(composer, None, True)` now raise `TypeError` instead of silently
+binding `True` to `width`.
+
+Do not rely on the PR description as the only migration record.
+
+### Step 4: Mark The Older Design Partially Superseded
+
+Add a short status note to the 2026-06-09 design:
+
+- target adapter and focused-editor work remains valid;
+- generic ownership of running abort/steer/follow-up is superseded by the
+  2026-08-22 ownership design.
+
+Do not rewrite historical implementation steps.
+
+## Task 5: Final Verification And Review Gate
+
+**Files:** verify all files changed by Tasks 1-4
+
+### Step 1: Focused Regression
+
+```bash
+.venv/bin/python -m pytest \
+  tests/tui/test_input_routing.py \
+  tests/harnesstui/conversation/test_input.py \
+  tests/harnesstui/conversation/test_clipboard_input.py \
+  tests/coding/test_screen_coding_tui_input.py \
+  --skip-host-runtime \
+  -q
+```
+
+### Step 2: Boundary And Playback Regression
+
+```bash
+.venv/bin/python -m pytest \
+  tests/tui/test_import_boundaries.py \
+  tests/harnesstui/testing/test_import_boundaries.py \
+  tests/harnesstui/testing/test_input_playback.py \
+  tests/harnesstui/testing/test_screen_loop_playback.py \
+  --skip-host-runtime \
+  -q
+```
+
+### Step 3: Coding Conversation Playback And Loop Regression
+
+```bash
+.venv/bin/python -m pytest \
+  tests/coding/test_screen_tui_playback_harness.py \
+  tests/coding/test_screen_coding_tui_loop.py \
+  --skip-host-runtime \
+  -q
+```
+
+### Step 4: Broader Subsystem Regression
+
+```bash
+.venv/bin/python -m pytest tests/tui tests/harnesstui --skip-host-runtime -q
+.venv/bin/python -m pytest \
+  tests/coding \
+  --skip-host-runtime \
+  -m "not live and not tui_render_contract" \
+  -q
+```
+
+If a broader suite has a known unrelated failure, record the exact failing test
+and prove the focused baseline remains unchanged. Do not weaken or skip a new
+input failure.
+
+### Step 5: Re-run The PR 2 Example Without Editing It
+
+- [ ] Verify PR 3 has no diff for
+  `examples/tui/29_composer_bottom_frame.py` relative to the recorded PR 3 base.
+- [ ] Repeat the PR 2 interactive matrix unchanged against the new Router.
+- [ ] Confirm cancel policy executes once for both Escape and Ctrl+C, Alt+Up
+  restores only follow-up, idle Ctrl+C exits, and idle/running `/quit` retain
+  the PR 2 behavior.
+
+Do not patch the example inside PR 3 to make this gate pass. If the PR 2 adapter
+is not dual-version compatible, stop and repair/re-review the PR split.
+
+### Step 6: Static Validation
+
+```bash
+.venv/bin/python -m ruff check \
+  src/loushang/tui/input.py \
+  src/loushang/harnesstui/conversation/input.py \
+  examples/tui/29_composer_bottom_frame.py \
+  tests/tui/test_input_routing.py \
+  tests/harnesstui/conversation/test_input.py
+git diff --check
+```
+
+### Step 7: Manual Diff Review
+
+Verify:
+
+- [ ] no production file under `src/loushang/harnesstui` changed behavior;
+- [ ] no production file under `src/loushang/coding` changed;
+- [ ] generic InputRouter has no conversation state or result construction;
+- [ ] package-wide AST gate prevents direct constant conversation intent
+  producers elsewhere under `src/loushang/tui/`, including positional and
+  keyword call forms;
+- [ ] public constructor makes all configuration after `surface_host`
+  keyword-only and excludes `_jump_mode`;
+- [ ] existing routing priorities were not reordered beyond deleted
+  conversation branches;
+- [ ] jump-mode Escape/Ctrl+C remains consumed after surface, focused-editor,
+  and completion priority;
+- [ ] custom `jumpForward=escape` cannot bypass those priorities;
+- [ ] with no pending jump, the same overlap emits `prompt_cancel` rather than
+  entering jump mode;
+- [ ] AST checker covers bare and attribute-form `InputIntent` constructors;
+- [ ] example-owned policy did not leak back into TUI;
+- [ ] docs distinguish current generic and conversation contracts;
+- [ ] no keybinding catalog, tagged-result, or route-deduplication work slipped
+  into the patch.
+
+## Commit And PR Guidance
+
+Recommended commits:
+
+1. `docs(tui): define input ownership boundary` — reviewed design, plan,
+   review record, and passing characterization where appropriate.
+2. `refactor(tui-example): own conversation demo input policy` — stateful
+   example adapter migration and its recorded interactive acceptance evidence.
+3. `refactor(tui): remove conversation semantics from input router` — red/green
+   boundary tests, implementation, package-level ownership gate, durable
+   architecture updates, and public migration guidance.
+
+Use `Refs #N` while the tracking issue remains open. Do not use `Fixes #N` if
+the issue also tracks deferred route deduplication or keybinding cleanup.
+
+PR 2 description must include the static/import commands and the complete
+interactive acceptance record, call out the intentional idle Ctrl+C alias fix,
+state that Alt+Up remains follow-up-only, and record idle/running exit-command
+behavior. PR 3 description must include:
+
+- the removed advanced constructor/method behavior;
+- proof that production Coding uses HarnessTUI rather than generic
+  `InputRouter`;
+- focused and playback commands with results;
+- explicit statement that effective Coding shortcuts did not change;
+- the pre-1.0 breaking API migration mapping;
+- proof that old positional state arguments fail loudly and `_jump_mode` is not
+  a public constructor parameter;
+- proof that PR 2's example file did not change and its matrix still passes;
+- rollback order PR 3, then PR 2, then PR 1;
+- deferred follow-ups that were intentionally excluded.
+
+## Stop Conditions
+
+Stop and return to design review if any of the following occurs:
+
+- a supported production or external consumer of `InputRouter(running=...)` is
+  identified;
+- keyword-only migration cannot prevent legacy positional calls from silently
+  rebinding;
+- preserving Coding behavior requires modifying Coding production code;
+- HarnessTUI must change routing order to accommodate the generic cut;
+- `prompt_cancel` cannot be introduced without broad widget intent migration;
+- the implementation begins to require a new whole-event route engine;
+- focused input or playback tests reveal an existing ambiguity not resolved by
+  the reviewed decision records.
+
+## Completion Criteria
+
+- The reviewed spec decisions TIO-DEC-001 through TIO-DEC-005 and TIO-DEC-007
+  are implemented.
+- All focused, boundary, and playback gates pass.
+- Constructor signature and legacy positional loud-failure tests pass.
+- The example adapter PR passed static/import smoke and the recorded
+  interactive acceptance matrix before and after the router cut without a PR 3
+  example diff.
+- Idle/running exit commands remain classified before submit/follow-up policy.
+- Generic `InputRouter` is conversation-state neutral.
+- HarnessTUI/Coding conversation behavior is unchanged.
+- Public docs and the stateful generic example use the new boundary.
+- Deferred work remains deferred and is not hidden in the implementation PR.

--- a/docs/superpowers/specs/2026-08-22-tui-harnesstui-input-ownership-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-22-tui-harnesstui-input-ownership-boundary-design.md
@@ -1,0 +1,704 @@
+# TUI And HarnessTUI Input Ownership Boundary Design
+
+## Status
+
+Approved for implementation after final independent acceptance review.
+
+- Spec version: `2026-08-22-r7`
+- Review verdict: Accept; no open findings
+- Implementation prerequisite: create or identify a tracking issue under the
+  high-risk change workflow before production code changes begin
+- Scope: semantic ownership between `loushang.tui` and
+  `loushang.harnesstui` only
+
+This design supersedes the conversation-semantics portions of
+`2026-06-09-tui-input-router-decouple-design.md`. The target protocols,
+`ComposerInputTarget`, and reusable editor key helpers introduced by that work
+remain valid and should be reused.
+
+## Context
+
+`loushang.tui` is the generic terminal UI substrate. It owns terminal input
+decoding, normalized input events, surfaces and focus routing, editor
+operations, completion, history, rendering, and terminal playback mechanics.
+
+`loushang.harnesstui` is the product-neutral composition layer between Harness
+conversation contracts and the generic terminal UI framework. Its documented
+responsibilities include conversation input, pending queues, abort, steer,
+follow-up, transcript reading, and reusable conversation-screen coordination.
+
+The current source does not fully respect that split:
+
+- `loushang.tui.input.InputRouter` accepts `running` and
+  `steering_supported`, defines `SubmitMode = submit | follow_up | steer`, emits
+  `abort`, `follow_up`, and `steer`, and interprets running Enter as follow-up.
+- `loushang.harnesstui.conversation.input.ConversationInputRouter` separately
+  interprets idle/running state, maps running Enter to steer, maps running
+  Alt+Enter to follow-up, coordinates queued messages, and maps cancel to
+  completion close, clear, pending-steer dispatch, or abort.
+- Both routers therefore contain adjacent conversation state machines with
+  different semantics for the same normalized key event.
+
+This overlap is a migration remainder, not a desired two-product variation.
+The production Coding screen already uses `ConversationInputRouter` through a
+HarnessTUI router factory; production code under `src/` does not construct the
+generic `InputRouter`. The only in-repository running-state consumer of generic
+`InputRouter` is the generic composer bottom-frame example, plus focused tests.
+
+## Problem Statement
+
+The ownership problem is semantic rather than merely mechanical:
+
+1. A generic editor router decides Agent/Harness conversation meaning.
+2. A Harness conversation router repeats generic editor routing to preserve a
+   different product-neutral conversation order.
+3. A shared input-intent envelope still advertises conversation outcomes even
+   though only an upper conversation layer should produce them.
+4. Contributors cannot tell whether changing running submit behavior belongs in
+   TUI or HarnessTUI.
+
+Trying to remove all duplication, redesign every input intent, split every
+keybinding catalog, and inject final Coding policy in one change would be too
+broad. The first tranche therefore establishes semantic ownership and preserves
+existing mechanical duplication where removing it would enlarge the change.
+
+## Goals
+
+- Make `loushang.harnesstui` the only owner of prompt/steer/follow-up/abort
+  interpretation for Harness-backed conversation screens.
+- Make generic `loushang.tui.InputRouter` independent of conversation run state.
+- Keep TUI responsible for terminal/editor mechanics and generic prompt submit
+  or cancel signals.
+- Preserve all current HarnessTUI and Coding user-visible behavior.
+- Keep active-surface, completion, selection, history, jump, paste, resize, and
+  editor behavior unchanged.
+- Keep the consumer migration and public router cut separately reviewable and
+  mergeable in TUI-lane PRs, with an explicit dependent rollback order.
+- Add executable ownership gates so conversation semantics cannot drift back
+  into the generic router.
+
+## Non-Goals
+
+- Do not make `ConversationInputRouter` delegate its entire routing order to
+  `InputRouter` in this tranche.
+- Do not deduplicate all prompt editing orchestration in the same PR as the
+  ownership cut.
+- Do not redesign `ConversationInputResult` into a tagged union yet.
+- Do not remove legacy `steer`/`follow_up` members from the shared
+  `InputIntentKind` envelope yet; stop the generic router from producing them.
+- Do not split `DEFAULT_KEYBINDINGS` into Core, HarnessTUI, and Product catalogs
+  yet.
+- Do not move approval, continuity, settings, dialog, question, or selection
+  intent kinds between packages.
+- Do not change Coding slash-command classification, attachment conversion,
+  clipboard directory policy, or product copy.
+- Do not change Harness Session, Agent loop, queue authority, or action host
+  behavior.
+- Do not change any effective keyboard shortcut in the Coding conversation
+  screen.
+- Do not add tests for the example script itself.
+
+## Current Ownership Evidence
+
+The accepted package direction is:
+
+```text
+loushang.coding.ui -> loushang.harnesstui -> loushang.tui
+```
+
+The package descriptions assign:
+
+- terminal rendering, input, layout, surfaces, widgets, and playback substrate
+  to `loushang.tui`;
+- product-neutral Harness conversation interaction and TUI composition to
+  `loushang.harnesstui`;
+- final Product policy and composition to `loushang.coding`.
+
+Current source-use inventory:
+
+| Consumer | Generic `InputRouter` | HarnessTUI `ConversationInputRouter` |
+| --- | --- | --- |
+| Coding production screen | no | yes |
+| HarnessTUI screen runner | no | yes |
+| generic TUI examples | yes | no |
+| `tests/tui` | yes | no |
+| `tests/harnesstui` | no | yes |
+| Coding TUI regression/playback | no | yes |
+
+This inventory makes a semantic cut in generic `InputRouter` low blast radius,
+provided the stateful generic example migrates first and public contracts move
+with the later router cut.
+
+## Target Ownership
+
+### `loushang.tui`
+
+Owns:
+
+- terminal byte stream to normalized `InputEvent` conversion;
+- key identifier normalization and generic keybinding mechanics;
+- active surface/focus routing;
+- prompt target protocols and `ComposerInputTarget`;
+- text and paste insertion;
+- selection, cursor, word, line, page, kill/yank, undo/redo, and jump editing;
+- completion navigation and application;
+- history traversal;
+- explicit newline insertion;
+- generic prompt `submit`, `prompt_cancel`, and render invalidation intents.
+
+Does not own:
+
+- whether a run is idle, running, or aborting;
+- whether submitted text is a new prompt, steer, or follow-up;
+- steering capability detection or downgrade policy;
+- pending steer/follow-up queue restoration;
+- transcript-reader commands or clipboard attachment coordination;
+- Product command/exit classification.
+
+### `loushang.harnesstui`
+
+Owns:
+
+- idle/running conversation input interpretation;
+- completion-submit behavior used by conversation commands;
+- running primary submit and alternate follow-up ordering;
+- prompt, steer, follow-up, and abort results;
+- pending queue restore and UI projection;
+- transcript-reader command routing;
+- product-neutral prompt attachment coordination;
+- conversation-screen surface priority and result projection.
+
+It continues to reuse generic TUI target adapters and editor helpers. Reusing
+mechanics does not transfer conversation policy into TUI.
+
+### `loushang.coding`
+
+No production change is required in this tranche. Coding continues to supply:
+
+- slash-command and exit predicates;
+- the Coding clipboard-image profile;
+- final action handlers and Product copy;
+- configured keybindings.
+
+Capability and downgrade decisions must remain above generic TUI. Current
+Coding uses HarnessTUI's default `running_submit_mode="steer"`; it does not yet
+inject an explicit capability policy. Moving that default into an explicit
+Coding policy remains deferred.
+
+Moving the default running-submit policy out of HarnessTUI and into an explicit
+Coding policy object is a possible later refinement, not a prerequisite for the
+TUI/HarnessTUI semantic cut.
+
+## Decision Index
+
+| ID | Decision | Status |
+| --- | --- | --- |
+| TIO-DEC-001 | TUI prompt routing is conversation-state neutral. | Approved |
+| TIO-DEC-002 | HarnessTUI remains the sole conversation semantic router. | Approved |
+| TIO-DEC-003 | Generic cancel is `prompt_cancel`, not run `abort`. | Approved |
+| TIO-DEC-004 | First tranche accepts temporary orchestration duplication. | Approved |
+| TIO-DEC-005 | Remove undocumented router knobs without a compatibility facade; retain the shared intent envelope. | Approved |
+| TIO-DEC-006 | Keybinding catalog and broad intent cleanup are deferred. | Deferred |
+| TIO-DEC-007 | Behavior is protected by focused, playback, and ownership gates. | Approved |
+
+## Decision Records
+
+### TIO-DEC-001: TUI Prompt Routing Is Conversation-State Neutral
+
+`InputRouter` will no longer accept or store `running` or
+`steering_supported`. Its `submit()` operation will have no mode parameter and
+will emit only a generic `submit` intent containing the current prompt text.
+
+Rationale:
+
+- run state is not an editor or terminal property;
+- the production conversation screen already uses HarnessTUI;
+- removing the branch eliminates the conflicting generic running-Enter rule;
+- the target adapters already isolate prompt editing operations.
+
+Rejected alternative: retain `running` but rename follow-up to a neutral
+alternate submit. This keeps run state in the generic layer and does not solve
+the ownership problem.
+
+### TIO-DEC-002: HarnessTUI Remains The Sole Conversation Semantic Router
+
+`ConversationInputRouter` keeps the current observable state machine:
+
+| Event | Condition | Result |
+| --- | --- | --- |
+| Enter | idle, non-empty | prompt or injected local/exit result |
+| Enter | running, non-empty | steer by current HarnessTUI policy |
+| Alt+Enter | running, non-empty | follow-up |
+| explicit newline key | any applicable state | insert newline |
+| Escape/Ctrl+C | completion visible | close completion |
+| Escape/Ctrl+C | running | request abort |
+| Escape/Ctrl+C | idle with pending steer | dispatch pending steer |
+| Escape/Ctrl+C | idle with draft | clear draft and staged attachments |
+| Alt+Up | pending queue present | restore queued text to composer |
+
+No production HarnessTUI behavior changes are allowed in the ownership-cut PR.
+
+Rejected alternative: migrate HarnessTUI onto a new shared whole-event router
+while removing generic conversation semantics. That combines ownership change,
+routing-order change, and deduplication in one high-risk patch.
+
+### TIO-DEC-003: Generic Cancel Is `prompt_cancel`
+
+After active surfaces and completion cancellation have had priority, generic
+`InputRouter` returns `InputIntent(kind="prompt_cancel")` for the configured
+cancel binding.
+
+A cancel key that also terminates a pending character-jump mode is already
+consumed by editor state and must not emit `prompt_cancel`. The router records
+that the jump was cancelled, still gives an active surface, focused editor, and
+completion their existing priority, and then swallows the cancel if none of
+those layers handled it. This preserves existing jump-mode Escape/Ctrl+C
+behavior without moving surface or completion policy into the application.
+
+`is_cancel` must be computed before the pending-jump toggle branch. If a custom
+keybinding assigns the same key to cancel and jump, the cancel priority path
+wins; repeated-jump early return is allowed only when `is_cancel` is false.
+This prevents a custom overlap from bypassing an active surface, focused
+editor, or completion. With no pending jump and no higher-priority consumer,
+the overlapped key emits `prompt_cancel` and must not enter jump mode.
+
+It does not decide whether cancel means clear, close, abort, or no-op. A generic
+application adapter owns that decision.
+
+The existing generic `abort` intent remains available to generic cancellable
+widgets that already use it; `InputRouter` simply stops producing it from
+conversation run state.
+
+Rejected alternatives:
+
+- continue emitting `abort`: misleading because generic `InputRouter` no
+  longer knows whether work is active;
+- silently ignore cancel: prevents generic applications from implementing a
+  policy outside TUI;
+- clear the composer inside `InputRouter`: makes cancel policy an editor side
+  effect and diverges from surface-first application control.
+
+### TIO-DEC-004: Accept Temporary Orchestration Duplication
+
+The first tranche does not make `ConversationInputRouter` call generic
+`InputRouter`. It continues to reuse:
+
+- `ComposerInputTarget`;
+- `route_editor_selection_key()`;
+- `route_prompt_completion_key()`;
+- `route_editor_editing_key()`.
+
+The duplicated handling around text/paste, jump mode, history, page movement,
+tab forcing, and routing order remains until a later behavior-preserving
+deduplication design.
+
+This is deliberate. Semantic ownership must be stable before deciding whether
+the shared unit should be a whole router, staged route engine, or smaller prompt
+editing controller.
+
+### TIO-DEC-005: Remove Undocumented Conversation Knobs Directly
+
+The package version is `0.1.0`. Repository production code does not construct
+generic `InputRouter`; the conversation-specific constructor fields and
+`submit(mode=...)` behavior are absent from the public TUI user guides.
+
+Therefore this tranche removes:
+
+- `InputRouter.running`;
+- `InputRouter.steering_supported`;
+- `SubmitMode`;
+- `submit(mode=...)`;
+- generic `follow_up` and `steer` output construction;
+- generic `edit_last_queued_prompt` command construction.
+
+It does not remove the `follow_up` and `steer` literal members from
+`InputIntentKind`. That type is a cross-package surface-intent envelope today,
+and removing members is unnecessary to establish producer ownership. The
+source ownership gate constrains what generic `InputRouter` constructs. Literal
+cleanup belongs with the deferred result-envelope redesign.
+
+No compatibility facade is introduced. A compatibility facade inside
+`loushang.tui` would keep the forbidden semantics in the package and create a
+second cleanup project. The stateful example migrates first in an independently
+mergeable PR. The public editing docs must carry a persistent pre-1.0 breaking
+change migration note, and the semantic-cut PR description must repeat it.
+
+Contract tests must verify the new constructor fields and zero-argument
+`submit()` signature, in addition to behavior tests. The migration note maps
+old `running=`, `steering_supported=`, and `submit(mode=...)` usage to either a
+HarnessTUI conversation router or an application-owned adapter.
+
+Because `InputRouter` is a public dataclass, deleting the third and fourth
+fields must not silently rebind old positional calls to `width` and `height`.
+The new constructor keeps only `composer` and `surface_host` positional, adds a
+`dataclasses.KW_ONLY` boundary before public configuration fields, and declares
+`_jump_mode` with `init=False`. Old third-position calls must fail loudly with
+`TypeError`; no compatibility facade is required.
+
+If evidence of an external supported consumer appears before implementation,
+this decision must be reopened rather than silently adding a permanent shim.
+
+### TIO-DEC-006: Defer Catalog And Broad Intent Cleanup
+
+The current default keybinding definitions include HarnessTUI- and
+Product-oriented action ids such as transcript open, queue edit, continuity,
+and clipboard-image paste. `InputIntentKind` also includes several surface and
+workflow actions beyond generic prompt routing.
+
+Those are real layering debts, but moving them requires a composable definition
+catalog and coordinated updates across settings, surfaces, HarnessTUI, and
+Coding. They are not required to stop generic `InputRouter` from deciding
+conversation state.
+
+Deferred follow-ups:
+
+1. split Core, HarnessTUI, and Product keybinding definitions;
+2. decide whether `InputIntentKind` should remain a shared structural envelope
+   or split into narrower typed results;
+3. replace `ConversationInputResult`'s optional-field result bag only in a
+   dedicated contract migration;
+4. reduce prompt-routing duplication after semantic ownership is green.
+
+### TIO-DEC-007: Executable Ownership And Behavior Gates
+
+The ownership cut must be proven at three levels:
+
+1. generic TUI input unit tests;
+2. HarnessTUI/Coding conversation regression tests;
+3. input and screen-loop playback with intermediate state assertions.
+
+A source-level architecture gate should prevent `InputRouter` from regaining
+conversation state fields. A package-wide AST producer gate over
+`src/loushang/tui/**/*.py` should prevent direct constant construction of
+`steer`, `follow_up`, or queued-edit intents. It checks both positional and
+keyword `InputIntent` arguments and has checker self-tests. It explicitly
+allows retained legacy literal declarations, unrelated generic `abort`
+producers, and existing structural dynamic-envelope forwarders such as
+configurable selection/dialog result kinds. Proving dynamic result values
+belongs to the deferred typed-envelope redesign. Constructor matching covers
+both bare `InputIntent(...)` names and attribute forms such as
+`input_module.InputIntent(...)`.
+
+## Target Generic `InputRouter` Contract
+
+Conceptual constructor after the cut:
+
+```python
+@dataclass(slots=True)
+class InputRouter:
+    composer: Composer | None = None
+    surface_host: SurfaceHost | None = None
+    _: KW_ONLY
+    width: int = 80
+    height: int = 24
+    keybindings: KeybindingManager | None = None
+    target: InitVar[PromptInputTarget | None] = None
+    _jump_mode: Literal["forward", "backward"] | None = field(
+        default=None,
+        init=False,
+    )
+```
+
+Conceptual submit contract:
+
+```python
+def submit(self) -> tuple[InputIntent, ...]:
+    text = self._target.value
+    if not text:
+        return ()
+    self._target.add_history(text)
+    self._target.clear()
+    return (InputIntent(kind="submit", text=text),)
+```
+
+The generic router continues to clear and add history on accepted non-empty
+submit. That is existing generic prompt behavior and not conversation policy.
+HarnessTUI retains its own attachment-aware submission path.
+
+## Target Generic Routing Order
+
+The generic order remains unchanged except for the removed conversation steps
+and the explicit distinction between jump cancellation and prompt cancellation:
+
+1. ignore key release events;
+2. compute `is_cancel`, then cancel or complete a pending character-jump mode,
+   recording when a cancel key terminated it; a repeated jump key may return
+   early only when it is not also cancel;
+3. route active surfaces first;
+4. route focused surface editor selection/editing and stop prompt fallback;
+5. route prompt selection before completion navigation;
+6. route active completion navigation/application/cancel;
+7. swallow cancel when it already terminated a pending jump;
+8. emit generic `prompt_cancel` only for a truly unconsumed cancel;
+9. enter character-jump mode;
+10. force/apply completion on Tab;
+11. emit generic submit on configured submit;
+12. insert explicit newline;
+13. perform visual movement or history traversal;
+14. perform page movement;
+15. route ordinary editing keys;
+16. route paste and text insertion;
+17. emit render invalidation for resize and SIGWINCH.
+
+Removed steps:
+
+- running cancel to abort;
+- queue edit command emission;
+- running submit mode interpretation;
+- steering capability downgrade.
+
+## Compatibility And Migration
+
+### In-repository consumers
+
+`examples/tui/29_composer_bottom_frame.py` migrates before the generic router
+cut and becomes an example of the correct application-adapter boundary:
+
+- generic `submit` is interpreted by the demo application according to its own
+  `app.running` state;
+- cancel is normalized through configured keybindings, routed once through the
+  old/new-compatible application adapter, and aborts only when demo work is
+  running;
+- the adapter treats old Router empty cancel and future `prompt_cancel` as the
+  same single application decision without double execution;
+- `/q`, `/quit`, and `/exit` are classified before idle/running submit policy;
+  a running exit cancels the active fake task before exiting;
+- idle Ctrl+C is intentionally fixed to exit by configured action matching;
+- Alt+Up restores only the last pending follow-up before generic prompt routing;
+- generic `InputRouter` is not reconstructed with `running=`;
+- the demo no longer depends on generic `follow_up`, `abort`, or
+  `edit_last_queued_prompt` outputs, so the example PR works both before and
+  after the router cut.
+
+No unit test is added specifically for this example, consistent with repository
+guidance. The example PR instead requires Ruff/import smoke plus a recorded
+interactive PTY or terminal acceptance sequence for idle submit, running
+follow-up, `/steer`, follow-up-only Alt+Up restore, idle Ctrl+C, and running
+cancel. The example has no completion provider, so completion cancel remains an
+automated generic/HarnessTUI/Coding gate rather than a fake manual example gate.
+
+### Public documentation
+
+The English and Chinese TUI editing guides must say explicitly:
+
+- `InputRouter` emits generic prompt intents;
+- application or HarnessTUI adapters interpret run-state behavior;
+- Harness-backed conversation applications should use HarnessTUI rather than
+  generic `InputRouter` for steer/follow-up/abort semantics.
+- removal of `running=`, `steering_supported=`, and `submit(mode=...)` is a
+  pre-1.0 breaking API change, with old-to-new migration examples.
+
+KD-002 and KD-003 must agree with the same owner split: HarnessTUI interprets
+idle/running conversation keys; capability/downgrade policy remains above TUI;
+current Coding uses the HarnessTUI steer default, while explicit Coding policy
+injection remains deferred.
+
+### Historical design
+
+The older target-decoupling spec remains useful history for the target adapter
+boundary, but its statement that generic `InputRouter` owns running abort and
+steer/follow-up submission is superseded by this design.
+
+## Rollout Plan
+
+### PR 1: Contract And Characterization
+
+- Link a tracking issue.
+- Land the reviewed design, implementation plan, and review record.
+- Add/strengthen passing tests that characterize current HarnessTUI/Coding
+  behavior.
+- Make no production behavior changes.
+- Do not add target-contract tests that are expected to fail against the
+  current generic router.
+
+### PR 2: Migrate The Stateful Example
+
+- Change only `examples/tui/29_composer_bottom_frame.py`.
+- Stop passing `running=` and stop consuming generic conversation outputs.
+- Move running submit, cancel, and Alt+Up queue policy into the demo adapter.
+- Preserve idle/running `/q`, `/quit`, and `/exit` behavior before submit
+  classification.
+- Treat idle Ctrl+C normalization as an explicit example-only bug fix and keep
+  Alt+Up scoped to pending follow-up.
+- Run static/import smoke and record the explicit interactive acceptance
+  sequence.
+- Keep current generic `InputRouter` production behavior unchanged.
+
+### PR 3: Generic Semantic Cut
+
+- Add the target generic boundary tests and source ownership gate, confirm the
+  intended failures, and land them with the green implementation.
+- Remove conversation state and output branches from generic `InputRouter`.
+- Add generic `prompt_cancel`.
+- Add `KW_ONLY`, hide `_jump_mode` from the constructor, and prove old third
+  positional calls fail rather than rebind.
+- Preserve jump-mode cancel consumption and surface/focused-editor/completion
+  priority, including custom jump/cancel key overlap.
+- Remove generic queue-edit routing.
+- Migrate generic tests, KD-002, KD-003, HarnessTUI ownership docs, public
+  guides, and the persistent API migration note.
+- Keep HarnessTUI and Coding production behavior unchanged.
+- Run the focused and playback gates below.
+- Re-run the PR 2 example interaction matrix without modifying the example.
+
+Stop after PR 3. Do not begin route deduplication, keybinding-catalog movement,
+or result-type redesign under the same tracking objective unless they receive a
+separate reviewed plan.
+
+Rollback is dependency-ordered, not arbitrary: revert PR 3 before PR 2, then
+PR 1 if desired. Reverting PR 2 while PR 3 remains would restore a `running=`
+caller against a constructor that no longer accepts it.
+
+## Verification Gates
+
+Focused baseline and regression:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/tui/test_input_routing.py \
+  tests/harnesstui/conversation/test_input.py \
+  tests/harnesstui/conversation/test_clipboard_input.py \
+  tests/coding/test_screen_coding_tui_input.py \
+  --skip-host-runtime \
+  -q
+```
+
+Boundary and playback:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/tui/test_import_boundaries.py \
+  tests/harnesstui/testing/test_import_boundaries.py \
+  tests/harnesstui/testing/test_input_playback.py \
+  tests/harnesstui/testing/test_screen_loop_playback.py \
+  --skip-host-runtime \
+  -q
+```
+
+Coding conversation playback and loop:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/coding/test_screen_tui_playback_harness.py \
+  tests/coding/test_screen_coding_tui_loop.py \
+  --skip-host-runtime \
+  -q
+```
+
+Broader subsystem regression:
+
+```bash
+.venv/bin/python -m pytest tests/tui tests/harnesstui --skip-host-runtime -q
+.venv/bin/python -m pytest \
+  tests/coding \
+  --skip-host-runtime \
+  -m "not live and not tui_render_contract" \
+  -q
+```
+
+Static checks:
+
+```bash
+.venv/bin/python -m ruff check \
+  src/loushang/tui/input.py \
+  src/loushang/harnesstui/conversation/input.py \
+  tests/tui/test_input_routing.py \
+  tests/harnesstui/conversation/test_input.py
+git diff --check
+```
+
+## Risks And Mitigations
+
+### Risk: public advanced callers rely on `running=`
+
+Mitigation: repository and public-doc inventory is recorded; project version is
+pre-1.0; PR description calls out the change; reopen TIO-DEC-005 if supported
+external consumers are identified before implementation.
+
+### Risk: Ctrl+C/Escape behavior changes in generic examples
+
+Mitigation: migrate the stateful demo adapter first; distinguish jump cancel
+from unconsumed prompt cancel; and keep surface, focused-editor, completion, and
+jump-mode priority regressions for both Escape and Ctrl+C.
+
+### Risk: generic change accidentally alters Coding conversation behavior
+
+Mitigation: Coding does not use generic `InputRouter`; run the full focused
+Coding screen input suite and HarnessTUI playback anyway.
+
+### Risk: contributors interpret retained keybinding entries as retained
+ownership
+
+Mitigation: document TIO-DEC-006 and add a package-wide AST producer gate.
+Catalog placement and retained literal declarations are not permission for any
+generic TUI module to produce conversation actions.
+
+### Risk: temporary route duplication persists indefinitely
+
+Mitigation: record deduplication as a named deferred follow-up, but do not make
+it a hidden completion requirement for this high-risk semantic cut.
+
+## Success Criteria
+
+- Generic `InputRouter` has no `running` or `steering_supported` state.
+- Generic input code defines no `SubmitMode` and constructs no `steer` or
+  `follow_up` intent.
+- Generic `InputRouter` does not emit a queued-message edit command.
+- Generic unconsumed cancel produces `prompt_cancel`, not run abort.
+- Escape/Ctrl+C that terminates a pending jump produces no `prompt_cancel`,
+  while active surface, focused editor, and completion priorities remain intact.
+- A package-wide producer gate rejects steer, follow-up, or queued-edit intent
+  direct constant construction anywhere under `src/loushang/tui/` and tests
+  both positional and keyword call forms.
+- Public constructor configuration after `surface_host` is keyword-only,
+  `_jump_mode` is not constructor state, and old third positional calls fail.
+- HarnessTUI remains the only owner of running Enter, running Alt+Enter,
+  pending-steer cancel, queue restore, and conversation abort behavior.
+- Coding conversation keyboard behavior is unchanged.
+- Active surface, completion, selection, history, paste, jump, resize, and
+  editing regressions pass.
+- Public TUI documentation describes the neutral boundary.
+- The production patch contains no route deduplication, keybinding catalog
+  migration, or Product-policy redesign.
+
+## Review Ledger
+
+| Finding | Priority | Disposition | Resolution in `r7` |
+| --- | --- | --- | --- |
+| Initial proposal combined semantic cut and whole-router deduplication. | P1 | Changes requested | Deduplication is explicitly deferred; first tranche changes ownership only. |
+| Removing public constructor knobs could create an unbounded compatibility project. | P1 | Accepted with constraint | Direct removal is allowed only because version is 0.1.0, production has no caller, and public guides do not document the knobs; reopen if contrary evidence appears. |
+| Reusing `abort` for generic cancel would retain conversation meaning. | P1 | Changes requested | Added distinct `prompt_cancel`; generic router no longer decides active-work abort. |
+| Moving keybinding catalogs now would expand the patch across settings and Products. | P2 | Deferred | Catalog composition is a separately reviewed follow-up. |
+| Optional-field `ConversationInputResult` invites invalid combinations. | P2 | Deferred | Tagged-result migration is separate from ownership cut. |
+| Old target-decoupling design still assigns running semantics to generic TUI. | P2 | Changes requested | This spec explicitly supersedes only that portion and retains the target adapter work. |
+| Full Coding policy injection is not necessary to cut TUI ownership. | P3 | Retained as follow-up | HarnessTUI current default remains behavior-compatible for this tranche. |
+| The initial task ordering mixed passing characterization with target red tests, making the PR 1 gate ambiguous. | P1 | Changes requested | PR 1 now contains current-behavior characterization only; target red tests and ownership gates begin and land in PR 3. |
+| Removing `steer`/`follow_up` from the shared `InputIntentKind` envelope adds API churn without changing router ownership. | P1 | Changes requested | Retain the literal members for now; forbid generic `InputRouter` from constructing them and defer envelope cleanup. |
+| Durable ownership docs were assigned to different PRs in the design and implementation plan. | P2 | Changes requested | PR 1 now contains reviewed decision artifacts and current characterization only; current architecture and public contract docs migrate with PR 3. |
+| Unconditional `prompt_cancel` would leak Escape/Ctrl+C after cancelling pending jump mode. | P1 | Changes requested | Added an explicit consumed-jump rule after surface/focused-editor/completion priority plus combination regressions. |
+| The semantic-cut PR also contained a stateful example event-loop rewrite. | P2 | Changes requested | Added a separately mergeable example-adapter PR before the public router cut. |
+| Example snapshot/scripted smoke does not execute the interactive event loop. | P2 | Changes requested | Added static/import checks and an explicit recorded PTY/terminal acceptance sequence. |
+| Class-scoped ownership gates do not protect the declared TUI package boundary. | P2 | Changes requested | Producer gate now scans all `src/loushang/tui/**/*.py`, with narrow legacy-literal and generic-abort exceptions. |
+| KD-003 would retain ambiguous Product-vs-HarnessTUI classification language. | P2 | Changes requested | KD-003 is now a required PR 3 migration document. |
+| Direct public API removal needs a durable migration contract. | P3 | Changes requested | Added signature tests and a persistent pre-1.0 migration note with replacement examples. |
+| Removing dataclass fields would silently rebind old third/fourth positional arguments. | P1 | Changes requested | Added a `KW_ONLY` constructor boundary, `init=False` internal jump state, exact signature tests, and a loud-failure migration contract. |
+| The example completion-cancel manual gate is unreachable and old/new cancel adaptation was underspecified. | P1 | Changes requested | Removed the unreachable manual step, specified a single-execution dual-version adapter, and require a zero-diff example re-run after PR 3. |
+| A custom jump binding can overlap cancel and trigger the current repeated-jump early return. | P2 | Changes requested | Compute cancel first, forbid early return on overlap, and add surface/focused-editor/completion overlap regressions. |
+| AST wording claimed more than direct constant analysis can prove. | P2 | Changes requested | Gate positional/keyword constant producers with checker self-tests; explicitly defer structural dynamic-envelope proof. |
+| Required HarnessTUI playback does not directly cover Coding steer/follow-up/abort paths. | P2 | Changes requested | Added the Coding playback and loop files as explicit mandatory gates. |
+| Example baseline text misstates idle Ctrl+C and Alt+Up behavior. | P2 | Changes requested | Record Ctrl+C normalization as an intentional example fix and constrain Alt+Up to last pending follow-up. |
+| Sandbox-safe pytest examples omitted `--skip-host-runtime`. | P3 | Changes requested | All required pytest commands now use the repository sandbox flag. |
+| PR 2 and PR 3 were described as independently reversible despite a constructor dependency. | P2 | Changes requested | Changed the claim to separately mergeable and documented rollback order PR 3, then PR 2, then PR 1. |
+| PR 2 did not freeze idle/running exit-command behavior. | P2 | Changes requested | Exit classification now precedes submit policy and is part of the before/after interaction matrix. |
+| Durable docs overstated current Coding capability injection. | P2 | Changes requested | State the invariant that policy stays above TUI, the current HarnessTUI steer default, and deferred Coding injection. |
+| Custom overlap lacked a no-pending-jump direct cancel test. | P3 | Changes requested | Added a no-pending overlap case requiring `prompt_cancel` rather than entering jump mode. |
+| AST gate did not explicitly cover attribute-form `InputIntent` constructors. | P3 | Changes requested | Checker and self-tests now cover both `ast.Name` and `ast.Attribute` constructors. |
+
+## Review Verdict
+
+**Final independent acceptance: Accept.**
+
+Revision `r7` has no open P0, P1, P2, or P3 findings. The five Round 3
+resolutions and retained `r6` safeguards were independently verified. The
+tracking issue and high-risk workflow remain prerequisites for production
+implementation.

--- a/docs/superpowers/specs/2026-08-22-tui-harnesstui-input-ownership-boundary-review.md
+++ b/docs/superpowers/specs/2026-08-22-tui-harnesstui-input-ownership-boundary-review.md
@@ -1,0 +1,178 @@
+# TUI And HarnessTUI Input Ownership Boundary Review
+
+## Review Target
+
+- Design:
+  `2026-08-22-tui-harnesstui-input-ownership-boundary-design.md`
+- Implementation plan:
+  `../plans/2026-08-22-tui-harnesstui-input-ownership-refactor.md`
+- Independent review Round 1 target: `2026-08-22-r4`
+- Independent review Round 2 target: `2026-08-22-r5`
+- Independent review Round 3 target: `2026-08-22-r6`
+- Current revised target: `2026-08-22-r7`
+- Review scope: architecture, API compatibility, regression strategy, rollout,
+  and rollback boundaries
+
+## Current Status
+
+**Final acceptance verdict: Accept.**
+
+Round 3 found three P2 and two P3 findings. Revision `r7` incorporated every
+requested change. A fresh independent acceptance reviewer found no open
+findings and approved the plan for implementation.
+Approval does not extend to route deduplication, keybinding catalog movement,
+result-type redesign, or Coding policy injection.
+
+## Evidence Reviewed
+
+- Generic `InputRouter` currently stores `running` and
+  `steering_supported`, defines `SubmitMode`, constructs steer/follow-up
+  intents, maps running cancel to abort, and emits a queued-edit command.
+- `ConversationInputRouter` independently owns the production conversation
+  state machine, including running Enter, running Alt+Enter, abort, pending
+  steer, queue restore, transcript, and attachment paths.
+- Production Coding uses the HarnessTUI router factory; no production module
+  under `src/` constructs generic `InputRouter`.
+- The stateful in-repository generic consumer is
+  `examples/tui/29_composer_bottom_frame.py`, plus generic TUI tests.
+- `InputRouter` is a top-level public export, while `SubmitMode` is not.
+- The public package version is `0.1.0`.
+- Focused input plus import-boundary/playback baselines passed: 131 tests.
+- Coding conversation playback/loop passed: 46 tests.
+- Broader `tests/tui tests/harnesstui` passed: 1,752 tests.
+- Focused Ruff and example snapshot/scripted smoke passed.
+
+## Round 1 Independent Findings And `r5` Resolutions
+
+| ID | Priority | Independent finding | Resolution in `r5` |
+| --- | --- | --- | --- |
+| TIO-IREV-001 | P1 | Unconditional `prompt_cancel` leaks after Escape/Ctrl+C cancels pending jump mode. | Record jump cancellation, preserve surface/focused-editor/completion priority, then swallow that cancel; add the full priority matrix. |
+| TIO-IREV-002 | P2 | The semantic-cut PR also rewrites the stateful example event loop. | Split a separately mergeable example-adapter PR before the public router cut. |
+| TIO-IREV-003 | P2 | Snapshot/scripted smoke bypasses the modified interactive example loop. | Require Ruff/import smoke plus a recorded interactive PTY/terminal acceptance matrix. |
+| TIO-IREV-004 | P2 | A class-scoped producer gate is weaker than the declared TUI package boundary. | Scan all `src/loushang/tui/**/*.py` with AST, while allowing legacy literal declarations and unrelated generic abort producers. |
+| TIO-IREV-005 | P2 | KD-003 retains ambiguous Product-vs-HarnessTUI classification language. | Add KD-003 to PR 3 and explicitly assign conversation key interpretation to HarnessTUI. |
+| TIO-IREV-006 | P3 | Direct removal of a public pre-1.0 API lacks a durable migration contract. | Add constructor/submit signature tests and persistent English/Chinese migration guidance with replacement mappings. |
+
+## Round 2 Independent Findings And `r6` Resolutions
+
+| ID | Priority | Independent finding | Resolution in `r6` |
+| --- | --- | --- | --- |
+| TIO-IREV2-001 | P1 | Removing dataclass state fields can silently rebind legacy third/fourth positional arguments to `width`/`height`. | Add `KW_ONLY`, make `_jump_mode` `init=False`, assert the exact signature, and require legacy third-position calls to raise `TypeError`. |
+| TIO-IREV2-002 | P1 | The example has no completion provider, so its manual completion gate is unreachable; old/new cancel adaptation was not single-execution. | Remove that manual gate, specify normalized old/new-compatible cancel adaptation, and re-run the PR 2 matrix after PR 3 with zero example diff. |
+| TIO-IREV2-003 | P2 | A custom jump binding can overlap cancel and hit the repeated-jump early return. | Compute cancel first, disallow early return on overlap, and add surface/focused-editor/completion overlap regressions. |
+| TIO-IREV2-004 | P2 | The package AST gate claimed more than direct constant analysis could prove. | Check positional/keyword constants with checker self-tests and explicitly defer structural dynamic-envelope proof. |
+| TIO-IREV2-005 | P2 | Required HarnessTUI playback does not directly cover Coding steer/follow-up/abort paths. | Add Coding playback and loop files as mandatory baseline and PR 3 gates. |
+| TIO-IREV2-006 | P2 | Example baseline text misstated idle Ctrl+C normalization and Alt+Up scope. | Make Ctrl+C an explicit example-only alias fix and keep Alt+Up follow-up-only. |
+| TIO-IREV2-007 | P3 | Sandbox-safe pytest commands omitted `--skip-host-runtime`. | Add the repository sandbox flag to every required pytest command. |
+
+## Round 3 Independent Findings And `r7` Resolutions
+
+| ID | Priority | Independent finding | Resolution in `r7` |
+| --- | --- | --- | --- |
+| TIO-IREV3-001 | P2 | PR 2/PR 3 were called independently reversible despite a constructor dependency. | Describe them as separately mergeable and require rollback order PR 3, PR 2, PR 1 with a recorded PR 2 SHA. |
+| TIO-IREV3-002 | P2 | PR 2 omitted idle/running exit-command behavior. | Classify `/q`, `/quit`, `/exit` before submit policy and add idle/running PTY rows plus the zero-diff PR 3 re-run. |
+| TIO-IREV3-003 | P2 | Durable docs overstated current Coding capability injection. | State the above-TUI invariant, current HarnessTUI steer default, static steer/follow-up mapping, and deferred Coding injection. |
+| TIO-IREV3-004 | P3 | Custom jump/cancel overlap lacked a no-pending-jump direct cancel gate. | Require `prompt_cancel` with no pending jump and prove later text is not consumed as a jump target. |
+| TIO-IREV3-005 | P3 | AST gate did not explicitly cover attribute-form `InputIntent` construction. | Recognize and self-test both `ast.Name` and `ast.Attribute` constructor targets. |
+
+## Retain, Rewrite, Defer
+
+Retain now:
+
+- `coding -> harnesstui -> tui` dependency direction;
+- HarnessTUI as the sole conversation input semantic owner;
+- `prompt_cancel` as a neutral generic signal;
+- `ComposerInputTarget`, focused-editor separation, and reusable editor helpers;
+- HarnessTUI's current routing order and observable shortcut behavior;
+- existing generic `abort` intent for unrelated cancellable widgets;
+- legacy `steer`/`follow_up` members in the shared `InputIntentKind` envelope,
+  without generic TUI production.
+
+Rewrite in this change:
+
+- stateful example adapter ownership before the router cut;
+- generic `InputRouter` constructor and submit contract;
+- jump-aware generic cancel routing;
+- package-wide producer gates;
+- KD-002, KD-003, HarnessTUI ownership docs, and public API migration guidance.
+
+Defer:
+
+- Core/HarnessTUI/Product keybinding catalog composition;
+- whole-event route reuse or staged editing-controller extraction;
+- typed redesign of `ConversationInputResult`;
+- cleanup or splitting of the shared `InputIntentKind` envelope;
+- explicit Coding injection of running-submit policy.
+
+## Revised Approval Constraints
+
+PR 1 must:
+
+- contain no production behavior change;
+- add only tests that pass against current production behavior;
+- record the package boundary and link the tracking issue.
+
+PR 2 must:
+
+- change only `examples/tui/29_composer_bottom_frame.py`;
+- remain compatible with the current generic Router;
+- stop passing `running=` and stop consuming generic conversation outputs;
+- use one normalized cancel path that works against both old empty cancel and
+  future `prompt_cancel` without double execution;
+- explicitly fix idle Ctrl+C alias handling and preserve follow-up-only Alt+Up;
+- preserve idle/running `/q`, `/quit`, and `/exit` before submit classification;
+- preserve observable demo behavior with a reachable interactive acceptance
+  matrix, not snapshot-only evidence.
+
+PR 3 must:
+
+- change no production file under `loushang.harnesstui`, `loushang.coding`, or
+  `loushang.harness`;
+- preserve HarnessTUI/Coding keyboard behavior and routing priorities;
+- preserve jump-mode cancel consumption after surface/focused-editor/completion
+  priority, including a custom jump/cancel binding overlap;
+- make configuration after `surface_host` keyword-only and keep `_jump_mode`
+  out of the public constructor;
+- land target red tests with their green implementation;
+- reject direct constant conversation producers across the complete
+  `loushang.tui` package, with positional/keyword and bare/attribute-form
+  checker self-tests;
+- update KD-002, KD-003, public docs, and durable API migration guidance;
+- pass focused, boundary, playback, and broader subsystem gates;
+- re-run PR 2's matrix without modifying its example file;
+- stop after semantic ownership is cut.
+
+## Required Stop Conditions
+
+Return to design review instead of expanding the patch if:
+
+- a supported consumer of `InputRouter(running=...)`,
+  `steering_supported=...`, or `submit(mode=...)` is identified;
+- preservation requires a HarnessTUI or Coding production change;
+- the example cannot migrate independently against the old Router;
+- keyword-only migration cannot prevent positional calls from silently
+  rebinding;
+- a new shared whole-event route engine becomes necessary;
+- adding `prompt_cancel` triggers a broad intent migration;
+- playback exposes an unresolved ordering difference.
+
+Rollback must follow PR 3, then PR 2, then PR 1. PR 2 must not be reverted while
+the narrowed PR 3 constructor remains.
+
+## Final Acceptance Review
+
+**Verdict: Accept. No P0, P1, or lower-priority open findings.**
+
+The independent reviewer verified:
+
+- dependency-ordered rollback PR 3, then PR 2, then PR 1;
+- idle/running exit classification and the before/after/zero-diff PTY gates;
+- current HarnessTUI steer default versus deferred explicit Coding policy;
+- no-pending and pending jump/cancel overlap behavior;
+- bare/attribute and positional/keyword direct-constant AST coverage;
+- retained `KW_ONLY`, `_jump_mode init=False`, dual-version single cancel,
+  sandbox-safe pytest commands, and Coding playback gates.
+
+The reviewer accepted the existing independent baseline evidence: 110 focused,
+21 boundary/playback, 46 Coding playback/loop, and 1,752 broader TUI/HarnessTUI
+tests passed.


### PR DESCRIPTION
## Summary

- define the reviewed r7 ownership boundary between generic `tui` input mechanics and HarnessTUI conversation semantics
- record the characterization matrix, three-PR migration sequence, rollback points, and acceptance gates
- include the independent acceptance review with an Accept verdict and no open findings

This is PR 1 of the sequence and changes documentation only. It intentionally makes no production behavior change.

## Verification

- focused input/router/HarnessTUI suite: 110 passed
- boundary/playback suite: 21 passed
- Coding playback/loop suite: 46 passed
- independent broader TUI + HarnessTUI review run: 1752 passed
- Ruff and example snapshot/scripted checks passed during review

## Follow-up

PR 2 will migrate only the example/demo adapter. PR 3 will remove conversation policy from the generic router and complete the HarnessTUI production cutover.

Refs #462