### PR TITLE
feat(tui): support Windows clipboard image paste

### DIFF
--- a/docs/en/reference/tui-editing.md
+++ b/docs/en/reference/tui-editing.md
@@ -106,7 +106,8 @@ Keybinding defaults are composed by owner. Generic TUI provides the Core
 catalogs when those surfaces are constructed. Duplicate action definitions
 fail during catalog composition, while user overrides are retained until the
 owning catalog is available. Clipboard-image paste is the conversation action
-`conversation.input.pasteImage` (Ctrl+V by default).
+`conversation.input.pasteImage` (Ctrl+V by default; native Windows also provides
+Alt+V as a fallback when the terminal intercepts Ctrl+V).
 
 ### Input intent contract
 

--- a/docs/zh-CN/reference/tui-editing.md
+++ b/docs/zh-CN/reference/tui-editing.md
@@ -90,7 +90,8 @@ follow-up 使用 `conversation.input.followUp`（默认 Alt+Enter）。空闲时
 `TUI_CORE_KEYBINDING_CATALOG`；HarnessTUI 在构造会话或 continuity surface 时
 追加相应 catalog。重复 action 定义会在组合时直接失败，用户覆盖则保留到对应
 catalog 加载后再解析。剪贴板图片粘贴使用会话 action
-`conversation.input.pasteImage`（默认 Ctrl+V）。
+`conversation.input.pasteImage`（默认 Ctrl+V；原生 Windows 还支持 Alt+V
+备用键，供终端拦截 Ctrl+V 时使用）。
 
 ### 输入意图契约
 

--- a/src/loushang/harnesstui/conversation/input_policy.py
+++ b/src/loushang/harnesstui/conversation/input_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
@@ -23,6 +24,12 @@ CONVERSATION_KEYBINDING_DEFINITIONS = {
 }
 CONVERSATION_KEYBINDING_CATALOG = KeybindingCatalog.from_definitions(
     CONVERSATION_KEYBINDING_DEFINITIONS
+)
+_WINDOWS_CONVERSATION_KEYBINDING_CATALOG = KeybindingCatalog.from_definitions(
+    {
+        **CONVERSATION_KEYBINDING_DEFINITIONS,
+        CONVERSATION_PASTE_IMAGE_ACTION: ("ctrl+v", "alt+v"),
+    }
 )
 
 
@@ -59,6 +66,8 @@ DEFAULT_CONVERSATION_INPUT_POLICY = ConversationInputPolicy()
 
 def conversation_keybinding_manager(
     keybindings: KeybindingManager | KeybindingConfig | None = None,
+    *,
+    platform_name: str | None = None,
 ) -> KeybindingManager:
     """Compose conversation actions over generic keybinding definitions."""
 
@@ -67,7 +76,13 @@ def conversation_keybinding_manager(
         if isinstance(keybindings, KeybindingManager)
         else KeybindingManager(keybindings)
     )
-    return manager.with_catalog(CONVERSATION_KEYBINDING_CATALOG)
+    resolved_platform = sys.platform if platform_name is None else platform_name
+    catalog = (
+        _WINDOWS_CONVERSATION_KEYBINDING_CATALOG
+        if resolved_platform == "win32"
+        else CONVERSATION_KEYBINDING_CATALOG
+    )
+    return manager.with_catalog(catalog)
 
 
 __all__ = [

--- a/src/loushang/tui/clipboard_image.py
+++ b/src/loushang/tui/clipboard_image.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import ctypes
 import os
+import struct
 import subprocess
 import sys
 import tempfile
+import time
 import uuid
 from collections.abc import Callable, Mapping
 from contextlib import suppress
@@ -14,6 +17,16 @@ from pathlib import Path
 from typing import Protocol
 
 SUPPORTED_IMAGE_MIME_TYPES = ("image/png", "image/jpeg", "image/webp", "image/gif")
+
+_CF_DIB = 8
+_CF_DIBV5 = 17
+_WINDOWS_PNG_CLIPBOARD_FORMATS = ("PNG", "image/png")
+_WINDOWS_CLIPBOARD_OPEN_ATTEMPTS = 5
+_WINDOWS_CLIPBOARD_RETRY_SECONDS = 0.05
+_BITMAP_FILE_HEADER_SIZE = 14
+_BITMAP_INFO_HEADER_SIZE = 40
+_BI_BITFIELDS = 3
+_BI_ALPHABITFIELDS = 6
 
 _MACOS_CLIPBOARD_IMAGE_SCRIPT = r'''
 ObjC.import("AppKit")
@@ -101,6 +114,7 @@ class _ClipboardImageReadContext:
     environment: Mapping[str, str]
     runner: CommandRunner
     native_reader: NativeClipboardReader | None
+    allow_host_native: bool
 
 
 class _ClipboardImageBackend(Protocol):
@@ -144,6 +158,7 @@ def read_clipboard_image(
         environment=environment,
         runner=_run_command if runner is None else runner,
         native_reader=native_reader,
+        allow_host_native=runner is None,
     )
     for backend in _resolve_clipboard_image_backends(host_kind):
         image = backend(context)
@@ -238,13 +253,17 @@ def _read_clipboard_image_via_wsl_powershell(context: _ClipboardImageReadContext
             "Add-Type -AssemblyName System.Windows.Forms; "
             "Add-Type -AssemblyName System.Drawing; "
             "$path = $env:LOUSHANG_WSL_CLIPBOARD_IMAGE_PATH; "
-            "$img = [System.Windows.Forms.Clipboard]::GetImage(); "
+            "$img = $null; "
+            "for ($attempt = 0; $attempt -lt 5 -and -not $img; $attempt++) { "
+            "try { $img = [System.Windows.Forms.Clipboard]::GetImage() } catch {}; "
+            "if (-not $img) { Start-Sleep -Milliseconds 50 } "
+            "}; "
             "if ($img) { $img.Save($path, [System.Drawing.Imaging.ImageFormat]::Png); Write-Output 'ok' } "
             "else { Write-Output 'empty' }"
         )
         result = context.runner(
             "powershell.exe",
-            ("-NoProfile", "-Command", script),
+            ("-NoProfile", "-STA", "-Command", script),
             timeout_seconds=5.0,
             env={**dict(context.environment), "LOUSHANG_WSL_CLIPBOARD_IMAGE_PATH": windows_path},
         )
@@ -259,6 +278,140 @@ def _read_clipboard_image_via_wsl_powershell(context: _ClipboardImageReadContext
             path.unlink()
 
 
+def _read_clipboard_image_via_windows_native(
+    context: _ClipboardImageReadContext,
+) -> ClipboardImage | None:
+    if not context.allow_host_native:
+        return None
+    try:
+        user32 = ctypes.windll.user32  # type: ignore[attr-defined]
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        _configure_windows_clipboard_api(user32, kernel32)
+    except (AttributeError, OSError, TypeError):
+        return None
+    opened = False
+    for _attempt in range(_WINDOWS_CLIPBOARD_OPEN_ATTEMPTS):
+        try:
+            opened = bool(user32.OpenClipboard(None))
+        except (OSError, TypeError, ValueError):
+            return None
+        if opened:
+            break
+        time.sleep(_WINDOWS_CLIPBOARD_RETRY_SECONDS)
+    if not opened:
+        return None
+    try:
+        for format_name in _WINDOWS_PNG_CLIPBOARD_FORMATS:
+            format_id = int(user32.RegisterClipboardFormatW(format_name))
+            payload = _windows_clipboard_payload(
+                user32,
+                kernel32,
+                format_id,
+            )
+            if payload:
+                return ClipboardImage(bytes=payload, mime_type="image/png")
+        for format_id in (_CF_DIBV5, _CF_DIB):
+            dib = _windows_clipboard_payload(user32, kernel32, format_id)
+            if not dib:
+                continue
+            bitmap = _windows_dib_to_bmp(dib)
+            if bitmap is not None:
+                return ClipboardImage(bytes=bitmap, mime_type="image/bmp")
+    except (OSError, TypeError, ValueError):
+        return None
+    finally:
+        with suppress(Exception):
+            user32.CloseClipboard()
+    return None
+
+
+def _configure_windows_clipboard_api(user32: object, kernel32: object) -> None:
+    user32.OpenClipboard.argtypes = [ctypes.c_void_p]  # type: ignore[attr-defined]
+    user32.OpenClipboard.restype = ctypes.c_int  # type: ignore[attr-defined]
+    user32.CloseClipboard.argtypes = []  # type: ignore[attr-defined]
+    user32.CloseClipboard.restype = ctypes.c_int  # type: ignore[attr-defined]
+    user32.RegisterClipboardFormatW.argtypes = [ctypes.c_wchar_p]  # type: ignore[attr-defined]
+    user32.RegisterClipboardFormatW.restype = ctypes.c_uint  # type: ignore[attr-defined]
+    user32.IsClipboardFormatAvailable.argtypes = [ctypes.c_uint]  # type: ignore[attr-defined]
+    user32.IsClipboardFormatAvailable.restype = ctypes.c_int  # type: ignore[attr-defined]
+    user32.GetClipboardData.argtypes = [ctypes.c_uint]  # type: ignore[attr-defined]
+    user32.GetClipboardData.restype = ctypes.c_void_p  # type: ignore[attr-defined]
+    kernel32.GlobalSize.argtypes = [ctypes.c_void_p]  # type: ignore[attr-defined]
+    kernel32.GlobalSize.restype = ctypes.c_size_t  # type: ignore[attr-defined]
+    kernel32.GlobalLock.argtypes = [ctypes.c_void_p]  # type: ignore[attr-defined]
+    kernel32.GlobalLock.restype = ctypes.c_void_p  # type: ignore[attr-defined]
+    kernel32.GlobalUnlock.argtypes = [ctypes.c_void_p]  # type: ignore[attr-defined]
+    kernel32.GlobalUnlock.restype = ctypes.c_int  # type: ignore[attr-defined]
+
+
+def _windows_clipboard_payload(
+    user32: object,
+    kernel32: object,
+    format_id: int,
+) -> bytes | None:
+    if format_id <= 0 or not user32.IsClipboardFormatAvailable(format_id):  # type: ignore[attr-defined]
+        return None
+    handle = user32.GetClipboardData(format_id)  # type: ignore[attr-defined]
+    if not handle:
+        return None
+    size = int(kernel32.GlobalSize(handle))  # type: ignore[attr-defined]
+    if size <= 0:
+        return None
+    pointer = kernel32.GlobalLock(handle)  # type: ignore[attr-defined]
+    if not pointer:
+        return None
+    try:
+        return ctypes.string_at(pointer, size)
+    finally:
+        kernel32.GlobalUnlock(handle)  # type: ignore[attr-defined]
+
+
+def _windows_dib_to_bmp(dib: bytes) -> bytes | None:
+    if len(dib) < 12:
+        return None
+    dib_header_size = struct.unpack_from("<I", dib)[0]
+    if dib_header_size == 12:
+        if len(dib) < 12:
+            return None
+        bit_count = struct.unpack_from("<H", dib, 10)[0]
+        palette_entry_size = 3
+        compression = 0
+        colors_used = 0
+    elif dib_header_size >= _BITMAP_INFO_HEADER_SIZE:
+        if len(dib) < _BITMAP_INFO_HEADER_SIZE or dib_header_size > len(dib):
+            return None
+        bit_count = struct.unpack_from("<H", dib, 14)[0]
+        compression = struct.unpack_from("<I", dib, 16)[0]
+        colors_used = struct.unpack_from("<I", dib, 32)[0]
+        palette_entry_size = 4
+    else:
+        return None
+    palette_entries = colors_used or (1 << bit_count if bit_count <= 8 else 0)
+    mask_size = (
+        (16 if compression == _BI_ALPHABITFIELDS else 12)
+        if dib_header_size == _BITMAP_INFO_HEADER_SIZE
+        and compression in {_BI_BITFIELDS, _BI_ALPHABITFIELDS}
+        else 0
+    )
+    pixel_offset = (
+        _BITMAP_FILE_HEADER_SIZE
+        + dib_header_size
+        + mask_size
+        + palette_entries * palette_entry_size
+    )
+    if pixel_offset > _BITMAP_FILE_HEADER_SIZE + len(dib):
+        return None
+    file_size = _BITMAP_FILE_HEADER_SIZE + len(dib)
+    file_header = b"BM" + struct.pack(
+        "<IHHI",
+        file_size,
+        0,
+        0,
+        pixel_offset,
+    )
+    return file_header + dib
+
+
 def _read_clipboard_image_via_windows_powershell(context: _ClipboardImageReadContext) -> ClipboardImage | None:
     path = Path(tempfile.gettempdir()) / f"loushang-win-clip-{uuid.uuid4().hex}.png"
     try:
@@ -266,14 +419,18 @@ def _read_clipboard_image_via_windows_powershell(context: _ClipboardImageReadCon
             "Add-Type -AssemblyName System.Windows.Forms; "
             "Add-Type -AssemblyName System.Drawing; "
             "$path = $env:LOUSHANG_CLIPBOARD_IMAGE_PATH; "
-            "$img = [System.Windows.Forms.Clipboard]::GetImage(); "
+            "$img = $null; "
+            "for ($attempt = 0; $attempt -lt 5 -and -not $img; $attempt++) { "
+            "try { $img = [System.Windows.Forms.Clipboard]::GetImage() } catch {}; "
+            "if (-not $img) { Start-Sleep -Milliseconds 50 } "
+            "}; "
             "if ($img) { $img.Save($path, [System.Drawing.Imaging.ImageFormat]::Png); Write-Output 'ok' } "
             "else { Write-Output 'empty' }"
         )
         for command in ("powershell.exe", "powershell"):
             result = context.runner(
                 command,
-                ("-NoProfile", "-Command", script),
+                ("-NoProfile", "-STA", "-Command", script),
                 timeout_seconds=5.0,
                 env={**dict(context.environment), "LOUSHANG_CLIPBOARD_IMAGE_PATH": str(path)},
             )
@@ -298,6 +455,8 @@ def _resolve_clipboard_host_kind(
 ) -> _ClipboardHostKind:
     if _is_macos(platform_name):
         return _ClipboardHostKind.MACOS
+    if platform_name.startswith("win"):
+        return _ClipboardHostKind.WINDOWS
     if _is_wsl(environment, probe_proc=probe_proc):
         return _ClipboardHostKind.WSL
     if _is_native_windows(platform_name, environment):
@@ -326,6 +485,7 @@ def _resolve_clipboard_image_backends(
             )
         case _ClipboardHostKind.WINDOWS:
             return (
+                _read_clipboard_image_via_windows_native,
                 _read_clipboard_image_via_windows_powershell,
                 _read_clipboard_image_via_injected_reader,
             )

--- a/src/loushang/tui/terminal_backends/windows.py
+++ b/src/loushang/tui/terminal_backends/windows.py
@@ -13,6 +13,8 @@ from functools import partial
 from typing import Any
 
 _EXTENDED_KEY_SEQUENCES = {
+    # msvcrt.getwch() exposes native Alt+V as NUL followed by scan code 0x2F.
+    "/": "\x1bv",
     "H": "\x1b[A",
     "P": "\x1b[B",
     "M": "\x1b[C",
@@ -56,6 +58,47 @@ _ENABLE_PROCESSED_OUTPUT = 0x0001
 _ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 _STD_INPUT_HANDLE = -10
 _STD_OUTPUT_HANDLE = -11
+_KEY_EVENT = 0x0001
+_RIGHT_ALT_PRESSED = 0x0001
+_LEFT_ALT_PRESSED = 0x0002
+_VK_MENU = 0x12
+_VK_LMENU = 0xA4
+_VK_RMENU = 0xA5
+_VK_V = 0x56
+_KEY_STATE_DOWN_MASK = 0x8000
+_MAX_PEEKED_INPUT_RECORDS = 32
+
+
+class _WindowsCharUnion(ctypes.Union):
+    _fields_ = [
+        ("UnicodeChar", ctypes.c_wchar),
+        ("AsciiChar", ctypes.c_char),
+    ]
+
+
+class _WindowsKeyEventRecord(ctypes.Structure):
+    _fields_ = [
+        ("bKeyDown", ctypes.c_int32),
+        ("wRepeatCount", ctypes.c_uint16),
+        ("wVirtualKeyCode", ctypes.c_uint16),
+        ("wVirtualScanCode", ctypes.c_uint16),
+        ("uChar", _WindowsCharUnion),
+        ("dwControlKeyState", ctypes.c_uint32),
+    ]
+
+
+class _WindowsInputEventUnion(ctypes.Union):
+    _fields_ = [
+        ("KeyEvent", _WindowsKeyEventRecord),
+        ("padding", ctypes.c_byte * 16),
+    ]
+
+
+class _WindowsInputRecord(ctypes.Structure):
+    _fields_ = [
+        ("EventType", ctypes.c_uint16),
+        ("Event", _WindowsInputEventUnion),
+    ]
 
 
 def _load_console_module() -> Any | None:
@@ -349,11 +392,24 @@ def _read_from_module(console: Any) -> str:
     return chunk + _read_escape_burst(console)
 
 
-def _read_logical_character(console: Any) -> str:
+def _read_logical_character(
+    console: Any,
+    *,
+    recover_plain_alt: bool = True,
+) -> str:
+    pending_alt_modifier = (
+        _windows_pending_alt_modifier() if recover_plain_alt else False
+    )
     char = console.getwch()
     if char in {"\x00", "\xe0"}:
         extended = console.getwch()
         return _EXTENDED_KEY_SEQUENCES.get(extended, char + extended)
+    if recover_plain_alt and char.lower() == "v" and (
+        pending_alt_modifier or _windows_alt_pressed()
+    ):
+        # Some Windows VT hosts preserve the physical Alt key state but expose
+        # Alt+V through getwch() as an unmodified printable character.
+        return "\x1bv"
     if _is_high_surrogate(char):
         trailing = console.getwch()
         if _is_low_surrogate(trailing):
@@ -368,6 +424,54 @@ def _read_logical_character(console: Any) -> str:
     if _is_low_surrogate(char):
         return _REPLACEMENT_CHARACTER
     return char
+
+
+def _windows_alt_pressed() -> bool:
+    try:
+        state = int(ctypes.windll.user32.GetAsyncKeyState(_VK_MENU))  # type: ignore[attr-defined]
+    except (AttributeError, OSError, TypeError, ValueError):
+        return False
+    return bool(state & _KEY_STATE_DOWN_MASK)
+
+
+def _windows_pending_alt_modifier() -> bool:
+    try:
+        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        handle = ctypes.c_void_p(kernel32.GetStdHandle(_STD_INPUT_HANDLE))
+        available = ctypes.c_uint32()
+        if not kernel32.GetNumberOfConsoleInputEvents(
+            handle,
+            ctypes.byref(available),
+        ):
+            return False
+        record_count = min(int(available.value), _MAX_PEEKED_INPUT_RECORDS)
+        if record_count <= 0:
+            return False
+        records = (_WindowsInputRecord * record_count)()
+        peeked = ctypes.c_uint32()
+        if not kernel32.PeekConsoleInputW(
+            handle,
+            records,
+            record_count,
+            ctypes.byref(peeked),
+        ):
+            return False
+    except (AttributeError, OSError, TypeError, ValueError):
+        return False
+    alt_mask = _LEFT_ALT_PRESSED | _RIGHT_ALT_PRESSED
+    for record in records[: int(peeked.value)]:
+        if record.EventType != _KEY_EVENT:
+            continue
+        key = record.Event.KeyEvent
+        if not key.bKeyDown:
+            continue
+        if key.wVirtualKeyCode in {_VK_MENU, _VK_LMENU, _VK_RMENU}:
+            return True
+        return bool(
+            key.wVirtualKeyCode == _VK_V
+            and key.dwControlKeyState & alt_mask
+        )
+    return False
 
 
 def _read_escape_burst(console: Any) -> str:
@@ -394,7 +498,7 @@ def _read_escape_burst(console: Any) -> str:
                 break
             time.sleep(_INPUT_POLL_INTERVAL_SECONDS)
             continue
-        chunk = _read_logical_character(console)
+        chunk = _read_logical_character(console, recover_plain_alt=False)
         if not chunk:
             break
         remaining = _ESCAPE_BURST_MAX_CHARS - size

--- a/tests/harnesstui/conversation/test_clipboard_input.py
+++ b/tests/harnesstui/conversation/test_clipboard_input.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import pytest
+
 from loushang.harnesstui.conversation.attachments import (
     PromptImageAttachment,
     PromptImageAttachmentOutcome,
@@ -96,7 +98,9 @@ def test_clipboard_builder_satisfies_standard_router_factory_contract() -> None:
 
 def test_standard_clipboard_image_profile_is_harnesstui_owned(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr("sys.platform", "win32")
     app = _ConversationApp(str(tmp_path))
     assert STANDARD_CLIPBOARD_IMAGE_INPUT_PROFILE.status_copy.attached_prefix == (
         "Attached clipboard image: "
@@ -111,7 +115,7 @@ def test_standard_clipboard_image_profile_is_harnesstui_owned(
         clipboard_image_name_factory=lambda: "shared",
     )
 
-    result = router.handle(InputEvent(kind="key", key="ctrl+v"))
+    result = router.handle(InputEvent(kind="key", key="alt+v"))
 
     expected = tmp_path / ".loushang" / "clipboard" / "clipboard-shared.png"
     assert expected.read_bytes() == b"png"
@@ -124,7 +128,9 @@ def test_standard_clipboard_image_profile_is_harnesstui_owned(
 
 def test_clipboard_image_uses_the_conversation_action_override(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr("sys.platform", "win32")
     app = _ConversationApp(str(tmp_path))
     router = _builder()(
         app,
@@ -137,10 +143,12 @@ def test_clipboard_image_uses_the_conversation_action_override(
         clipboard_image_name_factory=lambda: "override",
     )
 
-    ignored = router.handle(InputEvent(kind="key", key="ctrl+v"))
+    ignored_ctrl = router.handle(InputEvent(kind="key", key="ctrl+v"))
+    ignored_alt = router.handle(InputEvent(kind="key", key="alt+v"))
     attached = router.handle(InputEvent(kind="key", key="ctrl+p"))
 
-    assert ignored.kind == "ignored"
+    assert ignored_ctrl.kind == "ignored"
+    assert ignored_alt.kind == "ignored"
     assert isinstance(attached, ConversationClipboardResult)
 
 

--- a/tests/harnesstui/conversation/test_input.py
+++ b/tests/harnesstui/conversation/test_input.py
@@ -56,11 +56,22 @@ class _ConversationApp:
         self.state.queue_steer(text)
 
 
-def test_conversation_keybinding_catalog_owns_conversation_actions() -> None:
-    manager = conversation_keybinding_manager()
+@pytest.mark.parametrize(
+    ("platform_name", "paste_keys"),
+    [
+        ("linux", ("ctrl+v",)),
+        ("darwin", ("ctrl+v",)),
+        ("win32", ("ctrl+v", "alt+v")),
+    ],
+)
+def test_conversation_keybinding_catalog_owns_conversation_actions(
+    platform_name: str,
+    paste_keys: tuple[str, ...],
+) -> None:
+    manager = conversation_keybinding_manager(platform_name=platform_name)
 
     assert manager.keys_for(CONVERSATION_FOLLOW_UP_ACTION) == ("alt+enter",)
-    assert manager.keys_for(CONVERSATION_PASTE_IMAGE_ACTION) == ("ctrl+v",)
+    assert manager.keys_for(CONVERSATION_PASTE_IMAGE_ACTION) == paste_keys
     assert manager.keys_for(CONVERSATION_QUEUE_EDIT_LAST_ACTION) == ("alt+up",)
     assert manager.keys_for("app.clipboard.pasteImage") == ()
 

--- a/tests/harnesstui/testing/test_screen_loop_playback.py
+++ b/tests/harnesstui/testing/test_screen_loop_playback.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 
 import pytest
 
+from loushang.harnesstui.conversation.input import bind_clipboard_image_input_router
 from loushang.harnesstui.conversation.screen_state import ScreenConversationState
 from loushang.harnesstui.testing.screen_loop_playback import (
     BlockingPromptController,
@@ -13,6 +14,7 @@ from loushang.harnesstui.testing.screen_loop_playback import (
     ConversationScreenLoopScenario,
     ScriptedInputChunk,
 )
+from loushang.tui.clipboard_image import ClipboardImage
 from loushang.tui.core import RenderConstraints, RenderResult
 from loushang.tui.framework import SurfaceHost
 from loushang.tui.input import BRACKETED_PASTE_END, BRACKETED_PASTE_START
@@ -169,6 +171,61 @@ def test_screen_loop_playback_preserves_focus_and_paste_tails_at_idle_deadline()
     assert prompts == [pasted]
     assert "[I" not in result.output
     assert "[201~" not in result.output
+
+
+def test_screen_loop_playback_routes_windows_alt_v_to_clipboard_image(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("sys.platform", "win32")
+
+    def app_factory(*, now):
+        app = _ScreenApp(clock=now)
+        app.state.cwd = str(tmp_path)
+        return app
+
+    clipboard_router = bind_clipboard_image_input_router()
+
+    def input_router_factory(
+        *, app, should_exit, is_local_command, keybindings, width, height
+    ):
+        return clipboard_router(
+            app=app,
+            should_exit=should_exit,
+            is_local_command=is_local_command,
+            keybindings=keybindings,
+            width=width,
+            height=height,
+            clipboard_image_reader=lambda: ClipboardImage(
+                bytes=b"png",
+                mime_type="image/png",
+            ),
+            clipboard_image_name_factory=lambda: "playback",
+        )
+
+    playback = ConversationScreenLoopPlayback(
+        app_factory=app_factory,
+        interruption_message="interrupted",
+        cancellation_message="cancelled",
+        width=40,
+        height=8,
+        input_router_factory=input_router_factory,
+    )
+
+    result = playback.run(
+        # The Windows backend normalizes native getwch() bytes NUL + 0x2F
+        # (the V scan code) into this terminal-style Alt+V sequence.
+        (0.00, "\x1bv"),
+        (0.01, ""),
+    )
+
+    marker = "@.loushang/clipboard/clipboard-playback.png"
+    result.assert_exit_code(0)
+    result.assert_composer_text(f"{marker} ")
+    assert (tmp_path / ".loushang" / "clipboard" / "clipboard-playback.png").read_bytes() == b"png"
+    assert playback.app.state.status_message == (
+        "Attached clipboard image: .loushang/clipboard/clipboard-playback.png"
+    )
 
 
 def test_screen_loop_scenario_builds_timed_input_recipe() -> None:

--- a/tests/tui/test_clipboard_image.py
+++ b/tests/tui/test_clipboard_image.py
@@ -32,12 +32,35 @@ def _tiny_tiff_1x1_red() -> bytes:
     return output.getvalue()
 
 
+def test_windows_dib_payload_builds_a_valid_bitmap_file() -> None:
+    from PIL import Image
+
+    from loushang.tui.clipboard_image import _windows_dib_to_bmp
+
+    bitmap = _tiny_bmp_1x1_red()
+    rebuilt = _windows_dib_to_bmp(bitmap[14:])
+
+    assert rebuilt == bitmap
+    assert rebuilt is not None
+    with Image.open(BytesIO(rebuilt)) as image:
+        assert image.convert("RGB").getpixel((0, 0)) == (255, 0, 0)
+
+
 @pytest.mark.parametrize(
     ("platform_name", "env", "expected"),
     [
         ("darwin", {"WAYLAND_DISPLAY": "wayland-0", "WSL_DISTRO_NAME": "Ubuntu"}, "macos"),
         ("linux", {"OS": "Windows_NT", "WSL_DISTRO_NAME": "Ubuntu"}, "wsl"),
         ("win32", {"OS": "Windows_NT"}, "windows"),
+        (
+            "win32",
+            {
+                "OS": "Windows_NT",
+                "WSLENV": "WT_SESSION",
+                "WSL_DISTRO_NAME": "Ubuntu",
+            },
+            "windows",
+        ),
         ("linux", {"WAYLAND_DISPLAY": "wayland-0"}, "wayland"),
         ("linux", {}, "x11"),
     ],
@@ -63,7 +86,10 @@ def test_clipboard_image_resolves_host_kind(
     [
         ("macos", ("macos_native", "pngpaste", "injected_reader")),
         ("wsl", ("wl_paste", "xclip", "wsl_powershell", "injected_reader")),
-        ("windows", ("windows_powershell", "injected_reader")),
+        (
+            "windows",
+            ("windows_native", "windows_powershell", "injected_reader"),
+        ),
         ("wayland", ("wl_paste", "xclip", "injected_reader")),
         ("x11", ("injected_reader", "xclip")),
     ],
@@ -187,6 +213,7 @@ def test_clipboard_image_uses_wsl_powershell_fallback(tmp_path) -> None:
     assert image.mime_type == "image/png"
     assert calls[-2][0] == "wslpath"
     assert calls[-1][0] == "powershell.exe"
+    assert calls[-1][1][:3] == ("-NoProfile", "-STA", "-Command")
 
 
 def test_clipboard_image_prefers_macos_native_png() -> None:
@@ -350,7 +377,8 @@ def test_clipboard_image_uses_native_windows_powershell_without_wslpath(tmp_path
     assert image.mime_type == "image/png"
     assert len(calls) == 1
     assert calls[0][0] == "powershell.exe"
-    assert calls[0][1][:2] == ("-NoProfile", "-Command")
+    assert calls[0][1][:3] == ("-NoProfile", "-STA", "-Command")
+    assert "Start-Sleep -Milliseconds 50" in calls[0][1][3]
 
 
 def test_clipboard_command_runner_forwards_environment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tui/test_terminal_input_windows.py
+++ b/tests/tui/test_terminal_input_windows.py
@@ -66,6 +66,76 @@ def test_read_input_chunk_keeps_windows_focus_report_atomic(monkeypatch: Any) ->
     )
 
 
+def test_read_input_chunk_normalizes_native_windows_alt_v(monkeypatch: Any) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    _install_fake_console(monkeypatch, chars=["\x00", "/"])
+
+    result = asyncio.run(read_input_chunk(_TtyInput()))
+
+    assert result == "\x1bv"
+    assert InputReader().feed(result) == (
+        InputEvent(kind="key", key="alt+v", raw="\x1bv"),
+    )
+
+
+def test_read_input_chunk_recovers_alt_v_when_vt_input_drops_modifier(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        "loushang.tui.terminal_backends.windows._windows_pending_alt_modifier",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "loushang.tui.terminal_backends.windows._windows_alt_pressed",
+        lambda: False,
+    )
+    _install_fake_console(monkeypatch, chars=["v"])
+
+    result = asyncio.run(read_input_chunk(_TtyInput()))
+
+    assert result == "\x1bv"
+    assert InputReader().feed(result) == (
+        InputEvent(kind="key", key="alt+v", raw="\x1bv"),
+    )
+
+
+def test_read_input_chunk_does_not_duplicate_escape_for_legacy_alt_v(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        "loushang.tui.terminal_backends.windows._windows_pending_alt_modifier",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "loushang.tui.terminal_backends.windows._windows_alt_pressed",
+        lambda: True,
+    )
+    _install_fake_console(monkeypatch, chars=["\x1b", "v"])
+
+    result = asyncio.run(read_input_chunk(_TtyInput()))
+
+    assert result == "\x1bv"
+    assert InputReader().feed(result) == (
+        InputEvent(kind="key", key="alt+v", raw="\x1bv"),
+    )
+
+
+def test_read_input_chunk_keeps_plain_v_without_alt_modifier(monkeypatch: Any) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(
+        "loushang.tui.terminal_backends.windows._windows_alt_pressed",
+        lambda: False,
+    )
+    _install_fake_console(monkeypatch, chars=["v"])
+
+    result = asyncio.run(read_input_chunk(_TtyInput()))
+
+    assert result == "v"
+    assert InputReader().feed(result) == (InputEvent(kind="text", text="v"),)
+
+
 def test_read_input_chunk_keeps_windows_bracketed_paste_atomic(
     monkeypatch: Any,
 ) -> None:


### PR DESCRIPTION
## Summary

- add Windows-only Alt+V fallback for clipboard image paste
- normalize native and VT Windows Alt+V input without inserting a literal `v`
- read PNG/DIB clipboard images through the native Win32 clipboard API, with PowerShell fallback
- correctly classify native Windows even when WSL environment variables are present
- document the Windows fallback and add regression/playback coverage

## Validation

- `uv run pytest tests/tui tests/harnesstui -q --skip-host-runtime` (1855 passed, 13 skipped)
- Ruff checks on all changed files
- `uv run mypy src/loushang/tui/clipboard_image.py src/loushang/tui/terminal_backends/windows.py`
- physical PowerShell probe confirmed Alt+V routes and attaches a PNG clipboard image