### PR TITLE
refactor(tui): remove conversation semantics from input router

### DIFF
--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -14,7 +14,7 @@ For lifecycle wiring, see [TUI Runner](tui-runner.md).
 | --- | --- | --- |
 | `TextInput` | Single-line fields such as search, filters, and small prompts. | Grapheme cluster |
 | `Composer` | Multi-line prompt editors, bottom-frame composers, paste markers, history, and completions. | Composer atom |
-| `InputRouter` | User-like routing for Composer key, text, paste, completion, history, submit, and surface events. | Composer atom |
+| `InputRouter` | User-like editor routing plus neutral `submit` and `prompt_cancel` intents. | Composer atom |
 | `SelectionRange` / `SelectionController` | Reusable anchor/focus selection state. | Supplied by the owning buffer |
 
 Editing indexes are not terminal cell columns. Wide CJK, emoji, combining
@@ -83,9 +83,35 @@ assert composer.value == "alpha beta"
 result = composer.render(RenderConstraints(width=72, max_height=6))
 ```
 
+`InputRouter` is conversation-neutral. A non-empty Enter produces one `submit`
+intent; an unconsumed Escape or Ctrl+C produces `prompt_cancel`. Active
+surfaces, focused editors, completions, and pending character jumps keep their
+existing priority and may consume cancellation first. The application decides
+whether a neutral submit starts work, queues a follow-up, or steers an active
+run, and whether prompt cancellation exits, clears, or aborts work.
+Harness-backed conversation applications should use Harnesstui's
+`ConversationInputRouter` for that run-state policy.
+
 Composer selections use atom indexes. Normal text is split into grapheme-like
 text atoms; large paste markers are single atoms and are never split by range
 editing.
+
+## Pre-1.0 InputRouter Migration
+
+The generic router no longer owns conversation state. This is an intentional
+pre-1.0 breaking boundary:
+
+| Old API | Harness-backed replacement | Generic application replacement |
+| --- | --- | --- |
+| `InputRouter(running=...)` | Project state into `ConversationInputRouter`. | Interpret generic `submit` from application state. |
+| `steering_supported=...` | Select `running_submit_mode="steer"` when supported, otherwise `"follow_up"`. | Make the capability decision in the application adapter. |
+| `submit(mode=...)` | Use the HarnessTUI running-submit route. | Call zero-argument `submit()` and apply application policy to its result. |
+| Third/fourth positional state arguments | Use explicit HarnessTUI configuration. | Use keyword-only generic configuration plus application state. |
+
+Only `composer` and `surface_host` remain positional. `width`, `height`,
+`keybindings`, and `target` are keyword-only. Legacy calls such as
+`InputRouter(composer, None, True)` now raise `TypeError` instead of silently
+binding `True` to `width`.
 
 ## Default Editing Keys
 

--- a/docs/en/user-guide/tui.md
+++ b/docs/en/user-guide/tui.md
@@ -109,6 +109,11 @@ router.route(InputEvent(kind="key", key="shift+left"))
 router.route(InputEvent(kind="key", key="ctrl+k"))
 ```
 
+The generic `InputRouter` emits neutral `submit` and `prompt_cancel` intents;
+your application decides what they mean for its current state. Use Harnesstui's
+`ConversationInputRouter` when a Harness-backed conversation needs running
+submit, steer/follow-up, queue restore, and abort semantics.
+
 `TextInput` selection indexes are grapheme clusters. `Composer` selection indexes are composer atoms, so paste markers remain atomic. Display width is handled by rendering.
 
 ## Examples

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -341,6 +341,14 @@ explicit entrypoints:
 - `loushang.harnesstui.conversation.screen_runner` owns the reusable terminal
   read/route/run loop over explicit screen, router, and result ports.
 
+`ConversationInputRouter` is the sole Harness conversation-input semantic
+owner. It interprets idle/running Enter, running-submit steer or follow-up,
+pending queue restore, and conversation cancellation. It reuses TUI
+`ComposerInputTarget` and editor helper functions, but does not delegate whole
+events to generic `loushang.tui.InputRouter` as a second run-state router.
+Generic TUI emits only neutral prompt/editor signals and has no conversation
+running state.
+
 These modules build conversation interaction from neutral UI values. They do
 not own a Harness Session, persistence, runtime construction, Product intent
 classes, model-facing image types, workspace paths, command policy, or product
@@ -521,6 +529,12 @@ outcomes through an optional product callback. Coding alone chooses the
 neutral attachments to `ImagePart` at the model-dispatch boundary. Its screen
 loop is a thin binding around `run_conversation_screen`; test-only aliases for
 shared runner and terminal helpers are not product APIs.
+
+Coding currently uses the router default `running_submit_mode="steer"` rather
+than injecting an explicit steering-capability policy. That injection remains
+deferred. Coding still supplies slash-command classification, final actions,
+and Product copy; the generic TUI router is not part of this conversation
+state machine.
 
 ## Plain Conversation Presentation
 

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-002-input-event-routing.md
@@ -18,10 +18,12 @@ in this order:
 5. global keybindings
 
 The generic prompt route uses a `PromptInputTarget` boundary. `InputRouter`
-owns routing priority and prompt intents, while concrete editors provide
-operations through target adapters such as `ComposerInputTarget`. Product
-adapters may reuse target helper functions, but they keep their own routing
-order when product semantics differ.
+owns editor routing priority and emits only neutral prompt intents such as
+`submit` and `prompt_cancel`, while concrete editors provide operations through
+target adapters such as `ComposerInputTarget`. Application adapters interpret
+those intents from their own state. Harness-backed conversations use
+Harnesstui's `ConversationInputRouter` for running submit, follow-up, steer,
+queue restore, and abort policy instead of teaching generic TUI about a run.
 
 Focused surface editors may expose an editor target through
 `editor_input_target()`. `SurfaceHost.route_input_result()` distinguishes
@@ -30,14 +32,16 @@ surface intents from consumed events without changing the compatibility
 surface-first: surface intents win, consumed surface events stop fallback, and
 only declined events may route ordinary text, paste, selection, and editing keys
 to the focused editor target. Prompt-only actions such as submit, newline,
-history, completion, queue editing, and jump setup do not mutate prompt state
+history, completion, and jump setup do not mutate prompt state
 while a focused editor target owns the editing lane.
 
 Keybindings are configuration-owned by the runtime or product adapter. The
 coding product adapter loads configured keybindings from settings and passes
 them into the native input router. UI parts may handle routed events, but they
-should return semantic intents such as submit, move selection, close surface,
-approval decision, abort, change model, or open command surface.
+should return semantic intents such as submit, prompt cancel, move selection,
+close surface, approval decision, change model, or open command surface.
+Conversation abort and queue actions belong to the HarnessTUI or Product
+adapter that knows the active run state.
 
 ## Capability Detection And Startup Handshake
 
@@ -98,12 +102,17 @@ normalized input events:
 - paste marker is an editor atom that may stand in for a large payload while the
   full payload remains available for submission
 
-These editor primitives are local to the focused prompt target until the product
-adapter receives a submit, steer, or follow-up intent.
+These editor primitives are local to the focused prompt target until the generic
+router emits `submit` or `prompt_cancel`. The application or HarnessTUI adapter
+then applies run-state and capability policy.
 
 ## Test Obligations
 
-- active surfaces receive Esc before run abort handling
+- active surfaces receive cancel before generic `prompt_cancel` or HarnessTUI
+  abort handling
+- Escape and Ctrl+C that terminate pending jump mode emit no prompt cancel
+- active surfaces, focused editors, and completion cancellation keep priority
+  over prompt cancel, including overlapping custom bindings
 - paste newlines do not accidentally submit prompts
 - paste control sequences are not executed
 - CSI-u Ctrl+letter encodings inside bracketed paste become literal paste text

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-003-abort-steer-follow-up-sequence.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-003-abort-steer-follow-up-sequence.md
@@ -6,13 +6,27 @@ Define the time-sensitive interaction model while a product run is active.
 
 ## Design
 
-The composer stays usable during an active run. Submitted text is classified by
-the product adapter:
+The composer stays usable during an active run. Harnesstui's
+`ConversationInputRouter` is the sole shared conversation-input semantic owner:
+it interprets idle and running Enter, running-submit alternatives, queue
+restore, and conversation cancellation from explicit conversation state. It
+reuses generic TUI editor targets and key helpers, but does not delegate the
+whole event to generic `InputRouter` as a second conversation state machine.
+
+Generic `loushang.tui.InputRouter` emits only neutral `submit` and
+`prompt_cancel` signals. It does not know whether a run is active and does not
+construct follow-up, steer, queue-edit, or conversation-abort intents.
+Conversation text is classified above that generic layer:
 
 - follow-up: queued for a later turn
 - steer: delivered to the active run when the product supports live steering
 - abort: control action that cancels or interrupts the active run
 - surface action: handled by the active surface before active-run controls
+
+Capability and downgrade policy also stays above generic TUI. Coding currently
+uses `ConversationInputRouter`'s default `running_submit_mode="steer"`; it has
+not yet injected an explicit steering-capability policy. Coding continues to
+own slash-command classification, final Product actions, and Product copy.
 
 Pending follow-up and steering items are rendered in the pending queue area. The
 queue is transient bottom-frame UI and grows upward. Queued text remains visible
@@ -21,8 +35,11 @@ the composer, or cancelled.
 
 ## Priority
 
-If a surface is active, Esc is first offered to that surface. Only if the surface
-does not consume Esc may it become an abort intent for an active run.
+`ConversationInputRouter` preserves surface, focused-editor, completion, and
+pending-steer priorities before conversation cancellation. If a surface is
+active, Esc is first offered to that surface. Only if no higher-priority owner
+consumes it may the HarnessTUI adapter request abort for an active run. Generic
+TUI's independent jump-mode cancellation never decides whether work is aborted.
 
 ## Test Obligations
 
@@ -31,3 +48,7 @@ does not consume Esc may it become an abort intent for an active run.
 - unavailable steering is rejected or downgraded visibly
 - edit-queue restores pending text into the composer
 - abort removes running chrome, commits interruption state, and restores focus
+- generic `InputRouter` produces no follow-up, steer, queue-edit, or
+  conversation-abort result
+- Coding conversation playback preserves its effective shortcuts without
+  depending on generic `InputRouter`

--- a/docs/superpowers/specs/2026-06-09-tui-input-router-decouple-design.md
+++ b/docs/superpowers/specs/2026-06-09-tui-input-router-decouple-design.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Draft for implementation planning.
+Partially superseded by
+[TUI/HarnessTUI Input Ownership Boundary](2026-08-22-tui-harnesstui-input-ownership-boundary-design.md).
+The target-adapter and focused-editor design remains valid. Statements that
+generic `InputRouter` owns running abort, steer, follow-up, or queued-message
+semantics are historical and no longer describe the current contract.
 
 ## Context
 

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -12,7 +12,7 @@
 | --- | --- | --- |
 | `TextInput` | 搜索、过滤、小型 prompt 等单行输入。 | Grapheme cluster |
 | `Composer` | 多行 prompt 编辑器、bottom-frame composer、paste marker、历史和 completion。 | Composer atom |
-| `InputRouter` | 按真实用户输入路径路由 Composer 的 key、text、paste、completion、history、submit 和 surface event。 | Composer atom |
+| `InputRouter` | 按真实用户输入路径处理编辑，并产生中立的 `submit`、`prompt_cancel` intent。 | Composer atom |
 | `SelectionRange` / `SelectionController` | 可复用的 anchor/focus selection 状态。 | 由所属 buffer 决定 |
 
 编辑索引不是终端显示列。CJK、emoji、组合字符和 paste marker 都保持稳定的逻辑索引；显示宽度只属于渲染和 hit-test 层。
@@ -73,7 +73,30 @@ assert composer.value == "alpha beta"
 result = composer.render(RenderConstraints(width=72, max_height=6))
 ```
 
+`InputRouter` 不理解会话运行态。非空 Enter 只产生一个 `submit` intent；
+未被消费的 Escape 或 Ctrl+C 产生 `prompt_cancel`。活跃 surface、聚焦编辑器、
+completion 和待完成的字符跳转仍拥有更高优先级，可以先消费取消键。应用适配层
+决定中立提交是启动任务、排队 follow-up 还是 steer 当前任务，也决定 prompt
+cancel 是退出、清空还是中断工作。基于 Harness 的会话应用应使用 Harnesstui 的
+`ConversationInputRouter` 承担运行态策略。
+
 Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文本 atom；大型 paste marker 是单个 atom，range edit 不会把它拆开。
+
+## Pre-1.0 InputRouter 迁移
+
+通用 Router 不再拥有会话状态。这是一次有意的 pre-1.0 边界收窄：
+
+| 旧 API | 基于 Harness 的替代方式 | 通用应用的替代方式 |
+| --- | --- | --- |
+| `InputRouter(running=...)` | 将状态投影给 `ConversationInputRouter`。 | 由应用状态解释通用 `submit`。 |
+| `steering_supported=...` | 支持时选择 `running_submit_mode="steer"`，否则选择 `"follow_up"`。 | 在应用适配层决定能力策略。 |
+| `submit(mode=...)` | 使用 HarnessTUI 的运行中提交路由。 | 调用无参数 `submit()`，再由应用解释结果。 |
+| 第三个/第四个位置状态参数 | 改用显式 HarnessTUI 配置。 | 改用仅限关键字的通用配置与应用状态。 |
+
+只有 `composer` 和 `surface_host` 仍可作为位置参数；`width`、`height`、
+`keybindings` 和 `target` 都必须使用关键字。旧调用
+`InputRouter(composer, None, True)` 现在会抛出 `TypeError`，不会把 `True`
+静默绑定到 `width`。
 
 ## 默认编辑快捷键
 

--- a/docs/zh-CN/user-guide/tui.md
+++ b/docs/zh-CN/user-guide/tui.md
@@ -109,6 +109,10 @@ router.route(InputEvent(kind="key", key="shift+left"))
 router.route(InputEvent(kind="key", key="ctrl+k"))
 ```
 
+通用 `InputRouter` 只产生中立的 `submit` 和 `prompt_cancel` intent，具体含义由
+应用结合自身状态决定。基于 Harness 的会话如果需要运行中提交、steer/follow-up、
+队列恢复和中断语义，应使用 Harnesstui 的 `ConversationInputRouter`。
+
 `TextInput` selection 索引用 grapheme cluster。`Composer` selection 索引用 composer atom，因此 paste marker 会保持原子性。显示宽度由渲染层处理。
 
 ## 示例

--- a/src/loushang/tui/input.py
+++ b/src/loushang/tui/input.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import re
-from dataclasses import InitVar, dataclass, field
+from dataclasses import KW_ONLY, InitVar, dataclass, field
 from typing import Literal, Protocol, cast
 
 from loushang.tui.framework import SurfaceHost
@@ -12,6 +12,7 @@ from loushang.tui.ui_parts import Composer
 InputEventKind = Literal["key", "text", "paste", "resize", "focus", "mouse", "signal"]
 InputIntentKind = Literal[
     "submit",
+    "prompt_cancel",
     "follow_up",
     "steer",
     "abort",
@@ -34,7 +35,6 @@ InputIntentKind = Literal[
     "command_cancel",
     "consumed",
 ]
-SubmitMode = Literal["submit", "follow_up", "steer"]
 KeyEventType = Literal["press", "repeat", "release"]
 
 ESC = "\x1b"
@@ -701,13 +701,12 @@ class _SurfaceRoute:
 class InputRouter:
     composer: Composer | None = None
     surface_host: SurfaceHost | None = None
-    running: bool = False
-    steering_supported: bool = False
+    _: KW_ONLY
     width: int = 80
     height: int = 24
     keybindings: KeybindingManager | None = None
-    _jump_mode: Literal["forward", "backward"] | None = None
     target: InitVar[PromptInputTarget | None] = None
+    _jump_mode: Literal["forward", "backward"] | None = field(default=None, init=False)
     _target: PromptInputTarget = field(init=False, repr=False)
 
     def __post_init__(self, target: PromptInputTarget | None) -> None:
@@ -726,16 +725,20 @@ class InputRouter:
         if event.kind == "key" and event.event_type == "release":
             return ()
         if event.kind == "key":
+            keybindings = self._keybindings()
+            is_cancel = keybindings.matches(event.key, "tui.select.cancel")
+            cancelled_pending_jump = False
             if self._jump_mode is not None:
-                keybindings = self._keybindings()
                 if keybindings.matches(event.key, "tui.editor.jumpForward") or keybindings.matches(
                     event.key,
                     "tui.editor.jumpBackward",
                 ):
                     self._jump_mode = None
-                    return ()
-                self._jump_mode = None
-            keybindings = self._keybindings()
+                    if not is_cancel:
+                        return ()
+                else:
+                    self._jump_mode = None
+                cancelled_pending_jump = is_cancel
             surface_route = self._route_surface_first(event)
             if surface_route.intents:
                 return surface_route.intents
@@ -752,16 +755,16 @@ class InputRouter:
                 return ()
             if target.has_completions and route_prompt_completion_key(target, event.key, keybindings=keybindings):
                 return ()
-            if keybindings.matches(event.key, "tui.select.cancel") and self.running:
-                return (InputIntent(kind="abort"),)
+            if is_cancel:
+                if cancelled_pending_jump:
+                    return ()
+                return (InputIntent(kind="prompt_cancel"),)
             if keybindings.matches(event.key, "tui.editor.jumpForward"):
                 self._jump_mode = "forward"
                 return ()
             if keybindings.matches(event.key, "tui.editor.jumpBackward"):
                 self._jump_mode = "backward"
                 return ()
-            if keybindings.matches(event.key, "tui.queue.editLast"):
-                return (InputIntent(kind="command", note="edit_last_queued_prompt"),)
             if keybindings.matches(event.key, "tui.input.tab"):
                 target.refresh_completions(force=True, explicit=True)
                 if target.has_completions:
@@ -819,20 +822,14 @@ class InputRouter:
             return (InputIntent(kind="invalidate_render"),)
         return ()
 
-    def submit(self, *, mode: SubmitMode = "submit") -> tuple[InputIntent, ...]:
+    def submit(self) -> tuple[InputIntent, ...]:
         target = self._target
         text = target.value
         if not text:
             return ()
         target.add_history(text)
         target.clear()
-        if not self.running:
-            return (InputIntent(kind="submit", text=text),)
-        if mode == "steer":
-            if self.steering_supported:
-                return (InputIntent(kind="steer", text=text),)
-            return (InputIntent(kind="follow_up", text=text, note="steer_unavailable"),)
-        return (InputIntent(kind="follow_up", text=text),)
+        return (InputIntent(kind="submit", text=text),)
 
     def _route_surface_first(self, event: InputEvent) -> _SurfaceRoute:
         if self.surface_host is None:

--- a/tests/tui/test_import_boundaries.py
+++ b/tests/tui/test_import_boundaries.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import os
 import subprocess
 import sys
@@ -46,6 +47,61 @@ def test_loushang_tui_public_models_are_not_owned_by_compat_module() -> None:
     assert not Path("src/loushang/tui/compat.py").exists()
     for name, module_name in expected_modules.items():
         assert getattr(tui, name).__module__ == module_name
+
+
+def test_tui_input_router_defines_no_conversation_state_or_submit_mode() -> None:
+    from dataclasses import fields
+
+    import loushang.tui.input as input_module
+    from loushang.tui import InputRouter
+
+    router_fields = {router_field.name for router_field in fields(InputRouter)}
+
+    assert "running" not in router_fields
+    assert "steering_supported" not in router_fields
+    assert not hasattr(input_module, "SubmitMode")
+
+
+def test_tui_package_does_not_construct_conversation_input_intents() -> None:
+    violations: list[str] = []
+    for source_path in sorted(Path("src/loushang/tui").rglob("*.py")):
+        violations.extend(
+            _conversation_intent_producer_violations(
+                source_path.read_text(encoding="utf-8"),
+                filename=str(source_path),
+            )
+        )
+
+    assert violations == []
+
+
+def test_conversation_intent_producer_checker_rejects_direct_constants() -> None:
+    call_forms = (
+        'InputIntent("steer")',
+        'InputIntent(kind="steer")',
+        'InputIntent("follow_up")',
+        'InputIntent(kind="follow_up")',
+        'InputIntent("command", "", "edit_last_queued_prompt")',
+        'InputIntent(kind="command", note="edit_last_queued_prompt")',
+    )
+
+    for call_form in call_forms:
+        for expression in (call_form, f"tui.{call_form}"):
+            assert _conversation_intent_producer_violations(expression), expression
+
+
+def test_conversation_intent_producer_checker_allows_generic_and_dynamic_forms() -> None:
+    allowed_sources = (
+        'InputIntent("abort")',
+        'tui.InputIntent(kind="abort")',
+        "InputIntent(kind=kind, note=note)",
+        'tui.InputIntent(kind=kind, note="edit_last_queued_prompt")',
+        'InputIntentKind = Literal["steer", "follow_up"]',
+        '"InputIntent(kind=\\"steer\\")"',
+    )
+
+    for source in allowed_sources:
+        assert _conversation_intent_producer_violations(source) == (), source
 
 
 def test_import_boundary_check_does_not_replace_loaded_tui_classes() -> None:
@@ -193,3 +249,47 @@ sys.meta_path.insert(0, BlockPosixTerminalModules())
         capture_output=True,
         check=False,
     )
+
+
+def _conversation_intent_producer_violations(
+    source: str,
+    *,
+    filename: str = "<source>",
+) -> tuple[str, ...]:
+    violations: list[str] = []
+    for node in ast.walk(ast.parse(source, filename=filename)):
+        if not isinstance(node, ast.Call) or not _is_input_intent_constructor(node.func):
+            continue
+        kind = _literal_call_argument(node, position=0, keyword="kind")
+        note = _literal_call_argument(node, position=2, keyword="note")
+        if kind in {"steer", "follow_up"}:
+            violations.append(f"{filename}:{node.lineno}: forbidden {kind} InputIntent producer")
+        elif kind == "command" and note == "edit_last_queued_prompt":
+            violations.append(f"{filename}:{node.lineno}: forbidden queued-edit InputIntent producer")
+    return tuple(violations)
+
+
+def _is_input_intent_constructor(node: ast.expr) -> bool:
+    return (isinstance(node, ast.Name) and node.id == "InputIntent") or (
+        isinstance(node, ast.Attribute) and node.attr == "InputIntent"
+    )
+
+
+def _literal_call_argument(
+    call: ast.Call,
+    *,
+    position: int,
+    keyword: str,
+) -> str | None:
+    if len(call.args) > position:
+        return _string_literal(call.args[position])
+    for item in call.keywords:
+        if item.arg == keyword:
+            return _string_literal(item.value)
+    return None
+
+
+def _string_literal(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None

--- a/tests/tui/test_input_routing.py
+++ b/tests/tui/test_input_routing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import inspect
+from dataclasses import dataclass, field, fields
 from typing import Any, Literal
 
 import pytest
@@ -455,6 +456,71 @@ def test_input_router_rejects_composer_and_target_together() -> None:
         InputRouter(composer=Composer(prompt="> "), target=FakePromptTarget())
 
 
+def test_input_router_constructor_exposes_only_generic_configuration() -> None:
+    parameters = inspect.signature(InputRouter).parameters
+
+    assert tuple(parameters) == (
+        "composer",
+        "surface_host",
+        "width",
+        "height",
+        "keybindings",
+        "target",
+    )
+    assert parameters["composer"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert parameters["surface_host"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert all(
+        parameters[name].kind is inspect.Parameter.KEYWORD_ONLY
+        for name in ("width", "height", "keybindings", "target")
+    )
+    router_fields = {router_field.name: router_field for router_field in fields(InputRouter)}
+    assert "running" not in router_fields
+    assert "steering_supported" not in router_fields
+    assert router_fields["_jump_mode"].init is False
+
+    with pytest.raises(TypeError):
+        InputRouter(Composer(prompt="> "), None, True)
+
+
+def test_input_router_submit_accepts_no_conversation_mode() -> None:
+    composer = Composer(prompt="> ")
+    composer.insert_text("later")
+    router = InputRouter(composer=composer)
+
+    assert tuple(inspect.signature(InputRouter.submit).parameters) == ("self",)
+    assert router.submit() == (InputIntent(kind="submit", text="later"),)
+
+    with pytest.raises(TypeError):
+        router.submit(mode="steer")  # type: ignore[call-arg]
+
+
+def test_input_router_submit_is_conversation_neutral() -> None:
+    composer = Composer(prompt="> ")
+    composer.insert_text("later")
+    router = InputRouter(composer=composer)
+
+    assert router.route(InputEvent(kind="key", key="enter")) == (
+        InputIntent(kind="submit", text="later"),
+    )
+
+
+@pytest.mark.parametrize("cancel_key", ["escape", "ctrl_c"])
+def test_input_router_unconsumed_cancel_emits_prompt_cancel(cancel_key: str) -> None:
+    router = InputRouter(composer=Composer(prompt="> "))
+
+    assert router.route(InputEvent(kind="key", key=cancel_key)) == (
+        InputIntent(kind="prompt_cancel"),
+    )
+
+
+def test_input_router_does_not_own_conversation_queue_editing() -> None:
+    composer = Composer(prompt="> ")
+    router = InputRouter(composer=composer)
+
+    assert router.route(InputEvent(kind="key", key="alt+up")) == ()
+    assert composer.value == ""
+
+
 def test_input_router_routes_text_paste_and_submit_through_target() -> None:
     target = FakePromptTarget()
     router = InputRouter(target=target)
@@ -530,14 +596,15 @@ def test_input_router_jump_mode_moves_to_next_or_previous_character() -> None:
     assert composer.value == "bc ef abc"
 
 
-def test_input_router_escape_cancels_jump_mode_without_editing() -> None:
+@pytest.mark.parametrize("cancel_key", ["escape", "ctrl_c"])
+def test_input_router_cancel_terminates_pending_jump_without_prompt_cancel(cancel_key: str) -> None:
     composer = Composer(prompt="> ")
     composer.insert_text("abc def")
     composer.move_to_line_start()
     router = InputRouter(composer=composer)
 
     assert router.route(InputEvent(kind="key", key="ctrl+]")) == ()
-    assert router.route(InputEvent(kind="key", key="escape")) == ()
+    assert router.route(InputEvent(kind="key", key=cancel_key)) == ()
     assert router.route(InputEvent(kind="text", text="d")) == ()
 
     assert composer.value == "dabc def"
@@ -740,16 +807,37 @@ def test_input_router_shift_tab_selects_previous_completion_without_applying() -
     assert composer.value == "/hello"
 
 
-def test_input_router_escape_closes_completion_before_running_abort() -> None:
+def test_input_router_escape_closes_completion_before_prompt_cancel() -> None:
     composer = Composer(prompt="> ")
     composer.insert_text("/he")
     composer.set_completion_items((CompletionItem(value="/help", label="/help"),))
-    router = InputRouter(composer=composer, running=True, width=20)
+    router = InputRouter(composer=composer, width=20)
 
     assert router.route(InputEvent(kind="key", key="escape")) == ()
 
     assert composer.value == "/he"
     assert not composer.has_completions
+
+
+@pytest.mark.parametrize("custom_overlap", [False, True])
+def test_input_router_completion_wins_after_pending_jump_cancel(custom_overlap: bool) -> None:
+    keybindings = (
+        KeybindingManager({"tui.editor.jumpForward": ("escape",)})
+        if custom_overlap
+        else KeybindingManager()
+    )
+    composer = Composer(prompt="> ")
+    composer.insert_text("abc def")
+    composer.move_to_line_start()
+    router = InputRouter(composer=composer, keybindings=keybindings)
+    pending_jump_key = "ctrl+alt+]" if custom_overlap else "ctrl+]"
+
+    assert router.route(InputEvent(kind="key", key=pending_jump_key)) == ()
+    composer.set_completion_items((CompletionItem(value="abc", label="abc"),))
+    assert router.route(InputEvent(kind="key", key="escape")) == ()
+    assert not composer.has_completions
+    assert router.route(InputEvent(kind="text", text="d")) == ()
+    assert composer.value == "dabc def"
 
 
 def test_input_router_enter_submits_text_without_applying_completion() -> None:
@@ -859,21 +947,21 @@ def test_input_router_ctrl_j_and_alt_enter_insert_explicit_newline() -> None:
     assert composer.value == "first\nsecond\n"
 
 
-def test_input_router_alt_up_requests_edit_last_queued_prompt() -> None:
-    composer = Composer(prompt="> ")
-    router = InputRouter(composer=composer)
-
-    assert router.route(InputEvent(kind="key", key="alt_up")) == (InputIntent(kind="command", note="edit_last_queued_prompt"),)
-    assert composer.value == ""
-
-
-def test_surface_receives_escape_before_active_run_abort() -> None:
+@pytest.mark.parametrize("custom_overlap", [False, True])
+def test_surface_receives_cancel_after_pending_jump(custom_overlap: bool) -> None:
+    keybindings = (
+        KeybindingManager({"tui.editor.jumpForward": ("escape",)})
+        if custom_overlap
+        else KeybindingManager()
+    )
     composer = Composer(prompt="> ")
     focus = EscConsumer()
     host = SurfaceHost()
     host.open_surface(Surface(renderable=DummyRenderable(), focus_target=focus))
-    router = InputRouter(composer=composer, surface_host=host, running=True)
+    router = InputRouter(composer=composer, surface_host=host, keybindings=keybindings)
+    pending_jump_key = "ctrl+alt+]" if custom_overlap else "ctrl+]"
 
+    assert router.route(InputEvent(kind="key", key=pending_jump_key)) == ()
     intents = router.route(InputEvent(kind="key", key="esc"))
 
     assert intents == (InputIntent(kind="surface_close"),)
@@ -962,14 +1050,58 @@ def test_input_router_does_not_submit_prompt_while_focused_editor_target_is_acti
     assert prompt.value == "prompt"
 
 
-def test_input_router_does_not_abort_running_prompt_while_focused_editor_target_is_active() -> None:
+@pytest.mark.parametrize("custom_overlap", [False, True])
+def test_focused_editor_receives_cancel_after_pending_jump(custom_overlap: bool) -> None:
+    class RecordingEditorFocus(DecliningEditorFocus):
+        def __init__(self, target: object) -> None:
+            super().__init__(target)
+            self.keys: list[str] = []
+
+        def handle_input(self, event: Any) -> bool:
+            if isinstance(event, InputEvent) and event.kind == "key":
+                self.keys.append(event.key)
+            return False
+
+    keybindings = (
+        KeybindingManager({"tui.editor.jumpForward": ("escape",)})
+        if custom_overlap
+        else KeybindingManager()
+    )
     prompt = Composer(prompt="> ")
+    prompt.insert_text("abc def")
+    prompt.move_to_line_start()
+    router = InputRouter(composer=prompt, keybindings=keybindings)
+    pending_jump_key = "ctrl+alt+]" if custom_overlap else "ctrl+]"
+    assert router.route(InputEvent(kind="key", key=pending_jump_key)) == ()
+
     field = TextInput()
+    focus = RecordingEditorFocus(field.editor_input_target())
     host = SurfaceHost()
-    host.open_surface(Surface(renderable=DummyRenderable(), focus_target=DecliningEditorFocus(field.editor_input_target())))
-    router = InputRouter(composer=prompt, surface_host=host, running=True)
+    handle = host.open_surface(Surface(renderable=DummyRenderable(), focus_target=focus))
+    router.surface_host = host
 
     assert router.route(InputEvent(kind="key", key="escape")) == ()
+    assert focus.keys == ["esc"]
+
+    handle.close(reason="test")
+    assert router.route(InputEvent(kind="text", text="d")) == ()
+    assert prompt.value == "dabc def"
+
+
+def test_custom_jump_cancel_overlap_without_pending_jump_emits_prompt_cancel() -> None:
+    composer = Composer(prompt="> ")
+    composer.insert_text("abc def")
+    composer.move_to_line_start()
+    router = InputRouter(
+        composer=composer,
+        keybindings=KeybindingManager({"tui.editor.jumpForward": ("escape",)}),
+    )
+
+    assert router.route(InputEvent(kind="key", key="escape")) == (
+        InputIntent(kind="prompt_cancel"),
+    )
+    assert router.route(InputEvent(kind="text", text="d")) == ()
+    assert composer.value == "dabc def"
 
 
 def test_input_router_prompt_jump_text_wins_before_focused_editor_fallback() -> None:
@@ -1004,22 +1136,6 @@ def test_input_router_does_not_leak_searchable_surface_text_to_prompt() -> None:
     assert tuple(item.selected_value for item in surface._filtered_items) == ("/status",)
 
 
-def test_ctrl_c_during_running_turn_routes_abort_intent() -> None:
-    composer = Composer(prompt="> ")
-    router = InputRouter(composer=composer, running=True)
-
-    intents = router.route(InputEvent(kind="key", key="ctrl_c"))
-
-    assert intents == (InputIntent(kind="abort"),)
-
-
-def test_escape_when_idle_does_not_create_abort_intent() -> None:
-    composer = Composer(prompt="> ")
-    router = InputRouter(composer=composer, running=False)
-
-    assert router.route(InputEvent(kind="key", key="esc")) == ()
-
-
 def test_alt_enter_inserts_explicit_newline_without_submit() -> None:
     composer = Composer(prompt="> ")
     composer.insert_text("first")
@@ -1037,36 +1153,3 @@ def test_resize_and_sigwinch_events_request_render_invalidation() -> None:
 
     assert router.route(InputEvent(kind="resize", columns=120, rows=50)) == (InputIntent(kind="invalidate_render"),)
     assert router.route(InputEvent(kind="signal", signal="sigwinch")) == (InputIntent(kind="invalidate_render"),)
-
-
-def test_enter_while_running_queues_follow_up_and_clears_composer() -> None:
-    composer = Composer(prompt="> ")
-    composer.insert_text("later")
-    router = InputRouter(composer=composer, running=True)
-
-    intents = router.route(InputEvent(kind="key", key="enter"))
-
-    assert intents == (InputIntent(kind="follow_up", text="later"),)
-    assert composer.value == ""
-
-
-def test_configured_steer_submit_routes_steer_when_supported() -> None:
-    composer = Composer(prompt="> ")
-    composer.insert_text("look at logs")
-    router = InputRouter(composer=composer, running=True, steering_supported=True)
-
-    intents = router.submit(mode="steer")
-
-    assert intents == (InputIntent(kind="steer", text="look at logs"),)
-    assert composer.value == ""
-
-
-def test_unavailable_steer_downgrades_to_visible_follow_up() -> None:
-    composer = Composer(prompt="> ")
-    composer.insert_text("look at logs")
-    router = InputRouter(composer=composer, running=True, steering_supported=False)
-
-    intents = router.submit(mode="steer")
-
-    assert intents == (InputIntent(kind="follow_up", text="look at logs", note="steer_unavailable"),)
-    assert composer.value == ""


### PR DESCRIPTION
## Summary

- make `tui.InputRouter` a generic editor router: it no longer owns conversation run state or chooses steer/follow-up semantics
- replace generic prompt cancellation output with the neutral `prompt_cancel` intent while retaining legacy intent literals for downstream compatibility
- move pending-jump cancellation behind surface, focused-editor, and completion priorities; remove generic `Alt+Up` queued-input policy
- add package-wide AST architecture tests that prevent `loushang.tui` from directly constructing steer/follow-up/queued-edit intents
- update architecture and public migration documentation

Refs #462. Follows planning PR #463 and adapter-seam PR #465.

## Stack / audit trail

- PR3 base: `d516b39bce8ab096ad3ec11a0407ce7323234472` (merged PR #465)
- PR3 head: `9fd993852c21a3489b9dd90c5aa19466d022dd9a`
- PR2 base: `312cc79087478a25270c54964903a81d8c475fb1`
- PR2 head: `b4c4676a82de59aa12c79f0a3039240b77f894e6`
- PR2 merge: `d516b39bce8ab096ad3ec11a0407ce7323234472`

## API / behavior change

Removed from the generic router:

- `SubmitMode`
- `InputRouter.running`
- `InputRouter.steering_supported`
- `InputRouter.submit(mode)`
- the third/fourth positional constructor slots previously used by conversation state

The constructor now accepts only `composer` and `surface_host` positionally; `width`, `height`, `keybindings`, and `target` are keyword-only. `submit()` is zero-argument and always emits `submit`.

Unconsumed `Escape` / `Ctrl+C` now emits `prompt_cancel`. Surface ownership, focused editor handling, completion handling, and jump handling retain priority. A custom `jumpForward=escape` overlap has a regression test.

Conversation semantics remain with `harnesstui.ConversationInputRouter` or application state. Coding already routes through Harnesstui; production Coding/Harnesstui/example sources have no diff in this PR, and the effective shortcut behavior is unchanged.

## Architecture guard

The package-wide AST test scans `src/loushang/tui/**/*.py` and rejects direct constant producers for steer, follow-up, and queued-edit semantics, covering positional and keyword arguments plus bare-name and attribute enum forms. It intentionally permits unrelated `abort`, dynamic values, and literal data.

## Migration

| Before | After |
| --- | --- |
| `InputRouter(..., running=...)` | `ConversationInputRouter` or application run state |
| `steering_supported=...` | Harness `running_submit_mode` or application capability |
| `router.submit(mode)` | Harness route, or generic zero-argument `router.submit()` |
| third/fourth positional constructor args | explicit Harness ownership; generic options by keyword |

This is a pre-1.0 breaking cleanup. Passing an old third positional argument now fails with `TypeError` instead of being silently reinterpreted.

## Verification

- new regression slice: `19 passed` (observed RED first: `12 failed, 7 passed` against the PR3 base)
- generic routing + import boundaries: `85 passed`
- focused TUI/Harnesstui/Coding gate: `116 passed`
- boundary/playback: `25 passed`
- Coding playback/loop: `46 passed`
- full TUI + Harnesstui: `1762 passed`
- `make check-harnesstui`: Ruff clean, mypy `139` sources clean, `1267 passed, 65 deselected`
- `make check-architecture-docs`: `5 passed`
- changed generic router mypy: clean
- relevant Ruff and `git diff --check`: clean
- snapshot and scripted example checks: clean

PTY verification of the existing example adapter:

- idle Enter starts a run
- running Enter queues follow-up
- `/steer` remains a separate explicit path
- `Alt+Up` restores queued input rather than converting it to steer
- running Escape and Ctrl+C each abort once
- idle Escape is a no-op; idle Ctrl+C exits cleanly
- running `/quit` exits cleanly

`examples/tui/29_composer_bottom_frame.py`, `src/loushang/harnesstui`, `src/loushang/coding`, and `src/loushang/harness` have zero production diff from the PR3 base.

## Known pre-existing local gate issues

- the broad Coding suite stalls at `tests/coding/test_agent_runtime_roundtrip.py::test_agent_messages_roundtrip_through_persisted_session_manager`; the exact test also times out in the clean pre-PR3 baseline worktree, so it is unrelated to this change
- broad `make typecheck-tui` reports 69 existing errors in 19 files; the changed `src/loushang/tui/input.py` passes direct mypy, and `make check-harnesstui` is green

## Rollback / deferred scope

Rollback order for the stack is PR3, then PR2, then PR1/planning changes as applicable.

Deferred intentionally: route deduplication, a centralized keybinding catalog, result-type redesign, and explicit Coding capability injection.
