### PR TITLE
docs(plugin): freeze PLC9B safe package boundary

### DIFF
--- a/docs/internals/architecture/harness/plugin/README.md
+++ b/docs/internals/architecture/harness/plugin/README.md
@@ -72,6 +72,10 @@ Neither may silently override a narrower implemented owner contract.
   freezes the internal transport-neutral command/query boundary, read-only
   owner-revisioned projection, one-way enablement migration, and Coding CLI
   adaptation without widening the public author SDK.
+- [PLC9B Safe Package Boundary Contract](plugin-lifecycle-plc9b-contract.md)
+  freezes the design-only Package acquisition owner, exact entrypoint
+  inventory, versioned wheel/closure/publication evidence, fail-closed recovery,
+  and mandatory adversarial acceptance matrix without implementing extraction.
 - [Plugin Authoring Guide](plugin-authoring-guide.md) documents the minimum
   stable Provider, Skill package, validation, and developer-conformance flows.
 - [PAP4 Capability Admission Contract](plugin-capability-admission-pap4-contract.md)

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9-inventory.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9-inventory.md
@@ -7,6 +7,8 @@
 - Effect: descriptive and test-frozen only; it grants no new runtime authority.
 - Companion decision:
   [Plugin Lifecycle PLC9.0 Baseline](plugin-lifecycle-plc9-baseline.md).
+- PLC9B.0 refinement:
+  [Safe Package Boundary Contract](plugin-lifecycle-plc9b-contract.md).
 
 This inventory distinguishes accepted reusable owners, Product adapters,
 parallel compatibility paths, and missing target boundaries. “Migrate” or
@@ -116,6 +118,116 @@ source bytes through safe extraction and dependency verification to immutable
 publication. PLC9B must create that composition without claiming that
 `PluginRevisionStore` validates archives or that `PluginPackageLifecycleLedger`
 materializes packages.
+
+## PLC9B.0 Exact Entrypoint And Owner Inventory
+
+PLC9B.0 freezes the pre-runtime-migration snapshot at parent `4bd71d63`: 70
+exact `(source path, qualified scope, lifecycle symbol)` rows and 111 source
+occurrences. The executable architecture guard parses Python syntax rather than
+matching comments. Any count or qualified-site change must update this canonical
+inventory and receive the same security-boundary review.
+
+| Entrypoint/owner group | Current exact owner | PLC9B target authority and gate |
+| --- | --- | --- |
+| Coding Package query | `src/loushang/coding/cli/__main__.py::_run_list_packages` | Read-only query may remain; a future Plugin-bound artifact action must use the common application gate and cannot construct a materializer |
+| CLI launch flags | `src/loushang/harness/cli/agent_args.py::agent_cli_argument_values` | Inert projection only; startup execution classifies before any side effect |
+| Shared CLI Package dispatch | `src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle` and `_invoke_source_operation` | Transport adapter calls the one PLC9B application port or returns stable refusal |
+| RPC Package transport | `src/loushang/harness/host/rpc/commands/packages.py::_PackageCapabilities`, `_DynamicPackageCapabilities`, and `RpcPackageCommands` | Transport capability cannot use dynamic fallback as authority; classify and route/refuse before Session/materializer mutation |
+| Public Session forwarding | `src/loushang/harness/session/facade_optional.py::SessionPackagePort` and `SessionFacadeOptionalOperations` | Typed forwarding only; no concrete Package owner import or unsafe fallback |
+| Session lifecycle compatibility | `src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter` | Temporary adapter routes/refuses Plugin-bound input; dynamic method lookup grants no authority |
+| Product Package composition | `src/loushang/harness/resources/packages/session.py::SessionPackageController` and `operations.py::PackageOperationsRuntime` | Retain non-Plugin behavior; Plugin-bound transaction enters the single Package lifecycle owner |
+| Startup source materialization | `src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver.resolve_configured_sources_sync` | Missing/ambiguous Plugin-bound Sources fail closed; startup is never a publication owner |
+| Current general materializer | `src/loushang/harness/resources/packages/materializer.py::PackageMaterializer` | Narrow to source/cache compatibility or compose behind the PLC9B owner; direct sync/check, remove, and forget routes cannot publish/delete Plugin revisions |
+| Future complete transaction | one Package lifecycle composition in `loushang.harness.resources.packages` (absent in PLC9B.0) | Sole owner of quarantine, limits, inert extraction, wheel/closure verification, immutable publication coordination, durable phases, and final receipt |
+| Source adapter | future typed Source Authority byte/provenance port over current policy/Git/Python inputs (absent in PLC9B.0) | Authenticated provenance and bounded streaming only; never receives an owner path or publication/binding authority |
+| Publication primitive | `src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore` | Revalidate/freeze/rename verified trees and return exact handles; not an archive, Source, wheel, closure, or desired-state owner |
+| Recursive closure evidence | future closure v2 owned by the PLC9B Package lifecycle owner (absent in PLC9B.0) | New versioned recursive artifact graph; `PluginDependencyClosureLock` v1 remains replay-only |
+| Retention evidence | `src/loushang/harness/plugin_management/package_lifecycle.py::PluginPackageLifecycleLedger` | Consumes publication/selection evidence for retention; never acquires, extracts, publishes, selects, or deletes by itself |
+
+The following block is machine-checked. `count` includes a method definition,
+call, or dynamic string lookup inside the named qualified scope exactly as
+defined by the PLC9 baseline scanner.
+
+<!-- plc9b-entrypoint-inventory:start -->
+```text
+src/loushang/coding/cli/__main__.py::_run_list_packages::get_packages = 2
+src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::check_package_updates = 1
+src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::update_packages = 1
+src/loushang/harness/cli/package_lifecycle.py::_invoke_source_operation::uninstall_package = 2
+src/loushang/harness/cli/package_lifecycle.py::_invoke_source_operation::uninstall_package_async = 1
+src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::check_package_updates = 3
+src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::install_package = 2
+src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::materialize_package = 1
+src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::remove_package = 1
+src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::uninstall_package = 2
+src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::update_package = 1
+src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::update_packages = 4
+src/loushang/harness/host/rpc/commands/packages.py::RpcPackageCommands.bindings::get_packages = 1
+src/loushang/harness/host/rpc/commands/packages.py::RpcPackageCommands.get_packages::get_packages = 6
+src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.check_package_updates::check_package_updates = 2
+src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.get_packages::get_packages = 2
+src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.install_package::install_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.materialize_package::materialize_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.remove_package::remove_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.uninstall_package::uninstall_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.uninstall_package::uninstall_package_async = 1
+src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.update_package::update_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.update_packages::update_packages = 2
+src/loushang/harness/host/rpc/commands/packages.py::_PackageCapabilities.check_package_updates::check_package_updates = 1
+src/loushang/harness/host/rpc/commands/packages.py::_PackageCapabilities.get_packages::get_packages = 1
+src/loushang/harness/host/rpc/commands/packages.py::_PackageCapabilities.install_package::install_package = 1
+src/loushang/harness/host/rpc/commands/packages.py::_PackageCapabilities.materialize_package::materialize_package = 1
+src/loushang/harness/host/rpc/commands/packages.py::_PackageCapabilities.remove_package::remove_package = 1
+src/loushang/harness/host/rpc/commands/packages.py::_PackageCapabilities.uninstall_package::uninstall_package = 1
+src/loushang/harness/host/rpc/commands/packages.py::_PackageCapabilities.update_package::update_package = 1
+src/loushang/harness/host/rpc/commands/packages.py::_PackageCapabilities.update_packages::update_packages = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.check_package_updates::check_package_updates = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_remote_source_sync::materialize_remote_source_sync = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.check_package_updates::check_package_updates = 2
+src/loushang/harness/resources/packages/session.py::SessionPackageController.get_packages::get_packages = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.install_package::install_package = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.materialize_package::materialize_package = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.remove_package::remove_package = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.uninstall_package::uninstall_package = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.uninstall_package_async::uninstall_package_async = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.update_package::update_package = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.update_packages::update_packages = 1
+src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver.resolve_configured_sources_sync::materialize_remote_source_sync = 1
+src/loushang/harness/session/facade_optional.py::SessionFacadeOptionalOperations.check_package_updates::check_package_updates = 2
+src/loushang/harness/session/facade_optional.py::SessionFacadeOptionalOperations.get_packages::get_packages = 2
+src/loushang/harness/session/facade_optional.py::SessionFacadeOptionalOperations.install_package::install_package = 2
+src/loushang/harness/session/facade_optional.py::SessionFacadeOptionalOperations.materialize_package::materialize_package = 2
+src/loushang/harness/session/facade_optional.py::SessionFacadeOptionalOperations.remove_package::remove_package = 2
+src/loushang/harness/session/facade_optional.py::SessionFacadeOptionalOperations.uninstall_package::uninstall_package = 2
+src/loushang/harness/session/facade_optional.py::SessionFacadeOptionalOperations.uninstall_package_async::uninstall_package_async = 2
+src/loushang/harness/session/facade_optional.py::SessionFacadeOptionalOperations.update_package::update_package = 2
+src/loushang/harness/session/facade_optional.py::SessionFacadeOptionalOperations.update_packages::update_packages = 2
+src/loushang/harness/session/facade_optional.py::SessionPackagePort.check_package_updates::check_package_updates = 1
+src/loushang/harness/session/facade_optional.py::SessionPackagePort.get_packages::get_packages = 1
+src/loushang/harness/session/facade_optional.py::SessionPackagePort.install_package::install_package = 1
+src/loushang/harness/session/facade_optional.py::SessionPackagePort.materialize_package::materialize_package = 1
+src/loushang/harness/session/facade_optional.py::SessionPackagePort.remove_package::remove_package = 1
+src/loushang/harness/session/facade_optional.py::SessionPackagePort.uninstall_package::uninstall_package = 1
+src/loushang/harness/session/facade_optional.py::SessionPackagePort.uninstall_package_async::uninstall_package_async = 1
+src/loushang/harness/session/facade_optional.py::SessionPackagePort.update_package::update_package = 1
+src/loushang/harness/session/facade_optional.py::SessionPackagePort.update_packages::update_packages = 1
+src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter.check_package_updates::check_package_updates = 2
+src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter.get_packages::get_packages = 2
+src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter.install_package::install_package = 2
+src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter.materialize_package::materialize_package = 2
+src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter.remove_package::remove_package = 2
+src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter.uninstall_package::uninstall_package = 2
+src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter.uninstall_package::uninstall_package_async = 2
+src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter.update_package::update_package = 2
+src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdapter.update_packages::update_packages = 2
+```
+<!-- plc9b-entrypoint-inventory:end -->
+
+The occurrence block does not replace the broader seam inventory above it:
+`PackageOperationsRuntime`, mutable `remove_remote_source`, binding/history
+forgetting, source backends, publication primitives, and lifecycle evidence are
+owner/bypass surfaces even when their function names do not match the frozen
+entrypoint-symbol scanner.
 
 ## Execution And Containment Seams
 

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9-inventory.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9-inventory.md
@@ -121,11 +121,13 @@ materializes packages.
 
 ## PLC9B.0 Exact Entrypoint And Owner Inventory
 
-PLC9B.0 freezes the pre-runtime-migration snapshot at parent `4bd71d63`: 70
-exact `(source path, qualified scope, lifecycle symbol)` rows and 111 source
-occurrences. The executable architecture guard parses Python syntax rather than
-matching comments. Any count or qualified-site change must update this canonical
-inventory and receive the same security-boundary review.
+PLC9B.0 freezes the pre-runtime-migration snapshot at parent `4bd71d63` in two
+independent source-wide inventories: 95 ingress/declaration rows with 151
+occurrences, and 117 effect/capability rows with 132 occurrences. The executable
+guard parses Python syntax across `src/loushang`, including module/class/function
+scope, imports/renamed imports, names, attributes, and exact dynamic strings.
+Any count or qualified-site change must update this canonical inventory and
+receive the same security-boundary review.
 
 | Entrypoint/owner group | Current exact owner | PLC9B target authority and gate |
 | --- | --- | --- |
@@ -138,21 +140,33 @@ inventory and receive the same security-boundary review.
 | Product Package composition | `src/loushang/harness/resources/packages/session.py::SessionPackageController` and `operations.py::PackageOperationsRuntime` | Retain non-Plugin behavior; Plugin-bound transaction enters the single Package lifecycle owner |
 | Startup source materialization | `src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver.resolve_configured_sources_sync` | Missing/ambiguous Plugin-bound Sources fail closed; startup is never a publication owner |
 | Current general materializer | `src/loushang/harness/resources/packages/materializer.py::PackageMaterializer` | Narrow to source/cache compatibility or compose behind the PLC9B owner; direct sync/check, remove, and forget routes cannot publish/delete Plugin revisions |
-| Future complete transaction | one Package lifecycle composition in `loushang.harness.resources.packages` (absent in PLC9B.0) | Sole owner of quarantine, limits, inert extraction, wheel/closure verification, immutable publication coordination, durable phases, and final receipt |
+| Future ingress/classifier | one Package lifecycle ingress composition in `loushang.harness.resources.packages` (absent in PLC9B.0) | Sole three-way classification authority; transports submit unclassified requests and cannot choose non-Plugin fallback |
+| Future complete transaction | one Package lifecycle composition in `loushang.harness.resources.packages` (absent in PLC9B.0) | Sole owner of quarantine, limits, inert extraction, wheel/closure verification, retention-pin coordination, staged committed-set publication, durable phases, and final receipt |
 | Source adapter | future typed Source Authority byte/provenance port over current policy/Git/Python inputs (absent in PLC9B.0) | Authenticated provenance and bounded streaming only; never receives an owner path or publication/binding authority |
-| Publication primitive | `src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore` | Revalidate/freeze/rename verified trees and return exact handles; not an archive, Source, wheel, closure, or desired-state owner |
-| Recursive closure evidence | future closure v2 owned by the PLC9B Package lifecycle owner (absent in PLC9B.0) | New versioned recursive artifact graph; `PluginDependencyClosureLock` v1 remains replay-only |
-| Retention evidence | `src/loushang/harness/plugin_management/package_lifecycle.py::PluginPackageLifecycleLedger` | Consumes publication/selection evidence for retention; never acquires, extracts, publishes, selects, or deletes by itself |
+| Publication primitive | `src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore` | Current final-namespace publish/reopen is reusable tree verification but insufficient for Package commit; future staging consumes only a verified-candidate capability and durable receipts carry stable refs, never live handles |
+| Commit admission | future read-only Package commit-admission port (absent in PLC9B.0) | Proves stable-ref membership in one committed set before the store returns a short-lived verified handle; raw digest/source is insufficient |
+| Recursive closure evidence | future closure v2 owned by the PLC9B Package lifecycle owner (absent in PLC9B.0) | Every node binds Source-envelope, acquisition, wheel, stable publication-ref, and environment evidence; `PluginDependencyClosureLock` v1 remains replay-only |
+| Retention evidence | future narrow retention port over `src/loushang/harness/plugin_management/package_lifecycle.py::PluginPackageLifecycleLedger` | Transaction pins cover the complete graph before staging and transfer only after desired evidence; Package owner does not import the ledger, which never acquires, extracts, publishes, selects, or deletes by itself |
 
-The following block is machine-checked. `count` includes a method definition,
-call, or dynamic string lookup inside the named qualified scope exactly as
-defined by the PLC9 baseline scanner.
+The first machine-checked block freezes lifecycle ingress declarations,
+forwarding calls, module-level transport specifications, and dynamic strings.
 
 <!-- plc9b-entrypoint-inventory:start -->
 ```text
-src/loushang/coding/cli/__main__.py::_run_list_packages::get_packages = 2
-src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::check_package_updates = 1
-src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::update_packages = 1
+src/loushang/coding/cli/__main__.py::_run_list_packages::get_packages = 5
+src/loushang/harness/cli/agent_args.py::AgentCliArgs::check_package_updates = 1
+src/loushang/harness/cli/agent_args.py::AgentCliArgs::update_packages = 1
+src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::check_package_updates = 2
+src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::install_package = 1
+src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::materialize_package = 1
+src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::remove_package = 1
+src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::uninstall_package = 1
+src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::update_package = 1
+src/loushang/harness/cli/agent_args.py::agent_cli_argument_values::update_packages = 2
+src/loushang/harness/cli/host_operations.py::agent_standard_cli_operation_request::check_package_updates = 1
+src/loushang/harness/cli/host_operations.py::agent_standard_cli_operation_request::update_packages = 1
+src/loushang/harness/cli/launch.py::agent_cli_launch_plan::check_package_updates = 2
+src/loushang/harness/cli/launch.py::agent_cli_launch_plan::update_packages = 2
 src/loushang/harness/cli/package_lifecycle.py::_invoke_source_operation::uninstall_package = 2
 src/loushang/harness/cli/package_lifecycle.py::_invoke_source_operation::uninstall_package_async = 1
 src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::check_package_updates = 3
@@ -162,7 +176,21 @@ src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::remove_pac
 src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::uninstall_package = 2
 src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::update_package = 1
 src/loushang/harness/cli/package_lifecycle.py::run_package_lifecycle::update_packages = 4
-src/loushang/harness/host/rpc/commands/packages.py::RpcPackageCommands.bindings::get_packages = 1
+src/loushang/harness/cli/profile.py::<module>::check_package_updates = 1
+src/loushang/harness/cli/profile.py::<module>::install_package = 1
+src/loushang/harness/cli/profile.py::<module>::materialize_package = 1
+src/loushang/harness/cli/profile.py::<module>::remove_package = 1
+src/loushang/harness/cli/profile.py::<module>::uninstall_package = 1
+src/loushang/harness/cli/profile.py::<module>::update_package = 1
+src/loushang/harness/cli/profile.py::<module>::update_packages = 1
+src/loushang/harness/host/rpc/commands/packages.py::<module>::check_package_updates = 2
+src/loushang/harness/host/rpc/commands/packages.py::<module>::install_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::<module>::materialize_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::<module>::remove_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::<module>::uninstall_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::<module>::update_package = 2
+src/loushang/harness/host/rpc/commands/packages.py::<module>::update_packages = 2
+src/loushang/harness/host/rpc/commands/packages.py::RpcPackageCommands.bindings::get_packages = 2
 src/loushang/harness/host/rpc/commands/packages.py::RpcPackageCommands.get_packages::get_packages = 6
 src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.check_package_updates::check_package_updates = 2
 src/loushang/harness/host/rpc/commands/packages.py::_DynamicPackageCapabilities.get_packages::get_packages = 2
@@ -223,11 +251,138 @@ src/loushang/harness/session/lifecycle_adapter.py::SessionLifecycleOperationAdap
 ```
 <!-- plc9b-entrypoint-inventory:end -->
 
-The occurrence block does not replace the broader seam inventory above it:
-`PackageOperationsRuntime`, mutable `remove_remote_source`, binding/history
-forgetting, source backends, publication primitives, and lifecycle evidence are
-owner/bypass surfaces even when their function names do not match the frozen
-entrypoint-symbol scanner.
+The second machine-checked block freezes capability construction/reference and
+effect seams across Product composition, operations, source resolution,
+materialization, mutable remove/forget, Plugin publish/bind/reopen, and revision
+store access. It counts renamed imports as their original sensitive symbol.
+
+<!-- plc9b-effect-inventory:start -->
+```text
+src/loushang/coding/_base_plugin.py::<module>::CodingPackageMaterializer = 1
+src/loushang/coding/_base_plugin.py::prepare_coding_base_plugin_assembly::CodingPackageMaterializer = 2
+src/loushang/coding/_base_plugin.py::prepare_managed_coding_base_plugin_assembly::CodingPackageMaterializer = 2
+src/loushang/coding/_base_plugin.py::prepare_managed_coding_base_plugin_assembly::reopen_plugin_package = 1
+src/loushang/coding/_capability_plugin_composition.py::<module>::CodingPackageMaterializer = 1
+src/loushang/coding/_capability_plugin_composition.py::_resolve_managed_capability_plugins::CodingPackageMaterializer = 1
+src/loushang/coding/_capability_plugin_composition.py::_resolve_managed_capability_plugins::reopen_plugin_package = 1
+src/loushang/coding/_capability_plugin_composition.py::_validate_preparation_inputs::CodingPackageMaterializer = 2
+src/loushang/coding/_capability_plugin_composition.py::prepare_coding_capability_plugin_composition::CodingPackageMaterializer = 1
+src/loushang/coding/bootstrap.py::<module>::CodingPackageMaterializer = 1
+src/loushang/coding/bootstrap.py::<module>::GitPackageMaterializerBackend = 1
+src/loushang/coding/bootstrap.py::_create_agent_session::CodingPackageMaterializer = 4
+src/loushang/coding/bootstrap.py::_create_agent_session::GitPackageMaterializerBackend = 1
+src/loushang/coding/bootstrap.py::_default_package_materializer::CodingPackageMaterializer = 2
+src/loushang/coding/bootstrap.py::_default_package_materializer::GitPackageMaterializerBackend = 1
+src/loushang/coding/bootstrap.py::create_agent_session::CodingPackageMaterializer = 1
+src/loushang/coding/bootstrap.py::create_agent_session_from_services::CodingPackageMaterializer = 1
+src/loushang/coding/bootstrap.py::create_agent_session_result::CodingPackageMaterializer = 1
+src/loushang/coding/continuity_bootstrap.py::<module>::CodingPackageMaterializer = 1
+src/loushang/coding/continuity_bootstrap.py::<module>::GitPackageMaterializerBackend = 1
+src/loushang/coding/continuity_bootstrap.py::<module>::PackageMaterializer = 1
+src/loushang/coding/continuity_bootstrap.py::_coding_continuity_materializer::CodingPackageMaterializer = 2
+src/loushang/coding/continuity_bootstrap.py::_coding_continuity_materializer::GitPackageMaterializerBackend = 1
+src/loushang/coding/continuity_bootstrap.py::_continuity_runtime_inputs::PackageMaterializer = 1
+src/loushang/coding/continuity_bootstrap.py::_continuity_runtime_inputs::reopen_plugin_package = 1
+src/loushang/coding/continuity_bootstrap.py::_inspect_continuity_source::PackageMaterializer = 1
+src/loushang/coding/continuity_bootstrap.py::_publish_continuity_runtime::PackageMaterializer = 1
+src/loushang/coding/continuity_bootstrap.py::bind_coding_configured_continuity::PackageMaterializer = 1
+src/loushang/coding/lsp/_plugin_opt_in.py::<module>::CodingPackageMaterializer = 1
+src/loushang/coding/lsp/_plugin_opt_in.py::assemble_coding_lsp_plugin_opt_in::CodingPackageMaterializer = 1
+src/loushang/coding/lsp/_plugin_opt_in.py::prepare_coding_lsp_plugin_opt_in::CodingPackageMaterializer = 1
+src/loushang/coding/resource_runtime.py::<module>::CodingPackageMaterializer = 1
+src/loushang/coding/resource_runtime.py::<module>::PackageMaterializer = 1
+src/loushang/coding/resource_runtime.py::CodingPackageMaterializer::CodingPackageMaterializer = 1
+src/loushang/coding/resource_runtime.py::CodingPackageMaterializer::PackageMaterializer = 1
+src/loushang/coding/session/agent_session.py::<module>::CodingPackageMaterializer = 1
+src/loushang/coding/session/agent_session.py::AgentSession.__init__::CodingPackageMaterializer = 1
+src/loushang/harness/resources/packages/__init__.py::<module>::GitPackageMaterializerBackend = 2
+src/loushang/harness/resources/packages/__init__.py::<module>::PackageMaterializer = 2
+src/loushang/harness/resources/packages/__init__.py::<module>::PackageOperationsRuntime = 2
+src/loushang/harness/resources/packages/__init__.py::<module>::PackageSourceResolver = 2
+src/loushang/harness/resources/packages/__init__.py::<module>::PythonPackageInstallerBackend = 2
+src/loushang/harness/resources/packages/catalog.py::<module>::PackageMaterializer = 1
+src/loushang/harness/resources/packages/catalog.py::PackageCatalogBuilder._local_plugin_entry::PackageMaterializer = 1
+src/loushang/harness/resources/packages/catalog.py::PackageCatalogBuilder.collect::PackageMaterializer = 1
+src/loushang/harness/resources/packages/catalog.py::PackageCatalogBuilder.remote_package_entry::PackageMaterializer = 1
+src/loushang/harness/resources/packages/catalog.py::collect_package_catalog::PackageMaterializer = 1
+src/loushang/harness/resources/packages/materializer.py::<module>::PluginRevisionStore = 1
+src/loushang/harness/resources/packages/materializer.py::GitPackageMaterializerBackend::GitPackageMaterializerBackend = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer::PackageMaterializer = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.__init__::PluginRevisionStore = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.__init__::PythonPackageInstallerBackend = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.bind_plugin_packages::bind_plugin_packages = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.forget_plugin_binding::forget_plugin_binding = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.forget_remote_source::forget_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_remote_source::materialize_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_remote_source_sync::materialize_remote_source_sync = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.publish_plugin_packages::publish_all = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.publish_plugin_packages::publish_plugin_packages = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.rebind_plugin_packages::rebind_plugin_packages = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.remove_remote_source::remove_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.reopen_plugin_package::PluginRevisionStore.reopen = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.reopen_plugin_package::reopen_plugin_package = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_all_remote_sources::update_all_remote_sources = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_all_remote_sources::update_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_remote_source::update_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_remote_source_sync::update_remote_source_sync = 1
+src/loushang/harness/resources/packages/materializer.py::PythonPackageInstallerBackend::PythonPackageInstallerBackend = 1
+src/loushang/harness/resources/packages/materializer.py::_record_with_local_git_state::GitPackageMaterializerBackend = 1
+src/loushang/harness/resources/packages/operations.py::<module>::PackageOperationsRuntime = 1
+src/loushang/harness/resources/packages/operations.py::PackageMaterializerPort.forget_remote_source::forget_remote_source = 1
+src/loushang/harness/resources/packages/operations.py::PackageMaterializerPort.materialize_remote_source::materialize_remote_source = 1
+src/loushang/harness/resources/packages/operations.py::PackageMaterializerPort.remove_remote_source::remove_remote_source = 1
+src/loushang/harness/resources/packages/operations.py::PackageMaterializerPort.update_all_remote_sources::update_all_remote_sources = 1
+src/loushang/harness/resources/packages/operations.py::PackageMaterializerPort.update_remote_source::update_remote_source = 1
+src/loushang/harness/resources/packages/operations.py::PackageOperationsRuntime::PackageOperationsRuntime = 1
+src/loushang/harness/resources/packages/operations.py::PackageOperationsRuntime._forget_remote_source::forget_remote_source = 1
+src/loushang/harness/resources/packages/operations.py::PackageOperationsRuntime.materialize::materialize_remote_source = 1
+src/loushang/harness/resources/packages/operations.py::PackageOperationsRuntime.remove::remove_remote_source = 1
+src/loushang/harness/resources/packages/operations.py::PackageOperationsRuntime.update::update_remote_source = 1
+src/loushang/harness/resources/packages/operations.py::PackageOperationsRuntime.update_all::update_all_remote_sources = 1
+src/loushang/harness/resources/packages/projection.py::<module>::PackageMaterializer = 1
+src/loushang/harness/resources/packages/projection.py::collect_projected_package_entries::PackageMaterializer = 1
+src/loushang/harness/resources/packages/roots.py::<module>::PackageMaterializer = 1
+src/loushang/harness/resources/packages/roots.py::configure_resource_loader_roots::PackageMaterializer = 1
+src/loushang/harness/resources/packages/roots.py::resolve_package_resource_roots::PackageMaterializer = 1
+src/loushang/harness/resources/packages/session.py::<module>::PackageMaterializer = 2
+src/loushang/harness/resources/packages/session.py::<module>::PackageOperationsRuntime = 1
+src/loushang/harness/resources/packages/session.py::<module>::PackageSourceResolver = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController::PackageOperationsRuntime = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.__post_init__::PackageOperationsRuntime = 1
+src/loushang/harness/resources/packages/session.py::SessionPackageController.prepare_configured_remote_package_records::PackageSourceResolver = 1
+src/loushang/harness/resources/packages/source_resolver.py::<module>::PackageMaterializer = 1
+src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver::PackageMaterializer = 1
+src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver::PackageSourceResolver = 1
+src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver.resolve_configured_sources_sync::materialize_remote_source_sync = 1
+src/loushang/harness/resources/plugins/__init__.py::<module>::PluginRevisionStore = 2
+src/loushang/harness/resources/plugins/authority.py::PluginBindingStore.bind_plugin_packages::bind_plugin_packages = 1
+src/loushang/harness/resources/plugins/authority.py::PluginBindingStore.publish_plugin_packages::publish_plugin_packages = 1
+src/loushang/harness/resources/plugins/authority.py::PluginResolutionAuthority.publish_runtime::bind_plugin_packages = 1
+src/loushang/harness/resources/plugins/authority.py::PluginResolutionAuthority.publish_runtime::publish_plugin_packages = 1
+src/loushang/harness/resources/plugins/revisions.py::<module>::PluginRevisionStore = 1
+src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore::PluginRevisionStore = 1
+src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore.publish::PluginRevisionStore.publish = 1
+src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore.publish_all::PluginRevisionStore.publish = 1
+src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore.publish_all::publish_all = 1
+src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore.reopen::PluginRevisionStore.reopen = 1
+src/loushang/harness/session/agent_adapter.py::<module>::PackageMaterializer = 1
+src/loushang/harness/session/agent_adapter.py::AgentSessionAdapterMixin::PackageMaterializer = 1
+src/loushang/harness/session/agent_product.py::<module>::PackageMaterializer = 1
+src/loushang/harness/session/agent_product.py::AgentProductSession.__init__::PackageMaterializer = 1
+src/loushang/harness/session/bootstrap_configuration.py::<module>::PackageMaterializer = 1
+src/loushang/harness/session/bootstrap_configuration.py::<module>::PackageSourceResolver = 1
+src/loushang/harness/session/bootstrap_configuration.py::StandardAgentSessionConfigurationRequest::PackageMaterializer = 1
+src/loushang/harness/session/bootstrap_configuration.py::StandardAgentSessionConfigurationRuntime._package_sources::PackageSourceResolver = 1
+src/loushang/harness/session/bootstrap_construction.py::<module>::PackageMaterializer = 1
+src/loushang/harness/session/bootstrap_construction.py::AgentProductConstructionBinding.construct::PackageMaterializer = 1
+```
+<!-- plc9b-effect-inventory:end -->
+
+Static syntax cannot prove a complete Python call graph. Computed reflection,
+string-built sensitive names, and callable laundering are forbidden, and later
+runtime route-conformance must prove one owner plus negative side effects. The
+effect inventory ensures that acquiring or referencing a known sensitive
+capability in a new scope cannot pass silently.
 
 ## Execution And Containment Seams
 

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9-inventory.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9-inventory.md
@@ -123,7 +123,7 @@ materializes packages.
 
 PLC9B.0 freezes the pre-runtime-migration snapshot at parent `4bd71d63` in two
 independent source-wide inventories: 95 ingress/declaration rows with 151
-occurrences, and 117 effect/capability rows with 132 occurrences. The executable
+occurrences, and 141 effect/capability rows with 156 occurrences. The executable
 guard parses Python syntax across `src/loushang`, including module/class/function
 scope, imports/renamed imports, names, attributes, and exact dynamic strings.
 Any count or qualified-site change must update this canonical inventory and
@@ -143,9 +143,11 @@ receive the same security-boundary review.
 | Future ingress/classifier | one Package lifecycle ingress composition in `loushang.harness.resources.packages` (absent in PLC9B.0) | Sole three-way classification authority; transports submit unclassified requests and cannot choose non-Plugin fallback |
 | Future complete transaction | one Package lifecycle composition in `loushang.harness.resources.packages` (absent in PLC9B.0) | Sole owner of quarantine, limits, inert extraction, wheel/closure verification, retention-pin coordination, staged committed-set publication, durable phases, and final receipt |
 | Source adapter | future typed Source Authority byte/provenance port over current policy/Git/Python inputs (absent in PLC9B.0) | Authenticated provenance and bounded streaming only; never receives an owner path or publication/binding authority |
-| Publication primitive | `src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore` | Current final-namespace publish/reopen is reusable tree verification but insufficient for Package commit; future staging consumes only a verified-candidate capability and durable receipts carry stable refs, never live handles |
-| Commit admission | future read-only Package commit-admission port (absent in PLC9B.0) | Proves stable-ref membership in one committed set before the store returns a short-lived verified handle; raw digest/source is insufficient |
-| Recursive closure evidence | future closure v2 owned by the PLC9B Package lifecycle owner (absent in PLC9B.0) | Every node binds Source-envelope, acquisition, wheel, stable publication-ref, and environment evidence; `PluginDependencyClosureLock` v1 remains replay-only |
+| Neutral artifact publication primitive | future inert artifact-store evolution in `loushang.harness.resources.packages` (absent in PLC9B.0) | Sole physical owner of dependency trees and their `VerifiedArtifactRefV1` values; it never stores/designates a Plugin root or commits/admits a graph |
+| Plugin-root publication primitive | `src/loushang/harness/resources/plugins/revisions.py::PluginRevisionStore` | Sole physical owner of the root tree and its only stable `PluginRevisionRefV1`, bound to Installation/Plugin identity; it never owns dependencies or logical set commit |
+| Committed-set owner | future PLC9B Package lifecycle owner (absent in PLC9B.0) | Sole writer of `CommittedPackageSetRefV1`, binding one designated Plugin root plus exact dependency refs to request/operation, Product/scope, identities, closure/set digest, and commit revision |
+| Commit admission | future read-only Package commit-admission port (absent in PLC9B.0) | Proves that the requested `PluginRevisionRefV1` is the designated root of the exact committed set for the request/operation, Product/scope, Installation/Plugin, and closure digest; dependency-as-root and cross-set/scope/Plugin refs fail without reopening |
+| Recursive closure evidence | future closure v2 owned by the PLC9B Package lifecycle owner (absent in PLC9B.0) | Freezes a prepublication verified plan first, then constructs immutable nodes/lock once from exact typed stable refs; digested evidence is never patched and `PluginDependencyClosureLock` v1 remains replay-only |
 | Retention evidence | future narrow retention port over `src/loushang/harness/plugin_management/package_lifecycle.py::PluginPackageLifecycleLedger` | Transaction pins cover the complete graph before staging and transfer only after desired evidence; Package owner does not import the ledger, which never acquires, extracts, publishes, selects, or deletes by itself |
 
 The first machine-checked block freezes lifecycle ingress declarations,
@@ -310,21 +312,44 @@ src/loushang/harness/resources/packages/materializer.py::GitPackageMaterializerB
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer::PackageMaterializer = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.__init__::PluginRevisionStore = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.__init__::PythonPackageInstallerBackend = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.__init__::_plugin_revision_store = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer._bind_plugin_packages::_bind_plugin_packages = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer._run_backend_for_record::_run_backend_for_record = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer._run_backend_for_record_sync::_run_backend_for_record_sync = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.bind_plugin_packages::_bind_plugin_packages = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.bind_plugin_packages::bind_plugin_packages = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.forget_plugin_binding::forget_plugin_binding = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.forget_remote_source::forget_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_remote_source::_run_backend_for_record = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_remote_source::materialize_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_remote_source::prepare_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_remote_source_sync::_run_backend_for_record_sync = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_remote_source_sync::materialize_remote_source_sync = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_remote_source_sync::prepare_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_temporary_remote_source::_run_backend_for_record = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_temporary_remote_source::materialize_temporary_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_temporary_remote_source_sync::_run_backend_for_record_sync = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.materialize_temporary_remote_source_sync::materialize_temporary_remote_source_sync = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.prepare_remote_source::prepare_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.publish_plugin_packages::PluginRevisionStore.publish_all = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.publish_plugin_packages::_plugin_revision_store = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.publish_plugin_packages::publish_all = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.publish_plugin_packages::publish_plugin_packages = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.rebind_plugin_packages::_bind_plugin_packages = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.rebind_plugin_packages::rebind_plugin_packages = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.remove_remote_source::remove_remote_source = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.reopen_plugin_package::PluginRevisionStore.reopen = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.reopen_plugin_package::_plugin_revision_store = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.reopen_plugin_package::reopen_plugin_package = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_all_remote_sources::update_all_remote_sources = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_all_remote_sources::update_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_remote_source::_run_backend_for_record = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_remote_source::prepare_remote_source = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_remote_source::update_remote_source = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_remote_source_sync::_run_backend_for_record_sync = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_remote_source_sync::prepare_remote_source = 1
 src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.update_remote_source_sync::update_remote_source_sync = 1
+src/loushang/harness/resources/packages/materializer.py::PackageMaterializer.uses_storage_authority::_plugin_revision_store = 1
 src/loushang/harness/resources/packages/materializer.py::PythonPackageInstallerBackend::PythonPackageInstallerBackend = 1
 src/loushang/harness/resources/packages/materializer.py::_record_with_local_git_state::GitPackageMaterializerBackend = 1
 src/loushang/harness/resources/packages/operations.py::<module>::PackageOperationsRuntime = 1
@@ -353,6 +378,7 @@ src/loushang/harness/resources/packages/session.py::SessionPackageController.pre
 src/loushang/harness/resources/packages/source_resolver.py::<module>::PackageMaterializer = 1
 src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver::PackageMaterializer = 1
 src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver::PackageSourceResolver = 1
+src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver.prepare_configured_remote_records::prepare_remote_source = 1
 src/loushang/harness/resources/packages/source_resolver.py::PackageSourceResolver.resolve_configured_sources_sync::materialize_remote_source_sync = 1
 src/loushang/harness/resources/plugins/__init__.py::<module>::PluginRevisionStore = 2
 src/loushang/harness/resources/plugins/authority.py::PluginBindingStore.bind_plugin_packages::bind_plugin_packages = 1

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9b-contract.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9b-contract.md
@@ -1,0 +1,277 @@
+# Plugin Lifecycle PLC9B Safe Package Boundary Contract
+
+## Status
+
+- Contract version: PLC9B.0.
+- Delivery status: design-only. No runtime acquisition, archive extraction,
+  dependency resolution, or publication route is implemented by this change.
+- Scope: the future Plugin-bound Package acquisition boundary, its exact
+  callers and owners, versioned evidence, failure semantics, and adversarial
+  acceptance matrix.
+- Public author SDK effect: none.
+- Out of scope: PLC9A2 transport activation, `local_worker` or
+  `remote_service`, source builds, artifact GC/deletion, private-data deletion,
+  and removal of compatibility paths.
+
+This contract refines the PLC9.0 safe Package lifecycle decision. It does not
+make the current `PythonPackageInstallerBackend`, Git materializer, direct
+materializer calls, or startup auto-materialization safe. Until a later PLC9B
+runtime slice satisfies every gate below, a Plugin-bound artifact operation
+must remain unavailable or fail closed without mutation.
+
+## First Principles
+
+1. Untrusted bytes are data, never a pathname, command, module, or build plan.
+2. The component that owns the destination root also owns limits, extraction,
+   verification, publication, and recovery. A source adapter cannot choose or
+   reopen an owner path.
+3. Authentication, provenance, content integrity, archive safety, dependency
+   closure, and runtime admission are distinct claims with distinct evidence.
+4. Validate the complete recursive artifact graph before making any revision
+   selectable. A valid leaf does not make an incomplete closure valid.
+5. Publication is immutable and digest addressed. Selection changes only from
+   a durable receipt over the exact published set; a directory appearing is
+   not a commit.
+6. Every budget is checked while consuming input. A post-extraction size check
+   cannot contain an archive bomb.
+7. Recovery proves or repeats an idempotent transition. It never guesses that
+   an interrupted operation succeeded and never falls back to an unsafe peer.
+8. One policy and one owner gate every CLI, RPC, Session, startup, and direct
+   materializer route. Transport shape does not confer authority.
+
+## Ownership And Dependency Boundary
+
+The accepted dependency direction is:
+
+```text
+CLI / RPC / Session / startup / direct compatibility adapter
+  -> Plugin-bound Package application port or fail-closed classifier
+     -> PLC9B Package lifecycle owner in loushang.harness.resources.packages
+        -> Source Authority byte/provenance port
+        -> owner-created quarantine and verification primitives
+        -> PluginRevisionStore immutable-publication primitive
+        -> durable Package transaction receipt
+  -> management command consumes an exact verified revision
+
+PluginPackageLifecycleLedger <- publication/selection retention evidence
+```
+
+The single PLC9B Package lifecycle owner belongs in
+`loushang.harness.resources.packages`, where Package acquisition and storage
+composition already live. It does not belong in `foundation`, a transport, a
+Product adapter, `plugin_management`, a source backend, or the public
+`loushang.plugin` author SDK.
+
+Ownership is deliberately split only at stable evidence boundaries:
+
+| Boundary | Sole authority | Explicit non-authority |
+| --- | --- | --- |
+| Source Authority port | authenticate an origin, return versioned provenance, expected content identity when available, and a bounded byte stream | cannot choose a filesystem path, extract, resolve dependencies, publish, bind, enable, or delete |
+| PLC9B Package lifecycle owner | create/pin quarantine, enforce all budgets, inspect/extract, verify wheels and recursive closure, coordinate immutable publication, journal phases, and issue the final receipt | cannot execute package code, mutate desired enablement, invent Source provenance, or delete live revisions |
+| `PluginRevisionStore` | revalidate a safe regular tree, freeze content identity, atomically publish an immutable Plugin revision, and return a verified handle | does not authenticate Sources, parse archives, verify wheel metadata/closure, or decide desired state |
+| closure-v2 evidence owner | bind every recursive verified wheel artifact and the exact resolution environment into one canonical graph digest | v1 replay records are not upgraded or reinterpreted as recursive evidence |
+| `PluginPackageLifecycleLedger` | retain Package/Instance/pin/cleanup evidence used by later GC | does not acquire bytes, extract, publish, select, or erase artifacts |
+| management application | consume an exact verified revision in a separately authorized install/update command | does not accept mutable source paths or infer success from publication alone |
+
+Source-specific adapters may perform network or local-source reads only behind
+the Source Authority port. The Package owner supplies the write sink and
+budgets; adapters stream bytes into that sink and return provenance. They never
+receive the quarantine pathname. The sink distrusts adapter-supplied filenames,
+media types, sizes, digests, and dependency claims until it verifies them.
+
+## Versioned Evidence Model
+
+The names below freeze record responsibilities, not Python API names. Runtime
+types are intentionally absent in PLC9B.0.
+
+| Evidence | Required immutable facts |
+| --- | --- |
+| authenticated source envelope v1 | operation identity, canonical source identity, origin kind, authentication decision and authority identity, requested locator, expected artifact digest if declared, policy revision, capture time, and schema version |
+| bounded acquisition receipt v1 | envelope fingerprint, actual byte digest and count, transfer limit, termination disposition, owner sink identity, and source-adapter result; no source pathname |
+| quarantine receipt v1 | owner root identity, private operation-directory identity, applied entry/byte/depth/path/compression budgets, platform normalization profile, and creation phase |
+| verified wheel artifact v1 | canonical distribution name/version, wheel filename and compatible tags, artifact digest/size, canonical metadata digests, complete RECORD verification, and extraction-tree digest |
+| dependency closure lock v2 | root artifact, every recursive artifact digest and verified identity, directed dependency edges, normalized requirement/marker evaluation, exact resolution-environment fingerprint, canonical order, and graph digest |
+| immutable publication receipt v1 | operation identity, source/acquisition/quarantine/closure fingerprints, exact published revision identities and handles, store/root identity, phase sequence, and commit revision |
+
+`PluginDependencyClosureLock` v1 remains replay-only and keeps its existing
+meaning: final package-tree digest plus installed `name==version` facts. A v1
+record never satisfies PLC9B recursive verification, and no reader may decode
+v1 bytes as closure v2. An unsupported future evidence version fails closed.
+
+All digests name the algorithm and canonical encoding. The resolution
+environment covers every input that can change marker or wheel compatibility
+selection. Canonical distribution names are compared after the same specified
+normalization, and two artifacts that normalize to one name are a conflict,
+not last-writer-wins.
+
+## Owner Transaction And Recovery
+
+The durable phase machine is monotonic:
+
+```text
+accepted
+  -> acquiring
+  -> acquired
+  -> inspecting
+  -> extracted
+  -> closure_verified
+  -> publishing
+  -> published
+  -> committed
+```
+
+Any pre-commit phase may record `rejected` or `retryable_failure` with the last
+proved evidence. `committed` is terminal for the same operation identity and
+input fingerprint. A retry with the same identity and fingerprint resumes or
+returns the same receipt; the same identity with different input fails closed.
+
+- `accepted` records policy/provenance intent before untrusted bytes enter the
+  owner sink.
+- `acquiring` through `closure_verified` operate only in an owner-created,
+  private, identity-pinned quarantine. Every archive entry is normalized and
+  authorized before any object is created.
+- `publishing` may create digest-addressed immutable objects idempotently. Such
+  objects remain unselectable until the complete `published` set is proven and
+  the final receipt reaches `committed`.
+- A crash after an immutable rename but before `committed` leaves only an inert,
+  content-addressed orphan. Recovery reopens it through the store, revalidates
+  its exact identity, and either completes the same receipt or retains it for
+  evidence-backed later GC. It never trusts directory existence alone.
+- Binding or desired-state mutation is a later application command over the
+  committed receipt. PLC9B publication cannot implicitly enable a Plugin.
+
+The owner uses one stable lock order over transaction journal, quarantine
+identity, digest publication, and final receipt. Concurrent retries of the same
+fingerprint converge. A different fingerprint for the same operation is
+rejected. Independent digests may proceed concurrently, but a publication
+collision succeeds only when the already-published object reopens as the exact
+verified identity.
+
+## Safe Acquisition, Inspection, And Extraction
+
+Before runtime implementation is accepted, the owner must prove all of the
+following on every supported platform:
+
+- transport and decompressed byte limits, entry count, directory depth,
+  component length, total path length, per-entry expansion, and aggregate
+  expansion are enforced while reading;
+- absolute, root-relative, parent-traversal, empty, dot, drive, UNC, alternate
+  data stream, reserved-device, trailing-dot/space, and platform-ambiguous
+  names are rejected before filesystem creation;
+- duplicate names and names colliding after separator, Unicode, case, or
+  platform normalization are rejected globally;
+- only regular files and directories are accepted; symlinks, hard links,
+  junctions/reparse points, devices, sockets, and FIFOs are rejected in both
+  archive metadata and the materialized tree;
+- every create/open is root-relative, no-follow, exclusive where required, and
+  checked against the pinned owner root; ancestor or entry replacement fails
+  closed;
+- malformed headers, inconsistent local/central metadata, overlap, truncation,
+  unsupported compression/encryption, duplicate records, and trailing payload
+  fail closed; and
+- rejection closes handles, records evidence, and leaves no selectable
+  revision, binding, desired-state change, or attacker-controlled file outside
+  quarantine.
+
+Python artifacts are verified wheel-only. The owner verifies filename,
+compatible tags, `WHEEL`, `METADATA`, and the complete `RECORD` relation before
+canonical-tree publication. Missing, mismatched, duplicate, or unlisted files
+are rejected. Metadata is parsed as inert bytes; no module import, entry point,
+setup script, build backend, package-manager hook, or adjacent executable is
+invoked. Source distributions are unconditionally rejected by PLC9B. A future
+contained build service requires a separate contract and may return only a
+digest-addressed wheel to this same boundary.
+
+## Exact Entrypoint Gate
+
+The canonical source occurrence inventory is maintained in
+`plugin-lifecycle-plc9-inventory.md` and verified from the Python AST. PLC9B.0
+freezes 70 exact `(path, qualified scope, lifecycle symbol)` rows containing
+111 occurrences. The inventory includes:
+
+- Coding and shared CLI queries/commands;
+- RPC Package capabilities and bindings;
+- Session public ports, facade forwarding, and lifecycle adaptation;
+- `SessionPackageController` and `PackageOperationsRuntime` composition;
+- startup `PackageSourceResolver` auto-materialization; and
+- direct `PackageMaterializer` sync/check and mutable remove/forget seams.
+
+Adding, deleting, renaming, or changing the count of an inventoried site must
+update the inventory and architecture guard in the same reviewed change. A
+dynamic lookup, alias, generated binding, new UI/SDK transport, or internal
+direct call is not exempt.
+
+During implementation every entrypoint must classify the target before side
+effects. A non-Plugin Package may retain its separately documented behavior. A
+Plugin-bound or indeterminate target either calls the one PLC9B application
+port with typed input or returns a stable refusal. It cannot fall through to
+the current `uv`/`pip`, Git checkout publication, direct mutable removal, or
+startup auto-materialization path.
+
+## Adversarial Acceptance Matrix
+
+The following matrix is mandatory runtime evidence for later PLC9B delivery.
+PLC9B.0 freezes the cases but deliberately creates or executes no artifact.
+
+| ID | Stage | Adversarial input or interleaving | Required result and negative evidence |
+| --- | --- | --- | --- |
+| B-ACQ-01 | source | unauthenticated origin, changed authority, stale policy, or provenance mismatch | reject before acquisition; no bytes accepted, quarantine, publication, binding, or execution |
+| B-ACQ-02 | acquire | stream exceeds byte limit, stalls past limit, changes declared length, or digest mismatches | terminate and reject while streaming; bounded residue only, no publish/bind/execute |
+| B-ACQ-03 | acquire | malformed/truncated archive, unsupported encryption/compression, overlapping entries, central/local header mismatch, or trailing payload | reject during inert inspection; no extraction outside quarantine and no publish/bind/execute |
+| B-PATH-01 | inspect | absolute POSIX path, root-relative path, empty/dot name, or `..` traversal at any depth | reject the whole artifact before creation; no outside write, publish, bind, or execution |
+| B-PATH-02 | inspect | backslash/forward-slash ambiguity, Windows drive/UNC path, ADS, reserved device, or trailing dot/space | reject under the frozen platform normalization profile; no create/publish/bind/execute |
+| B-PATH-03 | inspect | duplicate or collision after separator, Unicode, case-fold, or canonical distribution-name normalization | reject the complete artifact; never overwrite or choose a winner |
+| B-PATH-04 | extract | component/path/depth limit exceeded or ancestor/entry identity changes between validation and create | fail closed through pinned root-relative I/O; no outside write or selectable revision |
+| B-TYPE-01 | inspect | symlink, hard link, device, socket, FIFO, junction, reparse point, or disguised special entry | reject in metadata and materialized-tree recheck; no target dereference, publish, bind, or execution |
+| B-LIMIT-01 | acquire/extract | entry-count, per-entry, aggregate decompressed-byte, compression-ratio, nesting, or sparse-file budget exceeded | stop at the first exceeded budget; bounded cleanup, no publish/bind/execute |
+| B-WHEEL-01 | classify | sdist, source tree, editable input, arbitrary ZIP, or unsupported wheel tags | reject; no build backend, setup script, package manager, import, hook, or adjacent executable runs |
+| B-WHEEL-02 | verify artifact | wheel filename disagrees with `METADATA`, `WHEEL` is invalid, identity/version is ambiguous, or required metadata is duplicated/missing | reject before canonicalization; no publish/bind/execute |
+| B-WHEEL-03 | verify artifact | `RECORD` missing, hash/size mismatch, duplicate path, unlisted extracted file, listed file absent, or RECORD self-rule invalid | reject the whole wheel; no partial tree or revision becomes selectable |
+| B-WHEEL-04 | verify artifact | archive mutates or is replaced between digest, inspection, extraction, and verification | fail closed on identity recheck; no reopen by attacker pathname and no publish/bind/execute |
+| B-CLOSURE-01 | resolve closure | dependency artifact missing, digest mismatch, unauthorized origin, incompatible tag/marker, or unresolved requirement | reject the complete recursive graph; no root-only publication receipt or selection |
+| B-CLOSURE-02 | resolve closure | cycle, duplicate normalized project name, conflicting versions, graph reorder, or environment-fingerprint mismatch | deterministically reject or reproduce the identical canonical graph; never last-writer-wins |
+| B-CLOSURE-03 | replay | v1 closure is presented as v2, v2 field is unknown, or future schema is unsupported | reject as insufficient/unsupported; preserve v1 bytes and never reinterpret them |
+| B-PUB-01 | publish | attacker precreates quarantine, swaps an ancestor, inserts a special entry, or races final destination | owner-exclusive create/identity checks reject; no attacker path is trusted or overwritten |
+| B-PUB-02 | publish | destination digest already exists with same name but different bytes/identity | reject collision; never replace the existing immutable revision or issue a receipt |
+| B-PUB-03 | publish | exact verified digest already exists | reopen and revalidate exact store identity, then idempotently reuse; no mutable overwrite |
+| B-CRASH-01 | every phase | crash before/after each journal edge from `accepted` through `committed` | fail closed or replay only the same fingerprint; no false commit, unsafe fallback, implicit bind, or execution |
+| B-CRASH-02 | publish/commit | crash after one or more immutable renames but before final committed receipt | published objects remain inert; revalidate and roll forward or retain for evidence-backed GC; no implicit bind/execute |
+| B-CONCUR-01 | all | concurrent same operation/fingerprint, same operation/different fingerprint, or different operations/same digest | same input converges; conflicting input rejects; exact digest reuse revalidates; no duplicate receipt or unsafe overwrite, and locks do not deadlock |
+| B-ENTRY-01 | entry gate | each inventoried CLI, RPC, Session, startup, operations, and direct materializer route receives Plugin-bound input | every route reaches the one owner or stable fail-closed refusal before mutation; no peer publication path |
+| B-ENTRY-02 | entry gate | target classification is missing, ambiguous, spoofed, or changes during dispatch | treat as Plugin-bound/unsafe and reject; no non-Plugin fallback, source removal, or lockfile mutation |
+| B-NOEXEC-01 | all | package contains import traps, entry points, setup/build hooks, executable names, or malicious metadata text | treat all as inert bytes; assert zero child process, import, hook, network side effect, or code execution |
+| B-STATE-01 | reject/retry | any case above fails after journal or quarantine creation | fail closed with a stable diagnostic plus bounded recoverable evidence; no desired state, binding, mutable source history, or live revision changes |
+
+Each case requires positive owner-port evidence and negative observation of
+filesystem escape, process spawn/import, network reuse beyond the authorized
+source read, immutable publication, Package binding, desired-state mutation,
+and unsafe fallback. Platform-specific name and reparse cases run natively on
+their platform; unsupported host emulation cannot count as the only evidence.
+
+## Rollout, Rollback, And Deletion Gates
+
+PLC9B runtime work must land dark and fail closed before routes are activated.
+Activation requires all matrix cases, exact-entry routing tests, crash/replay
+tests, and cross-platform root-containment tests. There is no rollback to the
+current installer for Plugin-bound input: disabling the new owner disables the
+artifact command. Roll forward repairs only from versioned evidence and exact
+digests.
+
+The current `PythonPackageInstallerBackend`, Git publication behavior, startup
+auto-materialization, direct mutable removal, binding/history forgetting, and
+synchronous compatibility calls remain visible migration debt. They may be
+narrowed or deleted only after:
+
+1. every inventoried Plugin-bound route reaches the PLC9B owner or refusal;
+2. no production caller can publish a Plugin revision through the peer path;
+3. closure-v1 replay and downgrade refusal fixtures pass;
+4. non-Plugin Package behavior has a separately accepted owner and regression
+   evidence;
+5. rollback disables Plugin artifact operations instead of restoring an unsafe
+   implementation; and
+6. the canonical inventory and negative architecture guard prove that the
+   deleted symbol cannot be reconstructed through dynamic fallback.
+
+PLC9A2 may project non-artifact management operations after PLC9A1, but it may
+not expose materialize/install/update/remove/uninstall for Plugin-bound targets
+until this runtime gate passes. PLC9C, PLC9D, and PLC9E remain separate slices.

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9b-contract.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9b-contract.md
@@ -22,9 +22,9 @@ must remain unavailable or fail closed without mutation.
 ## First Principles
 
 1. Untrusted bytes are data, never a pathname, command, module, or build plan.
-2. The component that owns the destination root also owns limits, extraction,
-   verification, publication, and recovery. A source adapter cannot choose or
-   reopen an owner path.
+2. Each writable root has one owner. The Package transaction owner owns the
+   acquisition/quarantine root and passes an already-verified candidate
+   capability to the immutable-store owner; neither side reopens a caller path.
 3. Authentication, provenance, content integrity, archive safety, dependency
    closure, and runtime admission are distinct claims with distinct evidence.
 4. Validate the complete recursive artifact graph before making any revision
@@ -36,8 +36,9 @@ must remain unavailable or fail closed without mutation.
    cannot contain an archive bomb.
 7. Recovery proves or repeats an idempotent transition. It never guesses that
    an interrupted operation succeeded and never falls back to an unsafe peer.
-8. One policy and one owner gate every CLI, RPC, Session, startup, and direct
-   materializer route. Transport shape does not confer authority.
+8. One ingress/classification authority and one transaction owner gate every
+   CLI, RPC, Session, startup, and direct materializer route. Transport shape
+   and a caller-supplied “non-Plugin” boolean confer no authority.
 
 ## Ownership And Dependency Boundary
 
@@ -45,15 +46,18 @@ The accepted dependency direction is:
 
 ```text
 CLI / RPC / Session / startup / direct compatibility adapter
-  -> Plugin-bound Package application port or fail-closed classifier
-     -> PLC9B Package lifecycle owner in loushang.harness.resources.packages
-        -> Source Authority byte/provenance port
-        -> owner-created quarantine and verification primitives
-        -> PluginRevisionStore immutable-publication primitive
-        -> durable Package transaction receipt
-  -> management command consumes an exact verified revision
+  -> one Package lifecycle ingress + classification authority
+     -> Plugin-bound or indeterminate: PLC9B Package lifecycle owner
+        -> per-artifact Source Authority byte/provenance port
+        -> owner-created quarantine + verified-candidate capability
+        -> narrow retention-pin port
+        -> PluginRevisionStore staging + atomic committed-set manifest
+        -> durable Package commit receipt with stable revision refs
+     -> non-Plugin: separately accepted non-Plugin authority only
 
-PluginPackageLifecycleLedger <- publication/selection retention evidence
+management command -> Package commit-admission port -> exact stable revision ref
+                   -> PluginRevisionStore returns short-lived verified handle
+PluginPackageLifecycleLedger <- narrow retention evidence port
 ```
 
 The single PLC9B Package lifecycle owner belongs in
@@ -66,18 +70,49 @@ Ownership is deliberately split only at stable evidence boundaries:
 
 | Boundary | Sole authority | Explicit non-authority |
 | --- | --- | --- |
-| Source Authority port | authenticate an origin, return versioned provenance, expected content identity when available, and a bounded byte stream | cannot choose a filesystem path, extract, resolve dependencies, publish, bind, enable, or delete |
-| PLC9B Package lifecycle owner | create/pin quarantine, enforce all budgets, inspect/extract, verify wheels and recursive closure, coordinate immutable publication, journal phases, and issue the final receipt | cannot execute package code, mutate desired enablement, invent Source provenance, or delete live revisions |
-| `PluginRevisionStore` | revalidate a safe regular tree, freeze content identity, atomically publish an immutable Plugin revision, and return a verified handle | does not authenticate Sources, parse archives, verify wheel metadata/closure, or decide desired state |
-| closure-v2 evidence owner | bind every recursive verified wheel artifact and the exact resolution environment into one canonical graph digest | v1 replay records are not upgraded or reinterpreted as recursive evidence |
-| `PluginPackageLifecycleLedger` | retain Package/Instance/pin/cleanup evidence used by later GC | does not acquire bytes, extract, publish, select, or erase artifacts |
-| management application | consume an exact verified revision in a separately authorized install/update command | does not accept mutable source paths or infer success from publication alone |
+| Package lifecycle ingress/classification authority | classify one typed request as `plugin_bound`, `non_plugin`, or `indeterminate`; bind the decision to owner revisions and an input fingerprint | transports cannot classify, submit a boolean, inspect an archive, or choose a fallback |
+| Source Authority port | authenticate one root or dependency origin and return versioned provenance, expected content identity when available, and a bounded byte stream | cannot choose a filesystem path, extract, resolve dependencies, publish, bind, enable, or delete |
+| PLC9B Package lifecycle owner | own quarantine, enforce every budget, inspect/extract, verify every wheel and recursive node, coordinate pins/staging/commit, journal phases, and issue the final receipt | cannot execute package code, mutate desired enablement, invent Source provenance, or delete live revisions |
+| `PluginRevisionStore` evolution | consume a pinned verified-candidate capability, stage/freeze content, publish an atomic committed-set manifest, and reopen a stable committed ref as a short-lived verified handle | current digest/source-only `reopen` and final-namespace `publish` do not satisfy Package commit admission; the store does not authenticate Sources, parse archives, verify closure, or decide desired state |
+| closure-v2 evidence owner | bind every recursive node to its source, acquisition, wheel-verification and publication evidence plus the exact resolution environment | v1 replay records are not upgraded or reinterpreted as recursive evidence |
+| Package commit-admission port | prove that a stable revision ref is a member of one exact committed publication receipt and closure graph | cannot create refs, accept raw digests, mutate desired state, or return an uncommitted/staged object |
+| narrow retention port over `PluginPackageLifecycleLedger` | obtain/transfer/release transaction and dependency pins for the exact root and dependency set | Package owner does not import the concrete ledger; the ledger does not acquire, extract, publish, select, or erase artifacts |
+| management application | verify commit admission, reopen an exact stable ref, and consume it in a separately authorized install/update command | does not accept mutable source paths, raw digest/source pairs, live handles in durable records, or infer success from publication alone |
 
 Source-specific adapters may perform network or local-source reads only behind
 the Source Authority port. The Package owner supplies the write sink and
 budgets; adapters stream bytes into that sink and return provenance. They never
 receive the quarantine pathname. The sink distrusts adapter-supplied filenames,
 media types, sizes, digests, and dependency claims until it verifies them.
+
+## Single Classification Authority
+
+The future Package lifecycle ingress accepts the original command, source
+locator, Product/scope, authenticated caller context, and requested Package or
+Plugin identity. It does not accept a classification result from the caller.
+Its versioned `PluginBoundPackageClassificationV1` evidence contains:
+
+- exactly one decision: `plugin_bound`, `non_plugin`, or `indeterminate`;
+- the canonical request fingerprint and canonical Source identity without
+  credentials, URL query, or fragment;
+- every basis fact and its owner revision: explicit Plugin command intent,
+  existing Plugin binding/history, configured Source kind, accepted independent
+  non-Plugin authority, and policy revision; and
+- decision revision, expiry/recheck rule, and classifier schema/epoch.
+
+Explicit Plugin intent or existing Plugin binding/history is `plugin_bound`.
+Only evidence from a separately accepted non-Plugin authority can yield
+`non_plugin`. A filename, URL suffix, caller flag, missing binding, current
+manifest, or Source backend cannot do so. Everything else is `indeterminate`.
+An indeterminate request may enter the PLC9B owner for bounded inert inspection
+when policy explicitly permits; otherwise it returns
+`package_target_classification_indeterminate`. It never enters the legacy
+installer, and inert inspection never hands bytes to that installer afterward.
+
+Every route uses the same classification vector. The Package owner rechecks the
+classification fingerprint before acquisition and before committed-set
+publication. Changed or expired owner facts produce
+`package_target_classification_changed`; they cannot be patched by a transport.
 
 ## Versioned Evidence Model
 
@@ -86,23 +121,31 @@ types are intentionally absent in PLC9B.0.
 
 | Evidence | Required immutable facts |
 | --- | --- |
-| authenticated source envelope v1 | operation identity, canonical source identity, origin kind, authentication decision and authority identity, requested locator, expected artifact digest if declared, policy revision, capture time, and schema version |
-| bounded acquisition receipt v1 | envelope fingerprint, actual byte digest and count, transfer limit, termination disposition, owner sink identity, and source-adapter result; no source pathname |
-| quarantine receipt v1 | owner root identity, private operation-directory identity, applied entry/byte/depth/path/compression budgets, platform normalization profile, and creation phase |
+| Plugin-bound classification v1 | request fingerprint, three-way decision, basis facts with owner revisions, policy revision, recheck rule, classifier epoch, and redacted canonical Source identity |
+| authenticated source envelope v1 | operation/node identity, canonical credential-free source identity, origin kind, authentication decision and authority identity, requested locator digest, expected artifact digest if declared, redirect policy, policy revision, capture time, and schema version |
+| bounded acquisition receipt v1 | node identity, envelope fingerprint, actual byte digest/count, request/redirect/time budgets, termination disposition, owner sink identity, and source-adapter result; no source pathname or secret |
+| quarantine receipt v1 | owner root identity, private operation-directory identity, every byte/entry/path/parser/memory/time/closure/solver budget and consumption, platform normalization profile, attempt epoch, and creation phase |
 | verified wheel artifact v1 | canonical distribution name/version, wheel filename and compatible tags, artifact digest/size, canonical metadata digests, complete RECORD verification, and extraction-tree digest |
-| dependency closure lock v2 | root artifact, every recursive artifact digest and verified identity, directed dependency edges, normalized requirement/marker evaluation, exact resolution-environment fingerprint, canonical order, and graph digest |
-| immutable publication receipt v1 | operation identity, source/acquisition/quarantine/closure fingerprints, exact published revision identities and handles, store/root identity, phase sequence, and commit revision |
+| dependency closure node v2 | canonical project identity, source-envelope fingerprint, acquisition-receipt fingerprint, wheel-evidence fingerprint, artifact/tree digests, normalized requirements, selected edges, and later stable publication ref |
+| dependency closure lock v2 | root node, every recursive node, directed edges, marker evaluation, exact resolution-environment fingerprint, canonical order, node/set counts, and graph digest |
+| retention-pin receipt v1 | operation/attempt, exact root and dependency candidates, pin kind/owner revision/lease, acquisition/release/transfer state, and recovery identity |
+| immutable publication receipt v1 | operation identity, classification and quarantine fingerprints, complete closure graph/set digest, exact stable published revision refs (never live handles), committed-set manifest identity, retention-pin evidence, store/root identity, phase sequence, and commit revision |
+| Package lifecycle status/failure v1 | operation/request fingerprint, phase, attempt epoch, terminal disposition, evidence references, stable failure code/stage/retryability/operator action, redacted bounded details, and status revision |
 
 `PluginDependencyClosureLock` v1 remains replay-only and keeps its existing
 meaning: final package-tree digest plus installed `name==version` facts. A v1
 record never satisfies PLC9B recursive verification, and no reader may decode
 v1 bytes as closure v2. An unsupported future evidence version fails closed.
 
-All digests name the algorithm and canonical encoding. The resolution
-environment covers every input that can change marker or wheel compatibility
-selection. Canonical distribution names are compared after the same specified
-normalization, and two artifacts that normalize to one name are a conflict,
-not last-writer-wins.
+PLC9B v1 identities use lowercase hexadecimal SHA-256 over strict UTF-8 JSON:
+sorted object keys, no duplicate keys, no floats, no insignificant whitespace,
+and exact non-secret strings. Wheel `RECORD` accepts `sha256`, `sha384`, or
+`sha512`; weaker/unknown algorithms fail closed, and an empty hash/size is
+allowed only for the RECORD file and its explicitly permitted signature files.
+The resolution environment covers every input that can change marker or wheel
+compatibility selection. Canonical distribution names are compared after the
+same specified normalization, and two artifacts that normalize to one name are
+a terminal conflict, never a cycle-tolerant or last-writer-wins choice.
 
 ## Owner Transaction And Recovery
 
@@ -110,51 +153,116 @@ The durable phase machine is monotonic:
 
 ```text
 accepted
+  -> classified
   -> acquiring
   -> acquired
   -> inspecting
   -> extracted
+  -> resolving_closure
   -> closure_verified
-  -> publishing
-  -> published
+  -> transaction_pinned
+  -> staging
+  -> set_published
   -> committed
 ```
 
-Any pre-commit phase may record `rejected` or `retryable_failure` with the last
-proved evidence. `committed` is terminal for the same operation identity and
-input fingerprint. A retry with the same identity and fingerprint resumes or
-returns the same receipt; the same identity with different input fails closed.
+`rejected`, `cancelled`, and `committed` are terminal operation dispositions.
+`retryable_failure` terminates only one numbered attempt. A retry of the same
+operation/request fingerprint obtains a greater attempt epoch and resumes from
+the last proved evidence; changed input is
+`package_operation_identity_conflict`. The request fingerprint binds command,
+Product/scope, canonical credential-free Source identity, requested identity,
+classification/policy revisions, quota profile, and resolution environment.
+Once acquisition wins its compare-and-swap, all later attempts must reproduce
+the same actual artifact digest and evidence chain.
 
-- `accepted` records policy/provenance intent before untrusted bytes enter the
-  owner sink.
+- `accepted` records the fixed request fingerprint before untrusted bytes enter
+  the owner sink; `classified` records the single authority decision.
 - `acquiring` through `closure_verified` operate only in an owner-created,
   private, identity-pinned quarantine. Every archive entry is normalized and
   authorized before any object is created.
-- `publishing` may create digest-addressed immutable objects idempotently. Such
-  objects remain unselectable until the complete `published` set is proven and
-  the final receipt reaches `committed`.
-- A crash after an immutable rename but before `committed` leaves only an inert,
-  content-addressed orphan. Recovery reopens it through the store, revalidates
-  its exact identity, and either completes the same receipt or retains it for
-  evidence-backed later GC. It never trusts directory existence alone.
-- Binding or desired-state mutation is a later application command over the
-  committed receipt. PLC9B publication cannot implicitly enable a Plugin.
+- `transaction_pinned` obtains a versioned transaction pin over the root and
+  every dependency before anything enters a store namespace.
+- `staging` gives the immutable store only a pinned verified-candidate
+  capability, not a pathname. Staged refs are owner-private and cannot be
+  reopened by management or the current digest/source API.
+- `set_published` is one atomic committed-set manifest over the complete graph.
+  A crash before that edge leaves only staged, unselectable content. Recovery
+  revalidates staged identity and either advances the same set or transfers it
+  to evidence-backed cleanup. Directory existence alone is never admission.
+- `committed` durably binds the set manifest and transaction pin. The read-only
+  Package commit-admission port is the only route from a stable ref to a
+  short-lived `VerifiedRevisionHandle`.
+- A later desired install/update first obtains dependency-retention pins under
+  one handoff identity, then commits desired state, then presents the durable
+  desired receipt to the retention port. That owner atomically records handoff
+  completion and releases the transaction pin. There is no cross-owner atomic
+  claim: a crash leaves both pins, never a zero-pin gap, and exact replay
+  completes the same handoff. Rejection, cancellation, or never-selected
+  publication keeps the transaction pin visible to the same recovery state
+  machine. PLC9D owns physical artifact deletion; PLC9B owns bounded quarantine
+  cleanup and cannot silently drop retention evidence.
 
-The owner uses one stable lock order over transaction journal, quarantine
-identity, digest publication, and final receipt. Concurrent retries of the same
-fingerprint converge. A different fingerprint for the same operation is
-rejected. Independent digests may proceed concurrently, but a publication
-collision succeeds only when the already-published object reopens as the exact
-verified identity.
+Slow Source I/O, parsing, hashing, and extraction never hold the journal lock.
+Each attempt instead owns a bounded lease/fencing epoch. Every phase append is
+an expected-phase compare-and-swap over `(operation, request fingerprint,
+attempt epoch, prior journal revision)`. A stale worker cannot append, renew a
+lease, stage, publish a set, or commit after a newer recovery attempt has won.
+Store/transaction/pin locks have a fixed order and bounded critical sections.
+Concurrent same-input attempts converge; different input rejects; an existing
+digest is reusable only after exact candidate, set-membership, and store-identity
+revalidation.
+
+## Status, Diagnostics, And Operator Actions
+
+`PackageLifecycleFailureV1` is a closed, versioned application record. It
+contains `code`, `stage`, `retryable`, `operator_action`, `operation_id`,
+`evidence_ref`, and bounded redacted details. `operator_action` is exactly one
+of `none`, `retry`, `repair`, `upgrade_runtime`, `offline_restore`, or
+`review_policy`. The initial code set is:
+
+| Code family | Retry/action rule |
+| --- | --- |
+| `package_target_classification_indeterminate`, `package_target_classification_changed` | terminal for this request; review policy or submit a new request after owner facts change |
+| `package_source_unauthorized`, `package_source_provenance_changed` | terminal; review policy/source authority |
+| `package_acquisition_limit_exceeded`, `package_operation_timed_out` | retryable only when no acquired digest won; otherwise terminal for the same request |
+| `package_acquisition_digest_mismatch`, `package_artifact_identity_changed` | terminal security failure |
+| `package_archive_malformed`, `package_archive_path_rejected`, `package_archive_name_collision`, `package_archive_entry_type_rejected` | terminal artifact rejection |
+| `package_resource_limit_exceeded`, `package_wheel_metadata_invalid`, `package_wheel_record_invalid`, `package_artifact_type_rejected` | terminal artifact rejection; a new artifact requires a new operation |
+| `package_closure_artifact_invalid`, `package_closure_conflict`, `package_closure_evidence_unsupported` | terminal for the graph/evidence version |
+| `package_publication_root_untrusted`, `package_publication_collision`, `package_commit_admission_denied` | terminal security failure; repair never overwrites or admits an uncommitted ref |
+| `package_operation_interrupted` | retryable with a greater fenced attempt epoch |
+| `package_operation_identity_conflict` | terminal; caller must use a new operation identity |
+| `package_operation_cancelled` | terminal and operator-requested; a retry is a new operation |
+| `package_runtime_epoch_unsupported` | terminal in-process; upgrade runtime or offline restore |
+| `package_route_unavailable` | terminal while PLC9B is disabled; never invokes a peer installer |
+
+Every transport projects the same record without changing the code or
+retryability. CLI emits the code, operation id and evidence reference and exits
+`1`; exit `2` remains parser/usage failure and `130` remains user interruption.
+RPC returns the record as its structured command error. Session raises one typed
+Package lifecycle application error carrying the record. Startup emits the same
+diagnostic and aborts configuration for Plugin-bound or indeterminate input; it
+cannot silently continue with a missing Plugin. Query returns
+`PackageLifecycleStatusV1`; retry, cancel, and repair are typed owner operations,
+not transport-local mutations.
+
+Diagnostics, journals, fingerprints, and digests never contain credentials,
+authorization headers, URL user-info/query/fragment, private registry tokens,
+or raw unbounded metadata. Canonical Source identity strips those fields before
+hashing. Details use an allowlist and length limits; an opaque evidence ref is
+used for privileged inspection.
 
 ## Safe Acquisition, Inspection, And Extraction
 
 Before runtime implementation is accepted, the owner must prove all of the
 following on every supported platform:
 
-- transport and decompressed byte limits, entry count, directory depth,
-  component length, total path length, per-entry expansion, and aggregate
-  expansion are enforced while reading;
+- request/redirect/artifact counts, transport/decompressed bytes, entry count,
+  directory and closure depth, closure node/edge count, component/total path
+  length, per-entry/aggregate expansion, parser and metadata memory, CPU and
+  wall-clock time, dependency-solver steps, marker operations, and sparse-file
+  allocation are hard limits enforced incrementally while consuming input;
 - absolute, root-relative, parent-traversal, empty, dot, drive, UNC, alternate
   data stream, reserved-device, trailing-dot/space, and platform-ambiguous
   names are rejected before filesystem creation;
@@ -182,12 +290,30 @@ invoked. Source distributions are unconditionally rejected by PLC9B. A future
 contained build service requires a separate contract and may return only a
 digest-addressed wheel to this same boundary.
 
+Rejected/cancelled quarantine is owner-local temporary state, not artifact GC.
+The versioned quota profile bounds outstanding quarantine count, aggregate
+bytes, and maximum age per store. A terminal disposition attempts immediate
+rooted cleanup; cleanup failure records `package_operation_interrupted`, keeps a
+bounded tombstone/status projection, and blocks new admission before exceeding
+the store quota. Repair retries only exact owner-root cleanup. Evidence journals
+retain bounded fingerprints/status, not untrusted bytes; TTL never authorizes
+deletion of a committed or pinned immutable revision.
+The operation's terminal `rejected`/`cancelled` disposition never reopens; a
+separate `cleanup_retryable` substatus records cleanup progress and repair.
+
 ## Exact Entrypoint Gate
 
 The canonical source occurrence inventory is maintained in
-`plugin-lifecycle-plc9-inventory.md` and verified from the Python AST. PLC9B.0
-freezes 70 exact `(path, qualified scope, lifecycle symbol)` rows containing
-111 occurrences. The inventory includes:
+`plugin-lifecycle-plc9-inventory.md` and verified from the Python AST across all
+of `src/loushang`. It has two independent machine-checked blocks:
+
+- an ingress/declaration inventory of 95 exact `(path, qualified scope,
+  lifecycle symbol)` rows and 151 occurrences; and
+- an effect/capability inventory of 117 exact rows and 132 occurrences covering
+  materializer/backend/store/source-resolver/operations construction plus
+  materialize/update/remove/forget/publish/bind/reopen capabilities.
+
+Together the inventories include:
 
 - Coding and shared CLI queries/commands;
 - RPC Package capabilities and bindings;
@@ -196,63 +322,177 @@ freezes 70 exact `(path, qualified scope, lifecycle symbol)` rows containing
 - startup `PackageSourceResolver` auto-materialization; and
 - direct `PackageMaterializer` sync/check and mutable remove/forget seams.
 
-Adding, deleting, renaming, or changing the count of an inventoried site must
-update the inventory and architecture guard in the same reviewed change. A
-dynamic lookup, alias, generated binding, new UI/SDK transport, or internal
-direct call is not exempt.
+The scanner counts module/class/function definitions, imports and renamed
+imports, names, attribute access, and exact dynamic strings at the narrowest
+scope. Adding, deleting, renaming, or changing a count requires the same
+reviewed inventory update. Computed reflection, string-built method names, and
+callable laundering are forbidden, not “unseen means allowed.” Static inventory
+does not claim a complete Python call graph: runtime route-conformance and
+negative side-effect tests remain an activation gate.
 
-During implementation every entrypoint must classify the target before side
-effects. A non-Plugin Package may retain its separately documented behavior. A
-Plugin-bound or indeterminate target either calls the one PLC9B application
-port with typed input or returns a stable refusal. It cannot fall through to
-the current `uv`/`pip`, Git checkout publication, direct mutable removal, or
-startup auto-materialization path.
+During implementation every entrypoint submits the unclassified typed request
+to the one ingress authority before side effects. Only independently proved
+`non_plugin` input may reach separately accepted behavior. `plugin_bound` or
+`indeterminate` enters the PLC9B owner or returns the stable classified refusal.
+It cannot fall through to the current `uv`/`pip`, Git checkout publication,
+direct mutable removal, or startup auto-materialization path. Transport modules
+may import only the future application port/records; the concrete materializer,
+backend, store, classifier, ledger, and quarantine owner remain forbidden.
 
 ## Adversarial Acceptance Matrix
 
-The following matrix is mandatory runtime evidence for later PLC9B delivery.
-PLC9B.0 freezes the cases but deliberately creates or executes no artifact.
+The machine-readable manifest below is the mandatory runtime evidence plan.
+PLC9B.0 deliberately leaves every row `planned`: no fixture or artifact is
+created or executed in this design slice. Runtime activation must change each
+row to `required`, provide the exact collected pytest node and workflow job, and
+make either a missing node or a skip fail that job.
 
-| ID | Stage | Adversarial input or interleaving | Required result and negative evidence |
-| --- | --- | --- | --- |
-| B-ACQ-01 | source | unauthenticated origin, changed authority, stale policy, or provenance mismatch | reject before acquisition; no bytes accepted, quarantine, publication, binding, or execution |
-| B-ACQ-02 | acquire | stream exceeds byte limit, stalls past limit, changes declared length, or digest mismatches | terminate and reject while streaming; bounded residue only, no publish/bind/execute |
-| B-ACQ-03 | acquire | malformed/truncated archive, unsupported encryption/compression, overlapping entries, central/local header mismatch, or trailing payload | reject during inert inspection; no extraction outside quarantine and no publish/bind/execute |
-| B-PATH-01 | inspect | absolute POSIX path, root-relative path, empty/dot name, or `..` traversal at any depth | reject the whole artifact before creation; no outside write, publish, bind, or execution |
-| B-PATH-02 | inspect | backslash/forward-slash ambiguity, Windows drive/UNC path, ADS, reserved device, or trailing dot/space | reject under the frozen platform normalization profile; no create/publish/bind/execute |
-| B-PATH-03 | inspect | duplicate or collision after separator, Unicode, case-fold, or canonical distribution-name normalization | reject the complete artifact; never overwrite or choose a winner |
-| B-PATH-04 | extract | component/path/depth limit exceeded or ancestor/entry identity changes between validation and create | fail closed through pinned root-relative I/O; no outside write or selectable revision |
-| B-TYPE-01 | inspect | symlink, hard link, device, socket, FIFO, junction, reparse point, or disguised special entry | reject in metadata and materialized-tree recheck; no target dereference, publish, bind, or execution |
-| B-LIMIT-01 | acquire/extract | entry-count, per-entry, aggregate decompressed-byte, compression-ratio, nesting, or sparse-file budget exceeded | stop at the first exceeded budget; bounded cleanup, no publish/bind/execute |
-| B-WHEEL-01 | classify | sdist, source tree, editable input, arbitrary ZIP, or unsupported wheel tags | reject; no build backend, setup script, package manager, import, hook, or adjacent executable runs |
-| B-WHEEL-02 | verify artifact | wheel filename disagrees with `METADATA`, `WHEEL` is invalid, identity/version is ambiguous, or required metadata is duplicated/missing | reject before canonicalization; no publish/bind/execute |
-| B-WHEEL-03 | verify artifact | `RECORD` missing, hash/size mismatch, duplicate path, unlisted extracted file, listed file absent, or RECORD self-rule invalid | reject the whole wheel; no partial tree or revision becomes selectable |
-| B-WHEEL-04 | verify artifact | archive mutates or is replaced between digest, inspection, extraction, and verification | fail closed on identity recheck; no reopen by attacker pathname and no publish/bind/execute |
-| B-CLOSURE-01 | resolve closure | dependency artifact missing, digest mismatch, unauthorized origin, incompatible tag/marker, or unresolved requirement | reject the complete recursive graph; no root-only publication receipt or selection |
-| B-CLOSURE-02 | resolve closure | cycle, duplicate normalized project name, conflicting versions, graph reorder, or environment-fingerprint mismatch | deterministically reject or reproduce the identical canonical graph; never last-writer-wins |
-| B-CLOSURE-03 | replay | v1 closure is presented as v2, v2 field is unknown, or future schema is unsupported | reject as insufficient/unsupported; preserve v1 bytes and never reinterpret them |
-| B-PUB-01 | publish | attacker precreates quarantine, swaps an ancestor, inserts a special entry, or races final destination | owner-exclusive create/identity checks reject; no attacker path is trusted or overwritten |
-| B-PUB-02 | publish | destination digest already exists with same name but different bytes/identity | reject collision; never replace the existing immutable revision or issue a receipt |
-| B-PUB-03 | publish | exact verified digest already exists | reopen and revalidate exact store identity, then idempotently reuse; no mutable overwrite |
-| B-CRASH-01 | every phase | crash before/after each journal edge from `accepted` through `committed` | fail closed or replay only the same fingerprint; no false commit, unsafe fallback, implicit bind, or execution |
-| B-CRASH-02 | publish/commit | crash after one or more immutable renames but before final committed receipt | published objects remain inert; revalidate and roll forward or retain for evidence-backed GC; no implicit bind/execute |
-| B-CONCUR-01 | all | concurrent same operation/fingerprint, same operation/different fingerprint, or different operations/same digest | same input converges; conflicting input rejects; exact digest reuse revalidates; no duplicate receipt or unsafe overwrite, and locks do not deadlock |
-| B-ENTRY-01 | entry gate | each inventoried CLI, RPC, Session, startup, operations, and direct materializer route receives Plugin-bound input | every route reaches the one owner or stable fail-closed refusal before mutation; no peer publication path |
-| B-ENTRY-02 | entry gate | target classification is missing, ambiguous, spoofed, or changes during dispatch | treat as Plugin-bound/unsafe and reject; no non-Plugin fallback, source removal, or lockfile mutation |
-| B-NOEXEC-01 | all | package contains import traps, entry points, setup/build hooks, executable names, or malicious metadata text | treat all as inert bytes; assert zero child process, import, hook, network side effect, or code execution |
-| B-STATE-01 | reject/retry | any case above fails after journal or quarantine creation | fail closed with a stable diagnostic plus bounded recoverable evidence; no desired state, binding, mutable source history, or live revision changes |
+`platform` is `any`, `posix-native`, or `windows-native`. `disposition` is the
+exact journal result. Oracles use a closed vocabulary: `no_outside_write`,
+`no_process`, `no_import`, `no_extra_network`, `no_publication`, `no_binding`,
+`no_desired`, `no_peer_fallback`, `no_secret`, `bounded_residue`,
+`same_receipt`, `pin_visible`, `single_owner`, and `no_skip`.
 
-Each case requires positive owner-port evidence and negative observation of
-filesystem escape, process spawn/import, network reuse beyond the authorized
-source read, immutable publication, Package binding, desired-state mutation,
-and unsafe fallback. Platform-specific name and reparse cases run natively on
-their platform; unsupported host emulation cannot count as the only evidence.
+<!-- plc9b-adversarial-manifest:start -->
+```text
+case_id | platform | barrier | fixture | code | disposition | oracles | test_node | workflow | status
+B-CLASS-PLUGIN | any | classified | explicit_plugin_intent | ok | classified@plugin_bound | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLASS-PLUGIN] | harness-quality.yml#plc9b-linux-native | planned
+B-CLASS-NONPLUGIN | any | classified | independent_non_plugin_evidence | ok | classified@non_plugin | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLASS-NONPLUGIN] | harness-quality.yml#plc9b-linux-native | planned
+B-CLASS-INDETERMINATE | any | classified | unknown_source | package_target_classification_indeterminate | rejected@classified | no_publication;no_binding;no_desired;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLASS-INDETERMINATE] | harness-quality.yml#plc9b-linux-native | planned
+B-CLASS-CHANGED | any | staging | classification_revision_race | package_target_classification_changed | rejected@staging | no_publication;no_binding;no_desired;no_peer_fallback;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLASS-CHANGED] | harness-quality.yml#plc9b-linux-native | planned
+B-CLASS-SPOOF | any | classified | caller_non_plugin_boolean | package_target_classification_indeterminate | rejected@classified | single_owner;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLASS-SPOOF] | harness-quality.yml#plc9b-linux-native | planned
+B-ACQ-AUTH | any | acquiring | unauthenticated_origin | package_source_unauthorized | rejected@acquiring | no_extra_network;no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ACQ-AUTH] | harness-quality.yml#plc9b-linux-native | planned
+B-ACQ-PROVENANCE | any | acquiring | changed_authority | package_source_provenance_changed | rejected@acquiring | no_publication;no_binding;no_peer_fallback;no_secret | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ACQ-PROVENANCE] | harness-quality.yml#plc9b-linux-native | planned
+B-ACQ-BYTES | any | acquiring | byte_limit | package_acquisition_limit_exceeded | retryable_failure@acquiring | bounded_residue;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ACQ-BYTES] | harness-quality.yml#plc9b-linux-native | planned
+B-ACQ-REDIRECT | any | acquiring | redirect_limit | package_acquisition_limit_exceeded | retryable_failure@acquiring | bounded_residue;no_extra_network;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ACQ-REDIRECT] | harness-quality.yml#plc9b-linux-native | planned
+B-ACQ-TIMEOUT | any | acquiring | wall_clock_limit | package_operation_timed_out | retryable_failure@acquiring | bounded_residue;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ACQ-TIMEOUT] | harness-quality.yml#plc9b-linux-native | planned
+B-ACQ-DIGEST | any | acquired | declared_digest_mismatch | package_acquisition_digest_mismatch | rejected@acquired | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ACQ-DIGEST] | harness-quality.yml#plc9b-linux-native | planned
+B-ACQ-IDENTITY | any | inspecting | archive_replacement | package_artifact_identity_changed | rejected@inspecting | no_outside_write;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ACQ-IDENTITY] | harness-quality.yml#plc9b-linux-native | planned
+B-ARCH-TRUNCATED | any | inspecting | truncated_archive | package_archive_malformed | rejected@inspecting | bounded_residue;no_outside_write;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ARCH-TRUNCATED] | harness-quality.yml#plc9b-linux-native | planned
+B-ARCH-HEADERS | any | inspecting | inconsistent_headers | package_archive_malformed | rejected@inspecting | no_outside_write;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ARCH-HEADERS] | harness-quality.yml#plc9b-linux-native | planned
+B-ARCH-OVERLAP | any | inspecting | overlapping_entries | package_archive_malformed | rejected@inspecting | no_outside_write;no_publication;bounded_residue | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ARCH-OVERLAP] | harness-quality.yml#plc9b-linux-native | planned
+B-ARCH-COMPRESSION | any | inspecting | unsupported_compression_or_encryption | package_archive_malformed | rejected@inspecting | no_process;no_outside_write;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ARCH-COMPRESSION] | harness-quality.yml#plc9b-linux-native | planned
+B-ARCH-TRAILING | any | inspecting | trailing_payload | package_archive_malformed | rejected@inspecting | no_outside_write;no_publication;no_binding | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ARCH-TRAILING] | harness-quality.yml#plc9b-linux-native | planned
+B-PATH-ABSOLUTE | any | inspecting | absolute_path | package_archive_path_rejected | rejected@inspecting | no_outside_write;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-ABSOLUTE] | harness-quality.yml#plc9b-linux-native | planned
+B-PATH-TRAVERSAL | any | inspecting | parent_traversal | package_archive_path_rejected | rejected@inspecting | no_outside_write;no_publication;no_binding | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-TRAVERSAL] | harness-quality.yml#plc9b-linux-native | planned
+B-PATH-EMPTY | any | inspecting | empty_or_dot_component | package_archive_path_rejected | rejected@inspecting | no_outside_write;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-EMPTY] | harness-quality.yml#plc9b-linux-native | planned
+B-PATH-WIN-ROOT | windows-native | inspecting | drive_or_unc_path | package_archive_path_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-WIN-ROOT] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-PATH-WIN-ADS | windows-native | inspecting | alternate_data_stream | package_archive_path_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-WIN-ADS] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-PATH-WIN-RESERVED | windows-native | inspecting | reserved_device_name | package_archive_path_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-WIN-RESERVED] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-PATH-WIN-TRAILING | windows-native | inspecting | trailing_dot_or_space | package_archive_path_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-WIN-TRAILING] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-PATH-COLLISION-SEP | any | inspecting | separator_collision | package_archive_name_collision | rejected@inspecting | no_outside_write;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-COLLISION-SEP] | harness-quality.yml#plc9b-linux-native | planned
+B-PATH-COLLISION-UNICODE | any | inspecting | unicode_collision | package_archive_name_collision | rejected@inspecting | no_outside_write;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-COLLISION-UNICODE] | harness-quality.yml#plc9b-linux-native | planned
+B-PATH-COLLISION-CASE | windows-native | inspecting | casefold_collision | package_archive_name_collision | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PATH-COLLISION-CASE] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-TYPE-SYMLINK | posix-native | inspecting | symlink_entry | package_archive_entry_type_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-TYPE-SYMLINK] | harness-quality.yml#plc9b-linux-native | planned
+B-TYPE-HARDLINK | posix-native | inspecting | hardlink_entry | package_archive_entry_type_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-TYPE-HARDLINK] | harness-quality.yml#plc9b-linux-native | planned
+B-TYPE-DEVICE | posix-native | inspecting | device_entry | package_archive_entry_type_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-TYPE-DEVICE] | harness-quality.yml#plc9b-linux-native | planned
+B-TYPE-SOCKET | posix-native | inspecting | socket_entry | package_archive_entry_type_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-TYPE-SOCKET] | harness-quality.yml#plc9b-linux-native | planned
+B-TYPE-FIFO | posix-native | inspecting | fifo_entry | package_archive_entry_type_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-TYPE-FIFO] | harness-quality.yml#plc9b-linux-native | planned
+B-TYPE-REPARSE | windows-native | inspecting | reparse_entry | package_archive_entry_type_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-TYPE-REPARSE] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-TYPE-JUNCTION | windows-native | inspecting | junction_entry | package_archive_entry_type_rejected | rejected@inspecting | no_outside_write;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-TYPE-JUNCTION] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-LIMIT-ENTRY | any | inspecting | entry_or_expansion_budget | package_resource_limit_exceeded | rejected@inspecting | bounded_residue;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-LIMIT-ENTRY] | harness-quality.yml#plc9b-linux-native | planned
+B-LIMIT-MEMORY | any | inspecting | parser_or_metadata_memory | package_resource_limit_exceeded | rejected@inspecting | bounded_residue;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-LIMIT-MEMORY] | harness-quality.yml#plc9b-linux-native | planned
+B-LIMIT-CPU | any | inspecting | cpu_or_wall_budget | package_resource_limit_exceeded | rejected@inspecting | bounded_residue;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-LIMIT-CPU] | harness-quality.yml#plc9b-linux-native | planned
+B-LIMIT-GRAPH | any | resolving_closure | closure_node_edge_depth | package_resource_limit_exceeded | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-LIMIT-GRAPH] | harness-quality.yml#plc9b-linux-native | planned
+B-LIMIT-SOLVER | any | resolving_closure | solver_or_marker_steps | package_resource_limit_exceeded | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-LIMIT-SOLVER] | harness-quality.yml#plc9b-linux-native | planned
+B-LIMIT-REQUESTS | any | acquiring | request_redirect_artifact_count | package_resource_limit_exceeded | rejected@acquiring | no_extra_network;no_publication;bounded_residue | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-LIMIT-REQUESTS] | harness-quality.yml#plc9b-linux-native | planned
+B-WHEEL-SDIST | any | inspecting | source_distribution | package_artifact_type_rejected | rejected@inspecting | no_process;no_import;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-WHEEL-SDIST] | harness-quality.yml#plc9b-linux-native | planned
+B-WHEEL-ZIP | any | inspecting | arbitrary_zip_or_editable | package_artifact_type_rejected | rejected@inspecting | no_process;no_import;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-WHEEL-ZIP] | harness-quality.yml#plc9b-linux-native | planned
+B-WHEEL-TAGS | any | inspecting | unsupported_wheel_tags | package_artifact_type_rejected | rejected@inspecting | no_publication;no_binding | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-WHEEL-TAGS] | harness-quality.yml#plc9b-linux-native | planned
+B-WHEEL-METADATA | any | extracted | wheel_metadata_mismatch | package_wheel_metadata_invalid | rejected@extracted | no_publication;no_binding;no_desired | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-WHEEL-METADATA] | harness-quality.yml#plc9b-linux-native | planned
+B-WHEEL-RECORD-HASH | any | extracted | record_hash_or_size | package_wheel_record_invalid | rejected@extracted | no_publication;no_binding;no_desired | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-WHEEL-RECORD-HASH] | harness-quality.yml#plc9b-linux-native | planned
+B-WHEEL-RECORD-SET | any | extracted | record_missing_or_unlisted | package_wheel_record_invalid | rejected@extracted | no_publication;no_binding;no_desired | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-WHEEL-RECORD-SET] | harness-quality.yml#plc9b-linux-native | planned
+B-WHEEL-RECORD-ALGO | any | extracted | weak_or_unknown_record_hash | package_wheel_record_invalid | rejected@extracted | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-WHEEL-RECORD-ALGO] | harness-quality.yml#plc9b-linux-native | planned
+B-CLOSURE-MISSING | any | resolving_closure | missing_dependency | package_closure_artifact_invalid | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLOSURE-MISSING] | harness-quality.yml#plc9b-linux-native | planned
+B-CLOSURE-DIGEST | any | resolving_closure | dependency_digest_mismatch | package_closure_artifact_invalid | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLOSURE-DIGEST] | harness-quality.yml#plc9b-linux-native | planned
+B-CLOSURE-ORIGIN | any | resolving_closure | dependency_unauthorized_origin | package_closure_artifact_invalid | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLOSURE-ORIGIN] | harness-quality.yml#plc9b-linux-native | planned
+B-CLOSURE-MARKER | any | resolving_closure | marker_or_environment_mismatch | package_closure_conflict | rejected@resolving_closure | no_publication;no_binding;no_desired | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLOSURE-MARKER] | harness-quality.yml#plc9b-linux-native | planned
+B-CLOSURE-NAME | any | resolving_closure | duplicate_name_or_version | package_closure_conflict | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLOSURE-NAME] | harness-quality.yml#plc9b-linux-native | planned
+B-CLOSURE-CYCLE | any | resolving_closure | dependency_cycle | package_closure_conflict | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLOSURE-CYCLE] | harness-quality.yml#plc9b-linux-native | planned
+B-CLOSURE-V1 | any | resolving_closure | v1_or_future_evidence | package_closure_evidence_unsupported | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLOSURE-V1] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-PRECREATE | any | staging | precreated_quarantine | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-PRECREATE] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-SWAP | any | staging | ancestor_or_entry_swap | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-SWAP] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-COLLISION | any | set_published | same_digest_different_identity | package_publication_collision | rejected@staging | no_publication;no_binding;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-COLLISION] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-REUSE | any | set_published | exact_committed_set_exists | ok | committed@committed | same_receipt;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-REUSE] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-UNCOMMITTED | any | set_published | stable_ref_without_commit_receipt | package_commit_admission_denied | rejected@staging | no_binding;no_desired;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-UNCOMMITTED] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-ACCEPTED | any | accepted | crash_edge | package_operation_interrupted | retryable_failure@accepted | same_receipt;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-ACCEPTED] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-CLASSIFIED | any | classified | crash_edge | package_operation_interrupted | retryable_failure@classified | same_receipt;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-CLASSIFIED] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-ACQUIRING | any | acquiring | crash_edge | package_operation_interrupted | retryable_failure@acquiring | same_receipt;bounded_residue;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-ACQUIRING] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-ACQUIRED | any | acquired | crash_edge | package_operation_interrupted | retryable_failure@acquired | same_receipt;bounded_residue;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-ACQUIRED] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-INSPECTING | any | inspecting | crash_edge | package_operation_interrupted | retryable_failure@inspecting | same_receipt;bounded_residue;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-INSPECTING] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-EXTRACTED | any | extracted | crash_edge | package_operation_interrupted | retryable_failure@extracted | same_receipt;bounded_residue;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-EXTRACTED] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-RESOLVING | any | resolving_closure | crash_edge | package_operation_interrupted | retryable_failure@resolving_closure | same_receipt;bounded_residue;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-RESOLVING] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-CLOSURE | any | closure_verified | crash_edge | package_operation_interrupted | retryable_failure@closure_verified | same_receipt;no_publication;no_binding | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-CLOSURE] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-PINNED | any | transaction_pinned | crash_edge | package_operation_interrupted | retryable_failure@transaction_pinned | same_receipt;pin_visible;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-PINNED] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-STAGING | any | staging | crash_edge | package_operation_interrupted | retryable_failure@staging | same_receipt;pin_visible;no_binding | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-STAGING] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-SET | any | set_published | crash_edge | package_operation_interrupted | retryable_failure@set_published | same_receipt;pin_visible;no_binding;no_desired | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-SET] | harness-quality.yml#plc9b-linux-native | planned
+B-CRASH-COMMITTED | any | committed | crash_after_edge | ok | committed@committed | same_receipt;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-COMMITTED] | harness-quality.yml#plc9b-linux-native | planned
+B-CONCUR-SAME | any | each_phase | concurrent_same_fingerprint | ok | committed@committed | same_receipt;single_owner;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CONCUR-SAME] | harness-quality.yml#plc9b-linux-native | planned
+B-CONCUR-CONFLICT | any | classified | concurrent_different_fingerprint | package_operation_identity_conflict | rejected@classified | single_owner;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CONCUR-CONFLICT] | harness-quality.yml#plc9b-linux-native | planned
+B-CONCUR-STALE | any | each_phase | stale_attempt_epoch | package_operation_identity_conflict | rejected@prior_phase | single_owner;no_publication;no_binding;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CONCUR-STALE] | harness-quality.yml#plc9b-linux-native | planned
+B-ENTRY-CLI | any | classified | cli_plugin_bound | ok | committed@committed | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-CLI] | harness-quality.yml#plc9b-linux-native | planned
+B-ENTRY-RPC | any | classified | rpc_plugin_bound | ok | committed@committed | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-RPC] | harness-quality.yml#plc9b-linux-native | planned
+B-ENTRY-SESSION | any | classified | session_plugin_bound | ok | committed@committed | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-SESSION] | harness-quality.yml#plc9b-linux-native | planned
+B-ENTRY-STARTUP | any | classified | startup_plugin_bound | ok | committed@committed | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-STARTUP] | harness-quality.yml#plc9b-linux-native | planned
+B-ENTRY-OPERATIONS | any | classified | operations_plugin_bound | ok | committed@committed | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-OPERATIONS] | harness-quality.yml#plc9b-linux-native | planned
+B-ENTRY-MATERIALIZER | any | classified | direct_materializer_plugin_bound | package_route_unavailable | rejected@classified | single_owner;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-MATERIALIZER] | harness-quality.yml#plc9b-linux-native | planned
+B-ENTRY-PUBLISH | any | staging | direct_publish_or_bind | package_route_unavailable | rejected@staging | single_owner;no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-PUBLISH] | harness-quality.yml#plc9b-linux-native | planned
+B-ENTRY-DISABLED | any | classified | plc9b_owner_disabled | package_route_unavailable | rejected@classified | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-DISABLED] | harness-quality.yml#plc9b-linux-native | planned
+B-NOEXEC-IMPORT | any | extracted | import_trap | ok | committed@committed | no_process;no_import;no_extra_network | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-NOEXEC-IMPORT] | harness-quality.yml#plc9b-linux-native | planned
+B-NOEXEC-SETUP | any | extracted | setup_or_build_hook | package_artifact_type_rejected | rejected@extracted | no_process;no_import;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-NOEXEC-SETUP] | harness-quality.yml#plc9b-linux-native | planned
+B-NOEXEC-ENTRYPOINT | any | extracted | malicious_entrypoint_metadata | ok | committed@committed | no_process;no_import;no_extra_network | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-NOEXEC-ENTRYPOINT] | harness-quality.yml#plc9b-linux-native | planned
+B-NOEXEC-ADJACENT | any | extracted | adjacent_executable | ok | committed@committed | no_process;no_import;no_extra_network | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-NOEXEC-ADJACENT] | harness-quality.yml#plc9b-linux-native | planned
+B-STATE-CANCEL-EARLY | any | each_phase_before_transaction_pinned | operator_cancel | package_operation_cancelled | cancelled@prior_phase | bounded_residue;no_publication;no_binding;no_desired | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-CANCEL-EARLY] | harness-quality.yml#plc9b-linux-native | planned
+B-STATE-CANCEL-PINNED | any | each_precommit_phase_from_transaction_pinned | operator_cancel | package_operation_cancelled | cancelled@prior_phase | no_binding;no_desired;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-CANCEL-PINNED] | harness-quality.yml#plc9b-linux-native | planned
+B-STATE-REJECT-CLEANUP | any | rejected | quarantine_cleanup_failure | package_operation_interrupted | rejected@cleanup_retryable | bounded_residue;no_binding;no_desired;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-REJECT-CLEANUP] | harness-quality.yml#plc9b-linux-native | planned
+B-STATE-SECRETS | any | each_phase | credentialed_private_locator | ok | committed@committed | no_secret;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-SECRETS] | harness-quality.yml#plc9b-linux-native | planned
+B-STATE-STATUS | any | rejected | transport_status_mapping | package_archive_malformed | rejected@inspecting | same_receipt;no_secret;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-STATUS] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-EPOCH | any | accepted | newer_lifecycle_epoch | package_runtime_epoch_unsupported | rejected@accepted | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-EPOCH] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-MIXED | any | accepted | mixed_fence_aware_processes | package_runtime_epoch_unsupported | rejected@accepted | single_owner;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-MIXED] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-LEGACY | any | classified | legacy_lock_binding_revision | package_closure_evidence_unsupported | rejected@classified | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-LEGACY] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-ROLLFORWARD | any | retryable_failure | upgrade_downgrade_rollforward | ok | committed@committed | same_receipt;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-ROLLFORWARD] | harness-quality.yml#plc9b-linux-native | planned
+```
+<!-- plc9b-adversarial-manifest:end -->
+
+Native Windows rows run only in the named Windows workflow and native POSIX
+rows in the named Harness workflow. The job collects the exact node ids and
+rejects skips; unsupported-host emulation is never the only evidence. General
+rows also observe filesystem/process/import/network/publication/binding/desired
+state and peer-fallback oracles, not merely an exception string.
+
+## Epoch, Upgrade, And Downgrade Fence
+
+The future owner records a Package lifecycle epoch and minimum fence-aware
+runtime against the exact Package-store root identity before any v2 transaction
+or staged object. Every fence-aware process checks that record before Source,
+lockfile, binding, revision, or quarantine access. A newer epoch, an active
+different-epoch lease, or unknown evidence yields
+`package_runtime_epoch_unsupported`; mixed-epoch writers are never admitted.
+
+A pre-fence binary cannot be made safe by a record it does not understand.
+Direct downgrade after any B epoch state exists is unsupported. The only
+pre-fence recovery is an offline restore of the complete pre-B Package store,
+Source configuration, lock/binding history, desired-state backup, and fence
+record, followed by exclusive old-runtime startup. Otherwise operators upgrade
+to the minimum fence-aware runtime and roll forward. Crash recovery by an older
+fence-aware epoch also refuses before touching paths.
+
+Existing lockfiles, bindings, closure-v1 records, and published revisions remain
+replay/retention evidence but are `legacy_unverified`; they never satisfy B
+classification, recursive closure, commit admission, or dependency pinning.
+Existing desired/Instance state is not silently deleted, rebound, or claimed as
+B-verified. Adoption requires authenticated reacquisition and the complete B
+transaction under a new operation. If reacquisition is impossible, a future
+explicit operator trust-import contract is required; PLC9B.0 does not invent
+one. Upgrade -> downgrade refusal -> roll-forward, mixed-process, old-state, and
+offline-restore fixtures are mandatory manifest cases.
 
 ## Rollout, Rollback, And Deletion Gates
 
 PLC9B runtime work must land dark and fail closed before routes are activated.
-Activation requires all matrix cases, exact-entry routing tests, crash/replay
-tests, and cross-platform root-containment tests. There is no rollback to the
+Activation requires every manifest row to be `required` and collected without
+skip, exact-entry/effect routing tests, crash/replay tests, epoch/adoption
+fixtures, and cross-platform root-containment tests. There is no rollback to the
 current installer for Plugin-bound input: disabling the new owner disables the
 artifact command. Roll forward repairs only from versioned evidence and exact
 digests.
@@ -264,13 +504,15 @@ narrowed or deleted only after:
 
 1. every inventoried Plugin-bound route reaches the PLC9B owner or refusal;
 2. no production caller can publish a Plugin revision through the peer path;
-3. closure-v1 replay and downgrade refusal fixtures pass;
+3. closure-v1 replay, epoch/mixed-process/adoption, and downgrade refusal
+   fixtures pass;
 4. non-Plugin Package behavior has a separately accepted owner and regression
    evidence;
 5. rollback disables Plugin artifact operations instead of restoring an unsafe
    implementation; and
-6. the canonical inventory and negative architecture guard prove that the
-   deleted symbol cannot be reconstructed through dynamic fallback.
+6. the canonical ingress/effect inventories and negative architecture guard
+   freeze every known capability acquisition site, while runtime conformance
+   rejects computed reflection, callable laundering, and dynamic fallback.
 
 PLC9A2 may project non-artifact management operations after PLC9A1, but it may
 not expose materialize/install/update/remove/uninstall for Plugin-bound targets

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9b-contract.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9b-contract.md
@@ -51,11 +51,11 @@ CLI / RPC / Session / startup / direct compatibility adapter
         -> per-artifact Source Authority byte/provenance port
         -> owner-created quarantine + verified-candidate capability
         -> narrow retention-pin port
-        -> PluginRevisionStore staging + atomic committed-set manifest
-        -> durable Package commit receipt with stable revision refs
+        -> neutral artifact staging + designated Plugin-root publication
+        -> atomic committed-set manifest + durable Package commit receipt
      -> non-Plugin: separately accepted non-Plugin authority only
 
-management command -> Package commit-admission port -> exact stable revision ref
+management command -> Package commit-admission port -> exact designated root ref
                    -> PluginRevisionStore returns short-lived verified handle
 PluginPackageLifecycleLedger <- narrow retention evidence port
 ```
@@ -73,9 +73,10 @@ Ownership is deliberately split only at stable evidence boundaries:
 | Package lifecycle ingress/classification authority | classify one typed request as `plugin_bound`, `non_plugin`, or `indeterminate`; bind the decision to owner revisions and an input fingerprint | transports cannot classify, submit a boolean, inspect an archive, or choose a fallback |
 | Source Authority port | authenticate one root or dependency origin and return versioned provenance, expected content identity when available, and a bounded byte stream | cannot choose a filesystem path, extract, resolve dependencies, publish, bind, enable, or delete |
 | PLC9B Package lifecycle owner | own quarantine, enforce every budget, inspect/extract, verify every wheel and recursive node, coordinate pins/staging/commit, journal phases, and issue the final receipt | cannot execute package code, mutate desired enablement, invent Source provenance, or delete live revisions |
-| `PluginRevisionStore` evolution | consume a pinned verified-candidate capability, stage/freeze content, publish an atomic committed-set manifest, and reopen a stable committed ref as a short-lived verified handle | current digest/source-only `reopen` and final-namespace `publish` do not satisfy Package commit admission; the store does not authenticate Sources, parse archives, verify closure, or decide desired state |
+| neutral artifact store evolution | consume pinned verified-candidate capabilities and issue `VerifiedArtifactRefV1` values only for inert dependency trees | cannot store or designate the Plugin root, commit a graph, authenticate Sources, verify closure, decide desired state, or return a selectable live handle |
+| `PluginRevisionStore` evolution | consume the designated root candidate and issue one `PluginRevisionRefV1` bound to Installation/Plugin identity | current digest/source-only `reopen` and final-namespace `publish` do not satisfy Package commit admission; the store does not own dependencies, committed sets, Source authentication, closure, or desired state |
 | closure-v2 evidence owner | bind every recursive node to its source, acquisition, wheel-verification and publication evidence plus the exact resolution environment | v1 replay records are not upgraded or reinterpreted as recursive evidence |
-| Package commit-admission port | prove that a stable revision ref is a member of one exact committed publication receipt and closure graph | cannot create refs, accept raw digests, mutate desired state, or return an uncommitted/staged object |
+| Package commit-admission port | prove that a designated `PluginRevisionRefV1` is the root of one exact `CommittedPackageSetRefV1` for the request/operation, Product/scope, Installation/Plugin, and closure digest | cannot admit a dependency as root, mix refs from another set/operation/scope/Plugin, accept raw digests, mutate desired state, or return an uncommitted/staged object |
 | narrow retention port over `PluginPackageLifecycleLedger` | obtain/transfer/release transaction and dependency pins for the exact root and dependency set | Package owner does not import the concrete ledger; the ledger does not acquire, extract, publish, select, or erase artifacts |
 | management application | verify commit admission, reopen an exact stable ref, and consume it in a separately authorized install/update command | does not accept mutable source paths, raw digest/source pairs, live handles in durable records, or infer success from publication alone |
 
@@ -126,11 +127,14 @@ types are intentionally absent in PLC9B.0.
 | bounded acquisition receipt v1 | node identity, envelope fingerprint, actual byte digest/count, request/redirect/time budgets, termination disposition, owner sink identity, and source-adapter result; no source pathname or secret |
 | quarantine receipt v1 | owner root identity, private operation-directory identity, every byte/entry/path/parser/memory/time/closure/solver budget and consumption, platform normalization profile, attempt epoch, and creation phase |
 | verified wheel artifact v1 | canonical distribution name/version, wheel filename and compatible tags, artifact digest/size, canonical metadata digests, complete RECORD verification, and extraction-tree digest |
-| dependency closure node v2 | canonical project identity, source-envelope fingerprint, acquisition-receipt fingerprint, wheel-evidence fingerprint, artifact/tree digests, normalized requirements, selected edges, and later stable publication ref |
-| dependency closure lock v2 | root node, every recursive node, directed edges, marker evaluation, exact resolution-environment fingerprint, canonical order, node/set counts, and graph digest |
+| verified closure plan v2 | designated root identity and role, every recursive node's canonical project identity, source-envelope fingerprint, acquisition-receipt fingerprint, wheel-evidence fingerprint, artifact/tree digests, normalized requirements, selected edges, markers, environment fingerprint, canonical order, counts, and prepublication graph digest; no stable refs yet |
+| dependency closure node v2 | one immutable node constructed after staging from the corresponding verified-plan node plus exactly one typed stable publication ref and its store identity |
+| dependency closure lock v2 | designated root node, every recursive immutable node, directed edges, marker evaluation, exact resolution-environment fingerprint, canonical order, node/set counts, and final graph/set digest |
+| typed stable refs v1 | `VerifiedArtifactRefV1` is a neutral dependency-only artifact ref, `PluginRevisionRefV1` is the designated Installation/Plugin root's only physical stable ref, and `CommittedPackageSetRefV1` binds exactly one root plus dependency refs to the request/operation, Product/scope, identities, closure digest, and commit revision |
 | retention-pin receipt v1 | operation/attempt, exact root and dependency candidates, pin kind/owner revision/lease, acquisition/release/transfer state, and recovery identity |
-| immutable publication receipt v1 | operation identity, classification and quarantine fingerprints, complete closure graph/set digest, exact stable published revision refs (never live handles), committed-set manifest identity, retention-pin evidence, store/root identity, phase sequence, and commit revision |
-| Package lifecycle status/failure v1 | operation/request fingerprint, phase, attempt epoch, terminal disposition, evidence references, stable failure code/stage/retryability/operator action, redacted bounded details, and status revision |
+| retention handoff receipt v1 | handoff identity/receipt fingerprint, committed Package operation/receipt, exact transaction/dependency pin sets, desired command identity and expected revision, attempt epoch, state/revision, durable desired receipt when committed, and replay identity |
+| immutable publication receipt v1 | operation/request identity, Product/scope and Installation/Plugin identities, classification and quarantine fingerprints, designated-root role/ref, complete closure graph/set digest, exact typed stable refs (never live handles), committed-set ref, retention-pin evidence, store/root identities, phase sequence, and commit revision |
+| Package lifecycle status/failure v1 | subject kind/id, operation/request fingerprint, phase, attempt epoch, terminal disposition, evidence references, stable failure code/stage/retryability/retry domain/operator action, redacted bounded details, and status revision |
 
 `PluginDependencyClosureLock` v1 remains replay-only and keeps its existing
 meaning: final package-tree digest plus installed `name==version` facts. A v1
@@ -146,6 +150,22 @@ The resolution environment covers every input that can change marker or wheel
 compatibility selection. Canonical distribution names are compared after the
 same specified normalization, and two artifacts that normalize to one name are
 a terminal conflict, never a cycle-tolerant or last-writer-wins choice.
+
+Closure evidence has two construction edges. `closure_verified` freezes the
+complete `VerifiedClosurePlanV2` before publication and proves all Source,
+artifact, resolution, and graph facts without pretending stable refs exist.
+After every candidate is staged, the owner constructs every immutable closure
+node and `DependencyClosureLockV2` once from the plan plus typed refs. Digested
+evidence is never patched in place. The Package owner then writes the sole
+`CommittedPackageSetRefV1`; neutral and Plugin-root stores retain authority only
+over their respective typed refs.
+
+There is no second physical root publication: the root closure node contains
+exactly one `PluginRevisionRefV1` and its `PluginRevisionStore` identity, while
+every dependency node contains exactly one `VerifiedArtifactRefV1` and neutral
+store identity. The Package owner coordinates transaction retention across the
+set and cleans only its quarantine; each store owns ref integrity/reopen, and
+PLC9D later owns pin-authorized physical deletion through those store owners.
 
 ## Owner Transaction And Recovery
 
@@ -191,24 +211,56 @@ the same actual artifact digest and evidence chain.
   revalidates staged identity and either advances the same set or transfers it
   to evidence-backed cleanup. Directory existence alone is never admission.
 - `committed` durably binds the set manifest and transaction pin. The read-only
-  Package commit-admission port is the only route from a stable ref to a
-  short-lived `VerifiedRevisionHandle`.
-- A later desired install/update first obtains dependency-retention pins under
-  one handoff identity, then commits desired state, then presents the durable
-  desired receipt to the retention port. That owner atomically records handoff
-  completion and releases the transaction pin. There is no cross-owner atomic
-  claim: a crash leaves both pins, never a zero-pin gap, and exact replay
-  completes the same handoff. Rejection, cancellation, or never-selected
+  Package commit-admission port is the only route from a designated root ref to
+  a short-lived `VerifiedRevisionHandle`. Admission checks the request and
+  operation fingerprints, Product/scope, Installation/Plugin identities,
+  designated-root role/ref, exact committed-set identity, and closure/set
+  digest. A dependency, a ref from another set, or a wrong operation, scope, or
+  Plugin fails without reopening any store object.
+- A later desired install/update uses one durable `RetentionHandoffReceiptV1`
+  state machine: `opened -> dependency_pinned -> desired_committed -> settled`
+  (or `aborted` before desired commit). It first obtains the exact dependency
+  pin set under the handoff identity, then commits desired state with an
+  expected-revision CAS, then presents that durable desired receipt to the
+  retention port. Only after the retention owner atomically records `settled`
+  may it release the transaction pin. There is no cross-owner atomic claim: a
+  crash before desired commit leaves the transaction pin plus any acquired
+  dependency pins; a crash after desired commit leaves both complete pin sets;
+  replay from any edge converges to the exact set and never creates a zero-pin
+  gap. A rejected desired CAS aborts/releases only dependency pins and retains
+  the transaction pin. Stale receipts and concurrent replay cannot release or
+  widen either set. Rejection, cancellation, or never-selected
   publication keeps the transaction pin visible to the same recovery state
   machine. PLC9D owns physical artifact deletion; PLC9B owns bounded quarantine
   cleanup and cannot silently drop retention evidence.
 
 Slow Source I/O, parsing, hashing, and extraction never hold the journal lock.
-Each attempt instead owns a bounded lease/fencing epoch. Every phase append is
+Before creating a quarantine, each attempt reserves bytes/count against the
+global quota and obtains a unique, owner-created, isolated directory plus a
+bounded lease/fencing epoch. A stale attempt can write only inside that exact
+directory until its lease/deadline and cannot write a newer attempt's directory
+or any staged/publication namespace; its bounded residue remains charged until
+rooted cleanup succeeds. Every phase append is
 an expected-phase compare-and-swap over `(operation, request fingerprint,
 attempt epoch, prior journal revision)`. A stale worker cannot append, renew a
 lease, stage, publish a set, or commit after a newer recovery attempt has won.
-Store/transaction/pin locks have a fixed order and bounded critical sections.
+No owner holds its lock while calling another owner, performing I/O, or waiting
+on a lease. Publication and later selection are two distinct lock-free sagas:
+
+1. The Package owner performs and releases its operation-phase CAS; calls the
+   retention port to acquire the transaction pin and waits for that owner to
+   release; calls stores in canonical `(store identity, typed ref)` order, each
+   store holding and releasing only its own lock; performs/releases the
+   committed-set CAS; then performs/releases the operation `committed` CAS and
+   returns the receipt. It never calls the desired application.
+2. A later management command first passes commit admission, calls the retention
+   owner to acquire exact dependency pins and record `dependency_pinned`, calls
+   the desired owner for its expected-revision CAS after the retention call has
+   returned, then calls the retention owner again to record `desired_committed`
+   and `settled` and release the transaction pin. Rejection calls that same
+   retention owner to record `aborted` and release only dependency pins.
+
+No cross-owner locks are nested, and every critical section is bounded.
 Concurrent same-input attempts converge; different input rejects; an existing
 digest is reusable only after exact candidate, set-membership, and store-identity
 revalidation.
@@ -216,8 +268,13 @@ revalidation.
 ## Status, Diagnostics, And Operator Actions
 
 `PackageLifecycleFailureV1` is a closed, versioned application record. It
-contains `code`, `stage`, `retryable`, `operator_action`, `operation_id`,
-`evidence_ref`, and bounded redacted details. `operator_action` is exactly one
+contains `code`, `stage`, `retryable`, `retry_domain`, `operator_action`,
+`subject_kind`, `subject_id`, `operation_id`, `evidence_ref`, and bounded
+redacted details. Subject kind is versioned and routes a typed command to the
+exact operation, handoff receipt, or cleanup tombstone; a handoff subject id is
+its handoff identity plus receipt fingerprint. `retry_domain` is exactly one of
+`none`, `operation`, `handoff`, or `cleanup`; cleanup retryability never
+reopens or retries a terminal operation. `operator_action` is exactly one
 of `none`, `retry`, `repair`, `upgrade_runtime`, `offline_restore`, or
 `review_policy`. The initial code set is:
 
@@ -232,10 +289,34 @@ of `none`, `retry`, `repair`, `upgrade_runtime`, `offline_restore`, or
 | `package_closure_artifact_invalid`, `package_closure_conflict`, `package_closure_evidence_unsupported` | terminal for the graph/evidence version |
 | `package_publication_root_untrusted`, `package_publication_collision`, `package_commit_admission_denied` | terminal security failure; repair never overwrites or admits an uncommitted ref |
 | `package_operation_interrupted` | retryable with a greater fenced attempt epoch |
+| `package_attempt_stale` | terminal local refusal for the stale attempt; retry/recovery continues under the already-winning operation identity |
+| `package_quarantine_cleanup_retryable` | terminal operation plus retryable owner-root cleanup substatus; retry domain `cleanup`, operator action `repair` |
 | `package_operation_identity_conflict` | terminal; caller must use a new operation identity |
 | `package_operation_cancelled` | terminal and operator-requested; a retry is a new operation |
+| `package_retention_handoff_interrupted` | retryable fenced replay of the same handoff receipt; exact pins remain visible |
+| `package_desired_revision_conflict` | terminal handoff abort; desired state and transaction pin remain unchanged |
+| `package_retention_handoff_stale` | terminal caller refusal with no journal or pin mutation |
 | `package_runtime_epoch_unsupported` | terminal in-process; upgrade runtime or offline restore |
 | `package_route_unavailable` | terminal while PLC9B is disabled; never invokes a peer installer |
+
+The retry policy is independently machine checked. `conditional` becomes true
+only when the named condition is proved by the failure evidence; transports do
+not reinterpret it. A typed retry requires the matching subject kind/id and
+never falls through to another domain.
+
+<!-- plc9b-retry-policy:start -->
+```text
+selector | retryability | retry_domain | retry_action
+package_acquisition_limit_exceeded | conditional:no_acquired_digest | operation | retry
+package_operation_timed_out | conditional:no_acquired_digest | operation | retry
+package_operation_interrupted | true | operation | retry
+package_retention_handoff_interrupted | true | handoff | retry
+package_quarantine_cleanup_retryable | true | cleanup | repair
+package_attempt_stale | false | none | none
+package_retention_handoff_stale | false | none | none
+default | false | none | none
+```
+<!-- plc9b-retry-policy:end -->
 
 Every transport projects the same record without changing the code or
 retryability. CLI emits the code, operation id and evidence reference and exits
@@ -293,9 +374,11 @@ digest-addressed wheel to this same boundary.
 Rejected/cancelled quarantine is owner-local temporary state, not artifact GC.
 The versioned quota profile bounds outstanding quarantine count, aggregate
 bytes, and maximum age per store. A terminal disposition attempts immediate
-rooted cleanup; cleanup failure records `package_operation_interrupted`, keeps a
+rooted cleanup; cleanup failure records
+`package_quarantine_cleanup_retryable` in retry domain `cleanup`, keeps a
 bounded tombstone/status projection, and blocks new admission before exceeding
-the store quota. Repair retries only exact owner-root cleanup. Evidence journals
+the store quota. Repair retries only exact owner-root cleanup and never resumes
+the terminal Package operation. Evidence journals
 retain bounded fingerprints/status, not untrusted bytes; TTL never authorizes
 deletion of a committed or pinned immutable revision.
 The operation's terminal `rejected`/`cancelled` disposition never reopens; a
@@ -309,7 +392,7 @@ of `src/loushang`. It has two independent machine-checked blocks:
 
 - an ingress/declaration inventory of 95 exact `(path, qualified scope,
   lifecycle symbol)` rows and 151 occurrences; and
-- an effect/capability inventory of 117 exact rows and 132 occurrences covering
+- an effect/capability inventory of 141 exact rows and 156 occurrences covering
   materializer/backend/store/source-resolver/operations construction plus
   materialize/update/remove/forget/publish/bind/reopen capabilities.
 
@@ -348,10 +431,27 @@ row to `required`, provide the exact collected pytest node and workflow job, and
 make either a missing node or a skip fail that job.
 
 `platform` is `any`, `posix-native`, or `windows-native`. `disposition` is the
-exact journal result. Oracles use a closed vocabulary: `no_outside_write`,
+caller-visible response outcome, not permission to append a terminal journal
+row. The separate journal-effect policy below resolves each response to an
+owned append or to `no_append:unchanged`; a refusal can never terminate or
+alter an already-valid winner. Oracles use a closed vocabulary: `no_outside_write`,
 `no_process`, `no_import`, `no_extra_network`, `no_publication`, `no_binding`,
 `no_desired`, `no_peer_fallback`, `no_secret`, `bounded_residue`,
-`same_receipt`, `pin_visible`, `single_owner`, and `no_skip`.
+`same_receipt`, `pin_visible`, `single_owner`, `b_namespace_unreachable`,
+`exact_pin_set`, `no_zero_pin`,
+`transaction_pin_released`, `desired_unchanged`, `handle_released`,
+`no_reopen`, `no_handle_issued`, `dependency_pins_released`,
+`instance_unchanged`, `binding_unchanged`, `enablement_unchanged`,
+`legacy_snapshot_exact`, and `no_skip`. `handle_released` is proved after both
+success and refusal by native rename/delete/open probes against every opened
+root/ancestor/entry handle; garbage collection or process exit is not proof.
+Each `*_unchanged` oracle compares the named canonical projection's exact
+before/after revision and bytes, not merely absence of a new row.
+For restore, `legacy_snapshot_exact` compares the restored result to the
+authenticated pre-B backup. For adoption, it compares the legacy namespace
+before/after. Both cover the legacy root pointer, fence, Source configuration,
+lock/binding history, desired/Instance/enablement state, and store bytes as one
+snapshot; a newly isolated B publication is outside that comparison.
 
 <!-- plc9b-adversarial-manifest:start -->
 ```text
@@ -411,10 +511,25 @@ B-CLOSURE-NAME | any | resolving_closure | duplicate_name_or_version | package_c
 B-CLOSURE-CYCLE | any | resolving_closure | dependency_cycle | package_closure_conflict | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLOSURE-CYCLE] | harness-quality.yml#plc9b-linux-native | planned
 B-CLOSURE-V1 | any | resolving_closure | v1_or_future_evidence | package_closure_evidence_unsupported | rejected@resolving_closure | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CLOSURE-V1] | harness-quality.yml#plc9b-linux-native | planned
 B-PUB-PRECREATE | any | staging | precreated_quarantine | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-PRECREATE] | harness-quality.yml#plc9b-linux-native | planned
-B-PUB-SWAP | any | staging | ancestor_or_entry_swap | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-SWAP] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-POSIX-ROOT-SWAP | posix-native | staging | root_rename_replace_swap | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible;handle_released;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-POSIX-ROOT-SWAP] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-POSIX-ANCESTOR-SWAP | posix-native | staging | ancestor_rename_replace_swap | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible;handle_released;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-POSIX-ANCESTOR-SWAP] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-POSIX-HANDLE-SUCCESS | posix-native | committed | successful_native_handle_lifecycle | ok | committed@committed | same_receipt;pin_visible;handle_released;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-POSIX-HANDLE-SUCCESS] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-POSIX-HANDLE-REJECT | posix-native | rejected | rejected_native_handle_lifecycle | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible;handle_released;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-POSIX-HANDLE-REJECT] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-SWAP-WINDOWS | windows-native | staging | ancestor_or_entry_reparse_swap | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible;handle_released;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-SWAP-WINDOWS] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-PUB-WIN-ROOT-ABA | windows-native | staging | root_rename_replace_aba | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible;handle_released;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-WIN-ROOT-ABA] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-PUB-WIN-ANCESTOR-ABA | windows-native | staging | ancestor_junction_reparse_aba | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible;handle_released;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-WIN-ANCESTOR-ABA] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-PUB-WIN-HANDLE-SUCCESS | windows-native | committed | successful_native_handle_lifecycle | ok | committed@committed | same_receipt;pin_visible;handle_released;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-WIN-HANDLE-SUCCESS] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-PUB-WIN-HANDLE-REJECT | windows-native | rejected | rejected_native_handle_lifecycle | package_publication_root_untrusted | rejected@staging | no_outside_write;no_publication;pin_visible;handle_released;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-WIN-HANDLE-REJECT] | windows-shell-compatibility.yml#plc9b-windows-native | planned
 B-PUB-COLLISION | any | set_published | same_digest_different_identity | package_publication_collision | rejected@staging | no_publication;no_binding;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-COLLISION] | harness-quality.yml#plc9b-linux-native | planned
 B-PUB-REUSE | any | set_published | exact_committed_set_exists | ok | committed@committed | same_receipt;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-REUSE] | harness-quality.yml#plc9b-linux-native | planned
-B-PUB-UNCOMMITTED | any | set_published | stable_ref_without_commit_receipt | package_commit_admission_denied | rejected@staging | no_binding;no_desired;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-UNCOMMITTED] | harness-quality.yml#plc9b-linux-native | planned
+B-PUB-UNCOMMITTED | any | set_published | stable_ref_without_commit_receipt | package_commit_admission_denied | rejected@staging | no_binding;no_desired;pin_visible;no_reopen;no_handle_issued;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-PUB-UNCOMMITTED] | harness-quality.yml#plc9b-linux-native | planned
+B-ADMISSION-DEPENDENCY | any | committed | dependency_ref_claimed_as_root | package_commit_admission_denied | rejected@committed | no_binding;no_desired;pin_visible;no_reopen;no_handle_issued;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ADMISSION-DEPENDENCY] | harness-quality.yml#plc9b-linux-native | planned
+B-ADMISSION-WRONG-SET | any | committed | ref_from_other_committed_set | package_commit_admission_denied | rejected@committed | no_binding;no_desired;pin_visible;no_reopen;no_handle_issued;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ADMISSION-WRONG-SET] | harness-quality.yml#plc9b-linux-native | planned
+B-ADMISSION-WRONG-REQUEST | any | committed | request_fingerprint_mismatch | package_commit_admission_denied | rejected@committed | no_binding;no_desired;pin_visible;no_reopen;no_handle_issued;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ADMISSION-WRONG-REQUEST] | harness-quality.yml#plc9b-linux-native | planned
+B-ADMISSION-WRONG-OPERATION | any | committed | operation_fingerprint_mismatch | package_commit_admission_denied | rejected@committed | no_binding;no_desired;pin_visible;no_reopen;no_handle_issued;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ADMISSION-WRONG-OPERATION] | harness-quality.yml#plc9b-linux-native | planned
+B-ADMISSION-WRONG-SCOPE | any | committed | product_or_scope_mismatch | package_commit_admission_denied | rejected@committed | no_binding;no_desired;pin_visible;no_reopen;no_handle_issued;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ADMISSION-WRONG-SCOPE] | harness-quality.yml#plc9b-linux-native | planned
+B-ADMISSION-WRONG-PLUGIN | any | committed | installation_or_plugin_mismatch | package_commit_admission_denied | rejected@committed | no_binding;no_desired;pin_visible;no_reopen;no_handle_issued;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ADMISSION-WRONG-PLUGIN] | harness-quality.yml#plc9b-linux-native | planned
+B-ADMISSION-DIGEST-TAMPER | any | committed | closure_or_set_digest_tamper | package_commit_admission_denied | rejected@committed | no_binding;no_desired;pin_visible;no_reopen;no_handle_issued;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ADMISSION-DIGEST-TAMPER] | harness-quality.yml#plc9b-linux-native | planned
 B-CRASH-ACCEPTED | any | accepted | crash_edge | package_operation_interrupted | retryable_failure@accepted | same_receipt;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-ACCEPTED] | harness-quality.yml#plc9b-linux-native | planned
 B-CRASH-CLASSIFIED | any | classified | crash_edge | package_operation_interrupted | retryable_failure@classified | same_receipt;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-CLASSIFIED] | harness-quality.yml#plc9b-linux-native | planned
 B-CRASH-ACQUIRING | any | acquiring | crash_edge | package_operation_interrupted | retryable_failure@acquiring | same_receipt;bounded_residue;no_publication | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-ACQUIRING] | harness-quality.yml#plc9b-linux-native | planned
@@ -429,7 +544,13 @@ B-CRASH-SET | any | set_published | crash_edge | package_operation_interrupted |
 B-CRASH-COMMITTED | any | committed | crash_after_edge | ok | committed@committed | same_receipt;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CRASH-COMMITTED] | harness-quality.yml#plc9b-linux-native | planned
 B-CONCUR-SAME | any | each_phase | concurrent_same_fingerprint | ok | committed@committed | same_receipt;single_owner;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CONCUR-SAME] | harness-quality.yml#plc9b-linux-native | planned
 B-CONCUR-CONFLICT | any | classified | concurrent_different_fingerprint | package_operation_identity_conflict | rejected@classified | single_owner;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CONCUR-CONFLICT] | harness-quality.yml#plc9b-linux-native | planned
-B-CONCUR-STALE | any | each_phase | stale_attempt_epoch | package_operation_identity_conflict | rejected@prior_phase | single_owner;no_publication;no_binding;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CONCUR-STALE] | harness-quality.yml#plc9b-linux-native | planned
+B-CONCUR-STALE | any | each_phase | stale_attempt_epoch | package_attempt_stale | rejected@prior_phase | single_owner;no_publication;no_binding;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-CONCUR-STALE] | harness-quality.yml#plc9b-linux-native | planned
+B-HANDOFF-BEFORE-DESIRED | any | dependency_pinned | crash_after_dependency_pins | package_retention_handoff_interrupted | retryable_failure@dependency_pinned | exact_pin_set;no_zero_pin;desired_unchanged;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-HANDOFF-BEFORE-DESIRED] | harness-quality.yml#plc9b-linux-native | planned
+B-HANDOFF-AFTER-DESIRED | any | desired_committed | crash_before_handoff_settlement | package_retention_handoff_interrupted | retryable_failure@desired_committed | exact_pin_set;no_zero_pin;pin_visible;same_receipt | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-HANDOFF-AFTER-DESIRED] | harness-quality.yml#plc9b-linux-native | planned
+B-HANDOFF-AFTER-SETTLEMENT | any | settled | replay_after_transaction_pin_release | ok | settled@settled | exact_pin_set;no_zero_pin;transaction_pin_released;same_receipt | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-HANDOFF-AFTER-SETTLEMENT] | harness-quality.yml#plc9b-linux-native | planned
+B-HANDOFF-DESIRED-REJECT | any | dependency_pinned | desired_expected_revision_rejected | package_desired_revision_conflict | rejected@dependency_pinned | exact_pin_set;no_zero_pin;dependency_pins_released;desired_unchanged;pin_visible | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-HANDOFF-DESIRED-REJECT] | harness-quality.yml#plc9b-linux-native | planned
+B-HANDOFF-STALE-RECEIPT | any | each_handoff_phase | stale_handoff_receipt | package_retention_handoff_stale | rejected@prior_handoff | exact_pin_set;no_zero_pin;desired_unchanged;same_receipt | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-HANDOFF-STALE-RECEIPT] | harness-quality.yml#plc9b-linux-native | planned
+B-HANDOFF-CONCURRENT-REPLAY | any | each_handoff_phase | concurrent_exact_handoff_replay | ok | settled@settled | exact_pin_set;no_zero_pin;transaction_pin_released;same_receipt;single_owner | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-HANDOFF-CONCURRENT-REPLAY] | harness-quality.yml#plc9b-linux-native | planned
 B-ENTRY-CLI | any | classified | cli_plugin_bound | ok | committed@committed | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-CLI] | harness-quality.yml#plc9b-linux-native | planned
 B-ENTRY-RPC | any | classified | rpc_plugin_bound | ok | committed@committed | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-RPC] | harness-quality.yml#plc9b-linux-native | planned
 B-ENTRY-SESSION | any | classified | session_plugin_bound | ok | committed@committed | single_owner;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-ENTRY-SESSION] | harness-quality.yml#plc9b-linux-native | planned
@@ -444,15 +565,97 @@ B-NOEXEC-ENTRYPOINT | any | extracted | malicious_entrypoint_metadata | ok | com
 B-NOEXEC-ADJACENT | any | extracted | adjacent_executable | ok | committed@committed | no_process;no_import;no_extra_network | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-NOEXEC-ADJACENT] | harness-quality.yml#plc9b-linux-native | planned
 B-STATE-CANCEL-EARLY | any | each_phase_before_transaction_pinned | operator_cancel | package_operation_cancelled | cancelled@prior_phase | bounded_residue;no_publication;no_binding;no_desired | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-CANCEL-EARLY] | harness-quality.yml#plc9b-linux-native | planned
 B-STATE-CANCEL-PINNED | any | each_precommit_phase_from_transaction_pinned | operator_cancel | package_operation_cancelled | cancelled@prior_phase | no_binding;no_desired;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-CANCEL-PINNED] | harness-quality.yml#plc9b-linux-native | planned
-B-STATE-REJECT-CLEANUP | any | rejected | quarantine_cleanup_failure | package_operation_interrupted | rejected@cleanup_retryable | bounded_residue;no_binding;no_desired;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-REJECT-CLEANUP] | harness-quality.yml#plc9b-linux-native | planned
+B-STATE-REJECT-CLEANUP | any | rejected | quarantine_cleanup_failure | package_quarantine_cleanup_retryable | rejected@cleanup_retryable | bounded_residue;no_binding;no_desired;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-REJECT-CLEANUP] | harness-quality.yml#plc9b-linux-native | planned
 B-STATE-SECRETS | any | each_phase | credentialed_private_locator | ok | committed@committed | no_secret;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-SECRETS] | harness-quality.yml#plc9b-linux-native | planned
 B-STATE-STATUS | any | rejected | transport_status_mapping | package_archive_malformed | rejected@inspecting | same_receipt;no_secret;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-STATE-STATUS] | harness-quality.yml#plc9b-linux-native | planned
 B-COMPAT-EPOCH | any | accepted | newer_lifecycle_epoch | package_runtime_epoch_unsupported | rejected@accepted | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-EPOCH] | harness-quality.yml#plc9b-linux-native | planned
 B-COMPAT-MIXED | any | accepted | mixed_fence_aware_processes | package_runtime_epoch_unsupported | rejected@accepted | single_owner;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-MIXED] | harness-quality.yml#plc9b-linux-native | planned
-B-COMPAT-LEGACY | any | classified | legacy_lock_binding_revision | package_closure_evidence_unsupported | rejected@classified | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-LEGACY] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-LEGACY | any | classified | legacy_binding_history_hint | ok | classified@plugin_bound | no_publication;no_binding;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-LEGACY] | harness-quality.yml#plc9b-linux-native | planned
 B-COMPAT-ROLLFORWARD | any | retryable_failure | upgrade_downgrade_rollforward | ok | committed@committed | same_receipt;pin_visible;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-ROLLFORWARD] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-CUTOVER-POSIX | posix-native | accepted | offline_quiescent_namespaced_cutover | ok | accepted@epoch_fenced | single_owner;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-CUTOVER-POSIX] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-CUTOVER-WINDOWS | windows-native | accepted | offline_quiescent_namespaced_cutover | ok | accepted@epoch_fenced | single_owner;no_publication;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-CUTOVER-WINDOWS] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-COMPAT-PREFENCE-LIVE-POSIX | posix-native | accepted | pre_fence_writer_blocks_cutover | package_runtime_epoch_unsupported | rejected@pre_fence | single_owner;no_publication;no_binding;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-PREFENCE-LIVE-POSIX] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-PREFENCE-LIVE-WINDOWS | windows-native | accepted | pre_fence_writer_blocks_cutover | package_runtime_epoch_unsupported | rejected@pre_fence | single_owner;no_publication;no_binding;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-PREFENCE-LIVE-WINDOWS] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-COMPAT-OFFLINE-RESTORE-POSIX | posix-native | accepted | complete_pre_b_restore_exclusive_old_runtime | ok | accepted@offline_restore | single_owner;legacy_snapshot_exact;b_namespace_unreachable;no_peer_fallback;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-OFFLINE-RESTORE-POSIX] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-OFFLINE-RESTORE-WINDOWS | windows-native | accepted | complete_pre_b_restore_exclusive_old_runtime | ok | accepted@offline_restore | single_owner;legacy_snapshot_exact;b_namespace_unreachable;no_peer_fallback;no_skip | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-OFFLINE-RESTORE-WINDOWS] | windows-shell-compatibility.yml#plc9b-windows-native | planned
+B-COMPAT-ADOPT | any | committed | authenticated_legacy_reacquisition | ok | committed@committed | same_receipt;pin_visible;legacy_snapshot_exact;desired_unchanged;instance_unchanged;binding_unchanged;enablement_unchanged | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-ADOPT] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-ADOPT-UNAUTHORIZED | any | acquiring | legacy_reacquisition_unauthorized | package_source_unauthorized | rejected@acquiring | legacy_snapshot_exact;desired_unchanged;instance_unchanged;binding_unchanged;enablement_unchanged;no_publication;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-ADOPT-UNAUTHORIZED] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-ADOPT-UNAVAILABLE | any | acquiring | registry_network_temporarily_unavailable | package_operation_timed_out | retryable_failure@acquiring | bounded_residue;legacy_snapshot_exact;desired_unchanged;instance_unchanged;binding_unchanged;enablement_unchanged;no_publication;no_extra_network;no_peer_fallback | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-ADOPT-UNAVAILABLE] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-ADOPT-CRASH | any | each_precommit_phase | adoption_crash_and_retry | package_operation_interrupted | retryable_failure@prior_phase | same_receipt;bounded_residue;legacy_snapshot_exact;desired_unchanged;instance_unchanged;binding_unchanged;enablement_unchanged | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-ADOPT-CRASH] | harness-quality.yml#plc9b-linux-native | planned
+B-COMPAT-ADOPT-CRASH-AFTER-COMMITTED | any | committed | adoption_crash_after_committed_edge | ok | committed@committed | same_receipt;pin_visible;legacy_snapshot_exact;desired_unchanged;instance_unchanged;binding_unchanged;enablement_unchanged | tests/harness/resources/packages/test_plc9b_adversarial.py::test_manifest_case[B-COMPAT-ADOPT-CRASH-AFTER-COMMITTED] | harness-quality.yml#plc9b-linux-native | planned
 ```
 <!-- plc9b-adversarial-manifest:end -->
+
+The first matching selector below determines both the sole journal owner and
+its transition; caller response never selects a journal. Every `append_once`
+uses a stable event identity plus expected journal revision, permits one winning
+CAS, and requires exact replay to return the original receipt with byte-for-byte
+unchanged revision/state. `response_state` means the response state to the left
+of `@`, not its diagnostic code. `no_append:unchanged` performs no append in any
+domain. In particular, a handoff never mutates the already-committed Package
+operation journal.
+
+The closed domains and legal appended states are: `operation` = every monotonic
+phase from `accepted` through `committed`, plus terminal `rejected` or
+`cancelled`; `attempt` = `retryable_failure`;
+`handoff_attempt` = `retryable_failure`; `handoff` = `aborted` or `settled`;
+`cleanup` = `cleanup_retryable`; and `epoch` = `epoch_fenced`. Domain `none`
+has only `no_append:unchanged`. All terminal states and retryable attempt
+outcomes are append-once; exact replay never adds another status revision.
+
+Each domain maps to one concrete authority and stable subject journal key.
+Fingerprints, epochs, and revisions are genesis-bound or expected-CAS values,
+never key components that could fork a conflicting request into an empty peer
+journal. Caller ports request a transition; they never write the target journal
+directly.
+
+<!-- plc9b-journal-domain-authority:start -->
+```text
+journal_domain | sole_authority | stable_journal_key | bound_or_expected_cas_value | allowed_writer_port
+operation | PLC9B Package lifecycle owner | operation_id | request_fingerprint+prior_journal_revision | PackageOperationJournalCAS
+attempt | PLC9B Package lifecycle owner | operation_id+attempt_epoch | parent_request_fingerprint+parent_journal_revision | PackageAttemptJournalCAS
+handoff_attempt | retention-handoff owner over PluginPackageLifecycleLedger | handoff_id+attempt_epoch | parent_receipt_fingerprint+parent_handoff_revision | RetentionHandoffJournalCAS
+handoff | retention-handoff owner over PluginPackageLifecycleLedger | handoff_id | receipt_fingerprint+prior_handoff_revision | RetentionHandoffJournalCAS
+cleanup | PLC9B Package lifecycle owner | quarantine_tombstone_id | cleanup_revision | PackageCleanupJournalCAS
+epoch | Package epoch cutover coordinator in Package lifecycle composition | store_root_identity | current_epoch+prior_fence_revision | PackageEpochJournalCAS
+none | no authority | no journal | no value | no writer
+```
+<!-- plc9b-journal-domain-authority:end -->
+
+<!-- plc9b-journal-effect-policy:start -->
+```text
+selector | journal_domain | journal_transition
+B-PUB-REUSE | none | no_append:unchanged
+B-PUB-UNCOMMITTED | none | no_append:unchanged
+B-ADMISSION-* | none | no_append:unchanged
+B-CRASH-COMMITTED | operation | append_once:committed_then_no_append
+B-CRASH-* | attempt | append_once:retryable_failure_then_no_append
+B-ACQ-BYTES | attempt | append_once:retryable_failure_then_no_append
+B-ACQ-REDIRECT | attempt | append_once:retryable_failure_then_no_append
+B-ACQ-TIMEOUT | attempt | append_once:retryable_failure_then_no_append
+B-CONCUR-SAME | operation | append_once:committed_then_no_append
+B-CONCUR-CONFLICT | none | no_append:unchanged
+B-CONCUR-STALE | none | no_append:unchanged
+B-HANDOFF-BEFORE-DESIRED | handoff_attempt | append_once:retryable_failure_then_no_append
+B-HANDOFF-AFTER-DESIRED | handoff_attempt | append_once:retryable_failure_then_no_append
+B-HANDOFF-AFTER-SETTLEMENT | none | no_append:unchanged
+B-HANDOFF-DESIRED-REJECT | handoff | append_once:aborted_then_no_append
+B-HANDOFF-STALE-RECEIPT | none | no_append:unchanged
+B-HANDOFF-CONCURRENT-REPLAY | handoff | append_once:settled_then_no_append
+B-ENTRY-PUBLISH | none | no_append:unchanged
+B-ENTRY-DISABLED | none | no_append:unchanged
+B-STATE-REJECT-CLEANUP | cleanup | append_once:cleanup_retryable_then_no_append
+B-COMPAT-EPOCH | none | no_append:unchanged
+B-COMPAT-MIXED | none | no_append:unchanged
+B-COMPAT-CUTOVER-* | epoch | append_once:epoch_fenced_then_no_append
+B-COMPAT-PREFENCE-LIVE-* | none | no_append:unchanged
+B-COMPAT-OFFLINE-RESTORE-* | none | no_append:unchanged
+B-COMPAT-ADOPT-UNAVAILABLE | attempt | append_once:retryable_failure_then_no_append
+B-COMPAT-ADOPT-CRASH | attempt | append_once:retryable_failure_then_no_append
+B-COMPAT-ADOPT-CRASH-AFTER-COMMITTED | none | no_append:unchanged
+default | operation | append_once:response_state_then_no_append
+```
+<!-- plc9b-journal-effect-policy:end -->
 
 Native Windows rows run only in the named Windows workflow and native POSIX
 rows in the named Harness workflow. The job collects the exact node ids and
@@ -462,30 +665,57 @@ state and peer-fallback oracles, not merely an exception string.
 
 ## Epoch, Upgrade, And Downgrade Fence
 
-The future owner records a Package lifecycle epoch and minimum fence-aware
-runtime against the exact Package-store root identity before any v2 transaction
-or staged object. Every fence-aware process checks that record before Source,
-lockfile, binding, revision, or quarantine access. A newer epoch, an active
-different-epoch lease, or unknown evidence yields
+The first B epoch is an offline, fail-closed cutover rather than a record that
+an already-running pre-fence writer could ignore. The coordinator exclusively
+holds the existing common coordination lock, proves all legacy leases and
+process registrations quiescent, snapshots the complete pre-B state, creates a
+fresh identity-pinned B-epoch namespace unreachable through old writable root
+names, writes the minimum-runtime fence, and atomically switches the Product
+root pointer. Only then may the first B transaction start. The legacy namespace
+becomes read-only replay/restore input. If quiescence, exclusive ownership,
+snapshot durability, or atomic pointer replacement cannot be proved, cutover
+aborts without changing either root. Supervisors also refuse to start a
+pre-fence binary against the new root.
+
+This establishes the Package lifecycle epoch and minimum fence-aware runtime
+against the exact new root identity before any B transaction or staged object.
+
+Every fence-aware process checks the epoch record and exact Package-store root
+identity before Source, lockfile, binding, revision, or quarantine access. A
+newer epoch, an active different-epoch lease, or unknown evidence yields
 `package_runtime_epoch_unsupported`; mixed-epoch writers are never admitted.
 
 A pre-fence binary cannot be made safe by a record it does not understand.
 Direct downgrade after any B epoch state exists is unsupported. The only
 pre-fence recovery is an offline restore of the complete pre-B Package store,
 Source configuration, lock/binding history, desired-state backup, and fence
-record, followed by exclusive old-runtime startup. Otherwise operators upgrade
-to the minimum fence-aware runtime and roll forward. Crash recovery by an older
+record, including the exact legacy root pointer, followed by exclusive
+old-runtime startup. Restore writes no B-epoch Package, handoff, cleanup, or
+epoch journal; optional operator audit lives outside both restored and B store
+namespaces. Native fixtures prove the restored snapshot byte-for-byte, that the
+B namespace/fence are unreachable from the restored root and old runtime, and
+successful exclusive old-runtime startup. Otherwise operators
+upgrade to the minimum fence-aware runtime and roll forward. Crash recovery by an older
 fence-aware epoch also refuses before touching paths.
 
 Existing lockfiles, bindings, closure-v1 records, and published revisions remain
-replay/retention evidence but are `legacy_unverified`; they never satisfy B
-classification, recursive closure, commit admission, or dependency pinning.
-Existing desired/Instance state is not silently deleted, rebound, or claimed as
-B-verified. Adoption requires authenticated reacquisition and the complete B
-transaction under a new operation. If reacquisition is impossible, a future
-explicit operator trust-import contract is required; PLC9B.0 does not invent
-one. Upgrade -> downgrade refusal -> roll-forward, mixed-process, old-state, and
-offline-restore fixtures are mandatory manifest cases.
+replay/retention evidence but are `legacy_unverified`. Existing binding/history
+is a one-way input that may classify a request as `plugin_bound`; it cannot
+prove `non_plugin` and cannot satisfy B recursive closure, commit admission, or
+dependency pinning. Existing desired/Instance/binding state is never silently
+deleted, rebound, enabled, disabled, or claimed as B-verified.
+
+Adoption requires authenticated reacquisition and the complete B transaction
+under a new operation. Successful adoption publishes evidence but does not
+implicitly change desired, Instance, binding, or enablement state. Crash/retry
+uses the same operation fingerprint and receipt. If reacquisition is
+unavailable, all legacy state remains byte-for-byte authoritative and visible;
+the attempt refuses without implicit rebind/enable. A future explicit operator
+trust-import contract would require separate review; PLC9B.0 does not invent
+one. Upgrade -> downgrade refusal -> roll-forward, native initial cutover with
+live pre-fence-writer refusal, authenticated adoption, unavailable
+reacquisition, adoption crash/retry, old-state, and exclusive offline-restore
+fixtures are mandatory manifest cases.
 
 ## Rollout, Rollback, And Deletion Gates
 

--- a/src/loushang/coding/_plugin_lifecycle.py
+++ b/src/loushang/coding/_plugin_lifecycle.py
@@ -1620,7 +1620,7 @@ def _supports_descriptor_relative_private_state_io() -> bool:
 
 
 def _supports_portable_private_state_io() -> bool:
-    """Return whether open child handles pin parent paths on this host."""
+    """Return whether identity-checked Windows root descriptors are available."""
 
     return os.name == "nt"
 

--- a/src/loushang/harness/journal/jsonl.py
+++ b/src/loushang/harness/journal/jsonl.py
@@ -1027,9 +1027,9 @@ def _open_windows_file_at(
 def _open_windows_lock_file(path: Path, *, create: bool) -> Iterator[Any]:
     """Open a regular Windows lock without following a reparse point.
 
-    The handle intentionally omits ``FILE_SHARE_DELETE``.  While it is open,
-    Windows cannot replace the lock file or rename its parent directory; this
-    pins the already-validated private root for portable compatibility reads.
+    The handle intentionally omits ``FILE_SHARE_DELETE`` so the opened lock
+    entry cannot be replaced while held.  Parent/root anchoring requires the
+    descriptor-relative APIs above; this path-based helper does not provide it.
     """
 
     import ctypes

--- a/tests/architecture/test_plugin_lifecycle_plc9a1_contract.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9a1_contract.py
@@ -31,6 +31,8 @@ ENABLEMENT_MIGRATION = Path(
 )
 CODING_LIFECYCLE = Path("src/loushang/coding/_plugin_lifecycle.py")
 WINDOWS_WORKFLOW = Path(".github/workflows/windows-shell-compatibility.yml")
+CODING_MANAGEMENT_TEST = Path("tests/coding/test_plugin_management_cli.py")
+JOURNAL_TEST = Path("tests/harness/journal/test_jsonl.py")
 
 
 def _source(path: Path) -> str:
@@ -170,6 +172,8 @@ def test_plc9a1_coding_transport_adapter_does_not_construct_owner_stores() -> No
     config_runtime = _source(CONFIG_RUNTIME)
     config_file_transaction = _source(CONFIG_FILE_TRANSACTION)
     journal = _source(JOURNAL)
+    coding_management_test = _source(CODING_MANAGEMENT_TEST)
+    journal_test = _source(JOURNAL_TEST)
     desired_ledger = _source(DESIRED_LEDGER)
     enablement_migration = _source(ENABLEMENT_MIGRATION)
 
@@ -197,6 +201,13 @@ def test_plc9a1_coding_transport_adapter_does_not_construct_owner_stores() -> No
     assert "file_list_directory" in lifecycle
     assert "share_read_write" in lifecycle
     assert "tests/coding/test_plugin_management_cli.py" in windows_workflow
+    assert "test_windows_descriptor_relative_read_rejects_reparse_child" in (
+        coding_management_test
+    )
+    assert "test_windows_compatibility_reconcile_survives_full_root_aba" in (
+        coding_management_test
+    )
+    assert r'"entry\0tail"' in journal_test
     assert "file_flag_open_reparse_point" in journal
     assert "NtCreateFile" in journal
     assert "root_directory" in journal

--- a/tests/architecture/test_plugin_lifecycle_plc9b_contract.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9b_contract.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from pathlib import Path
+
+CONTRACT = Path(
+    "docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9b-contract.md"
+)
+INVENTORY = Path(
+    "docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9-inventory.md"
+)
+INDEX = Path("docs/internals/architecture/harness/plugin/README.md")
+BASELINE_TEST = Path("tests/architecture/test_plugin_lifecycle_plc9_baseline.py")
+PACKAGE_ROOT = Path("src/loushang/harness/resources/packages")
+PACKAGE_MATERIALIZER = PACKAGE_ROOT / "materializer.py"
+PACKAGE_OPERATIONS = PACKAGE_ROOT / "operations.py"
+PACKAGE_SOURCE_RESOLVER = PACKAGE_ROOT / "source_resolver.py"
+PLUGIN_REVISIONS = Path("src/loushang/harness/resources/plugins/revisions.py")
+PLUGIN_DEPENDENCIES = Path("src/loushang/harness/resources/plugins/dependencies.py")
+PACKAGE_LIFECYCLE = Path("src/loushang/harness/plugin_management/package_lifecycle.py")
+AUTHOR_SDK = Path("src/loushang/plugin/__init__.py")
+
+PACKAGE_ENTRYPOINT_ROOTS = (
+    Path("src/loushang/coding/cli"),
+    Path("src/loushang/harness/cli"),
+    Path("src/loushang/harness/host/rpc/commands"),
+    Path("src/loushang/harness/session"),
+    PACKAGE_ROOT,
+)
+PACKAGE_ENTRYPOINT_SYMBOLS = {
+    "get_packages",
+    "materialize_package",
+    "install_package",
+    "update_package",
+    "update_packages",
+    "check_package_updates",
+    "remove_package",
+    "uninstall_package",
+    "uninstall_package_async",
+    "materialize_remote_source_sync",
+}
+EXPECTED_MATRIX_IDS = {
+    "B-ACQ-01",
+    "B-ACQ-02",
+    "B-ACQ-03",
+    "B-PATH-01",
+    "B-PATH-02",
+    "B-PATH-03",
+    "B-PATH-04",
+    "B-TYPE-01",
+    "B-LIMIT-01",
+    "B-WHEEL-01",
+    "B-WHEEL-02",
+    "B-WHEEL-03",
+    "B-WHEEL-04",
+    "B-CLOSURE-01",
+    "B-CLOSURE-02",
+    "B-CLOSURE-03",
+    "B-PUB-01",
+    "B-PUB-02",
+    "B-PUB-03",
+    "B-CRASH-01",
+    "B-CRASH-02",
+    "B-CONCUR-01",
+    "B-ENTRY-01",
+    "B-ENTRY-02",
+    "B-NOEXEC-01",
+    "B-STATE-01",
+}
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+class _QualifiedFunctionVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        self.scope: list[str] = []
+        self.functions: list[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef]] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.scope.append(node.name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def _visit_function(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> None:
+        qualified = ".".join((*self.scope, node.name))
+        self.functions.append((qualified, node))
+        self.scope.append(node.name)
+        self.generic_visit(node)
+        self.scope.pop()
+
+
+def _package_entrypoint_scope_counts() -> Counter[tuple[Path, str, str]]:
+    counts: Counter[tuple[Path, str, str]] = Counter()
+    for root in PACKAGE_ENTRYPOINT_ROOTS:
+        for path in root.rglob("*.py"):
+            source = _source(path)
+            if not any(symbol in source for symbol in PACKAGE_ENTRYPOINT_SYMBOLS):
+                continue
+            visitor = _QualifiedFunctionVisitor()
+            visitor.visit(ast.parse(source, filename=str(path)))
+            for qualified, function in visitor.functions:
+                if function.name in PACKAGE_ENTRYPOINT_SYMBOLS:
+                    counts[(path, qualified, function.name)] += 1
+                for node in ast.walk(function):
+                    symbol: str | None = None
+                    if isinstance(node, ast.Call):
+                        if isinstance(node.func, ast.Name):
+                            symbol = node.func.id
+                        elif isinstance(node.func, ast.Attribute):
+                            symbol = node.func.attr
+                    elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                        symbol = node.value
+                    if symbol in PACKAGE_ENTRYPOINT_SYMBOLS:
+                        counts[(path, qualified, symbol)] += 1
+    return counts
+
+
+def _documented_entrypoint_counts() -> Counter[tuple[Path, str, str]]:
+    inventory = _source(INVENTORY)
+    block = inventory.split("<!-- plc9b-entrypoint-inventory:start -->", 1)[1]
+    block = block.split("<!-- plc9b-entrypoint-inventory:end -->", 1)[0]
+    counts: Counter[tuple[Path, str, str]] = Counter()
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("src/"):
+            continue
+        qualified_site, raw_count = line.rsplit(" = ", 1)
+        raw_path, scope, symbol = qualified_site.rsplit("::", 2)
+        key = (Path(raw_path), scope, symbol)
+        assert key not in counts, key
+        counts[key] = int(raw_count)
+    return counts
+
+
+def _adversarial_matrix() -> dict[str, tuple[str, str, str]]:
+    contract = _source(CONTRACT)
+    section = contract.split("## Adversarial Acceptance Matrix", 1)[1]
+    section = section.split("## Rollout, Rollback, And Deletion Gates", 1)[0]
+    rows: dict[str, tuple[str, str, str]] = {}
+    for line in section.splitlines():
+        if not line.startswith("| B-"):
+            continue
+        cells = tuple(cell.strip() for cell in line.strip("|").split("|"))
+        assert len(cells) == 4, cells
+        case_id, stage, adversary, outcome = cells
+        assert case_id not in rows, case_id
+        rows[case_id] = (stage, adversary, outcome)
+    return rows
+
+
+def test_plc9b_contract_is_indexed_and_explicitly_design_only() -> None:
+    contract = _source(CONTRACT)
+    index = _source(INDEX)
+    inventory = _source(INVENTORY)
+
+    assert index.count("(plugin-lifecycle-plc9b-contract.md)") == 1
+    assert inventory.count("(plugin-lifecycle-plc9b-contract.md)") == 1
+    assert "Contract version: PLC9B.0" in contract
+    assert "Delivery status: design-only" in contract
+    assert "No runtime acquisition, archive extraction" in contract
+    assert "Public author SDK effect: none" in contract
+    for deferred in (
+        "PLC9A2 transport activation",
+        "`local_worker`",
+        "`remote_service`",
+        "source builds",
+        "artifact GC/deletion",
+        "private-data deletion",
+    ):
+        assert deferred in contract
+
+
+def test_plc9b_canonical_entrypoint_inventory_exactly_matches_source_ast() -> None:
+    documented = _documented_entrypoint_counts()
+    actual = _package_entrypoint_scope_counts()
+
+    assert len(documented) == 70
+    assert sum(documented.values()) == 111
+    assert actual == documented
+    assert "test_plc9_freezes_named_package_lifecycle_sites_and_occurrences" in (
+        _source(BASELINE_TEST)
+    )
+
+
+def test_plc9b_freezes_one_high_cohesion_owner_and_narrow_dependencies() -> None:
+    contract = _source(CONTRACT)
+    inventory = _source(INVENTORY)
+
+    for required in (
+        "one Package lifecycle composition in `loushang.harness.resources.packages`",
+        "Authenticated provenance and bounded streaming only",
+        "Sole owner of quarantine, limits, inert extraction",
+        "never acquires, extracts, publishes, selects, or deletes by itself",
+    ):
+        assert required in inventory
+    assert "does not authenticate Sources, parse archives" in contract
+    assert "does not belong in `foundation`" in contract
+    assert "does not belong in `foundation`, a transport, a\nProduct adapter" in (
+        contract
+    )
+    for exact_existing_owner in (
+        "materializer.py::PackageMaterializer",
+        "operations.py::PackageOperationsRuntime",
+        "revisions.py::PluginRevisionStore",
+        "dependencies.py::PluginDependencyClosureLock",
+        "package_lifecycle.py::PluginPackageLifecycleLedger",
+    ):
+        assert exact_existing_owner in inventory
+
+
+def test_plc9b_evidence_is_versioned_and_v1_is_never_reinterpreted() -> None:
+    contract = _source(CONTRACT)
+    dependencies = _source(PLUGIN_DEPENDENCIES)
+
+    for evidence in (
+        "authenticated source envelope v1",
+        "bounded acquisition receipt v1",
+        "quarantine receipt v1",
+        "verified wheel artifact v1",
+        "dependency closure lock v2",
+        "immutable publication receipt v1",
+    ):
+        assert evidence in contract
+    assert 'PLUGIN_DEPENDENCY_LOCK_FORMAT = "loushang.plugin-dependency-lock/v1"' in (
+        dependencies
+    )
+    assert "v1 remains replay-only" in contract
+    assert "never satisfies PLC9B recursive verification" in contract
+    assert "no reader may decode\nv1 bytes as closure v2" in contract
+    assert "unsupported future evidence version fails closed" in contract
+
+
+def test_plc9b_transaction_never_confuses_publication_with_selection() -> None:
+    contract = _source(CONTRACT)
+
+    ordered_phases = (
+        "accepted",
+        "acquiring",
+        "acquired",
+        "inspecting",
+        "extracted",
+        "closure_verified",
+        "publishing",
+        "published",
+        "committed",
+    )
+    positions = [contract.index(f"  -> {phase}") for phase in ordered_phases[1:]]
+    assert positions == sorted(positions)
+    for boundary in (
+        "remain unselectable until",
+        "A crash after an immutable rename",
+        "never trusts directory existence alone",
+        "cannot implicitly enable a Plugin",
+        "same identity with different input fails closed",
+    ):
+        assert boundary in contract
+
+
+def test_plc9b_adversarial_matrix_is_complete_and_fail_closed() -> None:
+    matrix = _adversarial_matrix()
+
+    assert set(matrix) == EXPECTED_MATRIX_IDS
+    for case_id, (stage, adversary, outcome) in matrix.items():
+        assert stage, case_id
+        assert adversary, case_id
+        assert any(
+            token in outcome
+            for token in (
+                "reject",
+                "fail closed",
+                "fail-closed",
+                "terminate",
+                "stop",
+                "revalidate",
+                "converges",
+                "inert",
+                "zero child process",
+            )
+        ), case_id
+        assert any(
+            token in outcome for token in ("no ", "never ", "zero ", "unselectable")
+        ), case_id
+
+
+def test_plc9b_matrix_covers_every_route_and_native_platform_evidence() -> None:
+    matrix = _adversarial_matrix()
+    entry_case = " ".join(matrix["B-ENTRY-01"])
+    contract = _source(CONTRACT)
+
+    for route in (
+        "CLI",
+        "RPC",
+        "Session",
+        "startup",
+        "operations",
+        "direct materializer",
+    ):
+        assert route in entry_case
+    assert "unsupported host emulation cannot count as the only evidence" in contract
+    assert "Source distributions are unconditionally rejected" in contract
+    assert "zero child process, import, hook, network side effect" in entry_case or (
+        "zero child process, import, hook, network side effect" in contract
+    )
+
+
+def test_plc9b_zero_runtime_claim_preserves_visible_unsafe_debt() -> None:
+    contract = _source(CONTRACT)
+    materializer = _source(PACKAGE_MATERIALIZER)
+    operations = _source(PACKAGE_OPERATIONS)
+    resolver = _source(PACKAGE_SOURCE_RESOLVER)
+    revisions = _source(PLUGIN_REVISIONS)
+    lifecycle = _source(PACKAGE_LIFECYCLE)
+    author_sdk = _source(AUTHOR_SDK)
+
+    assert "class PythonPackageInstallerBackend:" in materializer
+    assert '"pip",\n                    "install",' in materializer
+    assert (
+        '"-m",\n                    "pip",\n                    "install",'
+        in materializer
+    )
+    assert "--only-binary" not in materializer
+    assert "def remove_remote_source(" in materializer
+    assert "def forget_remote_source(" in materializer
+    assert "def forget_plugin_binding(" in materializer
+    assert "def uninstall_sync(" in operations
+    assert "materialize_remote_source_sync" in resolver
+    assert "class PluginRevisionStore:" in revisions
+    assert "class PluginPackageLifecycleLedger:" in lifecycle
+    assert "current `PythonPackageInstallerBackend`" in contract
+    assert "must remain unavailable or fail closed without mutation" in contract
+    assert not (PACKAGE_ROOT / "lifecycle.py").exists()
+    for forbidden in (
+        "PackageLifecycleOwner",
+        "BoundedAcquisitionReceipt",
+        "VerifiedWheelArtifact",
+        "DependencyClosureLockV2",
+    ):
+        assert forbidden not in author_sdk
+
+
+def test_plc9b_rollback_never_restores_the_unsafe_installer() -> None:
+    contract = _source(CONTRACT)
+
+    for boundary in (
+        "There is no rollback to the\ncurrent installer for Plugin-bound input",
+        "disabling the new owner disables the\nartifact command",
+        "cannot fall through to\nthe current `uv`/`pip`",
+        "rollback disables Plugin artifact operations instead of restoring an unsafe",
+    ):
+        assert boundary in contract

--- a/tests/architecture/test_plugin_lifecycle_plc9b_contract.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9b_contract.py
@@ -21,13 +21,7 @@ PLUGIN_DEPENDENCIES = Path("src/loushang/harness/resources/plugins/dependencies.
 PACKAGE_LIFECYCLE = Path("src/loushang/harness/plugin_management/package_lifecycle.py")
 AUTHOR_SDK = Path("src/loushang/plugin/__init__.py")
 
-PACKAGE_ENTRYPOINT_ROOTS = (
-    Path("src/loushang/coding/cli"),
-    Path("src/loushang/harness/cli"),
-    Path("src/loushang/harness/host/rpc/commands"),
-    Path("src/loushang/harness/session"),
-    PACKAGE_ROOT,
-)
+SOURCE_ROOT = Path("src/loushang")
 PACKAGE_ENTRYPOINT_SYMBOLS = {
     "get_packages",
     "materialize_package",
@@ -40,33 +34,73 @@ PACKAGE_ENTRYPOINT_SYMBOLS = {
     "uninstall_package_async",
     "materialize_remote_source_sync",
 }
-EXPECTED_MATRIX_IDS = {
-    "B-ACQ-01",
-    "B-ACQ-02",
-    "B-ACQ-03",
-    "B-PATH-01",
-    "B-PATH-02",
-    "B-PATH-03",
-    "B-PATH-04",
-    "B-TYPE-01",
-    "B-LIMIT-01",
-    "B-WHEEL-01",
-    "B-WHEEL-02",
-    "B-WHEEL-03",
-    "B-WHEEL-04",
-    "B-CLOSURE-01",
-    "B-CLOSURE-02",
-    "B-CLOSURE-03",
-    "B-PUB-01",
-    "B-PUB-02",
-    "B-PUB-03",
-    "B-CRASH-01",
-    "B-CRASH-02",
-    "B-CONCUR-01",
-    "B-ENTRY-01",
-    "B-ENTRY-02",
-    "B-NOEXEC-01",
-    "B-STATE-01",
+PACKAGE_EFFECT_SYMBOLS = {
+    "CodingPackageMaterializer",
+    "GitPackageMaterializerBackend",
+    "PackageMaterializer",
+    "PackageOperationsRuntime",
+    "PackageSourceResolver",
+    "PluginRevisionStore",
+    "PythonPackageInstallerBackend",
+    "bind_plugin_packages",
+    "forget_plugin_binding",
+    "forget_remote_source",
+    "materialize_remote_source",
+    "materialize_remote_source_sync",
+    "publish_all",
+    "publish_plugin_packages",
+    "rebind_plugin_packages",
+    "reopen_plugin_package",
+    "remove_remote_source",
+    "update_all_remote_sources",
+    "update_remote_source",
+    "update_remote_source_sync",
+}
+EXPECTED_MANIFEST_CATEGORY_COUNTS = {
+    "ACQ": 7,
+    "ARCH": 5,
+    "CLASS": 5,
+    "CLOSURE": 7,
+    "COMPAT": 4,
+    "CONCUR": 3,
+    "CRASH": 12,
+    "ENTRY": 8,
+    "LIMIT": 6,
+    "NOEXEC": 4,
+    "PATH": 10,
+    "PUB": 5,
+    "STATE": 5,
+    "TYPE": 7,
+    "WHEEL": 7,
+}
+MANIFEST_FIELDS = (
+    "case_id",
+    "platform",
+    "barrier",
+    "fixture",
+    "code",
+    "disposition",
+    "oracles",
+    "test_node",
+    "workflow",
+    "status",
+)
+ALLOWED_PLATFORMS = {"any", "posix-native", "windows-native"}
+ALLOWED_ORACLES = {
+    "bounded_residue",
+    "no_binding",
+    "no_desired",
+    "no_extra_network",
+    "no_import",
+    "no_outside_write",
+    "no_peer_fallback",
+    "no_process",
+    "no_publication",
+    "no_secret",
+    "no_skip",
+    "pin_visible",
+    "same_receipt",
+    "single_owner",
 }
 
 
@@ -78,8 +112,13 @@ class _QualifiedFunctionVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.scope: list[str] = []
         self.functions: list[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef]] = []
+        self.scopes: list[
+            tuple[str, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef]
+        ] = []
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        qualified = ".".join((*self.scope, node.name))
+        self.scopes.append((qualified, node))
         self.scope.append(node.name)
         self.generic_visit(node)
         self.scope.pop()
@@ -96,34 +135,104 @@ class _QualifiedFunctionVisitor(ast.NodeVisitor):
     ) -> None:
         qualified = ".".join((*self.scope, node.name))
         self.functions.append((qualified, node))
+        self.scopes.append((qualified, node))
         self.scope.append(node.name)
         self.generic_visit(node)
         self.scope.pop()
 
 
-def _package_entrypoint_scope_counts() -> Counter[tuple[Path, str, str]]:
+def _node_scope(visitor: _QualifiedFunctionVisitor, node: ast.AST) -> str:
+    if not hasattr(node, "lineno"):
+        return "<module>"
+    enclosing = [
+        (qualified, scope)
+        for qualified, scope in visitor.scopes
+        if scope.lineno <= node.lineno <= scope.end_lineno
+    ]
+    if not enclosing:
+        return "<module>"
+    return max(
+        enclosing,
+        key=lambda item: (
+            item[0].count("."),
+            -int(item[1].end_lineno - item[1].lineno),
+        ),
+    )[0]
+
+
+def _semantic_scope_counts(
+    symbols: set[str],
+) -> Counter[tuple[Path, str, str]]:
     counts: Counter[tuple[Path, str, str]] = Counter()
-    for root in PACKAGE_ENTRYPOINT_ROOTS:
-        for path in root.rglob("*.py"):
-            source = _source(path)
-            if not any(symbol in source for symbol in PACKAGE_ENTRYPOINT_SYMBOLS):
+    for path in SOURCE_ROOT.rglob("*.py"):
+        source = _source(path)
+        if not any(symbol in source for symbol in symbols):
+            continue
+        tree = ast.parse(source, filename=str(path))
+        visitor = _QualifiedFunctionVisitor()
+        visitor.visit(tree)
+        aliases: dict[str, str] = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Import, ast.ImportFrom)):
                 continue
-            visitor = _QualifiedFunctionVisitor()
-            visitor.visit(ast.parse(source, filename=str(path)))
-            for qualified, function in visitor.functions:
-                if function.name in PACKAGE_ENTRYPOINT_SYMBOLS:
-                    counts[(path, qualified, function.name)] += 1
-                for node in ast.walk(function):
-                    symbol: str | None = None
-                    if isinstance(node, ast.Call):
-                        if isinstance(node.func, ast.Name):
-                            symbol = node.func.id
-                        elif isinstance(node.func, ast.Attribute):
-                            symbol = node.func.attr
-                    elif isinstance(node, ast.Constant) and isinstance(node.value, str):
-                        symbol = node.value
-                    if symbol in PACKAGE_ENTRYPOINT_SYMBOLS:
-                        counts[(path, qualified, symbol)] += 1
+            for alias in node.names:
+                original = alias.name.rsplit(".", 1)[-1]
+                if original in symbols:
+                    aliases[alias.asname or original] = original
+        for node in ast.walk(tree):
+            symbol: str | None = None
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                symbol = node.name
+            elif isinstance(node, ast.Name):
+                symbol = aliases.get(node.id, node.id)
+            elif isinstance(node, ast.Attribute):
+                symbol = node.attr
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                symbol = node.value
+            elif isinstance(node, ast.alias):
+                symbol = node.name.rsplit(".", 1)[-1]
+            if symbol in symbols:
+                counts[(path, _node_scope(visitor, node), symbol)] += 1
+    return counts
+
+
+def _package_entrypoint_scope_counts() -> Counter[tuple[Path, str, str]]:
+    return _semantic_scope_counts(PACKAGE_ENTRYPOINT_SYMBOLS)
+
+
+def _package_effect_scope_counts() -> Counter[tuple[Path, str, str]]:
+    counts = _semantic_scope_counts(PACKAGE_EFFECT_SYMBOLS)
+    for path in (PACKAGE_MATERIALIZER, PLUGIN_REVISIONS):
+        tree = ast.parse(_source(path), filename=str(path))
+        visitor = _QualifiedFunctionVisitor()
+        visitor.visit(tree)
+        for node in ast.walk(tree):
+            token: str | None = None
+            scope = _node_scope(visitor, node)
+            if (
+                path == PLUGIN_REVISIONS
+                and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and scope
+                in {"PluginRevisionStore.publish", "PluginRevisionStore.reopen"}
+            ):
+                token = scope
+            elif (
+                path == PLUGIN_REVISIONS
+                and scope.startswith("PluginRevisionStore.")
+                and isinstance(node, ast.Attribute)
+                and node.attr == "publish"
+            ):
+                token = "PluginRevisionStore.publish"
+            elif (
+                path == PACKAGE_MATERIALIZER
+                and isinstance(node, ast.Attribute)
+                and node.attr == "reopen"
+                and isinstance(node.value, ast.Attribute)
+                and node.value.attr == "_plugin_revision_store"
+            ):
+                token = "PluginRevisionStore.reopen"
+            if token is not None:
+                counts[(path, scope, token)] += 1
     return counts
 
 
@@ -144,19 +253,44 @@ def _documented_entrypoint_counts() -> Counter[tuple[Path, str, str]]:
     return counts
 
 
-def _adversarial_matrix() -> dict[str, tuple[str, str, str]]:
-    contract = _source(CONTRACT)
-    section = contract.split("## Adversarial Acceptance Matrix", 1)[1]
-    section = section.split("## Rollout, Rollback, And Deletion Gates", 1)[0]
-    rows: dict[str, tuple[str, str, str]] = {}
-    for line in section.splitlines():
-        if not line.startswith("| B-"):
+def _documented_effect_counts() -> Counter[tuple[Path, str, str]]:
+    inventory = _source(INVENTORY)
+    block = inventory.split("<!-- plc9b-effect-inventory:start -->", 1)[1]
+    block = block.split("<!-- plc9b-effect-inventory:end -->", 1)[0]
+    counts: Counter[tuple[Path, str, str]] = Counter()
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("src/"):
             continue
-        cells = tuple(cell.strip() for cell in line.strip("|").split("|"))
-        assert len(cells) == 4, cells
-        case_id, stage, adversary, outcome = cells
+        qualified_site, raw_count = line.rsplit(" = ", 1)
+        raw_path, scope, symbol = qualified_site.rsplit("::", 2)
+        key = (Path(raw_path), scope, symbol)
+        assert key not in counts, key
+        counts[key] = int(raw_count)
+    return counts
+
+
+def _adversarial_manifest() -> dict[str, dict[str, str]]:
+    contract = _source(CONTRACT)
+    block = contract.split("<!-- plc9b-adversarial-manifest:start -->", 1)[1]
+    block = block.split("<!-- plc9b-adversarial-manifest:end -->", 1)[0]
+    rows: dict[str, dict[str, str]] = {}
+    header: tuple[str, ...] | None = None
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line or line == "```text" or line == "```":
+            continue
+        cells = tuple(cell.strip() for cell in line.split("|"))
+        if header is None:
+            header = cells
+            assert header == MANIFEST_FIELDS
+            continue
+        assert len(cells) == len(MANIFEST_FIELDS), cells
+        row = dict(zip(MANIFEST_FIELDS, cells, strict=True))
+        case_id = row["case_id"]
         assert case_id not in rows, case_id
-        rows[case_id] = (stage, adversary, outcome)
+        rows[case_id] = row
+    assert header == MANIFEST_FIELDS
     return rows
 
 
@@ -186,12 +320,54 @@ def test_plc9b_canonical_entrypoint_inventory_exactly_matches_source_ast() -> No
     documented = _documented_entrypoint_counts()
     actual = _package_entrypoint_scope_counts()
 
-    assert len(documented) == 70
-    assert sum(documented.values()) == 111
+    assert len(documented) == 95
+    assert sum(documented.values()) == 151
     assert actual == documented
     assert "test_plc9_freezes_named_package_lifecycle_sites_and_occurrences" in (
         _source(BASELINE_TEST)
     )
+
+
+def test_plc9b_effect_inventory_freezes_owner_and_bypass_capabilities() -> None:
+    documented = _documented_effect_counts()
+    actual = _package_effect_scope_counts()
+
+    assert len(documented) == 117
+    assert sum(documented.values()) == 132
+    assert actual == documented
+    for required in (
+        (
+            PACKAGE_OPERATIONS,
+            "PackageOperationsRuntime.materialize",
+            "materialize_remote_source",
+        ),
+        (
+            PACKAGE_MATERIALIZER,
+            "PackageMaterializer.publish_plugin_packages",
+            "publish_plugin_packages",
+        ),
+        (
+            PACKAGE_MATERIALIZER,
+            "PackageMaterializer.remove_remote_source",
+            "remove_remote_source",
+        ),
+        (
+            PACKAGE_MATERIALIZER,
+            "PackageMaterializer.forget_plugin_binding",
+            "forget_plugin_binding",
+        ),
+        (
+            Path("src/loushang/harness/resources/plugins/authority.py"),
+            "PluginResolutionAuthority.publish_runtime",
+            "publish_plugin_packages",
+        ),
+        (
+            Path("src/loushang/harness/session/bootstrap_configuration.py"),
+            "StandardAgentSessionConfigurationRuntime._package_sources",
+            "PackageSourceResolver",
+        ),
+    ):
+        assert required in documented
 
 
 def test_plc9b_freezes_one_high_cohesion_owner_and_narrow_dependencies() -> None:
@@ -225,12 +401,16 @@ def test_plc9b_evidence_is_versioned_and_v1_is_never_reinterpreted() -> None:
     dependencies = _source(PLUGIN_DEPENDENCIES)
 
     for evidence in (
+        "Plugin-bound classification v1",
         "authenticated source envelope v1",
         "bounded acquisition receipt v1",
         "quarantine receipt v1",
         "verified wheel artifact v1",
+        "dependency closure node v2",
         "dependency closure lock v2",
+        "retention-pin receipt v1",
         "immutable publication receipt v1",
+        "Package lifecycle status/failure v1",
     ):
         assert evidence in contract
     assert 'PLUGIN_DEPENDENCY_LOCK_FORMAT = "loushang.plugin-dependency-lock/v1"' in (
@@ -240,6 +420,12 @@ def test_plc9b_evidence_is_versioned_and_v1_is_never_reinterpreted() -> None:
     assert "never satisfies PLC9B recursive verification" in contract
     assert "no reader may decode\nv1 bytes as closure v2" in contract
     assert "unsupported future evidence version fails closed" in contract
+    assert "exact stable published revision refs (never live handles)" in contract
+    assert "source-envelope fingerprint" in contract
+    assert "acquisition-receipt fingerprint" in contract
+    assert "wheel-evidence fingerprint" in contract
+    assert "lowercase hexadecimal SHA-256" in contract
+    assert "`sha256`, `sha384`, or\n`sha512`" in contract
 
 
 def test_plc9b_transaction_never_confuses_publication_with_selection() -> None:
@@ -247,72 +433,188 @@ def test_plc9b_transaction_never_confuses_publication_with_selection() -> None:
 
     ordered_phases = (
         "accepted",
+        "classified",
         "acquiring",
         "acquired",
         "inspecting",
         "extracted",
+        "resolving_closure",
         "closure_verified",
-        "publishing",
-        "published",
+        "transaction_pinned",
+        "staging",
+        "set_published",
         "committed",
     )
     positions = [contract.index(f"  -> {phase}") for phase in ordered_phases[1:]]
     assert positions == sorted(positions)
     for boundary in (
-        "remain unselectable until",
-        "A crash after an immutable rename",
-        "never trusts directory existence alone",
-        "cannot implicitly enable a Plugin",
-        "same identity with different input fails closed",
+        "Staged refs are owner-private",
+        "one atomic committed-set manifest",
+        "Directory existence alone is never admission",
+        "Package commit-admission port is the only route",
+        "expected-phase compare-and-swap",
+        "A stale worker cannot append",
     ):
         assert boundary in contract
 
 
-def test_plc9b_adversarial_matrix_is_complete_and_fail_closed() -> None:
-    matrix = _adversarial_matrix()
+def test_plc9b_adversarial_manifest_is_structured_countable_and_planned() -> None:
+    manifest = _adversarial_manifest()
+    categories = Counter(case_id.split("-", 2)[1] for case_id in manifest)
 
-    assert set(matrix) == EXPECTED_MATRIX_IDS
-    for case_id, (stage, adversary, outcome) in matrix.items():
-        assert stage, case_id
-        assert adversary, case_id
-        assert any(
-            token in outcome
-            for token in (
-                "reject",
-                "fail closed",
-                "fail-closed",
-                "terminate",
-                "stop",
-                "revalidate",
-                "converges",
-                "inert",
-                "zero child process",
+    assert len(manifest) == 95
+    assert categories == EXPECTED_MANIFEST_CATEGORY_COUNTS
+    for case_id, row in manifest.items():
+        assert row["platform"] in ALLOWED_PLATFORMS, case_id
+        assert row["barrier"], case_id
+        assert row["fixture"], case_id
+        assert row["code"], case_id
+        assert "@" in row["disposition"], case_id
+        oracles = set(row["oracles"].split(";"))
+        assert oracles <= ALLOWED_ORACLES, case_id
+        assert oracles, case_id
+        assert row["test_node"].endswith(f"[{case_id}]"), case_id
+        assert row["status"] == "planned", case_id
+        assert "#plc9b-" in row["workflow"], case_id
+        if row["platform"] == "windows-native":
+            assert row["workflow"].startswith("windows-shell-compatibility.yml"), (
+                case_id
             )
-        ), case_id
-        assert any(
-            token in outcome for token in ("no ", "never ", "zero ", "unselectable")
-        ), case_id
+            assert "no_skip" in oracles, case_id
+        elif row["platform"] == "posix-native":
+            assert row["workflow"].startswith("harness-quality.yml"), case_id
+            assert "no_skip" in oracles, case_id
 
 
-def test_plc9b_matrix_covers_every_route_and_native_platform_evidence() -> None:
-    matrix = _adversarial_matrix()
-    entry_case = " ".join(matrix["B-ENTRY-01"])
+def test_plc9b_manifest_covers_every_route_and_native_platform_evidence() -> None:
+    manifest = _adversarial_manifest()
     contract = _source(CONTRACT)
 
-    for route in (
-        "CLI",
-        "RPC",
-        "Session",
-        "startup",
-        "operations",
-        "direct materializer",
+    for route_case in (
+        "B-ENTRY-CLI",
+        "B-ENTRY-RPC",
+        "B-ENTRY-SESSION",
+        "B-ENTRY-STARTUP",
+        "B-ENTRY-OPERATIONS",
+        "B-ENTRY-MATERIALIZER",
+        "B-ENTRY-PUBLISH",
+        "B-ENTRY-DISABLED",
     ):
-        assert route in entry_case
-    assert "unsupported host emulation cannot count as the only evidence" in contract
+        assert route_case in manifest
+    for phase_case in (
+        "B-CRASH-ACCEPTED",
+        "B-CRASH-CLASSIFIED",
+        "B-CRASH-ACQUIRING",
+        "B-CRASH-ACQUIRED",
+        "B-CRASH-INSPECTING",
+        "B-CRASH-EXTRACTED",
+        "B-CRASH-RESOLVING",
+        "B-CRASH-CLOSURE",
+        "B-CRASH-PINNED",
+        "B-CRASH-STAGING",
+        "B-CRASH-SET",
+        "B-CRASH-COMMITTED",
+    ):
+        assert phase_case in manifest
+    assert "unsupported-host emulation is never the only evidence" in contract
     assert "Source distributions are unconditionally rejected" in contract
-    assert "zero child process, import, hook, network side effect" in entry_case or (
-        "zero child process, import, hook, network side effect" in contract
+    assert set(manifest["B-NOEXEC-IMPORT"]["oracles"].split(";")) >= {
+        "no_process",
+        "no_import",
+        "no_extra_network",
+    }
+
+
+def test_plc9b_freezes_single_classification_and_commit_admission_authorities() -> None:
+    contract = _source(CONTRACT)
+
+    for boundary in (
+        "does not accept a classification result from the caller",
+        "exactly one decision: `plugin_bound`, `non_plugin`, or `indeterminate`",
+        "Only evidence from a separately accepted non-Plugin authority",
+        "It never enters the legacy\ninstaller",
+        "rechecks the\nclassification fingerprint before acquisition and before committed-set",
+        "Package commit-admission port",
+        "current digest/source-only `reopen`",
+    ):
+        assert boundary in contract
+
+
+def test_plc9b_freezes_status_redaction_and_transport_conformance() -> None:
+    contract = _source(CONTRACT)
+
+    for field in (
+        "`code`",
+        "`stage`",
+        "`retryable`",
+        "`operator_action`",
+        "`operation_id`",
+        "`evidence_ref`",
+    ):
+        assert field in contract
+    for action in (
+        "`none`",
+        "`retry`",
+        "`repair`",
+        "`upgrade_runtime`",
+        "`offline_restore`",
+        "`review_policy`",
+    ):
+        assert action in contract
+    assert "CLI emits the code, operation id and evidence reference and exits\n`1`" in (
+        contract
     )
+    assert "RPC returns the record as its structured command error" in contract
+    assert "Session raises one typed\nPackage lifecycle application error" in contract
+    assert "Startup emits the same\ndiagnostic and aborts configuration" in contract
+    for secret in (
+        "authorization headers",
+        "URL user-info/query/fragment",
+        "private registry tokens",
+    ):
+        assert secret in contract
+
+
+def test_plc9b_freezes_retention_transfer_and_downgrade_fence() -> None:
+    contract = _source(CONTRACT)
+    normalized = " ".join(contract.split())
+
+    for retention in (
+        "transaction pin over the root and every dependency",
+        "obtains dependency-retention pins under one handoff identity",
+        "atomically records handoff completion and releases the transaction pin",
+        "a crash leaves both pins, never a zero-pin gap",
+        "Package owner does not import the concrete ledger",
+    ):
+        assert retention in normalized
+    for compatibility in (
+        "Package lifecycle epoch and minimum fence-aware runtime",
+        "Direct downgrade after any B epoch state exists is unsupported",
+        "offline restore of the complete pre-B Package store",
+        "mixed-epoch writers are never admitted",
+        "`legacy_unverified`",
+        "never satisfy B classification, recursive closure, commit admission",
+        "Adoption requires authenticated reacquisition",
+    ):
+        assert compatibility in normalized
+
+
+def test_plc9b_transport_surfaces_do_not_import_concrete_effect_owners() -> None:
+    transport_paths = (
+        Path("src/loushang/harness/cli/package_lifecycle.py"),
+        Path("src/loushang/harness/host/rpc/commands/packages.py"),
+        Path("src/loushang/harness/session/facade_optional.py"),
+        Path("src/loushang/harness/session/lifecycle_adapter.py"),
+    )
+    forbidden_modules = (
+        "loushang.harness.resources.packages.materializer",
+        "loushang.harness.resources.plugins.revisions",
+        "loushang.harness.plugin_management.package_lifecycle",
+    )
+
+    for path in transport_paths:
+        source = _source(path)
+        assert not any(module in source for module in forbidden_modules), path
 
 
 def test_plc9b_zero_runtime_claim_preserves_visible_unsafe_debt() -> None:
@@ -352,11 +654,12 @@ def test_plc9b_zero_runtime_claim_preserves_visible_unsafe_debt() -> None:
 
 def test_plc9b_rollback_never_restores_the_unsafe_installer() -> None:
     contract = _source(CONTRACT)
+    normalized = " ".join(contract.split())
 
     for boundary in (
-        "There is no rollback to the\ncurrent installer for Plugin-bound input",
-        "disabling the new owner disables the\nartifact command",
-        "cannot fall through to\nthe current `uv`/`pip`",
+        "There is no rollback to the current installer for Plugin-bound input",
+        "disabling the new owner disables the artifact command",
+        "cannot fall through to the current `uv`/`pip`",
         "rollback disables Plugin artifact operations instead of restoring an unsafe",
     ):
-        assert boundary in contract
+        assert boundary in normalized

--- a/tests/architecture/test_plugin_lifecycle_plc9b_contract.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9b_contract.py
@@ -42,11 +42,18 @@ PACKAGE_EFFECT_SYMBOLS = {
     "PackageSourceResolver",
     "PluginRevisionStore",
     "PythonPackageInstallerBackend",
+    "_bind_plugin_packages",
+    "_plugin_revision_store",
+    "_run_backend_for_record",
+    "_run_backend_for_record_sync",
     "bind_plugin_packages",
     "forget_plugin_binding",
     "forget_remote_source",
     "materialize_remote_source",
     "materialize_remote_source_sync",
+    "materialize_temporary_remote_source",
+    "materialize_temporary_remote_source_sync",
+    "prepare_remote_source",
     "publish_all",
     "publish_plugin_packages",
     "rebind_plugin_packages",
@@ -58,17 +65,19 @@ PACKAGE_EFFECT_SYMBOLS = {
 }
 EXPECTED_MANIFEST_CATEGORY_COUNTS = {
     "ACQ": 7,
+    "ADMISSION": 7,
     "ARCH": 5,
     "CLASS": 5,
     "CLOSURE": 7,
-    "COMPAT": 4,
+    "COMPAT": 15,
     "CONCUR": 3,
     "CRASH": 12,
     "ENTRY": 8,
+    "HANDOFF": 6,
     "LIMIT": 6,
     "NOEXEC": 4,
     "PATH": 10,
-    "PUB": 5,
+    "PUB": 13,
     "STATE": 5,
     "TYPE": 7,
     "WHEEL": 7,
@@ -87,21 +96,45 @@ MANIFEST_FIELDS = (
 )
 ALLOWED_PLATFORMS = {"any", "posix-native", "windows-native"}
 ALLOWED_ORACLES = {
+    "b_namespace_unreachable",
     "bounded_residue",
+    "binding_unchanged",
+    "dependency_pins_released",
+    "desired_unchanged",
+    "exact_pin_set",
+    "handle_released",
+    "enablement_unchanged",
+    "instance_unchanged",
+    "legacy_snapshot_exact",
     "no_binding",
     "no_desired",
     "no_extra_network",
     "no_import",
+    "no_handle_issued",
     "no_outside_write",
     "no_peer_fallback",
     "no_process",
     "no_publication",
+    "no_reopen",
     "no_secret",
     "no_skip",
+    "no_zero_pin",
     "pin_visible",
     "same_receipt",
     "single_owner",
+    "transaction_pin_released",
 }
+
+
+def _plugin_revision_receiver_token(node: ast.AST) -> str | None:
+    if (
+        isinstance(node, ast.Attribute)
+        and node.attr in {"publish", "publish_all", "reopen"}
+        and isinstance(node.value, ast.Attribute)
+        and node.value.attr == "_plugin_revision_store"
+    ):
+        return f"PluginRevisionStore.{node.attr}"
+    return None
 
 
 def _source(path: Path) -> str:
@@ -202,7 +235,10 @@ def _package_entrypoint_scope_counts() -> Counter[tuple[Path, str, str]]:
 
 def _package_effect_scope_counts() -> Counter[tuple[Path, str, str]]:
     counts = _semantic_scope_counts(PACKAGE_EFFECT_SYMBOLS)
-    for path in (PACKAGE_MATERIALIZER, PLUGIN_REVISIONS):
+    for path in SOURCE_ROOT.rglob("*.py"):
+        source = _source(path)
+        if path != PLUGIN_REVISIONS and "_plugin_revision_store" not in source:
+            continue
         tree = ast.parse(_source(path), filename=str(path))
         visitor = _QualifiedFunctionVisitor()
         visitor.visit(tree)
@@ -223,14 +259,8 @@ def _package_effect_scope_counts() -> Counter[tuple[Path, str, str]]:
                 and node.attr == "publish"
             ):
                 token = "PluginRevisionStore.publish"
-            elif (
-                path == PACKAGE_MATERIALIZER
-                and isinstance(node, ast.Attribute)
-                and node.attr == "reopen"
-                and isinstance(node.value, ast.Attribute)
-                and node.value.attr == "_plugin_revision_store"
-            ):
-                token = "PluginRevisionStore.reopen"
+            else:
+                token = _plugin_revision_receiver_token(node)
             if token is not None:
                 counts[(path, scope, token)] += 1
     return counts
@@ -294,6 +324,82 @@ def _adversarial_manifest() -> dict[str, dict[str, str]]:
     return rows
 
 
+def _journal_effect_policy() -> list[tuple[str, str, str]]:
+    contract = _source(CONTRACT)
+    block = contract.split("<!-- plc9b-journal-effect-policy:start -->", 1)[1]
+    block = block.split("<!-- plc9b-journal-effect-policy:end -->", 1)[0]
+    policy: list[tuple[str, str, str]] = []
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line or line in {
+            "```text",
+            "```",
+            "selector | journal_domain | journal_transition",
+        }:
+            continue
+        selector, domain, transition = (
+            cell.strip() for cell in line.split("|", 2)
+        )
+        policy.append((selector, domain, transition))
+    return policy
+
+
+def _journal_policy_for(case_id: str) -> tuple[str, str]:
+    for selector, domain, transition in _journal_effect_policy():
+        if selector == "default":
+            return domain, transition
+        if selector.endswith("*") and case_id.startswith(selector[:-1]):
+            return domain, transition
+        if selector == case_id:
+            return domain, transition
+    raise AssertionError(f"no journal policy for {case_id}")
+
+
+def _journal_domain_authorities() -> dict[str, tuple[str, str, str, str]]:
+    contract = _source(CONTRACT)
+    block = contract.split("<!-- plc9b-journal-domain-authority:start -->", 1)[1]
+    block = block.split("<!-- plc9b-journal-domain-authority:end -->", 1)[0]
+    authorities: dict[str, tuple[str, str, str, str]] = {}
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line or line in {
+            "```text",
+            "```",
+            "journal_domain | sole_authority | stable_journal_key | bound_or_expected_cas_value | allowed_writer_port",
+        }:
+            continue
+        domain, authority, stable_key, bound_value, port = (
+            cell.strip() for cell in line.split("|", 4)
+        )
+        assert domain not in authorities, domain
+        authorities[domain] = (authority, stable_key, bound_value, port)
+    return authorities
+
+
+def _retry_policy() -> list[tuple[str, str, str, str]]:
+    contract = _source(CONTRACT)
+    block = contract.split("<!-- plc9b-retry-policy:start -->", 1)[1]
+    block = block.split("<!-- plc9b-retry-policy:end -->", 1)[0]
+    policy: list[tuple[str, str, str, str]] = []
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line or line in {
+            "```text",
+            "```",
+            "selector | retryability | retry_domain | retry_action",
+        }:
+            continue
+        policy.append(tuple(cell.strip() for cell in line.split("|", 3)))
+    return policy
+
+
+def _retry_policy_for(code: str) -> tuple[str, str, str]:
+    for selector, retryability, domain, action in _retry_policy():
+        if selector == code or selector == "default":
+            return retryability, domain, action
+    raise AssertionError(f"no retry policy for {code}")
+
+
 def test_plc9b_contract_is_indexed_and_explicitly_design_only() -> None:
     contract = _source(CONTRACT)
     index = _source(INDEX)
@@ -329,12 +435,14 @@ def test_plc9b_canonical_entrypoint_inventory_exactly_matches_source_ast() -> No
 
 
 def test_plc9b_effect_inventory_freezes_owner_and_bypass_capabilities() -> None:
+    inventory = _source(INVENTORY)
     documented = _documented_effect_counts()
     actual = _package_effect_scope_counts()
 
-    assert len(documented) == 117
-    assert sum(documented.values()) == 132
+    assert len(documented) == 141
+    assert sum(documented.values()) == 156
     assert actual == documented
+    assert "141 effect/capability rows with 156 occurrences" in inventory
     for required in (
         (
             PACKAGE_OPERATIONS,
@@ -366,8 +474,46 @@ def test_plc9b_effect_inventory_freezes_owner_and_bypass_capabilities() -> None:
             "StandardAgentSessionConfigurationRuntime._package_sources",
             "PackageSourceResolver",
         ),
+        (
+            PACKAGE_MATERIALIZER,
+            "PackageMaterializer.materialize_remote_source",
+            "prepare_remote_source",
+        ),
+        (
+            PACKAGE_MATERIALIZER,
+            "PackageMaterializer.materialize_temporary_remote_source",
+            "_run_backend_for_record",
+        ),
+        (
+            PACKAGE_SOURCE_RESOLVER,
+            "PackageSourceResolver.prepare_configured_remote_records",
+            "prepare_remote_source",
+        ),
+        (
+            PACKAGE_MATERIALIZER,
+            "PackageMaterializer.publish_plugin_packages",
+            "PluginRevisionStore.publish_all",
+        ),
     ):
         assert required in documented
+
+
+def test_plc9b_effect_scanner_recognizes_private_revision_store_receivers() -> None:
+    tree = ast.parse(
+        "owner._plugin_revision_store.publish(value)\n"
+        "owner._plugin_revision_store.publish_all(values)\n"
+        "owner._plugin_revision_store.reopen(ref)\n"
+    )
+
+    assert {
+        token
+        for node in ast.walk(tree)
+        if (token := _plugin_revision_receiver_token(node)) is not None
+    } == {
+        "PluginRevisionStore.publish",
+        "PluginRevisionStore.publish_all",
+        "PluginRevisionStore.reopen",
+    }
 
 
 def test_plc9b_freezes_one_high_cohesion_owner_and_narrow_dependencies() -> None:
@@ -381,7 +527,8 @@ def test_plc9b_freezes_one_high_cohesion_owner_and_narrow_dependencies() -> None
         "never acquires, extracts, publishes, selects, or deletes by itself",
     ):
         assert required in inventory
-    assert "does not authenticate Sources, parse archives" in contract
+    assert "neutral artifact store evolution" in contract
+    assert "cannot store or designate the Plugin root, commit a graph" in contract
     assert "does not belong in `foundation`" in contract
     assert "does not belong in `foundation`, a transport, a\nProduct adapter" in (
         contract
@@ -406,9 +553,12 @@ def test_plc9b_evidence_is_versioned_and_v1_is_never_reinterpreted() -> None:
         "bounded acquisition receipt v1",
         "quarantine receipt v1",
         "verified wheel artifact v1",
+        "verified closure plan v2",
         "dependency closure node v2",
         "dependency closure lock v2",
+        "typed stable refs v1",
         "retention-pin receipt v1",
+        "retention handoff receipt v1",
         "immutable publication receipt v1",
         "Package lifecycle status/failure v1",
     ):
@@ -420,7 +570,7 @@ def test_plc9b_evidence_is_versioned_and_v1_is_never_reinterpreted() -> None:
     assert "never satisfies PLC9B recursive verification" in contract
     assert "no reader may decode\nv1 bytes as closure v2" in contract
     assert "unsupported future evidence version fails closed" in contract
-    assert "exact stable published revision refs (never live handles)" in contract
+    assert "exact typed stable refs (never live handles)" in contract
     assert "source-envelope fingerprint" in contract
     assert "acquisition-receipt fingerprint" in contract
     assert "wheel-evidence fingerprint" in contract
@@ -462,7 +612,7 @@ def test_plc9b_adversarial_manifest_is_structured_countable_and_planned() -> Non
     manifest = _adversarial_manifest()
     categories = Counter(case_id.split("-", 2)[1] for case_id in manifest)
 
-    assert len(manifest) == 95
+    assert len(manifest) == 127
     assert categories == EXPECTED_MANIFEST_CATEGORY_COUNTS
     for case_id, row in manifest.items():
         assert row["platform"] in ALLOWED_PLATFORMS, case_id
@@ -484,6 +634,240 @@ def test_plc9b_adversarial_manifest_is_structured_countable_and_planned() -> Non
         elif row["platform"] == "posix-native":
             assert row["workflow"].startswith("harness-quality.yml"), case_id
             assert "no_skip" in oracles, case_id
+
+
+def test_plc9b_manifest_separates_caller_response_from_journal_effect() -> None:
+    manifest = _adversarial_manifest()
+    policy = _journal_effect_policy()
+
+    assert policy[-1] == (
+        "default",
+        "operation",
+        "append_once:response_state_then_no_append",
+    )
+    assert "caller-visible response outcome" in _source(CONTRACT)
+    resolved = {case_id: _journal_policy_for(case_id) for case_id in manifest}
+    expected_domains = {
+        "operation",
+        "attempt",
+        "handoff_attempt",
+        "handoff",
+        "cleanup",
+        "epoch",
+        "none",
+    }
+    assert {domain for domain, _transition in resolved.values()} <= expected_domains
+    authorities = _journal_domain_authorities()
+    assert authorities == {
+        "operation": (
+            "PLC9B Package lifecycle owner",
+            "operation_id",
+            "request_fingerprint+prior_journal_revision",
+            "PackageOperationJournalCAS",
+        ),
+        "attempt": (
+            "PLC9B Package lifecycle owner",
+            "operation_id+attempt_epoch",
+            "parent_request_fingerprint+parent_journal_revision",
+            "PackageAttemptJournalCAS",
+        ),
+        "handoff_attempt": (
+            "retention-handoff owner over PluginPackageLifecycleLedger",
+            "handoff_id+attempt_epoch",
+            "parent_receipt_fingerprint+parent_handoff_revision",
+            "RetentionHandoffJournalCAS",
+        ),
+        "handoff": (
+            "retention-handoff owner over PluginPackageLifecycleLedger",
+            "handoff_id",
+            "receipt_fingerprint+prior_handoff_revision",
+            "RetentionHandoffJournalCAS",
+        ),
+        "cleanup": (
+            "PLC9B Package lifecycle owner",
+            "quarantine_tombstone_id",
+            "cleanup_revision",
+            "PackageCleanupJournalCAS",
+        ),
+        "epoch": (
+            "Package epoch cutover coordinator in Package lifecycle composition",
+            "store_root_identity",
+            "current_epoch+prior_fence_revision",
+            "PackageEpochJournalCAS",
+        ),
+        "none": ("no authority", "no journal", "no value", "no writer"),
+    }
+    assert set(authorities) == expected_domains
+    for no_append in (
+        "B-PUB-UNCOMMITTED",
+        "B-ADMISSION-DEPENDENCY",
+        "B-ADMISSION-WRONG-SET",
+        "B-ADMISSION-WRONG-SCOPE",
+        "B-ADMISSION-WRONG-PLUGIN",
+        "B-CONCUR-CONFLICT",
+        "B-CONCUR-STALE",
+        "B-HANDOFF-STALE-RECEIPT",
+        "B-ENTRY-PUBLISH",
+        "B-ENTRY-DISABLED",
+        "B-COMPAT-EPOCH",
+        "B-COMPAT-MIXED",
+        "B-COMPAT-PREFENCE-LIVE-POSIX",
+        "B-COMPAT-PREFENCE-LIVE-WINDOWS",
+        "B-COMPAT-OFFLINE-RESTORE-POSIX",
+        "B-COMPAT-OFFLINE-RESTORE-WINDOWS",
+    ):
+        assert resolved[no_append] == ("none", "no_append:unchanged")
+    cleanup = manifest["B-STATE-REJECT-CLEANUP"]
+    assert cleanup["code"] == "package_quarantine_cleanup_retryable"
+    assert resolved["B-STATE-REJECT-CLEANUP"] == (
+        "cleanup",
+        "append_once:cleanup_retryable_then_no_append",
+    )
+    assert resolved["B-HANDOFF-DESIRED-REJECT"] == (
+        "handoff",
+        "append_once:aborted_then_no_append",
+    )
+
+
+def test_plc9b_manifest_freezes_legal_response_code_and_effect_combinations() -> None:
+    manifest = _adversarial_manifest()
+    legal_states = {
+        "operation": {
+            "accepted",
+            "classified",
+            "acquiring",
+            "acquired",
+            "inspecting",
+            "extracted",
+            "resolving_closure",
+            "closure_verified",
+            "transaction_pinned",
+            "staging",
+            "set_published",
+            "committed",
+            "rejected",
+            "cancelled",
+        },
+        "attempt": {"retryable_failure"},
+        "handoff_attempt": {"retryable_failure"},
+        "handoff": {"aborted", "settled"},
+        "cleanup": {"cleanup_retryable"},
+        "epoch": {"epoch_fenced"},
+    }
+
+    for case_id, row in manifest.items():
+        response, _stage = row["disposition"].split("@", 1)
+        domain, transition = _journal_policy_for(case_id)
+        if row["code"] == "ok":
+            assert response in {"accepted", "classified", "committed", "settled"}
+        elif row["code"] == "package_operation_cancelled":
+            assert response == "cancelled"
+        elif row["code"] in {
+            "package_operation_interrupted",
+            "package_retention_handoff_interrupted",
+        }:
+            assert response == "retryable_failure"
+        elif row["code"] in {
+            "package_acquisition_limit_exceeded",
+            "package_operation_timed_out",
+        }:
+            assert response == "retryable_failure"
+        else:
+            assert response == "rejected"
+
+        if domain == "none":
+            assert transition == "no_append:unchanged"
+            continue
+        assert transition.startswith("append_once:")
+        assert transition.endswith("_then_no_append")
+        appended_state = transition.removeprefix("append_once:").removesuffix(
+            "_then_no_append"
+        )
+        if appended_state == "response_state":
+            appended_state = response
+        assert appended_state in legal_states[domain], (case_id, domain, transition)
+
+
+def test_plc9b_retry_policy_routes_only_to_the_typed_subject_domain() -> None:
+    manifest = _adversarial_manifest()
+    policy = _retry_policy()
+
+    assert policy[-1] == ("default", "false", "none", "none")
+    selectors = [selector for selector, *_rest in policy]
+    assert len(selectors) == len(set(selectors))
+    assert selectors.count("default") == 1
+    assert _retry_policy_for("package_operation_interrupted") == (
+        "true",
+        "operation",
+        "retry",
+    )
+    assert _retry_policy_for("package_retention_handoff_interrupted") == (
+        "true",
+        "handoff",
+        "retry",
+    )
+    assert _retry_policy_for("package_quarantine_cleanup_retryable") == (
+        "true",
+        "cleanup",
+        "repair",
+    )
+    assert _retry_policy_for("package_retention_handoff_stale") == (
+        "false",
+        "none",
+        "none",
+    )
+    for case_id, row in manifest.items():
+        response = row["disposition"].split("@", 1)[0]
+        retryability, domain, _action = _retry_policy_for(row["code"])
+        if response == "retryable_failure":
+            assert retryability == "true" or retryability.startswith("conditional:")
+            expected_domain = (
+                "handoff"
+                if row["code"] == "package_retention_handoff_interrupted"
+                else "operation"
+            )
+            assert domain == expected_domain, case_id
+
+
+def test_plc9b_freezes_closure_admission_and_lock_boundaries() -> None:
+    contract = _source(CONTRACT)
+    normalized = " ".join(contract.split())
+
+    for closure_boundary in (
+        "`closure_verified` freezes the complete `VerifiedClosurePlanV2`",
+        "without pretending stable refs exist",
+        "constructs every immutable closure node",
+        "Digested evidence is never patched in place",
+    ):
+        assert closure_boundary in normalized
+    for physical_owner_boundary in (
+        "There is no second physical root publication",
+        "exactly one `PluginRevisionRefV1`",
+        "every dependency node contains exactly one `VerifiedArtifactRefV1`",
+        "PLC9D later owns pin-authorized physical deletion",
+    ):
+        assert physical_owner_boundary in normalized
+    for admission_binding in (
+        "request and operation fingerprints",
+        "Product/scope",
+        "Installation/Plugin identities",
+        "designated-root role/ref",
+        "exact committed-set identity",
+        "closure/set digest",
+        "A dependency, a ref from another set, or a wrong operation, scope, or Plugin",
+    ):
+        assert admission_binding in normalized
+    for lock_boundary in (
+        "No owner holds its lock while calling another owner",
+        "No cross-owner locks are nested",
+        "calls stores in canonical `(store identity, typed ref)` order",
+        "committed-set CAS",
+        "operation `committed` CAS",
+        "It never calls the desired application",
+        "later management command first passes commit admission",
+        "retention owner again to record `desired_committed` and `settled`",
+    ):
+        assert lock_boundary in normalized
 
 
 def test_plc9b_manifest_covers_every_route_and_native_platform_evidence() -> None:
@@ -516,6 +900,289 @@ def test_plc9b_manifest_covers_every_route_and_native_platform_evidence() -> Non
         "B-CRASH-COMMITTED",
     ):
         assert phase_case in manifest
+    native_publication_contract = {
+        "B-PUB-POSIX-ROOT-SWAP": (
+            "posix-native",
+            "root_rename_replace_swap",
+            "package_publication_root_untrusted",
+            "rejected@staging",
+            {
+                "no_outside_write",
+                "no_publication",
+                "pin_visible",
+                "handle_released",
+                "no_skip",
+            },
+        ),
+        "B-PUB-POSIX-ANCESTOR-SWAP": (
+            "posix-native",
+            "ancestor_rename_replace_swap",
+            "package_publication_root_untrusted",
+            "rejected@staging",
+            {
+                "no_outside_write",
+                "no_publication",
+                "pin_visible",
+                "handle_released",
+                "no_skip",
+            },
+        ),
+        "B-PUB-POSIX-HANDLE-SUCCESS": (
+            "posix-native",
+            "successful_native_handle_lifecycle",
+            "ok",
+            "committed@committed",
+            {"same_receipt", "pin_visible", "handle_released", "no_skip"},
+        ),
+        "B-PUB-POSIX-HANDLE-REJECT": (
+            "posix-native",
+            "rejected_native_handle_lifecycle",
+            "package_publication_root_untrusted",
+            "rejected@staging",
+            {
+                "no_outside_write",
+                "no_publication",
+                "pin_visible",
+                "handle_released",
+                "no_skip",
+            },
+        ),
+        "B-PUB-SWAP-WINDOWS": (
+            "windows-native",
+            "ancestor_or_entry_reparse_swap",
+            "package_publication_root_untrusted",
+            "rejected@staging",
+            {
+                "no_outside_write",
+                "no_publication",
+                "pin_visible",
+                "handle_released",
+                "no_skip",
+            },
+        ),
+        "B-PUB-WIN-ROOT-ABA": (
+            "windows-native",
+            "root_rename_replace_aba",
+            "package_publication_root_untrusted",
+            "rejected@staging",
+            {
+                "no_outside_write",
+                "no_publication",
+                "pin_visible",
+                "handle_released",
+                "no_skip",
+            },
+        ),
+        "B-PUB-WIN-ANCESTOR-ABA": (
+            "windows-native",
+            "ancestor_junction_reparse_aba",
+            "package_publication_root_untrusted",
+            "rejected@staging",
+            {
+                "no_outside_write",
+                "no_publication",
+                "pin_visible",
+                "handle_released",
+                "no_skip",
+            },
+        ),
+        "B-PUB-WIN-HANDLE-SUCCESS": (
+            "windows-native",
+            "successful_native_handle_lifecycle",
+            "ok",
+            "committed@committed",
+            {"same_receipt", "pin_visible", "handle_released", "no_skip"},
+        ),
+        "B-PUB-WIN-HANDLE-REJECT": (
+            "windows-native",
+            "rejected_native_handle_lifecycle",
+            "package_publication_root_untrusted",
+            "rejected@staging",
+            {
+                "no_outside_write",
+                "no_publication",
+                "pin_visible",
+                "handle_released",
+                "no_skip",
+            },
+        ),
+    }
+    native_publication_barriers = {
+        "B-PUB-POSIX-ROOT-SWAP": "staging",
+        "B-PUB-POSIX-ANCESTOR-SWAP": "staging",
+        "B-PUB-POSIX-HANDLE-SUCCESS": "committed",
+        "B-PUB-POSIX-HANDLE-REJECT": "rejected",
+        "B-PUB-SWAP-WINDOWS": "staging",
+        "B-PUB-WIN-ROOT-ABA": "staging",
+        "B-PUB-WIN-ANCESTOR-ABA": "staging",
+        "B-PUB-WIN-HANDLE-SUCCESS": "committed",
+        "B-PUB-WIN-HANDLE-REJECT": "rejected",
+    }
+    assert set(native_publication_contract) == set(native_publication_barriers)
+    for case_id, expected in native_publication_contract.items():
+        platform, fixture, code, disposition, expected_oracles = expected
+        row = manifest[case_id]
+        assert (
+            row["barrier"],
+            row["platform"],
+            row["fixture"],
+            row["code"],
+            row["disposition"],
+        ) == (
+            native_publication_barriers[case_id],
+            platform,
+            fixture,
+            code,
+            disposition,
+        )
+        assert set(row["oracles"].split(";")) == expected_oracles
+        expected_workflow = (
+            "windows-shell-compatibility.yml#plc9b-windows-native"
+            if platform == "windows-native"
+            else "harness-quality.yml#plc9b-linux-native"
+        )
+        assert row["workflow"] == expected_workflow
+    handle_probe_contract = _source(CONTRACT)
+    for probe in ("rename/delete/open probes", "garbage collection", "process exit"):
+        assert probe in handle_probe_contract
+    for native_case in (
+        "B-COMPAT-CUTOVER-POSIX",
+        "B-COMPAT-CUTOVER-WINDOWS",
+        "B-COMPAT-PREFENCE-LIVE-POSIX",
+        "B-COMPAT-PREFENCE-LIVE-WINDOWS",
+    ):
+        assert native_case in manifest
+        assert "no_skip" in manifest[native_case]["oracles"].split(";")
+    for admission_case in (
+        "B-ADMISSION-DEPENDENCY",
+        "B-ADMISSION-WRONG-SET",
+        "B-ADMISSION-WRONG-REQUEST",
+        "B-ADMISSION-WRONG-OPERATION",
+        "B-ADMISSION-WRONG-SCOPE",
+        "B-ADMISSION-WRONG-PLUGIN",
+        "B-ADMISSION-DIGEST-TAMPER",
+    ):
+        assert admission_case in manifest
+        assert manifest[admission_case]["code"] == (
+            "package_commit_admission_denied"
+        )
+        assert {"no_reopen", "no_handle_issued"} <= set(
+            manifest[admission_case]["oracles"].split(";")
+        )
+    assert {"no_reopen", "no_handle_issued"} <= set(
+        manifest["B-PUB-UNCOMMITTED"]["oracles"].split(";")
+    )
+    for handoff_case in (
+        "B-HANDOFF-BEFORE-DESIRED",
+        "B-HANDOFF-AFTER-DESIRED",
+        "B-HANDOFF-AFTER-SETTLEMENT",
+        "B-HANDOFF-DESIRED-REJECT",
+        "B-HANDOFF-STALE-RECEIPT",
+        "B-HANDOFF-CONCURRENT-REPLAY",
+    ):
+        assert handoff_case in manifest
+        assert "exact_pin_set" in manifest[handoff_case]["oracles"].split(";")
+        assert "no_zero_pin" in manifest[handoff_case]["oracles"].split(";")
+    for settled_case in (
+        "B-HANDOFF-AFTER-SETTLEMENT",
+        "B-HANDOFF-CONCURRENT-REPLAY",
+    ):
+        assert "transaction_pin_released" in manifest[settled_case][
+            "oracles"
+        ].split(";")
+    assert "dependency_pins_released" in manifest[
+        "B-HANDOFF-DESIRED-REJECT"
+    ]["oracles"].split(";")
+    unchanged = {
+        "legacy_snapshot_exact",
+        "desired_unchanged",
+        "instance_unchanged",
+        "binding_unchanged",
+        "enablement_unchanged",
+    }
+    compatibility_contract = {
+        "B-COMPAT-OFFLINE-RESTORE-POSIX": (
+            "posix-native",
+            "accepted",
+            "complete_pre_b_restore_exclusive_old_runtime",
+            "ok",
+            "accepted@offline_restore",
+            {"single_owner", "legacy_snapshot_exact", "b_namespace_unreachable", "no_peer_fallback", "no_skip"},
+            "harness-quality.yml#plc9b-linux-native",
+        ),
+        "B-COMPAT-OFFLINE-RESTORE-WINDOWS": (
+            "windows-native",
+            "accepted",
+            "complete_pre_b_restore_exclusive_old_runtime",
+            "ok",
+            "accepted@offline_restore",
+            {"single_owner", "legacy_snapshot_exact", "b_namespace_unreachable", "no_peer_fallback", "no_skip"},
+            "windows-shell-compatibility.yml#plc9b-windows-native",
+        ),
+        "B-COMPAT-ADOPT": (
+            "any",
+            "committed",
+            "authenticated_legacy_reacquisition",
+            "ok",
+            "committed@committed",
+            unchanged | {"same_receipt", "pin_visible"},
+            "harness-quality.yml#plc9b-linux-native",
+        ),
+        "B-COMPAT-ADOPT-UNAUTHORIZED": (
+            "any",
+            "acquiring",
+            "legacy_reacquisition_unauthorized",
+            "package_source_unauthorized",
+            "rejected@acquiring",
+            unchanged | {"no_publication", "no_peer_fallback"},
+            "harness-quality.yml#plc9b-linux-native",
+        ),
+        "B-COMPAT-ADOPT-UNAVAILABLE": (
+            "any",
+            "acquiring",
+            "registry_network_temporarily_unavailable",
+            "package_operation_timed_out",
+            "retryable_failure@acquiring",
+            unchanged
+            | {
+                "bounded_residue",
+                "no_publication",
+                "no_extra_network",
+                "no_peer_fallback",
+            },
+            "harness-quality.yml#plc9b-linux-native",
+        ),
+        "B-COMPAT-ADOPT-CRASH": (
+            "any",
+            "each_precommit_phase",
+            "adoption_crash_and_retry",
+            "package_operation_interrupted",
+            "retryable_failure@prior_phase",
+            unchanged | {"same_receipt", "bounded_residue"},
+            "harness-quality.yml#plc9b-linux-native",
+        ),
+        "B-COMPAT-ADOPT-CRASH-AFTER-COMMITTED": (
+            "any",
+            "committed",
+            "adoption_crash_after_committed_edge",
+            "ok",
+            "committed@committed",
+            unchanged | {"same_receipt", "pin_visible"},
+            "harness-quality.yml#plc9b-linux-native",
+        ),
+    }
+    for case_id, expected in compatibility_contract.items():
+        row = manifest[case_id]
+        platform, barrier, fixture, code, disposition, oracles, workflow = expected
+        assert (
+            row["platform"],
+            row["barrier"],
+            row["fixture"],
+            row["code"],
+            row["disposition"],
+            set(row["oracles"].split(";")),
+            row["workflow"],
+        ) == (platform, barrier, fixture, code, disposition, oracles, workflow)
     assert "unsupported-host emulation is never the only evidence" in contract
     assert "Source distributions are unconditionally rejected" in contract
     assert set(manifest["B-NOEXEC-IMPORT"]["oracles"].split(";")) >= {
@@ -547,7 +1214,10 @@ def test_plc9b_freezes_status_redaction_and_transport_conformance() -> None:
         "`code`",
         "`stage`",
         "`retryable`",
+        "`retry_domain`",
         "`operator_action`",
+        "`subject_kind`",
+        "`subject_id`",
         "`operation_id`",
         "`evidence_ref`",
     ):
@@ -581,9 +1251,10 @@ def test_plc9b_freezes_retention_transfer_and_downgrade_fence() -> None:
 
     for retention in (
         "transaction pin over the root and every dependency",
-        "obtains dependency-retention pins under one handoff identity",
-        "atomically records handoff completion and releases the transaction pin",
-        "a crash leaves both pins, never a zero-pin gap",
+        "obtains the exact dependency pin set under the handoff identity",
+        "atomically records `settled` may it release the transaction pin",
+        "never creates a zero-pin gap",
+        "expected-revision CAS",
         "Package owner does not import the concrete ledger",
     ):
         assert retention in normalized
@@ -593,8 +1264,12 @@ def test_plc9b_freezes_retention_transfer_and_downgrade_fence() -> None:
         "offline restore of the complete pre-B Package store",
         "mixed-epoch writers are never admitted",
         "`legacy_unverified`",
-        "never satisfy B classification, recursive closure, commit admission",
+        "may classify a request as `plugin_bound`",
+        "cannot satisfy B recursive closure, commit admission",
         "Adoption requires authenticated reacquisition",
+        "already-running pre-fence writer could ignore",
+        "fresh identity-pinned B-epoch namespace",
+        "does not implicitly change desired, Instance, binding, or enablement state",
     ):
         assert compatibility in normalized
 

--- a/tests/coding/test_plugin_management_cli.py
+++ b/tests/coding/test_plugin_management_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, nullcontext
@@ -554,6 +555,108 @@ def test_windows_private_directory_handle_anchors_child_reads(
 
 @pytest.mark.skipif(
     lifecycle_module.os.name != "nt",
+    reason="requires native Windows reparse-point semantics",
+)
+def test_windows_descriptor_relative_read_rejects_reparse_child(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "private-state"
+    root.mkdir()
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text("attacker", encoding="utf-8")
+    (root / "linked.jsonl").symlink_to(outside)
+    expected = lifecycle_module._validate_existing_private_directory(root)
+
+    with lifecycle_module._open_windows_private_directory(root, expected) as descriptor:
+        with pytest.raises(OSError, match="direct regular file"):
+            lifecycle_module.read_journal_file_at(descriptor, "linked.jsonl")
+
+
+@pytest.mark.skipif(
+    lifecycle_module.os.name != "nt",
+    reason="requires native Windows rooted-handle ABA semantics",
+)
+def test_windows_compatibility_reconcile_survives_full_root_aba(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LOUSHANG_HOME", str(tmp_path / "home"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    layout = resolve_coding_plugin_lifecycle_state_layout(workspace)
+    trusted = build_coding_plugin_lifecycle(layout, startup_id="trusted-root")
+    key = trusted.installation_key("managed-pack")
+    try:
+        trusted.migrate_legacy_enablement(
+            key,
+            _package("managed-pack"),
+            legacy_disabled=True,
+            manifest_enabled_default=True,
+            legacy_input_fingerprint=plugin_enablement_legacy_input_fingerprint(
+                key,
+                legacy_disabled=True,
+                manifest_enabled_default=True,
+            ),
+        )
+    finally:
+        trusted.release_owned_process_startup_lease()
+
+    trusted_detached = tmp_path / "trusted-detached"
+    attacker_detached = tmp_path / "attacker-detached"
+
+    @contextmanager
+    def replace_root_for_capture(_captured):  # type: ignore[no-untyped-def]
+        with _open_windows_delete_shared_directory(layout.root) as descriptor:
+            layout.root.rename(trusted_detached)
+            attacker = build_coding_plugin_lifecycle(
+                layout,
+                startup_id="attacker-root",
+            )
+            try:
+                attacker.migrate_legacy_enablement(
+                    key,
+                    _package("managed-pack"),
+                    legacy_disabled=False,
+                    manifest_enabled_default=True,
+                    legacy_input_fingerprint=(
+                        plugin_enablement_legacy_input_fingerprint(
+                            key,
+                            legacy_disabled=False,
+                            manifest_enabled_default=True,
+                        )
+                    ),
+                )
+            finally:
+                attacker.release_owned_process_startup_lease()
+            try:
+                yield descriptor
+            finally:
+                layout.root.rename(attacker_detached)
+                trusted_detached.rename(layout.root)
+
+    monkeypatch.setattr(
+        lifecycle_module,
+        "_pin_portable_private_directory_chain",
+        replace_root_for_capture,
+    )
+    monkeypatch.setattr(
+        lifecycle_module,
+        "_assert_private_directory_chain_stable",
+        lambda _captured: None,
+    )
+    settings = _SettingsManager(_Settings())
+    writer = bind_coding_plugin_enablement_compatibility(layout, settings)
+    assert writer is not None
+
+    writer.reconcile()
+
+    assert settings.settings.disabled_plugins == ("managed-pack",)
+    assert layout.root.is_dir()
+    assert attacker_detached.is_dir()
+
+
+@pytest.mark.skipif(
+    lifecycle_module.os.name != "nt",
     reason="requires native Windows rooted-handle I/O",
 )
 def test_windows_portable_compatibility_existing_root_uses_anchored_io(
@@ -608,6 +711,59 @@ def test_windows_portable_compatibility_absent_root_is_noop(
     writer.reconcile()
 
     assert layout.root.exists() is False
+
+
+@contextmanager
+def _open_windows_delete_shared_directory(path: Path):  # type: ignore[no-untyped-def]
+    import ctypes
+    import msvcrt
+    from ctypes import wintypes
+
+    win_dll = getattr(ctypes, "WinDLL")
+    kernel32 = win_dll("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    create_file.restype = wintypes.HANDLE
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = (wintypes.HANDLE,)
+    close_handle.restype = wintypes.BOOL
+    file_list_directory = 0x00000001
+    file_read_attributes = 0x00000080
+    share_read_write_delete = 0x00000001 | 0x00000002 | 0x00000004
+    open_existing = 3
+    file_flag_open_reparse_point = 0x00200000
+    file_flag_backup_semantics = 0x02000000
+    handle = create_file(
+        str(path),
+        file_list_directory | file_read_attributes,
+        share_read_write_delete,
+        None,
+        open_existing,
+        file_flag_open_reparse_point | file_flag_backup_semantics,
+        None,
+    )
+    if handle == ctypes.c_void_p(-1).value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    descriptor: int | None = None
+    try:
+        descriptor = msvcrt.open_osfhandle(
+            handle,
+            os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOINHERIT", 0),
+        )
+        yield descriptor
+    finally:
+        if descriptor is None:
+            close_handle(handle)
+        else:
+            os.close(descriptor)
 
 
 def test_portable_compatibility_capture_leaves_absent_state_root_absent(

--- a/tests/harness/journal/test_jsonl.py
+++ b/tests/harness/journal/test_jsonl.py
@@ -69,7 +69,15 @@ def test_descriptor_relative_journal_apis_reject_non_child_names() -> None:
 
     from loushang.harness.journal import journal_file_lock_at, read_journal_file_at
 
-    for name in ("", ".", "..", "parent/child", "parent\\child", "entry:stream"):
+    for name in (
+        "",
+        ".",
+        "..",
+        "parent/child",
+        "parent\\child",
+        "entry:stream",
+        "entry\0tail",
+    ):
         with pytest.raises(ValueError, match="one direct component"):
             read_journal_file_at(-1, name)
         with pytest.raises(ValueError, match="one direct component"):


### PR DESCRIPTION
Summary

- close the remaining PLC9A1 comment, NUL/reparse, and native Windows ABA review debt
- freeze the PLC9B.0 safe Package lifecycle boundary, ownership model, evidence, recovery, and compatibility contracts
- add exact 95/151 ingress and 141/156 effect inventories plus a 127-case planned adversarial matrix
- add architecture guards for journal authorities, typed retry routing, native publication, adoption, and offline restore

Validation

- .venv/bin/python -m pytest tests/architecture -q: 358 passed
- PLC9, PLC9A1, and PLC9B focused architecture regression: 42 passed
- Ruff and git diff --check passed
- three-view architecture, correctness, and product/security reviews: PASS with no remaining P0/P1/P2

Scope

Design and architecture-test slice only. It does not implement runtime acquisition or extraction, execute untrusted artifacts, invoke uv/pip, or activate PLC9A2.