### PR TITLE
refactor(harnesstui): unify input router factory contract

### DIFF
--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -138,6 +138,13 @@ Submit, cancel, resize, surface routing, clipboard images, local commands,
 completion Enter, and running steer/follow-up policy are deliberately not part
 of those shared helpers because their ordering or meaning differs by owner.
 
+Production conversation-router construction uses one standard factory contract
+owned with HarnessTUI conversation input and re-exported by the screen runner.
+The clipboard-enabled builder is a compatible extension that only exposes
+optional environment and test dependencies. Product adapters bind their policy
+and profile, then pass that factory directly without a type cast. This contract
+is an input-composition seam; it does not define a plugin lifecycle.
+
 Composer selections use atom indexes. Normal text is split into grapheme-like
 text atoms; large paste markers are single atoms and are never split by range
 editing.

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -116,6 +116,12 @@ presentation adapter 才能在准入后把声明转换为 `InputIntent[str]`。
 以及运行中的 steer/follow-up 策略不会进入这些共享 helper，因为它们的顺序或
 含义由不同所有者决定。
 
+生产环境中的会话 Router 构造只使用一个标准 Factory 契约。该契约与
+HarnessTUI 会话输入放在同一 owner 中，并由 screen runner 重导出。带剪贴板
+能力的 Builder 是兼容扩展，只额外暴露可选的环境与测试依赖。产品适配器绑定
+自己的策略和 profile 后直接传入该 Factory，不再使用类型强制转换。这个契约
+只是输入装配接缝，并不定义插件生命周期。
+
 Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文本 atom；大型 paste marker 是单个 atom，range edit 不会把它拆开。
 
 ## Pre-1.0 InputRouter 迁移

--- a/src/loushang/coding/ui/screen_input.py
+++ b/src/loushang/coding/ui/screen_input.py
@@ -1,16 +1,11 @@
 from __future__ import annotations
 
-from typing import cast
-
 from loushang.harnesstui.conversation.host import ConversationScreenRunProfile
 from loushang.harnesstui.conversation.input import (
     bind_clipboard_image_input_router,
 )
 from loushang.harnesstui.conversation.input_policy import (
     DEFAULT_CONVERSATION_INPUT_POLICY,
-)
-from loushang.harnesstui.conversation.screen_runner import (
-    ConversationInputRouterFactoryPort,
 )
 
 CODING_INTERRUPTION_MESSAGE = (
@@ -24,10 +19,7 @@ build_screen_input_router = bind_clipboard_image_input_router(
     policy=CODING_CONVERSATION_INPUT_POLICY,
 )
 CODING_SCREEN_RUN_PROFILE = ConversationScreenRunProfile(
-    input_router_factory=cast(
-        ConversationInputRouterFactoryPort,
-        build_screen_input_router,
-    ),
+    input_router_factory=build_screen_input_router,
     interruption_message=CODING_INTERRUPTION_MESSAGE,
     cancellation_message=CODING_CANCELLATION_MESSAGE,
 )

--- a/src/loushang/harnesstui/conversation/input.py
+++ b/src/loushang/harnesstui/conversation/input.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Protocol, TypeAlias, cast
+from typing import Literal, Protocol, TypeAlias
 
 from loushang.harnesstui.conversation.attachments import (
     ClipboardImageNameFactory,
@@ -66,29 +66,6 @@ class ConversationScreenInputPort(Protocol):
     def queue_followup(self, text: str) -> None: ...
 
     def queue_steer(self, text: str) -> None: ...
-
-
-class ClipboardImageConversationInputPort(ConversationScreenInputPort, Protocol):
-    """Conversation input surface capable of presenting clipboard status."""
-
-    def set_status(self, message: str | None) -> None: ...
-
-
-class ClipboardImageInputRouterBuilder(Protocol):
-    """Construct a clipboard-enabled router from one bound workspace profile."""
-
-    def __call__(
-        self,
-        app: ClipboardImageConversationInputPort,
-        should_exit: Callable[[str], bool],
-        is_local_command: Callable[[str], bool] = ...,
-        keybindings: KeybindingManager | KeybindingConfig | None = ...,
-        width: int = ...,
-        height: int = ...,
-        clipboard_image_reader: ClipboardImageReader = ...,
-        clipboard_image_dir: Path | str | None = ...,
-        clipboard_image_name_factory: ClipboardImageNameFactory = ...,
-    ) -> ConversationInputRouter: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -193,6 +170,44 @@ ConversationInputResult: TypeAlias = (
     | ConversationAbortResult
     | ConversationExitResult
 )
+
+
+class ConversationInputRouterPort(Protocol):
+    """Route one decoded terminal input event to a conversation result."""
+
+    def handle(self, event: InputEvent) -> ConversationInputResult: ...
+
+
+class ConversationInputRouterFactoryPort(Protocol):
+    """Construct a product-neutral conversation input adapter."""
+
+    def __call__(
+        self,
+        *,
+        app: ConversationScreenInputPort,
+        should_exit: Callable[[str], bool],
+        is_local_command: Callable[[str], bool],
+        keybindings: KeybindingManager | KeybindingConfig | None,
+        width: int,
+        height: int,
+    ) -> ConversationInputRouterPort: ...
+
+
+class ClipboardImageInputRouterBuilder(ConversationInputRouterFactoryPort, Protocol):
+    """Standard router factory with optional clipboard test dependencies."""
+
+    def __call__(
+        self,
+        app: ConversationScreenInputPort,
+        should_exit: Callable[[str], bool],
+        is_local_command: Callable[[str], bool] = ...,
+        keybindings: KeybindingManager | KeybindingConfig | None = ...,
+        width: int = ...,
+        height: int = ...,
+        clipboard_image_reader: ClipboardImageReader = ...,
+        clipboard_image_dir: Path | str | None = ...,
+        clipboard_image_name_factory: ClipboardImageNameFactory = ...,
+    ) -> ConversationInputRouter: ...
 
 
 @dataclass(slots=True)
@@ -491,7 +506,7 @@ def bind_clipboard_image_input_router(
     """
 
     def build(
-        app: ClipboardImageConversationInputPort,
+        app: ConversationScreenInputPort,
         should_exit: Callable[[str], bool],
         is_local_command: Callable[[str], bool] = lambda _text: False,
         keybindings: KeybindingManager | KeybindingConfig | None = None,
@@ -505,8 +520,8 @@ def bind_clipboard_image_input_router(
     ) -> ConversationInputRouter:
         router: ConversationInputRouter
 
-        def current_app() -> ClipboardImageConversationInputPort:
-            return cast(ClipboardImageConversationInputPort, router.app)
+        def current_app() -> ConversationScreenInputPort:
+            return router.app
 
         def stage_image() -> PromptImageAttachmentOutcome:
             bound_app = current_app()
@@ -524,7 +539,7 @@ def bind_clipboard_image_input_router(
         def present_outcome(outcome: PromptImageAttachmentOutcome) -> None:
             message = profile.status_copy.message(outcome)
             if message is not None:
-                current_app().set_status(message)
+                current_app().state.set_status(message)
 
         router = ConversationInputRouter(
             app=app,
@@ -543,7 +558,6 @@ def bind_clipboard_image_input_router(
 
 
 __all__ = [
-    "ClipboardImageConversationInputPort",
     "ClipboardImageInputProfile",
     "ClipboardImageInputRouterBuilder",
     "ClipboardImageStatusCopy",
@@ -556,6 +570,8 @@ __all__ = [
     "ConversationInputIgnored",
     "ConversationInputResult",
     "ConversationInputRouter",
+    "ConversationInputRouterFactoryPort",
+    "ConversationInputRouterPort",
     "ConversationInputPolicy",
     "ConversationLocalResult",
     "ConversationPromptResult",

--- a/src/loushang/harnesstui/conversation/screen_runner.py
+++ b/src/loushang/harnesstui/conversation/screen_runner.py
@@ -16,6 +16,8 @@ from loushang.harnesstui.conversation.input import (
     ConversationInputIgnored,
     ConversationInputResult,
     ConversationInputRouter,
+    ConversationInputRouterFactoryPort,
+    ConversationInputRouterPort,
     ConversationLocalResult,
     ConversationPromptResult,
     ConversationScreenInputPort,
@@ -26,7 +28,7 @@ from loushang.harnesstui.surface.controller import promote_pending_page_surface
 from loushang.tui import _runner_utils
 from loushang.tui.core import RenderConstraints, RenderResult
 from loushang.tui.framework import SurfaceHost
-from loushang.tui.input import InputEvent, InputIntent, InputReader
+from loushang.tui.input import InputIntent, InputReader
 from loushang.tui.keybindings import KeybindingConfig, KeybindingManager
 from loushang.tui.render_loop import RenderLoop
 from loushang.tui.runtime import TuiRuntime
@@ -82,27 +84,6 @@ class ConversationScreenPort(ConversationScreenInputPort, Protocol):
 
 
 ConversationInputResultPort: TypeAlias = ConversationInputResult
-
-
-class ConversationInputRouterPort(Protocol):
-    """Route one decoded terminal input event to a neutral action."""
-
-    def handle(self, event: InputEvent) -> ConversationInputResult: ...
-
-
-class ConversationInputRouterFactoryPort(Protocol):
-    """Construct the product's conversation input adapter."""
-
-    def __call__(
-        self,
-        *,
-        app: ConversationScreenPort,
-        should_exit: ShouldExit,
-        is_local_command: LocalCommandPredicate,
-        keybindings: KeybindingManager | KeybindingConfig | None,
-        width: int,
-        height: int,
-    ) -> ConversationInputRouterPort: ...
 
 
 _finish_tui_exit = _runner_utils.finish_tui_exit

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -897,6 +897,8 @@ def test_shared_conversation_interaction_separates_product_and_clipboard_policy(
     assert "class ScreenInputResult" not in screen_input
     assert "class ScreenInputRouter" not in screen_input
     assert "bind_clipboard_image_input_router(" in screen_input
+    assert "ConversationInputRouterFactoryPort" not in screen_input
+    assert "cast(" not in screen_input
     assert "PromptIntent" in intents
     assert "BashIntent" in intents
     assert "ConversationRoutingProfile" in shared

--- a/tests/coding/ui/test_screen_input.py
+++ b/tests/coding/ui/test_screen_input.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from loushang.coding.ui.screen_app import ScreenCodingTuiApp
-from loushang.coding.ui.screen_input import build_screen_input_router
+from loushang.coding.ui.screen_input import (
+    CODING_SCREEN_RUN_PROFILE,
+    build_screen_input_router,
+)
 from loushang.harnesstui.conversation.agent_binding import (
     agent_image_parts_from_prompt_attachments,
 )
@@ -20,6 +23,22 @@ def _app(*, cwd: str = "/repo") -> ScreenCodingTuiApp:
         session_label="abcd",
         now=lambda: 12.0,
     )
+
+
+def test_coding_screen_profile_uses_the_standard_input_factory_contract() -> None:
+    factory = CODING_SCREEN_RUN_PROFILE.input_router_factory
+    assert factory is build_screen_input_router
+
+    router = factory(
+        app=_app(),
+        should_exit=lambda _text: False,
+        is_local_command=lambda _text: False,
+        keybindings=None,
+        width=80,
+        height=24,
+    )
+
+    assert router.handle(InputEvent(kind="text", text="hello")).kind == "handled"
 
 
 def test_prompt_image_attachments_convert_at_the_agent_boundary() -> None:

--- a/tests/harnesstui/conversation/test_clipboard_input.py
+++ b/tests/harnesstui/conversation/test_clipboard_input.py
@@ -15,6 +15,7 @@ from loushang.harnesstui.conversation.input import (
     ClipboardImageStatusCopy,
     ConversationClipboardResult,
     ConversationFollowupResult,
+    ConversationInputRouterFactoryPort,
     bind_clipboard_image_input_router,
 )
 from loushang.harnesstui.conversation.input_policy import ConversationInputPolicy
@@ -30,7 +31,6 @@ class _ConversationApp:
     state: ScreenConversationState = field(init=False)
     active_surface: object | None = None
     surface_host: SurfaceHost | None = None
-    statuses: list[str | None] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         self.state = ScreenConversationState(cwd=self.cwd)
@@ -48,9 +48,6 @@ class _ConversationApp:
 
     def queue_steer(self, text: str) -> None:
         self.state.queue_steer(text)
-
-    def set_status(self, message: str | None) -> None:
-        self.statuses.append(message)
 
 
 _COPY = ClipboardImageStatusCopy(
@@ -71,6 +68,30 @@ def _builder():
             status_copy=_COPY,
         )
     )
+
+
+def _standard_factory(
+    factory: ConversationInputRouterFactoryPort,
+) -> ConversationInputRouterFactoryPort:
+    return factory
+
+
+def test_clipboard_builder_satisfies_standard_router_factory_contract() -> None:
+    app = _ConversationApp("/repo")
+    factory = _standard_factory(_builder())
+
+    router = factory(
+        app=app,
+        should_exit=lambda _text: False,
+        is_local_command=lambda _text: False,
+        keybindings=None,
+        width=80,
+        height=12,
+    )
+
+    result = router.handle(InputEvent(kind="text", text="hello"))
+    assert result.kind == "handled"
+    assert app.composer.value == "hello"
 
 
 def test_standard_clipboard_image_profile_is_harnesstui_owned(
@@ -96,9 +117,9 @@ def test_standard_clipboard_image_profile_is_harnesstui_owned(
     assert expected.read_bytes() == b"png"
     assert isinstance(result, ConversationClipboardResult)
     assert app.composer.value == "@.loushang/clipboard/clipboard-shared.png "
-    assert app.statuses == [
+    assert app.state.status_message == (
         "Attached clipboard image: .loushang/clipboard/clipboard-shared.png"
-    ]
+    )
 
 
 def test_clipboard_image_uses_the_conversation_action_override(
@@ -145,8 +166,8 @@ def test_clipboard_image_input_binding_follows_the_replaced_app(
     assert expected.read_bytes() == b"png"
     assert not (tmp_path / "original" / "images").exists()
     assert replacement.composer.value == "@images/clipboard-sample.png "
-    assert replacement.statuses == ["attached: images/clipboard-sample.png"]
-    assert original.statuses == []
+    assert replacement.state.status_message == "attached: images/clipboard-sample.png"
+    assert original.state.status_message is None
     assert isinstance(result, ConversationClipboardResult)
     assert result.outcome.attachment is not None
     assert result.outcome.attachment.path == expected


### PR DESCRIPTION
## Summary

- own the production conversation input router and factory ports beside HarnessTUI conversation input, with screen_runner retaining compatibility re-exports
- make the clipboard-enabled builder a typed extension of the standard factory and remove the Coding-side cast
- use the existing conversation state status seam so the factory app contract stays minimal
- add HarnessTUI and Coding construction contracts plus English and Chinese boundary documentation

## Scope boundaries

- no shortcut or keybinding changes
- no router branch-order or steer/follow-up policy changes
- no prompt-routing expansion, plugin lifecycle, result-dispatch, or playback-factory refactor
- no tracking issue by user request for this continuing refactor

## Validation

- `uv run ruff check` on the changed source and tests
- `make lint-harnesstui`
- `make typecheck-harnesstui` — 142 source files
- focused input/factory matrix — 99 passed
- `make test-harnesstui` outside the sandbox — 1294 passed, 65 deselected by the target marker
- `git diff --check`