### PR TITLE
feat(hosting): add Linux native launch preparation

### DIFF
--- a/.github/workflows/hosting-quality.yml
+++ b/.github/workflows/hosting-quality.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --extra dev
 
-      - name: Lint Hosting H0-H4
+      - name: Lint Hosting H0-H6
         run: >-
           uv run --extra dev ruff check
           src/loushang/hosting
@@ -51,15 +51,47 @@ jobs:
           tests/architecture/test_hosting_h2_platform_contract.py
           tests/architecture/test_hosting_h3_endpoint.py
           tests/architecture/test_hosting_h4_child_session.py
+          tests/architecture/test_hosting_h6_launch_preparation.py
+          tests/architecture/test_hosting_h6_posix_native.py
+          tests/architecture/test_hosted_product_runtime_v1_baseline.py
           tests/architecture/test_hosting_architecture_baseline.py
 
-      - name: Typecheck Hosting H0-H4
+      - name: Typecheck Hosting H0-H6
         run: >-
           uv run --extra dev mypy --follow-imports=silent
           src/loushang/hosting
           src/loushang/harness/workspace/process/hosting_compat.py
 
-      - name: Test Hosting H0-H4 contract
+      - name: Create H6.2 native report directory
+        if: matrix.os == 'ubuntu-24.04'
+        run: uv run python -c "from pathlib import Path; Path('.artifacts').mkdir(exist_ok=True)"
+
+      - name: H6.2 Linux native adversarial gate
+        if: matrix.os == 'ubuntu-24.04'
+        env:
+          PYTEST_ADDOPTS: >-
+            -o faulthandler_timeout=60
+            --junitxml=.artifacts/h6-posix-native.xml
+        run: >-
+          uv run --extra dev python scripts/dev/run_pytest.py
+          tests/hosting/test_posix_launch_preparation.py
+          -q
+
+      - name: Reject empty, skipped, or failing H6.2 native report
+        if: matrix.os == 'ubuntu-24.04'
+        run: >-
+          uv run python scripts/dev/verify_pytest_xml.py
+          .artifacts/h6-posix-native.xml
+
+      - name: Upload H6.2 Linux native report
+        if: always() && matrix.os == 'ubuntu-24.04'
+        uses: actions/upload-artifact@v4
+        with:
+          name: h6-posix-native-pytest-report
+          path: .artifacts/h6-posix-native.xml
+          if-no-files-found: error
+
+      - name: Test Hosting H0-H6 contract
         env:
           LOUSHANG_HOSTING_EXPECTED_BACKEND: ${{ matrix.backend }}
           LOUSHANG_HOSTING_EXPECTED_ENDPOINT: ${{ matrix.endpoint }}
@@ -72,5 +104,8 @@ jobs:
           tests/architecture/test_hosting_h2_platform_contract.py
           tests/architecture/test_hosting_h3_endpoint.py
           tests/architecture/test_hosting_h4_child_session.py
+          tests/architecture/test_hosting_h6_launch_preparation.py
+          tests/architecture/test_hosting_h6_posix_native.py
+          tests/architecture/test_hosted_product_runtime_v1_baseline.py
           tests/architecture/test_hosting_architecture_baseline.py
           -q

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ HOSTING_TEST_PATHS := \
 	tests/architecture/test_hosting_h4_child_session.py \
 	tests/architecture/test_hosting_h5_worker_adapter.py \
 	tests/architecture/test_hosting_h6_launch_preparation.py \
+	tests/architecture/test_hosting_h6_posix_native.py \
 	tests/architecture/test_hosted_product_runtime_v1_baseline.py \
 	tests/architecture/test_hosting_architecture_baseline.py
 

--- a/docs/internals/architecture/hosting/README.md
+++ b/docs/internals/architecture/hosting/README.md
@@ -42,11 +42,13 @@ H5 adds a default-dark Harness Worker aggregate adapter, explicit typed owner
 selection, stable pathless diagnostics, and a future-attempt rollback latch.
 The Current Harness Worker route remains unchanged; required-containment
 sealed-descriptor transfer and Product/native activation remain separate gaps.
-H6.0 records the accepted opaque managed-preparation contract. H6.1 now
-implements its private fake-backed ownership core and records non-committing
-POSIX/Windows feasibility mappings; native H6.2/H6.3 proof and the H6.4 Harness
-adapter remain open. It changes no runtime owner or public API and leaves H5
-dark.
+H6.0 records the accepted opaque managed-preparation contract. H6.1 implements
+its private fake-backed ownership core and records non-committing POSIX/Windows
+feasibility mappings. H6.2 adds the first private Linux x86_64 native profiles: a
+direct static-ELF mechanics oracle and a release profile that pins a static
+caller-admitted containment launcher beside its payload. Native H6.3 Windows
+proof and the H6.4 Harness adapter remain open. No runtime owner or public API
+changes, and H5 remains dark.
 
 Current process mechanics remain implemented inside Harness, principally by:
 
@@ -208,11 +210,12 @@ model.
 11. [H5 Default-Dark Harness Worker Adapter](harness-worker-adapter-h5.md);
 12. [H6 Managed Launch Preparation](managed-launch-preparation-h6.md);
 13. [H6.1 Managed Launch Preparation Feasibility Record](validation/managed-launch-preparation-h6-feasibility.md);
-14. [Hosted Product Runtime V1 Current Inventory](validation/hosted-product-runtime-v1-inventory.md);
-15. [Hosted Application Support Boundary](key-designs/hosted-application-support-boundary.md);
-16. [ARD-002: Hosting Top-Level Placement](../decisions/ARD-002-hosting-top-level-placement.md);
-17. [Traceability](traceability.md);
-18. current source, tests, and generated package facts.
+14. [H6.2 POSIX Native Managed Launch Preparation Record](validation/managed-launch-preparation-h6-posix-native.md);
+15. [Hosted Product Runtime V1 Current Inventory](validation/hosted-product-runtime-v1-inventory.md);
+16. [Hosted Application Support Boundary](key-designs/hosted-application-support-boundary.md);
+17. [ARD-002: Hosting Top-Level Placement](../decisions/ARD-002-hosting-top-level-placement.md);
+18. [Traceability](traceability.md);
+19. current source, tests, and generated package facts.
 
 ## Current-To-Target Gaps
 
@@ -242,9 +245,10 @@ model.
 - `implemented`: the H5 default-dark aggregate Worker adapter, Supervisor
   session entrypoint, explicit no-fallback selector, pathless diagnostics, and
   future-attempt rollback latch.
-- `partial`: H6.1 implements a private, fake-backed opaque managed-preparation
-  transaction and freezes its cross-platform ownership protocol; no public
-  contract, native H6.2/H6.3 adapter, Harness H6.4 adapter, or activation exists.
+- `partial`: H6.1 implements the private opaque ownership protocol and H6.2
+  implements private Linux x86_64 static-closure direct and required-containment
+  profiles with retained native evidence. No public contract, Windows H6.3
+  adapter, Harness H6.4 adapter, or activation exists.
 - `missing`: a reviewed Product/native Worker activation route; PLC9C5 remains
   separate from Hosting extraction and H6 does not pre-approve it.
 - `missing`: daemon/service-instance lifecycle remains a trigger-gated future

--- a/docs/internals/architecture/hosting/managed-launch-preparation-h6.md
+++ b/docs/internals/architecture/hosting/managed-launch-preparation-h6.md
@@ -7,7 +7,7 @@
 - Parent: `loushang`
 - Authority: normative accepted design
 - Design status: accepted
-- Implementation status: partial — H6.1 private fake-backed core
+- Implementation status: partial — H6.1 core and H6.2 Linux native profiles
 - Activation status: forbidden; H5 remains default-dark
 - Owner: Loushang Hosting architecture
 
@@ -201,10 +201,13 @@ ambiguous spawn/transfer -------------------------------> FENCED
   section containing the unique inheritance-manifest claim, sole OS process
   creation effect, and synchronous process attachment callback. Caller
   cancellation is observed only after its outcome is known and cleanup is
-  owned. The attempt mints the only valid `not-created` receipt; the matched
-  backend crosses its effect gate immediately before OS creation, and any
-  receipt observed after that gate or an attachment witness is invalid. An
-  unknowable outcome becomes `FENCED`, never a retry authority.
+  owned. The attempt mints the only valid pre-effect `not-created` receipt; the
+  matched backend crosses its effect gate immediately before OS creation. A
+  trusted native backend may then mint a distinct settled-without-process
+  receipt only when the operating-system attempt conclusively returned with no
+  owned process. Neither receipt is valid after an attachment witness. An
+  unreceipted or unknowable post-effect outcome becomes `FENCED`, never a retry
+  authority.
 - A close racing with capture/verify/claim waits for that owner operation. It
   must not close a descriptor or handle whose transfer outcome is unresolved.
   Repeated close joins one idempotent cleanup operation.
@@ -326,6 +329,10 @@ admit its interpreter/loader chain; sealing payload bytes alone is not enough.
 Loader-affecting environment, dependency search roots, and admitted dynamic
 dependency or platform-image identities are part of the adversarial oracle;
 library replacement and search-order substitution must fail closed.
+Absence of startup `PT_INTERP`/`PT_DYNAMIC` closes only the kernel startup
+loader chain; runtime executable mapping, `dlopen`, subsequent exec, and
+process-group escape remain part of caller-owned profile evidence bound to the
+exact captured launcher/payload identities.
 
 ### Windows
 
@@ -351,7 +358,7 @@ and tree-lifetime properties have native evidence.
 | --- | --- | --- |
 | H6.0 | this responsibility/contract baseline, Current inventory, and absence guards | architecture review accepts ownership; no runtime activation |
 | H6.1 | non-committing POSIX/Windows feasibility probes followed by a private fake-backed two-sided opaque preparation transaction | both probes support one core state machine; caller/Hosting ownership and the complete concurrency/fault matrix pass; no public activation |
-| H6.2 | Linux native preparation backend | required-containment and executable/cwd/descriptor adversarial oracle passes |
+| H6.2 | implemented private Linux static-closure preparation profiles | required-containment and executable/cwd/descriptor adversarial oracle passes |
 | H6.3 | Windows native preparation backend | AppContainer/token, handle-list, Job, identity, and cleanup oracle passes |
 | H6.4 | dark Harness preparation adapter and H5 parity matrix | Current and Hosting owners are independently conformant; default remains Current |
 
@@ -359,6 +366,14 @@ H6.1 is implemented as a private, default-dark core. Its non-committing POSIX
 and Windows mapping probes and fake-backed lifecycle evidence are retained in
 [H6.1 Managed Launch Preparation Feasibility Record](validation/managed-launch-preparation-h6-feasibility.md).
 No H6.2/H6.3 native adapter or H6.4 Harness adapter is implied by that result.
+
+H6.2 is implemented for two exact Linux x86_64 profiles. The release profile pins a
+caller-admitted static containment launcher and static payload, rejects every
+dynamic loader/interpreter chain, binds an empty loader environment and exact
+profile digest, and retains a non-skippable Ubuntu adversarial oracle. See the
+[H6.2 POSIX native record](validation/managed-launch-preparation-h6-posix-native.md).
+This evidence does not make dynamic bubblewrap or an arbitrary Worker
+entrypoint conformant, and it adds no public composition route.
 
 The H6.1 probes perform no production spawn and reserve no public API. H6.2,
 H6.3, and the fake-backed part of H6.4 may be developed in parallel only after

--- a/docs/internals/architecture/hosting/traceability.md
+++ b/docs/internals/architecture/hosting/traceability.md
@@ -76,7 +76,7 @@ H1 deliberately proves no OS process-tree behavior. That delta remains H2.
 | atomic Child Session Host | `implemented` | H4 transaction order, failure/cancellation matrix, joint lifetime, observation correlation, and native factory round trip remain green |
 | Harness mechanics migration | `partial` | H2c dark adapter parity remains green; sealed-descriptor cases stay on Current owner until a later contract is accepted |
 | default-dark Harness Worker adapter | `implemented` | H5 aggregate mapping, Supervisor session integration, selection, no-fallback, diagnostics, and rollback gates remain green |
-| Hosting-consumable managed preparation | `partial` | H6.1 private fake-backed ownership and feasibility gates are implemented; H6.2/H6.3 native evidence and H6.4 Harness parity remain |
+| Hosting-consumable managed preparation | `partial` | H6.1 ownership and H6.2 private Linux x86_64 static-closure native evidence are implemented; H6.3 Windows evidence and H6.4 Harness parity remain |
 | Product/native Worker path absent | `missing` | separate PLC9C5 activation review and gates |
 
 The mechanism baseline is implemented through H4: contracts, process owner,

--- a/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
+++ b/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
@@ -8,7 +8,7 @@
 - Authority: descriptive — source-backed Current inventory
 - Design status: not-applicable
 - Implementation status: not-applicable
-- Delivery parent: `82df045d`
+- Delivery parent: `a9c3e9f4`
 - Effect: none; this record grants no runtime or activation authority
 - Owner: Loushang architecture
 
@@ -29,11 +29,13 @@ this inventory as implemented facts.
 | Inherited Peer Endpoint Host | `src/loushang/hosting/_endpoint_host.py`, `src/loushang/hosting/_endpoint_backend.py`, `src/loushang/hosting/_posix_endpoint.py`, and `src/loushang/hosting/_windows_endpoint.py` | bounded anonymous endpoint pair, strict child-side inheritance, raw byte transport, and cleanup |
 | Child Session Host | `src/loushang/hosting/_child_session_host.py` | atomic endpoint-plus-process acquisition/publication and joint close |
 | private H6.1 launch preparation | `src/loushang/hosting/_launch_preparation.py` | request/profile/closure plus unforgeable attempt binding, opaque capture, final verification, matched-backend spawn, explicit fencing, and ordered cleanup; fake-backed and default-dark only |
+| private H6.2 Linux x86_64 preparation | `src/loushang/hosting/_posix_launch_preparation.py` and `src/loushang/hosting/_posix_process.py` | sealed static launcher/payload, retained cwd, closed invocation/profile identity, exact endpoint-plus-preparation descriptor manifest, and conservative post-effect fencing; private and default-dark |
 | restrained composition | `src/loushang/hosting/runtime.py` | `create_process_host` and `create_child_session_host`; no public backend/plugin registry |
 
-The stable public owners are implemented through H5; H6.1 adds only a private
-fake-backed transaction core. They expose no native executable/cwd/containment
-material in the public request, preparation lease, or factory.
+The stable public owners are implemented through H5; H6.1 and H6.2 add only a
+private transaction core and Linux native profiles. They expose no native
+executable/cwd/containment material in the public request, preparation lease,
+or factory.
 
 ## Current Harness Preparation And Worker Owners
 
@@ -58,7 +60,7 @@ material in the public request, preparation lease, or factory.
 | --- | --- | --- | --- |
 | executable/cwd | Harness private request retains native descriptors plus identity | Hosting `ProcessLaunchRequest` contains absolute strings | `hosting_compat` fails closed rather than substitute mutable paths |
 | containment | Harness `ProcessContainmentPlan` may rewrite the exact process request and owns semantic evidence | Hosting preparation lease exposes only `request`, `verify_current`, and `close` | lifecycle can be delegated, but native spawn material cannot be consumed |
-| inherited resources | Harness Current path extracts private launch descriptors | H6.1 can combine endpoint and opaque preparation inheritance internally | the fake-backed protocol exists, but no Harness or native adapter supplies material |
+| inherited resources | Harness Current path extracts private launch descriptors | H6.1 combines endpoint and opaque preparation inheritance internally; H6.2 supplies exact Linux static-profile material | no Harness adapter currently supplies the private H6.2 profile |
 | Windows required containment | PLC9B includes a purpose-specific AppContainer/Job implementation for legacy restore | Hosting owns generic Job/endpoint mechanics | no accepted managed Worker preparation adapter or parity claim |
 | Product activation | PLC9C1--C4 provide declaration, launch, supervisor, and one dark domain adapter | H5 provides an explicit dark Hosting owner | no Product composition selects and publishes the native path |
 
@@ -85,7 +87,7 @@ not evidence of those packages or runtime routes.
 | Gap | Target owner | Closure gate |
 | --- | --- | --- |
 | opaque request-bound native preparation | Hosting Contract/Platform components | implemented privately in H6.1; fake ownership, concurrency/fault, and no-raw-handle gates are retained |
-| exact Linux executable/cwd/containment transfer | Hosting platform adapter with caller-owned requirements | H6.2 retained native adversarial oracle |
+| exact Linux executable/cwd/containment transfer | Hosting platform adapter with caller-owned requirements | implemented for the private static-closure profiles; H6.2 retained native adversarial oracle remains green |
 | exact Windows executable/cwd/containment transfer | Hosting platform adapter with caller-owned requirements | H6.3 retained native adversarial oracle |
 | Harness-to-Hosting managed preparation parity | Harness Sandbox/Worker adapter over Hosting | H6.4 independent Current/Hosting parity; still default-dark |
 | Product catalog, no-default routing, scoped runtime lifetime | proposed AppHost | A0 contracts and two-unrelated-fake-Product conformance |

--- a/docs/internals/architecture/hosting/validation/managed-launch-preparation-h6-feasibility.md
+++ b/docs/internals/architecture/hosting/validation/managed-launch-preparation-h6-feasibility.md
@@ -8,7 +8,7 @@
 - Authority: descriptive — implementation validation record
 - Design status: not-applicable
 - Implementation status: implemented
-- Native activation: none; H6.2 and H6.3 remain required
+- Native activation: none; this H6.1 record grants no native conformance
 - Runtime posture: private and default-dark; Current remains the default owner
 - Delivery parent: `82df045d`
 - Owner: Loushang Hosting maintainers
@@ -128,9 +128,9 @@ and H6.3 native evidence.
 surface, dependency direction, source inventory, dark composition, and matrix
 presence.
 
-## Remaining Native Gates
+## Subsequent Native Gates
 
-- H6.2: implement and retain the Linux/POSIX adversarial oracle.
+- H6.2: implemented separately by the retained Linux/POSIX adversarial oracle.
 - H6.3: implement and retain the Windows adversarial oracle.
 - H6.4: adapt the Harness preparation owner and prove Current/Hosting parity
   without changing the default owner or enabling Product activation.

--- a/docs/internals/architecture/hosting/validation/managed-launch-preparation-h6-posix-native.md
+++ b/docs/internals/architecture/hosting/validation/managed-launch-preparation-h6-posix-native.md
@@ -1,0 +1,125 @@
+# H6.2 POSIX Native Managed Launch Preparation Record
+
+## Status
+
+- ID: `HOST-H6.2-POSIX-NATIVE`
+- Scope: `hosting`
+- Parent: `HOST-H6`
+- Authority: descriptive — implementation validation record
+- Design status: not-applicable
+- Implementation status: implemented
+- Native activation: none; the private backend requires explicit trusted injection
+- Runtime posture: default-dark; Current remains the default Worker owner
+- Delivery parent: `a9c3e9f4`
+- Owner: Loushang Hosting maintainers
+
+## Result
+
+H6.2 implements a Linux x86_64-only, private managed-launch preparation backend for
+two deliberately closed static-ELF profiles. The release profile,
+`posix-static-contained-elf-v1`, captures both a caller-admitted containment
+launcher and its payload into separate write-sealed memfds, retains the cwd by
+directory descriptor, and invokes the launcher through one fixed private
+argument protocol. The caller continues to own the meaning and admission of
+the containment profile; Hosting proves only that the admitted launcher,
+payload, cwd, profile digest, and invocation reached the sole spawn effect.
+
+No public Hosting contract or factory selects this backend. No Harness Worker
+route is activated by H6.2.
+
+## Supported Native Profiles
+
+| Profile | Purpose | Closed execution identity |
+| --- | --- | --- |
+| `posix-static-elf-v1` | direct native-mechanics oracle | one static payload digest, cwd device/inode, and Linux x86_64 syscall ABI |
+| `posix-static-contained-elf-v1` | required-containment release profile | static launcher digest, static payload digest, cwd device/inode, caller-owned containment-profile digest, fixed invocation protocol, and Linux x86_64 syscall ABI |
+
+Both profiles require absolute executable and cwd paths at capture, an empty
+effective environment, bounded regular executable files, the current machine
+ELF identity, and no `PT_INTERP` or `PT_DYNAMIC` program header. Scripts,
+dynamically loaded executables, mutable loader search, and ambient fallback are
+therefore rejected rather than described as closed.
+
+This check closes the kernel's startup ELF interpreter/loader chain. It does
+not prove that arbitrary admitted static code will never later map executable
+content, call `dlopen`, or exec another image. Runtime code-loading and child
+execution constraints remain caller-owned semantic evidence bound to the exact
+launcher, payload, and containment-profile digests; an adapter without that
+evidence cannot admit this profile.
+
+The direct profile remains useful as a smaller descriptor and lifecycle
+oracle. Required-containment conformance depends on the contained profile; a
+direct static launch is not described as a security sandbox.
+
+## Ownership And Spawn Mechanics
+
+1. The reservation-scoped H6.1 capture capability calls the exact Linux
+   backend.
+2. The backend opens source paths with `O_NOFOLLOW`, checks stable metadata and
+   content digests while copying, seals each memfd against write, growth,
+   shrink, and further seal changes, and opens the cwd as a directory.
+3. The material attaches synchronously to the active Child Session reservation
+   before capture returns.
+4. Final verification rechecks memfd identity, seals, complete digest, and cwd
+   identity immediately before claim.
+5. The matched POSIX Process backend claims the endpoint and preparation
+   descriptors, rejects every collision, and supplies only their de-duplicated
+   union through `pass_fds` with `close_fds=True`.
+6. For the contained profile, the sealed launcher receives the exact protocol,
+   profile digest, payload descriptor, preparation descriptor manifest, and
+   original payload argv. The test launcher closes preparation descriptors on
+   payload exec and applies the admitted profile before that exec, including
+   denial of process-group/session escape required by the POSIX tree owner.
+7. Process-group ownership and the H6.1 joined lease reclaim the tree, endpoint,
+   native material, caller semantic lease, and capacity.
+
+The sole effect authority can distinguish three facts: validation failed
+before creation, a future narrow native creation primitive settled with proof
+that no process remains, or the outcome is unknown. The current asyncio POSIX
+operation spans native creation plus transport and child-watcher setup, so this
+backend does not mint the second receipt from its exceptions. Once its effect
+gate is crossed, every unreceipted failure remains fenced and blocks retry.
+
+## Retained Native Oracle
+
+`tests/hosting/test_posix_launch_preparation.py` compiles static native fixtures
+and proves:
+
+- payload, containment launcher, and cwd replacement after capture cannot
+  substitute the launched identities;
+- the contained launcher applies `PR_SET_NO_NEW_PRIVS` and a seccomp profile
+  that rejects network socket creation plus descendant `setsid`/`setpgid`
+  escape before executing the payload;
+- dynamic loader/interpreter chains, symlink traversal, non-empty loader
+  environment, digest mismatch, cwd mismatch, and inconsistent closure fail
+  closed;
+- unrelated inheritable descriptors do not reach the child and endpoint plus
+  preparation descriptor collisions fail before the effect;
+- an exception injected after native creation leaves the reservation and host
+  fenced, retains ownership debt, and blocks a fresh retry;
+- cancellation after process creation still attaches and reclaims the complete
+  process group; and
+- a reported Linux `close(2)` failure consumes that descriptor owner before
+  the call and never retries a numeric fd that another thread may have reused.
+
+The Ubuntu Hosting workflow emits `h6-posix-native.xml`, rejects an empty,
+skipped, failing, or error report, and retains that report as an artifact. A
+missing static compiler or unsupported Linux primitive fails the native gate;
+it is not converted into a skip.
+
+## Explicit Limits
+
+- This evidence is Linux x86_64-specific. Other Linux architectures, macOS,
+  and other POSIX systems do not select either profile until retained native
+  evidence is added for a new exact platform identity.
+- Hosting does not ship, discover, or approve a containment launcher. Trusted
+  composition must supply one whose identity and semantic evidence were
+  admitted by the caller-owned Sandbox authority.
+- An admitted launcher/profile must forbid descendant process-group escape and
+  constrain any runtime code-loading or subsequent exec behavior required by
+  its Sandbox policy. The static ELF header check alone is not that evidence.
+- The current dynamic bubblewrap Worker path is not silently reclassified as
+  this static profile. H6.4 must adapt an eligible exact launcher/profile or
+  remain unavailable for that request.
+- Product activation, Worker handshake, generation publication, fallback, and
+  policy interpretation remain outside Hosting and unchanged.

--- a/src/loushang/hosting/_launch_preparation.py
+++ b/src/loushang/hosting/_launch_preparation.py
@@ -460,6 +460,15 @@ class _ManagedSpawnNotCreated(Exception):
         self._receipt = receipt
 
 
+class _ManagedSpawnSettledWithoutProcess(Exception):
+    """Authority receipt for an attempted effect known to own no process."""
+
+    def __init__(self, cause: BaseException, receipt: object) -> None:
+        super().__init__("managed launch attempt settled without a process")
+        self.cause = cause
+        self._receipt = receipt
+
+
 class _ManagedSpawnEffect:
     """One authority-owned witness around the native process-creation effect."""
 
@@ -497,11 +506,34 @@ class _ManagedSpawnEffect:
 
         return _ManagedSpawnNotCreated(cause, self._receipt)
 
+    def settled_without_process(
+        self, cause: BaseException
+    ) -> _ManagedSpawnSettledWithoutProcess:
+        """Settle one begun native attempt that proved it owns no process."""
+
+        with self._lock:
+            if self._state != "started" or self._attached is not None:
+                raise RuntimeError(
+                    "managed process attempt cannot settle without a process"
+                )
+            self._state = "settled-without-process"
+            return _ManagedSpawnSettledWithoutProcess(cause, self._receipt)
+
     def accepts(self, failure: _ManagedSpawnNotCreated) -> bool:
         with self._lock:
             return (
                 failure._receipt is self._receipt
                 and self._state == "ready"
+                and self._attached is None
+            )
+
+    def accepts_settled(
+        self, failure: _ManagedSpawnSettledWithoutProcess
+    ) -> bool:
+        with self._lock:
+            return (
+                failure._receipt is self._receipt
+                and self._state == "settled-without-process"
                 and self._attached is None
             )
 
@@ -659,6 +691,10 @@ class _ManagedPreparationLease(LaunchPreparationLease, _ManagedProcessPreparatio
             return process
         except _ManagedSpawnNotCreated as failure:
             if effect.accepts(failure):
+                outcome = "not-created"
+            raise failure.cause from failure
+        except _ManagedSpawnSettledWithoutProcess as failure:
+            if effect.accepts_settled(failure):
                 outcome = "not-created"
             raise failure.cause from failure
         finally:

--- a/src/loushang/hosting/_posix_launch_preparation.py
+++ b/src/loushang/hosting/_posix_launch_preparation.py
@@ -1,0 +1,824 @@
+"""Private H6.2 Linux static-closure launch preparation.
+
+The native profiles are intentionally narrow: bounded static ELF images are
+copied into write-sealed memfds and one cwd directory is retained by file
+descriptor. Scripts and dynamically loaded executables are rejected because
+these profiles cannot prove their interpreter or loader closure. The
+contained profile pins a caller-admitted static containment launcher beside
+the payload; Hosting binds its identity and invocation but does not interpret
+the caller-owned containment meaning.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import platform
+import stat
+import struct
+import sys
+import threading
+from collections.abc import Callable
+from ctypes import CDLL, c_char_p, c_int, c_uint, get_errno
+from dataclasses import dataclass
+
+from ._launch_preparation import (
+    _CapturedLaunchMaterial,
+    _LaunchCaptureSpec,
+    _ManagedSpawnEffect,
+)
+from ._process_backend import (
+    _ProcessBackend,
+    _ProcessInheritance,
+    _ProcessTransport,
+)
+from .contracts import ProcessLaunchRequest
+from .errors import HostingError, HostingFailureCategory
+
+try:  # pragma: no cover - import availability is platform-specific
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None  # type: ignore[assignment]
+
+_DIRECT_PROFILE_ID = "posix-static-elf-v1"
+_CONTAINED_PROFILE_ID = "posix-static-contained-elf-v1"
+_CONTAINMENT_ARGUMENT_PROTOCOL = "loushang-static-containment-launch/v1"
+_PLATFORM_IDENTITY = "platform:linux-x86_64-syscall-abi"
+_SUPPORTED_MACHINES = frozenset({"amd64", "x86_64"})
+_MAX_EXECUTABLE_BYTES = 64 * 1024 * 1024
+_COPY_CHUNK_BYTES = 1024 * 1024
+_MFD_CLOEXEC = 0x0001
+_MFD_ALLOW_SEALING = 0x0002
+_F_ADD_SEALS = 1033
+_F_GET_SEALS = 1034
+_F_SEAL_SEAL = 0x0001
+_F_SEAL_SHRINK = 0x0002
+_F_SEAL_GROW = 0x0004
+_F_SEAL_WRITE = 0x0008
+_PT_DYNAMIC = 2
+_PT_INTERP = 3
+
+
+@dataclass(frozen=True, slots=True)
+class _PosixStaticLaunchCaptureSpec(_LaunchCaptureSpec):
+    """Typed Linux profile selected only by trusted private composition."""
+
+    executable_sha256: str
+    cwd_device: int
+    cwd_inode: int
+
+    def __post_init__(self) -> None:
+        super(_PosixStaticLaunchCaptureSpec, self).__post_init__()
+        if self.profile_id != _DIRECT_PROFILE_ID:
+            raise ValueError("POSIX static launch profile_id is unsupported")
+        _require_sha256(self.executable_sha256, name="executable")
+        if (
+            type(self.cwd_device) is not int
+            or self.cwd_device < 0
+            or type(self.cwd_inode) is not int
+            or self.cwd_inode < 1
+        ):
+            raise ValueError("POSIX static cwd identity is invalid")
+        if not self.request.argv[0].startswith("/") or not self.request.cwd.startswith(
+            "/"
+        ):
+            raise ValueError("POSIX static launch paths must be absolute")
+        if self.request.effective_environment:
+            raise ValueError("POSIX static closure requires an empty environment")
+        expected_closure = (
+            f"static-elf:sha256:{self.executable_sha256}",
+            f"cwd:posix:{self.cwd_device}:{self.cwd_inode}",
+            _PLATFORM_IDENTITY,
+        )
+        if self.execution_closure != expected_closure:
+            raise ValueError("POSIX static execution closure is inconsistent")
+
+
+@dataclass(frozen=True, slots=True)
+class _PosixStaticContainedLaunchCaptureSpec(_LaunchCaptureSpec):
+    """Caller-selected static launcher and payload with a closed invocation."""
+
+    launcher_path: str
+    launcher_sha256: str
+    executable_sha256: str
+    cwd_device: int
+    cwd_inode: int
+    containment_profile_sha256: str
+
+    def __post_init__(self) -> None:
+        super(_PosixStaticContainedLaunchCaptureSpec, self).__post_init__()
+        if self.profile_id != _CONTAINED_PROFILE_ID:
+            raise ValueError("POSIX contained launch profile_id is unsupported")
+        for name, digest in (
+            ("launcher", self.launcher_sha256),
+            ("executable", self.executable_sha256),
+            ("containment profile", self.containment_profile_sha256),
+        ):
+            _require_sha256(digest, name=name)
+        if (
+            type(self.cwd_device) is not int
+            or self.cwd_device < 0
+            or type(self.cwd_inode) is not int
+            or self.cwd_inode < 1
+        ):
+            raise ValueError("POSIX contained cwd identity is invalid")
+        if (
+            not isinstance(self.launcher_path, str)
+            or not self.launcher_path.startswith("/")
+            or "\0" in self.launcher_path
+            or not self.request.argv[0].startswith("/")
+            or not self.request.cwd.startswith("/")
+        ):
+            raise ValueError("POSIX contained launch paths must be absolute")
+        if self.request.effective_environment:
+            raise ValueError("POSIX contained closure requires an empty environment")
+        expected_closure = (
+            f"containment-launcher-static-elf:sha256:{self.launcher_sha256}",
+            f"payload-static-elf:sha256:{self.executable_sha256}",
+            f"cwd:posix:{self.cwd_device}:{self.cwd_inode}",
+            f"containment-profile:sha256:{self.containment_profile_sha256}",
+            f"invocation:{_CONTAINMENT_ARGUMENT_PROTOCOL}",
+            _PLATFORM_IDENTITY,
+        )
+        if self.execution_closure != expected_closure:
+            raise ValueError("POSIX contained execution closure is inconsistent")
+
+
+class _PosixStaticLaunchCaptureBackend:
+    """Linux acquisition half matched to ``_PosixProcessBackend``."""
+
+    backend_id = "posix-process-group-v1"
+
+    def __init__(self) -> None:
+        if (
+            os.name != "posix"
+            or not sys.platform.startswith("linux")
+            or platform.machine().lower() not in _SUPPORTED_MACHINES
+            or fcntl is None
+            or not _memfd_available()
+            or not callable(getattr(os, "pread", None))
+            or any(
+                type(getattr(os, name, None)) is not int
+                for name in ("O_CLOEXEC", "O_DIRECTORY", "O_NOFOLLOW")
+            )
+        ):
+            raise HostingError(
+                HostingFailureCategory.PLATFORM_UNSUPPORTED,
+                "POSIX static launch preparation requires Linux x86_64 memfd sealing",
+            )
+        if not os.path.isdir("/proc/self/fd"):
+            raise HostingError(
+                HostingFailureCategory.PLATFORM_UNSUPPORTED,
+                "POSIX static launch preparation requires procfs descriptor paths",
+            )
+
+    async def capture(
+        self,
+        spec: _LaunchCaptureSpec,
+        *,
+        attempt_id: str,
+        attempt_token: object,
+        on_capture: Callable[[_CapturedLaunchMaterial], None],
+    ) -> "_PosixStaticLaunchMaterial":
+        if type(spec) is _PosixStaticLaunchCaptureSpec:
+            return await self._capture_direct(
+                spec,
+                attempt_id=attempt_id,
+                attempt_token=attempt_token,
+                on_capture=on_capture,
+            )
+        if type(spec) is _PosixStaticContainedLaunchCaptureSpec:
+            return await self._capture_contained(
+                spec,
+                attempt_id=attempt_id,
+                attempt_token=attempt_token,
+                on_capture=on_capture,
+            )
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_FAILED,
+            "POSIX launch preparation requires an exact static profile",
+        )
+
+    async def _capture_direct(
+        self,
+        spec: _PosixStaticLaunchCaptureSpec,
+        *,
+        attempt_id: str,
+        attempt_token: object,
+        on_capture: Callable[[_CapturedLaunchMaterial], None],
+    ) -> "_PosixStaticLaunchMaterial":
+        executable = _capture_static_elf(
+            spec.request.argv[0], expected_digest=spec.executable_sha256
+        )
+        cwd = -1
+        try:
+            cwd = _capture_cwd(
+                spec.request.cwd,
+                expected_identity=(spec.cwd_device, spec.cwd_inode),
+            )
+            material = _PosixStaticLaunchMaterial(
+                spec=spec,
+                attempt_id=attempt_id,
+                attempt_token=attempt_token,
+                executable_descriptor=executable,
+                cwd_descriptor=cwd,
+            )
+            executable = -1
+            cwd = -1
+            await _attach_captured(material, on_capture=on_capture)
+            return material
+        except BaseException as primary:
+            _close_local_descriptor(cwd, primary=primary, role="cwd")
+            _close_local_descriptor(
+                executable,
+                primary=primary,
+                role="executable",
+            )
+            raise
+
+    async def _capture_contained(
+        self,
+        spec: _PosixStaticContainedLaunchCaptureSpec,
+        *,
+        attempt_id: str,
+        attempt_token: object,
+        on_capture: Callable[[_CapturedLaunchMaterial], None],
+    ) -> "_PosixStaticLaunchMaterial":
+        launcher = _capture_static_elf(
+            spec.launcher_path, expected_digest=spec.launcher_sha256
+        )
+        executable = -1
+        cwd = -1
+        try:
+            executable = _capture_static_elf(
+                spec.request.argv[0], expected_digest=spec.executable_sha256
+            )
+            cwd = _capture_cwd(
+                spec.request.cwd,
+                expected_identity=(spec.cwd_device, spec.cwd_inode),
+            )
+            material = _PosixStaticLaunchMaterial(
+                spec=spec,
+                attempt_id=attempt_id,
+                attempt_token=attempt_token,
+                executable_descriptor=executable,
+                cwd_descriptor=cwd,
+                launcher_descriptor=launcher,
+            )
+            launcher = -1
+            executable = -1
+            cwd = -1
+            await _attach_captured(material, on_capture=on_capture)
+            return material
+        except BaseException as primary:
+            _close_local_descriptor(cwd, primary=primary, role="cwd")
+            _close_local_descriptor(
+                executable,
+                primary=primary,
+                role="executable",
+            )
+            _close_local_descriptor(
+                launcher,
+                primary=primary,
+                role="containment launcher",
+            )
+            raise
+
+
+async def _attach_captured(
+    material: "_PosixStaticLaunchMaterial",
+    *,
+    on_capture: Callable[[_CapturedLaunchMaterial], None],
+) -> None:
+    try:
+        on_capture(material)
+    except BaseException as primary:
+        try:
+            await material.close()
+        except BaseException as cleanup:
+            primary.add_note(
+                f"POSIX captured material cleanup also failed: {cleanup}"
+            )
+            raise primary from cleanup
+        raise
+
+
+class _PosixStaticLaunchMaterial:
+    """One attempt-bound set of retained executable, cwd, and launcher fds."""
+
+    backend_id = "posix-process-group-v1"
+
+    def __init__(
+        self,
+        *,
+        spec: _PosixStaticLaunchCaptureSpec
+        | _PosixStaticContainedLaunchCaptureSpec,
+        attempt_id: str,
+        attempt_token: object,
+        executable_descriptor: int,
+        cwd_descriptor: int,
+        launcher_descriptor: int = -1,
+    ) -> None:
+        self._spec = spec
+        self._attempt_id = attempt_id
+        self._attempt_token = attempt_token
+        self._executable_descriptor = executable_descriptor
+        self._cwd_descriptor = cwd_descriptor
+        self._launcher_descriptor = launcher_descriptor
+        executable_stat = os.fstat(executable_descriptor)
+        self._executable_identity = (executable_stat.st_dev, executable_stat.st_ino)
+        self._launcher_identity: tuple[int, int] | None = None
+        if launcher_descriptor >= 0:
+            launcher_stat = os.fstat(launcher_descriptor)
+            self._launcher_identity = (launcher_stat.st_dev, launcher_stat.st_ino)
+        self._inherited_slot_count = 3 if launcher_descriptor >= 0 else 2
+        self._state = "captured"
+        self._lock = threading.Lock()
+
+    @property
+    def attempt_id(self) -> str:
+        return self._attempt_id
+
+    @property
+    def attempt_token(self) -> object:
+        return self._attempt_token
+
+    @property
+    def profile_id(self) -> str:
+        return self._spec.profile_id
+
+    @property
+    def execution_closure(self) -> tuple[str, ...]:
+        return self._spec.execution_closure
+
+    @property
+    def request(self) -> ProcessLaunchRequest:
+        return self._spec.request
+
+    @property
+    def inherited_slot_count(self) -> int:
+        return self._inherited_slot_count
+
+    async def verify_current(self, request: ProcessLaunchRequest) -> None:
+        if request != self._spec.request:
+            raise HostingError(
+                HostingFailureCategory.PREPARATION_FAILED,
+                "POSIX static launch request changed before verification",
+            )
+        with self._lock:
+            if self._state != "captured":
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "POSIX static launch material cannot be verified",
+                )
+            _verify_static_descriptor(
+                self._executable_descriptor,
+                expected_digest=self._spec.executable_sha256,
+                expected_identity=self._executable_identity,
+            )
+            _verify_cwd_descriptor(
+                self._cwd_descriptor,
+                expected_identity=(self._spec.cwd_device, self._spec.cwd_inode),
+            )
+            if type(self._spec) is _PosixStaticContainedLaunchCaptureSpec:
+                if self._launcher_descriptor < 0 or self._launcher_identity is None:
+                    raise HostingError(
+                        HostingFailureCategory.PREPARATION_STALE,
+                        "POSIX containment launcher is unavailable",
+                    )
+                _verify_static_descriptor(
+                    self._launcher_descriptor,
+                    expected_digest=self._spec.launcher_sha256,
+                    expected_identity=self._launcher_identity,
+                )
+            self._state = "verified"
+
+    async def spawn(
+        self,
+        backend: _ProcessBackend,
+        request: ProcessLaunchRequest,
+        *,
+        effect: _ManagedSpawnEffect,
+        on_spawn: Callable[[_ProcessTransport], None],
+        inheritance: _ProcessInheritance | None,
+    ) -> _ProcessTransport:
+        from ._posix_process import _PosixProcessBackend
+
+        if type(backend) is not _PosixProcessBackend:
+            raise effect.not_created(
+                HostingError(
+                    HostingFailureCategory.ENDPOINT_TRANSFER_FAILED,
+                    "POSIX static material received a mismatched process backend",
+                )
+            )
+        return await backend._spawn_static_prepared(
+            self,
+            request,
+            effect=effect,
+            on_spawn=on_spawn,
+            inheritance=inheritance,
+        )
+
+    def _claim_descriptors(self) -> tuple[int, int, int | None]:
+        with self._lock:
+            if self._state != "verified":
+                raise HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "POSIX static material is not verified for spawn",
+                )
+            self._state = "claimed"
+            return (
+                self._executable_descriptor,
+                self._cwd_descriptor,
+                self._launcher_descriptor if self._launcher_descriptor >= 0 else None,
+            )
+
+    def _contained_invocation(
+        self,
+        *,
+        executable_descriptor: int,
+        cwd_descriptor: int,
+        launcher_descriptor: int,
+    ) -> tuple[str, ...]:
+        if type(self._spec) is not _PosixStaticContainedLaunchCaptureSpec:
+            raise RuntimeError("POSIX direct material has no containment invocation")
+        return (
+            self._spec.launcher_path,
+            "--loushang-protocol",
+            _CONTAINMENT_ARGUMENT_PROTOCOL,
+            "--loushang-profile-sha256",
+            self._spec.containment_profile_sha256,
+            "--loushang-payload-fd",
+            str(executable_descriptor),
+            "--loushang-preparation-fds",
+            f"{launcher_descriptor},{executable_descriptor},{cwd_descriptor}",
+            "--",
+            *self._spec.request.argv,
+        )
+
+    def _mark_transferred(self) -> None:
+        with self._lock:
+            if self._state != "claimed":
+                raise RuntimeError("POSIX static transfer state is inconsistent")
+            self._state = "transferred"
+
+    async def close(self) -> None:
+        with self._lock:
+            if self._state == "closed":
+                return
+            descriptors = (
+                ("_executable_descriptor", self._executable_descriptor),
+                ("_cwd_descriptor", self._cwd_descriptor),
+                ("_launcher_descriptor", self._launcher_descriptor),
+            )
+        failures: list[BaseException] = []
+        for attribute, descriptor in descriptors:
+            if descriptor < 0:
+                continue
+            # Linux releases the numeric descriptor early in close(2), even
+            # when a later flush/reporting step returns an error. Never retry
+            # that number: another thread may already have reused it.
+            with self._lock:
+                if getattr(self, attribute) != descriptor:
+                    continue
+                setattr(self, attribute, -1)
+            try:
+                os.close(descriptor)
+            except BaseException as error:
+                failures.append(error)
+        with self._lock:
+            self._state = (
+                "closed"
+                if self._executable_descriptor < 0
+                and self._cwd_descriptor < 0
+                and self._launcher_descriptor < 0
+                else "close-failed"
+            )
+        if failures:
+            raise BaseExceptionGroup(
+                "POSIX static launch descriptor cleanup failed",
+                failures,
+            )
+
+
+def _capture_static_elf(path: str, *, expected_digest: str) -> int:
+    source_flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    source_flags |= getattr(os, "O_NOFOLLOW", 0)
+    source = os.open(path, source_flags)
+    destination = -1
+    try:
+        destination = _ensure_preparation_descriptor(_create_memfd())
+        before = os.fstat(source)
+        if (
+            not stat.S_ISREG(before.st_mode)
+            or not before.st_mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            or before.st_size < 1
+            or before.st_size > _MAX_EXECUTABLE_BYTES
+        ):
+            raise HostingError(
+                HostingFailureCategory.PREPARATION_FAILED,
+                "POSIX static executable is not a bounded executable file",
+            )
+        digest = hashlib.sha256()
+        copied = 0
+        while copied < before.st_size:
+            chunk = os.read(source, min(_COPY_CHUNK_BYTES, before.st_size - copied))
+            if not chunk:
+                break
+            digest.update(chunk)
+            _write_all(destination, chunk)
+            copied += len(chunk)
+        extra = os.read(source, 1)
+        after = os.fstat(source)
+        if (
+            copied != before.st_size
+            or extra
+            or (
+                before.st_dev,
+                before.st_ino,
+                before.st_size,
+                before.st_mtime_ns,
+                before.st_ctime_ns,
+            )
+            != (
+                after.st_dev,
+                after.st_ino,
+                after.st_size,
+                after.st_mtime_ns,
+                after.st_ctime_ns,
+            )
+            or digest.hexdigest() != expected_digest
+        ):
+            raise HostingError(
+                HostingFailureCategory.PREPARATION_FAILED,
+                "POSIX static executable changed during capture",
+            )
+        os.fchmod(destination, 0o500)
+        assert fcntl is not None
+        fcntl.fcntl(destination, _F_ADD_SEALS, _required_seals())
+        _verify_static_elf(destination, size=copied)
+        destination_stat = os.fstat(destination)
+        _verify_static_descriptor(
+            destination,
+            expected_digest=expected_digest,
+            expected_identity=(destination_stat.st_dev, destination_stat.st_ino),
+        )
+    except BaseException as primary:
+        _close_local_descriptor(
+            destination,
+            primary=primary,
+            role="captured executable",
+        )
+        _close_local_descriptor(source, primary=primary, role="source executable")
+        raise
+    try:
+        os.close(source)
+    except BaseException as primary:
+        _close_local_descriptor(
+            destination,
+            primary=primary,
+            role="captured executable",
+        )
+        raise
+    return destination
+
+
+def _capture_cwd(path: str, *, expected_identity: tuple[int, int]) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = _ensure_preparation_descriptor(os.open(path, flags))
+    try:
+        _verify_cwd_descriptor(
+            descriptor,
+            expected_identity=expected_identity,
+        )
+        return descriptor
+    except BaseException as primary:
+        _close_local_descriptor(descriptor, primary=primary, role="cwd")
+        raise
+
+
+def _verify_static_descriptor(
+    descriptor: int,
+    *,
+    expected_digest: str,
+    expected_identity: tuple[int, int],
+) -> None:
+    metadata = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or (metadata.st_dev, metadata.st_ino) != expected_identity
+        or metadata.st_size < 1
+        or metadata.st_size > _MAX_EXECUTABLE_BYTES
+    ):
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_STALE,
+            "POSIX sealed executable identity changed",
+        )
+    assert fcntl is not None
+    if fcntl.fcntl(descriptor, _F_GET_SEALS) & _required_seals() != _required_seals():
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_STALE,
+            "POSIX executable memfd is no longer sealed",
+        )
+    if _descriptor_digest(descriptor, metadata.st_size) != expected_digest:
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_STALE,
+            "POSIX sealed executable digest changed",
+        )
+
+
+def _verify_cwd_descriptor(
+    descriptor: int,
+    *,
+    expected_identity: tuple[int, int],
+) -> None:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode) or (
+        metadata.st_dev,
+        metadata.st_ino,
+    ) != expected_identity:
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_STALE,
+            "POSIX cwd directory identity changed",
+        )
+
+
+def _verify_static_elf(descriptor: int, *, size: int) -> None:
+    header = os.pread(descriptor, min(size, 64), 0)
+    if len(header) < 58 or header[:4] != b"\x7fELF":
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_FAILED,
+            "POSIX static profile requires an ELF executable",
+        )
+    elf_class = header[4]
+    byte_order = header[5]
+    if elf_class != 2 or byte_order != 1:
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_FAILED,
+            "POSIX ELF header is unsupported",
+        )
+    endian = "<" if byte_order == 1 else ">"
+    machine = struct.unpack_from(f"{endian}H", header, 18)[0]
+    if machine != 62:
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_FAILED,
+            "POSIX static ELF does not match the running machine",
+        )
+    program_offset = struct.unpack_from(f"{endian}Q", header, 32)[0]
+    entry_size = struct.unpack_from(f"{endian}H", header, 54)[0]
+    entry_count = struct.unpack_from(f"{endian}H", header, 56)[0]
+    if entry_size < 4 or entry_count < 1 or entry_count > 1024:
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_FAILED,
+            "POSIX ELF program-header table is invalid",
+        )
+    table_size = entry_size * entry_count
+    if program_offset > size or table_size > size - program_offset:
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_FAILED,
+            "POSIX ELF program-header table is out of bounds",
+        )
+    table = os.pread(descriptor, table_size, program_offset)
+    if len(table) != table_size:
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_FAILED,
+            "POSIX ELF program-header table is incomplete",
+        )
+    program_types = {
+        struct.unpack_from(f"{endian}I", table, offset)[0]
+        for offset in range(0, table_size, entry_size)
+    }
+    if _PT_INTERP in program_types or _PT_DYNAMIC in program_types:
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_FAILED,
+            "POSIX static profile rejects interpreter or dynamic-loader closure",
+        )
+
+
+def _descriptor_digest(descriptor: int, size: int) -> str:
+    digest = hashlib.sha256()
+    offset = 0
+    while offset < size:
+        chunk = os.pread(descriptor, min(_COPY_CHUNK_BYTES, size - offset), offset)
+        if not chunk:
+            break
+        digest.update(chunk)
+        offset += len(chunk)
+    if offset != size:
+        raise HostingError(
+            HostingFailureCategory.PREPARATION_STALE,
+            "POSIX sealed executable read was incomplete",
+        )
+    return digest.hexdigest()
+
+
+def _write_all(descriptor: int, body: bytes) -> None:
+    view = memoryview(body)
+    offset = 0
+    while offset < len(view):
+        written = os.write(descriptor, view[offset:])
+        if written <= 0:
+            raise OSError("POSIX executable capture made no forward progress")
+        offset += written
+
+
+def _required_seals() -> int:
+    return _F_SEAL_SEAL | _F_SEAL_SHRINK | _F_SEAL_GROW | _F_SEAL_WRITE
+
+
+def _close_local_descriptor(
+    descriptor: int,
+    *,
+    primary: BaseException,
+    role: str,
+) -> None:
+    if descriptor < 0:
+        return
+    try:
+        os.close(descriptor)
+    except BaseException as cleanup:
+        primary.add_note(f"POSIX {role} cleanup also failed: {cleanup}")
+
+
+def _ensure_preparation_descriptor(descriptor: int) -> int:
+    if descriptor >= 3:
+        try:
+            os.set_inheritable(descriptor, False)
+            return descriptor
+        except BaseException as primary:
+            try:
+                os.close(descriptor)
+            except BaseException as cleanup:
+                primary.add_note(
+                    f"POSIX descriptor normalization cleanup also failed: {cleanup}"
+                )
+            raise
+    assert fcntl is not None
+    try:
+        duplicate = fcntl.fcntl(
+            descriptor,
+            getattr(fcntl, "F_DUPFD_CLOEXEC", 1030),
+            3,
+        )
+    except BaseException as primary:
+        _close_local_descriptor(
+            descriptor,
+            primary=primary,
+            role="low descriptor after duplication failure",
+        )
+        raise
+    try:
+        os.close(descriptor)
+        return duplicate
+    except BaseException as primary:
+        _close_local_descriptor(
+            duplicate,
+            primary=primary,
+            role="duplicate descriptor",
+        )
+        raise
+
+
+def _require_sha256(value: object, *, name: str) -> None:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ValueError(f"POSIX static {name} digest is invalid")
+
+
+def _memfd_available() -> bool:
+    if callable(getattr(os, "memfd_create", None)):
+        return True
+    return getattr(CDLL(None, use_errno=True), "memfd_create", None) is not None
+
+
+def _create_memfd() -> int:
+    native = getattr(os, "memfd_create", None)
+    if callable(native):
+        return native(
+            "loushang-hosting-static-elf",
+            _MFD_CLOEXEC | _MFD_ALLOW_SEALING,
+        )
+    libc = CDLL(None, use_errno=True)
+    create = getattr(libc, "memfd_create", None)
+    if create is None:
+        raise HostingError(
+            HostingFailureCategory.PLATFORM_UNSUPPORTED,
+            "POSIX static launch preparation requires memfd_create",
+        )
+    create.argtypes = (c_char_p, c_uint)
+    create.restype = c_int
+    descriptor = create(
+        b"loushang-hosting-static-elf",
+        _MFD_CLOEXEC | _MFD_ALLOW_SEALING,
+    )
+    if descriptor < 0:
+        error_number = get_errno()
+        raise OSError(error_number, os.strerror(error_number))
+    return descriptor
+
+
+__all__: list[str] = []

--- a/src/loushang/hosting/_posix_launch_preparation.py
+++ b/src/loushang/hosting/_posix_launch_preparation.py
@@ -553,9 +553,8 @@ def _capture_static_elf(path: str, *, expected_digest: str) -> int:
                 HostingFailureCategory.PREPARATION_FAILED,
                 "POSIX static executable changed during capture",
             )
-        os.fchmod(destination, 0o500)
-        assert fcntl is not None
-        fcntl.fcntl(destination, _F_ADD_SEALS, _required_seals())
+        _fchmod(destination, 0o500)
+        _fcntl_call(destination, _F_ADD_SEALS, _required_seals())
         _verify_static_elf(destination, size=copied)
         destination_stat = os.fstat(destination)
         _verify_static_descriptor(
@@ -615,8 +614,7 @@ def _verify_static_descriptor(
             HostingFailureCategory.PREPARATION_STALE,
             "POSIX sealed executable identity changed",
         )
-    assert fcntl is not None
-    if fcntl.fcntl(descriptor, _F_GET_SEALS) & _required_seals() != _required_seals():
+    if _fcntl_call(descriptor, _F_GET_SEALS) & _required_seals() != _required_seals():
         raise HostingError(
             HostingFailureCategory.PREPARATION_STALE,
             "POSIX executable memfd is no longer sealed",
@@ -645,7 +643,7 @@ def _verify_cwd_descriptor(
 
 
 def _verify_static_elf(descriptor: int, *, size: int) -> None:
-    header = os.pread(descriptor, min(size, 64), 0)
+    header = _pread(descriptor, min(size, 64), 0)
     if len(header) < 58 or header[:4] != b"\x7fELF":
         raise HostingError(
             HostingFailureCategory.PREPARATION_FAILED,
@@ -679,7 +677,7 @@ def _verify_static_elf(descriptor: int, *, size: int) -> None:
             HostingFailureCategory.PREPARATION_FAILED,
             "POSIX ELF program-header table is out of bounds",
         )
-    table = os.pread(descriptor, table_size, program_offset)
+    table = _pread(descriptor, table_size, program_offset)
     if len(table) != table_size:
         raise HostingError(
             HostingFailureCategory.PREPARATION_FAILED,
@@ -700,7 +698,7 @@ def _descriptor_digest(descriptor: int, size: int) -> str:
     digest = hashlib.sha256()
     offset = 0
     while offset < size:
-        chunk = os.pread(descriptor, min(_COPY_CHUNK_BYTES, size - offset), offset)
+        chunk = _pread(descriptor, min(_COPY_CHUNK_BYTES, size - offset), offset)
         if not chunk:
             break
         digest.update(chunk)
@@ -754,9 +752,8 @@ def _ensure_preparation_descriptor(descriptor: int) -> int:
                     f"POSIX descriptor normalization cleanup also failed: {cleanup}"
                 )
             raise
-    assert fcntl is not None
     try:
-        duplicate = fcntl.fcntl(
+        duplicate = _fcntl_call(
             descriptor,
             getattr(fcntl, "F_DUPFD_CLOEXEC", 1030),
             3,
@@ -778,6 +775,46 @@ def _ensure_preparation_descriptor(descriptor: int) -> int:
             role="duplicate descriptor",
         )
         raise
+
+
+def _fchmod(descriptor: int, mode: int) -> None:
+    operation = getattr(os, "fchmod", None)
+    if not callable(operation):
+        raise HostingError(
+            HostingFailureCategory.PLATFORM_UNSUPPORTED,
+            "POSIX static launch preparation requires fchmod",
+        )
+    operation(descriptor, mode)
+
+
+def _pread(descriptor: int, size: int, offset: int) -> bytes:
+    operation = getattr(os, "pread", None)
+    if not callable(operation):
+        raise HostingError(
+            HostingFailureCategory.PLATFORM_UNSUPPORTED,
+            "POSIX static launch preparation requires pread",
+        )
+    body = operation(descriptor, size, offset)
+    if not isinstance(body, bytes):
+        raise TypeError("POSIX pread returned non-bytes data")
+    return body
+
+
+def _fcntl_call(descriptor: int, command: int, argument: int | None = None) -> int:
+    operation = getattr(fcntl, "fcntl", None)
+    if not callable(operation):
+        raise HostingError(
+            HostingFailureCategory.PLATFORM_UNSUPPORTED,
+            "POSIX static launch preparation requires fcntl",
+        )
+    result = (
+        operation(descriptor, command)
+        if argument is None
+        else operation(descriptor, command, argument)
+    )
+    if not isinstance(result, int):
+        raise TypeError("POSIX fcntl returned a non-integer result")
+    return result
 
 
 def _require_sha256(value: object, *, name: str) -> None:

--- a/src/loushang/hosting/_posix_process.py
+++ b/src/loushang/hosting/_posix_process.py
@@ -7,8 +7,9 @@ import os
 import signal
 import subprocess
 from collections.abc import Callable
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
+from ._launch_preparation import _ManagedSpawnEffect
 from ._process_backend import _ProcessInheritance, _ProcessTransport
 from .contracts import (
     ProcessLaunchRequest,
@@ -17,6 +18,9 @@ from .contracts import (
     ProcessStdoutMode,
 )
 from .errors import HostingError, HostingFailureCategory
+
+if TYPE_CHECKING:
+    from ._posix_launch_preparation import _PosixStaticLaunchMaterial
 
 _TREE_POLL_SECONDS = 0.01
 _FAILED_ATTACHMENT_SETTLEMENT_SECONDS = 1.0
@@ -211,6 +215,11 @@ class _PosixProcessBackend:
         self,
         request: ProcessLaunchRequest,
         endpoint_descriptors: tuple[int, int] | None = None,
+        *,
+        argv: tuple[str, ...] | None = None,
+        executable: str | None = None,
+        cwd: str | None = None,
+        pass_fds: tuple[int, ...] = (),
     ) -> _PosixProcess:
         if endpoint_descriptors is None:
             stdin: int = (
@@ -225,12 +234,19 @@ class _PosixProcessBackend:
             )
         else:
             stdin, stdout = endpoint_descriptors
+        # The high-level asyncio operation spans native creation and transport /
+        # child-watcher setup.  An exception from it cannot certify which stage
+        # failed, so this backend deliberately does not mint a
+        # settled-without-process receipt.  Once the effect gate is crossed,
+        # every such failure remains fenced.
         process = await asyncio.create_subprocess_exec(
-            *request.argv,
-            cwd=request.cwd,
+            *(request.argv if argv is None else argv),
+            executable=executable,
+            cwd=request.cwd if cwd is None else cwd,
             env=dict(request.effective_environment),
             start_new_session=True,
             close_fds=True,
+            pass_fds=pass_fds,
             stdin=stdin,
             stdout=stdout,
             stderr=(
@@ -246,6 +262,110 @@ class _PosixProcessBackend:
             process.kill()
             await process.wait()
             raise
+
+    async def _spawn_static_prepared(
+        self,
+        material: "_PosixStaticLaunchMaterial",
+        request: ProcessLaunchRequest,
+        *,
+        effect: _ManagedSpawnEffect,
+        on_spawn: Callable[[_ProcessTransport], None],
+        inheritance: _ProcessInheritance | None,
+    ) -> _PosixProcess:
+        from ._posix_launch_preparation import _PosixStaticLaunchMaterial
+
+        if type(material) is not _PosixStaticLaunchMaterial:
+            raise effect.not_created(
+                HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "POSIX process backend requires static launch material",
+                )
+            )
+        if request != material.request:
+            raise effect.not_created(
+                HostingError(
+                    HostingFailureCategory.PREPARATION_FAILED,
+                    "POSIX static launch request changed before spawn",
+                )
+            )
+        if inheritance is None:
+            raise effect.not_created(
+                HostingError(
+                    HostingFailureCategory.ENDPOINT_TRANSFER_FAILED,
+                    "POSIX static child launch requires endpoint inheritance",
+                )
+            )
+        if (
+            request.streams.stdin is not ProcessStdinMode.CLOSED
+            or request.streams.stdout is not ProcessStdoutMode.DISCARD
+        ):
+            raise effect.not_created(
+                HostingError(
+                    HostingFailureCategory.ENDPOINT_TRANSFER_FAILED,
+                    "POSIX static inherited endpoint reserves stdin and stdout",
+                )
+            )
+        endpoint_descriptors = _claim_endpoint(inheritance, self.backend_id)
+        assert endpoint_descriptors is not None
+        (
+            executable_descriptor,
+            cwd_descriptor,
+            launcher_descriptor,
+        ) = material._claim_descriptors()
+        preparation_descriptors = tuple(
+            descriptor
+            for descriptor in (
+                executable_descriptor,
+                cwd_descriptor,
+                launcher_descriptor,
+            )
+            if descriptor is not None
+        )
+        if (
+            len(set(preparation_descriptors)) != len(preparation_descriptors)
+            or set(endpoint_descriptors) & set(preparation_descriptors)
+            or any(
+                descriptor < 3
+                for descriptor in (*endpoint_descriptors, *preparation_descriptors)
+            )
+        ):
+            raise effect.not_created(
+                HostingError(
+                    HostingFailureCategory.ENDPOINT_TRANSFER_FAILED,
+                    "POSIX endpoint and preparation descriptors collide",
+                )
+            )
+        inherited_descriptors = tuple(
+            dict.fromkeys((*endpoint_descriptors, *preparation_descriptors))
+        )
+        argv = (
+            request.argv
+            if launcher_descriptor is None
+            else material._contained_invocation(
+                executable_descriptor=executable_descriptor,
+                cwd_descriptor=cwd_descriptor,
+                launcher_descriptor=launcher_descriptor,
+            )
+        )
+        spawn_descriptor = (
+            executable_descriptor
+            if launcher_descriptor is None
+            else launcher_descriptor
+        )
+        executable = f"/proc/self/fd/{spawn_descriptor}"
+        effect.begin_effect()
+        process = await self._spawn_once(
+            request,
+            endpoint_descriptors,
+            argv=argv,
+            executable=executable,
+            cwd=f"/proc/self/fd/{cwd_descriptor}",
+            pass_fds=inherited_descriptors,
+        )
+        on_spawn(process)
+        inheritance.mark_transferred()
+        material._mark_transferred()
+        return process
 
     def tree_exited(self, process: _ProcessTransport) -> bool:
         return not _require_posix_process(process).group_exists()

--- a/tests/architecture/test_architecture_documentation.py
+++ b/tests/architecture/test_architecture_documentation.py
@@ -41,6 +41,8 @@ INITIAL_GOVERNED_DOCUMENTS = (
     ARCHITECTURE_ROOT / "hosting/managed-launch-preparation-h6.md",
     ARCHITECTURE_ROOT
     / "hosting/validation/managed-launch-preparation-h6-feasibility.md",
+    ARCHITECTURE_ROOT
+    / "hosting/validation/managed-launch-preparation-h6-posix-native.md",
     ARCHITECTURE_ROOT / "hosting/validation/hosted-product-runtime-v1-inventory.md",
     ARCHITECTURE_ROOT / "hosting/key-designs/hosted-application-support-boundary.md",
     ARCHITECTURE_ROOT / "drafts/apphost-top-level-placement.md",

--- a/tests/architecture/test_hosted_product_runtime_v1_baseline.py
+++ b/tests/architecture/test_hosted_product_runtime_v1_baseline.py
@@ -37,6 +37,7 @@ CURRENT_SOURCE_SEAMS = (
     HOSTING_SOURCE / "_process_host.py",
     HOSTING_SOURCE / "_child_session_host.py",
     HOSTING_SOURCE / "_launch_preparation.py",
+    HOSTING_SOURCE / "_posix_launch_preparation.py",
     HOSTING_SOURCE / "_posix_process.py",
     HOSTING_SOURCE / "_windows_process.py",
     HOSTING_SOURCE / "_win32_process.py",
@@ -130,7 +131,9 @@ def test_baseline_documents_are_status_honest_and_indexed() -> None:
             "Parent": "loushang",
             "Authority": "normative accepted design",
             "Design status": "accepted",
-            "Implementation status": "partial — H6.1 private fake-backed core",
+            "Implementation status": (
+                "partial — H6.1 core and H6.2 Linux native profiles"
+            ),
             "Activation status": "forbidden; H5 remains default-dark",
         },
         INVENTORY: {

--- a/tests/architecture/test_hosting_h0_contract.py
+++ b/tests/architecture/test_hosting_h0_contract.py
@@ -33,6 +33,7 @@ H4_PRIVATE_MODULES = {
 }
 H6_PRIVATE_MODULES = {
     HOSTING_ROOT / "_launch_preparation.py",
+    HOSTING_ROOT / "_posix_launch_preparation.py",
 }
 FORBIDDEN_PUBLIC_TERMS = {
     "Approval",

--- a/tests/architecture/test_hosting_h6_launch_preparation.py
+++ b/tests/architecture/test_hosting_h6_launch_preparation.py
@@ -53,6 +53,7 @@ def test_h6_1_core_is_private_default_dark_and_authority_free() -> None:
         "_ReservationLaunchCapture",
         "_ManagedSpawnEffect",
         "_ManagedSpawnNotCreated",
+        "_ManagedSpawnSettledWithoutProcess",
     ):
         assert private_name in core
         assert private_name not in public
@@ -139,6 +140,7 @@ def test_h6_1_transaction_attaches_then_uses_matched_backend_double_dispatch() -
     assert "class _ManagedLaunchPreparationPort(ABC)" in core
     assert "effect.begin_effect()" in _read(RUNTIME_TESTS)
     assert "if effect.accepts(failure):" in core
+    assert "if effect.accepts_settled(failure):" in core
     assert "on_orphan_spawn(process)" in core
     assert "await self._material.spawn(" in core
     assert "isinstance(prepared, _ManagedProcessPreparation)" in process_host

--- a/tests/architecture/test_hosting_h6_posix_native.py
+++ b/tests/architecture/test_hosting_h6_posix_native.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+HOSTING = Path("src/loushang/hosting")
+NATIVE = HOSTING / "_posix_launch_preparation.py"
+PROCESS = HOSTING / "_posix_process.py"
+CORE = HOSTING / "_launch_preparation.py"
+PUBLIC = (
+    HOSTING / "__init__.py",
+    HOSTING / "contracts.py",
+    HOSTING / "runtime.py",
+)
+RUNTIME_TESTS = Path("tests/hosting/test_posix_launch_preparation.py")
+PLATFORM_TESTS = Path("tests/hosting/test_posix_launch_preparation_platform.py")
+RECORD = (
+    Path("docs/internals/architecture/hosting/validation")
+    / "managed-launch-preparation-h6-posix-native.md"
+)
+WORKFLOW = Path(".github/workflows/hosting-quality.yml")
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _imports(path: Path) -> set[str]:
+    imports: set[str] = set()
+    for node in ast.walk(ast.parse(_read(path), filename=str(path))):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            imports.add(node.module)
+    return imports
+
+
+def test_h6_2_native_profiles_are_private_closed_and_product_neutral() -> None:
+    native = _read(NATIVE)
+    public = "\n".join(_read(path) for path in PUBLIC)
+
+    assert "__all__: list[str] = []" in native
+    for private_name in (
+        "_PosixStaticLaunchCaptureSpec",
+        "_PosixStaticContainedLaunchCaptureSpec",
+        "_PosixStaticLaunchCaptureBackend",
+        "_PosixStaticLaunchMaterial",
+    ):
+        assert private_name in native
+        assert private_name not in public
+    for profile in (
+        "posix-static-elf-v1",
+        "posix-static-contained-elf-v1",
+        "loushang-static-containment-launch/v1",
+    ):
+        assert profile in native
+    for closure_identity in (
+        "containment-launcher-static-elf:sha256:",
+        "payload-static-elf:sha256:",
+        "containment-profile:sha256:",
+        "platform:linux-x86_64-syscall-abi",
+    ):
+        assert closure_identity in native
+    assert "effective_environment" in native
+    assert "_PT_INTERP in program_types" in native
+    assert "_PT_DYNAMIC in program_types" in native
+    assert not any(
+        name.startswith(("loushang.harness", "loushang.coding", "loushang.apphost"))
+        for name in _imports(NATIVE)
+    )
+
+
+def test_h6_2_native_spawn_has_one_exact_manifest_and_conservative_fence() -> None:
+    native = _read(NATIVE)
+    process = _read(PROCESS)
+    core = _read(CORE)
+
+    for operation in (
+        'getattr(os, "O_NOFOLLOW", 0)',
+        "_MFD_ALLOW_SEALING",
+        "_F_SEAL_WRITE",
+        "_verify_static_descriptor",
+        "_verify_cwd_descriptor",
+        "_claim_descriptors",
+        "_contained_invocation",
+    ):
+        assert operation in native
+    assert "set(endpoint_descriptors) & set(preparation_descriptors)" in process
+    assert "pass_fds=inherited_descriptors" in process
+    assert process.index("effect.begin_effect()") < process.index(
+        "process = await self._spawn_once("
+    )
+    assert "settled_without_process" not in process
+    assert "every such failure remains fenced" in process
+    assert "class _ManagedSpawnSettledWithoutProcess" in core
+    assert "effect.accepts_settled(failure)" in core
+
+
+def test_h6_2_native_adversarial_gate_is_retained_and_non_skippable_on_linux() -> None:
+    tests = _read(RUNTIME_TESTS)
+    tree = ast.parse(tests, filename=str(RUNTIME_TESTS))
+    test_functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    required = (
+        "test_posix_static_profile_pins_executable_and_cwd_across_replacement",
+        "test_posix_static_profile_preserves_original_argv_zero",
+        "test_posix_contained_profile_pins_launcher_payload_and_applies_profile",
+        "test_posix_contained_profile_blocks_descendant_group_escape",
+        "test_posix_contained_profile_rejects_unproved_launcher_chain",
+        "test_posix_contained_launcher_rejects_profile_substitution_before_payload",
+        "test_posix_static_profile_rejects_dynamic_loader_closure",
+        "test_posix_static_profile_classifies_truncated_elf_header",
+        "test_posix_static_profile_rejects_symlinked_executable",
+        "test_posix_static_spawn_closes_unlisted_inheritable_descriptor",
+        "test_posix_static_capture_normalizes_closed_stdio_descriptor_numbers",
+        "test_posix_low_descriptor_duplication_failure_closes_original",
+        "test_posix_static_capture_rejects_digest_and_cwd_identity_mismatch",
+        "test_posix_static_memfd_failure_closes_open_source",
+        "test_posix_static_native_descriptor_collision_fails_before_effect",
+        "test_posix_static_post_create_error_stays_fenced",
+        "test_posix_static_close_error_never_retries_reused_descriptor",
+        "test_posix_static_native_early_exit_rolls_back_before_publication",
+        "test_posix_static_cancellation_after_os_create_reclaims_process",
+    )
+    for name in required:
+        function = test_functions[name]
+        assert any(isinstance(node, ast.Assert) for node in ast.walk(function))
+        assert not any(
+            "skip" in ast.unparse(decorator)
+            for decorator in function.decorator_list
+        )
+
+    workflow = _read(WORKFLOW)
+    assert "tests/hosting/test_posix_launch_preparation.py" in workflow
+    assert "h6-posix-native.xml" in workflow
+    assert "verify_pytest_xml.py" in workflow
+    assert "test_posix_static_launch_backend_is_exactly_linux_or_fails_closed" in _read(
+        PLATFORM_TESTS
+    )
+    assert RECORD.is_file()

--- a/tests/hosting/test_posix_launch_preparation.py
+++ b/tests/hosting/test_posix_launch_preparation.py
@@ -1,0 +1,1360 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import platform
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import textwrap
+from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from functools import wraps
+from pathlib import Path
+from typing import ParamSpec
+
+import pytest
+
+from loushang.hosting import (
+    ChildSessionRequest,
+    HostingError,
+    HostingFailureCategory,
+    ProcessLaunchRequest,
+    ProcessStderrMode,
+    ProcessStdinMode,
+    ProcessStdoutMode,
+    ProcessStreamSpec,
+)
+from loushang.hosting._child_session_host import _ChildSessionHost
+from loushang.hosting._endpoint_host import _InheritedEndpointHost
+from loushang.hosting._launch_preparation import (
+    _LaunchCapturePort,
+    _ManagedLaunchPreparationPort,
+    _ManagedLaunchPreparationResult,
+    _ManagedSpawnEffect,
+    _ManagedSpawnNotCreated,
+    _ManagedSpawnSettledWithoutProcess,
+)
+from loushang.hosting._posix_endpoint import _PosixEndpointBackend
+from loushang.hosting._posix_launch_preparation import (
+    _PosixStaticContainedLaunchCaptureSpec,
+    _PosixStaticLaunchCaptureBackend,
+    _PosixStaticLaunchCaptureSpec,
+)
+from loushang.hosting._posix_process import _PosixProcessBackend
+from loushang.hosting._process_host import _ProcessHost, _ProcessHostLimits
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix"
+    or not sys.platform.startswith("linux")
+    or platform.machine().lower() not in {"amd64", "x86_64"},
+    reason="Linux x86_64 sealed-memfd launch preparation",
+)
+_P = ParamSpec("_P")
+
+
+def _async_test(
+    function: Callable[_P, Awaitable[None]],
+) -> Callable[_P, None]:
+    @wraps(function)
+    def run(*args: _P.args, **kwargs: _P.kwargs) -> None:
+        asyncio.run(function(*args, **kwargs))
+
+    return run
+
+
+class _SemanticLease:
+    def __init__(self, request: ProcessLaunchRequest) -> None:
+        self.request = request
+        self.verify_calls = 0
+        self.close_calls = 0
+
+    async def verify_current(self) -> None:
+        self.verify_calls += 1
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+class _StaticPreparationPort(_ManagedLaunchPreparationPort):
+    def __init__(
+        self,
+        spec: _PosixStaticLaunchCaptureSpec
+        | _PosixStaticContainedLaunchCaptureSpec,
+        *,
+        pause_after_capture: bool = False,
+    ) -> None:
+        self.spec = spec
+        self.lease = _SemanticLease(spec.request)
+        self.captured = asyncio.Event()
+        self.release = asyncio.Event()
+        if not pause_after_capture:
+            self.release.set()
+
+    async def prepare(self, request: ProcessLaunchRequest) -> _SemanticLease:
+        raise AssertionError("POSIX static preparation requires managed capture")
+
+    async def prepare_managed(
+        self,
+        request: ProcessLaunchRequest,
+        capture: _LaunchCapturePort,
+    ) -> _ManagedLaunchPreparationResult:
+        returned = False
+        try:
+            assert request == self.spec.request
+            binding = await capture.capture(self.spec)
+            self.captured.set()
+            await self.release.wait()
+            result = _ManagedLaunchPreparationResult(self.lease, binding)
+            returned = True
+            return result
+        finally:
+            if not returned:
+                await self.lease.close()
+
+
+def _native_host(
+    process_backend: _PosixProcessBackend | None = None,
+    capture_backend: _PosixStaticLaunchCaptureBackend | None = None,
+) -> _ChildSessionHost:
+    process_backend = process_backend or _PosixProcessBackend()
+    return _ChildSessionHost(
+        _ProcessHost(
+            process_backend,
+            limits=_ProcessHostLimits(
+                max_processes=1,
+                termination_grace_seconds=0.05,
+            ),
+        ),
+        _InheritedEndpointHost(_PosixEndpointBackend(), max_endpoints=1),
+        max_sessions=1,
+        launch_capture_backend=capture_backend
+        or _PosixStaticLaunchCaptureBackend(),
+        max_capture_slots=3,
+    )
+
+
+def _compile_static_fixture(path: Path, *, marker: str) -> None:
+    compiler = shutil.which("cc")
+    if compiler is None:
+        pytest.fail("H6.2 native gate requires a C compiler")
+    source = path.with_suffix(".c")
+    source.write_text(
+        """
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+int main(int argc, char **argv) {
+    char release;
+    if (argc == 2) {
+        if (strcmp(argv[1], "--print-argv0") == 0) {
+            printf("%s\\n", argv[0]);
+            if (fflush(stdout) != 0) return 73;
+            return read(STDIN_FILENO, &release, 1) == 1 ? 0 : 74;
+        }
+        printf("%s\\n", fcntl(atoi(argv[1]), F_GETFD) == -1 ? "closed" : "open");
+        if (fflush(stdout) != 0) return 72;
+        return read(STDIN_FILENO, &release, 1) == 1 ? 0 : 74;
+    }
+    struct stat cwd;
+    if (stat(".", &cwd) != 0) return 70;
+    printf("%s:%llu\\n", MARKER, (unsigned long long)cwd.st_ino);
+    if (fflush(stdout) != 0) return 71;
+    return read(STDIN_FILENO, &release, 1) == 1 ? 0 : 74;
+}
+""".replace("MARKER", f'"{marker}"'),
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        (compiler, "-static", "-O2", "-s", "-o", str(path), str(source)),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.fail(f"H6.2 static fixture compilation failed: {completed.stderr}")
+
+
+def _compile_containment_launcher(
+    path: Path,
+    *,
+    profile_sha256: str,
+) -> None:
+    compiler = shutil.which("cc")
+    if compiler is None:
+        pytest.fail("H6.2 native gate requires a C compiler")
+    source = path.with_suffix(".c")
+    source.write_text(
+        r'''
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/audit.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <asm/unistd.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static int close_on_exec(int fd) {
+    int flags = fcntl(fd, F_GETFD);
+    return flags < 0 ? -1 : fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
+
+static int install_profile(void) {
+    struct sock_filter filter[] = {
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+                 offsetof(struct seccomp_data, arch)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, AUDIT_ARCH_X86_64, 1, 0),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS,
+                 offsetof(struct seccomp_data, nr)),
+        BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K, __X32_SYSCALL_BIT, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_socket, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | EPERM),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_setsid, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | EPERM),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_setpgid, 0, 1),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | EPERM),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    };
+    struct sock_fprog program = {
+        .len = (unsigned short)(sizeof(filter) / sizeof(filter[0])),
+        .filter = filter,
+    };
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) return -1;
+    return prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &program);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 11) return 80;
+    if (strcmp(argv[1], "--loushang-protocol") != 0 ||
+        strcmp(argv[2], "loushang-static-containment-launch/v1") != 0 ||
+        strcmp(argv[3], "--loushang-profile-sha256") != 0 ||
+        strcmp(argv[5], "--loushang-payload-fd") != 0 ||
+        strcmp(argv[7], "--loushang-preparation-fds") != 0 ||
+        strcmp(argv[9], "--") != 0) return 81;
+    if (strcmp(argv[4], PROFILE_SHA256) != 0) {
+        char release;
+        printf("profile-rejected\n");
+        if (fflush(stdout) != 0) return 88;
+        return read(STDIN_FILENO, &release, 1) == 1 ? 87 : 89;
+    }
+    int payload = atoi(argv[6]);
+    int launcher = -1, listed_payload = -1, cwd = -1;
+    if (sscanf(argv[8], "%d,%d,%d", &launcher, &listed_payload, &cwd) != 3 ||
+        payload < 0 || payload != listed_payload) return 82;
+    if (close_on_exec(launcher) != 0 || close_on_exec(payload) != 0 ||
+        close_on_exec(cwd) != 0) return 83;
+    if (install_profile() != 0) return 84;
+    char executable[64];
+    if (snprintf(executable, sizeof(executable), "/proc/self/fd/%d", payload) < 0)
+        return 85;
+    char *environment[] = {NULL};
+    execve(executable, &argv[10], environment);
+    return 86;
+}
+'''.replace("PROFILE_SHA256", f'"{profile_sha256}"'),
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        (compiler, "-static", "-O2", "-s", "-o", str(path), str(source)),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.fail(
+            f"H6.2 containment launcher compilation failed: {completed.stderr}"
+        )
+
+
+def _compile_containment_payload(path: Path, *, marker: str) -> None:
+    compiler = shutil.which("cc")
+    if compiler is None:
+        pytest.fail("H6.2 native gate requires a C compiler")
+    source = path.with_suffix(".c")
+    source.write_text(
+        r'''
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <unistd.h>
+int main(int argc, char **argv) {
+    if (prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0) != 1) return 90;
+    errno = 0;
+    int descriptor = socket(AF_INET, SOCK_STREAM, 0);
+    if (descriptor >= 0 || errno != EPERM) return 91;
+    if (argc == 2 && strcmp(argv[1], "--attempt-group-escape") == 0) {
+        pid_t child = fork();
+        if (child < 0) return 94;
+        if (child == 0) {
+            int blocked = 1;
+            errno = 0;
+            if (setsid() != -1 || errno != EPERM) blocked = 0;
+            errno = 0;
+            if (setpgid(0, 0) != -1 || errno != EPERM) blocked = 0;
+            printf("%s:%d\n", blocked ? "escape-blocked" : "escape-open", getpid());
+            fflush(stdout);
+            if (!blocked) return 95;
+            for (;;) pause();
+        }
+        for (;;) pause();
+    }
+    struct stat cwd;
+    if (stat(".", &cwd) != 0) return 92;
+    printf("%s:contained:%llu\n", MARKER, (unsigned long long)cwd.st_ino);
+    if (fflush(stdout) != 0) return 93;
+    char release;
+    return read(STDIN_FILENO, &release, 1) == 1 ? 0 : 96;
+}
+'''.replace("MARKER", f'"{marker}"'),
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        (compiler, "-static", "-O2", "-s", "-o", str(path), str(source)),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.fail(f"H6.2 containment payload compilation failed: {completed.stderr}")
+
+
+def _compile_immediate_exit_fixture(path: Path, *, return_code: int) -> None:
+    compiler = shutil.which("cc")
+    if compiler is None:
+        pytest.fail("H6.2 native gate requires a C compiler")
+    source = path.with_suffix(".c")
+    source.write_text(
+        f"int main(void) {{ return {return_code}; }}\n",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        (compiler, "-static", "-O2", "-s", "-o", str(path), str(source)),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.fail(f"H6.2 early-exit fixture compilation failed: {completed.stderr}")
+
+
+def _compile_pausing_fixture(path: Path) -> None:
+    compiler = shutil.which("cc")
+    if compiler is None:
+        pytest.fail("H6.2 native gate requires a C compiler")
+    source = path.with_suffix(".c")
+    source.write_text(
+        "#include <unistd.h>\nint main(void) { for (;;) pause(); }\n",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        (compiler, "-static", "-O2", "-s", "-o", str(path), str(source)),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        pytest.fail(f"H6.2 pausing fixture compilation failed: {completed.stderr}")
+
+
+def _spec(
+    executable: Path,
+    cwd: Path,
+    *arguments: str,
+) -> _PosixStaticLaunchCaptureSpec:
+    executable = executable.absolute()
+    cwd = cwd.absolute()
+    digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+    cwd_stat = cwd.stat()
+    request = ProcessLaunchRequest(
+        argv=(str(executable), *arguments),
+        cwd=str(cwd),
+        effective_environment=(),
+        streams=ProcessStreamSpec(
+            stdin=ProcessStdinMode.CLOSED,
+            stdout=ProcessStdoutMode.DISCARD,
+            stderr=ProcessStderrMode.CAPTURE_TAIL,
+        ),
+    )
+    return _PosixStaticLaunchCaptureSpec(
+        request=request,
+        profile_id="posix-static-elf-v1",
+        execution_closure=(
+            f"static-elf:sha256:{digest}",
+            f"cwd:posix:{cwd_stat.st_dev}:{cwd_stat.st_ino}",
+            "platform:linux-x86_64-syscall-abi",
+        ),
+        executable_sha256=digest,
+        cwd_device=cwd_stat.st_dev,
+        cwd_inode=cwd_stat.st_ino,
+    )
+
+
+def _contained_spec(
+    launcher: Path,
+    executable: Path,
+    cwd: Path,
+    *arguments: str,
+    profile_sha256: str,
+) -> _PosixStaticContainedLaunchCaptureSpec:
+    launcher = launcher.absolute()
+    executable = executable.absolute()
+    cwd = cwd.absolute()
+    launcher_digest = hashlib.sha256(launcher.read_bytes()).hexdigest()
+    executable_digest = hashlib.sha256(executable.read_bytes()).hexdigest()
+    cwd_stat = cwd.stat()
+    request = ProcessLaunchRequest(
+        argv=(str(executable), *arguments),
+        cwd=str(cwd),
+        effective_environment=(),
+        streams=ProcessStreamSpec(
+            stdin=ProcessStdinMode.CLOSED,
+            stdout=ProcessStdoutMode.DISCARD,
+            stderr=ProcessStderrMode.CAPTURE_TAIL,
+        ),
+    )
+    return _PosixStaticContainedLaunchCaptureSpec(
+        request=request,
+        profile_id="posix-static-contained-elf-v1",
+        execution_closure=(
+            f"containment-launcher-static-elf:sha256:{launcher_digest}",
+            f"payload-static-elf:sha256:{executable_digest}",
+            f"cwd:posix:{cwd_stat.st_dev}:{cwd_stat.st_ino}",
+            f"containment-profile:sha256:{profile_sha256}",
+            "invocation:loushang-static-containment-launch/v1",
+            "platform:linux-x86_64-syscall-abi",
+        ),
+        launcher_path=str(launcher),
+        launcher_sha256=launcher_digest,
+        executable_sha256=executable_digest,
+        cwd_device=cwd_stat.st_dev,
+        cwd_inode=cwd_stat.st_ino,
+        containment_profile_sha256=profile_sha256,
+    )
+
+
+async def _read_line(read: Callable[[int], Awaitable[bytes]]) -> bytes:
+    chunks: list[bytes] = []
+    size = 0
+    while size < 4096:
+        chunk = await read(min(1024, 4096 - size))
+        if not chunk:
+            return b"".join(chunks)
+        chunks.append(chunk)
+        size += len(chunk)
+        if b"\n" in chunk:
+            return b"".join(chunks)
+    raise AssertionError("native fixture line exceeded its bound")
+
+
+def _linux_process_identity(pid: int) -> tuple[int, str] | None:
+    try:
+        body = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    fields = body[body.rfind(")") + 2 :].split()
+    return int(fields[19]), fields[0]
+
+
+@_async_test
+async def test_posix_static_profile_pins_executable_and_cwd_across_replacement(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    preparation = _StaticPreparationPort(spec, pause_after_capture=True)
+    host = _native_host()
+    start = asyncio.create_task(
+        host.start(ChildSessionRequest(spec.request), preparation)
+    )
+    await preparation.captured.wait()
+
+    moved_executable = tmp_path / "captured-executable"
+    executable.rename(moved_executable)
+    _compile_static_fixture(executable, marker="substituted")
+    pinned_cwd = tmp_path / "captured-cwd"
+    cwd.rename(pinned_cwd)
+    cwd.mkdir()
+    preparation.release.set()
+
+    lease = await start
+    output = await _read_line(lease.endpoint.read)
+    await lease.endpoint.write(b"x")
+    result = await lease.process.wait()
+    await lease.close()
+    await host.close()
+
+    assert result.return_code == 0
+    assert output == f"admitted:{spec.cwd_inode}\n".encode()
+    assert preparation.lease.verify_calls == 1
+    assert preparation.lease.close_calls == 1
+
+
+@_async_test
+async def test_posix_static_profile_preserves_original_argv_zero(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd, "--print-argv0")
+    host = _native_host()
+
+    lease = await host.start(
+        ChildSessionRequest(spec.request),
+        _StaticPreparationPort(spec),
+    )
+    assert await _read_line(lease.endpoint.read) == f"{executable}\n".encode()
+    await lease.endpoint.write(b"x")
+    assert (await lease.process.wait()).return_code == 0
+    await lease.close()
+    await host.close()
+
+
+@_async_test
+async def test_posix_contained_profile_pins_launcher_payload_and_applies_profile(
+    tmp_path: Path,
+) -> None:
+    profile_sha256 = hashlib.sha256(b"deny-network-and-no-new-privileges").hexdigest()
+    launcher = tmp_path / "launcher"
+    executable = tmp_path / "payload"
+    _compile_containment_launcher(launcher, profile_sha256=profile_sha256)
+    _compile_containment_payload(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _contained_spec(
+        launcher,
+        executable,
+        cwd,
+        profile_sha256=profile_sha256,
+    )
+    preparation = _StaticPreparationPort(spec, pause_after_capture=True)
+    host = _native_host()
+    start = asyncio.create_task(
+        host.start(ChildSessionRequest(spec.request), preparation)
+    )
+    await preparation.captured.wait()
+
+    launcher.rename(tmp_path / "captured-launcher")
+    executable.rename(tmp_path / "captured-payload")
+    _compile_static_fixture(launcher, marker="substituted-launcher")
+    _compile_containment_payload(executable, marker="substituted-payload")
+    pinned_cwd = tmp_path / "captured-cwd"
+    cwd.rename(pinned_cwd)
+    cwd.mkdir()
+    preparation.release.set()
+
+    lease = await start
+    output = await _read_line(lease.endpoint.read)
+    await lease.endpoint.write(b"x")
+    result = await lease.process.wait()
+    await lease.close()
+    await host.close()
+
+    assert result.return_code == 0
+    assert output == f"admitted:contained:{spec.cwd_inode}\n".encode()
+    assert preparation.lease.verify_calls == 1
+    assert preparation.lease.close_calls == 1
+
+
+@_async_test
+async def test_posix_contained_profile_blocks_descendant_group_escape(
+    tmp_path: Path,
+) -> None:
+    profile_sha256 = hashlib.sha256(
+        b"deny-network-and-process-group-escape"
+    ).hexdigest()
+    launcher = tmp_path / "launcher"
+    executable = tmp_path / "payload"
+    _compile_containment_launcher(launcher, profile_sha256=profile_sha256)
+    _compile_containment_payload(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _contained_spec(
+        launcher,
+        executable,
+        cwd,
+        "--attempt-group-escape",
+        profile_sha256=profile_sha256,
+    )
+    host = _native_host()
+
+    lease = await host.start(
+        ChildSessionRequest(spec.request),
+        _StaticPreparationPort(spec),
+    )
+    output = await _read_line(lease.endpoint.read)
+    marker, raw_pid = output.decode().strip().split(":", maxsplit=1)
+    descendant_pid = int(raw_pid)
+    assert marker == "escape-blocked"
+    assert descendant_pid > 0
+    descendant_identity = _linux_process_identity(descendant_pid)
+    assert descendant_identity is not None
+
+    await lease.close()
+    await host.close()
+    deadline = asyncio.get_running_loop().time() + 2.0
+    while True:
+        current = _linux_process_identity(descendant_pid)
+        if (
+            current is None
+            or current[0] != descendant_identity[0]
+            or current[1] == "Z"
+        ):
+            break
+        if asyncio.get_running_loop().time() >= deadline:
+            pytest.fail("contained descendant remained live after session close")
+        await asyncio.sleep(0.01)
+
+
+def test_posix_contained_profile_rejects_unproved_launcher_chain(
+    tmp_path: Path,
+) -> None:
+    profile_sha256 = hashlib.sha256(b"required-profile").hexdigest()
+    executable = tmp_path / "payload"
+    _compile_containment_payload(executable, marker="payload")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    dynamic_launcher = Path(sys.executable).resolve()
+    spec = _contained_spec(
+        dynamic_launcher,
+        executable,
+        cwd,
+        profile_sha256=profile_sha256,
+    )
+    backend = _PosixStaticLaunchCaptureBackend()
+
+    async def capture() -> None:
+        with pytest.raises(HostingError) as failure:
+            await backend.capture(
+                spec,
+                attempt_id="dynamic-launcher-attempt",
+                attempt_token=object(),
+                on_capture=lambda material: None,
+            )
+        assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+
+    asyncio.run(capture())
+
+
+@_async_test
+async def test_posix_contained_launcher_rejects_profile_substitution_before_payload(
+    tmp_path: Path,
+) -> None:
+    admitted_profile = hashlib.sha256(b"admitted-profile").hexdigest()
+    substituted_profile = hashlib.sha256(b"substituted-profile").hexdigest()
+    launcher = tmp_path / "launcher"
+    executable = tmp_path / "payload"
+    _compile_containment_launcher(launcher, profile_sha256=admitted_profile)
+    _compile_containment_payload(executable, marker="must-not-run")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _contained_spec(
+        launcher,
+        executable,
+        cwd,
+        profile_sha256=substituted_profile,
+    )
+    host = _native_host()
+
+    lease = await host.start(
+        ChildSessionRequest(spec.request),
+        _StaticPreparationPort(spec),
+    )
+    assert await _read_line(lease.endpoint.read) == b"profile-rejected\n"
+    await lease.endpoint.write(b"x")
+    assert (await lease.process.wait()).return_code == 87
+    await lease.close()
+    await host.close()
+
+
+@_async_test
+async def test_posix_static_profile_rejects_dynamic_loader_closure(
+    tmp_path: Path,
+) -> None:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    executable = Path(sys.executable).resolve()
+    spec = _spec(executable, cwd)
+    preparation = _StaticPreparationPort(spec)
+    host = _native_host()
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(ChildSessionRequest(spec.request), preparation)
+
+    assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+    assert preparation.lease.close_calls == 1
+    await host.close()
+
+
+def test_posix_static_profile_classifies_truncated_elf_header(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "truncated"
+    executable.write_bytes(b"\x7fELF\x02\x01" + b"\0" * 49)
+    executable.chmod(0o755)
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    backend = _PosixStaticLaunchCaptureBackend()
+
+    async def capture() -> None:
+        with pytest.raises(HostingError) as failure:
+            await backend.capture(
+                spec,
+                attempt_id="truncated-elf-attempt",
+                attempt_token=object(),
+                on_capture=lambda material: None,
+            )
+        assert failure.value.category is HostingFailureCategory.PREPARATION_FAILED
+
+    asyncio.run(capture())
+
+
+def test_posix_static_profile_rejects_symlinked_executable(tmp_path: Path) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    symlink = tmp_path / "linked"
+    symlink.symlink_to(executable)
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    linked_request = ProcessLaunchRequest(
+        argv=(str(symlink),),
+        cwd=spec.request.cwd,
+        effective_environment=(),
+        streams=spec.request.streams,
+    )
+    linked_spec = _PosixStaticLaunchCaptureSpec(
+        request=linked_request,
+        profile_id=spec.profile_id,
+        execution_closure=spec.execution_closure,
+        executable_sha256=spec.executable_sha256,
+        cwd_device=spec.cwd_device,
+        cwd_inode=spec.cwd_inode,
+    )
+    backend = _PosixStaticLaunchCaptureBackend()
+
+    async def capture() -> None:
+        with pytest.raises(OSError) as failure:
+            await backend.capture(
+                linked_spec,
+                attempt_id="symlink-attempt",
+                attempt_token=object(),
+                on_capture=lambda material: None,
+            )
+        assert failure.value.errno is not None
+
+    asyncio.run(capture())
+
+
+def test_posix_static_profile_requires_empty_environment_and_exact_closure(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    with pytest.raises(ValueError, match="empty environment"):
+        _PosixStaticLaunchCaptureSpec(
+            request=ProcessLaunchRequest(
+                argv=spec.request.argv,
+                cwd=spec.request.cwd,
+                effective_environment=(("PATH", "/tmp"),),
+                streams=spec.request.streams,
+            ),
+            profile_id=spec.profile_id,
+            execution_closure=spec.execution_closure,
+            executable_sha256=spec.executable_sha256,
+            cwd_device=spec.cwd_device,
+            cwd_inode=spec.cwd_inode,
+        )
+    with pytest.raises(ValueError, match="execution closure"):
+        _PosixStaticLaunchCaptureSpec(
+            request=spec.request,
+            profile_id=spec.profile_id,
+            execution_closure=("not-the-admitted-closure",),
+            executable_sha256=spec.executable_sha256,
+            cwd_device=spec.cwd_device,
+            cwd_inode=spec.cwd_inode,
+        )
+
+
+def test_posix_static_capture_leaves_descriptors_non_inheritable_until_spawn(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    backend = _PosixStaticLaunchCaptureBackend()
+    captured = []
+
+    async def capture() -> None:
+        material = await backend.capture(
+            spec,
+            attempt_id="inheritability-attempt",
+            attempt_token=object(),
+            on_capture=captured.append,
+        )
+        assert material is captured[0]
+        assert os.get_inheritable(material._executable_descriptor) is False
+        assert os.get_inheritable(material._cwd_descriptor) is False
+        assert stat.S_IMODE(os.fstat(material._executable_descriptor).st_mode) == 0o500
+        await material.close()
+
+    asyncio.run(capture())
+
+
+def test_posix_static_capture_normalizes_closed_stdio_descriptor_numbers(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    code = textwrap.dedent(
+        """
+        import asyncio
+        import hashlib
+        import os
+        import sys
+        from loushang.hosting import (
+            ProcessLaunchRequest,
+            ProcessStderrMode,
+            ProcessStdinMode,
+            ProcessStdoutMode,
+            ProcessStreamSpec,
+        )
+        from loushang.hosting._posix_launch_preparation import (
+            _PosixStaticLaunchCaptureBackend,
+            _PosixStaticLaunchCaptureSpec,
+        )
+
+        executable, cwd = sys.argv[1:]
+        digest = hashlib.sha256(open(executable, "rb").read()).hexdigest()
+        cwd_stat = os.stat(cwd)
+        request = ProcessLaunchRequest(
+            argv=(executable,),
+            cwd=cwd,
+            effective_environment=(),
+            streams=ProcessStreamSpec(
+                stdin=ProcessStdinMode.CLOSED,
+                stdout=ProcessStdoutMode.DISCARD,
+                stderr=ProcessStderrMode.CAPTURE_TAIL,
+            ),
+        )
+        spec = _PosixStaticLaunchCaptureSpec(
+            request=request,
+            profile_id="posix-static-elf-v1",
+            execution_closure=(
+                f"static-elf:sha256:{digest}",
+                f"cwd:posix:{cwd_stat.st_dev}:{cwd_stat.st_ino}",
+                "platform:linux-x86_64-syscall-abi",
+            ),
+            executable_sha256=digest,
+            cwd_device=cwd_stat.st_dev,
+            cwd_inode=cwd_stat.st_ino,
+        )
+
+        async def main():
+            material = await _PosixStaticLaunchCaptureBackend().capture(
+                spec,
+                attempt_id="low-fd-attempt",
+                attempt_token=object(),
+                on_capture=lambda material: None,
+            )
+            if min(material._executable_descriptor, material._cwd_descriptor) < 3:
+                os._exit(97)
+            await material.close()
+
+        asyncio.run(main())
+        """
+    )
+
+    def close_stdin_and_stdout() -> None:
+        for descriptor in (0, 1):
+            with suppress(OSError):
+                os.close(descriptor)
+
+    completed = subprocess.run(
+        (sys.executable, "-c", code, str(executable), str(cwd)),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        preexec_fn=close_stdin_and_stdout,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_posix_low_descriptor_duplication_failure_closes_original(
+    tmp_path: Path,
+) -> None:
+    sentinel = tmp_path / "low-descriptor-sentinel"
+    sentinel.write_bytes(b"sentinel")
+    code = textwrap.dedent(
+        """
+        import os
+        import sys
+        import loushang.hosting._posix_launch_preparation as preparation
+
+        os.close(0)
+        descriptor = os.open(sys.argv[1], os.O_RDONLY)
+        if descriptor != 0:
+            raise SystemExit(90)
+
+        def fail_duplicate(*args):
+            raise OSError("injected descriptor duplication failure")
+
+        preparation.fcntl.fcntl = fail_duplicate
+        try:
+            preparation._ensure_preparation_descriptor(descriptor)
+        except OSError as error:
+            if "injected descriptor duplication failure" not in str(error):
+                raise SystemExit(91)
+        else:
+            raise SystemExit(92)
+        try:
+            os.fstat(descriptor)
+        except OSError:
+            raise SystemExit(0)
+        raise SystemExit(93)
+        """
+    )
+    completed = subprocess.run(
+        (sys.executable, "-c", code, str(sentinel)),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+@_async_test
+async def test_posix_static_spawn_closes_unlisted_inheritable_descriptor(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    sentinel = os.open(tmp_path / "sentinel", os.O_CREAT | os.O_RDWR, 0o600)
+    os.set_inheritable(sentinel, True)
+    spec = _spec(executable, cwd, str(sentinel))
+    host = _native_host()
+    try:
+        lease = await host.start(
+            ChildSessionRequest(spec.request),
+            _StaticPreparationPort(spec),
+        )
+        output = await _read_line(lease.endpoint.read)
+        await lease.endpoint.write(b"x")
+        result = await lease.process.wait()
+        await lease.close()
+        assert result.return_code == 0
+        assert output == b"closed\n"
+    finally:
+        await host.close()
+        os.close(sentinel)
+
+
+def test_posix_static_capture_rejects_digest_and_cwd_identity_mismatch(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    original = _spec(executable, cwd)
+    backend = _PosixStaticLaunchCaptureBackend()
+
+    async def capture(
+        spec: _PosixStaticLaunchCaptureSpec,
+        expected: HostingFailureCategory,
+    ) -> None:
+        with pytest.raises(HostingError) as failure:
+            await backend.capture(
+                spec,
+                attempt_id="mismatch-attempt",
+                attempt_token=object(),
+                on_capture=lambda material: None,
+            )
+        assert failure.value.category is expected
+
+    wrong_digest = "0" * 64
+    asyncio.run(
+        capture(
+            _PosixStaticLaunchCaptureSpec(
+                request=original.request,
+                profile_id=original.profile_id,
+                execution_closure=(
+                    f"static-elf:sha256:{wrong_digest}",
+                    f"cwd:posix:{original.cwd_device}:{original.cwd_inode}",
+                    "platform:linux-x86_64-syscall-abi",
+                ),
+                executable_sha256=wrong_digest,
+                cwd_device=original.cwd_device,
+                cwd_inode=original.cwd_inode,
+            ),
+            HostingFailureCategory.PREPARATION_FAILED,
+        )
+    )
+    asyncio.run(
+        capture(
+            _PosixStaticLaunchCaptureSpec(
+                request=original.request,
+                profile_id=original.profile_id,
+                execution_closure=(
+                    f"static-elf:sha256:{original.executable_sha256}",
+                    f"cwd:posix:{original.cwd_device}:{original.cwd_inode + 1}",
+                    "platform:linux-x86_64-syscall-abi",
+                ),
+                executable_sha256=original.executable_sha256,
+                cwd_device=original.cwd_device,
+                cwd_inode=original.cwd_inode + 1,
+            ),
+            HostingFailureCategory.PREPARATION_STALE,
+        )
+    )
+
+
+def test_posix_static_memfd_failure_closes_open_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    source_descriptor = -1
+    original_open = os.open
+
+    def observe_open(path: str, flags: int, mode: int = 0o777) -> int:
+        nonlocal source_descriptor
+        descriptor = original_open(path, flags, mode)
+        if path == str(executable):
+            source_descriptor = descriptor
+        return descriptor
+
+    def fail_memfd() -> int:
+        raise OSError("injected memfd failure")
+
+    monkeypatch.setattr(
+        "loushang.hosting._posix_launch_preparation.os.open", observe_open
+    )
+    monkeypatch.setattr(
+        "loushang.hosting._posix_launch_preparation._create_memfd", fail_memfd
+    )
+    backend = _PosixStaticLaunchCaptureBackend()
+
+    async def capture() -> None:
+        with pytest.raises(OSError, match="injected memfd failure"):
+            await backend.capture(
+                spec,
+                attempt_id="memfd-failure-attempt",
+                attempt_token=object(),
+                on_capture=lambda material: None,
+            )
+
+    asyncio.run(capture())
+    assert source_descriptor >= 0
+    with pytest.raises(OSError):
+        os.fstat(source_descriptor)
+
+
+def test_posix_static_native_descriptor_collision_fails_before_effect(
+    tmp_path: Path,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    capture_backend = _PosixStaticLaunchCaptureBackend()
+    process_backend = _PosixProcessBackend()
+    captured = []
+
+    class _CollidingInheritance:
+        backend_id = process_backend.backend_id
+
+        def claim(self, *, backend_id: str) -> tuple[int, ...]:
+            assert backend_id == self.backend_id
+            return (
+                captured[0]._executable_descriptor,
+                captured[0]._executable_descriptor,
+            )
+
+        def mark_transferred(self) -> None:
+            raise AssertionError("collision must fail before transfer")
+
+        async def close(self) -> None:
+            return
+
+    async def exercise() -> None:
+        material = await capture_backend.capture(
+            spec,
+            attempt_id="collision-attempt",
+            attempt_token=object(),
+            on_capture=captured.append,
+        )
+        await material.verify_current(spec.request)
+        effect = _ManagedSpawnEffect()
+        with pytest.raises(_ManagedSpawnNotCreated) as failure:
+            await process_backend._spawn_static_prepared(
+                material,
+                spec.request,
+                effect=effect,
+                on_spawn=lambda process: None,
+                inheritance=_CollidingInheritance(),
+            )
+        assert isinstance(failure.value.cause, HostingError)
+        assert (
+            failure.value.cause.category
+            is HostingFailureCategory.ENDPOINT_TRANSFER_FAILED
+        )
+        assert effect.accepts(failure.value)
+        await material.close()
+
+    asyncio.run(exercise())
+
+
+def test_managed_spawn_effect_accepts_only_its_settled_attempt_receipt() -> None:
+    effect = _ManagedSpawnEffect()
+    effect.begin_effect()
+    failure = effect.settled_without_process(OSError("known exec failure"))
+
+    assert isinstance(failure, _ManagedSpawnSettledWithoutProcess)
+    assert effect.accepts_settled(failure)
+
+    other = _ManagedSpawnEffect()
+    other.begin_effect()
+    assert not other.accepts_settled(failure)
+    with pytest.raises(RuntimeError, match="cannot settle"):
+        effect.settled_without_process(OSError("duplicate settlement"))
+
+
+@_async_test
+async def test_posix_static_post_create_error_stays_fenced(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "pausing"
+    _compile_pausing_fixture(executable)
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    process_backend = _PosixProcessBackend()
+    capture_backend = _PosixStaticLaunchCaptureBackend()
+    original_create = asyncio.create_subprocess_exec
+    original_capture = capture_backend.capture
+    created: list[asyncio.subprocess.Process] = []
+    captured = []
+
+    async def create_then_fail(*args: object, **kwargs: object):
+        process = await original_create(*args, **kwargs)  # type: ignore[arg-type]
+        created.append(process)
+        raise OSError("injected post-create transport failure")
+
+    async def observe_capture(*args: object, **kwargs: object):
+        material = await original_capture(*args, **kwargs)  # type: ignore[arg-type]
+        captured.append(material)
+        return material
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_then_fail)
+    monkeypatch.setattr(capture_backend, "capture", observe_capture)
+    host = _native_host(process_backend, capture_backend)
+    failed_preparation = _StaticPreparationPort(spec)
+
+    try:
+        with pytest.raises(HostingError) as failure:
+            await host.start(ChildSessionRequest(spec.request), failed_preparation)
+        assert failure.value.category is HostingFailureCategory.SPAWN_FAILED
+        assert len(created) == 1
+        os.killpg(created[0].pid, 0)
+        assert host._state == "faulted"
+        assert host._process_host._state == "faulted"
+        assert failed_preparation.lease.close_calls == 0
+
+        with pytest.raises(HostingError) as retry:
+            await host.start(
+                ChildSessionRequest(spec.request),
+                _StaticPreparationPort(spec),
+            )
+        assert retry.value.category is HostingFailureCategory.HOST_CLOSED
+    finally:
+        for process in created:
+            with suppress(ProcessLookupError):
+                os.killpg(process.pid, signal.SIGKILL)
+            await process.wait()
+            transport = getattr(process, "_transport", None)
+            close_transport = getattr(transport, "close", None)
+            if callable(close_transport):
+                close_transport()
+        for material in captured:
+            await material.close()
+        await failed_preparation.lease.close()
+
+
+def test_posix_static_close_error_never_retries_reused_descriptor(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    backend = _PosixStaticLaunchCaptureBackend()
+    captured = []
+
+    async def exercise() -> None:
+        material = await backend.capture(
+            spec,
+            attempt_id="cleanup-attempt",
+            attempt_token=object(),
+            on_capture=captured.append,
+        )
+        executable_descriptor = material._executable_descriptor
+        cwd_descriptor = material._cwd_descriptor
+        original_close = os.close
+        failed = False
+        reused_descriptor = -1
+
+        def fail_executable_once(descriptor: int) -> None:
+            nonlocal failed, reused_descriptor
+            if descriptor == executable_descriptor and not failed:
+                failed = True
+                original_close(descriptor)
+                reused_descriptor = os.open(
+                    tmp_path / "reused-sentinel",
+                    os.O_CREAT | os.O_RDWR,
+                    0o600,
+                )
+                raise OSError("injected descriptor close failure")
+            original_close(descriptor)
+
+        monkeypatch.setattr(
+            "loushang.hosting._posix_launch_preparation.os.close",
+            fail_executable_once,
+        )
+        with pytest.raises(BaseExceptionGroup):
+            await material.close()
+        assert reused_descriptor == executable_descriptor
+        assert os.fstat(reused_descriptor).st_ino > 0
+        with pytest.raises(OSError):
+            os.fstat(cwd_descriptor)
+        await material.close()
+        assert os.fstat(reused_descriptor).st_ino > 0
+        original_close(reused_descriptor)
+
+    asyncio.run(exercise())
+
+
+@_async_test
+async def test_posix_static_native_early_exit_rolls_back_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "early-exit"
+    _compile_immediate_exit_fixture(executable, return_code=23)
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    process_backend = _PosixProcessBackend()
+    original_spawn = process_backend._spawn_once
+    observed_return_codes: list[int] = []
+
+    async def observe_exit(*args: object, **kwargs: object):
+        process = await original_spawn(*args, **kwargs)  # type: ignore[arg-type]
+        observed_return_codes.append(await process.wait())
+        return process
+
+    monkeypatch.setattr(process_backend, "_spawn_once", observe_exit)
+    preparation = _StaticPreparationPort(spec)
+    host = _native_host(process_backend)
+
+    with pytest.raises(HostingError) as failure:
+        await host.start(ChildSessionRequest(spec.request), preparation)
+    assert failure.value.category is HostingFailureCategory.CHILD_EXITED_EARLY
+    assert observed_return_codes == [23]
+    assert preparation.lease.close_calls == 1
+    await host.close()
+
+
+@_async_test
+async def test_posix_static_cancellation_after_os_create_reclaims_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executable = tmp_path / "admitted"
+    _compile_static_fixture(executable, marker="admitted")
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    spec = _spec(executable, cwd)
+    process_backend = _PosixProcessBackend()
+    original_spawn = process_backend._spawn_once
+    created = asyncio.Event()
+    release = asyncio.Event()
+    processes = []
+
+    async def gated_spawn(*args: object, **kwargs: object):
+        process = await original_spawn(*args, **kwargs)  # type: ignore[arg-type]
+        processes.append(process)
+        created.set()
+        await release.wait()
+        return process
+
+    monkeypatch.setattr(process_backend, "_spawn_once", gated_spawn)
+    preparation = _StaticPreparationPort(spec)
+    host = _native_host(process_backend)
+    start = asyncio.create_task(
+        host.start(ChildSessionRequest(spec.request), preparation)
+    )
+    await created.wait()
+
+    start.cancel()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await start
+    await host.close()
+
+    assert len(processes) == 1
+    assert not processes[0].group_exists()
+    assert preparation.lease.close_calls == 1

--- a/tests/hosting/test_posix_launch_preparation_platform.py
+++ b/tests/hosting/test_posix_launch_preparation_platform.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+import platform
+import sys
+
+import pytest
+
+from loushang.hosting import HostingError, HostingFailureCategory
+from loushang.hosting._posix_launch_preparation import (
+    _PosixStaticLaunchCaptureBackend,
+)
+
+
+def test_posix_static_launch_backend_is_exactly_linux_or_fails_closed() -> None:
+    if (
+        os.name == "posix"
+        and sys.platform.startswith("linux")
+        and platform.machine().lower() in {"amd64", "x86_64"}
+    ):
+        backend = _PosixStaticLaunchCaptureBackend()
+        assert backend.backend_id == "posix-process-group-v1"
+        return
+
+    with pytest.raises(HostingError) as failure:
+        _PosixStaticLaunchCaptureBackend()
+    assert failure.value.category is HostingFailureCategory.PLATFORM_UNSUPPORTED


### PR DESCRIPTION
## Summary
- add private Linux x86_64 static-ELF and contained managed launch preparation profiles
- bind sealed executable/launcher material, cwd identity, exact descriptor inheritance, and conservative post-effect fencing
- add native adversarial, architecture, inventory, and retained CI evidence

## Review
- architecture: PASS
- lifecycle/ownership: PASS
- test/CI evidence: PASS

## Validation
- make check-architecture-docs (5 passed)
- make check-hosting (262 passed, 6 skipped)
- focused H6.2 suite (49 passed)