### PR TITLE
refactor(harnesstui): compose keybinding catalogs

### DIFF
--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -101,6 +101,13 @@ Physical keys remain independently configurable: Enter is
 `tui.input.newLine`; `ConversationInputRouter` resolves the running-state
 priority.
 
+Keybinding defaults are composed by owner. Generic TUI provides the Core
+`TUI_CORE_KEYBINDING_CATALOG`; HarnessTUI adds conversation or continuity
+catalogs when those surfaces are constructed. Duplicate action definitions
+fail during catalog composition, while user overrides are retained until the
+owning catalog is available. Clipboard-image paste is the conversation action
+`conversation.input.pasteImage` (Ctrl+V by default).
+
 Composer selections use atom indexes. Normal text is split into grapheme-like
 text atoms; large paste markers are single atoms and are never split by range
 editing.
@@ -121,6 +128,11 @@ Only `composer` and `surface_host` remain positional. `width`, `height`,
 `keybindings`, and `target` are keyword-only. Legacy calls such as
 `InputRouter(composer, None, True)` now raise `TypeError` instead of silently
 binding `True` to `width`.
+
+The former `app.clipboard.pasteImage` setting is replaced by
+`conversation.input.pasteImage`. This pre-1.0 rename reflects that clipboard
+images are a shared HarnessTUI conversation capability rather than a Coding
+application action.
 
 ## Default Editing Keys
 

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -322,9 +322,12 @@ conversation Python package initializer.
 
 ## Conversation Interaction Control
 
-The reusable control plane for a full-screen conversation lives behind seven
+The reusable control plane for a full-screen conversation lives behind eight
 explicit entrypoints:
 
+- `loushang.harnesstui.conversation.clipboard_policy` owns the standard
+  workspace staging path and user-facing copy for conversation clipboard
+  images;
 - `loushang.harnesstui.conversation.input_policy` owns neutral projected input
   capabilities, steer-first/fallback policy, and conversation keybinding
   definitions;
@@ -353,14 +356,14 @@ Generic TUI emits only neutral prompt/editor signals and has no conversation
 running state.
 
 These modules build conversation interaction from neutral UI values. They do
-not own a Harness Session, persistence, runtime construction, Product intent
-classes, model-facing image types, workspace paths, command policy, or product
-copy. `ConversationRoutingProfile` receives the parser, exit predicate, local
-action mapping, follow-up projection, command effect resolver, and lifecycle
-as explicit callbacks, then compiles them into the existing
-`ConversationHostProfile`. In particular, Coding keeps `PromptIntent` and
-`BashIntent`, `ImagePart`, Session and observability setup, `.loushang` storage
-policy, and its interruption, queue, and error messages.
+not own a Harness Session, runtime construction, Product intent classes,
+model-facing image types, or command policy. `ConversationRoutingProfile`
+receives the parser, exit predicate, local action mapping, follow-up projection,
+command effect resolver, and lifecycle as explicit callbacks, then compiles
+them into the existing `ConversationHostProfile`. Harnesstui's standard
+clipboard profile owns `.loushang/clipboard` staging and generic outcome copy;
+Coding keeps `PromptIntent` and `BashIntent`, `ImagePart`, Session and
+observability setup, and its interruption, queue, and error messages.
 
 The action host is a dependency-inversion seam, not a second lifecycle or
 dispatch engine. Plain products may compose the existing run-control,
@@ -526,12 +529,12 @@ from being recreated accidentally.
 
 Coding's screen input binding now constructs the canonical
 `ConversationInputRouter` directly. Harnesstui keeps staged prompt images as
-neutral `PromptImageAttachment` values through routing and exposes clipboard
-outcomes through an optional product callback. Coding alone chooses the
-`.loushang/clipboard` workspace path, presents product status copy, and converts
-neutral attachments to `ImagePart` at the model-dispatch boundary. Its screen
-loop is a thin binding around `run_conversation_screen`; test-only aliases for
-shared runner and terminal helpers are not product APIs.
+neutral `PromptImageAttachment` values through routing, provides the standard
+workspace clipboard profile, and exposes clipboard outcomes through an optional
+caller callback. Coding consumes that shared profile and converts neutral
+attachments to `ImagePart` at the model-dispatch boundary. Its screen loop is a
+thin binding around `run_conversation_screen`; test-only aliases for shared
+runner and terminal helpers are not product APIs.
 
 Harness `SessionOperationRuntime` declares and enforces steering and follow-up
 input delivery through `SessionInputCapabilities`. The standard Agent binding
@@ -542,12 +545,14 @@ default and may bind another `ConversationInputPolicy` without changing the
 Harness capability declaration. Capability projection reads resolver binding
 metadata and must not resolve an active Session during application preparation.
 
-Harnesstui owns the `conversation.input.followUp` keybinding action and its
-Alt+Enter default. User keybinding settings may override the physical key,
-while running-state interpretation remains in `ConversationInputRouter`.
-Coding formats its hotkey help from the resolved keybindings instead of
-hard-coding Alt+Enter. Coding still supplies slash-command classification,
-final actions, and Product copy; the generic TUI router is not part of this
+Generic TUI exposes an immutable, duplicate-safe `KeybindingCatalog` and owns
+only its Core action definitions. Harnesstui composes separate conversation and
+continuity catalogs over Core. The conversation catalog owns
+`conversation.input.followUp`, `conversation.input.pasteImage`, and queue edit;
+the continuity catalog owns preview, domain, and sort. User settings remain raw
+until the applicable catalog is composed, so plugin actions can be configured
+without moving their defaults into TUI. Coding formats its hotkey help from the
+resolved conversation catalog. The generic TUI router is not part of this
 conversation state machine.
 
 ## Plain Conversation Presentation

--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-003-abort-steer-follow-up-sequence.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-003-abort-steer-follow-up-sequence.md
@@ -38,6 +38,13 @@ Physical keys remain separate from that capability policy. Generic
 Alt+Enter remains `tui.input.newLine`. The conversation router resolves that
 intentional overlap from explicit running state before newline handling.
 
+Default actions are composed through duplicate-safe `KeybindingCatalog`
+instances. Generic TUI owns the Core catalog; HarnessTUI owns the conversation
+catalog containing follow-up, queue edit, and
+`conversation.input.pasteImage`, plus a separate continuity catalog. Clipboard
+platform reads remain a TUI primitive, while the standard workspace staging
+profile and outcome copy belong to HarnessTUI rather than Coding.
+
 Pending follow-up and steering items are rendered in the pending queue area. The
 queue is transient bottom-frame UI and grows upward. Queued text remains visible
 until the product adapter reports it has been delivered, rejected, restored to

--- a/docs/superpowers/specs/2026-08-22-tui-harnesstui-input-ownership-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-22-tui-harnesstui-input-ownership-boundary-design.md
@@ -87,11 +87,13 @@ existing mechanical duplication where removing it would enlarge the change.
 - Do not remove legacy `steer`/`follow_up` members from the shared
   `InputIntentKind` envelope yet; stop the generic router from producing them.
 - Do not split `DEFAULT_KEYBINDINGS` into Core, HarnessTUI, and Product catalogs
-  yet.
+  in this tranche; follow-up #479 later introduced duplicate-safe catalog
+  composition.
 - Do not move approval, continuity, settings, dialog, question, or selection
   intent kinds between packages.
 - Do not change Coding slash-command classification, attachment conversion,
-  clipboard directory policy, or product copy.
+  clipboard directory policy, or product copy in this tranche; follow-up #479
+  later moved the standard clipboard profile and generic copy to HarnessTUI.
 - Do not change Harness Session, Agent loop, queue authority, or action host
   behavior.
 - Do not change any effective keyboard shortcut in the Coding conversation
@@ -350,7 +352,8 @@ conversation state.
 
 Deferred follow-ups:
 
-1. split Core, HarnessTUI, and Product keybinding definitions;
+1. split Core, HarnessTUI, and Product keybinding definitions — completed by
+   follow-up #479 for Core, conversation, and continuity catalogs;
 2. decide whether `InputIntentKind` should remain a shared structural envelope
    or split into narrower typed results;
 3. replace `ConversationInputResult`'s optional-field result bag only in a

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -86,6 +86,12 @@ Harnesstui 默认对运行中的普通提交采用 steer-first，并在 steer �
 follow-up 使用 `conversation.input.followUp`（默认 Alt+Enter）。空闲时 Alt+Enter
 仍按 `tui.input.newLine` 插入换行，运行态优先级由 `ConversationInputRouter` 解释。
 
+快捷键默认值按所有者组合。通用 TUI 提供 Core
+`TUI_CORE_KEYBINDING_CATALOG`；HarnessTUI 在构造会话或 continuity surface 时
+追加相应 catalog。重复 action 定义会在组合时直接失败，用户覆盖则保留到对应
+catalog 加载后再解析。剪贴板图片粘贴使用会话 action
+`conversation.input.pasteImage`（默认 Ctrl+V）。
+
 Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文本 atom；大型 paste marker 是单个 atom，range edit 不会把它拆开。
 
 ## Pre-1.0 InputRouter 迁移
@@ -103,6 +109,10 @@ Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文
 `keybindings` 和 `target` 都必须使用关键字。旧调用
 `InputRouter(composer, None, True)` 现在会抛出 `TypeError`，不会把 `True`
 静默绑定到 `width`。
+
+原 `app.clipboard.pasteImage` 配置已替换为
+`conversation.input.pasteImage`。这是一次 pre-1.0 重命名，用于明确剪贴板图片是
+HarnessTUI 公共会话能力，而不是 Coding 应用私有 action。
 
 ## 默认编辑快捷键
 

--- a/src/loushang/coding/ui/hotkeys.py
+++ b/src/loushang/coding/ui/hotkeys.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from loushang.coding.ui.screen_input import CODING_CONVERSATION_INPUT_POLICY
 from loushang.harnesstui.conversation.input_policy import (
     CONVERSATION_FOLLOW_UP_ACTION,
+    CONVERSATION_QUEUE_EDIT_LAST_ACTION,
     ConversationInputCapabilities,
     ConversationInputPolicy,
     conversation_keybinding_manager,
@@ -31,7 +32,7 @@ def format_hotkeys(
     )
     edit_queue_key = _action_key(
         manager,
-        "tui.queue.editLast",
+        CONVERSATION_QUEUE_EDIT_LAST_ACTION,
         separator="-",
     )
     primary_mode = policy.resolve_running_submit(capabilities)

--- a/src/loushang/coding/ui/screen_input.py
+++ b/src/loushang/coding/ui/screen_input.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import cast
 
 from loushang.harnesstui.conversation.host import ConversationScreenRunProfile
 from loushang.harnesstui.conversation.input import (
-    ClipboardImageInputProfile,
-    ClipboardImageStatusCopy,
     bind_clipboard_image_input_router,
 )
 from loushang.harnesstui.conversation.input_policy import (
@@ -21,23 +18,9 @@ CODING_INTERRUPTION_MESSAGE = (
 )
 CODING_CANCELLATION_MESSAGE = "Operation aborted"
 
-_CODING_CLIPBOARD_INPUT = ClipboardImageInputProfile(
-    directory=lambda app: Path(app.state.cwd) / ".loushang" / "clipboard",
-    display_root=lambda app: Path(app.state.cwd),
-    status_copy=ClipboardImageStatusCopy(
-        empty="No clipboard image found.",
-        read_error_prefix="Unable to read clipboard image: ",
-        unsupported_prefix="Unsupported clipboard image type: ",
-        write_error_prefix="Unable to attach clipboard image: ",
-        attached_prefix="Attached clipboard image: ",
-        unknown_type="unknown",
-    ),
-)
-
 CODING_CONVERSATION_INPUT_POLICY = DEFAULT_CONVERSATION_INPUT_POLICY
 
 build_screen_input_router = bind_clipboard_image_input_router(
-    _CODING_CLIPBOARD_INPUT,
     policy=CODING_CONVERSATION_INPUT_POLICY,
 )
 CODING_SCREEN_RUN_PROFILE = ConversationScreenRunProfile(

--- a/src/loushang/harnesstui/continuity/keybindings.py
+++ b/src/loushang/harnesstui/continuity/keybindings.py
@@ -1,0 +1,43 @@
+"""Keybinding catalog owned by HarnessTUI continuity surfaces."""
+
+from __future__ import annotations
+
+from loushang.tui.keybindings import (
+    KeybindingCatalog,
+    KeybindingConfig,
+    KeybindingManager,
+)
+
+CONTINUITY_PREVIEW_ACTION = "tui.continuity.preview"
+CONTINUITY_DOMAIN_ACTION = "tui.continuity.domain"
+CONTINUITY_SORT_ACTION = "tui.continuity.sort"
+
+CONTINUITY_KEYBINDING_DEFINITIONS = {
+    CONTINUITY_PREVIEW_ACTION: ("space",),
+    CONTINUITY_DOMAIN_ACTION: ("tab",),
+    CONTINUITY_SORT_ACTION: ("ctrl+s",),
+}
+CONTINUITY_KEYBINDING_CATALOG = KeybindingCatalog.from_definitions(
+    CONTINUITY_KEYBINDING_DEFINITIONS
+)
+
+
+def continuity_keybinding_manager(
+    keybindings: KeybindingManager | KeybindingConfig | None = None,
+) -> KeybindingManager:
+    manager = (
+        keybindings
+        if isinstance(keybindings, KeybindingManager)
+        else KeybindingManager(keybindings)
+    )
+    return manager.with_catalog(CONTINUITY_KEYBINDING_CATALOG)
+
+
+__all__ = [
+    "CONTINUITY_DOMAIN_ACTION",
+    "CONTINUITY_KEYBINDING_CATALOG",
+    "CONTINUITY_KEYBINDING_DEFINITIONS",
+    "CONTINUITY_PREVIEW_ACTION",
+    "CONTINUITY_SORT_ACTION",
+    "continuity_keybinding_manager",
+]

--- a/src/loushang/harnesstui/continuity/surface.py
+++ b/src/loushang/harnesstui/continuity/surface.py
@@ -17,6 +17,12 @@ from loushang.harness.continuity import (
     ContinuityTarget,
     StableContinuityReference,
 )
+from loushang.harnesstui.continuity.keybindings import (
+    CONTINUITY_DOMAIN_ACTION,
+    CONTINUITY_PREVIEW_ACTION,
+    CONTINUITY_SORT_ACTION,
+    continuity_keybinding_manager,
+)
 from loushang.harnesstui.surface.view import ScreenSurfaceView
 from loushang.tui import (
     CursorDeclaration,
@@ -91,11 +97,7 @@ class ContinuitySurface:
         self._theme = theme if theme is not None else CONTINUITY_PAGE_THEME
         self._include_summary = include_summary or (lambda _summary: True)
         self._selection_action = selection_action
-        self._keybindings = (
-            keybindings
-            if isinstance(keybindings, KeybindingManager)
-            else KeybindingManager(keybindings)
-        )
+        self._keybindings = continuity_keybinding_manager(keybindings)
         self._query = ContinuityQuery(page_size=page_size)
         self._summaries: list[ContinuitySummary] = []
         self._targets: dict[str, ContinuityTarget] = {}
@@ -277,12 +279,12 @@ class ContinuitySurface:
             f"{self._key_label('tui.select.cancel')} exit",
         ]
         if len(self._domain_options) > 1:
-            hints.append(f"{self._key_label('tui.continuity.domain')} domain")
+            hints.append(f"{self._key_label(CONTINUITY_DOMAIN_ACTION)} domain")
         if len(self._sort_options()) > 1:
-            hints.append(f"{self._key_label('tui.continuity.sort')} sort")
+            hints.append(f"{self._key_label(CONTINUITY_SORT_ACTION)} sort")
         hints.extend(
             (
-                f"{self._key_label('tui.continuity.preview')} preview",
+                f"{self._key_label(CONTINUITY_PREVIEW_ACTION)} preview",
                 f"{self._key_label('tui.select.up')}/"
                 f"{self._key_label('tui.select.down')} browse",
             )
@@ -683,9 +685,9 @@ class ContinuitySurface:
         if event.kind != "key":
             return event
         actions = (
-            ("tui.continuity.preview", "space"),
-            ("tui.continuity.domain", "tab"),
-            ("tui.continuity.sort", "ctrl+s"),
+            (CONTINUITY_PREVIEW_ACTION, "space"),
+            (CONTINUITY_DOMAIN_ACTION, "tab"),
+            (CONTINUITY_SORT_ACTION, "ctrl+s"),
             ("tui.select.confirm", "enter"),
             ("tui.select.cancel", "escape"),
             ("tui.select.up", "up"),

--- a/src/loushang/harnesstui/conversation/clipboard_policy.py
+++ b/src/loushang/harnesstui/conversation/clipboard_policy.py
@@ -1,0 +1,87 @@
+"""Shared policy for clipboard images attached to conversation prompts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from loushang.harnesstui.conversation.attachments import (
+    PromptImageAttachmentOutcome,
+)
+
+
+class ClipboardImageInputApp(Protocol):
+    @property
+    def state(self) -> object: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ClipboardImageStatusCopy:
+    """User-facing copy for neutral clipboard attachment outcomes."""
+
+    empty: str
+    read_error_prefix: str
+    unsupported_prefix: str
+    write_error_prefix: str
+    attached_prefix: str
+    unknown_type: str
+
+    def message(self, outcome: PromptImageAttachmentOutcome) -> str | None:
+        if outcome.kind == "empty":
+            return self.empty
+        if outcome.kind == "read_error":
+            return f"{self.read_error_prefix}{outcome.error_message}"
+        if outcome.kind == "unsupported":
+            return f"{self.unsupported_prefix}{outcome.mime_type or self.unknown_type}"
+        if outcome.kind == "write_error":
+            return f"{self.write_error_prefix}{outcome.error_message}"
+        if outcome.attachment is not None:
+            return f"{self.attached_prefix}{outcome.attachment.display_path}"
+        return None
+
+
+ClipboardImageAppPath = Callable[[ClipboardImageInputApp], Path | str]
+
+
+@dataclass(frozen=True, slots=True)
+class ClipboardImageInputProfile:
+    """Workspace and copy policy for shared conversation image input."""
+
+    directory: ClipboardImageAppPath
+    display_root: ClipboardImageAppPath
+    status_copy: ClipboardImageStatusCopy
+
+
+def _app_cwd(app: ClipboardImageInputApp) -> Path:
+    cwd = getattr(app.state, "cwd", None)
+    if not isinstance(cwd, str) or not cwd:
+        raise TypeError("Clipboard image input requires app.state.cwd")
+    return Path(cwd)
+
+
+STANDARD_CLIPBOARD_IMAGE_STATUS_COPY = ClipboardImageStatusCopy(
+    empty="No clipboard image found.",
+    read_error_prefix="Unable to read clipboard image: ",
+    unsupported_prefix="Unsupported clipboard image type: ",
+    write_error_prefix="Unable to attach clipboard image: ",
+    attached_prefix="Attached clipboard image: ",
+    unknown_type="unknown",
+)
+
+STANDARD_CLIPBOARD_IMAGE_INPUT_PROFILE = ClipboardImageInputProfile(
+    directory=lambda app: _app_cwd(app) / ".loushang" / "clipboard",
+    display_root=_app_cwd,
+    status_copy=STANDARD_CLIPBOARD_IMAGE_STATUS_COPY,
+)
+
+
+__all__ = [
+    "ClipboardImageAppPath",
+    "ClipboardImageInputApp",
+    "ClipboardImageInputProfile",
+    "ClipboardImageStatusCopy",
+    "STANDARD_CLIPBOARD_IMAGE_INPUT_PROFILE",
+    "STANDARD_CLIPBOARD_IMAGE_STATUS_COPY",
+]

--- a/src/loushang/harnesstui/conversation/input.py
+++ b/src/loushang/harnesstui/conversation/input.py
@@ -14,8 +14,15 @@ from loushang.harnesstui.conversation.attachments import (
     new_prompt_image_name_token,
     stage_clipboard_image,
 )
+from loushang.harnesstui.conversation.clipboard_policy import (
+    STANDARD_CLIPBOARD_IMAGE_INPUT_PROFILE,
+    ClipboardImageInputProfile,
+    ClipboardImageStatusCopy,
+)
 from loushang.harnesstui.conversation.input_policy import (
     CONVERSATION_FOLLOW_UP_ACTION,
+    CONVERSATION_PASTE_IMAGE_ACTION,
+    CONVERSATION_QUEUE_EDIT_LAST_ACTION,
     DEFAULT_CONVERSATION_INPUT_POLICY,
     ConversationInputPolicy,
     RunningSubmitMode,
@@ -61,45 +68,8 @@ class ClipboardImageConversationInputPort(ConversationScreenInputPort, Protocol)
     def set_status(self, message: str | None) -> None: ...
 
 
-@dataclass(frozen=True, slots=True)
-class ClipboardImageStatusCopy:
-    """Caller-supplied copy for neutral clipboard attachment outcomes."""
-
-    empty: str
-    read_error_prefix: str
-    unsupported_prefix: str
-    write_error_prefix: str
-    attached_prefix: str
-    unknown_type: str
-
-    def message(self, outcome: PromptImageAttachmentOutcome) -> str | None:
-        if outcome.kind == "empty":
-            return self.empty
-        if outcome.kind == "read_error":
-            return f"{self.read_error_prefix}{outcome.error_message}"
-        if outcome.kind == "unsupported":
-            return f"{self.unsupported_prefix}{outcome.mime_type or self.unknown_type}"
-        if outcome.kind == "write_error":
-            return f"{self.write_error_prefix}{outcome.error_message}"
-        if outcome.attachment is not None:
-            return f"{self.attached_prefix}{outcome.attachment.display_path}"
-        return None
-
-
-ClipboardImageAppPath = Callable[[ConversationScreenInputPort], Path | str]
-
-
-@dataclass(frozen=True, slots=True)
-class ClipboardImageInputProfile:
-    """Product policy injected into app-aware clipboard image routing."""
-
-    directory: ClipboardImageAppPath
-    display_root: ClipboardImageAppPath
-    status_copy: ClipboardImageStatusCopy
-
-
 class ClipboardImageInputRouterBuilder(Protocol):
-    """Construct a clipboard-enabled router from one bound product profile."""
+    """Construct a clipboard-enabled router from one bound workspace profile."""
 
     def __call__(
         self,
@@ -292,7 +262,7 @@ class ConversationInputRouter:
                 self._jump_mode = None
                 return ConversationInputHandled()
             self._jump_mode = None
-        if keybindings.matches(event.key, "tui.queue.editLast"):
+        if keybindings.matches(event.key, CONVERSATION_QUEUE_EDIT_LAST_ACTION):
             self._restore_queued_messages()
             return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.transcript.open"):
@@ -324,7 +294,7 @@ class ConversationInputRouter:
             if self.app.composer.has_completions:
                 self.app.composer.apply_selected_completion()
             return ConversationInputHandled()
-        if keybindings.matches(event.key, "app.clipboard.pasteImage"):
+        if keybindings.matches(event.key, CONVERSATION_PASTE_IMAGE_ACTION):
             return self._paste_clipboard_image()
         if keybindings.matches(event.key, "tui.editor.jumpForward"):
             self._jump_mode = "forward"
@@ -544,7 +514,7 @@ class ConversationInputRouter:
 
 
 def bind_clipboard_image_input_router(
-    profile: ClipboardImageInputProfile,
+    profile: ClipboardImageInputProfile = STANDARD_CLIPBOARD_IMAGE_INPUT_PROFILE,
     *,
     policy: ConversationInputPolicy = DEFAULT_CONVERSATION_INPUT_POLICY,
 ) -> ClipboardImageInputRouterBuilder:

--- a/src/loushang/harnesstui/conversation/input_policy.py
+++ b/src/loushang/harnesstui/conversation/input_policy.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
 from loushang.tui.keybindings import (
+    KeybindingCatalog,
     KeybindingConfig,
     KeybindingManager,
 )
@@ -13,9 +14,16 @@ from loushang.tui.keybindings import (
 RunningSubmitMode: TypeAlias = Literal["steer", "follow_up"]
 
 CONVERSATION_FOLLOW_UP_ACTION = "conversation.input.followUp"
+CONVERSATION_PASTE_IMAGE_ACTION = "conversation.input.pasteImage"
+CONVERSATION_QUEUE_EDIT_LAST_ACTION = "tui.queue.editLast"
 CONVERSATION_KEYBINDING_DEFINITIONS = {
     CONVERSATION_FOLLOW_UP_ACTION: ("alt+enter",),
+    CONVERSATION_PASTE_IMAGE_ACTION: ("ctrl+v",),
+    CONVERSATION_QUEUE_EDIT_LAST_ACTION: ("alt+up",),
 }
+CONVERSATION_KEYBINDING_CATALOG = KeybindingCatalog.from_definitions(
+    CONVERSATION_KEYBINDING_DEFINITIONS
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,12 +67,15 @@ def conversation_keybinding_manager(
         if isinstance(keybindings, KeybindingManager)
         else KeybindingManager(keybindings)
     )
-    return manager.with_definitions(CONVERSATION_KEYBINDING_DEFINITIONS)
+    return manager.with_catalog(CONVERSATION_KEYBINDING_CATALOG)
 
 
 __all__ = [
     "CONVERSATION_FOLLOW_UP_ACTION",
+    "CONVERSATION_KEYBINDING_CATALOG",
     "CONVERSATION_KEYBINDING_DEFINITIONS",
+    "CONVERSATION_PASTE_IMAGE_ACTION",
+    "CONVERSATION_QUEUE_EDIT_LAST_ACTION",
     "ConversationInputCapabilities",
     "ConversationInputPolicy",
     "DEFAULT_CONVERSATION_INPUT_POLICY",

--- a/src/loushang/tui/__init__.py
+++ b/src/loushang/tui/__init__.py
@@ -94,6 +94,8 @@ from loushang.tui.input import (
     sanitize_paste_text,
 )
 from loushang.tui.keybindings import (
+    TUI_CORE_KEYBINDING_CATALOG,
+    KeybindingCatalog,
     KeybindingConfig,
     KeybindingConflict,
     KeybindingManager,
@@ -476,6 +478,7 @@ __all__ = [
     "ImageProtocol",
     "ImageProtocolSelection",
     "InfoPanel",
+    "KeybindingCatalog",
     "KeybindingConfig",
     "KeybindingConflict",
     "KeybindingManager",
@@ -598,6 +601,7 @@ __all__ = [
     "TextField",
     "TextFormatter",
     "TextInput",
+    "TUI_CORE_KEYBINDING_CATALOG",
     "Toggle",
     "Toolbar",
     "ToolbarAction",

--- a/src/loushang/tui/keybindings.py
+++ b/src/loushang/tui/keybindings.py
@@ -6,9 +6,57 @@ from dataclasses import dataclass
 KeyId = str
 KeybindingAction = str
 KeybindingConfig = Mapping[KeybindingAction, KeyId | Sequence[KeyId] | None]
+KeybindingDefinitions = Mapping[KeybindingAction, KeyId | Sequence[KeyId]]
 
 
-DEFAULT_KEYBINDINGS: dict[KeybindingAction, tuple[KeyId, ...]] = {
+@dataclass(frozen=True, slots=True)
+class KeybindingCatalog:
+    """Immutable action definitions composed across package and plugin owners."""
+
+    entries: tuple[tuple[KeybindingAction, tuple[KeyId, ...]], ...]
+
+    def __post_init__(self) -> None:
+        seen: set[KeybindingAction] = set()
+        for action, _keys in self.entries:
+            if not action:
+                raise ValueError("Keybinding action ids must be non-empty")
+            if action in seen:
+                raise ValueError(
+                    f"Duplicate keybinding action definition: {action}"
+                )
+            seen.add(action)
+
+    @classmethod
+    def from_definitions(
+        cls,
+        definitions: KeybindingDefinitions,
+    ) -> "KeybindingCatalog":
+        return cls(
+            tuple(
+                (action, (keys,) if isinstance(keys, str) else tuple(keys))
+                for action, keys in definitions.items()
+            )
+        )
+
+    def definitions(self) -> dict[KeybindingAction, tuple[KeyId, ...]]:
+        return dict(self.entries)
+
+    def compose(self, *catalogs: "KeybindingCatalog") -> "KeybindingCatalog":
+        merged = self.definitions()
+        for catalog in catalogs:
+            for action, keys in catalog.entries:
+                if action in merged:
+                    raise ValueError(
+                        f"Duplicate keybinding action definition: {action}"
+                    )
+                merged[action] = keys
+        return KeybindingCatalog.from_definitions(merged)
+
+
+TUI_CORE_KEYBINDING_DEFINITIONS: dict[
+    KeybindingAction,
+    tuple[KeyId, ...],
+] = {
     "tui.editor.cursorUp": ("up",),
     "tui.editor.cursorDown": ("down",),
     "tui.editor.cursorLeft": ("left", "ctrl+b"),
@@ -42,18 +90,21 @@ DEFAULT_KEYBINDINGS: dict[KeybindingAction, tuple[KeyId, ...]] = {
     "tui.input.tab": ("tab",),
     "tui.input.copy": ("ctrl+c",),
     "tui.transcript.open": ("ctrl+o",),
-    "app.clipboard.pasteImage": ("ctrl+v",),
-    "tui.queue.editLast": ("alt+up",),
     "tui.select.up": ("up", "shift+tab"),
     "tui.select.down": ("down", "alt+down"),
     "tui.select.pageUp": ("pageUp",),
     "tui.select.pageDown": ("pageDown",),
     "tui.select.confirm": ("enter",),
     "tui.select.cancel": ("escape", "ctrl+c"),
-    "tui.continuity.preview": ("space",),
-    "tui.continuity.domain": ("tab",),
-    "tui.continuity.sort": ("ctrl+s",),
 }
+
+TUI_CORE_KEYBINDING_CATALOG = KeybindingCatalog.from_definitions(
+    TUI_CORE_KEYBINDING_DEFINITIONS
+)
+
+# Compatibility name for callers that consume the generic TUI defaults as a
+# mapping. Upper-layer actions intentionally do not belong in this mapping.
+DEFAULT_KEYBINDINGS = TUI_CORE_KEYBINDING_DEFINITIONS
 
 _MODIFIER_ORDER = ("ctrl", "shift", "alt", "super")
 _ALIASES = {
@@ -91,11 +142,24 @@ class KeybindingManager:
     def __init__(
         self,
         user_bindings: KeybindingConfig | None = None,
-        definitions: Mapping[KeybindingAction, Sequence[KeyId]] | None = None,
+        definitions: KeybindingDefinitions | None = None,
+        *,
+        catalog: KeybindingCatalog | None = None,
     ) -> None:
+        if definitions is not None and catalog is not None:
+            raise TypeError("Pass definitions or catalog, not both")
+        self._catalog = (
+            catalog
+            if catalog is not None
+            else (
+                TUI_CORE_KEYBINDING_CATALOG
+                if definitions is None
+                else KeybindingCatalog.from_definitions(definitions)
+            )
+        )
         self._definitions = {
             action: tuple(normalize_key_id(key) for key in keys)
-            for action, keys in (definitions or DEFAULT_KEYBINDINGS).items()
+            for action, keys in self._catalog.entries
         }
         self._user_bindings = dict(user_bindings or {})
         self._resolved: dict[KeybindingAction, tuple[KeyId, ...]] = {}
@@ -114,14 +178,39 @@ class KeybindingManager:
     def resolved(self) -> dict[KeybindingAction, tuple[KeyId, ...]]:
         return dict(self._resolved)
 
+    @property
+    def catalog(self) -> KeybindingCatalog:
+        return self._catalog
+
+    def with_catalog(self, catalog: KeybindingCatalog) -> "KeybindingManager":
+        """Compose an upper-layer catalog while preserving raw user overrides."""
+
+        current = self._catalog.definitions()
+        additions: dict[KeybindingAction, tuple[KeyId, ...]] = {}
+        for action, keys in catalog.entries:
+            if action not in current:
+                additions[action] = keys
+                continue
+            if current[action] != keys:
+                raise ValueError(
+                    f"Duplicate keybinding action definition: {action}"
+                )
+        if not additions:
+            return self
+        return KeybindingManager(
+            self._user_bindings,
+            catalog=self._catalog.compose(
+                KeybindingCatalog.from_definitions(additions)
+            ),
+        )
+
     def with_definitions(
         self,
-        definitions: Mapping[KeybindingAction, Sequence[KeyId]],
+        definitions: KeybindingDefinitions,
     ) -> "KeybindingManager":
         """Return a manager with additional actions and the same user overrides."""
 
-        merged = {**self._definitions, **definitions}
-        return KeybindingManager(self._user_bindings, definitions=merged)
+        return self.with_catalog(KeybindingCatalog.from_definitions(definitions))
 
     def _rebuild(self) -> None:
         claims: dict[KeyId, set[KeybindingAction]] = {}

--- a/tests/architecture/test_import_boundaries.py
+++ b/tests/architecture/test_import_boundaries.py
@@ -1906,6 +1906,7 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
     assert "`loushang.harnesstui.conversation.window_budget`" in text
     assert "`loushang.harnesstui.conversation.source`" in text
     assert "`loushang.harnesstui.conversation.attachments`" in text
+    assert "`loushang.harnesstui.conversation.clipboard_policy`" in text
     assert "`loushang.harnesstui.conversation.control`" in text
     assert "`loushang.harnesstui.conversation.dispatch`" in text
     assert "`loushang.harnesstui.conversation.input`" in text
@@ -1959,6 +1960,7 @@ def test_harnesstui_architecture_lists_stable_capability_entrypoints() -> None:
 def test_harnesstui_capability_entrypoints_exist() -> None:
     paths = (
         Path("src/loushang/harnesstui/conversation/attachments.py"),
+        Path("src/loushang/harnesstui/conversation/clipboard_policy.py"),
         Path("src/loushang/harnesstui/conversation/control.py"),
         Path("src/loushang/harnesstui/conversation/dispatch.py"),
         Path("src/loushang/harnesstui/conversation/input.py"),
@@ -2023,6 +2025,7 @@ import importlib
 import sys
 
 for module_name in (
+    "loushang.harnesstui.conversation.clipboard_policy",
     "loushang.harnesstui.conversation.control",
     "loushang.harnesstui.conversation.dispatch",
     "loushang.harnesstui.conversation.input",
@@ -2073,9 +2076,26 @@ def test_conversation_input_policy_owns_actions_without_raw_router_keys() -> Non
     assert 'CONVERSATION_FOLLOW_UP_ACTION = "conversation.input.followUp"' in (
         policy_source
     )
+    assert 'CONVERSATION_PASTE_IMAGE_ACTION = "conversation.input.pasteImage"' in (
+        policy_source
+    )
     assert "follow_up_keys" not in router_source
     assert "running_submit_mode" not in router_source
     assert "conversation.input.followUp" not in tui_keybindings
+    assert "conversation.input.pasteImage" not in tui_keybindings
+    assert "app.clipboard.pasteImage" not in tui_keybindings
+    assert "tui.queue.editLast" not in tui_keybindings
+    assert "tui.continuity.preview" not in tui_keybindings
+
+
+def test_coding_screen_input_does_not_own_clipboard_image_policy() -> None:
+    source = Path("src/loushang/coding/ui/screen_input.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "ClipboardImageInputProfile" not in source
+    assert "ClipboardImageStatusCopy" not in source
+    assert "_CODING_CLIPBOARD_INPUT" not in source
 
 
 def test_importing_catalog_interaction_entrypoints_stays_product_neutral() -> None:

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -833,7 +833,9 @@ def test_shared_interaction_types_are_not_redefined_in_coding_ui() -> None:
     assert offenders == []
 
 
-def test_shared_conversation_interaction_does_not_own_coding_policy_or_copy() -> None:
+def test_shared_conversation_interaction_separates_product_and_clipboard_policy() -> (
+    None
+):
     shared = "\n".join(
         Path(f"src/loushang/harnesstui/conversation/{module}.py").read_text(
             encoding="utf-8"
@@ -871,6 +873,9 @@ def test_shared_conversation_interaction_does_not_own_coding_policy_or_copy() ->
     screen_input = Path("src/loushang/coding/ui/screen_input.py").read_text(
         encoding="utf-8"
     )
+    clipboard_policy = Path(
+        "src/loushang/harnesstui/conversation/clipboard_policy.py"
+    ).read_text(encoding="utf-8")
     product_binding = Path("src/loushang/coding/ui/product_binding.py").read_text(
         encoding="utf-8"
     )
@@ -885,7 +890,10 @@ def test_shared_conversation_interaction_does_not_own_coding_policy_or_copy() ->
     assert "Operation aborted" in screen_input
     assert "ImagePart" not in screen_input
     assert "ImagePart" in product_binding
-    assert '".loushang" / "clipboard"' in screen_input
+    assert '".loushang" / "clipboard"' not in screen_input
+    assert '".loushang" / "clipboard"' in clipboard_policy
+    assert "Attached clipboard image: " in clipboard_policy
+    assert "ClipboardImageInputProfile" not in screen_input
     assert "class ScreenInputResult" not in screen_input
     assert "class ScreenInputRouter" not in screen_input
     assert "bind_clipboard_image_input_router(" in screen_input

--- a/tests/coding/ui/test_screen_input.py
+++ b/tests/coding/ui/test_screen_input.py
@@ -61,7 +61,7 @@ def test_coding_input_binding_follows_a_replaced_app(tmp_path: Path) -> None:
     )
 
 
-def test_coding_input_binding_preserves_product_clipboard_status_copy(
+def test_coding_input_binding_uses_shared_clipboard_status_copy(
     tmp_path: Path,
 ) -> None:
     def fail_to_read():

--- a/tests/harnesstui/continuity/test_surface.py
+++ b/tests/harnesstui/continuity/test_surface.py
@@ -21,6 +21,12 @@ from loushang.harnesstui.continuity import (
     build_continuity_surface_view,
     run_continuity_picker,
 )
+from loushang.harnesstui.continuity.keybindings import (
+    CONTINUITY_DOMAIN_ACTION,
+    CONTINUITY_PREVIEW_ACTION,
+    CONTINUITY_SORT_ACTION,
+    continuity_keybinding_manager,
+)
 from loushang.harnesstui.surface.controller import normalize_surface_intent
 from loushang.tui import (
     InputEvent,
@@ -35,6 +41,15 @@ from loushang.tui import (
 @dataclass
 class _Provider:
     descriptor: ContinuityProviderDescriptor
+
+
+def test_continuity_keybinding_catalog_owns_continuity_actions() -> None:
+    manager = continuity_keybinding_manager()
+
+    assert manager.keys_for(CONTINUITY_PREVIEW_ACTION) == ("space",)
+    assert manager.keys_for(CONTINUITY_DOMAIN_ACTION) == ("tab",)
+    assert manager.keys_for(CONTINUITY_SORT_ACTION) == ("ctrl+s",)
+    assert continuity_keybinding_manager(manager) is manager
 
 
 def _reference(hub: "_Hub") -> StableContinuityReference:

--- a/tests/harnesstui/conversation/test_clipboard_input.py
+++ b/tests/harnesstui/conversation/test_clipboard_input.py
@@ -7,6 +7,9 @@ from loushang.harnesstui.conversation.attachments import (
     PromptImageAttachment,
     PromptImageAttachmentOutcome,
 )
+from loushang.harnesstui.conversation.clipboard_policy import (
+    STANDARD_CLIPBOARD_IMAGE_INPUT_PROFILE,
+)
 from loushang.harnesstui.conversation.input import (
     ClipboardImageInputProfile,
     ClipboardImageStatusCopy,
@@ -68,6 +71,56 @@ def _builder():
             status_copy=_COPY,
         )
     )
+
+
+def test_standard_clipboard_image_profile_is_harnesstui_owned(
+    tmp_path: Path,
+) -> None:
+    app = _ConversationApp(str(tmp_path))
+    assert STANDARD_CLIPBOARD_IMAGE_INPUT_PROFILE.status_copy.attached_prefix == (
+        "Attached clipboard image: "
+    )
+    router = bind_clipboard_image_input_router()(
+        app,
+        should_exit=lambda _text: False,
+        clipboard_image_reader=lambda: ClipboardImage(
+            bytes=b"png",
+            mime_type="image/png",
+        ),
+        clipboard_image_name_factory=lambda: "shared",
+    )
+
+    result = router.handle(InputEvent(kind="key", key="ctrl+v"))
+
+    expected = tmp_path / ".loushang" / "clipboard" / "clipboard-shared.png"
+    assert expected.read_bytes() == b"png"
+    assert isinstance(result, ConversationClipboardResult)
+    assert app.composer.value == "@.loushang/clipboard/clipboard-shared.png "
+    assert app.statuses == [
+        "Attached clipboard image: .loushang/clipboard/clipboard-shared.png"
+    ]
+
+
+def test_clipboard_image_uses_the_conversation_action_override(
+    tmp_path: Path,
+) -> None:
+    app = _ConversationApp(str(tmp_path))
+    router = _builder()(
+        app,
+        should_exit=lambda _text: False,
+        keybindings={"conversation.input.pasteImage": ("ctrl+p",)},
+        clipboard_image_reader=lambda: ClipboardImage(
+            bytes=b"png",
+            mime_type="image/png",
+        ),
+        clipboard_image_name_factory=lambda: "override",
+    )
+
+    ignored = router.handle(InputEvent(kind="key", key="ctrl+v"))
+    attached = router.handle(InputEvent(kind="key", key="ctrl+p"))
+
+    assert ignored.kind == "ignored"
+    assert isinstance(attached, ConversationClipboardResult)
 
 
 def test_clipboard_image_input_binding_follows_the_replaced_app(

--- a/tests/harnesstui/conversation/test_input.py
+++ b/tests/harnesstui/conversation/test_input.py
@@ -21,8 +21,12 @@ from loushang.harnesstui.conversation.input import (
     ConversationSurfaceResult,
 )
 from loushang.harnesstui.conversation.input_policy import (
+    CONVERSATION_FOLLOW_UP_ACTION,
+    CONVERSATION_PASTE_IMAGE_ACTION,
+    CONVERSATION_QUEUE_EDIT_LAST_ACTION,
     ConversationInputCapabilities,
     ConversationInputPolicy,
+    conversation_keybinding_manager,
 )
 from loushang.harnesstui.conversation.screen_state import ScreenConversationState
 from loushang.tui import Composer, InputEvent, InputIntent, SurfaceHost
@@ -50,6 +54,21 @@ class _ConversationApp:
 
     def queue_steer(self, text: str) -> None:
         self.state.queue_steer(text)
+
+
+def test_conversation_keybinding_catalog_owns_conversation_actions() -> None:
+    manager = conversation_keybinding_manager()
+
+    assert manager.keys_for(CONVERSATION_FOLLOW_UP_ACTION) == ("alt+enter",)
+    assert manager.keys_for(CONVERSATION_PASTE_IMAGE_ACTION) == ("ctrl+v",)
+    assert manager.keys_for(CONVERSATION_QUEUE_EDIT_LAST_ACTION) == ("alt+up",)
+    assert manager.keys_for("app.clipboard.pasteImage") == ()
+
+
+def test_conversation_keybinding_catalog_is_idempotent_for_bound_managers() -> None:
+    manager = conversation_keybinding_manager()
+
+    assert conversation_keybinding_manager(manager) is manager
 
 
 def _attachment(tmp_path: Path, *, name: str = "image") -> PromptImageAttachment:

--- a/tests/tui/test_input_routing.py
+++ b/tests/tui/test_input_routing.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 import pytest
 
 from loushang.tui import (
+    TUI_CORE_KEYBINDING_CATALOG,
     CommandSurface,
     CompletionItem,
     CompletionProvider,
@@ -16,6 +17,7 @@ from loushang.tui import (
     InputIntent,
     InputReader,
     InputRouter,
+    KeybindingCatalog,
     KeybindingConflict,
     KeybindingManager,
     RenderConstraints,
@@ -420,7 +422,6 @@ def test_keybinding_manager_normalizes_legacy_alt_arrow_aliases() -> None:
 
     assert manager.matches("alt_left", "tui.editor.cursorWordLeft")
     assert manager.matches("alt_right", "tui.editor.cursorWordRight")
-    assert manager.matches("alt_up", "tui.queue.editLast")
     assert manager.matches("alt_down", "tui.select.down")
 
 
@@ -447,6 +448,56 @@ def test_keybinding_manager_extends_definitions_without_losing_user_overrides() 
     assert manager.keys_for("conversation.input.followUp") == ()
     assert extended.keys_for("conversation.input.followUp") == ("ctrl+enter",)
     assert extended.keys_for("tui.input.submit") == ("enter",)
+
+
+def test_keybinding_catalog_composes_plugin_actions_with_user_overrides() -> None:
+    plugin_catalog = KeybindingCatalog.from_definitions(
+        {"plugin.action": "ctrl+p"}
+    )
+    catalog = TUI_CORE_KEYBINDING_CATALOG.compose(plugin_catalog)
+    manager = KeybindingManager(
+        {"plugin.action": ("alt+p",)},
+        catalog=catalog,
+    )
+
+    assert manager.keys_for("tui.input.submit") == ("enter",)
+    assert manager.keys_for("plugin.action") == ("alt+p",)
+
+
+def test_composed_catalog_reports_cross_owner_user_binding_conflicts() -> None:
+    catalog = TUI_CORE_KEYBINDING_CATALOG.compose(
+        KeybindingCatalog.from_definitions({"plugin.action": ("ctrl+p",)})
+    )
+    manager = KeybindingManager(
+        {
+            "tui.input.submit": ("ctrl+p",),
+            "plugin.action": ("ctrl+p",),
+        },
+        catalog=catalog,
+    )
+
+    assert manager.conflicts() == (
+        KeybindingConflict(
+            key="ctrl+p",
+            action_ids=("plugin.action", "tui.input.submit"),
+        ),
+    )
+
+
+def test_keybinding_catalog_rejects_duplicate_action_ownership() -> None:
+    first = KeybindingCatalog.from_definitions({"plugin.action": ("ctrl+p",)})
+    second = KeybindingCatalog.from_definitions({"plugin.action": ("alt+p",)})
+
+    with pytest.raises(ValueError, match="plugin.action"):
+        first.compose(second)
+
+
+def test_tui_core_keybinding_catalog_excludes_upper_layer_actions() -> None:
+    manager = KeybindingManager()
+
+    assert manager.keys_for("conversation.input.pasteImage") == ()
+    assert manager.keys_for("tui.queue.editLast") == ()
+    assert manager.keys_for("tui.continuity.preview") == ()
 
 
 def test_keybinding_manager_matches_terminal_underscore_undo_alias() -> None:


### PR DESCRIPTION
## Summary

- introduce an immutable, duplicate-safe TUI keybinding catalog and preserve raw user overrides across catalog composition
- move conversation and continuity action defaults out of the generic TUI catalog into HarnessTUI-owned catalogs
- move the standard clipboard-image staging profile and generic status copy from Coding into HarnessTUI while keeping OS clipboard reads in TUI
- rename the pre-1.0 clipboard action to conversation.input.pasteImage and document the ownership boundary

## Validation

- make lint-harnesstui typecheck-tui typecheck-harnesstui check-architecture-docs
- make test-tui: 1290 passed
- make test-harnesstui: 1286 passed, 65 deselected by marker
- make test-tui-render-contract: 168 passed

Closes #479