### PR TITLE
fix(tui): preserve native scrollback across resume

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
+++ b/docs/internals/architecture/tui/native-terminal-core/testing-strategy.md
@@ -49,6 +49,16 @@ Use the playback harness to script input, product events, streaming chunks,
 surface events, and resize events. Assert both logical transcript and terminal
 operations.
 
+Playback frames are also reusable terminal-operation traces: a successful trace
+can be replayed against a fresh FakeTerminal without invoking the renderer.
+When native scrollback is preserved, the trace contract rejects erase-display
+operations (`clear_screen` and `clear_from_cursor`), because emulator history
+behavior for those operations is not portable. JSONL artifacts include the
+scrollback-size delta and safety result; `--include-frames` also includes the
+concrete operation payloads and serialized output. FakeTerminal keeps scrollback in immutable
+shared chunks so long-session replay remains append-linear while old frame
+snapshots stay stable.
+
 Examples:
 
 - submit prompt, stream assistant, commit worked divider
@@ -128,7 +138,10 @@ shared real CLI `/quit` contract in
 
 tmux is a separate terminal-implementation integration. Its marker only proves
 pane history and scrollback behavior and must not be used as the Windows
-equivalent of ConPTY.
+equivalent of ConPTY. Marker assertions require every settled history line to
+appear exactly once and in order. The tmux suite includes live transcript
+replacement, line-budget trimming, and post-resume streaming so FakeTerminal's
+portable screen model is not the sole oracle for emulator-specific history.
 
 Run the local collections with:
 

--- a/src/loushang/tui/playback.py
+++ b/src/loushang/tui/playback.py
@@ -32,6 +32,7 @@ class RenderDiagnostics:
     render_end: int | None = None
     viewport_top: int = 0
     previous_viewport_top: int = 0
+    scrollback_frontier_rebased: bool = False
     logical_cursor_row: int = 0
     logical_cursor_column: int = 0
     hardware_cursor_row: int = 0
@@ -96,6 +97,20 @@ class PlaybackStep:
             raise AssertionError("expected diagnostics to report clear scrollback")
         if self.frame is None or not self.frame.clear_scrollback_emitted:
             raise AssertionError("expected frame to emit clear scrollback")
+
+    @property
+    def native_scrollback_safe(self) -> bool:
+        return not _native_scrollback_unsafe_operations(self.diagnostics)
+
+    def assert_native_scrollback_safe(self) -> None:
+        unsafe = _native_scrollback_unsafe_operations(self.diagnostics)
+        if not unsafe:
+            return
+        kinds = ", ".join(operation.kind for operation in unsafe)
+        raise AssertionError(
+            f"step {self.index} preserved native scrollback but emitted "
+            f"history-sensitive erase operations: {kinds}"
+        )
 
 
 PlaybackRender = Callable[
@@ -317,12 +332,32 @@ class PlaybackResult:
         clear_screen = TerminalOperation.clear_screen()
         clear_scrollback = TerminalOperation.clear_scrollback()
         for step in self.steps:
+            step.assert_native_scrollback_safe()
             assert clear_screen not in step.diagnostics.operations
             assert clear_scrollback not in step.diagnostics.operations
             step.assert_no_clear_scrollback()
             if step.frame is not None:
                 assert clear_screen.serialize() not in step.frame.serialized_output
                 assert clear_scrollback.serialize() not in step.frame.serialized_output
+
+    def assert_native_scrollback_safe(self, *, skip_first: bool = False) -> None:
+        steps = self.steps[1:] if skip_first else self.steps
+        for step in steps:
+            step.assert_native_scrollback_safe()
+
+    def replay_terminal_trace(
+        self, port: FakeTerminalPort | None = None
+    ) -> FakeTerminalPort:
+        """Replay successful terminal frames without invoking the renderer again."""
+        if port is None:
+            initial_size = self.steps[0].size if self.steps else self.port.size()
+            port = FakeTerminalPort(size=initial_size)
+        for step in self.steps:
+            if port.size() != step.size:
+                port.resize(step.size)
+            if step.flush_succeeded:
+                port.flush(step.diagnostics.operations)
+        return port
 
     def assert_no_clear_scrollback(self) -> None:
         clear_scrollback = TerminalOperation.clear_scrollback()
@@ -499,6 +534,17 @@ class PlaybackResult:
                 if step.frame is not None
                 else step.diagnostics.clear_scrollback_emitted
             ),
+            "native_scrollback_safe": step.native_scrollback_safe,
+            "scrollback_size": (
+                {
+                    "before": len(step.frame.screen_before.scrollback_lines),
+                    "after": len(step.frame.screen_after.scrollback_lines),
+                    "delta": len(step.frame.screen_after.scrollback_lines)
+                    - len(step.frame.screen_before.scrollback_lines),
+                }
+                if step.frame is not None
+                else None
+            ),
             "visible_lines": list(
                 step.frame.screen_after.visible_lines
                 if step.frame is not None
@@ -512,6 +558,10 @@ class PlaybackResult:
         }
         if include_frames:
             row["serialized_output"] = serialized_output
+            row["operation_trace"] = [
+                _operation_payload(operation)
+                for operation in step.diagnostics.operations
+            ]
         return row
 
 
@@ -522,6 +572,7 @@ class PlaybackFrameBudget:
     max_serialized_output_bytes: int | None = None
     max_changed_visible_lines: int | None = None
     require_synchronized: bool = False
+    require_native_scrollback_safe: bool = False
 
     def assert_result(
         self, result: PlaybackResult, *, skip_first: bool = False
@@ -546,6 +597,8 @@ class PlaybackFrameBudget:
             )
         if self.require_synchronized:
             _assert_synchronized_or_noop_frames(result, skip_first=skip_first)
+        if self.require_native_scrollback_safe:
+            result.assert_native_scrollback_safe(skip_first=skip_first)
 
 
 @dataclass(slots=True)
@@ -597,6 +650,35 @@ def _normalize_diagnostics(diagnostics: RenderDiagnostics) -> RenderDiagnostics:
     if diagnostics.clear_scrollback_emitted == clear_scrollback_emitted:
         return diagnostics
     return replace(diagnostics, clear_scrollback_emitted=clear_scrollback_emitted)
+
+
+def _native_scrollback_unsafe_operations(
+    diagnostics: RenderDiagnostics,
+) -> tuple[TerminalOperation, ...]:
+    if diagnostics.clear_scrollback_emitted:
+        return ()
+    return tuple(
+        operation
+        for operation in diagnostics.operations
+        if operation.kind in {"clear_screen", "clear_from_cursor"}
+    )
+
+
+def _operation_payload(operation: TerminalOperation) -> dict[str, Any]:
+    payload: dict[str, Any] = {"kind": operation.kind}
+    if operation.text:
+        payload["text"] = operation.text
+    if operation.row is not None:
+        payload["row"] = operation.row
+    if operation.column is not None:
+        payload["column"] = operation.column
+    if operation.bottom is not None:
+        payload["bottom"] = operation.bottom
+    if operation.lines:
+        payload["lines"] = operation.lines
+    if operation.active is not None:
+        payload["active"] = operation.active
+    return payload
 
 
 def _screen_anchor_row(

--- a/src/loushang/tui/render_loop.py
+++ b/src/loushang/tui/render_loop.py
@@ -325,6 +325,7 @@ class TranscriptWindowTrimmedResetStrategy:
             cursor=context.cursor,
             declared_cursor=context.declared_cursor,
             repaint_reason=runtime.baseline_reset_reason,
+            scrollback_frontier_rebased=True,
             delete_kitty_image_sequences=context.previous_kitty_delete_sequences,
         )
 
@@ -353,6 +354,9 @@ class BaselineResetStrategy:
             operation_class="baseline_repaint",
             repaint_kind="recovery",
             repaint_reason=runtime.baseline_reset_reason,
+            scrollback_frontier_rebased=_is_transcript_window_replacement(
+                runtime.baseline_reset_reason
+            ),
             delete_kitty_image_sequences=context.previous_kitty_delete_sequences,
         )
 
@@ -778,6 +782,7 @@ class RenderLoop:
         operation_class: str = "managed_viewport_repaint",
         repaint_kind: str | None = "recovery",
         append_start: int | None = None,
+        scrollback_frontier_rebased: bool = False,
         delete_kitty_image_sequences: tuple[str, ...] = (),
     ) -> RenderDiagnostics:
         viewport_top = _viewport_top(current_lines, size)
@@ -795,6 +800,7 @@ class RenderLoop:
                 scrollback_viewport_top=self.scrollback_viewport_top,
                 size=size,
                 hardware_cursor_row=self.hardware_cursor_row,
+                rebase_scrollback_frontier=scrollback_frontier_rebased,
                 delete_kitty_image_sequences=delete_kitty_image_sequences,
             ),
             changed_range=changed_range,
@@ -803,6 +809,7 @@ class RenderLoop:
             appended_lines=max(0, len(current_lines) - len(previous_lines)),
             repaint_kind=repaint_kind,
             repaint_reason=repaint_reason,
+            scrollback_frontier_rebased=scrollback_frontier_rebased,
             cursor=cursor,
             hardware_cursor_row=_hardware_row_after_write(current_lines, cursor=declared_cursor),
             hardware_cursor_column=cursor.column,
@@ -815,7 +822,7 @@ class RenderLoop:
         self.previous_raw_lines = diagnostics.raw_logical_lines
         self.previous_size = size
         self.previous_viewport_top = diagnostics.viewport_top
-        if diagnostics.clear_scrollback_emitted:
+        if diagnostics.clear_scrollback_emitted or diagnostics.scrollback_frontier_rebased:
             self.scrollback_viewport_top = diagnostics.viewport_top
         else:
             self.scrollback_viewport_top = max(
@@ -847,8 +854,18 @@ class RenderLoop:
         repaint_reason: str,
         width_changed: bool = False,
         height_changed: bool = False,
+        scrollback_frontier_rebased: bool = False,
         delete_kitty_image_sequences: tuple[str, ...] = (),
     ) -> RenderDiagnostics:
+        previous_visible_row_count = min(
+            size.rows,
+            (
+                self.previous_size.rows
+                if self.previous_size is not None
+                else size.rows
+            ),
+            len(previous_lines),
+        )
         return self._diagnostics(
             current_lines=current_lines,
             previous_lines=previous_lines,
@@ -862,12 +879,17 @@ class RenderLoop:
                 ),
                 cursor=declared_cursor,
                 viewport_top=_viewport_top(current_lines, size),
+                clear_row_count=max(
+                    min(size.rows, len(current_lines)),
+                    previous_visible_row_count,
+                ),
                 delete_kitty_image_sequences=delete_kitty_image_sequences,
             ),
             changed_range=changed_range,
             viewport_top=_viewport_top(current_lines, size),
             repaint_kind=repaint_kind,
             repaint_reason=repaint_reason,
+            scrollback_frontier_rebased=scrollback_frontier_rebased,
             width_changed=width_changed,
             height_changed=height_changed,
             cursor=cursor,
@@ -890,6 +912,7 @@ class RenderLoop:
         render_end: int | None = None,
         repaint_kind: str | None = None,
         repaint_reason: str | None = None,
+        scrollback_frontier_rebased: bool = False,
         width_changed: bool = False,
         height_changed: bool = False,
         cursor: CursorDeclaration | None = None,
@@ -911,6 +934,7 @@ class RenderLoop:
             render_end=render_end,
             viewport_top=viewport_top,
             previous_viewport_top=self.previous_viewport_top,
+            scrollback_frontier_rebased=scrollback_frontier_rebased,
             logical_cursor_row=logical_cursor.row,
             logical_cursor_column=logical_cursor.column,
             hardware_cursor_row=terminal_cursor_row,
@@ -1129,21 +1153,38 @@ def _repaint_operations(
     clear_scrollback: bool,
     cursor: CursorDeclaration | None,
     viewport_top: int,
+    clear_row_count: int,
     delete_kitty_image_sequences: tuple[str, ...] = (),
 ) -> tuple[TerminalOperation, ...]:
     render_lines = lines if clear_scrollback else lines[viewport_top:]
-    operations: list[TerminalOperation] = [
-        *_kitty_delete_operations(delete_kitty_image_sequences),
-        TerminalOperation.clear_screen(),
-    ]
+    operations: list[TerminalOperation] = list(
+        _kitty_delete_operations(delete_kitty_image_sequences)
+    )
     if clear_scrollback:
-        operations.append(TerminalOperation.clear_scrollback())
-    operations.extend(_write_lines(render_lines))
+        operations.extend(
+            (
+                TerminalOperation.clear_screen(),
+                TerminalOperation.clear_scrollback(),
+                *_write_lines(render_lines),
+            )
+        )
+        current_row = viewport_top + max(0, len(render_lines) - 1)
+    else:
+        operations.append(TerminalOperation.move_cursor(row=0, column=0))
+        operations.extend(
+            _write_cleared_lines(
+                (
+                    *render_lines,
+                    *("" for _ in range(clear_row_count - len(render_lines))),
+                )
+            )
+        )
+        current_row = viewport_top + max(0, clear_row_count - 1)
     return _render_then_position_cursor(
         tuple(operations),
         cursor=cursor,
         viewport_top=viewport_top,
-        current_row=viewport_top + max(0, len(render_lines) - 1),
+        current_row=current_row,
     )
 
 
@@ -1157,6 +1198,7 @@ def _managed_viewport_repaint_operations(
     scrollback_viewport_top: int,
     size: TerminalSize,
     hardware_cursor_row: int,
+    rebase_scrollback_frontier: bool = False,
     delete_kitty_image_sequences: tuple[str, ...] = (),
 ) -> tuple[TerminalOperation, ...]:
     visible_lines = lines[viewport_top : viewport_top + size.rows]
@@ -1188,29 +1230,39 @@ def _managed_viewport_repaint_operations(
             operations.append(TerminalOperation.carriage_return())
         current_physical_row = row
 
-    # A terminal cannot edit a line after it enters scrollback. Refresh the
-    # logical rows that are about to leave the viewport before scrolling them.
-    for offset in range(scroll_count):
-        move_to(offset)
-        operations.append(TerminalOperation.clear_line())
-        line_index = scroll_start + offset
-        if line_index < len(lines):
-            operations.append(TerminalOperation.write(lines[line_index]))
-
-    if scroll_count:
-        move_to(size.rows - 1)
+    if rebase_scrollback_frontier:
+        # A replacement or prefix trim starts a new logical-row epoch. Preserve
+        # existing native scrollback, but do not replay the new epoch's hidden
+        # prefix through coordinates that belonged to the previous epoch.
+        move_to(0)
         operations.extend(
-            TerminalOperation.newline()
-            for _ in range(scroll_count)
+            _write_cleared_lines(
+                (*visible_lines, *("" for _ in range(size.rows - len(visible_lines))))
+            )
         )
         current_physical_row = size.rows - 1
-
-    # Clear once, then paint at most one screen. The final visible line does
-    # not emit a newline, so this phase cannot submit anything to scrollback.
-    move_to(0)
-    operations.append(TerminalOperation.clear_from_cursor())
-    operations.extend(_write_lines(visible_lines))
-    current_physical_row = max(0, len(visible_lines) - 1)
+    elif scroll_count:
+        # Stream the complete departing suffix from row zero so every logical
+        # row enters scrollback exactly once. Scrolling the existing viewport
+        # first would also commit stale snapshots of the protected bottom frame
+        # on real terminals before the repaint can replace them.
+        move_to(0)
+        operations.extend(
+            _write_cleared_lines(
+                lines[scroll_start : viewport_top + size.rows]
+            )
+        )
+        current_physical_row = max(0, len(visible_lines) - 1)
+    else:
+        # Clear and repaint each visible row without ED, which tmux may preserve
+        # as a complete old-screen snapshot in native scrollback.
+        move_to(0)
+        operations.extend(
+            _write_cleared_lines(
+                (*visible_lines, *("" for _ in range(size.rows - len(visible_lines))))
+            )
+        )
+        current_physical_row = size.rows - 1
 
     operations.append(TerminalOperation.end_synchronized_update())
     if cursor is not None:
@@ -1393,6 +1445,19 @@ def _write_lines(lines: Sequence[str]) -> tuple[TerminalOperation, ...]:
     return tuple(operations)
 
 
+def _write_cleared_lines(lines: Sequence[str]) -> tuple[TerminalOperation, ...]:
+    operations: list[TerminalOperation] = []
+    last_index = len(lines) - 1
+    for index, line in enumerate(lines):
+        operations.append(TerminalOperation.clear_line())
+        operations.append(
+            TerminalOperation.write(
+                line if index == last_index else f"{line}\r\n"
+            )
+        )
+    return tuple(operations)
+
+
 def _wrap_synchronized(operations: tuple[TerminalOperation, ...]) -> tuple[TerminalOperation, ...]:
     return (
         TerminalOperation.begin_synchronized_update(),
@@ -1481,6 +1546,12 @@ def _should_clear_scrollback(*, policy: ClearScrollbackPolicy, repaint_kind: str
     if policy == "resize":
         return repaint_kind == "resize"
     return False
+
+
+def _is_transcript_window_replacement(reason: str) -> bool:
+    return reason == "transcript_window_replaced" or reason.startswith(
+        "transcript_window_replaced:"
+    )
 
 
 def _hardware_row_after_write(

--- a/src/loushang/tui/terminal.py
+++ b/src/loushang/tui/terminal.py
@@ -2,15 +2,104 @@ from __future__ import annotations
 
 import os
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
 from dataclasses import replace as dataclass_replace
 from pathlib import Path
-from typing import Protocol, TextIO, TypeVar, runtime_checkable
+from typing import Protocol, TextIO, TypeVar, overload, runtime_checkable
 
 from loushang.tui.cell_width import _extract_control_sequence
 
 T = TypeVar("T")
+
+_HISTORY_CHUNK_SIZE = 64
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class _PersistentLineHistory(Sequence[str]):
+    """Immutable append-optimized line history used by deterministic playback."""
+
+    _previous: _PersistentLineHistory | None = None
+    _chunk: tuple[str, ...] = ()
+    _length: int = 0
+
+    @classmethod
+    def empty(cls) -> _PersistentLineHistory:
+        return cls()
+
+    @classmethod
+    def from_lines(cls, lines: Sequence[str]) -> _PersistentLineHistory:
+        history = cls.empty()
+        for start in range(0, len(lines), _HISTORY_CHUNK_SIZE):
+            chunk = tuple(lines[start : start + _HISTORY_CHUNK_SIZE])
+            history = cls(
+                _previous=history if history else None,
+                _chunk=chunk,
+                _length=history._length + len(chunk),
+            )
+        return history
+
+    def append(self, line: str) -> _PersistentLineHistory:
+        if len(self._chunk) < _HISTORY_CHUNK_SIZE:
+            return _PersistentLineHistory(
+                _previous=self._previous,
+                _chunk=(*self._chunk, line),
+                _length=self._length + 1,
+            )
+        return _PersistentLineHistory(
+            _previous=self,
+            _chunk=(line,),
+            _length=self._length + 1,
+        )
+
+    def __bool__(self) -> bool:
+        return self._length > 0
+
+    def __len__(self) -> int:
+        return self._length
+
+    def __iter__(self) -> Iterator[str]:
+        chunks: list[tuple[str, ...]] = []
+        history: _PersistentLineHistory | None = self
+        while history is not None:
+            if history._chunk:
+                chunks.append(history._chunk)
+            history = history._previous
+        for chunk in reversed(chunks):
+            yield from chunk
+
+    @overload
+    def __getitem__(self, index: int) -> str: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> tuple[str, ...]: ...
+
+    def __getitem__(self, index: int | slice) -> str | tuple[str, ...]:
+        if isinstance(index, slice):
+            return tuple(self)[index]
+        normalized = index if index >= 0 else self._length + index
+        if normalized < 0 or normalized >= self._length:
+            raise IndexError("line history index out of range")
+        history: _PersistentLineHistory | None = self
+        while history is not None:
+            chunk_start = history._length - len(history._chunk)
+            if normalized >= chunk_start:
+                return history._chunk[normalized - chunk_start]
+            history = history._previous
+        raise IndexError("line history index out of range")
+
+    def __add__(self, other: Sequence[str]) -> tuple[str, ...]:
+        return (*self, *other)
+
+    def __radd__(self, other: Sequence[str]) -> tuple[str, ...]:
+        return (*other, *self)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Sequence) or isinstance(other, (str, bytes)):
+            return False
+        return len(self) == len(other) and all(
+            left == right for left, right in zip(self, other, strict=True)
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -175,7 +264,9 @@ class FakeScreen:
     size: TerminalSize
     visible_lines: tuple[str, ...]
     cell_styles: tuple[tuple[FakeCellStyle, ...], ...]
-    scrollback_lines: tuple[str, ...] = ()
+    scrollback_lines: Sequence[str] = field(
+        default_factory=_PersistentLineHistory.empty
+    )
     cursor_row: int = 0
     cursor_column: int = 0
     viewport_top: int = 0
@@ -248,7 +339,7 @@ class FakeScreen:
             )
         if operation.kind == "clear_scrollback":
             return self._replace(
-                scrollback_lines=(),
+                scrollback_lines=_PersistentLineHistory.empty(),
                 viewport_top=0,
                 scrollback_cleared=True,
             )
@@ -330,7 +421,9 @@ class FakeScreen:
                 size=self.size,
                 visible_lines=(*self.visible_lines[1:], ""),
                 cell_styles=(*self.cell_styles[1:], _empty_style_row(self.size.columns)),
-                scrollback_lines=(*self.scrollback_lines, self.visible_lines[0]),
+                scrollback_lines=_append_history_line(
+                    self.scrollback_lines, self.visible_lines[0]
+                ),
                 cursor_row=self.size.rows - 1,
                 cursor_column=0,
                 viewport_top=self.viewport_top + 1,
@@ -353,7 +446,9 @@ class FakeScreen:
                 size=self.size,
                 visible_lines=(*self.visible_lines[1:], ""),
                 cell_styles=(*self.cell_styles[1:], _empty_style_row(self.size.columns)),
-                scrollback_lines=(*self.scrollback_lines, self.visible_lines[0]),
+                scrollback_lines=_append_history_line(
+                    self.scrollback_lines, self.visible_lines[0]
+                ),
                 cursor_row=bottom,
                 cursor_column=0,
                 viewport_top=self.viewport_top + 1,
@@ -420,7 +515,7 @@ class FakeScreen:
         *,
         visible_lines: tuple[str, ...] | None = None,
         cell_styles: tuple[tuple[FakeCellStyle, ...], ...] | None = None,
-        scrollback_lines: tuple[str, ...] | None = None,
+        scrollback_lines: Sequence[str] | None = None,
         cursor_row: int | None = None,
         cursor_column: int | None = None,
         viewport_top: int | None = None,
@@ -444,6 +539,14 @@ class FakeScreen:
             autowrap_pending=self.autowrap_pending if autowrap_pending is None else autowrap_pending,
             active_style=self.active_style if active_style is None else active_style,
         )
+
+
+def _append_history_line(
+    history: Sequence[str], line: str
+) -> _PersistentLineHistory:
+    if not isinstance(history, _PersistentLineHistory):
+        history = _PersistentLineHistory.from_lines(history)
+    return history.append(line)
 
 
 def _empty_style_row(columns: int) -> tuple[FakeCellStyle, ...]:

--- a/tests/coding/test_screen_coding_tui_pty_smoke.py
+++ b/tests/coding/test_screen_coding_tui_pty_smoke.py
@@ -36,9 +36,7 @@ def test_screen_tui_tmux_pty_preserves_compact_history_and_streamed_tail(
 
     early_lines = tuple(f"PLAYBACK_EARLY_{index:03d}" for index in range(1, 81))
     after_lines = tuple(f"AFTER_COMPACT_{index:03d}" for index in range(1, 41))
-    _assert_ordered_lines(captured, early_lines)
-    _assert_ordered_lines(captured, after_lines)
-    assert captured.count(after_lines[-1]) == 1
+    _assert_lines_once_in_order(captured, (*early_lines, *after_lines))
     assert "Context compacted (500000 tokens before)" in captured
     assert "hidden summary line one" not in captured
     assert "hidden summary line two" not in captured
@@ -77,9 +75,7 @@ def test_screen_tui_tmux_pty_auto_compaction_preserves_history_and_resume(
 
     early_lines = tuple(f"AUTO_EARLY_{index:03d}" for index in range(1, 81))
     after_lines = tuple(f"AUTO_AFTER_{index:03d}" for index in range(1, 41))
-    _assert_ordered_lines(captured, early_lines)
-    _assert_ordered_lines(captured, after_lines)
-    assert captured.count(after_lines[-1]) == 1
+    _assert_lines_once_in_order(captured, (*early_lines, *after_lines))
     assert "Context compacted (" in captured
     assert "AUTO_COMPACT_PRIVATE_SUMMARY" not in captured
 
@@ -112,6 +108,36 @@ def test_screen_tui_tmux_pty_auto_compaction_preserves_history_and_resume(
     assert early_lines[-1] in jsonl
     assert after_lines[0] in jsonl
     assert after_lines[-1] in jsonl
+
+
+@pytest.mark.tui_tmux_integration
+def test_screen_tui_tmux_pty_live_resume_trim_streams_each_line_once(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("tmux PTY regression uses POSIX terminals")
+    tmux = shutil.which("tmux")
+    if tmux is None and os.environ.get("LOUSHANG_REQUIRE_TMUX") == "1":
+        pytest.fail("required tmux executable was not found")
+    if tmux is None:
+        pytest.skip("tmux is not installed")
+
+    captured = _run_tmux_fixture(
+        tmp_path=tmp_path,
+        tmux=tmux,
+        fixture_name="resume_trim_pty_fixture.py",
+        ready_name="resume-trim-playback.ready",
+        socket_name=f"loushang-resume-trim-{os.getpid()}",
+        session_name="resume-trim",
+        ready_timeout_seconds=30,
+        visible_sentinel="POST_RESUME_040",
+    )
+
+    # Only the settled prefix is guaranteed to have entered native history.
+    # The still-visible old tail is intentionally overwritten by replacement.
+    old_lines = tuple(f"PRE_RESUME_{index:03d}" for index in range(1, 41))
+    post_lines = tuple(f"POST_RESUME_{index:03d}" for index in range(1, 41))
+    _assert_lines_once_in_order(captured, (*old_lines, *post_lines))
 
 
 def _run_tmux_fixture(
@@ -203,9 +229,9 @@ def _run_tmux_fixture(
         )
 
 
-def _assert_ordered_lines(captured: str, lines: tuple[str, ...]) -> None:
+def _assert_lines_once_in_order(captured: str, lines: tuple[str, ...]) -> None:
     counts = {line: captured.count(line) for line in lines}
-    assert all(count >= 1 for count in counts.values()), (counts, captured)
+    assert all(count == 1 for count in counts.values()), (counts, captured)
     positions = [captured.find(line) for line in lines]
     assert positions == sorted(positions)
 

--- a/tests/coding/test_screen_coding_tui_terminal_playback.py
+++ b/tests/coding/test_screen_coding_tui_terminal_playback.py
@@ -282,8 +282,9 @@ def test_screen_coding_tui_long_stream_commits_history_without_partial_scroll_re
     assert protected_steps
     assert all("Working" in _visible_text(port) for _step in protected_steps)
     assert all(
-        TerminalOperation.clear_from_cursor() in step.diagnostics.operations
-        for step in protected_steps[-1:]
+        TerminalOperation.clear_from_cursor() not in step.diagnostics.operations
+        and TerminalOperation.clear_line() in step.diagnostics.operations
+        for step in protected_steps
     )
     assert all(
         operation.kind not in {"set_scroll_region", "reset_scroll_region"}
@@ -638,6 +639,68 @@ def test_screen_coding_tui_resumed_long_transcript_input_and_timer_share_bounded
 
     assert all("Working" in scenario.visible_text() for _ in (1, 3))
     scenario.assert_visible_contains("› x")
+
+
+def test_screen_coding_tui_live_resume_rebases_scrollback_before_streaming() -> None:
+    scenario = ScreenTuiScenario(width=100, height=18, now=3.0)
+    app = scenario.app
+    app.start_prompt("existing turn", started_at=0.0)
+    scenario.render()
+    app.begin_assistant()
+    app.append_assistant_chunk("existing answer")
+    scenario.render()
+    app.end_assistant()
+    app.complete_run(elapsed_seconds=1.0)
+    scenario.render()
+
+    app.replace_transcript_window(
+        build_synthetic_long_transcript_records(
+            turns=40,
+            tail_tool_output_lines=600,
+        ),
+        reason="resume",
+    )
+    app.trim_active_transcript_window()
+    assert app.state.evicted_prefix_record_count > 0
+    rebase = scenario.render()
+
+    rebase.assert_operation_class("managed_viewport_repaint")
+    rebase.assert_no_clear_scrollback()
+    assert TerminalOperation.clear_screen() not in rebase.diagnostics.operations
+    assert rebase.diagnostics.scrollback_frontier_rebased is True
+
+    app.start_prompt("post resume turn", started_at=0.0)
+    scenario.render()
+    app.begin_assistant()
+    sentinels = tuple(f"POST_RESUME_{index:03d}" for index in range(24))
+    streaming_steps = []
+    for start in range(0, len(sentinels), 4):
+        app.append_assistant_chunk("\n".join(sentinels[start : start + 4]) + "\n")
+        streaming_steps.append(scenario.render())
+
+    terminal_text = strip_control_sequences(
+        "\n".join(
+            (
+                *scenario.port.screen.scrollback_lines,
+                *scenario.port.screen.visible_lines,
+            )
+        )
+    )
+
+    assert any(
+        step.diagnostics.operation_class == "protected_append_update"
+        for step in streaming_steps
+    )
+    assert all(
+        TerminalOperation.clear_screen() not in step.diagnostics.operations
+        and TerminalOperation.clear_from_cursor() not in step.diagnostics.operations
+        and TerminalOperation.clear_scrollback() not in step.diagnostics.operations
+        for step in streaming_steps
+    )
+    assert all(terminal_text.count(sentinel) == 1 for sentinel in sentinels)
+    assert [terminal_text.index(sentinel) for sentinel in sentinels] == sorted(
+        terminal_text.index(sentinel) for sentinel in sentinels
+    )
 
 
 def _app() -> ScreenCodingTuiApp:

--- a/tests/coding/test_tui_render_performance_contract.py
+++ b/tests/coding/test_tui_render_performance_contract.py
@@ -29,6 +29,7 @@ pytestmark = pytest.mark.tui_render_contract
                 max_serialized_output_bytes=768,
                 max_changed_visible_lines=8,
                 require_synchronized=True,
+                require_native_scrollback_safe=True,
             ),
         ),
         (
@@ -42,6 +43,7 @@ pytestmark = pytest.mark.tui_render_contract
                 max_serialized_output_bytes=2_000,
                 max_changed_visible_lines=3,
                 require_synchronized=True,
+                require_native_scrollback_safe=True,
             ),
         ),
         (
@@ -55,6 +57,7 @@ pytestmark = pytest.mark.tui_render_contract
                 max_serialized_output_bytes=3_000,
                 max_changed_visible_lines=20,
                 require_synchronized=True,
+                require_native_scrollback_safe=True,
             ),
         ),
         (
@@ -68,6 +71,7 @@ pytestmark = pytest.mark.tui_render_contract
                 max_serialized_output_bytes=90_000,
                 max_changed_visible_lines=18,
                 require_synchronized=True,
+                require_native_scrollback_safe=True,
             ),
         ),
     ),

--- a/tests/coding/tui_support/resume_trim_pty_fixture.py
+++ b/tests/coding/tui_support/resume_trim_pty_fixture.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+from loushang.coding.ui.screen_app import ScreenCodingTuiApp
+from loushang.harnesstui.testing.performance import (
+    build_synthetic_long_transcript_records,
+)
+from loushang.tui import ProcessTerminalPort, RenderLoop, TerminalSize, TuiRuntime
+
+
+def _render_resume_trim_playback(*, ready_file: Path) -> None:
+    app = ScreenCodingTuiApp(
+        model_label="faux/resume-trim",
+        cwd="/repo",
+        branch="main",
+        session_label="pty-resume-trim",
+        now=lambda: 3.0,
+    )
+    terminal = ProcessTerminalPort(
+        output=sys.stdout,
+        size_provider=lambda: TerminalSize(columns=80, rows=18),
+        track_screen=False,
+    )
+    runtime = TuiRuntime(render_loop=RenderLoop(app), terminal=terminal)
+
+    app.start_prompt("before live resume", started_at=0.0)
+    runtime.render_now()
+    app.begin_assistant()
+    for index in range(1, 81):
+        app.append_assistant_chunk(f"PRE_RESUME_{index:03d}\n")
+        runtime.render_now()
+    app.end_assistant()
+    app.complete_run(elapsed_seconds=1.0)
+    runtime.render_now()
+
+    app.replace_transcript_window(
+        build_synthetic_long_transcript_records(
+            turns=40,
+            tail_tool_output_lines=600,
+        ),
+        reason="resume",
+    )
+    app.trim_active_transcript_window()
+    runtime.render_now()
+
+    app.start_prompt("after live resume", started_at=2.0)
+    runtime.render_now()
+    app.begin_assistant()
+    for index in range(1, 41):
+        suffix = "\n" if index < 40 else ""
+        app.append_assistant_chunk(f"POST_RESUME_{index:03d}{suffix}")
+        runtime.render_now()
+    app.end_assistant()
+    app.complete_run(elapsed_seconds=1.0)
+    runtime.render_now()
+
+    ready_file.touch()
+    while True:
+        time.sleep(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ready-file", type=Path, required=True)
+    args = parser.parse_args()
+    _render_resume_trim_playback(ready_file=args.ready_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/coding/tui_support/scenarios/budgets.py
+++ b/tests/coding/tui_support/scenarios/budgets.py
@@ -8,6 +8,7 @@ INTERACTION_FRAME_BUDGET = PlaybackFrameBudget(
     max_serialized_output_bytes=768,
     max_changed_visible_lines=8,
     require_synchronized=True,
+    require_native_scrollback_safe=True,
 )
 
 LONG_TRANSCRIPT_FRAME_BUDGET = PlaybackFrameBudget(
@@ -16,4 +17,5 @@ LONG_TRANSCRIPT_FRAME_BUDGET = PlaybackFrameBudget(
     max_serialized_output_bytes=2_000,
     max_changed_visible_lines=3,
     require_synchronized=True,
+    require_native_scrollback_safe=True,
 )

--- a/tests/coding/tui_support/scenarios/product.py
+++ b/tests/coding/tui_support/scenarios/product.py
@@ -26,6 +26,7 @@ PRODUCT_COMPOSED_FRAME_BUDGET = PlaybackFrameBudget(
     max_serialized_output_bytes=3_000,
     max_changed_visible_lines=20,
     require_synchronized=True,
+    require_native_scrollback_safe=True,
 )
 
 PRODUCT_STREAMING_CONTROL_FRAME_BUDGET = PlaybackFrameBudget(
@@ -34,6 +35,7 @@ PRODUCT_STREAMING_CONTROL_FRAME_BUDGET = PlaybackFrameBudget(
     max_serialized_output_bytes=90_000,
     max_changed_visible_lines=18,
     require_synchronized=True,
+    require_native_scrollback_safe=True,
 )
 
 

--- a/tests/tui/test_playback_harness.py
+++ b/tests/tui/test_playback_harness.py
@@ -225,6 +225,8 @@ def test_playback_result_writes_jsonl_for_manual_inspection(tmp_path) -> None:
             "changed_visible_lines": 1,
             "synchronized": False,
             "clear_scrollback_emitted": False,
+            "native_scrollback_safe": True,
+            "scrollback_size": {"before": 0, "after": 0, "delta": 0},
             "visible_lines": ["hello", "", "", "", ""],
             "scrollback_lines": [],
         }
@@ -306,6 +308,13 @@ def test_playback_result_writes_trace_and_final_screen_artifacts(tmp_path) -> No
     trace_row = json.loads(artifacts.trace.read_text(encoding="utf-8"))
     assert trace_row["operation_class"] == "changed_range_update"
     assert trace_row["serialized_output"] == "hello"
+    assert trace_row["native_scrollback_safe"] is True
+    assert trace_row["scrollback_size"] == {
+        "before": 0,
+        "after": 0,
+        "delta": 0,
+    }
+    assert trace_row["operation_trace"] == [{"kind": "write", "text": "hello"}]
     assert artifacts.screen.read_text(encoding="utf-8") == "hello\n\n\n\n"
     assert artifacts.terminal.read_text(encoding="utf-8") == "hello\n\n\n\n"
 
@@ -929,7 +938,8 @@ def test_playback_step_asserts_operation_class_and_scrollback_policy() -> None:
             clear_scrollback_policy="disabled",
             operations=(
                 TerminalOperation.begin_synchronized_update(),
-                TerminalOperation.clear_screen(),
+                TerminalOperation.move_cursor(row=0, column=0),
+                TerminalOperation.clear_line(),
                 TerminalOperation.write(f"{size.columns}x{size.rows}"),
                 TerminalOperation.end_synchronized_update(),
             ),
@@ -943,10 +953,94 @@ def test_playback_step_asserts_operation_class_and_scrollback_policy() -> None:
 
     step.assert_operation_class("resize_repaint")
     step.assert_no_clear_scrollback()
+    step.assert_native_scrollback_safe()
     assert step.diagnostics.width_changed is True
     assert step.diagnostics.height_changed is True
     assert step.frame is not None
     assert step.frame.clear_scrollback_emitted is False
+
+
+def test_playback_step_rejects_history_sensitive_erase_when_preserving_scrollback() -> (
+    None
+):
+    harness = PlaybackHarness(
+        render=lambda _event, _size, _previous: RenderDiagnostics(
+            current_logical_lines=("unsafe",),
+            operation_class="baseline_repaint",
+            operations=(
+                TerminalOperation.clear_from_cursor(),
+                TerminalOperation.clear_screen(),
+            ),
+        )
+    )
+
+    step = harness.play([PlaybackEvent("render")])[0]
+
+    assert step.native_scrollback_safe is False
+    with pytest.raises(
+        AssertionError,
+        match="preserved native scrollback.*clear_from_cursor, clear_screen",
+    ):
+        step.assert_native_scrollback_safe()
+
+
+def test_playback_result_replays_successful_terminal_trace_without_renderer() -> None:
+    frames = iter(
+        (
+            (TerminalOperation.write("first"),),
+            (
+                TerminalOperation.move_cursor(row=0, column=0),
+                TerminalOperation.clear_line(),
+                TerminalOperation.write("second"),
+            ),
+        )
+    )
+    harness = PlaybackHarness(
+        render=lambda _event, _size, _previous: RenderDiagnostics(
+            current_logical_lines=("frame",),
+            operations=next(frames),
+        ),
+        port=FakeTerminalPort(size=TerminalSize(columns=20, rows=5)),
+    )
+    steps = harness.play(
+        [PlaybackEvent("render"), PlaybackEvent.resize(columns=30, rows=6)]
+    )
+    result = PlaybackResult(steps=steps, port=harness.port)
+
+    replayed = result.replay_terminal_trace()
+
+    assert replayed.size() == TerminalSize(columns=30, rows=6)
+    assert replayed.screen == harness.port.screen
+    assert tuple(frame.operations for frame in replayed.frames) == tuple(
+        step.diagnostics.operations for step in steps
+    )
+
+
+def test_fake_terminal_long_history_is_append_optimized_and_snapshot_stable() -> None:
+    port = FakeTerminalPort(size=TerminalSize(columns=20, rows=3))
+    lines = tuple(f"line {index:04d}" for index in range(2_048))
+
+    port.flush((TerminalOperation.write("\r\n".join(lines)),))
+    snapshot = port.screen
+    port.flush(
+        (
+            TerminalOperation.newline(),
+            TerminalOperation.write("line 2048"),
+        )
+    )
+
+    assert snapshot.scrollback_lines + snapshot.visible_lines == lines
+    assert snapshot.scrollback_lines[0] == "line 0000"
+    assert snapshot.scrollback_lines[-1] == "line 2044"
+    assert snapshot.scrollback_lines[-3:] == (
+        "line 2042",
+        "line 2043",
+        "line 2044",
+    )
+    assert port.screen.scrollback_lines + port.screen.visible_lines == (
+        *lines,
+        "line 2048",
+    )
 
 
 def test_playback_step_asserts_explicit_clear_scrollback() -> None:
@@ -974,6 +1068,7 @@ def test_playback_step_asserts_explicit_clear_scrollback() -> None:
 
     step.assert_operation_class("recovery_repaint")
     step.assert_has_clear_scrollback()
+    step.assert_native_scrollback_safe()
     assert step.diagnostics.clear_scrollback_emitted is True
     assert step.frame is not None
     assert step.frame.clear_scrollback_emitted is True

--- a/tests/tui/test_render_loop.py
+++ b/tests/tui/test_render_loop.py
@@ -1280,7 +1280,88 @@ def test_changed_range_above_viewport_rewrites_managed_viewport_without_clearing
     step.assert_operation_class("managed_viewport_repaint")
     step.assert_no_clear_scrollback()
     assert TerminalOperation.clear_screen() not in step.diagnostics.operations
+    assert TerminalOperation.clear_from_cursor() not in step.diagnostics.operations
     assert step.diagnostics.repaint_reason == "changed_range_above_viewport"
+
+
+@pytest.mark.parametrize("viewport_advance", (5, 6, 15))
+def test_changed_range_above_viewport_commits_large_advance_without_gaps(
+    viewport_advance: int,
+) -> None:
+    initial_lines = tuple(f"line {index}" for index in range(5))
+    root = StaticRoot(initial_lines)
+    port = FakeTerminalPort(size=TerminalSize(columns=30, rows=5))
+    runtime = TuiRuntime(
+        render_loop=RenderLoop(root, clear_scrollback_policy="disabled"),
+        terminal=port,
+    )
+    runtime.render_now()
+    root.lines = (
+        "LINE 0",
+        *tuple(f"line {index}" for index in range(1, 5 + viewport_advance)),
+    )
+
+    step = runtime.render_now()
+
+    step.assert_operation_class("managed_viewport_repaint")
+    step.assert_no_clear_scrollback()
+    assert TerminalOperation.clear_screen() not in step.diagnostics.operations
+    assert TerminalOperation.clear_from_cursor() not in step.diagnostics.operations
+    assert step.diagnostics.repaint_reason == "changed_range_above_viewport"
+    assert step.diagnostics.viewport_top - step.diagnostics.previous_viewport_top == viewport_advance
+    assert port.screen.scrollback_lines + port.screen.visible_lines == root.lines
+
+
+def test_trimmed_transcript_rebases_scrollback_before_protected_append() -> None:
+    history = tuple(f"history {index}" for index in range(12))
+    footer = (
+        "",
+        "working 1.00s",
+        "",
+        f"› {CURSOR_MARKER}",
+        "",
+        "status running",
+    )
+    root = TextRoot("\n".join((*history, *footer)))
+    port = FakeTerminalPort(size=TerminalSize(columns=40, rows=8))
+    render_loop = RenderLoop(root, clear_scrollback_policy="disabled")
+    runtime = TuiRuntime(render_loop=render_loop, terminal=port)
+    runtime.render_now()
+    physical_before_trim = port.screen.scrollback_lines + port.screen.visible_lines
+
+    root.text = "\n".join((*history[-2:], *footer))
+    render_loop.reset_baseline("transcript_window_trimmed:active_line_budget")
+    rebase = runtime.render_now()
+
+    rebase.assert_operation_class("managed_viewport_repaint")
+    rebase.assert_no_clear_scrollback()
+    assert TerminalOperation.clear_screen() not in rebase.diagnostics.operations
+    assert TerminalOperation.clear_from_cursor() not in rebase.diagnostics.operations
+    assert rebase.diagnostics.scrollback_frontier_rebased is True
+    assert port.screen.scrollback_lines + port.screen.visible_lines == physical_before_trim
+
+    root.text = "\n".join((*history[-2:], "append 0", "append 1", *footer))
+    first_append = runtime.render_now()
+    root.text = "\n".join(
+        (*history[-2:], "append 0", "append 1", "append 2", "append 3", *footer)
+    )
+    second_append = runtime.render_now()
+
+    first_append.assert_operation_class("protected_append_update")
+    second_append.assert_operation_class("protected_append_update")
+    assert port.screen.scrollback_lines + port.screen.visible_lines == (
+        *history,
+        "append 0",
+        "append 1",
+        "append 2",
+        "append 3",
+        "",
+        "working 1.00s",
+        "",
+        "›",
+        "",
+        "status running",
+    )
 
 
 def test_baseline_reset_repaints_active_screen_without_diffing_against_old_lines() -> None:
@@ -1295,10 +1376,42 @@ def test_baseline_reset_repaints_active_screen_without_diffing_against_old_lines
 
     step.assert_operation_class("baseline_repaint")
     step.assert_no_clear_scrollback()
+    assert TerminalOperation.clear_screen() not in step.diagnostics.operations
+    assert TerminalOperation.clear_from_cursor() not in step.diagnostics.operations
+    assert TerminalOperation.clear_line() in step.diagnostics.operations
     assert step.diagnostics.repaint_kind == "recovery"
     assert step.diagnostics.repaint_reason == "transcript_window_replaced"
+    assert step.diagnostics.scrollback_frontier_rebased is True
     assert step.diagnostics.previous_rendered_lines == ("old transcript", "status")
     assert step.diagnostics.current_logical_lines == ("compacted summary", "recent suffix", "status")
+
+
+def test_failed_trimmed_rebase_flush_does_not_advance_scrollback_frontier() -> None:
+    initial_lines = tuple(f"history {index}" for index in range(20))
+    root = StaticRoot(initial_lines)
+    port = FakeTerminalPort(size=TerminalSize(columns=30, rows=5))
+    render_loop = RenderLoop(root, clear_scrollback_policy="disabled")
+    runtime = TuiRuntime(render_loop=render_loop, terminal=port)
+    runtime.render_now()
+    committed_revision = render_loop.committed_frame_revision
+    committed_frontier = render_loop.scrollback_viewport_top
+    screen_before = port.screen
+
+    root.lines = initial_lines[-5:]
+    render_loop.reset_baseline("transcript_window_trimmed:active_line_budget")
+    port.fail_next_flush(RuntimeError("write failed"))
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        runtime.render_now()
+
+    assert render_loop.committed_frame_revision == committed_revision
+    assert render_loop.scrollback_viewport_top == committed_frontier
+    assert port.screen == screen_before
+
+    retry = runtime.render_now()
+
+    assert retry.diagnostics.scrollback_frontier_rebased is True
+    assert render_loop.scrollback_viewport_top == retry.diagnostics.viewport_top
 
 
 def test_failed_runtime_flush_does_not_advance_render_loop_snapshot() -> None:


### PR DESCRIPTION
## Summary
- preserve terminal scrollback across transcript replacement, trimming, and large viewport advances
- add scrollback-safe playback traces and append-linear FakeTerminal history
- strengthen tmux PTY coverage with exact-once resume/trim streaming assertions

## Validation
- make test-tui-render-contract (174 passed)
- tmux PTY integration (3 passed)
- make check-harnesstui (1294 passed, 66 deselected; Ruff and mypy passed)
- playback focused regressions (127 passed)
- testing strategy docs (13 passed)