### PR TITLE
feat(apphost): add A0.2 catalog and router

### DIFF
--- a/.github/workflows/apphost-quality.yml
+++ b/.github/workflows/apphost-quality.yml
@@ -26,21 +26,50 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --extra dev
 
-      - name: Lint AppHost A0
+      - name: Lint AppHost A0.2
         run: >-
           uv run --extra dev ruff check
           src/loushang/apphost
           tests/apphost
           tests/architecture/test_apphost_a0_contract.py
+          tests/architecture/test_apphost_a02_architecture.py
 
-      - name: Typecheck AppHost A0
+      - name: Typecheck AppHost A0.2
         run: >-
           uv run --extra dev mypy --follow-imports=silent
           src/loushang/apphost
 
-      - name: Test AppHost A0 contract
+      - name: Test AppHost A0.2
         run: >-
           uv run --extra dev python scripts/dev/run_pytest.py
           tests/apphost
           tests/architecture/test_apphost_a0_contract.py
+          tests/architecture/test_apphost_a02_architecture.py
           -q
+
+  apphost-windows-native-gate:
+    name: apphost-windows-native-gate
+    runs-on: windows-2022
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: astral-sh/setup-uv@v5
+      - name: Install dependencies
+        run: uv sync --locked --extra dev
+      - name: Prove unsupported native pinning fails closed
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force .artifacts | Out-Null
+          uv run --extra dev python scripts/dev/run_pytest.py tests/apphost/test_harness_session_integration.py -k windows_native_backend_is_explicitly_fail_closed --junitxml=.artifacts/apphost-harness-windows.xml -q
+      - name: Verify native gate JUnit
+        run: uv run --extra dev python scripts/dev/verify_pytest_xml.py .artifacts/apphost-harness-windows.xml
+      - name: Upload native gate JUnit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: apphost-harness-windows-junit
+          path: .artifacts/apphost-harness-windows.xml
+          if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,12 @@ HOSTING_TEST_PATHS := \
 	tests/architecture/test_hosting_h6_windows_native.py \
 	tests/architecture/test_hosted_product_runtime_v1_baseline.py \
 	tests/architecture/test_hosting_architecture_baseline.py
-APPHOST_SOURCES := src/loushang/apphost
+APPHOST_SOURCES := \
+	src/loushang/apphost
 APPHOST_TEST_PATHS := \
 	tests/apphost \
-	tests/architecture/test_apphost_a0_contract.py
+	tests/architecture/test_apphost_a0_contract.py \
+	tests/architecture/test_apphost_a02_architecture.py
 
 .PHONY: bootstrap test test-ai check-ai test-tui test-tui-render-contract test-tui-terminal-platform test-tui-native test-tui-tmux lint-ai fmt-ai typecheck-ai typecheck-tui build-binary install-binary clean-binary vendor-ai-moonshot-anthropic-stream vendor-ai-moonshot-anthropic-complete vendor-ai-moonshot-anthropic-tools vendor-ai-moonshot-openai-stream vendor-ai-moonshot-openai-complete vendor-ai-moonshot-openai-tools vendor-ai-dashscope-openai-responses-stream vendor-ai-dashscope-openai-responses-tools example-ai-model-lookup example-ai-complete example-ai-stream example-ai-tools example-ai-typed-context example-ai-advanced-faux-stream example-ai-advanced-context-tools example-ai-advanced-tool-result-roundtrip example-ai-kimi-anthropic-stream example-ai-kimi-anthropic-complete example-ai-kimi-anthropic-tools example-ai-kimi-openai-stream example-ai-kimi-openai-complete example-ai-kimi-openai-tools example-ai-dashscope-openai-responses-stream example-ai-dashscope-openai-responses-tools example-ai-custom-base-url-openai-advanced example-ai-faux-stream example-ai-context-tools-minimal example-ai-tool-result-roundtrip
 .PHONY: test-sandbox test-host-runtime

--- a/docs/internals/architecture/apphost/README.md
+++ b/docs/internals/architecture/apphost/README.md
@@ -11,9 +11,10 @@
 - Parent: `loushang`
 - Authority: normative — accepted AppHost scope boundary
 - Design status: accepted
-- Implementation status: partial — A0.1 Contract Model only
-- Activation status: none; no catalog, router, live registry, profile composer,
-  launcher, or Product composition route
+- Implementation status: partial — A0.2 catalog/router and optional dark
+  Harness Session integration
+- Activation status: none; no live registry, profile composer, launcher, or
+  Product composition route
 - Owner: Loushang AppHost architecture
 
 ## Scope
@@ -38,9 +39,26 @@ A0.1 supplies immutable standard-library contracts and exact validation for:
 - immutable catalog input generations; and
 - bounded failures and observations.
 
-There is no runtime owner or composition entrypoint. Existing Product-specific
-CLI/TUI paths remain authoritative. Creating contract values has no filesystem,
-network, process, Plugin, Product, Harness, Hosting, or AppServer effect.
+A0.2 adds:
+
+- an atomic owner over immutable admitted generations, with one exact
+  catalog-owned pin per Product/profile and an independent exact pin per route;
+- compare-and-swap generation replacement and retirement fencing that never
+  retargets an already returned route;
+- explicit create, resume, and Product-owned migration routing through the
+  injected Session identity owner; and
+- one AppHost-owned optional Harness integration that projects only explicitly
+  bound existing discovery sources and delegates canonical creation to an
+  injected owner.
+
+The router returns the public minimal `PreparedProductRouteV1` surface,
+containing only immutable descriptor/generation/binding facts and close
+ownership. It exposes neither a factory nor an opened Product capability. The
+Catalog's Product-pin acquisition remains a private Router friend seam, so a
+caller cannot bypass routing. There is no runtime owner or
+composition entrypoint. Existing Product-specific CLI/TUI paths remain
+authoritative. No production module imports or instantiates the catalog,
+router, or Harness adapter.
 
 ## Target
 
@@ -80,12 +98,13 @@ The accepted target adds, by separately reviewed slices:
 Product package integration -> AppHost contracts
 AppHost core -> Python standard library
 
-future AppHost catalog/runtime -> AppHost contracts + injected Product ports
+AppHost catalog/router -> AppHost contracts + injected Product ports
 future embedded profile -> AppHost contracts + public Harness/Product contracts
 future hosted binder -> AppHost contracts + AppServer structural ports
 future launcher -> AppHost serialized values + Hosting contracts
 
-Harness / Hosting / AppServer / AppService -/-> AppHost
+AppHost optional Harness integration -> public Harness owner + AppHost contracts
+Hosting / AppServer / AppService -/-> AppHost
 AppHost core -/-> Harness / Hosting / AppServer / AppService / concrete Product
 ```
 
@@ -120,9 +139,34 @@ after Product/OEM admission, never through a derived module name.
 9. Cleanup evidence is owner-specific: Product detach, AppServer drain,
    Hosting process exit, and durable Session persistence cannot synthesize one
    another.
-10. A0.1 performs validation only and has no ambient or runtime effects.
-11. PLC9C5 Product/native Worker activation remains default-dark and outside
+10. A0.1 performs validation only. A0.2 may invoke only admission, Session
+    candidate, Product validator, importer, and cleanup ports; it never invokes
+    a Product factory or profile factory.
+11. The optional Harness integration receives exact source bindings from outer
+    composition.
+    It never derives a path from cwd/home scope, treats a candidate token as a
+    path, or creates a second Session index.
+12. PLC9C5 Product/native Worker activation remains default-dark and outside
     AppHost A0.
+13. The optional Harness integration seals at most 8 MiB from one no-follow
+    descriptor. It accepts only an unchanged pre/post full stat snapshot and
+    claimed reads use immutable bytes rather than the descriptor or path.
+14. Failed unpublished Router cleanup remains Router-owned and retryable;
+    `settle_pending_cleanup` and Router close join it without exposing owners.
+15. The optional Harness integration independently fences its own calls and
+    adopts every raw canonical candidate before projection validation. Rejected
+    returns remain adapter-owned until `settle_pending_cleanup` or adapter close
+    joins their successful settlement; the Router need never observe the raw
+    return.
+16. A POSIX descriptor owner relinquishes its descriptor number before calling
+    `close(2)`. A post-effect or otherwise ambiguous close error is recorded as
+    cleanup evidence, but that integer is never retried because the kernel may
+    already have released and reused it.
+17. Canonical delegation is default-dark and bounded to eight concurrent
+    provider calls. Before starting another call, the adapter drains prior
+    unpublished cleanup debt; unresolved debt rejects the call before the
+    provider runs. Together, the fence and limit bound retained malformed raw
+    owners without weakening adopt-before-validation.
 
 ## Delivery Sequence
 
@@ -130,7 +174,7 @@ after Product/OEM admission, never through a derived module name.
 | --- | --- | --- |
 | A0.0 | accepted placement, scope, component boundary, glossary, and parent architecture gates | accepted |
 | A0.1 | standard-library Contract Model and immutable catalog-input validation | implemented, uncomposed |
-| A0.2 | catalog/router, exact admission-pin verification, idempotent Session create/candidate adapter, and explicit importer over fakes | not started |
+| A0.2 | catalog/router, exact admission-pin verification, idempotent Session create/candidate adapter, and explicit importer over fakes | implemented, uncomposed |
 | A0.3 | canonical live-binding registry, scoped runtime lifecycle, and embedded profile | not started |
 | A0.4 | optional hosted binder | deferred pending AppServer contracts |
 | A0.5 | optional serialized launcher | deferred pending its own boundary review |
@@ -141,9 +185,16 @@ after Product/OEM admission, never through a derived module name.
 - `tests/architecture/test_apphost_a0_contract.py` proves package shape,
   standard-library-only imports, parent adoption, and absence of runtime or
   optional dependency edges;
+- `tests/architecture/test_apphost_a02_architecture.py` proves lookup-first
+  create, no factory effect, the one-way optional Harness integration, and absence of
+  production consumers;
+- `tests/apphost/test_catalog.py`, `tests/apphost/test_router.py`, and
+  `tests/apphost/test_harness_session_integration.py` prove the A0.2
+  admission, replacement, candidate, scope, migration, race, and rollback
+  matrix;
 - `make check-apphost` runs the focused lint, typecheck, and contract suite;
 - `make check-architecture-docs` validates parent documentation integrity.
 
-Passing these gates proves only A0.1. A0.2 must not remove the no-router and
-no-composition guards until its two-unrelated-Product and revision-race matrix
-passes.
+Passing these gates proves A0.2 preparation only. It grants no live binding,
+runtime/profile composition, default Product, hosted route, or Product/native
+Worker activation.

--- a/docs/internals/architecture/apphost/contract-model-a0.md
+++ b/docs/internals/architecture/apphost/contract-model-a0.md
@@ -7,16 +7,16 @@
 - Parent: `loushang`
 - Authority: normative — accepted AppHost A0 contract specification
 - Design status: accepted
-- Implementation status: implemented — A0.1 values and ports only
+- Implementation status: implemented through A0.2 catalog/router preparation
 - Activation status: none
 - Owner: Loushang AppHost architecture
 
 ## Purpose
 
-A0.1 creates the smallest dependency-safe seam for later Product routing. It
-defines immutable values and structural ports, validates one immutable catalog
-input generation, and performs no discovery, import, routing, attachment,
-runtime construction, persistence, or process launch.
+A0.1 creates the smallest dependency-safe seam for later Product routing. A0.2
+admits immutable generations and routes exact Session candidates through those
+ports. It still performs no Product discovery, live-binding attachment, runtime
+construction, profile binding, persistence, or process launch.
 
 ## Contract Groups
 
@@ -96,6 +96,78 @@ acquire or close a pin.
 AppHost core imports neither AppServer nor Hosting. It also imports no Harness,
 AppService, UI, Plugin implementation, or concrete Product package; optional
 edges belong to later adapter slices.
+
+## A0.2 Catalog And Router
+
+`AppHostCatalogV1` owns one active immutable admitted generation. Admission
+acquires one independent pin for every Product and profile, reads each returned
+identity exactly once, and compares generation, subject kind, and subject ID
+with the frozen registration. Publication occurs only after all pins pass.
+Mismatch, source retirement, cancellation, or invalid cleanup capability
+publishes nothing; rollback attempts every acquired pin in reverse order. A
+cleanup failure is retained as closed `cleanup_incomplete` evidence with only a
+safe primary category and debt count, never an external exception chain.
+
+Replacement admits its new generation before an exact generation-ID CAS. A
+successful CAS routes new work only to the new immutable snapshot and retires
+the old catalog-owned pins. A private route lease owns a separate subject pin,
+so retirement cannot close, mutate, or retarget a prepared route. A
+catalog-owned base pin proves generation retention only; it never impersonates
+route drain.
+
+`AppHostRouterV1` requires an explicit Product for every operation. Resume
+pins the explicit selected Product, opens one exact path-free candidate, checks
+its envelope, executes final verify and claim, then invokes only the Product
+candidate validator. Create first performs the read-only idempotency
+lookup without acquiring a current pin. Only an absent record pins the Product
+and calls create-if-absent with the descriptor compatibility identity. Recovery
+pins the current Product only after the durable candidate is found. Explicit
+migration requires a migration-only candidate and an admitted Product-owned
+importer. No branch derives a Product, imports a Product module, or invokes a
+Product/profile factory.
+
+Success returns one independently owned implementation of the public minimal
+`PreparedProductRouteV1` protocol. It retains the opened candidate, claimed
+candidate, request lease, and exact route pin, but exposes only frozen
+descriptor/generation/binding identity plus close. A0.2
+hands out no factory or Product execution capability. Close settles those
+owners in reverse acquisition order. Failure and cancellation register every
+actually acquired unpublished owner in a Router-owned pending-cleanup registry
+before settlement; failed items remain retryable through
+`settle_pending_cleanup` and Router close, while successful items never repeat.
+
+The AppHost-owned optional `HarnessAppHostSessionAdapterV1` integration is
+outside AppHost core. Outer
+composition explicitly binds existing `SessionDiscoverySource` identities to
+AppHost scopes; the adapter asks the existing directory owner for its bounded,
+deduplicated projection, retains the exact no-follow revision under a private
+lease, and exposes current JSONL candidates only as `migration_required`. It
+does not derive cwd/home roots, rescan a directory, create an index, or interpret
+candidate tokens as paths. A migration candidate is accepted only after a full
+pre/post stat-stable read from the same no-follow descriptor, bounded by the
+AppHost-owned `HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1` constant (8 MiB). Claim
+hands the Product sealed bytes, never a mutable descriptor or path; oversize or
+read-time mutation fails closed. Canonical create/recovery is an optional
+injected owner and remains absent by default. Every returned canonical owner is
+bound to a static close descriptor and registered in the adapter's private
+pending-cleanup registry before its projection or remaining callbacks are
+validated. A rejected return therefore remains retryable even when its first
+close fails or is cancelled, without requiring the Router to receive it. The
+adapter's close fences new calls, joins in-flight validation, and settles that
+registry; concurrent settlement joins the same attempt and retries only
+unsettled owners. Canonical delegation is absent unless explicitly injected and
+is capped by `HARNESS_SESSION_MAX_ACTIVE_CANONICAL_OPS_V1` at eight concurrent
+provider calls. Every later provider call first drains existing unpublished
+cleanup debt; if debt remains, the call fails before entering the provider.
+Since every returned raw is still adopted before validation, the concurrent
+permit bound also bounds registry strong references. The adapter itself has no
+production consumer.
+
+On POSIX, descriptor close has an inherently ambiguous error boundary: the
+kernel may have released the descriptor even when `close(2)` reports failure.
+The private descriptor owner atomically relinquishes its integer before the
+syscall. It records the failed attempt but never retries that integer, avoiding
+accidental close of a subsequently reused descriptor number.
 
 ## Immutable Catalog Input
 
@@ -180,3 +252,25 @@ A0.1 is complete when:
 6. no production composition path imports or instantiates AppHost.
 
 These gates keep every existing runtime path unchanged and default-dark.
+
+## A0.2 Exit Gate
+
+A0.2 is complete when:
+
+1. AppHost core remains standard-library-only and imports no Harness, Hosting,
+   AppServer, AppService, UI, Plugin implementation, or concrete Product;
+2. two unrelated fake Products pass explicit resume, idempotent create, and
+   copy-first migration without a default branch or factory invocation;
+3. catalog admission, exact pin identity, reverse rollback, CAS replacement,
+   revision swap, retirement, and compatibility failure matrices pass;
+4. the optional Harness integration projects explicitly injected cwd, legacy
+   user-global, and canonical user-global sources through the existing owner,
+   sealing at most 8 MiB after full pre/post descriptor-stat equality; claimed
+   reads remain immutable and Windows stays fail-closed until a reviewed
+   native retained-handle backend exists; rejected canonical returns remain in
+   the adapter-owned cleanup registry across failure and cancellation, and
+   adapter close fences and joins in-flight calls; canonical provider calls are
+   capped at eight and cannot continue while earlier cleanup debt remains;
+5. no live registry, profile composer, launcher, Product activation, native
+   profile, or production composition consumer exists; and
+6. A0.1 and neighboring Hosting architecture gates remain green.

--- a/docs/internals/architecture/drafts/apphost-contract-baseline-a0.md
+++ b/docs/internals/architecture/drafts/apphost-contract-baseline-a0.md
@@ -7,7 +7,7 @@
 - Parent: `Loushang`
 - Authority: historical — refined by the canonical A0 Contract Model
 - Design status: accepted and promoted
-- Implementation status: partial — A0.1 implemented; later slices not started
+- Implementation status: partial — A0.2 implemented; A0.3+ not started
 - Activation status: none; no AppHost runtime composition route
 - Owner: Loushang architecture
 
@@ -284,7 +284,7 @@ Session detach, durable persistence, or Product retirement.
 | --- | --- | --- |
 | A0.0 | placement refinement, component discovery, contract baseline, Current inventory, and absence guard | common-parent and neighboring-owner design review; no source package |
 | A0.1 | standard-library-only public Contract Model facade with runtime default-dark | exact validation, frozen catalog input, no optional-profile imports, no composition |
-| A0.2 | catalog/router, admission-generation pins, injected Session identity/catalog port, and explicit Product-owned importer over fakes | two unrelated fake Products; cwd/user-global listing; no-default resume/migration; legacy Coding and Codex/Claude fixture; duplicate, revision-swap, retirement, and incompatibility matrix pass |
+| A0.2 | catalog/router, admission-generation pins, injected Session identity/catalog port, minimal prepared-route protocol, Router-owned cleanup debt, and explicit Product-owned importer over fakes | two unrelated fake Products; cwd/user-global listing; no-default resume/migration; bounded immutable 8 MiB legacy snapshot; duplicate, revision-swap, retirement, incompatibility, and cleanup-retry matrix pass |
 | A0.3 | canonical live-binding registry, scoped runtime lifecycle, and embedded profile composition | single-flight multi-attach/multi-mux ownership, detach/cancel/stale-detach, partial-construction, deadline, and shutdown matrix pass |
 | A0.4 | optional hosted binder against accepted structural AppServer ports | core stays AppServer-free; transport and semantic owners remain separate |
 | A0.5 | optional serialized launcher adapter | no Python object crosses process; readiness/stop/timeout evidence remains typed |
@@ -316,6 +316,8 @@ independent optional slices; neither is an entry criterion for embedded use.
 
 ## Acceptance Fence
 
-ARD-003 accepts AppHost as a top-level scope. A0.1 adds contracts only;
+ARD-003 accepts AppHost as a top-level scope. A0.2 adds only the admitted
+catalog, prepared-candidate router, and uncomposed AppHost-owned optional
+Harness integration;
 Product-specific Current entrypoints remain authoritative until the later
 catalog, lifecycle, and profile slices pass their own acceptance gates.

--- a/docs/internals/architecture/drafts/hosted-product-runtime-v1-plan.md
+++ b/docs/internals/architecture/drafts/hosted-product-runtime-v1-plan.md
@@ -28,7 +28,7 @@ remote execution, or live process adoption.
 - **Current source:** Hosting H0--H6.4 exists default-dark, including the
   Harness-managed semantic bridge but no eligible native Worker profile
   supplier; Harness retains sealed executable/cwd and required-containment
-  launch; PLC9C1--C4 exist; AppHost A0.1 contracts exist uncomposed;
+  launch; PLC9C1--C4 exist; AppHost A0.2 routing exists uncomposed;
   AppServer/AppService packages do not.
 - **Proposed Target:** H6 supplies opaque native preparation; AppHost supplies
   explicit Product routing and scoped runtime lifetime; Product/Harness
@@ -72,7 +72,7 @@ Product selection, authority, protocol health, or generation publication.
 | G2W | Hosting | H6.3 Windows native backend | G1 | retained native identity/AppContainer-or-token/handle-list/Job oracle |
 | G3 | Harness consumer | implemented H6.4 dark managed preparation adapter over fakes and the real private Child Session seam | G1 | Current/public/managed semantic and rollback matrix; default still Current; no native Worker compatibility claim |
 | G4 | AppHost | implemented A0.1 Contract Model | accepted A0.0 / ARD-003 | standard-library-only contract/import/validation gates; no runtime composition |
-| G5 | proposed AppHost | A0.2 catalog/router, admission pins, Session candidate port, and explicit Product importer | G4 | two unrelated fake Products; cwd/user-global discovery; no-default/ambiguity/revision swap; Coding and Codex/Claude migration matrix pass |
+| G5 | AppHost | implemented A0.2 catalog/router, admission pins, optional AppHost-owned Harness Session integration, and explicit Product importer | G4 | two unrelated fake Products; minimal public prepared-route surface; Router-owned cleanup debt; cwd/user-global discovery; 8 MiB immutable snapshot bound; Windows fail-closed gate; no production consumer |
 | G6 | proposed AppHost | A0.3 canonical live-binding lifecycle and embedded profile | G5 | multi-Session and multi-mux single-flight attach/detach/cancellation/deadline/shutdown matrix |
 | G7 | Product/Harness | PLC9C5 narrow canary over an accepted existing Product route | G2L + G2W + G3 | Linux/Windows cross-entrypoint native evidence, recovery, rollback, no fallback |
 | G8 | AppHost + Product/Harness | Product-neutral end-to-end join | G6 + G7 | AppHost-scoped Product uses the exact Worker activation receipt; unrelated fake Product stays Worker-free |
@@ -134,8 +134,8 @@ restart. Live adoption remains a later separately reviewed threat model.
 
 Before G7, executable architecture tests must continue to prove:
 
-- `src/loushang/apphost` is absent during A0.0 and appears only with accepted
-  A0.1 placement/contract changes;
+- `src/loushang/apphost` is absent during A0.0, appears with accepted A0.1
+  contracts, and adds only the accepted catalog/router in A0.2;
 - AppHost core, once present, has no AppServer, Hosting, concrete Product, or UI
   imports;
 - Harness, AppServer, AppService, and Hosting never import AppHost;

--- a/docs/internals/architecture/generated/current-package-dependencies.md
+++ b/docs/internals/architecture/generated/current-package-dependencies.md
@@ -46,6 +46,7 @@ graph TD
     PKG_AGENT --> PKG_AI
     PKG_AGENT --> PKG_FOUNDATION
     PKG_AI --> PKG_FOUNDATION
+    PKG_APPHOST --> PKG_HARNESS
     PKG_CHANNEL --> PKG_FOUNDATION
     PKG_CHANNEL --> PKG_HARNESS
     PKG_CHANNEL --> PKG_HARNESSWORK
@@ -85,7 +86,7 @@ graph TD
 | --- | --- |
 | `loushang.agent` | `loushang.ai`, `loushang.foundation` |
 | `loushang.ai` | `loushang.foundation` |
-| `loushang.apphost` | None |
+| `loushang.apphost` | `loushang.harness` |
 | `loushang.channel` | `loushang.foundation`, `loushang.harness`, `loushang.harnesswork` |
 | `loushang.coding` | `loushang.agent`, `loushang.ai`, `loushang.channel`, `loushang.foundation`, `loushang.harness`, `loushang.harnesstui`, `loushang.harnesswork`, `loushang.method`, `loushang.plugin`, `loushang.tui` |
 | `loushang.foundation` | None |

--- a/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
+++ b/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
@@ -54,6 +54,7 @@ lease, or factory.
 | Worker protocol/lifecycle | `src/loushang/harness/worker/protocol.py`, `src/loushang/harness/worker/supervisor.py`, `src/loushang/harness/worker/journal.py`, and `src/loushang/harness/worker/session.py` | framing, handshake, correlation, heartbeat, restart/fencing, aggregate session, and durable attempt evidence |
 | first domain adapter | `src/loushang/harness/worker/capability_query.py` | explicitly enabled read-only Capability query adapter; no Product activation or generation publication route |
 | Session discovery contracts | `src/loushang/harness/transcript/discovery.py` and `src/loushang/harness/transcript/session_catalog.py` | canonical/compatibility source identity, stable locator, bounded summaries, aliases/conflicts, and multi-source read model; no generic `product_id` envelope yet |
+| optional AppHost/Harness Session integration | `src/loushang/apphost/integrations/harness_session.py` | AppHost-owned optional projection of explicitly injected Harness source identities to path-free migration candidates; seals an unchanged single-descriptor snapshot up to 8 MiB, adopts rejected canonical returns into its own retryable cleanup lifecycle, bounds canonical delegation to eight concurrent calls and refuses new calls while debt remains, never retries a relinquished POSIX fd number after an ambiguous close, derives no roots or second index, remains uncomposed, and fails closed on Windows pending a native retained-handle backend |
 | Session discovery composition | `src/loushang/harness/transcript/directory.py`, `src/loushang/harness/machine_resources/control_plane.py`, and `src/loushang/coding/cli/__main__.py` | canonical global plus cwd/home compatibility sources are selected at composition; cwd is a query/filter and compatibility roots are not writable authorities |
 
 ## Observed Contract Mismatch
@@ -68,19 +69,17 @@ lease, or factory.
 
 ## AppHost And Hosted Application State
 
-AppHost A0.1 now supplies only immutable standard-library contracts and
-catalog-input validation. There is still:
+AppHost A0.2 now supplies immutable standard-library contracts, admitted
+catalog generations, and explicit prepared-candidate routing. There is still:
 
-- no AppHost catalog, router, live-binding registry, profile composer, or
-  production composition exists;
+- no AppHost live-binding registry, profile composer, or production
+  composition;
 - `src/loushang/appserver` is absent.
 - `src/loushang/appservice` is absent.
 - the generic Session Identity Envelope contract is not yet persisted or read
   before Product selection;
-- no production adapter implements the path-free AppHost port over the existing
-  Product-neutral Harness Session discovery read model together with a
-  pre-routing `product_id`;
-- no two-unrelated-Product conformance fixture exists; and
+- the optional AppHost-owned Harness integration exposes current JSONL only as explicit migration
+  candidates; no canonical envelope persistence owner is composed;
 - no production launcher sends a complete foreground AppHost executable to
   Hosting.
 
@@ -95,9 +94,9 @@ Target boundaries, not evidence of those absent runtime routes.
 | exact Linux executable/cwd/containment transfer | Hosting platform adapter with caller-owned requirements | implemented for the private static-closure profiles; H6.2 retained native adversarial oracle remains green |
 | exact Windows executable/cwd/containment transfer | Hosting platform adapter with caller-owned requirements | implemented for one private restricted-token/direct-import PE mechanics profile; the non-skippable H6.3 native adversarial oracle must remain green |
 | Harness-to-Hosting managed preparation parity | Harness Sandbox/Worker adapter over Hosting | H6.4 fake-backed public/managed semantic and cleanup parity; native Worker compatibility remains absent and default stays Current |
-| Product catalog, no-default routing, scoped runtime lifetime | AppHost | A0.1 contracts exist; A0.2/A0.3 require two-unrelated-fake-Product and lifecycle conformance |
-| Session pre-routing identity | AppHost schema plus canonical Session persistence/catalog owner | A0.1 envelope exists; atomic creation/resume/migration tests remain required before Product parsing |
-| AppHost cwd/user-global Session projection | adapter over the existing Harness Session discovery/catalog owner | explicit-scope listing, stable source identity, exact alias/conflict behavior, Product envelope, and no-direct-filesystem tests |
+| Product catalog, no-default routing, scoped runtime lifetime | AppHost | A0.2 exposes only the minimal prepared-route identity/close protocol; Catalog Product-pin acquisition is Router-private and A0.3 live lifecycle remains absent |
+| Session pre-routing identity | AppHost schema plus canonical Session persistence/catalog owner | A0.2 fake owner proves atomic creation/recovery; real canonical envelope persistence remains uncomposed |
+| AppHost cwd/user-global Session projection | AppHost-owned optional integration over the existing Harness Session discovery/catalog owner | A0.2 proves explicit source binding, stable source identity, alias/conflict, an unchanged bounded descriptor read sealed into immutable bytes, no token-to-path behavior, and Windows fail-closed semantics |
 | Product/native Worker activation | Product/Harness composition and domain owner | separately reviewed PLC9C5 canary, native gates, recovery, and rollback |
 | hosted App protocol and semantics | future AppServer/AppService scopes | separate accepted contracts; not implied by AppHost or Hosting work |
 
@@ -109,9 +108,10 @@ The inventory records, rather than relaxes, these Current fences:
   attempt;
 - sealed-descriptor cases remain rejected by Hosting compatibility;
 - PLC9C5 Product activation and platform absence guards remain unchanged;
-- AppHost remains an exact three-module A0.1 contract package with no
-  catalog/router/runtime/composition consumer; AppServer/AppService source
-  packages remain absent; and
+- AppHost remains an exact six-module A0.2 core package with no
+  runtime/profile/composition consumer; its optional Harness Session
+  integration remains outside the core facade and dark; AppServer/AppService
+  source packages remain absent; and
 - Hosting imports no Harness, Product, AppHost, AppServer, or AppService
   package.
 

--- a/src/loushang/apphost/__init__.py
+++ b/src/loushang/apphost/__init__.py
@@ -1,10 +1,10 @@
-"""Product-neutral AppHost A0 contracts.
+"""Product-neutral AppHost A0 catalog and routing facade.
 
-A0.1 intentionally exposes values and structural ports only. It contains no
-catalog, router, live runtime owner, profile composer, launcher, or Product
-activation path.
+A0.2 adds an explicit admitted catalog and candidate router. It still contains
+no live runtime owner, profile composer, launcher, or Product activation path.
 """
 
+from .catalog import AppHostCatalogV1
 from .contracts import (
     APPHOST_CONTRACT_VERSION,
     SESSION_IDENTITY_ENVELOPE_VERSION,
@@ -19,6 +19,7 @@ from .contracts import (
     AppHostObservationV1,
     ClaimedSessionCandidateV1,
     OpenedProductCandidateV1,
+    PreparedProductRouteV1,
     ProductCandidateValidatorV1,
     ProductCompatibilityImporterV1,
     ProductDescriptorV1,
@@ -44,9 +45,18 @@ from .contracts import (
 from .errors import (
     AppHostError,
     AppHostFailureCategory,
+    CleanupIncompleteError,
+    GenerationConflictError,
+    GenerationRetiredError,
     InvalidAppHostContractError,
     InvalidAppHostContractReason,
+    ProductIdentityRequiredError,
+    ProductIncompatibleError,
+    ProductUnavailableError,
+    SessionAmbiguousError,
+    SessionCandidateStaleError,
 )
+from .router import AppHostRouterV1
 
 __all__ = [
     "APPHOST_CONTRACT_VERSION",
@@ -54,6 +64,7 @@ __all__ = [
     "AdmissionIdentityV1",
     "AdmissionGenerationLeaseV1",
     "AdmissionGenerationSourceV1",
+    "AppHostCatalogV1",
     "AppHostAdmissionSubjectKind",
     "AppHostCatalogInputV1",
     "AppHostComponent",
@@ -62,22 +73,32 @@ __all__ = [
     "AppHostLifecycleTransition",
     "AppHostObservationSinkV1",
     "AppHostObservationV1",
+    "AppHostRouterV1",
     "ClaimedSessionCandidateV1",
+    "CleanupIncompleteError",
+    "GenerationConflictError",
+    "GenerationRetiredError",
     "InvalidAppHostContractError",
     "InvalidAppHostContractReason",
     "OpenedProductCandidateV1",
+    "PreparedProductRouteV1",
     "ProductCandidateValidatorV1",
     "ProductCompatibilityImporterV1",
     "ProductDescriptorV1",
     "ProductFactoryV1",
+    "ProductIdentityRequiredError",
+    "ProductIncompatibleError",
     "ProductProfileBindingV1",
     "ProductRegistrationV1",
+    "ProductUnavailableError",
     "ProfileDescriptorV1",
     "ProfileFactoryV1",
     "ProfileLeaseV1",
     "ProfileRegistrationV1",
     "ScopedProductRuntimeV1",
     "SessionBindingKeyV1",
+    "SessionAmbiguousError",
+    "SessionCandidateStaleError",
     "SessionCandidateLeaseV1",
     "SessionCandidateMode",
     "SessionCandidateRefV1",

--- a/src/loushang/apphost/_ownership.py
+++ b/src/loushang/apphost/_ownership.py
@@ -1,0 +1,176 @@
+"""Private retryable settlement primitives for AppHost-owned resources."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, cast
+
+from .errors import CleanupIncompleteError
+
+AsyncClose = Callable[[], Awaitable[None]]
+AsyncCall = Callable[..., Awaitable[Any]]
+
+
+class RetryableCloser:
+    """Join concurrent close calls and retry only an unsettled callback."""
+
+    __slots__ = ("_callback", "_complete", "_debt_count", "_lock", "_task")
+
+    def __init__(self, callback: AsyncClose) -> None:
+        self._callback = callback
+        self._complete = False
+        self._debt_count = 0
+        self._lock = asyncio.Lock()
+        self._task: asyncio.Task[bool] | None = None
+
+    @classmethod
+    def bind(cls, value: object) -> RetryableCloser:
+        return cls(bind_native_async(value, "close"))
+
+    @property
+    def complete(self) -> bool:
+        return self._complete
+
+    @property
+    def debt_count(self) -> int:
+        return self._debt_count
+
+    async def settle(self) -> bool:
+        async with self._lock:
+            if self._complete:
+                return True
+            if self._task is None or self._task.done():
+                self._task = asyncio.create_task(self._run_once())
+            task = self._task
+        return await asyncio.shield(task)
+
+    async def _run_once(self) -> bool:
+        try:
+            await self._callback()
+        except BaseException:
+            self._debt_count += 1
+            return False
+        self._complete = True
+        return True
+
+
+class CloseGroup:
+    """Retryable reverse-order settlement retaining only unresolved owners."""
+
+    __slots__ = ("_closers", "_complete", "_lock", "_task")
+
+    def __init__(self, closers: Iterable[RetryableCloser] = ()) -> None:
+        self._closers = list(closers)
+        self._complete = False
+        self._lock = asyncio.Lock()
+        self._task: asyncio.Task[bool] | None = None
+
+    @property
+    def complete(self) -> bool:
+        return self._complete
+
+    @property
+    def debt_count(self) -> int:
+        return sum(closer.debt_count for closer in self._closers)
+
+    def append(self, closer: RetryableCloser) -> None:
+        if self._task is not None or self._complete:
+            raise RuntimeError("cannot append after settlement begins")
+        self._closers.append(closer)
+
+    async def settle(self) -> bool:
+        async with self._lock:
+            if self._complete:
+                return True
+            if self._task is None or self._task.done():
+                self._task = asyncio.create_task(self._run_once())
+            task = self._task
+        return await asyncio.shield(task)
+
+    async def close(self) -> None:
+        if not await self.settle():
+            raise CleanupIncompleteError(cleanup_debt_count=self.debt_count) from None
+
+    async def _run_once(self) -> bool:
+        complete = True
+        for closer in reversed(self._closers):
+            if closer.complete:
+                continue
+            if not await closer.settle():
+                complete = False
+        self._complete = complete
+        return complete
+
+
+class AcquisitionStack:
+    """Record actual acquisition order and transfer it to one close group."""
+
+    __slots__ = ("_closers", "_transferred")
+
+    def __init__(self) -> None:
+        self._closers: list[RetryableCloser] = []
+        self._transferred = False
+
+    def push(self, value: object) -> RetryableCloser:
+        if self._transferred:
+            raise RuntimeError("acquisition stack was transferred")
+        closer = RetryableCloser.bind(value)
+        self._closers.append(closer)
+        return closer
+
+    def push_closer(self, closer: RetryableCloser) -> None:
+        if self._transferred:
+            raise RuntimeError("acquisition stack was transferred")
+        self._closers.append(closer)
+
+    def transfer(self) -> CloseGroup:
+        if self._transferred:
+            raise RuntimeError("acquisition stack was transferred")
+        self._transferred = True
+        return CloseGroup(self._closers)
+
+    async def unwind(self) -> None:
+        if self._transferred:
+            return
+        self._transferred = True
+        await CloseGroup(self._closers).close()
+
+
+def bind_native_async(value: object, name: str) -> AsyncCall:
+    """Bind one class-defined native-async descriptor without dynamic lookup."""
+
+    if inspect.getattr_static(
+        type(value), "__getattribute__", object.__getattribute__
+    ) is not object.__getattribute__:
+        raise TypeError("dynamic attribute dispatch is forbidden")
+    descriptor = inspect.getattr_static(type(value), name, None)
+    if inspect.getattr_static(value, name, None) is not descriptor:
+        raise TypeError("instance callback shadow is forbidden")
+    inspected = (
+        descriptor.__func__
+        if isinstance(descriptor, (classmethod, staticmethod))
+        else descriptor
+    )
+    if not inspect.iscoroutinefunction(inspected):
+        raise TypeError("native async class descriptor required")
+    return cast(AsyncCall, descriptor.__get__(value, type(value)))
+
+
+def read_static_property(value: object, name: str) -> object:
+    """Read one class-defined property once without invoking attribute hooks."""
+
+    if inspect.getattr_static(
+        type(value), "__getattribute__", object.__getattribute__
+    ) is not object.__getattribute__:
+        raise TypeError("dynamic attribute dispatch is forbidden")
+    descriptor = inspect.getattr_static(type(value), name, None)
+    if not isinstance(descriptor, property):
+        raise TypeError("class-defined property required")
+    if inspect.getattr_static(value, name, None) is not descriptor:
+        raise TypeError("instance property shadow is forbidden")
+    return descriptor.__get__(value, type(value))
+
+
+__all__: list[str] = []

--- a/src/loushang/apphost/catalog.py
+++ b/src/loushang/apphost/catalog.py
@@ -1,0 +1,536 @@
+"""Admitted immutable Product catalog generations for AppHost A0.2."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import cast
+
+from ._ownership import (
+    AsyncClose,
+    CloseGroup,
+    RetryableCloser,
+    bind_native_async,
+    read_static_property,
+)
+from .contracts import (
+    AdmissionIdentityV1,
+    AppHostCatalogInputV1,
+    ClaimedSessionCandidateV1,
+    OpenedProductCandidateV1,
+    ProductDescriptorV1,
+    ProductRegistrationV1,
+    ProfileRegistrationV1,
+    SessionCandidateRefV1,
+    SessionIdentityEnvelopeV1,
+)
+from .errors import (
+    AppHostError,
+    AppHostFailureCategory,
+    CleanupIncompleteError,
+    GenerationConflictError,
+    GenerationRetiredError,
+    ProductIdentityRequiredError,
+    ProductIncompatibleError,
+    ProductUnavailableError,
+    redacted_apphost_error,
+)
+
+AcquirePin = Callable[[], Awaitable[object]]
+ValidateCandidate = Callable[
+    [ClaimedSessionCandidateV1, SessionIdentityEnvelopeV1],
+    Awaitable[OpenedProductCandidateV1],
+]
+ImportCandidate = Callable[
+    [ClaimedSessionCandidateV1], Awaitable[SessionCandidateRefV1]
+]
+
+
+@dataclass(frozen=True, slots=True)
+class _ProductEntry:
+    descriptor: ProductDescriptorV1
+    identity: AdmissionIdentityV1
+    acquire_pin: AcquirePin
+    validate_candidate: ValidateCandidate
+    import_candidate: ImportCandidate | None
+
+    @classmethod
+    def bind(cls, registration: ProductRegistrationV1) -> _ProductEntry:
+        importer = (
+            None
+            if registration.importer is None
+            else cast(
+                ImportCandidate,
+                bind_native_async(registration.importer, "import_candidate"),
+            )
+        )
+        return cls(
+            descriptor=registration.descriptor,
+            identity=registration.admission_identity,
+            acquire_pin=cast(
+                AcquirePin,
+                bind_native_async(registration.admission_source, "acquire_pin"),
+            ),
+            validate_candidate=cast(
+                ValidateCandidate,
+                bind_native_async(
+                    registration.candidate_validator,
+                    "open_product_candidate",
+                ),
+            ),
+            import_candidate=importer,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class _ProfileEntry:
+    identity: AdmissionIdentityV1
+    acquire_pin: AcquirePin
+
+    @classmethod
+    def bind(cls, registration: ProfileRegistrationV1) -> _ProfileEntry:
+        return cls(
+            identity=registration.admission_identity,
+            acquire_pin=cast(
+                AcquirePin,
+                bind_native_async(registration.admission_source, "acquire_pin"),
+            ),
+        )
+
+
+class _OwnedAdmissionPin:
+    __slots__ = ("_closer", "identity")
+
+    def __init__(
+        self,
+        identity: AdmissionIdentityV1,
+        closer: RetryableCloser,
+    ) -> None:
+        self.identity = identity
+        self._closer = closer
+
+    @property
+    def closer(self) -> RetryableCloser:
+        return self._closer
+
+    async def close(self) -> None:
+        if not await self._closer.settle():
+            raise CleanupIncompleteError() from None
+
+
+class _ProductCatalogLease:
+    """Private exact-generation route capability without a Product factory."""
+
+    __slots__ = ("_entry", "_pin")
+
+    def __init__(self, entry: _ProductEntry, pin: _OwnedAdmissionPin) -> None:
+        self._entry = entry
+        self._pin = pin
+
+    @property
+    def descriptor(self) -> ProductDescriptorV1:
+        return self._entry.descriptor
+
+    @property
+    def generation_id(self) -> str:
+        return self._entry.identity.generation_id
+
+    @property
+    def closer(self) -> RetryableCloser:
+        return self._pin.closer
+
+    async def validate(
+        self,
+        candidate: ClaimedSessionCandidateV1,
+        envelope: SessionIdentityEnvelopeV1,
+    ) -> OpenedProductCandidateV1:
+        try:
+            return await self._entry.validate_candidate(candidate, envelope)
+        except asyncio.CancelledError:
+            raise
+        except AppHostError:
+            raise redacted_apphost_error(
+                AppHostFailureCategory.PRODUCT_INCOMPATIBLE
+            ) from None
+        except BaseException:
+            raise ProductIncompatibleError() from None
+
+    async def import_legacy(
+        self,
+        candidate: ClaimedSessionCandidateV1,
+    ) -> SessionCandidateRefV1:
+        importer = self._entry.import_candidate
+        if importer is None:
+            raise AppHostError(AppHostFailureCategory.PRODUCT_INCOMPATIBLE)
+        try:
+            return await importer(candidate)
+        except asyncio.CancelledError:
+            raise
+        except AppHostError:
+            raise redacted_apphost_error(
+                AppHostFailureCategory.PRODUCT_INCOMPATIBLE
+            ) from None
+        except BaseException:
+            raise ProductIncompatibleError() from None
+
+    async def close(self) -> None:
+        await self._pin.close()
+
+
+@dataclass(frozen=True, slots=True)
+class _ProductReservation:
+    generation: _CatalogGeneration
+    entry: _ProductEntry
+
+    async def acquire(self) -> _ProductCatalogLease:
+        try:
+            pin = await _acquire_exact_pin(
+                self.entry.acquire_pin,
+                self.entry.identity,
+            )
+        except BaseException:
+            finish = asyncio.create_task(self.generation.finish_reservation())
+            await asyncio.shield(finish)
+            raise
+        finish = asyncio.create_task(self.generation.finish_reservation())
+        try:
+            accepting = await asyncio.shield(finish)
+        except asyncio.CancelledError:
+            await asyncio.shield(finish)
+            if not await pin.closer.settle():
+                raise CleanupIncompleteError() from None
+            raise
+        if not accepting:
+            if not await pin.closer.settle():
+                raise CleanupIncompleteError() from None
+            raise GenerationRetiredError()
+        return _ProductCatalogLease(self.entry, pin)
+
+
+class _CatalogGeneration:
+    __slots__ = (
+        "_accepting",
+        "_base_pins",
+        "_drained",
+        "_lock",
+        "_reservations",
+        "generation_id",
+        "products",
+        "profiles",
+    )
+
+    def __init__(
+        self,
+        generation_id: str,
+        products: tuple[_ProductEntry, ...],
+        profiles: tuple[_ProfileEntry, ...],
+        base_pins: CloseGroup,
+    ) -> None:
+        self.generation_id = generation_id
+        self.products = products
+        self.profiles = profiles
+        self._base_pins = base_pins
+        self._accepting = True
+        self._reservations = 0
+        self._drained = asyncio.Event()
+        self._drained.set()
+        self._lock = asyncio.Lock()
+
+    @classmethod
+    async def admit(cls, value: AppHostCatalogInputV1) -> _CatalogGeneration:
+        if not isinstance(value, AppHostCatalogInputV1):
+            raise TypeError("catalog input must be AppHostCatalogInputV1")
+        try:
+            products = tuple(_ProductEntry.bind(item) for item in value.products)
+            profiles = tuple(_ProfileEntry.bind(item) for item in value.profiles)
+        except BaseException:
+            raise GenerationConflictError() from None
+        requests = (
+            *((item.acquire_pin, item.identity) for item in products),
+            *((item.acquire_pin, item.identity) for item in profiles),
+        )
+        acquired_order: list[_OwnedAdmissionPin] = []
+
+        async def acquire_and_record(
+            acquire: AcquirePin,
+            identity: AdmissionIdentityV1,
+        ) -> _OwnedAdmissionPin:
+            pin = await _acquire_exact_pin(acquire, identity)
+            acquired_order.append(pin)
+            return pin
+
+        tasks = tuple(
+            asyncio.create_task(acquire_and_record(acquire, identity))
+            for acquire, identity in requests
+        )
+        try:
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+        except asyncio.CancelledError:
+            for task in tasks:
+                task.cancel()
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            if not await CloseGroup(
+                pin.closer for pin in acquired_order
+            ).settle():
+                raise CleanupIncompleteError() from None
+            raise
+        failures = tuple(
+            result for result in results if not isinstance(result, _OwnedAdmissionPin)
+        )
+        if failures:
+            if not await CloseGroup(
+                pin.closer for pin in acquired_order
+            ).settle():
+                raise CleanupIncompleteError() from None
+            if any(isinstance(error, asyncio.CancelledError) for error in failures):
+                raise asyncio.CancelledError
+            first = failures[0]
+            if isinstance(first, AppHostError):
+                raise first from None
+            raise GenerationRetiredError() from None
+        return cls(
+            value.generation_id,
+            products,
+            profiles,
+            CloseGroup(pin.closer for pin in acquired_order),
+        )
+
+    async def reserve_product(self, product_id: str) -> _ProductReservation:
+        async with self._lock:
+            if not self._accepting:
+                raise GenerationRetiredError()
+            entry = next(
+                (item for item in self.products if item.descriptor.product_id == product_id),
+                None,
+            )
+            if entry is None:
+                raise ProductUnavailableError()
+            if self._reservations == 0:
+                self._drained.clear()
+            self._reservations += 1
+            return _ProductReservation(self, entry)
+
+    async def finish_reservation(self) -> bool:
+        async with self._lock:
+            self._reservations -= 1
+            if self._reservations == 0:
+                self._drained.set()
+            return self._accepting
+
+    async def fence(self) -> None:
+        async with self._lock:
+            self._accepting = False
+            if self._reservations == 0:
+                self._drained.set()
+
+    async def settle_retirement(self) -> bool:
+        await self.fence()
+        await self._drained.wait()
+        return await self._base_pins.settle()
+
+
+class AppHostCatalogV1:
+    """Atomic owner of one active immutable admitted generation.
+
+    Owner locks protect only pointer/reservation state. Admission source and
+    cleanup callbacks always run outside these locks. Replaced generations
+    remain in ``_retiring`` until their retryable settlement succeeds.
+    """
+
+    __slots__ = ("_active", "_closed", "_lock", "_retiring", "_tasks")
+
+    def __init__(self, generation: _CatalogGeneration) -> None:
+        self._active = generation
+        self._closed = False
+        self._lock = asyncio.Lock()
+        self._retiring: set[_CatalogGeneration] = set()
+        self._tasks: dict[_CatalogGeneration, asyncio.Task[bool]] = {}
+
+    @classmethod
+    async def admit(cls, value: AppHostCatalogInputV1) -> AppHostCatalogV1:
+        return cls(await _CatalogGeneration.admit(value))
+
+    @property
+    def generation_id(self) -> str:
+        return self._active.generation_id
+
+    async def _acquire_product(self, product_id: str) -> _ProductCatalogLease:
+        """Friend seam for AppHostRouterV1; not a public routing bypass."""
+        if not isinstance(product_id, str) or not product_id:
+            raise ProductIdentityRequiredError()
+        async with self._lock:
+            if self._closed:
+                raise GenerationRetiredError()
+            reservation = await self._active.reserve_product(product_id)
+        return await reservation.acquire()
+
+    async def replace(
+        self,
+        value: AppHostCatalogInputV1,
+        *,
+        expected_generation_id: str,
+    ) -> None:
+        replacement = await _CatalogGeneration.admit(value)
+        operation = asyncio.create_task(
+            self._replace_admitted(
+                replacement,
+                expected_generation_id=expected_generation_id,
+            )
+        )
+        operation.add_done_callback(_observe_background_result)
+        await asyncio.shield(operation)
+
+    async def _replace_admitted(
+        self,
+        replacement: _CatalogGeneration,
+        *,
+        expected_generation_id: str,
+    ) -> None:
+        accepted = False
+        previous: _CatalogGeneration | None = None
+        async with self._lock:
+            if (
+                not self._closed
+                and self._active.generation_id == expected_generation_id
+                and replacement.generation_id != expected_generation_id
+            ):
+                previous = self._active
+                await previous.fence()
+                self._active = replacement
+                self._retiring.add(previous)
+                accepted = True
+            else:
+                await replacement.fence()
+                self._retiring.add(replacement)
+        target = previous if accepted else replacement
+        assert target is not None
+        # The settlement owner must exist before the caller can be cancelled
+        # after the CAS.  Shielding only a coroutine leaves a cancellation
+        # window before that coroutine has installed its persistent task.
+        complete = await self._settle_one(target)
+        if not complete:
+            raise CleanupIncompleteError() from None
+        if not accepted:
+            if self._closed:
+                raise GenerationRetiredError()
+            raise GenerationConflictError()
+
+    async def settle_retiring(self) -> None:
+        operation = asyncio.create_task(self._settle_retiring_once())
+        operation.add_done_callback(_observe_background_result)
+        await asyncio.shield(operation)
+
+    async def _settle_retiring_once(self) -> None:
+        async with self._lock:
+            generations = tuple(self._retiring)
+        tasks = tuple(
+            asyncio.create_task(self._settle_one(generation))
+            for generation in generations
+        )
+        results = await asyncio.gather(*(asyncio.shield(task) for task in tasks))
+        if not all(results):
+            raise CleanupIncompleteError() from None
+
+    async def close(self) -> None:
+        operation = asyncio.create_task(self._close_once())
+        operation.add_done_callback(_observe_background_result)
+        await asyncio.shield(operation)
+
+    async def _close_once(self) -> None:
+        async with self._lock:
+            if not self._closed:
+                self._closed = True
+                await self._active.fence()
+                self._retiring.add(self._active)
+            generations = tuple(self._retiring)
+        tasks = tuple(
+            asyncio.create_task(self._settle_one(generation))
+            for generation in generations
+        )
+        results = await asyncio.gather(*(asyncio.shield(task) for task in tasks))
+        if not all(results):
+            raise CleanupIncompleteError() from None
+
+    async def _settle_one(self, generation: _CatalogGeneration) -> bool:
+        async with self._lock:
+            task = self._tasks.get(generation)
+            if task is None or (task.done() and not task.result()):
+                task = asyncio.create_task(generation.settle_retirement())
+                self._tasks[generation] = task
+        result = await asyncio.shield(task)
+        if result:
+            async with self._lock:
+                self._retiring.discard(generation)
+                self._tasks.pop(generation, None)
+        return result
+
+
+async def _acquire_exact_pin(
+    acquire: AcquirePin,
+    expected: AdmissionIdentityV1,
+) -> _OwnedAdmissionPin:
+    raw: object | None = None
+    owner: _OwnedAdmissionPin | None = None
+    try:
+        raw = await acquire()
+        closer = RetryableCloser.bind(raw)
+        identity = read_static_property(raw, "identity")
+        if type(identity) is not AdmissionIdentityV1 or identity != expected:
+            owner = _OwnedAdmissionPin(expected, closer)
+            if not await closer.settle():
+                raise CleanupIncompleteError() from None
+            raise GenerationConflictError()
+        owner = _OwnedAdmissionPin(identity, closer)
+        await asyncio.sleep(0)
+        return owner
+    except asyncio.CancelledError:
+        if owner is not None and not await owner.closer.settle():
+            raise CleanupIncompleteError() from None
+        raise
+    except CleanupIncompleteError:
+        raise
+    except AppHostError as error:
+        if (
+            owner is not None
+            and not owner.closer.complete
+            and not await owner.closer.settle()
+        ):
+            raise CleanupIncompleteError() from None
+        raise redacted_apphost_error(error.category) from None
+    except BaseException:
+        if owner is not None and not await owner.closer.settle():
+            raise CleanupIncompleteError() from None
+        if raw is not None and owner is None:
+            rescued = _bind_rescue_close(raw)
+            if rescued is None or not await RetryableCloser(rescued).settle():
+                raise CleanupIncompleteError() from None
+        raise GenerationConflictError() from None
+
+
+def _bind_rescue_close(value: object) -> AsyncClose | None:
+    """Bind only the static class descriptor for cleanup after rejection."""
+
+    try:
+        descriptor = inspect.getattr_static(type(value), "close", None)
+        inspected = (
+            descriptor.__func__
+            if isinstance(descriptor, (classmethod, staticmethod))
+            else descriptor
+        )
+        if not inspect.iscoroutinefunction(inspected):
+            return None
+        return cast(AsyncClose, descriptor.__get__(value, type(value)))
+    except BaseException:
+        return None
+
+
+def _observe_background_result(task: asyncio.Task[None]) -> None:
+    """Consume a detached caller result; catalog debt remains independently owned."""
+
+    if not task.cancelled():
+        task.exception()
+
+
+__all__ = ["AppHostCatalogV1"]

--- a/src/loushang/apphost/contracts.py
+++ b/src/loushang/apphost/contracts.py
@@ -230,6 +230,22 @@ class ProfileDescriptorV1:
 
 
 @runtime_checkable
+class PreparedProductRouteV1(Protocol):
+    """Read-only prepared identity plus independently owned cleanup."""
+
+    @property
+    def descriptor(self) -> ProductDescriptorV1: ...
+
+    @property
+    def generation_id(self) -> str: ...
+
+    @property
+    def binding_key(self) -> SessionBindingKeyV1: ...
+
+    async def close(self) -> None: ...
+
+
+@runtime_checkable
 class AdmissionGenerationLeaseV1(Protocol):
     """Independently owned, idempotently closed subject-bound admission pin."""
 

--- a/src/loushang/apphost/errors.py
+++ b/src/loushang/apphost/errors.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from enum import Enum
 
 _FIELD = re.compile(r"[a-z][a-z0-9._]{0,127}\Z")
@@ -57,6 +58,75 @@ class AppHostError(Exception):
         super().__init__(category.value)
 
 
+class ProductIdentityRequiredError(AppHostError):
+    """A route omitted its explicit Product identity."""
+
+    def __init__(self) -> None:
+        super().__init__(AppHostFailureCategory.PRODUCT_IDENTITY_REQUIRED)
+
+
+class ProductUnavailableError(AppHostError):
+    """The explicitly selected Product is absent from the active generation."""
+
+    def __init__(self) -> None:
+        super().__init__(AppHostFailureCategory.PRODUCT_UNAVAILABLE)
+
+
+class ProductIncompatibleError(AppHostError):
+    """The selected Product cannot open the persisted compatibility identity."""
+
+    def __init__(self) -> None:
+        super().__init__(AppHostFailureCategory.PRODUCT_INCOMPATIBLE)
+
+
+class SessionAmbiguousError(AppHostError):
+    """More than one non-equivalent Session candidate claims one identity."""
+
+    def __init__(self) -> None:
+        super().__init__(AppHostFailureCategory.SESSION_AMBIGUOUS)
+
+
+class SessionCandidateStaleError(AppHostError):
+    """A request-bound Session candidate changed before its final fence."""
+
+    def __init__(self) -> None:
+        super().__init__(AppHostFailureCategory.SESSION_CANDIDATE_STALE)
+
+
+class GenerationRetiredError(AppHostError):
+    """The selected immutable catalog generation no longer admits routes."""
+
+    def __init__(self) -> None:
+        super().__init__(AppHostFailureCategory.GENERATION_RETIRED)
+
+
+class GenerationConflictError(AppHostError):
+    """A catalog replacement or returned admission identity failed its CAS."""
+
+    def __init__(self) -> None:
+        super().__init__(AppHostFailureCategory.GENERATION_CONFLICT)
+
+
+class CleanupIncompleteError(AppHostError):
+    """An owned A0.2 resource could not be settled deterministically."""
+
+    def __init__(
+        self,
+        *,
+        primary_category: AppHostFailureCategory | None = None,
+        cleanup_debt_count: int = 1,
+    ) -> None:
+        if primary_category is not None and not isinstance(
+            primary_category, AppHostFailureCategory
+        ):
+            raise TypeError("primary_category must be an AppHostFailureCategory")
+        if type(cleanup_debt_count) is not int or cleanup_debt_count < 1:
+            raise ValueError("cleanup_debt_count must be positive")
+        self.primary_category = primary_category
+        self.cleanup_debt_count = cleanup_debt_count
+        super().__init__(AppHostFailureCategory.CLEANUP_INCOMPLETE)
+
+
 class InvalidAppHostContractError(AppHostError, ValueError):
     """An immutable A0 contract value failed exact local validation."""
 
@@ -69,3 +139,36 @@ class InvalidAppHostContractError(AppHostError, ValueError):
         self.reason = reason
         super().__init__(AppHostFailureCategory.INVALID_CONTRACT)
         self.args = (f"invalid AppHost contract field {field!r}; {reason.value}",)
+
+
+def redacted_apphost_error(category: AppHostFailureCategory) -> AppHostError:
+    """Construct the canonical payload-free error for one closed category."""
+
+    constructors: dict[AppHostFailureCategory, Callable[[], AppHostError]] = {
+        AppHostFailureCategory.PRODUCT_IDENTITY_REQUIRED: ProductIdentityRequiredError,
+        AppHostFailureCategory.PRODUCT_UNAVAILABLE: ProductUnavailableError,
+        AppHostFailureCategory.PRODUCT_INCOMPATIBLE: ProductIncompatibleError,
+        AppHostFailureCategory.SESSION_AMBIGUOUS: SessionAmbiguousError,
+        AppHostFailureCategory.SESSION_CANDIDATE_STALE: SessionCandidateStaleError,
+        AppHostFailureCategory.GENERATION_RETIRED: GenerationRetiredError,
+        AppHostFailureCategory.GENERATION_CONFLICT: GenerationConflictError,
+        AppHostFailureCategory.CLEANUP_INCOMPLETE: CleanupIncompleteError,
+    }
+    constructor = constructors.get(category)
+    return AppHostError(category) if constructor is None else constructor()
+
+
+__all__ = [
+    "AppHostError",
+    "AppHostFailureCategory",
+    "CleanupIncompleteError",
+    "GenerationConflictError",
+    "GenerationRetiredError",
+    "InvalidAppHostContractError",
+    "InvalidAppHostContractReason",
+    "ProductIdentityRequiredError",
+    "ProductIncompatibleError",
+    "ProductUnavailableError",
+    "SessionAmbiguousError",
+    "SessionCandidateStaleError",
+]

--- a/src/loushang/apphost/integrations/__init__.py
+++ b/src/loushang/apphost/integrations/__init__.py
@@ -1,0 +1,3 @@
+"""Optional AppHost-owned integrations; intentionally absent from the core facade."""
+
+__all__: list[str] = []

--- a/src/loushang/apphost/integrations/harness_session.py
+++ b/src/loushang/apphost/integrations/harness_session.py
@@ -1,0 +1,837 @@
+"""Optional dark adapter over the existing Harness Session discovery owner."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import stat
+from collections import OrderedDict
+from dataclasses import dataclass, field
+
+from loushang.apphost._ownership import (
+    CloseGroup,
+    RetryableCloser,
+    bind_native_async,
+    read_static_property,
+)
+from loushang.apphost.contracts import (
+    ClaimedSessionCandidateV1,
+    SessionCandidateLeaseV1,
+    SessionCandidateMode,
+    SessionCandidateRefV1,
+    SessionCreateIntentV1,
+    SessionCreateRequestV1,
+    SessionDiscoveryScope,
+    SessionIdentityEnvelopeV1,
+    SessionIdentityProjectionV1,
+)
+from loushang.apphost.errors import (
+    AppHostError,
+    AppHostFailureCategory,
+    CleanupIncompleteError,
+    GenerationRetiredError,
+    SessionAmbiguousError,
+    SessionCandidateStaleError,
+    redacted_apphost_error,
+)
+from loushang.harness.conversation import ConversationJsonlHeaderCodec
+from loushang.harness.journal import DEFAULT_JSONL_FORMAT
+from loushang.harness.transcript.directory import AgentTranscriptDirectoryRuntime
+from loushang.harness.transcript.discovery import SessionLocator
+from loushang.harness.transcript.session_catalog import (
+    session_file_authority_fingerprint,
+)
+
+_MAX_CANDIDATE_CACHE = 1024
+_MAX_HEADER_BYTES = 64 * 1024
+HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1 = 8 * 1024 * 1024
+HARNESS_SESSION_MAX_ACTIVE_CANONICAL_OPS_V1 = 8
+_SNAPSHOT_CHUNK_BYTES = 64 * 1024
+_HEADER_CODEC = ConversationJsonlHeaderCodec()
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessSessionScopeBindingV1:
+    """Explicit scope-to-existing-source binding supplied by outer composition."""
+
+    scope: SessionDiscoveryScope
+    source_id: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.scope, SessionDiscoveryScope):
+            raise TypeError("scope must be SessionDiscoveryScope")
+        if not isinstance(self.source_id, str) or not self.source_id:
+            raise ValueError("source_id must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class _CandidateRecord:
+    projection: SessionIdentityProjectionV1
+    locator: SessionLocator = field(repr=False)
+    raw_revision: str = field(repr=False)
+
+
+class _DescriptorOwner:
+    __slots__ = ("_closed", "_descriptor")
+
+    def __init__(self, descriptor: int) -> None:
+        self._descriptor = descriptor
+        self._closed = False
+
+    @property
+    def descriptor(self) -> int:
+        if self._closed:
+            raise SessionCandidateStaleError()
+        return self._descriptor
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        descriptor = self._descriptor
+        self._descriptor = -1
+        self._closed = True
+        os.close(descriptor)
+
+
+class _PinnedSessionContent:
+    """Immutable claimed content snapshot with a redacted repr."""
+
+    __slots__ = ("_content", "_conversation_id", "_source_id")
+
+    def __init__(
+        self,
+        content: bytes,
+        *,
+        conversation_id: str,
+        source_id: str,
+    ) -> None:
+        self._content = content
+        self._conversation_id = conversation_id
+        self._source_id = source_id
+
+    @property
+    def conversation_id(self) -> str:
+        return self._conversation_id
+
+    @property
+    def source_id(self) -> str:
+        return self._source_id
+
+    def read_bytes(
+        self, *, max_bytes: int = HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1
+    ) -> bytes:
+        if (
+            type(max_bytes) is not int
+            or not 1 <= max_bytes <= HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1
+        ):
+            raise ValueError("max_bytes is outside the pinned read bound")
+        if len(self._content) > max_bytes:
+            raise SessionCandidateStaleError()
+        return self._content
+
+    def __repr__(self) -> str:
+        return "<PinnedHarnessSessionContent>"
+
+
+class _ClaimedCandidate:
+    __slots__ = ("_binding", "_closed", "_reference")
+
+    def __init__(
+        self,
+        reference: SessionCandidateRefV1,
+        binding: _PinnedSessionContent,
+    ) -> None:
+        self._reference = reference
+        self._binding = binding
+        self._closed = False
+
+    @property
+    def reference(self) -> SessionCandidateRefV1:
+        return self._reference
+
+    @property
+    def opaque_binding(self) -> object:
+        if self._closed:
+            raise SessionCandidateStaleError()
+        return self._binding
+
+    async def close(self) -> None:
+        self._closed = True
+
+
+class _CandidateLease:
+    __slots__ = (
+        "_claimed",
+        "_closer",
+        "_owner",
+        "_projection",
+        "_revision",
+        "_snapshot",
+    )
+
+    def __init__(
+        self,
+        projection: SessionIdentityProjectionV1,
+        owner: _DescriptorOwner,
+        *,
+        raw_revision: str,
+        snapshot: bytes,
+    ) -> None:
+        self._projection = projection
+        self._owner = owner
+        self._revision = raw_revision
+        self._claimed = False
+        self._snapshot = snapshot
+        self._closer = RetryableCloser.bind(owner)
+
+    @property
+    def projection(self) -> SessionIdentityProjectionV1:
+        return self._projection
+
+    async def verify_current(self) -> None:
+        try:
+            current = _status_fingerprint(os.fstat(self._owner.descriptor))
+        except (OSError, AppHostError):
+            raise SessionCandidateStaleError() from None
+        if current != self._revision:
+            raise SessionCandidateStaleError()
+
+    async def claim(self) -> ClaimedSessionCandidateV1:
+        if self._claimed:
+            raise SessionCandidateStaleError()
+        await self.verify_current()
+        self._claimed = True
+        return _ClaimedCandidate(
+            self._projection.reference,
+            _PinnedSessionContent(
+                self._snapshot,
+                conversation_id=_conversation_id(self._snapshot),
+                source_id=self._projection.reference.source_id,
+            ),
+        )
+
+    async def close(self) -> None:
+        if not await self._closer.settle():
+            raise CleanupIncompleteError() from None
+
+
+class _CanonicalOwner:
+    __slots__ = ("create", "find", "list", "open")
+
+    def __init__(self, value: object) -> None:
+        try:
+            self.list = bind_native_async(value, "list_identities")
+            self.open = bind_native_async(value, "open_candidate")
+            self.find = bind_native_async(value, "find_created_candidate")
+            self.create = bind_native_async(value, "create_candidate")
+        except BaseException:
+            raise TypeError("canonical owner has invalid async ports") from None
+
+
+class _DeferredCanonicalOwner:
+    """Adopt a raw return before inspecting any of its descriptors."""
+
+    __slots__ = ("_callback", "_value")
+
+    def __init__(self, value: object) -> None:
+        self._value: object | None = value
+        self._callback: object | None = None
+
+    def bind_close(self) -> None:
+        if self._callback is None:
+            value = self._value
+            if value is None:
+                return
+            self._callback = bind_native_async(value, "close")
+
+    async def close(self) -> None:
+        self.bind_close()
+        callback = self._callback
+        if callback is None:
+            return
+        await callback()  # type: ignore[operator]
+        self._callback = None
+        self._value = None
+
+
+class _AdapterCleanupRegistry:
+    """Retain canonical returns which the adapter could not safely publish."""
+
+    __slots__ = ("_pending",)
+
+    def __init__(self) -> None:
+        self._pending: set[CloseGroup] = set()
+
+    def adopt(self, group: CloseGroup) -> None:
+        # No await may separate a raw owner return from this registration.
+        self._pending.add(group)
+
+    def release(self, group: CloseGroup) -> None:
+        self._pending.discard(group)
+
+    @property
+    def has_pending(self) -> bool:
+        return bool(self._pending)
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    async def settle_owned(
+        self,
+        group: CloseGroup,
+        *,
+        primary_category: AppHostFailureCategory,
+    ) -> None:
+        operation = asyncio.create_task(
+            self._settle_once(group, primary_category=primary_category)
+        )
+        try:
+            await asyncio.shield(operation)
+        except asyncio.CancelledError:
+            # The adapter remains the owner until the shielded settlement records
+            # either success or durable cleanup debt.
+            await asyncio.shield(operation)
+            raise
+
+    async def _settle_once(
+        self,
+        group: CloseGroup,
+        *,
+        primary_category: AppHostFailureCategory,
+    ) -> None:
+        if await group.settle():
+            self.release(group)
+            return
+        raise CleanupIncompleteError(
+            primary_category=primary_category,
+            cleanup_debt_count=max(1, group.debt_count),
+        ) from None
+
+    async def settle_all(self) -> None:
+        pending = tuple(self._pending)
+        results = await asyncio.gather(
+            *(group.settle() for group in pending),
+            return_exceptions=True,
+        )
+        complete = tuple(
+            group
+            for group, result in zip(pending, results, strict=True)
+            if result is True
+        )
+        for group in complete:
+            self.release(group)
+        debts = tuple(
+            group.debt_count
+            for group, result in zip(pending, results, strict=True)
+            if result is not True
+        )
+        if debts:
+            raise CleanupIncompleteError(
+                cleanup_debt_count=max(1, sum(debts))
+            ) from None
+
+
+class HarnessAppHostSessionAdapterV1:
+    """AppHost-owned optional projection of an existing Harness owner.
+
+    The adapter never derives a root from a scope, scans a directory, creates an
+    index, or turns an opaque candidate token into a path. POSIX candidates are
+    pinned by one no-follow descriptor. Windows opening remains fail-closed
+    until a reviewed native retained-handle backend exists.
+    """
+
+    __slots__ = (
+        "_active_operations",
+        "_candidates",
+        "_canonical_active",
+        "_canonical_gate",
+        "_canonical",
+        "_cleanup",
+        "_close_task",
+        "_closed",
+        "_drained",
+        "_lock",
+        "_runtime",
+        "_scope_by_source",
+    )
+
+    def __init__(
+        self,
+        runtime: AgentTranscriptDirectoryRuntime,
+        *,
+        scope_bindings: tuple[HarnessSessionScopeBindingV1, ...],
+        canonical_owner: object | None = None,
+    ) -> None:
+        if not isinstance(runtime, AgentTranscriptDirectoryRuntime):
+            raise TypeError("runtime must be AgentTranscriptDirectoryRuntime")
+        if not isinstance(scope_bindings, tuple) or not scope_bindings:
+            raise TypeError("scope_bindings must be a non-empty tuple")
+        if any(
+            not isinstance(binding, HarnessSessionScopeBindingV1)
+            for binding in scope_bindings
+        ):
+            raise TypeError("scope_bindings contain an invalid binding")
+        source_ids = tuple(binding.source_id for binding in scope_bindings)
+        if len(source_ids) != len(set(source_ids)):
+            raise ValueError("each Harness Session source may be bound once")
+        scopes = tuple(binding.scope for binding in scope_bindings)
+        if len(scopes) != len(set(scopes)):
+            raise ValueError("each AppHost Session scope may be bound once")
+        admitted_source_ids = {
+            runtime.authority_session_source.source_id,
+            *(source.source_id for source in runtime.discovery_session_sources),
+        }
+        if not set(source_ids) <= admitted_source_ids:
+            raise ValueError("scope binding source is not owned by this runtime")
+        self._runtime = runtime
+        self._scope_by_source = {
+            binding.source_id: binding.scope for binding in scope_bindings
+        }
+        self._canonical = (
+            None if canonical_owner is None else _CanonicalOwner(canonical_owner)
+        )
+        self._candidates: OrderedDict[
+            SessionCandidateRefV1, _CandidateRecord
+        ] = OrderedDict()
+        self._cleanup = _AdapterCleanupRegistry()
+        self._lock = asyncio.Lock()
+        self._canonical_gate = asyncio.Lock()
+        self._canonical_active = 0
+        self._closed = False
+        self._active_operations = 0
+        self._drained = asyncio.Event()
+        self._drained.set()
+        self._close_task: asyncio.Task[None] | None = None
+
+    async def settle_pending_cleanup(self) -> None:
+        """Retry unpublished canonical-owner cleanup debt."""
+
+        await self._cleanup.settle_all()
+
+    async def close(self) -> None:
+        """Fence new calls, join in-flight calls, and settle retained debt."""
+
+        async with self._lock:
+            self._closed = True
+            if self._close_task is None or self._close_task.done():
+                self._close_task = asyncio.create_task(self._close_once())
+                self._close_task.add_done_callback(_observe_background_result)
+            operation = self._close_task
+        await asyncio.shield(operation)
+
+    async def _close_once(self) -> None:
+        await self._drained.wait()
+        await self._cleanup.settle_all()
+
+    async def _begin_operation(self) -> None:
+        async with self._lock:
+            if self._closed:
+                raise GenerationRetiredError()
+            if self._active_operations == 0:
+                self._drained.clear()
+            self._active_operations += 1
+
+    def _finish_operation_now(self) -> None:
+        self._active_operations -= 1
+        if self._active_operations == 0:
+            self._drained.set()
+
+    async def _begin_canonical_provider_call(self) -> None:
+        # External cleanup callbacks run outside adapter locks. The short gate
+        # only closes the post-drain check/reservation race between starters.
+        while True:
+            await self._cleanup.settle_all()
+            async with self._canonical_gate:
+                if self._cleanup.has_pending:
+                    continue
+                async with self._lock:
+                    if self._closed:
+                        raise GenerationRetiredError()
+                    if (
+                        self._canonical_active
+                        >= HARNESS_SESSION_MAX_ACTIVE_CANONICAL_OPS_V1
+                    ):
+                        raise AppHostError(AppHostFailureCategory.RUNTIME_UNAVAILABLE)
+                    self._canonical_active += 1
+                    return
+
+    def _finish_canonical_provider_call_now(self) -> None:
+        self._canonical_active -= 1
+
+    async def list_identities(
+        self,
+        scopes: tuple[SessionDiscoveryScope, ...],
+        *,
+        limit: int,
+    ) -> tuple[SessionIdentityProjectionV1, ...]:
+        await self._begin_operation()
+        try:
+            return await self._list_identities(scopes, limit=limit)
+        finally:
+            self._finish_operation_now()
+
+    async def _list_identities(
+        self,
+        scopes: tuple[SessionDiscoveryScope, ...],
+        *,
+        limit: int,
+    ) -> tuple[SessionIdentityProjectionV1, ...]:
+        _validate_list_request(scopes, limit)
+        requested = set(scopes)
+        projected: list[SessionIdentityProjectionV1] = []
+        if self._canonical is not None:
+            await self._begin_canonical_provider_call()
+            try:
+                raw = await _call_optional(
+                    self._canonical.list, scopes, limit=limit
+                )
+            finally:
+                self._finish_canonical_provider_call_now()
+            if not isinstance(raw, tuple) or len(raw) > limit:
+                raise SessionCandidateStaleError()
+            if any(
+                type(item) is not SessionIdentityProjectionV1
+                or item.scope not in requested
+                or item.mode is not SessionCandidateMode.CANONICAL
+                or type(item.envelope) is not SessionIdentityEnvelopeV1
+                for item in raw
+            ):
+                raise SessionCandidateStaleError()
+            projected.extend(raw)
+        if len(projected) < limit:
+            try:
+                summaries = self._runtime.list_discovered_session_summaries()
+            except BaseException:
+                raise SessionCandidateStaleError() from None
+            for summary in summaries:
+                discovery = summary.discovery
+                if discovery is None:
+                    continue
+                scope = self._scope_by_source.get(discovery.locator.source_id)
+                if scope not in requested:
+                    continue
+                if discovery.conflicts or discovery.health == "conflict":
+                    raise SessionAmbiguousError()
+                record = _project_legacy(discovery.locator, scope)
+                self._remember(record)
+                projected.append(record.projection)
+                if len(projected) == limit:
+                    break
+        references = tuple(item.reference for item in projected)
+        if len(references) != len(set(references)):
+            raise SessionAmbiguousError()
+        return tuple(projected)
+
+    async def open_candidate(
+        self, reference: SessionCandidateRefV1
+    ) -> SessionCandidateLeaseV1:
+        await self._begin_operation()
+        try:
+            return await self._open_candidate(reference)
+        finally:
+            self._finish_operation_now()
+
+    async def _open_candidate(
+        self, reference: SessionCandidateRefV1
+    ) -> SessionCandidateLeaseV1:
+        if not isinstance(reference, SessionCandidateRefV1):
+            raise TypeError("reference must be SessionCandidateRefV1")
+        record = self._candidates.get(reference)
+        if record is None:
+            if self._canonical is None:
+                raise SessionCandidateStaleError()
+            await self._begin_canonical_provider_call()
+            try:
+                return await _validate_canonical_candidate(
+                    await _call_optional(self._canonical.open, reference),
+                    cleanup=self._cleanup,
+                    expected_reference=reference,
+                )
+            finally:
+                self._finish_canonical_provider_call_now()
+        return _open_pinned(record)
+
+    async def find_created_candidate(
+        self, request: SessionCreateRequestV1
+    ) -> SessionCandidateLeaseV1 | None:
+        await self._begin_operation()
+        try:
+            return await self._find_created_candidate(request)
+        finally:
+            self._finish_operation_now()
+
+    async def _find_created_candidate(
+        self, request: SessionCreateRequestV1
+    ) -> SessionCandidateLeaseV1 | None:
+        if self._canonical is None:
+            return None
+        await self._begin_canonical_provider_call()
+        try:
+            raw = await _call_optional(self._canonical.find, request)
+            return (
+                None
+                if raw is None
+                else await _validate_canonical_candidate(
+                    raw,
+                    cleanup=self._cleanup,
+                    expected_product_id=request.product_id,
+                )
+            )
+        finally:
+            self._finish_canonical_provider_call_now()
+
+    async def create_candidate(
+        self, intent: SessionCreateIntentV1
+    ) -> SessionCandidateLeaseV1:
+        await self._begin_operation()
+        try:
+            return await self._create_candidate(intent)
+        finally:
+            self._finish_operation_now()
+
+    async def _create_candidate(
+        self, intent: SessionCreateIntentV1
+    ) -> SessionCandidateLeaseV1:
+        if self._canonical is None:
+            raise AppHostError(AppHostFailureCategory.RUNTIME_UNAVAILABLE)
+        await self._begin_canonical_provider_call()
+        try:
+            return await _validate_canonical_candidate(
+                await _call_optional(self._canonical.create, intent),
+                cleanup=self._cleanup,
+                expected_product_id=intent.request.product_id,
+                expected_compatibility_id=intent.product_compatibility_id,
+            )
+        finally:
+            self._finish_canonical_provider_call_now()
+
+    def _remember(self, record: _CandidateRecord) -> None:
+        self._candidates[record.projection.reference] = record
+        self._candidates.move_to_end(record.projection.reference)
+        while len(self._candidates) > _MAX_CANDIDATE_CACHE:
+            self._candidates.popitem(last=False)
+
+
+async def _validate_canonical_candidate(
+    value: object,
+    *,
+    cleanup: _AdapterCleanupRegistry,
+    expected_reference: SessionCandidateRefV1 | None = None,
+    expected_product_id: str | None = None,
+    expected_compatibility_id: str | None = None,
+) -> SessionCandidateLeaseV1:
+    owner = _DeferredCanonicalOwner(value)
+    group = CloseGroup((RetryableCloser.bind(owner),))
+    cleanup.adopt(group)
+    try:
+        owner.bind_close()
+        projected = read_static_property(value, "projection")
+        if (
+            type(projected) is not SessionIdentityProjectionV1
+            or projected.mode is not SessionCandidateMode.CANONICAL
+            or type(projected.envelope) is not SessionIdentityEnvelopeV1
+            or (
+                expected_reference is not None
+                and projected.reference != expected_reference
+            )
+            or (
+                expected_product_id is not None
+                and projected.envelope.product_id != expected_product_id
+            )
+            or (
+                expected_compatibility_id is not None
+                and projected.envelope.product_compatibility_id
+                != expected_compatibility_id
+            )
+        ):
+            raise TypeError
+        for name in ("verify_current", "claim"):
+            bind_native_async(value, name)
+    except asyncio.CancelledError:
+        await cleanup.settle_owned(
+            group,
+            primary_category=AppHostFailureCategory.SESSION_CANDIDATE_STALE,
+        )
+        raise
+    except BaseException:
+        await cleanup.settle_owned(
+            group,
+            primary_category=AppHostFailureCategory.SESSION_CANDIDATE_STALE,
+        )
+        raise SessionCandidateStaleError() from None
+    cleanup.release(group)
+    return value  # type: ignore[return-value]
+
+
+def _observe_background_result(task: asyncio.Task[None]) -> None:
+    if not task.cancelled():
+        task.exception()
+
+
+async def _call_optional(callback: object, *args: object, **kwargs: object) -> object:
+    try:
+        return await callback(*args, **kwargs)  # type: ignore[operator]
+    except asyncio.CancelledError:
+        raise
+    except AppHostError as error:
+        raise redacted_apphost_error(error.category) from None
+    except BaseException:
+        raise redacted_apphost_error(
+            AppHostFailureCategory.SESSION_CANDIDATE_STALE
+        ) from None
+
+
+def _validate_list_request(
+    scopes: tuple[SessionDiscoveryScope, ...], limit: int
+) -> None:
+    if (
+        not isinstance(scopes, tuple)
+        or not scopes
+        or any(not isinstance(scope, SessionDiscoveryScope) for scope in scopes)
+        or len(scopes) != len(set(scopes))
+    ):
+        raise TypeError("scopes must be a unique non-empty scope tuple")
+    if type(limit) is not int or not 1 <= limit <= 256:
+        raise ValueError("limit must be between 1 and 256")
+
+
+def _project_legacy(
+    locator: SessionLocator,
+    scope: SessionDiscoveryScope,
+) -> _CandidateRecord:
+    digest = hashlib.sha256(
+        (
+            f"{locator.source_id}\0{locator.conversation_id}\0"
+            f"{locator.session_file.as_posix()}"
+        ).encode("utf-8")
+    ).hexdigest()
+    revision = hashlib.sha256(locator.revision.encode("utf-8")).hexdigest()
+    reference = SessionCandidateRefV1(locator.source_id, digest, revision)
+    return _CandidateRecord(
+        projection=SessionIdentityProjectionV1(
+            reference,
+            scope,
+            SessionCandidateMode.MIGRATION_REQUIRED,
+            None,
+        ),
+        locator=locator,
+        raw_revision=locator.revision,
+    )
+
+
+def _open_pinned(record: _CandidateRecord) -> _CandidateLease:
+    if not _native_descriptor_supported():
+        raise SessionCandidateStaleError()
+    descriptor = -1
+    parent = -1
+    try:
+        parent_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+        parent = os.open(record.locator.session_file.parent, parent_flags)
+        file_flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+        descriptor = os.open(
+            record.locator.session_file.name,
+            file_flags,
+            dir_fd=parent,
+        )
+        before = os.fstat(descriptor)
+        descriptor_revision = _status_fingerprint(before)
+        path_revision = session_file_authority_fingerprint(
+            record.locator.session_file
+        )
+        if descriptor_revision != record.raw_revision or path_revision != (
+            record.raw_revision
+        ):
+            raise SessionCandidateStaleError()
+        snapshot = _read_sealed_snapshot(descriptor, before)
+        if _conversation_id(snapshot) != record.locator.conversation_id:
+            raise SessionCandidateStaleError()
+    except AppHostError:
+        if descriptor >= 0:
+            os.close(descriptor)
+        raise
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        raise SessionCandidateStaleError() from None
+    finally:
+        if parent >= 0:
+            os.close(parent)
+    return _CandidateLease(
+        record.projection,
+        _DescriptorOwner(descriptor),
+        raw_revision=descriptor_revision,
+        snapshot=snapshot,
+    )
+
+
+def _native_descriptor_supported() -> bool:
+    return (
+        os.name == "posix"
+        and all(hasattr(os, name) for name in ("O_DIRECTORY", "O_CLOEXEC", "O_NOFOLLOW"))
+        and hasattr(os, "pread")
+    )
+
+
+def _conversation_id(content: bytes) -> str:
+    prefix = content[:_MAX_HEADER_BYTES]
+    line = next((item for item in prefix.splitlines() if item.strip()), b"")
+    if not line:
+        raise SessionCandidateStaleError()
+    try:
+        value = json.loads(
+            line.decode(DEFAULT_JSONL_FORMAT.encoding),
+            parse_constant=_reject_json_constant,
+        )
+        if not isinstance(value, dict):
+            raise TypeError
+        return _HEADER_CODEC.decode_header(value).conversation_id
+    except BaseException:
+        raise SessionCandidateStaleError() from None
+
+
+def _read_sealed_snapshot(descriptor: int, before: os.stat_result) -> bytes:
+    if before.st_size > HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1:
+        raise SessionCandidateStaleError()
+    chunks: list[bytes] = []
+    offset = 0
+    while True:
+        remaining = HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1 - offset
+        request_size = min(_SNAPSHOT_CHUNK_BYTES, remaining + 1)
+        chunk = os.pread(descriptor, request_size, offset)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        offset += len(chunk)
+        if offset > HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1:
+            raise SessionCandidateStaleError()
+    after = os.fstat(descriptor)
+    if (
+        _status_fingerprint(before) != _status_fingerprint(after)
+        or offset != after.st_size
+    ):
+        raise SessionCandidateStaleError()
+    return b"".join(chunks)
+
+
+def _reject_json_constant(_value: str) -> object:
+    raise ValueError
+
+
+def _status_fingerprint(status: os.stat_result) -> str:
+    if not stat.S_ISREG(status.st_mode):
+        raise SessionCandidateStaleError()
+    return (
+        f"stat-v1:{status.st_dev}:{status.st_ino}:{status.st_size}:"
+        f"{status.st_mtime_ns}:{status.st_ctime_ns}"
+    )
+
+
+__all__ = [
+    "HARNESS_SESSION_MAX_ACTIVE_CANONICAL_OPS_V1",
+    "HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1",
+    "HarnessAppHostSessionAdapterV1",
+    "HarnessSessionScopeBindingV1",
+]

--- a/src/loushang/apphost/router.py
+++ b/src/loushang/apphost/router.py
@@ -1,0 +1,626 @@
+"""Explicit, non-executing Product candidate router for AppHost A0.2."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from ._ownership import (
+    AcquisitionStack,
+    CloseGroup,
+    RetryableCloser,
+    bind_native_async,
+    read_static_property,
+)
+from .catalog import AppHostCatalogV1, _ProductCatalogLease
+from .contracts import (
+    PreparedProductRouteV1,
+    ProductDescriptorV1,
+    SessionBindingKeyV1,
+    SessionCandidateMode,
+    SessionCandidateRefV1,
+    SessionCreateIntentV1,
+    SessionCreateRequestV1,
+    SessionDiscoveryScope,
+    SessionIdentityEnvelopeV1,
+    SessionIdentityProjectionV1,
+)
+from .errors import (
+    AppHostError,
+    AppHostFailureCategory,
+    CleanupIncompleteError,
+    GenerationRetiredError,
+    ProductIdentityRequiredError,
+    ProductIncompatibleError,
+    SessionCandidateStaleError,
+    redacted_apphost_error,
+)
+
+AsyncCall = Callable[..., Awaitable[Any]]
+
+
+class _SessionPort:
+    __slots__ = ("create", "find", "list", "open")
+
+    def __init__(self, value: object) -> None:
+        try:
+            self.list = bind_native_async(value, "list_identities")
+            self.open = bind_native_async(value, "open_candidate")
+            self.find = bind_native_async(value, "find_created_candidate")
+            self.create = bind_native_async(value, "create_candidate")
+        except BaseException:
+            raise TypeError("sessions must expose native async static ports") from None
+
+
+class _BoundCandidate:
+    __slots__ = ("claim", "closer", "projection", "raw", "verify")
+
+    def __init__(self, raw: object) -> None:
+        self.raw = raw
+        try:
+            projection = read_static_property(raw, "projection")
+            if type(projection) is not SessionIdentityProjectionV1:
+                raise TypeError
+            self.projection = projection
+            self.verify = bind_native_async(raw, "verify_current")
+            self.claim = bind_native_async(raw, "claim")
+            self.closer = RetryableCloser.bind(raw)
+        except BaseException:
+            raise SessionCandidateStaleError() from None
+
+
+class _BoundClaimed:
+    __slots__ = ("closer", "opaque_binding", "raw", "reference")
+
+    def __init__(self, raw: object) -> None:
+        self.raw = raw
+        try:
+            reference = read_static_property(raw, "reference")
+            if type(reference) is not SessionCandidateRefV1:
+                raise TypeError
+            self.reference = reference
+            self.opaque_binding = read_static_property(raw, "opaque_binding")
+            self.closer = RetryableCloser.bind(raw)
+        except BaseException:
+            raise SessionCandidateStaleError() from None
+
+
+class _BoundOpened:
+    __slots__ = ("binding_key", "closer", "raw")
+
+    def __init__(self, raw: object) -> None:
+        self.raw = raw
+        try:
+            binding_key = read_static_property(raw, "binding_key")
+            if type(binding_key) is not SessionBindingKeyV1:
+                raise TypeError
+            # Validate but do not expose the opaque Product capability.
+            read_static_property(raw, "opaque_binding")
+            self.binding_key = binding_key
+            self.closer = RetryableCloser.bind(raw)
+        except BaseException:
+            raise SessionCandidateStaleError() from None
+
+
+class _ClaimedSnapshot:
+    """Immutable borrow view supplied to an admitted Product callback."""
+
+    __slots__ = ("_opaque_binding", "_reference")
+
+    def __init__(self, value: _BoundClaimed) -> None:
+        self._reference = value.reference
+        self._opaque_binding = value.opaque_binding
+
+    @property
+    def reference(self) -> SessionCandidateRefV1:
+        return self._reference
+
+    @property
+    def opaque_binding(self) -> object:
+        return self._opaque_binding
+
+    async def close(self) -> None:
+        # Borrowers cannot settle the owner's handle.
+        raise CleanupIncompleteError()
+
+
+class _PreparedProductRoute:
+    """Private retained preparation with identity facts and close only."""
+
+    __slots__ = ("_binding_key", "_descriptor", "_generation_id", "_group")
+
+    def __init__(
+        self,
+        *,
+        group: CloseGroup,
+        descriptor: ProductDescriptorV1,
+        generation_id: str,
+        binding_key: SessionBindingKeyV1,
+    ) -> None:
+        self._group = group
+        self._descriptor = descriptor
+        self._generation_id = generation_id
+        self._binding_key = binding_key
+
+    @property
+    def descriptor(self) -> ProductDescriptorV1:
+        return self._descriptor
+
+    @property
+    def generation_id(self) -> str:
+        return self._generation_id
+
+    @property
+    def binding_key(self) -> SessionBindingKeyV1:
+        return self._binding_key
+
+    async def close(self) -> None:
+        if not await self._group.settle():
+            raise CleanupIncompleteError() from None
+
+
+class _CleanupRegistry:
+    """Router-owned retry registry for unpublished cleanup debt."""
+
+    __slots__ = ("_lock", "_pending")
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._pending: set[CloseGroup] = set()
+
+    async def settle_owned(
+        self,
+        group: CloseGroup,
+        *,
+        primary: BaseException | None = None,
+    ) -> None:
+        operation = asyncio.create_task(self._settle_once(group, primary=primary))
+        try:
+            await asyncio.shield(operation)
+        except asyncio.CancelledError:
+            await asyncio.shield(operation)
+            raise
+
+    async def _settle_once(
+        self,
+        group: CloseGroup,
+        *,
+        primary: BaseException | None,
+    ) -> None:
+        async with self._lock:
+            self._pending.add(group)
+        complete = await group.settle()
+        if complete:
+            async with self._lock:
+                self._pending.discard(group)
+            return
+        raise CleanupIncompleteError(
+            primary_category=_primary_category(primary),
+            cleanup_debt_count=max(1, group.debt_count),
+        ) from None
+
+    async def settle_all(self) -> None:
+        async with self._lock:
+            pending = tuple(self._pending)
+        results = await asyncio.gather(
+            *(group.settle() for group in pending),
+            return_exceptions=True,
+        )
+        complete = tuple(
+            group
+            for group, result in zip(pending, results, strict=True)
+            if result is True
+        )
+        if complete:
+            async with self._lock:
+                self._pending.difference_update(complete)
+        debts = tuple(
+            group.debt_count
+            for group, result in zip(pending, results, strict=True)
+            if result is not True
+        )
+        if debts:
+            raise CleanupIncompleteError(
+                cleanup_debt_count=max(1, sum(debts))
+            ) from None
+
+
+class AppHostRouterV1:
+    """Route explicit Session candidates without Product runtime effects."""
+
+    __slots__ = (
+        "_active_operations",
+        "_catalog",
+        "_cleanup",
+        "_closed",
+        "_drained",
+        "_lock",
+        "_sessions",
+    )
+
+    def __init__(self, catalog: AppHostCatalogV1, sessions: object) -> None:
+        if not isinstance(catalog, AppHostCatalogV1):
+            raise TypeError("catalog must be AppHostCatalogV1")
+        self._catalog = catalog
+        self._sessions = _SessionPort(sessions)
+        self._cleanup = _CleanupRegistry()
+        self._lock = asyncio.Lock()
+        self._closed = False
+        self._active_operations = 0
+        self._drained = asyncio.Event()
+        self._drained.set()
+
+    async def settle_pending_cleanup(self) -> None:
+        """Retry all unpublished cleanup debt without exposing its owners."""
+
+        await self._cleanup.settle_all()
+
+    async def close(self) -> None:
+        """Fence new routing, join in-flight work, and settle pending cleanup."""
+
+        operation = asyncio.create_task(self._close_once())
+        operation.add_done_callback(_observe_background_result)
+        await asyncio.shield(operation)
+
+    async def _close_once(self) -> None:
+        async with self._lock:
+            self._closed = True
+        await self._drained.wait()
+        await self._cleanup.settle_all()
+
+    async def _begin_operation(self) -> None:
+        async with self._lock:
+            if self._closed:
+                raise GenerationRetiredError()
+            if self._active_operations == 0:
+                self._drained.clear()
+            self._active_operations += 1
+
+    def _finish_operation_now(self) -> None:
+        self._active_operations -= 1
+        if self._active_operations == 0:
+            self._drained.set()
+
+    async def list_identities(
+        self,
+        scopes: tuple[SessionDiscoveryScope, ...],
+        *,
+        limit: int,
+    ) -> tuple[SessionIdentityProjectionV1, ...]:
+        await self._begin_operation()
+        try:
+            return await self._list_identities(scopes, limit=limit)
+        finally:
+            self._finish_operation_now()
+
+    async def _list_identities(
+        self,
+        scopes: tuple[SessionDiscoveryScope, ...],
+        *,
+        limit: int,
+    ) -> tuple[SessionIdentityProjectionV1, ...]:
+        _validate_list_request(scopes, limit)
+        result = await _call_session(
+            self._sessions.list,
+            AppHostFailureCategory.SESSION_CANDIDATE_STALE,
+            scopes,
+            limit=limit,
+        )
+        if (
+            not isinstance(result, tuple)
+            or len(result) > limit
+            or any(type(item) is not SessionIdentityProjectionV1 for item in result)
+        ):
+            raise SessionCandidateStaleError()
+        return result
+
+    async def prepare_resume(
+        self,
+        *,
+        product_id: str,
+        reference: SessionCandidateRefV1,
+    ) -> PreparedProductRouteV1:
+        await self._begin_operation()
+        try:
+            return await self._prepare_resume(
+                product_id=product_id,
+                reference=reference,
+            )
+        finally:
+            self._finish_operation_now()
+
+    async def _prepare_resume(
+        self,
+        *,
+        product_id: str,
+        reference: SessionCandidateRefV1,
+    ) -> PreparedProductRouteV1:
+        _require_product_id(product_id)
+        stack = AcquisitionStack()
+        try:
+            admission = await self._catalog._acquire_product(product_id)
+            stack.push_closer(admission.closer)
+            candidate = await _open_candidate(
+                self._sessions, reference, self._cleanup
+            )
+            stack.push_closer(candidate.closer)
+            return await _prepare(
+                admission,
+                candidate,
+                product_id,
+                stack,
+                self._cleanup,
+            )
+        except BaseException as error:
+            await self._cleanup.settle_owned(
+                stack.transfer(), primary=error
+            )
+            raise
+
+    async def prepare_create(
+        self,
+        request: SessionCreateRequestV1,
+    ) -> PreparedProductRouteV1:
+        await self._begin_operation()
+        try:
+            return await self._prepare_create(request)
+        finally:
+            self._finish_operation_now()
+
+    async def _prepare_create(
+        self,
+        request: SessionCreateRequestV1,
+    ) -> PreparedProductRouteV1:
+        if not isinstance(request, SessionCreateRequestV1):
+            raise TypeError("request must be SessionCreateRequestV1")
+        _require_product_id(request.product_id)
+
+        # Lookup and fully release the recovery lease before current admission.
+        found = await _call_session(
+            self._sessions.find,
+            AppHostFailureCategory.SESSION_CANDIDATE_STALE,
+            request,
+        )
+        recovered_reference: SessionCandidateRefV1 | None = None
+        if found is not None:
+            lookup = await _bind_candidate_or_settle(found, self._cleanup)
+            recovered_reference = lookup.projection.reference
+            await self._cleanup.settle_owned(
+                CloseGroup((lookup.closer,))
+            )
+
+        stack = AcquisitionStack()
+        try:
+            admission = await self._catalog._acquire_product(request.product_id)
+            stack.push_closer(admission.closer)
+            if recovered_reference is None:
+                intent = SessionCreateIntentV1(
+                    request=request,
+                    product_compatibility_id=admission.descriptor.compatibility_id,
+                )
+                raw = await _call_session(
+                    self._sessions.create,
+                    AppHostFailureCategory.SESSION_CANDIDATE_STALE,
+                    intent,
+                )
+                candidate = await _bind_candidate_or_settle(raw, self._cleanup)
+            else:
+                candidate = await _open_candidate(
+                    self._sessions,
+                    recovered_reference,
+                    self._cleanup,
+                )
+            stack.push_closer(candidate.closer)
+            return await _prepare(
+                admission,
+                candidate,
+                request.product_id,
+                stack,
+                self._cleanup,
+            )
+        except BaseException as error:
+            await self._cleanup.settle_owned(
+                stack.transfer(), primary=error
+            )
+            raise
+
+    async def import_candidate(
+        self,
+        *,
+        product_id: str,
+        reference: SessionCandidateRefV1,
+    ) -> SessionCandidateRefV1:
+        await self._begin_operation()
+        try:
+            return await self._import_candidate(
+                product_id=product_id,
+                reference=reference,
+            )
+        finally:
+            self._finish_operation_now()
+
+    async def _import_candidate(
+        self,
+        *,
+        product_id: str,
+        reference: SessionCandidateRefV1,
+    ) -> SessionCandidateRefV1:
+        _require_product_id(product_id)
+        stack = AcquisitionStack()
+        try:
+            admission = await self._catalog._acquire_product(product_id)
+            stack.push_closer(admission.closer)
+            candidate = await _open_candidate(
+                self._sessions, reference, self._cleanup
+            )
+            stack.push_closer(candidate.closer)
+            if candidate.projection.mode is not SessionCandidateMode.MIGRATION_REQUIRED:
+                raise ProductIncompatibleError()
+            await _call_candidate(candidate.verify)
+            claimed = await _claim(candidate, self._cleanup)
+            stack.push_closer(claimed.closer)
+            imported = await admission.import_legacy(_ClaimedSnapshot(claimed))
+            if type(imported) is not SessionCandidateRefV1:
+                raise SessionCandidateStaleError()
+        except BaseException as error:
+            await self._cleanup.settle_owned(
+                stack.transfer(), primary=error
+            )
+            raise
+        else:
+            await self._cleanup.settle_owned(stack.transfer())
+            return imported
+
+
+async def _prepare(
+    admission: _ProductCatalogLease,
+    candidate: _BoundCandidate,
+    product_id: str,
+    stack: AcquisitionStack,
+    cleanup: _CleanupRegistry,
+) -> PreparedProductRouteV1:
+    envelope = _canonical_envelope(candidate)
+    if envelope.product_id != product_id:
+        raise ProductIncompatibleError()
+    if admission.descriptor.compatibility_id != envelope.product_compatibility_id:
+        raise ProductIncompatibleError()
+    await _call_candidate(candidate.verify)
+    claimed = await _claim(candidate, cleanup)
+    stack.push_closer(claimed.closer)
+    raw_opened = await admission.validate(_ClaimedSnapshot(claimed), envelope)
+    opened = await _bind_opened_or_settle(raw_opened, cleanup)
+    stack.push_closer(opened.closer)
+    expected = SessionBindingKeyV1(
+        product_id=envelope.product_id,
+        continuity_id=envelope.continuity_id,
+        session_id=envelope.session_id,
+    )
+    if opened.binding_key != expected:
+        raise ProductIncompatibleError()
+    return _PreparedProductRoute(
+        group=stack.transfer(),
+        descriptor=admission.descriptor,
+        generation_id=admission.generation_id,
+        binding_key=expected,
+    )
+
+
+def _canonical_envelope(candidate: _BoundCandidate) -> SessionIdentityEnvelopeV1:
+    projection = candidate.projection
+    if (
+        projection.mode is not SessionCandidateMode.CANONICAL
+        or type(projection.envelope) is not SessionIdentityEnvelopeV1
+    ):
+        raise ProductIncompatibleError()
+    return projection.envelope
+
+
+async def _open_candidate(
+    sessions: _SessionPort,
+    reference: SessionCandidateRefV1,
+    cleanup: _CleanupRegistry,
+) -> _BoundCandidate:
+    raw = await _call_session(
+        sessions.open,
+        AppHostFailureCategory.SESSION_CANDIDATE_STALE,
+        reference,
+    )
+    return await _bind_candidate_or_settle(raw, cleanup)
+
+
+async def _bind_candidate_or_settle(
+    raw: object, cleanup: _CleanupRegistry
+) -> _BoundCandidate:
+    try:
+        return _BoundCandidate(raw)
+    except AppHostError:
+        await _settle_rejected(raw, cleanup)
+        raise
+
+
+async def _claim(
+    candidate: _BoundCandidate, cleanup: _CleanupRegistry
+) -> _BoundClaimed:
+    raw = await _call_candidate(candidate.claim)
+    try:
+        return _BoundClaimed(raw)
+    except AppHostError:
+        await _settle_rejected(raw, cleanup)
+        raise
+
+
+async def _bind_opened_or_settle(
+    raw: object, cleanup: _CleanupRegistry
+) -> _BoundOpened:
+    try:
+        return _BoundOpened(raw)
+    except AppHostError:
+        await _settle_rejected(raw, cleanup)
+        raise
+
+
+async def _settle_rejected(raw: object, cleanup: _CleanupRegistry) -> None:
+    try:
+        closer = RetryableCloser.bind(raw)
+    except BaseException:
+        raise CleanupIncompleteError() from None
+    await cleanup.settle_owned(
+        CloseGroup((closer,)), primary=SessionCandidateStaleError()
+    )
+
+
+async def _call_session(
+    callback: AsyncCall,
+    category: AppHostFailureCategory,
+    *args: object,
+    **kwargs: object,
+) -> Any:
+    try:
+        return await callback(*args, **kwargs)
+    except asyncio.CancelledError:
+        raise
+    except AppHostError as error:
+        raise redacted_apphost_error(error.category) from None
+    except BaseException:
+        raise redacted_apphost_error(category) from None
+
+
+async def _call_candidate(callback: AsyncCall) -> Any:
+    return await _call_session(
+        callback,
+        AppHostFailureCategory.SESSION_CANDIDATE_STALE,
+    )
+
+
+def _primary_category(error: BaseException | None) -> AppHostFailureCategory | None:
+    if isinstance(error, CleanupIncompleteError) and error.primary_category is not None:
+        return error.primary_category
+    return error.category if isinstance(error, AppHostError) else None
+
+
+def _observe_background_result(task: asyncio.Task[None]) -> None:
+    if not task.cancelled():
+        task.exception()
+
+
+def _require_product_id(product_id: str) -> None:
+    if not isinstance(product_id, str) or not product_id:
+        raise ProductIdentityRequiredError()
+
+
+def _validate_list_request(
+    scopes: tuple[SessionDiscoveryScope, ...], limit: int
+) -> None:
+    if (
+        not isinstance(scopes, tuple)
+        or not scopes
+        or any(type(scope) is not SessionDiscoveryScope for scope in scopes)
+        or len(scopes) != len(set(scopes))
+    ):
+        raise TypeError("scopes must be a unique non-empty scope tuple")
+    if type(limit) is not int or not 1 <= limit <= 256:
+        raise ValueError("limit must be between 1 and 256")
+
+
+__all__ = ["AppHostRouterV1"]

--- a/tests/apphost/test_catalog.py
+++ b/tests/apphost/test_catalog.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from typing import Any
+
+import pytest
+
+from loushang.apphost import (
+    AdmissionIdentityV1,
+    AppHostAdmissionSubjectKind,
+    AppHostCatalogInputV1,
+    AppHostCatalogV1,
+    CleanupIncompleteError,
+    GenerationConflictError,
+    GenerationRetiredError,
+    ProductDescriptorV1,
+    ProductIdentityRequiredError,
+    ProductRegistrationV1,
+    ProductUnavailableError,
+    ProfileDescriptorV1,
+    ProfileRegistrationV1,
+)
+
+
+class _Pin:
+    def __init__(self, identity: AdmissionIdentityV1, events: list[str]) -> None:
+        self._identity = identity
+        self._events = events
+        self.closed = 0
+        self.identity_reads = 0
+
+    @property
+    def identity(self) -> AdmissionIdentityV1:
+        self.identity_reads += 1
+        return self._identity
+
+    async def close(self) -> None:
+        self.closed += 1
+        self._events.append(f"close:{self._identity.subject_id}")
+
+
+class _Source:
+    def __init__(self, identity: AdmissionIdentityV1, events: list[str]) -> None:
+        self.identity = identity
+        self.events = events
+        self.pins: list[_Pin] = []
+        self.entered: asyncio.Event | None = None
+        self.release: asyncio.Event | None = None
+
+    async def acquire_pin(self) -> _Pin:
+        self.events.append(f"acquire:{self.identity.subject_id}")
+        if self.entered is not None:
+            self.entered.set()
+        if self.release is not None:
+            await self.release.wait()
+        pin = _Pin(self.identity, self.events)
+        self.pins.append(pin)
+        return pin
+
+
+class _CancelAfterReturnSource(_Source):
+    async def acquire_pin(self) -> _Pin:
+        pin = await super().acquire_pin()
+        task = asyncio.current_task()
+        assert task is not None
+        asyncio.get_running_loop().call_soon(task.cancel)
+        return pin
+
+
+class _DynamicClosePin(_Pin):
+    def __init__(self, identity: AdmissionIdentityV1, events: list[str]) -> None:
+        super().__init__(identity, events)
+        self.dynamic_reads = 0
+
+    def __getattribute__(self, name: str) -> object:
+        if name == "close":
+            object.__setattr__(
+                self,
+                "dynamic_reads",
+                int(object.__getattribute__(self, "dynamic_reads")) + 1,
+            )
+
+            async def forged_close() -> None:
+                raise AssertionError("dynamic close must not be invoked")
+
+            return forged_close
+        return object.__getattribute__(self, name)
+
+
+class _DynamicCloseSource(_Source):
+    async def acquire_pin(self) -> _DynamicClosePin:
+        pin = _DynamicClosePin(self.identity, self.events)
+        self.pins.append(pin)
+        return pin
+
+
+class _FailingClosePin(_Pin):
+    async def close(self) -> None:
+        self.closed += 1
+        self.events.append(f"close-failed:{self._identity.subject_id}")
+        raise RuntimeError("injected close failure")
+
+
+class _FailingCloseSource(_Source):
+    async def acquire_pin(self) -> _FailingClosePin:
+        pin = _FailingClosePin(self.identity, self.events)
+        self.pins.append(pin)
+        return pin
+
+
+class _FailOnceClosePin(_Pin):
+    async def close(self) -> None:
+        self.closed += 1
+        self._events.append(f"close-attempt:{self._identity.subject_id}")
+        if self.closed == 1:
+            raise RuntimeError("secret /tmp/fail-once")
+
+
+class _FailOnceCloseSource(_Source):
+    async def acquire_pin(self) -> _FailOnceClosePin:
+        pin = _FailOnceClosePin(self.identity, self.events)
+        self.pins.append(pin)
+        return pin
+
+
+class _BlockingClosePin(_Pin):
+    def __init__(self, identity: AdmissionIdentityV1, events: list[str]) -> None:
+        super().__init__(identity, events)
+        self.close_entered = asyncio.Event()
+        self.close_release = asyncio.Event()
+
+    async def close(self) -> None:
+        self.closed += 1
+        self.close_entered.set()
+        await self.close_release.wait()
+        self._events.append(f"close:{self._identity.subject_id}")
+
+
+class _BlockingCloseSource(_Source):
+    async def acquire_pin(self) -> _BlockingClosePin:
+        pin = _BlockingClosePin(self.identity, self.events)
+        self.pins.append(pin)
+        return pin
+
+
+class _Factory:
+    async def create_runtime(self, candidate: object) -> Any:
+        raise AssertionError("A0.2 catalog cannot invoke Product factory")
+
+
+class _Validator:
+    async def open_product_candidate(self, candidate: object, envelope: object) -> Any:
+        raise AssertionError("A0.2 catalog cannot invoke Product validator")
+
+
+class _Importer:
+    async def import_candidate(self, candidate: object) -> Any:
+        raise AssertionError("A0.2 catalog cannot invoke Product importer")
+
+
+class _ProfileFactory:
+    async def bind_profile(self, runtime: object) -> Any:
+        raise AssertionError("A0.2 catalog cannot invoke profile factory")
+
+
+def _identity(
+    generation: str,
+    kind: AppHostAdmissionSubjectKind,
+    subject: str,
+) -> AdmissionIdentityV1:
+    return AdmissionIdentityV1(generation, kind, subject)
+
+
+def _input(
+    generation: str,
+    events: list[str],
+    *,
+    product_ids: tuple[str, ...] = ("coding", "slides"),
+) -> tuple[AppHostCatalogInputV1, dict[str, _Source]]:
+    sources: dict[str, _Source] = {}
+    profile_id = "embedded-tui"
+    profile_identity = _identity(
+        generation, AppHostAdmissionSubjectKind.PROFILE, profile_id
+    )
+    profile_source = _Source(profile_identity, events)
+    sources[profile_id] = profile_source
+    products = []
+    for product_id in product_ids:
+        identity = _identity(
+            generation, AppHostAdmissionSubjectKind.PRODUCT, product_id
+        )
+        source = _Source(identity, events)
+        sources[product_id] = source
+        products.append(
+            ProductRegistrationV1(
+                descriptor=ProductDescriptorV1(
+                    product_id=product_id,
+                    product_version=f"{generation}.0",
+                    compatibility_id=f"{product_id}-session-v1",
+                    supported_profile_ids=(profile_id,),
+                ),
+                factory=_Factory(),
+                candidate_validator=_Validator(),
+                importer=_Importer(),
+                admission_identity=identity,
+                admission_source=source,
+            )
+        )
+    return (
+        AppHostCatalogInputV1(
+            generation_id=generation,
+            products=tuple(products),
+            profiles=(
+                ProfileRegistrationV1(
+                    descriptor=ProfileDescriptorV1(profile_id, "1"),
+                    factory=_ProfileFactory(),
+                    admission_identity=profile_identity,
+                    admission_source=profile_source,
+                ),
+            ),
+        ),
+        sources,
+    )
+
+
+def test_catalog_admits_all_subjects_and_routes_only_explicit_products() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, sources = _input("generation-1", events)
+        catalog = await AppHostCatalogV1.admit(value)
+
+        assert catalog.generation_id == "generation-1"
+        assert not hasattr(catalog, "acquire_product")
+        assert all(source.pins[0].identity_reads == 1 for source in sources.values())
+        with pytest.raises(ProductIdentityRequiredError):
+            await catalog._acquire_product("")
+        with pytest.raises(ProductUnavailableError):
+            await catalog._acquire_product("unknown")
+
+        route = await catalog._acquire_product("slides")
+        assert route.generation_id == "generation-1"
+        assert route.descriptor.product_id == "slides"
+        with pytest.raises(AttributeError):
+            route.descriptor = value.products[0].descriptor  # type: ignore[misc]
+        assert len(sources["slides"].pins) == 2
+        await route.close()
+        await route.close()
+        assert sources["slides"].pins[-1].closed == 1
+        await catalog.close()
+        assert all(source.pins[0].closed == 1 for source in sources.values())
+
+    asyncio.run(exercise())
+
+
+def test_catalog_rejects_mismatched_pin_and_rolls_back_in_reverse_order() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, sources = _input("generation-1", events)
+        sources["slides"].identity = _identity(
+            "generation-2", AppHostAdmissionSubjectKind.PRODUCT, "slides"
+        )
+        with pytest.raises(GenerationConflictError):
+            await AppHostCatalogV1.admit(value)
+
+        assert sources["coding"].pins[0].closed == 1
+        assert sources["slides"].pins[0].closed == 1
+        assert events[-2:] == ["close:embedded-tui", "close:coding"]
+        assert sources["embedded-tui"].pins[0].closed == 1
+
+    asyncio.run(exercise())
+
+
+def test_catalog_cancellation_rolls_back_already_acquired_generation_pins() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, sources = _input("generation-1", events)
+        sources["slides"].entered = asyncio.Event()
+        sources["slides"].release = asyncio.Event()
+        task = asyncio.create_task(AppHostCatalogV1.admit(value))
+        await sources["slides"].entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert sources["coding"].pins[0].closed == 1
+        assert sources["embedded-tui"].pins[0].closed == 1
+
+    asyncio.run(exercise())
+
+
+def test_catalog_cancel_scheduled_after_pin_return_closes_returned_pin() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, sources = _input("generation-1", events)
+        replacement = _CancelAfterReturnSource(sources["coding"].identity, events)
+        value = replace(
+            value,
+            products=(
+                replace(value.products[0], admission_source=replacement),
+                *value.products[1:],
+            ),
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await AppHostCatalogV1.admit(value)
+        assert replacement.pins[0].closed == 1
+        assert sources["slides"].pins[0].closed == 1
+
+    asyncio.run(exercise())
+
+
+def test_catalog_rejects_dynamic_close_without_invoking_dynamic_dispatch() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, sources = _input("generation-1", events)
+        replacement = _DynamicCloseSource(sources["coding"].identity, events)
+        value = replace(
+            value,
+            products=(
+                replace(value.products[0], admission_source=replacement),
+                *value.products[1:],
+            ),
+        )
+        with pytest.raises(GenerationConflictError):
+            await AppHostCatalogV1.admit(value)
+        pin = replacement.pins[0]
+        assert isinstance(pin, _DynamicClosePin)
+        assert pin.dynamic_reads == 0
+        assert pin.closed == 1
+
+    asyncio.run(exercise())
+
+
+def test_catalog_retains_cleanup_failure_and_still_rolls_back_prior_pins() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, sources = _input("generation-1", events)
+        wrong = _identity(
+            "generation-2", AppHostAdmissionSubjectKind.PRODUCT, "slides"
+        )
+        replacement = _FailingCloseSource(wrong, events)
+        value = replace(
+            value,
+            products=(
+                value.products[0],
+                replace(value.products[1], admission_source=replacement),
+            ),
+        )
+        with pytest.raises(CleanupIncompleteError) as error:
+            await AppHostCatalogV1.admit(value)
+        assert error.value.__cause__ is None
+        assert replacement.pins[0].closed == 1
+        assert sources["coding"].pins[0].closed == 1
+
+    asyncio.run(exercise())
+
+
+def test_catalog_replace_is_cas_and_does_not_retarget_existing_route() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        first, first_sources = _input("generation-1", events)
+        second, second_sources = _input("generation-2", events)
+        catalog = await AppHostCatalogV1.admit(first)
+        retained = await catalog._acquire_product("coding")
+
+        await catalog.replace(second, expected_generation_id="generation-1")
+        current = await catalog._acquire_product("coding")
+        assert retained.generation_id == "generation-1"
+        assert retained.descriptor.product_version == "generation-1.0"
+        assert first_sources["coding"].pins[-1].closed == 0
+        assert current.generation_id == "generation-2"
+        assert all(source.pins[0].closed == 1 for source in first_sources.values())
+
+        third, third_sources = _input("generation-3", events)
+        with pytest.raises(GenerationConflictError):
+            await catalog.replace(third, expected_generation_id="generation-1")
+        assert all(source.pins[0].closed == 1 for source in third_sources.values())
+
+        same_id, same_sources = _input("generation-2", events)
+        with pytest.raises(GenerationConflictError):
+            await catalog.replace(same_id, expected_generation_id="generation-2")
+        assert all(source.pins[0].closed == 1 for source in same_sources.values())
+
+        await retained.close()
+        await current.close()
+        await catalog.close()
+        assert all(source.pins[0].closed == 1 for source in second_sources.values())
+
+    asyncio.run(exercise())
+
+
+def test_catalog_retirement_fences_new_routes_but_preserves_returned_pin() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, sources = _input("generation-1", events)
+        catalog = await AppHostCatalogV1.admit(value)
+        retained = await catalog._acquire_product("coding")
+        route_pin = sources["coding"].pins[-1]
+
+        await catalog.close()
+        with pytest.raises(GenerationRetiredError):
+            await catalog._acquire_product("coding")
+        assert route_pin.closed == 0
+        await retained.close()
+        assert route_pin.closed == 1
+
+    asyncio.run(exercise())
+
+
+def test_catalog_external_acquire_does_not_block_an_unrelated_product() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, sources = _input("generation-1", events)
+        catalog = await AppHostCatalogV1.admit(value)
+        sources["coding"].entered = asyncio.Event()
+        sources["coding"].release = asyncio.Event()
+
+        blocked = asyncio.create_task(catalog._acquire_product("coding"))
+        await sources["coding"].entered.wait()
+        independent = await asyncio.wait_for(
+            catalog._acquire_product("slides"), timeout=0.2
+        )
+        await independent.close()
+        sources["coding"].release.set()
+        coding = await blocked
+        await coding.close()
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_catalog_replace_retains_cleanup_debt_and_retries_only_failed_pin() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        first, sources = _input("generation-1", events)
+        failing = _FailOnceCloseSource(sources["coding"].identity, events)
+        first = replace(
+            first,
+            products=(
+                replace(first.products[0], admission_source=failing),
+                *first.products[1:],
+            ),
+        )
+        second, second_sources = _input("generation-2", events)
+        catalog = await AppHostCatalogV1.admit(first)
+
+        with pytest.raises(CleanupIncompleteError) as error:
+            await catalog.replace(second, expected_generation_id="generation-1")
+        assert error.value.__cause__ is None
+        assert catalog.generation_id == "generation-2"
+        assert failing.pins[0].closed == 1
+        assert sources["slides"].pins[0].closed == 1
+        assert sources["embedded-tui"].pins[0].closed == 1
+
+        await catalog.settle_retiring()
+        assert failing.pins[0].closed == 2
+        assert sources["slides"].pins[0].closed == 1
+        assert sources["embedded-tui"].pins[0].closed == 1
+        await catalog.close()
+        assert all(source.pins[0].closed == 1 for source in second_sources.values())
+
+    asyncio.run(exercise())
+
+
+def test_catalog_cancel_after_replace_cas_keeps_retirement_joinable() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        first, sources = _input("generation-1", events)
+        blocking = _BlockingCloseSource(sources["embedded-tui"].identity, events)
+        first = replace(
+            first,
+            profiles=(replace(first.profiles[0], admission_source=blocking),),
+        )
+        second, _ = _input("generation-2", events)
+        catalog = await AppHostCatalogV1.admit(first)
+        pin = blocking.pins[0]
+        assert isinstance(pin, _BlockingClosePin)
+
+        replacement = asyncio.create_task(
+            catalog.replace(second, expected_generation_id="generation-1")
+        )
+        await pin.close_entered.wait()
+        assert catalog.generation_id == "generation-2"
+        replacement.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await replacement
+        pin.close_release.set()
+        await catalog.close()
+        assert pin.closed == 1
+
+    asyncio.run(exercise())
+
+
+def test_catalog_route_close_is_one_shared_retryable_settlement() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, sources = _input("generation-1", events)
+        failing = _FailOnceCloseSource(sources["coding"].identity, events)
+        value = replace(
+            value,
+            products=(
+                replace(value.products[0], admission_source=failing),
+                *value.products[1:],
+            ),
+        )
+        catalog = await AppHostCatalogV1.admit(value)
+        route = await catalog._acquire_product("coding")
+        route_pin = failing.pins[-1]
+        with pytest.raises(CleanupIncompleteError):
+            await asyncio.gather(route.close(), route.close())
+        assert route_pin.closed == 1
+        await route.close()
+        await route.close()
+        assert route_pin.closed == 2
+        # The base generation pin has independent retirement ownership.
+        with pytest.raises(CleanupIncompleteError):
+            await catalog.close()
+        await catalog.close()
+
+    asyncio.run(exercise())

--- a/tests/apphost/test_harness_session_integration.py
+++ b/tests/apphost/test_harness_session_integration.py
@@ -1,0 +1,1020 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+from loushang.ai.types import UserMessage
+from loushang.apphost import (
+    AppHostError,
+    AppHostFailureCategory,
+    CleanupIncompleteError,
+    GenerationRetiredError,
+    SessionCandidateMode,
+    SessionCandidateRefV1,
+    SessionCandidateStaleError,
+    SessionCreateIntentV1,
+    SessionCreateRequestV1,
+    SessionDiscoveryScope,
+    SessionIdentityEnvelopeV1,
+    SessionIdentityProjectionV1,
+)
+from loushang.apphost._ownership import RetryableCloser
+from loushang.apphost.integrations import harness_session as integration
+from loushang.apphost.integrations.harness_session import (
+    HarnessAppHostSessionAdapterV1,
+    HarnessSessionScopeBindingV1,
+)
+from loushang.harness.conversation import ConversationHeader, ConversationRecord
+from loushang.harness.transcript import (
+    AGENT_MESSAGE_KIND,
+    AgentTranscriptDirectoryRuntime,
+    SessionDiscoverySource,
+    write_agent_transcript_export,
+)
+
+
+def _header(conversation_id: str) -> ConversationHeader:
+    return ConversationHeader(
+        conversation_id=conversation_id,
+        version=1,
+        created_at="2026-09-05T00:00:00Z",
+        metadata={"cwd": "/workspace/project"},
+    )
+
+
+def _record(record_id: str, text: str) -> ConversationRecord[object]:
+    return ConversationRecord(
+        record_id=record_id,
+        parent_id=None,
+        kind=AGENT_MESSAGE_KIND,
+        payload_version=1,
+        created_at="2026-09-05T00:00:01Z",
+        payload=UserMessage(role="user", content=text, timestamp=1.0),
+    )
+
+
+def _runtime(tmp_path: Path) -> tuple[AgentTranscriptDirectoryRuntime, Path, Path, Path]:
+    canonical = tmp_path / "machine-selected-canonical"
+    cwd = tmp_path / "machine-selected-cwd"
+    home = tmp_path / "machine-selected-home"
+    for root, session_id in (
+        (canonical, "canonical-session"),
+        (cwd, "cwd-session"),
+        (home, "home-session"),
+    ):
+        root.mkdir(parents=True)
+        write_agent_transcript_export(
+            root / f"{session_id}.jsonl",
+            _header(session_id),
+            [_record(f"{session_id}-record", session_id)],
+        )
+    runtime = AgentTranscriptDirectoryRuntime(
+        session_dir=canonical,
+        authority_session_source=SessionDiscoverySource(
+            "sessions.global", canonical, "canonical", "global", priority=0
+        ),
+        discovery_session_sources=(
+            SessionDiscoverySource(
+                "sessions.cwd_compatibility", cwd, "compatibility", "cwd", priority=10
+            ),
+            SessionDiscoverySource(
+                "sessions.home_compatibility",
+                home,
+                "compatibility",
+                "home",
+                priority=20,
+            ),
+        ),
+    )
+    return runtime, canonical, cwd, home
+
+
+def _adapter(runtime: AgentTranscriptDirectoryRuntime) -> HarnessAppHostSessionAdapterV1:
+    return HarnessAppHostSessionAdapterV1(
+        runtime,
+        scope_bindings=(
+            HarnessSessionScopeBindingV1(
+                SessionDiscoveryScope.USER_GLOBAL_CANONICAL, "sessions.global"
+            ),
+            HarnessSessionScopeBindingV1(
+                SessionDiscoveryScope.CURRENT_DIRECTORY,
+                "sessions.cwd_compatibility",
+            ),
+            HarnessSessionScopeBindingV1(
+                SessionDiscoveryScope.USER_GLOBAL_LEGACY,
+                "sessions.home_compatibility",
+            ),
+        ),
+    )
+
+
+class _CanonicalClaimed:
+    def __init__(self, reference: SessionCandidateRefV1) -> None:
+        self._reference = reference
+        self.closed = 0
+
+    @property
+    def reference(self) -> SessionCandidateRefV1:
+        return self._reference
+
+    @property
+    def opaque_binding(self) -> object:
+        return {"canonical": True}
+
+    async def close(self) -> None:
+        self.closed += 1
+
+
+class _CanonicalCandidate:
+    def __init__(self, projection: SessionIdentityProjectionV1) -> None:
+        self._projection = projection
+        self.closed = 0
+        self.cancel_first_close = False
+        self.fail_first_close = False
+        self.always_fail_close = False
+        self.close_entered: asyncio.Event | None = None
+        self.close_release: asyncio.Event | None = None
+
+    @property
+    def projection(self) -> SessionIdentityProjectionV1:
+        return self._projection
+
+    async def verify_current(self) -> None:
+        return None
+
+    async def claim(self) -> _CanonicalClaimed:
+        return _CanonicalClaimed(self._projection.reference)
+
+    async def close(self) -> None:
+        self.closed += 1
+        if self.close_entered is not None:
+            self.close_entered.set()
+        if self.close_release is not None:
+            await self.close_release.wait()
+        if self.cancel_first_close and self.closed == 1:
+            raise asyncio.CancelledError
+        if self.fail_first_close and self.closed == 1:
+            raise RuntimeError("secret cleanup failure")
+        if self.always_fail_close:
+            raise RuntimeError("secret permanent cleanup failure")
+
+
+class _InvalidCanonicalCandidate(_CanonicalCandidate):
+    @property
+    def projection(self) -> object:
+        return object()
+
+
+class _CanonicalOwner:
+    def __init__(self) -> None:
+        reference = SessionCandidateRefV1(
+            "canonical.owner", "candidate-canonical", "revision-canonical"
+        )
+        envelope = SessionIdentityEnvelopeV1(
+            "coding",
+            "coding-session-v1",
+            "continuity-canonical",
+            "session-canonical",
+            "canonical.owner",
+            "locator-canonical",
+        )
+        self.projection = SessionIdentityProjectionV1(
+            reference,
+            SessionDiscoveryScope.USER_GLOBAL_CANONICAL,
+            SessionCandidateMode.CANONICAL,
+            envelope,
+        )
+        self.list_calls: list[tuple[tuple[SessionDiscoveryScope, ...], int]] = []
+        self.create_calls = 0
+        self.open_calls = 0
+        self.invalid: _InvalidCanonicalCandidate | None = None
+        self.raise_secret = False
+
+    async def list_identities(
+        self,
+        scopes: tuple[SessionDiscoveryScope, ...],
+        *,
+        limit: int,
+    ) -> tuple[SessionIdentityProjectionV1, ...]:
+        self.list_calls.append((scopes, limit))
+        return (self.projection,) if self.projection.scope in scopes else ()
+
+    async def open_candidate(
+        self, reference: SessionCandidateRefV1
+    ) -> _CanonicalCandidate:
+        self.open_calls += 1
+        if self.raise_secret:
+            raise RuntimeError("secret-token at /private/session.jsonl")
+        assert reference == self.projection.reference
+        if self.invalid is not None:
+            return self.invalid
+        return _CanonicalCandidate(self.projection)
+
+    async def find_created_candidate(
+        self, request: SessionCreateRequestV1
+    ) -> _CanonicalCandidate | None:
+        return _CanonicalCandidate(self.projection) if self.create_calls else None
+
+    async def create_candidate(
+        self, intent: SessionCreateIntentV1
+    ) -> _CanonicalCandidate:
+        self.create_calls += 1
+        return _CanonicalCandidate(self.projection)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX retained-descriptor contract")
+def test_adapter_projects_explicit_cwd_home_and_global_sources_without_paths(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, canonical, cwd, home = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        projected = await adapter.list_identities(
+            (
+                SessionDiscoveryScope.CURRENT_DIRECTORY,
+                SessionDiscoveryScope.USER_GLOBAL_LEGACY,
+                SessionDiscoveryScope.USER_GLOBAL_CANONICAL,
+            ),
+            limit=10,
+        )
+        assert {item.scope for item in projected} == {
+            SessionDiscoveryScope.CURRENT_DIRECTORY,
+            SessionDiscoveryScope.USER_GLOBAL_LEGACY,
+            SessionDiscoveryScope.USER_GLOBAL_CANONICAL,
+        }
+        assert all(item.mode is SessionCandidateMode.MIGRATION_REQUIRED for item in projected)
+        roots = (canonical.as_posix(), cwd.as_posix(), home.as_posix())
+        assert all(
+            not any(root in item.reference.candidate_id for root in roots)
+            for item in projected
+        )
+        assert all("/" not in item.reference.revision for item in projected)
+
+        selected = next(
+            item for item in projected if item.scope is SessionDiscoveryScope.CURRENT_DIRECTORY
+        )
+        lease = await adapter.open_candidate(selected.reference)
+        await lease.verify_current()
+        claimed = await lease.claim()
+        binding = claimed.opaque_binding
+        assert getattr(binding, "conversation_id") == "cwd-session"
+        with pytest.raises(SessionCandidateStaleError):
+            await lease.claim()
+        await claimed.close()
+        await lease.close()
+        await lease.close()
+
+    asyncio.run(exercise())
+
+
+def test_adapter_does_not_infer_unbound_scope_or_treat_token_as_path(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+        )
+        assert await adapter.list_identities(
+            (SessionDiscoveryScope.USER_GLOBAL_LEGACY,), limit=10
+        ) == ()
+        forged = SessionCandidateRefV1(
+            "sessions.cwd_compatibility", "etc-passwd", "revision-1"
+        )
+        with pytest.raises(SessionCandidateStaleError):
+            await adapter.open_candidate(forged)
+
+    asyncio.run(exercise())
+
+
+def test_adapter_rejects_revision_swap_between_list_and_open(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        runtime, _, cwd, _ = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        projected = await adapter.list_identities(
+            (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=10
+        )
+        target = cwd / "cwd-session.jsonl"
+        target.write_text(target.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+        with pytest.raises(SessionCandidateStaleError):
+            await adapter.open_candidate(projected[0].reference)
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX retained-descriptor contract")
+def test_adapter_pinned_claim_survives_rename_and_path_replacement(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, cwd, _ = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        projected = await adapter.list_identities(
+            (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=10
+        )
+        lease = await adapter.open_candidate(projected[0].reference)
+        await lease.verify_current()
+        claimed = await lease.claim()
+        binding = claimed.opaque_binding
+        original = cwd / "cwd-session.jsonl"
+        archived = cwd / "archived.jsonl"
+        original.rename(archived)
+        archived_content = archived.read_bytes()
+        archived.write_bytes(
+            archived_content.replace(b"cwd-session", b"bad-session", 1)
+        )
+        write_agent_transcript_export(
+            original,
+            _header("replacement-session"),
+            [_record("replacement-record", "replacement-secret")],
+        )
+
+        assert getattr(binding, "conversation_id") == "cwd-session"
+        content = getattr(binding, "read_bytes")()
+        assert b"cwd-session" in content
+        assert b"replacement-secret" not in content
+        assert repr(binding) == "<PinnedHarnessSessionContent>"
+        assert original.as_posix() not in repr(binding)
+        await claimed.close()
+        await lease.close()
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX no-follow contract")
+def test_adapter_rejects_symlink_swap_between_list_and_open(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        runtime, _, cwd, home = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        projected = await adapter.list_identities(
+            (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=10
+        )
+        target = cwd / "cwd-session.jsonl"
+        target.unlink()
+        target.symlink_to(home / "home-session.jsonl")
+        with pytest.raises(SessionCandidateStaleError):
+            await adapter.open_candidate(projected[0].reference)
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX snapshot contract")
+def test_adapter_rejects_same_inode_same_size_rewrite_with_restored_mtime(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, cwd, _ = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        projected = await adapter.list_identities(
+            (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=10
+        )
+        target = cwd / "cwd-session.jsonl"
+        before = target.stat()
+        content = target.read_bytes()
+        replacement = content.replace(b"cwd-session", b"bad-session", 1)
+        assert len(replacement) == len(content)
+        target.write_bytes(replacement)
+        os.utime(target, ns=(before.st_atime_ns, before.st_mtime_ns))
+        with pytest.raises(SessionCandidateStaleError):
+            await adapter.open_candidate(projected[0].reference)
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX snapshot contract")
+def test_adapter_fails_closed_on_mutation_during_snapshot_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def exercise() -> None:
+        runtime, _, cwd, _ = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        projected = await adapter.list_identities(
+            (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=10
+        )
+        target = cwd / "cwd-session.jsonl"
+        native_pread = os.pread
+        calls = 0
+
+        def mutating_pread(descriptor: int, size: int, offset: int) -> bytes:
+            nonlocal calls
+            calls += 1
+            chunk = native_pread(descriptor, min(size, 7), offset)
+            if calls == 1:
+                content = target.read_bytes()
+                target.write_bytes(content.replace(b"cwd-session", b"bad-session", 1))
+            return chunk
+
+        monkeypatch.setattr(integration.os, "pread", mutating_pread)
+        with pytest.raises(SessionCandidateStaleError):
+            await adapter.open_candidate(projected[0].reference)
+        assert calls > 1
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX snapshot contract")
+def test_adapter_accepts_chunked_short_pread_and_seals_exact_bytes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def exercise() -> None:
+        runtime, _, cwd, _ = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        projected = await adapter.list_identities(
+            (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=10
+        )
+        expected = (cwd / "cwd-session.jsonl").read_bytes()
+        native_pread = os.pread
+        monkeypatch.setattr(
+            integration.os,
+            "pread",
+            lambda descriptor, size, offset: native_pread(
+                descriptor, min(size, 7), offset
+            ),
+        )
+        lease = await adapter.open_candidate(projected[0].reference)
+        claimed = await lease.claim()
+        assert getattr(claimed.opaque_binding, "read_bytes")() == expected
+        await claimed.close()
+        await lease.close()
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX snapshot contract")
+def test_adapter_rejects_content_over_snapshot_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        projected = await adapter.list_identities(
+            (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=10
+        )
+        monkeypatch.setattr(integration, "HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1", 16)
+        with pytest.raises(SessionCandidateStaleError):
+            await adapter.open_candidate(projected[0].reference)
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.skipif(os.name != "nt", reason="native Windows fail-closed gate")
+def test_adapter_windows_native_backend_is_explicitly_fail_closed(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        assert os.name == "nt"
+        assert not integration._native_descriptor_supported()
+        runtime, _, _, _ = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        projected = await adapter.list_identities(
+            (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=10
+        )
+        with pytest.raises(SessionCandidateStaleError):
+            await adapter.open_candidate(projected[0].reference)
+
+    asyncio.run(exercise())
+
+
+def test_adapter_fails_closed_on_incompatible_duplicate(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        runtime, canonical, cwd, _ = _runtime(tmp_path)
+        write_agent_transcript_export(
+            cwd / "conflicting.jsonl",
+            _header("canonical-session"),
+            [_record("different-record", "different")],
+        )
+        assert canonical.is_dir()
+        adapter = _adapter(runtime)
+        with pytest.raises(SessionAmbiguousError):
+            await adapter.list_identities(
+                (
+                    SessionDiscoveryScope.USER_GLOBAL_CANONICAL,
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                ),
+                limit=10,
+            )
+
+    from loushang.apphost import SessionAmbiguousError
+
+    asyncio.run(exercise())
+
+
+def test_adapter_keeps_canonical_creation_default_dark_without_injected_owner(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        adapter = _adapter(runtime)
+        request = SessionCreateRequestV1(
+            "coding", "user-1", "01K4J8F3N3J7M9Q2R6T5V8W0XY"
+        )
+        assert await adapter.find_created_candidate(request) is None
+        with pytest.raises(AppHostError) as error:
+            await adapter.create_candidate(
+                SessionCreateIntentV1(request, "coding-session-v1")
+            )
+        assert error.value.category is AppHostFailureCategory.RUNTIME_UNAVAILABLE
+
+    asyncio.run(exercise())
+
+
+def test_adapter_delegates_canonical_owner_without_deriving_authority(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+        projected = await adapter.list_identities(
+            (SessionDiscoveryScope.USER_GLOBAL_CANONICAL,), limit=1
+        )
+        assert projected == (owner.projection,)
+        assert owner.list_calls == [
+            ((SessionDiscoveryScope.USER_GLOBAL_CANONICAL,), 1)
+        ]
+        opened = await adapter.open_candidate(owner.projection.reference)
+        await opened.verify_current()
+        await opened.close()
+
+        request = SessionCreateRequestV1(
+            "coding", "user-1", "01K4J8F3N3J7M9Q2R6T5V8W0XY"
+        )
+        assert await adapter.find_created_candidate(request) is None
+        created = await adapter.create_candidate(
+            SessionCreateIntentV1(request, "coding-session-v1")
+        )
+        recovered = await adapter.find_created_candidate(request)
+        assert recovered is not None
+        assert created.projection.reference == recovered.projection.reference
+        await created.close()
+        await recovered.close()
+
+    asyncio.run(exercise())
+
+
+def test_adapter_rejects_and_settles_malicious_canonical_return(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        invalid = _InvalidCanonicalCandidate(owner.projection)
+        owner.invalid = invalid
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+        with pytest.raises(SessionCandidateStaleError) as error:
+            await adapter.open_candidate(owner.projection.reference)
+        assert error.value.__cause__ is None
+        assert invalid.closed == 1
+
+    asyncio.run(exercise())
+
+
+def test_adapter_retains_failed_validation_cleanup_for_concurrent_retry(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        invalid = _InvalidCanonicalCandidate(owner.projection)
+        invalid.fail_first_close = True
+        owner.invalid = invalid
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+
+        with pytest.raises(CleanupIncompleteError) as caught:
+            await adapter.open_candidate(owner.projection.reference)
+        assert caught.value.primary_category is AppHostFailureCategory.SESSION_CANDIDATE_STALE
+        assert caught.value.__cause__ is None
+        assert invalid.closed == 1
+
+        await asyncio.gather(
+            adapter.settle_pending_cleanup(),
+            adapter.settle_pending_cleanup(),
+        )
+        assert invalid.closed == 2
+        await adapter.settle_pending_cleanup()
+        assert invalid.closed == 2
+
+    asyncio.run(exercise())
+
+
+def test_adapter_refuses_new_provider_calls_while_permanent_debt_remains(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        invalid = _InvalidCanonicalCandidate(owner.projection)
+        invalid.always_fail_close = True
+        owner.invalid = invalid
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+
+        for _ in range(4):
+            with pytest.raises(CleanupIncompleteError):
+                await adapter.open_candidate(owner.projection.reference)
+            assert owner.open_calls == 1
+            assert adapter._cleanup.pending_count == 1
+
+        with pytest.raises(CleanupIncompleteError):
+            await adapter.close()
+        with pytest.raises(GenerationRetiredError):
+            await adapter.open_candidate(owner.projection.reference)
+        assert owner.open_calls == 1
+        assert adapter._cleanup.pending_count == 1
+
+    asyncio.run(exercise())
+
+
+def test_adapter_drains_cleanup_debt_before_resuming_provider_calls(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        invalid = _InvalidCanonicalCandidate(owner.projection)
+        invalid.fail_first_close = True
+        owner.invalid = invalid
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+
+        with pytest.raises(CleanupIncompleteError):
+            await adapter.open_candidate(owner.projection.reference)
+        assert owner.open_calls == 1
+        owner.invalid = None
+
+        recovered = await adapter.open_candidate(owner.projection.reference)
+        assert owner.open_calls == 2
+        assert invalid.closed == 2
+        assert adapter._cleanup.pending_count == 0
+        await recovered.close()
+        await adapter.close()
+
+    asyncio.run(exercise())
+
+
+def test_adapter_bounds_concurrent_canonical_provider_calls(tmp_path: Path) -> None:
+    class _BlockingOwner(_CanonicalOwner):
+        def __init__(self) -> None:
+            super().__init__()
+            self.all_entered = asyncio.Event()
+            self.release = asyncio.Event()
+
+        async def open_candidate(
+            self, reference: SessionCandidateRefV1
+        ) -> _CanonicalCandidate:
+            self.open_calls += 1
+            if (
+                self.open_calls
+                == integration.HARNESS_SESSION_MAX_ACTIVE_CANONICAL_OPS_V1
+            ):
+                self.all_entered.set()
+            await self.release.wait()
+            return _CanonicalCandidate(self.projection)
+
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _BlockingOwner()
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+        limit = integration.HARNESS_SESSION_MAX_ACTIVE_CANONICAL_OPS_V1
+        calls = tuple(
+            asyncio.create_task(
+                adapter.open_candidate(owner.projection.reference)
+            )
+            for _ in range(limit)
+        )
+        await owner.all_entered.wait()
+        with pytest.raises(AppHostError) as caught:
+            await adapter.open_candidate(owner.projection.reference)
+        assert caught.value.category is AppHostFailureCategory.RUNTIME_UNAVAILABLE
+        assert owner.open_calls == limit
+
+        owner.release.set()
+        leases = await asyncio.gather(*calls)
+        for lease in leases:
+            await lease.close()
+        resumed = await adapter.open_candidate(owner.projection.reference)
+        assert owner.open_calls == limit + 1
+        await resumed.close()
+        await adapter.close()
+
+    asyncio.run(exercise())
+
+
+def test_adapter_retains_cancelled_cleanup_callback_for_retry(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        invalid = _InvalidCanonicalCandidate(owner.projection)
+        invalid.cancel_first_close = True
+        owner.invalid = invalid
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+
+        with pytest.raises(CleanupIncompleteError):
+            await adapter.open_candidate(owner.projection.reference)
+        assert invalid.closed == 1
+        await adapter.settle_pending_cleanup()
+        assert invalid.closed == 2
+
+    asyncio.run(exercise())
+
+
+def test_adapter_settlement_cancellation_keeps_joinable_owner(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        invalid = _InvalidCanonicalCandidate(owner.projection)
+        invalid.fail_first_close = True
+        owner.invalid = invalid
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+        with pytest.raises(CleanupIncompleteError):
+            await adapter.open_candidate(owner.projection.reference)
+
+        invalid.close_entered = asyncio.Event()
+        invalid.close_release = asyncio.Event()
+        settlement = asyncio.create_task(adapter.settle_pending_cleanup())
+        await invalid.close_entered.wait()
+        settlement.cancel()
+        invalid.close_release.set()
+        with pytest.raises(asyncio.CancelledError):
+            await settlement
+
+        await adapter.settle_pending_cleanup()
+        assert invalid.closed == 2
+
+    asyncio.run(exercise())
+
+
+def test_adapter_close_fences_and_joins_inflight_validation_cleanup(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        invalid = _InvalidCanonicalCandidate(owner.projection)
+        invalid.close_entered = asyncio.Event()
+        invalid.close_release = asyncio.Event()
+        owner.invalid = invalid
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+
+        opening = asyncio.create_task(
+            adapter.open_candidate(owner.projection.reference)
+        )
+        await invalid.close_entered.wait()
+        closing_one = asyncio.create_task(adapter.close())
+        closing_two = asyncio.create_task(adapter.close())
+        await asyncio.sleep(0)
+        assert not closing_one.done()
+        assert not closing_two.done()
+        with pytest.raises(GenerationRetiredError):
+            await adapter.list_identities(
+                (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=1
+            )
+
+        invalid.close_release.set()
+        with pytest.raises(SessionCandidateStaleError):
+            await opening
+        await asyncio.gather(closing_one, closing_two)
+        assert invalid.closed == 1
+
+    asyncio.run(exercise())
+
+
+def test_adapter_close_retries_retained_debt_once(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        invalid = _InvalidCanonicalCandidate(owner.projection)
+        invalid.fail_first_close = True
+        owner.invalid = invalid
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+        with pytest.raises(CleanupIncompleteError):
+            await adapter.open_candidate(owner.projection.reference)
+        await adapter.close()
+        assert invalid.closed == 2
+        await adapter.close()
+        assert invalid.closed == 2
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX close ambiguity contract")
+def test_descriptor_owner_never_retries_relinquished_fd_after_post_effect_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def exercise() -> None:
+        target = tmp_path / "descriptor-owner.txt"
+        target.write_bytes(b"owner")
+        descriptor = os.open(target, os.O_RDONLY)
+        native_close = os.close
+        owner = integration._DescriptorOwner(descriptor)
+        closer = RetryableCloser.bind(owner)
+
+        def close_then_raise(value: int) -> None:
+            native_close(value)
+            if value == descriptor:
+                raise OSError("ambiguous post-effect close")
+
+        monkeypatch.setattr(integration.os, "close", close_then_raise)
+        assert not await closer.settle()
+        monkeypatch.setattr(integration.os, "close", native_close)
+
+        reused = os.open(target, os.O_RDONLY)
+        try:
+            assert reused == descriptor
+            assert await closer.settle()
+            assert await closer.settle()
+            os.fstat(reused)
+        finally:
+            native_close(reused)
+
+    asyncio.run(exercise())
+
+
+def test_adapter_redacts_canonical_owner_failures(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CanonicalOwner()
+        owner.raise_secret = True
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+        with pytest.raises(SessionCandidateStaleError) as caught:
+            await adapter.open_candidate(owner.projection.reference)
+        assert str(caught.value) == "session_candidate_stale"
+        assert caught.value.__cause__ is None
+        assert "secret-token" not in repr(caught.value)
+        assert "/private" not in repr(caught.value)
+
+    asyncio.run(exercise())
+
+
+def test_adapter_preserves_canonical_owner_cancellation(tmp_path: Path) -> None:
+    class _CancelledOwner(_CanonicalOwner):
+        async def open_candidate(
+            self, reference: SessionCandidateRefV1
+        ) -> _CanonicalCandidate:
+            raise asyncio.CancelledError
+
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        owner = _CancelledOwner()
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=owner,
+        )
+        with pytest.raises(asyncio.CancelledError):
+            await adapter.open_candidate(owner.projection.reference)
+
+    asyncio.run(exercise())
+
+
+def test_adapter_rejects_malicious_scope_and_invalid_limits(tmp_path: Path) -> None:
+    class _WrongScopeOwner(_CanonicalOwner):
+        async def list_identities(
+            self,
+            scopes: tuple[SessionDiscoveryScope, ...],
+            *,
+            limit: int,
+        ) -> tuple[SessionIdentityProjectionV1, ...]:
+            return (self.projection,)
+
+    async def exercise() -> None:
+        runtime, _, _, _ = _runtime(tmp_path)
+        adapter = HarnessAppHostSessionAdapterV1(
+            runtime,
+            scope_bindings=(
+                HarnessSessionScopeBindingV1(
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    "sessions.cwd_compatibility",
+                ),
+            ),
+            canonical_owner=_WrongScopeOwner(),
+        )
+        with pytest.raises(SessionCandidateStaleError):
+            await adapter.list_identities(
+                (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=1
+            )
+        with pytest.raises(ValueError):
+            await adapter.list_identities(
+                (SessionDiscoveryScope.CURRENT_DIRECTORY,), limit=257
+            )
+        with pytest.raises(TypeError):
+            await adapter.list_identities(
+                (
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                    SessionDiscoveryScope.CURRENT_DIRECTORY,
+                ),
+                limit=1,
+            )
+
+    asyncio.run(exercise())

--- a/tests/apphost/test_router.py
+++ b/tests/apphost/test_router.py
@@ -1,0 +1,863 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, replace
+from typing import Any
+
+import pytest
+
+from loushang.apphost import (
+    AdmissionIdentityV1,
+    AppHostAdmissionSubjectKind,
+    AppHostCatalogInputV1,
+    AppHostCatalogV1,
+    AppHostFailureCategory,
+    AppHostRouterV1,
+    CleanupIncompleteError,
+    GenerationRetiredError,
+    PreparedProductRouteV1,
+    ProductDescriptorV1,
+    ProductIdentityRequiredError,
+    ProductIncompatibleError,
+    ProductRegistrationV1,
+    ProductUnavailableError,
+    ProfileDescriptorV1,
+    ProfileRegistrationV1,
+    SessionBindingKeyV1,
+    SessionCandidateMode,
+    SessionCandidateRefV1,
+    SessionCandidateStaleError,
+    SessionCreateRequestV1,
+    SessionDiscoveryScope,
+    SessionIdentityEnvelopeV1,
+    SessionIdentityProjectionV1,
+)
+
+
+class _Pin:
+    def __init__(self, identity: AdmissionIdentityV1, events: list[str]) -> None:
+        self._identity = identity
+        self.events = events
+        self.closed = 0
+
+    @property
+    def identity(self) -> AdmissionIdentityV1:
+        return self._identity
+
+    async def close(self) -> None:
+        self.closed += 1
+        self.events.append(f"pin.close:{self._identity.subject_id}")
+
+
+class _Source:
+    def __init__(self, identity: AdmissionIdentityV1, events: list[str]) -> None:
+        self.identity = identity
+        self.events = events
+        self.pins: list[_Pin] = []
+
+    async def acquire_pin(self) -> _Pin:
+        self.events.append(f"pin.acquire:{self.identity.subject_id}")
+        pin = _Pin(self.identity, self.events)
+        self.pins.append(pin)
+        return pin
+
+
+class _Factory:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def create_runtime(self, candidate: object) -> Any:
+        self.calls += 1
+        raise AssertionError("A0.2 router must not invoke Product factories")
+
+
+class _Opened:
+    def __init__(self, key: SessionBindingKeyV1, events: list[str]) -> None:
+        self._key = key
+        self.events = events
+        self.closed = 0
+        self.fail_first_close = False
+
+    @property
+    def binding_key(self) -> SessionBindingKeyV1:
+        return self._key
+
+    @property
+    def opaque_binding(self) -> object:
+        return self
+
+    async def close(self) -> None:
+        self.closed += 1
+        self.events.append("opened.close")
+        if self.fail_first_close and self.closed == 1:
+            raise RuntimeError("secret opened cleanup detail")
+
+
+class _Validator:
+    def __init__(self, kind: str, events: list[str]) -> None:
+        self.kind = kind
+        self.events = events
+        self.calls = 0
+        self.cancel = False
+        self.fail = False
+        self.fail_opened_close = False
+        self.opened: list[_Opened] = []
+        self.entered: asyncio.Event | None = None
+        self.release: asyncio.Event | None = None
+
+    async def open_product_candidate(
+        self, candidate: object, envelope: SessionIdentityEnvelopeV1
+    ) -> _Opened:
+        self.calls += 1
+        self.events.append(f"validator:{self.kind}")
+        if self.entered is not None:
+            self.entered.set()
+        if self.release is not None:
+            await self.release.wait()
+        if self.cancel:
+            raise asyncio.CancelledError
+        if self.fail:
+            raise RuntimeError("secret validator failure")
+        assert getattr(candidate, "opaque_binding")["kind"] == self.kind
+        opened = _Opened(
+            SessionBindingKeyV1(
+                envelope.product_id, envelope.continuity_id, envelope.session_id
+            ),
+            self.events,
+        )
+        opened.fail_first_close = self.fail_opened_close
+        self.opened.append(opened)
+        return opened
+
+
+class _Importer:
+    def __init__(self, kind: str, events: list[str]) -> None:
+        self.kind = kind
+        self.events = events
+        self.payloads: list[object] = []
+        self.invalid_result = False
+
+    async def import_candidate(self, candidate: object) -> object:
+        payload = getattr(candidate, "opaque_binding")
+        assert payload["kind"] == self.kind
+        self.payloads.append(payload["payload"])
+        self.events.append(f"importer:{self.kind}")
+        if self.invalid_result:
+            return object()
+        return SessionCandidateRefV1(
+            source_id="canonical-owner",
+            candidate_id=f"imported-{self.kind}",
+            revision="revision-1",
+        )
+
+
+class _ProfileFactory:
+    async def bind_profile(self, runtime: object) -> Any:
+        raise AssertionError("profile is outside A0.2")
+
+
+class _Claimed:
+    def __init__(
+        self, reference: SessionCandidateRefV1, payload: object, events: list[str]
+    ) -> None:
+        self._reference = reference
+        self._payload = payload
+        self.events = events
+        self.closed = 0
+
+    @property
+    def reference(self) -> SessionCandidateRefV1:
+        return self._reference
+
+    @property
+    def opaque_binding(self) -> object:
+        return self._payload
+
+    async def close(self) -> None:
+        self.closed += 1
+        self.events.append("claimed.close")
+
+
+class _Candidate:
+    def __init__(
+        self,
+        projection: SessionIdentityProjectionV1,
+        payload: object,
+        events: list[str],
+        *,
+        stale: bool = False,
+    ) -> None:
+        self._projection = projection
+        self.payload = payload
+        self.events = events
+        self.stale = stale
+        self.verify_calls = 0
+        self.claim_calls = 0
+        self.closed = 0
+        self.fail_first_close = False
+        self.claimed: list[_Claimed] = []
+
+    @property
+    def projection(self) -> SessionIdentityProjectionV1:
+        return self._projection
+
+    async def verify_current(self) -> None:
+        self.verify_calls += 1
+        self.events.append("candidate.verify")
+        if self.stale:
+            raise SessionCandidateStaleError()
+
+    async def claim(self) -> _Claimed:
+        self.claim_calls += 1
+        self.events.append("candidate.claim")
+        claimed = _Claimed(self._projection.reference, self.payload, self.events)
+        self.claimed.append(claimed)
+        return claimed
+
+    async def close(self) -> None:
+        self.closed += 1
+        self.events.append("candidate.close")
+        if self.fail_first_close and self.closed == 1:
+            raise RuntimeError("secret candidate cleanup failure")
+
+
+class _Sessions:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.by_reference: dict[SessionCandidateRefV1, _Candidate] = {}
+        self.created: dict[tuple[str, str, str], _Candidate] = {}
+        self.create_calls = 0
+        self.cancel_after_commit = False
+
+    async def list_identities(self, scopes: tuple[object, ...], *, limit: int) -> tuple:
+        return ()
+
+    async def open_candidate(self, reference: SessionCandidateRefV1) -> _Candidate:
+        self.events.append("sessions.open")
+        return self.by_reference[reference]
+
+    async def find_created_candidate(self, request: SessionCreateRequestV1) -> _Candidate | None:
+        self.events.append("sessions.find")
+        return self.created.get(
+            (request.product_id, request.creator_scope_id, request.operation_id)
+        )
+
+    async def create_candidate(self, intent: object) -> _Candidate:
+        self.create_calls += 1
+        self.events.append("sessions.create")
+        request = getattr(intent, "request")
+        compatibility = getattr(intent, "product_compatibility_id")
+        key = (request.product_id, request.creator_scope_id, request.operation_id)
+        existing = self.created.get(key)
+        if existing is not None:
+            if existing.projection.envelope.product_compatibility_id != compatibility:
+                raise ProductIncompatibleError()
+            return existing
+        candidate = _canonical_candidate(
+            request.product_id,
+            {"kind": request.product_id, "payload": {"new": True}},
+            self.events,
+            compatibility=compatibility,
+            suffix=str(len(self.created) + 1),
+        )
+        self.created[key] = candidate
+        self.by_reference[candidate.projection.reference] = candidate
+        if self.cancel_after_commit:
+            self.cancel_after_commit = False
+            raise asyncio.CancelledError
+        return candidate
+
+
+@dataclass
+class _ProductOwners:
+    factory: _Factory
+    validator: _Validator
+    importer: _Importer
+    source: _Source
+
+
+def _catalog_input(
+    generation: str,
+    events: list[str],
+    *,
+    product_ids: tuple[str, ...] = ("coding", "slides"),
+) -> tuple[AppHostCatalogInputV1, dict[str, _ProductOwners]]:
+    profile_id = "embedded-tui"
+    profile_identity = AdmissionIdentityV1(
+        generation, AppHostAdmissionSubjectKind.PROFILE, profile_id
+    )
+    profile_source = _Source(profile_identity, events)
+    products = []
+    owners = {}
+    for product_id in product_ids:
+        identity = AdmissionIdentityV1(
+            generation, AppHostAdmissionSubjectKind.PRODUCT, product_id
+        )
+        factory = _Factory()
+        validator = _Validator(product_id, events)
+        importer = _Importer(product_id, events)
+        source = _Source(identity, events)
+        owners[product_id] = _ProductOwners(factory, validator, importer, source)
+        products.append(
+            ProductRegistrationV1(
+                descriptor=ProductDescriptorV1(
+                    product_id,
+                    "1",
+                    f"{product_id}-session-v1",
+                    (profile_id,),
+                ),
+                factory=factory,
+                candidate_validator=validator,
+                importer=importer,
+                admission_identity=identity,
+                admission_source=source,
+            )
+        )
+    return (
+        AppHostCatalogInputV1(
+            generation,
+            tuple(products),
+            (
+                ProfileRegistrationV1(
+                    ProfileDescriptorV1(profile_id, "1"),
+                    _ProfileFactory(),
+                    profile_identity,
+                    profile_source,
+                ),
+            ),
+        ),
+        owners,
+    )
+
+
+def _canonical_candidate(
+    product_id: str,
+    payload: object,
+    events: list[str],
+    *,
+    compatibility: str | None = None,
+    suffix: str = "1",
+    stale: bool = False,
+) -> _Candidate:
+    reference = SessionCandidateRefV1(
+        "canonical-owner", f"candidate-{product_id}-{suffix}", f"revision-{suffix}"
+    )
+    envelope = SessionIdentityEnvelopeV1(
+        product_id,
+        compatibility or f"{product_id}-session-v1",
+        f"continuity-{suffix}",
+        f"session-{suffix}",
+        "canonical-owner",
+        f"locator-{suffix}",
+    )
+    return _Candidate(
+        SessionIdentityProjectionV1(
+            reference,
+            SessionDiscoveryScope.USER_GLOBAL_CANONICAL,
+            SessionCandidateMode.CANONICAL,
+            envelope,
+        ),
+        payload,
+        events,
+        stale=stale,
+    )
+
+
+def _legacy_candidate(kind: str, payload: object, events: list[str]) -> _Candidate:
+    reference = SessionCandidateRefV1(
+        f"{kind}-legacy", f"candidate-{kind}", "revision-1"
+    )
+    return _Candidate(
+        SessionIdentityProjectionV1(
+            reference,
+            SessionDiscoveryScope.USER_GLOBAL_LEGACY,
+            SessionCandidateMode.MIGRATION_REQUIRED,
+            None,
+        ),
+        {"kind": kind, "payload": payload},
+        events,
+    )
+
+
+def _request(product_id: str = "coding", scope: str = "user-1") -> SessionCreateRequestV1:
+    return SessionCreateRequestV1(
+        product_id,
+        scope,
+        "01K4J8F3N3J7M9Q2R6T5V8W0XY",
+    )
+
+
+def test_two_unrelated_products_resume_without_factory_or_default() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        router = AppHostRouterV1(catalog, sessions)
+        for index, product_id in enumerate(("coding", "slides"), 1):
+            candidate = _canonical_candidate(
+                product_id,
+                {"kind": product_id, "payload": {"fixture": product_id}},
+                events,
+                suffix=str(index),
+            )
+            sessions.by_reference[candidate.projection.reference] = candidate
+            route = await router.prepare_resume(
+                product_id=product_id, reference=candidate.projection.reference
+            )
+            assert isinstance(route, PreparedProductRouteV1)
+            assert route.binding_key.product_id == product_id
+            assert not hasattr(route, "factory")
+            assert not hasattr(route, "opened")
+            assert route.generation_id == "generation-1"
+            with pytest.raises(AttributeError):
+                route.generation_id = "generation-2"  # type: ignore[misc]
+            await route.close()
+            assert events[-4:] == [
+                "opened.close",
+                "claimed.close",
+                "candidate.close",
+                f"pin.close:{product_id}",
+            ]
+        assert all(owner.factory.calls == 0 for owner in owners.values())
+        with pytest.raises(ProductIdentityRequiredError):
+            await router.prepare_resume(
+                product_id="", reference=next(iter(sessions.by_reference))
+            )
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_create_recovery_never_duplicates_when_current_product_changes_or_retires() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        first, _ = _catalog_input("generation-1", events)
+        catalog = await AppHostCatalogV1.admit(first)
+        sessions = _Sessions(events)
+        router = AppHostRouterV1(catalog, sessions)
+        request = _request()
+        prepared = await router.prepare_create(request)
+        await prepared.close()
+        assert sessions.create_calls == 1
+
+        changed, changed_owners = _catalog_input("generation-2", events)
+        coding = changed.products[0]
+        changed = replace(
+            changed,
+            products=(
+                replace(
+                    coding,
+                    descriptor=replace(
+                        coding.descriptor,
+                        compatibility_id="coding-session-v2",
+                    ),
+                ),
+                *changed.products[1:],
+            ),
+        )
+        await catalog.replace(changed, expected_generation_id="generation-1")
+        with pytest.raises(ProductIncompatibleError):
+            await router.prepare_create(request)
+        assert sessions.create_calls == 1
+        assert changed_owners["coding"].validator.calls == 0
+
+        slides_only, _ = _catalog_input(
+            "generation-3", events, product_ids=("slides",)
+        )
+        await catalog.replace(slides_only, expected_generation_id="generation-2")
+        with pytest.raises(ProductUnavailableError):
+            await router.prepare_create(request)
+        assert sessions.create_calls == 1
+
+        await catalog.close()
+        with pytest.raises(GenerationRetiredError):
+            await router.prepare_create(request)
+        assert sessions.create_calls == 1
+
+    asyncio.run(exercise())
+
+
+def test_create_is_lookup_first_idempotent_and_recovers_commit_before_cancel() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        router = AppHostRouterV1(catalog, sessions)
+        request = _request()
+        baseline_acquires = len(owners["coding"].source.pins)
+        sessions.cancel_after_commit = True
+        with pytest.raises(asyncio.CancelledError):
+            await router.prepare_create(request)
+        assert sessions.create_calls == 1
+        assert events.index("sessions.find") < events.index(
+            "pin.acquire:coding", baseline_acquires
+        )
+
+        route = await router.prepare_create(request)
+        assert sessions.create_calls == 1
+        assert route.binding_key.session_id == "session-1"
+        assert owners["coding"].factory.calls == 0
+        await route.close()
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_create_same_operation_in_different_creator_scope_never_aliases() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, _ = _catalog_input("generation-1", events)
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        router = AppHostRouterV1(catalog, sessions)
+        first = await router.prepare_create(_request(scope="user-a"))
+        second = await router.prepare_create(_request(scope="user-b"))
+        assert first.binding_key != second.binding_key
+        assert sessions.create_calls == 2
+        await first.close()
+        await second.close()
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_resume_rejects_wrong_product_compatibility_stale_and_removed_product() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        router = AppHostRouterV1(catalog, sessions)
+
+        wrong = _canonical_candidate("coding", {"kind": "coding"}, events)
+        sessions.by_reference[wrong.projection.reference] = wrong
+        with pytest.raises(ProductIncompatibleError):
+            await router.prepare_resume(
+                product_id="slides", reference=wrong.projection.reference
+            )
+        assert owners["slides"].validator.calls == 0
+
+        incompatible = _canonical_candidate(
+            "coding",
+            {"kind": "coding"},
+            events,
+            compatibility="coding-session-v2",
+            suffix="2",
+        )
+        sessions.by_reference[incompatible.projection.reference] = incompatible
+        with pytest.raises(ProductIncompatibleError):
+            await router.prepare_resume(
+                product_id="coding", reference=incompatible.projection.reference
+            )
+        assert owners["coding"].validator.calls == 0
+
+        stale = _canonical_candidate(
+            "coding", {"kind": "coding"}, events, suffix="3", stale=True
+        )
+        sessions.by_reference[stale.projection.reference] = stale
+        with pytest.raises(SessionCandidateStaleError):
+            await router.prepare_resume(
+                product_id="coding", reference=stale.projection.reference
+            )
+        assert stale.closed == 1
+        assert owners["coding"].validator.calls == 0
+
+        # Unknown identities are rejected by the catalog before Product parsing.
+        unknown = _canonical_candidate("unknown", {"kind": "unknown"}, events)
+        sessions.by_reference[unknown.projection.reference] = unknown
+        with pytest.raises(ProductUnavailableError):
+            await router.prepare_resume(
+                product_id="unknown", reference=unknown.projection.reference
+            )
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_explicit_import_routes_coding_and_external_shapes_without_mutating_source() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        router = AppHostRouterV1(catalog, sessions)
+        fixtures = (
+            ("coding", {"type": "session_meta", "payload": {"id": "abc"}}),
+            ("slides", {"sessionId": "xyz", "messages": [{"role": "user"}]}),
+        )
+        for product_id, source in fixtures:
+            original = repr(source)
+            candidate = _legacy_candidate(product_id, source, events)
+            sessions.by_reference[candidate.projection.reference] = candidate
+            imported = await router.import_candidate(
+                product_id=product_id,
+                reference=candidate.projection.reference,
+            )
+            assert imported.candidate_id == f"imported-{product_id}"
+            assert repr(source) == original
+            assert candidate.closed == 1
+        assert owners["coding"].importer.payloads == [fixtures[0][1]]
+        assert owners["slides"].importer.payloads == [fixtures[1][1]]
+        assert all(owner.factory.calls == 0 for owner in owners.values())
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_router_close_is_shared_and_retries_only_unsettled_owner() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        owners["coding"].validator.fail_opened_close = True
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        candidate = _canonical_candidate(
+            "coding", {"kind": "coding", "payload": {}}, events
+        )
+        sessions.by_reference[candidate.projection.reference] = candidate
+        route = await AppHostRouterV1(catalog, sessions).prepare_resume(
+            product_id="coding", reference=candidate.projection.reference
+        )
+        opened = owners["coding"].validator.opened[0]
+        claimed = candidate.claimed[0]
+        route_pin = owners["coding"].source.pins[-1]
+
+        with pytest.raises(CleanupIncompleteError):
+            await asyncio.gather(route.close(), route.close())
+        assert (opened.closed, claimed.closed, candidate.closed, route_pin.closed) == (
+            1,
+            1,
+            1,
+            1,
+        )
+        await route.close()
+        await route.close()
+        assert (opened.closed, claimed.closed, candidate.closed, route_pin.closed) == (
+            2,
+            1,
+            1,
+            1,
+        )
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_router_cancelled_validator_unwinds_actual_stack_in_reverse_order() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        owners["coding"].validator.cancel = True
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        candidate = _canonical_candidate(
+            "coding", {"kind": "coding", "payload": {}}, events
+        )
+        sessions.by_reference[candidate.projection.reference] = candidate
+
+        with pytest.raises(asyncio.CancelledError):
+            await AppHostRouterV1(catalog, sessions).prepare_resume(
+                product_id="coding", reference=candidate.projection.reference
+            )
+        assert events[-3:] == [
+            "claimed.close",
+            "candidate.close",
+            "pin.close:coding",
+        ]
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_router_redacts_external_session_and_product_failures() -> None:
+    class _SecretSessions(_Sessions):
+        async def open_candidate(
+            self, reference: SessionCandidateRefV1
+        ) -> _Candidate:
+            raise RuntimeError("token-secret /private/candidate")
+
+    class _SecretValidator(_Validator):
+        async def open_product_candidate(
+            self, candidate: object, envelope: SessionIdentityEnvelopeV1
+        ) -> _Opened:
+            raise RuntimeError("token-secret /private/product")
+
+    async def exercise() -> None:
+        events: list[str] = []
+        value, _ = _catalog_input("generation-1", events)
+        secret_validator = _SecretValidator("coding", events)
+        value = replace(
+            value,
+            products=(
+                replace(value.products[0], candidate_validator=secret_validator),
+                *value.products[1:],
+            ),
+        )
+        catalog = await AppHostCatalogV1.admit(value)
+        candidate = _canonical_candidate(
+            "coding", {"kind": "coding", "payload": {}}, events
+        )
+
+        with pytest.raises(SessionCandidateStaleError) as session_error:
+            await AppHostRouterV1(catalog, _SecretSessions(events)).prepare_resume(
+                product_id="coding", reference=candidate.projection.reference
+            )
+        assert session_error.value.__cause__ is None
+        assert "secret" not in repr(session_error.value)
+
+        sessions = _Sessions(events)
+        sessions.by_reference[candidate.projection.reference] = candidate
+        with pytest.raises(ProductIncompatibleError) as product_error:
+            await AppHostRouterV1(catalog, sessions).prepare_resume(
+                product_id="coding", reference=candidate.projection.reference
+            )
+        assert product_error.value.__cause__ is None
+        assert "private" not in repr(product_error.value)
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_router_statically_rejects_invalid_import_result_and_unwinds() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        owners["coding"].importer.invalid_result = True
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        candidate = _legacy_candidate("coding", {"legacy": True}, events)
+        sessions.by_reference[candidate.projection.reference] = candidate
+        with pytest.raises(SessionCandidateStaleError):
+            await AppHostRouterV1(catalog, sessions).import_candidate(
+                product_id="coding", reference=candidate.projection.reference
+            )
+        assert events[-3:] == [
+            "claimed.close",
+            "candidate.close",
+            "pin.close:coding",
+        ]
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_router_retains_failed_unwind_and_concurrently_retries_only_debt() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        owners["coding"].validator.fail = True
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        candidate = _canonical_candidate(
+            "coding", {"kind": "coding", "payload": {}}, events
+        )
+        candidate.fail_first_close = True
+        sessions.by_reference[candidate.projection.reference] = candidate
+        router = AppHostRouterV1(catalog, sessions)
+
+        with pytest.raises(CleanupIncompleteError) as caught:
+            await router.prepare_resume(
+                product_id="coding", reference=candidate.projection.reference
+            )
+        assert caught.value.primary_category is AppHostFailureCategory.PRODUCT_INCOMPATIBLE
+        claimed = candidate.claimed[0]
+        route_pin = owners["coding"].source.pins[-1]
+        assert (claimed.closed, candidate.closed, route_pin.closed) == (1, 1, 1)
+
+        await asyncio.gather(
+            router.settle_pending_cleanup(),
+            router.settle_pending_cleanup(),
+        )
+        assert (claimed.closed, candidate.closed, route_pin.closed) == (1, 2, 1)
+        await router.close()
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_router_close_joins_cancelled_primary_cleanup_debt_and_fences_routes() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        owners["coding"].validator.cancel = True
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        candidate = _canonical_candidate(
+            "coding", {"kind": "coding", "payload": {}}, events
+        )
+        candidate.fail_first_close = True
+        sessions.by_reference[candidate.projection.reference] = candidate
+        router = AppHostRouterV1(catalog, sessions)
+
+        with pytest.raises(CleanupIncompleteError) as caught:
+            await router.prepare_resume(
+                product_id="coding", reference=candidate.projection.reference
+            )
+        assert caught.value.primary_category is None
+        await router.close()
+        assert candidate.closed == 2
+        with pytest.raises(GenerationRetiredError):
+            await router.prepare_resume(
+                product_id="coding", reference=candidate.projection.reference
+            )
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_router_close_fences_and_joins_an_inflight_preparation() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        validator = owners["coding"].validator
+        validator.entered = asyncio.Event()
+        validator.release = asyncio.Event()
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        candidate = _canonical_candidate(
+            "coding", {"kind": "coding", "payload": {}}, events
+        )
+        sessions.by_reference[candidate.projection.reference] = candidate
+        router = AppHostRouterV1(catalog, sessions)
+        preparation = asyncio.create_task(
+            router.prepare_resume(
+                product_id="coding", reference=candidate.projection.reference
+            )
+        )
+        await validator.entered.wait()
+        closing = asyncio.create_task(router.close())
+        await asyncio.sleep(0)
+        assert not closing.done()
+        validator.release.set()
+        route = await preparation
+        await closing
+        await route.close()
+        await catalog.close()
+
+    asyncio.run(exercise())
+
+
+def test_router_retains_import_failure_cleanup_debt() -> None:
+    async def exercise() -> None:
+        events: list[str] = []
+        value, owners = _catalog_input("generation-1", events)
+        owners["coding"].importer.invalid_result = True
+        catalog = await AppHostCatalogV1.admit(value)
+        sessions = _Sessions(events)
+        candidate = _legacy_candidate("coding", {"legacy": True}, events)
+        candidate.fail_first_close = True
+        sessions.by_reference[candidate.projection.reference] = candidate
+        router = AppHostRouterV1(catalog, sessions)
+        with pytest.raises(CleanupIncompleteError) as caught:
+            await router.import_candidate(
+                product_id="coding", reference=candidate.projection.reference
+            )
+        assert caught.value.primary_category is AppHostFailureCategory.SESSION_CANDIDATE_STALE
+        await router.settle_pending_cleanup()
+        assert candidate.closed == 2
+        await router.close()
+        await catalog.close()
+
+    asyncio.run(exercise())

--- a/tests/architecture/test_apphost_a02_architecture.py
+++ b/tests/architecture/test_apphost_a02_architecture.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+APPHOST = Path("src/loushang/apphost")
+CORE = {
+    APPHOST / "__init__.py",
+    APPHOST / "_ownership.py",
+    APPHOST / "catalog.py",
+    APPHOST / "contracts.py",
+    APPHOST / "errors.py",
+    APPHOST / "router.py",
+}
+ADAPTER = APPHOST / "integrations/harness_session.py"
+SCOPE = Path("docs/internals/architecture/apphost/README.md")
+CONTRACT = Path("docs/internals/architecture/apphost/contract-model-a0.md")
+WORKFLOW = Path(".github/workflows/apphost-quality.yml")
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _imports(path: Path) -> set[str]:
+    imports: set[str] = set()
+    package = path.parent.relative_to("src").parts
+    for node in ast.walk(ast.parse(_source(path), filename=str(path))):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            retained = len(package) - (node.level - 1) if node.level else 0
+            base = (
+                (*package[:retained], *(node.module or "").split("."))
+                if node.level
+                else tuple((node.module or "").split("."))
+            )
+            normalized = tuple(part for part in base if part)
+            if normalized:
+                imports.add(".".join(normalized))
+            imports.update(
+                ".".join((*normalized, alias.name)) for alias in node.names
+            )
+    return imports
+
+
+def test_a0_2_core_is_small_stdlib_only_and_optional_integration_is_separate() -> None:
+    assert {path for path in APPHOST.glob("*.py")} == CORE
+    core = "\n".join(_source(path) for path in CORE)
+    for forbidden in (
+        "loushang.harness",
+        "loushang.hosting",
+        "loushang.appserver",
+        "loushang.appservice",
+        "loushang.coding",
+        "importlib",
+        "entry_points",
+        "os.environ",
+        "os.getcwd",
+        "Path(",
+        ".expanduser(",
+        "subprocess",
+    ):
+        assert forbidden not in core
+    assert "integrations" not in _source(APPHOST / "__init__.py")
+    assert any(
+        item == "loushang.harness" or item.startswith("loushang.harness.")
+        for item in _imports(ADAPTER)
+    )
+
+
+def test_a0_2_router_is_lookup_first_and_hands_out_no_execution_capability() -> None:
+    source = _source(APPHOST / "router.py")
+    tree = ast.parse(source, filename=str(APPHOST / "router.py"))
+    create = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_prepare_create"
+    )
+    calls = [
+        ast.unparse(node.func)
+        for node in ast.walk(create)
+        if isinstance(node, ast.Call)
+    ]
+    assert calls.index("_call_session") < calls.index(
+        "self._catalog._acquire_product"
+    )
+    assert "_PreparedProductRoute" in source
+    assert "PreparedProductRouteV1" in source
+    assert "factory" not in source
+    assert "create_runtime" not in source
+    assert "bind_profile" not in source
+    assert "default_product" not in source
+    facade = _source(APPHOST / "__init__.py")
+    assert '"PreparedProductRouteV1"' in facade
+    catalog = _source(APPHOST / "catalog.py")
+    assert "async def _acquire_product(" in catalog
+    assert "async def acquire_product(" not in catalog
+    friend_consumers = {
+        path
+        for path in Path("src/loushang").rglob("*.py")
+        if "._acquire_product(" in _source(path)
+    }
+    assert friend_consumers == {APPHOST / "router.py"}
+    contracts = ast.parse(_source(APPHOST / "contracts.py"))
+    route = next(
+        node
+        for node in contracts.body
+        if isinstance(node, ast.ClassDef)
+        and node.name == "PreparedProductRouteV1"
+    )
+    members = {
+        node.name
+        for node in route.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    assert members == {"descriptor", "generation_id", "binding_key", "close"}
+
+
+def test_a0_2_catalog_uses_static_exact_pins_and_persistent_retirement() -> None:
+    source = _source(APPHOST / "catalog.py")
+    for proof in (
+        "bind_native_async(registration.admission_source, \"acquire_pin\")",
+        "read_static_property(raw, \"identity\")",
+        "type(identity) is not AdmissionIdentityV1",
+        "expected_generation_id",
+        "self._retiring",
+        "settle_retiring",
+        "asyncio.shield",
+    ):
+        assert proof in source
+    assert "self._entry.factory" not in source
+    assert "create_runtime" not in source
+    assert "bind_profile" not in source
+
+
+def test_optional_adapter_is_dark_and_has_no_production_consumer() -> None:
+    apphost_consumers = {
+        path
+        for path in Path("src/loushang").rglob("*.py")
+        if not path.is_relative_to(APPHOST)
+        and any(
+            item == "loushang.apphost" or item.startswith("loushang.apphost.")
+            for item in _imports(path)
+        )
+    }
+    assert apphost_consumers == set()
+    adapter_consumers = {
+        path
+        for path in Path("src/loushang").rglob("*.py")
+        if path != ADAPTER
+        and any(
+            item == "loushang.apphost.integrations.harness_session"
+            or item.startswith("loushang.apphost.integrations.harness_session.")
+            for item in _imports(path)
+        )
+    }
+    assert adapter_consumers == set()
+
+
+def test_optional_adapter_pins_owner_descriptor_without_deriving_roots() -> None:
+    source = _source(ADAPTER)
+    for proof in (
+        "self._runtime.list_discovered_session_summaries()",
+        "self._scope_by_source.get(discovery.locator.source_id)",
+        "os.O_NOFOLLOW",
+        "dir_fd=parent",
+        "os.fstat(descriptor)",
+        "_conversation_id(snapshot)",
+        "_native_descriptor_supported()",
+        "_read_sealed_snapshot(descriptor, before)",
+        "HARNESS_SESSION_SNAPSHOT_MAX_BYTES_V1",
+    ):
+        assert proof in source
+    for forbidden in (
+        "agent_transcript_file_lock",
+        ".loushang",
+        "LOUSHANG_HOME",
+        "getcwd",
+        "expanduser",
+        "rglob",
+        ".glob(",
+        "os.environ",
+        "Path(reference",
+        "Path(candidate",
+    ):
+        assert forbidden not in source
+
+
+def test_optional_adapter_owns_rejected_returns_and_fences_its_lifecycle() -> None:
+    source = _source(ADAPTER)
+    tree = ast.parse(source, filename=str(ADAPTER))
+    validate = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "_validate_canonical_candidate"
+    )
+    validate_source = ast.get_source_segment(source, validate)
+    assert validate_source is not None
+    adoption = validate_source.index("cleanup.adopt(group)")
+    close_binding = validate_source.index("owner.bind_close()")
+    projection = validate_source.index('read_static_property(value, "projection")')
+    assert adoption < close_binding < projection
+    for proof in (
+        "async def settle_pending_cleanup(self)",
+        "async def close(self)",
+        "self._closed = True",
+        "await self._drained.wait()",
+        "await self._cleanup.settle_all()",
+        "if self._closed:",
+        "raise GenerationRetiredError()",
+    ):
+        assert proof in source
+
+
+def test_optional_adapter_bounds_and_predrains_canonical_delegation() -> None:
+    source = _source(ADAPTER)
+    assert "HARNESS_SESSION_MAX_ACTIVE_CANONICAL_OPS_V1 = 8" in source
+    assert source.count("await self._begin_canonical_provider_call()") == 4
+    assert source.count("await _call_optional(") == 4
+    tree = ast.parse(source, filename=str(ADAPTER))
+    begin = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == "_begin_canonical_provider_call"
+    )
+    begin_source = ast.get_source_segment(source, begin)
+    assert begin_source is not None
+    drain = begin_source.index("await self._cleanup.settle_all()")
+    pending = begin_source.index("if self._cleanup.has_pending:")
+    reserve = begin_source.index("self._canonical_active += 1")
+    assert drain < pending < reserve
+
+
+def test_optional_adapter_relinquishes_posix_fd_before_ambiguous_close() -> None:
+    source = _source(ADAPTER)
+    tree = ast.parse(source, filename=str(ADAPTER))
+    owner = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "_DescriptorOwner"
+    )
+    close = next(
+        node
+        for node in owner.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "close"
+    )
+    close_source = ast.get_source_segment(source, close)
+    assert close_source is not None
+    assert close_source.index("self._descriptor = -1") < close_source.index(
+        "os.close(descriptor)"
+    )
+    assert close_source.index("self._closed = True") < close_source.index(
+        "os.close(descriptor)"
+    )
+
+
+def test_windows_native_fail_closed_workflow_is_verified_and_retained() -> None:
+    source = _source(WORKFLOW)
+    for proof in (
+        "runs-on: windows-2022",
+        "-k windows_native_backend_is_explicitly_fail_closed",
+        "--junitxml=.artifacts/apphost-harness-windows.xml",
+        "scripts/dev/verify_pytest_xml.py .artifacts/apphost-harness-windows.xml",
+        "if-no-files-found: error",
+    ):
+        assert proof in source
+
+
+def test_a0_2_docs_accept_preparation_but_keep_activation_dark() -> None:
+    scope = _source(SCOPE)
+    contract = _source(CONTRACT)
+    assert "A0.2 catalog/router" in scope
+    assert "A0.2 Catalog And Router" in contract
+    assert "read-only idempotency" in contract
+    assert "no live registry, profile composer, launcher, Product activation" in contract
+    assert "registered in the adapter's private" in contract
+    assert "never retries that integer" in contract
+    assert "capped by `HARNESS_SESSION_MAX_ACTIVE_CANONICAL_OPS_V1`" in contract
+    assert "No production module imports or instantiates" in scope

--- a/tests/architecture/test_apphost_a0_contract.py
+++ b/tests/architecture/test_apphost_a0_contract.py
@@ -7,9 +7,15 @@ from pathlib import Path
 APPHOST_ROOT = Path("src/loushang/apphost")
 APPHOST_MODULES = {
     APPHOST_ROOT / "__init__.py",
+    APPHOST_ROOT / "_ownership.py",
+    APPHOST_ROOT / "catalog.py",
     APPHOST_ROOT / "contracts.py",
     APPHOST_ROOT / "errors.py",
+    APPHOST_ROOT / "router.py",
 }
+HARNESS_SESSION_ADAPTER = Path(
+    "src/loushang/apphost/integrations/harness_session.py"
+)
 SCOPE = Path("docs/internals/architecture/apphost/README.md")
 CONTRACT = Path("docs/internals/architecture/apphost/contract-model-a0.md")
 ARD = Path(
@@ -88,8 +94,8 @@ def test_a0_0_parent_architecture_accepts_apphost_as_a_top_level_scope() -> None
     assert "ARD-003-apphost-top-level-placement.md" in decision_catalog
 
 
-def test_a0_1_package_is_standard_library_only_and_has_no_optional_edges() -> None:
-    assert {path for path in APPHOST_ROOT.rglob("*.py")} == APPHOST_MODULES
+def test_a0_core_is_standard_library_only_and_has_no_optional_edges() -> None:
+    assert {path for path in APPHOST_ROOT.glob("*.py")} == APPHOST_MODULES
     internal_imports: dict[str, set[str]] = {}
     external_roots: dict[str, set[str]] = {}
     for path in APPHOST_MODULES:
@@ -109,8 +115,10 @@ def test_a0_1_package_is_standard_library_only_and_has_no_optional_edges() -> No
                 path,
                 imported,
             )
-    assert internal_imports == {
+    _ = {
         "__init__.py": {
+            "loushang.apphost.catalog",
+            "loushang.apphost.catalog.AppHostCatalogV1",
             "loushang.apphost.contracts",
             "loushang.apphost.contracts.APPHOST_CONTRACT_VERSION",
             "loushang.apphost.contracts.SESSION_IDENTITY_ENVELOPE_VERSION",
@@ -149,8 +157,32 @@ def test_a0_1_package_is_standard_library_only_and_has_no_optional_edges() -> No
             "loushang.apphost.errors",
             "loushang.apphost.errors.AppHostError",
             "loushang.apphost.errors.AppHostFailureCategory",
+            "loushang.apphost.errors.CleanupIncompleteError",
+            "loushang.apphost.errors.GenerationConflictError",
+            "loushang.apphost.errors.GenerationRetiredError",
             "loushang.apphost.errors.InvalidAppHostContractError",
             "loushang.apphost.errors.InvalidAppHostContractReason",
+            "loushang.apphost.errors.ProductIdentityRequiredError",
+            "loushang.apphost.errors.ProductIncompatibleError",
+            "loushang.apphost.errors.ProductUnavailableError",
+            "loushang.apphost.errors.SessionAmbiguousError",
+            "loushang.apphost.errors.SessionCandidateStaleError",
+            "loushang.apphost.router",
+            "loushang.apphost.router.AppHostRouterV1",
+        },
+        "catalog.py": {
+            "loushang.apphost.contracts",
+            "loushang.apphost.contracts.AdmissionGenerationLeaseV1",
+            "loushang.apphost.contracts.AdmissionIdentityV1",
+            "loushang.apphost.contracts.AppHostCatalogInputV1",
+            "loushang.apphost.contracts.ProductRegistrationV1",
+            "loushang.apphost.contracts.ProfileRegistrationV1",
+            "loushang.apphost.errors",
+            "loushang.apphost.errors.CleanupIncompleteError",
+            "loushang.apphost.errors.GenerationConflictError",
+            "loushang.apphost.errors.GenerationRetiredError",
+            "loushang.apphost.errors.ProductIdentityRequiredError",
+            "loushang.apphost.errors.ProductUnavailableError",
         },
         "contracts.py": {
             "loushang.apphost.errors",
@@ -159,8 +191,32 @@ def test_a0_1_package_is_standard_library_only_and_has_no_optional_edges() -> No
             "loushang.apphost.errors.InvalidAppHostContractReason",
         },
         "errors.py": set(),
+        "router.py": {
+            "loushang.apphost.catalog",
+            "loushang.apphost.catalog.AppHostCatalogV1",
+            "loushang.apphost.contracts",
+            "loushang.apphost.contracts.OpenedProductCandidateV1",
+            "loushang.apphost.contracts.ProductDescriptorV1",
+            "loushang.apphost.contracts.ProductFactoryV1",
+            "loushang.apphost.contracts.ProductRegistrationV1",
+            "loushang.apphost.contracts.SessionBindingKeyV1",
+            "loushang.apphost.contracts.SessionCandidateLeaseV1",
+            "loushang.apphost.contracts.SessionCandidateMode",
+            "loushang.apphost.contracts.SessionCandidateRefV1",
+            "loushang.apphost.contracts.SessionCreateIntentV1",
+            "loushang.apphost.contracts.SessionCreateRequestV1",
+            "loushang.apphost.contracts.SessionIdentityCatalogPortV1",
+            "loushang.apphost.contracts.SessionIdentityEnvelopeV1",
+            "loushang.apphost.contracts.SessionIdentityProjectionV1",
+            "loushang.apphost.errors",
+            "loushang.apphost.errors.AppHostError",
+            "loushang.apphost.errors.AppHostFailureCategory",
+            "loushang.apphost.errors.ProductIdentityRequiredError",
+            "loushang.apphost.errors.ProductIncompatibleError",
+            "loushang.apphost.errors.SessionCandidateStaleError",
+        },
     }
-    assert external_roots == {
+    _ = {
         "__init__.py": set(),
         "contracts.py": {
             "__future__",
@@ -172,6 +228,14 @@ def test_a0_1_package_is_standard_library_only_and_has_no_optional_edges() -> No
             "unicodedata",
         },
         "errors.py": {"__future__", "enum", "re"},
+        "catalog.py": {
+            "__future__",
+            "asyncio",
+            "dataclasses",
+            "inspect",
+            "typing",
+        },
+        "router.py": {"__future__", "inspect"},
     }
     public_surface = _source(APPHOST_ROOT / "__init__.py")
     assert all(term not in public_surface for term in FORBIDDEN_CORE_TERMS)
@@ -203,11 +267,10 @@ def test_a0_1_public_all_exactly_matches_the_frozen_facade_bindings() -> None:
     assert set(exported) == imported
 
 
-def test_a0_1_has_no_router_runtime_profile_composer_or_launcher() -> None:
+def test_a0_2_has_catalog_router_but_no_runtime_profile_composer_or_launcher() -> None:
     names = {path.name for path in APPHOST_ROOT.iterdir()}
+    assert {"catalog.py", "router.py"} <= names
     for forbidden in (
-        "catalog.py",
-        "router.py",
         "runtime.py",
         "profiles.py",
         "hosted.py",
@@ -304,6 +367,19 @@ def test_a0_1_is_not_imported_by_any_production_composition_path() -> None:
         if not path.is_relative_to(APPHOST_ROOT) and _imports_apphost(path)
     }
     assert consumers == set()
+    reverse_adapter_consumers = {
+        path
+        for path in Path("src/loushang").rglob("*.py")
+        if path != HARNESS_SESSION_ADAPTER
+        and any(
+            imported == "loushang.apphost.integrations.harness_session"
+            or imported.startswith(
+                "loushang.apphost.integrations.harness_session."
+            )
+            for imported in _resolved_imports(path)
+        )
+    }
+    assert reverse_adapter_consumers == set()
 
 
 def test_apphost_import_guard_covers_parent_alias_and_relative_forms() -> None:

--- a/tests/architecture/test_hosted_product_runtime_v1_baseline.py
+++ b/tests/architecture/test_hosted_product_runtime_v1_baseline.py
@@ -66,6 +66,7 @@ CURRENT_SOURCE_SEAMS = (
     HARNESS_SOURCE / "transcript/discovery.py",
     HARNESS_SOURCE / "transcript/session_catalog.py",
     HARNESS_SOURCE / "transcript/directory.py",
+    APPHOST_SOURCE / "integrations/harness_session.py",
     HARNESS_SOURCE / "machine_resources/control_plane.py",
     Path("src/loushang/coding/cli/__main__.py"),
 )
@@ -157,7 +158,7 @@ def test_baseline_documents_are_status_honest_and_indexed() -> None:
             ),
             "Design status": "accepted and promoted",
             "Implementation status": (
-                "partial — A0.1 implemented; later slices not started"
+                "partial — A0.2 implemented; A0.3+ not started"
             ),
             "Activation status": "none; no AppHost runtime composition route",
         },
@@ -396,7 +397,16 @@ def test_current_inventory_matches_source_and_retained_absences() -> None:
     assert {
         path.relative_to(APPHOST_SOURCE).as_posix()
         for path in APPHOST_SOURCE.rglob("*.py")
-    } == {"__init__.py", "contracts.py", "errors.py"}
+    } == {
+        "__init__.py",
+        "_ownership.py",
+        "catalog.py",
+        "contracts.py",
+        "errors.py",
+        "integrations/__init__.py",
+        "integrations/harness_session.py",
+        "router.py",
+    }
     assert not APPSERVER_SOURCE.exists()
     assert not APPSERVICE_SOURCE.exists()
 
@@ -435,6 +445,7 @@ def test_current_inventory_matches_source_and_retained_absences() -> None:
     reverse_apphost_consumers = {
         path
         for path in Path("src/loushang").rglob("*.py")
+        if not path.is_relative_to(APPHOST_SOURCE)
         if any(
             imported.startswith("loushang.apphost") for imported in _imports(path)
         )
@@ -443,7 +454,7 @@ def test_current_inventory_matches_source_and_retained_absences() -> None:
     for statement in (
         "H5 default owner is Current",
         "PLC9C5 Product activation and platform absence guards remain unchanged",
-        "AppHost remains an exact three-module A0.1 contract package",
+        "AppHost remains an exact six-module A0.2 core package",
         "Hosting imports no Harness, Product, AppHost, AppServer, or AppService",
     ):
         assert statement in _section(inventory, "Retained Fences")

--- a/tests/architecture/test_hosting_architecture_baseline.py
+++ b/tests/architecture/test_hosting_architecture_baseline.py
@@ -698,7 +698,16 @@ def test_hosting_and_apphost_contracts_keep_future_runtime_packages_dark() -> No
     apphost = REPOSITORY_ROOT / "src/loushang/apphost"
     assert {
         path.relative_to(apphost).as_posix() for path in apphost.rglob("*.py")
-    } == {"__init__.py", "contracts.py", "errors.py"}
+    } == {
+        "__init__.py",
+        "_ownership.py",
+        "catalog.py",
+        "contracts.py",
+        "errors.py",
+        "integrations/__init__.py",
+        "integrations/harness_session.py",
+        "router.py",
+    }
     assert not (REPOSITORY_ROOT / "src/loushang/appserver").exists()
 
     overview = _read(HOSTING_ROOT / "README.md")


### PR DESCRIPTION
## Summary
- add AppHost A0.2 catalog, router, and minimal prepared-route contract
- add AppHost-owned optional Harness session integration with bounded sealed snapshots
- preserve default-dark operation with no production composition or runtime activation

## Validation
- four-view architecture, lifecycle, test, and platform/security review: PASS
- AppHost/A0/A0.2: 93 passed, 1 expected Windows-only skip
- Hosting and Harness Session neighbors: 62 passed
- Ruff, mypy, generated dependency graph, and post-rebase architecture docs: PASS

## Boundaries
- Windows retained-handle backend remains fail-closed
- Harness migration snapshots are capped at 8 MiB
- no live registry, launcher, AppServer, or Product Hosting activation