### PR TITLE
refactor(coding): inject screen run profile

### DIFF
--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -145,6 +145,12 @@ optional environment and test dependencies. Product adapters bind their policy
 and profile, then pass that factory directly without a type cast. This contract
 is an input-composition seam; it does not define a plugin lifecycle.
 
+Coding's `run_coding_tui()` accepts that immutable screen run profile at its
+composition-root boundary and defaults to `CODING_SCREEN_RUN_PROFILE`. A Product
+adapter may inject another profile without changing HarnessTUI or the screen
+binding; the entry point only passes the selected value through and performs no
+plugin discovery or lifecycle management.
+
 Composer selections use atom indexes. Normal text is split into grapheme-like
 text atoms; large paste markers are single atoms and are never split by range
 editing.

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -122,6 +122,11 @@ HarnessTUI 会话输入放在同一 owner 中，并由 screen runner 重导出�
 自己的策略和 profile 后直接传入该 Factory，不再使用类型强制转换。这个契约
 只是输入装配接缝，并不定义插件生命周期。
 
+Coding 的 `run_coding_tui()` 在组合根边界接受这个不可变的 screen run profile，
+默认值仍是 `CODING_SCREEN_RUN_PROFILE`。Product adapter 可以注入其他 profile，
+不必修改 HarnessTUI 或 screen binding；该入口只负责透传已选值，不执行插件
+发现或生命周期管理。
+
 Composer selection 使用 atom 索引。普通文本会拆成类 grapheme 的文本 atom；大型 paste marker 是单个 atom，range edit 不会把它拆开。
 
 ## Pre-1.0 InputRouter 迁移

--- a/src/loushang/coding/ui/mode.py
+++ b/src/loushang/coding/ui/mode.py
@@ -31,6 +31,7 @@ from loushang.harnesstui.conversation.application_host import (
     run_prepared_screen_conversation,
 )
 from loushang.harnesstui.conversation.host import (
+    ConversationScreenRunProfile,
     run_action_host_conversation_screen,
 )
 from loushang.harnesstui.conversation.run_context import (
@@ -52,6 +53,7 @@ async def run_coding_tui(
     stdout: TextIO,
     stderr: TextIO,
     verbose: bool = False,
+    screen_run_profile: ConversationScreenRunProfile = CODING_SCREEN_RUN_PROFILE,
 ) -> int:
     return await run_tui_launch_shell(
         stdin=stdin,
@@ -66,6 +68,7 @@ async def run_coding_tui(
                 stdout=stdout,
                 stderr=stderr,
                 verbose=verbose,
+                screen_run_profile=screen_run_profile,
             ),
             run_plain=partial(
                 _run_plain_tui,
@@ -90,6 +93,7 @@ async def _run_screen_interactive_tui(
     stdout: TextIO,
     stderr: TextIO,
     verbose: bool,
+    screen_run_profile: ConversationScreenRunProfile,
 ) -> int:
     snapshot = await load_coding_tui_startup_view(runtime=runtime, session=session)
     app = ScreenCodingTuiApp(
@@ -155,7 +159,7 @@ async def _run_screen_interactive_tui(
             cwd=snapshot.cwd,
             mode="tui",
         ),
-        profile=CODING_SCREEN_RUN_PROFILE,
+        profile=screen_run_profile,
         trace=_trace,
         stdout=stdout,
         now=time.monotonic,

--- a/tests/coding/test_ui_import_boundaries.py
+++ b/tests/coding/test_ui_import_boundaries.py
@@ -420,6 +420,13 @@ def test_mode_is_only_the_coding_tui_composition_root() -> None:
     ):
         assert token in source
 
+    assert (
+        "screen_run_profile: ConversationScreenRunProfile = "
+        "CODING_SCREEN_RUN_PROFILE" in source
+    )
+    assert "profile=screen_run_profile" in source
+    assert "profile=CODING_SCREEN_RUN_PROFILE" not in source
+
     for token in (
         "class _CodingTuiSessionPort",
         "build_agent_screen_conversation_projection",

--- a/tests/coding/test_ui_mode.py
+++ b/tests/coding/test_ui_mode.py
@@ -124,10 +124,18 @@ class _Session:
 
 
 def test_run_coding_tui_uses_screen_loop_for_interactive_terminal(monkeypatch) -> None:
+    from dataclasses import replace
+
     from loushang.coding.ui import mode
+    from loushang.coding.ui.screen_input import CODING_SCREEN_RUN_PROFILE
 
     session = _Session()
     captured: dict[str, object] = {}
+    custom_profile = replace(
+        CODING_SCREEN_RUN_PROFILE,
+        interruption_message="Plugin interrupted",
+        cancellation_message="Plugin cancelled",
+    )
 
     async def fake_screen_loop(**kwargs):
         captured.update(kwargs)
@@ -148,6 +156,7 @@ def test_run_coding_tui_uses_screen_loop_for_interactive_terminal(monkeypatch) -
             stdin=_TTYStringIO(),
             stdout=_TTYStringIO(),
             stderr=StringIO(),
+            screen_run_profile=custom_profile,
         )
     )
 
@@ -156,7 +165,7 @@ def test_run_coding_tui_uses_screen_loop_for_interactive_terminal(monkeypatch) -
     assert captured["action_host"].__class__.__name__ == (
         "PresentedConversationActionHost"
     )
-    assert captured["profile"].__class__.__name__ == "ConversationScreenRunProfile"
+    assert captured["profile"] is custom_profile
     assert callable(captured["handle_local"])
     assert callable(captured["handle_surface_intent"])
 


### PR DESCRIPTION
## Summary

- accept an immutable `ConversationScreenRunProfile` at the `run_coding_tui` composition-root boundary
- preserve `CODING_SCREEN_RUN_PROFILE` as the default and pass the selected value unchanged to the shared screen binding
- cover custom profile identity and freeze the removal of the inner hard-coded profile selection
- document the entry-point seam in English and Chinese

## Scope boundaries

- no router, shortcut, keybinding, steer/follow-up, or plain-mode behavior changes
- no plugin discovery, manifest, registry, activation, or lifecycle implementation
- no profile aggregation or playback-factory refactor
- no tracking issue by user request for this continuing refactor

## Validation

- regression first: custom profile initially failed with an unexpected keyword argument
- focused Coding TUI mode and boundary matrix — 61 passed outside the sandbox
- `make lint-harnesstui`
- `make typecheck-harnesstui` — 142 source files
- `git diff --check`