### PR TITLE
fix(tui): release rows after completion closes

### DIFF
--- a/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-011-command-and-selection-surfaces.md
+++ b/docs/internals/architecture/tui/native-terminal-core/key-designs/KD-011-command-and-selection-surfaces.md
@@ -62,9 +62,9 @@ Rules:
   terminal scrollback as historical transcript content.
 - While completion is open, the ordinary status row is hidden. It returns after
   completion closes.
-- Completion close must not move the composer row. The bottom frame may keep a
-  transient height floor for the current frame and fill released rows with
-  separator/status/blank rows.
+- Completion close must release the suggestion rows immediately. The render
+  loop clears the stale rows and keeps its cursor estimate synchronized while
+  the ordinary separator and status rows return.
 - When `/quit` or another exit command is submitted, the runtime must clean the
   current completion/status area so the shell prompt starts on a clean new line.
 
@@ -180,7 +180,8 @@ replacement for the selection color.
 - slash completion hides ordinary status and restores it after close.
 - slash completion updates in place and does not enter scrollback history.
 - slash completion exit commands leave the shell prompt on a clean line.
-- closing inline completion keeps the composer row visually anchored.
+- closing inline completion releases its rows and leaves the cursor on the
+  composer.
 - model selection suppresses ordinary composer and status rows.
 - model selection uses `>` without shifting ordinal/content columns.
 - model selection aligns ordinals, model names, current markers, descriptions,

--- a/src/loushang/tui/ui_parts/composer.py
+++ b/src/loushang/tui/ui_parts/composer.py
@@ -940,24 +940,12 @@ class BottomFrame:
     working_line: WorkingLine | None = None
     pending_queue: PendingQueueView | None = None
     surface: Any | None = None
-    _completion_height_floor: int = field(default=0, init=False, repr=False)
 
     def render(self, constraints: RenderConstraints) -> RenderResult:
         if constraints.max_height == 1:
             composer_result = self.composer.render(RenderConstraints(width=constraints.width, max_height=1))
             return _frame_result([line.text for line in composer_result.lines][-1:], constraints, composer_result.cursor, cursor_offset=0)
-        result = ScreenRegionStack(self.regions()).render(constraints)
-        if self.composer.has_completions:
-            self._completion_height_floor = max(self._completion_height_floor, len(result.lines))
-            return result
-        return self._pad_to_completion_height_floor(result, constraints)
-
-    def _pad_to_completion_height_floor(self, result: RenderResult, constraints: RenderConstraints) -> RenderResult:
-        if self._completion_height_floor <= len(result.lines) or len(result.lines) >= constraints.max_height:
-            return result
-        target_height = min(self._completion_height_floor, constraints.max_height)
-        padded_lines = [*result.lines, *(RenderLine("") for _ in range(target_height - len(result.lines)))]
-        return RenderResult.from_lines(padded_lines, constraints=constraints, cursor=result.cursor)
+        return ScreenRegionStack(self.regions()).render(constraints)
 
     def regions(self) -> tuple[ScreenRegion, ...]:
         regions: list[ScreenRegion] = []

--- a/tests/coding/test_screen_coding_tui_terminal_playback.py
+++ b/tests/coding/test_screen_coding_tui_terminal_playback.py
@@ -302,7 +302,7 @@ def test_screen_coding_tui_long_stream_commits_history_without_partial_scroll_re
     assert all(TerminalOperation.clear_screen() not in step.diagnostics.operations for step in protected_steps)
 
 
-def test_screen_coding_tui_completion_close_keeps_footer_height_and_cursor_anchor() -> None:
+def test_screen_coding_tui_completion_close_reclaims_rows_and_keeps_cursor_synced() -> None:
     app = _app()
     app.composer.set_completion_provider(
         CompletionProvider(
@@ -314,7 +314,7 @@ def test_screen_coding_tui_completion_close_keeps_footer_height_and_cursor_ancho
     )
     app.start_prompt("previous", started_at=0.0)
     app.begin_assistant()
-    app.append_assistant_chunk("done")
+    app.append_assistant_chunk("\n".join(f"done {index}" for index in range(16)))
     app.end_assistant()
     app.complete_run(elapsed_seconds=1.0)
     router = build_screen_input_router(app, should_exit=lambda text: text == "/quit", is_local_command=lambda text: text.startswith("/"))
@@ -330,12 +330,21 @@ def test_screen_coding_tui_completion_close_keeps_footer_height_and_cursor_ancho
 
     visible = tuple(strip_control_sequences(line).rstrip() for line in port.screen.visible_lines)
 
-    assert len(collapsed.diagnostics.current_logical_lines) == len(expanded.diagnostics.current_logical_lines)
+    assert len(collapsed.diagnostics.current_logical_lines) < len(
+        expanded.diagnostics.current_logical_lines
+    )
     assert collapsed.frame is not None
-    assert collapsed.frame.screen_after.cursor_row == collapsed.diagnostics.hardware_cursor_row
+    assert collapsed.frame.screen_after.cursor_row == (
+        collapsed.diagnostics.hardware_cursor_row
+        - collapsed.diagnostics.viewport_top
+    )
     assert recalled.frame is not None
-    assert recalled.frame.screen_after.cursor_row == recalled.diagnostics.hardware_cursor_row
+    assert recalled.frame.screen_after.cursor_row == (
+        recalled.diagnostics.hardware_cursor_row
+        - recalled.diagnostics.viewport_top
+    )
     assert visible.count("kimi | repo | main | abcd | idle | perm=standard") == 1
+    assert visible[-1] == "kimi | repo | main | abcd | idle | perm=standard"
 
 
 def test_screen_coding_tui_active_window_trim_rewrites_viewport_without_clearing_screen() -> None:

--- a/tests/tui/test_composer_bottom_frame.py
+++ b/tests/tui/test_composer_bottom_frame.py
@@ -1588,7 +1588,7 @@ def test_bottom_frame_hides_status_while_completion_list_is_visible() -> None:
     assert "model" not in rendered
 
 
-def test_bottom_frame_keeps_completion_height_floor_after_completion_closes() -> None:
+def test_bottom_frame_releases_completion_height_after_completion_closes() -> None:
     composer = Composer(prompt="> ")
     composer.insert_text("/")
     frame = BottomFrame(
@@ -1619,7 +1619,6 @@ def test_bottom_frame_keeps_completion_height_floor_after_completion_closes() ->
         "> ",
         "",
         "model",
-        "",
     )
 
 


### PR DESCRIPTION
## Summary

- remove the persistent completion-height floor from the TUI bottom frame
- release suggestion rows immediately when completion closes
- keep shrink repaint cursor diagnostics covered by terminal playback
- update the command/selection surface contract

## Validation

- `uv run pytest tests/tui --skip-host-runtime -q -p no:cacheprovider` — 1340 passed, 13 skipped
- `uv run pytest tests/harnesstui tests/coding -m tui_render_contract -q -p no:cacheprovider` — 68 passed
- `uv run ruff check src/loushang/tui/ui_parts/composer.py tests/tui/test_composer_bottom_frame.py tests/coding/test_screen_coding_tui_terminal_playback.py`
- `uv run mypy src/loushang/tui`