### PR TITLE
fix(harnesstui): restore quality gate

### DIFF
--- a/src/loushang/harnesstui/continuity/runner.py
+++ b/src/loushang/harnesstui/continuity/runner.py
@@ -97,10 +97,21 @@ async def run_continuity_picker(
             # Stop the loop even if the user never presses another key.
             run_context.request_stop(0)
 
+    def activation_done_callback(
+        target: ContinuityTarget,
+    ) -> Callable[[asyncio.Task[object]], None]:
+        def on_activation_done(task: asyncio.Task[object]) -> None:
+            _on_activation_done(task, target)
+
+        return on_activation_done
+
     def start(context: TuiRunContext) -> None:
         nonlocal run_context, load_task
         run_context = context
         load_task = asyncio.create_task(content.start())
+
+    async def activate_target(target: ContinuityTarget) -> object:
+        return await activate(target)
 
     async def handle_input(
         event: InputEvent,
@@ -123,11 +134,9 @@ async def run_continuity_picker(
                     continue
                 if not content.begin_activation():
                     return TuiInputResult(render_requested=True)
-                activation = asyncio.create_task(activate(target))
+                activation = asyncio.create_task(activate_target(target))
                 activation_task = activation
-                activation.add_done_callback(
-                    lambda task, target=target: _on_activation_done(task, target)
-                )
+                activation.add_done_callback(activation_done_callback(target))
                 return TuiInputResult(render_requested=True)
             if kind in {"surface_close", "dialog_cancel"}:
                 return context.stop()

--- a/src/loushang/harnesstui/continuity/surface.py
+++ b/src/loushang/harnesstui/continuity/surface.py
@@ -906,8 +906,8 @@ def _summary_descriptions(
     )
     show_status = any(status for _time, _context, status in rows)
     descriptions: list[str] = []
-    for time, context, status in rows:
-        facts = [_right_align(time, time_width)]
+    for time_text, context, status in rows:
+        facts = [_right_align(time_text, time_width)]
         if context_width:
             facts.append(
                 truncate_to_width(

--- a/src/loushang/harnesstui/surface/controller.py
+++ b/src/loushang/harnesstui/surface/controller.py
@@ -29,6 +29,7 @@ SurfaceEventSource = Literal[
     "command",
     "settings",
     "session",
+    "session_cancel",
     "delete",
     "fork",
     "rename",

--- a/tests/harnesstui/surface/test_workflow.py
+++ b/tests/harnesstui/surface/test_workflow.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import pytest
-
 import asyncio
 from dataclasses import dataclass, field, replace
 from types import SimpleNamespace
+
+import pytest
 
 from loushang.harness.commands import CommandDef, CommandKind
 from loushang.harness.continuity import ContinuityTarget


### PR DESCRIPTION
## Summary

- avoid shadowing the imported `time` module and restore Ruff import ordering
- include the existing `session_cancel` event source in the shared surface type contract
- wrap the general continuity activation `Awaitable` in a coroutine and use a typed completion callback

These are behavior-preserving lint/type corrections already present as failures on `main`. This PR is kept separate so the input-ownership planning PR #463 remains documentation-only.

## Verification

- `make lint-harnesstui`: passed
- `make typecheck-harnesstui`: 139 source files passed
- `.venv/bin/python -m pytest tests/harnesstui/continuity/test_surface.py tests/harnesstui/surface/test_workflow.py -q`: 39 passed
- `make test-harnesstui`: 1263 passed, 65 deselected
- `git diff --check`: passed

Unblocks #463.