### PR TITLE
fix(tui): type widget option forwarding

### DIFF
--- a/src/loushang/tui/tui.py
+++ b/src/loushang/tui/tui.py
@@ -3,17 +3,21 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass, field
+from typing import TypedDict, Unpack
 
 from loushang.tui.core import RenderConstraints, RenderResult
 from loushang.tui.extensions import ExtensionHandle
 from loushang.tui.framework import (
     Container,
     Focusable,
+    OverlayAnchor,
     Renderable,
     ScreenRoot,
+    SizeValue,
     Surface,
     SurfaceHandle,
     SurfaceHost,
+    SurfacePresentation,
 )
 from loushang.tui.playback import PlaybackStep
 from loushang.tui.render_loop import RenderLoop
@@ -24,9 +28,27 @@ from loushang.tui.terminal import (
     TerminalOperation,
     TerminalPort,
     TerminalProgressReporter,
+    TerminalSize,
 )
 
 InputListener = Callable[[object], object]
+
+
+class _SurfaceOptions(TypedDict, total=False):
+    presentation: SurfacePresentation
+    captures_focus: bool
+    non_capturing: bool
+    row: SizeValue | None
+    column: SizeValue | None
+    col: SizeValue | None
+    width: SizeValue | None
+    min_width: int | None
+    max_height: SizeValue | None
+    anchor: OverlayAnchor
+    offset_x: int
+    offset_y: int
+    margin: int | dict[str, int] | None
+    visible: Callable[[TerminalSize], bool] | None
 
 
 @dataclass(slots=True)
@@ -62,7 +84,7 @@ class Tui:
         renderable: Renderable,
         *,
         focus_target: Focusable | None = None,
-        **surface_options: object,
+        **surface_options: Unpack[_SurfaceOptions],
     ) -> SurfaceHandle:
         target = focus_target or (renderable if isinstance(renderable, Focusable) else None)
         surface = Surface(renderable=renderable, focus_target=target, **surface_options)

--- a/src/loushang/tui/ui_parts/widgets/button.py
+++ b/src/loushang/tui/ui_parts/widgets/button.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, TypedDict, Unpack
 
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
@@ -14,6 +14,15 @@ from loushang.tui.ui_parts.widgets._utils import (
 )
 
 ButtonKind = Literal["default", "primary", "danger", "ghost"]
+
+
+class _ButtonOptions(TypedDict, total=False):
+    kind: ButtonKind
+    disabled: bool
+    on_press: Callable[[], object] | None
+    theme: ThemeResolver | None
+    theme_token: str | None
+    focused: bool
 
 
 @dataclass(slots=True)
@@ -51,7 +60,9 @@ class Button:
         return RenderResult.from_lines([RenderLine(rendered)][: constraints.max_height], constraints=constraints)
 
 
-def IconButton(icon: str, *, label: str = "", **kwargs: object) -> Button:
+def IconButton(
+    icon: str, *, label: str = "", **kwargs: Unpack[_ButtonOptions]
+) -> Button:
     return Button(label=label, icon=icon, **kwargs)
 
 

--- a/src/loushang/tui/ui_parts/widgets/data_grid.py
+++ b/src/loushang/tui/ui_parts/widgets/data_grid.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field, replace
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from math import isfinite
 from types import MappingProxyType
-from typing import Literal, TextIO
+from typing import Any, Literal, TextIO, TypedDict, Unpack, cast
 
 from loushang.tui.cell_width import (
     autowrap_safe_width,
@@ -35,6 +35,37 @@ DataGridFilterMode = Literal["contains", "prefix"]
 DataGridCellKey = tuple[str, str]
 
 DATA_GRID_SEPARATOR = "  "
+
+
+class _DataGridOptions(TypedDict, total=False):
+    active_row_key: str | None
+    active_column_key: str | None
+    cursor_mode: DataGridCursorMode
+    selection_mode: DataGridSelectionMode
+    show_header: bool
+    show_row_labels: bool
+    fixed_columns: int
+    zebra_stripes: bool
+    empty_text: str
+    wrap_rows: bool
+    wrap_columns: bool
+    theme: ThemeResolver | None
+    focused: bool
+
+
+class _CsvReaderOptions(TypedDict, total=False):
+    fieldnames: Sequence[str] | None
+    restkey: str | None
+    restval: str | None
+    delimiter: str
+    quotechar: str | None
+    escapechar: str | None
+    doublequote: bool
+    skipinitialspace: bool
+    lineterminator: str
+    quoting: Literal[0, 1, 2, 3]
+    strict: bool
+
 
 __all__ = [
     "CompactNumberFormatter",
@@ -362,7 +393,7 @@ class DataGrid:
         *,
         columns: Sequence[DataGridColumn] | None = None,
         row_key_field: str | None = None,
-        **grid_options: object,
+        **grid_options: Unpack[_DataGridOptions],
     ) -> DataGrid:
         normalized_records = _normalize_adapter_records(records)
         grid_columns = tuple(columns) if columns is not None else _columns_from_records(normalized_records)
@@ -377,7 +408,7 @@ class DataGrid:
         records_key: str = "records",
         columns: Sequence[DataGridColumn] | None = None,
         row_key_field: str | None = None,
-        **grid_options: object,
+        **grid_options: Unpack[_DataGridOptions],
     ) -> DataGrid:
         payload = _json_payload(data)
         records = _records_from_json_payload(payload, records_key=records_key)
@@ -392,7 +423,7 @@ class DataGrid:
         row_key_field: str | None = None,
         dialect: str = "excel",
         csv_options: Mapping[str, object] | None = None,
-        **grid_options: object,
+        **grid_options: Unpack[_DataGridOptions],
     ) -> DataGrid:
         records, header_columns = _records_from_csv(data, dialect=dialect, csv_options=csv_options)
         return cls.from_records(
@@ -1878,7 +1909,7 @@ def _normalize_adapter_records(records: Iterable[Mapping[str, object]]) -> tuple
     return tuple(normalized)
 
 
-def _string_key_record(record: Mapping[object, object]) -> dict[str, object]:
+def _string_key_record(record: Mapping[Any, object]) -> dict[str, object]:
     result: dict[str, object] = {}
     for key, value in record.items():
         text_key = str(key)
@@ -1958,7 +1989,8 @@ def _records_from_csv(
     stream = io.StringIO(data) if isinstance(data, str) else data
     if not hasattr(stream, "read"):
         raise TypeError("CSV data must be a string or text stream")
-    reader = csv.DictReader(stream, dialect=dialect, **dict(csv_options or {}))
+    reader_options = cast(_CsvReaderOptions, dict(csv_options or {}))
+    reader = csv.DictReader(stream, dialect=dialect, **reader_options)
     if not reader.fieldnames:
         raise ValueError("CSV input must include a header row")
     fieldnames = tuple(str(field) for field in reader.fieldnames)

--- a/src/loushang/tui/ui_parts/widgets/dialog.py
+++ b/src/loushang/tui/ui_parts/widgets/dialog.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol, TypeGuard
 
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
 from loushang.tui.theme import ThemeResolver
 from loushang.tui.ui_parts.widgets._utils import style_text
+
+if TYPE_CHECKING:
+    from loushang.tui.input import InputIntentKind
+
+
+class _FocusableBody(Protocol):
+    def focus(self) -> None: ...
+
+    def blur(self) -> None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -122,7 +132,7 @@ class ConfirmDialog(Dialog):
         )
 
 
-def _input_intent(kind: str) -> object:
+def _input_intent(kind: InputIntentKind) -> object:
     from loushang.tui.input import InputIntent
 
     return InputIntent(kind=kind)
@@ -153,7 +163,7 @@ def _dialog_result(
     return RenderResult.from_lines(lines[: constraints.max_height], constraints=constraints)
 
 
-def _is_focusable(value: object) -> bool:
+def _is_focusable(value: object) -> TypeGuard[_FocusableBody]:
     return all(callable(getattr(value, name, None)) for name in ("focus", "blur"))
 
 

--- a/src/loushang/tui/ui_parts/widgets/toast.py
+++ b/src/loushang/tui/ui_parts/widgets/toast.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field, replace
-from typing import Literal
+from typing import Literal, TypedDict, Unpack, cast, overload
 
 from loushang.tui.cell_width import autowrap_safe_width, truncate_to_width
 from loushang.tui.core import RenderConstraints, RenderLine, RenderResult
@@ -15,6 +15,19 @@ _NowMs = Callable[[], int]
 _VALID_KINDS = frozenset({"info", "success", "warning", "danger"})
 
 __all__ = ["Toast", "ToastKind", "ToastStack"]
+
+
+class _ToastOptions(TypedDict, total=False):
+    title: str
+    kind: ToastKind
+    value: str
+    duration_ms: int | None
+    created_at_ms: int | None
+    dismissible: bool
+
+
+class _ToastOverrides(_ToastOptions, total=False):
+    message: str
 
 
 def _monotonic_ms() -> int:
@@ -102,11 +115,17 @@ class ToastStack:
             visible = tuple(reversed(visible))
         return visible[: self.max_visible]
 
-    def push(self, toast: Toast | str, **overrides: object) -> str:
+    @overload
+    def push(self, toast: str, **overrides: Unpack[_ToastOptions]) -> str: ...
+
+    @overload
+    def push(self, toast: Toast, **overrides: Unpack[_ToastOverrides]) -> str: ...
+
+    def push(self, toast: Toast | str, **overrides: Unpack[_ToastOverrides]) -> str:
         if isinstance(toast, str):
             if "message" in overrides:
                 raise TypeError("Toast message cannot be overridden when pushing a string")
-            candidate = Toast(toast, **overrides)
+            candidate = Toast(toast, **cast(_ToastOptions, overrides))
         elif isinstance(toast, Toast):
             candidate = replace(toast, **overrides) if overrides else toast
         else:


### PR DESCRIPTION
## Summary

- type widget and surface option forwarding with precise `TypedDict`/`Unpack` contracts
- preserve Toast override validation while distinguishing string and Toast inputs
- declare Dialog focus detection as a type guard and narrow DataGrid adapter boundaries

## Scope

- 5 source files
- 35 type errors eliminated
- no input-routing, focus, rendering, parsing, or option-forwarding behavior changes

## Verification

- focused mypy: no issues found in 5 source files
- cumulative `make typecheck-tui`: 55 errors / 9 files -> 20 errors / 4 files
- focused runtime baseline before change: 195 passed outside sandbox
- focused runtime regression after change: 195 passed outside sandbox
- Ruff lint, import smoke, and Git diff checks passed

Refs #467
