### PR TITLE
refactor(tui): share prompt routing primitives

### DIFF
--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -126,6 +126,18 @@ Harness Plugin declarations stay independent of TUI; only an owning
 presentation adapter may translate an admitted declaration into an
 `InputIntent[str]`.
 
+Prompt editing mechanics are shared below the two routers. Neutral helpers in
+`loushang.tui.input` apply text or character jumps, paste text, force explicit
+Tab completion, and perform vertical/history/page navigation. They mutate only
+the supplied editor target and return no TUI or conversation intent. Each
+router keeps its existing ordering and translates a handled action into its
+own result: generic `InputRouter` returns no intent, while
+`ConversationInputRouter` returns `ConversationInputHandled`.
+
+Submit, cancel, resize, surface routing, clipboard images, local commands,
+completion Enter, and running steer/follow-up policy are deliberately not part
+of those shared helpers because their ordering or meaning differs by owner.
+
 Composer selections use atom indexes. Normal text is split into grapheme-like
 text atoms; large paste markers are single atoms and are never split by range
 editing.

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -105,6 +105,17 @@ catalog 加载后再解析。剪贴板图片粘贴使用会话 action
 有意接受任意字符串。未来的 Harness Plugin 声明不依赖 TUI；只有承担所有权的
 presentation adapter 才能在准入后把声明转换为 `InputIntent[str]`。
 
+两个 Router 下方共享 Prompt 编辑机械。`loushang.tui.input` 中的中立 helper
+负责普通文本或字符跳转、粘贴、显式 Tab completion，以及垂直移动、历史和翻页。
+它们只修改传入的 editor target，不产生 TUI intent 或 conversation result。
+两个 Router 各自保留原有分支顺序，并把“已处理”转换为自己的结果：通用
+`InputRouter` 不返回 intent，`ConversationInputRouter` 返回
+`ConversationInputHandled`。
+
+提交、取消、resize、surface 路由、剪贴板图片、本地命令、completion Enter，
+以及运行中的 steer/follow-up 策略不会进入这些共享 helper，因为它们的顺序或
+含义由不同所有者决定。
+
 Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文本 atom；大型 paste marker 是单个 atom，range edit 不会把它拆开。
 
 ## Pre-1.0 InputRouter 迁移

--- a/src/loushang/harnesstui/conversation/input.py
+++ b/src/loushang/harnesstui/conversation/input.py
@@ -35,9 +35,15 @@ from loushang.tui.input import (
     ComposerInputTarget,
     InputEvent,
     InputIntent,
+    PromptJumpDirection,
+    apply_prompt_paste,
+    apply_prompt_text,
+    prompt_jump_direction_for_key,
     route_editor_editing_key,
     route_editor_selection_key,
     route_prompt_completion_key,
+    route_prompt_explicit_completion_key,
+    route_prompt_vertical_navigation_key,
 )
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
 
@@ -202,7 +208,7 @@ class ConversationInputRouter:
     height: int = 12
     prompt_image_stager: PromptImageAttachmentStager | None = None
     clipboard_outcome_presenter: ClipboardOutcomePresenter | None = None
-    _jump_mode: Literal["forward", "backward"] | None = None
+    _jump_mode: PromptJumpDirection | None = None
     _pending_prompt_images: PendingPromptImageRegistry = field(
         default_factory=PendingPromptImageRegistry,
         init=False,
@@ -228,18 +234,16 @@ class ConversationInputRouter:
         if self.app.active_surface is not None:
             return self._route_active_surface(event)
         if event.kind == "text":
-            if self._jump_mode is not None:
-                self.app.composer.jump_to_char(
-                    event.text,
-                    direction=self._jump_mode,
-                )
-                self._jump_mode = None
-                return ConversationInputHandled()
-            self.app.composer.insert_text(event.text)
+            apply_prompt_text(
+                self._composer_target,
+                event.text,
+                jump_direction=self._jump_mode,
+            )
+            self._jump_mode = None
             return ConversationInputHandled()
         if event.kind == "paste":
             self._jump_mode = None
-            self.app.composer.paste(event.text)
+            apply_prompt_paste(self._composer_target, event.text)
             return ConversationInputHandled()
         if event.kind == "resize":
             if event.columns:
@@ -251,14 +255,12 @@ class ConversationInputRouter:
             return ConversationInputIgnored()
 
         keybindings = self._keybindings()
+        jump_direction = prompt_jump_direction_for_key(
+            event.key,
+            keybindings=keybindings,
+        )
         if self._jump_mode is not None:
-            if keybindings.matches(
-                event.key,
-                "tui.editor.jumpForward",
-            ) or keybindings.matches(
-                event.key,
-                "tui.editor.jumpBackward",
-            ):
+            if jump_direction is not None:
                 self._jump_mode = None
                 return ConversationInputHandled()
             self._jump_mode = None
@@ -282,55 +284,32 @@ class ConversationInputRouter:
             "tui.input.submit",
         ):
             return self._submit_selected_completion()
-        if self.app.composer.has_completions and self._route_completion_key(
-            event,
-            keybindings,
+        if self.app.composer.has_completions and route_prompt_completion_key(
+            self._composer_target,
+            event.key,
+            keybindings=keybindings,
         ):
             return ConversationInputHandled()
         if keybindings.matches(event.key, "tui.select.cancel"):
             return self._abort_or_clear()
-        if keybindings.matches(event.key, "tui.input.tab"):
-            self.app.composer.refresh_completions(force=True, explicit=True)
-            if self.app.composer.has_completions:
-                self.app.composer.apply_selected_completion()
+        if route_prompt_explicit_completion_key(
+            self._composer_target,
+            event.key,
+            keybindings=keybindings,
+        ):
             return ConversationInputHandled()
         if keybindings.matches(event.key, CONVERSATION_PASTE_IMAGE_ACTION):
             return self._paste_clipboard_image()
-        if keybindings.matches(event.key, "tui.editor.jumpForward"):
-            self._jump_mode = "forward"
+        if jump_direction is not None:
+            self._jump_mode = jump_direction
             return ConversationInputHandled()
-        if keybindings.matches(event.key, "tui.editor.jumpBackward"):
-            self._jump_mode = "backward"
-            return ConversationInputHandled()
-        if keybindings.matches(event.key, "tui.editor.cursorUp"):
-            if self.app.composer.browsing_history:
-                self.app.composer.history_previous()
-            elif (
-                not self.app.composer.value
-                or not self.app.composer.move_visual_up(width=self.width)
-            ):
-                self.app.composer.history_previous()
-            return ConversationInputHandled()
-        if keybindings.matches(event.key, "tui.editor.cursorDown"):
-            if self.app.composer.browsing_history:
-                self.app.composer.history_next()
-            elif (
-                not self.app.composer.value
-                or not self.app.composer.move_visual_down(width=self.width)
-            ):
-                self.app.composer.history_next()
-            return ConversationInputHandled()
-        if keybindings.matches(event.key, "tui.editor.pageUp"):
-            self.app.composer.move_visual_page_up(
-                width=self.width,
-                visible_lines=self._composer_page_lines(),
-            )
-            return ConversationInputHandled()
-        if keybindings.matches(event.key, "tui.editor.pageDown"):
-            self.app.composer.move_visual_page_down(
-                width=self.width,
-                visible_lines=self._composer_page_lines(),
-            )
+        if route_prompt_vertical_navigation_key(
+            self._composer_target,
+            event.key,
+            keybindings=keybindings,
+            width=self.width,
+            height=self.height,
+        ):
             return ConversationInputHandled()
         if self.app.state.running and keybindings.matches(
             event.key, CONVERSATION_FOLLOW_UP_ACTION
@@ -348,17 +327,6 @@ class ConversationInputRouter:
         ):
             return ConversationInputHandled()
         return ConversationInputIgnored()
-
-    def _route_completion_key(
-        self,
-        event: InputEvent,
-        keybindings: KeybindingManager,
-    ) -> bool:
-        return route_prompt_completion_key(
-            self._composer_target,
-            event.key,
-            keybindings=keybindings,
-        )
 
     def _submit_selected_completion(self) -> ConversationInputResult:
         should_submit_after_completion = self.app.composer.value.lstrip().startswith(
@@ -443,9 +411,6 @@ class ConversationInputRouter:
         if isinstance(self.keybindings, KeybindingManager):
             return self.keybindings
         return KeybindingManager(self.keybindings)
-
-    def _composer_page_lines(self) -> int:
-        return max(2, min(10, self.height))
 
     def _route_active_surface(self, event: InputEvent) -> ConversationInputResult:
         handler = getattr(self.app.active_surface, "handle_input", None)

--- a/src/loushang/tui/input.py
+++ b/src/loushang/tui/input.py
@@ -14,6 +14,7 @@ _InputIntentKindT = TypeVar("_InputIntentKindT", bound=str, covariant=True)
 # Temporary import-path compatibility; production annotations use precise envelopes.
 InputIntentKind: TypeAlias = str
 PromptInputIntentKind: TypeAlias = Literal["submit", "prompt_cancel", "invalidate_render"]
+PromptJumpDirection: TypeAlias = Literal["forward", "backward"]
 KeyEventType = Literal["press", "repeat", "release"]
 
 ESC = "\x1b"
@@ -374,7 +375,7 @@ class PromptInputTarget(EditorInputTarget, Protocol):
 
     def move_visual_page_down(self, *, width: int, visible_lines: int) -> None: ...
 
-    def jump_to_char(self, text: str, *, direction: Literal["forward", "backward"]) -> None: ...
+    def jump_to_char(self, text: str, *, direction: PromptJumpDirection) -> None: ...
 
     def refresh_completions(self, *, force: bool = False, explicit: bool = False) -> None: ...
 
@@ -502,7 +503,7 @@ class ComposerInputTarget:
     def move_visual_page_down(self, *, width: int, visible_lines: int) -> None:
         self.composer.move_visual_page_down(width=width, visible_lines=visible_lines)
 
-    def jump_to_char(self, text: str, *, direction: Literal["forward", "backward"]) -> None:
+    def jump_to_char(self, text: str, *, direction: PromptJumpDirection) -> None:
         self.composer.jump_to_char(text, direction=direction)
 
     def refresh_completions(self, *, force: bool = False, explicit: bool = False) -> None:
@@ -697,7 +698,7 @@ class InputRouter:
     height: int = 24
     keybindings: KeybindingManager | None = None
     target: InitVar[PromptInputTarget | None] = None
-    _jump_mode: Literal["forward", "backward"] | None = field(default=None, init=False)
+    _jump_mode: PromptJumpDirection | None = field(default=None, init=False)
     _target: PromptInputTarget = field(init=False, repr=False)
 
     def __post_init__(self, target: PromptInputTarget | None) -> None:
@@ -718,12 +719,13 @@ class InputRouter:
         if event.kind == "key":
             keybindings = self._keybindings()
             is_cancel = keybindings.matches(event.key, "tui.select.cancel")
+            jump_direction = prompt_jump_direction_for_key(
+                event.key,
+                keybindings=keybindings,
+            )
             cancelled_pending_jump = False
             if self._jump_mode is not None:
-                if keybindings.matches(event.key, "tui.editor.jumpForward") or keybindings.matches(
-                    event.key,
-                    "tui.editor.jumpBackward",
-                ):
+                if jump_direction is not None:
                     self._jump_mode = None
                     if not is_cancel:
                         return ()
@@ -750,33 +752,27 @@ class InputRouter:
                 if cancelled_pending_jump:
                     return ()
                 return (_prompt_input_intent("prompt_cancel"),)
-            if keybindings.matches(event.key, "tui.editor.jumpForward"):
-                self._jump_mode = "forward"
+            if jump_direction is not None:
+                self._jump_mode = jump_direction
                 return ()
-            if keybindings.matches(event.key, "tui.editor.jumpBackward"):
-                self._jump_mode = "backward"
-                return ()
-            if keybindings.matches(event.key, "tui.input.tab"):
-                target.refresh_completions(force=True, explicit=True)
-                if target.has_completions:
-                    target.apply_selected_completion()
+            if route_prompt_explicit_completion_key(
+                target,
+                event.key,
+                keybindings=keybindings,
+            ):
                 return ()
             if keybindings.matches(event.key, "tui.input.submit"):
                 return self.submit()
             if keybindings.matches(event.key, "tui.input.newLine"):
                 target.insert_newline()
                 return ()
-            if keybindings.matches(event.key, "tui.editor.cursorUp"):
-                self._move_up_or_history()
-                return ()
-            if keybindings.matches(event.key, "tui.editor.cursorDown"):
-                self._move_down_or_history()
-                return ()
-            if keybindings.matches(event.key, "tui.editor.pageUp"):
-                target.move_visual_page_up(width=self.width, visible_lines=self._composer_page_lines())
-                return ()
-            if keybindings.matches(event.key, "tui.editor.pageDown"):
-                target.move_visual_page_down(width=self.width, visible_lines=self._composer_page_lines())
+            if route_prompt_vertical_navigation_key(
+                target,
+                event.key,
+                keybindings=keybindings,
+                width=self.width,
+                height=self.height,
+            ):
                 return ()
             if route_editor_editing_key(target, event.key, keybindings=keybindings):
                 return ()
@@ -789,13 +785,17 @@ class InputRouter:
                 return ()
             focused_target = self._focused_editor_target()
             if focused_target is not None:
-                focused_target.paste(event.text)
+                apply_prompt_paste(focused_target, event.text)
                 return ()
-            target.paste(event.text)
+            apply_prompt_paste(target, event.text)
             return ()
         if event.kind == "text":
             if self._jump_mode is not None:
-                target.jump_to_char(event.text, direction=self._jump_mode)
+                apply_prompt_text(
+                    target,
+                    event.text,
+                    jump_direction=self._jump_mode,
+                )
                 self._jump_mode = None
                 return ()
             surface_route = self._route_surface_first(event)
@@ -807,7 +807,7 @@ class InputRouter:
             if focused_target is not None:
                 focused_target.insert_text(event.text)
                 return ()
-            target.insert_text(event.text)
+            apply_prompt_text(target, event.text)
             return ()
         if event.kind == "resize" or (event.kind == "signal" and event.signal == "sigwinch"):
             return (_prompt_input_intent("invalidate_render"),)
@@ -848,27 +848,10 @@ class InputRouter:
         target = current()
         return cast(EditorInputTarget, target) if target is not None else None
 
-    def _move_up_or_history(self) -> None:
-        target = self._target
-        if target.browsing_history:
-            target.history_previous()
-        elif not target.value or not target.move_visual_up(width=self.width):
-            target.history_previous()
-
-    def _move_down_or_history(self) -> None:
-        target = self._target
-        if target.browsing_history:
-            target.history_next()
-        elif not target.value or not target.move_visual_down(width=self.width):
-            target.history_next()
-
     def _keybindings(self) -> KeybindingManager:
         if self.keybindings is None:
             self.keybindings = KeybindingManager()
         return self.keybindings
-
-    def _composer_page_lines(self) -> int:
-        return max(2, min(10, self.height))
 
 
 def _input_intents(result: object) -> tuple[InputIntent[str], ...]:
@@ -925,6 +908,81 @@ def _split_paste_payload_and_pending_end_marker(text: str) -> tuple[str, str]:
         if BRACKETED_PASTE_END.startswith(suffix):
             return text[:-length], suffix
     return text, ""
+
+
+def prompt_jump_direction_for_key(
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> PromptJumpDirection | None:
+    keybindings = keybindings or KeybindingManager()
+    if keybindings.matches(key, "tui.editor.jumpForward"):
+        return "forward"
+    if keybindings.matches(key, "tui.editor.jumpBackward"):
+        return "backward"
+    return None
+
+
+def apply_prompt_text(
+    target: PromptInputTarget,
+    text: str,
+    *,
+    jump_direction: PromptJumpDirection | None = None,
+) -> None:
+    if jump_direction is not None:
+        target.jump_to_char(text, direction=jump_direction)
+        return
+    target.insert_text(text)
+
+
+def apply_prompt_paste(target: EditorInputTarget, text: str) -> None:
+    target.paste(text)
+
+
+def route_prompt_explicit_completion_key(
+    target: PromptInputTarget,
+    key: str,
+    *,
+    keybindings: KeybindingManager | None = None,
+) -> bool:
+    keybindings = keybindings or KeybindingManager()
+    if not keybindings.matches(key, "tui.input.tab"):
+        return False
+    target.refresh_completions(force=True, explicit=True)
+    if target.has_completions:
+        target.apply_selected_completion()
+    return True
+
+
+def route_prompt_vertical_navigation_key(
+    target: PromptInputTarget,
+    key: str,
+    *,
+    width: int,
+    height: int,
+    keybindings: KeybindingManager | None = None,
+) -> bool:
+    keybindings = keybindings or KeybindingManager()
+    if keybindings.matches(key, "tui.editor.cursorUp"):
+        if target.browsing_history:
+            target.history_previous()
+        elif not target.value or not target.move_visual_up(width=width):
+            target.history_previous()
+        return True
+    if keybindings.matches(key, "tui.editor.cursorDown"):
+        if target.browsing_history:
+            target.history_next()
+        elif not target.value or not target.move_visual_down(width=width):
+            target.history_next()
+        return True
+    visible_lines = max(2, min(10, height))
+    if keybindings.matches(key, "tui.editor.pageUp"):
+        target.move_visual_page_up(width=width, visible_lines=visible_lines)
+        return True
+    if keybindings.matches(key, "tui.editor.pageDown"):
+        target.move_visual_page_down(width=width, visible_lines=visible_lines)
+        return True
+    return False
 
 
 def route_editor_editing_key(

--- a/tests/harnesstui/conversation/test_input.py
+++ b/tests/harnesstui/conversation/test_input.py
@@ -285,6 +285,33 @@ def test_conversation_input_router_keeps_exit_and_local_policy_injected() -> Non
     assert app.state.running is False
 
 
+def test_conversation_input_router_translates_shared_prompt_editing_to_handled() -> None:
+    app = _ConversationApp()
+    app.composer.add_history("history")
+    app.composer.insert_text("abc def")
+    app.composer.move_to_line_start()
+    router = ConversationInputRouter(
+        app=app,
+        should_exit=lambda _text: False,
+        width=7,
+        height=3,
+    )
+
+    jump = router.handle(InputEvent(kind="key", key="ctrl+]"))
+    jump_text = router.handle(InputEvent(kind="text", text="d"))
+    paste = router.handle(InputEvent(kind="paste", text="!"))
+    page = router.handle(InputEvent(kind="key", key="pageDown"))
+
+    app.composer.clear()
+    history = router.handle(InputEvent(kind="key", key="up"))
+
+    assert all(
+        isinstance(result, ConversationInputHandled)
+        for result in (jump, jump_text, paste, page, history)
+    )
+    assert app.composer.value == "history"
+
+
 def test_conversation_input_router_handles_local_command_while_run_is_active() -> None:
     app = _ConversationApp()
     app.start_prompt("question")

--- a/tests/tui/test_input_routing.py
+++ b/tests/tui/test_input_routing.py
@@ -30,8 +30,13 @@ from loushang.tui import (
     TextInput,
 )
 from loushang.tui.input import (
+    apply_prompt_paste,
+    apply_prompt_text,
+    prompt_jump_direction_for_key,
     route_editor_editing_key,
     route_editor_selection_key,
+    route_prompt_explicit_completion_key,
+    route_prompt_vertical_navigation_key,
 )
 
 
@@ -634,6 +639,87 @@ def test_editor_key_helpers_route_to_target_operations() -> None:
     assert route_editor_selection_key(target, "shift+left")
 
     assert target.calls == ["move_left", "select_char_left"]
+
+
+def test_prompt_text_and_paste_primitives_apply_only_editor_mechanics() -> None:
+    target = FakePromptTarget()
+
+    apply_prompt_text(target, "alpha")
+    apply_prompt_text(target, "x", jump_direction="forward")
+    apply_prompt_paste(target, "beta\ngamma")
+
+    assert target.calls == [
+        "insert_text:alpha",
+        "jump_to_char:forward:x",
+        "paste:beta\ngamma",
+    ]
+
+
+def test_prompt_jump_direction_uses_configured_core_actions() -> None:
+    keybindings = KeybindingManager(
+        {
+            "tui.editor.jumpForward": ("alt+f",),
+            "tui.editor.jumpBackward": ("alt+b",),
+        }
+    )
+
+    assert prompt_jump_direction_for_key("alt+f", keybindings=keybindings) == "forward"
+    assert prompt_jump_direction_for_key("alt+b", keybindings=keybindings) == "backward"
+    assert prompt_jump_direction_for_key("enter", keybindings=keybindings) is None
+
+
+def test_prompt_explicit_completion_primitive_refreshes_before_applying() -> None:
+    target = FakePromptTarget()
+
+    assert not route_prompt_explicit_completion_key(target, "enter")
+    assert route_prompt_explicit_completion_key(target, "tab")
+    assert target.calls == [
+        "refresh_completions:True:True",
+        "apply_selected_completion",
+    ]
+
+
+def test_prompt_vertical_navigation_primitive_handles_history_and_pages() -> None:
+    target = FakePromptTarget(value="draft")
+
+    assert route_prompt_vertical_navigation_key(
+        target,
+        "up",
+        width=7,
+        height=3,
+    )
+    target.browsing_history = True
+    assert route_prompt_vertical_navigation_key(
+        target,
+        "down",
+        width=7,
+        height=3,
+    )
+    assert route_prompt_vertical_navigation_key(
+        target,
+        "pageUp",
+        width=7,
+        height=3,
+    )
+    assert route_prompt_vertical_navigation_key(
+        target,
+        "pageDown",
+        width=7,
+        height=1,
+    )
+    assert not route_prompt_vertical_navigation_key(
+        target,
+        "enter",
+        width=7,
+        height=3,
+    )
+    assert target.calls == [
+        "move_visual_up:7",
+        "history_previous",
+        "history_next",
+        "move_visual_page_up:7:3",
+        "move_visual_page_down:7:2",
+    ]
 
 
 def test_input_router_alt_angle_moves_to_line_boundaries() -> None:


### PR DESCRIPTION
## Summary

- extract conversation-neutral prompt editing primitives for text/jump application, paste, configured jump-key recognition, explicit Tab completion, and vertical/history/page navigation
- reuse those primitives from both generic InputRouter and HarnessTUI ConversationInputRouter
- keep each router responsible for branch ordering and for translating a handled edit into its own result type
- add direct primitive tests, HarnessTUI result-translation regression coverage, and English/Chinese ownership documentation

## Ownership preserved

The shared helpers mutate only the supplied editor target and return bool, direction, or None. They do not construct InputIntent or ConversationInputResult and do not understand running state.

The following remain owner-specific and in their original order: submit, cancel, resize, surface routing, completion Enter, clipboard images, local commands, abort/clear, and steer/follow-up policy.

No tracking issue was created, following the user request for this refactor sequence.

## Validation

- focused baseline before changes: 136 passed
- focused TUI/HarnessTUI/Coding regression after changes: 141 passed
- TUI mypy: 90 source files, no issues
- HarnessTUI/Coding-boundary mypy: 142 source files, no issues
- TUI and HarnessTUI Ruff: passed
- architecture dependency check and diff check: passed
- full sandbox-safe suite, run outside the managed sandbox: 7930 passed, 19 skipped, 3 failed

Two failures are the unchanged legacy-007 and legacy-019 offline example baseline. The third was an unrelated Harness JSONL load performance budget under full-suite system load; its exact test passed immediately when rerun alone outside the sandbox. No performance threshold or unrelated Harness code was changed.