### PR TITLE
fix(tui): distinguish configured approval choices

### DIFF
--- a/src/loushang/tui/surfaces.py
+++ b/src/loushang/tui/surfaces.py
@@ -505,9 +505,11 @@ class ApprovalSurface:
         self,
     ) -> tuple[ApprovalChoice, ...]:
         if self.options:
-            choices = list(self.options)
-            self.selected_index = max(0, min(self.selected_index, len(choices) - 1))
-            return tuple(choices)
+            configured_choices = list(self.options)
+            self.selected_index = max(
+                0, min(self.selected_index, len(configured_choices) - 1)
+            )
+            return tuple(configured_choices)
         choices: list[ApprovalChoice] = [
             ApprovalChoice("allow_once", "Allow this action once", "y"),
         ]


### PR DESCRIPTION
## Summary

- distinguish explicitly configured approval choices from the fallback choice list
- eliminate the local `choices` redefinition without changing approval behavior

## Verification

- focused RED: `surfaces.py` reported 1 `no-redef` error before the change
- focused mypy: no issues found
- cumulative `make typecheck-tui`: 62 errors / 15 files -> 61 errors / 14 files
- Ruff: passed
- runtime (outside sandbox): 70 passed

Refs #467
