### PR TITLE
docs(harness): accept PLC9C5 C5.0 activation baseline

### DIFF
--- a/.github/workflows/hosting-quality.yml
+++ b/.github/workflows/hosting-quality.yml
@@ -63,6 +63,7 @@ jobs:
           tests/architecture/test_hosting_h6_posix_native.py
           tests/architecture/test_hosting_h6_windows_native.py
           tests/architecture/test_hosted_product_runtime_v1_baseline.py
+          tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py
           tests/architecture/test_hosting_architecture_baseline.py
 
       - name: Typecheck Hosting H0-H6
@@ -154,5 +155,6 @@ jobs:
           tests/architecture/test_hosting_h6_posix_native.py
           tests/architecture/test_hosting_h6_windows_native.py
           tests/architecture/test_hosted_product_runtime_v1_baseline.py
+          tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py
           tests/architecture/test_hosting_architecture_baseline.py
           -q

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ HARNESS_TEST_PATHS := \
 	tests/architecture/test_plugin_lifecycle_plc9a2_contract.py \
 	tests/architecture/test_plugin_lifecycle_plc9b_contract.py \
 	tests/architecture/test_plugin_lifecycle_plc9c0_baseline.py \
+	tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py \
 	tests/architecture/test_session_model_call_closure_contract.py
 HOSTING_SOURCES := \
 	src/loushang/hosting \
@@ -147,6 +148,7 @@ HOSTING_TEST_PATHS := \
 	tests/architecture/test_hosting_h6_posix_native.py \
 	tests/architecture/test_hosting_h6_windows_native.py \
 	tests/architecture/test_hosted_product_runtime_v1_baseline.py \
+	tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py \
 	tests/architecture/test_hosting_architecture_baseline.py
 
 .PHONY: bootstrap test test-ai check-ai test-tui test-tui-render-contract test-tui-terminal-platform test-tui-native test-tui-tmux lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip

--- a/docs/internals/architecture/drafts/hosted-product-runtime-v1-plan.md
+++ b/docs/internals/architecture/drafts/hosted-product-runtime-v1-plan.md
@@ -73,7 +73,7 @@ Product selection, authority, protocol health, or generation publication.
 | G4 | proposed AppHost | A0.1 Contract Model | G0A plus parent acceptance prerequisites | standard-library-only contract/import/validation gates |
 | G5 | proposed AppHost | A0.2 catalog/router, admission pins, Session candidate port, and explicit Product importer | G4 | two unrelated fake Products; cwd/user-global discovery; no-default/ambiguity/revision swap; Coding and Codex/Claude migration matrix pass |
 | G6 | proposed AppHost | A0.3 canonical live-binding lifecycle and embedded profile | G5 | multi-Session and multi-mux single-flight attach/detach/cancellation/deadline/shutdown matrix |
-| G7 | Product/Harness | PLC9C5 narrow canary over an accepted existing Product route | G2L + G2W + G3 | Linux/Windows cross-entrypoint native evidence, recovery, rollback, no fallback |
+| G7 | Product/Harness | PLC9C5 narrow canary over an accepted existing Product route; C5.0 design/guards, C5.1 receipt/lifecycle, C5.2 Linux, C5.3 Windows mechanics/rejection, and C5.4 Linux Product convergence; Windows activation needs a later separately accepted containment profile | G2L + G2W + G3 | Linux Product/native evidence plus Windows fail-closed evidence land first; G7 closes only after separate Windows required-containment, cross-entrypoint, recovery, rollback, and no-fallback evidence |
 | G8 | AppHost + Product/Harness | Product-neutral end-to-end join | G6 + G7 | AppHost-scoped Product uses the exact Worker activation receipt; unrelated fake Product stays Worker-free |
 | G9 | common parent | v1 closure | G8 | owner deletion decision, docs/ARD promotion, clean dependency graph, operational drill |
 
@@ -98,7 +98,8 @@ or G8 critical path.
 2. Require deterministic fake lifecycle tests before native platform or
    Product composition.
 3. Retain Linux and Windows evidence separately; neither substitutes for the
-   other and a rerun cannot erase a deterministic defect.
+   other and a rerun cannot erase a deterministic defect. H6.3's Windows
+   restricted mechanics are not Product required-containment evidence.
 4. Keep Current and Hosting owners independently runnable through G8 rollback
    drills, but never retry the other owner within one launch attempt.
 5. Activate only an explicit Product/contribution allowlist with a versioned
@@ -126,6 +127,15 @@ The first PLC9C5 canary must cover at least:
 | rollback | future attempts return to Current owner; in-flight owner is sticky; no same-attempt fallback |
 | entrypoint | every Current canary-capable CLI/TUI/Product composition path shares the exact activation receipt; hosted paths join only after A0.4 is separately accepted |
 
+The accepted
+[PLC9C5 C5.0 baseline](../harness/plugin/plugin-lifecycle-plc9c5-c50-baseline.md)
+and [Current inventory](../harness/plugin/plugin-lifecycle-plc9c5-c50-inventory.md)
+assign every row to C5.1--C5.4 or to the explicit post-C5.4 Windows gate and
+freeze the Linux/Windows shape deltas. C5.0 does not satisfy G7 and changes no
+runtime activation guard. C5.4 may land the first Linux-only canary, but G7
+and therefore G8 remain open until Windows has a separately security-reviewed
+required-containment profile; unsupported Windows attempts fail closed.
+
 The first production route fences and terminates a surviving old Worker before
 restart. Live adoption remains a later separately reviewed threat model.
 
@@ -142,7 +152,10 @@ Before G7, executable architecture tests must continue to prove:
 - H5 owner selection defaults to `"current"`, performs no environment lookup,
   and never falls back within an attempt;
 - no non-Worker production module composes the H5 adapter; and
-- the PLC9C5 guard is revised only in the G7 Product/native activation change.
+- the PLC9C5 production-composition guard is revised only by C5.4 after the
+  C5.1 receipt, C5.2 Linux, and C5.3 Windows mechanics/rejection evidence
+  exists; C5.4 revises only the Linux canary absence and cannot close G7;
+  C5.0 removes no runtime guard; and
 - inventory source paths equal the executable expected set, and the G9 deletion
   change includes a reverse import/composition scan proving no Current owner
   consumer remains.

--- a/docs/internals/architecture/harness/plugin/README.md
+++ b/docs/internals/architecture/harness/plugin/README.md
@@ -329,7 +329,13 @@ Neither may silently override a narrower implemented owner contract.
   The proposed [HOST-H6 managed preparation contract](../../hosting/managed-launch-preparation-h6.md)
   and [Hosted Product Runtime V1 plan](../../drafts/hosted-product-runtime-v1-plan.md)
   define the next mechanical and cross-scope gates; neither changes the C5
-  activation fence.
+  activation fence. The accepted
+  [PLC9C5 C5.0 Product/Native Worker Activation Baseline](plugin-lifecycle-plc9c5-c50-baseline.md)
+  and its source-backed
+  [Current inventory](plugin-lifecycle-plc9c5-c50-inventory.md) split C5 into
+  receipt/lifecycle, Linux native, Windows mechanics/rejection, and Linux
+  Product-convergence slices. C5.0 itself is design/guards only: every runtime
+  route remains default-dark and Product activation remains absent.
 - [Plugin Authoring Guide](plugin-authoring-guide.md) documents the minimum
   stable Provider, Skill package, validation, and developer-conformance flows.
 - [PAP4 Capability Admission Contract](plugin-capability-admission-pap4-contract.md)
@@ -367,6 +373,7 @@ public SDK shape cannot be inferred from them.
 - [PLC1A Baseline](plugin-lifecycle-plc1a-baseline.md)
 - [PLC9.0 Baseline](plugin-lifecycle-plc9-baseline.md)
 - [PLC9.0 Owner And Peer Inventory](plugin-lifecycle-plc9-inventory.md)
+- [PLC9C5 C5.0 Current Product/Native Worker Inventory](plugin-lifecycle-plc9c5-c50-inventory.md)
 - [Resource Catalog RCP0 Baseline](resource-catalog-rcp0-baseline.md)
 
 Baselines freeze source and authority facts required by later contracts. Review

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-coding-pluginization-plan.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-coding-pluginization-plan.md
@@ -57,6 +57,14 @@
   source inventory, and architecture guards were accepted on
   `harness/plugin-plc9-baseline` after architecture, correctness/security, and
   Product/test review on 2026-08-31; they grant no runtime authority.
+  PLC9C1--PLC9C4 now implement the inert local-Worker declaration, owner-only
+  launch, bounded supervisor, and default-dark read-only Capability adapter.
+  The accepted
+  [PLC9C5 C5.0 baseline](plugin-lifecycle-plc9c5-c50-baseline.md) and
+  [Current inventory](plugin-lifecycle-plc9c5-c50-inventory.md) plan
+  receipt/lifecycle, Linux native, Windows mechanics/rejection, and final Linux
+  Coding Product-convergence slices while retaining every production
+  activation guard.
 - Scope: one delivery order for the common Plugin lifecycle, ordinary
   Definition / Provider / Consumer authoring primitives, `coding.lsp`,
   `coding.base`, `coding.arch`, management control, pre-LSP internal Resource/

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9-inventory.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9-inventory.md
@@ -821,7 +821,7 @@ capability in a new scope cannot pass silently.
 | Default-dark Hosting Worker seam | `src/loushang/harness/worker/session.py`, `src/loushang/harness/worker/hosting_adapter.py`, `src/loushang/harness/worker/owner_selection.py`, and `src/loushang/harness/worker/supervisor.py::WorkerSupervisor.start_session` | HOST-H5 adds an atomic process-plus-transport session shape, exact Worker-to-Hosting mapping, explicit Current/Hosting selection, pathless diagnostics, no-fallback routing, and future-attempt rollback; no non-Worker production module composes it | Retain as migration evidence only; the existing Sandbox sealed-descriptor preparation is not Hosting-consumable, so this is not PLC9C5 Product/native activation |
 | Product-neutral Worker protocol and supervisor | `src/loushang/harness/worker/protocol.py`, `src/loushang/harness/worker/supervisor.py`, and `src/loushang/harness/worker/journal.py` | Exact bounded canonical-JSON frames over an injected byte transport; owns handshake, direction/state validation, correlation/tombstones, heartbeat, shutdown, process-exit fencing, and durable contiguous attempt epoch/restart budget | Retain as mechanism only; it owns no semantic action, contribution publication, rollback, or retirement |
 | Exact read-only Capability Worker adapter | `src/loushang/harness/worker/capability_query.py::{CapabilityQueryWorkerAdapter,bind_capability_query_worker_adapter}` | Binds one Plugin/contribution/Product/scope/owner generation to a sorted Capability allowlist, rechecks authority around every response, returns typed descriptors, and fences invalid/stale output; construction is disabled by policy unless explicitly enabled | Retain as the C4 low-authority canary; it has no publish, retire, mutation, credential, or arbitrary execution capability |
-| Product/native Worker activation | absent through PLC9C4 | No production Product route connects a child to the injected byte transport, publishes a generation, or claims Linux/Windows native handle/containment conformance | PLC9C5 must add exact platform evidence and Product rollback/recovery without weakening default-dark behavior |
+| Product/native Worker activation | absent through PLC9C4 and PLC9C5 C5.0 | No production Product route connects a child to the injected byte transport, publishes a generation, or claims Linux/Windows native handle/containment conformance; the accepted C5.0 baseline adds only design, exact inventory, and guards | C5.1--C5.4 add receipt/lifecycle, Linux native, Windows mechanics/rejection, then exact Linux Product convergence evidence without weakening default-dark behavior; Windows Product activation remains closed pending a separate accepted required-containment profile; see the [C5.0 baseline](plugin-lifecycle-plc9c5-c50-baseline.md) and [inventory](plugin-lifecycle-plc9c5-c50-inventory.md) |
 | Remote-service topology | absent through PLC9C4 | No service identity, authentication, egress, tenant, residency, or remote revocation contract exists | Defer to a separate threat model; never add it as a `local_worker` compatibility arm |
 
 The internal Plugin `local_worker` declaration and supervised mechanism exist
@@ -875,7 +875,8 @@ PLC9A1 contract:
   the existing Package RPC surface are bound through A2;
 - complete bounded byte/archive/wheel materialization transaction;
 - Product/native Worker activation, IPC handle binding, platform conformance,
-  domain generation publication, and recovery/rollback composition;
+  domain generation publication, and recovery/rollback composition; C5.0
+  documents and guards these absences but implements none of them;
 - `remote_service` topology contract and client;
 - executable artifact-GC owner/receipt;
 - generic Plugin-private data deletion command/receipt; and

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c0-baseline.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c0-baseline.md
@@ -2,7 +2,8 @@
 
 ## Status And Authority
 
-- Slice: PLC9C.0 baseline plus PLC9C1--PLC9C4 internal Worker mechanism.
+- Slice: PLC9C.0 baseline plus PLC9C1--PLC9C4 internal Worker mechanism and
+  accepted PLC9C5 C5.0 design/guard baseline.
 - Implementation base: `90f6a9de` on `main` / `lane/harness`.
 - Delivery branch: `harness/plugin-plc9c-worker-containment`.
 - Status: reviewed implementation candidate. Architecture,
@@ -23,8 +24,12 @@ This baseline refines the
 against the current source-backed
 [PLC9 inventory](plugin-lifecycle-plc9-inventory.md#execution-and-containment-seams).
 Current source and executable tests remain authoritative for implemented
-behavior. PLC9C5 must revise this document and inventory in the same change
-that introduces Product activation or native IPC/platform evidence.
+behavior. PLC9C5 C5.0 may revise this document and inventory only to index its
+target design and strengthen absence/deletion guards; it does not revise the
+Product activation or native IPC/platform absence. A later C5 slice must
+revise each exact guard in the same change as the corresponding implementation
+and replacement evidence.
+
 The proposed [HOST-H6 managed preparation design](../../hosting/managed-launch-preparation-h6.md)
 and [Hosted Product Runtime V1 plan](../../drafts/hosted-product-runtime-v1-plan.md)
 are prerequisites and coordination inputs only; they do not revise this
@@ -276,7 +281,16 @@ does not silently become optional.
 | PLC9C2 | owner-only `ManagedWorkerLaunchPort` minted by Process/Sandbox composition | Process Host owns the capacity reservation; required containment and final owner/identity evidence pass before the OS spawner; generic/raw bypasses fail |
 | PLC9C3 | product-neutral bounded transport/session protocol and supervisor | framing, nonce, heartbeat, correlation, limits, cancellation, shutdown, crash fencing, exclusive supervisor epoch, and restart budget have independent evidence |
 | PLC9C4 | one read-only, low-authority domain adapter and vertical slice | semantic actions remain Host-side; no publication before handshake/domain admission; stale/crashed Worker cannot publish or retire a generation |
-| PLC9C5 | Product activation, recovery, native platform evidence, and rollback | Linux/Windows required-containment gates and cross-entrypoint conformance pass without fallback |
+| PLC9C5 | Product activation, recovery, native platform evidence, and rollback, split by the C5.0 baseline below | Linux canary lands first; Windows remains fail closed until a separate required-containment gate and cross-entrypoint conformance pass without fallback |
+
+The accepted
+[PLC9C5 C5.0 baseline](plugin-lifecycle-plc9c5-c50-baseline.md) and
+[source-backed Current inventory](plugin-lifecycle-plc9c5-c50-inventory.md)
+refine that final row into C5.0 design/guards, C5.1 receipt/lifecycle contracts,
+C5.2 Linux native evidence, C5.3 Windows mechanics/rejection evidence, and C5.4
+exact Linux Coding Product convergence. C5.0 adds no runtime symbol or
+activation route. C5.4 does not close the parent G7 Windows
+required-containment row.
 
 PLC9C1 must not reinterpret declaration IR v2 or document v1. It introduces an
 additive versioned shape with explicit compatibility behavior. PLC9C2 must not
@@ -293,7 +307,8 @@ Guard revisions are intentionally incremental:
 | PLC9C2 | only `ManagedWorkerLaunchPort` absence and its Process/Sandbox composition inventory | protocol/supervisor, domain adapter/publication, author runtime owners, and `remote_service` remain absent |
 | PLC9C3 | only protocol/supervisor absence after bounded state-machine evidence lands | domain publication/retirement, author runtime owners, and `remote_service` remain closed |
 | PLC9C4 | only the selected domain-adapter absence after its conformance evidence lands | other domains, mutation/deletion authority, public runtime owners, and `remote_service` remain closed |
-| PLC9C5 | Product activation absence for the accepted vertical slice | unsupported platforms, undeclared fallbacks, other domains, and `remote_service` remain fail-closed |
+| PLC9C5 C5.0 | no activation guard is removed; add exact C5 Current inventory, mismatch, slice, and deletion guards | Product activation, native-profile consumers, unsupported platforms, undeclared fallbacks, other domains, and `remote_service` remain fail-closed |
+| PLC9C5 C5.1--C5.4 | revise only the receipt/lifecycle contracts, the single private Linux bridge, Windows mechanics/rejection evidence, then the exact Linux Product-composition guard named by the C5.0 transition ledger | default Current, explicit allowlist, no same-attempt fallback, Windows Product activation, unsupported platforms, other domains, author runtime owners, and `remote_service` remain fail-closed |
 
 The guard-transition ledger is append-only at the slice boundary:
 
@@ -304,7 +319,8 @@ The guard-transition ledger is append-only at the slice boundary:
 | PLC9C1 -> PLC9C2 | remove only the launch-port absence token after Process/Sandbox owner-composition tests pass |
 | PLC9C2 -> PLC9C3 | remove only named supervisor/protocol absence tokens after bounded state-machine, crash-fence, and restart-budget tests pass |
 | PLC9C3 -> PLC9C4 | remove only the selected domain-adapter absence token after exact semantic-admission and generation-owner conformance passes |
-| PLC9C4 -> PLC9C5 | remove only the accepted Product-activation/platform absence guard; every unlisted environment and undeclared fallback remains closed |
+| PLC9C4 -> PLC9C5 C5.0 | remove no runtime guard; index the design/inventory and freeze exact Current mismatches and retained owners |
+| C5.0 -> C5.1--C5.4 | follow the C5.0 append-only transition ledger: receipt/lifecycle, one exact private Linux profile bridge, Windows mechanics/rejection, then exact Linux Coding Product composition; Windows Product activation, every unlisted environment, and every undeclared fallback remain closed |
 
 Computed imports, reflection, aliases, and callable laundering do not bypass a
 retained guard. Static tests cover direct and relative imports; review and
@@ -341,7 +357,8 @@ bounded unsupported-platform or containment-unavailable reason.
 
 ## Frozen Forbidden Routes
 
-Until PLC9C5 intentionally revises these guards:
+Until the owning PLC9C5 C5.1--C5.4 slice intentionally revises each exact
+guard with replacement evidence:
 
 - `local_worker` and its Worker configuration exist only in the additive
   internal index-v3/IR-v3/document-v2 codec; `remote_service` remains absent,
@@ -380,4 +397,5 @@ PLC9C1--PLC9C4 are complete only when:
 Passing PLC9C1--PLC9C4 permits a separately reviewed PLC9C5 Product/native
 activation change. It does not pre-approve an IPC platform binding, Sandbox
 backend, Product recovery policy, public SDK surface, generation publication,
-or remote topology.
+or remote topology. Accepting C5.0 permits only the first C5.1 contract slice;
+it keeps every production path default-dark.

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c50-baseline.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c50-baseline.md
@@ -1,0 +1,463 @@
+# PLC9C5 C5.0 Product/Native Worker Activation Baseline
+
+## Status
+
+- ID: `PLC9C5-C5.0`
+- Scope: `loushang.harness` Worker activation boundary plus one Product-owned
+  canary composition
+- Parent: `PLC9C`
+- Authority: normative accepted design
+- Design status: accepted
+- Implementation status: implemented — C5.0 documentation/guards only;
+  C5.1--C5.4 not-started
+- Activation status: closed; every production route remains default-dark
+- Observation base: `cb01f723`
+- Owner: Harness Worker architecture with Product, Hosting, and domain-owner
+  review
+
+## Purpose And Acceptance Boundary
+
+C5.0 fixes the design, Current inventory, dependency direction, rollout
+matrix, and executable absence/deletion guards for PLC9C5. It adds no runtime
+contract, native profile supplier, Product composition, configuration key, or
+activation side effect. Accepting this document authorizes only C5.1 design
+contract implementation; it does not authorize a Product to request the
+Hosting owner.
+
+The first canary is one exact, read-only `capability_provider` contribution
+selected by the Coding Product. Coding is the first evidence Product, not the
+owner of the shared Worker mechanism. Work, PPT, Design, or a future AppHost
+Product can reuse the same Harness contracts only by supplying their own
+explicit Product policy and admission receipt. C5.0 does not add an AppHost,
+AppServer, AppService, UI, author-SDK, or remote-service dependency.
+
+This baseline refines the
+[PLC9C Local Worker Boundary](plugin-lifecycle-plc9c0-baseline.md), uses the
+source-backed [C5.0 Current inventory](plugin-lifecycle-plc9c5-c50-inventory.md),
+and implements the G7 planning gate in the
+[Hosted Product Runtime V1 delivery plan](../../drafts/hosted-product-runtime-v1-plan.md).
+The accepted [HOST-H6 managed preparation design](../../hosting/managed-launch-preparation-h6.md)
+and its H6.4 Harness parity evidence remain mechanical prerequisites, not
+Product activation authority.
+
+## First-Principles Decisions
+
+1. **Selection is authority, detection is not.** Only an explicit Product
+   allowlist entry for one immutable Plugin revision and contribution may ask
+   for a Worker owner. An environment variable, host platform, available
+   backend, discovered executable, missing setting, or test fixture can never
+   choose Hosting.
+2. **The receipt is the join.** One immutable, pathless Product activation
+   receipt binds Product/scope/Session, Plugin revision, declaration and Worker
+   configuration, declared and effective required/optional policy, requested
+   owner, allowed native profile catalog and policy closure, policy revision,
+   and selection generation.
+   Every downstream preparation, attempt, status, and rollback record must
+   point to that exact receipt.
+3. **A profile is an admitted capability, not configuration text.** Product
+   policy chooses from named logical profiles. A narrow Harness/Hosting friend
+   adapter maps an already admitted receipt to one exact private H6 native
+   profile. Product code never imports H6 private specifications or handles;
+   Hosting never reads Product, Plugin, Approval, or generation vocabulary.
+4. **One attempt has one owner.** The owner snapshot is taken before the first
+   acquisition and stays sticky until that attempt terminates. Failure after
+   selection never retries Current or Hosting inside the same attempt.
+5. **Health precedes semantic visibility.** A PID, native spawn, endpoint, H6
+   lease, protocol handshake, or activation receipt alone publishes no domain
+   generation. Required contribution failure aborts Product/Session
+   activation; optional failure may produce an explicit degraded state only.
+6. **Rollback changes future policy.** A kill switch or rollback latch first
+   forbids new Hosting attempts, then fences, drains, and terminates existing
+   attempts through their exact owners. Future attempts may use the Current
+   process owner only after the prior receipt becomes stale and Product issues
+   a new Current-owner receipt. An in-process or different-Worker fallback
+   additionally needs a distinct contribution identity.
+7. **Recovery proves absence before restart.** The first route never adopts a
+   surviving Worker. Restart requires durable attempt evidence, generation
+   fencing, and proof that the complete prior process tree was reaped. Unknown
+   state fails closed.
+8. **Entrypoints share composition, not flags.** Coding CLI, native TUI, RPC,
+   channel, prompt, plain, and workflow routes that construct an Agent Product
+   Session must consume the same Product receipt at their shared construction
+   boundary. Early-dispatch commands that do not construct that Session are
+   not canary-capable and must remain unable to activate a Worker.
+
+## System Boundary And Responsibility Chain
+
+```text
+Coding Product policy / another explicit Product policy
+  -> immutable Product Worker activation receipt
+     -> Product-owned canary composition adapter
+        -> Harness Worker admission + sticky owner router
+           -> Current Process/Sandbox owner
+           OR
+           -> Harness-to-Hosting native profile friend adapter
+              -> Hosting opaque H6 preparation + atomic Child Session
+        -> Worker supervisor + exact Capability query adapter
+           -> exact Product/domain readiness owner
+
+Session discovery/catalog -> selected locator + Product profile validation
+                          -> Product receipt (never the reverse)
+```
+
+The selected Plugin reservation is the source of declared requiredness. The
+Product is the sole writer of the effective activation policy after rejoining
+that reservation: it may strengthen an optional contribution to required, but
+it cannot downgrade a declared required contribution to optional.
+Harness Worker is the sole writer of Worker-attempt admission and protocol
+state. Hosting is the sole writer of native preparation/process/endpoint
+state. The exact domain owner is the sole writer of generation visibility and
+retirement. Session discovery is a read model and grants none of those
+authorities.
+
+## Dependency Contract
+
+| Scope | May depend on | Receives or returns | Forbidden dependency or authority |
+| --- | --- | --- | --- |
+| exact Product adapter | public Harness declaration/selection and Worker activation contracts | an explicit allowlist decision that preserves declared requiredness, a pathless activation receipt, and a separate current-evidence port | private Hosting modules, raw Process/Sandbox owners, native paths/handles, environment-driven owner selection |
+| Harness Worker activation coordinator | Product receipt plus public Worker, Sandbox, and domain ports | one sticky attempt plan and bounded status | selecting a Product, reading ambient configuration, publishing a domain generation, same-attempt fallback |
+| Harness native-profile friend adapter | validated Product receipt, Worker runtime binding, injected H6 capability | one exact private H6 preparation port or a fail-closed unsupported result | Product policy, Plugin management, generation state, raw material export, profile substitution |
+| Hosting | Hosting contracts and private platform mechanics only | opaque preparation, atomic process/endpoint lease, bounded evidence | Harness, Product, Plugin, AppHost, domain status, Approval, Authorization, or fallback imports |
+| Worker supervisor | launch/session port, protocol transport, durable attempt journal | handshake/health/fence/shutdown evidence | Product selection, native material, semantic publication or retirement |
+| Capability canary adapter | healthy supervisor plus exact Capability authority reader | bounded read-only descriptors | mutation, deletion, credentials, arbitrary execution, registrar/Store/ledger access |
+| Session discovery/profile validation | configured canonical and compatibility sources plus Product profile codec | selected stable locator, alias/conflict facts, validated Product snapshot | Worker activation, writable root authority, inferring Product from cwd or filename |
+| presenter/transport | Product Session application port | Product-owned status projection | constructing receipts, selecting profiles, importing Worker/Hosting implementations |
+
+The only new private cross-package edge contemplated by C5 is
+`src/loushang/harness/worker/_native_profile_bridge.py`. That one private
+Harness Worker module owns Linux dispatch and is the sole possible owner of
+any later accepted Windows dispatch, loads platform code explicitly and
+lazily, and exposes only `ProductWorkerNativeProfilePort` to the coordinator.
+It may import exactly
+`_PosixStaticContainedLaunchCaptureSpec` and
+`_PosixStaticLaunchCaptureBackend` for the accepted Linux path. The existing
+Windows private names remain forbidden until a later transition names the
+exact symbols it needs; `_win32_process` and raw platform APIs are never legal
+imports. No second friend module and no import from the public
+`hosting_adapter.py` are permitted. Public Hosting contracts remain
+Product-neutral, and Product packages depend only on public Harness
+records/ports.
+
+`src/loushang/harness/worker/__init__.py` is the Worker public API owner. C5.1
+may add only `ProductWorkerActivationPolicyV1`,
+`ProductWorkerActivationReceiptV1`,
+`ProductWorkerActivationAuthorityPort`, and
+`ProductWorkerActivationCoordinator` to that public surface. C5.2 may add only
+`ProductWorkerNativeProfilePort`. Private bridge/profile types, Product
+adapters, Hosting specifications, native material, and platform handles must
+never be exported there.
+
+## Activation Receipt Contract For C5.1
+
+C5.1 may introduce an authority-free schema and validator with these exact
+semantic fields; spelling and serialization are fixed only by the C5.1
+contract change:
+
+| Receipt fact | Required binding |
+| --- | --- |
+| Product scope | `product_id`, Product runtime/scope identity, Session identity |
+| Session route | new-Session marker or an opaque fingerprint of the exact selected source/locator/revision; no filesystem path is exposed |
+| immutable contribution | Plugin id, immutable revision digest, contribution id, reservation/declaration/Worker-configuration fingerprints |
+| policy | declared and effective required versus optional, Product policy revision, explicit enabled/disabled decision; effective policy cannot weaken the declaration |
+| owner | requested owner, owner-selection generation, no-fallback invariant |
+| native eligibility | logical profile id, immutable native-profile catalog revision, exact allowed native profile ids, and an opaque native-policy-closure fingerprint; for Linux this binds the admitted payload, static launcher, and containment-profile digests; no raw path, descriptor, handle, token, or environment |
+| freshness | receipt version and issue sequence/nonce plus Product policy, locator, owner-selection, and kill-switch generations; the coordinator separately receives a Product-owned current-evidence port so the receipt remains immutable and serializable |
+
+`WorkerHostingActivationV1` is currently only an owner-selector input and
+`WorkerHostingSelectionV1` is only a diagnostic snapshot. Neither is the
+Product receipt. `WorkerLaunchEvidenceV1` proves one launch request, not the
+Product decision that authorized it. C5.1 must bind those existing records to
+one receipt rather than reinterpret any of them.
+
+The expected and realized policy-closure fingerprints share one canonical
+hash domain, `loushang.worker.native-policy-closure.v1`. Its length-prefixed
+UTF-8 fields, in fixed order, are native-profile catalog revision, native
+profile id, payload SHA-256, containment-launcher SHA-256, and containment-
+profile SHA-256; absent fields use the contract's explicit empty marker. The
+receipt carries the expected fingerprint. Native attempt evidence recomputes
+the realized fingerprint from the captured, private H6 material, and admission
+requires exact equality. The separate full `execution_closure` fingerprint
+also binds cwd identity, invocation, and observed platform facts for audit and
+substitution evidence; it is never directly compared with the policy-closure
+fingerprint because their hash domains differ.
+
+The authority port returns an exact current witness over
+`(receipt fingerprint, Product-policy revision, selected-locator revision,
+owner-selection generation, kill-switch generation)`. The coordinator must
+validate it while holding one serialized admission lease before first native
+acquisition and retain that lease until the attempt is registered and the H6
+process effect has either begun or settled without a process. Before domain
+publication, the coordinator reacquires that same serialized admission gate;
+current-witness verification and the domain-owner publication CAS occur inside
+one lease with no awaitable/user callback gap. The CAS compares the receipt's
+Product-policy, locator, owner-selection, and kill-switch generations as well
+as `(receipt fingerprint, attempt id, owner generation)`. A kill switch latches
+and stales generations under the same gate, so an old receipt either publishes
+before the latch and enters the enumerated active set or its publication CAS
+fails with no visibility. Retirement uses the exact receipt/attempt/owner key,
+and a stale attempt can retire only its own exact generation. A restart-budget
+claim is legal only after protocol terminal, exact domain retirement, and
+durable tree cleanup settlement have all joined by CAS.
+
+The H6 attempt evidence records the immutable native-profile catalog revision,
+the realized policy-closure fingerprint, the separate full
+`execution_closure` fingerprint, and the logical/native profile ids. The
+coordinator compares catalog/profile identity and the same-domain expected and
+realized policy-closure fingerprints before publication. H6 remains
+Product-neutral: it validates captured material against its private spec,
+while the serialized Harness admission lease closes the policy-change race
+through process-effect registration.
+
+C5.1 also introduces a Product-neutral durable cleanup settlement/debt
+contract keyed by receipt fingerprint, attempt id, owner generation, host
+identity, and boot identity. A protocol terminal record is not cleanup
+settlement. On coordinator restart, an unknown same-boot tree is durable debt
+and blocks restart; a trusted changed-boot witness may prove the old local OS
+tree absent. Platform-specific crash settlement evidence is an exit gate of
+C5.2/C5.3, not something deferred to Product composition.
+
+The guard ledger reserves these transition tokens so later slices revise an
+exact absence instead of inventing a neighboring contract:
+
+| Token | First permitted slice | Meaning |
+| --- | --- | --- |
+| `ProductWorkerActivationPolicyV1` | C5.1 | authority-free explicit Product policy input |
+| `ProductWorkerActivationReceiptV1` | C5.1 | validated pathless decision join |
+| `ProductWorkerActivationAuthorityPort` | C5.1 | separate Product-owned current-evidence fence |
+| `ProductWorkerActivationCoordinator` | C5.1 | Product-neutral aggregate over injected owners; no Product selection |
+| `WorkerCleanupSettlementV1` | C5.1 | durable exact-attempt tree-settlement witness |
+| `WorkerCleanupDebtV1` | C5.1 | durable unknown/unsettled tree fence |
+| `ProductWorkerNativeProfilePort` | C5.2 | confined native-profile binding port implemented per accepted platform |
+| `bind_coding_product_worker_canary` | C5.4 | the sole first production Product composition root |
+
+## Native Compatibility Delta
+
+H6.4 proves that a caller-managed preparation port survives the Harness
+semantic fence. It does not prove that either native profile can consume the
+Current Worker shape.
+
+| Platform/profile | Already proven | Blocking C5 delta | Owning slice |
+| --- | --- | --- | --- |
+| Linux x86_64, excluding WSL, `posix-static-contained-elf-v1` | H6.2 seals one static launcher and payload, retains cwd, transfers only the exact endpoint/preparation descriptors, and owns process-group cleanup; its selector does **not** distinguish WSL today | Product policy must admit the exact payload/launcher/containment-profile closure; the selected Worker executable must be a supported static ELF; the unique bridge must classify WSL/unknown Linux before H6 selection, with Microsoft-kernel fixtures rejected fail closed; same-boot crash uncertainty remains durable cleanup debt | C5.1 contract then C5.2 Linux native canary |
+| Windows AMD64 `windows-restricted-direct-import-pe-v1` | H6.3 locks PE/cwd/ancestors, creates a restricted token and kill-on-close Job, constrains the handle list, and proves direct-import mechanics | **Not accepted as Product required containment.** It is a trusted-payload mechanics profile only. A Hosting-private opaque builder must obtain locked file identities and query `GetWindowsDirectoryW` for a canonical absolute `SystemRoot`; it never reads `os.environ`. Ambient `SystemRoot` poisoning is ignored, while any caller-supplied environment/SystemRoot is rejected before acquisition. Harness/Product never receives raw handles or environment. The builder preserves H6.3 discarded stderr and cannot reuse H6.4's piped-stderr mapping. Windows Product canary remains closed until a separate security-reviewed containment profile is accepted | C5.3 retained mechanics/fail-closed gate; no Product activation |
+| macOS, WSL, unknown Linux classifier result, non-x86_64 Linux, non-AMD64 Windows, every unlisted environment | no accepted PLC9C5 Product native profile | remain unsupported with a stable fail-closed result; no best-effort/current same-attempt downgrade | retained through C5.4 |
+
+Platform observation may choose among the receipt's already allowed native
+profiles only after the receipt explicitly requests Hosting. It may reject an
+unsupported host, but it cannot cause Hosting selection.
+
+The first Product canary is therefore Linux-only. The parent G7 Windows
+required-containment row remains deliberately open: current H6.3 evidence
+cannot satisfy it, and C5.3 must prove both that its mechanics are retained and
+that Product required-containment policy rejects that profile. A future slice
+may reopen Windows only with a separately accepted profile and exact guard
+transition; C5.0 does not pre-authorize an AppContainer or claim equivalence.
+
+## G7 Acceptance Coverage
+
+The rows below reproduce the parent G7 matrix without narrowing it. C5.0 adds
+slice ownership and evidence rules; a later slice cannot declare G7 complete
+by testing only its platform.
+
+| Dimension | Required cases | Owning slice and evidence |
+| --- | --- | --- |
+| Product route | explicit selected Product, missing Product, wrong Product, disabled contribution | C5.1 receipt validation; C5.4 real Coding Product composition |
+| Session route | canonical and cwd/home compatibility projections, tampered/unknown Product envelope, alias, conflict, and changed locator | C5.4 selects a stable locator and validates Coding's persisted Product profile before issuing a receipt; generic pre-routing AppHost behavior remains G5/G8 |
+| contribution policy | required success/failure and optional success/degraded failure | C5.1 deterministic aggregate contract; C5.4 Product readiness conformance |
+| native platform | Linux required containment and Windows required containment; unsupported hosts fail closed | C5.2 retained Linux native report; C5.3 retained Windows mechanics and required-containment rejection report; C5.4 unsupported-host conformance; G7 stays open until a separate Windows required-containment profile is accepted |
+| preparation | executable/cwd replacement, stale authority, handle/fd substitution, unsupported profile | C5.2/C5.3 adversarial native tests plus C5.4 receipt-freshness tests |
+| lifecycle | cancellation at each acquisition, early exit, handshake failure, heartbeat loss, clean stop, forced kill | C5.2/C5.3 platform ownership tests and C5.4 aggregate lifecycle tests |
+| recovery | prior attempt absent, confirmed reaped, uncertain tree, restart-budget exhaustion, host restart | C5.1 durable settlement/debt contract; C5.2/C5.3 platform crash evidence; C5.4 Product recovery drill; adoption remains forbidden |
+| publication | no generation before handshake/domain admission; stale attempt cannot publish or retire successor | C5.1 fake owner contract and C5.4 real Capability owner conformance |
+| rollback | future attempts return to Current owner; in-flight owner is sticky; no same-attempt fallback | C5.1 serialized admission/active-registry contract and C5.4 forced rollback drill |
+| entrypoint | every Current canary-capable CLI/TUI/Product composition path shares the exact activation receipt; hosted paths join only after A0.4 is separately accepted | C5.4 cross-entrypoint receipt identity report; early-dispatch non-Session routes remain unable to activate |
+
+For the Session row, Coding already persists a Product-bound runtime profile
+and refuses a foreign Product snapshot when restoring. C5.4 may reuse that
+Product-owned validation after discovery selects a stable locator. It must not
+claim the generic pre-routing Session Identity Envelope proposed for AppHost,
+and G7 remains independent of AppHost G5/G6.
+
+## Product Activation And Rollback Matrix
+
+| State or event | Required contribution | Optional contribution | Owner/publication invariant |
+| --- | --- | --- | --- |
+| receipt omitted or disabled | Product/Session uses Current behavior and reports `disabled_by_policy` for the canary | same | no Hosting construction, native acquisition, process, handshake, or generation |
+| receipt invalid, stale, foreign, or ambiguous | activation fails atomically as unavailable | degraded continuation is legal only when an independent current reservation/policy witness proves the contribution optional; an invalid receipt's optional bit is never evidence | if current requiredness cannot be proven independently, fail closed; no process and no domain publication |
+| native profile unsupported or preparation rejected before spawn | activation fails atomically | explicit degraded result is allowed | selected owner is not retried; no spawn/publication |
+| spawn or handshake/domain admission fails | activation fails and owned native/process/endpoint state is reclaimed | explicit degraded result after complete reclamation | no generation; no other owner within the attempt |
+| healthy and domain-admitted | Product may become ready | Product may become ready | exact receipt/attempt becomes visible only through the domain owner |
+| runtime health lost after visibility | Product becomes unavailable until explicit recovery/replacement | Product becomes degraded while unrelated contributions continue | stale attempt fenced; exact generation revoked/drained before restart |
+| rollback or kill switch | new Hosting attempts are forbidden; required Product readiness reflects the disabled state | new Hosting attempts are forbidden and Product may remain degraded | under the same serialized gate: atomically close Hosting admission, bump/stale the generation, then enumerate the complete active registry; in-flight owners stay sticky while fenced/drained/terminated; the durable latch is restored closed after host restart; a future Current attempt requires a new receipt/selection snapshot |
+| cleanup debt or uncertain old tree | recovery remains unavailable | degraded only if Product policy permits omission | no restart, no fallback, no success settlement |
+
+Status and diagnostics are pathless, bounded, and versioned. They distinguish
+at least disabled policy, unsupported platform/profile, stale authority,
+containment/preparation failure, launch failure, handshake/protocol failure,
+runtime loss, cleanup debt, and restart exhaustion.
+
+## Delivery Slices
+
+| Slice | Delivery | Exit condition | Production default |
+| --- | --- | --- | --- |
+| C5.0 | this target baseline, exact Current inventory, G7/mismatch/rollback matrices, and deletion/absence guards | five-view design review passes; targeted architecture/static checks pass | unchanged Current; no Product activation symbols or composition |
+| C5.1 | authority-free Product activation receipt, explicit allowlist/policy validation, serialized admission/active registry, durable cleanup settlement/debt, status vocabulary, and deterministic fake aggregate | required/optional, stale/foreign/disabled, receipt-to-attempt identity, pre-acquire freshness, atomic pre-publication witness+CAS including the kill-switch interleaving, exact-generation retirement CAS, restart latch, settlement/debt, and sticky rollback tests pass | receipt omission disables Hosting; no native or production composition |
+| C5.2 | Linux x86_64 contained-profile implementation in the unique private bridge and canary oracle | exact catalog/expected-realized policy/full execution closure, static payload/launcher/profile, WSL/unknown/non-x86 classifier rejection, fd inheritance/substitution, cancellation, same-boot crash debt, changed-boot absence, process-tree cleanup, and sentinel redaction rows pass in the retained required report | no production Product composition |
+| C5.3 | Windows AMD64 Hosting-private trusted-payload profile builder, restricted-mechanics oracle, and Product rejection gate | native file identity, `GetWindowsDirectoryW` canonical absolute `SystemRoot`, ambient poisoning ignored, caller environment rejected, discarded stderr, token/Job/handle-list substitution, cancellation, restart uncertainty, sentinel redaction, and explicit required-containment rejection pass in the retained required report | no Windows Product activation and no production Product composition |
+| C5.4 | one explicit Linux Coding Product canary composition, Session/entrypoint convergence, recovery, rollback, status, and publication closure | all non-Windows G7 rows and Linux required containment pass with no required skip; Windows and every unsupported profile fail closed; ordered rollback/recovery and receipt identity reports pass | Current unless the exact Product allowlist/receipt explicitly selects Hosting on accepted Linux; parent G7 remains open on Windows |
+
+C5.1 through C5.3 may add callable construction mechanisms for deterministic
+and native conformance, but they may not bind them from a production Product
+root. C5.3's Windows builder stays Hosting-private and remains rejected by
+Product required-containment policy. C5.4 is the only slice allowed to revise
+the exact Linux production-composition absence guard.
+Even then, default owner selection remains Current.
+
+## Future Evidence Manifest And Drill Ledger
+
+Later slices replace each named absence with a required, uploaded JUnit report.
+`scripts/dev/verify_pytest_xml.py` must observe a nonempty report with zero
+skips, failures, and errors. A C5 manifest verifier added with C5.1 must also
+enforce the minimum count and exact case ids below; every case is a required
+row, never an optional test hidden behind a skip.
+
+| Report id | JUnit path | Minimum tests | Exact required case ids |
+| --- | --- | --- | --- |
+| `PLC9C5-C5.1-CONTRACT` | `.artifacts/plc9c5-c51-contract.xml` | 20 | `C51-CURRENT-REQUIREDNESS`, `C51-INVALID-RECEIPT`, `C51-STALE-RECEIPT`, `C51-FOREIGN-RECEIPT`, `C51-POLICY-CLOSURE-CODEC`, `C51-PREACQUIRE-FRESHNESS`, `C51-PREPUBLISH-ATOMIC-CAS`, `C51-KILLSWITCH-PUBLISH-RACE`, `C51-RECEIPT-ATTEMPT-CLOSURE`, `C51-EXACT-RETIRE-CAS`, `C51-KILLSWITCH-ADMISSION-RACE`, `C51-RESTART-LATCH`, `C51-CLEANUP-SETTLED`, `C51-CLEANUP-DEBT`, `C51-STICKY-OWNER`, `C51-NO-FALLBACK`, `C51-REQUIRED-SUCCESS`, `C51-OPTIONAL-DEGRADED`, `C51-PUBLICATION-FENCE`, `C51-SENTINEL-REDACTION` |
+| `PLC9C5-C5.2-LINUX-NATIVE` | `.artifacts/plc9c5-c52-linux-native.xml` | 14 | `C52-EXACT-CLOSURE`, `C52-CATALOG-MISMATCH`, `C52-POLICY-CLOSURE-MISMATCH`, `C52-EXEC-CLOSURE-MISMATCH`, `C52-WSL-MICROSOFT-REJECT`, `C52-UNKNOWN-CLASSIFIER-REJECT`, `C52-NON-X86-REJECT`, `C52-FD-SUBSTITUTION`, `C52-CANCEL-PRE-EFFECT`, `C52-CANCEL-POST-EFFECT`, `C52-DESCENDANT-CLEANUP`, `C52-SAMEBOOT-DEBT`, `C52-CHANGEDBOOT-ABSENCE`, `C52-SENTINEL-REDACTION` |
+| `PLC9C5-C5.3-WINDOWS-MECHANICS` | `.artifacts/plc9c5-c53-windows-mechanics.xml` | 12 | `C53-REQUIRED-CONTAINMENT-REJECT`, `C53-LOCKED-IDENTITY-SUBSTITUTION`, `C53-TRUSTED-SYSTEMROOT`, `C53-AMBIENT-SYSTEMROOT-POISONING`, `C53-CALLER-ENVIRONMENT-REJECT`, `C53-DISCARDED-STDERR`, `C53-RESTRICTED-TOKEN`, `C53-JOB-TREE-CLEANUP`, `C53-HANDLE-SUBSTITUTION`, `C53-CANCEL-PRE-POST-EFFECT`, `C53-RESTART-UNCERTAINTY`, `C53-SENTINEL-REDACTION` |
+| `PLC9C5-C5.4-LINUX-PRODUCT` | `.artifacts/plc9c5-c54-linux-product.xml` | 25 | `C54-PRODUCT-SELECTED`, `C54-PRODUCT-MISSING`, `C54-PRODUCT-WRONG`, `C54-PRODUCT-DISABLED`, `C54-SESSION-CANONICAL`, `C54-SESSION-CWD`, `C54-SESSION-HOME`, `C54-SESSION-TAMPERED`, `C54-SESSION-ALIAS`, `C54-SESSION-CONFLICT`, `C54-SESSION-CHANGED`, `C54-REQUIRED-SUCCESS`, `C54-REQUIRED-FAILURE`, `C54-OPTIONAL-SUCCESS`, `C54-OPTIONAL-DEGRADED`, `C54-CLOSURE-FRESHNESS`, `C54-HANDSHAKE-HEALTH-PUBLICATION`, `C54-UNSUPPORTED-WINDOWS`, `C54-UNSUPPORTED-WSL`, `C54-UNSUPPORTED-NON-X86`, `C54-UNSUPPORTED-MACOS`, `C54-ORDERED-ROLLBACK`, `C54-RECOVERY-MATRIX`, `C54-SHARED-ENTRYPOINT-RECEIPT`, `C54-SENTINEL-REDACTION` |
+
+The rollback drill has this fixed order:
+
+| Step | Required observation |
+| --- | --- |
+| `R1-LATCH-FUTURE` | atomically latch future Hosting admission closed and stale its generation |
+| `R2-FENCE-ATTEMPTS` | fence every exact attempt in the complete active registry |
+| `R3-REVOKE-DRAIN` | revoke and drain only each attempt's exact domain generation |
+| `R4-TERMINATE-TREE` | terminate each exact owner's complete process tree |
+| `R5-SETTLE-OR-DEBT` | durably record tree settlement or cleanup debt |
+| `R6-SETTLE-READINESS` | settle required/optional Product readiness |
+| `R7-ISSUE-CURRENT` | only now issue a new Current-owner receipt |
+
+The recovery report records these ordered durable observations:
+
+| Step | Required observation |
+| --- | --- |
+| `V1-PRIOR-ABSENT` | no prior attempt exists |
+| `V2-EXACT-REAPED` | the exact prior tree has a settlement witness |
+| `V3-SAMEBOOT-UNKNOWN` | same-boot uncertainty remains durable debt and blocks restart |
+| `V4-CHANGEDBOOT-ABSENT` | trusted changed-boot identity proves the old local tree absent |
+| `V5-BUDGET-EXHAUSTED` | restart budget exhaustion remains terminal |
+| `V6-HOST-RESTART` | durable latch, receipt, generation, settlement/debt, and budget facts reconstruct the decision |
+
+No protocol terminal phase or PID absence substitutes for tree settlement.
+Every slice injects path, secret, descriptor/handle, and ambient-environment
+sentinels at these exact points:
+
+| Step | Injection point |
+| --- | --- |
+| `S1-POLICY-REJECTION` | policy/receipt rejection |
+| `S2-NATIVE-REJECTION` | native preparation rejection |
+| `S3-LAUNCH-FAILURE` | launch failure |
+| `S4-PROTOCOL-FAILURE` | protocol or health failure |
+| `S5-CLEANUP-DEBT` | cleanup debt serialization |
+| `S6-STATUS-SERIALIZATION` | final Product/status serialization |
+
+Reports and bounded diagnostics must contain only stable reason codes and
+opaque fingerprints.
+
+## Guard Transition And Deletion Ledger
+
+| Transition | Guard intentionally revised | Guards retained |
+| --- | --- | --- |
+| PLC9C4 -> C5.0 | index this design/inventory and freeze Current source/mismatch facts | every runtime symbol, private-profile import, Product composition, default Current, no-fallback, author-SDK, unsupported-platform, and `remote_service` absence |
+| C5.0 -> C5.1 | only the named receipt/policy/coordinator/cleanup contracts and the four named Worker public exports | native profile imports outside Hosting, production Product composition, default Current, unsupported platforms, other domains, remote topology; all other Worker public exports remain exact |
+| C5.1 -> C5.2 | create only `src/loushang/harness/worker/_native_profile_bridge.py`, add only `ProductWorkerNativeProfilePort` publicly, and admit its two exact POSIX private imports plus retained Linux report | Windows private imports, a second friend module, raw platform APIs, production Product composition, default Current, WSL/unknown classifiers, other domains, remote topology |
+| C5.2 -> C5.3 | only one Hosting-private trusted-payload builder using `GetWindowsDirectoryW` plus retained Windows mechanics/rejection evidence; no Harness consumer or Windows private friend import is added | production Product composition, Windows required-containment activation, ambient/caller environment trust, default Current, unsupported platforms, other domains, remote topology |
+| C5.3 -> C5.4 | only the exact Linux Coding Product canary composition and named Product report absence | default Current, explicit allowlist, no same-attempt fallback, Windows/unsupported platforms, other domains, author-SDK runtime owners, remote topology |
+| C5.4 -> future Windows activation | only a separately accepted Windows required-containment profile, its exact same-module private imports, and required native/Product reports | every Product/contribution/platform not named by that later acceptance remains closed; G7/G8 cannot close earlier |
+
+The Current Worker owner, `WorkerSessionOwnerRouter`, H6 native profiles and
+their retained native oracles, Session discovery/profile validation, and the
+Capability generation owner cannot be deleted during C5.1--C5.4. Their
+deletion requires G9 evidence that every supported consumer has converged and
+rollback no longer needs the Current path. A new implementation is not proof
+that the old owner is unused.
+
+## C5.0 Executable Guards
+
+While C5.0 is the active baseline, architecture tests must prove:
+
+- the baseline and inventory are indexed once and reproduce every G7 matrix
+  dimension and required case from the parent plan;
+- every Current inventory source exists and the documented source set is exact;
+- no source defines the C5.1 receipt/coordinator/profile-binding target symbols;
+- no non-Worker production module composes the H5 owner selector, H6 adapter,
+  or C4 Capability adapter; Sandbox remains the sole non-Worker importer of
+  the existing Worker launch capability;
+- H6 private POSIX/Windows profile specifications are imported only within
+  Hosting; the H6.4 private preparation friend edge remains confined to the
+  existing Worker adapter; the future platform-profile friend is absent and
+  reserved to exactly `_native_profile_bridge.py`;
+- Coding Product and presenter modules import no Harness Worker or Hosting
+  implementation;
+- owner selection still defaults to Current, performs no environment lookup,
+  and contains one direct call with no cross-owner exception retry;
+- `remote_service`, author-SDK runtime owners, AppHost coupling, unsupported
+  platform fallback, and production activation remain absent; and
+- the retained deletion symbols/files for Current launch, rollback, native
+  preparation, Session identity validation, and domain authority still exist.
+
+Static syntax cannot exclude computed imports, reflection, or callable
+laundering. Those routes are forbidden; focused runtime side-effect tests and
+five-view review complement the executable static guard in every later slice.
+
+## Five-View Review Packet
+
+Review C5.0 independently through these views:
+
+1. **Architecture and dependency:** sole writers, Product-neutral Harness,
+   confined private friend edge, and AppHost independence.
+2. **Product and Session:** explicit Product/Contribution selection,
+   required/optional semantics, Coding-specific restore evidence, and exact
+   cross-entrypoint convergence.
+3. **Security and native containment:** immutable catalog/policy/execution
+   closure, Linux launcher/profile and WSL-classifier admission, Windows
+   trusted-mechanics-only rejection, unsupported-host fail closure, and no raw
+   material escape.
+4. **Lifecycle and rollback:** acquisition attachment, cancellation, cleanup
+   debt, process-tree proof, serialized admission and active registry,
+   exact-generation publication/retirement CAS, sticky attempts, recovery, and
+   kill-switch ordering.
+5. **Testing and operations:** exact Current inventory, deletion/absence guard
+   strength, retained Linux/Windows reports, required-skip policy, pathless
+   diagnostics, and rollback drill observability.
+
+The review must confirm these resolved decisions before C5.1 begins:
+
+- The existing Coding Agent Product construction boundary is the narrowest
+  accepted first canary route; every non-Session early dispatch is excluded.
+- The single `_native_profile_bridge.py` friend is the only platform-profile
+  consumer; C5.2 admits exactly the named POSIX symbols and does not widen the
+  Hosting public API.
+- The Linux canary requires both a static payload and static containment
+  launcher, an admitted containment-profile digest, and a non-WSL exact
+  classifier result.
+- H6.3 Windows restricted-token/Job mechanics are not accepted Product required
+  containment. C5.3 preserves Hosting-owned trusted `SystemRoot` and discarded
+  stderr, and proves Product rejection; Windows activation needs a separate
+  accepted profile and transition.
+- The receipt binds immutable native catalog plus the canonical expected policy
+  closure; same-domain realized policy closure is compared for authorization,
+  while separate full H6 execution-closure evidence, serialized authority
+  witnesses, exact-generation CAS, and durable cleanup settlement/debt make
+  status, publication, recovery, and rollback independently auditable.
+
+## C5.0 Exit Gate
+
+C5.0 is accepted only when the design and exact inventory land together, all
+five review views report no unresolved high/medium risk, focused architecture
+and documentation checks pass, and the diff contains no production source
+under `src/loushang`. Acceptance leaves every runtime route default-dark and
+does not permit Product activation.

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c50-inventory.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c50-inventory.md
@@ -1,0 +1,128 @@
+# PLC9C5 C5.0 Current Product/Native Worker Inventory
+
+## Status
+
+- ID: `PLC9C5-C5.0-INVENTORY`
+- Scope: `Product / Harness Worker / Hosting / Session`
+- Parent: `PLC9C5-C5.0`
+- Authority: descriptive — source-backed Current inventory
+- Design status: not-applicable
+- Implementation status: not-applicable
+- Observation base: `cb01f723`
+- Effect: none; this inventory grants no runtime or activation authority
+- Owner: Harness Worker architecture
+
+## Reading Rule
+
+This inventory records Current facts at the observation base. Source and
+executable tests remain higher authority. Target names in the companion C5.0
+baseline are proposals, not implemented contracts. A source row records the
+narrow seam needed to reason about C5; it does not transfer that source's
+authority to Product or Plugin management.
+
+## Exact Current Source Set
+
+| ID | Exact source | Current fact | C5 disposition |
+| --- | --- | --- | --- |
+| `C5-CUR-DECL` | `src/loushang/harness/resources/plugins/declarations.py` and `src/loushang/harness/resources/plugins/selection.py` | versioned inert `local_worker` declaration/selection exists for `capability_provider`; declared required/optional and exact Worker configuration are data only | retain; Product must rejoin the exact selected reservation and immutable revision before a receipt and cannot downgrade declared requiredness |
+| `C5-CUR-PRODUCT-CORE` | `src/loushang/harness/session/bootstrap_construction.py` and `src/loushang/harness/session/agent_product.py` | one Product-bound Agent Session construction path exists; it owns Product callbacks and final Session assembly but has no Worker activation input | reuse as the shared canary-capable construction boundary; do not put activation in presenters |
+| `C5-CUR-CODING-PRODUCT` | `src/loushang/coding/bootstrap.py` and `src/loushang/coding/cli/__main__.py` | Coding supplies an explicit `product_id` and converges ordinary Agent/TUI/RPC/channel/plain/workflow modes through one runtime builder; early-dispatch workspace/LSP/multiagent routes are separate | first Product evidence only; C5.4 must inventory exact canary-capable callers and keep every excluded route dark |
+| `C5-CUR-PACKAGE-PRODUCT` | `src/loushang/harness/resources/packages/product_contract.py`, `src/loushang/harness/resources/packages/product_runtime.py`, `src/loushang/harness/resources/packages/product_activation.py`, and `src/loushang/harness/resources/packages/product_composition.py` | PLC9A2 owns Package lifecycle routing for CLI/RPC/Session/startup/operations; it is not a generic Product catalog and contains no Worker authority | retain as Product composition precedent; do not extend its Package-specific receipt into Worker activation |
+| `C5-CUR-SESSION-PROFILE` | `src/loushang/harness/transcript/runtime_profile.py` and `src/loushang/coding/session_manager.py` | Coding persists a Product-bound runtime profile and refuses foreign Product profile snapshots on restore | reuse for the Coding-specific G7 resume row after locator selection; do not claim generic AppHost pre-routing identity |
+| `C5-CUR-SESSION-DISCOVERY` | `src/loushang/harness/transcript/discovery.py`, `src/loushang/harness/transcript/directory.py`, `src/loushang/harness/transcript/session_catalog.py`, and `src/loushang/harness/machine_resources/control_plane.py` | canonical global plus cwd/home compatibility sources have stable source/locator, alias/conflict, and read-only projection semantics | retain; discovery selects a candidate and grants no Worker/Product authority |
+| `C5-CUR-WORKER-PUBLIC` | `src/loushang/harness/worker/__init__.py` | public Worker contracts currently export launch/session/supervisor, owner selection, H6.4 adapter, and C4 query-adapter mechanics, but no Product activation or native-profile contract | freeze the exact Current `__all__`; C5.1 may add only the four named public activation contracts and C5.2 only `ProductWorkerNativeProfilePort`; private bridge/platform types remain unexported |
+| `C5-CUR-WORKER-IDENTITY` | `src/loushang/harness/worker/contracts.py` | launch identity binds Plugin revision/contribution/Product/scope/generation/attempt; runtime binding captures executable digest and generic filesystem stat identity | retain; C5 receipt must bind this identity, while Windows native identity remains a separate gap |
+| `C5-CUR-CURRENT-LAUNCH` | `src/loushang/harness/worker/launch.py` and `src/loushang/harness/sandbox/runtime.py` | Process/Sandbox composition privately mints the Current managed Worker launch capability with required containment | retain through rollback; Sandbox is the only non-Worker production importer of the Worker launch capability |
+| `C5-CUR-WORKER-SESSION` | `src/loushang/harness/worker/session.py`, `src/loushang/harness/worker/protocol.py`, `src/loushang/harness/worker/supervisor.py`, and `src/loushang/harness/worker/journal.py` | atomic session abstraction, bounded protocol, health/fencing, and durable protocol-attempt phase evidence exist over injected launch/transport owners; the journal has no receipt, OS-tree owner, boot identity, or cleanup-settlement witness | retain as mechanism; a terminal protocol phase is not resource settlement and none may select Product policy or publish a domain generation |
+| `C5-CUR-DOMAIN-CANARY` | `src/loushang/harness/worker/capability_query.py` | one read-only Capability adapter exists behind `enabled=False`, rechecks exact authority, and publishes nothing | retain as the only C5 canary domain; no other domain or effectful operation enters C5 |
+| `C5-CUR-DOMAIN-GENERATION` | `src/loushang/harness/capabilities/component_host.py`, `src/loushang/harness/capabilities/owner_component_host.py`, and `src/loushang/harness/capabilities/component_runtime.py` | Capability hosts prepare exact bindings without publication; the owner component runtime/binder alone owns atomic generation publication and retirement | retain as the sole domain writer; C5.4 may delegate to it only after receipt, handshake, and domain admission all remain current |
+| `C5-CUR-HOSTING-BRIDGE` | `src/loushang/harness/worker/hosting_adapter.py` and `src/loushang/harness/worker/owner_selection.py` | H6.4 preserves injected managed preparation; H5 selects Current by default and never falls back within an attempt; the reserved `_native_profile_bridge.py` does not exist | retain; only that exact private future module may dispatch native profiles, while public `hosting_adapter.py` remains profile-blind |
+| `C5-CUR-H6-CORE` | `src/loushang/hosting/_launch_preparation.py` and `src/loushang/hosting/_child_session_host.py` | H6 owns request-bound one-use opaque preparation and atomic process/endpoint lifetime | consume through the confined friend seam only; no Product vocabulary or raw material crosses the boundary |
+| `C5-CUR-H6-LINUX` | `src/loushang/hosting/_posix_launch_preparation.py` and `src/loushang/hosting/_posix_process.py` | Linux x86_64 has private direct and contained static-ELF profiles with retained native evidence, but the selector currently accepts WSL when memfd/proc checks pass | C5.2 may use only the contained profile after Product closure admission and a separate non-WSL exact classifier succeeds |
+| `C5-CUR-H6-WINDOWS` | `src/loushang/hosting/_windows_launch_preparation.py`, `src/loushang/hosting/_windows_process.py`, and `src/loushang/hosting/_win32_process.py` | Windows AMD64 has one private restricted-token/direct-import profile and Job/handle-list process mechanics; it is trusted-payload mechanics, not accepted Product required containment | C5.3 retains the oracle and proves Product rejection; it must not enable Windows Product activation |
+
+The exact source set above is executable inventory. Proposed C5 files are not
+added until their owning guard transition lands.
+
+## Current Composition And Absence Facts
+
+- `SandboxExecutionRuntime` is the only non-Worker production source importing
+  the existing Worker launch capability.
+- No non-Worker production source names `HostingManagedWorkerSessionAdapter`,
+  `WorkerHostingActivationV1`, `WorkerSessionOwnerRouter`, or
+  `bind_capability_query_worker_adapter`.
+- Coding source imports no Harness Worker or Hosting implementation.
+- H6 private POSIX and Windows profile specifications are confined to Hosting;
+  the only non-Hosting private H6 preparation import is the reviewed H6.4
+  Worker adapter.
+- The reserved future platform-profile consumer
+  `src/loushang/harness/worker/_native_profile_bridge.py` is absent; no public
+  Worker module imports a private platform profile.
+- `WorkerHostingActivationV1.owner` defaults to `"current"`; selection reads no
+  environment and one attempt calls exactly one selected owner.
+- No Product Worker activation receipt, Product Worker aggregate coordinator,
+  eligible native Worker profile supplier, native canary report, production
+  allowlist, or cross-entrypoint receipt report exists.
+- `remote_service` remains absent from the declaration/runtime topology and the
+  public author SDK has no Worker runtime owner.
+
+## Current Shape Mismatches
+
+| Boundary | Current producer | Current consumer | Result before C5.1--C5.4 |
+| --- | --- | --- | --- |
+| Product selection | Coding Product identity and inert Plugin selection | H5 accepts only a typed Current/Hosting owner input | no versioned Product decision joins the exact contribution to the owner selection |
+| activation evidence | H5 selection and launch evidence describe owner/request mechanics | Product readiness and required/optional policy need a durable decision reference | no Product activation receipt exists |
+| Linux contained profile | Worker runtime has payload digest and package-root stat identity | H6.2 contained spec additionally requires static launcher digest, containment-profile digest, closed invocation, and a C5 classifier that rejects WSL/unknown Linux before selection | no eligible Linux Worker profile supplier or WSL oracle exists |
+| Windows identity | Worker runtime records executable digest and generic `st_dev/st_ino` fields | H6.3 requires locked volume/file identities for executable, cwd, and ancestors | no accepted identity adapter exists |
+| Windows request | H6.4 Worker mapping uses an empty environment and piped stderr; the H6.3 native fixture reads ambient `os.environ["SystemRoot"]` | H6.3 requires one absolute `SystemRoot` environment entry and discarded stderr | the exact requests are incompatible; C5.3 needs a Hosting-private `GetWindowsDirectoryW` source that ignores ambient poisoning and rejects caller environment |
+| Windows containment meaning | Product requires accepted required containment | H6.3 proves restricted-token/Job/direct-import mechanics, not AppContainer equivalence or full loader closure | current profile is explicitly rejected for Product required containment; Windows canary is deferred |
+| restart settlement | Worker journal records protocol phase/restart ordinal | safe restart needs receipt/generation plus protocol terminal, exact domain retirement, and durable complete-tree settlement keyed by host/boot identity | no cleanup settlement/debt contract or safe same-boot crash recovery exists |
+| kill-switch admission | H5 snapshots owner under a lock, then starts after releasing it | rollback must close future Hosting admission and register every sticky in-flight attempt atomically | no Product activation gate or complete active-attempt registry exists |
+| Session resume | discovery yields canonical/compatibility locator facts; Coding later validates its Product runtime snapshot | G7 needs Product identity and an opaque exact source/locator/revision fingerprint fixed before issuing a Worker receipt | no common operation currently binds selected locator revision to Worker activation |
+| entrypoints | ordinary Coding Agent modes converge through shared construction, while early subcommands dispatch separately | G7 requires one receipt across every canary-capable Product entrypoint | no Worker receipt is passed anywhere; excluded early routes are not explicitly frozen yet |
+| rollback | H5 latch redirects future attempts to Current | Product kill switch also needs active attempt fence/drain/terminate and readiness settlement | no Product-level rollback coordinator exists |
+
+## Current-To-Target Closure Ledger
+
+| Gap | Target sole writer | First permitted slice | Completion evidence |
+| --- | --- | --- | --- |
+| explicit allowlist and required/optional decision | exact Product adapter | C5.1 | deterministic missing/wrong/disabled/stale policy tests |
+| pathless activation receipt schema/freshness | Harness Worker contract, value issued by Product | C5.1 | canonical same-domain expected/realized policy closure plus separate full execution-closure evidence, strict version/field/fingerprint, and pre-acquire/pre-publication current-witness tests |
+| serialized admission and active-attempt registry | Harness Worker coordinator | C5.1 | owner-snapshot/rollback race and durable restart-latch tests |
+| durable cleanup settlement/debt | Harness Worker contract over injected owner evidence | C5.1 fake; C5.2/C5.3 platform evidence | protocol-terminal/domain-retired/tree-settled CAS, same-boot unknown debt, and changed-boot absence tests |
+| Product readiness/rollback aggregate | exact Product/domain owner over injected Worker status | C5.1 fake, C5.4 production | atomic pre-publication witness+CAS under the admission gate, kill-switch-before-publish no-visibility race, exact-generation retirement CAS, required/optional, ordered kill-switch, and cleanup-debt tests |
+| Linux contained native binding | the single private `_native_profile_bridge.py` plus Hosting | C5.2 | retained nonskipped Linux report with WSL/unknown rejection and execution-closure evidence |
+| Windows restricted mechanics rejection | Hosting-private trusted-payload builder; the Harness bridge boundary remains closed to Windows private imports | C5.3 | `GetWindowsDirectoryW` trust, ambient poisoning/caller-environment rejection, discarded stderr, retained mechanics report, and Product required-containment rejection |
+| Coding Product composition | Coding Product root | C5.4 only | exact allowlist route plus negative side-effect tests |
+| Session/entrypoint convergence | Coding Product construction and Session identity owners | C5.4 | canonical/cwd/home, alias/conflict/tamper, and shared receipt report |
+| recovery/rollback drill | Product/domain, Worker supervisor, Process/Hosting owners each settle their own state | C5.4 | latch-first, fence/revoke/drain, tree settlement/debt, readiness settlement, then new-Current receipt; prior-absent/reaped/uncertain/exhausted/host-restart evidence |
+
+## Retained Deletion Fences
+
+Until G9 separately accepts owner removal, C5 work must retain:
+
+- the exact Current Worker `__all__` public surface, with only the explicitly
+  named per-slice additions allowed;
+- Current `ManagedWorkerLaunchPort` and its Process/Sandbox composition;
+- `WorkerSessionOwnerRouter.rollback_to_current()` and direct no-fallback start;
+- `WorkerSupervisor` protocol health, durable journal, fence, and ordered
+  shutdown behavior;
+- the C4 read-only Capability adapter and exact Capability generation owner;
+- H6 Linux/Windows private profiles, process backends, Child Session owner, and
+  retained native oracles;
+- Session canonical/compatibility discovery and Coding Product-profile restore
+  validation; and
+- the H5/H6.4 default-dark tests and architecture import guards.
+
+Deleting a source because a new path exists, changing a default, weakening a
+native report to optional/skip, or removing a guard in an earlier slice is an
+architecture failure. C5.4 success permits one explicit canary; it does not by
+itself prove the Current owner unused.
+
+## Inventory Exit Rule
+
+Every later C5 slice must update this inventory in the same change as a source
+or guard transition. The update names the exact added consumer/import, the
+guard removed, its replacement runtime evidence, the retained rollback owner,
+and any new platform exclusion. Uncertain or indirect evidence leaves the row
+open.

--- a/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
+++ b/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
@@ -105,7 +105,8 @@ The inventory records, rather than relaxes, these Current fences:
 - H5 default owner is Current and a selected owner never falls back during an
   attempt;
 - sealed-descriptor cases remain rejected by Hosting compatibility;
-- PLC9C5 Product activation and platform absence guards remain unchanged;
+- PLC9C5 C5.0 design/inventory may be indexed, but Product activation, native
+  profile consumption, and platform absence guards remain unchanged;
 - AppHost/AppServer/AppService source packages remain absent; and
 - Hosting imports no Harness, Product, AppHost, AppServer, or AppService
   package.

--- a/tests/architecture/test_architecture_documentation.py
+++ b/tests/architecture/test_architecture_documentation.py
@@ -46,6 +46,10 @@ INITIAL_GOVERNED_DOCUMENTS = (
     ARCHITECTURE_ROOT
     / "hosting/validation/managed-launch-preparation-h6-windows-native.md",
     ARCHITECTURE_ROOT / "hosting/validation/hosted-product-runtime-v1-inventory.md",
+    ARCHITECTURE_ROOT
+    / "harness/plugin/plugin-lifecycle-plc9c5-c50-baseline.md",
+    ARCHITECTURE_ROOT
+    / "harness/plugin/plugin-lifecycle-plc9c5-c50-inventory.md",
     ARCHITECTURE_ROOT / "hosting/key-designs/hosted-application-support-boundary.md",
     ARCHITECTURE_ROOT / "drafts/apphost-top-level-placement.md",
     ARCHITECTURE_ROOT / "drafts/apphost-component-discovery-a0.md",

--- a/tests/architecture/test_hosted_product_runtime_v1_baseline.py
+++ b/tests/architecture/test_hosted_product_runtime_v1_baseline.py
@@ -432,13 +432,16 @@ def test_current_inventory_matches_source_and_retained_absences() -> None:
         )
     }
     assert reverse_apphost_consumers == set()
+    retained_fences = " ".join(_section(inventory, "Retained Fences").split())
     for statement in (
         "H5 default owner is Current",
-        "PLC9C5 Product activation and platform absence guards remain unchanged",
+        "PLC9C5 C5.0 design/inventory may be indexed",
+        "Product activation, native profile consumption, and platform absence "
+        "guards remain unchanged",
         "AppHost/AppServer/AppService source packages remain absent",
         "Hosting imports no Harness, Product, AppHost, AppServer, or AppService",
     ):
-        assert statement in _section(inventory, "Retained Fences")
+        assert statement in retained_fences
 
 
 def test_current_session_discovery_roots_preserve_exact_modes(tmp_path: Path) -> None:
@@ -537,11 +540,14 @@ def test_plc9c5_and_h5_activation_fences_are_unchanged() -> None:
     h6 = _read(H6)
     plan = _read(DELIVERY_PLAN)
     normalized_plc9c = " ".join(plc9c.split())
-    assert "Until PLC9C5 intentionally revises these guards:" in plc9c
     assert (
-        "PLC9C4 -> PLC9C5 | remove only the accepted Product-activation/platform "
-        "absence guard"
+        "Until the owning PLC9C5 C5.1--C5.4 slice intentionally revises each exact"
+        in normalized_plc9c
+    )
+    assert (
+        "PLC9C4 -> PLC9C5 C5.0 | remove no runtime guard"
     ) in normalized_plc9c
+    assert "C5.0 removes no runtime guard" in " ".join(plan.split())
     assert "they do not revise this activation guard" in normalized_plc9c
     assert "the PLC9C5 Product-activation/platform absence guard remains intact" in h6
     assert "zero runtime activation" in plan

--- a/tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py
@@ -1,0 +1,872 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+BASELINE = Path(
+    "docs/internals/architecture/harness/plugin/"
+    "plugin-lifecycle-plc9c5-c50-baseline.md"
+)
+INVENTORY = Path(
+    "docs/internals/architecture/harness/plugin/"
+    "plugin-lifecycle-plc9c5-c50-inventory.md"
+)
+PLC9C = Path(
+    "docs/internals/architecture/harness/plugin/"
+    "plugin-lifecycle-plc9c0-baseline.md"
+)
+PLUGIN_INDEX = Path("docs/internals/architecture/harness/plugin/README.md")
+DELIVERY_PLAN = Path(
+    "docs/internals/architecture/drafts/hosted-product-runtime-v1-plan.md"
+)
+HOSTED_INVENTORY = Path(
+    "docs/internals/architecture/hosting/validation/"
+    "hosted-product-runtime-v1-inventory.md"
+)
+
+SOURCE_ROOT = Path("src/loushang")
+HARNESS_ROOT = SOURCE_ROOT / "harness"
+WORKER_ROOT = HARNESS_ROOT / "worker"
+SANDBOX_RUNTIME = HARNESS_ROOT / "sandbox/runtime.py"
+CODING_ROOT = SOURCE_ROOT / "coding"
+HOSTING_ROOT = SOURCE_ROOT / "hosting"
+APPHOST_ROOT = SOURCE_ROOT / "apphost"
+AUTHOR_ROOT = SOURCE_ROOT / "plugin"
+
+OWNER_SELECTION = WORKER_ROOT / "owner_selection.py"
+CAPABILITY_ADAPTER = WORKER_ROOT / "capability_query.py"
+HOSTING_ADAPTER = WORKER_ROOT / "hosting_adapter.py"
+POSIX_PROFILE = HOSTING_ROOT / "_posix_launch_preparation.py"
+WINDOWS_PROFILE = HOSTING_ROOT / "_windows_launch_preparation.py"
+WORKER_PUBLIC = WORKER_ROOT / "__init__.py"
+NATIVE_PROFILE_BRIDGE = WORKER_ROOT / "_native_profile_bridge.py"
+POSIX_NATIVE_TESTS = Path("tests/hosting/test_posix_launch_preparation.py")
+WINDOWS_NATIVE_TESTS = Path(
+    "tests/hosting/test_windows_launch_preparation_native.py"
+)
+POSIX_ARCHITECTURE_GUARD = Path(
+    "tests/architecture/test_hosting_h6_posix_native.py"
+)
+WINDOWS_ARCHITECTURE_GUARD = Path(
+    "tests/architecture/test_hosting_h6_windows_native.py"
+)
+HOSTING_WORKFLOW = Path(".github/workflows/hosting-quality.yml")
+REPORT_VERIFIER = Path("scripts/dev/verify_pytest_xml.py")
+MAKEFILE = Path("Makefile")
+
+EXPECTED_CURRENT_SOURCE_PATHS = {
+    "src/loushang/coding/bootstrap.py",
+    "src/loushang/coding/cli/__main__.py",
+    "src/loushang/coding/session_manager.py",
+    "src/loushang/harness/capabilities/component_host.py",
+    "src/loushang/harness/capabilities/component_runtime.py",
+    "src/loushang/harness/capabilities/owner_component_host.py",
+    "src/loushang/harness/machine_resources/control_plane.py",
+    "src/loushang/harness/resources/packages/product_activation.py",
+    "src/loushang/harness/resources/packages/product_composition.py",
+    "src/loushang/harness/resources/packages/product_contract.py",
+    "src/loushang/harness/resources/packages/product_runtime.py",
+    "src/loushang/harness/resources/plugins/declarations.py",
+    "src/loushang/harness/resources/plugins/selection.py",
+    "src/loushang/harness/sandbox/runtime.py",
+    "src/loushang/harness/session/agent_product.py",
+    "src/loushang/harness/session/bootstrap_construction.py",
+    "src/loushang/harness/transcript/directory.py",
+    "src/loushang/harness/transcript/discovery.py",
+    "src/loushang/harness/transcript/runtime_profile.py",
+    "src/loushang/harness/transcript/session_catalog.py",
+    "src/loushang/harness/worker/capability_query.py",
+    "src/loushang/harness/worker/__init__.py",
+    "src/loushang/harness/worker/contracts.py",
+    "src/loushang/harness/worker/hosting_adapter.py",
+    "src/loushang/harness/worker/journal.py",
+    "src/loushang/harness/worker/launch.py",
+    "src/loushang/harness/worker/owner_selection.py",
+    "src/loushang/harness/worker/protocol.py",
+    "src/loushang/harness/worker/session.py",
+    "src/loushang/harness/worker/supervisor.py",
+    "src/loushang/hosting/_child_session_host.py",
+    "src/loushang/hosting/_launch_preparation.py",
+    "src/loushang/hosting/_posix_launch_preparation.py",
+    "src/loushang/hosting/_posix_process.py",
+    "src/loushang/hosting/_win32_process.py",
+    "src/loushang/hosting/_windows_launch_preparation.py",
+    "src/loushang/hosting/_windows_process.py",
+}
+
+RESERVED_TRANSITION_TOKENS = {
+    "ProductWorkerActivationPolicyV1",
+    "ProductWorkerActivationReceiptV1",
+    "ProductWorkerActivationAuthorityPort",
+    "ProductWorkerActivationCoordinator",
+    "ProductWorkerNativeProfilePort",
+    "WorkerCleanupSettlementV1",
+    "WorkerCleanupDebtV1",
+    "bind_coding_product_worker_canary",
+}
+
+CURRENT_WORKER_PUBLIC_EXPORTS = {
+    "CAPABILITY_WORKER_ADMISSION_VERSION",
+    "CAPABILITY_WORKER_AUTHORITY_VERSION",
+    "CAPABILITY_WORKER_BINDING_VERSION",
+    "CAPABILITY_WORKER_DESCRIPTOR_VERSION",
+    "MAX_CAPABILITY_WORKER_DESCRIPTORS",
+    "MAX_CAPABILITY_WORKER_FACETS_PER_DESCRIPTOR",
+    "MAX_CAPABILITY_WORKER_IDENTIFIER_LENGTH",
+    "WORKER_LAUNCH_EVIDENCE_VERSION",
+    "WORKER_LAUNCH_IDENTITY_VERSION",
+    "WORKER_LAUNCH_REQUEST_VERSION",
+    "WORKER_DIAGNOSTIC_READ_MAX_BYTES",
+    "WORKER_HOSTING_ACTIVATION_VERSION",
+    "WORKER_HOSTING_ENDPOINT_READ_CHUNK_BYTES",
+    "WORKER_HOSTING_SELECTION_VERSION",
+    "WORKER_RUNTIME_BINDING_VERSION",
+    "WORKER_ATTEMPT_RECORD_VERSION",
+    "WORKER_PROTOCOL_MAX_FRAME_BYTES",
+    "WORKER_PROTOCOL_MAX_JSON_CONTAINERS",
+    "WORKER_PROTOCOL_MAX_JSON_DEPTH",
+    "WORKER_PROTOCOL_MESSAGE_VERSION",
+    "WORKER_SUPERVISOR_LIMITS_VERSION",
+    "WORKER_SUPERVISOR_MAX_ATTEMPTS",
+    "WORKER_SUPERVISOR_MAX_IN_FLIGHT",
+    "WORKER_SUPERVISOR_MAX_MESSAGES_PER_SESSION",
+    "WORKER_SUPERVISOR_MAX_TIMEOUT_SECONDS",
+    "WORKER_SUPERVISOR_MAX_TOMBSTONES",
+    "WORKER_SUPERVISOR_STATUS_VERSION",
+    "AsyncioStreamWorkerTransport",
+    "CapabilityQueryWorkerAdapter",
+    "CapabilityWorkerAdapterError",
+    "CapabilityWorkerAdmissionV1",
+    "CapabilityWorkerAuthorityV1",
+    "CapabilityWorkerBindingV1",
+    "CapabilityWorkerDescriptorV1",
+    "bind_capability_query_worker_adapter",
+    "bind_current_worker_session_port",
+    "HostingManagedWorkerSessionAdapter",
+    "ManagedWorkerLaunchPort",
+    "ManagedWorkerLaunchRequestV1",
+    "ManagedWorkerProcessControl",
+    "ManagedWorkerProcess",
+    "ManagedWorkerSession",
+    "ManagedWorkerSessionLaunchPort",
+    "WorkerHostingActivationError",
+    "WorkerHostingActivationV1",
+    "WorkerHostingSelectionV1",
+    "WorkerBindingError",
+    "WorkerAttemptPhase",
+    "WorkerAttemptRecordV1",
+    "WorkerByteTransport",
+    "WorkerFrameCodec",
+    "WorkerFramedTransport",
+    "WorkerLaunchEvidenceV1",
+    "WorkerLaunchIdentityV1",
+    "WorkerRuntimeBindingV1",
+    "WorkerProtocolError",
+    "WorkerProtocolMessage",
+    "WorkerRemoteFailure",
+    "WorkerSessionOwner",
+    "WorkerSessionOwnerRouter",
+    "WorkerSupervisor",
+    "WorkerSupervisorError",
+    "WorkerSupervisorJournal",
+    "WorkerSupervisorJournalError",
+    "WorkerSupervisorLimitsV1",
+    "WorkerSupervisorStatusV1",
+}
+
+EXPECTED_FUTURE_REPORTS = (
+    (
+        "PLC9C5-C5.1-CONTRACT",
+        ".artifacts/plc9c5-c51-contract.xml",
+        20,
+        (
+            "C51-CURRENT-REQUIREDNESS",
+            "C51-INVALID-RECEIPT",
+            "C51-STALE-RECEIPT",
+            "C51-FOREIGN-RECEIPT",
+            "C51-POLICY-CLOSURE-CODEC",
+            "C51-PREACQUIRE-FRESHNESS",
+            "C51-PREPUBLISH-ATOMIC-CAS",
+            "C51-KILLSWITCH-PUBLISH-RACE",
+            "C51-RECEIPT-ATTEMPT-CLOSURE",
+            "C51-EXACT-RETIRE-CAS",
+            "C51-KILLSWITCH-ADMISSION-RACE",
+            "C51-RESTART-LATCH",
+            "C51-CLEANUP-SETTLED",
+            "C51-CLEANUP-DEBT",
+            "C51-STICKY-OWNER",
+            "C51-NO-FALLBACK",
+            "C51-REQUIRED-SUCCESS",
+            "C51-OPTIONAL-DEGRADED",
+            "C51-PUBLICATION-FENCE",
+            "C51-SENTINEL-REDACTION",
+        ),
+    ),
+    (
+        "PLC9C5-C5.2-LINUX-NATIVE",
+        ".artifacts/plc9c5-c52-linux-native.xml",
+        14,
+        (
+            "C52-EXACT-CLOSURE",
+            "C52-CATALOG-MISMATCH",
+            "C52-POLICY-CLOSURE-MISMATCH",
+            "C52-EXEC-CLOSURE-MISMATCH",
+            "C52-WSL-MICROSOFT-REJECT",
+            "C52-UNKNOWN-CLASSIFIER-REJECT",
+            "C52-NON-X86-REJECT",
+            "C52-FD-SUBSTITUTION",
+            "C52-CANCEL-PRE-EFFECT",
+            "C52-CANCEL-POST-EFFECT",
+            "C52-DESCENDANT-CLEANUP",
+            "C52-SAMEBOOT-DEBT",
+            "C52-CHANGEDBOOT-ABSENCE",
+            "C52-SENTINEL-REDACTION",
+        ),
+    ),
+    (
+        "PLC9C5-C5.3-WINDOWS-MECHANICS",
+        ".artifacts/plc9c5-c53-windows-mechanics.xml",
+        12,
+        (
+            "C53-REQUIRED-CONTAINMENT-REJECT",
+            "C53-LOCKED-IDENTITY-SUBSTITUTION",
+            "C53-TRUSTED-SYSTEMROOT",
+            "C53-AMBIENT-SYSTEMROOT-POISONING",
+            "C53-CALLER-ENVIRONMENT-REJECT",
+            "C53-DISCARDED-STDERR",
+            "C53-RESTRICTED-TOKEN",
+            "C53-JOB-TREE-CLEANUP",
+            "C53-HANDLE-SUBSTITUTION",
+            "C53-CANCEL-PRE-POST-EFFECT",
+            "C53-RESTART-UNCERTAINTY",
+            "C53-SENTINEL-REDACTION",
+        ),
+    ),
+    (
+        "PLC9C5-C5.4-LINUX-PRODUCT",
+        ".artifacts/plc9c5-c54-linux-product.xml",
+        25,
+        (
+            "C54-PRODUCT-SELECTED",
+            "C54-PRODUCT-MISSING",
+            "C54-PRODUCT-WRONG",
+            "C54-PRODUCT-DISABLED",
+            "C54-SESSION-CANONICAL",
+            "C54-SESSION-CWD",
+            "C54-SESSION-HOME",
+            "C54-SESSION-TAMPERED",
+            "C54-SESSION-ALIAS",
+            "C54-SESSION-CONFLICT",
+            "C54-SESSION-CHANGED",
+            "C54-REQUIRED-SUCCESS",
+            "C54-REQUIRED-FAILURE",
+            "C54-OPTIONAL-SUCCESS",
+            "C54-OPTIONAL-DEGRADED",
+            "C54-CLOSURE-FRESHNESS",
+            "C54-HANDSHAKE-HEALTH-PUBLICATION",
+            "C54-UNSUPPORTED-WINDOWS",
+            "C54-UNSUPPORTED-WSL",
+            "C54-UNSUPPORTED-NON-X86",
+            "C54-UNSUPPORTED-MACOS",
+            "C54-ORDERED-ROLLBACK",
+            "C54-RECOVERY-MATRIX",
+            "C54-SHARED-ENTRYPOINT-RECEIPT",
+            "C54-SENTINEL-REDACTION",
+        ),
+    ),
+)
+
+EXPECTED_DRILL_LEDGER = (
+    ("R1-LATCH-FUTURE", "atomically latch future Hosting admission closed and stale its generation"),
+    ("R2-FENCE-ATTEMPTS", "fence every exact attempt in the complete active registry"),
+    ("R3-REVOKE-DRAIN", "revoke and drain only each attempt's exact domain generation"),
+    ("R4-TERMINATE-TREE", "terminate each exact owner's complete process tree"),
+    ("R5-SETTLE-OR-DEBT", "durably record tree settlement or cleanup debt"),
+    ("R6-SETTLE-READINESS", "settle required/optional Product readiness"),
+    ("R7-ISSUE-CURRENT", "only now issue a new Current-owner receipt"),
+    ("V1-PRIOR-ABSENT", "no prior attempt exists"),
+    ("V2-EXACT-REAPED", "the exact prior tree has a settlement witness"),
+    (
+        "V3-SAMEBOOT-UNKNOWN",
+        "same-boot uncertainty remains durable debt and blocks restart",
+    ),
+    (
+        "V4-CHANGEDBOOT-ABSENT",
+        "trusted changed-boot identity proves the old local tree absent",
+    ),
+    ("V5-BUDGET-EXHAUSTED", "restart budget exhaustion remains terminal"),
+    (
+        "V6-HOST-RESTART",
+        "durable latch, receipt, generation, settlement/debt, and budget facts reconstruct the decision",
+    ),
+    ("S1-POLICY-REJECTION", "policy/receipt rejection"),
+    ("S2-NATIVE-REJECTION", "native preparation rejection"),
+    ("S3-LAUNCH-FAILURE", "launch failure"),
+    ("S4-PROTOCOL-FAILURE", "protocol or health failure"),
+    ("S5-CLEANUP-DEBT", "cleanup debt serialization"),
+    ("S6-STATUS-SERIALIZATION", "final Product/status serialization"),
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _section(text: str, heading: str) -> str:
+    marker = f"## {heading}\n"
+    assert marker in text
+    return text.split(marker, maxsplit=1)[1].split("\n## ", maxsplit=1)[0]
+
+
+def _status(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    current: str | None = None
+    for line in _section(_read(path), "Status").splitlines():
+        if line.startswith("- ") and ":" in line:
+            name, value = line[2:].split(":", maxsplit=1)
+            current = name
+            result[name] = value.strip().strip("`")
+            continue
+        if current is not None and line.startswith("  "):
+            result[current] = f"{result[current]} {line.strip()}"
+    return result
+
+
+def _table_rows(section: str) -> tuple[tuple[str, ...], ...]:
+    rows: list[tuple[str, ...]] = []
+    for line in section.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = tuple(cell.strip().strip("`") for cell in line.strip("|").split("|"))
+        if not cells or all(re.fullmatch(r":?-{3,}:?", cell) for cell in cells):
+            continue
+        rows.append(cells)
+    return tuple(rows[1:])
+
+
+def _documented_sources(text: str) -> set[str]:
+    return set(re.findall(r"`(src/loushang/[^`]+\.py)`", text))
+
+
+def _resolve_import_from(path: Path, node: ast.ImportFrom) -> set[str]:
+    module = node.module or ""
+    if node.level:
+        package = list(path.with_suffix("").parts[1:-1])
+        retained = len(package) - (node.level - 1)
+        assert retained >= 0
+        base = (*package[:retained], *module.split(".")) if module else tuple(
+            package[:retained]
+        )
+        module = ".".join(base)
+    result = {module} if module else set()
+    result.update(
+        f"{module}.{alias.name}" if module else alias.name
+        for alias in node.names
+        if alias.name != "*"
+    )
+    return result
+
+
+def _imports(path: Path) -> set[str]:
+    result: set[str] = set()
+    for node in ast.walk(ast.parse(_read(path), filename=str(path))):
+        if isinstance(node, ast.Import):
+            result.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            result.update(_resolve_import_from(path, node))
+    return result
+
+
+def _qualified_definitions(path: Path) -> set[str]:
+    result: set[str] = set()
+    scope: list[str] = []
+
+    def visit(node: ast.AST) -> None:
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            scope.append(node.name)
+            result.add(".".join(scope))
+            for child in node.body:
+                visit(child)
+            scope.pop()
+            return
+        for child in ast.iter_child_nodes(node):
+            visit(child)
+
+    visit(ast.parse(_read(path), filename=str(path)))
+    return result
+
+
+def _literal_string_collection(path: Path, name: str) -> set[str]:
+    tree = ast.parse(_read(path), filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+        if not any(isinstance(target, ast.Name) and target.id == name for target in targets):
+            continue
+        value = node.value
+        assert value is not None
+        result = ast.literal_eval(value)
+        assert isinstance(result, (list, tuple, set, frozenset))
+        assert all(isinstance(item, str) for item in result)
+        return set(result)
+    raise AssertionError(f"{name} not found in {path}")
+
+
+def _top_level_test_functions(path: Path) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    return {
+        node.name: node
+        for node in ast.parse(_read(path), filename=str(path)).body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    }
+
+
+def _future_report_rows(section: str) -> tuple[
+    tuple[str, str, int, tuple[str, ...]], ...
+]:
+    rows: list[tuple[str, str, int, tuple[str, ...]]] = []
+    for line in section.splitlines():
+        if not line.startswith("| `PLC9C5-"):
+            continue
+        cells = tuple(cell.strip() for cell in line.strip("|").split("|"))
+        assert len(cells) == 4
+        rows.append(
+            (
+                cells[0].strip("`"),
+                cells[1].strip("`"),
+                int(cells[2]),
+                tuple(re.findall(r"`([^`]+)`", cells[3])),
+            )
+        )
+    return tuple(rows)
+
+
+def _drill_ledger_rows(section: str) -> tuple[tuple[str, str], ...]:
+    rows: list[tuple[str, str]] = []
+    for line in section.splitlines():
+        if not re.match(r"\| `[RVS][0-9]-", line):
+            continue
+        cells = tuple(cell.strip() for cell in line.strip("|").split("|"))
+        assert len(cells) == 2
+        rows.append((cells[0].strip("`"), cells[1]))
+    return tuple(rows)
+
+
+def _function_source(path: Path, qualified_name: str) -> str:
+    source = _read(path)
+    tree = ast.parse(source, filename=str(path))
+    scope: list[str] = []
+
+    def visit(node: ast.AST) -> str | None:
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            scope.append(node.name)
+            if ".".join(scope) == qualified_name:
+                return ast.get_source_segment(source, node)
+            for child in node.body:
+                result = visit(child)
+                if result is not None:
+                    return result
+            scope.pop()
+            return None
+        for child in ast.iter_child_nodes(node):
+            result = visit(child)
+            if result is not None:
+                return result
+        return None
+
+    result = visit(tree)
+    assert result is not None
+    return result
+
+
+def test_c50_status_is_honest_and_documents_are_indexed_once() -> None:
+    assert _status(BASELINE) == {
+        "ID": "PLC9C5-C5.0",
+        "Scope": (
+            "loushang.harness` Worker activation boundary plus one Product-owned "
+            "canary composition"
+        ),
+        "Parent": "PLC9C",
+        "Authority": "normative accepted design",
+        "Design status": "accepted",
+        "Implementation status": (
+            "implemented — C5.0 documentation/guards only; C5.1--C5.4 "
+            "not-started"
+        ),
+        "Activation status": "closed; every production route remains default-dark",
+        "Observation base": "cb01f723",
+        "Owner": (
+            "Harness Worker architecture with Product, Hosting, and domain-owner "
+            "review"
+        ),
+    }
+    inventory_status = _status(INVENTORY)
+    assert inventory_status["ID"] == "PLC9C5-C5.0-INVENTORY"
+    assert inventory_status["Authority"] == (
+        "descriptive — source-backed Current inventory"
+    )
+    assert inventory_status["Design status"] == "not-applicable"
+    assert inventory_status["Implementation status"] == "not-applicable"
+    assert inventory_status["Effect"] == (
+        "none; this inventory grants no runtime or activation authority"
+    )
+    index = _read(PLUGIN_INDEX)
+    assert index.count("(plugin-lifecycle-plc9c5-c50-baseline.md)") == 1
+    assert index.count("(plugin-lifecycle-plc9c5-c50-inventory.md)") == 2
+    for related in (PLC9C, DELIVERY_PLAN, HOSTED_INVENTORY):
+        text = _read(related)
+        assert "PLC9C5 C5.0" in text
+        assert "default-dark" in text or "activation" in text
+
+
+def test_c50_current_inventory_source_set_is_exact_and_present() -> None:
+    documented = _documented_sources(
+        _section(_read(INVENTORY), "Exact Current Source Set")
+    )
+    assert documented == EXPECTED_CURRENT_SOURCE_PATHS
+    assert all(Path(path).is_file() for path in documented)
+    identifiers = tuple(
+        row[0]
+        for row in _table_rows(_section(_read(INVENTORY), "Exact Current Source Set"))
+    )
+    assert identifiers == (
+        "C5-CUR-DECL",
+        "C5-CUR-PRODUCT-CORE",
+        "C5-CUR-CODING-PRODUCT",
+        "C5-CUR-PACKAGE-PRODUCT",
+        "C5-CUR-SESSION-PROFILE",
+        "C5-CUR-SESSION-DISCOVERY",
+        "C5-CUR-WORKER-PUBLIC",
+        "C5-CUR-WORKER-IDENTITY",
+        "C5-CUR-CURRENT-LAUNCH",
+        "C5-CUR-WORKER-SESSION",
+        "C5-CUR-DOMAIN-CANARY",
+        "C5-CUR-DOMAIN-GENERATION",
+        "C5-CUR-HOSTING-BRIDGE",
+        "C5-CUR-H6-CORE",
+        "C5-CUR-H6-LINUX",
+        "C5-CUR-H6-WINDOWS",
+    )
+
+
+def test_c50_reproduces_the_complete_parent_g7_matrix() -> None:
+    parent_rows = _table_rows(_section(_read(DELIVERY_PLAN), "G7 Canary Acceptance Matrix"))
+    child_rows = _table_rows(_section(_read(BASELINE), "G7 Acceptance Coverage"))
+    assert all(len(row) == 3 and row[2] for row in child_rows)
+    assert tuple(row[:2] for row in child_rows) == parent_rows
+    assert tuple(row[0] for row in child_rows) == (
+        "Product route",
+        "Session route",
+        "contribution policy",
+        "native platform",
+        "preparation",
+        "lifecycle",
+        "recovery",
+        "publication",
+        "rollback",
+        "entrypoint",
+    )
+    assert tuple(
+        row[0] for row in _table_rows(_section(_read(BASELINE), "Delivery Slices"))
+    ) == ("C5.0", "C5.1", "C5.2", "C5.3", "C5.4")
+    required_evidence = {
+        "Product route": ("C5.1", "C5.4", "Coding Product composition"),
+        "Session route": ("C5.4", "stable locator", "AppHost"),
+        "contribution policy": ("C5.1", "C5.4", "readiness"),
+        "native platform": (
+            "C5.2",
+            "Linux native report",
+            "C5.3",
+            "Windows mechanics",
+            "G7 stays open",
+        ),
+        "preparation": ("C5.2/C5.3", "adversarial native", "C5.4"),
+        "lifecycle": ("C5.2/C5.3", "platform ownership", "C5.4"),
+        "recovery": ("C5.1", "C5.2/C5.3", "C5.4", "adoption remains forbidden"),
+        "publication": ("C5.1", "C5.4", "Capability owner"),
+        "rollback": ("C5.1", "active-registry", "C5.4", "rollback drill"),
+        "entrypoint": ("C5.4", "entrypoint receipt", "early-dispatch"),
+    }
+    evidence_by_dimension = {row[0]: row[2] for row in child_rows}
+    for dimension, tokens in required_evidence.items():
+        assert all(token in evidence_by_dimension[dimension] for token in tokens)
+
+
+def test_c50_freezes_dependency_and_native_shape_decisions() -> None:
+    baseline = " ".join(_read(BASELINE).split())
+    inventory = " ".join(_read(INVENTORY).split())
+    for statement in (
+        "Selection is authority, detection is not",
+        "The receipt is the join",
+        "A profile is an admitted capability, not configuration text",
+        "One attempt has one owner",
+        "Health precedes semantic visibility",
+        "Rollback changes future policy",
+        "Recovery proves absence before restart",
+        "Entrypoints share composition, not flags",
+        "cannot downgrade a declared required contribution to optional",
+        "opaque fingerprint of the exact selected source/locator/revision",
+        "immutable native-profile catalog revision",
+        "opaque native-policy-closure fingerprint",
+        "loushang.worker.native-policy-closure.v1",
+        "same-domain expected and realized policy-closure fingerprints",
+        "never directly compared with the policy-closure fingerprint",
+        "separate full `execution_closure` fingerprint",
+        "serialized admission lease",
+        "current-witness verification and the domain-owner publication CAS occur inside one lease",
+        "durable cleanup settlement/debt contract",
+        "protocol terminal record is not cleanup settlement",
+        "the prior receipt becomes stale",
+        "no same-attempt fallback",
+        "generic pre-routing AppHost behavior remains G5/G8",
+        "The first Product canary is therefore Linux-only",
+        "G7 stays open until a separate Windows required-containment profile",
+        "GetWindowsDirectoryW",
+        "Ambient `SystemRoot` poisoning is ignored",
+        "caller-supplied environment/SystemRoot is rejected",
+        "_native_profile_bridge.py",
+    ):
+        assert statement in baseline
+    for mismatch in (
+        "static launcher digest",
+        "containment-profile digest",
+        "generic `st_dev/st_ino` fields",
+        "one absolute `SystemRoot` environment entry",
+        "ambient `os.environ[\"SystemRoot\"]`",
+        "discarded stderr",
+        "restricted-token/Job/direct-import mechanics",
+        "selector currently accepts WSL",
+        "current profile is explicitly rejected for Product required containment",
+        "no cleanup settlement/debt contract",
+        "no Product activation gate or complete active-attempt registry",
+        "no Product-level rollback coordinator exists",
+    ):
+        assert mismatch in inventory
+
+    future_evidence = _section(
+        _read(BASELINE), "Future Evidence Manifest And Drill Ledger"
+    )
+    normalized_evidence = " ".join(future_evidence.split())
+    assert "zero skips, failures, and errors" in normalized_evidence
+    assert "ambient-environment sentinels" in normalized_evidence
+    assert _future_report_rows(future_evidence) == EXPECTED_FUTURE_REPORTS
+    assert _drill_ledger_rows(future_evidence) == EXPECTED_DRILL_LEDGER
+
+
+def test_c50_runtime_contract_and_product_composition_remain_absent() -> None:
+    production_sources = tuple(SOURCE_ROOT.rglob("*.py"))
+    source = "\n".join(_read(path) for path in production_sources)
+    assert RESERVED_TRANSITION_TOKENS.isdisjoint(source.split())
+    for token in RESERVED_TRANSITION_TOKENS:
+        assert token not in source
+
+    composition_names = {
+        "HostingManagedWorkerSessionAdapter",
+        "WorkerHostingActivationV1",
+        "WorkerSessionOwnerRouter",
+        "bind_capability_query_worker_adapter",
+    }
+    outside_worker = {
+        path
+        for path in production_sources
+        if not path.is_relative_to(WORKER_ROOT)
+        and any(name in _read(path) for name in composition_names)
+    }
+    assert outside_worker == set()
+
+    worker_consumers = {
+        path
+        for path in HARNESS_ROOT.rglob("*.py")
+        if not path.is_relative_to(WORKER_ROOT)
+        and any(
+            imported.startswith("loushang.harness.worker")
+            for imported in _imports(path)
+        )
+    }
+    assert worker_consumers == {SANDBOX_RUNTIME}
+    assert _literal_string_collection(WORKER_PUBLIC, "__all__") == (
+        CURRENT_WORKER_PUBLIC_EXPORTS
+    )
+    assert not NATIVE_PROFILE_BRIDGE.exists()
+
+
+def test_c50_keeps_private_profiles_confined_and_product_layers_clean() -> None:
+    profile_modules = {
+        "loushang.hosting._posix_launch_preparation",
+        "loushang.hosting._windows_launch_preparation",
+    }
+    profile_consumers = {
+        path
+        for path in SOURCE_ROOT.rglob("*.py")
+        if not path.is_relative_to(HOSTING_ROOT)
+        and _imports(path) & profile_modules
+    }
+    assert profile_consumers == set()
+
+    private_preparation = "loushang.hosting._launch_preparation"
+    preparation_consumers = {
+        path
+        for path in SOURCE_ROOT.rglob("*.py")
+        if not path.is_relative_to(HOSTING_ROOT)
+        and private_preparation in _imports(path)
+    }
+    assert preparation_consumers == {HOSTING_ADAPTER}
+
+    posix = _read(POSIX_PROFILE).lower()
+    assert "wsl" not in posix
+    assert "microsoft" not in posix
+
+    forbidden_product_imports = (
+        "loushang.harness.worker",
+        "loushang.hosting",
+    )
+    for root in (CODING_ROOT, APPHOST_ROOT):
+        if not root.is_dir():
+            continue
+        imports = {
+            imported for path in root.rglob("*.py") for imported in _imports(path)
+        }
+        assert not any(
+            imported.startswith(forbidden_product_imports) for imported in imports
+        )
+
+
+def test_c50_import_guard_resolves_relative_and_parent_alias_forms() -> None:
+    probes = {
+        "from ...hosting._posix_launch_preparation import "
+        "_PosixStaticContainedLaunchCaptureSpec": (
+            "loushang.hosting._posix_launch_preparation"
+        ),
+        "from loushang.hosting import _windows_launch_preparation": (
+            "loushang.hosting._windows_launch_preparation"
+        ),
+        "from ...hosting import _launch_preparation": (
+            "loushang.hosting._launch_preparation"
+        ),
+    }
+    for source, expected in probes.items():
+        node = ast.parse(source).body[0]
+        assert isinstance(node, ast.ImportFrom)
+        assert expected in _resolve_import_from(HOSTING_ADAPTER, node)
+
+
+def test_c50_owner_selection_is_default_current_and_has_no_retry() -> None:
+    selection = _read(OWNER_SELECTION)
+    start = _function_source(OWNER_SELECTION, "WorkerSessionOwnerRouter.start")
+    assert 'owner: WorkerSessionOwner = "current"' in selection
+    assert "os.environ" not in selection
+    assert "getenv" not in selection
+    assert start.count("return await port.start(") == 1
+    assert "except" not in start
+    assert "_current.start" not in start
+    assert "_hosting.start" not in start
+
+    adapter_bind = _function_source(
+        CAPABILITY_ADAPTER,
+        "bind_capability_query_worker_adapter",
+    )
+    assert "enabled: bool = False" in adapter_bind
+    assert "worker_disabled_by_policy" in adapter_bind
+
+
+def test_c50_deletion_fences_retain_exact_owners_and_oracles() -> None:
+    expected_definitions = {
+        WORKER_ROOT / "launch.py": {"ManagedWorkerLaunchPort"},
+        SANDBOX_RUNTIME: {
+            "SandboxExecutionRuntime.bind_managed_worker_launch_port"
+        },
+        OWNER_SELECTION: {
+            "WorkerSessionOwnerRouter",
+            "WorkerSessionOwnerRouter.rollback_to_current",
+        },
+        WORKER_ROOT / "supervisor.py": {
+            "WorkerSupervisor",
+            "WorkerSupervisor.start_session",
+        },
+        CAPABILITY_ADAPTER: {"bind_capability_query_worker_adapter"},
+        HARNESS_ROOT / "capabilities/component_host.py": {
+            "CapabilityComponentHost"
+        },
+        HARNESS_ROOT / "capabilities/owner_component_host.py": {
+            "CapabilityOwnerComponentHost"
+        },
+        HARNESS_ROOT / "capabilities/component_runtime.py": {
+            "CapabilityOwnerComponentBinder",
+            "CapabilityOwnerComponentRuntime",
+        },
+        HARNESS_ROOT / "transcript/runtime_profile.py": {
+            "AgentTranscriptProfileRuntime.validate_snapshot"
+        },
+        POSIX_PROFILE: {"_PosixStaticContainedLaunchCaptureSpec"},
+        WINDOWS_PROFILE: {"_WindowsRestrictedLaunchCaptureSpec"},
+    }
+    for path, definitions in expected_definitions.items():
+        assert path.is_file()
+        assert definitions <= _qualified_definitions(path)
+
+    for oracle in (
+        POSIX_NATIVE_TESTS,
+        WINDOWS_NATIVE_TESTS,
+        POSIX_ARCHITECTURE_GUARD,
+        WINDOWS_ARCHITECTURE_GUARD,
+        Path("tests/architecture/test_hosting_h5_worker_adapter.py"),
+        Path("tests/architecture/test_hosting_h6_harness_parity.py"),
+        REPORT_VERIFIER,
+    ):
+        assert oracle.is_file()
+
+    required_native_tests = {
+        POSIX_NATIVE_TESTS: {
+            "test_posix_contained_profile_pins_launcher_payload_and_applies_profile",
+            "test_posix_contained_profile_blocks_descendant_group_escape",
+            "test_posix_static_native_early_exit_rolls_back_before_publication",
+            "test_posix_static_cancellation_after_os_create_reclaims_process",
+        },
+        WINDOWS_NATIVE_TESTS: {
+            "test_windows_restricted_native_locks_identity_and_runs_restricted",
+            "test_windows_restricted_native_job_reclaims_descendant",
+        },
+    }
+    for path, names in required_native_tests.items():
+        functions = _top_level_test_functions(path)
+        assert names <= functions.keys()
+        for name in names:
+            assert not any(
+                "skip" in ast.unparse(decorator)
+                for decorator in functions[name].decorator_list
+            )
+
+    posix_guard = _read(POSIX_ARCHITECTURE_GUARD)
+    windows_guard = _read(WINDOWS_ARCHITECTURE_GUARD)
+    assert "native_adversarial_gate_is_retained_and_non_skippable" in posix_guard
+    assert "windows_native_oracle_and_report_are_retained" in windows_guard
+
+    workflow = _read(HOSTING_WORKFLOW)
+    for required in (
+        "ubuntu-24.04",
+        "windows-2022",
+        "H6.2 Linux native adversarial gate",
+        "H6.3 Windows native adversarial gate",
+        "tests/hosting/test_posix_launch_preparation.py",
+        "tests/hosting/test_windows_launch_preparation_native.py",
+        ".artifacts/h6-posix-native.xml",
+        ".artifacts/h6-windows-native.xml",
+        "scripts/dev/verify_pytest_xml.py",
+        "actions/upload-artifact@v4",
+        "tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py",
+    ):
+        assert required in workflow
+    makefile = _read(MAKEFILE)
+    assert makefile.count(
+        "tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py"
+    ) == 2
+
+    declarations = _read(
+        HARNESS_ROOT / "resources/plugins/declarations.py"
+    )
+    author = "\n".join(_read(path) for path in AUTHOR_ROOT.rglob("*.py"))
+    assert "remote_service" not in declarations
+    assert "remote_service" not in author
+    assert "local_worker" not in author

--- a/tests/hosting/test_windows_process.py
+++ b/tests/hosting/test_windows_process.py
@@ -522,21 +522,45 @@ async def test_windows_native_parallel_spawns_exclude_ambient_handles(
 ) -> None:
     import msvcrt
 
+    names = ("sentinel-a", "sentinel-b")
     descriptors = [
-        os.open(tmp_path / name, os.O_CREAT | os.O_RDWR)
-        for name in ("sentinel-a", "sentinel-b")
+        os.open(tmp_path / name, os.O_CREAT | os.O_RDWR) for name in names
     ]
     handles = [msvcrt.get_osfhandle(descriptor) for descriptor in descriptors]
     for handle in handles:
         os.set_handle_inheritable(handle, True)
-    code = (
-        "import ctypes,sys; flags=ctypes.c_ulong(); "
-        "get=ctypes.windll.kernel32.GetHandleInformation; "
-        "print(''.join('1' if get(int(value),ctypes.byref(flags)) else '0' "
-        "for value in sys.argv[1:]))"
+    code = """
+import ctypes
+import sys
+
+get_path = ctypes.windll.kernel32.GetFinalPathNameByHandleW
+get_path.argtypes = (
+    ctypes.c_void_p,
+    ctypes.c_wchar_p,
+    ctypes.c_ulong,
+    ctypes.c_ulong,
+)
+get_path.restype = ctypes.c_ulong
+
+
+def is_same_file(value, expected_name):
+    buffer = ctypes.create_unicode_buffer(32768)
+    length = get_path(ctypes.c_void_p(int(value)), buffer, len(buffer), 0)
+    return bool(length) and buffer.value.casefold().endswith(
+        "\\\\" + expected_name.casefold()
+    )
+
+
+pairs = zip(sys.argv[1::2], sys.argv[2::2], strict=True)
+print("".join("1" if is_same_file(*pair) else "0" for pair in pairs))
+"""
+    arguments = tuple(
+        item
+        for handle, name in zip(handles, names, strict=True)
+        for item in (str(handle), name)
     )
     requests = [
-        _request(tmp_path, code, *(str(handle) for handle in handles))
+        _request(tmp_path, code, *arguments)
         for _ in range(2)
     ]
     host = create_process_host(max_processes=2)


### PR DESCRIPTION
## Summary
- accept the PLC9C5 C5.0 design-only Product/native Worker activation baseline
- freeze Current inventory, dependency/activation/rollback matrices, and deletion/absence guards
- keep production activation default-dark; admit only a future Linux-first canary while Windows required containment stays closed
- wire the architecture guard into Harness and Hosting quality gates

## Review
Five-view review passed: architecture/dependency, Product/Session, platform/security, lifecycle/rollback, and testing/operations.

## Validation
- PLC9C5 C5.0 architecture guard: 9 passed
- adjacent hosted runtime / PLC9C / documentation architecture suite: 23 passed
- make check-architecture-docs: 5 passed
- Ruff and git diff --check passed

No production source under src/loushang is changed.