### PR TITLE
feat(hosting): add opaque managed launch core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ HOSTING_TEST_PATHS := \
 	tests/architecture/test_hosting_h3_endpoint.py \
 	tests/architecture/test_hosting_h4_child_session.py \
 	tests/architecture/test_hosting_h5_worker_adapter.py \
+	tests/architecture/test_hosting_h6_launch_preparation.py \
 	tests/architecture/test_hosted_product_runtime_v1_baseline.py \
 	tests/architecture/test_hosting_architecture_baseline.py
 

--- a/docs/internals/architecture/hosting/README.md
+++ b/docs/internals/architecture/hosting/README.md
@@ -42,8 +42,11 @@ H5 adds a default-dark Harness Worker aggregate adapter, explicit typed owner
 selection, stable pathless diagnostics, and a future-attempt rollback latch.
 The Current Harness Worker route remains unchanged; required-containment
 sealed-descriptor transfer and Product/native activation remain separate gaps.
-H6.0 now records a proposed opaque managed-preparation contract and native
-proof plan. It changes no runtime owner or public API and leaves H5 dark.
+H6.0 records the accepted opaque managed-preparation contract. H6.1 now
+implements its private fake-backed ownership core and records non-committing
+POSIX/Windows feasibility mappings; native H6.2/H6.3 proof and the H6.4 Harness
+adapter remain open. It changes no runtime owner or public API and leaves H5
+dark.
 
 Current process mechanics remain implemented inside Harness, principally by:
 
@@ -203,12 +206,13 @@ model.
 9. [H3 Inherited Peer Endpoint](inherited-peer-endpoint-h3.md);
 10. [H4 Atomic Child Session](atomic-child-session-h4.md);
 11. [H5 Default-Dark Harness Worker Adapter](harness-worker-adapter-h5.md);
-12. [H6 Proposed Managed Launch Preparation](managed-launch-preparation-h6.md);
-13. [Hosted Product Runtime V1 Current Inventory](validation/hosted-product-runtime-v1-inventory.md);
-14. [Hosted Application Support Boundary](key-designs/hosted-application-support-boundary.md);
-15. [ARD-002: Hosting Top-Level Placement](../decisions/ARD-002-hosting-top-level-placement.md);
-16. [Traceability](traceability.md);
-17. current source, tests, and generated package facts.
+12. [H6 Managed Launch Preparation](managed-launch-preparation-h6.md);
+13. [H6.1 Managed Launch Preparation Feasibility Record](validation/managed-launch-preparation-h6-feasibility.md);
+14. [Hosted Product Runtime V1 Current Inventory](validation/hosted-product-runtime-v1-inventory.md);
+15. [Hosted Application Support Boundary](key-designs/hosted-application-support-boundary.md);
+16. [ARD-002: Hosting Top-Level Placement](../decisions/ARD-002-hosting-top-level-placement.md);
+17. [Traceability](traceability.md);
+18. current source, tests, and generated package facts.
 
 ## Current-To-Target Gaps
 
@@ -238,9 +242,9 @@ model.
 - `implemented`: the H5 default-dark aggregate Worker adapter, Supervisor
   session entrypoint, explicit no-fallback selector, pathless diagnostics, and
   future-attempt rollback latch.
-- `proposed`: H6 specifies a Hosting-consumable opaque managed-preparation
-  capability and exact Linux/Windows proof obligations; no implementation or
-  public contract exists yet.
+- `partial`: H6.1 implements a private, fake-backed opaque managed-preparation
+  transaction and freezes its cross-platform ownership protocol; no public
+  contract, native H6.2/H6.3 adapter, Harness H6.4 adapter, or activation exists.
 - `missing`: a reviewed Product/native Worker activation route; PLC9C5 remains
   separate from Hosting extraction and H6 does not pre-approve it.
 - `missing`: daemon/service-instance lifecycle remains a trigger-gated future

--- a/docs/internals/architecture/hosting/managed-launch-preparation-h6.md
+++ b/docs/internals/architecture/hosting/managed-launch-preparation-h6.md
@@ -5,9 +5,9 @@
 - ID: `HOST-H6`
 - Scope: `hosting`
 - Parent: `loushang`
-- Authority: normative proposed design
-- Design status: proposed
-- Implementation status: not-started
+- Authority: normative accepted design
+- Design status: accepted
+- Implementation status: partial — H6.1 private fake-backed core
 - Activation status: forbidden; H5 remains default-dark
 - Owner: Loushang Hosting architecture
 
@@ -148,6 +148,13 @@ their meaning:
 - the Hosting half owns native resource acquisition, private spawn binding,
   one-use consumption, and native cleanup.
 
+Until `prepare_managed` returns a result, any caller semantic candidate remains
+caller-owned. A managed preparation adapter that raises or is cancelled after
+capture must close that candidate through its own cancellation-safe owner
+operation; Hosting simultaneously rolls back every native material already
+attached to the reservation. Once the result returns and its binding is
+consumed, the joined preparation lease owns both cleanup paths.
+
 H6.1 must select and prove one common composition protocol. Candidate shapes
 include typed opaque binding slots or private double-dispatch into the selected
 backend. String placeholder substitution, duck-typed raw-handle carriers, and
@@ -194,7 +201,10 @@ ambiguous spawn/transfer -------------------------------> FENCED
   section containing the unique inheritance-manifest claim, sole OS process
   creation effect, and synchronous process attachment callback. Caller
   cancellation is observed only after its outcome is known and cleanup is
-  owned. An unknowable outcome becomes `FENCED`, never a retry authority.
+  owned. The attempt mints the only valid `not-created` receipt; the matched
+  backend crosses its effect gate immediately before OS creation, and any
+  receipt observed after that gate or an attachment witness is invalid. An
+  unknowable outcome becomes `FENCED`, never a retry authority.
 - A close racing with capture/verify/claim waits for that owner operation. It
   must not close a descriptor or handle whose transfer outcome is unresolved.
   Repeated close joins one idempotent cleanup operation.
@@ -211,11 +221,16 @@ Resource classes have explicit successful release points:
 
 No successful path leaves native material owned only by a callback-local
 variable. A capture acquisition failure that cannot close all attached
-material faults and retains the reservation as cleanup debt.
+material faults and retains the reservation as cleanup debt. A joined native
+plus caller preparation is likewise attached to the Child Session reservation
+before endpoint acquisition and remains there until Process Host accepts it.
+Lower Process/Endpoint cleanup debt is retained by exact session and source;
+an unrelated `CLEANUP_FAILED` exception is never treated as proof that a lower
+owner still holds resources.
 
-## Proposed Contract Properties
+## Accepted Contract Properties
 
-The future exact schema must express only the minimum neutral constraints that
+The private H6.1 schema expresses only the minimum neutral constraints that
 Hosting can enforce mechanically:
 
 - normalized expected launch-request fingerprint;
@@ -249,10 +264,10 @@ platform-specific private representation may be richer, but remains behind the
 selected Hosting backend.
 
 The existing caller-provided `LaunchPreparationPort` remains the semantic
-fence. H6 may extend its result through a new versioned opaque capability or a
-separate required port, but must preserve H0--H5 compatibility. Field-level API
-selection is deferred until the POSIX and Windows feasibility spikes prove one
-common ownership protocol.
+fence. H6.1 adds a separate private managed-preparation port and reservation
+capture capability while preserving H0--H5 compatibility. Native H6.2/H6.3
+profile data remains private behind matched backend double-dispatch; promotion
+of any author-facing field is a separate versioned contract decision.
 
 ## Successful Interaction
 
@@ -339,6 +354,11 @@ and tree-lifetime properties have native evidence.
 | H6.2 | Linux native preparation backend | required-containment and executable/cwd/descriptor adversarial oracle passes |
 | H6.3 | Windows native preparation backend | AppContainer/token, handle-list, Job, identity, and cleanup oracle passes |
 | H6.4 | dark Harness preparation adapter and H5 parity matrix | Current and Hosting owners are independently conformant; default remains Current |
+
+H6.1 is implemented as a private, default-dark core. Its non-committing POSIX
+and Windows mapping probes and fake-backed lifecycle evidence are retained in
+[H6.1 Managed Launch Preparation Feasibility Record](validation/managed-launch-preparation-h6-feasibility.md).
+No H6.2/H6.3 native adapter or H6.4 Harness adapter is implied by that result.
 
 The H6.1 probes perform no production spawn and reserve no public API. H6.2,
 H6.3, and the fake-backed part of H6.4 may be developed in parallel only after

--- a/docs/internals/architecture/hosting/traceability.md
+++ b/docs/internals/architecture/hosting/traceability.md
@@ -76,7 +76,7 @@ H1 deliberately proves no OS process-tree behavior. That delta remains H2.
 | atomic Child Session Host | `implemented` | H4 transaction order, failure/cancellation matrix, joint lifetime, observation correlation, and native factory round trip remain green |
 | Harness mechanics migration | `partial` | H2c dark adapter parity remains green; sealed-descriptor cases stay on Current owner until a later contract is accepted |
 | default-dark Harness Worker adapter | `implemented` | H5 aggregate mapping, Supervisor session integration, selection, no-fallback, diagnostics, and rollback gates remain green |
-| Hosting-consumable managed preparation | `proposed` | review the H6.0 two-sided responsibility/proof baseline; H6.1 must accept a fake-backed opaque capability without raw handles or mutable-path substitution |
+| Hosting-consumable managed preparation | `partial` | H6.1 private fake-backed ownership and feasibility gates are implemented; H6.2/H6.3 native evidence and H6.4 Harness parity remain |
 | Product/native Worker path absent | `missing` | separate PLC9C5 activation review and gates |
 
 The mechanism baseline is implemented through H4: contracts, process owner,
@@ -84,7 +84,8 @@ endpoint owner, exact platform sets, atomic child sessions, and the dark
 Harness compatibility slice, and the H5 default-dark Worker aggregate adapter.
 Overall migration remains partial because no production Worker owner has
 switched to Hosting and the Current sealed-executable preparation cannot yet be
-consumed by Hosting. The proposed
-[H6 Managed Launch Preparation](managed-launch-preparation-h6.md) and
+consumed by Hosting. The accepted, partially implemented
+[H6 Managed Launch Preparation](managed-launch-preparation-h6.md), its
+[H6.1 feasibility record](validation/managed-launch-preparation-h6-feasibility.md), and the
 [source-backed Current inventory](validation/hosted-product-runtime-v1-inventory.md)
 define the next closure gates without changing those Current facts.

--- a/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
+++ b/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
@@ -8,7 +8,7 @@
 - Authority: descriptive — source-backed Current inventory
 - Design status: not-applicable
 - Implementation status: not-applicable
-- Inventory base: `a2370857`
+- Delivery parent: `82df045d`
 - Effect: none; this record grants no runtime or activation authority
 - Owner: Loushang architecture
 
@@ -28,10 +28,12 @@ this inventory as implemented facts.
 | platform process adapters | `src/loushang/hosting/_posix_process.py`, `src/loushang/hosting/_windows_process.py`, and `src/loushang/hosting/_win32_process.py` | POSIX process-group and Windows Job Object creation/ownership mechanics |
 | Inherited Peer Endpoint Host | `src/loushang/hosting/_endpoint_host.py`, `src/loushang/hosting/_endpoint_backend.py`, `src/loushang/hosting/_posix_endpoint.py`, and `src/loushang/hosting/_windows_endpoint.py` | bounded anonymous endpoint pair, strict child-side inheritance, raw byte transport, and cleanup |
 | Child Session Host | `src/loushang/hosting/_child_session_host.py` | atomic endpoint-plus-process acquisition/publication and joint close |
+| private H6.1 launch preparation | `src/loushang/hosting/_launch_preparation.py` | request/profile/closure plus unforgeable attempt binding, opaque capture, final verification, matched-backend spawn, explicit fencing, and ordered cleanup; fake-backed and default-dark only |
 | restrained composition | `src/loushang/hosting/runtime.py` | `create_process_host` and `create_child_session_host`; no public backend/plugin registry |
 
-These owners are implemented through H4. They expose no native
-executable/cwd/containment material in the public request or preparation lease.
+The stable public owners are implemented through H5; H6.1 adds only a private
+fake-backed transaction core. They expose no native executable/cwd/containment
+material in the public request, preparation lease, or factory.
 
 ## Current Harness Preparation And Worker Owners
 
@@ -56,7 +58,7 @@ executable/cwd/containment material in the public request or preparation lease.
 | --- | --- | --- | --- |
 | executable/cwd | Harness private request retains native descriptors plus identity | Hosting `ProcessLaunchRequest` contains absolute strings | `hosting_compat` fails closed rather than substitute mutable paths |
 | containment | Harness `ProcessContainmentPlan` may rewrite the exact process request and owns semantic evidence | Hosting preparation lease exposes only `request`, `verify_current`, and `close` | lifecycle can be delegated, but native spawn material cannot be consumed |
-| inherited resources | Harness Current path extracts private launch descriptors | Hosting backend accepts only its private endpoint inheritance object | there is no reviewed composition of both sets |
+| inherited resources | Harness Current path extracts private launch descriptors | H6.1 can combine endpoint and opaque preparation inheritance internally | the fake-backed protocol exists, but no Harness or native adapter supplies material |
 | Windows required containment | PLC9B includes a purpose-specific AppContainer/Job implementation for legacy restore | Hosting owns generic Job/endpoint mechanics | no accepted managed Worker preparation adapter or parity claim |
 | Product activation | PLC9C1--C4 provide declaration, launch, supervisor, and one dark domain adapter | H5 provides an explicit dark Hosting owner | no Product composition selects and publishes the native path |
 
@@ -82,7 +84,7 @@ not evidence of those packages or runtime routes.
 
 | Gap | Target owner | Closure gate |
 | --- | --- | --- |
-| opaque request-bound native preparation | Hosting Contract/Platform components | H6.1 fake ownership protocol plus no-raw-handle surface gate |
+| opaque request-bound native preparation | Hosting Contract/Platform components | implemented privately in H6.1; fake ownership, concurrency/fault, and no-raw-handle gates are retained |
 | exact Linux executable/cwd/containment transfer | Hosting platform adapter with caller-owned requirements | H6.2 retained native adversarial oracle |
 | exact Windows executable/cwd/containment transfer | Hosting platform adapter with caller-owned requirements | H6.3 retained native adversarial oracle |
 | Harness-to-Hosting managed preparation parity | Harness Sandbox/Worker adapter over Hosting | H6.4 independent Current/Hosting parity; still default-dark |

--- a/docs/internals/architecture/hosting/validation/managed-launch-preparation-h6-feasibility.md
+++ b/docs/internals/architecture/hosting/validation/managed-launch-preparation-h6-feasibility.md
@@ -1,0 +1,139 @@
+# H6.1 Managed Launch Preparation Feasibility Record
+
+## Status
+
+- ID: `HOST-H6.1-FEASIBILITY`
+- Scope: `hosting`
+- Parent: `HOST-H6`
+- Authority: descriptive — implementation validation record
+- Design status: not-applicable
+- Implementation status: implemented
+- Native activation: none; H6.2 and H6.3 remain required
+- Runtime posture: private and default-dark; Current remains the default owner
+- Delivery parent: `82df045d`
+- Owner: Loushang Hosting maintainers
+
+## Question And Answer
+
+Can one private, request-bound ownership protocol represent the POSIX and
+Windows launch-preparation mechanics without exposing native values or moving
+policy meaning into Hosting?
+
+Yes. Both platform probes map to the same lifecycle:
+
+`MINTED -> CAPTURING -> CAPTURED -> VERIFYING -> VERIFIED -> CLAIMED -> ATTACHED -> CLOSED`
+
+with `FAULTED -> CLOSED` for known failures and terminal `FENCED` when the
+spawn outcome is not known. The
+common protocol needs only a normalized request, a selected profile identity,
+an execution-closure identity list, backend and attempt binding, synchronous
+owner attachment, final verification, one-use spawn settlement, and idempotent
+close where reclamation authority is known. Platform payloads remain private
+to the selected adapter.
+
+This is a representation and ownership result, not native correctness
+evidence. No production process is launched by these probes, and no public
+contract is added.
+
+## POSIX Mapping Probe
+
+| Common operation | POSIX-private realization considered | H6.1 conclusion |
+| --- | --- | --- |
+| capture | open and retain executable/cwd/launcher/dependency descriptors with non-inheritable defaults | representable by one backend-owned material object |
+| attach | synchronously register that object with the active host reservation before returning from acquisition | common callback rule is sufficient |
+| verify | compare descriptor identity and required file/native properties immediately before spawn | common asynchronous final fence is sufficient |
+| spawn | matched-backend double-dispatch combines the private material with endpoint inheritance inside the selected POSIX adapter | common opaque spawn capability is sufficient without flattening platform material |
+| transfer | the same backend-owned operation acknowledges process attachment and descriptor transfer before it returns | common attached/not-created/fenced settlement is sufficient |
+| close | close every retained descriptor and profile support object, aggregating failures | common idempotent close is sufficient |
+
+A native H6.2 profile must still prove the actual executable, cwd,
+interpreter/loader, launcher, dependency/search policy, containment, descriptor
+allowlist, process-group, and cleanup behavior. Path re-open, ambient
+inheritance, and mutable-path fallback remain forbidden.
+
+## Windows Mapping Probe
+
+| Common operation | Windows-private realization considered | H6.1 conclusion |
+| --- | --- | --- |
+| capture | retain executable/directory handles, selected token or AppContainer material, and profile support objects | representable by one backend-owned material object |
+| attach | synchronously register the object with the active reservation before any cancellable continuation | common callback rule is sufficient |
+| verify | recheck file/image, token/profile, loader/search, and platform-image identities adjacent to spawn | common asynchronous final fence is sufficient |
+| spawn | matched-backend double-dispatch supplies private token/profile/image material while composing the exact handle list inside the selected Windows adapter | common opaque spawn capability is sufficient without flattening platform material |
+| transfer | the same backend-owned operation acknowledges creation, process attachment, Job attachment, and handle transfer before it returns | common attached/not-created/fenced settlement is sufficient |
+| close | close handles, token/profile objects, attribute-list support, and other reachable ownership | common idempotent close is sufficient |
+
+A native H6.3 profile must still prove these Win32 operations on retained
+Windows CI. Fake Win32 results, POSIX results, Job ownership alone, or a handle
+list alone cannot promote the native gate.
+
+## Frozen Private Core
+
+H6.1 implements the common protocol privately in
+`loushang.hosting._launch_preparation` and joins it to the private Child Session
+transaction. The core has these deliberate properties:
+
+- the public H0--H5 contracts and factories are unchanged;
+- trusted preparation code receives a reservation-scoped capture capability,
+  never a backend or native value;
+- a non-owning opaque binding is valid only for the backend, attempt,
+  reservation, request, profile, and execution closure that minted it;
+- captured material attaches to the reservation before capture returns;
+- caller semantic cleanup and Hosting native cleanup remain distinct but are
+  joined under one preparation lease;
+- the captured material participates in the unique spawn through a
+  matched-backend double-dispatch; the platform adapter alone composes endpoint
+  and preparation resources into one collision-free native manifest;
+- the attempt-owned effect gate mints and validates the only explicit
+  not-created receipt; a receipt after effect start or attachment is rejected,
+  while every unreceipted error after claim enters `FENCED` and keeps cleanup
+  debt;
+- close, cancellation, replay, retarget, cross-reservation use, ambiguous
+  spawn, and cleanup debt fail closed.
+
+Capture authority is attached to Child Session Host because it is the only
+current aggregate that owns both endpoint inheritance and the Process Host
+start transaction. Process Host recognizes the private managed preparation
+lease and invokes its matched-backend double-dispatch. A standalone capture
+route remains absent until a concrete consumer requires it and can retain the
+same capacity and publication invariants.
+
+## Executable Evidence
+
+`tests/hosting/test_child_session_host.py` covers:
+
+- successful capture, final verification, matched-backend manifest, transfer,
+  and close;
+- concurrent double capture, double bind, verify replay, and spawn replay;
+- callback failure and cancellation after attachment;
+- cancellation combined with different returned capture/process objects or a
+  missing process callback, with every returned owner retained for rollback;
+- retarget and cross-reservation binding rejection;
+- per-capture quota rejection and endpoint/preparation slot collision;
+- native verification failure and final-fence cancellation;
+- missing/different backend attachment contract violations;
+- claimed-spawn/close and verify/close linearization;
+- known-attached cancellation, unknown-outcome fencing, and host-close races;
+- cross-host fresh attempt tokens and pre-spawn identity revalidation;
+- caller-owned failed-callback cleanup and recursive capacity refusal; and
+- native, orphan, and joined-owner cleanup debt with ordered retry, plus exact
+  lower-owner/session debt settlement.
+
+Two executable profile-identity examples use POSIX- and Windows-oriented
+labels through the same opaque lifecycle. They prove only that the common
+core preserves opaque profile identity and execution-closure metadata; they
+do not model platform resource shapes, invoke OS APIs, or replace the H6.2
+and H6.3 native evidence.
+
+`tests/architecture/test_hosting_h6_launch_preparation.py` locks the private
+surface, dependency direction, source inventory, dark composition, and matrix
+presence.
+
+## Remaining Native Gates
+
+- H6.2: implement and retain the Linux/POSIX adversarial oracle.
+- H6.3: implement and retain the Windows adversarial oracle.
+- H6.4: adapt the Harness preparation owner and prove Current/Hosting parity
+  without changing the default owner or enabling Product activation.
+
+Failure of either native gate does not invalidate the common state machine; it
+leaves that platform/profile unsupported and fail-closed.

--- a/src/loushang/hosting/_child_session_host.py
+++ b/src/loushang/hosting/_child_session_host.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import uuid
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TypeVar, cast
 
 from ._endpoint_host import _InheritedEndpointHost, _InheritedEndpointLease
+from ._launch_preparation import (
+    _CapturedLaunchMaterial,
+    _LaunchCaptureBackend,
+    _ManagedLaunchPreparationPort,
+    _ManagedLaunchPreparationResult,
+    _ReservationLaunchCapture,
+)
 from ._process_backend import _ProcessInheritance
 from ._process_host import _ProcessHost
 from .contracts import (
@@ -31,6 +39,7 @@ from .contracts import (
 from .errors import HostingError, HostingFailureCategory
 
 _T = TypeVar("_T")
+_MAX_MANAGED_LAUNCH_SLOTS = 64
 
 
 class _DeferredProcessInheritance(_ProcessInheritance):
@@ -80,6 +89,27 @@ class _DeferredProcessInheritance(_ProcessInheritance):
         return self._bound
 
 
+@dataclass(frozen=True, slots=True)
+class _NestedCleanupDebt:
+    """Exact lower-owner debt retained for one Child Session transaction."""
+
+    session_id: str
+    error: BaseException
+    process: bool
+    endpoint: bool
+
+    def settled(
+        self,
+        process_host: _ProcessHost,
+        endpoint_host: _InheritedEndpointHost,
+    ) -> bool:
+        return (
+            not self.process or not process_host._has_cleanup_debt(self.session_id)
+        ) and (
+            not self.endpoint or not endpoint_host._has_cleanup_debt(self.session_id)
+        )
+
+
 @dataclass(slots=True)
 class _SessionReservation:
     reservation_id: int
@@ -87,13 +117,56 @@ class _SessionReservation:
     owner: asyncio.Task[object]
     settled: asyncio.Event
     endpoint: _InheritedEndpointLease | None = None
+    launch_captures: list[_CapturedLaunchMaterial] = field(default_factory=list)
+    pending_preparation: LaunchPreparationLease | None = None
     process: ProcessLease | None = None
+    retained_cleanup_debt: "_NestedCleanupDebt | None" = None
     cleanup_error: BaseException | None = None
 
     def attach_endpoint(self, endpoint: _InheritedEndpointLease) -> None:
         if self.endpoint is not None and self.endpoint is not endpoint:
             raise RuntimeError("child-session reservation already owns an endpoint")
         self.endpoint = endpoint
+
+    def attach_launch_capture(self, material: _CapturedLaunchMaterial) -> None:
+        if any(owned is material for owned in self.launch_captures):
+            return
+        if len(self.launch_captures) >= 2:
+            raise RuntimeError("child-session launch capture debt bound is exhausted")
+        self.launch_captures.append(material)
+
+    def release_launch_capture(self, material: _CapturedLaunchMaterial) -> None:
+        if not any(owned is material for owned in self.launch_captures):
+            raise RuntimeError("child-session launch capture owner is inconsistent")
+        self.launch_captures = [
+            owned for owned in self.launch_captures if owned is not material
+        ]
+
+    def attach_pending_preparation(
+        self, preparation: LaunchPreparationLease
+    ) -> None:
+        if (
+            self.pending_preparation is not None
+            and self.pending_preparation is not preparation
+        ):
+            raise RuntimeError("child-session reservation already owns preparation")
+        self.pending_preparation = preparation
+
+    def replace_pending_preparation(
+        self,
+        expected: LaunchPreparationLease,
+        replacement: LaunchPreparationLease,
+    ) -> None:
+        if self.pending_preparation is not expected:
+            raise RuntimeError("child-session preparation owner is inconsistent")
+        self.pending_preparation = replacement
+
+    def release_pending_preparation(
+        self, preparation: LaunchPreparationLease
+    ) -> None:
+        if self.pending_preparation is not preparation:
+            raise RuntimeError("child-session preparation owner is inconsistent")
+        self.pending_preparation = None
 
     def attach_process(self, process: ProcessLease) -> None:
         if self.process is not None and self.process is not process:
@@ -108,42 +181,74 @@ class _SessionPreparationPort(LaunchPreparationPort):
         endpoint_host: _InheritedEndpointHost,
         deferred: _DeferredProcessInheritance,
         reservation: _SessionReservation,
+        capture_backend: _LaunchCaptureBackend | None,
+        max_capture_slots: int,
     ) -> None:
         self._caller = caller
         self._endpoint_host = endpoint_host
         self._deferred = deferred
         self._reservation = reservation
+        self._capture_backend = capture_backend
+        self._max_capture_slots = max_capture_slots
 
     async def prepare(
         self, request: ProcessLaunchRequest
     ) -> LaunchPreparationLease:
-        prepared = await self._caller.prepare(request)
+        capture: _ReservationLaunchCapture | None = None
+        managed_result: _ManagedLaunchPreparationResult | None = None
+        if self._capture_backend is not None and isinstance(
+            self._caller, _ManagedLaunchPreparationPort
+        ):
+            capture = _ReservationLaunchCapture(
+                self._capture_backend,
+                attempt_id=self._reservation.session_id,
+                max_inherited_slots=self._max_capture_slots,
+                on_capture=self._reservation.attach_launch_capture,
+                on_orphan=self._reservation.attach_launch_capture,
+            )
+            managed_result = await self._caller.prepare_managed(request, capture)
+            if not isinstance(managed_result, _ManagedLaunchPreparationResult):
+                raise TypeError("managed preparation port returned an invalid result")
+            prepared = managed_result.lease
+        else:
+            prepared = await self._caller.prepare(request)
         if not isinstance(prepared, LaunchPreparationLease):
             raise TypeError("preparation port returned an invalid lease")
+        self._reservation.attach_pending_preparation(prepared)
         try:
             prepared_request = prepared.request
             if not isinstance(prepared_request, ProcessLaunchRequest):
                 raise TypeError("preparation lease returned an invalid request")
             _validate_session_process_request(prepared_request)
+            managed = (
+                capture.bind_result(managed_result)
+                if capture is not None and managed_result is not None
+                else None
+            )
+            if managed is not None:
+                assert capture is not None
+                material = capture.material
+                if material is None:
+                    raise RuntimeError("managed launch capture was not attached")
+                self._reservation.replace_pending_preparation(prepared, managed)
+                self._reservation.release_launch_capture(material)
             endpoint = await self._endpoint_host.create(
                 session_id=self._reservation.session_id
             )
             self._reservation.attach_endpoint(endpoint)
+            if capture is None:
+                self._deferred.bind(endpoint.inheritance)
+                self._reservation.release_pending_preparation(prepared)
+                return prepared
+            assert managed is not None
             self._deferred.bind(endpoint.inheritance)
-        except BaseException as primary:
-            cleanup = asyncio.create_task(
-                prepared.close(),
-                name=f"hosting-{self._reservation.session_id}-preparation-rollback",
-            )
-            try:
-                await _await_owned(cleanup)
-            except BaseException as cleanup_error:
-                primary.add_note(
-                    f"child-session preparation rollback also failed: {cleanup_error}"
-                )
-                raise primary from cleanup_error
+            self._reservation.release_pending_preparation(managed)
+            return managed
+        except BaseException:
+            # The aggregate reservation owns the pending preparation until the
+            # Process Host can attach it synchronously after this method returns.
             raise
-        return prepared
+        raise AssertionError("unreachable child-session preparation path")
 
 
 class _HostedChildSession(ChildSessionLease):
@@ -244,19 +349,35 @@ class _ChildSessionHost(ChildSessionHostingPort):
         *,
         max_sessions: int,
         observation_sink: HostingObservationSink | None = None,
+        launch_capture_backend: _LaunchCaptureBackend | None = None,
+        max_capture_slots: int = 8,
     ) -> None:
         if type(max_sessions) is not int or max_sessions < 1:
             raise ValueError("max_sessions must be a positive integer")
+        if (
+            type(max_capture_slots) is not int
+            or max_capture_slots < 1
+            or max_capture_slots > _MAX_MANAGED_LAUNCH_SLOTS
+        ):
+            raise ValueError("max_capture_slots is invalid")
+        if (
+            launch_capture_backend is not None
+            and launch_capture_backend.backend_id != process_host._backend_id
+        ):
+            raise ValueError("launch capture backend must match the process backend")
         self._process_host = process_host
         self._endpoint_host = endpoint_host
         self._max_sessions = max_sessions
         self._observation_sink = observation_sink
+        self._launch_capture_backend = launch_capture_backend
+        self._max_capture_slots = max_capture_slots
         self._backend_id = (
             f"{process_host._backend_id}+{endpoint_host._backend_id}"
         )
         self._lock = asyncio.Lock()
         self._state = "open"
         self._next_id = 1
+        self._instance_id = uuid.uuid4().hex
         self._reservations: dict[int, _SessionReservation] = {}
         self._leases: set[_HostedChildSession] = set()
         self._close_task: asyncio.Task[None] | None = None
@@ -285,7 +406,7 @@ class _ChildSessionHost(ChildSessionHostingPort):
                 )
             reservation_id = self._next_id
             self._next_id += 1
-            session_id = f"child-session-{reservation_id}"
+            session_id = f"child-session-{self._instance_id}-{reservation_id}"
             reservation = _SessionReservation(
                 reservation_id,
                 session_id,
@@ -306,6 +427,8 @@ class _ChildSessionHost(ChildSessionHostingPort):
                 self._endpoint_host,
                 deferred,
                 reservation,
+                self._launch_capture_backend,
+                self._max_capture_slots,
             )
             process = await self._process_host._start_with_inheritance(
                 request.process,
@@ -341,9 +464,16 @@ class _ChildSessionHost(ChildSessionHostingPort):
             return lease
         except BaseException as caught:
             primary = _session_failure(caught)
-            cleanup_debt = _find_cleanup_debt(caught)
-            if cleanup_debt is not None:
-                reservation.cleanup_error = cleanup_debt
+            process_debt = self._process_host._has_cleanup_debt(session_id)
+            endpoint_debt = self._endpoint_host._has_cleanup_debt(session_id)
+            if process_debt or endpoint_debt:
+                reservation.retained_cleanup_debt = _NestedCleanupDebt(
+                    session_id=session_id,
+                    error=caught,
+                    process=process_debt,
+                    endpoint=endpoint_debt,
+                )
+                reservation.cleanup_error = caught
             self._emit(
                 reservation,
                 HostingLifecycleTransition.FAILED,
@@ -394,6 +524,7 @@ class _ChildSessionHost(ChildSessionHostingPort):
 
     async def _rollback(self, reservation: _SessionReservation) -> None:
         self._emit(reservation, HostingLifecycleTransition.CLEANING)
+        reservation.cleanup_error = None
         failures: list[BaseException] = []
         if reservation.process is not None:
             try:
@@ -405,18 +536,33 @@ class _ChildSessionHost(ChildSessionHostingPort):
                 await reservation.endpoint.close()
             except BaseException as exc:
                 failures.append(exc)
+        if reservation.pending_preparation is not None:
+            pending = reservation.pending_preparation
+            try:
+                await pending.close()
+                reservation.release_pending_preparation(pending)
+            except BaseException as exc:
+                failures.append(exc)
+        for material in tuple(reservation.launch_captures):
+            try:
+                await material.close()
+                reservation.release_launch_capture(material)
+            except BaseException as exc:
+                failures.append(exc)
         if failures:
             local_failure = BaseExceptionGroup(
                 "child-session rollback failed", failures
             )
             reservation.cleanup_error = (
                 local_failure
-                if reservation.cleanup_error is None
+                if reservation.retained_cleanup_debt is None
                 else BaseExceptionGroup(
                     "child-session cleanup debt",
-                    [reservation.cleanup_error, local_failure],
+                    [reservation.retained_cleanup_debt.error, local_failure],
                 )
             )
+        elif reservation.retained_cleanup_debt is not None:
+            reservation.cleanup_error = reservation.retained_cleanup_debt.error
         if reservation.cleanup_error is not None:
             async with self._lock:
                 if self._state == "open":
@@ -441,16 +587,35 @@ class _ChildSessionHost(ChildSessionHostingPort):
             await asyncio.gather(
                 *(reservation.settled.wait() for reservation in reservations)
             )
+        debt_reservations = tuple(
+            reservation
+            for reservation in reservations
+            if reservation.cleanup_error is not None
+        )
+        retained_debts = tuple(
+            reservation.cleanup_error
+            for reservation in debt_reservations
+            if reservation.cleanup_error is not None
+        )
+        local_debt_results = await asyncio.gather(
+            *(
+                self._rollback(reservation)
+                for reservation in debt_reservations
+                if reservation.retained_cleanup_debt is None
+            ),
+            return_exceptions=True,
+        )
         async with self._lock:
             leases = tuple(self._leases)
         results = await asyncio.gather(
             *(lease.close() for lease in leases), return_exceptions=True
         )
-        failures: list[BaseException] = [
-            reservation.cleanup_error
-            for reservation in reservations
-            if reservation.cleanup_error is not None
-        ]
+        failures: list[BaseException] = list(retained_debts)
+        failures.extend(
+            result
+            for result in local_debt_results
+            if isinstance(result, BaseException)
+        )
         failures.extend(
             result for result in results if isinstance(result, BaseException)
         )
@@ -462,6 +627,32 @@ class _ChildSessionHost(ChildSessionHostingPort):
         failures.extend(
             result for result in backend_results if isinstance(result, BaseException)
         )
+        upstream_debts = tuple(
+            reservation
+            for reservation in debt_reservations
+            if reservation.retained_cleanup_debt is not None
+        )
+        settled_upstream = tuple(
+            reservation
+            for reservation in upstream_debts
+            if reservation.retained_cleanup_debt is not None
+            and reservation.retained_cleanup_debt.settled(
+                self._process_host,
+                self._endpoint_host,
+            )
+        )
+        if settled_upstream:
+            for reservation in settled_upstream:
+                reservation.retained_cleanup_debt = None
+            upstream_results = await asyncio.gather(
+                *(self._rollback(reservation) for reservation in settled_upstream),
+                return_exceptions=True,
+            )
+            failures.extend(
+                result
+                for result in upstream_results
+                if isinstance(result, BaseException)
+            )
         async with self._lock:
             self._state = "closed"
         if failures:
@@ -578,28 +769,6 @@ def _validate_session_process_request(request: ProcessLaunchRequest) -> None:
             HostingFailureCategory.ENDPOINT_TRANSFER_FAILED,
             "child sessions reserve process stdin and stdout for the endpoint",
         )
-
-
-def _find_cleanup_debt(error: BaseException) -> BaseException | None:
-    pending = [error]
-    seen: set[int] = set()
-    while pending:
-        candidate = pending.pop()
-        if id(candidate) in seen:
-            continue
-        seen.add(id(candidate))
-        if (
-            isinstance(candidate, HostingError)
-            and candidate.category is HostingFailureCategory.CLEANUP_FAILED
-        ):
-            return candidate
-        if isinstance(candidate, BaseExceptionGroup):
-            pending.extend(candidate.exceptions)
-        if candidate.__cause__ is not None:
-            pending.append(candidate.__cause__)
-        if candidate.__context__ is not None:
-            pending.append(candidate.__context__)
-    return None
 
 
 __all__: list[str] = []

--- a/src/loushang/hosting/_endpoint_host.py
+++ b/src/loushang/hosting/_endpoint_host.py
@@ -231,6 +231,13 @@ class _InheritedEndpointHost:
         self._leases: set[_InheritedEndpointLease] = set()
         self._close_task: asyncio.Task[None] | None = None
 
+    def _has_cleanup_debt(self, session_id: str) -> bool:
+        return any(
+            reservation.session_id == session_id
+            and reservation.cleanup_error is not None
+            for reservation in self._reservations.values()
+        )
+
     async def create(self, *, session_id: str | None = None) -> _InheritedEndpointLease:
         owner = asyncio.current_task()
         if owner is None:

--- a/src/loushang/hosting/_launch_preparation.py
+++ b/src/loushang/hosting/_launch_preparation.py
@@ -1,0 +1,740 @@
+"""Private H6.1 request-bound opaque launch-preparation ownership.
+
+This module deliberately has no public composition entrypoint.  It freezes the
+cross-platform ownership state machine against deterministic fakes before the
+H6.2 and H6.3 native adapters exist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol, TypeVar, cast, runtime_checkable
+
+from ._process_backend import (
+    _ManagedProcessPreparation,
+    _ProcessBackend,
+    _ProcessInheritance,
+    _ProcessTransport,
+)
+from .contracts import LaunchPreparationLease, ProcessLaunchRequest
+from .errors import HostingError, HostingFailureCategory
+
+_T = TypeVar("_T")
+_MAX_PROFILE_ID_LENGTH = 128
+_MAX_ATTEMPT_ID_LENGTH = 128
+_MAX_CLOSURE_IDENTITIES = 64
+_MAX_IDENTITY_LENGTH = 512
+_MAX_BACKEND_ID_LENGTH = 128
+_MAX_INHERITED_SLOTS = 64
+
+
+@dataclass(frozen=True, slots=True)
+class _LaunchCaptureSpec:
+    """Neutral capture intent; platform details remain inside the backend."""
+
+    request: ProcessLaunchRequest
+    profile_id: str
+    execution_closure: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request, ProcessLaunchRequest):
+            raise TypeError("launch capture requires a ProcessLaunchRequest")
+        if (
+            not isinstance(self.profile_id, str)
+            or not self.profile_id
+            or len(self.profile_id) > _MAX_PROFILE_ID_LENGTH
+            or self.profile_id != self.profile_id.strip()
+            or "\0" in self.profile_id
+        ):
+            raise ValueError("launch capture profile_id is invalid")
+        closure = tuple(self.execution_closure)
+        if not closure or len(closure) > _MAX_CLOSURE_IDENTITIES:
+            raise ValueError("launch capture execution closure is invalid")
+        if any(
+            not isinstance(identity, str)
+            or not identity
+            or len(identity) > _MAX_IDENTITY_LENGTH
+            or identity != identity.strip()
+            or "\0" in identity
+            for identity in closure
+        ):
+            raise ValueError("launch capture execution identity is invalid")
+        if len(set(closure)) != len(closure):
+            raise ValueError("launch capture execution identities must be unique")
+        object.__setattr__(self, "execution_closure", closure)
+
+
+class _OpaqueLaunchBinding:
+    """Non-owning token proving which reservation produced captured material."""
+
+    __slots__ = ("_authority", "_nonce")
+
+    def __init__(self, authority: object, nonce: object) -> None:
+        self._authority = authority
+        self._nonce = nonce
+
+
+@dataclass(frozen=True, slots=True)
+class _ManagedLaunchPreparationResult:
+    """Caller semantic lease joined to one opaque Hosting binding."""
+
+    lease: LaunchPreparationLease
+    binding: _OpaqueLaunchBinding
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.lease, LaunchPreparationLease):
+            raise TypeError("managed preparation returned an invalid caller lease")
+        if not isinstance(self.binding, _OpaqueLaunchBinding):
+            raise TypeError("managed preparation returned an invalid opaque binding")
+
+
+@runtime_checkable
+class _LaunchCapturePort(Protocol):
+    """Leaf capability minted for one already-reserved start transaction."""
+
+    async def capture(self, spec: _LaunchCaptureSpec) -> _OpaqueLaunchBinding: ...
+
+
+class _ManagedLaunchPreparationPort(ABC):
+    """Private two-sided caller port; the public H0--H5 port stays unchanged."""
+
+    @abstractmethod
+    async def prepare_managed(
+        self,
+        request: ProcessLaunchRequest,
+        capture: _LaunchCapturePort,
+    ) -> _ManagedLaunchPreparationResult:
+        raise NotImplementedError
+
+
+@runtime_checkable
+class _CapturedLaunchMaterial(Protocol):
+    """Backend-owned native material; raw values never cross the caller seam."""
+
+    @property
+    def backend_id(self) -> str: ...
+
+    @property
+    def attempt_id(self) -> str: ...
+
+    @property
+    def attempt_token(self) -> object: ...
+
+    @property
+    def profile_id(self) -> str: ...
+
+    @property
+    def execution_closure(self) -> tuple[str, ...]: ...
+
+    @property
+    def request(self) -> ProcessLaunchRequest: ...
+
+    @property
+    def inherited_slot_count(self) -> int: ...
+
+    async def verify_current(self, request: ProcessLaunchRequest) -> None: ...
+
+    async def spawn(
+        self,
+        backend: _ProcessBackend,
+        request: ProcessLaunchRequest,
+        *,
+        effect: "_ManagedSpawnEffect",
+        on_spawn: Callable[[_ProcessTransport], None],
+        inheritance: _ProcessInheritance | None,
+    ) -> _ProcessTransport:
+        """Perform matched-backend preparation plus the unique spawn effect."""
+
+    async def close(self) -> None: ...
+
+
+class _LaunchCaptureBackend(Protocol):
+    """Selected-platform acquisition seam used only by trusted composition."""
+
+    @property
+    def backend_id(self) -> str: ...
+
+    async def capture(
+        self,
+        spec: _LaunchCaptureSpec,
+        *,
+        attempt_id: str,
+        attempt_token: object,
+        on_capture: Callable[[_CapturedLaunchMaterial], None],
+    ) -> _CapturedLaunchMaterial:
+        """Acquire and attach before the first post-acquisition cancellation point."""
+
+
+class _ReservationLaunchCapture(_LaunchCapturePort):
+    """One reservation-bound acquisition authority and state coordinator."""
+
+    def __init__(
+        self,
+        backend: _LaunchCaptureBackend,
+        *,
+        attempt_id: str,
+        max_inherited_slots: int,
+        on_capture: Callable[[_CapturedLaunchMaterial], None],
+        on_orphan: Callable[[_CapturedLaunchMaterial], None],
+    ) -> None:
+        if (
+            type(max_inherited_slots) is not int
+            or max_inherited_slots < 1
+            or max_inherited_slots > _MAX_INHERITED_SLOTS
+        ):
+            raise ValueError("managed launch inherited-slot bound is invalid")
+        backend_id = backend.backend_id
+        if (
+            not isinstance(backend_id, str)
+            or not backend_id
+            or len(backend_id) > _MAX_BACKEND_ID_LENGTH
+            or backend_id != backend_id.strip()
+            or "\0" in backend_id
+        ):
+            raise ValueError("managed launch backend_id is invalid")
+        if (
+            not isinstance(attempt_id, str)
+            or not attempt_id
+            or len(attempt_id) > _MAX_ATTEMPT_ID_LENGTH
+            or attempt_id != attempt_id.strip()
+            or "\0" in attempt_id
+        ):
+            raise ValueError("managed launch attempt_id is invalid")
+        self._backend = backend
+        self._attempt_id = attempt_id
+        self._max_inherited_slots = max_inherited_slots
+        self._on_capture = on_capture
+        self._on_orphan = on_orphan
+        self._attempt_token = object()
+        self._state = "minted"
+        self._material: _CapturedLaunchMaterial | None = None
+        self._spec: _LaunchCaptureSpec | None = None
+        self._binding_nonce = object()
+        self._state_lock = threading.Lock()
+        self._operation_lock = asyncio.Lock()
+
+    @property
+    def state(self) -> str:
+        with self._state_lock:
+            return self._state
+
+    @property
+    def material(self) -> _CapturedLaunchMaterial | None:
+        with self._state_lock:
+            return self._material
+
+    async def capture(self, spec: _LaunchCaptureSpec) -> _OpaqueLaunchBinding:
+        if not isinstance(spec, _LaunchCaptureSpec):
+            raise TypeError("managed launch capture requires _LaunchCaptureSpec")
+        async with self._operation_lock:
+            with self._state_lock:
+                if self._state != "minted":
+                    raise HostingError(
+                        HostingFailureCategory.PREPARATION_FAILED,
+                        "managed launch capture is single-use",
+                    )
+                self._state = "capturing"
+                self._spec = spec
+            task = asyncio.create_task(
+                self._backend.capture(
+                    spec,
+                    attempt_id=self._attempt_id,
+                    attempt_token=self._attempt_token,
+                    on_capture=self._attach,
+                ),
+                name=f"hosting-{self._attempt_id}-native-capture",
+            )
+            try:
+                returned = await _await_owned(task)
+            except BaseException as primary:
+                with self._state_lock:
+                    attached = self._material
+                    self._state = "closed" if attached is None else "faulted"
+                if task.done() and not task.cancelled():
+                    try:
+                        orphan = task.result()
+                    except BaseException:
+                        pass
+                    else:
+                        if orphan is not attached:
+                            self._attach_orphan(orphan, primary=primary)
+                raise
+            with self._state_lock:
+                attached = self._material
+                if returned is attached:
+                    self._state = "captured"
+                    return _OpaqueLaunchBinding(self, self._binding_nonce)
+                self._state = "faulted"
+            if attached is None:
+                contract_error = RuntimeError(
+                    "launch capture backend returned before owner attachment"
+                )
+                try:
+                    self._validate_material(returned)
+                    self._on_capture(returned)
+                except BaseException as attach_error:
+                    self._attach_orphan(returned, primary=attach_error)
+                    raise contract_error from attach_error
+                with self._state_lock:
+                    self._material = returned
+                    self._state = "captured"
+                raise contract_error
+            contract_error = RuntimeError(
+                "launch capture backend returned a different material owner"
+            )
+            self._attach_orphan(returned, primary=contract_error)
+            raise contract_error
+
+    def bind_result(
+        self,
+        result: _ManagedLaunchPreparationResult,
+    ) -> "_ManagedPreparationLease":
+        if not isinstance(result, _ManagedLaunchPreparationResult):
+            raise TypeError("managed launch preparation returned an invalid result")
+        prepared_request = result.lease.request
+        if not isinstance(prepared_request, ProcessLaunchRequest):
+            raise TypeError("managed caller lease returned an invalid request")
+        with self._state_lock:
+            binding = result.binding
+            if (
+                binding._authority is not self
+                or binding._nonce is not self._binding_nonce
+            ):
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch binding targets a different reservation",
+                )
+            if self._state != "captured" or self._material is None:
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch binding is unavailable",
+                )
+            if self._spec is None or self._spec.request != prepared_request:
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch capture does not match the prepared request",
+                )
+            material = self._material
+            self._binding_nonce = object()
+            return _ManagedPreparationLease(result.lease, material, self)
+
+    def _attach(self, material: _CapturedLaunchMaterial) -> None:
+        with self._state_lock:
+            if self._state != "capturing" or self._material is not None:
+                raise RuntimeError("launch capture material attached more than once")
+            self._validate_material(material)
+            self._on_capture(material)
+            self._material = material
+
+    def _validate_material(self, material: object) -> None:
+        if not isinstance(material, _CapturedLaunchMaterial):
+            raise TypeError("launch capture backend returned invalid material")
+        assert self._spec is not None
+        if (
+            material.backend_id != self._backend.backend_id
+            or material.attempt_id != self._attempt_id
+            or material.attempt_token is not self._attempt_token
+            or material.request != self._spec.request
+            or material.profile_id != self._spec.profile_id
+            or material.execution_closure != self._spec.execution_closure
+        ):
+            raise HostingError(
+                HostingFailureCategory.PREPARATION_FAILED,
+                "captured launch material has incompatible identity",
+            )
+        count = material.inherited_slot_count
+        if type(count) is not int or count < 0 or count > self._max_inherited_slots:
+            raise HostingError(
+                HostingFailureCategory.CAPACITY_EXHAUSTED,
+                "captured launch material exceeds its inherited-slot bound",
+            )
+
+    def _attach_orphan(self, material: object, *, primary: BaseException) -> None:
+        if not isinstance(material, _CapturedLaunchMaterial):
+            return
+        try:
+            self._on_orphan(material)
+        except BaseException as attach_error:
+            primary.add_note(
+                f"orphan launch material attachment also failed: {attach_error}"
+            )
+
+    def begin_verify(self, material: _CapturedLaunchMaterial) -> None:
+        with self._state_lock:
+            if self._material is not material or self._state != "captured":
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch material cannot be verified in its current state",
+                )
+            try:
+                self._validate_material(material)
+            except BaseException:
+                self._state = "faulted"
+                raise
+            self._state = "verifying"
+
+    def finish_verify(self, material: _CapturedLaunchMaterial, *, success: bool) -> None:
+        with self._state_lock:
+            if self._material is not material or self._state != "verifying":
+                raise RuntimeError("managed launch verification state is inconsistent")
+            self._state = "verified" if success else "captured"
+
+    def begin_spawn(
+        self,
+        material: _CapturedLaunchMaterial,
+        *,
+        backend_id: str,
+    ) -> None:
+        with self._state_lock:
+            if self._material is not material or self._state != "verified":
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch material is not verified for spawn",
+                )
+            try:
+                self._validate_material(material)
+            except BaseException:
+                self._state = "faulted"
+                raise
+            if backend_id != self._backend.backend_id:
+                self._state = "faulted"
+                raise HostingError(
+                    HostingFailureCategory.ENDPOINT_TRANSFER_FAILED,
+                    "managed launch material targets a different process backend",
+                )
+            self._state = "claimed"
+
+    def reject_spawn(self, material: _CapturedLaunchMaterial) -> None:
+        with self._state_lock:
+            if self._material is material and self._state == "verified":
+                self._state = "faulted"
+
+    def finish_spawn(
+        self,
+        material: _CapturedLaunchMaterial,
+        *,
+        outcome: str,
+    ) -> None:
+        with self._state_lock:
+            if self._material is not material or self._state != "claimed":
+                raise RuntimeError("managed launch spawn state is inconsistent")
+            if outcome not in {"attached", "not-created", "fenced"}:
+                raise ValueError("managed launch spawn outcome is invalid")
+            self._state = {
+                "attached": "attached",
+                "not-created": "faulted",
+                "fenced": "fenced",
+            }[outcome]
+
+    def mark_closed(self, material: _CapturedLaunchMaterial, *, success: bool) -> None:
+        with self._state_lock:
+            if self._material is material:
+                self._state = "closed" if success else "faulted"
+
+    def begin_close(self, material: _CapturedLaunchMaterial) -> None:
+        with self._state_lock:
+            if self._material is not material:
+                raise RuntimeError("managed launch close owner is inconsistent")
+            if self._state == "closed":
+                return
+            if self._state == "closing":
+                raise RuntimeError("managed launch close is already active")
+            if self._state == "fenced":
+                raise HostingError(
+                    HostingFailureCategory.CLEANUP_FAILED,
+                    "managed launch outcome is fenced and cannot be reclaimed",
+                )
+            self._state = "closing"
+
+
+class _ManagedSpawnNotCreated(Exception):
+    """Authority-minted receipt that the unique OS creation effect did not run."""
+
+    def __init__(self, cause: BaseException, receipt: object) -> None:
+        super().__init__("managed launch did not create a process")
+        self.cause = cause
+        self._receipt = receipt
+
+
+class _ManagedSpawnEffect:
+    """One authority-owned witness around the native process-creation effect."""
+
+    def __init__(self) -> None:
+        self._receipt = object()
+        self._state = "ready"
+        self._attached: _ProcessTransport | None = None
+        self._lock = threading.Lock()
+
+    def begin_effect(self) -> None:
+        """Fence immediately before the backend may create an OS process."""
+
+        with self._lock:
+            if self._state != "ready":
+                raise RuntimeError("managed process creation effect began more than once")
+            self._state = "started"
+
+    def observe_attachment(self, process: _ProcessTransport) -> None:
+        with self._lock:
+            if self._state == "ready":
+                self._attached = process
+                self._state = "invalid-attached"
+                raise RuntimeError(
+                    "managed process attached before its creation effect gate"
+                )
+            if self._attached is not None and self._attached is not process:
+                raise RuntimeError("managed process attachment identity changed")
+            if self._state not in {"started", "attached"}:
+                raise RuntimeError("managed process attachment state is invalid")
+            self._attached = process
+            self._state = "attached"
+
+    def not_created(self, cause: BaseException) -> _ManagedSpawnNotCreated:
+        """Mint a receipt; it remains valid only while no effect has begun."""
+
+        return _ManagedSpawnNotCreated(cause, self._receipt)
+
+    def accepts(self, failure: _ManagedSpawnNotCreated) -> bool:
+        with self._lock:
+            return (
+                failure._receipt is self._receipt
+                and self._state == "ready"
+                and self._attached is None
+            )
+
+
+class _ManagedPreparationLease(LaunchPreparationLease, _ManagedProcessPreparation):
+    """Joins caller semantics and Hosting native ownership without blending them."""
+
+    def __init__(
+        self,
+        caller: LaunchPreparationLease,
+        material: _CapturedLaunchMaterial,
+        authority: _ReservationLaunchCapture,
+    ) -> None:
+        self._caller = caller
+        self._material = material
+        self._authority = authority
+        self._operation_lock = asyncio.Lock()
+        self._verify_task: asyncio.Task[None] | None = None
+        self._spawn_task: asyncio.Task[_ProcessTransport] | None = None
+        self._close_task: asyncio.Task[None] | None = None
+        self._caller_closed = False
+        self._material_closed = False
+
+    @property
+    def request(self) -> ProcessLaunchRequest:
+        return self._caller.request
+
+    @property
+    def backend_id(self) -> str:
+        return self._material.backend_id
+
+    async def verify_current(self) -> None:
+        async with self._operation_lock:
+            if self._close_task is not None:
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch preparation is closing",
+                )
+            if self._verify_task is not None:
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch preparation verification is single-use",
+                )
+            self._authority.begin_verify(self._material)
+            task = asyncio.create_task(
+                self._verify_owned(),
+                name=f"hosting-{self._material.attempt_id}-preparation-verify",
+            )
+            self._verify_task = task
+        await _await_owned(task)
+
+    async def _verify_owned(self) -> None:
+        success = False
+        try:
+            await self._caller.verify_current()
+            await self._material.verify_current(self.request)
+            success = True
+        finally:
+            self._authority.finish_verify(self._material, success=success)
+
+    async def spawn_prepared(
+        self,
+        backend: _ProcessBackend,
+        request: ProcessLaunchRequest,
+        *,
+        on_spawn: Callable[[_ProcessTransport], None],
+        on_orphan_spawn: Callable[[_ProcessTransport], None],
+        inheritance: _ProcessInheritance | None,
+    ) -> _ProcessTransport:
+        async with self._operation_lock:
+            if self._close_task is not None:
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch preparation is closing",
+                )
+            if self._spawn_task is not None:
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch spawn is single-use",
+                )
+            if request != self.request:
+                self._authority.reject_spawn(self._material)
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "managed launch spawn request was retargeted",
+                )
+            self._authority.begin_spawn(
+                self._material,
+                backend_id=backend.backend_id,
+            )
+            task = asyncio.create_task(
+                self._spawn_owned(
+                    backend,
+                    request,
+                    on_spawn=on_spawn,
+                    on_orphan_spawn=on_orphan_spawn,
+                    inheritance=inheritance,
+                ),
+                name=f"hosting-{self._material.attempt_id}-prepared-spawn",
+            )
+            self._spawn_task = task
+        return await _await_owned(task)
+
+    async def _spawn_owned(
+        self,
+        backend: _ProcessBackend,
+        request: ProcessLaunchRequest,
+        *,
+        on_spawn: Callable[[_ProcessTransport], None],
+        on_orphan_spawn: Callable[[_ProcessTransport], None],
+        inheritance: _ProcessInheritance | None,
+    ) -> _ProcessTransport:
+        outcome = "fenced"
+        attached: _ProcessTransport | None = None
+        effect = _ManagedSpawnEffect()
+
+        def attach(process: _ProcessTransport) -> None:
+            nonlocal attached
+            if attached is None:
+                on_spawn(process)
+                attached = process
+                effect.observe_attachment(process)
+                return
+            if process is attached:
+                on_spawn(process)
+                return
+            on_orphan_spawn(process)
+            raise RuntimeError(
+                "managed process backend attached more than one process"
+            )
+
+        try:
+            process = await self._material.spawn(
+                backend,
+                request,
+                effect=effect,
+                on_spawn=attach,
+                inheritance=inheritance,
+            )
+            if attached is None:
+                on_spawn(process)
+                attached = process
+                effect.observe_attachment(process)
+                outcome = "attached"
+                raise RuntimeError(
+                    "managed process backend returned before owner attachment"
+                )
+            if process is not attached:
+                on_orphan_spawn(process)
+                outcome = "attached"
+                raise RuntimeError(
+                    "managed process backend returned a different process owner"
+                )
+            outcome = "attached"
+            return process
+        except _ManagedSpawnNotCreated as failure:
+            if effect.accepts(failure):
+                outcome = "not-created"
+            raise failure.cause from failure
+        finally:
+            self._authority.finish_spawn(self._material, outcome=outcome)
+
+    async def close(self) -> None:
+        async with self._operation_lock:
+            task = self._close_task
+            if task is None:
+                task = asyncio.create_task(
+                    self._close_owned(),
+                    name=f"hosting-{self._material.attempt_id}-preparation-close",
+                )
+                self._close_task = task
+        try:
+            await _await_owned(task)
+        except BaseException:
+            async with self._operation_lock:
+                if self._close_task is task and _owner_task_failed(task):
+                    self._close_task = None
+            raise
+
+    async def _close_owned(self) -> None:
+        verify = self._verify_task
+        if verify is not None and not verify.done():
+            await asyncio.gather(asyncio.shield(verify), return_exceptions=True)
+        spawn = self._spawn_task
+        if spawn is not None and not spawn.done():
+            await asyncio.gather(asyncio.shield(spawn), return_exceptions=True)
+        self._authority.begin_close(self._material)
+        failures: list[BaseException] = []
+        if not self._material_closed:
+            try:
+                await self._material.close()
+            except BaseException as error:
+                failures.append(error)
+            else:
+                self._material_closed = True
+        if not self._caller_closed:
+            try:
+                await self._caller.close()
+            except BaseException as error:
+                failures.append(error)
+            else:
+                self._caller_closed = True
+        success = self._caller_closed and self._material_closed
+        self._authority.mark_closed(self._material, success=success)
+        if failures:
+            raise BaseExceptionGroup(
+                "managed launch preparation cleanup failed",
+                failures,
+            )
+
+
+async def _await_owned(task: asyncio.Task[_T]) -> _T:
+    cancellation: asyncio.CancelledError | None = None
+    while True:
+        try:
+            result = await asyncio.shield(task)
+            break
+        except asyncio.CancelledError as exc:
+            if task.cancelled():
+                raise
+            if cancellation is None:
+                cancellation = exc
+        except BaseException as exc:
+            if cancellation is not None:
+                raise cancellation from exc
+            raise
+    if cancellation is not None:
+        raise cancellation
+    return cast(_T, result)
+
+
+def _owner_task_failed(task: asyncio.Task[object]) -> bool:
+    return task.done() and (task.cancelled() or task.exception() is not None)
+
+
+__all__: list[str] = []

--- a/src/loushang/hosting/_process_backend.py
+++ b/src/loushang/hosting/_process_backend.py
@@ -7,6 +7,7 @@ with deterministic fakes only.
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import Protocol
 
@@ -76,6 +77,22 @@ class _ProcessBackend(Protocol):
 
     async def close_backend(self) -> None:
         """Release backend-owned executor or platform support resources."""
+
+
+class _ManagedProcessPreparation(ABC):
+    """Private H6 double-dispatch seam for one backend-owned spawn effect."""
+
+    @abstractmethod
+    async def spawn_prepared(
+        self,
+        backend: _ProcessBackend,
+        request: ProcessLaunchRequest,
+        *,
+        on_spawn: Callable[[_ProcessTransport], None],
+        on_orphan_spawn: Callable[[_ProcessTransport], None],
+        inheritance: _ProcessInheritance | None,
+    ) -> _ProcessTransport:
+        raise NotImplementedError
 
 
 __all__: list[str] = []

--- a/src/loushang/hosting/_process_host.py
+++ b/src/loushang/hosting/_process_host.py
@@ -14,6 +14,7 @@ from enum import Enum
 from typing import TypeVar, cast
 
 from ._process_backend import (
+    _ManagedProcessPreparation,
     _ProcessBackend,
     _ProcessInheritance,
     _ProcessTransport,
@@ -117,6 +118,7 @@ class _Reservation:
     session_id: str | None = None
     preparation: LaunchPreparationLease | None = None
     process: _ProcessTransport | None = None
+    orphan_processes: list[_ProcessTransport] = field(default_factory=list)
     cleanup_error: _CleanupError | None = None
 
     def attach_preparation(self, preparation: LaunchPreparationLease) -> None:
@@ -128,6 +130,13 @@ class _Reservation:
         if self.process is not None and self.process is not process:
             raise RuntimeError("process reservation already owns a process")
         self.process = process
+
+    def attach_orphan_process(self, process: _ProcessTransport) -> None:
+        if self.process is process or any(
+            owned is process for owned in self.orphan_processes
+        ):
+            return
+        self.orphan_processes.append(process)
 
 
 class _BoundedByteTail:
@@ -681,6 +690,13 @@ class _ProcessHost:
             session_id=None,
         )
 
+    def _has_cleanup_debt(self, session_id: str) -> bool:
+        return any(
+            reservation.session_id == session_id
+            and reservation.cleanup_error is not None
+            for reservation in self._reservations.values()
+        )
+
     async def _start_with_inheritance(
         self,
         request: ProcessLaunchRequest,
@@ -746,11 +762,20 @@ class _ProcessHost:
                 HostingLifecycleTransition.SPAWNING,
                 session_id=session_id,
             )
-            process = await self._backend.spawn(
-                prepared_request,
-                on_spawn=reservation.attach_process,
-                inheritance=inheritance,
-            )
+            if isinstance(prepared, _ManagedProcessPreparation):
+                process = await prepared.spawn_prepared(
+                    self._backend,
+                    prepared_request,
+                    on_spawn=reservation.attach_process,
+                    on_orphan_spawn=reservation.attach_orphan_process,
+                    inheritance=inheritance,
+                )
+            else:
+                process = await self._backend.spawn(
+                    prepared_request,
+                    on_spawn=reservation.attach_process,
+                    inheritance=inheritance,
+                )
             if reservation.process is None:
                 # Salvage the returned object so a broken backend cannot turn
                 # its own missing callback into an unowned process leak.
@@ -872,6 +897,19 @@ class _ProcessHost:
             session_id=reservation.session_id,
         )
         try:
+            remaining_orphans: list[_ProcessTransport] = []
+            for orphan in reservation.orphan_processes:
+                failure_count = len(failures)
+                await _reclaim_unpublished(
+                    self._backend,
+                    orphan,
+                    self._limits,
+                    self._timeouts,
+                    failures,
+                )
+                if len(failures) != failure_count:
+                    remaining_orphans.append(orphan)
+            reservation.orphan_processes = remaining_orphans
             if reservation.process is not None:
                 failure_count = len(failures)
                 await _reclaim_unpublished(

--- a/tests/architecture/test_architecture_documentation.py
+++ b/tests/architecture/test_architecture_documentation.py
@@ -39,6 +39,8 @@ INITIAL_GOVERNED_DOCUMENTS = (
     ARCHITECTURE_ROOT / "hosting/contract-model-h0.md",
     ARCHITECTURE_ROOT / "hosting/traceability.md",
     ARCHITECTURE_ROOT / "hosting/managed-launch-preparation-h6.md",
+    ARCHITECTURE_ROOT
+    / "hosting/validation/managed-launch-preparation-h6-feasibility.md",
     ARCHITECTURE_ROOT / "hosting/validation/hosted-product-runtime-v1-inventory.md",
     ARCHITECTURE_ROOT / "hosting/key-designs/hosted-application-support-boundary.md",
     ARCHITECTURE_ROOT / "drafts/apphost-top-level-placement.md",

--- a/tests/architecture/test_hosted_product_runtime_v1_baseline.py
+++ b/tests/architecture/test_hosted_product_runtime_v1_baseline.py
@@ -36,6 +36,7 @@ CURRENT_SOURCE_SEAMS = (
     HOSTING_SOURCE / "_process_backend.py",
     HOSTING_SOURCE / "_process_host.py",
     HOSTING_SOURCE / "_child_session_host.py",
+    HOSTING_SOURCE / "_launch_preparation.py",
     HOSTING_SOURCE / "_posix_process.py",
     HOSTING_SOURCE / "_windows_process.py",
     HOSTING_SOURCE / "_win32_process.py",
@@ -127,9 +128,9 @@ def test_baseline_documents_are_status_honest_and_indexed() -> None:
             "ID": "HOST-H6",
             "Scope": "hosting",
             "Parent": "loushang",
-            "Authority": "normative proposed design",
-            "Design status": "proposed",
-            "Implementation status": "not-started",
+            "Authority": "normative accepted design",
+            "Design status": "accepted",
+            "Implementation status": "partial — H6.1 private fake-backed core",
             "Activation status": "forbidden; H5 remains default-dark",
         },
         INVENTORY: {
@@ -186,7 +187,7 @@ def test_h6_keeps_authority_outside_and_native_material_opaque() -> None:
     h6 = _read(H6)
     normalized_h6 = " ".join(h6.split())
     responsibility = _section(h6, "Responsibility Boundary")
-    contract = _section(h6, "Proposed Contract Properties")
+    contract = _section(h6, "Accepted Contract Properties")
 
     for statement in (
         "Meaning stays with the caller; mechanism stays with Hosting",

--- a/tests/architecture/test_hosting_h0_contract.py
+++ b/tests/architecture/test_hosting_h0_contract.py
@@ -31,6 +31,9 @@ H3_PRIVATE_MODULES = {
 H4_PRIVATE_MODULES = {
     HOSTING_ROOT / "_child_session_host.py",
 }
+H6_PRIVATE_MODULES = {
+    HOSTING_ROOT / "_launch_preparation.py",
+}
 FORBIDDEN_PUBLIC_TERMS = {
     "Approval",
     "Authorization",
@@ -60,6 +63,7 @@ def test_hosting_package_is_standard_library_only_and_product_neutral() -> None:
         | H2_PRIVATE_MODULES
         | H3_PRIVATE_MODULES
         | H4_PRIVATE_MODULES
+        | H6_PRIVATE_MODULES
     )
     assert {path for path in HOSTING_ROOT.rglob("*.py")} == modules
 

--- a/tests/architecture/test_hosting_h6_launch_preparation.py
+++ b/tests/architecture/test_hosting_h6_launch_preparation.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+HOSTING = Path("src/loushang/hosting")
+CORE = HOSTING / "_launch_preparation.py"
+CHILD_SESSION = HOSTING / "_child_session_host.py"
+PROCESS_BACKEND = HOSTING / "_process_backend.py"
+PROCESS_HOST = HOSTING / "_process_host.py"
+ENDPOINT_HOST = HOSTING / "_endpoint_host.py"
+PUBLIC_SURFACES = (
+    HOSTING / "__init__.py",
+    HOSTING / "contracts.py",
+    HOSTING / "runtime.py",
+)
+FEASIBILITY = (
+    Path("docs/internals/architecture/hosting/validation")
+    / "managed-launch-preparation-h6-feasibility.md"
+)
+RUNTIME_TESTS = Path("tests/hosting/test_child_session_host.py")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _imports(path: Path) -> set[str]:
+    imports: set[str] = set()
+    for node in ast.walk(ast.parse(_read(path), filename=str(path))):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imports.add(node.module)
+    return imports
+
+
+def test_h6_1_core_is_private_default_dark_and_authority_free() -> None:
+    core = _read(CORE)
+    child_session = _read(CHILD_SESSION)
+    process_backend = _read(PROCESS_BACKEND)
+    public = "\n".join(_read(path) for path in PUBLIC_SURFACES)
+
+    assert "__all__: list[str] = []" in core
+    assert "launch_capture_backend" in child_session
+    assert "launch_capture_backend" not in public
+    for private_name in (
+        "_LaunchCaptureSpec",
+        "_OpaqueLaunchBinding",
+        "_ManagedLaunchPreparationPort",
+        "_CapturedLaunchMaterial",
+        "_LaunchCaptureBackend",
+        "_ReservationLaunchCapture",
+        "_ManagedSpawnEffect",
+        "_ManagedSpawnNotCreated",
+    ):
+        assert private_name in core
+        assert private_name not in public
+    assert "_ManagedProcessPreparation" in process_backend
+    assert "_ManagedProcessPreparation" not in public
+
+    imports = (
+        _imports(CORE)
+        | _imports(CHILD_SESSION)
+        | _imports(PROCESS_BACKEND)
+        | _imports(PROCESS_HOST)
+    )
+    forbidden = (
+        "loushang.harness",
+        "loushang.coding",
+        "loushang.apphost",
+        "loushang.appserver",
+        "loushang.appservice",
+    )
+    assert not any(name.startswith(forbidden) for name in imports)
+    for authority_word in (
+        "ApprovalReceipt",
+        "Authorization",
+        "WorkerLaunchAuthority",
+        "PluginGeneration",
+        "ProductId",
+    ):
+        assert authority_word not in core
+        assert authority_word not in child_session
+
+
+def test_h6_1_binding_and_state_are_request_attempt_backend_bound() -> None:
+    core = _read(CORE)
+
+    for field in (
+        "request: ProcessLaunchRequest",
+        "profile_id: str",
+        "execution_closure: tuple[str, ...]",
+        "attempt_id: str",
+        "attempt_token: object",
+        "backend_id",
+        "binding._authority is not self",
+        "binding._nonce is not self._binding_nonce",
+        "self._spec.request != prepared_request",
+        "material.request != self._spec.request",
+        "material.attempt_id != self._attempt_id",
+        "material.attempt_token is not self._attempt_token",
+        "material.profile_id != self._spec.profile_id",
+        "material.execution_closure != self._spec.execution_closure",
+    ):
+        assert field in core
+
+    for state in (
+        '"minted"',
+        '"capturing"',
+        '"captured"',
+        '"verifying"',
+        '"verified"',
+        '"claimed"',
+        '"attached"',
+        '"closing"',
+        '"closed"',
+        '"faulted"',
+        '"fenced"',
+    ):
+        assert state in core
+
+
+def test_h6_1_transaction_attaches_then_uses_matched_backend_double_dispatch() -> None:
+    core = _read(CORE)
+    session = _read(CHILD_SESSION)
+    process_host = _read(PROCESS_HOST)
+
+    capture_body = core.split(
+        "    async def capture(self, spec: _LaunchCaptureSpec)", maxsplit=1
+    )[1].split("    def bind_result(", maxsplit=1)[0]
+    assert capture_body.index("on_capture=self._attach") < capture_body.index(
+        "return _OpaqueLaunchBinding"
+    )
+    assert session.index("attach_launch_capture") < session.index(
+        "release_launch_capture"
+    )
+    assert "self._binding_nonce = object()" in core
+    assert "class _ManagedLaunchPreparationPort(ABC)" in core
+    assert "effect.begin_effect()" in _read(RUNTIME_TESTS)
+    assert "if effect.accepts(failure):" in core
+    assert "on_orphan_spawn(process)" in core
+    assert "await self._material.spawn(" in core
+    assert "isinstance(prepared, _ManagedProcessPreparation)" in process_host
+    assert "await prepared.spawn_prepared(" in process_host
+    assert "self._deferred.bind(endpoint.inheritance)" in session
+    assert "await self._caller.verify_current()" in core
+    assert "await self._material.verify_current(self.request)" in core
+    assert "class _NestedCleanupDebt" in session
+    assert "retained_cleanup_debt.settled(" in session
+    assert "def _has_cleanup_debt(self, session_id: str)" in process_host
+    assert "def _has_cleanup_debt(self, session_id: str)" in _read(ENDPOINT_HOST)
+    assert "_find_cleanup_debt" not in session
+
+
+def test_h6_1_fault_and_concurrency_matrix_is_executable() -> None:
+    tests = _read(RUNTIME_TESTS)
+    tree = ast.parse(tests, filename=str(RUNTIME_TESTS))
+    async_tests = {
+        node.name: node for node in tree.body if isinstance(node, ast.AsyncFunctionDef)
+    }
+    required_tests = (
+        "test_managed_launch_joins_opaque_material_into_one_spawn_manifest",
+        "test_managed_launch_callback_failure_after_capture_reclaims_before_endpoint",
+        "test_managed_launch_cancellation_after_capture_reclaims_reservation",
+        "test_managed_launch_capture_is_single_use_under_concurrency",
+        "test_managed_launch_rejects_retarget_before_endpoint_acquisition",
+        "test_managed_launch_rejects_cross_reservation_binding",
+        "test_managed_launch_slot_bound_and_collision_fail_closed",
+        "test_managed_launch_native_verify_failure_prevents_spawn",
+        "test_managed_launch_backend_contract_mismatch_closes_both_materials",
+        "test_managed_launch_cancelled_different_capture_retains_both_materials",
+        "test_managed_launch_missing_attachment_is_salvaged_then_rejected",
+        "test_managed_launch_close_waits_for_claimed_spawn_and_rejects_replay",
+        "test_managed_launch_verify_and_close_share_one_owner_operation",
+        "test_managed_launch_final_fence_cancellation_prevents_spawn",
+        "test_managed_launch_ambiguous_spawn_cancellation_reclaims_every_owner",
+        "test_managed_launch_host_close_waits_for_attached_capture",
+        "test_managed_launch_cleanup_debt_is_retained_and_retried_on_host_close",
+        "test_managed_launch_joined_owner_survives_endpoint_failure",
+        "test_managed_launch_binding_is_consumed_by_the_first_bind",
+        "test_managed_launch_attached_then_capture_error_reclaims_both_owners",
+        "test_managed_launch_pre_attachment_error_acquires_no_native_owner",
+        "test_managed_launch_orphan_cleanup_failure_is_owned_and_retried",
+        "test_managed_launch_attempt_identity_is_unique_across_hosts",
+        "test_managed_launch_cached_material_cannot_cross_attempt_tokens",
+        "test_managed_launch_revalidates_identity_immediately_before_spawn",
+        "test_managed_launch_concurrent_verify_is_one_use",
+        "test_managed_launch_dual_cleanup_failure_retries_in_dependency_order",
+        "test_managed_launch_unknown_spawn_outcome_fences_host_and_attempt",
+        "test_managed_launch_cancelled_missing_spawn_callback_is_salvaged",
+        "test_managed_launch_cancelled_different_spawn_retains_both_processes",
+        "test_managed_launch_not_created_receipt_after_effect_fences_attempt",
+        "test_managed_launch_missing_effect_gate_is_attached_then_fenced",
+        "test_managed_launch_attachment_invalidates_forged_not_created_receipt",
+        "test_managed_launch_transfer_fault_reclaims_process_but_keeps_fence",
+        "test_managed_launch_recursive_start_cannot_bypass_reserved_capacity",
+        "test_managed_launch_profile_identities_use_the_same_opaque_protocol",
+        "test_managed_launch_private_process_seam_is_nominal_not_duck_typed",
+        "test_managed_launch_private_caller_seam_is_nominal_and_default_dark",
+    )
+    for test_name in required_tests:
+        test = async_tests[test_name]
+        assert any(isinstance(node, ast.Assert) for node in ast.walk(test))
+        decorators = {ast.unparse(decorator) for decorator in test.decorator_list}
+        assert not any("skip" in decorator for decorator in decorators)
+
+    makefile = _read(Path("Makefile"))
+    assert "HOSTING_TEST_PATHS :=" in makefile
+    assert "\ttests/hosting \\" in makefile
+
+
+def test_h6_1_feasibility_record_separates_common_core_from_native_claims() -> None:
+    record = " ".join(_read(FEASIBILITY).split())
+
+    for statement in (
+        "No production process is launched by these probes",
+        "POSIX Mapping Probe",
+        "Windows Mapping Probe",
+        "common protocol",
+        "synchronously register",
+        "H6.2",
+        "H6.3",
+        "H6.4",
+        "default-dark",
+        "no public contract",
+    ):
+        assert statement.lower() in record.lower()

--- a/tests/hosting/test_child_session_host.py
+++ b/tests/hosting/test_child_session_host.py
@@ -32,6 +32,20 @@ from loushang.hosting._endpoint_backend import (
     _SingleUseProcessInheritance,
 )
 from loushang.hosting._endpoint_host import _InheritedEndpointHost
+from loushang.hosting._launch_preparation import (
+    _CapturedLaunchMaterial,
+    _LaunchCaptureBackend,
+    _LaunchCapturePort,
+    _LaunchCaptureSpec,
+    _ManagedLaunchPreparationPort,
+    _ManagedLaunchPreparationResult,
+    _ManagedSpawnEffect,
+    _OpaqueLaunchBinding,
+    _ReservationLaunchCapture,
+)
+from loushang.hosting._process_backend import (
+    _ProcessBackend as _ProcessBackendPort,
+)
 from loushang.hosting._process_backend import (
     _ProcessInheritance,
     _ProcessTransport,
@@ -75,6 +89,7 @@ class _Preparation:
         self.request = request
         self.events = events
         self.verify_error = verify_error
+        self.close_error_once: BaseException | None = None
         self.close_calls = 0
 
     async def verify_current(self) -> None:
@@ -85,6 +100,10 @@ class _Preparation:
     async def close(self) -> None:
         self.events.append("preparation-close")
         self.close_calls += 1
+        if self.close_error_once is not None:
+            error = self.close_error_once
+            self.close_error_once = None
+            raise error
 
 
 class _PreparationPort:
@@ -226,11 +245,23 @@ class _ProcessBackend:
         self.spawn_error: BaseException | None = None
         self.early_exit = False
         self.block_spawn = False
+        self.skip_managed_attachment = False
+        self.return_different_managed_process = False
+        self.managed_process_created = asyncio.Event()
+        self.block_after_managed_claim = False
+        self.managed_claimed = asyncio.Event()
+        self.managed_claim_release = asyncio.Event()
+        self.managed_claim_release.set()
+        self.ambiguous_spawn_error: BaseException | None = None
+        self.not_created_after_effect_error: BaseException | None = None
+        self.skip_managed_effect_gate = False
+        self.callback_error_as_not_created = False
         self.spawn_attached = asyncio.Event()
         self.spawn_release = asyncio.Event()
         self.close_handle_calls = 0
         self.close_handle_error_once: BaseException | None = None
         self.close_calls = 0
+        self.expected_inheritance = (51, 51)
 
     async def spawn(
         self,
@@ -243,7 +274,10 @@ class _ProcessBackend:
         if self.spawn_error is not None:
             raise self.spawn_error
         assert inheritance is not None
-        assert inheritance.claim(backend_id=self.backend_id) == (51, 51)
+        inherited = inheritance.claim(backend_id=self.backend_id)
+        self.events.append("inheritance-claimed")
+        assert inherited == self.expected_inheritance
+        self.events.append("process-create")
         process = _Process(self.events, early_exit=self.early_exit)
         self.processes.append(process)
         inheritance.mark_transferred()
@@ -251,6 +285,73 @@ class _ProcessBackend:
         self.spawn_attached.set()
         if self.block_spawn:
             await self.spawn_release.wait()
+        return process
+
+    async def spawn_managed(
+        self,
+        request: ProcessLaunchRequest,
+        *,
+        material: _CapturedMaterial,
+        effect: _ManagedSpawnEffect,
+        on_spawn: Callable[[_ProcessTransport], None],
+        inheritance: _ProcessInheritance | None,
+    ) -> _Process:
+        self.events.append("spawn")
+        if self.spawn_error is not None:
+            raise effect.not_created(self.spawn_error)
+        assert inheritance is not None
+        endpoint_values = inheritance.claim(backend_id=self.backend_id)
+        preparation_values = material.claim_for_spawn(backend_id=self.backend_id)
+        if (
+            len(preparation_values) != material.inherited_slot_count
+            or any(type(value) is not int or value < 0 for value in preparation_values)
+            or len(set(preparation_values)) != len(preparation_values)
+        ):
+            raise effect.not_created(
+                HostingError(
+                    HostingFailureCategory.ENDPOINT_TRANSFER_FAILED,
+                    "managed preparation returned an invalid inheritance manifest",
+                )
+            )
+        if set(endpoint_values) & set(preparation_values):
+            raise effect.not_created(
+                HostingError(
+                    HostingFailureCategory.ENDPOINT_TRANSFER_FAILED,
+                    "endpoint and preparation inheritance slots collide",
+                )
+            )
+        inherited = (*endpoint_values, *preparation_values)
+        self.events.append("inheritance-claimed")
+        assert inherited == self.expected_inheritance
+        self.managed_claimed.set()
+        if self.block_after_managed_claim:
+            await self.managed_claim_release.wait()
+        if self.ambiguous_spawn_error is not None:
+            raise self.ambiguous_spawn_error
+        if not self.skip_managed_effect_gate:
+            effect.begin_effect()
+        self.events.append("process-create")
+        process = _Process(self.events, early_exit=self.early_exit)
+        self.processes.append(process)
+        self.managed_process_created.set()
+        if self.not_created_after_effect_error is not None:
+            raise effect.not_created(self.not_created_after_effect_error)
+        if not self.skip_managed_attachment:
+            try:
+                on_spawn(process)
+            except BaseException as callback_error:
+                if self.callback_error_as_not_created:
+                    raise effect.not_created(callback_error) from callback_error
+                raise
+        inheritance.mark_transferred()
+        material.mark_transferred()
+        self.spawn_attached.set()
+        if self.block_spawn:
+            await self.spawn_release.wait()
+        if self.return_different_managed_process:
+            different = _Process(self.events, early_exit=self.early_exit)
+            self.processes.append(different)
+            return different
         return process
 
     def tree_exited(self, process: _ProcessTransport) -> bool:
@@ -283,10 +384,240 @@ class _ProcessBackend:
         self.close_calls += 1
 
 
+class _CapturedMaterial:
+    backend_id = "fake-process-v1"
+
+    def __init__(
+        self,
+        request: ProcessLaunchRequest,
+        attempt_id: str,
+        attempt_token: object,
+        events: list[str],
+        *,
+        slots: tuple[int, ...] = (61, 62),
+        profile_id: str = "fake-profile-v1",
+        execution_closure: tuple[str, ...] = (
+            "launcher:fake-v1",
+            "payload:fake-v1",
+        ),
+    ) -> None:
+        self.request = request
+        self.attempt_id = attempt_id
+        self.attempt_token = attempt_token
+        self.events = events
+        self.slots = slots
+        self.profile_id = profile_id
+        self.execution_closure = execution_closure
+        self.verify_error: BaseException | None = None
+        self.close_error_once: BaseException | None = None
+        self.transfer_error: BaseException | None = None
+        self.block_verify = False
+        self.verify_entered = asyncio.Event()
+        self.verify_release = asyncio.Event()
+        self.verify_release.set()
+        self.claim_calls = 0
+        self.transfer_calls = 0
+        self.close_calls = 0
+
+    @property
+    def inherited_slot_count(self) -> int:
+        return len(self.slots)
+
+    async def verify_current(self, request: ProcessLaunchRequest) -> None:
+        self.events.append("native-verify")
+        assert request == self.request
+        self.verify_entered.set()
+        if self.block_verify:
+            await self.verify_release.wait()
+        if self.verify_error is not None:
+            raise self.verify_error
+
+    def claim_for_spawn(self, *, backend_id: str) -> tuple[int, ...]:
+        self.events.append("native-claim")
+        self.claim_calls += 1
+        assert backend_id == self.backend_id
+        return self.slots
+
+    def mark_transferred(self) -> None:
+        self.events.append("native-transfer")
+        self.transfer_calls += 1
+        if self.transfer_error is not None:
+            raise self.transfer_error
+
+    async def spawn(
+        self,
+        backend: _ProcessBackendPort,
+        request: ProcessLaunchRequest,
+        *,
+        effect: _ManagedSpawnEffect,
+        on_spawn: Callable[[_ProcessTransport], None],
+        inheritance: _ProcessInheritance | None,
+    ) -> _ProcessTransport:
+        if not isinstance(backend, _ProcessBackend):
+            raise effect.not_created(
+                HostingError(
+                    HostingFailureCategory.ENDPOINT_TRANSFER_FAILED,
+                    "fake material received a mismatched backend",
+                )
+            )
+        return await backend.spawn_managed(
+            request,
+            material=self,
+            effect=effect,
+            on_spawn=on_spawn,
+            inheritance=inheritance,
+        )
+
+    async def close(self) -> None:
+        self.events.append("native-close")
+        self.close_calls += 1
+        if self.close_error_once is not None:
+            error = self.close_error_once
+            self.close_error_once = None
+            raise error
+
+
+class _CaptureBackend:
+    backend_id = "fake-process-v1"
+
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        slots: tuple[int, ...] = (61, 62),
+    ) -> None:
+        self.events = events
+        self.slots = slots
+        self.materials: list[_CapturedMaterial] = []
+        self.skip_attachment = False
+        self.return_different = False
+        self.different_close_error_once: BaseException | None = None
+        self.error_before_attachment: BaseException | None = None
+        self.replay_material: _CapturedMaterial | None = None
+        self.error_after_attachment: BaseException | None = None
+        self.block_after_attachment = False
+        self.attached = asyncio.Event()
+        self.release = asyncio.Event()
+        self.release.set()
+
+    async def capture(
+        self,
+        spec: _LaunchCaptureSpec,
+        *,
+        attempt_id: str,
+        attempt_token: object,
+        on_capture: Callable[[_CapturedLaunchMaterial], None],
+    ) -> _CapturedMaterial:
+        self.events.append("native-capture")
+        if self.error_before_attachment is not None:
+            raise self.error_before_attachment
+        if self.replay_material is not None:
+            on_capture(self.replay_material)
+            return self.replay_material
+        material = _CapturedMaterial(
+            spec.request,
+            attempt_id,
+            attempt_token,
+            self.events,
+            slots=self.slots,
+            profile_id=spec.profile_id,
+            execution_closure=spec.execution_closure,
+        )
+        self.materials.append(material)
+        if not self.skip_attachment:
+            try:
+                on_capture(material)
+            except BaseException:
+                await material.close()
+                raise
+            self.events.append("native-attached")
+            self.attached.set()
+        if self.block_after_attachment:
+            await self.release.wait()
+        if self.error_after_attachment is not None:
+            raise self.error_after_attachment
+        if self.return_different:
+            different = _CapturedMaterial(
+                spec.request,
+                attempt_id,
+                attempt_token,
+                self.events,
+                slots=self.slots,
+                profile_id=spec.profile_id,
+                execution_closure=spec.execution_closure,
+            )
+            self.materials.append(different)
+            different.close_error_once = self.different_close_error_once
+            return different
+        return material
+
+
+class _ManagedPreparationPort(_ManagedLaunchPreparationPort):
+    def __init__(
+        self,
+        request: ProcessLaunchRequest,
+        events: list[str],
+        *,
+        profile_id: str = "fake-profile-v1",
+        execution_closure: tuple[str, ...] = (
+            "launcher:fake-v1",
+            "payload:fake-v1",
+        ),
+    ) -> None:
+        self.preparation = _Preparation(request, events)
+        self.events = events
+        self.profile_id = profile_id
+        self.execution_closure = execution_closure
+        self.capture_returned = asyncio.Event()
+        self.release = asyncio.Event()
+        self.release.set()
+        self.error_after_capture: BaseException | None = None
+        self.return_request: ProcessLaunchRequest | None = None
+        self.binding_override: _OpaqueLaunchBinding | None = None
+
+    async def prepare(self, request: ProcessLaunchRequest) -> _Preparation:
+        raise AssertionError("managed preparation must use its private port")
+
+    async def prepare_managed(
+        self,
+        request: ProcessLaunchRequest,
+        capture: _LaunchCapturePort,
+    ) -> _ManagedLaunchPreparationResult:
+        returned = False
+        try:
+            self.events.append("managed-prepare")
+            binding = await capture.capture(
+                _LaunchCaptureSpec(
+                    request=request,
+                    profile_id=self.profile_id,
+                    execution_closure=self.execution_closure,
+                )
+            )
+            self.events.append("capture-returned")
+            self.capture_returned.set()
+            await self.release.wait()
+            if self.error_after_capture is not None:
+                raise self.error_after_capture
+            if self.return_request is not None:
+                self.preparation.request = self.return_request
+            result = _ManagedLaunchPreparationResult(
+                self.preparation,
+                self.binding_override or binding,
+            )
+            returned = True
+            return result
+        finally:
+            if not returned:
+                cleanup = asyncio.create_task(self.preparation.close())
+                await asyncio.shield(cleanup)
+
+
 def _fake_host(
     events: list[str],
     *,
     max_sessions: int = 1,
+    launch_capture_backend: _LaunchCaptureBackend | None = None,
+    max_capture_slots: int = 8,
 ) -> tuple[_ChildSessionHost, _ProcessBackend, _EndpointBackend]:
     process_backend = _ProcessBackend(events)
     endpoint_backend = _EndpointBackend(events)
@@ -303,6 +634,8 @@ def _fake_host(
             process_host,
             endpoint_host,
             max_sessions=max_sessions,
+            launch_capture_backend=launch_capture_backend,
+            max_capture_slots=max_capture_slots,
         ),
         process_backend,
         endpoint_backend,
@@ -820,6 +1153,1288 @@ async def test_child_session_rollback_failure_retains_capacity_debt() -> None:
     assert faulted.value.category is HostingFailureCategory.HOST_CLOSED
     with pytest.raises(BaseExceptionGroup):
         await host.close()
+
+
+@_async_test
+async def test_managed_launch_joins_opaque_material_into_one_spawn_manifest() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+
+    lease = await host.start(ChildSessionRequest(request), preparation)
+
+    material = capture_backend.materials[0]
+    ordered = (
+        "managed-prepare",
+        "native-capture",
+        "native-attached",
+        "capture-returned",
+        "endpoint-create",
+        "verify",
+        "native-verify",
+        "spawn",
+        "native-claim",
+        "process-create",
+        "child-copy-close",
+        "native-transfer",
+    )
+    assert tuple(sorted(ordered, key=events.index)) == ordered
+    assert material.claim_calls == 1
+    assert material.transfer_calls == 1
+
+    await lease.close()
+    await host.close()
+
+    assert preparation.preparation.close_calls == 1
+    assert material.close_calls == 1
+    assert endpoint_backend.transports[0].close_calls == 1
+
+
+@_async_test
+async def test_managed_launch_callback_failure_after_capture_reclaims_before_endpoint() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+    preparation.error_after_capture = OSError("caller failed after capture")
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(ChildSessionRequest(request), preparation)
+
+    assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+    assert preparation.preparation.close_calls == 1
+    assert capture_backend.materials[0].close_calls == 1
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_cancellation_after_capture_reclaims_reservation() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+    preparation.release.clear()
+    start = asyncio.create_task(
+        host.start(ChildSessionRequest(request), preparation)
+    )
+    await preparation.capture_returned.wait()
+
+    start.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await start
+    await host.close()
+
+    assert capture_backend.materials[0].close_calls == 1
+    assert preparation.preparation.close_calls == 1
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+
+
+@_async_test
+async def test_managed_launch_capture_is_single_use_under_concurrency() -> None:
+    events: list[str] = []
+    backend = _CaptureBackend(events)
+    request = _process_request()
+    attached: list[_CapturedLaunchMaterial] = []
+    capture = _ReservationLaunchCapture(
+        backend,
+        attempt_id="attempt-1",
+        max_inherited_slots=8,
+        on_capture=attached.append,
+        on_orphan=attached.append,
+    )
+    spec = _LaunchCaptureSpec(
+        request=request,
+        profile_id="fake-profile-v1",
+        execution_closure=("launcher:fake-v1", "payload:fake-v1"),
+    )
+    backend.block_after_attachment = True
+    backend.release.clear()
+    first = asyncio.create_task(capture.capture(spec))
+    second = asyncio.create_task(capture.capture(spec))
+    await backend.attached.wait()
+    assert not first.done()
+    assert not second.done()
+    backend.release.set()
+    results = await asyncio.gather(first, second, return_exceptions=True)
+
+    assert sum(isinstance(result, _OpaqueLaunchBinding) for result in results) == 1
+    failures = [result for result in results if isinstance(result, HostingError)]
+    assert len(failures) == 1
+    assert failures[0].category is HostingFailureCategory.PREPARATION_FAILED
+    assert len(backend.materials) == 1
+    assert attached == [backend.materials[0]]
+    await backend.materials[0].close()
+
+
+@_async_test
+async def test_managed_launch_rejects_retarget_before_endpoint_acquisition() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+    preparation.return_request = ProcessLaunchRequest(
+        argv=(sys.executable, "-c", "raise SystemExit(3)"),
+        cwd=request.cwd,
+        effective_environment=request.effective_environment,
+        streams=request.streams,
+    )
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(ChildSessionRequest(request), preparation)
+
+    assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+    assert preparation.preparation.close_calls == 1
+    assert capture_backend.materials[0].close_calls == 1
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_rejects_cross_reservation_binding() -> None:
+    events: list[str] = []
+    request = _process_request()
+    backend = _CaptureBackend(events)
+    first_materials: list[_CapturedLaunchMaterial] = []
+    second_materials: list[_CapturedLaunchMaterial] = []
+    first = _ReservationLaunchCapture(
+        backend,
+        attempt_id="attempt-1",
+        max_inherited_slots=8,
+        on_capture=first_materials.append,
+        on_orphan=first_materials.append,
+    )
+    second = _ReservationLaunchCapture(
+        backend,
+        attempt_id="attempt-2",
+        max_inherited_slots=8,
+        on_capture=second_materials.append,
+        on_orphan=second_materials.append,
+    )
+    spec = _LaunchCaptureSpec(
+        request=request,
+        profile_id="fake-profile-v1",
+        execution_closure=("launcher:fake-v1", "payload:fake-v1"),
+    )
+    binding = await first.capture(spec)
+    await second.capture(spec)
+
+    with pytest.raises(HostingError) as failure:
+        second.bind_result(
+            _ManagedLaunchPreparationResult(_Preparation(request, events), binding)
+        )
+
+    assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+    await asyncio.gather(first_materials[0].close(), second_materials[0].close())
+
+
+@_async_test
+async def test_managed_launch_slot_bound_and_collision_fail_closed() -> None:
+    for slots, expected_category in (
+        (tuple(range(9)), HostingFailureCategory.CAPACITY_EXHAUSTED),
+        ((51, 61), HostingFailureCategory.ENDPOINT_TRANSFER_FAILED),
+        ((-1, 61), HostingFailureCategory.ENDPOINT_TRANSFER_FAILED),
+        ((61, 61), HostingFailureCategory.ENDPOINT_TRANSFER_FAILED),
+    ):
+        events: list[str] = []
+        capture_backend = _CaptureBackend(events, slots=slots)
+        host, process_backend, endpoint_backend = _fake_host(
+            events,
+            launch_capture_backend=capture_backend,
+            max_capture_slots=8,
+        )
+        request = _process_request()
+
+        with pytest.raises(HostingError) as failure:
+            await host.start(
+                ChildSessionRequest(request),
+                _ManagedPreparationPort(request, events),
+            )
+
+        assert failure.value.category is expected_category
+        assert capture_backend.materials[0].close_calls == 1
+        assert process_backend.processes == []
+        if len(slots) <= 8:
+            assert endpoint_backend.transports[0].close_calls == 1
+        else:
+            assert endpoint_backend.transports == []
+        await host.close()
+
+
+@_async_test
+async def test_managed_launch_native_verify_failure_prevents_spawn() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+    capture_backend.block_after_attachment = True
+    capture_backend.release.clear()
+    start = asyncio.create_task(host.start(ChildSessionRequest(request), preparation))
+    await capture_backend.attached.wait()
+    capture_backend.materials[0].verify_error = OSError("native identity changed")
+    capture_backend.release.set()
+
+    with pytest.raises(HostingError) as failure:
+        await start
+
+    assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+    assert capture_backend.materials[0].close_calls == 1
+    assert process_backend.processes == []
+    assert endpoint_backend.transports[0].close_calls == 1
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_backend_contract_mismatch_closes_both_materials() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    capture_backend.return_different = True
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+
+    with pytest.raises(HostingError):
+        await host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+
+    assert [material.close_calls for material in capture_backend.materials] == [1, 1]
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_cancelled_different_capture_retains_both_materials() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    capture_backend.block_after_attachment = True
+    capture_backend.return_different = True
+    capture_backend.release.clear()
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+    start = asyncio.create_task(
+        host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+    )
+    await capture_backend.attached.wait()
+
+    start.cancel()
+    capture_backend.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await start
+
+    assert len(capture_backend.materials) == 2
+    assert [material.close_calls for material in capture_backend.materials] == [1, 1]
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_missing_attachment_is_salvaged_then_rejected() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    capture_backend.skip_attachment = True
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+
+    with pytest.raises(HostingError):
+        await host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+
+    assert capture_backend.materials[0].close_calls == 1
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_close_waits_for_claimed_spawn_and_rejects_replay() -> None:
+    events: list[str] = []
+    request = _process_request()
+    capture_backend = _CaptureBackend(events)
+    process_backend = _ProcessBackend(events)
+    attached: list[_CapturedLaunchMaterial] = []
+    capture = _ReservationLaunchCapture(
+        capture_backend,
+        attempt_id="attempt-close-race",
+        max_inherited_slots=8,
+        on_capture=attached.append,
+        on_orphan=attached.append,
+    )
+    binding = await capture.capture(
+        _LaunchCaptureSpec(
+            request=request,
+            profile_id="fake-profile-v1",
+            execution_closure=("launcher:fake-v1", "payload:fake-v1"),
+        )
+    )
+    managed = capture.bind_result(
+        _ManagedLaunchPreparationResult(_Preparation(request, events), binding)
+    )
+    await managed.verify_current()
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    process_backend.block_after_managed_claim = True
+    process_backend.managed_claim_release.clear()
+    inheritance = _SingleUseProcessInheritance(
+        backend_id=process_backend.backend_id,
+        values=(51, 51),
+        close_values=lambda: None,
+    )
+    spawned: list[_ProcessTransport] = []
+    orphaned: list[_ProcessTransport] = []
+    spawn = asyncio.create_task(
+        managed.spawn_prepared(
+            process_backend,
+            request,
+            on_spawn=spawned.append,
+            on_orphan_spawn=orphaned.append,
+            inheritance=inheritance,
+        )
+    )
+    await process_backend.managed_claimed.wait()
+
+    close = asyncio.create_task(managed.close())
+    await asyncio.sleep(0)
+    assert capture.state == "claimed"
+    assert not close.done()
+    assert attached[0].close_calls == 0
+    process_backend.managed_claim_release.set()
+    process = await spawn
+    await close
+    with pytest.raises(HostingError):
+        await managed.spawn_prepared(
+            process_backend,
+            request,
+            on_spawn=spawned.append,
+            on_orphan_spawn=orphaned.append,
+            inheritance=inheritance,
+        )
+    assert spawned == [process]
+    assert attached[0].claim_calls == 1
+    assert attached[0].close_calls == 1
+
+
+@_async_test
+async def test_managed_launch_verify_and_close_share_one_owner_operation() -> None:
+    events: list[str] = []
+    request = _process_request()
+    backend = _CaptureBackend(events)
+    attached: list[_CapturedLaunchMaterial] = []
+    capture = _ReservationLaunchCapture(
+        backend,
+        attempt_id="attempt-verify-close",
+        max_inherited_slots=8,
+        on_capture=attached.append,
+        on_orphan=attached.append,
+    )
+    binding = await capture.capture(
+        _LaunchCaptureSpec(
+            request=request,
+            profile_id="fake-profile-v1",
+            execution_closure=("launcher:fake-v1", "payload:fake-v1"),
+        )
+    )
+    material = backend.materials[0]
+    material.block_verify = True
+    material.verify_release.clear()
+    managed = capture.bind_result(
+        _ManagedLaunchPreparationResult(_Preparation(request, events), binding)
+    )
+    verify = asyncio.create_task(managed.verify_current())
+    await material.verify_entered.wait()
+    close = asyncio.create_task(managed.close())
+    await asyncio.sleep(0)
+    assert not close.done()
+
+    material.verify_release.set()
+    await verify
+    await close
+
+    assert material.close_calls == 1
+    assert capture.state == "closed"
+
+
+@_async_test
+async def test_managed_launch_final_fence_cancellation_prevents_spawn() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+    capture_backend.block_after_attachment = True
+    capture_backend.release.clear()
+    start = asyncio.create_task(host.start(ChildSessionRequest(request), preparation))
+    await capture_backend.attached.wait()
+    material = capture_backend.materials[0]
+    material.block_verify = True
+    material.verify_release.clear()
+    capture_backend.release.set()
+    await material.verify_entered.wait()
+
+    start.cancel()
+    await asyncio.sleep(0)
+    assert not start.done()
+    material.verify_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await start
+
+    assert process_backend.processes == []
+    assert material.close_calls == 1
+    assert endpoint_backend.transports[0].close_calls == 1
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_ambiguous_spawn_cancellation_reclaims_every_owner() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    process_backend.block_spawn = True
+    request = _process_request()
+    start = asyncio.create_task(
+        host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+    )
+    await process_backend.spawn_attached.wait()
+
+    start.cancel()
+    await asyncio.sleep(0)
+    assert not start.done()
+    process_backend.spawn_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await start
+
+    assert process_backend.close_handle_calls == 1
+    assert endpoint_backend.transports[0].close_calls == 1
+    assert capture_backend.materials[0].close_calls == 1
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_host_close_waits_for_attached_capture() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    capture_backend.block_after_attachment = True
+    capture_backend.release.clear()
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+    start = asyncio.create_task(
+        host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+    )
+    await capture_backend.attached.wait()
+
+    close = asyncio.create_task(host.close())
+    await asyncio.sleep(0)
+    assert not close.done()
+    assert not start.done()
+    capture_backend.release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await start
+    await close
+
+    assert capture_backend.materials[0].close_calls == 1
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+
+
+@_async_test
+async def test_managed_launch_cleanup_debt_is_retained_and_retried_on_host_close() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, _, _ = _fake_host(events, launch_capture_backend=capture_backend)
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+    preparation.error_after_capture = OSError("caller failed")
+    capture_backend.block_after_attachment = True
+    capture_backend.release.clear()
+    start = asyncio.create_task(host.start(ChildSessionRequest(request), preparation))
+    await capture_backend.attached.wait()
+    material = capture_backend.materials[0]
+    material.close_error_once = OSError("native close failed")
+    capture_backend.release.set()
+
+    with pytest.raises(HostingError):
+        await start
+
+    assert host._state == "faulted"
+    assert material.close_calls == 1
+    with pytest.raises(BaseExceptionGroup):
+        await host.close()
+    assert material.close_calls == 2
+    assert not host._reservations
+
+
+@_async_test
+async def test_managed_launch_joined_owner_survives_endpoint_failure() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    capture_backend.block_after_attachment = True
+    capture_backend.release.clear()
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    endpoint_backend.create_error_after_attach = HostingError(
+        HostingFailureCategory.ENDPOINT_UNAVAILABLE,
+        "endpoint failed after managed preparation joined",
+    )
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+    start = asyncio.create_task(host.start(ChildSessionRequest(request), preparation))
+    await capture_backend.attached.wait()
+    material = capture_backend.materials[0]
+    material.close_error_once = OSError("transient joined native cleanup")
+    capture_backend.release.set()
+
+    with pytest.raises(HostingError) as failure:
+        await start
+
+    assert failure.value.category is HostingFailureCategory.ENDPOINT_UNAVAILABLE
+    assert process_backend.processes == []
+    assert endpoint_backend.transports[0].close_calls == 1
+    assert material.close_calls == 1
+    assert preparation.preparation.close_calls == 1
+    assert len(host._reservations) == 1
+    with pytest.raises(BaseExceptionGroup):
+        await host.close()
+    assert material.close_calls == 2
+    assert preparation.preparation.close_calls == 1
+    assert not host._reservations
+
+
+@_async_test
+async def test_managed_launch_binding_is_consumed_by_the_first_bind() -> None:
+    events: list[str] = []
+    request = _process_request()
+    backend = _CaptureBackend(events)
+    attached: list[_CapturedLaunchMaterial] = []
+    capture = _ReservationLaunchCapture(
+        backend,
+        attempt_id="attempt-binding",
+        max_inherited_slots=8,
+        on_capture=attached.append,
+        on_orphan=attached.append,
+    )
+    binding = await capture.capture(
+        _LaunchCaptureSpec(
+            request=request,
+            profile_id="fake-profile-v1",
+            execution_closure=("launcher:fake-v1", "payload:fake-v1"),
+        )
+    )
+    result = _ManagedLaunchPreparationResult(_Preparation(request, events), binding)
+
+    managed = capture.bind_result(result)
+    with pytest.raises(HostingError) as replay:
+        capture.bind_result(result)
+
+    assert replay.value.category is HostingFailureCategory.PREPARATION_FAILED
+    await managed.close()
+    assert attached[0].close_calls == 1
+
+
+@_async_test
+async def test_managed_launch_attached_then_capture_error_reclaims_both_owners() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    capture_backend.error_after_attachment = OSError("capture failed after attach")
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(ChildSessionRequest(request), preparation)
+
+    assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+    assert preparation.preparation.close_calls == 1
+    assert capture_backend.materials[0].close_calls == 1
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_pre_attachment_error_acquires_no_native_owner() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    capture_backend.error_before_attachment = OSError("capture did not acquire")
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+    preparation = _ManagedPreparationPort(request, events)
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(ChildSessionRequest(request), preparation)
+
+    assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+    assert preparation.preparation.close_calls == 1
+    assert capture_backend.materials == []
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_orphan_cleanup_failure_is_owned_and_retried() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    capture_backend.return_different = True
+    capture_backend.different_close_error_once = OSError("orphan close failed")
+    host, _, _ = _fake_host(events, launch_capture_backend=capture_backend)
+    request = _process_request()
+
+    with pytest.raises(HostingError):
+        await host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+
+    assert host._state == "faulted"
+    assert [material.close_calls for material in capture_backend.materials] == [1, 1]
+    assert len(host._reservations) == 1
+    with pytest.raises(BaseExceptionGroup):
+        await host.close()
+    assert [material.close_calls for material in capture_backend.materials] == [1, 2]
+    assert not host._reservations
+
+
+@_async_test
+async def test_managed_launch_attempt_identity_is_unique_across_hosts() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    first_host, first_process, _ = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    second_host, second_process, _ = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    first_process.expected_inheritance = (51, 51, 61, 62)
+    second_process.expected_inheritance = (51, 51, 61, 62)
+    request = _process_request()
+
+    first = await first_host.start(
+        ChildSessionRequest(request),
+        _ManagedPreparationPort(request, events),
+    )
+    second = await second_host.start(
+        ChildSessionRequest(request),
+        _ManagedPreparationPort(request, events),
+    )
+
+    first_material, second_material = capture_backend.materials
+    assert first_material.attempt_id != second_material.attempt_id
+    assert first_material.attempt_token is not second_material.attempt_token
+    await first.close()
+    await second.close()
+    await first_host.close()
+    await second_host.close()
+
+
+@_async_test
+async def test_managed_launch_cached_material_cannot_cross_attempt_tokens() -> None:
+    events: list[str] = []
+    request = _process_request()
+    backend = _CaptureBackend(events)
+    first_owned: list[_CapturedLaunchMaterial] = []
+    second_owned: list[_CapturedLaunchMaterial] = []
+    first = _ReservationLaunchCapture(
+        backend,
+        attempt_id="host-a-attempt-1",
+        max_inherited_slots=8,
+        on_capture=first_owned.append,
+        on_orphan=first_owned.append,
+    )
+    second = _ReservationLaunchCapture(
+        backend,
+        attempt_id="host-b-attempt-1",
+        max_inherited_slots=8,
+        on_capture=second_owned.append,
+        on_orphan=second_owned.append,
+    )
+    spec = _LaunchCaptureSpec(
+        request=request,
+        profile_id="fake-profile-v1",
+        execution_closure=("launcher:fake-v1", "payload:fake-v1"),
+    )
+    await first.capture(spec)
+    backend.replay_material = backend.materials[0]
+
+    with pytest.raises(HostingError) as replay:
+        await second.capture(spec)
+
+    assert replay.value.category is HostingFailureCategory.PREPARATION_FAILED
+    assert first_owned == [backend.materials[0]]
+    assert second_owned == []
+    assert backend.materials[0].close_calls == 0
+    await backend.materials[0].close()
+
+
+@pytest.mark.parametrize(
+    "identity_field",
+    (
+        "request",
+        "backend_id",
+        "attempt_id",
+        "attempt_token",
+        "profile_id",
+        "execution_closure",
+    ),
+)
+@_async_test
+async def test_managed_launch_revalidates_identity_immediately_before_spawn(
+    identity_field: str,
+) -> None:
+    events: list[str] = []
+    request = _process_request()
+    capture_backend = _CaptureBackend(events)
+    attached: list[_CapturedLaunchMaterial] = []
+    capture = _ReservationLaunchCapture(
+        capture_backend,
+        attempt_id="attempt-final-identity",
+        max_inherited_slots=8,
+        on_capture=attached.append,
+        on_orphan=attached.append,
+    )
+    binding = await capture.capture(
+        _LaunchCaptureSpec(
+            request=request,
+            profile_id="fake-profile-v1",
+            execution_closure=("launcher:fake-v1", "payload:fake-v1"),
+        )
+    )
+    managed = capture.bind_result(
+        _ManagedLaunchPreparationResult(_Preparation(request, events), binding)
+    )
+    await managed.verify_current()
+    material = capture_backend.materials[0]
+    replacements: dict[str, object] = {
+        "request": ProcessLaunchRequest(
+            argv=(sys.executable, "-c", "raise SystemExit(9)"),
+            cwd=request.cwd,
+            effective_environment=request.effective_environment,
+            streams=request.streams,
+        ),
+        "backend_id": "foreign-process-v1",
+        "attempt_id": "foreign-attempt",
+        "attempt_token": object(),
+        "profile_id": "foreign-profile-v1",
+        "execution_closure": ("launcher:foreign", "payload:foreign"),
+    }
+    setattr(material, identity_field, replacements[identity_field])
+
+    with pytest.raises(HostingError) as failure:
+        await managed.spawn_prepared(
+            _ProcessBackend(events),
+            request,
+            on_spawn=lambda process: None,
+            on_orphan_spawn=lambda process: None,
+            inheritance=_SingleUseProcessInheritance(
+                backend_id="fake-process-v1",
+                values=(51, 51),
+                close_values=lambda: None,
+            ),
+        )
+
+    assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+    assert material.claim_calls == 0
+    await managed.close()
+
+
+@_async_test
+async def test_managed_launch_concurrent_verify_is_one_use() -> None:
+    events: list[str] = []
+    request = _process_request()
+    backend = _CaptureBackend(events)
+    attached: list[_CapturedLaunchMaterial] = []
+    capture = _ReservationLaunchCapture(
+        backend,
+        attempt_id="attempt-verify-replay",
+        max_inherited_slots=8,
+        on_capture=attached.append,
+        on_orphan=attached.append,
+    )
+    binding = await capture.capture(
+        _LaunchCaptureSpec(
+            request=request,
+            profile_id="fake-profile-v1",
+            execution_closure=("launcher:fake-v1", "payload:fake-v1"),
+        )
+    )
+    material = backend.materials[0]
+    material.block_verify = True
+    material.verify_release.clear()
+    managed = capture.bind_result(
+        _ManagedLaunchPreparationResult(_Preparation(request, events), binding)
+    )
+    first = asyncio.create_task(managed.verify_current())
+    await material.verify_entered.wait()
+
+    with pytest.raises(HostingError) as replay:
+        await managed.verify_current()
+    material.verify_release.set()
+    await first
+
+    assert replay.value.category is HostingFailureCategory.PREPARATION_FAILED
+    assert events.count("native-verify") == 1
+    await managed.close()
+
+
+@_async_test
+async def test_managed_launch_dual_cleanup_failure_retries_in_dependency_order() -> None:
+    events: list[str] = []
+    request = _process_request()
+    backend = _CaptureBackend(events)
+    attached: list[_CapturedLaunchMaterial] = []
+    capture = _ReservationLaunchCapture(
+        backend,
+        attempt_id="attempt-dual-cleanup",
+        max_inherited_slots=8,
+        on_capture=attached.append,
+        on_orphan=attached.append,
+    )
+    binding = await capture.capture(
+        _LaunchCaptureSpec(
+            request=request,
+            profile_id="fake-profile-v1",
+            execution_closure=("launcher:fake-v1", "payload:fake-v1"),
+        )
+    )
+    caller = _Preparation(request, events)
+    caller.close_error_once = OSError("caller cleanup")
+    material = backend.materials[0]
+    material.close_error_once = OSError("native cleanup")
+    managed = capture.bind_result(_ManagedLaunchPreparationResult(caller, binding))
+
+    with pytest.raises(BaseExceptionGroup) as first:
+        await managed.close()
+
+    assert len(first.value.exceptions) == 2
+    assert events.index("native-close") < events.index("preparation-close")
+    await managed.close()
+    assert material.close_calls == 2
+    assert caller.close_calls == 2
+    assert capture.state == "closed"
+
+
+@_async_test
+async def test_managed_launch_unknown_spawn_outcome_fences_host_and_attempt() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    process_backend.ambiguous_spawn_error = OSError("spawn outcome unavailable")
+    request = _process_request()
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+
+    material = capture_backend.materials[0]
+    assert failure.value.category is HostingFailureCategory.SPAWN_FAILED
+    assert material.claim_calls == 1
+    assert material.close_calls == 0
+    assert process_backend.processes == []
+    assert endpoint_backend.transports[0].close_calls == 1
+    assert host._state == "faulted"
+    with pytest.raises(HostingError) as fenced:
+        await host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+    assert fenced.value.category is HostingFailureCategory.HOST_CLOSED
+    with pytest.raises(BaseExceptionGroup):
+        await host.close()
+    assert material.close_calls == 0
+    assert host._reservations
+
+
+@_async_test
+async def test_managed_launch_cancelled_missing_spawn_callback_is_salvaged() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    process_backend.skip_managed_attachment = True
+    process_backend.block_spawn = True
+    process_backend.spawn_release.clear()
+    request = _process_request()
+    start = asyncio.create_task(
+        host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+    )
+    await process_backend.managed_process_created.wait()
+
+    start.cancel()
+    process_backend.spawn_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await start
+
+    assert len(process_backend.processes) == 1
+    assert process_backend.close_handle_calls == 1
+    assert capture_backend.materials[0].close_calls == 1
+    assert endpoint_backend.transports[0].close_calls == 1
+    assert not host._reservations
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_cancelled_different_spawn_retains_both_processes() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    process_backend.return_different_managed_process = True
+    process_backend.block_spawn = True
+    process_backend.spawn_release.clear()
+    request = _process_request()
+    start = asyncio.create_task(
+        host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+    )
+    await process_backend.spawn_attached.wait()
+
+    start.cancel()
+    process_backend.spawn_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await start
+
+    assert len(process_backend.processes) == 2
+    assert process_backend.close_handle_calls == 2
+    assert capture_backend.materials[0].close_calls == 1
+    assert endpoint_backend.transports[0].close_calls == 1
+    assert not host._reservations
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_not_created_receipt_after_effect_fences_attempt() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    process_backend.not_created_after_effect_error = OSError(
+        "adapter misreported a post-effect failure"
+    )
+    request = _process_request()
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+
+    assert failure.value.category is HostingFailureCategory.SPAWN_FAILED
+    assert len(process_backend.processes) == 1
+    assert process_backend.close_handle_calls == 0
+    assert capture_backend.materials[0].close_calls == 0
+    assert endpoint_backend.transports[0].close_calls == 1
+    assert host._state == "faulted"
+    with pytest.raises(BaseExceptionGroup):
+        await host.close()
+
+
+@_async_test
+async def test_managed_launch_missing_effect_gate_is_attached_then_fenced() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    process_backend.skip_managed_effect_gate = True
+    request = _process_request()
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+
+    assert failure.value.category is HostingFailureCategory.SPAWN_FAILED
+    assert len(process_backend.processes) == 1
+    assert process_backend.close_handle_calls == 1
+    assert capture_backend.materials[0].close_calls == 0
+    assert endpoint_backend.transports[0].close_calls == 1
+    assert host._state == "faulted"
+    with pytest.raises(BaseExceptionGroup):
+        await host.close()
+
+
+@_async_test
+async def test_managed_launch_attachment_invalidates_forged_not_created_receipt() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    process_backend.skip_managed_effect_gate = True
+    process_backend.callback_error_as_not_created = True
+    request = _process_request()
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+
+    assert failure.value.category is HostingFailureCategory.SPAWN_FAILED
+    assert len(process_backend.processes) == 1
+    assert process_backend.close_handle_calls == 1
+    assert capture_backend.materials[0].close_calls == 0
+    assert endpoint_backend.transports[0].close_calls == 1
+    assert host._state == "faulted"
+    with pytest.raises(BaseExceptionGroup):
+        await host.close()
+
+
+@_async_test
+async def test_managed_launch_transfer_fault_reclaims_process_but_keeps_fence() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    capture_backend.block_after_attachment = True
+    capture_backend.release.clear()
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    request = _process_request()
+    start = asyncio.create_task(
+        host.start(
+            ChildSessionRequest(request),
+            _ManagedPreparationPort(request, events),
+        )
+    )
+    await capture_backend.attached.wait()
+    material = capture_backend.materials[0]
+    material.transfer_error = OSError("native transfer acknowledgement failed")
+    capture_backend.release.set()
+
+    with pytest.raises(HostingError) as failure:
+        await start
+
+    assert failure.value.category is HostingFailureCategory.SPAWN_FAILED
+    assert len(process_backend.processes) == 1
+    assert process_backend.close_handle_calls == 1
+    assert endpoint_backend.transports[0].close_calls == 1
+    assert material.transfer_calls == 1
+    assert material.close_calls == 0
+    assert host._state == "faulted"
+    with pytest.raises(BaseExceptionGroup):
+        await host.close()
+    assert material.close_calls == 0
+
+
+@_async_test
+async def test_managed_launch_recursive_start_cannot_bypass_reserved_capacity() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, endpoint_backend = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+
+    class _RecursivePreparation(_ManagedLaunchPreparationPort):
+        async def prepare(self, candidate: ProcessLaunchRequest) -> _Preparation:
+            raise AssertionError("managed path expected")
+
+        async def prepare_managed(
+            self,
+            candidate: ProcessLaunchRequest,
+            capture: _LaunchCapturePort,
+        ) -> _ManagedLaunchPreparationResult:
+            await host.start(
+                ChildSessionRequest(candidate),
+                _PreparationPort(_Preparation(candidate, events), events),
+            )
+            raise AssertionError("recursive start must not acquire capacity")
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(ChildSessionRequest(request), _RecursivePreparation())
+
+    assert failure.value.category is HostingFailureCategory.CAPACITY_EXHAUSTED
+    assert capture_backend.materials == []
+    assert process_backend.processes == []
+    assert endpoint_backend.transports == []
+    await host.close()
+
+
+@pytest.mark.parametrize(
+    ("profile_id", "execution_closure"),
+    (
+        (
+            "posix-descriptor-profile-v1",
+            ("launcher:posix-fake", "loader:posix-fake", "payload:fake"),
+        ),
+        (
+            "windows-token-handle-profile-v1",
+            ("image:windows-fake", "loader:windows-fake", "payload:fake"),
+        ),
+    ),
+)
+@_async_test
+async def test_managed_launch_profile_identities_use_the_same_opaque_protocol(
+    profile_id: str,
+    execution_closure: tuple[str, ...],
+) -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, _ = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    process_backend.expected_inheritance = (51, 51, 61, 62)
+    request = _process_request()
+
+    lease = await host.start(
+        ChildSessionRequest(request),
+        _ManagedPreparationPort(
+            request,
+            events,
+            profile_id=profile_id,
+            execution_closure=execution_closure,
+        ),
+    )
+
+    material = capture_backend.materials[0]
+    assert material.profile_id == profile_id
+    assert material.execution_closure == execution_closure
+    await lease.close()
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_private_process_seam_is_nominal_not_duck_typed() -> None:
+    events: list[str] = []
+    host, process_backend, _ = _fake_host(events)
+    request = _process_request()
+
+    class _LookalikePreparation(_Preparation):
+        async def spawn_prepared(self, *args: object, **kwargs: object) -> _Process:
+            raise AssertionError("ordinary caller must not enter the private H6 seam")
+
+    preparation = _LookalikePreparation(request, events)
+    lease = await host.start(
+        ChildSessionRequest(request),
+        _PreparationPort(preparation, events),
+    )
+
+    assert len(process_backend.processes) == 1
+    await lease.close()
+    await host.close()
+
+
+@_async_test
+async def test_managed_launch_private_caller_seam_is_nominal_and_default_dark() -> None:
+    events: list[str] = []
+    capture_backend = _CaptureBackend(events)
+    host, process_backend, _ = _fake_host(
+        events,
+        launch_capture_backend=capture_backend,
+    )
+    request = _process_request()
+
+    class _LookalikePort(_PreparationPort):
+        async def prepare_managed(
+            self,
+            candidate: ProcessLaunchRequest,
+            capture: _LaunchCapturePort,
+        ) -> _ManagedLaunchPreparationResult:
+            raise AssertionError("ordinary caller must not enter the private H6 seam")
+
+    lease = await host.start(
+        ChildSessionRequest(request),
+        _LookalikePort(_Preparation(request, events), events),
+    )
+
+    assert len(process_backend.processes) == 1
+    assert capture_backend.materials == []
+    await lease.close()
+    await host.close()
 
 
 @pytest.mark.skipif(os.name != "posix", reason="native POSIX child session")


### PR DESCRIPTION
## Summary
- add the private, default-dark H6.1 opaque launch-capture and managed-preparation state machine
- join capture, endpoint inheritance, and process spawn under reservation-bound ownership with exact effect receipts and fail-closed fencing
- retain orphan/native/joined/lower-owner cleanup debt through cancellation and contract violations
- record the accepted H6 design, feasibility boundary, traceability, and executable architecture gates

## Review
Three independent views passed with no remaining P0-P2:
- architecture and dependency boundary
- lifecycle, ownership, cancellation, and cleanup debt
- test matrix and evidence quality

## Validation
- make check-hosting (236 passed, 6 skipped; Ruff and mypy passed)
- make check-architecture-docs (5 passed)
- focused final H6.1 matrix (76 passed)
- git diff --check