### PR TITLE
fix(tui): align leaf component type contracts

### DIFF
--- a/src/loushang/tui/framework.py
+++ b/src/loushang/tui/framework.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, replace
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 from loushang.tui.cell_width import (
     autowrap_safe_width,
@@ -784,7 +784,7 @@ def surface_presentation(
         or raw in _OVERLAY_PRESENTATIONS
         or raw in _PAGE_PRESENTATIONS
     ):
-        return raw
+        return cast(SurfacePresentation, raw)
     return default
 
 
@@ -808,7 +808,7 @@ def surface_is_bottom_exclusive(surface: object) -> bool:
 
 def _compose_overlay(
     base_lines: list[str],
-    overlay_lines: tuple[RenderLine, ...] | list[RenderLine],
+    overlay_lines: Sequence[RenderLine],
     *,
     row: int,
     column: int,

--- a/src/loushang/tui/markdown/renderer.py
+++ b/src/loushang/tui/markdown/renderer.py
@@ -5,7 +5,7 @@ import inspect
 import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from functools import lru_cache
+from functools import lru_cache, partial
 from typing import Protocol, TypeAlias, cast
 
 from markdown_it import MarkdownIt
@@ -993,7 +993,8 @@ def _render_markdown_blocks(
         if render_cache is not None and index < stable_block_count:
             block_lines = render_cache.get_or_render(
                 (block, *block_cache_context),
-                lambda block=block: _render_markdown_block(
+                partial(
+                    _render_markdown_block,
                     block,
                     width=width,
                     theme=theme,

--- a/src/loushang/tui/transcript.py
+++ b/src/loushang/tui/transcript.py
@@ -306,7 +306,7 @@ def render_transcript_records(
         markdown_streaming_key=markdown_streaming_key,
     )
     rendered = view.render(RenderConstraints(width=width, max_height=max_height))
-    return rendered.lines
+    return tuple(rendered.lines)
 
 
 def _record_is_transient(record: DisplayRecord) -> bool:

--- a/src/loushang/tui/ui_parts/widgets/directory_tree.py
+++ b/src/loushang/tui/ui_parts/widgets/directory_tree.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from loushang.tui.core import RenderConstraints, RenderResult
 from loushang.tui.theme import ThemeResolver
@@ -317,7 +317,7 @@ class DirectoryTree:
             return False
         return not (self.ignore_matcher is not None and self.ignore_matcher(path))
 
-    def _sort_tuple(self, path: Path) -> object:
+    def _sort_tuple(self, path: Path) -> tuple[Any, ...]:
         if self.sort_key is not None:
             return (self.sort_key(path), path.name.casefold(), path.name)
         return (path.name.casefold(), path.name)

--- a/src/loushang/tui/ui_parts/widgets/selection.py
+++ b/src/loushang/tui/ui_parts/widgets/selection.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loushang.tui.core import RenderConstraints, RenderResult
 from loushang.tui.theme import ThemeResolver
 
+if TYPE_CHECKING:
+    from loushang.tui.surfaces import SelectItem
+
 
 @dataclass(slots=True)
 class SelectList:
-    items: list[object] | tuple[object, ...]
+    items: list[SelectItem] | tuple[SelectItem, ...]
     max_visible: int = 5
     close_on_escape: bool = False
     theme: ThemeResolver | None = None


### PR DESCRIPTION
## Summary

- align surface composition and presentation narrowing with their runtime contracts
- preserve tuple return contracts and give markdown cache callbacks an inferable callable type
- align SelectList items and directory sort keys with the values their implementations consume

## Scope

- 5 source files
- 6 type errors eliminated
- no input-routing or interaction behavior changes

## Verification

- focused mypy: no issues found in 5 source files
- cumulative `make typecheck-tui`: 61 errors / 14 files -> 55 errors / 9 files
- focused runtime baseline before change: 207 passed outside sandbox
- focused runtime regression after change: 207 passed outside sandbox
- Ruff lint and Git diff checks passed

Refs #467
