### PR TITLE
fix(tui): widen selection cursor callback result

### DIFF
--- a/src/loushang/tui/selection_controller.py
+++ b/src/loushang/tui/selection_controller.py
@@ -12,7 +12,7 @@ __all__ = ["SelectionController"]
 class SelectionController:
     length: Callable[[], int]
     cursor: Callable[[], int]
-    set_cursor: Callable[[int], None]
+    set_cursor: Callable[[int], object]
     _selection: SelectionRange | None = None
 
     @property


### PR DESCRIPTION
## Summary

- widen `SelectionController.set_cursor` from `Callable[[int], None]` to `Callable[[int], object]`
- accept cursor setters that report whether the cursor moved, such as `EditorBuffer.move_cursor_to()`
- keep runtime behavior unchanged because `SelectionController` intentionally ignores the callback result

Refs #467.

## Scope

This is the first small slice of the TUI typecheck-baseline cleanup. The production diff is one annotation line; it does not change input routing, selection behavior, or the TUI/HarnessTUI ownership boundary.

## Verification

- focused mypy over SelectionController, TextInput, and TextArea: `Success: no issues found in 3 source files`
- cumulative `make typecheck-tui` baseline: `69 errors in 19 files` -> `67 errors in 17 files`
- focused runtime regression outside the managed sandbox: `43 passed`
- Ruff: passed
- `git diff --check`: passed
