### PR TITLE
refactor(harnesstui): discriminate input outcomes

### DIFF
--- a/docs/superpowers/plans/2026-08-22-harnesstui-conversation-input-outcome-refactor.md
+++ b/docs/superpowers/plans/2026-08-22-harnesstui-conversation-input-outcome-refactor.md
@@ -1,0 +1,233 @@
+# HarnessTUI Conversation Input Outcome Refactor Plan
+
+> Tracking issue: #475
+> Design: `docs/superpowers/specs/2026-08-22-harnesstui-conversation-input-outcome-design.md`
+
+## Objective
+
+Replace the optional-field HarnessTUI conversation input result with a closed,
+discriminated union while preserving router order, runner behavior, playback
+artifacts, and Coding keyboard semantics.
+
+Land the implementation as one coherent multi-file PR. Do not split individual
+variant, runner, or playback changes into separate PRs.
+
+## Baseline
+
+- base commit: `f97ac58a6b5197e673ff29d70bd90eac3c9c12ca`
+- branch: `harnesstui/discriminated-input-outcomes`
+- focused HarnessTUI baseline: 30 passed
+- Coding input/playback baseline: 82 passed
+- direct old result constructions: 46
+
+## Scope
+
+Expected production and test files:
+
+1. `src/loushang/harnesstui/conversation/input.py`
+2. `src/loushang/harnesstui/conversation/screen_runner.py`
+3. `src/loushang/harnesstui/testing/input_playback.py`
+4. `src/loushang/harnesstui/testing/ports.py`
+5. `tests/harnesstui/conversation/test_input.py`
+6. `tests/harnesstui/conversation/test_clipboard_input.py`
+7. `tests/harnesstui/conversation/test_screen_runner.py`
+8. `tests/harnesstui/testing/test_input_playback.py`
+9. Coding playback/scenario compatibility files only where type migration
+   requires them.
+
+The two design/plan documents travel with the implementation so the PR remains
+self-contained and reviewable.
+
+## Task 0: Freeze And Record The Baseline
+
+- [x] Create issue #475.
+- [x] Use the clean long-lived TUI worktree.
+- [x] Create `harnesstui/discriminated-input-outcomes` from `f97ac58a`.
+- [x] Run and record the 30-test HarnessTUI focused baseline.
+- [x] Run and record the 82-test Coding compatibility baseline.
+- [x] Record the sandbox-first pytest exception in the issue.
+
+## Task 1: Add Result Contract Tests
+
+Files:
+
+- modify `tests/harnesstui/conversation/test_input.py`
+- optionally add a focused result-contract test module only if the existing
+  input test file becomes unclear
+
+Steps:
+
+1. [x] Add tests for the ten concrete variants and fixed `kind` values.
+2. [x] Assert handled renders and ignored does not render.
+3. [x] Assert text/attachment variants expose coupled payloads.
+4. [x] Assert the old optional-field construction API is unavailable.
+5. [x] Add representative router assertions for prompt, local, steer, follow-up,
+   surface, clipboard, abort, handled, ignored, and exit.
+6. [x] Run the focused test slice and record the expected red failures before
+   implementing the variants.
+
+Do not commit red tests separately. They land green with the implementation.
+
+## Task 2: Define The Closed Result Union
+
+File:
+
+- modify `src/loushang/harnesstui/conversation/input.py`
+
+Steps:
+
+1. [x] Add frozen, slotted result variants with `init=False` literal `kind` and
+   fixed `render_requested` fields.
+2. [x] Define `ConversationInputResult` as their `TypeAlias` union.
+3. [x] Replace every old constructor in the router mechanically.
+4. [x] Keep control-flow branches and helper ordering unchanged.
+5. [x] Export the alias and concrete variants from the module `__all__`.
+6. [x] Run focused router and clipboard tests.
+7. [x] Inspect the diff specifically for accidental route-order changes.
+
+## Task 3: Make Runner Dispatch Exhaustive
+
+Files:
+
+- modify `src/loushang/harnesstui/conversation/screen_runner.py`
+- modify `tests/harnesstui/conversation/test_screen_runner.py`
+
+Steps:
+
+1. [x] Replace the optional-field `ConversationInputResultPort` with the closed
+   result union at the router factory boundary.
+2. [x] Dispatch by concrete variant.
+3. [x] End the dispatch with `assert_never` so new variants require an explicit
+   runner branch.
+4. [x] Preserve exit and abort early-control-flow behavior.
+5. [x] Preserve prompt attachment forwarding and all handler return handling.
+6. [x] Add a test proving one variant invokes only one handler.
+7. [x] Run focused runner tests.
+
+Do not refactor terminal polling, task lifecycle, or handler abstractions in
+this task.
+
+## Task 4: Preserve Playback Artifacts
+
+Files:
+
+- modify `src/loushang/harnesstui/testing/input_playback.py`
+- modify `src/loushang/harnesstui/testing/ports.py`
+- modify `tests/harnesstui/testing/test_input_playback.py`
+- modify Coding scenario binding only if the now-closed result type eliminates
+  an obsolete generic cast
+
+Steps:
+
+1. [x] Replace the structural optional-field port with the closed result union.
+2. [x] Simplify playback router generics only as required by that union.
+3. [x] Pattern-match every variant in the default serializer.
+4. [x] Emit exactly the existing artifact keys and values; do not add `kind`.
+5. [x] Add a table-driven serializer test covering every variant.
+6. [x] Run HarnessTUI playback and Coding scenario baselines.
+
+Stop if existing scenario snapshots require updates for value changes.
+
+## Task 5: Static And Architecture Review
+
+1. Run Ruff on all changed Python files.
+2. Run focused mypy on the changed modules.
+3. Run `make typecheck-tui`.
+4. Run `make typecheck-harnesstui`.
+5. Run `git diff --check`.
+6. Search for legacy field-bag names and classify every remaining match:
+
+```bash
+rg -n \
+  'prompt_text|prompt_attachments|local_text|steer_text|steer_attachments|followup_text|followup_attachments|surface_intent|abort_requested' \
+  src/loushang/harnesstui/conversation \
+  src/loushang/harnesstui/testing
+```
+
+Serializer compatibility keys may remain. Result objects and runner dispatch
+must not retain the optional-field protocol.
+
+## Task 6: Regression Gates
+
+Run all pytest commands outside the filesystem sandbox on the first attempt.
+
+Focused HarnessTUI:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/harnesstui/conversation/test_input.py \
+  tests/harnesstui/conversation/test_clipboard_input.py \
+  tests/harnesstui/conversation/test_screen_runner.py \
+  tests/harnesstui/testing/test_input_playback.py \
+  tests/harnesstui/testing/test_screen_loop_playback.py \
+  --skip-host-runtime -q
+```
+
+Coding compatibility:
+
+```bash
+.venv/bin/python -m pytest \
+  tests/coding/test_screen_coding_tui_input.py \
+  tests/coding/test_screen_tui_playback_harness.py \
+  tests/coding/test_screen_coding_tui_playback.py \
+  --skip-host-runtime -q
+```
+
+Broader gates:
+
+```bash
+make check-harnesstui
+.venv/bin/python -m pytest tests/tui tests/harnesstui --skip-host-runtime -q
+```
+
+Run the repository's dedicated cross-platform/render CI after the PR is
+published. Do not treat marker deselection as failure when the Make target
+intentionally selects a complementary suite; record the selected test count.
+
+## Task 7: Commit, PR, And Merge
+
+1. Confirm at least the coherent production/test surface above is included;
+   do not publish single-file migration PRs.
+2. Commit with `Refs #475` while review remains open.
+3. Push and create one implementation PR against `main`.
+4. PR description must include:
+   - old field-bag to variant migration;
+   - public/pre-1.0 compatibility note;
+   - proof of artifact schema stability;
+   - baseline and post-change test counts;
+   - explicit exclusions: no route dedup, keybinding move, or policy change.
+5. Wait for all CI checks.
+6. Use `Fixes #475` only when the closed union, runner, playback, tests, and
+   docs all land together and no required work remains.
+
+## Review Checklist
+
+- [x] Every current router branch maps to one variant.
+- [x] No variant permits a payload belonging to another kind.
+- [x] `kind` and `render_requested` cannot be overridden by callers.
+- [x] Runner dispatch is exhaustive.
+- [x] Abort and exit retain their current early control flow.
+- [x] Playback artifacts have no key or value churn.
+- [x] Coding behavior is unchanged.
+- [x] No generic TUI production file changes.
+- [x] No route deduplication or keybinding movement appears in the diff.
+- [x] Typecheck baselines remain zero.
+- [x] Pytest ran outside the sandbox first.
+
+## Rollback
+
+The result declarations, router construction migration, runner dispatch, and
+playback adapter are one atomic compatibility unit and must be reverted
+together. No later route-deduplication work may depend on this branch until this
+PR is merged and green.
+
+## Completion Criteria
+
+- the reviewed result union is implemented across router, runner, and playback;
+- at least the expected multi-file production/test surface is migrated in one
+  PR;
+- focused and broad regression gates pass;
+- both TUI typecheck targets remain clean;
+- default playback artifacts remain compatible;
+- issue #475 contains the baseline and final verification record;
+- deferred routing and policy work remains deferred.

--- a/docs/superpowers/specs/2026-08-22-harnesstui-conversation-input-outcome-design.md
+++ b/docs/superpowers/specs/2026-08-22-harnesstui-conversation-input-outcome-design.md
@@ -1,0 +1,333 @@
+# HarnessTUI Discriminated Conversation Input Outcomes
+
+Status: implementation complete; author review passed; PR review pending
+Tracking: #475
+Base: `f97ac58a6b5197e673ff29d70bd90eac3c9c12ca`
+
+## Decision Summary
+
+Replace the optional-field `ConversationInputResult` data class with a closed
+union of immutable result variants. Each variant represents one primary routed
+outcome and carries only the payload valid for that outcome. The screen runner
+dispatches the union exhaustively. Playback continues to emit its current
+default artifact fields through a compatibility serializer.
+
+This is a HarnessTUI result-boundary refactor. It does not alter generic TUI
+routing, conversation key interpretation, or product policy.
+
+## Current Problem
+
+`ConversationInputResult` currently exposes these independent fields:
+
+- prompt text and attachments;
+- local-command text;
+- steer text and attachments;
+- follow-up text and attachments;
+- one surface intent;
+- one clipboard outcome;
+- an abort flag;
+- an exit code;
+- a render flag.
+
+All fields have independent defaults. Invalid states such as a prompt and exit
+in the same result, attachments without their text, or abort plus steer are
+therefore constructible. The standard router does not intentionally create
+those states, but neither its type nor its constructor prevents them.
+
+The looseness propagates into consumers:
+
+- `screen_runner.py` probes every optional field in sequence and can dispatch
+  more than one action for one event;
+- playback defines a structural port that repeats the optional field bag;
+- the default playback serializer must know every field independently;
+- test routers construct the loose data class directly.
+
+The source baseline contains 46 direct `ConversationInputResult(...)`
+constructions. Focused pre-change baselines are 30 passing HarnessTUI tests and
+82 passing Coding compatibility tests.
+
+## Goals
+
+- One input event has exactly one result variant.
+- Each result variant owns only its valid payload.
+- Text and attachments cannot become detached.
+- Handled-with-render and ignored-without-render are explicit outcomes.
+- Runner dispatch is exhaustive and cannot silently ignore a new variant.
+- Playback remains product-neutral.
+- Existing default playback artifact keys and values remain stable.
+- HarnessTUI and Coding keyboard behavior remains byte-for-byte compatible at
+  the existing playback and loop boundaries.
+
+## Non-Goals
+
+- Changing `loushang.tui.InputRouter` or its `InputIntent` envelope.
+- Reusing generic `InputRouter` from `ConversationInputRouter`.
+- Reordering surface, completion, cancel, queue, clipboard, or submit routing.
+- Changing running Enter, Alt+Enter, Escape, or Ctrl+C semantics.
+- Moving keybindings between generic and conversation catalogs.
+- Injecting new Coding capability or submit policy.
+- Redesigning clipboard staging or attachment storage.
+- Changing the default playback artifact schema.
+
+## Result Model
+
+Use frozen, slotted data classes with an `init=False` literal `kind` field. The
+supported result type is a closed union alias:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ConversationInputHandled:
+    kind: Literal["handled"] = field(default="handled", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationInputIgnored:
+    kind: Literal["ignored"] = field(default="ignored", init=False)
+    render_requested: bool = field(default=False, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationPromptResult:
+    text: str
+    attachments: tuple[object, ...] | None = None
+    kind: Literal["prompt"] = field(default="prompt", init=False)
+    render_requested: bool = field(default=True, init=False)
+```
+
+The complete union contains:
+
+| Variant | Kind | Payload |
+| --- | --- | --- |
+| `ConversationInputHandled` | `handled` | none |
+| `ConversationInputIgnored` | `ignored` | none |
+| `ConversationPromptResult` | `prompt` | `text`, `attachments` |
+| `ConversationLocalResult` | `local` | `text` |
+| `ConversationSteerResult` | `steer` | `text`, `attachments` |
+| `ConversationFollowupResult` | `follow_up` | `text`, `attachments` |
+| `ConversationSurfaceResult` | `surface` | `intent` |
+| `ConversationClipboardResult` | `clipboard` | `outcome` |
+| `ConversationAbortResult` | `abort` | none |
+| `ConversationExitResult` | `exit` | `exit_code` |
+
+The attachment payload remains `tuple[object, ...] | None` at this product-neutral
+runner boundary. The standard router supplies `PromptImageAttachment` values,
+while custom product adapters retain the previous ability to supply another
+neutral attachment representation.
+
+`ConversationInputResult` becomes the type alias over those ten classes. It is
+no longer a constructible field bag. The concrete variants are the supported
+construction API.
+
+### Why Separate Handled And Ignored
+
+The old empty result had two meanings:
+
+- editor or surface state changed and should render;
+- the event was ignored and should not render.
+
+A free `render_requested` Boolean on every variant would preserve an invalid or
+unnecessary state dimension. Two zero-payload variants retain the observable
+scheduling distinction without allowing action results to opt out of their
+normal render path.
+
+### Why A Class Union Instead Of One Tagged Data Class
+
+A single class with `kind` plus optional `text`, `attachments`, `intent`,
+`outcome`, and `exit_code` would still permit invalid payload combinations and
+would require runtime validation. Separate classes follow the existing
+`ConversationIntent` union style and make payload validity visible to mypy.
+
+## Router Migration
+
+`ConversationInputRouter.handle()` and its helpers retain their current branch
+order. Only result construction changes:
+
+| Current construction | New construction |
+| --- | --- |
+| `ConversationInputResult()` | `ConversationInputHandled()` |
+| `ConversationInputResult(render_requested=False)` | `ConversationInputIgnored()` |
+| `prompt_text=..., prompt_attachments=...` | `ConversationPromptResult(text=..., attachments=...)` |
+| `local_text=...` | `ConversationLocalResult(text=...)` |
+| `steer_text=..., steer_attachments=...` | `ConversationSteerResult(...)` |
+| `followup_text=..., followup_attachments=...` | `ConversationFollowupResult(...)` |
+| `surface_intent=...` | `ConversationSurfaceResult(intent=...)` |
+| `clipboard_outcome=...` | `ConversationClipboardResult(outcome=...)` |
+| `abort_requested=True` | `ConversationAbortResult()` |
+| `exit_code=...` | `ConversationExitResult(exit_code=...)` |
+
+No helper is moved, shared, or reordered in this change.
+
+## Runner Dispatch
+
+The runner accepts the concrete closed union rather than a structural protocol
+that reproduces all optional fields. Dispatch narrows by concrete variant and
+ends with `assert_never(result)` so a newly added variant fails type checking
+until the runner handles it.
+
+Semantics remain:
+
+- exit renders once and returns the requested code;
+- abort performs the existing cancellation sequence and continues the loop;
+- prompt starts the active prompt task;
+- local, steer, follow-up, and surface call their existing handlers;
+- clipboard and handled request a render but no external handler;
+- ignored performs no action and does not request a render.
+
+The runner must not dispatch more than one action from one result.
+
+## Playback Compatibility
+
+The testing ports use the same closed union. The generic result type parameter
+is removed unless an implementation consumer is found that requires it; current
+production and tests all use the standard HarnessTUI result contract.
+
+`default_conversation_result_payload()` pattern-matches the variant and emits
+the exact existing keys:
+
+```text
+prompt_text
+prompt_attachment_count
+local_text
+steer_text
+steer_attachment_count
+followup_text
+followup_attachment_count
+surface_intent
+abort_requested
+exit_code
+render_requested
+```
+
+No `kind` key is added in this tranche. This lets scenario snapshots remain a
+behavioral oracle rather than turning the type migration into an artifact
+migration. Clipboard results continue to serialize as a render-only neutral
+result because that is the current artifact behavior.
+
+## API Compatibility
+
+`ConversationInputResult` is exported from its module `__all__`, but it is not
+re-exported from the `loushang.harnesstui` or
+`loushang.harnesstui.conversation` package roots and is not documented as a
+public user API. Repository production has no custom result implementation.
+
+The project is pre-1.0. Direct field-bag construction is intentionally replaced
+by explicit variant construction. The PR must call out this migration and keep
+the failure loud; it must not retain a permissive compatibility constructor
+that recreates invalid combinations.
+
+## Verification Strategy
+
+### Contract tests
+
+- each concrete result exposes the expected fixed `kind`;
+- handled and ignored have fixed render behavior;
+- payload variants contain only their valid dataclass fields;
+- old field-bag construction fails loudly;
+- the router returns the expected variant for every existing action path.
+
+### Runner tests
+
+- prompt attachment forwarding remains unchanged;
+- exactly one handler runs for one primary result;
+- ignored does not render;
+- handled and clipboard render;
+- abort and exit preserve their special control flow;
+- a new union member produces a static exhaustiveness obligation.
+
+### Playback tests
+
+- existing scenario payloads remain identical;
+- every variant maps to the old default payload schema;
+- attachment counts and surface intent encoding remain unchanged.
+
+### Regression gates
+
+- the 30-test HarnessTUI focused baseline;
+- the 82-test Coding input/playback baseline;
+- full relevant HarnessTUI and Coding playback/loop suites;
+- `make typecheck-tui` and `make typecheck-harnesstui`;
+- Ruff and `git diff --check`;
+- final repository CI, including cross-platform TUI gates.
+
+All pytest commands run outside the filesystem sandbox on the first attempt due
+to the workspace's verified selector/self-pipe `EPERM` failure inside it.
+
+## Risks And Mitigations
+
+### Risk: hidden custom router depends on structural result fields
+
+Mitigation: repository and documentation inventory is clean; the change is
+pre-1.0 and called out explicitly. Stop if a supported custom result producer is
+identified during review.
+
+### Risk: route order changes during mechanical constructor migration
+
+Mitigation: do not move branches or helpers; compare the router's control-flow
+diff independently from result declarations; run focused input playback before
+and after.
+
+### Risk: playback snapshots churn
+
+Mitigation: serialize variants back to the current field schema and add direct
+schema compatibility tests before updating any snapshot.
+
+### Risk: runner accidentally changes multi-handler behavior
+
+The current standard router creates one primary field at a time, so exhaustive
+single-result dispatch preserves supported behavior. Add a regression proving
+one variant calls only its matching handler.
+
+### Risk: result union and intent union become confused
+
+`InputIntent` and `ConversationIntent` describe inputs to other layers. The new
+union describes the outcome of terminal event routing. Names retain the
+`Result` suffix and no intent types move in this tranche.
+
+## Stop Conditions
+
+Return to design review if:
+
+- a supported product needs to produce multiple primary actions for one event;
+- a supported custom result type cannot migrate to the closed union;
+- artifact compatibility requires changing existing playback snapshots;
+- preserving behavior requires route-order or keybinding changes;
+- the refactor begins to require generic/conversation route deduplication;
+- focused input or runner baselines regress before implementation changes.
+
+## Acceptance Criteria
+
+- `ConversationInputResult` is a closed union of payload-valid variants.
+- No optional-field result bag remains.
+- Router result construction is variant-based with unchanged branch order.
+- Runner dispatch is exhaustive and single-action.
+- Playback default artifacts retain their current schema and values.
+- HarnessTUI and Coding interaction regressions remain green.
+- Both TUI typecheck targets remain at zero errors.
+- No blanket ignore, route deduplication, keybinding move, or product-policy
+  change enters the patch.
+
+## Author Review Record
+
+The implementation was reviewed against the baseline control flow before the
+broader regression run. This is an author review, not an independent review.
+
+| Finding | Priority | Resolution |
+| --- | --- | --- |
+| Text-action attachment payloads were initially narrowed to `PromptImageAttachment`, while the existing runner port deliberately accepts neutral `object` attachments. | P1 | Restored `tuple[object, ...] | None` on prompt, steer, and follow-up variants; the standard router still supplies concrete prompt-image attachments. |
+| Transcript-open returns a dynamic render decision rather than a fixed action result. | P2 | Map success to `ConversationInputHandled` and failure to `ConversationInputIgnored`; do not restore a caller-controlled render Boolean. |
+| The old structural result port appeared extensible, but the runner could only interpret its fixed optional fields. | P2 | Replace it with an alias to the closed union; keep the legacy port name as a type alias for annotation migration without admitting unknown runtime actions. |
+| Playback compatibility could be claimed without covering every new variant. | P1 | Added a table-driven test over all ten variants and the exact legacy field schema; no `kind` artifact key was added. |
+| Mechanical result replacement could accidentally reorder routing branches. | P1 | Reviewed the router diff separately; condition and helper order is unchanged. Focused and broad playback gates pass. |
+
+Verification at author-review completion:
+
+- HarnessTUI focused baseline: 30 passed before, 33 passed after three new
+  result-contract tests;
+- Coding input/playback compatibility: 82 passed before and after;
+- complete TUI/HarnessTUI suite: 1765 passed;
+- `make check-harnesstui`: 1270 passed, 65 marker-deselected;
+- TUI mypy: 90 source files clean;
+- HarnessTUI mypy: 139 source files clean;
+- architecture documentation: 5 passed;
+- focused Ruff and diff checks: clean.

--- a/src/loushang/harnesstui/conversation/input.py
+++ b/src/loushang/harnesstui/conversation/input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Protocol, cast
+from typing import Literal, Protocol, TypeAlias, cast
 
 from loushang.harnesstui.conversation.attachments import (
     ClipboardImageNameFactory,
@@ -112,21 +112,107 @@ class ClipboardImageInputRouterBuilder(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
-class ConversationInputResult:
-    """Product-neutral outcome of routing one conversation input event."""
+class ConversationInputHandled:
+    """An input event changed local interaction state and needs a render."""
 
-    prompt_text: str | None = None
-    prompt_attachments: tuple[PromptImageAttachment, ...] | None = None
-    local_text: str | None = None
-    steer_text: str | None = None
-    steer_attachments: tuple[PromptImageAttachment, ...] | None = None
-    followup_text: str | None = None
-    followup_attachments: tuple[PromptImageAttachment, ...] | None = None
-    surface_intent: InputIntent | None = None
-    clipboard_outcome: PromptImageAttachmentOutcome | None = None
-    abort_requested: bool = False
-    exit_code: int | None = None
-    render_requested: bool = True
+    kind: Literal["handled"] = field(default="handled", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationInputIgnored:
+    """An input event produced no state change and needs no render."""
+
+    kind: Literal["ignored"] = field(default="ignored", init=False)
+    render_requested: bool = field(default=False, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationPromptResult:
+    """Start one idle conversation prompt."""
+
+    text: str
+    attachments: tuple[object, ...] | None = None
+    kind: Literal["prompt"] = field(default="prompt", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationLocalResult:
+    """Dispatch one product-local command."""
+
+    text: str
+    kind: Literal["local"] = field(default="local", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationSteerResult:
+    """Steer the active conversation run."""
+
+    text: str
+    attachments: tuple[object, ...] | None = None
+    kind: Literal["steer"] = field(default="steer", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationFollowupResult:
+    """Queue one follow-up behind the active conversation run."""
+
+    text: str
+    attachments: tuple[object, ...] | None = None
+    kind: Literal["follow_up"] = field(default="follow_up", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationSurfaceResult:
+    """Forward one intent emitted by an active surface."""
+
+    intent: InputIntent
+    kind: Literal["surface"] = field(default="surface", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationClipboardResult:
+    """Report one clipboard-image staging outcome."""
+
+    outcome: PromptImageAttachmentOutcome
+    kind: Literal["clipboard"] = field(default="clipboard", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationAbortResult:
+    """Request cancellation of the active conversation run."""
+
+    kind: Literal["abort"] = field(default="abort", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationExitResult:
+    """Exit the conversation screen with one process status."""
+
+    exit_code: int
+    kind: Literal["exit"] = field(default="exit", init=False)
+    render_requested: bool = field(default=True, init=False)
+
+
+ConversationInputResult: TypeAlias = (
+    ConversationInputHandled
+    | ConversationInputIgnored
+    | ConversationPromptResult
+    | ConversationLocalResult
+    | ConversationSteerResult
+    | ConversationFollowupResult
+    | ConversationSurfaceResult
+    | ConversationClipboardResult
+    | ConversationAbortResult
+    | ConversationExitResult
+)
 
 
 @dataclass(slots=True)
@@ -164,7 +250,7 @@ class ConversationInputRouter:
 
     def handle(self, event: InputEvent) -> ConversationInputResult:
         if event.kind == "key" and event.event_type == "release":
-            return ConversationInputResult(render_requested=False)
+            return ConversationInputIgnored()
         if self._runtime_surface_active():
             return self._route_runtime_surface(event)
         if self.app.active_surface is not None:
@@ -176,21 +262,21 @@ class ConversationInputRouter:
                     direction=self._jump_mode,
                 )
                 self._jump_mode = None
-                return ConversationInputResult()
+                return ConversationInputHandled()
             self.app.composer.insert_text(event.text)
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if event.kind == "paste":
             self._jump_mode = None
             self.app.composer.paste(event.text)
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if event.kind == "resize":
             if event.columns:
                 self.width = event.columns
             if event.rows:
                 self.height = event.rows
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if event.kind != "key":
-            return ConversationInputResult(render_requested=False)
+            return ConversationInputIgnored()
 
         keybindings = self._keybindings()
         if self._jump_mode is not None:
@@ -202,21 +288,23 @@ class ConversationInputRouter:
                 "tui.editor.jumpBackward",
             ):
                 self._jump_mode = None
-                return ConversationInputResult()
+                return ConversationInputHandled()
             self._jump_mode = None
         if keybindings.matches(event.key, "tui.queue.editLast"):
             self._restore_queued_messages()
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.transcript.open"):
-            return ConversationInputResult(
-                render_requested=self.app.open_transcript_reader()
+            return (
+                ConversationInputHandled()
+                if self.app.open_transcript_reader()
+                else ConversationInputIgnored()
             )
         if route_editor_selection_key(
             self._composer_target,
             event.key,
             keybindings=keybindings,
         ):
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if self.app.composer.has_completions and keybindings.matches(
             event.key,
             "tui.input.submit",
@@ -226,22 +314,22 @@ class ConversationInputRouter:
             event,
             keybindings,
         ):
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.select.cancel"):
             return self._abort_or_clear()
         if keybindings.matches(event.key, "tui.input.tab"):
             self.app.composer.refresh_completions(force=True, explicit=True)
             if self.app.composer.has_completions:
                 self.app.composer.apply_selected_completion()
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if keybindings.matches(event.key, "app.clipboard.pasteImage"):
             return self._paste_clipboard_image()
         if keybindings.matches(event.key, "tui.editor.jumpForward"):
             self._jump_mode = "forward"
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.editor.jumpBackward"):
             self._jump_mode = "backward"
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.editor.cursorUp"):
             if self.app.composer.browsing_history:
                 self.app.composer.history_previous()
@@ -250,7 +338,7 @@ class ConversationInputRouter:
                 or not self.app.composer.move_visual_up(width=self.width)
             ):
                 self.app.composer.history_previous()
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.editor.cursorDown"):
             if self.app.composer.browsing_history:
                 self.app.composer.history_next()
@@ -259,24 +347,24 @@ class ConversationInputRouter:
                 or not self.app.composer.move_visual_down(width=self.width)
             ):
                 self.app.composer.history_next()
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.editor.pageUp"):
             self.app.composer.move_visual_page_up(
                 width=self.width,
                 visible_lines=self._composer_page_lines(),
             )
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.editor.pageDown"):
             self.app.composer.move_visual_page_down(
                 width=self.width,
                 visible_lines=self._composer_page_lines(),
             )
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if self.app.state.running and event.key in self.follow_up_keys:
             return self._submit_running(mode="follow_up")
         if keybindings.matches(event.key, "tui.input.newLine"):
             self.app.composer.insert_newline()
-            return ConversationInputResult()
+            return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.input.submit"):
             return self._submit()
         if route_editor_editing_key(
@@ -284,8 +372,8 @@ class ConversationInputRouter:
             event.key,
             keybindings=keybindings,
         ):
-            return ConversationInputResult()
-        return ConversationInputResult(render_requested=False)
+            return ConversationInputHandled()
+        return ConversationInputIgnored()
 
     def _route_completion_key(
         self,
@@ -305,19 +393,19 @@ class ConversationInputRouter:
         self.app.composer.apply_selected_completion()
         if should_submit_after_completion:
             return self._submit()
-        return ConversationInputResult()
+        return ConversationInputHandled()
 
     def _abort_or_clear(self) -> ConversationInputResult:
         if self.app.state.running:
-            return ConversationInputResult(abort_requested=True)
+            return ConversationAbortResult()
         if self.app.state.pending_steers:
             pending_steer = self.app.state.pending_steers.pop(0)
-            return ConversationInputResult(steer_text=pending_steer)
+            return ConversationSteerResult(text=pending_steer)
         if self.app.composer.value:
             self.app.composer.clear()
             self._clear_prompt_attachments()
-            return ConversationInputResult()
-        return ConversationInputResult(render_requested=False)
+            return ConversationInputHandled()
+        return ConversationInputIgnored()
 
     def _restore_queued_messages(self) -> None:
         text = self.app.state.restore_queued_to_text()
@@ -327,23 +415,23 @@ class ConversationInputRouter:
     def _submit(self) -> ConversationInputResult:
         text = self.app.composer.value
         if not text.strip():
-            return ConversationInputResult(render_requested=False)
+            return ConversationInputIgnored()
         if self.should_exit(text.strip()):
             self.app.composer.clear()
             self._clear_prompt_attachments()
-            return ConversationInputResult(exit_code=0)
+            return ConversationExitResult(exit_code=0)
         if self.is_local_command(text.strip()):
             self.app.composer.clear()
             self._clear_prompt_attachments()
-            return ConversationInputResult(local_text=text.strip())
+            return ConversationLocalResult(text=text.strip())
         if self.app.state.running:
             return self._submit_running(mode=self.running_submit_mode)
         attachments = self._prompt_attachments_for_text(text)
         self.app.start_prompt(text)
         self._clear_prompt_attachments()
-        return ConversationInputResult(
-            prompt_text=text,
-            prompt_attachments=attachments,
+        return ConversationPromptResult(
+            text=text,
+            attachments=attachments,
         )
 
     def _submit_running(
@@ -353,21 +441,21 @@ class ConversationInputRouter:
     ) -> ConversationInputResult:
         text = self.app.composer.value
         if not text.strip():
-            return ConversationInputResult(render_requested=False)
+            return ConversationInputIgnored()
         attachments = self._prompt_attachments_for_text(text)
         self.app.composer.add_history(text)
         self.app.composer.clear()
         self._clear_prompt_attachments()
         if mode == "follow_up":
             self.app.queue_followup(text)
-            return ConversationInputResult(
-                followup_text=text,
-                followup_attachments=attachments,
+            return ConversationFollowupResult(
+                text=text,
+                attachments=attachments,
             )
         self.app.queue_steer(text)
-        return ConversationInputResult(
-            steer_text=text,
-            steer_attachments=attachments,
+        return ConversationSteerResult(
+            text=text,
+            attachments=attachments,
         )
 
     def _keybindings(self) -> KeybindingManager:
@@ -381,13 +469,13 @@ class ConversationInputRouter:
     def _route_active_surface(self, event: InputEvent) -> ConversationInputResult:
         handler = getattr(self.app.active_surface, "handle_input", None)
         if not callable(handler):
-            return ConversationInputResult(render_requested=False)
+            return ConversationInputIgnored()
         intent = handler(event)
         if isinstance(intent, InputIntent):
             if intent.kind == "consumed":
-                return ConversationInputResult()
-            return ConversationInputResult(surface_intent=intent)
-        return ConversationInputResult()
+                return ConversationInputHandled()
+            return ConversationSurfaceResult(intent=intent)
+        return ConversationInputHandled()
 
     def _runtime_surface_active(self) -> bool:
         surface_host = self.app.surface_host
@@ -399,7 +487,7 @@ class ConversationInputRouter:
     ) -> ConversationInputResult:
         surface_host = self.app.surface_host
         if surface_host is None:
-            return ConversationInputResult(render_requested=False)
+            return ConversationInputIgnored()
         intents = surface_host.route_input(
             event,
             close_on_intents=("surface_close", "dialog_cancel"),
@@ -407,24 +495,24 @@ class ConversationInputRouter:
         for intent in intents:
             if isinstance(intent, InputIntent):
                 if intent.kind == "consumed":
-                    return ConversationInputResult()
-                return ConversationInputResult(surface_intent=intent)
-        return ConversationInputResult()
+                    return ConversationInputHandled()
+                return ConversationSurfaceResult(intent=intent)
+        return ConversationInputHandled()
 
     def _paste_clipboard_image(self) -> ConversationInputResult:
         if self.prompt_image_stager is None:
-            return ConversationInputResult(render_requested=False)
+            return ConversationInputIgnored()
         outcome = self.prompt_image_stager()
         attachment = outcome.attachment
         if outcome.kind != "attached":
             self._present_clipboard_outcome(outcome)
-            return ConversationInputResult(clipboard_outcome=outcome)
+            return ConversationClipboardResult(outcome=outcome)
         if attachment is None:
             raise RuntimeError("attached clipboard outcome requires an attachment")
         self.app.composer.paste(f"{attachment.marker} ")
         self._pending_prompt_images.add(attachment)
         self._present_clipboard_outcome(outcome)
-        return ConversationInputResult(clipboard_outcome=outcome)
+        return ConversationClipboardResult(outcome=outcome)
 
     def _present_clipboard_outcome(
         self,
@@ -515,9 +603,19 @@ __all__ = [
     "ClipboardImageInputRouterBuilder",
     "ClipboardImageStatusCopy",
     "ClipboardOutcomePresenter",
+    "ConversationAbortResult",
+    "ConversationClipboardResult",
+    "ConversationExitResult",
+    "ConversationFollowupResult",
+    "ConversationInputHandled",
+    "ConversationInputIgnored",
     "ConversationInputResult",
     "ConversationInputRouter",
+    "ConversationLocalResult",
+    "ConversationPromptResult",
     "ConversationScreenInputPort",
+    "ConversationSteerResult",
+    "ConversationSurfaceResult",
     "PromptImageAttachmentStager",
     "RunningSubmitMode",
     "bind_clipboard_image_input_router",

--- a/src/loushang/harnesstui/conversation/screen_runner.py
+++ b/src/loushang/harnesstui/conversation/screen_runner.py
@@ -5,11 +5,22 @@ import inspect
 import shutil
 from collections.abc import Awaitable, Callable
 from contextlib import AbstractContextManager
-from typing import Any, Protocol, TextIO
+from typing import Any, Protocol, TextIO, TypeAlias, assert_never
 
 from loushang.harnesstui.conversation.input import (
+    ConversationAbortResult,
+    ConversationClipboardResult,
+    ConversationExitResult,
+    ConversationFollowupResult,
+    ConversationInputHandled,
+    ConversationInputIgnored,
+    ConversationInputResult,
     ConversationInputRouter,
+    ConversationLocalResult,
+    ConversationPromptResult,
     ConversationScreenInputPort,
+    ConversationSteerResult,
+    ConversationSurfaceResult,
 )
 from loushang.harnesstui.surface.controller import promote_pending_page_surface
 from loushang.tui import _runner_utils
@@ -70,47 +81,13 @@ class ConversationScreenPort(ConversationScreenInputPort, Protocol):
     def elapsed_seconds(self) -> float: ...
 
 
-class ConversationInputResultPort(Protocol):
-    """Neutral routed action consumed by a conversation screen runner."""
-
-    @property
-    def prompt_text(self) -> str | None: ...
-
-    @property
-    def prompt_attachments(self) -> tuple[object, ...] | None: ...
-
-    @property
-    def local_text(self) -> str | None: ...
-
-    @property
-    def steer_text(self) -> str | None: ...
-
-    @property
-    def steer_attachments(self) -> tuple[object, ...] | None: ...
-
-    @property
-    def followup_text(self) -> str | None: ...
-
-    @property
-    def followup_attachments(self) -> tuple[object, ...] | None: ...
-
-    @property
-    def surface_intent(self) -> InputIntent | None: ...
-
-    @property
-    def abort_requested(self) -> bool: ...
-
-    @property
-    def exit_code(self) -> int | None: ...
-
-    @property
-    def render_requested(self) -> bool: ...
+ConversationInputResultPort: TypeAlias = ConversationInputResult
 
 
 class ConversationInputRouterPort(Protocol):
     """Route one decoded terminal input event to a neutral action."""
 
-    def handle(self, event: InputEvent) -> ConversationInputResultPort: ...
+    def handle(self, event: InputEvent) -> ConversationInputResult: ...
 
 
 class ConversationInputRouterFactoryPort(Protocol):
@@ -295,14 +272,14 @@ async def run_conversation_screen(
 
                 for event in input_events:
                     result = router.handle(event)
-                    if result.exit_code is not None:
+                    if isinstance(result, ConversationExitResult):
                         runtime.render_now()
                         return _finish_tui_exit(
                             runtime=runtime,
                             stdout=stdout,
                             exit_code=result.exit_code,
                         )
-                    if result.abort_requested:
+                    if isinstance(result, ConversationAbortResult):
                         interrupt_pending_steer = pop_interrupt_pending_steer(app)
                         await abort_active(
                             app=app,
@@ -324,68 +301,77 @@ async def run_conversation_screen(
                             active_prompt_started_at = app.state.active_started_at
                             runtime.render_now()
                         continue
-                    if result.prompt_text is not None:
+                    if isinstance(result, ConversationPromptResult):
                         active_prompt_started_at = app.state.active_started_at
                         active_task = asyncio.create_task(
                             run_prompt_handler(
                                 handle_prompt,
-                                result.prompt_text,
-                                attachments=result.prompt_attachments,
+                                result.text,
+                                attachments=result.attachments,
                             )
                         )
-                    if result.local_text is not None and handle_local is not None:
-                        exit_code = await run_text_handler(
-                            handle_local,
-                            result.local_text,
-                        )
-                        if exit_code is not None:
-                            runtime.render_now()
-                            return _finish_tui_exit(
-                                runtime=runtime,
-                                stdout=stdout,
-                                exit_code=exit_code,
+                    elif isinstance(result, ConversationLocalResult):
+                        if handle_local is not None:
+                            exit_code = await run_text_handler(
+                                handle_local,
+                                result.text,
                             )
-                    if result.steer_text is not None and handle_steer is not None:
-                        exit_code = await run_text_handler(
-                            handle_steer,
-                            result.steer_text,
-                            attachments=result.steer_attachments,
-                        )
-                        if exit_code is not None:
-                            runtime.render_now()
-                            return _finish_tui_exit(
-                                runtime=runtime,
-                                stdout=stdout,
-                                exit_code=exit_code,
+                            if exit_code is not None:
+                                runtime.render_now()
+                                return _finish_tui_exit(
+                                    runtime=runtime,
+                                    stdout=stdout,
+                                    exit_code=exit_code,
+                                )
+                    elif isinstance(result, ConversationSteerResult):
+                        if handle_steer is not None:
+                            exit_code = await run_text_handler(
+                                handle_steer,
+                                result.text,
+                                attachments=result.attachments,
                             )
-                    if result.followup_text is not None and handle_followup is not None:
-                        exit_code = await run_text_handler(
-                            handle_followup,
-                            result.followup_text,
-                            attachments=result.followup_attachments,
-                        )
-                        if exit_code is not None:
-                            runtime.render_now()
-                            return _finish_tui_exit(
-                                runtime=runtime,
-                                stdout=stdout,
-                                exit_code=exit_code,
+                            if exit_code is not None:
+                                runtime.render_now()
+                                return _finish_tui_exit(
+                                    runtime=runtime,
+                                    stdout=stdout,
+                                    exit_code=exit_code,
+                                )
+                    elif isinstance(result, ConversationFollowupResult):
+                        if handle_followup is not None:
+                            exit_code = await run_text_handler(
+                                handle_followup,
+                                result.text,
+                                attachments=result.attachments,
                             )
-                    if (
-                        result.surface_intent is not None
-                        and handle_surface_intent is not None
-                    ):
-                        exit_code = await run_surface_intent_handler(
-                            handle_surface_intent,
-                            result.surface_intent,
-                        )
-                        if exit_code is not None:
-                            runtime.render_now()
-                            return _finish_tui_exit(
-                                runtime=runtime,
-                                stdout=stdout,
-                                exit_code=exit_code,
+                            if exit_code is not None:
+                                runtime.render_now()
+                                return _finish_tui_exit(
+                                    runtime=runtime,
+                                    stdout=stdout,
+                                    exit_code=exit_code,
+                                )
+                    elif isinstance(result, ConversationSurfaceResult):
+                        if handle_surface_intent is not None:
+                            exit_code = await run_surface_intent_handler(
+                                handle_surface_intent,
+                                result.intent,
                             )
+                            if exit_code is not None:
+                                runtime.render_now()
+                                return _finish_tui_exit(
+                                    runtime=runtime,
+                                    stdout=stdout,
+                                    exit_code=exit_code,
+                                )
+                    elif isinstance(result, ConversationClipboardResult):
+                        pass
+                    elif isinstance(result, ConversationInputHandled):
+                        pass
+                    elif isinstance(result, ConversationInputIgnored):
+                        pass
+                    else:
+                        assert_never(result)
                     if result.render_requested:
                         _request_runtime_render(runtime, "input")
     finally:

--- a/src/loushang/harnesstui/testing/input_playback.py
+++ b/src/loushang/harnesstui/testing/input_playback.py
@@ -2,11 +2,21 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
-from typing import Any, Generic, Self, TypeVar, cast
+from typing import Any, Generic, Self, TypeVar, assert_never, cast
 
-from loushang.harnesstui.conversation.input import ConversationInputRouter
-from loushang.harnesstui.conversation.screen_runner import (
-    ConversationInputResultPort,
+from loushang.harnesstui.conversation.input import (
+    ConversationAbortResult,
+    ConversationClipboardResult,
+    ConversationExitResult,
+    ConversationFollowupResult,
+    ConversationInputHandled,
+    ConversationInputIgnored,
+    ConversationInputResult,
+    ConversationInputRouter,
+    ConversationLocalResult,
+    ConversationPromptResult,
+    ConversationSteerResult,
+    ConversationSurfaceResult,
 )
 from loushang.harnesstui.testing.ports import (
     ConversationPlaybackAppPort,
@@ -48,23 +58,49 @@ def default_conversation_state_snapshot(
 
 
 def default_conversation_result_payload(
-    result: ConversationInputResultPort,
+    result: ConversationInputResult,
 ) -> Mapping[str, object]:
     """Serialize the neutral action surface of an input result."""
 
-    return {
-        "prompt_text": result.prompt_text,
-        "prompt_attachment_count": _attachment_count(result.prompt_attachments),
-        "local_text": result.local_text,
-        "steer_text": result.steer_text,
-        "steer_attachment_count": _attachment_count(result.steer_attachments),
-        "followup_text": result.followup_text,
-        "followup_attachment_count": _attachment_count(result.followup_attachments),
-        "surface_intent": _surface_intent_payload(result.surface_intent),
-        "abort_requested": result.abort_requested,
-        "exit_code": result.exit_code,
+    payload: dict[str, object] = {
+        "prompt_text": None,
+        "prompt_attachment_count": 0,
+        "local_text": None,
+        "steer_text": None,
+        "steer_attachment_count": 0,
+        "followup_text": None,
+        "followup_attachment_count": 0,
+        "surface_intent": None,
+        "abort_requested": False,
+        "exit_code": None,
         "render_requested": result.render_requested,
     }
+    if isinstance(result, ConversationPromptResult):
+        payload["prompt_text"] = result.text
+        payload["prompt_attachment_count"] = _attachment_count(result.attachments)
+    elif isinstance(result, ConversationLocalResult):
+        payload["local_text"] = result.text
+    elif isinstance(result, ConversationSteerResult):
+        payload["steer_text"] = result.text
+        payload["steer_attachment_count"] = _attachment_count(result.attachments)
+    elif isinstance(result, ConversationFollowupResult):
+        payload["followup_text"] = result.text
+        payload["followup_attachment_count"] = _attachment_count(result.attachments)
+    elif isinstance(result, ConversationSurfaceResult):
+        payload["surface_intent"] = _surface_intent_payload(result.intent)
+    elif isinstance(result, ConversationAbortResult):
+        payload["abort_requested"] = True
+    elif isinstance(result, ConversationExitResult):
+        payload["exit_code"] = result.exit_code
+    elif isinstance(result, ConversationClipboardResult):
+        pass
+    elif isinstance(result, ConversationInputHandled):
+        pass
+    elif isinstance(result, ConversationInputIgnored):
+        pass
+    else:
+        assert_never(result)
+    return payload
 
 
 class ConversationInputPlayback(Generic[AppT]):
@@ -85,8 +121,8 @@ class ConversationInputPlayback(Generic[AppT]):
     ) -> None:
         self.app = app
         self.reader = InputReader()
-        self.input_results: list[ConversationInputResultPort] = []
-        self.step_input_results: list[tuple[ConversationInputResultPort, ...]] = []
+        self.input_results: list[ConversationInputResult] = []
+        self.step_input_results: list[tuple[ConversationInputResult, ...]] = []
         self.step_state_snapshots: list[dict[str, object]] = []
         self._state_snapshot = state_snapshot or default_conversation_state_snapshot
         self._result_payload = result_payload or default_conversation_result_payload
@@ -143,7 +179,7 @@ class ConversationInputPlayback(Generic[AppT]):
         size: TerminalSize,
         _previous: RenderDiagnostics | None,
     ) -> RenderDiagnostics:
-        step_results: list[ConversationInputResultPort] = []
+        step_results: list[ConversationInputResult] = []
         if event.kind == "resize":
             _resize_router(self.router, size)
         elif event.kind == "input":
@@ -168,8 +204,8 @@ class ConversationInputPlayback(Generic[AppT]):
 class ConversationInputPlaybackResult(PlaybackResult, Generic[AppT]):
     """Terminal frames paired with neutral routed actions and state snapshots."""
 
-    input_results: tuple[ConversationInputResultPort, ...]
-    step_input_results: tuple[tuple[ConversationInputResultPort, ...], ...]
+    input_results: tuple[ConversationInputResult, ...]
+    step_input_results: tuple[tuple[ConversationInputResult, ...], ...]
     step_state_snapshots: tuple[dict[str, object], ...]
     app: AppT
     result_payload: ConversationResultPayloadPort
@@ -178,29 +214,51 @@ class ConversationInputPlaybackResult(PlaybackResult, Generic[AppT]):
         assert self.app.composer.value == expected
 
     def assert_prompt_texts(self, *expected: str) -> None:
-        assert _text_results(self.input_results, "prompt_text") == list(expected)
+        assert [
+            result.text
+            for result in self.input_results
+            if isinstance(result, ConversationPromptResult)
+        ] == list(expected)
 
     def assert_local_texts(self, *expected: str) -> None:
-        assert _text_results(self.input_results, "local_text") == list(expected)
+        assert [
+            result.text
+            for result in self.input_results
+            if isinstance(result, ConversationLocalResult)
+        ] == list(expected)
 
     def assert_steer_texts(self, *expected: str) -> None:
-        assert _text_results(self.input_results, "steer_text") == list(expected)
+        assert [
+            result.text
+            for result in self.input_results
+            if isinstance(result, ConversationSteerResult)
+        ] == list(expected)
 
     def assert_followup_texts(self, *expected: str) -> None:
-        assert _text_results(self.input_results, "followup_text") == list(expected)
+        assert [
+            result.text
+            for result in self.input_results
+            if isinstance(result, ConversationFollowupResult)
+        ] == list(expected)
 
     def assert_surface_intents(self, *expected: tuple[str, str]) -> None:
         assert [
-            (result.surface_intent.kind, result.surface_intent.text)
+            (result.intent.kind, result.intent.text)
             for result in self.input_results
-            if result.surface_intent is not None
+            if isinstance(result, ConversationSurfaceResult)
         ] == list(expected)
 
     def assert_abort_requested(self) -> None:
-        assert any(result.abort_requested for result in self.input_results)
+        assert any(
+            isinstance(result, ConversationAbortResult)
+            for result in self.input_results
+        )
 
     def assert_no_abort_requested(self) -> None:
-        assert not any(result.abort_requested for result in self.input_results)
+        assert not any(
+            isinstance(result, ConversationAbortResult)
+            for result in self.input_results
+        )
 
     def assert_pending_steers(self, *expected: str) -> None:
         assert self.app.state.pending_steers == list(expected)
@@ -298,7 +356,7 @@ def _default_input_router_factory(
     keybindings: KeybindingManager | KeybindingConfig | None,
     width: int,
     height: int,
-) -> ConversationPlaybackInputRouterPort[ConversationInputResultPort]:
+) -> ConversationPlaybackInputRouterPort:
     return ConversationInputRouter(
         app=app,
         should_exit=should_exit,
@@ -310,7 +368,7 @@ def _default_input_router_factory(
 
 
 def _resize_router(
-    router: ConversationPlaybackInputRouterPort[ConversationInputResultPort],
+    router: ConversationPlaybackInputRouterPort,
     size: TerminalSize,
 ) -> None:
     if hasattr(router, "width"):
@@ -327,14 +385,6 @@ def _surface_intent_payload(intent: InputIntent | None) -> dict[str, str] | None
     if intent is None:
         return None
     return {"kind": intent.kind, "text": intent.text}
-
-
-def _text_results(
-    results: tuple[ConversationInputResultPort, ...],
-    attribute: str,
-) -> list[str]:
-    values = [getattr(result, attribute) for result in results]
-    return [value for value in values if isinstance(value, str)]
 
 
 __all__ = [

--- a/src/loushang/harnesstui/testing/ports.py
+++ b/src/loushang/harnesstui/testing/ports.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import Protocol, TypeVar
 
-from loushang.harnesstui.conversation.input import ConversationScreenInputPort
+from loushang.harnesstui.conversation.input import (
+    ConversationInputResult,
+    ConversationScreenInputPort,
+)
 from loushang.harnesstui.conversation.screen_runner import (
-    ConversationInputResultPort,
     LocalCommandPredicate,
     ShouldExit,
 )
@@ -16,11 +18,6 @@ from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
 
 AppT_co = TypeVar("AppT_co", covariant=True)
 AppT_contra = TypeVar("AppT_contra", contravariant=True)
-InputResultT_co = TypeVar(
-    "InputResultT_co",
-    bound=ConversationInputResultPort,
-    covariant=True,
-)
 
 
 class ConversationPlaybackAppPort(ConversationScreenInputPort, Protocol):
@@ -31,12 +28,10 @@ class ConversationPlaybackAppPort(ConversationScreenInputPort, Protocol):
     def render(self, constraints: RenderConstraints) -> RenderResult: ...
 
 
-class ConversationPlaybackInputRouterPort(
-    Protocol[InputResultT_co],
-):
+class ConversationPlaybackInputRouterPort(Protocol):
     """Product adapter that routes one decoded input event."""
 
-    def handle(self, event: InputEvent) -> InputResultT_co: ...
+    def handle(self, event: InputEvent) -> ConversationInputResult: ...
 
 
 class ConversationPlaybackInputRouterFactoryPort(Protocol):
@@ -51,7 +46,7 @@ class ConversationPlaybackInputRouterFactoryPort(Protocol):
         keybindings: KeybindingManager | KeybindingConfig | None,
         width: int,
         height: int,
-    ) -> ConversationPlaybackInputRouterPort[ConversationInputResultPort]: ...
+    ) -> ConversationPlaybackInputRouterPort: ...
 
 
 class ConversationStateSnapshotPort(Protocol[AppT_contra]):
@@ -65,7 +60,7 @@ class ConversationResultPayloadPort(Protocol):
 
     def __call__(
         self,
-        result: ConversationInputResultPort,
+        result: ConversationInputResult,
     ) -> Mapping[str, object]: ...
 
 

--- a/tests/coding/test_screen_coding_tui_input.py
+++ b/tests/coding/test_screen_coding_tui_input.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+from loushang.harnesstui.conversation.input import (
+    ConversationFollowupResult,
+    ConversationInputHandled,
+    ConversationLocalResult,
+    ConversationPromptResult,
+    ConversationSteerResult,
+    ConversationSurfaceResult,
+)
 from loushang.tui import CompletionItem, InputEvent, InputIntent
 from loushang.tui.transcript import UserPromptRecord
 
@@ -21,7 +29,7 @@ def test_screen_input_router_idle_enter_starts_prompt_and_clears_composer() -> N
         InputEvent(kind="key", key="enter")
     )
 
-    assert result.prompt_text == "你好"
+    assert result == ConversationPromptResult(text="你好")
     assert app.composer.value == ""
     assert app.state.running is True
     assert isinstance(app.state.records[0], UserPromptRecord)
@@ -46,8 +54,7 @@ def test_screen_input_router_running_enter_queues_steer() -> None:
         InputEvent(kind="key", key="enter")
     )
 
-    assert result.prompt_text is None
-    assert result.steer_text == "请用中文"
+    assert result == ConversationSteerResult(text="请用中文")
     assert app.composer.value == ""
     assert app.state.pending_steers == ["请用中文"]
 
@@ -69,8 +76,7 @@ def test_screen_input_router_idle_escape_submits_pending_steer() -> None:
         InputEvent(kind="key", key="escape")
     )
 
-    assert result.prompt_text is None
-    assert result.steer_text == "你好"
+    assert result == ConversationSteerResult(text="你好")
     assert app.state.pending_steers == []
 
 
@@ -95,7 +101,7 @@ def test_screen_input_router_idle_interrupt_message_prefers_pending_steer() -> N
         InputEvent(kind="key", key="escape")
     )
 
-    assert result.steer_text == "你好"
+    assert result == ConversationSteerResult(text="你好")
     assert app.state.pending_steers == []
     assert app.composer.value == "草稿"
 
@@ -118,7 +124,7 @@ def test_screen_input_router_running_alt_enter_queues_followup() -> None:
         InputEvent(kind="key", key="alt+enter")
     )
 
-    assert result.followup_text == "继续"
+    assert result == ConversationFollowupResult(text="继续")
     assert app.composer.value == ""
     assert app.state.pending_followups == ["继续"]
 
@@ -142,7 +148,7 @@ def test_screen_input_router_escape_closes_completion_before_running_abort() -> 
         InputEvent(kind="key", key="escape")
     )
 
-    assert result.abort_requested is False
+    assert isinstance(result, ConversationInputHandled)
     assert app.state.running is True
     assert app.composer.value == "/he"
     assert not app.composer.has_completions
@@ -168,7 +174,7 @@ def test_screen_input_router_enter_applies_slash_completion_before_submit() -> N
         is_local_command=lambda text: text == "/model",
     ).handle(InputEvent(kind="key", key="enter"))
 
-    assert result.local_text == "/model"
+    assert result == ConversationLocalResult(text="/model")
     assert app.composer.value == ""
 
 
@@ -330,10 +336,11 @@ def test_screen_input_router_pastes_clipboard_image_as_attachment(tmp_path) -> N
     app.composer.insert_text("describe it")
     submit_result = router.handle(InputEvent(kind="key", key="enter"))
 
-    assert submit_result.prompt_text == "@.clips/clipboard-abc123.png describe it"
-    assert submit_result.prompt_attachments is not None
-    assert submit_result.prompt_attachments[0].mime_type == "image/png"
-    assert submit_result.prompt_attachments[0].bytes == payload
+    assert isinstance(submit_result, ConversationPromptResult)
+    assert submit_result.text == "@.clips/clipboard-abc123.png describe it"
+    assert submit_result.attachments is not None
+    assert submit_result.attachments[0].mime_type == "image/png"
+    assert submit_result.attachments[0].bytes == payload
 
 
 def test_screen_input_router_reports_empty_clipboard_image_without_editing(
@@ -535,8 +542,9 @@ def test_screen_input_router_orders_clipboard_images_by_marker_position(
 
     submit_result = router.handle(InputEvent(kind="key", key="enter"))
 
-    assert submit_result.prompt_attachments is not None
-    assert [image.bytes for image in submit_result.prompt_attachments] == [
+    assert isinstance(submit_result, ConversationPromptResult)
+    assert submit_result.attachments is not None
+    assert [image.bytes for image in submit_result.attachments] == [
         b"second",
         b"first",
     ]
@@ -574,13 +582,15 @@ def test_screen_input_router_uses_default_workspace_clipboard_directory_and_clea
     assert app.composer.value == f"{marker} "
 
     first_submit = router.handle(InputEvent(kind="key", key="enter"))
-    assert first_submit.prompt_attachments is not None
+    assert isinstance(first_submit, ConversationPromptResult)
+    assert first_submit.attachments is not None
 
     app.complete_run(elapsed_seconds=0.1)
     app.composer.set_text(f"reuse {marker}")
     second_submit = router.handle(InputEvent(kind="key", key="enter"))
 
-    assert second_submit.prompt_attachments is None
+    assert isinstance(second_submit, ConversationPromptResult)
+    assert second_submit.attachments is None
     assert saved_path.read_bytes() == b"png"
 
 
@@ -628,7 +638,7 @@ def test_screen_input_router_routes_local_slash_command_without_starting_prompt(
         is_local_command=lambda text: text == "/model",
     ).handle(InputEvent(kind="key", key="enter"))
 
-    assert result.local_text == "/model"
+    assert result == ConversationLocalResult(text="/model")
     assert app.composer.value == ""
     assert app.state.records == []
     assert app.state.running is False
@@ -660,7 +670,9 @@ def test_screen_input_router_routes_active_surface_before_composer() -> None:
         InputEvent(kind="key", key="enter")
     )
 
-    assert result.surface_intent == InputIntent(kind="select", text="chosen")
+    assert result == ConversationSurfaceResult(
+        intent=InputIntent(kind="select", text="chosen")
+    )
     assert app.composer.value == "draft"
     assert app.state.records == []
 
@@ -691,7 +703,9 @@ def test_screen_input_router_routes_runtime_overlay_before_composer() -> None:
         InputEvent(kind="key", key="enter")
     )
 
-    assert result.surface_intent == InputIntent(kind="command", text="/model")
+    assert result == ConversationSurfaceResult(
+        intent=InputIntent(kind="command", text="/model")
+    )
     assert app.composer.value == "draft"
     assert app.state.records == []
 
@@ -718,8 +732,7 @@ def test_screen_input_router_ctrl_o_opens_transcript_reader_overlay() -> None:
         InputEvent(kind="key", key="ctrl+o")
     )
 
-    assert result.render_requested is True
-    assert result.surface_intent is None
+    assert isinstance(result, ConversationInputHandled)
     assert len(app.surface_host.entries) == 1
     assert isinstance(
         app.surface_host.entries[0].surface.renderable, TranscriptReaderSurface
@@ -1017,8 +1030,7 @@ def test_screen_input_router_reader_strict_modal_consumes_tab_without_completion
     router.handle(InputEvent(kind="key", key="ctrl+o"))
     result = router.handle(InputEvent(kind="key", key="tab"))
 
-    assert result.render_requested is True
-    assert result.surface_intent is None
+    assert isinstance(result, ConversationInputHandled)
     assert len(app.surface_host.entries) == 1
     assert app.composer.value == "/mo"
     assert app.composer.has_completions
@@ -1047,7 +1059,9 @@ def test_screen_input_router_reader_ctrl_c_closes_then_text_routes_to_composer()
     close_result = router.handle(InputEvent(kind="key", key="ctrl+c"))
     text_result = router.handle(InputEvent(kind="text", text="x"))
 
-    assert close_result.surface_intent == InputIntent(kind="surface_close")
+    assert close_result == ConversationSurfaceResult(
+        intent=InputIntent(kind="surface_close")
+    )
     assert app.surface_host.entries == []
     assert text_result.render_requested is True
     assert app.composer.value == "x"

--- a/tests/coding/test_screen_coding_tui_playback.py
+++ b/tests/coding/test_screen_coding_tui_playback.py
@@ -11,6 +11,11 @@ from loushang.coding.ui.completion import coding_inline_completion_provider
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
 from loushang.coding.ui.screen_input import build_screen_input_router
 from loushang.coding.ui.screen_surfaces import ScreenSurfaceManager
+from loushang.harnesstui.conversation.input import (
+    ConversationAbortResult,
+    ConversationLocalResult,
+    ConversationSurfaceResult,
+)
 from loushang.harnesstui.status.provider import StatusProvider
 from loushang.tui import (
     FakeTerminalPort,
@@ -222,7 +227,8 @@ def test_screen_tui_playback_escape_clears_idle_draft_without_abort() -> None:
     assert all(step.flush_succeeded for step in result)
     assert app.composer.value == ""
     assert not any(
-        input_result.abort_requested for input_result in playback.input_results
+        isinstance(input_result, ConversationAbortResult)
+        for input_result in playback.input_results
     )
     assert "› draft" not in _plain_lines(result[-1].diagnostics)
     for step in result:
@@ -826,11 +832,11 @@ class _ScreenInteractivePlayback:
             )
         for event in events:
             result = self.router.handle(event)
-            if result.local_text is not None:
-                asyncio.run(self.surface_manager.handle_text(result.local_text))
-            if result.surface_intent is not None:
+            if isinstance(result, ConversationLocalResult):
+                asyncio.run(self.surface_manager.handle_text(result.text))
+            if isinstance(result, ConversationSurfaceResult):
                 asyncio.run(
-                    self.surface_manager.handle_surface_intent(result.surface_intent)
+                    self.surface_manager.handle_surface_intent(result.intent)
                 )
 
 

--- a/tests/coding/tui_support/scenario_binding.py
+++ b/tests/coding/tui_support/scenario_binding.py
@@ -16,7 +16,6 @@ from loushang.harnesstui.conversation.host import (
 )
 from loushang.harnesstui.conversation.screen_runner import (
     AbortHandler,
-    ConversationInputResultPort,
     ConversationInputRouterFactoryPort,
     ConversationScreenPort,
     LocalCommandPredicate,
@@ -52,9 +51,9 @@ def coding_scenario_input_router_factory(
     keybindings: KeybindingManager | KeybindingConfig | None,
     width: int,
     height: int,
-) -> ConversationPlaybackInputRouterPort[ConversationInputResultPort]:
+) -> ConversationPlaybackInputRouterPort:
     return cast(
-        ConversationPlaybackInputRouterPort[ConversationInputResultPort],
+        ConversationPlaybackInputRouterPort,
         build_screen_input_router(
             app=cast(ScreenCodingTuiApp, app),
             should_exit=should_exit,

--- a/tests/harnesstui/conversation/test_clipboard_input.py
+++ b/tests/harnesstui/conversation/test_clipboard_input.py
@@ -10,6 +10,8 @@ from loushang.harnesstui.conversation.attachments import (
 from loushang.harnesstui.conversation.input import (
     ClipboardImageInputProfile,
     ClipboardImageStatusCopy,
+    ConversationClipboardResult,
+    ConversationFollowupResult,
     bind_clipboard_image_input_router,
 )
 from loushang.harnesstui.conversation.screen_state import ScreenConversationState
@@ -91,9 +93,9 @@ def test_clipboard_image_input_binding_follows_the_replaced_app(
     assert replacement.composer.value == "@images/clipboard-sample.png "
     assert replacement.statuses == ["attached: images/clipboard-sample.png"]
     assert original.statuses == []
-    assert result.clipboard_outcome is not None
-    assert result.clipboard_outcome.attachment is not None
-    assert result.clipboard_outcome.attachment.path == expected
+    assert isinstance(result, ConversationClipboardResult)
+    assert result.outcome.attachment is not None
+    assert result.outcome.attachment.path == expected
 
 
 def test_clipboard_image_status_copy_formats_every_neutral_outcome(
@@ -159,6 +161,5 @@ def test_clipboard_image_input_binding_forwards_router_policy() -> None:
 
     result = router.handle(InputEvent(kind="key", key="enter"))
 
-    assert result.followup_text == "later"
-    assert result.steer_text is None
+    assert result == ConversationFollowupResult(text="later")
     assert app.state.pending_followups == ["later"]

--- a/tests/harnesstui/conversation/test_input.py
+++ b/tests/harnesstui/conversation/test_input.py
@@ -3,11 +3,23 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import pytest
+
 from loushang.harnesstui.conversation.attachments import (
     PromptImageAttachment,
     PromptImageAttachmentOutcome,
 )
-from loushang.harnesstui.conversation.input import ConversationInputRouter
+from loushang.harnesstui.conversation.input import (
+    ConversationClipboardResult,
+    ConversationExitResult,
+    ConversationFollowupResult,
+    ConversationInputHandled,
+    ConversationInputIgnored,
+    ConversationInputRouter,
+    ConversationLocalResult,
+    ConversationPromptResult,
+    ConversationSurfaceResult,
+)
 from loushang.harnesstui.conversation.screen_state import ScreenConversationState
 from loushang.tui import Composer, InputEvent, InputIntent, SurfaceHost
 
@@ -47,6 +59,48 @@ def _attachment(tmp_path: Path, *, name: str = "image") -> PromptImageAttachment
     )
 
 
+def test_conversation_input_results_are_discriminated_and_payload_valid() -> None:
+    from loushang.harnesstui.conversation.input import (
+        ConversationAbortResult,
+        ConversationClipboardResult,
+        ConversationExitResult,
+        ConversationFollowupResult,
+        ConversationInputHandled,
+        ConversationInputIgnored,
+        ConversationLocalResult,
+        ConversationPromptResult,
+        ConversationSteerResult,
+        ConversationSurfaceResult,
+    )
+
+    assert ConversationInputHandled().kind == "handled"
+    assert ConversationInputHandled().render_requested is True
+    assert ConversationInputIgnored().kind == "ignored"
+    assert ConversationInputIgnored().render_requested is False
+    assert ConversationPromptResult(text="prompt").kind == "prompt"
+    assert ConversationLocalResult(text="/local").kind == "local"
+    assert ConversationSteerResult(text="steer").kind == "steer"
+    assert ConversationFollowupResult(text="later").kind == "follow_up"
+    assert ConversationSurfaceResult(intent=InputIntent(kind="select")).kind == (
+        "surface"
+    )
+    assert ConversationClipboardResult(
+        outcome=PromptImageAttachmentOutcome(kind="empty")
+    ).kind == "clipboard"
+    assert ConversationAbortResult().kind == "abort"
+    assert ConversationExitResult(exit_code=7).kind == "exit"
+
+    with pytest.raises(TypeError):
+        ConversationPromptResult(text="prompt", exit_code=7)  # type: ignore[call-arg]
+
+
+def test_conversation_input_result_field_bag_constructor_is_removed() -> None:
+    from loushang.harnesstui.conversation.input import ConversationInputResult
+
+    with pytest.raises(TypeError):
+        ConversationInputResult(prompt_text="prompt")  # type: ignore[misc]
+
+
 def test_conversation_input_router_submits_neutral_prompt_attachments(
     tmp_path: Path,
 ) -> None:
@@ -66,10 +120,11 @@ def test_conversation_input_router_submits_neutral_prompt_attachments(
     app.composer.insert_text("describe")
     submit_result = router.handle(InputEvent(kind="key", key="enter"))
 
-    assert paste_result.clipboard_outcome is not None
-    assert paste_result.clipboard_outcome.attachment is attachment
-    assert submit_result.prompt_text == "@image.png describe"
-    assert submit_result.prompt_attachments == (attachment,)
+    assert isinstance(paste_result, ConversationClipboardResult)
+    assert paste_result.outcome.attachment is attachment
+    assert isinstance(submit_result, ConversationPromptResult)
+    assert submit_result.text == "@image.png describe"
+    assert submit_result.attachments == (attachment,)
     assert app.state.running is True
     assert app.composer.value == ""
 
@@ -94,9 +149,9 @@ def test_conversation_input_router_preserves_running_followup_priority(
 
     result = router.handle(InputEvent(kind="key", key="alt+enter"))
 
-    assert result.followup_text == "@image.png later"
-    assert result.followup_attachments == (attachment,)
-    assert result.steer_text is None
+    assert isinstance(result, ConversationFollowupResult)
+    assert result.text == "@image.png later"
+    assert result.attachments == (attachment,)
     assert app.state.pending_followups == ["@image.png later"]
 
 
@@ -115,7 +170,8 @@ def test_conversation_input_router_routes_active_surface_before_composer() -> No
 
     result = router.handle(InputEvent(kind="key", key="enter"))
 
-    assert result.surface_intent == InputIntent(kind="select", text="choice")
+    assert isinstance(result, ConversationSurfaceResult)
+    assert result.intent == InputIntent(kind="select", text="choice")
     assert app.composer.value == "draft"
     assert app.state.running is False
 
@@ -133,8 +189,8 @@ def test_conversation_input_router_keeps_exit_and_local_policy_injected() -> Non
     app.composer.set_text("/quit")
     exit_result = router.handle(InputEvent(kind="key", key="enter"))
 
-    assert local_result.local_text == "/model"
-    assert exit_result.exit_code == 0
+    assert local_result == ConversationLocalResult(text="/model")
+    assert exit_result == ConversationExitResult(exit_code=0)
     assert app.state.running is False
 
 
@@ -150,9 +206,7 @@ def test_conversation_input_router_handles_local_command_while_run_is_active() -
 
     result = router.handle(InputEvent(kind="key", key="enter"))
 
-    assert result.local_text == "/agents"
-    assert result.steer_text is None
-    assert result.followup_text is None
+    assert result == ConversationLocalResult(text="/agents")
     assert app.state.running is True
     assert app.state.pending_steers == []
     assert app.state.pending_followups == []
@@ -170,7 +224,7 @@ def test_conversation_input_router_restores_pending_messages() -> None:
 
     result = router.handle(InputEvent(kind="key", key="alt+up"))
 
-    assert result.render_requested is True
+    assert isinstance(result, ConversationInputHandled)
     assert app.composer.value == "first\nsecond"
     assert app.state.pending_steers == []
     assert app.state.pending_followups == []
@@ -187,8 +241,7 @@ def test_conversation_input_router_reports_unconfigured_clipboard_as_unhandled()
 
     result = router.handle(InputEvent(kind="key", key="ctrl+v"))
 
-    assert result.render_requested is False
-    assert result.clipboard_outcome is None
+    assert isinstance(result, ConversationInputIgnored)
 
 
 def test_conversation_input_router_presents_each_clipboard_outcome_once(
@@ -221,5 +274,7 @@ def test_conversation_input_router_presents_each_clipboard_outcome_once(
 
     assert [outcome.kind for outcome, _text in presented] == ["attached", "empty"]
     assert presented[0][1] == "@image.png "
-    assert attached.clipboard_outcome is presented[0][0]
-    assert empty.clipboard_outcome is presented[1][0]
+    assert isinstance(attached, ConversationClipboardResult)
+    assert isinstance(empty, ConversationClipboardResult)
+    assert attached.outcome is presented[0][0]
+    assert empty.outcome is presented[1][0]

--- a/tests/harnesstui/conversation/test_screen_runner.py
+++ b/tests/harnesstui/conversation/test_screen_runner.py
@@ -53,7 +53,11 @@ def test_prompt_handler_ignores_attachments_for_text_only_handler() -> None:
 
 
 def test_conversation_screen_forwards_neutral_attachments_end_to_end() -> None:
-    from loushang.harnesstui.conversation.input import ConversationInputResult
+    from loushang.harnesstui.conversation.input import (
+        ConversationInputIgnored,
+        ConversationInputResult,
+        ConversationPromptResult,
+    )
     from loushang.harnesstui.conversation.screen_runner import (
         run_conversation_screen,
     )
@@ -62,6 +66,7 @@ def test_conversation_screen_forwards_neutral_attachments_end_to_end() -> None:
     app = _RunnerApp()
     attachment = object()
     seen: dict[str, object] = {}
+    other_actions: list[str] = []
 
     class Router:
         def __init__(self, **_kwargs: object) -> None:
@@ -69,11 +74,11 @@ def test_conversation_screen_forwards_neutral_attachments_end_to_end() -> None:
 
         def handle(self, event: object) -> ConversationInputResult:
             if getattr(event, "kind", None) != "text":
-                return ConversationInputResult(render_requested=False)
+                return ConversationInputIgnored()
             app.state.active_started_at = app.now()
-            return ConversationInputResult(
-                prompt_text="describe",
-                prompt_attachments=(attachment,),
+            return ConversationPromptResult(
+                text="describe",
+                attachments=(attachment,),
             )
 
     async def handle_prompt(
@@ -90,7 +95,11 @@ def test_conversation_screen_forwards_neutral_attachments_end_to_end() -> None:
             stdin=StringIO("x"),
             stdout=StringIO(),
             handle_prompt=handle_prompt,
-            on_abort=lambda: None,
+            handle_local=lambda _text: other_actions.append("local"),
+            handle_steer=lambda _text: other_actions.append("steer"),
+            handle_followup=lambda _text: other_actions.append("follow_up"),
+            handle_surface_intent=lambda _intent: other_actions.append("surface"),
+            on_abort=lambda: other_actions.append("abort"),
             should_exit=lambda _text: False,
             terminal_mode_factory=lambda _stdin, _stdout: nullcontext(object()),
             terminal_size_provider=lambda: TerminalSize(columns=80, rows=24),
@@ -105,6 +114,7 @@ def test_conversation_screen_forwards_neutral_attachments_end_to_end() -> None:
         "text": "describe",
         "attachments": (attachment,),
     }
+    assert other_actions == []
 
 
 def test_finish_active_task_preserves_success_error_and_cancellation_state() -> None:

--- a/tests/harnesstui/testing/test_input_playback.py
+++ b/tests/harnesstui/testing/test_input_playback.py
@@ -3,10 +3,26 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 
+from loushang.harnesstui.conversation.attachments import (
+    PromptImageAttachmentOutcome,
+)
+from loushang.harnesstui.conversation.input import (
+    ConversationAbortResult,
+    ConversationClipboardResult,
+    ConversationExitResult,
+    ConversationFollowupResult,
+    ConversationInputHandled,
+    ConversationInputIgnored,
+    ConversationLocalResult,
+    ConversationPromptResult,
+    ConversationSteerResult,
+    ConversationSurfaceResult,
+)
 from loushang.harnesstui.conversation.screen_state import ScreenConversationState
 from loushang.harnesstui.testing.input_playback import (
     ConversationInputPlayback,
     ConversationInputScenario,
+    default_conversation_result_payload,
 )
 from loushang.tui.core import (
     CURSOR_MARKER,
@@ -14,6 +30,7 @@ from loushang.tui.core import (
     RenderResult,
 )
 from loushang.tui.framework import SurfaceHost
+from loushang.tui.input import InputIntent
 from loushang.tui.playback import PlaybackEvent
 from loushang.tui.ui_parts.composer import Composer
 
@@ -85,6 +102,56 @@ def test_input_scenario_is_a_product_neutral_fluent_recipe() -> None:
     result.assert_composer_text("")
 
 
+def test_default_result_payload_preserves_legacy_schema_for_every_variant() -> None:
+    neutral = {
+        "prompt_text": None,
+        "prompt_attachment_count": 0,
+        "local_text": None,
+        "steer_text": None,
+        "steer_attachment_count": 0,
+        "followup_text": None,
+        "followup_attachment_count": 0,
+        "surface_intent": None,
+        "abort_requested": False,
+        "exit_code": None,
+        "render_requested": True,
+    }
+    cases = (
+        (ConversationInputHandled(), {}),
+        (ConversationInputIgnored(), {"render_requested": False}),
+        (
+            ConversationPromptResult(text="prompt", attachments=(object(),)),
+            {"prompt_text": "prompt", "prompt_attachment_count": 1},
+        ),
+        (ConversationLocalResult(text="/local"), {"local_text": "/local"}),
+        (
+            ConversationSteerResult(text="steer", attachments=(object(),)),
+            {"steer_text": "steer", "steer_attachment_count": 1},
+        ),
+        (
+            ConversationFollowupResult(text="later", attachments=(object(),)),
+            {"followup_text": "later", "followup_attachment_count": 1},
+        ),
+        (
+            ConversationSurfaceResult(intent=InputIntent(kind="select", text="one")),
+            {"surface_intent": {"kind": "select", "text": "one"}},
+        ),
+        (
+            ConversationClipboardResult(
+                outcome=PromptImageAttachmentOutcome(kind="empty")
+            ),
+            {},
+        ),
+        (ConversationAbortResult(), {"abort_requested": True}),
+        (ConversationExitResult(exit_code=7), {"exit_code": 7}),
+    )
+
+    for result, changed in cases:
+        assert dict(default_conversation_result_payload(result)) == (
+            neutral | changed
+        )
+
+
 def test_input_playback_artifact_uses_injected_snapshot_and_result_payload(
     tmp_path,
 ) -> None:
@@ -93,7 +160,7 @@ def test_input_playback_artifact_uses_injected_snapshot_and_result_payload(
         app,
         state_snapshot=lambda current: {"draft": current.composer.value},
         result_payload=lambda result: {
-            "submitted": result.prompt_text is not None,
+            "submitted": isinstance(result, ConversationPromptResult),
         },
     )
     result = playback.run((PlaybackEvent.input("question"), PlaybackEvent.input("\r")))


### PR DESCRIPTION
## Summary

- replace the optional-field `ConversationInputResult` bag with ten frozen, slotted result variants and a closed union
- make handled-vs-ignored render scheduling explicit and non-overridable
- dispatch one primary result exhaustively in the shared conversation runner, with `assert_never` guarding future variants
- migrate playback ports and assertions from dynamic field probing to the closed union
- preserve the existing default playback artifact schema through an exhaustive compatibility serializer
- include the reviewed design, implementation plan, and author review record

Fixes #475.

## Result contract

The new union distinguishes handled, ignored, prompt, local, steer, follow-up, surface, clipboard, abort, and exit outcomes. Each payload variant exposes only its own valid fields, so prompt/abort/exit and similar cross-kind combinations are no longer constructible through the supported API.

Prompt, steer, and follow-up attachments remain product-neutral `object` tuples at the runner boundary. The standard router continues to supply `PromptImageAttachment` instances.

## Compatibility

- no generic `loushang.tui` production file changed
- no Coding production file changed
- input route order and shortcut interpretation are unchanged
- exit and abort retain their existing early control flow
- playback artifacts keep the exact existing keys and values; no `kind` field was added
- `ConversationInputResultPort` remains as a type alias to the closed union for annotation migration

This is a pre-1.0 internal API cleanup. Direct construction of the old optional-field `ConversationInputResult(...)` bag now fails loudly; callers use a concrete result variant.

Explicitly excluded: route deduplication, keybinding catalog movement, Coding policy injection, and unrelated TUI fixes.

## Verification

- result-contract RED: 2 expected failures against the old field bag
- focused HarnessTUI router/runner/playback: 30 passed before; 33 passed after adding 3 contract tests
- Coding input/playback compatibility: 82 passed before and after
- complete TUI + HarnessTUI suite: 1765 passed
- `make check-harnesstui`: Ruff clean, 139 mypy sources clean, 1270 passed, 65 marker-deselected
- `make typecheck-tui`: 90 source files clean
- `make typecheck-harnesstui`: 139 source files clean
- architecture documentation: 5 passed
- changed-file Ruff, direct mypy, import smoke, and `git diff --check`: clean

All pytest commands ran outside the filesystem sandbox on the first attempt because this workspace has a verified selector/self-pipe `EPERM` failure inside the sandbox.
