### PR TITLE
docs(architecture): merge Hosting and AppHost baseline

### DIFF
--- a/docs/internals/architecture/README.md
+++ b/docs/internals/architecture/README.md
@@ -98,6 +98,17 @@ nested-scope catalog for a proposed canonical V2 target plus implemented
 incremental contracts. Its presence in the scope tree does not advance that
 target to accepted status.
 
+Proposed top-level placements are under design:
+
+- [Hosting](hosting/README.md), a Product-neutral local process, inherited
+  peer IPC, and joint child-session lifetime substrate. Its package and
+  placement remain Target-only until the proposed decision is accepted and the
+  implementation absence guard is intentionally revised.
+- [AppHost Top-Level Placement](drafts/apphost-top-level-placement.md), the
+  proposed physical owner of the existing cross-Product Platform Host role.
+  Product catalog/routing and deployment profiles remain Target-only; they do
+  not move into Harness, AppServer, Hosting, or a concrete Product.
+
 A nested scope is not automatically a top-level subsystem. The parent owns its
 placement, composition policy, and sibling relationships; the child owns its
 black-box contract and internal component model.

--- a/docs/internals/architecture/drafts/README.md
+++ b/docs/internals/architecture/drafts/README.md
@@ -36,6 +36,7 @@ Standalone drafts:
 - [Loushang Future Target Architecture v3](future-loushang-architecture-v3.md)
 - [Application Service Refactor](application-service-refactor.md)
 - [AppService Hosted Boundary With An Embedded TUI](appservice-embedded-tui-hosted-boundary-plan.md)
+- [AppHost Top-Level Placement](apphost-top-level-placement.md)
 - [Loushang Runtime Architecture](loushang-runtime-architecture.md)
 - [Loushang Work / Method / Channel / Harness Architecture](loushang-work-method-channel-harness-architecture.md)
 - [Method / Ontology Action Driven Multi-Agent Collaboration Requirements](method-ontology-action-multi-agent-collaboration-requirements.md)
@@ -49,3 +50,4 @@ Standalone drafts:
 - [Application Model And Artifact Compiler](application-model-and-artifact-compiler.md)
 - [Pluggable Transcript Compaction Strategies](pluggable-transcript-compaction-strategies.md)
 - [Project-Declared Configuration And Pluggable Conversation Persistence](project-declared-configuration-and-pluggable-conversation-persistence.md)
+- [Hosting Top-Level Placement And Scope](hosting-top-level-placement.md)

--- a/docs/internals/architecture/drafts/apphost-top-level-placement.md
+++ b/docs/internals/architecture/drafts/apphost-top-level-placement.md
@@ -1,0 +1,473 @@
+# AppHost Top-Level Placement
+
+[Architecture](../README.md) · [Drafts](README.md) ·
+[Product And Platform Host Glossary](../../glossary/loushang-product.md) ·
+[AppService Hosted Boundary](appservice-embedded-tui-hosted-boundary-plan.md) ·
+[Hosting Support Boundary](../hosting/key-designs/hosted-application-support-boundary.md)
+
+## Status
+
+- ID: `APPHOST-DP-TOP-LEVEL`
+- Kind: package-placement decision
+- Scope: Loushang
+- Parent: none
+- Authority: normative target proposal
+- Design status: proposed
+- Implementation status: not-started
+- Owner: Loushang architecture
+
+## Current, Target, And Delta
+
+### Current
+
+- The [Product glossary](../../glossary/loushang-product.md) defines one
+  logical Platform Host that owns process-level Product discovery, OEM
+  selection, Product routing, shared-service composition, and final Runtime
+  release across CLI, TUI, RPC, Web, and embedded profiles.
+- Product-specific entrypoints currently assemble those concerns directly.
+- `loushang.harness.host` supplies Product-neutral single-Product stdio,
+  line-input, mode, action, task-drain, and lifecycle mechanics. It is not the
+  logical Platform Host and owns no Product catalog or deployment topology.
+- There is no `loushang.apphost`, `loushang.appserver`, or
+  `loushang.hosting` source package.
+
+### Proposed target
+
+The existing logical Platform Host receives one top-level physical owner:
+`loushang.apphost`. AppHost supports independently elected embedded, hosted,
+and daemon deployment profiles without creating a separate "Hosted Platform
+Host" or a second Product registry.
+
+### Explicit delta
+
+Acceptance would introduce AppHost contracts, an admitted Product catalog and
+router, scoped Product-runtime lifecycle, deployment-profile composition, and
+outer launch/service adapters. It would not itself introduce AppServer,
+Hosting, a daemon, or a GUI; those remain separately triggered dependencies.
+
+This proposed placement does not reserve concrete public symbols. The names
+below identify responsibilities that require component discovery before code
+is added.
+
+## Decision
+
+```text
+Product Package integration
+  -> AppHost Product contracts
+  -> Product public API
+  -> Harness public runtime/composition contracts
+  -> optional AppServer structural Product ports for a hosted adapter
+
+loushang.apphost
+  -> admitted Product catalog / router / scoped runtime lifecycle
+  -> Harness public host and runtime mechanisms
+  -> AppServer only in a hosted server profile
+  -> Hosting only in an outer launcher or daemon-control profile
+
+loushang.harness.host
+  -> lower-level single-Product host mechanics
+  -/-> AppHost / AppServer / Product packages
+```
+
+AppHost does not import a concrete Product package. Product Packages publish
+descriptors, factories, and optional profile adapters through an admitted
+registration boundary. Coding, PPT, Design, Research, Cowork, and OEM-defined
+Products are peers. `loushang.harnesswork` is the canonical shared durable
+Work subsystem used by Products; `loushang.work` is only its forwarding
+compatibility facade. Work is not a Product unless a separately admitted
+Product Package supplies its own Product Kernel and `product_id`.
+
+## Product And Profile Axes
+
+Product identity and delivery profile are orthogonal:
+
+```text
+Product identity
+  Coding / PPT / Design / Research / Cowork / OEM Product
+
+Host or presentation profile Plugin
+  embedded TUI / desktop app / WebUI / remote client
+```
+
+A CodingTUI Plugin and a CodingApp Plugin may be installed, enabled, and
+released independently while sharing the Coding Product Kernel, `product_id`,
+Session semantics, tools, policy, transcript, and Product Factory. They become
+different Products only if each supplies a distinct Product Kernel,
+descriptor, factory, `product_id`, policy, and continuity identity.
+
+These are canonical manifest-backed Plugin contributions, not a second AppHost
+Plugin kind, manager, registry, or lifecycle. The existing Product/OEM Plugin
+system owns manifest parsing, source trust, desired enablement, immutable
+content identity, activation generation, update, retirement, and final
+deletion. Product/OEM policy admits a profile contribution before any
+executable entrypoint is imported. AppHost receives only an immutable admitted
+profile descriptor and factory, selects one for the elected deployment
+profile, and owns the resulting profile instance and lease.
+
+Profile Plugins cannot replace AppHost Product admission, AppServer
+authentication, AppService authorization, Hosting lifecycle invariants, or
+another security owner. Daemon control is a built-in or OEM deployment profile,
+not an ordinary Product Plugin contribution and not dynamically replaceable by
+a Plugin.
+
+## AppHost Responsibility Boundary
+
+AppHost owns:
+
+- Product contract vocabulary, catalog projection, selection, and routing;
+- OEM/deployment admission orchestration over supplied policy;
+- mapping a persisted `product_id` and Session context to a scoped Product
+  Runtime handle;
+- deployment-profile selection and assembly;
+- process-local ownership and ordered release of Product Runtime handles; and
+- outer launch/service-control adapters when those profiles are elected.
+
+AppHost does not own:
+
+- Product Kernel behavior, Product resources, or Product presentation;
+- Product-internal Plugin, Capability, Resource, Tool, or Extension discovery
+  and activation;
+- Harness Runtime Profile resolution/binding or Product Runtime construction
+  mechanics that a Product Factory already owns;
+- App protocol, listeners, connections, framing, or delivery semantics;
+- OS process, inherited endpoint, or service-instance mechanisms; or
+- Session transcript, Blob, Work, log, trace, or artifact authority.
+
+A Product Factory uses existing Harness mechanisms and returns one narrow,
+scoped Product Runtime handle. AppHost never rebuilds a Capability graph,
+Resource loader, Plugin manager, or Runtime Profile beside that owner.
+
+### Existing Harness Host reuse
+
+- Embedded and legacy Product profiles may reuse `ProductHostRuntime`,
+  `ProductHostTaskTracker`, `ProductHostStreams`, and `CliApplicationRuntime`
+  where their current contracts fit.
+- AppHost does not parse the App protocol or build a second input loop.
+- AppServer may reuse an admitted low-level stdio/line-reading mechanism, but
+  owns its App Contract framing and connection semantics.
+- AppServer does not reinterpret the legacy Product RPC command schema as the
+  App Contract, and Harness Host does not acquire AppServer responsibilities.
+
+## Product Contracts And Hosted Integration
+
+The dependency inversion requires two distinct contracts:
+
+1. AppHost core owns Product descriptor, catalog, factory, and scoped
+   Runtime-handle contracts. They contain no AppServer types and may be
+   implemented by every Product Package.
+2. An optional `apphost.hosted` integration binder owns the AppHost-to-AppServer
+   composition edge. A Product Package may contribute an outer hosted adapter
+   factory that maps its public Product Runtime handle to AppServer's structural
+   Product Session, Work, projection, and interaction ports. Product domain core
+   does not import AppServer.
+
+The AppHost catalog records only Product/OEM-admitted descriptors, factories,
+profile contributions, and optional hosted integration factories. The hosted
+binder selects from that immutable catalog; it does not discover by importing a
+Product-internal module. AppHost core therefore need not import AppServer,
+Harness never returns AppServer types, the embedded profile does not import
+AppServer, and AppServer never imports a Product package.
+
+Product Factory is an outer composition contract, not another Session or
+Package runtime. Its implementation composes or delegates to the established
+`ProductSessionRuntime`, `AgentTranscriptSessionFactory`, and
+`PackageProductRuntimeFactoryPort` owners when those mechanisms are selected.
+It must not duplicate their transcript, resume, Capability, Package, Plugin, or
+disposal lifecycle.
+
+The process-level AppHost catalog contains descriptors and factory
+registrations, never one mutable Product Runtime singleton. Every new/open/
+resume Session resolves an explicit `product_id` and creates an independent
+scoped Product Runtime binding. A first delivery may allow only one Product ID
+in an AppServer process, but that constrains allowed identities, not the number
+or lifetime of Session Runtime handles. Multi-Product admission may remain
+deferred without changing this per-Session cardinality.
+
+### Multi-Aggregate Hosted Cardinality
+
+One target-process AppHost constructs one AppService coordinator. That
+coordinator may own zero or more application-level coordination aggregates,
+including a future named mux, and each aggregate may reference several
+independently scoped Session bindings. Aggregate count never creates another
+AppHost, AppServer listener, application `RunLease`, or process-level
+`RuntimeResourceOwner`.
+
+AppHost does not import an aggregate type, index its selector names, arbitrate
+membership, combine Session cursors, or acquire controller authority. Those
+semantics stay inside AppService and its typed App Contract. AppHost retains
+the scoped Product Runtime handles returned through that boundary and closes
+AppService once during the process shutdown protocol; AppService then fences
+all aggregate admission and attempts each distinct Session release exactly
+once. Process readiness means that the AppServer/AppService admission boundary
+is ready, not that any particular aggregate exists or is healthy.
+
+## Pre-Routing Session Identity
+
+Resume cannot select a Product by first invoking a Product-specific parser.
+Every newly written durable Session therefore has a small, generic, versioned
+**Session Identity Envelope** readable before Product selection. It contains:
+
+- an envelope schema/version and stable Session or conversation identity;
+- the required `product_id` and Product-owned locator/provider discriminator;
+- an immutable continuity identity or reference sufficient to reject an
+  incompatible authority; and
+- no Product payload, credentials, mutable runtime state, or default Product.
+
+A lightweight AppHost header reader validates only this envelope, resolves the
+explicit Product descriptor/factory, and then transfers the opaque Product
+locator to that Product's canonical transcript/continuity owner. The Session
+catalog and resume summary project `product_id` from the same envelope. AppHost
+owns the cross-Product envelope schema and read contract, not a second Session
+store: the Product-selected canonical conversation/continuity owner persists
+the envelope atomically with creation/publication of its durable Session.
+`ConversationHeader` and Product runtime-profile metadata are Current evidence,
+not yet a sufficient cross-Product routing contract: opaque metadata may omit
+or rename Product identity. Legacy Coding Sessions therefore enter through an
+explicit compatibility importer/migration that writes the new envelope, or
+resume fails with typed `ProductIdentityRequired`. No missing or unknown
+identity silently selects a default Product.
+
+## Runtime And Launcher Split
+
+Python objects and factories do not cross a process boundary. AppHost therefore
+has two distinct roles, even if they eventually share a top-level package:
+
+```text
+controller process
+  AppHost launcher
+    -> immutable executable + argv/env/profile/state references
+    -> Hosting Process Host or future Service Instance Controller
+
+external supervisor
+  -> complete foreground AppHost executable + signal/service-notification contract
+  -/-> Hosting library
+
+target process
+  AppHost runtime/bootstrap
+    -> resolve PlatformPaths once and load admitted descriptors/factories
+    -> construct one AppService composition coordinator
+    -> inject AppService into one AppServer connection runtime
+    -> per Session: read identity envelope -> resolve product_id
+                    -> create scoped Product Runtime + hosted binding
+```
+
+The launcher never sends an in-memory Product Factory, adapter, or AppService
+through Hosting. A foreground invocation may enter AppHost runtime directly
+without using Hosting at all. When a parent launches another foreground
+process, it launches the complete AppHost executable rather than asking an
+in-process AppHost to spawn its own AppServer object graph. AppHost is the
+composition root: it constructs AppService, injects it into AppServer, and owns
+whole-process shutdown ordering. AppServer neither constructs AppService nor
+owns its semantic lifecycle.
+
+## Deployment Profiles
+
+| Profile | AppHost responsibility | AppServer | Hosting |
+| --- | --- | --- | --- |
+| embedded | select Product and compose its direct UI/runtime binding | absent | absent unless Product explicitly launches a child mechanism |
+| hosted in-process | select Product and bind hosted adapter | in-process client/service/server runtime adapter | absent |
+| foreground server | target-process bootstrap and orderly release | listener/stdio connection runtime | optional outer launcher only |
+| externally supervised service | foreground entrypoint, readiness, graceful shutdown | listener/connection runtime | no library service controller; systemd/launchd/SCM/container is authority |
+| library-managed daemon | daemon-control profile, process-level readiness/stop bridge, and target bootstrap | listener/connection runtime plus transport-state port | future Service Instance Controller |
+
+Only the AppHost daemon-control profile may consume `hosting.service`:
+
+```text
+apphost daemon-control profile -> hosting.service -> complete AppHost process
+AppServer -/-> Hosting
+AppService -/-> hosting
+```
+
+Process liveness is not AppServer readiness, and neither is hosted Session
+recovery. The target-process AppHost bootstrap exposes one process-level
+readiness and stop boundary. It maps readiness to AppServer listener/admission
+state and maps stop to the ordered AppServer drain plus AppService shutdown.
+In a controller process, the AppHost daemon-control adapter converts the same
+versioned serialized readiness/control specification into the injected Hosting
+probe and stop behavior. An external supervisor invokes the same foreground
+entrypoint and observes signals or platform service notifications. AppServer
+supplies transport state but never imports Hosting; AppService owns its live
+registry; Product/HarnessWork stores own durable truth.
+
+## Cross-Scope Dependency And Responsibility
+
+This parent decision, not the Hosting child scope, governs the sibling graph:
+
+```text
+HarnessGUI / HarnessWebUI -> AppClient + App Contract
+AppServer -> AppService + App Contract + transport adapters
+AppService -> injected structural Product ports
+apphost.hosted -> AppHost Product contracts + AppServer Product ports
+Product outer integration -> Product public API + Harness public contracts
+AppHost launcher -> Hosting                              # optional
+
+AppServer -X-> Hosting
+AppService -X-> Hosting / concrete Product / UI frameworks
+Hosting -X-> AppHost / AppServer / AppService / Product / UI frameworks
+Harness -X-> AppHost / AppServer / concrete Product
+```
+
+| Scope | Owns | Explicitly does not own |
+| --- | --- | --- |
+| AppHost | Product catalog/routing, deployment composition, process-level assembly, Session-scoped Product binding ownership, ordered shutdown | Product semantics, App protocol, OS mechanism |
+| AppServer | listeners, connections, authentication, framing, admission, correlation, bounded byte/frame buffers, connection status | AppService construction, Product routing, semantic detach, process supervision |
+| AppService | hosted application coordination, logical attachment/mailbox/detach, snapshots, controller state, scoped Product-binding use | transport mechanics, Product discovery, OS process control |
+| Product outer integration | adaptation from admitted Product Runtime handles to AppServer structural ports | global catalog, App protocol, Hosting |
+| Hosting | local process, inherited endpoint, termination and optional generic service-instance mechanisms | AppServer/AppService/Product/UI semantics |
+| presentation profile | rendering/input/client binding and bounded unsubmitted draft | Product identity, security replacement, durable Blob storage |
+
+## Graceful Shutdown Protocol
+
+AppHost owns one bounded, idempotent state machine for direct foreground,
+externally supervised, and library-managed profiles:
+
+1. mark the process `stopping`; reject new bootstrap, Product resolution, and
+   profile activation;
+2. tell AppServer to stop accepting connections and reject new request
+   admission;
+3. tell AppServer to stop reading new frames and freeze/report connection state;
+   it does not drain writers yet and does not decide logical detach;
+4. tell AppService to reject new Sessions, perform the sole logical detach,
+   settle or interrupt admitted work by
+   explicit Product policy, clean up interactions, close logical attachments,
+   and request release through each Session-scoped Product binding's sole
+   idempotent close port;
+5. ensure AppHost releases all remaining Product Runtime handles and admitted
+   presentation-profile leases;
+6. drain-or-abort AppServer writers within the remaining deadline, then close
+   transports, listener, and connection records;
+7. close the process's one `RuntimeResourceOwner`; that owner alone revokes
+   projections, drains admitted operations, and closes its ArtifactStore and
+   `RunLease` as one transaction; and
+8. publish `stopped` readiness and let the foreground process exit.
+
+Repeated stop requests join the same operation. A phase failure is recorded but
+does not skip later cleanup phases; shutdown returns an aggregate typed result
+after all reachable owners have been attempted. One monotonic deadline bounds
+the sequence. On expiry, a controller-side Hosting owner or external supervisor
+may terminate, wait its configured grace period, kill the owned process tree,
+and reap it. A direct foreground AppHost force-closes its remaining local
+handles and exits nonzero; an external supervisor or operator remains the hard
+termination owner if the process cannot exit. Forced termination reports only
+raw process facts: it cannot claim semantic Session closure, delete persistent
+data, or synthesize successful AppService cleanup.
+
+## Machine-Resource Composition
+
+Each process resolves or receives exactly one admitted, immutable
+`PlatformPaths` at its outer composition root. A controller and its target are
+separate processes: only normalized, serialized, policy-admitted overrides,
+profile identifiers, and state references cross between them. The target
+constructs and validates its own `PlatformPaths` once. OEM/deployment overrides
+occur only at those roots. Narrow children are derived by lifecycle and
+injected:
+
+- service records and rotating observability use admitted subdirectories of
+  `PlatformPaths.state`;
+- listener/rendezvous paths use `PlatformPaths.runtime`;
+- atomic intermediates use `PlatformPaths.temporary`;
+- durable local Session transcripts use the canonical
+  `$LOUSHANG_HOME/data/sessions` authority;
+- durable Session Blob objects use
+  `$LOUSHANG_HOME/data/session-assets/<session-id>`; and
+- cwd `.loushang/sessions` and legacy `$LOUSHANG_HOME/sessions` remain
+  compatibility discovery/import inputs, never peer writable authorities.
+
+| Resource concern | Lifecycle owner | Placement/composition rule |
+| --- | --- | --- |
+| platform roots and run-lease primitive | Foundation | pure `PlatformPaths` plus Product-neutral `RuntimeScope`/`RunLease`; no Product or storage semantics |
+| shared configuration and Resource discovery | Harness configuration/resources | project `.loushang` is reviewable declaration; private generated state is user-global; Product admits policy and content |
+| application-run artifacts and machine inventory | Harness `RuntimeResourceOwner` | one effectful owner per application process; it alone owns the ArtifactStore/RunLease transaction and revocable projections |
+| durable Session transcripts | Harness conversation/transcript owner selected by Product | canonical writable default is `$LOUSHANG_HOME/data/sessions`; compatibility roots are discovery/import inputs only |
+| durable Session Blob objects | Harness Session Blob authority | canonical writable layout is `$LOUSHANG_HOME/data/session-assets/<session-id>` with immutable objects and manifest |
+| clipboard/image capture or upload | active presentation-client adapter | Native TUI is Current; GUI/WebUI own browser/OS selection without transferring storage to AppHost/AppServer/Hosting |
+| unsubmitted image/prompt draft | active client/input-router draft owner | bounded private client/run-local draft, removed on submit/cancel/disposal |
+| submitted image bytes | Harness Session Blob authority | validate and promote before a pathless durable reference enters the transcript |
+| logs, traces, diagnostics | producing observability service | bounded-retention state subdirectory; not Session content and not Hosting policy |
+| AppServer listener and transport scratch | AppServer transport | listener under runtime root, atomic scratch under temporary root, one transport cleanup owner |
+| AppService live registry and snapshots | AppService | live application state; durable recovery remains an explicit Product/store operation |
+| service-instance record | future Hosting Service Instance Controller | narrow injected state subdirectory containing mechanism facts only; retire removes it only after the exact process tree is confirmed reaped, and cleanup failure leaves conservative residue |
+
+Leaf AppHost, AppServer, AppService, Hosting, and Product adapters do not
+reread path environment variables or infer cwd/home. Presentation Profile
+Plugins own clipboard selection or upload and their bounded unsubmitted draft;
+submitted durable images cross the Harness transcript-image boundary into the
+Session Blob authority. AppHost, AppServer, and Hosting never become image
+stores. The detailed lifecycle rules remain owned by
+[Machine-Local Runtime Storage](../harness/machine-local-runtime-storage.md).
+
+## Lifetime Model
+
+Service-instance, application-run, and durable Session resources have different
+owners:
+
+- the optional Service Instance Controller owns only process identity,
+  operation serialization, readiness attempts, and its service record;
+- each AppHost target process is one application/presentation run and retains
+  at most one `RuntimeResourceOwner` for that process lifetime; that owner alone
+  acquires the `RunLease`, constructs the ArtifactStore, and exposes the
+  immutable `RuntimeScope` and revocable projections;
+- each hosted Session has its own transcript, Session Blob authority, and
+  independently scoped Product Runtime binding; switching or adding Sessions
+  does not imply another application `RunLease`;
+- adding, attaching, or closing an AppService coordination aggregate does not
+  imply another application `RunLease`, listener, service record, or
+  `RuntimeResourceOwner`;
+- a daemon target process likewise has one application-run scope for its
+  process lifetime, separate from the controller's service record;
+- Session transcript and Blob authorities outlive those process/run leases; and
+- stopping the daemon joins AppService and Product Runtime disposal but never
+  treats the service record or daemon RunLease as authority to delete Session
+  data.
+
+## Package-Placement Alternatives
+
+### Place inside `loushang.harness`
+
+Rejected. It would require Harness to import AppServer and deployment policy,
+reverse the stable substrate direction, and confuse Platform Host ownership
+with reusable single-Product mechanisms.
+
+### Create `loushang.harnesshost`
+
+Rejected. It would collide with the established `loushang.harness.host` term
+while still suggesting that Product catalog and deployment topology belong to
+Harness.
+
+### Place inside one Product
+
+Rejected. Coding, PPT, Design, Research, Cowork, and OEM Products must be peers
+under one Platform Host contract.
+
+### Top-level `loushang.apphost`
+
+Proposed. It realizes the existing Platform Host role and may depend inward on
+Harness, AppServer, and Hosting without making any of them depend outward on a
+Product or UI.
+
+## Acceptance And Implementation Gates
+
+Before this placement becomes accepted:
+
+1. AppHost component discovery must validate the contract/catalog/router,
+   runtime/lifecycle, profile-composition, and launcher boundaries.
+2. AppServer and Hosting dependencies must remain optional, profile-selected
+   edges.
+3. The Product integration contract must be proven with at least two
+   semantically unrelated fake Product Packages.
+4. Import gates must prohibit Harness, AppServer, AppService, and Hosting from
+   importing AppHost or concrete Product packages, and must prohibit every
+   AppServer subpackage from importing any Hosting package.
+5. Product resume tests must prove persisted `product_id` routing and reject an
+   unavailable or incompatible Product without default fallback.
+6. Launcher tests must prove only serializable launch material crosses the
+   process boundary and exercise readiness, graceful stop, and forced-timeout
+   reporting.
+7. Acceptance must update the parent Architecture Overview Diagram, subsystem
+   map, governance scope tree, cross-scope decision catalog, and every affected
+   scope document in the same architecture change; promote this draft into a
+   parent-owned `decisions/ARD-*`, obtain common-parent and affected-sibling
+   owner review, and add AppHost, Session Identity Envelope, and
+   Host/Presentation Profile Plugin to the canonical glossary/alias governance.
+
+Until implementation begins, `src/loushang/apphost` remains absent.

--- a/docs/internals/architecture/drafts/application-service-refactor.md
+++ b/docs/internals/architecture/drafts/application-service-refactor.md
@@ -2,14 +2,29 @@
 
 ## Status
 
-Proposed. This document defines a staged refactor, not an instruction to build
-a daemon, WebSocket transport, or new client protocol immediately.
+- ID: `APP-DP-SERVICE-REFACTOR`
+- Kind: delivery plan
+- Scope: AppServer / AppService
+- Parent: Loushang
+- Authority: normative target proposal
+- Design status: proposed
+- Implementation status: partial
+- Owner: Loushang application architecture
+
+This document defines a staged refactor, not an instruction to build a daemon,
+WebSocket transport, or new client protocol immediately. Phase 0 is Current
+and complete; AppHost, AppServer, AppService, and later phases are proposed and
+not started.
 
 The current delivery clarification is
 [AppService Hosted Boundary With An Embedded TUI](appservice-embedded-tui-hosted-boundary-plan.md):
 the default native TUI remains on the direct embedded path. References below
 to an embedded `AppClient` or Harnesstui migration are optional Product
 elections, not a prerequisite for AppService or the default local composition.
+Platform Host identity and Product catalog/routing ownership follow
+[AppHost Top-Level Placement](apphost-top-level-placement.md).
+OS process and daemon mechanisms follow the separate
+[Hosting Support Boundary](../hosting/key-designs/hosted-application-support-boundary.md).
 
 ## Decision
 
@@ -37,8 +52,13 @@ in-process message pump, or a second event bus.
 When at least one extraction trigger is real, Loushang may introduce a
 top-level `loushang.appserver` package. In that target architecture:
 
-- `AppService` is the single application boundary above Harness and injected
-  Work/Channel ports, while Product composition retains Method binding;
+- `AppHost` is the composition root that constructs AppService, injects it into
+  AppServer, and owns whole-process shutdown ordering;
+- `AppServer` owns the hosted server/connection runtime, listeners/connections,
+  authentication, framing, transport admission, and byte/frame delivery;
+- `AppService` is the transport-neutral application boundary over injected
+  Product Session, Work, and optional Channel ports, while Product composition
+  retains Method binding;
 - `AppClient` is the client-facing contract;
 - in-process, JSONL, and WebSocket connections are transport adapters over the
   same application protocol;
@@ -95,24 +115,52 @@ Once extracted, the target package is top-level because it coordinates several
 lower layers:
 
 ```text
-embedded Product composition root
-  -> Harnesstui prepared ports
-  -> Product Session binding -> Harness
+Coding UI composition -> Harnesstui -> TUI          # Current embedded profile
+Coding UI composition -> Coding Product -> Harness
 
-hosted Platform Host composition root
-  -> admitted Product Router / Factory
-  -> loushang.appserver.service
-       |-> injected Product Session port -> Harness
-       |-> injected Product Work port -> Work -> Harness
-       `-> injected Channel port -> Work / Harness
+Product Package integration
+  -> apphost Product contracts / Product public API / Harness public ports
+  -> optional appserver structural ports            # separate hosted module
 
-hosted clients, including an optional AppClient-backed Harnesstui profile
+apphost runtime/bootstrap -> appserver.server        # hosted profile only
+apphost launcher -> Hosting Process Host             # separate process only
+apphost daemon control -> hosting.service            # future accepted candidate
+appserver -X-> Hosting
+
+harnessgui / harnesswebui / other hosted clients
   -> appserver.client
   -> appserver.protocol
 
-appserver transports
+appserver.server
+  -> appserver.service
   -> appserver.protocol
+  -> appserver transports
+
+appserver.service
+  -> appserver-owned structural Product ports
+
+concrete Product adapter
+  -> appserver structural ports
+  -> Harness / Work / Channel public ports
+
+coding core -> Harness
+Harness -> Hosting                                  # elected mechanisms only
+
+Coding UI -X-> HarnessGUI / HarnessWebUI / AppServer / AppService
+Harnesstui -X-> Coding / HarnessGUI / HarnessWebUI / AppServer / AppService
+appserver.service -X-> Hosting / Coding / Harness / UI frameworks
+Hosting -X-> AppServer / AppService / Coding / Harness / UI frameworks
 ```
+
+HarnessGUI and HarnessWebUI depend on AppClient and the versioned App Contract,
+not on the AppServer implementation. CodingTUI is an independent embedded
+profile Plugin implemented by Coding UI over Product-neutral Harnesstui; it
+does not depend on either hosted GUI package. CodingApp may be a second
+installable profile Plugin without becoming a second Coding Product. The
+runtime hosted call chain flows from AppService through an injected port to the
+selected Product adapter, but the source dependency of that adapter points
+inward to the AppServer port contract and Harness APIs. Dependency inversion
+therefore keeps every Product core and AppService unaware of each other.
 
 Method selection, compilation, and `MethodPlan -> WorkPlanSpec` conversion
 remain a Product-binding responsibility. `WorkPlanSpec` is a target design
@@ -128,16 +176,35 @@ Package-level import rules:
 - `appserver.client` imports `appserver.protocol`, not service internals;
 - `appserver.transports` import protocol and transport mechanics, not Harness
   Session implementations;
-- `appserver.service` may adapt injected Harness, Work, and Channel ports;
+- `appserver.server` imports service, protocol, and elected transports and owns
+  connection admission;
+- `appserver.service` consumes its own structural Product Session, Work, and
+  optional Channel ports; it imports no Hosting, concrete Product, Harness,
+  Work implementation, or UI package;
+- AppServer and all its subpackages must not import any Hosting package;
+- AppHost owns Product contracts/catalog/routing and may import AppServer,
+  Hosting, and public Harness host/runtime contracts, but no concrete Product
+  internals;
 - Harness and Work never import AppServer; and
-- Harnesstui never imports `appserver.service`.
+- Coding UI never imports HarnessGUI, HarnessWebUI, `appserver.server`, or
+  `appserver.service`; and
+- Harnesstui never imports Coding, HarnessGUI, HarnessWebUI, AppServer, or
+  AppService.
 
-The Product composition root is the one deliberate Product-side importer: an
-allowlisted entrypoint such as Coding `ui.mode`, CLI bootstrap, or a future
-daemon bootstrap may import `appserver.service` to inject Product factories
-and ports. Product domain, Session implementation, tool, Policy, and
-presentation modules do not import AppServer. AppServer never imports a
-Product package.
+The top-level `loushang.apphost` is the one deliberate cross-Product Platform
+Host. It owns Product contracts, catalog, router, scoped Runtime lifecycle, and
+deployment-profile composition. Product Packages register descriptors,
+factories, and optional hosted integrations without AppHost importing their
+internals. `loushang.harnesswork` remains the canonical shared Product
+dependency rather than a Product by default; `loushang.work` is its forwarding
+compatibility facade. Product domain, Session implementation, tool, Policy, Coding UI,
+HarnessGUI, and HarnessWebUI modules do not import AppServer implementation.
+AppServer and AppHost never import concrete Product internals.
+
+This is distinct from the existing `loushang.harness.host`, which remains the
+lower-level Product-neutral line-input, stdio, mode, and host-runtime adapter
+layer. AppHost may consume those public contracts; Harness Host does not
+acquire AppServer, daemon, or deployment-composition responsibility.
 
 This placement preserves the existing `Harness <- Channel` direction rather
 than reintroducing `Harness -> Channel`.
@@ -152,6 +219,7 @@ src/loushang/appserver/
   protocol.py
   client.py
   service.py
+  server.py
   in_process.py
   transports/
     __init__.py
@@ -161,7 +229,15 @@ src/loushang/appserver/
 Subpackages such as `protocol/`, `service/`, or `client/` are created only when
 one of these files has multiple independently testable owners. WebSocket,
 authentication, SDK code generation, and daemon supervision are not empty
-placeholder modules.
+placeholder modules. AppServer never contains an adapter to any Hosting
+package.
+
+The separate `src/loushang/apphost/` package is introduced only with a named
+cross-Product Platform Host delivery. It owns Product contracts,
+catalog/routing, scoped Runtime lifecycle, and deployment-profile assembly,
+not an alternative App protocol or concrete Product adapter. Its component
+discovery and delivery are governed separately by
+[AppHost Top-Level Placement](apphost-top-level-placement.md).
 
 ## Responsibilities
 
@@ -207,6 +283,25 @@ Bash/selected-command execution and Session command dispatch remain their
 existing ports and are not added to `SessionOperationRuntime` merely to make
 the TUI call graph look uniform.
 
+### AppServer
+
+After extraction, `AppServer` owns the hosted server shell:
+
+- in-process, standard-I/O, local-listener, or remote connection profiles;
+- listener path and permissions, accept loops, connection identity, transport
+  authentication, framing, initialization, and resource admission;
+- per-connection request/response correlation, bounded byte/frame output,
+  transport backpressure, disconnect, and transport cleanup; and
+- reporting transport state and overload through a narrow port to the injected
+  AppService instance.
+
+It does not own Product Session or Work meaning, turn/Approval semantics,
+Product discovery, deployment topology, UI rendering, or OS process identity
+and supervision. It runs inside the target-process AppHost runtime, which
+constructs and semantically closes AppService. A separate AppHost launcher may
+use Hosting to start that complete executable, while an external supervisor may
+start it directly. AppServer never imports or calls any Hosting package.
+
 ### AppService
 
 After extraction, `AppService` owns application coordination only:
@@ -214,8 +309,8 @@ After extraction, `AppService` owns application coordination only:
 - a registry of service-owned live Session handles;
 - typed command dispatch onto injected Session and Work ports;
 - client-safe snapshots and read-model projection;
-- transport request/event correlation and routing of domain-owned interaction
-  IDs;
+- application operation tracking and routing of domain-owned interaction IDs
+  through an injected connection-output port;
 - connection subscriptions;
 - controller routing when several clients observe one Session;
 - idempotency admission for externally retried side effects; and
@@ -230,7 +325,23 @@ It does not own:
 - Method selection, compilation, projection, or Method-to-Work conversion;
 - transcript storage implementation;
 - terminal rendering or widget layout; or
-- JSONL, WebSocket, or operating-system daemon mechanics.
+- AppServer listeners, authentication, framing, transport request correlation,
+  JSONL, WebSocket, Hosting, or operating-system daemon mechanics.
+
+AppService owns one bounded logical delivery mailbox per attachment, including
+semantic priority, response reservation, safe delta coalescing, and the
+attachment-detach decision. AppServer owns the separate bounded byte/frame
+write buffer and reports overload/disconnect through a narrow port. The
+deployment bounds their combined capacity, and one ordered close sequence
+prevents duplicate cleanup ownership.
+
+A hosted profile may add an AppService-owned multi-Session coordination
+aggregate, such as a named mux space. That aggregate is application state, not
+a new AppHost, AppServer listener, Harness Capability, Product Runtime, or
+Hosting service. One AppService coordinator may own several such aggregates
+and several independently scoped Session bindings. Aggregate membership,
+attachment generations, and aggregate commands remain in AppService; AppHost
+and Hosting do not index or interpret aggregate names.
 
 ### AppClient
 
@@ -298,6 +409,11 @@ JSONL and a future WebSocket transport:
 They do not contain Session command handlers, Product capability discovery,
 approval policy, or read-model projection.
 
+These adapters are owned by AppServer, not Hosting. A local-listener adapter
+also owns its path, private permissions, accept loop, connection limits, and
+stale-listener cleanup. Hosting's inherited peer endpoint is reserved for an
+attached one-parent/one-child profile and is not a reconnectable listener.
+
 ### Channel
 
 Channel remains the boundary for `WorkOperation`, `WorkEvent`, and selected
@@ -351,6 +467,16 @@ revision        snapshot/read-model version
 
 Legacy RPC camelCase dictionaries and command names are compatibility inputs
 to an adapter; they do not define the new application protocol.
+
+Before `session/open` or resume invokes a Product-specific parser, AppHost reads
+the parent-defined generic versioned Session Identity Envelope. Its required
+`product_id`, continuity identity, and opaque locator select the admitted
+Product descriptor and factory; the resulting Product-specific owner then
+parses its own state. Each Session receives an independent scoped Product
+Runtime binding. A single-Product process only restricts the allowed ID; it does
+not create a process-global Session Runtime. Legacy Sessions without identity
+must pass an explicit compatibility importer/migration or fail with
+`ProductIdentityRequired`; a default Product is never inferred.
 
 ## Approval Interaction Boundary
 
@@ -465,6 +591,44 @@ Durable event storage is introduced only when Work recovery or an external
 client contract requires it. AppService must not create a second transcript or
 Work audit store.
 
+### Multi-Session Coordination Aggregates
+
+The first named-mux profile refines the Session snapshot contract without
+creating a cross-Session transaction. An aggregate attachment joins one
+serialized membership revision with one authoritative snapshot/cursor pair
+per visible Session. It publishes the initial client view only after every
+pair is valid, buffers each stream before exposure, and replays strictly after
+the corresponding cursor. There is no global cross-Session revision, cursor,
+event sequence, or claim that all snapshots represent one instant.
+
+An aggregate controller lease is an AppService coordination lease over the
+member set. It does not replace Session interaction ownership: AppService
+derives one generation-fenced presenter lease for each member Session. Attach
+publishes controller authority only after all required presenter leases are
+acquired, and rolls back the acquired set on failure. Adding a member while
+attached publishes neither that member nor its events until its Session
+binding, subscription, presenter lease, and snapshot/cursor pair are ready.
+Removing a member fences its aggregate event route and releases its presenter
+lease exactly once. Detach closes all derived leases, so each Session's
+existing Approval cleanup policy remains authoritative.
+
+Multi-stream delivery is bounded at two levels. AppService admits explicit
+limits for aggregate count, members per aggregate, total live Sessions,
+attachments, subscribed streams, and logical mailbox capacity; AppServer
+separately admits connections and byte/frame buffers. Fair scheduling or
+per-stream sub-budgets prevent one high-volume Session from starving another
+inside one aggregate attachment. Overload may detach that attachment and
+require a fresh snapshot, but cannot block another Session or aggregate.
+
+The first named-mux profile may constrain one connection to at most one active
+aggregate controller attachment while one AppHost endpoint serves several
+connections and aggregates. Aggregate create/member mutations use idempotency
+scopes that include principal, Product, operation, and the endpoint,
+aggregate, or member target as applicable. Aggregate close stops admission,
+fences attachments and member routes, attempts every independently owned
+Session release exactly once, and returns an aggregate result without hiding
+partial cleanup failure.
+
 ## Multi-Client Interaction
 
 Multiple observers are allowed. Exactly one connection is the current
@@ -513,6 +677,9 @@ remain inside Harnesstui and are not round-tripped through AppService.
 
 The default embedded Harnesstui profile continues to consume prepared ports and
 existing Session operations directly regardless of whether AppService exists.
+This CodingTUI composition is parallel to HarnessGUI and HarnessWebUI. It does
+not import either package, and installing or starting it does not require the
+hosted client/server stack.
 
 Before an elected Product binding cuts over to AppClient, the migration keeps a
 checked capability inventory. Every current Agent screen binding dependency is
@@ -639,7 +806,8 @@ client adapter.
 2. Implement `InProcessAppClient`.
 3. Run the same semantic scenarios against direct service and in-process
    client paths.
-4. Implement one ordered server-output path and deterministic disconnect.
+4. Implement one bounded AppService logical mailbox per attachment, an
+   injected connection-status port, and deterministic detach.
 5. Keep daemon, WebSocket, and durable replay out of scope.
 
 Exit criteria:
@@ -655,6 +823,13 @@ Exit criteria:
 
 Trigger: the Product elects to make the embedded AppClient path its
 authoritative Harnesstui binding. A remote transport is not required yet.
+
+This elects an AppClient-backed profile contribution through the canonical
+Product/OEM Plugin lifecycle. Manifest/trust/enablement/activation-generation
+owners admit it before import; AppHost consumes only the admitted immutable
+factory and owns the selected instance. This does not create another Plugin
+manager, turn Harnesstui into Coding, make CodingTUI depend on CodingApp, or
+create a second Product identity.
 
 1. Complete the checked Harnesstui capability inventory.
 2. Extend the typed protocol only for existing server-backed capabilities
@@ -686,25 +861,45 @@ boundary.
 2. Add the minimum transport authentication required by that deployment.
 3. Run embedded-versus-remote semantic parity and Harnesstui playback suites.
 4. Define bounded output and slow-client disconnect behavior.
+5. When a separate process is required, add an AppHost launcher that passes
+   only serializable launch material to Hosting Process Host and starts the
+   complete AppHost executable; direct foreground invocation uses no Hosting.
 
 Exit criteria:
 
 - changing connection type does not change user-visible conversation order;
-- bounded queues and slow clients have defined behavior; and
-- remote clients cannot receive raw domain objects or secrets.
+- bounded queues and slow clients have defined behavior;
+- remote clients cannot receive raw domain objects or secrets;
+- AppService imports neither Hosting nor the concrete Product implementation;
+- AppServer byte-buffer overload reports into the single AppService detach
+  path without a second close decision; and
+- no in-memory Product factory, adapter, or service object crosses process
+  launch.
 
 #### 4B — Daemon Ownership
 
-Trigger: sessions must outlive one CLI/client process.
+Trigger: sessions must outlive one CLI/client process. This trigger first
+requires a supervisor-ownership decision; it does not by itself justify
+`hosting.service`.
 
-1. Add daemon lifecycle around AppService.
-2. Define which Session state is persisted and what daemon restart restores.
-3. Add idempotency admission for externally retried side effects.
-4. Start reconnect with a fresh snapshot; add event replay only if required.
+1. Prefer an external systemd, launchd, Windows SCM, container, or deployment
+   supervisor when it is already authoritative.
+2. Only when a library-managed cross-platform lifecycle API is required, add
+   an AppHost daemon-control adapter over the separately accepted Hosting
+   Service Instance Controller.
+3. Define which Session state is persisted and what daemon restart restores.
+4. Add idempotency admission for externally retried side effects.
+5. Start reconnect with a fresh snapshot; add event replay only if required.
 
 Exit criteria:
 
 - daemon restart and Session/durable-run ownership are explicit;
+- AppHost is the only possible caller of `hosting.service`; AppServer owns the
+  listener and AppService owns live hosted Session coordination;
+- the service-instance record is separate from the target process's one
+  application-run `RuntimeScope`/`RunLease`; every Session has distinct
+  transcript/Blob authority and a scoped Product binding but no implied
+  per-Session application lease, and none can delete durable truth;
 - an external retry cannot duplicate an admitted side effect; and
 - disconnect cannot strand a blocking interaction.
 
@@ -746,8 +941,15 @@ Required suites:
   tests while `RemoteUiContext` remains active;
 - snapshot plus ordered-event convergence;
 - Harnesstui playback for streaming, approval, `/agents`, surfaces, resize,
-  abort turn, composite stop, and resume; and
-- import-boundary tests for every arrow in the target graph.
+  abort turn, composite stop, and resume;
+- import-boundary tests for every arrow in the target graph, including
+  Coding UI independence from HarnessGUI/HarnessWebUI, Harnesstui neutrality,
+  AppService independence from Hosting, and AppServer denial of every Hosting
+  package;
+- at least two unrelated fake Product Package integrations through AppHost;
+- persisted `product_id` resume routing with no default fallback; and
+- launcher tests proving that only serializable launch material crosses a
+  process boundary.
 
 In-process tests must not pass only because they bypass ordering or lifecycle
 rules that the remote transport enforces.
@@ -766,6 +968,14 @@ This refactor does not:
   client exists;
 - move Policy/Approval into the transport;
 - make every local TUI action a service round trip;
+- make CodingTUI depend on HarnessGUI, HarnessWebUI, AppServer, or AppService;
+- treat CodingTUI and CodingApp profile Plugins as distinct Products without
+  distinct Product Kernels and identities;
+- make HarnessGUI or HarnessWebUI import Coding internals or the AppServer
+  implementation instead of AppClient/App Contract;
+- put AppServer listeners, connection admission, or hosted Session semantics
+  in Hosting;
+- make AppServer supervise its process or call any Hosting package;
 - promise exactly-once execution across process crashes; or
 - introduce a general multi-user permission system.
 

--- a/docs/internals/architecture/drafts/appservice-embedded-tui-hosted-boundary-plan.md
+++ b/docs/internals/architecture/drafts/appservice-embedded-tui-hosted-boundary-plan.md
@@ -2,7 +2,9 @@
 
 [Architecture](../README.md) · [Drafts](README.md) ·
 [Future Architecture v3](future-loushang-architecture-v3.md) ·
-[Application Service Refactor](application-service-refactor.md)
+[Application Service Refactor](application-service-refactor.md) ·
+[AppHost Top-Level Placement](apphost-top-level-placement.md) ·
+[Hosting Support Boundary](../hosting/key-designs/hosted-application-support-boundary.md)
 
 ## Status
 
@@ -48,8 +50,9 @@ Plugin lifecycle, or provider-composition boundaries.
   Harnesstui and Product-owned adapters;
 - `SessionFacade`, `SessionOperationRuntime`, and the legacy JSONL RPC host
   provide current typed Session and transitional remote-host boundaries; and
-- there is no `loushang.appserver` package, App Contract, `AppClient`,
-  `AppService`, daemon-owned live Session router, or reconnect protocol.
+- there is no `loushang.apphost`, `loushang.appserver`, or
+  `loushang.hosting` package, App Contract, `AppClient`, `AppService`, hosted
+  live Session router, or reconnect protocol.
 
 The Current claims above are bounded by the evidence listed in the status
 block. The source and tests remain authoritative if this draft drifts.
@@ -77,34 +80,60 @@ Loushang keeps two first-class process profiles:
 
 ```text
 default local TUI
-  Harnesstui
+  CodingTUI profile Plugin / Coding UI composition
+    -> Product-neutral Harnesstui
     -> Product conversation UI binding
     -> embedded Product runtime
     -> per-Session Harness runtime
 
 hosted clients
-  WebUI / IDE / mobile / remote TUI
+  HarnessGUI / HarnessWebUI / IDE / mobile / remote TUI
     -> AppClient
     -> versioned App Contract
-    -> Hosted Platform Host
-         -> AppServer endpoint and transport lifecycle
+    -> AppServer endpoint and transport lifecycle
          -> AppService
-         -> resolved Product Session or Work port
-         -> per-Session Harness runtime or Work runtime
+              -> resolved Product Session or Work port
+              -> Product-owned adapter
+              -> per-Session Harness runtime or Work runtime
+
+target process
+  loushang.apphost runtime / Platform Host
+    -> admitted Product catalog / router / scoped factory
+    -> hosted Product integration
+    -> AppServer server/connection runtime
+
+controller process, only when library-managed launch is elected
+  AppHost launcher
+    -> complete AppHost executable and serializable launch material
+    -> Hosting Process Host or future Service Instance Controller
+
+external supervisor profile
+  systemd / launchd / Windows SCM / container
+    -> complete foreground AppHost executable + signal/notification contract
+    -X-> Hosting library
 ```
 
 The default TUI does not serialize commands through the App Contract and does
-not depend on `AppClient`, `AppService`, or a daemon. A future remote TUI mode
-may use `AppClient`, but that is a separate hosted composition selected at
-startup rather than a replacement for the embedded fast path.
+not depend on HarnessGUI, HarnessWebUI, `AppClient`, `AppServer`, `AppService`,
+or a daemon. A future remote TUI mode may use `AppClient`, but that is a
+separate hosted composition selected at startup rather than a replacement for
+the embedded fast path.
 
 The optional in-process `AppClient` described by v3 remains available when a
 Product explicitly elects an AppClient-backed profile. This plan declines that
 option for the default native TUI; it does not remove the option from the
 architecture.
 
+CodingTUI and CodingApp may be independently installable Host/Presentation
+Profile Plugins while remaining surfaces of the same Coding Product. Product
+identity is determined by Product Kernel, descriptor, factory, `product_id`,
+policy, and continuity—not by UI technology.
+
 AppService is the hosted application coordinator. It is not a universal UI
 backend, a Capability provider, a Plugin manager, or a second Harness runtime.
+AppServer is the hosted server/connection runtime profile around AppService.
+Hosting supplies optional OS process mechanisms to the outer Platform Host; it
+is not part of AppService and does not own AppServer listeners or connections.
 
 ## Why This Split
 
@@ -138,10 +167,13 @@ The split therefore shares execution semantics but not presentation plumbing:
 | App Contract | Versioned, client-safe request, response, event, snapshot, and interaction values | Not serialized Harness, Product, Plugin, or widget objects |
 | AppClient | Transport-neutral client contract for hosted surfaces | Not required by the default embedded TUI |
 | AppService | In-process hosted application coordinator | Not a transport, Product runtime, Harness Capability, or Plugin manager |
-| AppServer | Hosted process profile inside a Platform Host; owns endpoints and transport lifecycle | Not a second Platform Host, Product router, or owner of Product/Work semantics |
+| AppServer | Hosted server/connection runtime injected with AppService; owns listeners, connections, authentication, framing, admission, and transport lifecycle | Not AppService's constructor/semantic owner, a Platform Host, Product router, or OS process supervisor |
+| Hosting | Product-neutral OS process, inherited peer-endpoint, shutdown, and machine-resource mechanisms | Not AppService, an AppServer listener, a reconnect protocol, or a daemon policy by default |
+| AppHost / Platform Host | Cross-Product catalog, routing, scoped Runtime lifecycle, deployment-profile selection, and assembly | Not a Hosted-only sibling host, Product domain package, Harness, AppService, or UI framework |
+| Host/Presentation Profile Plugin | Installable binding for an embedded TUI, Coding App, WebUI, or another delivery surface | Not automatically a distinct Product or a replacement for host/security invariants |
 | Product Session port | Narrow Product-provided Session operations consumed by AppService | Not a universal Product interface or service locator |
 | Product Work port | Narrow Product-provided durable Work submission and observation operations | Not a synonym for every turn |
-| Harnesstui Product binding | Embedded adapter from Product-neutral TUI ports to one Product runtime | Not an App Contract adapter |
+| CodingTUI profile Plugin | Embedded Coding adapter over Product-neutral Harnesstui/TUI ports | Not Harnesstui itself, HarnessGUI, HarnessWebUI, or an App Contract adapter |
 
 The exact Product Session and Work port names remain deferred until the first
 hosted vertical slice proves the minimum methods. The implementation must not
@@ -153,28 +185,70 @@ profiles look structurally identical.
 The required source direction is:
 
 ```text
-Embedded Product composition root
-  -> Harnesstui public ports                    # embedded profile
-  -> Product runtime and Harness public ports
+Coding UI composition -> Harnesstui -> TUI      # Current embedded profile
+Coding UI composition -> Coding Product -> Harness
 
-Hosted Platform Host composition root
-  -> admitted Product Registry / Router / Factory
-  -> AppServer endpoints and transports
-       -> AppService
-       -> injected Product Session / Work / optional Channel ports
+Product Package integration
+  -> AppHost Product contracts / Product public API / Harness public ports
+  -> optional AppServer Product ports           # separate hosted edge module
+
+AppHost runtime -> AppServer server              # hosted profile only
+AppHost launcher -> Hosting Process Host         # separate process only
+AppHost daemon control -> hosting.service        # future accepted candidate
+AppServer -X-> Hosting
+
+HarnessGUI / HarnessWebUI -> AppClient / App Contract
+AppServer server -> AppService / App Contract / transport adapters
+AppService -> appserver-owned structural Product ports
+Concrete Product adapter -> appserver port contract / Product / Harness ports
+Coding core -> Harness
+Harness -> Hosting                               # elected mechanism use
 
 Harness -X-> AppService / AppClient / App Contract / Harnesstui / Product
-AppService -X-> concrete Product package / Harnesstui / Plugin internals
+AppService -X-> Hosting / concrete Product / Harnesstui / Plugin internals
+Coding core -X-> AppServer / AppService / HarnessGUI / HarnessWebUI
+Coding UI -X-> HarnessGUI / HarnessWebUI / AppServer / AppService
+Harnesstui -X-> Coding / HarnessGUI / HarnessWebUI / AppServer / AppService
+HarnessGUI / HarnessWebUI -X-> Coding internals / AppServer implementation
+Hosting -X-> Harness / AppServer / AppService / Coding / UI frameworks
 ```
 
-AppService may define the structural ports it consumes. A `ProductResolver` is
-only a narrow adapter over the Platform Host's already admitted Product
-Router/Factory; it does not own Product registration, Plugin discovery, OEM
-selection, provider resolution, or trust policy. Concrete Product or
-host-owned adapters implement the injected Session, Work, and optional Channel
-ports and may call Product and public Harness APIs. This preserves dependency
-inversion: AppService never imports `loushang.coding` or derives a Product
-implementation from an import path.
+The arrows above are source dependencies, not a requirement that each runtime
+call be direct. HarnessGUI and HarnessWebUI use AppClient and the App Contract;
+they do not import the AppServer implementation. CodingTUI is their sibling
+embedded presentation profile and never depends on either GUI package.
+
+AppHost, AppServer, and AppService are intentionally separate. AppHost is the
+composition root: it constructs AppService, injects it into AppServer, and owns
+whole-process shutdown order. AppHost also owns the Product catalog/router and
+selects a scoped Product factory. A Product
+Package's separate hosted integration adapts its public Runtime handle to the
+AppServer ports without making Product core depend on AppServer. AppServer
+admits and manages client connections, then delegates application requests to
+AppService. AppService coordinates hosted application state through injected
+Product ports and remains transport- and process-neutral.
+
+AppHost runtime performs in-process assembly. A different controller-process
+launcher may ask Hosting to start the complete AppHost executable using only
+serializable launch material. No Product factory, adapter, AppService, or
+AppServer object crosses that process boundary. AppServer never supervises
+itself.
+
+AppService may define the structural ports it consumes. A
+`ProductSessionResolver` is an injected narrow adapter over AppHost's already
+admitted Product catalog/router. Before Product-specific parsing, AppHost reads
+the generic versioned Session Identity Envelope defined by the parent placement
+and obtains its required `product_id` and opaque locator. Resolution returns a
+new scoped Product Runtime binding for each new/open/resume Session; a
+single-Product deployment limits allowed Product IDs but does not share one
+mutable Runtime handle among Sessions. Missing legacy identity requires an
+explicit compatibility migration or typed `ProductIdentityRequired`, never a
+default fallback. The resolver does not own
+Product registration, Plugin discovery, OEM selection, provider resolution,
+or trust policy. Hosted Product integration modules implement the injected
+Session, Work, projection, and optional Channel ports and may call Product and
+public Harness APIs. This preserves dependency inversion: AppService never
+imports a concrete Product or derives one from an import path.
 
 The embedded and hosted factories may share immutable Product definitions and
 configuration, but each invocation constructs independent mutable runtime
@@ -204,14 +278,15 @@ The following rules are mandatory:
    Plugin manager, Mount runtime, or private binding modules.
 3. AppService never discovers Plugins, selects providers, interprets discovery
    priority, refreshes a Capability graph, or disposes an individual provider.
-4. `ProductResolver` is supplied by the outer composition root. Resolving a
-   Product returns an immutable definition and scoped factories, not a global
-   mutable registry or service locator.
+4. `ProductSessionResolver` is supplied by AppHost's hosted profile. Resolving
+   an explicit `product_id` and Session context returns one scoped binding,
+   not a global mutable registry, service locator, or default-Product fallback.
 5. Product runtime activation may cause the owning Product/Host composition to
    bind a Capability graph. AppService sees only the resulting narrow Session,
    Work, event-projection, and interaction ports.
 6. Capability and Plugin lifecycle remains owned by the runtime scope that
-   bound it. AppService closes its hosted Session binding; it does not reach
+   bound it. AppService invokes the binding's sole idempotent close port while
+   AppHost remains the final scoped-lease owner; AppService does not reach
    inside that binding to tear down Mounts or Extensions.
 7. Plugin identity and provider provenance may appear only in an explicitly
    redacted, read-only diagnostic view produced by the authoritative Capability
@@ -224,6 +299,17 @@ The following rules are mandatory:
    transport authentication enforcement, this application-authorization
    enforcement, attachment/controller admission, idempotency, or delivery
    invariants through ordinary Harness variation.
+9. AppHost registers, admits, selects, and routes Product Packages. It does not
+   discover or activate a Product's internal Plugins, Capabilities, Resources,
+   Tools, or Extensions, and does not create a peer Runtime Profile resolver.
+   The scoped Product Factory uses the existing Harness owners and returns a
+   narrow Runtime handle.
+10. CodingTUI/CodingApp profile contributions use the canonical Product/OEM
+    Plugin manifest, trust, desired-state, activation-generation, and retirement
+    owners. AppHost consumes only an immutable admitted profile factory and owns
+    its selected instance; it creates no peer Plugin manager. Daemon control is
+    a built-in/OEM deployment profile and cannot be replaced by an ordinary
+    Product Plugin.
 
 If the AppService workstream discovers a missing Harness contract, it must not
 patch capability internals from the AppService branch. The missing contract is
@@ -262,9 +348,14 @@ The supported command shape may eventually be:
 
 ```text
 loushang tui                 # embedded default; no AppClient
-loushang daemon              # owns hosted Sessions and AppService
+loushang daemon              # hosts AppService in an AppHost daemon profile
 loushang tui --connect URL   # optional hosted/remote TUI; uses AppClient
 ```
+
+The daemon adapter owns process-level orchestration only. AppService owns the
+live hosted registry and attachment state, each scoped Product binding owns
+its Session Runtime and disposal lease, and Product/HarnessWork stores own durable
+recovery truth.
 
 The third command is deferred until a remote-TUI requirement is accepted.
 
@@ -449,6 +540,59 @@ position, and transient runtime-event sequence remain distinct identifiers.
 None is silently reused as another merely because its first implementation is
 an integer.
 
+### Multi-Session Coordination Aggregate
+
+AppService may own several application-level coordination aggregates when an
+accepted hosted profile requires them. The first concrete trigger is a named
+mux space containing an ordered, v1-disjoint set of hosted Sessions. The
+aggregate is not a Harness Capability, Product Runtime, AppHost instance,
+AppServer listener, Hosting service, or durable recovery store. AppHost
+constructs one AppService coordinator for the process and remains unaware of
+aggregate names and membership semantics.
+
+An aggregate attachment establishes a client-visible barrier composed from:
+
+- one serialized aggregate membership revision;
+- one authoritative snapshot and delivery cursor per visible Session;
+- buffering begun for every member stream before any initial view is exposed;
+  and
+- replay strictly after each corresponding Session cursor.
+
+There is no global cross-Session instant or cursor. A concurrent membership
+mutation waits behind the selected revision or returns a typed retry. A new
+member and its events become visible together only after its scoped Product
+binding, subscription, presenter lease, and snapshot/cursor pair are ready.
+Removing a member fences its aggregate route before releasing its presenter
+lease. Membership events are ordered before Session events that first
+reference an added member, and no removed member event is accepted from a
+superseded attachment generation.
+
+Exactly one aggregate controller may be projected onto several Sessions, but
+it creates no new interaction authority. AppService derives one existing
+generation-fenced presenter lease per member Session, publishes aggregate
+control only after the complete set is acquired, and rolls back partial
+acquisition. Detach closes the derived leases exactly once; the authoritative
+Session interaction owner applies its existing cleanup/fallback policy. A
+Session belongs to at most one such aggregate in the first profile, preventing
+controller ownership from aliasing across aggregates.
+
+The first profile constrains one connection to at most one active aggregate
+controller attachment; concurrent aggregates use independent connections.
+AppService enforces semantic limits for aggregate count, members per
+aggregate, total live Sessions, attachment count, subscribed streams, and
+logical mailbox capacity. AppServer separately enforces connection and
+byte/frame limits. Per-stream sub-budgets or fair scheduling prevent one noisy
+Session from starving another inside the shared logical mailbox. Aggregate
+overload detaches that attachment and converges through a fresh barrier; it
+does not stall unrelated Sessions or aggregates.
+
+Aggregate create and member mutations extend the idempotency target domain
+with the endpoint, aggregate, or member identity as applicable. Aggregate
+close first stops member admission, fences attachments and member routes, then
+attempts every distinct Session binding release exactly once and reports an
+aggregate result. One failure does not skip reachable releases or claim false
+cleanup success.
+
 ## Concurrency, Ordering, And Backpressure
 
 AppService uses separate coordination lanes per hosted Session:
@@ -464,22 +608,33 @@ Independent Sessions run concurrently. Session close prevents new admission,
 settles or rejects queued requests deterministically, and delegates runtime
 disposal to the owner of the resolved Product binding.
 
-Each attachment has bounded outbound delivery. Ephemeral deltas may be
-coalesced or discarded after the attachment is marked lagged. The service must
-never silently discard interaction requests, controller-lease changes, request
-responses, or terminal Turn and Work events. Critical enqueue failure marks
-only that attachment lagged and closes it; it does not block the Session event
+Membership mutations are serialized per aggregate, not by one process-global
+lock. Aggregate coordination never holds a Session mutation lock for a full
+model/tool run. Independent aggregates therefore preserve the existing
+cross-Session concurrency and failure isolation.
+
+Each attachment has one bounded **logical delivery mailbox** owned by
+AppService. It classifies semantic events, reserves response/interaction
+capacity, and may coalesce ephemeral deltas. It never silently discards
+interaction requests, controller-lease changes, request responses, or terminal
+Turn and Work events. Critical logical admission failure marks only that
+attachment lagged and initiates its detach; it does not block the Session event
 source or another attachment. Closing a controller attachment also closes its
 presenter lease and invokes existing interaction cleanup. Terminal state must
-remain recoverable from a fresh snapshot. Response capacity is reserved or
-isolated so notification pressure cannot make a request unanswerable. If the
-retained cursor is unavailable, AppService returns `SnapshotRequired` and
-requires convergence from a fresh atomic snapshot/cursor pair.
+remain recoverable from a fresh snapshot. If the retained cursor is
+unavailable, AppService returns `SnapshotRequired` and requires convergence
+from a fresh atomic snapshot/cursor pair.
 
-One ordered server-output writer per attachment prevents responses, events,
-and server-initiated interactions from racing on the transport. Request IDs,
-interaction IDs, event sequences, turn IDs, operation IDs, and revisions are
-different domains and cannot be overloaded.
+AppServer owns a separate bounded **byte/frame write buffer** and one ordered
+writer per connection. It does not coalesce or reinterpret semantic events.
+It reports `OutputOverloaded` or `Disconnected` through a narrow connection
+status port; AppService then performs the single attachment-detach sequence.
+The deployment declares a bounded sum of logical-mailbox and byte-buffer
+capacity per connection, and close order is AppServer input stop, AppService
+detach/interaction cleanup, then writer drain-or-abort. Contract tests cover
+that cross-layer bound and prove that neither layer creates a second close
+decision. Request IDs, interaction IDs, event sequences, turn IDs, operation
+IDs, and revisions are different domains and cannot be overloaded.
 
 ## Suggested Package Boundary
 
@@ -490,19 +645,28 @@ src/loushang/appserver/
   protocol/          # typed values, codec, version, schema fixtures
   ports.py           # narrow structural Product/host ports consumed by service
   service.py         # hosted coordination only
-  connection.py      # attachment, correlation, ordered output, close semantics
+  attachment.py      # logical mailbox, attachment/detach, controller semantics
+  server.py          # server runtime and connection admission; service injected
+  client.py          # transport-neutral hosted client contract when required
+  connection.py      # transport correlation, byte/frame writer, status reports
   transports/
-    jsonl.py         # first external transport when daemon is accepted
+    jsonl.py         # one possible first external transport
 ```
 
-`client.py` belongs here only when a real hosted client or contract-test driver
-needs it. An in-process client may be useful for service contract tests, but it
+`attachment.py` is part of the AppService semantic boundary even if it is
+physically shipped in `loushang.appserver`; `connection.py` never decides
+logical detach or interaction cleanup. `client.py` belongs here only when a
+real hosted client or contract-test driver needs it. AppServer contains no
+daemon supervisor or adapter to any Hosting package. An in-process client may be useful for service contract tests, but it
 is not the default Harnesstui backend and does not justify migrating the local
 TUI.
 
-The package must not import concrete Product, Harnesstui, Plugin-manager, or
-private Harness capability modules. Product-specific adapters live in the
-Product package or its outer composition root.
+The package must not import AppHost, any Hosting package, concrete Product, Harnesstui,
+Plugin-manager, or private Harness capability modules. Product-specific hosted
+integration lives at the Product Package's outer integration edge and is
+registered with AppHost. AppHost placement and runtime/launcher composition
+are governed by
+[AppHost Top-Level Placement](apphost-top-level-placement.md).
 
 ## Delivery Slices And Gates
 
@@ -548,9 +712,10 @@ Deliverables:
 
 - injected fake Product resolver and Session binding;
 - Session registry, one implicit single-controller connection, protocol
-  operation tracking, interaction forwarding, and ordered output;
+  operation tracking, interaction forwarding, and one bounded logical
+  attachment mailbox;
 - typed `Started` acknowledgement followed by strictly ordered events; and
-- bounded connection queues and deterministic close.
+- deterministic detach/close through an injected connection-status port.
 
 Gate: contract tests prove consumed/queued input cannot create a phantom Turn,
 every Started Turn converges to exactly one terminal event, stale-target
@@ -558,46 +723,62 @@ steer/interrupt cannot affect a newer Turn, independent Session concurrency,
 critical-queue cleanup, and no shadow Approval future. Cross-connection
 idempotency, reconnect, and multi-client takeover remain out of this slice.
 
-### Slice 3 — One Real Product Adapter
+### Slice 3 — One Real Hosted Product Integration
 
 Deliverables:
 
-- one Coding-owned adapter at the composition root;
+- one outer integration module for a named admitted Product at the AppHost
+  binding edge;
 - one hosted conversation flow using public Product/Harness contracts;
 - Product-specific event projection; and
 - parity tests for shared turn, interrupt, queue, and Approval semantics.
 
-Gate: the adapter does not cause AppService to import Coding and does not add an
-AppService dependency to Harness. Default embedded TUI behavior remains
-unchanged.
+Gate: the adapter does not cause AppService or AppHost to import Product
+internals and does not add an AppService dependency to Harness. AppHost first
+reads the versioned Session Identity Envelope, then resolves the admitted
+integration by explicit `product_id` and creates one independent scoped binding
+per Session; default embedded TUI behavior remains unchanged.
 
 ### Slice 4A — First External Connection
 
 Deliverables:
 
-- AppServer lifecycle inside the hosted Platform Host;
+- AppServer server-runtime lifecycle inside the target-process AppHost;
 - one local transport, preferably JSONL stdio or an accepted local IPC
   endpoint;
+- an optional controller-process AppHost launcher that passes only immutable,
+  serializable launch material to Hosting Process Host;
 - deterministic initialization, typed transport errors, and bounded slow-client
   disconnect; and
 - process-level authentication and resource admission appropriate to the
   transport.
 
 Gate: direct service and transport adapters pass the same contract scenarios,
-and a slow client cannot block a Session or another connection.
+a slow client cannot block a Session or another connection, and the AppServer
+transport—not Hosting—owns every reconnectable listener. An inherited peer
+endpoint is allowed only for an attached one-parent/one-child profile. A
+foreground direct invocation uses no Hosting; a launcher starts the complete
+AppHost executable rather than an in-memory AppServer/Product object graph.
 
 ### Slice 4B — Daemon Continuity
 
 Deliverables:
 
-- daemon-owned hosted Session lifecycle;
+- an explicit external-supervisor-versus-library-controller decision;
+- when library control is required, an AppHost daemon-control adapter over a
+  separately accepted Hosting Service Instance Controller;
+- AppService-hosted Session lifecycle inside the daemon process;
 - attach/detach plus atomic snapshot/resume-cursor convergence;
 - cross-connection idempotency admission for externally retried mutations; and
 - explicit restart behavior for live Session and durable Work state.
 
 Gate: a hosted Session survives client disconnect and reconnect without
 claiming embedded Session migration; cursor loss converges only through
-`SnapshotRequired`; and a retried mutation cannot duplicate an admitted effect.
+`SnapshotRequired`; a retried mutation cannot duplicate an admitted effect;
+Hosting owns only exact service-process mechanics; AppHost is its sole daemon
+caller; and AppServer and AppService retain listener and live hosted Session
+authority respectively. When systemd, launchd, Windows SCM, a container, or
+another external supervisor is authoritative, `hosting.service` is absent.
 
 ### Slice 4C — Multiple Clients
 
@@ -631,8 +812,8 @@ Recommended branch sequence:
 docs/appservice-embedded-hosted-boundary
 appserver/protocol-v1
 appserver/service-core
-appserver/coding-hosted-adapter
-appserver/daemon-local-ipc
+apphost/first-product-adapter
+apphost/daemon-control
 ```
 
 Each branch has a disjoint primary ownership budget. Protocol and service-core
@@ -656,8 +837,15 @@ or freezing private capability-planner types into the App Contract.
 | Invariant | Required evidence |
 | --- | --- |
 | Embedded TUI does not depend on AppClient | import-boundary test and unchanged embedded startup smoke |
+| Coding TUI profile is independent of hosted GUI packages | deny imports from hosted packages under `src/loushang/coding/ui/**`; preserve `coding.ui -> harnesstui -> tui`; embedded startup smoke |
+| Harnesstui remains Product-neutral | deny imports from Coding, HarnessGUI, HarnessWebUI, AppServer, and AppService |
 | Harness does not depend on AppService | architecture import test |
-| AppService is Product-neutral | fake-Product contract tests and concrete-Product import denylist |
+| AppService does not depend on Hosting | package import denylist and in-process service contract suite |
+| Hosted UIs consume only the client boundary | HarnessGUI/HarnessWebUI deny imports from Coding internals and AppServer implementation |
+| Hosting does not acquire AppServer authority | listener ownership, authentication, framing, and slow-client tests remain under AppServer transports |
+| AppHost and AppService are Product-neutral | at least two unrelated fake Product Package integrations, explicit product-id resolution, and concrete-Product import denylist |
+| Only serializable values cross launch | launcher contract tests reject live factories/adapters and the target process resolves Product by product ID |
+| Daemon control has one caller | AppHost daemon-profile import gate; AppServer denial of every Hosting package; external-supervisor scenario |
 | AppService does not manage Plugins or Mounts | package import denylist and lifecycle tests at Product binding boundary |
 | Turn admission is truthful | consumed, queued, rejected, and started outcomes cannot be confused |
 | Turn start is asynchronous | response precedes `turn/started` and every later event; exactly one terminal event follows |
@@ -667,6 +855,9 @@ or freezing private capability-planner types into the App Contract.
 | Slow clients cannot exhaust the host | ephemeral coalescing, critical-event disconnect, response-capacity, and per-attachment isolation tests |
 | External retries are idempotent | same key/payload returns the admitted result and a conflicting payload is rejected |
 | Sessions isolate execution | same-Session serialization and cross-Session concurrency tests |
+| Multi-Session aggregates isolate coordination | several aggregates, disjoint Session bindings, dynamic member barrier, partial-close, and no-global-cursor tests |
+| Aggregate control preserves Session authority | complete/partial presenter-lease acquisition, generation fencing, detach cleanup, and cross-aggregate alias rejection |
+| Multi-stream attachments remain bounded and fair | semantic cardinality limits, per-stream pressure, noisy-member isolation, and aggregate resync tests |
 | Protocol remains explicit | initialization, typed error, schema, compatibility/version, and no-generic-command tests |
 
 ## Non-Goals
@@ -674,6 +865,10 @@ or freezing private capability-planner types into the App Contract.
 This plan does not include:
 
 - migrating the default TUI to AppClient;
+- making CodingTUI depend on HarnessGUI, HarnessWebUI, AppServer, or
+  AppService;
+- treating CodingTUI and CodingApp profile Plugins as distinct Products without
+  distinct Product Kernels and identities;
 - making App Contract a universal in-process command bus;
 - moving terminal rendering or Product presentation into AppService;
 - making AppService a Harness Capability or Plugin replacement surface;
@@ -683,7 +878,10 @@ This plan does not include:
   Harness contract change uses a separate accepted Harness-lane task;
 - routing every turn through Work or Method;
 - automatic embedded-to-daemon Session or transcript transfer;
-- durable replay storage in the first AppService slice; or
+- durable replay storage in the first AppService slice;
+- making AppServer supervise its own process or consume any Hosting package;
+- placing AppServer listener, connection, protocol, or hosted Session
+  semantics in Hosting; or
 - WebSocket, P2P, relay, multi-tenant cloud, or mobile guarantees before their
   delivery gates are accepted.
 
@@ -694,6 +892,11 @@ the following:
 
 - Is there a named hosted client or background-Session requirement?
 - Does the default local TUI remain embedded and independent of AppClient?
+- Is CodingTUI independent of HarnessGUI and HarnessWebUI?
+- Are AppHost deployment topology, AppServer connection runtime, AppService
+  coordination, and Hosting OS process mechanisms separated?
+- Are CodingTUI and CodingApp modeled as profile Plugins independently of
+  Product identity?
 - Are Product Session and Work semantics still distinct?
 - Is AppService outside Harness Capability and Plugin composition?
 - Does AppService consume only explicitly injected Product ports?

--- a/docs/internals/architecture/drafts/hosting-top-level-placement.md
+++ b/docs/internals/architecture/drafts/hosting-top-level-placement.md
@@ -1,0 +1,171 @@
+# Proposed Hosting Top-Level Placement And Scope
+
+## Status
+
+- Scope: `hosting`
+- Parent: `loushang`
+- Authority: normative — proposed cross-scope placement decision candidate
+- Design status: proposed
+- Implementation status: not-started
+- Owner: Loushang architecture and Hosting architecture
+- Date: 2026-09-04
+
+## Context
+
+Harness currently contains reusable local process mechanics alongside the
+Policy, Approval, Authorization, Sandbox, Worker, Plugin, Capability, and
+Product-adapter semantics that consume them. PLC9C1–PLC9C4 made the distinction
+visible: process lifetime, inherited peer-endpoint lifetime, Worker protocol lifetime,
+and domain publication lifetime are separate authorities.
+
+Keeping every OS-facing mechanism inside Harness is viable for the current
+single consumer, but it makes the neutral mechanism appear to own Harness
+security/domain meaning and makes future trusted hosts depend on Harness for a
+process/IPC primitive. Moving it to Foundation would instead place stateful OS
+side effects beneath a package intended for small pure foundations.
+
+The decision must separate three questions:
+
+1. What Architecture Scope owns the mechanism?
+2. What Python import package carries it?
+3. When, if ever, should it become a separately distributed project?
+
+## Proposed Decision
+
+### 1. Propose `hosting` as a top-level Architecture Scope
+
+Hosting owns bounded local process, inherited peer endpoint, and joint child-session
+lifetime. It is a sibling consumed initially by Harness:
+
+```text
+Harness -> Hosting -> local OS
+Hosting -/-> Harness
+```
+
+The scope qualifies for promotion because it owns independent lifecycle,
+state, portability, trust-boundary mechanics, failures, required/provided
+ports, several stable components, and a separate conformance surface.
+
+### 2. Use the import package name `loushang.hosting`
+
+`hosting` names the responsibility without claiming that process is the only
+resource or that it owns Product runtime semantics.
+
+The names `loushang.plugin`, `loushang.process`, and `loushang.runtime` are not
+used:
+
+- `plugin` would confuse OS hosting with Plugin declarations, author SDK, and
+  domain publication;
+- `process` is too narrow once inherited peer endpoint and atomic child-session
+  ownership are included;
+- `runtime` collides with several existing runtime owners and suggests a
+  universal kernel.
+
+### 3. Keep one distribution initially
+
+The first implementation, if accepted, adds a top-level import package to the
+existing `loushang` distribution. It does not publish `loushang-hosting` as a
+separate distribution.
+
+Distribution extraction requires a second real independent consumer, a stable
+public specification, dependency/versioning evidence, and a separate packaging
+ARD. A hypothetical future consumer is not sufficient.
+
+### 4. Keep security and domain authority outside Hosting
+
+Hosting performs the final local OS operation but does not decide whether it is
+allowed. Harness retains Policy, Approval, Authorization, Sandbox meaning,
+Worker protocol/supervision, Plugin/Capability admission, and domain
+publication. Hosting receives exact material and a narrow preparation lease;
+its observations never certify those caller-owned meanings.
+
+### 5. Make process plus inherited peer endpoint one atomic optional aggregate
+
+Process hosting remains independently usable. A Child Session Host composes a
+process with an inherited peer endpoint when needed and returns both or neither. Worker
+protocol is a consumer of that byte channel, not a Hosting component.
+
+### 6. Migrate through compatibility facades
+
+Current Harness process contracts and behavior remain in place while neutral
+mechanics move by dependency-safe slices. A native Worker activation is a
+later, separate change; extraction alone cannot remove PLC9C default-dark
+guards.
+
+## Alternatives Considered
+
+### Keep all mechanics inside Harness
+
+Rejected as the target placement because it obscures the mechanism/meaning
+boundary and forces future trusted hosts through Harness. It remains the
+Current implementation until migration evidence exists.
+
+### Move mechanics into Foundation
+
+Rejected. Process creation, handle inheritance, cancellation, and cleanup own
+mutable OS lifecycle and platform failures; they are not a small pure value or
+cross-system utility foundation.
+
+### Put the mechanism in `loushang.plugin`
+
+Rejected. The current package is an author/inspection surface over Plugin
+semantics. Giving it process/IPC ownership would blur declaration, authority,
+hosting, and publication, and could imply that author code receives a launcher.
+
+### Adopt a generic go-plugin-style client as the boundary
+
+Rejected as the scope definition. The useful lesson is one owner for process,
+connection, and cleanup. Stdout address discovery, TCP-first transport,
+protocol handshake, magic-cookie checks, and reattach semantics are not
+Hosting invariants and do not replace Loushang Policy/Sandbox/domain owners.
+
+### Publish a separate distribution immediately
+
+Rejected until independent demand proves that release cadence, dependency
+budget, compatibility surface, and packaging cost are justified.
+
+## Consequences
+
+### Positive
+
+- OS resource truth gains one explicit neutral owner.
+- Harness authority remains explicit while reusing a smaller mechanism.
+- process, endpoint, protocol, and domain lifetimes can fail independently
+  without synthesizing one another's evidence.
+- platform conformance and cancellation cleanup become independently testable.
+- a future trusted host can reuse the substrate without importing Harness.
+
+### Costs and risks
+
+- migration temporarily requires compatibility facades and two documented
+  locations for Current versus Target.
+- an early public surface could freeze platform details, so concrete backends
+  and raw handles must remain private.
+- only Harness currently consumes the mechanics; the proposed scope must earn
+  its boundary through lifecycle/conformance evidence rather than speculative
+  reuse.
+- Hosting cannot enforce Harness policy by itself. Security claims remain valid
+  only at the Harness composition boundary and must have their own gates.
+
+## Acceptance And Supersession
+
+This decision candidate is proposed, not accepted. Acceptance requires
+three-view review
+covering architecture/ownership, security/lifecycle, and migration/test
+feasibility. Once accepted, it updates the Loushang AOD, subsystem map,
+governance scope tree, dependency gates, and gap ledger.
+
+No existing accepted Harness decision is superseded by this proposal. The
+Harness Process Hosting and PLC9C documents continue to govern Current behavior
+until a migration decision explicitly revises them.
+
+## References
+
+- [Hosting Scope](../hosting/README.md)
+- [Requirements](../hosting/requirements.md)
+- [System Context](../hosting/system-context.md)
+- [Component Model](../hosting/component-model.md)
+- [Harness Process Hosting Boundary](../harness/process-hosting-boundary.md)
+- [PLC9C Local Worker Boundary](../harness/plugin/plugin-lifecycle-plc9c0-baseline.md)
+- [HashiCorp go-plugin](https://github.com/hashicorp/go-plugin)
+- [Nomad Plugin Authoring](https://developer.hashicorp.com/nomad/plugins/author)

--- a/docs/internals/architecture/hosting/README.md
+++ b/docs/internals/architecture/hosting/README.md
@@ -1,0 +1,203 @@
+# Loushang Hosting Architecture
+
+## Status
+
+- Scope: `hosting`
+- Parent: `loushang`
+- Authority: normative — proposed top-level Architecture Scope
+- Design status: proposed
+- Implementation status: not-started
+- Owner: Loushang Hosting architecture
+
+## Scope
+
+Hosting is the proposed Product-neutral substrate for owning bounded local
+child execution. It creates and owns local processes, inherited peer byte
+endpoints,
+and the atomic lifetime that joins them into one child session.
+
+Hosting is a scope rather than a synonym for a package directory because it
+owns OS-facing lifecycle, identity, resource, portability, cancellation, and
+failure semantics. The placement is not yet decided; it is proposed in the
+[Hosting Top-Level Placement Draft](../drafts/hosting-top-level-placement.md).
+
+## Current
+
+There is no `src/loushang/hosting` package. Current process mechanics are
+implemented inside Harness, principally by:
+
+- `src/loushang/harness/workspace/process/`;
+- `src/loushang/harness/tools/process_hosting.py`;
+- `src/loushang/harness/sandbox/process.py`;
+- `src/loushang/harness/worker/`.
+
+Those paths remain authoritative Current facts. The existing
+[Harness Process Hosting Boundary](../harness/process-hosting-boundary.md) and
+[PLC9C Local Worker Boundary](../harness/plugin/plugin-lifecycle-plc9c0-baseline.md)
+remain authoritative for the implemented Harness behavior.
+
+## Target
+
+The proposed Target introduces `loushang.hosting` inside the existing
+`loushang` distribution. Harness consumes Hosting through narrow owner
+adapters. Hosting does not import Harness and does not acquire Harness
+authority merely because it performs the final OS operation.
+
+Target dependency direction:
+
+```text
+Product composition
+  -> Harness policy / approval / authorization / sandbox / Worker semantics
+       -> loushang.hosting process and child-session ports
+            -> local operating system
+
+loushang.harness -> loushang.hosting     # proposed
+loushang.hosting -> loushang.harness     # forbidden
+```
+
+Moving the code, publishing a separate distribution, and activating a native
+Worker route are distinct decisions. This proposal makes none of them Current.
+
+## Owns
+
+- shell-free local process creation and one-owner process lifetime;
+- bounded process capacity, stdio mechanics, exit settlement, termination,
+  kill fallback, and process-tree reclamation;
+- inherited native peer-endpoint creation and exact parent/child handle
+  ownership;
+- atomic process-plus-endpoint child-session creation and rollback;
+- platform-backend selection and explicit unsupported-platform failure;
+- neutral observations about resources Hosting actually created and closed.
+
+## Does Not Own
+
+- Product or Plugin selection, trust, admission, installation, or activation;
+- Policy, Approval, Authorization, credentials, Sandbox policy, or claims that
+  a launch is safe;
+- Worker framing, handshake, heartbeat, request correlation, restart, durable
+  attempt journals, or domain generation publication;
+- tool semantics, LSP semantics, Capability graphs, registries, or management
+  read models;
+- remote execution, scheduling, daemon discovery, live process adoption, or
+  surviving-process reattachment;
+- AppServer listener selection, accept loops, transport authentication,
+  connection routing, or slow-client policy;
+- durable Session state, log retention, trace storage, clipboard, images, or
+  Product artifact meaning.
+
+## Direct Actors And Neighboring Scopes
+
+| Actor or scope | Relationship to Hosting |
+| --- | --- |
+| Harness composition root | initial trusted consumer; supplies admitted requests and owns the security/domain interpretation |
+| Harness Sandbox adapter | implements the required preparation/cleanup port; Hosting treats it as mechanism, not proof of safety |
+| Harness Worker supervisor | receives a child-session lease and byte transport; retains protocol and restart ownership |
+| Cross-Product AppHost | its controller-side launcher may request exact hosting of the complete foreground AppHost executable; target-process composition and application meaning remain outside Hosting |
+| Local operating system | creates processes, descriptors/handles, endpoint pairs, exit status, and termination effects |
+| Future trusted host scopes | may consume the same ports only after a real use case and parent-level dependency review |
+| Plugin author SDK / Worker child | never receives a Hosting owner, raw process host, or endpoint factory |
+
+## Direct Child Components
+
+| ID | Component | Owns |
+| --- | --- | --- |
+| `HOST-CMP-CONTRACT` | Hosting Contract Model | immutable requests, leases, observations, stable failure categories, and required-port shapes |
+| `HOST-CMP-PROCESS` | Process Lifetime Host | process capacity, spawn attachment, stdio, exit convergence, termination, and reclamation |
+| `HOST-CMP-ENDPOINT` | Inherited Peer Endpoint Host | parent/child endpoint pairs, handle allowlisting/transfer, byte transport, and endpoint cleanup |
+| `HOST-CMP-SESSION` | Child Session Host | the atomic process-plus-endpoint transaction and joint lifetime |
+| `HOST-CMP-PLATFORM` | Platform Adapter Set | exact POSIX and Windows mechanics and fail-closed platform selection |
+
+The detailed responsibilities and allowed edges are in
+[Component Model](component-model.md). Candidate discovery and refinement are
+retained separately as validation evidence rather than treated as the final
+model.
+
+## Core Invariants
+
+1. A process, PID, descriptor, address, handshake, or log line never becomes
+   Policy, Approval, Sandbox, Plugin, or domain authority.
+2. Each OS resource has exactly one live owner and one idempotent close path.
+3. Child-session publication is atomic: the caller receives both a running
+   process lease and the host endpoint, or receives neither.
+4. Only the child endpoint is inheritable, only for the intended spawn; the
+   parent endpoint and ambient handles are not inherited.
+5. Cancellation never abandons an in-flight spawn, endpoint, process tree, or
+   external preparation cleanup.
+6. PID alone is never durable identity; v1 does not reattach to a surviving
+   process.
+7. Native byte transport carries bytes only. Framing and domain meaning remain
+   above Hosting.
+8. Unsupported or unproven platform behavior fails closed; there is no silent
+   TCP, stdio, filesystem-rendezvous, or uncontained fallback.
+9. Hosting chooses no user-home, workspace, log, or durable-state root. Any
+   unavoidable temporary artifact is caller-rooted, owner-private,
+   lease-bound, and removed during cleanup.
+10. Hosting observations report only Hosting facts and never synthesize
+    security or business evidence owned by a caller.
+
+## Vocabulary And Inherited Principles
+
+- Inherits the [Loushang Architecture Principles](../loushang-architecture-principles.md),
+  especially stable substrate, structural security, explicit authority, and
+  verification/traceability.
+- **Process lease**: the exclusive lifetime capability for one Hosting-owned
+  child process; it is not a durable identity or authority grant.
+- **Inherited peer endpoint**: a host/child local byte channel transferred only
+  to the intended child without service discovery or stdout address
+  negotiation. It is not an AppServer listener.
+- **Child session**: the atomic Hosting-owned aggregate of one process lease
+  and one inherited host peer endpoint. It is not a Harness Session or Worker protocol
+  session.
+- **Preparation lease**: caller-supplied exact spawn material, final validation,
+  and cleanup. Hosting does not reinterpret it as authorization or containment
+  proof.
+
+## Composition, Interaction And Dependency
+
+- [System Context](system-context.md) defines logical and physical boundaries,
+  trust flows, provided ports, and required ports.
+- [Component Discovery](validation/component-discovery.md) records candidate
+  functions, reference inputs, function mapping, and `split / merge / keep`.
+- [Component Model](component-model.md) defines final components, composition,
+  main interactions, and intended/forbidden dependencies.
+- [Hosted Application Support Boundary](key-designs/hosted-application-support-boundary.md)
+  defines how embedded, foreground, sidecar, and daemon profiles relate to
+  Hosting without moving AppService into this scope.
+- [Traceability](traceability.md) maps requirements to design and future gates.
+
+## Architecture Reading Order
+
+1. this scope overview;
+2. [Requirements](requirements.md);
+3. [System Context](system-context.md);
+4. [Component Discovery](validation/component-discovery.md);
+5. [Component Model](component-model.md);
+6. [Hosted Application Support Boundary](key-designs/hosted-application-support-boundary.md);
+7. [Hosting Top-Level Placement Draft](../drafts/hosting-top-level-placement.md);
+8. [Traceability](traceability.md);
+9. current Harness source, tests, and generated package facts.
+
+## Current-To-Target Gaps
+
+- `missing`: the `loushang.hosting` package and every proposed component.
+- `deviated`: if this Target is accepted, reusable process mechanics currently
+  reside under Harness rather than the proposed neutral owner; their Current
+  Harness contracts remain valid until migration.
+- `missing`: POSIX and Windows inherited peer-endpoint feasibility evidence.
+- `missing`: compatibility facades and a behavior-preserving migration plan.
+- `missing`: architecture import gates for the implemented package direction.
+- `missing`: a reviewed Product/native Worker activation route; PLC9C5 remains
+  separate from Hosting extraction.
+- `missing`: daemon/service-instance lifecycle remains a trigger-gated future
+  candidate and is not part of the five-component v1 baseline.
+
+## Change Triggers And Evidence
+
+- Any implementation start must intentionally revise the not-started guard in
+  `tests/architecture/test_hosting_architecture_baseline.py`.
+- Any top-level placement acceptance must update the AOD, subsystem map,
+  governance profile, generated facts, and cross-scope decision catalog.
+- Any public contract requires specification and contract tests before it is
+  called stable.
+- Source migration must retain the Harness behavior and default-dark Worker
+  gates until a separately reviewed activation slice changes them.

--- a/docs/internals/architecture/hosting/component-model.md
+++ b/docs/internals/architecture/hosting/component-model.md
@@ -1,0 +1,194 @@
+# Loushang Hosting Component Model
+
+## Status
+
+- Scope: `hosting`
+- Parent: `loushang`
+- Authority: normative — proposed final component model
+- Design status: proposed
+- Implementation status: not-started
+- Owner: Loushang Hosting architecture
+
+## Component Map
+
+| ID | Component | Owns | Does not own |
+| --- | --- | --- | --- |
+| `HOST-CMP-CONTRACT` | Hosting Contract Model | immutable launch/session requests, lease/observation shapes, stable failure taxonomy, required and provided port contracts | OS calls, policy decisions, protocol payloads, persistence |
+| `HOST-CMP-PROCESS` | Process Lifetime Host | capacity reservation, spawn attachment, bounded streams, exit convergence, terminate/kill/close, process-tree reclamation | executable admission, Sandbox meaning, restart/adoption, domain retirement |
+| `HOST-CMP-ENDPOINT` | Inherited Peer Endpoint Host | parent/child endpoint-pair creation, exact handle inheritance material, raw byte transport, peer closure, endpoint cleanup | listening endpoints, accept loops, framing, handshake, RPC, Worker semantics |
+| `HOST-CMP-SESSION` | Child Session Host | preparation + endpoint + process transaction, atomic publication, reverse rollback, joint close | Worker supervision, domain publication, durable Session state |
+| `HOST-CMP-PLATFORM` | Platform Adapter Set | POSIX/Windows process and endpoint primitives, handle allowlisting, process-tree signals, explicit support detection | caller policy, silent fallback, public plugin extensibility |
+
+## Composition View
+
+```mermaid
+flowchart TD
+    ROOT["Hosting composition root"]
+    CONTRACT["HOST-CMP-CONTRACT"]
+    SESSION["HOST-CMP-SESSION"]
+    PROCESS["HOST-CMP-PROCESS"]
+    ENDPOINT["HOST-CMP-ENDPOINT"]
+    PLATFORM["HOST-CMP-PLATFORM"]
+    PREP["consumer Launch Preparation Port"]
+    DIAG["consumer Observation Sink"]
+
+    ROOT -->|constructs| PLATFORM
+    ROOT -->|constructs with backend| PROCESS
+    ROOT -->|constructs with backend| ENDPOINT
+    ROOT -->|constructs with resource owners| SESSION
+    CONTRACT -->|defines contracts for| PROCESS
+    CONTRACT -->|defines contracts for| ENDPOINT
+    CONTRACT -->|defines contracts for| SESSION
+    SESSION -->|uses| PREP
+    PROCESS -.->|emits optional observations| DIAG
+    ENDPOINT -.->|emits optional observations| DIAG
+    SESSION -.->|emits optional observations| DIAG
+```
+
+This is construction/composition. It does not imply that Contract Model calls
+the resource owners or that an Observation Sink owns them.
+
+## Intended Dependency View
+
+```text
+session -> contract
+session -> process
+session -> endpoint
+process -> contract
+process -> platform contract
+endpoint -> contract
+endpoint -> platform contract
+platform adapters -> contract/private platform contracts
+
+process -/-> session
+endpoint -/-> session
+platform -/-> process/session owners
+hosting -/-> harness or any Product/domain scope
+```
+
+The composition root may import all Hosting components. Leaf platform adapter
+modules do not import the composition root or public package facade. POSIX and
+Windows adapters are mutually independent.
+
+## Component Interfaces
+
+Interface names below describe architectural roles, not frozen Python names.
+Exact fields belong in a later specification.
+
+### Contract Model
+
+Provides:
+
+- materialized process-launch and child-session request values;
+- process lease, host byte endpoint, and child-session lease protocols;
+- neutral lifecycle observation and stable failure categories;
+- Launch Preparation and Observation Sink required-port protocols.
+
+It carries no Plugin ID, Capability graph object, Tool request, Policy decision,
+Approval record, Sandbox status, Worker frame, or domain generation.
+
+### Process Lifetime Host
+
+Provides a bounded Process Hosting Port. It consumes one exact launch request,
+one preparation lease, and an internal platform process backend. It publishes a
+lease only after capacity, preparation, OS creation, attachment, and immediate
+post-spawn checks succeed.
+
+It owns the process until exit settlement and cleanup finish. A consumer may
+observe an exit; it cannot detach or transfer raw process ownership.
+
+Natural exit, explicit close, and cancellation converge on one state machine.
+After any caller-supplied semantic stop period has elapsed outside Hosting, the
+mechanism sequence is terminate owned process tree, bounded grace, kill
+remaining owned tree, reap, close handles, and publish one shared raw exit
+result. Failures are aggregated while later reachable reclamation continues.
+
+### Inherited Peer Endpoint Host
+
+Provides a private endpoint-pair operation to Child Session Host. It returns an
+owned host side plus single-use child inheritance material. Once spawn
+transfer settles, the child material is consumed or closed; it cannot be reused
+for a second process.
+
+The host byte endpoint exposes bounded read/write/close primitives. It has no
+message kind, correlation ID, heartbeat, or serialization choice.
+
+### Child Session Host
+
+Provides the Child Session Hosting Port. It is the only owner allowed to join
+endpoint creation and process start into a returned aggregate lease.
+
+The aggregate lease closes protocol-independent resources in a documented
+order and reports independent process, endpoint, and preparation failures. It
+does not convert close into domain retirement success.
+
+### Platform Adapter Set
+
+Provides private process and endpoint backend ports. Each concrete adapter
+declares an exact capability set; the composition root rejects missing required
+capabilities. The set has no dynamic third-party registration or Plugin
+loading surface.
+
+## Critical Interaction: Successful Child Session
+
+```text
+trusted Harness adapter
+  -> Child Session Host: start(exact request, preparation port)
+  -> preparation port: prepare
+  -> Inherited Peer Endpoint Host: create host/child pair
+  -> preparation lease: verify_current at final safe point
+  -> Process Lifetime Host: reserve and spawn with child-handle allowlist
+  -> Platform Adapter: create process and attach owner
+  -> Inherited Peer Endpoint Host: consume/close parent's child-side copy
+  -> Child Session Host: publish process lease + host endpoint + observations
+  -> Harness Worker Supervisor: perform protocol handshake
+```
+
+The last line is outside Hosting. A successful Hosting return proves neither a
+Worker handshake nor a domain publication.
+
+## Critical Interaction: Failure Or Cancellation
+
+```text
+failure/cancellation at any step
+  -> stop publication
+  -> reclaim attached or still-settling process tree, if any
+  -> close host and child endpoint resources, if any
+  -> close preparation lease
+  -> release process reservation
+  -> settle cleanup observations
+  -> propagate the primary failure/cancellation with cleanup context
+```
+
+Exact reverse order may be specialized by resource acquisition order, but no
+later cleanup is skipped after an earlier cleanup error. Cancellation is
+delayed until owned cleanup settles.
+
+## Error Boundary
+
+Hosting distinguishes at least:
+
+- invalid materialized request;
+- host closed or capacity exhausted;
+- preparation rejected/stale/failed;
+- endpoint unavailable or transfer failed;
+- platform unsupported;
+- spawn failed or child exited before publication;
+- read/write bound exceeded or peer closed;
+- termination/process-tree reclamation failed;
+- aggregate cleanup failed.
+
+Harness maps these neutral categories to Sandbox, Worker, Plugin, Product, and
+user-facing diagnostics. Hosting does not collapse or name those higher-level
+meanings.
+
+## Public Surface Restraint
+
+The initial package should expose only Contract Model values and composition
+entrypoints needed by trusted hosts. Concrete backends, raw spawners, endpoint
+factories, inherited-handle values, reservation objects, and cleanup
+coordinators remain private.
+
+Python import visibility is not a hostile-code security boundary. Structural
+gates prevent accidental cross-scope dependency and author-SDK exposure;
+untrusted Worker code is constrained by the external Harness/Sandbox boundary.

--- a/docs/internals/architecture/hosting/key-designs/hosted-application-support-boundary.md
+++ b/docs/internals/architecture/hosting/key-designs/hosted-application-support-boundary.md
@@ -1,0 +1,173 @@
+# Hosting Support Boundary For Hosted Applications
+
+[Hosting](../README.md) ·
+[System Context](../system-context.md) ·
+[AppHost Top-Level Placement](../../drafts/apphost-top-level-placement.md) ·
+[AppService Hosted Boundary](../../drafts/appservice-embedded-tui-hosted-boundary-plan.md) ·
+[Application Service Refactor](../../drafts/application-service-refactor.md)
+
+## Status
+
+- ID: `HOST-KD-HOSTED-APPLICATION`
+- Kind: key design
+- Scope: `hosting`
+- Parent: `loushang`
+- Authority: normative proposed design
+- Design status: proposed
+- Implementation status: not-started
+- Owner: Loushang Hosting architecture
+
+## Purpose
+
+This design fixes the boundary between OS hosting mechanisms and the future
+hosted application stack. Hosting supplies exact process, inherited-handle,
+shutdown, and machine-resource mechanisms. It does not acquire AppService,
+AppServer, Product, client, or presentation semantics merely because those
+systems can run in another process.
+
+The governing rule is:
+
+```text
+Hosting owns how a local process and its OS resources live.
+All protocol, application, Product, and presentation meaning stays with the
+external consumer graph governed by the parent AppHost decision.
+```
+
+## Deployment Profiles
+
+| Profile | State | Hosting participation | Consumer-side fact at the black-box edge |
+| --- | --- | --- | --- |
+| embedded Coding TUI | Current | bypass Hosting process services | no process/service request reaches Hosting |
+| in-process AppClient | Proposed Target | bypass OS Hosting | no process or endpoint request reaches Hosting |
+| foreground AppHost server over standard I/O | Proposed Target | an outer launcher may use Process Host to launch the complete AppHost executable | caller supplies only admitted serializable launch material |
+| attached one-parent/one-child sidecar | Proposed Hosting Target | Child Session Host and Inherited Peer Endpoint Host own spawn, transfer, closure, and termination | consumer owns framing, handshake, RPC, and semantic recovery |
+| local AppServer listener | Proposed Target | Hosting may launch the complete AppHost process but never receives or owns the listener | caller's readiness probe, not process liveness, reports application readiness |
+| externally supervised service | Deferred delivery profile | systemd, launchd, Windows SCM, container, or another supervisor owns process continuity | foreground AppHost entrypoint is outside Hosting service control |
+| library-managed daemon | Deferred Hosting candidate | AppHost daemon-control profile may use a future Service Instance Controller after separate acceptance | only versioned service-control inputs and readiness observations cross the boundary |
+| remote or cloud AppServer | Deferred delivery profile | no Hosting dependency unless this installation launches a local process | no local request reaches Hosting in the bypass case |
+
+An inherited peer endpoint is intentionally not a reconnectable or
+multi-client listener. Reusing that primitive as an AppServer listener would
+mix one child Session's ownership with independent client admission.
+
+## External Consumer Contract
+
+AppHost placement, sibling dependencies, Product catalog ownership, deployment
+profiles, and application responsibility allocation are governed by the
+parent-level
+[AppHost Top-Level Placement](../../drafts/apphost-top-level-placement.md).
+This Hosting child design specifies only Hosting's black-box relationship with
+trusted external consumers:
+
+| Consumer | Serializable/provided input | Hosting result | Hosting non-ownership |
+| --- | --- | --- | --- |
+| Harness composition | exact materialized launch request plus preparation lease | process lease or atomic child-session lease and neutral observations | Policy, Product/Worker protocol, domain publication |
+| controller-process AppHost launcher | complete executable identity, argv/environment allowlist, profile and state references | process lease, bounded diagnostics, raw exit facts | target-process object graph, AppServer readiness meaning, Session recovery |
+| AppHost daemon-control adapter | versioned serialized service/control specification and injected readiness probe | generic service-instance operation/result when that component is separately accepted | listener, AppService shutdown semantics, Product state |
+| external supervisor | foreground executable and platform-native signal/service contract | outside Hosting library scope | all Hosting service-controller behavior |
+
+Hosting never receives an in-memory Product factory, Runtime handle, hosted
+adapter, AppService, AppServer, or presentation object. A direct foreground
+AppHost executable bypasses Hosting. When a controller launches it, the entire
+AppHost target executable crosses the boundary and performs its own in-process
+composition.
+
+AppServer, AppService, Product packages, and UI packages are not Hosting
+consumers. In particular, every AppServer subpackage is forbidden from
+importing any `loushang.hosting` package. Hosting likewise never imports those
+application scopes. The parent AppHost decision owns the complete sibling
+graph and responsibility table.
+
+## Future Service Instance Controller
+
+`hosting.service` is a candidate namespace, not an accepted package or sixth
+baseline component. It becomes eligible only when a named local service must
+outlive its launching client and requires independent start, stop, restart, or
+reconcile operations.
+
+The candidate Service Instance Controller would own:
+
+- a narrow service-state directory derived once from the admitted
+  `PlatformPaths.state`, never an independently resolved home or cwd;
+- serialized lifecycle operations, instance epoch, and exact creation identity;
+- executable identity and stale process-record fencing;
+- idempotent start, stop, restart, inspect, and reconcile mechanics;
+- idempotent retire/removal of its mechanism-only record after the matching
+  process tree is confirmed reaped, with conservative residue on cleanup
+  failure;
+- readiness scheduling through an injected probe; and
+- a bounded launch-diagnostic handle containing mechanism facts only.
+
+Its bounded stop state machine is mechanism-only and convergent: issue the
+injected application stop request, wait the configured grace interval, then
+terminate, wait, kill the owned process tree, reap, close process handles, and
+publish raw exit/timeout facts. Failure in an earlier step never skips reachable
+reclamation. It cannot translate forced termination into successful
+AppService/Session closure.
+
+It would not own:
+
+- the App protocol or AppService lifecycle;
+- listener choice, connection authentication, framing, or slow-client policy;
+- application aggregate identity, membership, attachment/controller state,
+  multi-stream ordering, cardinality, or recovery;
+- Product Session recovery, transcript truth, durable Work, or reconnect
+  cursor semantics;
+- installation, upgrade, general system-service management, log retention, or
+  remote deployment.
+
+Only a parent-approved AppHost daemon-control profile may consume this
+mechanism. From Hosting's black-box perspective, the external consumer supplies
+a versioned, serialized application readiness/stop adapter; Hosting schedules
+and observes it without interpreting listener, application, Session, or Product
+state. External-supervisor profiles bypass this candidate. The parent
+[AppHost Top-Level Placement](../../drafts/apphost-top-level-placement.md) owns
+the target-process mapping and sibling orchestration. Promotion requires its
+own requirements, system context, component discovery, and acceptance gate
+under the architecture method.
+
+## Hosting Resource Contract
+
+The parent
+[AppHost Top-Level Placement](../../drafts/apphost-top-level-placement.md) and
+accepted
+[Machine-Local Runtime Storage](../../harness/machine-local-runtime-storage.md)
+decision govern cross-scope placement. At Hosting's black-box edge:
+
+- each controller or target process receives one immutable, admitted path
+  value from its own composition root; Hosting never rereads cwd, home, or path
+  environment variables;
+- a child-session lease owns only Hosting-created process, endpoint, bounded
+  stream, and rollback-temporary resources for that lease lifetime;
+- launch diagnostics are bounded mechanism facts routed to the caller-owned
+  observability sink; Hosting owns no log-retention policy;
+- a future service record contains only exact process/control facts in an
+  injected narrow state directory; and
+- Hosting never treats a process lease, run lease, or service record as
+  authority over transcripts, Session Blobs, application snapshots, listener
+  state, clipboard drafts, or Product artifacts.
+
+## Acceptance Invariants
+
+1. A controller-process AppHost launcher supplies only an admitted complete
+   executable and serializable launch material; Hosting never receives an
+   application object graph.
+2. The returned process/child-session lease and raw observations contain no
+   listener, protocol, application, Session-recovery, Product, or UI semantics.
+3. Application readiness and stop behavior enter only through a narrow injected
+   required port; Hosting does not import the consumer that implements it.
+4. A daemon cannot enter the baseline by renaming Child Session Host; it
+   requires the Service Instance Controller trigger and architecture review.
+5. Every Hosting-created process, endpoint, process record, launch diagnostic,
+   and rollback temporary has exactly one lifecycle owner.
+6. Running one or many application coordination aggregates does not change the
+   Hosting request, lease, readiness, service record, or process lifetime; only
+   the opaque AppHost target can interpret that application state.
+
+## Deferred Decisions
+
+- AppHost component/module details governed by the parent-level placement;
+- whether the first AppServer transport is standard I/O, a local listener, or
+  another accepted connection profile;
+- whether `hosting.service` is justified by a real daemon requirement; and
+- concrete public API names, which this proposed design does not reserve.

--- a/docs/internals/architecture/hosting/requirements.md
+++ b/docs/internals/architecture/hosting/requirements.md
@@ -1,0 +1,148 @@
+# Loushang Hosting Requirements
+
+## Status
+
+- Scope: `hosting`
+- Parent: `loushang`
+- Authority: normative — proposed requirements
+- Design status: proposed
+- Implementation status: not-started
+- Owner: Loushang Hosting architecture
+
+## Functional Requirements
+
+### HOST-FR-001 — Materialized local launch
+
+Hosting shall accept one immutable, shell-free, fully materialized local launch
+request and shall not perform Product command resolution, executable discovery,
+or environment inheritance by default.
+
+Acceptance: a request states exact argv, absolute cwd, complete effective
+environment, and explicit stream/endpoint intent; shell strings and implicit
+ambient environment are rejected.
+
+### HOST-FR-002 — One-owner process lifetime
+
+Hosting shall reserve capacity before spawn, attach every created process to
+exactly one lease, converge natural exit and explicit cleanup on one exit
+result, and reclaim the whole owned process tree.
+
+Acceptance: success, spawn failure, early exit, cancellation, terminate, kill,
+and host close have executable leak-free lifecycle cases.
+
+Termination targets the whole owned process tree: request graceful tree
+termination, wait one bounded OS-termination grace interval, kill the remaining
+owned tree, reap it, close every process handle, and settle all waiters on the
+same raw exit result. Cancellation or failure of an earlier step never skips a
+reachable reclamation step.
+
+### HOST-FR-003 — Inherited peer-endpoint ownership
+
+Hosting shall create a local host/child byte-endpoint pair and transfer only the
+child side through an explicit handle allowlist during spawn. This contract is
+not a named/listening endpoint for later clients.
+
+Acceptance: the host side is never inherited, unrelated ambient handles are
+not inherited, each side closes its unused peer, and peer closure is observable
+without interpreting an application protocol.
+
+### HOST-FR-004 — Atomic child session
+
+Hosting shall compose preparation, inherited peer-endpoint creation, process spawn,
+handle transfer, and publication as one child-session transaction.
+
+Acceptance: callers receive one process lease plus one host byte endpoint only
+after both are usable; every failure path closes all created resources and the
+preparation lease before propagating failure or cancellation.
+
+### HOST-FR-005 — Neutral lifecycle observations
+
+Hosting shall expose bounded, redacted observations for Hosting-owned facts:
+backend identity, opaque host/session identity, lifecycle transition, exit
+classification, and cleanup outcome.
+
+Acceptance: observations contain no environment values and make no Policy,
+Approval, containment, Plugin admission, protocol health, or domain publication
+claim.
+
+### HOST-FR-006 — Explicit platform support
+
+Hosting shall select an exact platform backend and reject unavailable or
+unproven required mechanics.
+
+Acceptance: there is no silent substitution of TCP, semantic stdout, filesystem
+address discovery, inherited ambient handles, or a weaker spawn/cleanup path.
+
+## Quality Requirements
+
+### HOST-QR-001 — Cancellation-safe cleanup
+
+Cleanup of acquired resources shall settle before caller cancellation is
+re-raised. Concurrent close calls shall share one idempotent owner operation.
+
+### HOST-QR-002 — Bounded resource use
+
+Hosts shall impose fixed owner-selected bounds on live/pending processes,
+writes, diagnostic tails, endpoint buffers, shutdown time, and cleanup work.
+Application frame and message limits remain outside Hosting.
+
+### HOST-QR-003 — Least ambient authority
+
+No child receives inherited credentials, descriptors/handles, cwd choice,
+environment, endpoint, or network capability merely because Hosting can create
+a process. Exact authority remains caller-owned and explicitly materialized.
+
+### HOST-QR-004 — Product-neutral dependency direction
+
+`loushang.hosting` shall have no import dependency on Harness, Coding, Plugin,
+Agent, AI, Method, Work, Channel, TUI, or Product packages. An initial
+implementation should use the standard library only; adding a Loushang
+dependency requires a reviewed boundary change.
+
+### HOST-QR-005 — Deterministic testability
+
+Process, endpoint, clock/timeout, and failure seams shall support fake-backed
+contract tests. Real-platform conformance tests supplement rather than replace
+deterministic lifecycle tests.
+
+### HOST-QR-006 — Exact portability evidence
+
+POSIX and Windows backends shall each prove their own creation, inheritance,
+closure, cancellation, and process-tree semantics. A platform name or common
+interface alone is not conformance evidence.
+
+## Constraints
+
+- Python 3.11+ and the current asyncio execution model.
+- Initial packaging remains one `loushang` distribution with a new top-level
+  import package only after implementation begins.
+- Current Harness public contracts and default-dark Worker behavior remain
+  compatible during migration.
+- Hosting is an in-process library, not a privileged daemon or security
+  boundary against untrusted co-resident Python code importing it.
+
+## Non-Goals
+
+- general plugin/RPC framework or author SDK;
+- process scheduler, service manager, remote executor, or cluster agent;
+- Worker protocol, restart/adoption journal, Capability publication, or domain
+  adapter;
+- Policy, Approval, Sandbox policy, credential broker, or trust evaluator;
+- durable process registry, PID reattachment, or live adoption in v1;
+- AppServer listener/accept loops, connection authentication, or transport
+  framing;
+- global log, trace, session, cache, image, clipboard, or temporary-root owner;
+- separate `loushang-hosting` distribution before independent demand exists.
+
+## Design Acceptance Criteria
+
+The design can enter implementation planning only when:
+
+1. the top-level placement and dependency direction receive cross-scope review;
+2. every requirement maps to one primary component and a planned gate;
+3. process, endpoint, and joint-session ownership are distinct and complete;
+4. security meanings retained by Harness are explicit;
+5. POSIX and Windows uncertainties have narrow validation plans;
+6. the compatibility and rollback boundary preserves Current Harness behavior;
+7. the implementation-absence guard is replaced by slice-specific gates rather
+   than simply deleted.

--- a/docs/internals/architecture/hosting/system-context.md
+++ b/docs/internals/architecture/hosting/system-context.md
@@ -1,0 +1,184 @@
+# Loushang Hosting System Context
+
+## Status
+
+- Scope: `hosting`
+- Parent: `loushang`
+- Authority: normative — proposed black-box context and boundary
+- Design status: proposed
+- Implementation status: not-started
+- Owner: Loushang Hosting architecture
+
+## Logical Context
+
+```mermaid
+flowchart LR
+    HARNESS["Harness authority and domain owners"]
+    PREP["Harness preparation / Sandbox adapter"]
+    WORKER["Harness Worker protocol and supervisor"]
+    APPHOST["controller-process AppHost launcher"]
+    HOSTING[["Hosting"]]
+    OS[("Local operating system")]
+
+    HARNESS -->|admitted exact launch| HOSTING
+    PREP -->|preparation lease and final validation| HOSTING
+    HOSTING -->|process + endpoint operations| OS
+    HOSTING -->|process lease + host byte endpoint| WORKER
+    APPHOST -->|complete foreground AppHost executable| HOSTING
+```
+
+All edges in this diagram are proposed Target relationships. Hosting sees an
+exact request and a preparation lease. It does not see user intent, Plugin
+selection, policy rules, approval UI, Worker frames, or domain publication.
+
+## Logical Actors And Sources Of Variation
+
+| Actor or variation | Boundary consequence |
+| --- | --- |
+| trusted consumer | requires narrow provided ports; does not make Hosting an admission owner |
+| external preparation owner | requires a one-shot preparation/validation/cleanup port without importing the owner |
+| local OS | requires platform adapters for spawn, handle transfer, waiting, and process-tree cleanup |
+| process exit and caller cancellation | require convergent lifecycle semantics rather than Product callbacks |
+| inherited peer-endpoint kind | requires byte-oriented behavior independent of Worker/RPC framing or AppServer listener semantics |
+| diagnostics consumer | requires a redacted observation sink, not a Logging subsystem dependency |
+| cross-Product AppHost | may request exact foreground/daemon process mechanics without transferring Product routing or AppServer authority |
+
+The Plugin, Worker protocol, LSP protocol, and Capability graph are not sources
+of internal Hosting component variation. They remain meanings above the
+black-box boundary.
+
+## Physical Context
+
+### Current observed placement
+
+```text
+loushang.harness.workspace.process     process records, local spawn, Host
+loushang.harness.tools                 Policy/Approval-bound launcher
+loushang.harness.sandbox               containment preparation and cleanup
+loushang.harness.worker                Worker launch identity/protocol/supervisor
+```
+
+There is no native Worker endpoint binding and no `loushang.hosting` package.
+
+### Proposed target placement
+
+```text
+same installed loushang distribution
+  loushang.hosting
+    contract model
+    process lifetime host
+    inherited peer endpoint host
+    child session host
+    POSIX / Windows platform adapters
+
+  loushang.harness
+    authority + Sandbox preparation adapter
+    Worker protocol / supervisor / journal / domain adapter
+    compatibility facades during migration
+```
+
+Separate distribution packaging, a helper daemon, remote RPC, and persisted
+reattachment metadata are outside the target.
+
+The relationship to embedded, foreground, sidecar, and daemon application
+profiles is defined by the
+[Hosted Application Support Boundary](key-designs/hosted-application-support-boundary.md).
+
+## Provided Ports
+
+### Process Hosting Port
+
+Accepts an exact materialized local process request plus an owner-supplied
+preparation lease and returns a process lease. The lease owns bounded stream
+access, wait, terminate, close, exit observation, and redacted diagnostics.
+
+This port is suitable for trusted consumers such as current LSP hosting. It is
+not directly given to a Plugin or Worker child.
+
+### Child Session Hosting Port
+
+Accepts an exact child-session request plus an owner-supplied preparation lease
+and atomically returns:
+
+- a process lease;
+- the host side of an inherited peer byte endpoint;
+- neutral creation/transfer observations.
+
+The port does not return the child endpoint, raw descriptor/handle factory,
+spawner, platform backend, or a reconnectable listener.
+
+## Required Ports
+
+### Launch Preparation Port
+
+The consumer provides a narrow adapter that materializes any caller-owned
+wrapper/containment setup, supplies a final `verify_current` operation for the
+last safe pre-spawn point, and owns idempotent cleanup.
+
+Hosting guarantees when this port is called and cleaned. Hosting does not
+claim the returned preparation is authorized, approved, or contained. Harness
+may make those claims only from its own Policy/Approval/Sandbox evidence and
+composition gates.
+
+### Lifecycle Observation Sink
+
+An optional consumer-owned sink accepts bounded Hosting observation records.
+The sink cannot influence launch or cleanup. Failure to record an observation
+does not transfer resource ownership or turn logs into lifecycle truth.
+
+### Platform Backend Ports
+
+Process and endpoint components require internal platform ports for exact OS
+operations. Only the Hosting composition root selects them. They are not
+public extension/plugin contracts.
+
+## Authority And Trust Boundary
+
+| Fact or decision | Sole owner |
+| --- | --- |
+| Product/Plugin selected and trusted | Product and Harness Plugin owners |
+| action allowed/approved/authorized | Harness Policy, Approval, Authorization |
+| containment required and active | Harness Sandbox owner |
+| exact OS process created/exited/reclaimed | Hosting Process Lifetime Host |
+| exact inherited endpoint pair created/transferred/closed | Hosting Inherited Peer Endpoint Host |
+| AppServer listener bound/accepted/closed | AppServer transport owner |
+| process plus endpoint published atomically | Hosting Child Session Host |
+| Worker handshaken/healthy/fenced | Harness Worker protocol/supervisor |
+| restart/adoption permitted | Product/Harness Worker lifecycle owner |
+| Capability generation published/retired | exact Harness/domain generation owner |
+
+Hosting observations may be inputs to a higher-level evidence record. They are
+never substitutes for the other rows.
+
+## State, Temporary Files, Logs, And Handles
+
+- Live Hosting state is in-memory and lease-owned. V1 writes no durable process
+  registry or adoption journal.
+- Native IPC should be anonymous/handle-based. No filesystem rendezvous or
+  stdout-reported address is the normal path.
+- AppServer listeners are a different topology. Their admitted path, private
+  directory, authentication, accept loop, and connection lifecycle remain with
+  the AppServer transport owner.
+- If a platform implementation proves an unavoidable temporary artifact, the
+  caller supplies the already-admitted runtime root; Hosting creates an
+  owner-private, unguessable, lease-bound child and removes it on every close
+  path. Hosting never chooses cwd, user home, or workspace as a fallback.
+- Stderr tails and lifecycle observations are bounded. Hosting does not choose
+  log directories or retention policy.
+- Environment values, inherited handle values, and temporary paths are not
+  ordinary status or audit fields.
+- Clipboard and image payloads have no relationship to Hosting and remain with
+  their existing owners.
+
+## Forbidden Boundary Crossings
+
+- `loushang.hosting` importing any Harness or Product module;
+- Hosting accepting Plugin declarations, Tool requests, Capability IDs, or
+  Worker protocol messages;
+- Harness presenting a Hosting observation as containment or publication proof;
+- Plugin/Worker code receiving a raw spawner, process host, endpoint factory,
+  preparation owner, or inherited ambient credential;
+- using PID, an endpoint address, stdout text, or a handshake as durable owner
+  identity;
+- introducing a transport fallback whose security and cleanup properties have
+  not passed the same platform contract.

--- a/docs/internals/architecture/hosting/traceability.md
+++ b/docs/internals/architecture/hosting/traceability.md
@@ -1,0 +1,54 @@
+# Loushang Hosting Traceability
+
+## Status
+
+- Scope: `hosting`
+- Parent: `loushang`
+- Authority: normative — proposed design traceability
+- Design status: proposed
+- Implementation status: not-started
+- Owner: Loushang Hosting architecture
+
+## Requirement Traceability
+
+| Requirement | Primary design owner | Boundary/design evidence | Planned executable evidence |
+| --- | --- | --- | --- |
+| `HOST-FR-001` | `HOST-CMP-CONTRACT` | requirements; Contract Model interface | request validation and no-ambient-environment contract tests |
+| `HOST-FR-002` | `HOST-CMP-PROCESS` | Process Lifetime Host; failure interaction | fake spawn lifecycle matrix and real process-tree conformance |
+| `HOST-FR-003` | `HOST-CMP-ENDPOINT` | Inherited Peer Endpoint Host; physical context | POSIX/Windows handle allowlist, peer closure, and leak tests |
+| `HOST-FR-004` | `HOST-CMP-SESSION` | Child Session Host; rollback interaction | fault injection at every acquisition/publication boundary |
+| `HOST-FR-005` | `HOST-CMP-CONTRACT` | authority table; observation boundary | redaction and no-security-claim schema tests |
+| `HOST-FR-006` | `HOST-CMP-PLATFORM` | explicit platform boundary | exact backend selection and unsupported-platform tests |
+| `HOST-QR-001` | Process, Endpoint, Session | lifecycle invariants | repeated/concurrent close and cancellation tests |
+| `HOST-QR-002` | Process, Endpoint | requirements and component interfaces | capacity/write/tail/buffer/shutdown bound tests |
+| `HOST-QR-003` | Session, Platform Adapter | trust boundary | inherited-handle and effective-environment adversarial tests |
+| `HOST-QR-004` | scope/composition root | [Hosting Top-Level Placement](../drafts/hosting-top-level-placement.md) and dependency view | top-level and internal import architecture gates |
+| `HOST-QR-005` | all components | discovery/refinement | fake-backed component contracts plus real conformance markers |
+| `HOST-QR-006` | `HOST-CMP-PLATFORM` | open validation questions | separate POSIX and Windows conformance manifests |
+
+## Baseline Evidence
+
+At design baseline, the only executable evidence is
+`tests/architecture/test_hosting_architecture_baseline.py`. It proves that:
+
+- the proposed documents and parent catalog entry exist;
+- Current Harness source seams named by discovery still exist;
+- the component set and forbidden dependency direction are explicit; and
+- no `src/loushang/hosting` implementation appears before the baseline guard is
+  deliberately revised.
+
+It does not prove runtime behavior. Each implementation slice must replace the
+relevant `missing` row with contract and platform evidence.
+
+## Implementation Readiness Delta
+
+| Gap | Classification | Closure condition |
+| --- | --- | --- |
+| top-level placement not accepted | `missing` | three-view review and accepted ARD/AOD updates |
+| exact public types unspecified | `missing` | versioned contract specification before public export |
+| POSIX endpoint choice unproven | `missing` | narrow real-host validation with handle-leak evidence |
+| Windows endpoint/spawn path unproven | `missing` | narrow Windows validation with strict handle-list evidence |
+| Harness mechanics not migrated | `missing` | compatibility slices preserve current Process Host contracts |
+| Product/native Worker path absent | `missing` | separate PLC9C5 activation review and gates |
+
+The design remains not-started until these gaps enter explicit delivery slices.

--- a/docs/internals/architecture/hosting/validation/component-discovery.md
+++ b/docs/internals/architecture/hosting/validation/component-discovery.md
@@ -1,0 +1,139 @@
+# Hosting Component Discovery And Refinement
+
+## Status
+
+- Scope: `hosting`
+- Parent: `loushang`
+- Authority: descriptive — design validation input
+- Design status: not-applicable
+- Implementation status: not-applicable
+- Owner: Loushang Hosting architecture
+
+## Purpose
+
+This record applies the Loushang component-identification method before fixing
+the final Hosting component model. It is validation evidence, not a second
+normative component inventory.
+
+## Discovery Inputs
+
+### Requirements and scenarios
+
+- one-shot trusted local process hosting;
+- long-lived local Worker with a non-stdio native byte channel;
+- cancellation during preparation or spawn;
+- child exit before publication;
+- endpoint-transfer failure after process creation;
+- host shutdown with several published and pending children;
+- unsupported or partially capable POSIX/Windows host.
+
+### Current facts
+
+- `harness.workspace.process` owns materialized requests, local spawn, process
+  reservations, bounded streams, exit convergence, and cleanup.
+- `harness.tools.process_hosting` binds Policy/Approval/Authorization and the
+  caller-owned preparation path.
+- `harness.sandbox.process` owns current containment preparation and cleanup.
+- `harness.worker` owns Worker launch identity, framing, supervisor, journal,
+  and read-only domain adaptation.
+
+These paths reveal reusable mechanics and existing authority seams. Their
+current module boundaries are inputs, not the target component answer.
+
+### Reference systems
+
+- [HashiCorp go-plugin](https://github.com/hashicorp/go-plugin) demonstrates
+  the value of one client lifetime owning a child process, connection, and
+  cleanup. Hosting adopts that lifetime lesson, not its stdout address
+  discovery, TCP-first transport, magic-cookie security posture, or immediate
+  reattach surface.
+- [Nomad plugin authoring](https://developer.hashicorp.com/nomad/plugins/author)
+  demonstrates separation between a generic plugin mechanism and domain plugin
+  contracts. Hosting goes further by leaving Plugin and Worker protocol meaning
+  entirely outside the OS substrate.
+
+Reference structure is evidence and counterexample material, not a template.
+
+## Candidate Function Inventory
+
+| ID | Candidate function | Important non-owner |
+| --- | --- | --- |
+| `HF-01` | validate immutable shell-free launch shape | Product command resolver |
+| `HF-02` | reserve and release bounded process capacity | Product scheduler |
+| `HF-03` | create/attach a child without cancellation leaks | Worker supervisor |
+| `HF-04` | expose bounded stdin/stdout/stderr mechanics | application protocol |
+| `HF-05` | converge wait, terminate, kill, close, and natural exit | domain retirement owner |
+| `HF-06` | reclaim an owned process tree | Sandbox policy |
+| `HF-07` | create a native host/child endpoint pair | Worker frame codec |
+| `HF-08` | allowlist and transfer only the child endpoint | Plugin declaration |
+| `HF-09` | close unused peer sides and detect peer closure | heartbeat policy |
+| `HF-10` | atomically publish process plus host endpoint | Capability publisher |
+| `HF-11` | roll back preparation, endpoint, and process in reverse order | durable restart journal |
+| `HF-12` | absorb POSIX/Windows OS variation | generic fallback selector |
+| `HF-13` | emit bounded neutral lifecycle observations | log store/retention owner |
+| `HF-14` | provide deterministic fake seams and platform conformance | Product test policy |
+
+## Candidate Components
+
+| Candidate | Classification | Reason to consider |
+| --- | --- | --- |
+| Hosting Contract Model | logical supporting component | stable requests, leases, errors, observations, and required ports survive implementation changes |
+| Process Lifetime Host | logical technical component | stable process resource and lifecycle center already spans several use cases |
+| Inherited Peer Endpoint Host | logical technical component | parent/child endpoint ownership and inheritance are independent of application framing and listening endpoints |
+| Child Session Host | logical functional component | owns a new atomic invariant that neither process nor endpoint owner can own alone |
+| Platform Adapter Set | boundary logical component | isolates POSIX/Windows process and handle variation |
+| Diagnostic Store | candidate responsibility cluster | rejected because retention/root policy belongs to consumers |
+| Preparation/Sandbox Host | candidate responsibility cluster | remains a required consumer port because security meaning is Harness-owned |
+| Reattach Registry | candidate responsibility cluster | deferred; v1 explicitly rejects adoption and durable PID identity |
+| Service Instance Controller | candidate responsibility cluster | deferred until an accepted daemon requires detached start/stop/reconcile and durable machine-state ownership |
+| Worker Protocol Host | candidate responsibility cluster | rejected from Hosting because bytes are not domain protocol |
+| Generic Plugin Client | candidate responsibility cluster | rejected because Plugin topology/handshake/publication are not OS hosting |
+
+## Function-To-Component Mapping
+
+| Function | Primary owner | Collaborators | Explicit non-owners |
+| --- | --- | --- | --- |
+| `HF-01`, `HF-13` | Contract Model | Process/Session hosts | Product resolver, log store |
+| `HF-02`–`HF-06` | Process Lifetime Host | Contract Model, Platform Adapter | Worker supervisor, Sandbox policy, domain retirement |
+| `HF-07`–`HF-09` | Inherited Peer Endpoint Host | Contract Model, Platform Adapter | listener/accept loop, frame codec, heartbeat owner |
+| `HF-10`, `HF-11` | Child Session Host | Process Host, Endpoint Host, preparation port | Capability publisher, restart journal |
+| `HF-12` | Platform Adapter Set | Process and Endpoint hosts | Product/platform policy |
+| `HF-14` | each component's conformance tests | fake and real platform fixtures | production diagnostics |
+
+The mapping is mostly one-to-many around Contract Model and Platform Adapter,
+and many-to-one around Child Session Host. No many-to-many cluster requires a
+generic manager.
+
+## Refinement: Split / Merge / Keep
+
+| Candidate | Decision | Rationale |
+| --- | --- | --- |
+| Contract Model | keep | one stable vocabulary and port owner; analogous to a fact model, not a type dump |
+| Process Lifetime Host | keep | strong resource/lifecycle center; useful without native IPC |
+| Inherited Peer Endpoint Host | keep | independent parent/child OS resource with distinct inheritance and closure invariants; its narrower name prevents listener ownership drift |
+| Child Session Host | keep | atomic cross-resource transaction is a stable responsibility, not a convenience facade |
+| Platform Adapter Set | keep as component group | POSIX and Windows adapters differ physically but implement one boundary responsibility |
+| Diagnostics | merge into owning components | records are component facts; storage/retention is external |
+| Preparation/Sandbox | keep outside via required port | moving it would transfer security authority into Hosting |
+| Reattach/adoption | defer | requires creation identity, durable CAS ownership, containment continuity, and a new threat model |
+| Service Instance Controller | defer | daemon lifecycle has a different durable owner and trigger from an attached Child Session |
+| Worker protocol/plugin client | exclude | violates mechanism-versus-meaning boundary |
+
+The final peer set contains five objects, within the method's `3-7` review
+range, and uses one consistent responsibility view: contract, two resource
+owners, their transaction owner, and the OS boundary adapter group.
+
+## Open Validation Questions
+
+1. Which POSIX endpoint primitive provides the smallest portable full-duplex
+   contract while preserving exact descriptor inheritance?
+2. Which Windows primitive and Python spawn path can prove a strict inherited
+   handle allowlist and bidirectional peer closure?
+3. Can current sealed executable and cwd identity mechanics move without
+   carrying Harness authorization meaning into Hosting?
+4. Which cleanup ordering preserves the current Process Host cancellation
+   guarantees when endpoint transfer fails after OS creation?
+
+These are narrow runtime-feasibility questions for later spikes. They do not
+block defining ownership, and their answers must not widen Hosting into Worker
+or Sandbox semantics.

--- a/tests/architecture/test_architecture_documentation.py
+++ b/tests/architecture/test_architecture_documentation.py
@@ -32,6 +32,19 @@ INITIAL_GOVERNED_DOCUMENTS = (
     ARCHITECTURE_ROOT / "coding/arch/system-context.md",
     ARCHITECTURE_ROOT / "coding/arch/component-model.md",
     ARCHITECTURE_ROOT / "coding/arch/traceability.md",
+    ARCHITECTURE_ROOT / "hosting/README.md",
+    ARCHITECTURE_ROOT / "hosting/requirements.md",
+    ARCHITECTURE_ROOT / "hosting/system-context.md",
+    ARCHITECTURE_ROOT / "hosting/component-model.md",
+    ARCHITECTURE_ROOT / "hosting/traceability.md",
+    ARCHITECTURE_ROOT
+    / "hosting/key-designs/hosted-application-support-boundary.md",
+    ARCHITECTURE_ROOT / "drafts/apphost-top-level-placement.md",
+    ARCHITECTURE_ROOT / "drafts/application-service-refactor.md",
+    ARCHITECTURE_ROOT
+    / "drafts/appservice-embedded-tui-hosted-boundary-plan.md",
+    ARCHITECTURE_ROOT / "drafts/hosting-top-level-placement.md",
+    ARCHITECTURE_ROOT / "hosting/validation/component-discovery.md",
 )
 MARKDOWN_LINK = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
 STATUS_VALUES = {

--- a/tests/architecture/test_hosting_architecture_baseline.py
+++ b/tests/architecture/test_hosting_architecture_baseline.py
@@ -1,0 +1,664 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+ARCHITECTURE_ROOT = REPOSITORY_ROOT / "docs/internals/architecture"
+HOSTING_ROOT = ARCHITECTURE_ROOT / "hosting"
+HOSTED_APPLICATION_BOUNDARY = (
+    HOSTING_ROOT / "key-designs/hosted-application-support-boundary.md"
+)
+APPHOST_PLACEMENT = ARCHITECTURE_ROOT / "drafts/apphost-top-level-placement.md"
+APPSERVICE_BOUNDARY = (
+    ARCHITECTURE_ROOT / "drafts/appservice-embedded-tui-hosted-boundary-plan.md"
+)
+APPSERVICE_REFACTOR = ARCHITECTURE_ROOT / "drafts/application-service-refactor.md"
+
+HOSTING_DOCUMENTS = (
+    HOSTING_ROOT / "README.md",
+    HOSTING_ROOT / "requirements.md",
+    HOSTING_ROOT / "system-context.md",
+    HOSTING_ROOT / "component-model.md",
+    HOSTING_ROOT / "traceability.md",
+    HOSTING_ROOT / "validation/component-discovery.md",
+    HOSTED_APPLICATION_BOUNDARY,
+    ARCHITECTURE_ROOT / "drafts/hosting-top-level-placement.md",
+)
+
+CURRENT_HARNESS_SEAMS = (
+    "src/loushang/harness/workspace/process/types.py",
+    "src/loushang/harness/workspace/process/local.py",
+    "src/loushang/harness/workspace/process/host.py",
+    "src/loushang/harness/tools/process_hosting.py",
+    "src/loushang/harness/sandbox/process.py",
+    "src/loushang/harness/worker/contracts.py",
+    "src/loushang/harness/worker/protocol.py",
+    "src/loushang/harness/worker/supervisor.py",
+    "src/loushang/harness/worker/journal.py",
+)
+
+COMPONENT_IDS = (
+    "HOST-CMP-CONTRACT",
+    "HOST-CMP-PROCESS",
+    "HOST-CMP-ENDPOINT",
+    "HOST-CMP-SESSION",
+    "HOST-CMP-PLATFORM",
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _section(text: str, heading: str) -> str:
+    marker = f"## {heading}\n"
+    assert marker in text
+    body = text.split(marker, maxsplit=1)[1]
+    return body.split("\n## ", maxsplit=1)[0]
+
+
+def _status_fields(path: Path) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    started = False
+    for line in _section(_read(path), "Status").splitlines():
+        if not started:
+            if not line.startswith("- "):
+                continue
+            started = True
+        elif not line:
+            break
+        if not line.startswith("- "):
+            continue
+        assert ":" in line, f"malformed Status field in {path}: {line!r}"
+        name, value = line[2:].split(":", maxsplit=1)
+        assert name not in fields, f"duplicate Status field {name!r} in {path}"
+        normalized = value.strip()
+        if normalized.startswith("`") and normalized.endswith("`"):
+            normalized = normalized[1:-1]
+        fields[name] = normalized
+    return fields
+
+
+def _table_rows(text: str, headers: tuple[str, ...]) -> tuple[tuple[str, ...], ...]:
+    lines = text.splitlines()
+    expected_header = "| " + " | ".join(headers) + " |"
+    start = lines.index(expected_header)
+    separator = tuple(cell.strip() for cell in lines[start + 1].strip("|").split("|"))
+    assert len(separator) == len(headers)
+    assert all(re.fullmatch(r":?-{3,}:?", cell) for cell in separator)
+
+    rows: list[tuple[str, ...]] = []
+    for line in lines[start + 2 :]:
+        if not line.startswith("|"):
+            break
+        cells = tuple(cell.strip() for cell in line.strip("|").split("|"))
+        assert len(cells) == len(headers), line
+        rows.append(cells)
+    return tuple(rows)
+
+
+def _assert_mapping_contains(actual: dict[str, str], expected: dict[str, str]) -> None:
+    for key, value in expected.items():
+        assert actual.get(key) == value
+
+
+def _numbered_steps(text: str, heading: str) -> tuple[str, ...]:
+    section = _section(text, heading)
+    matches = tuple(re.finditer(r"(?ms)^(\d+)\. (.*?)(?=^\d+\. |\n\n)", section))
+    assert tuple(int(match.group(1)) for match in matches) == tuple(
+        range(1, len(matches) + 1)
+    )
+    return tuple(" ".join(match.group(2).split()) for match in matches)
+
+
+def test_hosting_design_package_is_complete_and_proposed() -> None:
+    for path in HOSTING_DOCUMENTS:
+        assert path.is_file(), path.relative_to(REPOSITORY_ROOT)
+
+    expected_authority = {
+        HOSTING_ROOT / "README.md": "normative — proposed top-level Architecture Scope",
+        HOSTING_ROOT / "requirements.md": "normative — proposed requirements",
+        HOSTING_ROOT / "system-context.md": (
+            "normative — proposed black-box context and boundary"
+        ),
+        HOSTING_ROOT / "component-model.md": (
+            "normative — proposed final component model"
+        ),
+        HOSTING_ROOT / "traceability.md": ("normative — proposed design traceability"),
+        HOSTED_APPLICATION_BOUNDARY: "normative proposed design",
+        ARCHITECTURE_ROOT / "drafts/hosting-top-level-placement.md": (
+            "normative — proposed cross-scope placement decision candidate"
+        ),
+    }
+    for path, authority in expected_authority.items():
+        _assert_mapping_contains(
+            _status_fields(path),
+            {
+                "Scope": "hosting",
+                "Parent": "loushang",
+                "Authority": authority,
+                "Design status": "proposed",
+                "Implementation status": "not-started",
+            },
+        )
+
+    _assert_mapping_contains(
+        _status_fields(HOSTING_ROOT / "validation/component-discovery.md"),
+        {
+            "Scope": "hosting",
+            "Parent": "loushang",
+            "Authority": "descriptive — design validation input",
+            "Design status": "not-applicable",
+            "Implementation status": "not-applicable",
+        },
+    )
+    _assert_mapping_contains(
+        _status_fields(APPHOST_PLACEMENT),
+        {
+            "ID": "APPHOST-DP-TOP-LEVEL",
+            "Scope": "Loushang",
+            "Parent": "none",
+            "Authority": "normative target proposal",
+            "Design status": "proposed",
+            "Implementation status": "not-started",
+        },
+    )
+    _assert_mapping_contains(
+        _status_fields(APPSERVICE_BOUNDARY),
+        {
+            "ID": "APP-DP-HOSTED-BOUNDARY",
+            "Scope": "AppService / application host",
+            "Parent": "Loushang",
+            "Authority": "normative target proposal",
+            "Design status": "proposed",
+            "Implementation status": "not-started",
+        },
+    )
+    _assert_mapping_contains(
+        _status_fields(APPSERVICE_REFACTOR),
+        {
+            "ID": "APP-DP-SERVICE-REFACTOR",
+            "Scope": "AppServer / AppService",
+            "Parent": "Loushang",
+            "Authority": "normative target proposal",
+            "Design status": "proposed",
+            "Implementation status": "partial",
+        },
+    )
+
+    overview = _read(HOSTING_ROOT / "README.md")
+    assert "There is no `src/loushang/hosting` package." in _section(
+        overview, "Current"
+    )
+    assert "The proposed Target introduces `loushang.hosting`" in _section(
+        overview, "Target"
+    )
+    assert "## Current-To-Target Gaps" in overview
+
+    apphost = _read(APPHOST_PLACEMENT)
+    for heading in ("Current", "Proposed target", "Explicit delta"):
+        assert f"### {heading}" in _section(apphost, "Current, Target, And Delta")
+
+
+def test_hosting_parent_catalog_labels_the_scope_as_proposed() -> None:
+    catalog = _read(ARCHITECTURE_ROOT / "README.md")
+
+    proposed = _section(catalog, "Architecture Scope Tree").split(
+        "Proposed top-level placements are under design:\n", maxsplit=1
+    )[1]
+    assert (
+        "- [Hosting](hosting/README.md), a Product-neutral local process, "
+        "inherited\n  peer IPC, and joint child-session lifetime substrate."
+    ) in proposed
+    assert (
+        "- [AppHost Top-Level Placement]"
+        "(drafts/apphost-top-level-placement.md), the\n"
+        "  proposed physical owner of the existing cross-Product Platform "
+        "Host role."
+    ) in proposed
+    assert proposed.index("[Hosting]") < proposed.index("[AppHost Top-Level Placement]")
+
+
+def test_hosting_component_set_and_dependency_direction_are_explicit() -> None:
+    overview = _read(HOSTING_ROOT / "README.md")
+    component_model = _read(HOSTING_ROOT / "component-model.md")
+    boundary = _read(HOSTING_ROOT / "system-context.md")
+
+    component_rows = _table_rows(
+        _section(component_model, "Component Map"),
+        ("ID", "Component", "Owns", "Does not own"),
+    )
+    assert {row[0].strip("`"): row[1] for row in component_rows} == {
+        "HOST-CMP-CONTRACT": "Hosting Contract Model",
+        "HOST-CMP-PROCESS": "Process Lifetime Host",
+        "HOST-CMP-ENDPOINT": "Inherited Peer Endpoint Host",
+        "HOST-CMP-SESSION": "Child Session Host",
+        "HOST-CMP-PLATFORM": "Platform Adapter Set",
+    }
+    assert set(COMPONENT_IDS) == {row[0].strip("`") for row in component_rows}
+    for component_id in COMPONENT_IDS:
+        assert component_id in overview
+
+    assert "loushang.harness -> loushang.hosting     # proposed" in overview
+    assert "loushang.hosting -> loushang.harness     # forbidden" in overview
+    authority_rows = dict(
+        _table_rows(
+            _section(boundary, "Authority And Trust Boundary"),
+            ("Fact or decision", "Sole owner"),
+        )
+    )
+    assert authority_rows["action allowed/approved/authorized"] == (
+        "Harness Policy, Approval, Authorization"
+    )
+    assert authority_rows["containment required and active"] == (
+        "Harness Sandbox owner"
+    )
+    assert authority_rows["exact OS process created/exited/reclaimed"] == (
+        "Hosting Process Lifetime Host"
+    )
+    assert (
+        "### Child Session Hosting Port" in boundary
+        and "| Worker handshaken/healthy/fenced | Harness Worker protocol/supervisor |"
+        in boundary
+    )
+
+
+def test_hosted_application_responsibilities_and_dependencies_are_separated() -> None:
+    hosting_boundary = _read(HOSTED_APPLICATION_BOUNDARY)
+    apphost_placement = _read(APPHOST_PLACEMENT)
+    appservice_boundary = _read(APPSERVICE_BOUNDARY)
+    refactor = _read(APPSERVICE_REFACTOR)
+
+    assert (
+        "This Hosting child design specifies only Hosting's black-box "
+        "relationship" in hosting_boundary
+    )
+    assert (
+        "AppServer, AppService, Product packages, and UI packages are not Hosting\nconsumers."
+        in hosting_boundary
+    )
+    assert "AppServer -X-> Hosting" in apphost_placement
+    assert "Product identity and delivery profile are orthogonal" in apphost_placement
+    assert "### Multi-Aggregate Hosted Cardinality" in apphost_placement
+    assert (
+        "Aggregate count never creates another\nAppHost, AppServer listener, "
+        "application `RunLease`, or process-level\n`RuntimeResourceOwner`"
+        in apphost_placement
+    )
+    assert (
+        "AppHost does not import an aggregate type, index its selector names"
+        in apphost_placement
+    )
+    assert (
+        "`loushang.harnesswork` is the canonical shared durable\n"
+        "Work subsystem" in apphost_placement
+    )
+    assert (
+        "`loushang.work` is only its forwarding\ncompatibility facade"
+        in apphost_placement
+    )
+    assert "**Session Identity Envelope**" in apphost_placement
+    assert "ProductIdentityRequired" in apphost_placement
+    assert "external supervisor\n  -> complete foreground AppHost executable" in (
+        apphost_placement
+    )
+    assert "  -/-> Hosting library" in apphost_placement
+    assert "controller process\n  AppHost launcher" in apphost_placement
+    assert "immutable executable + argv/env/profile/state references" in (
+        apphost_placement
+    )
+    assert "target process\n  AppHost runtime/bootstrap" in apphost_placement
+    assert "exposes one process-level\nreadiness and stop boundary" in (
+        apphost_placement
+    )
+    shutdown_steps = _numbered_steps(apphost_placement, "Graceful Shutdown Protocol")
+    assert shutdown_steps == (
+        "mark the process `stopping`; reject new bootstrap, Product resolution, "
+        "and profile activation;",
+        "tell AppServer to stop accepting connections and reject new request "
+        "admission;",
+        "tell AppServer to stop reading new frames and freeze/report connection "
+        "state; it does not drain writers yet and does not decide logical detach;",
+        "tell AppService to reject new Sessions, perform the sole logical detach, "
+        "settle or interrupt admitted work by explicit Product policy, clean up "
+        "interactions, close logical attachments, and request release through each "
+        "Session-scoped Product binding's sole idempotent close port;",
+        "ensure AppHost releases all remaining Product Runtime handles and "
+        "admitted presentation-profile leases;",
+        "drain-or-abort AppServer writers within the remaining deadline, then close "
+        "transports, listener, and connection records;",
+        "close the process's one `RuntimeResourceOwner`; that owner alone revokes "
+        "projections, drains admitted operations, and closes its ArtifactStore and "
+        "`RunLease` as one transaction; and",
+        "publish `stopped` readiness and let the foreground process exit.",
+    )
+    assert "A phase failure is recorded but\ndoes not skip later cleanup phases" in (
+        apphost_placement
+    )
+    assert "One monotonic deadline bounds\nthe sequence" in apphost_placement
+    assert "kill the owned process tree" in apphost_placement
+    assert "A direct foreground AppHost force-closes its remaining local\nhandles" in (
+        apphost_placement
+    )
+    assert "$LOUSHANG_HOME/data/sessions` authority" in apphost_placement
+    assert "$LOUSHANG_HOME/data/session-assets/<session-id>`" in apphost_placement
+    assert (
+        "Each process resolves or receives exactly one admitted, immutable\n"
+        "`PlatformPaths` at its outer composition root" in apphost_placement
+    )
+    assert (
+        "only normalized, serialized, policy-admitted overrides,\n"
+        "profile identifiers, and state references cross between them"
+        in apphost_placement
+    )
+    assert "retains\n  at most one `RuntimeResourceOwner`" in apphost_placement
+    assert "does not imply another application `RunLease`" in apphost_placement
+    assert (
+        "compatibility discovery/import inputs, never peer writable authorities"
+        in apphost_placement
+    )
+    for owner_row in (
+        "| unsubmitted image/prompt draft | active client/input-router draft owner |",
+        "| submitted image bytes | Harness Session Blob authority |",
+        "| logs, traces, diagnostics | producing observability service |",
+        "| AppServer listener and transport scratch | AppServer transport |",
+        "| service-instance record | future Hosting Service Instance Controller |",
+    ):
+        assert owner_row in apphost_placement
+
+    responsibility_rows = {
+        row[0]: (row[1], row[2])
+        for row in _table_rows(
+            _section(apphost_placement, "Cross-Scope Dependency And Responsibility"),
+            ("Scope", "Owns", "Explicitly does not own"),
+        )
+    }
+    assert set(responsibility_rows) == {
+        "AppHost",
+        "AppServer",
+        "AppService",
+        "Product outer integration",
+        "Hosting",
+        "presentation profile",
+    }
+    assert "AppService construction" in responsibility_rows["AppServer"][1]
+    assert "logical attachment/mailbox/detach" in responsibility_rows["AppService"][0]
+
+    resource_rows = {
+        row[0]: (row[1], row[2])
+        for row in _table_rows(
+            _section(apphost_placement, "Machine-Resource Composition"),
+            ("Resource concern", "Lifecycle owner", "Placement/composition rule"),
+        )
+    }
+    assert resource_rows == {
+        "platform roots and run-lease primitive": (
+            "Foundation",
+            "pure `PlatformPaths` plus Product-neutral `RuntimeScope`/`RunLease`; "
+            "no Product or storage semantics",
+        ),
+        "shared configuration and Resource discovery": (
+            "Harness configuration/resources",
+            "project `.loushang` is reviewable declaration; private generated state "
+            "is user-global; Product admits policy and content",
+        ),
+        "application-run artifacts and machine inventory": (
+            "Harness `RuntimeResourceOwner`",
+            "one effectful owner per application process; it alone owns the "
+            "ArtifactStore/RunLease transaction and revocable projections",
+        ),
+        "durable Session transcripts": (
+            "Harness conversation/transcript owner selected by Product",
+            "canonical writable default is `$LOUSHANG_HOME/data/sessions`; "
+            "compatibility roots are discovery/import inputs only",
+        ),
+        "durable Session Blob objects": (
+            "Harness Session Blob authority",
+            "canonical writable layout is "
+            "`$LOUSHANG_HOME/data/session-assets/<session-id>` with immutable "
+            "objects and manifest",
+        ),
+        "clipboard/image capture or upload": (
+            "active presentation-client adapter",
+            "Native TUI is Current; GUI/WebUI own browser/OS selection without "
+            "transferring storage to AppHost/AppServer/Hosting",
+        ),
+        "unsubmitted image/prompt draft": (
+            "active client/input-router draft owner",
+            "bounded private client/run-local draft, removed on submit/cancel/disposal",
+        ),
+        "submitted image bytes": (
+            "Harness Session Blob authority",
+            "validate and promote before a pathless durable reference enters the "
+            "transcript",
+        ),
+        "logs, traces, diagnostics": (
+            "producing observability service",
+            "bounded-retention state subdirectory; not Session content and not "
+            "Hosting policy",
+        ),
+        "AppServer listener and transport scratch": (
+            "AppServer transport",
+            "listener under runtime root, atomic scratch under temporary root, one "
+            "transport cleanup owner",
+        ),
+        "AppService live registry and snapshots": (
+            "AppService",
+            "live application state; durable recovery remains an explicit "
+            "Product/store operation",
+        ),
+        "service-instance record": (
+            "future Hosting Service Instance Controller",
+            "narrow injected state subdirectory containing mechanism facts only; "
+            "retire removes it only after the exact process tree is confirmed "
+            "reaped, and cleanup failure leaves conservative residue",
+        ),
+    }
+    assert "AppService -X-> Hosting" in appservice_boundary
+    assert "Coding UI -X-> HarnessGUI / HarnessWebUI" in appservice_boundary
+    assert "Harnesstui -X-> Coding" in appservice_boundary
+    assert "appserver.service -X-> Hosting" in refactor
+    assert "### Multi-Session Coordination Aggregates" in refactor
+    assert "There is no global cross-Session revision" in refactor
+    assert "per-stream sub-budgets" in refactor
+    assert "### Multi-Session Coordination Aggregate" in appservice_boundary
+    assert "There is no global cross-Session instant or cursor" in (
+        appservice_boundary
+    )
+    assert "one connection to at most one active aggregate" in appservice_boundary
+    assert "attempts every distinct Session binding release exactly once" in (
+        appservice_boundary
+    )
+    assert (
+        "application aggregate identity, membership, attachment/controller state"
+        in hosting_boundary
+    )
+    assert (
+        "Running one or many application coordination aggregates does not change"
+        in hosting_boundary
+    )
+    assert (
+        "AppServer and all its subpackages must not import any Hosting package"
+        in refactor
+    )
+    assert (
+        "AppHost is the\ncomposition root: it constructs AppService, injects it "
+        "into AppServer" in appservice_boundary
+    )
+
+
+def test_rejected_boundary_phrases_do_not_reappear() -> None:
+    documents = tuple(
+        _read(path)
+        for path in (
+            HOSTED_APPLICATION_BOUNDARY,
+            APPHOST_PLACEMENT,
+            APPSERVICE_BOUNDARY,
+            APPSERVICE_REFACTOR,
+        )
+    )
+
+    rejected_claims = (
+        "AppServer daemon adapter",
+        "daemon-owned hosted Session",
+        "Coding / Work / PPT / Design",
+        "CodingTUI / Harnesstui",
+        "foreground AppServer can use Hosting",
+        "foreground AppServer process hosting",
+        "AppHost launcher OR external supervisor",
+        "AppServer -/-> hosting.service",
+        "appserver -X-> hosting.service",
+        "AppServer denial of `hosting.service`",
+        "construction and orderly close of one AppService",
+        "AppServer | Hosted server/connection runtime that constructs AppService",
+        "connection.py      # attachment",
+        "each Harness application/Session run",
+        "Every hosted application/Session run",
+        "kill the exact process",
+        "durable Session transcript and blobs |",
+    )
+    for text in documents:
+        for claim in rejected_claims:
+            assert claim not in text
+
+
+def test_hosting_traceability_covers_every_requirement_exactly_once() -> None:
+    requirements = _read(HOSTING_ROOT / "requirements.md")
+    requirement_ids = tuple(
+        re.findall(r"^### (HOST-(?:FR|QR)-\d{3}) — ", requirements, re.M)
+    )
+    trace_rows = _table_rows(
+        _section(_read(HOSTING_ROOT / "traceability.md"), "Requirement Traceability"),
+        (
+            "Requirement",
+            "Primary design owner",
+            "Boundary/design evidence",
+            "Planned executable evidence",
+        ),
+    )
+    traced_ids = tuple(row[0].strip("`") for row in trace_rows)
+    primary_owners = {row[0].strip("`"): row[1].strip("`") for row in trace_rows}
+
+    assert len(requirement_ids) == len(set(requirement_ids)) == 12
+    assert traced_ids == requirement_ids
+    assert trace_rows == (
+        (
+            "`HOST-FR-001`",
+            "`HOST-CMP-CONTRACT`",
+            "requirements; Contract Model interface",
+            "request validation and no-ambient-environment contract tests",
+        ),
+        (
+            "`HOST-FR-002`",
+            "`HOST-CMP-PROCESS`",
+            "Process Lifetime Host; failure interaction",
+            "fake spawn lifecycle matrix and real process-tree conformance",
+        ),
+        (
+            "`HOST-FR-003`",
+            "`HOST-CMP-ENDPOINT`",
+            "Inherited Peer Endpoint Host; physical context",
+            "POSIX/Windows handle allowlist, peer closure, and leak tests",
+        ),
+        (
+            "`HOST-FR-004`",
+            "`HOST-CMP-SESSION`",
+            "Child Session Host; rollback interaction",
+            "fault injection at every acquisition/publication boundary",
+        ),
+        (
+            "`HOST-FR-005`",
+            "`HOST-CMP-CONTRACT`",
+            "authority table; observation boundary",
+            "redaction and no-security-claim schema tests",
+        ),
+        (
+            "`HOST-FR-006`",
+            "`HOST-CMP-PLATFORM`",
+            "explicit platform boundary",
+            "exact backend selection and unsupported-platform tests",
+        ),
+        (
+            "`HOST-QR-001`",
+            "Process, Endpoint, Session",
+            "lifecycle invariants",
+            "repeated/concurrent close and cancellation tests",
+        ),
+        (
+            "`HOST-QR-002`",
+            "Process, Endpoint",
+            "requirements and component interfaces",
+            "capacity/write/tail/buffer/shutdown bound tests",
+        ),
+        (
+            "`HOST-QR-003`",
+            "Session, Platform Adapter",
+            "trust boundary",
+            "inherited-handle and effective-environment adversarial tests",
+        ),
+        (
+            "`HOST-QR-004`",
+            "scope/composition root",
+            "[Hosting Top-Level Placement]"
+            "(../drafts/hosting-top-level-placement.md) and dependency view",
+            "top-level and internal import architecture gates",
+        ),
+        (
+            "`HOST-QR-005`",
+            "all components",
+            "discovery/refinement",
+            "fake-backed component contracts plus real conformance markers",
+        ),
+        (
+            "`HOST-QR-006`",
+            "`HOST-CMP-PLATFORM`",
+            "open validation questions",
+            "separate POSIX and Windows conformance manifests",
+        ),
+    )
+    assert primary_owners == {
+        "HOST-FR-001": "HOST-CMP-CONTRACT",
+        "HOST-FR-002": "HOST-CMP-PROCESS",
+        "HOST-FR-003": "HOST-CMP-ENDPOINT",
+        "HOST-FR-004": "HOST-CMP-SESSION",
+        "HOST-FR-005": "HOST-CMP-CONTRACT",
+        "HOST-FR-006": "HOST-CMP-PLATFORM",
+        "HOST-QR-001": "Process, Endpoint, Session",
+        "HOST-QR-002": "Process, Endpoint",
+        "HOST-QR-003": "Session, Platform Adapter",
+        "HOST-QR-004": "scope/composition root",
+        "HOST-QR-005": "all components",
+        "HOST-QR-006": "HOST-CMP-PLATFORM",
+    }
+    qr004 = next(row for row in trace_rows if row[0] == "`HOST-QR-004`")
+    assert (
+        "[Hosting Top-Level Placement](../drafts/hosting-top-level-placement.md)"
+        in (qr004[2])
+    )
+
+
+def test_hosting_discovery_is_grounded_in_current_harness_facts() -> None:
+    discovery = _read(HOSTING_ROOT / "validation/component-discovery.md")
+
+    for relative_path in CURRENT_HARNESS_SEAMS:
+        assert (REPOSITORY_ROOT / relative_path).is_file(), relative_path
+
+    for current_owner in (
+        "harness.workspace.process",
+        "harness.tools.process_hosting",
+        "harness.sandbox.process",
+        "harness.worker",
+    ):
+        assert current_owner in discovery
+
+
+def test_proposed_runtime_packages_remain_default_dark_until_review() -> None:
+    for package in ("hosting", "apphost", "appserver"):
+        assert not (REPOSITORY_ROOT / f"src/loushang/{package}").exists()
+
+    overview = _read(HOSTING_ROOT / "README.md")
+    decision = _read(ARCHITECTURE_ROOT / "drafts/hosting-top-level-placement.md")
+    assert "Implementation status: not-started" in overview
+    assert "This decision candidate is proposed, not accepted." in decision
+    assert "extraction alone cannot remove PLC9C default-dark" in decision


### PR DESCRIPTION
## Summary
- merge the reviewed Hosting/AppHost architecture baseline from the harness integration lane
- keep Hosting, AppHost, AppServer, AppService, Product, and presentation ownership explicit
- freeze multi-Session aggregate support and implementation-absence gates before runtime work

## Validation
- all PR #527 required checks passed
- make check-architecture-docs (5 passed)
- pytest tests/architecture/test_hosting_architecture_baseline.py -q (8 passed)
- make check-harness (4268 passed, 38 skipped; Ruff and mypy clean)