### PR TITLE
refactor(harnesstui): separate input capabilities and policy

### DIFF
--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -92,6 +92,15 @@ run, and whether prompt cancellation exits, clears, or aborts work.
 Harness-backed conversation applications should use Harnesstui's
 `ConversationInputRouter` for that run-state policy.
 
+Harness declares steering and follow-up delivery through
+`SessionInputCapabilities`. Harnesstui uses a steer-first primary-submit policy
+and deterministically falls back to follow-up when steering is unavailable.
+Physical keys remain independently configurable: Enter is
+`tui.input.submit`, while explicit follow-up is
+`conversation.input.followUp` (Alt+Enter by default). Idle Alt+Enter remains
+`tui.input.newLine`; `ConversationInputRouter` resolves the running-state
+priority.
+
 Composer selections use atom indexes. Normal text is split into grapheme-like
 text atoms; large paste markers are single atoms and are never split by range
 editing.
@@ -104,7 +113,7 @@ pre-1.0 breaking boundary:
 | Old API | Harness-backed replacement | Generic application replacement |
 | --- | --- | --- |
 | `InputRouter(running=...)` | Project state into `ConversationInputRouter`. | Interpret generic `submit` from application state. |
-| `steering_supported=...` | Select `running_submit_mode="steer"` when supported, otherwise `"follow_up"`. | Make the capability decision in the application adapter. |
+| `steering_supported=...` | Project Harness `SessionInputCapabilities`; let Harnesstui `ConversationInputPolicy` select steer-first and fallback. | Interpret the projected capability in the application adapter. |
 | `submit(mode=...)` | Use the HarnessTUI running-submit route. | Call zero-argument `submit()` and apply application policy to its result. |
 | Third/fourth positional state arguments | Use explicit HarnessTUI configuration. | Use keyword-only generic configuration plus application state. |
 

--- a/docs/internals/architecture/harness/session-rpc-operations-boundary.md
+++ b/docs/internals/architecture/harness/session-rpc-operations-boundary.md
@@ -21,7 +21,16 @@ The standard groups are:
 JSON command name, a correlation id, Pi aliases, or a response envelope.
 `SessionOperationAvailability` is explicit: an unbound group fails with
 `SessionOperationUnavailableError`, rather than relying on an optional method
-or an implementation-specific `getattr` check.
+or an implementation-specific `getattr` check. Within the input group,
+`SessionInputCapabilities` separately declares steer and follow-up delivery.
+The standard Session guarantees both; restricted bindings may expose either
+action, and `SessionOperationRuntime` enforces the declaration before invoking
+the control port. Queue modes such as `all` and `one-at-a-time` remain
+delivery-drain policy and do not select a UI submit action.
+
+`SessionOperationResolver` carries the immutable input declaration as binding
+metadata. Adapters may inspect it without resolving an active Session; calling
+the resolver remains reserved for actual session operations.
 
 ## Ownership
 

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -322,9 +322,12 @@ conversation Python package initializer.
 
 ## Conversation Interaction Control
 
-The reusable control plane for a full-screen conversation lives behind six
+The reusable control plane for a full-screen conversation lives behind seven
 explicit entrypoints:
 
+- `loushang.harnesstui.conversation.input_policy` owns neutral projected input
+  capabilities, steer-first/fallback policy, and conversation keybinding
+  definitions;
 - `loushang.harnesstui.conversation.input` coordinates decoded input,
   completion, surfaces, running-submit modes, and neutral attachments;
 - `loushang.harnesstui.conversation.control` coordinates abort, steer, and
@@ -530,11 +533,22 @@ neutral attachments to `ImagePart` at the model-dispatch boundary. Its screen
 loop is a thin binding around `run_conversation_screen`; test-only aliases for
 shared runner and terminal helpers are not product APIs.
 
-Coding currently uses the router default `running_submit_mode="steer"` rather
-than injecting an explicit steering-capability policy. That injection remains
-deferred. Coding still supplies slash-command classification, final actions,
-and Product copy; the generic TUI router is not part of this conversation
-state machine.
+Harness `SessionOperationRuntime` declares and enforces steering and follow-up
+input delivery through `SessionInputCapabilities`. The standard Agent binding
+projects those Harness-owned declarations into Harnesstui's neutral
+`ConversationInputCapabilities`; the shared input policy is steer-first and
+falls back to follow-up when steering is unavailable. Coding accepts that
+default and may bind another `ConversationInputPolicy` without changing the
+Harness capability declaration. Capability projection reads resolver binding
+metadata and must not resolve an active Session during application preparation.
+
+Harnesstui owns the `conversation.input.followUp` keybinding action and its
+Alt+Enter default. User keybinding settings may override the physical key,
+while running-state interpretation remains in `ConversationInputRouter`.
+Coding formats its hotkey help from the resolved keybindings instead of
+hard-coding Alt+Enter. Coding still supplies slash-command classification,
+final actions, and Product copy; the generic TUI router is not part of this
+conversation state machine.
 
 ## Plain Conversation Presentation
 

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-003-abort-steer-follow-up-sequence.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-003-abort-steer-follow-up-sequence.md
@@ -23,10 +23,20 @@ Conversation text is classified above that generic layer:
 - abort: control action that cancels or interrupts the active run
 - surface action: handled by the active surface before active-run controls
 
-Capability and downgrade policy also stays above generic TUI. Coding currently
-uses `ConversationInputRouter`'s default `running_submit_mode="steer"`; it has
-not yet injected an explicit steering-capability policy. Coding continues to
-own slash-command classification, final Product actions, and Product copy.
+Capability and downgrade policy also stays above generic TUI. Harness
+`SessionInputCapabilities` declares whether steering and follow-up delivery are
+available. The Agent application adapter projects those declarations into
+Harnesstui's neutral `ConversationInputCapabilities`, and
+`ConversationInputPolicy` applies a steer-first primary-submit preference with
+a deterministic follow-up fallback. Coding may inject a different policy, and
+continues to own slash-command classification, final Product actions, and
+Product copy.
+
+Physical keys remain separate from that capability policy. Generic
+`tui.input.submit` continues to own Enter. Harnesstui registers the contextual
+`conversation.input.followUp` action with Alt+Enter as its default, while idle
+Alt+Enter remains `tui.input.newLine`. The conversation router resolves that
+intentional overlap from explicit running state before newline handling.
 
 Pending follow-up and steering items are rendered in the pending queue area. The
 queue is transient bottom-frame UI and grows upward. Queued text remains visible
@@ -46,6 +56,10 @@ TUI's independent jump-mode cancellation never decides whether work is aborted.
 - follow-up while running clears the composer and displays queued text
 - steer while running displays separately from follow-up
 - unavailable steering is rejected or downgraded visibly
+- Harness input capability declarations are enforced by Session operations and
+  projected without importing Harness into the neutral input-policy module
+- configured `conversation.input.followUp` bindings replace the default key
+  while preserving idle newline behavior
 - edit-queue restores pending text into the composer
 - abort removes running chrome, commits interruption state, and restores focus
 - generic `InputRouter` produces no follow-up, steer, queue-edit, or

--- a/docs/superpowers/plans/2026-08-22-tui-harnesstui-input-ownership-refactor.md
+++ b/docs/superpowers/plans/2026-08-22-tui-harnesstui-input-ownership-refactor.md
@@ -602,10 +602,12 @@ Correct KD-003 before updating the HarnessTUI README:
 - HarnessTUI conversation adapters interpret idle/running Enter,
   follow-up/steer alternatives, queue restore, and conversation abort;
 - capability and downgrade policy stays above generic TUI;
-- current Coding uses HarnessTUI's default `running_submit_mode="steer"` and
-  does not yet inject an explicit capability policy;
-- explicit Coding policy injection remains deferred, while Coding continues to
-  supply slash-command classification, final actions, and copy;
+- at implementation time Coding used HarnessTUI's default
+  `running_submit_mode="steer"`; follow-up #477 later replaced that implicit
+  seam with Harness-declared capabilities, HarnessTUI steer-first fallback,
+  and optional Product policy injection;
+- Coding continues to supply slash-command classification, final actions, and
+  copy;
 - generic TUI emits neutral prompt/editor signals only.
 
 Then document `ConversationInputRouter` as the sole Harness conversation input

--- a/docs/superpowers/specs/2026-08-22-tui-harnesstui-input-ownership-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-22-tui-harnesstui-input-ownership-boundary-design.md
@@ -180,14 +180,12 @@ No production change is required in this tranche. Coding continues to supply:
 - final action handlers and Product copy;
 - configured keybindings.
 
-Capability and downgrade decisions must remain above generic TUI. Current
-Coding uses HarnessTUI's default `running_submit_mode="steer"`; it does not yet
-inject an explicit capability policy. Moving that default into an explicit
-Coding policy remains deferred.
-
-Moving the default running-submit policy out of HarnessTUI and into an explicit
-Coding policy object is a possible later refinement, not a prerequisite for the
-TUI/HarnessTUI semantic cut.
+Capability and downgrade decisions must remain above generic TUI. At the time
+of this semantic cut, Coding used HarnessTUI's implicit
+`running_submit_mode="steer"`. Follow-up #477 replaced that deferred seam:
+Harness now declares steer/follow-up delivery capability, HarnessTUI owns a
+steer-first policy with capability-aware fallback, and Coding may override the
+policy without owning the capability fact.
 
 ## Decision Index
 
@@ -490,8 +488,8 @@ The English and Chinese TUI editing guides must say explicitly:
 
 KD-002 and KD-003 must agree with the same owner split: HarnessTUI interprets
 idle/running conversation keys; capability/downgrade policy remains above TUI;
-current Coding uses the HarnessTUI steer default, while explicit Coding policy
-injection remains deferred.
+Coding used the HarnessTUI steer default in this tranche; capability projection
+and optional Product policy injection were completed by follow-up #477.
 
 ### Historical design
 

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -80,6 +80,12 @@ completion 和待完成的字符跳转仍拥有更高优先级，可以先消费
 cancel 是退出、清空还是中断工作。基于 Harness 的会话应用应使用 Harnesstui 的
 `ConversationInputRouter` 承担运行态策略。
 
+Harness 通过 `SessionInputCapabilities` 声明 steer 与 follow-up 交付能力；
+Harnesstui 默认对运行中的普通提交采用 steer-first，并在 steer 不可用时确定性
+降级为 follow-up。物理键位独立配置：Enter 仍是 `tui.input.submit`，显式
+follow-up 使用 `conversation.input.followUp`（默认 Alt+Enter）。空闲时 Alt+Enter
+仍按 `tui.input.newLine` 插入换行，运行态优先级由 `ConversationInputRouter` 解释。
+
 Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文本 atom；大型 paste marker 是单个 atom，range edit 不会把它拆开。
 
 ## Pre-1.0 InputRouter 迁移
@@ -89,7 +95,7 @@ Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文
 | 旧 API | 基于 Harness 的替代方式 | 通用应用的替代方式 |
 | --- | --- | --- |
 | `InputRouter(running=...)` | 将状态投影给 `ConversationInputRouter`。 | 由应用状态解释通用 `submit`。 |
-| `steering_supported=...` | 支持时选择 `running_submit_mode="steer"`，否则选择 `"follow_up"`。 | 在应用适配层决定能力策略。 |
+| `steering_supported=...` | 由 Harness `SessionInputCapabilities` 声明能力，Harnesstui `ConversationInputPolicy` 选择 steer-first 与降级。 | 在应用适配层解释能力投影。 |
 | `submit(mode=...)` | 使用 HarnessTUI 的运行中提交路由。 | 调用无参数 `submit()`，再由应用解释结果。 |
 | 第三个/第四个位置状态参数 | 改用显式 HarnessTUI 配置。 | 改用仅限关键字的通用配置与应用状态。 |
 

--- a/src/loushang/coding/ui/hotkeys.py
+++ b/src/loushang/coding/ui/hotkeys.py
@@ -1,17 +1,114 @@
 from __future__ import annotations
 
+from loushang.coding.ui.screen_input import CODING_CONVERSATION_INPUT_POLICY
+from loushang.harnesstui.conversation.input_policy import (
+    CONVERSATION_FOLLOW_UP_ACTION,
+    ConversationInputCapabilities,
+    ConversationInputPolicy,
+    conversation_keybinding_manager,
+)
+from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
 
-def format_hotkeys() -> str:
+
+def format_hotkeys(
+    keybindings: KeybindingManager | KeybindingConfig | None = None,
+    *,
+    policy: ConversationInputPolicy = CODING_CONVERSATION_INPUT_POLICY,
+    capabilities: ConversationInputCapabilities = ConversationInputCapabilities(),
+) -> str:
+    manager = conversation_keybinding_manager(keybindings)
+    submit_key = _action_key(manager, "tui.input.submit")
+    follow_up_key = _action_key(manager, CONVERSATION_FOLLOW_UP_ACTION)
+    newline_key = _action_key(
+        manager,
+        "tui.input.newLine",
+        preferred="ctrl+j",
+    )
+    cancel_keys = _action_keys(
+        manager,
+        "tui.select.cancel",
+        separator="-",
+    )
+    edit_queue_key = _action_key(
+        manager,
+        "tui.queue.editLast",
+        separator="-",
+    )
+    primary_mode = policy.resolve_running_submit(capabilities)
+    primary_description = {
+        "steer": "steer current run",
+        "follow_up": "queue follow-up",
+        None: "input unavailable",
+    }[primary_mode]
+    follow_up_description = (
+        "queue follow-up" if capabilities.follow_up else "follow-up unavailable"
+    )
     return "\n".join(
         [
             "Hotkeys:",
-            "Idle Enter: submit prompt",
-            "Running Enter: steer current run",
-            "Running Alt+Enter: queue follow-up",
-            "Ctrl+J: insert newline",
-            "Esc/Ctrl-C: abort running request",
-            "Alt-Up: edit queued messages",
+            f"Idle {submit_key}: submit prompt",
+            f"Running {submit_key}: {primary_description}",
+            f"Running {follow_up_key}: {follow_up_description}",
+            f"{newline_key}: insert newline",
+            f"{cancel_keys}: abort running request",
+            f"{edit_queue_key}: edit queued messages",
             "/quit or /exit: quit",
+        ]
+    )
+
+
+def _action_key(
+    manager: KeybindingManager,
+    action: str,
+    *,
+    preferred: str | None = None,
+    separator: str = "+",
+) -> str:
+    keys = manager.keys_for(action)
+    if preferred in keys:
+        return _format_key(preferred, separator=separator)
+    return _format_key(keys[0], separator=separator) if keys else "Unbound"
+
+
+def _action_keys(
+    manager: KeybindingManager,
+    action: str,
+    *,
+    separator: str = "+",
+) -> str:
+    keys = manager.keys_for(action)
+    return (
+        "/".join(_format_key(key, separator=separator) for key in keys)
+        if keys
+        else "Unbound"
+    )
+
+
+def _format_key(key: str, *, separator: str = "+") -> str:
+    names = {
+        "escape": "Esc",
+        "enter": "Enter",
+        "up": "Up",
+        "down": "Down",
+        "left": "Left",
+        "right": "Right",
+    }
+    modifiers = {
+        "ctrl": "Ctrl",
+        "shift": "Shift",
+        "alt": "Alt",
+        "super": "Super",
+    }
+    parts = key.split("+")
+    if len(parts) == 1:
+        return names.get(key, key.upper() if len(key) == 1 else key.title())
+    return separator.join(
+        [
+            *(modifiers.get(part, part.title()) for part in parts[:-1]),
+            names.get(
+                parts[-1],
+                parts[-1].upper() if len(parts[-1]) == 1 else parts[-1].title(),
+            ),
         ]
     )
 

--- a/src/loushang/coding/ui/plain_app.py
+++ b/src/loushang/coding/ui/plain_app.py
@@ -51,6 +51,11 @@ def build_plain_coding_tui_app(
         verbose=verbose,
     )
 
+    def current_hotkeys() -> str:
+        settings_manager = getattr(session, "settings_manager", None)
+        get_keybindings = getattr(settings_manager, "get_keybindings", None)
+        return format_hotkeys(get_keybindings() if callable(get_keybindings) else None)
+
     return build_agent_plain_conversation_app(
         ports=build_agent_plain_conversation_ports(
             session=session,
@@ -68,7 +73,7 @@ def build_plain_coding_tui_app(
                 query=query,
                 choose=chooser,
             ),
-            hotkeys=format_hotkeys,
+            hotkeys=current_hotkeys,
             debug_status=lambda debug_path, scopes: debug_status_text(
                 debug_path,
                 scopes=scopes,

--- a/src/loushang/coding/ui/screen_input.py
+++ b/src/loushang/coding/ui/screen_input.py
@@ -9,6 +9,9 @@ from loushang.harnesstui.conversation.input import (
     ClipboardImageStatusCopy,
     bind_clipboard_image_input_router,
 )
+from loushang.harnesstui.conversation.input_policy import (
+    DEFAULT_CONVERSATION_INPUT_POLICY,
+)
 from loushang.harnesstui.conversation.screen_runner import (
     ConversationInputRouterFactoryPort,
 )
@@ -31,8 +34,11 @@ _CODING_CLIPBOARD_INPUT = ClipboardImageInputProfile(
     ),
 )
 
+CODING_CONVERSATION_INPUT_POLICY = DEFAULT_CONVERSATION_INPUT_POLICY
+
 build_screen_input_router = bind_clipboard_image_input_router(
-    _CODING_CLIPBOARD_INPUT
+    _CODING_CLIPBOARD_INPUT,
+    policy=CODING_CONVERSATION_INPUT_POLICY,
 )
 CODING_SCREEN_RUN_PROFILE = ConversationScreenRunProfile(
     input_router_factory=cast(
@@ -45,6 +51,7 @@ CODING_SCREEN_RUN_PROFILE = ConversationScreenRunProfile(
 
 __all__ = [
     "CODING_CANCELLATION_MESSAGE",
+    "CODING_CONVERSATION_INPUT_POLICY",
     "CODING_INTERRUPTION_MESSAGE",
     "CODING_SCREEN_RUN_PROFILE",
     "build_screen_input_router",

--- a/src/loushang/coding/ui/screen_surfaces.py
+++ b/src/loushang/coding/ui/screen_surfaces.py
@@ -83,7 +83,7 @@ class ScreenSurfaceManager(ScreenSurfaceWorkflow):
             ),
             build_settings_content=self._build_settings_content,
             terminal_diagnostics=self._terminal_diagnostics,
-            hotkeys=format_hotkeys,
+            hotkeys=self._format_hotkeys,
             request_render=app.request_render,
             on_approval=on_approval,
             command_catalog=command_catalog,
@@ -115,6 +115,14 @@ class ScreenSurfaceManager(ScreenSurfaceWorkflow):
         if self.runtime is None:
             return self.session
         return current_agent_runtime_session(self.runtime, self.session)
+
+    def _format_hotkeys(self) -> str:
+        settings_manager = getattr(self._current_session(), "settings_manager", None)
+        get_keybindings = getattr(settings_manager, "get_keybindings", None)
+        return format_hotkeys(
+            get_keybindings() if callable(get_keybindings) else None,
+            capabilities=self.coding_app.state.input_capabilities,
+        )
 
     async def _build_settings_content(self) -> object:
         session = self._current_session()

--- a/src/loushang/harness/session/__init__.py
+++ b/src/loushang/harness/session/__init__.py
@@ -289,6 +289,8 @@ if TYPE_CHECKING:
         model_identity_data,
     )
     from loushang.harness.session.operations import (
+        SessionInputCapabilities,
+        SessionInputCapability,
         SessionLifecycleOperationPorts,
         SessionOperationAvailability,
         SessionOperationCapability,
@@ -527,6 +529,8 @@ _EXPORT_MODULES = {
     "SessionMaintenanceBinding": "loushang.harness.session.bindings",
     "SessionModelBinding": "loushang.harness.session.bindings",
     "SessionModelPort": "loushang.harness.session.facade_optional",
+    "SessionInputCapabilities": "loushang.harness.session.operations",
+    "SessionInputCapability": "loushang.harness.session.operations",
     "SessionPackagePort": "loushang.harness.session.facade_optional",
     "SessionOperationAvailability": "loushang.harness.session.operations",
     "SessionOperationCapability": "loushang.harness.session.operations",

--- a/src/loushang/harness/session/operations.py
+++ b/src/loushang/harness/session/operations.py
@@ -20,8 +20,6 @@ from loushang.harness.session.facade import (
     require_active_session_control,
 )
 
-SessionOperationResolver = Callable[[], "SessionOperationRuntime"]
-
 
 class SessionOperationCapability(str, Enum):
     """A coherent group of optional Product session operations."""
@@ -34,8 +32,44 @@ class SessionOperationCapability(str, Enum):
     MAINTENANCE = "maintenance"
 
 
+class SessionInputCapability(str, Enum):
+    """One input-delivery action guaranteed by a bound Harness session."""
+
+    STEER = "steer"
+    FOLLOW_UP = "follow_up"
+
+
 class SessionOperationUnavailableError(RuntimeError):
     """Raised when a Product did not bind an optional operation group."""
+
+
+@dataclass(frozen=True)
+class SessionInputCapabilities:
+    """Explicit input-delivery capabilities for one session binding."""
+
+    capabilities: frozenset[SessionInputCapability]
+
+    @classmethod
+    def standard(cls) -> "SessionInputCapabilities":
+        """Declare the steer and follow-up guarantees of the standard Session."""
+
+        return cls(frozenset(SessionInputCapability))
+
+    @classmethod
+    def from_capabilities(
+        cls,
+        capabilities: Iterable[SessionInputCapability],
+    ) -> "SessionInputCapabilities":
+        return cls(frozenset(capabilities))
+
+    def supports(self, capability: SessionInputCapability) -> bool:
+        return capability in self.capabilities
+
+    def require(self, capability: SessionInputCapability) -> None:
+        if not self.supports(capability):
+            raise SessionOperationUnavailableError(
+                f"Session input capability is unavailable: {capability.value}"
+            )
 
 
 @dataclass(frozen=True)
@@ -115,6 +149,7 @@ class SessionOperationRuntime:
         control: SessionControlPort,
         *,
         availability: SessionOperationAvailability | None = None,
+        input_capabilities: SessionInputCapabilities | None = None,
         lifecycle: SessionLifecycleOperationPorts | None = None,
     ) -> None:
         self._control = control
@@ -123,11 +158,22 @@ class SessionOperationRuntime:
             if availability is None
             else availability
         )
+        self._input_capabilities = (
+            SessionInputCapabilities.standard()
+            if input_capabilities is None
+            else input_capabilities
+        )
         self._lifecycle = lifecycle
 
     @property
     def availability(self) -> SessionOperationAvailability:
         return self._availability
+
+    @property
+    def input_capabilities(self) -> SessionInputCapabilities:
+        if not self._availability.supports(SessionOperationCapability.INPUT):
+            return SessionInputCapabilities.from_capabilities(())
+        return self._input_capabilities
 
     async def prompt(
         self,
@@ -203,10 +249,12 @@ class SessionOperationRuntime:
 
     def steer(self, text: str, *, images: Iterable[ImagePart] = ()) -> None:
         self._require(SessionOperationCapability.INPUT)
+        self._input_capabilities.require(SessionInputCapability.STEER)
         self._control.steer(text, images=list(images) or None)
 
     def follow_up(self, text: str, *, images: Iterable[ImagePart] = ()) -> None:
         self._require(SessionOperationCapability.INPUT)
+        self._input_capabilities.require(SessionInputCapability.FOLLOW_UP)
         self._control.follow_up(text, images=list(images) or None)
 
     @property
@@ -319,11 +367,43 @@ class SessionOperationRuntime:
         return self._lifecycle
 
 
+@dataclass(frozen=True)
+class SessionOperationResolver:
+    """Callable binding whose capabilities can be inspected without a Session.
+
+    Resolving operations may require an active Session and must therefore stay
+    lazy.  Capability declarations are immutable binding metadata, so Product
+    adapters can project them before a Session exists without crossing that
+    runtime boundary.
+    """
+
+    get_control: Callable[[], SessionControlPort]
+    lifecycle: SessionLifecycleOperationPorts | None = None
+    availability: SessionOperationAvailability | None = None
+    declared_input_capabilities: SessionInputCapabilities | None = None
+
+    @property
+    def input_capabilities(self) -> SessionInputCapabilities:
+        availability = self.availability or SessionOperationAvailability.standard()
+        if not availability.supports(SessionOperationCapability.INPUT):
+            return SessionInputCapabilities.from_capabilities(())
+        return self.declared_input_capabilities or SessionInputCapabilities.standard()
+
+    def __call__(self) -> SessionOperationRuntime:
+        return SessionOperationRuntime(
+            self.get_control(),
+            availability=self.availability,
+            input_capabilities=self.declared_input_capabilities,
+            lifecycle=self.lifecycle,
+        )
+
+
 def current_session_operation_resolver(
     runtime: object,
     *,
     lifecycle: SessionLifecycleOperationPorts | None = None,
     availability: SessionOperationAvailability | None = None,
+    input_capabilities: SessionInputCapabilities | None = None,
 ) -> SessionOperationResolver:
     """Build a resolver that never retains a control from a replaced Session."""
 
@@ -331,6 +411,7 @@ def current_session_operation_resolver(
         lambda: require_active_session_control(runtime),
         lifecycle=lifecycle,
         availability=availability,
+        input_capabilities=input_capabilities,
     )
 
 
@@ -339,20 +420,21 @@ def session_operation_resolver(
     *,
     lifecycle: SessionLifecycleOperationPorts | None = None,
     availability: SessionOperationAvailability | None = None,
+    input_capabilities: SessionInputCapabilities | None = None,
 ) -> SessionOperationResolver:
     """Build a resolver from a Product-owned current-control callback."""
 
-    def resolve() -> SessionOperationRuntime:
-        return SessionOperationRuntime(
-            get_control(),
-            availability=availability,
-            lifecycle=lifecycle,
-        )
-
-    return resolve
+    return SessionOperationResolver(
+        get_control=get_control,
+        lifecycle=lifecycle,
+        availability=availability,
+        declared_input_capabilities=input_capabilities,
+    )
 
 
 __all__ = [
+    "SessionInputCapabilities",
+    "SessionInputCapability",
     "SessionOperationResolver",
     "SessionOperationAvailability",
     "SessionOperationCapability",

--- a/src/loushang/harnesstui/conversation/agent_application.py
+++ b/src/loushang/harnesstui/conversation/agent_application.py
@@ -11,6 +11,8 @@ from loushang.harness.approval import ApprovalOutcome
 from loushang.harness.presentation import RenderableToolDefinition
 from loushang.harness.session import (
     SessionApprovalInteractionPort,
+    SessionInputCapabilities,
+    SessionInputCapability,
     SessionOperationResolver,
 )
 from loushang.harness.session.model_selection import (
@@ -37,6 +39,9 @@ from loushang.harnesstui.conversation.application_host import (
 )
 from loushang.harnesstui.conversation.control import ConversationActionHost
 from loushang.harnesstui.conversation.host import ConversationScreenRunProfile
+from loushang.harnesstui.conversation.input_policy import (
+    ConversationInputCapabilities,
+)
 from loushang.harnesstui.conversation.intents import (
     QuitIntent,
     parse_conversation_intent,
@@ -141,6 +146,15 @@ async def load_agent_conversation_startup_view(
     )
 
 
+def _project_session_input_capabilities(
+    declared: SessionInputCapabilities,
+) -> ConversationInputCapabilities:
+    return ConversationInputCapabilities(
+        steer=declared.supports(SessionInputCapability.STEER),
+        follow_up=declared.supports(SessionInputCapability.FOLLOW_UP),
+    )
+
+
 @dataclass(frozen=True, slots=True)
 class AgentScreenConversationApplicationBinding(Generic[SurfaceT]):
     """Prepare shared Agent screen state around Product UI components."""
@@ -198,6 +212,12 @@ class AgentScreenConversationApplicationBinding(Generic[SurfaceT]):
                 if queue == "steering"
                 else operations.get_follow_up_messages()
             )
+
+        input_capabilities = (
+            _project_session_input_capabilities(self.get_operations.input_capabilities)
+            if self.get_operations is not None
+            else ConversationInputCapabilities()
+        )
 
         def refresh_session_label() -> None:
             self.app.state.session_label = session_label(active_session())
@@ -261,6 +281,7 @@ class AgentScreenConversationApplicationBinding(Generic[SurfaceT]):
                 if settings_manager is not None
                 else None
             ),
+            input_capabilities=input_capabilities,
             history_records=history_records,
             transcript_source_factory=lambda: MaterializedTranscriptSource(
                 materialize_records=materialize_history,

--- a/src/loushang/harnesstui/conversation/application_host.py
+++ b/src/loushang/harnesstui/conversation/application_host.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol, TextIO
 
 from loushang.harnesstui.conversation.control import ConversationActionHost
 from loushang.harnesstui.conversation.host import (
     ConversationScreenRunProfile,
+)
+from loushang.harnesstui.conversation.input_policy import (
+    ConversationInputCapabilities,
 )
 from loushang.harnesstui.conversation.plain_app import PlainConversationApp
 from loushang.harnesstui.conversation.run_context import (
@@ -114,6 +117,9 @@ class PreparedScreenConversationRun:
     should_exit: ShouldExit
     trace: TraceFn
     keybindings: KeybindingManager | KeybindingConfig | None = None
+    input_capabilities: ConversationInputCapabilities = field(
+        default_factory=ConversationInputCapabilities
+    )
     history_records: tuple[DisplayRecord, ...] = ()
     transcript_source_factory: Callable[[], TranscriptSource] | None = None
     completion_provider: object | None = None
@@ -176,6 +182,7 @@ async def run_prepared_screen_conversation(
 
 
 def _install_screen_state(run: PreparedScreenConversationRun) -> None:
+    run.app.state.input_capabilities = run.input_capabilities
     run.app.transcript_source_factory = run.transcript_source_factory
     if run.history_records:
         run.app.replace_transcript_window(run.history_records, reason="resume")

--- a/src/loushang/harnesstui/conversation/input.py
+++ b/src/loushang/harnesstui/conversation/input.py
@@ -14,6 +14,13 @@ from loushang.harnesstui.conversation.attachments import (
     new_prompt_image_name_token,
     stage_clipboard_image,
 )
+from loushang.harnesstui.conversation.input_policy import (
+    CONVERSATION_FOLLOW_UP_ACTION,
+    DEFAULT_CONVERSATION_INPUT_POLICY,
+    ConversationInputPolicy,
+    RunningSubmitMode,
+    conversation_keybinding_manager,
+)
 from loushang.harnesstui.conversation.screen_state import ScreenConversationState
 from loushang.tui import Composer, SurfaceHost
 from loushang.tui.clipboard_image import read_clipboard_image
@@ -27,7 +34,6 @@ from loushang.tui.input import (
 )
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
 
-RunningSubmitMode = Literal["steer", "follow_up"]
 PromptImageAttachmentStager = Callable[[], PromptImageAttachmentOutcome]
 ClipboardOutcomePresenter = Callable[[PromptImageAttachmentOutcome], None]
 
@@ -101,8 +107,6 @@ class ClipboardImageInputRouterBuilder(Protocol):
         should_exit: Callable[[str], bool],
         is_local_command: Callable[[str], bool] = ...,
         keybindings: KeybindingManager | KeybindingConfig | None = ...,
-        running_submit_mode: RunningSubmitMode = ...,
-        follow_up_keys: tuple[str, ...] = ...,
         width: int = ...,
         height: int = ...,
         clipboard_image_reader: ClipboardImageReader = ...,
@@ -223,8 +227,7 @@ class ConversationInputRouter:
     should_exit: Callable[[str], bool]
     is_local_command: Callable[[str], bool] = lambda _text: False
     keybindings: KeybindingManager | KeybindingConfig | None = None
-    running_submit_mode: RunningSubmitMode = "steer"
-    follow_up_keys: tuple[str, ...] = ("alt+enter",)
+    policy: ConversationInputPolicy = DEFAULT_CONVERSATION_INPUT_POLICY
     width: int = 80
     height: int = 12
     prompt_image_stager: PromptImageAttachmentStager | None = None
@@ -238,8 +241,7 @@ class ConversationInputRouter:
     _composer_target: ComposerInputTarget = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        if not isinstance(self.keybindings, KeybindingManager):
-            self.keybindings = KeybindingManager(self.keybindings)
+        self.keybindings = conversation_keybinding_manager(self.keybindings)
         self._composer_target = ComposerInputTarget(self.app.composer)
 
     def replace_app(self, app: ConversationScreenInputPort) -> None:
@@ -360,7 +362,9 @@ class ConversationInputRouter:
                 visible_lines=self._composer_page_lines(),
             )
             return ConversationInputHandled()
-        if self.app.state.running and event.key in self.follow_up_keys:
+        if self.app.state.running and keybindings.matches(
+            event.key, CONVERSATION_FOLLOW_UP_ACTION
+        ):
             return self._submit_running(mode="follow_up")
         if keybindings.matches(event.key, "tui.input.newLine"):
             self.app.composer.insert_newline()
@@ -425,7 +429,12 @@ class ConversationInputRouter:
             self._clear_prompt_attachments()
             return ConversationLocalResult(text=text.strip())
         if self.app.state.running:
-            return self._submit_running(mode=self.running_submit_mode)
+            mode = self.policy.resolve_running_submit(self.app.state.input_capabilities)
+            return (
+                ConversationInputIgnored()
+                if mode is None
+                else self._submit_running(mode=mode)
+            )
         attachments = self._prompt_attachments_for_text(text)
         self.app.start_prompt(text)
         self._clear_prompt_attachments()
@@ -439,6 +448,8 @@ class ConversationInputRouter:
         *,
         mode: RunningSubmitMode,
     ) -> ConversationInputResult:
+        if not self.app.state.input_capabilities.supports(mode):
+            return ConversationInputIgnored()
         text = self.app.composer.value
         if not text.strip():
             return ConversationInputIgnored()
@@ -534,6 +545,8 @@ class ConversationInputRouter:
 
 def bind_clipboard_image_input_router(
     profile: ClipboardImageInputProfile,
+    *,
+    policy: ConversationInputPolicy = DEFAULT_CONVERSATION_INPUT_POLICY,
 ) -> ClipboardImageInputRouterBuilder:
     """Bind app-aware staging and status presentation to a router builder.
 
@@ -547,8 +560,6 @@ def bind_clipboard_image_input_router(
         should_exit: Callable[[str], bool],
         is_local_command: Callable[[str], bool] = lambda _text: False,
         keybindings: KeybindingManager | KeybindingConfig | None = None,
-        running_submit_mode: RunningSubmitMode = "steer",
-        follow_up_keys: tuple[str, ...] = ("alt+enter",),
         width: int = 80,
         height: int = 12,
         clipboard_image_reader: ClipboardImageReader = read_clipboard_image,
@@ -585,8 +596,7 @@ def bind_clipboard_image_input_router(
             should_exit=should_exit,
             is_local_command=is_local_command,
             keybindings=keybindings,
-            running_submit_mode=running_submit_mode,
-            follow_up_keys=follow_up_keys,
+            policy=policy,
             width=width,
             height=height,
             prompt_image_stager=stage_image,
@@ -611,6 +621,7 @@ __all__ = [
     "ConversationInputIgnored",
     "ConversationInputResult",
     "ConversationInputRouter",
+    "ConversationInputPolicy",
     "ConversationLocalResult",
     "ConversationPromptResult",
     "ConversationScreenInputPort",

--- a/src/loushang/harnesstui/conversation/input_policy.py
+++ b/src/loushang/harnesstui/conversation/input_policy.py
@@ -1,0 +1,73 @@
+"""Product-neutral policy and keybindings for Harness conversation input."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, TypeAlias
+
+from loushang.tui.keybindings import (
+    KeybindingConfig,
+    KeybindingManager,
+)
+
+RunningSubmitMode: TypeAlias = Literal["steer", "follow_up"]
+
+CONVERSATION_FOLLOW_UP_ACTION = "conversation.input.followUp"
+CONVERSATION_KEYBINDING_DEFINITIONS = {
+    CONVERSATION_FOLLOW_UP_ACTION: ("alt+enter",),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationInputCapabilities:
+    """Harness-declared input facts projected into the neutral TUI adapter."""
+
+    steer: bool = True
+    follow_up: bool = True
+
+    def supports(self, mode: RunningSubmitMode) -> bool:
+        return self.steer if mode == "steer" else self.follow_up
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationInputPolicy:
+    """Choose the primary running-submit action with a deterministic fallback."""
+
+    primary_running_submit: RunningSubmitMode = "steer"
+
+    def resolve_running_submit(
+        self,
+        capabilities: ConversationInputCapabilities,
+    ) -> RunningSubmitMode | None:
+        primary = self.primary_running_submit
+        if capabilities.supports(primary):
+            return primary
+        fallback: RunningSubmitMode = "follow_up" if primary == "steer" else "steer"
+        return fallback if capabilities.supports(fallback) else None
+
+
+DEFAULT_CONVERSATION_INPUT_POLICY = ConversationInputPolicy()
+
+
+def conversation_keybinding_manager(
+    keybindings: KeybindingManager | KeybindingConfig | None = None,
+) -> KeybindingManager:
+    """Compose conversation actions over generic keybinding definitions."""
+
+    manager = (
+        keybindings
+        if isinstance(keybindings, KeybindingManager)
+        else KeybindingManager(keybindings)
+    )
+    return manager.with_definitions(CONVERSATION_KEYBINDING_DEFINITIONS)
+
+
+__all__ = [
+    "CONVERSATION_FOLLOW_UP_ACTION",
+    "CONVERSATION_KEYBINDING_DEFINITIONS",
+    "ConversationInputCapabilities",
+    "ConversationInputPolicy",
+    "DEFAULT_CONVERSATION_INPUT_POLICY",
+    "RunningSubmitMode",
+    "conversation_keybinding_manager",
+]

--- a/src/loushang/harnesstui/conversation/screen_state.py
+++ b/src/loushang/harnesstui/conversation/screen_state.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 
+from loushang.harnesstui.conversation.input_policy import (
+    ConversationInputCapabilities,
+)
 from loushang.harnesstui.status.line import StatusLineSettings
 from loushang.tui.transcript import (
     AssistantMessageRecord,
@@ -35,6 +38,9 @@ class ScreenConversationState:
     active_started_at: float | None = None
     pending_followups: list[str] = field(default_factory=list)
     pending_steers: list[str] = field(default_factory=list)
+    input_capabilities: ConversationInputCapabilities = field(
+        default_factory=ConversationInputCapabilities
+    )
     interruption_message: str | None = None
     status_message: str | None = None
     model_label: str | None = None

--- a/src/loushang/tui/keybindings.py
+++ b/src/loushang/tui/keybindings.py
@@ -114,6 +114,15 @@ class KeybindingManager:
     def resolved(self) -> dict[KeybindingAction, tuple[KeyId, ...]]:
         return dict(self._resolved)
 
+    def with_definitions(
+        self,
+        definitions: Mapping[KeybindingAction, Sequence[KeyId]],
+    ) -> "KeybindingManager":
+        """Return a manager with additional actions and the same user overrides."""
+
+        merged = {**self._definitions, **definitions}
+        return KeybindingManager(self._user_bindings, definitions=merged)
+
     def _rebuild(self) -> None:
         claims: dict[KeyId, set[KeybindingAction]] = {}
         for action, keys in self._user_bindings.items():

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1909,6 +1909,7 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.harnesstui.conversation.control`" in text
     assert "`loushang.harnesstui.conversation.dispatch`" in text
     assert "`loushang.harnesstui.conversation.input`" in text
+    assert "`loushang.harnesstui.conversation.input_policy`" in text
     assert "`loushang.harnesstui.conversation.run_context`" in text
     assert "`loushang.harnesstui.conversation.screen_runner`" in text
     assert "`loushang.harnesstui.conversation.application_host`" in text
@@ -1961,6 +1962,7 @@ def test_harnesstui_capability_entrypoints_exist() -> None:
         Path("src/loushang/harnesstui/conversation/control.py"),
         Path("src/loushang/harnesstui/conversation/dispatch.py"),
         Path("src/loushang/harnesstui/conversation/input.py"),
+        Path("src/loushang/harnesstui/conversation/input_policy.py"),
         Path("src/loushang/harnesstui/conversation/plain_target.py"),
         Path("src/loushang/harnesstui/conversation/projection.py"),
         Path("src/loushang/harnesstui/conversation/queue.py"),
@@ -2024,6 +2026,7 @@ for module_name in (
     "loushang.harnesstui.conversation.control",
     "loushang.harnesstui.conversation.dispatch",
     "loushang.harnesstui.conversation.input",
+    "loushang.harnesstui.conversation.input_policy",
     "loushang.harnesstui.conversation.run_context",
     "loushang.harnesstui.conversation.screen_app",
     "loushang.harnesstui.conversation.screen_frame",
@@ -2054,6 +2057,25 @@ assert forbidden == [], forbidden
     )
 
     assert completed.returncode == 0, completed.stderr
+
+
+def test_conversation_input_policy_owns_actions_without_raw_router_keys() -> None:
+    policy_source = Path(
+        "src/loushang/harnesstui/conversation/input_policy.py"
+    ).read_text(encoding="utf-8")
+    router_source = Path(
+        "src/loushang/harnesstui/conversation/input.py"
+    ).read_text(encoding="utf-8")
+    tui_keybindings = Path("src/loushang/tui/keybindings.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'CONVERSATION_FOLLOW_UP_ACTION = "conversation.input.followUp"' in (
+        policy_source
+    )
+    assert "follow_up_keys" not in router_source
+    assert "running_submit_mode" not in router_source
+    assert "conversation.input.followUp" not in tui_keybindings
 
 
 def test_importing_catalog_interaction_entrypoints_stays_product_neutral() -> None:

--- a/tests/coding/test_screen_coding_tui_input.py
+++ b/tests/coding/test_screen_coding_tui_input.py
@@ -129,6 +129,30 @@ def test_screen_input_router_running_alt_enter_queues_followup() -> None:
     assert app.state.pending_followups == ["继续"]
 
 
+def test_screen_input_router_honors_product_followup_keybinding() -> None:
+    from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+    from loushang.coding.ui.screen_input import build_screen_input_router
+
+    app = ScreenCodingTuiApp(
+        model_label="kimi",
+        cwd="/repo",
+        branch="main",
+        session_label="abcd",
+        now=lambda: 12.0,
+    )
+    app.start_prompt("当前代码有啥？", started_at=10.0)
+    app.composer.set_text("继续")
+
+    result = build_screen_input_router(
+        app,
+        should_exit=lambda text: False,
+        keybindings={"conversation.input.followUp": ("ctrl+enter",)},
+    ).handle(InputEvent(kind="key", key="ctrl+enter"))
+
+    assert result == ConversationFollowupResult(text="继续")
+    assert app.state.pending_followups == ["继续"]
+
+
 def test_screen_input_router_escape_closes_completion_before_running_abort() -> None:
     from loushang.coding.ui.screen_app import ScreenCodingTuiApp
     from loushang.coding.ui.screen_input import build_screen_input_router

--- a/tests/coding/test_screen_coding_tui_surfaces.py
+++ b/tests/coding/test_screen_coding_tui_surfaces.py
@@ -17,6 +17,9 @@ from loushang.harness.multiagent import (
     MultiAgentControl,
 )
 from loushang.harnesstui.conversation.fork import ForkPromptSurface
+from loushang.harnesstui.conversation.input_policy import (
+    ConversationInputCapabilities,
+)
 from loushang.harnesstui.multiagent import AgentTreeSurface
 from loushang.harnesstui.selection.model import (
     ModelSelectorSurface as SharedModelSelectorSurface,
@@ -388,6 +391,26 @@ def test_screen_surface_manager_opens_non_model_surfaces_in_runtime_overlay_host
 
         manager.close_surface()
         assert app.surface_host.entries == []
+
+
+def test_screen_surface_manager_renders_resolved_conversation_hotkeys() -> None:
+    class CustomHotkeySession(_Session):
+        def get_keybindings(self) -> dict[str, tuple[str, ...]]:
+            return {"conversation.input.followUp": ("ctrl+enter",)}
+
+    app = _app()
+    app.surface_host = SurfaceHost()
+    app.state.input_capabilities = ConversationInputCapabilities(
+        steer=True,
+        follow_up=False,
+    )
+    manager = _manager(app, CustomHotkeySession())
+
+    asyncio.run(manager.handle_text("/hotkeys"))
+
+    text = "\n".join(_surface_plain_lines(_only_overlay_view(app)))
+    assert "Running Ctrl+Enter: follow-up unavailable" in text
+    assert "Running Alt+Enter: queue follow-up" not in text
 
 
 def test_screen_surface_manager_opens_resume_as_full_screen_continuity_page() -> None:

--- a/tests/coding/test_ui_hotkeys.py
+++ b/tests/coding/test_ui_hotkeys.py
@@ -16,3 +16,26 @@ def test_format_hotkeys_documents_current_inline_bindings() -> None:
         "Alt-Up: edit queued messages\n"
         "/quit or /exit: quit"
     )
+
+
+def test_format_hotkeys_uses_resolved_conversation_followup_binding() -> None:
+    from loushang.coding.ui.hotkeys import format_hotkeys
+
+    text = format_hotkeys({"conversation.input.followUp": ("ctrl+enter",)})
+
+    assert "Running Ctrl+Enter: queue follow-up" in text
+    assert "Running Alt+Enter: queue follow-up" not in text
+
+
+def test_format_hotkeys_reports_an_unavailable_followup_capability() -> None:
+    from loushang.coding.ui.hotkeys import format_hotkeys
+    from loushang.harnesstui.conversation.input_policy import (
+        ConversationInputCapabilities,
+    )
+
+    text = format_hotkeys(
+        capabilities=ConversationInputCapabilities(steer=True, follow_up=False)
+    )
+
+    assert "Running Enter: steer current run" in text
+    assert "Running Alt+Enter: follow-up unavailable" in text

--- a/tests/coding/test_ui_plain_app.py
+++ b/tests/coding/test_ui_plain_app.py
@@ -319,8 +319,14 @@ def test_build_plain_coding_tui_app_wires_info_panel_presenter() -> None:
         session_id = "sid"
         session_name = "session-name"
 
+        def __init__(self) -> None:
+            self.settings_manager = self
+
         def get_thinking_level(self) -> str:
             return "high"
+
+        def get_keybindings(self) -> dict[str, tuple[str, ...]]:
+            return {"conversation.input.followUp": ("ctrl+enter",)}
 
     class Renderer:
         def render_status(self, text: str) -> None:
@@ -365,6 +371,7 @@ def test_build_plain_coding_tui_app_wires_info_panel_presenter() -> None:
     assert emitted == []
     assert seen and seen[0].title == "Hotkeys"
     assert "Running Enter: steer current run" in seen[0].lines
+    assert "Running Ctrl+Enter: queue follow-up" in seen[0].lines
 
 
 class _Writer:

--- a/tests/harness/session/test_operations.py
+++ b/tests/harness/session/test_operations.py
@@ -6,6 +6,8 @@ import pytest
 
 from loushang.harness.runtime import SessionOperationResult
 from loushang.harness.session import (
+    SessionInputCapabilities,
+    SessionInputCapability,
     SessionLifecycleOperationPorts,
     SessionOperationAvailability,
     SessionOperationCapability,
@@ -14,6 +16,7 @@ from loushang.harness.session import (
     SessionPromptRequest,
     current_session_operation_resolver,
     require_active_session,
+    session_operation_resolver,
 )
 
 
@@ -218,6 +221,60 @@ def test_session_operation_runtime_rejects_unbound_operation_group() -> None:
     assert not runtime.availability.supports(SessionOperationCapability.MAINTENANCE)
     with pytest.raises(SessionOperationUnavailableError, match="maintenance"):
         runtime.abort_compaction()
+
+
+def test_session_operation_runtime_declares_standard_input_capabilities() -> None:
+    runtime = SessionOperationRuntime(_Control())
+
+    assert runtime.input_capabilities.supports(SessionInputCapability.STEER)
+    assert runtime.input_capabilities.supports(SessionInputCapability.FOLLOW_UP)
+
+
+def test_session_operation_runtime_enforces_declared_input_capabilities() -> None:
+    control = _Control()
+    runtime = SessionOperationRuntime(
+        control,
+        input_capabilities=SessionInputCapabilities.from_capabilities(
+            (SessionInputCapability.FOLLOW_UP,)
+        ),
+    )
+
+    runtime.follow_up("later")
+    with pytest.raises(SessionOperationUnavailableError, match="steer"):
+        runtime.steer("now")
+
+    assert control.follow_up_messages == [("later", None)]
+    assert control.steering == []
+
+
+def test_session_operation_runtime_hides_input_capabilities_without_input_group() -> (
+    None
+):
+    runtime = SessionOperationRuntime(
+        _Control(),
+        availability=SessionOperationAvailability.from_capabilities(
+            (SessionOperationCapability.MAINTENANCE,)
+        ),
+    )
+
+    assert runtime.input_capabilities.capabilities == frozenset()
+
+
+def test_session_operation_resolver_exposes_capabilities_without_resolving_control() -> (
+    None
+):
+    def fail_if_resolved() -> _Control:
+        raise AssertionError("capability inspection must not resolve control")
+
+    resolve = session_operation_resolver(
+        fail_if_resolved,
+        input_capabilities=SessionInputCapabilities.from_capabilities(
+            (SessionInputCapability.FOLLOW_UP,)
+        ),
+    )
+
+    assert not resolve.input_capabilities.supports(SessionInputCapability.STEER)
+    assert resolve.input_capabilities.supports(SessionInputCapability.FOLLOW_UP)
 
 
 def test_session_prompt_request_requires_non_empty_text() -> None:

--- a/tests/harnesstui/conversation/test_agent_application.py
+++ b/tests/harnesstui/conversation/test_agent_application.py
@@ -7,6 +7,11 @@ from typing import Any, cast
 
 from loushang.ai.model import ModelSelection
 from loushang.harness.commands import CommandDescriptor
+from loushang.harness.session import (
+    SessionInputCapabilities,
+    SessionInputCapability,
+    session_operation_resolver,
+)
 from loushang.harnesstui.conversation.agent_application import (
     AgentPlainConversationApplicationBinding,
     AgentScreenConversationApplicationBinding,
@@ -124,6 +129,48 @@ def test_agent_screen_application_binding_prepares_shared_state() -> None:
             },
         )
     ]
+
+
+def test_agent_screen_application_binding_projects_harness_input_capabilities() -> None:
+    session = _Session()
+
+    class App:
+        state = SimpleNamespace(running=False)
+
+        def set_statusline_settings(self, settings: object) -> None:
+            self.settings = settings
+
+    def fail_if_resolved() -> Any:
+        raise AssertionError("capability projection must not resolve a Session")
+
+    get_operations = session_operation_resolver(
+        fail_if_resolved,
+        input_capabilities=SessionInputCapabilities.from_capabilities(
+            (SessionInputCapability.FOLLOW_UP,)
+        ),
+    )
+    binding = AgentScreenConversationApplicationBinding(
+        session=session,
+        app=cast(Any, App()),
+        action_host=cast(Any, object()),
+        build_surface=lambda _status: _Surface(),
+        startup=_startup(),
+        interaction_context=cast(Any, nullcontext()),
+        profile=ConversationScreenRunProfile(
+            input_router_factory=None,
+            interruption_message="Interrupted",
+            cancellation_message="Cancelled",
+        ),
+        trace=lambda _name, **_data: None,
+        stdout=cast(Any, SimpleNamespace(write=lambda _value: None)),
+        now=lambda: 1.0,
+        get_operations=get_operations,
+    )
+
+    prepared = binding.prepare()
+
+    assert prepared.input_capabilities.steer is False
+    assert prepared.input_capabilities.follow_up is True
 
 
 def test_agent_screen_surface_ports_bind_structural_research_session() -> None:

--- a/tests/harnesstui/conversation/test_application_host.py
+++ b/tests/harnesstui/conversation/test_application_host.py
@@ -14,6 +14,9 @@ from loushang.harnesstui.conversation.application_host import (
     run_prepared_screen_conversation,
 )
 from loushang.harnesstui.conversation.host import ConversationScreenRunProfile
+from loushang.harnesstui.conversation.input_policy import (
+    ConversationInputCapabilities,
+)
 from loushang.harnesstui.conversation.screen_app import ScreenConversationApp
 from loushang.harnesstui.conversation.screen_frame import (
     ScreenFrameCopy,
@@ -155,6 +158,9 @@ def test_prepared_screen_host_installs_state_and_unwinds_in_reverse() -> None:
     async def screen_runner(**kwargs: Any) -> int:
         events.append("runner")
         assert kwargs["app"].state.records == [UserPromptRecord("old prompt")]
+        assert kwargs["app"].state.input_capabilities == (
+            ConversationInputCapabilities()
+        )
         assert kwargs["app"].transcript_source_factory is not None
         return 7
 

--- a/tests/harnesstui/conversation/test_clipboard_input.py
+++ b/tests/harnesstui/conversation/test_clipboard_input.py
@@ -14,6 +14,7 @@ from loushang.harnesstui.conversation.input import (
     ConversationFollowupResult,
     bind_clipboard_image_input_router,
 )
+from loushang.harnesstui.conversation.input_policy import ConversationInputPolicy
 from loushang.harnesstui.conversation.screen_state import ScreenConversationState
 from loushang.tui import Composer, InputEvent, SurfaceHost
 from loushang.tui.clipboard_image import ClipboardImage
@@ -149,14 +150,20 @@ def test_clipboard_image_status_copy_formats_every_neutral_outcome(
     )
 
 
-def test_clipboard_image_input_binding_forwards_router_policy() -> None:
+def test_clipboard_image_input_binding_closes_over_router_policy() -> None:
     app = _ConversationApp("/workspace")
     app.start_prompt("running")
     app.composer.set_text("later")
-    router = _builder()(
+    router = bind_clipboard_image_input_router(
+        ClipboardImageInputProfile(
+            directory=lambda current: Path(current.state.cwd) / "images",
+            display_root=lambda current: Path(current.state.cwd),
+            status_copy=_COPY,
+        ),
+        policy=ConversationInputPolicy(primary_running_submit="follow_up"),
+    )(
         app,
         should_exit=lambda _text: False,
-        running_submit_mode="follow_up",
     )
 
     result = router.handle(InputEvent(kind="key", key="enter"))

--- a/tests/harnesstui/conversation/test_input.py
+++ b/tests/harnesstui/conversation/test_input.py
@@ -20,6 +20,10 @@ from loushang.harnesstui.conversation.input import (
     ConversationPromptResult,
     ConversationSurfaceResult,
 )
+from loushang.harnesstui.conversation.input_policy import (
+    ConversationInputCapabilities,
+    ConversationInputPolicy,
+)
 from loushang.harnesstui.conversation.screen_state import ScreenConversationState
 from loushang.tui import Composer, InputEvent, InputIntent, SurfaceHost
 
@@ -153,6 +157,74 @@ def test_conversation_input_router_preserves_running_followup_priority(
     assert result.text == "@image.png later"
     assert result.attachments == (attachment,)
     assert app.state.pending_followups == ["@image.png later"]
+
+
+def test_conversation_input_router_defaults_running_submit_to_steer() -> None:
+    app = _ConversationApp()
+    app.start_prompt("question")
+    app.composer.set_text("now")
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+    )
+
+    result = router.handle(InputEvent(kind="key", key="enter"))
+
+    assert result.kind == "steer"
+    assert app.state.pending_steers == ["now"]
+
+
+def test_conversation_input_router_falls_back_to_followup_without_steer() -> None:
+    app = _ConversationApp()
+    app.state.input_capabilities = ConversationInputCapabilities(
+        steer=False,
+        follow_up=True,
+    )
+    app.start_prompt("question")
+    app.composer.set_text("later")
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+    )
+
+    result = router.handle(InputEvent(kind="key", key="enter"))
+
+    assert result == ConversationFollowupResult(text="later")
+    assert app.state.pending_followups == ["later"]
+
+
+def test_conversation_input_router_uses_configured_followup_action() -> None:
+    app = _ConversationApp()
+    app.start_prompt("question")
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+        keybindings={"conversation.input.followUp": ("ctrl+enter",)},
+    )
+
+    app.composer.set_text("line")
+    newline = router.handle(InputEvent(kind="key", key="alt+enter"))
+    app.composer.insert_text("later")
+    follow_up = router.handle(InputEvent(kind="key", key="ctrl+enter"))
+
+    assert isinstance(newline, ConversationInputHandled)
+    assert follow_up == ConversationFollowupResult(text="line\nlater")
+    assert app.state.pending_followups == ["line\nlater"]
+
+
+def test_conversation_input_router_accepts_a_product_primary_submit_override() -> None:
+    app = _ConversationApp()
+    app.start_prompt("question")
+    app.composer.set_text("later")
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+        policy=ConversationInputPolicy(primary_running_submit="follow_up"),
+    )
+
+    result = router.handle(InputEvent(kind="key", key="enter"))
+
+    assert result == ConversationFollowupResult(text="later")
 
 
 def test_conversation_input_router_routes_active_surface_before_composer() -> None:

--- a/tests/tui/test_input_routing.py
+++ b/tests/tui/test_input_routing.py
@@ -439,6 +439,16 @@ def test_keybinding_manager_matches_default_redo_key() -> None:
     assert not manager.matches("ctrl+shift+z", "tui.editor.redo")
 
 
+def test_keybinding_manager_extends_definitions_without_losing_user_overrides() -> None:
+    manager = KeybindingManager({"conversation.input.followUp": ("ctrl+enter",)})
+
+    extended = manager.with_definitions({"conversation.input.followUp": ("alt+enter",)})
+
+    assert manager.keys_for("conversation.input.followUp") == ()
+    assert extended.keys_for("conversation.input.followUp") == ("ctrl+enter",)
+    assert extended.keys_for("tui.input.submit") == ("enter",)
+
+
 def test_keybinding_manager_matches_terminal_underscore_undo_alias() -> None:
     manager = KeybindingManager()
 


### PR DESCRIPTION
## Summary

- declare and enforce steer and follow-up delivery capabilities in Harness, with lazy resolver metadata
- give HarnessTUI a steer-first running-submit policy with deterministic capability fallback and a semantic follow-up keybinding action
- keep generic TUI limited to keybinding composition, while Coding binds the default policy and renders resolved key/capability help
- update architecture and user documentation for the ownership boundary

## Behavior

- idle Enter submits a prompt
- running Enter steers when supported, otherwise falls back to follow-up
- running Alt+Enter explicitly queues follow-up by default
- idle Alt+Enter remains newline
- conversation.input.followUp can be overridden in keybinding settings
- Coding has one explicit policy binding point for a future product override

## Validation

- Harness lint and mypy passed
- Harness: 2219 passed, 4 skipped
- generic TUI: 1286 passed
- HarnessTUI/Coding: 1279 passed, 65 marker-deselected
- TUI render contracts: 168 passed
- affected-layer follow-up regression: 70 passed
- architecture ownership checks passed

Closes #477