### PR TITLE
fix(tui): type tab navigation callback results

### DIFF
--- a/src/loushang/tui/ui_parts/widgets/tabs.py
+++ b/src/loushang/tui/ui_parts/widgets/tabs.py
@@ -129,7 +129,7 @@ class Tabs:
             return None
         return index
 
-    def _move_selection(self, delta: int) -> bool | None:
+    def _move_selection(self, delta: int) -> object:
         enabled = self._enabled_indices()
         if not enabled:
             return None
@@ -147,7 +147,7 @@ class Tabs:
             return False
         return self._set_value(self.tabs[next_index].value)
 
-    def _jump_selection(self, *, first: bool) -> bool | None:
+    def _jump_selection(self, *, first: bool) -> object:
         enabled = self._enabled_indices()
         if not enabled:
             return None


### PR DESCRIPTION
## Summary

- type Tabs navigation helpers with their actual `object` callback-result contract
- preserve string/custom `on_change` results as well as existing `True`, `False`, and `None` outcomes
- remove the three Tabs return-value errors from the TUI mypy baseline

Refs #467.

## Scope

This is the third independent TUI typecheck-baseline slice. Only two private method return annotations change; navigation and callback behavior remain unchanged.

## Verification

- observed focused RED on `origin/main`: 3 errors in `tabs.py`
- focused mypy after the change: `Success: no issues found in 1 source file`
- cumulative `make typecheck-tui` baseline: `65 errors in 16 files` -> `62 errors in 15 files`
- focused Tabs/TabGroup runtime regression outside the managed sandbox: `40 passed`
- Ruff: passed
- `git diff --check`: passed
