### PR TITLE
fix(tui): type tab group focus state

### DIFF
--- a/src/loushang/tui/ui_parts/widgets/tab_group.py
+++ b/src/loushang/tui/ui_parts/widgets/tab_group.py
@@ -11,7 +11,7 @@ from loushang.tui.core import (
 )
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.ui_parts.widgets._utils import callback_result
-from loushang.tui.ui_parts.widgets.tabs import TabItem, Tabs
+from loushang.tui.ui_parts.widgets.tabs import TabFocusState, TabItem, Tabs
 
 __all__ = ["TabGroup", "TabPage"]
 
@@ -269,7 +269,7 @@ class TabGroup:
         self._tabs.level = self.level
         self._tabs.selected_focus = self._selected_focus_state()
 
-    def _selected_focus_state(self) -> str:
+    def _selected_focus_state(self) -> TabFocusState:
         if not self.focused:
             return "none"
         return "header" if self.header_focused else "content"


### PR DESCRIPTION
## Summary

- type `TabGroup._selected_focus_state()` with the existing `TabFocusState` Literal contract
- keep the existing `none`, `header`, and `content` runtime states unchanged
- remove the two TabGroup-to-Tabs assignment errors from the TUI mypy baseline

Refs #467.

## Scope

This is the second independent TUI typecheck-baseline slice. It changes one import and one return annotation only; navigation, rendering, and input ownership behavior are unchanged.

## Verification

- observed focused RED on `origin/main`: 2 errors in `tab_group.py`
- focused mypy after the change: `Success: no issues found in 1 source file`
- cumulative `make typecheck-tui` baseline: `67 errors in 17 files` -> `65 errors in 16 files`
- focused TabGroup/Tabs runtime regression outside the managed sandbox: `40 passed`
- Ruff: passed
- `git diff --check`: passed
