### PR TITLE
fix(resources): support Windows metadata and test semantics

### DIFF
--- a/src/loushang/harness/resources/_safe_files.py
+++ b/src/loushang/harness/resources/_safe_files.py
@@ -179,7 +179,9 @@ def _capture_portable(
         )
         if (
             not _same_file_snapshot(metadata, after_read)
-            or not _same_file_snapshot(metadata, after_path)
+            or not _same_file_snapshot(before, after_path)
+            or (metadata.st_dev, metadata.st_ino)
+            != (after_path.st_dev, after_path.st_ino)
             or len(body) != metadata.st_size
         ):
             raise ContainedFileCaptureError(

--- a/tests/harness/resources/conftest.py
+++ b/tests/harness/resources/conftest.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def symlink_or_skip() -> Callable[..., None]:
+    def create(
+        link: Path,
+        target: str | Path,
+        *,
+        target_is_directory: bool = False,
+    ) -> None:
+        try:
+            link.symlink_to(target, target_is_directory=target_is_directory)
+        except NotImplementedError as exc:
+            pytest.skip(f"symbolic links are unavailable: {exc}")
+        except OSError as exc:
+            if os.name != "nt" or getattr(exc, "winerror", None) != 1314:
+                raise
+            pytest.skip(f"symbolic link privilege is unavailable: {exc}")
+
+    return create

--- a/tests/harness/resources/packages/test_catalog.py
+++ b/tests/harness/resources/packages/test_catalog.py
@@ -162,7 +162,7 @@ def test_package_projection_is_available_without_coding() -> None:
         "scope": "project",
         "version": "1.0.0",
         "source": "/workspace/packages/review-pack",
-        "path": "/workspace/packages/review-pack",
+        "path": str(Path("/workspace/packages/review-pack")),
         "enabled": True,
         "prompts": 0,
         "skills": 0,

--- a/tests/harness/resources/packages/test_inventory.py
+++ b/tests/harness/resources/packages/test_inventory.py
@@ -36,6 +36,7 @@ def test_package_inventory_preserves_skill_ignore_and_nested_stop_semantics(
 
 def test_package_inventory_rejects_symlink_reads_and_invalid_theme_json(
     tmp_path: Path,
+    symlink_or_skip,
 ) -> None:
     root = tmp_path / "package"
     prompts = root / "prompts"
@@ -44,7 +45,7 @@ def test_package_inventory_rejects_symlink_reads_and_invalid_theme_json(
     themes.mkdir(parents=True)
     outside_prompt = tmp_path / "outside.md"
     outside_prompt.write_text("outside", encoding="utf-8")
-    (prompts / "outside.md").symlink_to(outside_prompt)
+    symlink_or_skip(prompts / "outside.md", outside_prompt)
     (themes / "valid.json").write_text("{}", encoding="utf-8")
     (themes / "invalid.json").write_text("[]", encoding="utf-8")
 

--- a/tests/harness/resources/packages/test_roots.py
+++ b/tests/harness/resources/packages/test_roots.py
@@ -413,6 +413,7 @@ def test_resource_loader_rejects_changed_published_plugin_revision(
 
 def test_unsafe_plugin_revision_diagnostic_retains_configured_source(
     tmp_path: Path,
+    symlink_or_skip,
 ) -> None:
     root = tmp_path / "plugins" / "review-pack"
     root.mkdir(parents=True)
@@ -420,7 +421,7 @@ def test_unsafe_plugin_revision_diagnostic_retains_configured_source(
         json.dumps({"name": "review-pack"}),
         encoding="utf-8",
     )
-    (root / "linked.txt").symlink_to(tmp_path / "outside.txt")
+    symlink_or_skip(root / "linked.txt", tmp_path / "outside.txt")
     diagnostics = DiagnosticsService()
 
     with pytest.raises(PluginRevisionError) as caught:

--- a/tests/harness/resources/plugins/test_manifest.py
+++ b/tests/harness/resources/plugins/test_manifest.py
@@ -530,10 +530,11 @@ def test_plugin_manifest_parser_normalizes_compatible_package_root_alias(
 
 def test_package_manifest_view_projects_package_root_symlink_loop_as_diagnostic(
     tmp_path: Path,
+    symlink_or_skip,
 ) -> None:
     root = tmp_path / "review-pack"
     root.mkdir()
-    (root / "loop").symlink_to("loop")
+    symlink_or_skip(root / "loop", "loop")
     manifest_path = root / "plugin.json"
     manifest_path.write_text(
         json.dumps({"name": "review-pack", "packageRoot": "loop"}),
@@ -549,10 +550,11 @@ def test_package_manifest_view_projects_package_root_symlink_loop_as_diagnostic(
 
 def test_resource_package_view_projects_package_root_symlink_loop_as_diagnostic(
     tmp_path: Path,
+    symlink_or_skip,
 ) -> None:
     root = tmp_path / "resource-pack"
     root.mkdir()
-    (root / "loop").symlink_to("loop")
+    symlink_or_skip(root / "loop", "loop")
     manifest_path = root / "loushang-package.json"
     manifest_path.write_text(
         json.dumps({"name": "resource-pack", "packageRoot": "loop"}),
@@ -584,11 +586,12 @@ def test_package_manifest_view_projects_canonical_plugin_parser_error(
 
 def test_package_manifest_view_rejects_dangling_plugin_manifest_symlink(
     tmp_path: Path,
+    symlink_or_skip,
 ) -> None:
     root = tmp_path / "review-pack"
     root.mkdir()
     manifest_path = root / "plugin.json"
-    manifest_path.symlink_to(root / "missing-plugin.json")
+    symlink_or_skip(manifest_path, root / "missing-plugin.json")
 
     resolved = resolve_package_manifest(root)
 
@@ -599,6 +602,7 @@ def test_package_manifest_view_rejects_dangling_plugin_manifest_symlink(
 
 def test_resolver_rejects_package_root_replaced_after_resolution(
     tmp_path: Path,
+    symlink_or_skip,
 ) -> None:
     root = tmp_path / "review-pack"
     package_root = root / "resources"
@@ -612,7 +616,7 @@ def test_resolver_rejects_package_root_replaced_after_resolution(
     resolver = PluginResolver()
     plugin = resolver.resolve_plugin(root)
     package_root.rmdir()
-    package_root.symlink_to(outside, target_is_directory=True)
+    symlink_or_skip(package_root, outside, target_is_directory=True)
 
     with pytest.raises(PluginManifestError) as caught:
         resolver.resolve_resources(plugin)

--- a/tests/harness/resources/plugins/test_revisions.py
+++ b/tests/harness/resources/plugins/test_revisions.py
@@ -35,10 +35,11 @@ def test_revision_store_publishes_content_addressed_snapshot_and_keeps_source_id
     assert published.manifest.root == published.root
     assert published.manifest_path == published.root / "plugin.json"
     assert published.manifest_digest == package.manifest_digest
-    assert published.root.stat().st_mode & 0o077 == 0
-    assert (
-        published.root / "resources" / "prompts" / "review.md"
-    ).stat().st_mode & 0o077 == 0
+    if os.name == "posix":
+        assert published.root.stat().st_mode & 0o077 == 0
+        assert (
+            published.root / "resources" / "prompts" / "review.md"
+        ).stat().st_mode & 0o077 == 0
     handle.verify()
     with handle.open_file("resources/prompts/review.md") as stream:
         assert stream.read() == b"review v1"
@@ -65,8 +66,11 @@ def test_revision_store_keeps_staging_root_writable_until_atomic_publish(
         PluginManifestParser().parse(source)
     )
 
-    assert observed_staging_modes == [0o700]
-    assert stat.S_IMODE(published.root.stat().st_mode) == 0o500
+    if os.name == "posix":
+        assert observed_staging_modes == [0o700]
+        assert stat.S_IMODE(published.root.stat().st_mode) == 0o500
+    else:
+        assert len(observed_staging_modes) == 1
 
 
 def test_revision_store_removes_new_revision_when_final_freeze_fails(
@@ -159,6 +163,7 @@ def test_portable_revision_backend_preserves_verified_snapshot_contract(
 def test_portable_revision_backend_rejects_symbolic_links(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    symlink_or_skip,
 ) -> None:
     import loushang.harness.resources.plugins.revisions as revisions_module
 
@@ -168,7 +173,10 @@ def test_portable_revision_backend_rejects_symbolic_links(
         lambda: False,
     )
     source = _plugin(tmp_path / "source")
-    (source / "resources" / "prompts" / "linked.md").symlink_to("review.md")
+    symlink_or_skip(
+        source / "resources" / "prompts" / "linked.md",
+        "review.md",
+    )
 
     with pytest.raises(PluginRevisionError) as caught:
         PluginRevisionStore(tmp_path / "revisions").publish(
@@ -230,6 +238,7 @@ def test_revision_store_reopen_rehashes_complete_published_tree(
 def test_portable_revision_reopen_rejects_reparse_entry(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    symlink_or_skip,
 ) -> None:
     import loushang.harness.resources.plugins.revisions as revisions_module
 
@@ -242,7 +251,10 @@ def test_portable_revision_reopen_rejects_reparse_entry(
     prompt.parent.chmod(0o700)
     prompt.chmod(0o600)
     prompt.unlink()
-    prompt.symlink_to(source_root / "resources" / "prompts" / "review.md")
+    symlink_or_skip(
+        prompt,
+        source_root / "resources" / "prompts" / "review.md",
+    )
     monkeypatch.setattr(
         revisions_module,
         "_supports_descriptor_relative_revision_io",
@@ -313,9 +325,13 @@ def test_revision_handle_acquires_independently_disposable_lease(
 
 def test_revision_store_rejects_symbolic_links_without_publishing(
     tmp_path: Path,
+    symlink_or_skip,
 ) -> None:
     source = _plugin(tmp_path / "source")
-    (source / "resources" / "prompts" / "linked.md").symlink_to("review.md")
+    symlink_or_skip(
+        source / "resources" / "prompts" / "linked.md",
+        "review.md",
+    )
     store = PluginRevisionStore(tmp_path / "revisions")
 
     with pytest.raises(PluginRevisionError) as caught:
@@ -399,6 +415,7 @@ def test_verified_revision_detects_entry_added_after_directory_listing(
 
 def test_verified_revision_open_is_relative_nofollow_and_digest_checked(
     tmp_path: Path,
+    symlink_or_skip,
 ) -> None:
     source = _plugin(tmp_path / "source")
     published = PluginRevisionStore(tmp_path / "revisions").publish(
@@ -415,7 +432,10 @@ def test_verified_revision_open_is_relative_nofollow_and_digest_checked(
     prompt.parent.chmod(0o755)
     prompt.chmod(0o644)
     prompt.unlink()
-    prompt.symlink_to(source / "resources" / "prompts" / "review.md")
+    symlink_or_skip(
+        prompt,
+        source / "resources" / "prompts" / "review.md",
+    )
     with pytest.raises(PluginRevisionError) as symlink:
         handle.open_file("resources/prompts/review.md")
     assert symlink.value.code == "plugin_revision_changed"

--- a/tests/harness/resources/plugins/test_safe_files.py
+++ b/tests/harness/resources/plugins/test_safe_files.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+from loushang.harness.resources import _safe_files
 from loushang.harness.resources.plugins.safe_files import (
     ContainedFileCaptureError,
     capture_contained_regular_file,
@@ -37,12 +39,17 @@ def test_portable_capture_requests_binary_mode(
     target = root / "small.json"
     target.write_bytes(b"{\r\n}")
     binary_flag = 1 << 29
+    platform_binary_flag = getattr(os, "O_BINARY", 0)
     real_open = os.open
     opened_flags: list[int] = []
 
     def recording_open(path, flags, mode=0o777):
         opened_flags.append(flags)
-        return real_open(path, flags & ~binary_flag, mode)
+        return real_open(
+            path,
+            (flags & ~binary_flag) | platform_binary_flag,
+            mode,
+        )
 
     monkeypatch.setattr(os, "supports_dir_fd", set())
     monkeypatch.setattr(os, "O_BINARY", binary_flag, raising=False)
@@ -53,6 +60,40 @@ def test_portable_capture_requests_binary_mode(
     assert captured.body == b"{\r\n}"
     assert opened_flags
     assert all(flags & binary_flag for flags in opened_flags)
+
+
+def test_portable_capture_compares_stability_within_each_metadata_view(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "package"
+    root.mkdir()
+    target = root / "small.json"
+    target.write_bytes(b"{}")
+    real_path_metadata = _safe_files._portable_path_metadata
+
+    def path_metadata_with_distinct_ctime(*args, **kwargs):
+        metadata = real_path_metadata(*args, **kwargs)
+        return SimpleNamespace(
+            st_mode=metadata.st_mode,
+            st_dev=metadata.st_dev,
+            st_ino=metadata.st_ino,
+            st_size=metadata.st_size,
+            st_mtime_ns=metadata.st_mtime_ns,
+            st_ctime_ns=metadata.st_ctime_ns + 1,
+            st_file_attributes=getattr(metadata, "st_file_attributes", 0),
+        )
+
+    monkeypatch.setattr(os, "supports_dir_fd", set())
+    monkeypatch.setattr(
+        _safe_files,
+        "_portable_path_metadata",
+        path_metadata_with_distinct_ctime,
+    )
+
+    captured = capture_contained_regular_file(root, "small.json", max_bytes=2)
+
+    assert captured.body == b"{}"
 
 
 def test_contained_capture_rejects_link_traversal(tmp_path: Path) -> None:

--- a/tests/harness/resources/test_catalog_components_rcp2.py
+++ b/tests/harness/resources/test_catalog_components_rcp2.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 
@@ -292,15 +293,6 @@ async def _native_source_handles_are_narrow_and_discovery_is_generation_exact(
     root_handles = _root_handles(workspace, resource_root)
     with pytest.raises(TypeError, match="Host-minted"):
         type(root_handles[0])()
-    symlink = tmp_path / "resource-link"
-    symlink.symlink_to(resource_root, target_is_directory=True)
-    with pytest.raises(ValueError, match="must not be a symlink"):
-        mint_native_resource_root_handle(
-            handle_id="symlink-root",
-            root=symlink,
-            source_class="project_local",
-            root_kind="standard",
-        )
 
     shadow = await run_first_party_resource_catalog_shadow(
         product_id="coding",
@@ -333,19 +325,43 @@ async def _native_source_handles_are_narrow_and_discovery_is_generation_exact(
         await source_lease.aclose()
     assert await shadow.dispose() == ()
 
+
+def test_native_resource_root_handle_rejects_symlink(
+    tmp_path: Path,
+    symlink_or_skip: Callable[..., None],
+) -> None:
+    _workspace, resource_root, _skill_body = _fixture_workspace(tmp_path)
+    symlink = tmp_path / "resource-link"
+    symlink_or_skip(symlink, resource_root, target_is_directory=True)
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        mint_native_resource_root_handle(
+            handle_id="symlink-root",
+            root=symlink,
+            source_class="project_local",
+            root_kind="standard",
+        )
+
+
+def test_native_source_discovery_rejects_symlink(
+    tmp_path: Path,
+    symlink_or_skip: Callable[..., None],
+) -> None:
+    workspace, resource_root, _skill_body = _fixture_workspace(tmp_path)
     outside = tmp_path / "outside.md"
     outside.write_text("outside", encoding="utf-8")
-    (resource_root / "prompts" / "escape.md").symlink_to(outside)
+    symlink_or_skip(resource_root / "prompts" / "escape.md", outside)
     with pytest.raises(NativeResourceSourceError) as escaped:
-        await run_first_party_resource_catalog_shadow(
-            product_id="coding",
-            scope_id="workspace:test",
-            runtime_id="resource-shadow:symlink",
-            product_policy_revision="coding-resource-shadow-v1",
-            root_handles=root_handles,
-            issued_at=10,
-            expires_at=100,
-            now=20,
+        asyncio.run(
+            run_first_party_resource_catalog_shadow(
+                product_id="coding",
+                scope_id="workspace:test",
+                runtime_id="resource-shadow:symlink",
+                product_policy_revision="coding-resource-shadow-v1",
+                root_handles=_root_handles(workspace, resource_root),
+                issued_at=10,
+                expires_at=100,
+                now=20,
+            )
         )
     assert escaped.value.code == "resource_source_discovery_failed"
     assert escaped.value.reason == "symlink_not_allowed"


### PR DESCRIPTION
## Summary
- fix Windows/Python 3.14 resource capture false positives by comparing path and descriptor metadata within their own views
- retain cross-view file identity checks without requiring platform-dependent `st_ctime_ns` equality
- make the resource test suite platform-aware while preserving macOS/Linux symlink and POSIX permission coverage
- skip symlink tests only for unsupported APIs or Windows `WinError 1314`

## Validation
- `uv run --extra dev ruff check src/loushang/harness tests/harness tests/coding/test_agent_session_model_input.py tests/architecture/test_import_boundaries.py tests/architecture/test_capability_runtime_convergence_pr0.py tests/architecture/test_composition_lifecycle_authority_cla0.py tests/architecture/test_session_model_call_closure_contract.py`
- `uv run --extra dev pytest tests/harness/resources -q` (`412 passed, 15 skipped` on Windows without symlink privilege)
- Python 3.14.7 installed CLI: `loushang --list-skills --list-skills-format json` exits 0