### PR TITLE
fix(tui): stop resume picker after activation

### DIFF
--- a/src/loushang/tui/runner.py
+++ b/src/loushang/tui/runner.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import sys
 from collections.abc import Awaitable, Callable
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, suppress
 from dataclasses import dataclass, field
 from typing import TextIO
 
@@ -63,6 +63,7 @@ class TuiRunContext:
     terminal_context: object
     reader: InputReader
     _render_wakeup: asyncio.Event = field(repr=False)
+    _stop_wakeup: asyncio.Event = field(repr=False)
     _stop_exit_code: int | None = field(default=None, repr=False)
 
     def request_render(self, kind: RenderRequestKind = "input") -> None:
@@ -78,7 +79,7 @@ class TuiRunContext:
         """
 
         self._stop_exit_code = exit_code
-        self._render_wakeup.set()
+        self._stop_wakeup.set()
 
     def stop(self, exit_code: int = 0) -> TuiInputResult:
         return TuiInputResult(exit_code=exit_code)
@@ -124,6 +125,8 @@ class TuiRunner:
         )
         reader = InputReader()
         render_wakeup = asyncio.Event()
+        stop_wakeup = asyncio.Event()
+        stop_task: asyncio.Task[bool] | None = None
 
         previous_terminal = self.tui.terminal
         previous_runtime = self.tui._runtime
@@ -145,7 +148,9 @@ class TuiRunner:
                     terminal_context=terminal_context,
                     reader=reader,
                     _render_wakeup=render_wakeup,
+                    _stop_wakeup=stop_wakeup,
                 )
+                stop_task = asyncio.create_task(stop_wakeup.wait())
                 if on_start is not None:
                     start_result = on_start(context)
                     if inspect.isawaitable(start_result):
@@ -161,7 +166,7 @@ class TuiRunner:
                     data = await read_input_chunk_or_render_tick(
                         stdin,
                         runtime=runtime,
-                        active_task=None,
+                        active_task=stop_task,
                         input_chunk_reader=self.input_chunk_reader,
                         render_wakeup=render_wakeup,
                         pending_input_idle_ms=(
@@ -207,6 +212,10 @@ class TuiRunner:
                         if result.render_requested:
                             request_runtime_render(runtime, "input")
         finally:
+            if stop_task is not None and not stop_task.done():
+                stop_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await stop_task
             self.tui.terminal = previous_terminal
             self.tui._runtime = previous_runtime
             self.tui.terminal_context = previous_context

--- a/tests/tui/test_runner.py
+++ b/tests/tui/test_runner.py
@@ -416,3 +416,34 @@ def test_runner_exits_when_context_requests_stop_without_input() -> None:
         ).run(on_input=handle)
 
     assert asyncio.run(run()) == 5
+
+
+def test_runner_exits_when_background_task_requests_stop_while_input_waits() -> None:
+    tui = Tui()
+    tui.add_child(_MutableRenderable(("ready",)))
+
+    async def run() -> int:
+        async def wait_for_input(_stdin: object) -> str:
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        async def start(context: Any) -> None:
+            async def stop_later() -> None:
+                await asyncio.sleep(0)
+                context.request_stop(6)
+
+            asyncio.create_task(stop_later())
+
+        return await asyncio.wait_for(
+            TuiRunner(
+                tui,
+                stdin=StringIO(""),
+                stdout=StringIO(),
+                terminal_session_factory=_recording_terminal_session_factory(),
+                terminal_size_provider=lambda: TerminalSize(columns=20, rows=5),
+                input_chunk_reader=wait_for_input,
+            ).run(on_start=start),
+            timeout=0.1,
+        )
+
+    assert asyncio.run(run()) == 6


### PR DESCRIPTION
## Summary
- give TuiRunner a dedicated stop wakeup separate from render wakeups
- interrupt a blocked terminal input wait when background activation finishes
- add a regression test proving background stop completes without further keyboard input

## Validation
- Windows: 1358 passed, 13 skipped (tests/tui and tests/harnesstui/continuity)
- WSL Ubuntu: 1364 passed, 7 skipped (same suites)
- ruff check and format check on changed files

## Notes
- The full Windows suite has a pre-existing unrelated failure in AI credential storage because os.fchmod is unavailable on Windows.