### PR TITLE
feat(coding): add PLC9C5 Linux Worker canary

### DIFF
--- a/.github/workflows/harness-quality.yml
+++ b/.github/workflows/harness-quality.yml
@@ -108,6 +108,33 @@ jobs:
           path: .artifacts/plc9c5-c52-linux-native.xml
           if-no-files-found: error
 
+      - name: PLC9C5 C5.4 Linux Coding Product canary
+        env:
+          PYTEST_ADDOPTS: >-
+            -o faulthandler_timeout=60
+            --junitxml=.artifacts/plc9c5-c54-linux-product.xml
+        run: >-
+          uv run python scripts/dev/run_pytest.py
+          tests/harness/worker/test_coding_product_worker_canary.py
+          -q
+
+      - name: Reject skipped, failing, or incomplete PLC9C5 C5.4 evidence
+        run: |
+          uv run python scripts/dev/verify_pytest_xml.py \
+            .artifacts/plc9c5-c54-linux-product.xml
+          uv run python scripts/dev/verify_plc9c5_manifest.py \
+            docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-evidence-manifest.json \
+            PLC9C5-C5.4-LINUX-PRODUCT \
+            .artifacts/plc9c5-c54-linux-product.xml
+
+      - name: Upload PLC9C5 C5.4 Linux Product report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plc9c5-c54-linux-product-pytest-report
+          path: .artifacts/plc9c5-c54-linux-product.xml
+          if-no-files-found: error
+
       - name: Harness quality gate
         run: make check-harness
 

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ CODING_TUI_PRODUCT_TEST_PATHS := \
 	tests/coding/test_ui_session_view.py
 HARNESS_SOURCES := src/loushang/harness
 HARNESS_RUNTIME_SUPPORT_SOURCES := \
+	src/loushang/coding/_product_worker_canary.py \
 	src/loushang/foundation/platform_paths.py \
 	src/loushang/foundation/runtime_scope.py \
 	scripts/dev/run_pytest.py \
@@ -129,6 +130,7 @@ HARNESS_TEST_PATHS := \
 	tests/architecture/test_plugin_lifecycle_plc9c5_c51_contract.py \
 	tests/architecture/test_plugin_lifecycle_plc9c5_c52_linux_native.py \
 	tests/architecture/test_plugin_lifecycle_plc9c5_c53_windows_mechanics.py \
+	tests/architecture/test_plugin_lifecycle_plc9c5_c54_linux_product.py \
 	tests/architecture/test_session_model_call_closure_contract.py
 HOSTING_SOURCES := \
 	src/loushang/hosting \
@@ -245,6 +247,14 @@ test-plc9c5-c53-windows-mechanics:
 	uv --cache-dir .uv-cache run --extra dev python scripts/dev/verify_plc9c5_manifest.py docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-evidence-manifest.json PLC9C5-C5.3-WINDOWS-MECHANICS .artifacts/plc9c5-c53-windows-mechanics.xml
 
 check-plc9c5-c53-windows-mechanics: test-plc9c5-c53-windows-mechanics
+
+test-plc9c5-c54-linux-product:
+	mkdir -p .artifacts
+	uv --cache-dir .uv-cache run --extra dev $(PYTEST_RUNNER) tests/harness/worker/test_coding_product_worker_canary.py -q --junitxml=.artifacts/plc9c5-c54-linux-product.xml
+	uv --cache-dir .uv-cache run --extra dev python scripts/dev/verify_pytest_xml.py .artifacts/plc9c5-c54-linux-product.xml
+	uv --cache-dir .uv-cache run --extra dev python scripts/dev/verify_plc9c5_manifest.py docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-evidence-manifest.json PLC9C5-C5.4-LINUX-PRODUCT .artifacts/plc9c5-c54-linux-product.xml
+
+check-plc9c5-c54-linux-product: test-plc9c5-c54-linux-product
 
 check-hosting: lint-hosting typecheck-hosting test-hosting
 

--- a/docs/internals/architecture/harness/plugin/README.md
+++ b/docs/internals/architecture/harness/plugin/README.md
@@ -349,6 +349,11 @@ Neither may silently override a narrower implemented owner contract.
   adds one Hosting-private OS-sourced trusted-payload builder, retains the
   restricted-token/Job/handle-list mechanics report, and proves explicit
   Product required-containment rejection. Windows activation remains closed.
+- [PLC9C5 C5.4 Linux Coding Product Canary](plugin-lifecycle-plc9c5-c54-linux-product.md)
+  composes the one explicit Linux Coding canary over the retained Worker and
+  Hosting capabilities, joins stable Session and shared-entrypoint evidence,
+  and closes ordered rollback/recovery and publication evidence. Current stays
+  default and G7 remains open on Windows.
 - [Plugin Authoring Guide](plugin-authoring-guide.md) documents the minimum
   stable Provider, Skill package, validation, and developer-conformance flows.
 - [PAP4 Capability Admission Contract](plugin-capability-admission-pap4-contract.md)

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c50-baseline.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c50-baseline.md
@@ -8,10 +8,11 @@
 - Parent: `PLC9C`
 - Authority: normative accepted design
 - Design status: accepted
-- Implementation status: implemented through C5.3 — C5.0 design/guards, C5.1
-  receipt/lifecycle, C5.2 Linux native profile binding, and C5.3 Windows
-  mechanics/rejection; C5.4 not-started
-- Activation status: closed; every production route remains default-dark
+- Implementation status: implemented through C5.4 — C5.0 design/guards, C5.1
+  receipt/lifecycle, C5.2 Linux native profile binding, C5.3 Windows
+  mechanics/rejection, and the C5.4 Linux Coding Product canary
+- Activation status: explicit Linux Coding canary accepted; default remains
+  Current and Windows/every unlisted platform remain closed
 - Observation base: `cb01f723`
 - Owner: Harness Worker architecture with Product, Hosting, and domain-owner
   review
@@ -19,11 +20,13 @@
 ## Purpose And Acceptance Boundary
 
 C5.0 fixes the design, Current inventory, dependency direction, rollout
-matrix, and executable absence/deletion guards for PLC9C5. C5.1 adds the
+matrix, and executable transition/deletion guards for PLC9C5. C5.1 adds the
 receipt/lifecycle contract, C5.2 adds only the default-dark Linux native
 profile capability, and C5.3 retains the Windows mechanics while proving that
-they are not accepted Product containment. None authorizes a production
-Product composition to request the Hosting owner.
+they are not accepted Product containment. C5.4 adds the sole explicit Coding
+Product composition that may request Hosting when an exact receipt, stable
+Session locator, Linux native-profile capability, and Capability owner all
+converge. Omission and every unmatched route retain Current.
 
 The first canary is one exact, read-only `capability_provider` contribution
 selected by the Coding Product. Coding is the first evidence Product, not the
@@ -245,7 +248,7 @@ Current Worker shape.
 
 | Platform/profile | Already proven | Blocking C5 delta | Owning slice |
 | --- | --- | --- | --- |
-| Linux x86_64, excluding WSL, `posix-static-contained-elf-v1` | H6.2 seals one static launcher and payload, retains cwd, transfers only the exact endpoint/preparation descriptors, and owns process-group cleanup | implemented in C5.2: Product policy admits the exact payload/launcher/containment-profile closure; the unique bridge rejects WSL/unknown/non-x86 before H6 selection; same-boot crash uncertainty remains durable cleanup debt | C5.2 Linux native report implemented; no Product composition |
+| Linux x86_64, excluding WSL, `posix-static-contained-elf-v1` | H6.2 seals one static launcher and payload, retains cwd, transfers only the exact endpoint/preparation descriptors, and owns process-group cleanup | implemented in C5.2: Product policy admits the exact payload/launcher/containment-profile closure; the unique bridge rejects WSL/unknown/non-x86 before H6 selection; same-boot crash uncertainty remains durable cleanup debt | C5.2 Linux native report retained; consumed only by the exact C5.4 Coding Product root |
 | Windows AMD64 `windows-restricted-direct-import-pe-v1` | H6.3 locks PE/cwd/ancestors, creates a restricted token and kill-on-close Job, constrains the handle list, and proves direct-import mechanics | **Not accepted as Product required containment.** It is a trusted-payload mechanics profile only. A Hosting-private opaque builder must obtain locked file identities and query `GetWindowsDirectoryW` for a canonical absolute `SystemRoot`; it never reads `os.environ`. Ambient `SystemRoot` poisoning is ignored, while any caller-supplied environment/SystemRoot is rejected before acquisition. Harness/Product never receives raw handles or environment. The builder preserves H6.3 discarded stderr and cannot reuse H6.4's piped-stderr mapping. Windows Product canary remains closed until a separate security-reviewed containment profile is accepted | C5.3 retained mechanics/fail-closed gate; no Product activation |
 | macOS, WSL, unknown Linux classifier result, non-x86_64 Linux, non-AMD64 Windows, every unlisted environment | no accepted PLC9C5 Product native profile | remain unsupported with a stable fail-closed result; no best-effort/current same-attempt downgrade | retained through C5.4 |
 
@@ -396,24 +399,26 @@ that the old owner is unused.
 
 ## Per-Slice Executable Guards
 
-While C5.2 is the active implementation edge, architecture tests must prove:
+With C5.4 delivered, architecture tests must prove:
 
 - the baseline and inventory are indexed once and reproduce every G7 matrix
   dimension and required case from the parent plan;
 - every Current inventory source exists and the documented source set is exact;
-- only the named C5.1 receipt/coordinator contracts and C5.2 profile port exist;
-- no non-Worker production module composes the H5 owner selector, H6 adapter,
-  or C4 Capability adapter; Sandbox remains the sole non-Worker importer of
-  the existing Worker launch capability;
+- only the named C5.1 receipt/coordinator contracts, C5.2 profile port, and
+  exact C5.4 Coding Product root exist;
+- only the C5.4 Coding root outside Worker composes the H5 owner selector, H6
+  adapter, or C4 Capability adapter; Sandbox remains the sole non-Worker
+  importer of the existing Worker launch capability;
 - the sole `_native_profile_bridge.py` friend imports exactly the two accepted
   private POSIX profile symbols and no Windows/raw platform API; the H6.4
   private preparation edge remains confined to the existing Worker adapter;
-- Coding Product and presenter modules import no Harness Worker or Hosting
-  implementation;
+- only the exact Coding canary imports the reviewed C5.1 coordinator and C5.2
+  friend binder; no Coding or presenter module imports Hosting;
 - owner selection still defaults to Current, performs no environment lookup,
   and contains one direct call with no cross-owner exception retry;
 - `remote_service`, author-SDK runtime owners, AppHost coupling, unsupported
-  platform fallback, and production activation remain absent; and
+  platform fallback, and every Product activation outside the exact Linux
+  Coding canary remain absent; and
 - the retained deletion symbols/files for Current launch, rollback, native
   preparation, Session identity validation, and domain authority still exist.
 

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c50-inventory.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c50-inventory.md
@@ -8,16 +8,16 @@
 - Authority: descriptive — source-backed Current inventory
 - Design status: not-applicable
 - Implementation status: not-applicable
-- Observation base: C5.2 implementation candidate based on `cda62364`
+- Observation base: C5.4 implementation candidate based on `94b98d3d`
 - Effect: none; this inventory grants no runtime or activation authority
 - Owner: Harness Worker architecture
 
 ## Reading Rule
 
-This inventory records Current facts at the observation base and the exact C5.1
-and C5.2 transitions. Source and executable tests remain higher authority.
-Names owned by C5.4 remain proposals. A source row records the narrow seam needed to
-reason about C5; it does not transfer authority to Product or Plugin management.
+This inventory records Current facts at the observation base and the exact
+C5.1--C5.4 transitions. Source and executable tests remain higher authority. A
+source row records the narrow seam needed to reason about C5; it does not
+transfer authority to Product or Plugin management.
 
 ## Exact Current Source Set
 
@@ -25,14 +25,15 @@ reason about C5; it does not transfer authority to Product or Plugin management.
 | --- | --- | --- | --- |
 | `C5-CUR-DECL` | `src/loushang/harness/resources/plugins/declarations.py` and `src/loushang/harness/resources/plugins/selection.py` | versioned inert `local_worker` declaration/selection exists for `capability_provider`; declared required/optional and exact Worker configuration are data only | retain; Product must rejoin the exact selected reservation and immutable revision before a receipt and cannot downgrade declared requiredness |
 | `C5-CUR-PRODUCT-CORE` | `src/loushang/harness/session/bootstrap_construction.py` and `src/loushang/harness/session/agent_product.py` | one Product-bound Agent Session construction path exists; it owns Product callbacks and final Session assembly but has no Worker activation input | reuse as the shared canary-capable construction boundary; do not put activation in presenters |
-| `C5-CUR-CODING-PRODUCT` | `src/loushang/coding/bootstrap.py` and `src/loushang/coding/cli/__main__.py` | Coding supplies an explicit `product_id` and converges ordinary Agent/TUI/RPC/channel/plain/workflow modes through one runtime builder; early-dispatch workspace/LSP/multiagent routes are separate | first Product evidence only; C5.4 must inventory exact canary-capable callers and keep every excluded route dark |
+| `C5-CUR-CODING-PRODUCT` | `src/loushang/coding/bootstrap.py`, `src/loushang/coding/cli/__main__.py`, and `src/loushang/coding/_product_worker_canary.py` | Coding supplies an explicit `product_id`, converges ordinary Agent/TUI/RPC/channel/plain/workflow modes through one runtime builder, and owns the sole explicit Linux Worker canary composition; early-dispatch workspace/LSP/multiagent routes remain separate | implemented C5.4 Product evidence; the one canary consumes the public Harness Worker facade plus the exact reviewed C5.1 coordinator/C5.2 binder friend seams and keeps every excluded route dark |
 | `C5-CUR-PACKAGE-PRODUCT` | `src/loushang/harness/resources/packages/product_contract.py`, `src/loushang/harness/resources/packages/product_runtime.py`, `src/loushang/harness/resources/packages/product_activation.py`, and `src/loushang/harness/resources/packages/product_composition.py` | PLC9A2 owns Package lifecycle routing for CLI/RPC/Session/startup/operations; it is not a generic Product catalog and contains no Worker authority | retain as Product composition precedent; do not extend its Package-specific receipt into Worker activation |
 | `C5-CUR-SESSION-PROFILE` | `src/loushang/harness/transcript/runtime_profile.py` and `src/loushang/coding/session_manager.py` | Coding persists a Product-bound runtime profile and refuses foreign Product profile snapshots on restore | reuse for the Coding-specific G7 resume row after locator selection; do not claim generic AppHost pre-routing identity |
 | `C5-CUR-SESSION-DISCOVERY` | `src/loushang/harness/transcript/discovery.py`, `src/loushang/harness/transcript/directory.py`, `src/loushang/harness/transcript/session_catalog.py`, and `src/loushang/harness/machine_resources/control_plane.py` | canonical global plus cwd/home compatibility sources have stable source/locator, alias/conflict, and read-only projection semantics | retain; discovery selects a candidate and grants no Worker/Product authority |
 | `C5-CUR-WORKER-PUBLIC` | `src/loushang/harness/worker/__init__.py` | public Worker contracts export launch/session/supervisor, owner selection, H6.4 adapter, C4 query-adapter mechanics, exactly three C5.1 policy/receipt/authority contracts, and the single C5.2 `ProductWorkerNativeProfilePort` | freeze the exact Current `__all__`; private coordinator/cleanup/status/bridge/platform types remain unexported |
-| `C5-C51-RECEIPT-LIFECYCLE` | `src/loushang/harness/worker/product_activation.py` | strict pathless policy/receipt codec, statically bound synchronous Product-owned freshness gate, coordinator-wide callback reentry fence, deterministic CAS aggregate, closed monotonic attempt phases, sticky active registry, exact publication/retirement, durable restart policy plus pinned evidence-authority identity/fingerprint, two-phase retryable kill latch, retryable idempotent gate release, trusted cleanup settlement/debt, and exact registered-orphan no-effect recovery exist without a production consumer | retain as Product-neutral internal C5.1 aggregate; evidence authority is construction-pinned and record APIs accept only opaque witnesses; C5.2 may inject Linux native evidence but cannot add Product composition |
-| `C5-C52-LINUX-NATIVE` | `src/loushang/harness/worker/_native_profile_bridge.py` | one request-bound, single-use, pathless Linux contained-profile capability rejoins the C5.1 receipt to the exact Worker request, binds the static launcher digest and containment-profile digest, rejects WSL/unknown/non-x86 before lazily loading the two accepted private H6 POSIX symbols, and records policy/execution closure fingerprints | implemented and default-dark; no Product composition constructs it, Windows dispatch is absent, and Hosting retains all raw native material |
+| `C5-C51-RECEIPT-LIFECYCLE` | `src/loushang/harness/worker/product_activation.py` | strict pathless policy/receipt codec, statically bound synchronous Product-owned freshness gate, coordinator-wide callback reentry fence, deterministic CAS aggregate, closed monotonic attempt phases, sticky active registry, exact publication/retirement, durable restart policy plus pinned evidence-authority identity/fingerprint, two-phase retryable kill latch, retryable idempotent gate release, trusted cleanup settlement/debt, and exact registered-orphan no-effect recovery | retain as the Product-neutral internal C5.1 aggregate now consumed only by the exact C5.4 Coding root; evidence authority is construction-pinned and record APIs accept only opaque witnesses |
+| `C5-C52-LINUX-NATIVE` | `src/loushang/harness/worker/_native_profile_bridge.py` | one request-bound, single-use, pathless Linux contained-profile capability rejoins the C5.1 receipt to the exact Worker request, binds the static launcher digest and containment-profile digest, rejects WSL/unknown/non-x86 before lazily loading the two accepted private H6 POSIX symbols, and records policy/execution closure fingerprints | implemented and default-dark except for the sole explicit C5.4 Coding Product root; Windows dispatch is absent, and Hosting retains all raw native material |
 | `C5-C53-WINDOWS-MECHANICS` | `src/loushang/hosting/_windows_launch_preparation.py` and `src/loushang/hosting/_win32_process.py` | one Hosting-private builder rejects caller environment and non-discarded streams, obtains canonical `SystemRoot` from `GetWindowsDirectoryW`, snapshots locked executable/cwd identity, and emits the existing restricted-token/direct-import spec for capture-time reacquisition | implemented as retained mechanics only; no public export, Harness consumer, Windows Product activation, or required-containment claim |
+| `C5-C54-LINUX-PRODUCT` | `src/loushang/coding/_product_worker_canary.py` | one explicit Product root joins Coding Product/Session evidence, the exact receipt/request/native closure, Worker supervisor health, read-only Capability admission, injected host/boot identity, readiness, recovery, and ordered rollback | implemented for the exact Linux contained profile; omission is Current, no same-attempt fallback exists, and all Windows/unlisted profiles remain closed |
 | `C5-CUR-WORKER-IDENTITY` | `src/loushang/harness/worker/contracts.py` | launch identity binds Plugin revision/contribution/Product/scope/generation/attempt; runtime binding captures executable digest and generic filesystem stat identity | retain; C5 receipt must bind this identity, while Windows native identity remains a separate gap |
 | `C5-CUR-CURRENT-LAUNCH` | `src/loushang/harness/worker/launch.py` and `src/loushang/harness/sandbox/runtime.py` | Process/Sandbox composition privately mints the Current managed Worker launch capability with required containment | retain through rollback; Sandbox is the only non-Worker production importer of the Worker launch capability |
 | `C5-CUR-WORKER-SESSION` | `src/loushang/harness/worker/session.py`, `src/loushang/harness/worker/protocol.py`, `src/loushang/harness/worker/supervisor.py`, and `src/loushang/harness/worker/journal.py` | atomic session abstraction, bounded protocol, health/fencing, and durable protocol-attempt phase evidence exist over injected launch/transport owners; the journal has no receipt, OS-tree owner, boot identity, or cleanup-settlement witness | retain as mechanism; a terminal protocol phase is not resource settlement and none may select Product policy or publish a domain generation |
@@ -50,20 +51,22 @@ not added until their owning guard transition lands.
 
 - `SandboxExecutionRuntime` is the only non-Worker production source importing
   the existing Worker launch capability.
-- No non-Worker production source names `HostingManagedWorkerSessionAdapter`,
-  `WorkerHostingActivationV1`, `WorkerSessionOwnerRouter`, or
-  `bind_capability_query_worker_adapter`.
-- Coding source imports no Harness Worker or Hosting implementation.
+- Only `src/loushang/coding/_product_worker_canary.py` outside Worker names
+  `HostingManagedWorkerSessionAdapter`, `WorkerHostingActivationV1`,
+  `WorkerSessionOwnerRouter`, or `bind_capability_query_worker_adapter`.
+- Coding's exact canary root imports the public Harness Worker facade, the C5.1
+  coordinator, and the C5.2 friend binder, but no Hosting module; every other
+  Coding source remains free of Worker/Hosting composition imports.
 - H6 private Windows profile specifications remain confined to Hosting. The
   single C5.2 bridge lazily imports only the accepted POSIX contained spec and
   capture backend; the only non-Hosting private H6 preparation import remains
   the reviewed H6.4 Worker adapter.
 - `WorkerHostingActivationV1.owner` defaults to `"current"`; selection reads no
   environment and one attempt calls exactly one selected owner.
-- Product Worker C5.1 contracts and the C5.2 Linux profile capability exist
-  only inside Worker. The retained Linux native report is implemented, but no
-  production allowlist/issuer/state store, Product consumer, or cross-entrypoint
-  receipt report exists.
+- Product Worker C5.1 contracts and the C5.2 Linux profile capability remain
+  owned inside Worker. C5.4 adds one Coding consumer over injected Product,
+  native, machine-identity, durable-state, Capability, and cleanup owners; its
+  retained cross-entrypoint report is implemented.
 - `remote_service` remains absent from the declaration/runtime topology and the
   public author SDK has no Worker runtime owner.
 
@@ -71,17 +74,17 @@ not added until their owning guard transition lands.
 
 | Boundary | Current producer | Current consumer | Current result |
 | --- | --- | --- | --- |
-| Product selection | Coding Product identity and inert Plugin selection | H5 accepts only a typed Current/Hosting owner input | no versioned Product decision joins the exact contribution to the owner selection |
-| activation evidence | C5.1 defines strict pathless policy/receipt evidence; H5 selection and launch evidence remain separate mechanics | a future Product issuer and production composition | contract exists but no Product emits or consumes it |
-| Linux contained profile | C5.2 rejoins the Worker payload digest, retained cwd identity, trusted launcher/profile digests, receipt catalog, and same-domain policy closure | H6.2 contained spec consumes the exact closed invocation after a non-WSL Linux x86_64 gate | implemented behind a single-use default-dark port; no Product composition exists |
+| Product selection | Coding Product identity and exact C5.4 policy/receipt input | H5 typed Current/Hosting owner selection | exact Linux canary joins the decision; every omitted, disabled, foreign, or unlisted route remains Current/closed |
+| activation evidence | C5.1 strict pathless policy/receipt evidence | C5.4 Coding Product composition | the exact receipt/request/Session/native/Capability identities are joined before effect; no generic AppHost issuer exists |
+| Linux contained profile | C5.2 rejoins the Worker payload digest, retained cwd identity, trusted launcher/profile digests, receipt catalog, and same-domain policy closure | C5.4 invokes the exact friend binder and receives only its opaque port; H6.2 owns capture | implemented behind an explicit Linux-only Product canary; no platform material or native authority crosses into Coding |
 | Windows identity | the C5.3 Hosting-private builder snapshots locked volume/file identities and H6.3 reacquires them before spawn | Product required-containment profile admission | mechanics are implemented and substitution fails closed, but no accepted Product identity adapter/profile exists |
 | Windows request | the C5.3 builder accepts only an empty caller environment plus closed/discarded streams and obtains canonical `SystemRoot` through `GetWindowsDirectoryW` | H6.4 Worker mapping uses piped stderr | ambient poisoning is closed, while the deliberate stream mismatch keeps Product activation rejected |
 | Windows containment meaning | Product requires accepted required containment | H6.3 proves restricted-token/Job/direct-import mechanics, not AppContainer equivalence or full loader closure | current profile is explicitly rejected for Product required containment; Windows canary is deferred |
-| restart settlement | C5.1 joins protocol terminal, exact domain retirement, durable complete-tree settlement/debt, host/boot identity, restart budget, and construction-pinned evidence identity; C5.2/C5.3 retain Linux/Windows mechanics evidence | C5.4 Product recovery | platform evidence exists, but no production recovery route exists |
-| kill-switch admission | C5.1 serializes receipt admission, first-effect registration, publication, latch generation, and the complete fake active registry; every gate first drains only shared authority-domain `release_due` debt and registers a non-drainable `reserved` exit before ambiguous entry | C5.4 Product/domain owners | deterministic contract covers live reserved/held races and release faults after CAS or before admission return; no production activation gate is composed |
-| Session resume | discovery yields canonical/compatibility locator facts; Coding later validates its Product runtime snapshot | G7 needs Product identity and an opaque exact source/locator/revision fingerprint fixed before issuing a Worker receipt | no common operation currently binds selected locator revision to Worker activation |
-| entrypoints | ordinary Coding Agent modes converge through shared construction, while early subcommands dispatch separately | G7 requires one receipt across every canary-capable Product entrypoint | no Worker receipt is passed anywhere; excluded early routes are not explicitly frozen yet |
-| rollback | H5 retains future Current selection; C5.1 latch stales future Hosting admission and enumerates sticky attempts | C5.4 Product readiness plus native/domain termination owners | lifecycle aggregate exists; ordered production rollback remains absent |
+| restart settlement | C5.1 joins protocol terminal, exact domain retirement, durable complete-tree settlement/debt, host/boot identity, restart budget, and construction-pinned evidence identity; C5.2/C5.3 retain Linux/Windows mechanics evidence | C5.4 ordered recovery port | the Product requires the full V1--V6 vector and rejects incomplete/reordered recovery; owner-specific durable proof remains injected |
+| kill-switch admission | C5.1 serializes receipt admission, first-effect registration, publication, latch generation, and the complete active registry | C5.4 Product/domain owners | production canary latches first and conservatively treats an ambiguous publication call as possibly effectful |
+| Session resume | discovery yields canonical/compatibility locator facts and Coding validates its Product runtime snapshot | C5.4 exact Product root | selected locator provenance is hashed into the receipt and canonical/cwd/home/alias routes pass only when unambiguous and unchanged |
+| entrypoints | ordinary Coding Agent modes converge through shared construction, while early subcommands dispatch separately | C5.4 receipt projection | CLI/TUI/Product paths receive the identical receipt object; excluded early routes reject activation |
+| rollback | H5 retains future Current selection; C5.1 latch stales future Hosting admission and enumerates sticky attempts | C5.4 Product/domain/native owners | R1--R7 is executable: latch, fence, revoke/drain, terminate, settle/debt, readiness, then new Current |
 
 ## Current-To-Target Closure Ledger
 
@@ -94,13 +97,13 @@ not added until their owning guard transition lands.
 | Product readiness/rollback aggregate | exact Product/domain owner over injected Worker status | C5.1 fake, C5.4 production | atomic pre-publication witness+CAS under the admission gate, kill-switch-before-publish no-visibility race, exact-generation retirement CAS, required/optional, ordered kill-switch, and cleanup-debt tests |
 | Linux contained native binding | the single private `_native_profile_bridge.py` plus Hosting | C5.2 | retained nonskipped Linux report with WSL/unknown rejection and execution-closure evidence |
 | Windows restricted mechanics rejection | Hosting-private trusted-payload builder; the Harness bridge boundary remains closed to Windows private imports | C5.3 | implemented `GetWindowsDirectoryW` trust, ambient poisoning/caller-environment rejection, discarded stderr, retained mechanics report, and Product required-containment rejection |
-| Coding Product composition | Coding Product root | C5.4 only | exact allowlist route plus negative side-effect tests |
-| Session/entrypoint convergence | Coding Product construction and Session identity owners | C5.4 | canonical/cwd/home, alias/conflict/tamper, and shared receipt report |
-| recovery/rollback drill | Product/domain, Worker supervisor, Process/Hosting owners each settle their own state | C5.4 | latch-first, fence/revoke/drain, tree settlement/debt, readiness settlement, then new-Current receipt; prior-absent/reaped/uncertain/exhausted/host-restart evidence |
+| Coding Product composition | Coding Product root | C5.4 only | implemented exact allowlist route plus negative no-side-effect tests |
+| Session/entrypoint convergence | Coding Product construction and Session identity owners | C5.4 | implemented canonical/cwd/home, alias/conflict/tamper, and shared receipt report |
+| recovery/rollback drill | Product/domain, Worker supervisor, Process/Hosting owners each settle their own state | C5.4 | implemented latch-first R1--R7 and complete V1--V6 evidence validation |
 
-The first five rows have their C5.1 contract/fake evidence implemented by the
-required `PLC9C5-C5.1-CONTRACT` report. That evidence does not close their later
-native or production portions.
+The C5.1 contract/fake, C5.2 Linux native, C5.3 Windows mechanics/rejection, and
+C5.4 Linux Product reports are all retained. G7 remains open because Windows
+required containment has not been accepted.
 
 ## Retained Deletion Fences
 

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c54-linux-product.md
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c54-linux-product.md
@@ -1,0 +1,121 @@
+# PLC9C5 C5.4 Linux Coding Product Canary
+
+## Status
+
+- ID: `PLC9C5-C5.4-LINUX-PRODUCT`
+- Scope: one explicit Coding Product `capability_provider` Worker canary
+- Parent: `PLC9C5-C5.0`
+- Authority: normative implemented slice
+- Design status: accepted
+- Implementation status: implemented
+- Activation status: Linux x86_64 excluding WSL only, behind an exact Product
+  policy and receipt
+- Production default: Current
+- Parent gate: G7 remains open until a separate Windows required-containment
+  profile is accepted
+- Owner: Coding Product policy over Product-neutral Harness Worker and Hosting
+  capabilities
+
+## Boundary
+
+`bind_coding_product_worker_canary` is the only Product composition introduced
+by C5.4. Coding validates the exact Product, receipt, persisted Product profile,
+stable Session locator, Worker request, Capability authority, and injected
+machine host/boot identities. It imports the public Harness Worker facade plus
+the two exact reviewed Worker friend seams: the C5.1 activation coordinator and
+the C5.2 native-profile binder. It does not import Hosting, construct a
+platform capture specification, inspect native handles, or accept an
+environment-derived activation flag.
+
+The embedding composition supplies durable Product authority/state ports,
+trusted cleanup-evidence identity, trusted launcher/profile digests, and a
+Product-neutral Hosting capability. The Coding root constructs the real C5.1
+coordinator and asks the sole C5.2 friend binder for an opaque,
+receipt/request-bound `ProductWorkerNativeProfilePort`. Harness' existing
+adapter preserves the private H6 managed-capture seam. This keeps the
+dependency direction:
+
+```text
+Coding Product policy
+  -> exact Harness Worker coordinator + native-profile friend binder
+     -> opaque ProductWorkerNativeProfilePort + Hosting capability
+        -> Hosting-owned process, endpoint, and native resources
+```
+
+No receipt or disabled policy returns Current without constructing Hosting,
+native, process, protocol, or Capability state. An invalid required route is
+unavailable; an independently optional route may become degraded only after
+owned state is reclaimed. Neither path retries Current in the same attempt.
+Pure native-profile identity/closure validation precedes construction of the
+coordinator that initializes durable activation state.
+
+## Session And Entrypoint Join
+
+Selected Sessions require Coding's existing Product-profile validator plus a
+resumable `SessionDiscoveryMetadata`. The receipt fixes an opaque fingerprint
+of the exact source, locator, revision, mode, origin, aliases, and conflicts.
+Canonical global and cwd/home compatibility projections are accepted when
+unambiguous; a foreign Product profile, conflict, changed revision, or changed
+locator fingerprint is rejected before acquisition. Machine-local paths are
+hashed and never appear in status.
+
+CLI, TUI, and the shared Product construction path retrieve the same immutable
+receipt object from one canary composition. Early-dispatch LSP, workspace,
+multi-agent, package-management, and other non-Session routes remain unable to
+activate it.
+
+## Publication And Failure
+
+The serialized admission lease registers first effect before the selected
+Hosting owner starts. Worker handshake must become healthy, the read-only
+Capability adapter must admit the exact authority, and the activation
+coordinator must recheck native-policy closure before the Capability domain may
+publish. A publication call is treated as possibly effectful: an exception or
+cancellation after it begins triggers conservative fence, revoke/drain,
+termination, retirement, and settlement.
+
+Status is versioned, bounded, and pathless. It carries stable codes plus only
+receipt/attempt/generation fingerprints. Arbitrary exception text, paths,
+secrets, environment values, file descriptors, and handles do not cross the
+Product boundary.
+
+## Rollback And Recovery
+
+Rollback uses the fixed C5 order: latch future Hosting closed; fence exact
+attempts; revoke/drain exact Capability generations; terminate complete trees;
+record settlement or debt; settle Product readiness; only then issue a new
+Current selection. The existing router remains sticky for an in-flight owner,
+and a rollback never changes the owner of that same attempt.
+
+Recovery accepts only the full ordered V1–V6 evidence vector: prior absent,
+exact reaped, same-boot unknown debt, changed-boot absence, exhausted budget,
+and host-restart reconstruction. The Product composition delegates each fact
+to its owning durable port and rejects an incomplete or reordered vector.
+Adoption remains forbidden.
+
+## Required Evidence
+
+`PLC9C5-C5.4-LINUX-PRODUCT` is retained at
+`.artifacts/plc9c5-c54-linux-product.xml`. Its exact 25 case ids cover Product,
+Session, required/optional readiness, closure freshness, handshake-before-
+publication, unsupported hosts, rollback, recovery, shared entrypoints, and
+sentinel redaction. The report must contain zero skips, failures, and errors.
+
+## Retained Fences
+
+- Current remains the default and is retained for future rollback attempts;
+- Windows restricted mechanics remain rejected as Product required
+  containment, and G7 remains open;
+- WSL, macOS, non-x86 Linux, and every unlisted profile fail closed;
+- no same-attempt fallback, ambient activation flag, raw native authority,
+  effectful Worker domain, public author-SDK owner, or `remote_service` route;
+- no generic AppHost pre-routing Session identity claim; and
+- no Current owner or Capability generation owner deletion before G9 evidence.
+
+## Exit Gate
+
+C5.4 is complete only when the 25-row report is mandatory in Linux CI, the
+manifest verifier rejects missing/skipped/failing evidence, architecture tests
+prove the single Product root and exact dependency direction, earlier C5.1–C5.3
+reports stay implemented, and the inventory names the retained Current and
+Windows gaps honestly.

--- a/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-evidence-manifest.json
+++ b/docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-evidence-manifest.json
@@ -143,7 +143,7 @@
         "C54-SHARED-ENTRYPOINT-RECEIPT",
         "C54-SENTINEL-REDACTION"
       ],
-      "status": "planned"
+      "status": "implemented"
     }
   }
 }

--- a/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
+++ b/docs/internals/architecture/hosting/validation/hosted-product-runtime-v1-inventory.md
@@ -53,22 +53,25 @@ lease, or factory.
 | H5 owner selector | `src/loushang/harness/worker/owner_selection.py` | explicit typed Current/Hosting route with default `owner="current"`, no environment activation, no same-attempt fallback |
 | Worker protocol/lifecycle | `src/loushang/harness/worker/protocol.py`, `src/loushang/harness/worker/supervisor.py`, `src/loushang/harness/worker/journal.py`, and `src/loushang/harness/worker/session.py` | framing, handshake, correlation, heartbeat, restart/fencing, aggregate session, and durable attempt evidence |
 | first domain adapter | `src/loushang/harness/worker/capability_query.py` | explicitly enabled read-only Capability query adapter; no Product activation or generation publication route |
+| Product Worker lifecycle | `src/loushang/harness/worker/product_activation.py` | strict Product policy/receipt, serialized freshness gate, durable attempt aggregate, publication/retirement, kill switch, cleanup settlement/debt, and bounded restart evidence |
+| Linux Product native-profile friend | `src/loushang/harness/worker/_native_profile_bridge.py` | binds one exact C5.1 receipt/request to the single-use C5.2 Linux x86_64 contained profile while keeping Hosting-private capture material opaque |
 | Session discovery contracts | `src/loushang/harness/transcript/discovery.py` and `src/loushang/harness/transcript/session_catalog.py` | canonical/compatibility source identity, stable locator, bounded summaries, aliases/conflicts, and multi-source read model; no generic `product_id` envelope yet |
 | optional AppHost/Harness Session integration | `src/loushang/apphost/integrations/harness_session.py` | AppHost-owned optional projection of explicitly injected Harness source identities to path-free migration candidates; seals an unchanged single-descriptor snapshot up to 8 MiB, adopts rejected canonical returns into its own retryable cleanup lifecycle, bounds canonical delegation to eight concurrent calls and refuses new calls while debt remains, never retries a relinquished POSIX fd number after an ambiguous close, derives no roots or second index, remains uncomposed, and fails closed on Windows pending a native retained-handle backend |
 | AppHost live binding owner | `src/loushang/apphost/runtime.py` | process-local single-flight Product/runtime binding keyed by canonical Session identity, exact retained catalog generation, per-profile attachment lifetime, admission fencing, retryable dependency-ordered close, and bounded phased shutdown; remains explicitly constructed and uncomposed |
 | optional AppHost/AppServer binder | `src/loushang/apphost/hosted.py` | validates one explicitly selected profile as an exact AppServer structural port bundle and preserves the canonical binding identity; owns no listener, protocol, transport, or service semantics |
 | AppServer Product ports | `src/loushang/appserver/ports.py` | immutable contract-only identity and Product-supplied Session/projection/work/interaction port bundle; no runtime, listener, protocol, or composition owner |
 | Session discovery composition | `src/loushang/harness/transcript/directory.py`, `src/loushang/harness/machine_resources/control_plane.py`, and `src/loushang/coding/cli/__main__.py` | canonical global plus cwd/home compatibility sources are selected at composition; cwd is a query/filter and compatibility roots are not writable authorities |
+| Linux Coding Product canary | `src/loushang/coding/_product_worker_canary.py` | sole explicit C5.4 Product root; joins Coding Product/Session evidence to the real lifecycle coordinator, Linux profile friend, Worker health, Capability publication, rollback, and recovery; omission remains Current and Windows/unlisted profiles remain closed |
 
 ## Observed Contract Mismatch
 
 | Boundary | Producer shape | Consumer shape | Current result |
 | --- | --- | --- | --- |
 | executable/cwd | Harness private request retains native descriptors plus identity | Hosting `ProcessLaunchRequest` contains absolute strings | `hosting_compat` fails closed rather than substitute mutable paths |
-| containment | Harness `ProcessContainmentPlan` may rewrite the exact process request and owns semantic evidence | Hosting's public preparation lease exposes only `request`, `verify_current`, and `close`; H6 adds a private managed capture | C5.2 supplies one default-dark Linux contained-profile adapter through the H6.4 seam; no Product composition selects it |
-| inherited resources | Harness Current path extracts private launch descriptors | H6.1 combines endpoint and opaque preparation inheritance internally; H6.2/H6.3 supply exact platform-private material | H6.4 can preserve an injected managed port, but no composition currently supplies either native profile for a Worker |
+| containment | Harness `ProcessContainmentPlan` may rewrite the exact process request and owns semantic evidence | Hosting's public preparation lease exposes only `request`, `verify_current`, and `close`; H6 adds a private managed capture | C5.2 supplies one default-dark Linux contained-profile adapter through the H6.4 seam; only the exact C5.4 Coding Product canary selects it |
+| inherited resources | Harness Current path extracts private launch descriptors | H6.1 combines endpoint and opaque preparation inheritance internally; H6.2/H6.3 supply exact platform-private material | H6.4 preserves the injected managed port; the sole C5.4 Coding root binds the Linux profile, while Windows Product binding remains absent |
 | Windows required containment | PLC9B includes a purpose-specific AppContainer/Job implementation for legacy restore | Hosting H6.3 owns one narrower restricted-token/locked-PE profile | the managed semantic bridge exists, but no AppContainer equivalence, eligible Worker profile supplier, or native parity claim exists |
-| Product activation | PLC9C1--C4 provide declaration, launch, supervisor, and one dark domain adapter | H5 provides an explicit dark Hosting owner | no Product composition selects and publishes the native path |
+| Product activation | PLC9C1--C4 provide declaration, launch, supervisor, and one dark domain adapter; C5.1--C5.2 add exact lifecycle/native seams | H5 provides explicit Current/Hosting ownership | C5.4 adds one explicit Linux Coding canary; omission remains Current and all Windows/unlisted Product routes remain closed |
 
 ## AppHost And Hosted Application State
 
@@ -98,7 +101,7 @@ not implemented routes.
 | opaque request-bound native preparation | Hosting Contract/Platform components | implemented privately in H6.1; fake ownership, concurrency/fault, and no-raw-handle gates are retained |
 | exact Linux executable/cwd/containment transfer | Hosting platform adapter with caller-owned requirements | implemented for the private static-closure profiles; H6.2 retained native adversarial oracle remains green |
 | exact Windows executable/cwd/containment transfer | Hosting platform adapter with caller-owned requirements | implemented for one private restricted-token/direct-import PE mechanics profile; the non-skippable H6.3 native adversarial oracle must remain green |
-| Harness-to-Hosting managed preparation parity | Harness Sandbox/Worker adapter over Hosting | H6.4 fake-backed public/managed semantic and cleanup parity; native Worker compatibility remains absent and default stays Current |
+| Harness-to-Hosting managed preparation parity | Harness Sandbox/Worker adapter over Hosting | H6.4 public/managed semantic and cleanup parity plus the exact C5.2 Linux native bridge are implemented; C5.4 is their sole Product consumer, Windows native Worker compatibility remains absent, and default stays Current |
 | Product catalog, no-default routing, scoped runtime lifetime | AppHost | implemented through A0.3: the Router-private admission seam feeds one canonical live binding, exact generation retention, per-profile attachments, and bounded retryable shutdown; production composition remains absent |
 | Session pre-routing identity | AppHost schema plus canonical Session persistence/catalog owner | A0.2 fake owner proves atomic creation/recovery; real canonical envelope persistence remains uncomposed |
 | AppHost cwd/user-global Session projection | AppHost-owned optional integration over the existing Harness Session discovery/catalog owner | A0.2 proves explicit source binding, stable source identity, alias/conflict, an unchanged bounded descriptor read sealed into immutable bytes, no token-to-path behavior, and Windows fail-closed semantics |
@@ -113,8 +116,9 @@ The inventory records, rather than relaxes, these Current fences:
   attempt;
 - sealed-descriptor cases remain rejected by Hosting compatibility;
 - PLC9C5 C5.0 design/inventory, C5.1 receipt/lifecycle, C5.2 Linux profile,
-  and C5.3 Windows mechanics/rejection are implemented, but Product activation
-  and unsupported-platform guards remain unchanged;
+  C5.3 Windows mechanics/rejection, and C5.4 Linux Coding Product canary are
+  implemented; Windows Product activation and unsupported-platform guards
+  remain closed;
 - AppHost A0.4 remains explicitly constructed and dark: its core runtime owns
   live bindings, while optional Harness Session and AppServer port adapters stay
   outside the core facade; AppServer contains contracts only, AppService remains

--- a/src/loushang/coding/_product_worker_canary.py
+++ b/src/loushang/coding/_product_worker_canary.py
@@ -1,0 +1,1073 @@
+"""Explicit Linux-only Coding Product composition for a local Plugin Worker.
+
+The Product owns selection and readiness.  Harness owns Worker lifecycle and
+native-profile capabilities, while Hosting owns every process, endpoint, and
+platform resource.  This module joins those already-authorized capabilities;
+it never imports Hosting or manufactures native material.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Literal, NoReturn, Protocol, cast
+
+from loushang.coding.product_plan import CODING_PRODUCT_ID
+from loushang.harness.transcript.discovery import SessionDiscoveryMetadata
+from loushang.harness.worker import (
+    CapabilityQueryWorkerAdapter,
+    CapabilityWorkerAdmissionV1,
+    CapabilityWorkerAuthorityV1,
+    CapabilityWorkerBindingV1,
+    HostingManagedWorkerSessionAdapter,
+    ManagedWorkerLaunchRequestV1,
+    ManagedWorkerSessionLaunchPort,
+    ProductWorkerActivationAuthorityPort,
+    ProductWorkerActivationPolicyV1,
+    ProductWorkerActivationReceiptV1,
+    ProductWorkerNativeProfilePort,
+    WorkerBindingError,
+    WorkerHostingActivationV1,
+    WorkerSessionOwnerRouter,
+    WorkerSupervisor,
+    bind_capability_query_worker_adapter,
+)
+from loushang.harness.worker._native_profile_bridge import (
+    _bind_posix_static_contained_product_worker_profile,
+)
+from loushang.harness.worker.product_activation import (
+    ProductWorkerActivationCoordinator,
+)
+
+CODING_PRODUCT_WORKER_CANARY_VERSION = 1
+CODING_PRODUCT_WORKER_CANARY_ENTRYPOINTS = ("cli", "product", "tui")
+CODING_PRODUCT_WORKER_NATIVE_PROFILE_ID = "posix-static-contained-elf-v1"
+
+CodingWorkerCanaryReadiness = Literal[
+    "current",
+    "selected",
+    "starting",
+    "ready",
+    "degraded",
+    "unavailable",
+    "rolled_back",
+]
+
+_ROLLBACK_STEPS = (
+    "R1-LATCH-FUTURE",
+    "R2-FENCE-ATTEMPTS",
+    "R3-REVOKE-DRAIN",
+    "R4-TERMINATE-TREE",
+    "R5-SETTLE-OR-DEBT",
+    "R6-SETTLE-READINESS",
+    "R7-ISSUE-CURRENT",
+)
+_RECOVERY_STEPS = (
+    "V1-PRIOR-ABSENT",
+    "V2-EXACT-REAPED",
+    "V3-SAMEBOOT-UNKNOWN",
+    "V4-CHANGEDBOOT-ABSENT",
+    "V5-BUDGET-EXHAUSTED",
+    "V6-HOST-RESTART",
+)
+
+
+class CodingProductWorkerCanaryError(RuntimeError):
+    """Stable, redacted Product-composition failure."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class CodingProductWorkerCanaryStatusV1:
+    """Bounded pathless readiness projection for the Coding canary."""
+
+    code: str
+    readiness: CodingWorkerCanaryReadiness
+    required: bool
+    requested_owner: Literal["current", "hosting"]
+    effective_owner: Literal["current", "hosting"]
+    receipt_fingerprint: str | None = None
+    attempt_id: str | None = None
+    owner_generation: int | None = None
+    status_version: int = CODING_PRODUCT_WORKER_CANARY_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.code, str) or not self.code:
+            raise ValueError("Coding Worker canary status code is invalid")
+        if self.readiness not in {
+            "current",
+            "selected",
+            "starting",
+            "ready",
+            "degraded",
+            "unavailable",
+            "rolled_back",
+        }:
+            raise ValueError("Coding Worker canary readiness is invalid")
+        if type(self.required) is not bool:
+            raise TypeError("Coding Worker canary requiredness must be boolean")
+        if self.requested_owner not in {"current", "hosting"} or (
+            self.effective_owner not in {"current", "hosting"}
+        ):
+            raise ValueError("Coding Worker canary owner is invalid")
+        if (self.receipt_fingerprint is None) != (self.attempt_id is None):
+            raise ValueError("Coding Worker canary attempt identity is incomplete")
+        if (self.attempt_id is None) != (self.owner_generation is None):
+            raise ValueError("Coding Worker canary generation identity is incomplete")
+        if self.status_version != CODING_PRODUCT_WORKER_CANARY_VERSION:
+            raise ValueError("Coding Worker canary status version is unsupported")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "attemptId": self.attempt_id,
+            "code": self.code,
+            "effectiveOwner": self.effective_owner,
+            "ownerGeneration": self.owner_generation,
+            "readiness": self.readiness,
+            "receiptFingerprint": self.receipt_fingerprint,
+            "requestedOwner": self.requested_owner,
+            "required": self.required,
+            "statusVersion": self.status_version,
+        }
+
+
+class CodingProductWorkerCanaryDomainPort(Protocol):
+    """Capability-owner operations needed by the Product composition."""
+
+    async def publish(
+        self,
+        *,
+        adapter: CapabilityQueryWorkerAdapter,
+        admission: CapabilityWorkerAdmissionV1,
+        receipt_fingerprint: str,
+        attempt_id: str,
+        owner_generation: int,
+    ) -> None: ...
+
+    async def fence_attempt(
+        self,
+        *,
+        receipt_fingerprint: str,
+        attempt_id: str,
+        owner_generation: int,
+    ) -> None: ...
+
+    async def revoke_and_drain(
+        self,
+        *,
+        receipt_fingerprint: str,
+        attempt_id: str,
+        owner_generation: int,
+    ) -> None: ...
+
+    async def settle_readiness(
+        self,
+        *,
+        required: bool,
+        ready: bool,
+        code: str,
+    ) -> None: ...
+
+    async def issue_current(self, *, prior_receipt_fingerprint: str) -> object: ...
+
+
+class CodingProductWorkerCleanupPort(Protocol):
+    """Platform owner that records settlement or durable cleanup debt."""
+
+    async def settle(
+        self,
+        *,
+        receipt: ProductWorkerActivationReceiptV1,
+        request: ManagedWorkerLaunchRequestV1,
+        protocol_terminal: bool,
+        domain_retired: bool,
+    ) -> None: ...
+
+
+class CodingProductWorkerRecoveryPort(Protocol):
+    """Durable recovery drill owned by the injected lifecycle authorities."""
+
+    async def recover(
+        self,
+        *,
+        receipt: ProductWorkerActivationReceiptV1,
+        request: ManagedWorkerLaunchRequestV1,
+    ) -> tuple[str, ...]: ...
+
+
+class _ActivationAdmissionLease(Protocol):
+    def __enter__(self) -> _ActivationAdmissionLease: ...
+
+    def __exit__(self, *error: object) -> object: ...
+
+    def begin_effect(self) -> None: ...
+
+
+class CodingProductWorkerCanary:
+    """One selected attempt shared by every canary-capable Coding entrypoint."""
+
+    def __init__(
+        self,
+        *,
+        policy: ProductWorkerActivationPolicyV1 | None,
+        receipt: ProductWorkerActivationReceiptV1 | None,
+        coordinator: ProductWorkerActivationCoordinator | None,
+        supervisor: WorkerSupervisor | None,
+        request: ManagedWorkerLaunchRequestV1 | None,
+        session_port: WorkerSessionOwnerRouter | None,
+        native_profile: ProductWorkerNativeProfilePort | None,
+        capability_binding: CapabilityWorkerBindingV1 | None,
+        capability_authority_reader: Callable[[], CapabilityWorkerAuthorityV1] | None,
+        domain: CodingProductWorkerCanaryDomainPort | None,
+        cleanup: CodingProductWorkerCleanupPort | None,
+        recovery: CodingProductWorkerRecoveryPort | None,
+        host_identity: str | None,
+        boot_identity: str | None,
+        status: CodingProductWorkerCanaryStatusV1,
+    ) -> None:
+        self._policy = policy
+        self._receipt = receipt
+        self._coordinator = coordinator
+        self._supervisor = supervisor
+        self._request = request
+        self._session_port = session_port
+        self._native_profile = native_profile
+        self._capability_binding = capability_binding
+        self._capability_authority_reader = capability_authority_reader
+        self._domain = domain
+        self._cleanup = cleanup
+        self._recovery = recovery
+        self._host_identity = host_identity
+        self._boot_identity = boot_identity
+        self._status = status
+        self._adapter: CapabilityQueryWorkerAdapter | None = None
+        self._operation_lock = asyncio.Lock()
+
+    @property
+    def status(self) -> CodingProductWorkerCanaryStatusV1:
+        return self._status
+
+    @property
+    def rollback_steps(self) -> tuple[str, ...]:
+        return _ROLLBACK_STEPS
+
+    @property
+    def recovery_steps(self) -> tuple[str, ...]:
+        return _RECOVERY_STEPS
+
+    def receipt_for_entrypoint(
+        self,
+        entrypoint: str,
+    ) -> ProductWorkerActivationReceiptV1 | None:
+        """Return the one immutable receipt; early-dispatch routes stay dark."""
+
+        if entrypoint not in CODING_PRODUCT_WORKER_CANARY_ENTRYPOINTS:
+            raise CodingProductWorkerCanaryError(
+                "Coding entrypoint cannot activate the Worker canary",
+                code="coding_worker_entrypoint_unsupported",
+            )
+        return self._receipt
+
+    async def start(self, *, correlation_id: str) -> CodingProductWorkerCanaryStatusV1:
+        """Start, handshake, admit, and publish exactly one Hosting attempt."""
+
+        async with self._operation_lock:
+            if self._status.readiness == "ready":
+                return self._status
+            if self._status.effective_owner != "hosting":
+                return self._status
+            self._require_selected_components()
+            policy = cast(ProductWorkerActivationPolicyV1, self._policy)
+            receipt = cast(ProductWorkerActivationReceiptV1, self._receipt)
+            coordinator = cast(ProductWorkerActivationCoordinator, self._coordinator)
+            supervisor = cast(WorkerSupervisor, self._supervisor)
+            request = cast(ManagedWorkerLaunchRequestV1, self._request)
+            session_port = cast(WorkerSessionOwnerRouter, self._session_port)
+            domain = cast(CodingProductWorkerCanaryDomainPort, self._domain)
+            decision = coordinator.evaluate(policy, receipt)
+            if decision.get("reason") != "admitted":
+                return await self._settle_closed_decision(
+                    code=_stable_reason(decision.get("reason")),
+                )
+            self._status = self._attempt_status(
+                code="coding_worker_starting",
+                readiness="starting",
+            )
+            effect_started = False
+            domain_publish_started = False
+            try:
+                lease = cast(
+                    _ActivationAdmissionLease,
+                    coordinator.admission(
+                        policy=policy,
+                        receipt=receipt,
+                        attempt_id=request.identity.attempt_id,
+                        owner_generation=request.identity.owner_generation,
+                        host_identity=cast(str, self._host_identity),
+                        boot_identity=cast(str, self._boot_identity),
+                    ),
+                )
+                with lease:
+                    lease.begin_effect()
+                    effect_started = True
+                await supervisor.start_session(
+                    session_port=session_port,
+                    launch_request=request,
+                    correlation_id=correlation_id,
+                )
+                adapter = bind_capability_query_worker_adapter(
+                    supervisor=supervisor,
+                    binding=cast(CapabilityWorkerBindingV1, self._capability_binding),
+                    authority_reader=cast(
+                        Callable[[], CapabilityWorkerAuthorityV1],
+                        self._capability_authority_reader,
+                    ),
+                    enabled=True,
+                )
+                admission = adapter.admit()
+                coordinator.publish(
+                    receipt=receipt,
+                    attempt_id=request.identity.attempt_id,
+                    owner_generation=request.identity.owner_generation,
+                    realized_native_policy_closure_fingerprint=(
+                        cast(
+                            ProductWorkerNativeProfilePort,
+                            self._native_profile,
+                        ).realized_native_policy_closure_fingerprint
+                    ),
+                    native_profile_catalog_revision=policy.native_profile_catalog_revision,
+                    native_profile_id=policy.native_profile_id,
+                )
+                domain_publish_started = True
+                await domain.publish(
+                    adapter=adapter,
+                    admission=admission,
+                    receipt_fingerprint=receipt.fingerprint,
+                    attempt_id=request.identity.attempt_id,
+                    owner_generation=request.identity.owner_generation,
+                )
+                self._adapter = adapter
+                await domain.settle_readiness(
+                    required=policy.effective_required,
+                    ready=True,
+                    code="coding_worker_ready",
+                )
+                self._status = self._attempt_status(
+                    code="coding_worker_ready",
+                    readiness="ready",
+                )
+                return self._status
+            except asyncio.CancelledError:
+                if effect_started:
+                    await self._reclaim_failed_attempt(
+                        domain_publish_started=domain_publish_started,
+                    )
+                raise
+            except BaseException as exc:
+                if effect_started:
+                    await self._reclaim_failed_attempt(
+                        domain_publish_started=domain_publish_started,
+                    )
+                readiness: CodingWorkerCanaryReadiness = (
+                    "unavailable" if policy.effective_required else "degraded"
+                )
+                code = (
+                    "coding_worker_required_unavailable"
+                    if policy.effective_required
+                    else "coding_worker_optional_degraded"
+                )
+                self._status = self._attempt_status(code=code, readiness=readiness)
+                await domain.settle_readiness(
+                    required=policy.effective_required,
+                    ready=False,
+                    code=code,
+                )
+                if policy.effective_required:
+                    raise CodingProductWorkerCanaryError(
+                        "Required Coding Worker canary is unavailable",
+                        code=code,
+                    ) from exc
+                return self._status
+
+    async def rollback(self) -> CodingProductWorkerCanaryStatusV1:
+        """Run the fixed latch-first rollback sequence without same-attempt fallback."""
+
+        async with self._operation_lock:
+            self._require_selected_components()
+            policy = cast(ProductWorkerActivationPolicyV1, self._policy)
+            receipt = cast(ProductWorkerActivationReceiptV1, self._receipt)
+            coordinator = cast(ProductWorkerActivationCoordinator, self._coordinator)
+            supervisor = cast(WorkerSupervisor, self._supervisor)
+            request = cast(ManagedWorkerLaunchRequestV1, self._request)
+            domain = cast(CodingProductWorkerCanaryDomainPort, self._domain)
+            cleanup = cast(CodingProductWorkerCleanupPort, self._cleanup)
+            session_port = cast(WorkerSessionOwnerRouter, self._session_port)
+
+            coordinator.latch_kill_switch(
+                expected_generation=policy.kill_switch_generation
+            )
+            session_port.rollback_to_current()
+            await domain.fence_attempt(
+                receipt_fingerprint=receipt.fingerprint,
+                attempt_id=request.identity.attempt_id,
+                owner_generation=request.identity.owner_generation,
+            )
+            await domain.revoke_and_drain(
+                receipt_fingerprint=receipt.fingerprint,
+                attempt_id=request.identity.attempt_id,
+                owner_generation=request.identity.owner_generation,
+            )
+            coordinator.retire_exact(
+                receipt=receipt,
+                attempt_id=request.identity.attempt_id,
+                owner_generation=request.identity.owner_generation,
+            )
+            await supervisor.fence(code="coding_worker_rollback")
+            coordinator.record_protocol_terminal(
+                receipt=receipt,
+                attempt_id=request.identity.attempt_id,
+                owner_generation=request.identity.owner_generation,
+            )
+            await cleanup.settle(
+                receipt=receipt,
+                request=request,
+                protocol_terminal=True,
+                domain_retired=True,
+            )
+            await domain.settle_readiness(
+                required=policy.effective_required,
+                ready=False,
+                code="coding_worker_rollback_latched",
+            )
+            await domain.issue_current(prior_receipt_fingerprint=receipt.fingerprint)
+            self._status = self._attempt_status(
+                code="coding_worker_rollback_latched",
+                readiness="rolled_back",
+                effective_owner="current",
+            )
+            return self._status
+
+    async def recover(self) -> tuple[str, ...]:
+        """Require the complete ordered durable recovery matrix."""
+
+        async with self._operation_lock:
+            self._require_selected_components()
+            recovery = cast(CodingProductWorkerRecoveryPort, self._recovery)
+            steps = await recovery.recover(
+                receipt=cast(ProductWorkerActivationReceiptV1, self._receipt),
+                request=cast(ManagedWorkerLaunchRequestV1, self._request),
+            )
+            if steps != _RECOVERY_STEPS:
+                raise CodingProductWorkerCanaryError(
+                    "Coding Worker recovery evidence is incomplete",
+                    code="coding_worker_recovery_incomplete",
+                )
+            return steps
+
+    async def _reclaim_failed_attempt(
+        self,
+        *,
+        domain_publish_started: bool,
+    ) -> None:
+        receipt = cast(ProductWorkerActivationReceiptV1, self._receipt)
+        request = cast(ManagedWorkerLaunchRequestV1, self._request)
+        domain = cast(CodingProductWorkerCanaryDomainPort, self._domain)
+        coordinator = cast(ProductWorkerActivationCoordinator, self._coordinator)
+        supervisor = cast(WorkerSupervisor, self._supervisor)
+        cleanup = cast(CodingProductWorkerCleanupPort, self._cleanup)
+        with _suppress_failures():
+            await domain.fence_attempt(
+                receipt_fingerprint=receipt.fingerprint,
+                attempt_id=request.identity.attempt_id,
+                owner_generation=request.identity.owner_generation,
+            )
+        if domain_publish_started:
+            with _suppress_failures():
+                await domain.revoke_and_drain(
+                    receipt_fingerprint=receipt.fingerprint,
+                    attempt_id=request.identity.attempt_id,
+                    owner_generation=request.identity.owner_generation,
+                )
+        with _suppress_failures():
+            coordinator.retire_exact(
+                receipt=receipt,
+                attempt_id=request.identity.attempt_id,
+                owner_generation=request.identity.owner_generation,
+            )
+        with _suppress_failures():
+            await supervisor.fence(code="coding_worker_start_failed")
+        with _suppress_failures():
+            coordinator.record_protocol_terminal(
+                receipt=receipt,
+                attempt_id=request.identity.attempt_id,
+                owner_generation=request.identity.owner_generation,
+            )
+        with _suppress_failures():
+            await cleanup.settle(
+                receipt=receipt,
+                request=request,
+                protocol_terminal=True,
+                domain_retired=True,
+            )
+
+    async def _settle_closed_decision(
+        self,
+        *,
+        code: str,
+    ) -> CodingProductWorkerCanaryStatusV1:
+        policy = cast(ProductWorkerActivationPolicyV1, self._policy)
+        readiness: CodingWorkerCanaryReadiness = (
+            "unavailable" if policy.effective_required else "degraded"
+        )
+        stable_code = (
+            "coding_worker_required_unavailable"
+            if policy.effective_required
+            else "coding_worker_optional_degraded"
+        )
+        domain = cast(CodingProductWorkerCanaryDomainPort, self._domain)
+        await domain.settle_readiness(
+            required=policy.effective_required,
+            ready=False,
+            code=code,
+        )
+        self._status = self._attempt_status(
+            code=stable_code,
+            readiness=readiness,
+        )
+        if policy.effective_required:
+            raise CodingProductWorkerCanaryError(
+                "Required Coding Worker canary was rejected",
+                code=stable_code,
+            )
+        return self._status
+
+    def _attempt_status(
+        self,
+        *,
+        code: str,
+        readiness: CodingWorkerCanaryReadiness,
+        effective_owner: Literal["current", "hosting"] = "hosting",
+    ) -> CodingProductWorkerCanaryStatusV1:
+        policy = cast(ProductWorkerActivationPolicyV1, self._policy)
+        receipt = cast(ProductWorkerActivationReceiptV1, self._receipt)
+        request = cast(ManagedWorkerLaunchRequestV1, self._request)
+        return CodingProductWorkerCanaryStatusV1(
+            code=code,
+            readiness=readiness,
+            required=policy.effective_required,
+            requested_owner=policy.requested_owner,
+            effective_owner=effective_owner,
+            receipt_fingerprint=receipt.fingerprint,
+            attempt_id=request.identity.attempt_id,
+            owner_generation=request.identity.owner_generation,
+        )
+
+    def _require_selected_components(self) -> None:
+        components = (
+            self._policy,
+            self._receipt,
+            self._coordinator,
+            self._supervisor,
+            self._request,
+            self._session_port,
+            self._native_profile,
+            self._capability_binding,
+            self._capability_authority_reader,
+            self._domain,
+            self._cleanup,
+            self._recovery,
+            self._host_identity,
+            self._boot_identity,
+        )
+        if any(item is None for item in components):
+            raise CodingProductWorkerCanaryError(
+                "Coding Worker canary composition is incomplete",
+                code="coding_worker_composition_incomplete",
+            )
+
+
+def bind_coding_product_worker_canary(
+    *,
+    policy: ProductWorkerActivationPolicyV1 | None = None,
+    receipt: ProductWorkerActivationReceiptV1 | None = None,
+    session_discovery: SessionDiscoveryMetadata | None = None,
+    validate_product_session: Callable[[], None] | None = None,
+    authority: ProductWorkerActivationAuthorityPort | None = None,
+    evidence_authority: object | None = None,
+    trusted_evidence_authority_id: str | None = None,
+    trusted_evidence_authority_fingerprint: str | None = None,
+    activation_state_store: object | None = None,
+    restart_budget: int = 3,
+    supervisor: WorkerSupervisor | None = None,
+    worker_request: ManagedWorkerLaunchRequestV1 | None = None,
+    current_owner: ManagedWorkerSessionLaunchPort | None = None,
+    hosting: object | None = None,
+    containment_launcher_path: str | None = None,
+    containment_launcher_sha256: str | None = None,
+    containment_profile_sha256: str | None = None,
+    capability_binding: CapabilityWorkerBindingV1 | None = None,
+    capability_authority_reader: Callable[[], CapabilityWorkerAuthorityV1]
+    | None = None,
+    domain: CodingProductWorkerCanaryDomainPort | None = None,
+    cleanup: CodingProductWorkerCleanupPort | None = None,
+    recovery: CodingProductWorkerRecoveryPort | None = None,
+    host_identity: str | None = None,
+    boot_identity: str | None = None,
+) -> CodingProductWorkerCanary:
+    """Bind the sole Linux Coding Product canary; omission remains Current."""
+
+    if policy is None:
+        if receipt is not None:
+            _raise("coding_worker_product_missing")
+        return _current_canary(code="coding_worker_product_missing")
+    if not isinstance(policy, ProductWorkerActivationPolicyV1):
+        raise TypeError("Coding Worker canary requires typed Product policy")
+    if policy.product_id != CODING_PRODUCT_ID:
+        _raise("coding_worker_product_mismatch")
+    if not policy.enabled or policy.requested_owner == "current":
+        if receipt is not None:
+            _raise("coding_worker_disabled_receipt_present")
+        return _current_canary(
+            code="coding_worker_disabled_by_policy",
+            policy=policy,
+        )
+    if receipt is None:
+        code = (
+            "coding_worker_required_unavailable"
+            if policy.effective_required
+            else "coding_worker_optional_degraded"
+        )
+        readiness: CodingWorkerCanaryReadiness = (
+            "unavailable" if policy.effective_required else "degraded"
+        )
+        return CodingProductWorkerCanary(
+            policy=policy,
+            receipt=None,
+            coordinator=None,
+            supervisor=None,
+            request=None,
+            session_port=None,
+            native_profile=None,
+            capability_binding=None,
+            capability_authority_reader=None,
+            domain=None,
+            cleanup=None,
+            recovery=None,
+            host_identity=None,
+            boot_identity=None,
+            status=CodingProductWorkerCanaryStatusV1(
+                code=code,
+                readiness=readiness,
+                required=policy.effective_required,
+                requested_owner="hosting",
+                effective_owner="current",
+            ),
+        )
+    if not isinstance(receipt, ProductWorkerActivationReceiptV1) or (
+        receipt.policy != policy
+    ):
+        _raise("coding_worker_receipt_mismatch")
+    _validate_session(
+        policy,
+        session_discovery=session_discovery,
+        validate_product_session=validate_product_session,
+    )
+    _validate_selected_components(
+        policy=policy,
+        receipt=receipt,
+        authority=authority,
+        evidence_authority=evidence_authority,
+        trusted_evidence_authority_id=trusted_evidence_authority_id,
+        trusted_evidence_authority_fingerprint=(trusted_evidence_authority_fingerprint),
+        activation_state_store=activation_state_store,
+        restart_budget=restart_budget,
+        supervisor=supervisor,
+        request=worker_request,
+        current_owner=current_owner,
+        hosting=hosting,
+        containment_launcher_path=containment_launcher_path,
+        containment_launcher_sha256=containment_launcher_sha256,
+        containment_profile_sha256=containment_profile_sha256,
+        capability_binding=capability_binding,
+        capability_authority_reader=capability_authority_reader,
+        domain=domain,
+        cleanup=cleanup,
+        recovery=recovery,
+        host_identity=host_identity,
+        boot_identity=boot_identity,
+    )
+    assert worker_request is not None
+    assert authority is not None
+    assert evidence_authority is not None
+    assert trusted_evidence_authority_id is not None
+    assert trusted_evidence_authority_fingerprint is not None
+    assert activation_state_store is not None
+    assert containment_launcher_path is not None
+    assert containment_launcher_sha256 is not None
+    assert containment_profile_sha256 is not None
+    try:
+        native_profile = _bind_posix_static_contained_product_worker_profile(
+            receipt=receipt,
+            worker_request=worker_request,
+            native_profile_catalog_revision=policy.native_profile_catalog_revision,
+            launcher_path=containment_launcher_path,
+            launcher_sha256=containment_launcher_sha256,
+            containment_profile_sha256=containment_profile_sha256,
+        )
+    except WorkerBindingError as exc:
+        raise CodingProductWorkerCanaryError(
+            "Coding Worker native profile was rejected",
+            code=exc.code,
+        ) from exc
+    except (TypeError, ValueError) as exc:
+        raise CodingProductWorkerCanaryError(
+            "Coding Worker native profile configuration was rejected",
+            code="coding_worker_native_profile_configuration_invalid",
+        ) from exc
+    try:
+        coordinator = ProductWorkerActivationCoordinator(
+            authority=authority,
+            evidence_authority=evidence_authority,
+            trusted_evidence_authority_id=trusted_evidence_authority_id,
+            trusted_evidence_authority_fingerprint=(
+                trusted_evidence_authority_fingerprint
+            ),
+            state_store=activation_state_store,
+            restart_budget=restart_budget,
+        )
+    except Exception as exc:
+        raise CodingProductWorkerCanaryError(
+            "Coding Worker activation composition was rejected",
+            code="coding_worker_activation_composition_rejected",
+        ) from exc
+    session_port = WorkerSessionOwnerRouter(
+        current=cast(ManagedWorkerSessionLaunchPort, current_owner),
+        hosting=HostingManagedWorkerSessionAdapter(
+            hosting=hosting,  # type: ignore[arg-type]
+            preparation=native_profile,
+        ),
+        activation=WorkerHostingActivationV1(owner="hosting"),
+    )
+    return CodingProductWorkerCanary(
+        policy=policy,
+        receipt=receipt,
+        coordinator=coordinator,
+        supervisor=supervisor,
+        request=worker_request,
+        session_port=session_port,
+        native_profile=native_profile,
+        capability_binding=capability_binding,
+        capability_authority_reader=capability_authority_reader,
+        domain=domain,
+        cleanup=cleanup,
+        recovery=recovery,
+        host_identity=host_identity,
+        boot_identity=boot_identity,
+        status=CodingProductWorkerCanaryStatusV1(
+            code="coding_worker_selected",
+            readiness="selected",
+            required=policy.effective_required,
+            requested_owner="hosting",
+            effective_owner="hosting",
+            receipt_fingerprint=receipt.fingerprint,
+            attempt_id=worker_request.identity.attempt_id,
+            owner_generation=worker_request.identity.owner_generation,
+        ),
+    )
+
+
+def coding_product_worker_session_fingerprint(
+    discovery: SessionDiscoveryMetadata,
+) -> str:
+    """Hash exact locator provenance without exposing a machine-local path."""
+
+    if not isinstance(discovery, SessionDiscoveryMetadata):
+        raise TypeError("Coding Worker canary requires Session discovery metadata")
+    encoded = json.dumps(
+        discovery.to_dict(),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    digest = sha256()
+    digest.update(b"loushang.coding-product-worker-session/v1")
+    digest.update(len(encoded).to_bytes(8, "big"))
+    digest.update(encoded)
+    return digest.hexdigest()
+
+
+def _current_canary(
+    *,
+    code: str,
+    policy: ProductWorkerActivationPolicyV1 | None = None,
+) -> CodingProductWorkerCanary:
+    required = False if policy is None else policy.effective_required
+    requested_owner: Literal["current", "hosting"] = (
+        "current" if policy is None else policy.requested_owner
+    )
+    return CodingProductWorkerCanary(
+        policy=policy,
+        receipt=None,
+        coordinator=None,
+        supervisor=None,
+        request=None,
+        session_port=None,
+        native_profile=None,
+        capability_binding=None,
+        capability_authority_reader=None,
+        domain=None,
+        cleanup=None,
+        recovery=None,
+        host_identity=None,
+        boot_identity=None,
+        status=CodingProductWorkerCanaryStatusV1(
+            code=code,
+            readiness="current",
+            required=required,
+            requested_owner=requested_owner,
+            effective_owner="current",
+        ),
+    )
+
+
+def _validate_session(
+    policy: ProductWorkerActivationPolicyV1,
+    *,
+    session_discovery: SessionDiscoveryMetadata | None,
+    validate_product_session: Callable[[], None] | None,
+) -> None:
+    if policy.session_route == "selected" and not callable(validate_product_session):
+        _raise("coding_worker_session_product_evidence_missing")
+    if validate_product_session is not None:
+        if not callable(validate_product_session):
+            raise TypeError("Coding Worker Session validator is invalid")
+        try:
+            validate_product_session()
+        except BaseException as exc:
+            raise CodingProductWorkerCanaryError(
+                "Coding Worker Session Product profile was rejected",
+                code="coding_worker_session_product_mismatch",
+            ) from exc
+    if policy.session_route == "new":
+        if session_discovery is not None:
+            _raise("coding_worker_new_session_has_locator")
+        return
+    if not isinstance(session_discovery, SessionDiscoveryMetadata):
+        _raise("coding_worker_session_locator_missing")
+    if not session_discovery.resumable or session_discovery.conflicts:
+        _raise("coding_worker_session_locator_conflict")
+    locator = session_discovery.locator
+    if locator.conversation_id != policy.session_id:
+        _raise("coding_worker_session_identity_mismatch")
+    if locator.revision != policy.selected_locator_revision:
+        _raise("coding_worker_session_locator_changed")
+    if coding_product_worker_session_fingerprint(session_discovery) != (
+        policy.selected_locator_fingerprint
+    ):
+        _raise("coding_worker_session_locator_changed")
+
+
+def _validate_selected_components(
+    *,
+    policy: ProductWorkerActivationPolicyV1,
+    receipt: ProductWorkerActivationReceiptV1,
+    authority: ProductWorkerActivationAuthorityPort | None,
+    evidence_authority: object | None,
+    trusted_evidence_authority_id: str | None,
+    trusted_evidence_authority_fingerprint: str | None,
+    activation_state_store: object | None,
+    restart_budget: int,
+    supervisor: WorkerSupervisor | None,
+    request: ManagedWorkerLaunchRequestV1 | None,
+    current_owner: ManagedWorkerSessionLaunchPort | None,
+    hosting: object | None,
+    containment_launcher_path: str | None,
+    containment_launcher_sha256: str | None,
+    containment_profile_sha256: str | None,
+    capability_binding: CapabilityWorkerBindingV1 | None,
+    capability_authority_reader: Callable[[], CapabilityWorkerAuthorityV1] | None,
+    domain: CodingProductWorkerCanaryDomainPort | None,
+    cleanup: CodingProductWorkerCleanupPort | None,
+    recovery: CodingProductWorkerRecoveryPort | None,
+    host_identity: str | None,
+    boot_identity: str | None,
+) -> None:
+    if policy.native_profile_id != CODING_PRODUCT_WORKER_NATIVE_PROFILE_ID:
+        _raise("coding_worker_native_profile_unsupported")
+    _require_opaque(host_identity, name="host identity")
+    _require_opaque(boot_identity, name="boot identity")
+    if authority is None or any(
+        not callable(getattr(authority, name, None))
+        for name in (
+            "serialized_admission",
+            "current_witness",
+            "latch_kill_switch",
+        )
+    ):
+        _raise("coding_worker_composition_incomplete")
+    if evidence_authority is None or any(
+        not callable(getattr(evidence_authority, name, None))
+        for name in (
+            "verify_tree_settlement",
+            "verify_changed_boot_absence",
+            "verify_registered_lease_expired",
+        )
+    ):
+        _raise("coding_worker_composition_incomplete")
+    _require_opaque(
+        trusted_evidence_authority_id,
+        name="cleanup evidence authority identity",
+    )
+    _require_sha256(
+        trusted_evidence_authority_fingerprint,
+        name="cleanup evidence authority fingerprint",
+    )
+    if activation_state_store is None or any(
+        not callable(getattr(activation_state_store, name, None))
+        for name in ("load", "compare_and_swap")
+    ):
+        _raise("coding_worker_composition_incomplete")
+    if type(restart_budget) is not int or restart_budget < 0:
+        _raise("coding_worker_composition_incomplete")
+    if not isinstance(supervisor, WorkerSupervisor):
+        _raise("coding_worker_composition_incomplete")
+    if not isinstance(request, ManagedWorkerLaunchRequestV1):
+        _raise("coding_worker_composition_incomplete")
+    if supervisor.identity != request.identity:
+        _raise("coding_worker_supervisor_identity_mismatch")
+    if not callable(getattr(current_owner, "start", None)) or hosting is None:
+        _raise("coding_worker_composition_incomplete")
+    if not isinstance(containment_launcher_path, str) or not containment_launcher_path:
+        _raise("coding_worker_composition_incomplete")
+    _require_sha256(
+        containment_launcher_sha256,
+        name="containment launcher digest",
+    )
+    _require_sha256(
+        containment_profile_sha256,
+        name="containment profile digest",
+    )
+    if not isinstance(capability_binding, CapabilityWorkerBindingV1) or not callable(
+        capability_authority_reader
+    ):
+        _raise("coding_worker_composition_incomplete")
+    for owner, methods in (
+        (
+            domain,
+            (
+                "publish",
+                "fence_attempt",
+                "revoke_and_drain",
+                "settle_readiness",
+                "issue_current",
+            ),
+        ),
+        (cleanup, ("settle",)),
+        (recovery, ("recover",)),
+    ):
+        if owner is None or any(
+            not callable(getattr(owner, method, None)) for method in methods
+        ):
+            _raise("coding_worker_composition_incomplete")
+    identity = request.identity
+    expected = (
+        policy.product_id,
+        policy.product_scope_id,
+        policy.plugin_id,
+        policy.plugin_revision_digest,
+        policy.contribution_id,
+        policy.declaration_fingerprint,
+        policy.worker_configuration_fingerprint,
+        policy.owner_selection_generation,
+    )
+    actual = (
+        identity.product_id,
+        identity.scope_id,
+        identity.plugin_id,
+        identity.plugin_revision_digest,
+        identity.contribution_id,
+        identity.declaration_fingerprint,
+        identity.worker_configuration_fingerprint,
+        identity.owner_generation,
+    )
+    if expected != actual:
+        _raise("coding_worker_request_identity_mismatch")
+    binding_authority = capability_binding.authority
+    if (
+        capability_binding.plugin_id != identity.plugin_id
+        or capability_binding.contribution_id != identity.contribution_id
+        or capability_binding.product_id != identity.product_id
+        or capability_binding.scope_id != identity.scope_id
+        or binding_authority.plugin_revision_digest != identity.plugin_revision_digest
+        or binding_authority.declaration_fingerprint != identity.declaration_fingerprint
+        or binding_authority.owner_generation != identity.owner_generation
+        or binding_authority.product_policy_revision != policy.product_policy_revision
+    ):
+        _raise("coding_worker_capability_binding_mismatch")
+
+
+def _stable_reason(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        return "coding_worker_activation_rejected"
+    return f"coding_worker_{value}"
+
+
+def _require_opaque(value: object, *, name: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value.encode("utf-8")) > 128
+        or any(character.isspace() for character in value)
+    ):
+        raise CodingProductWorkerCanaryError(
+            f"Coding Worker {name} is invalid",
+            code="coding_worker_machine_identity_invalid",
+        )
+
+
+def _require_sha256(value: object, *, name: str) -> None:
+    if (
+        not isinstance(value, str)
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise CodingProductWorkerCanaryError(
+            f"Coding Worker {name} is invalid",
+            code="coding_worker_composition_digest_invalid",
+        )
+
+
+class _suppress_failures:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *_error: object) -> bool:
+        return True
+
+
+def _raise(code: str) -> NoReturn:
+    raise CodingProductWorkerCanaryError(
+        "Coding Worker canary composition was rejected",
+        code=code,
+    )
+
+
+__all__ = [
+    "CODING_PRODUCT_WORKER_CANARY_ENTRYPOINTS",
+    "CODING_PRODUCT_WORKER_CANARY_VERSION",
+    "CODING_PRODUCT_WORKER_NATIVE_PROFILE_ID",
+    "CodingProductWorkerCanary",
+    "CodingProductWorkerCanaryDomainPort",
+    "CodingProductWorkerCanaryError",
+    "CodingProductWorkerCanaryStatusV1",
+    "CodingProductWorkerCleanupPort",
+    "CodingProductWorkerRecoveryPort",
+    "bind_coding_product_worker_canary",
+    "coding_product_worker_session_fingerprint",
+]

--- a/src/loushang/harness/worker/product_activation.py
+++ b/src/loushang/harness/worker/product_activation.py
@@ -766,8 +766,9 @@ class ProductWorkerActivationCoordinator:
 
     The default state store is an inert deterministic fake.  A caller that
     needs restart durability injects one CAS store and gives the same store to
-    the reconstructed coordinator.  This slice intentionally has no production
-    composition root.
+    the reconstructed coordinator.  C5.1 introduced this owner without a
+    production root; the sole C5.4 Coding canary may now construct it from
+    explicitly injected durable authorities.
     """
 
     def __init__(

--- a/tests/architecture/test_hosted_product_runtime_v1_baseline.py
+++ b/tests/architecture/test_hosted_product_runtime_v1_baseline.py
@@ -63,6 +63,8 @@ CURRENT_SOURCE_SEAMS = (
     WORKER_SOURCE / "journal.py",
     WORKER_SOURCE / "session.py",
     WORKER_SOURCE / "capability_query.py",
+    WORKER_SOURCE / "product_activation.py",
+    WORKER_SOURCE / "_native_profile_bridge.py",
     HARNESS_SOURCE / "transcript/discovery.py",
     HARNESS_SOURCE / "transcript/session_catalog.py",
     HARNESS_SOURCE / "transcript/directory.py",
@@ -72,6 +74,7 @@ CURRENT_SOURCE_SEAMS = (
     APPSERVER_SOURCE / "ports.py",
     HARNESS_SOURCE / "machine_resources/control_plane.py",
     Path("src/loushang/coding/cli/__main__.py"),
+    Path("src/loushang/coding/_product_worker_canary.py"),
 )
 
 
@@ -465,8 +468,9 @@ def test_current_inventory_matches_source_and_retained_absences() -> None:
     for statement in (
         "H5 default owner is Current",
         "PLC9C5 C5.0 design/inventory, C5.1 receipt/lifecycle, C5.2 Linux profile, "
-        "and C5.3 Windows mechanics/rejection are implemented",
-        "Product activation and unsupported-platform guards remain unchanged",
+        "C5.3 Windows mechanics/rejection, and C5.4 Linux Coding Product canary "
+        "are implemented",
+        "Windows Product activation and unsupported-platform guards remain closed",
         "AppHost A0.4 remains explicitly constructed and dark",
         "Hosting imports no Harness, Product, AppHost, AppServer, or AppService",
     ):
@@ -537,7 +541,7 @@ def test_delivery_plan_has_parallel_streams_and_one_activation_join() -> None:
     assert "never retry the other owner within one launch attempt" in normalized
 
 
-def test_current_worker_route_has_no_outside_composition_or_fallback() -> None:
+def test_current_worker_route_has_one_exact_composition_and_no_fallback() -> None:
     activation_names = {
         "HostingManagedWorkerSessionAdapter",
         "WorkerHostingActivationV1",
@@ -549,7 +553,7 @@ def test_current_worker_route_has_no_outside_composition_or_fallback() -> None:
         if not path.is_relative_to(WORKER_SOURCE)
         and any(name in _read(path) for name in activation_names)
     }
-    assert consumers == set()
+    assert consumers == {Path("src/loushang/coding/_product_worker_canary.py")}
 
     selection = _read(WORKER_SOURCE / "owner_selection.py")
     assert 'owner: WorkerSessionOwner = "current"' in selection

--- a/tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9c5_c50_baseline.py
@@ -30,6 +30,7 @@ HARNESS_ROOT = SOURCE_ROOT / "harness"
 WORKER_ROOT = HARNESS_ROOT / "worker"
 SANDBOX_RUNTIME = HARNESS_ROOT / "sandbox/runtime.py"
 CODING_ROOT = SOURCE_ROOT / "coding"
+CODING_CANARY = CODING_ROOT / "_product_worker_canary.py"
 HOSTING_ROOT = SOURCE_ROOT / "hosting"
 APPHOST_ROOT = SOURCE_ROOT / "apphost"
 AUTHOR_ROOT = SOURCE_ROOT / "plugin"
@@ -57,6 +58,7 @@ MAKEFILE = Path("Makefile")
 
 EXPECTED_CURRENT_SOURCE_PATHS = {
     "src/loushang/coding/bootstrap.py",
+    "src/loushang/coding/_product_worker_canary.py",
     "src/loushang/coding/cli/__main__.py",
     "src/loushang/coding/session_manager.py",
     "src/loushang/harness/capabilities/component_host.py",
@@ -545,12 +547,15 @@ def test_c50_status_is_honest_and_documents_are_indexed_once() -> None:
         "Parent": "PLC9C",
         "Authority": "normative accepted design",
         "Design status": "accepted",
-            "Implementation status": (
-                "implemented through C5.3 — C5.0 design/guards, C5.1 "
-                "receipt/lifecycle, C5.2 Linux native profile binding, and C5.3 "
-                "Windows mechanics/rejection; C5.4 not-started"
+        "Implementation status": (
+            "implemented through C5.4 — C5.0 design/guards, C5.1 "
+            "receipt/lifecycle, C5.2 Linux native profile binding, C5.3 Windows "
+            "mechanics/rejection, and the C5.4 Linux Coding Product canary"
         ),
-        "Activation status": "closed; every production route remains default-dark",
+        "Activation status": (
+            "explicit Linux Coding canary accepted; default remains Current and "
+            "Windows/every unlisted platform remain closed"
+        ),
         "Observation base": "cb01f723",
         "Owner": (
             "Harness Worker architecture with Product, Hosting, and domain-owner "
@@ -595,9 +600,10 @@ def test_c50_current_inventory_source_set_is_exact_and_present() -> None:
         "C5-CUR-SESSION-DISCOVERY",
         "C5-CUR-WORKER-PUBLIC",
         "C5-C51-RECEIPT-LIFECYCLE",
-            "C5-C52-LINUX-NATIVE",
-            "C5-C53-WINDOWS-MECHANICS",
-            "C5-CUR-WORKER-IDENTITY",
+        "C5-C52-LINUX-NATIVE",
+        "C5-C53-WINDOWS-MECHANICS",
+        "C5-C54-LINUX-PRODUCT",
+        "C5-CUR-WORKER-IDENTITY",
         "C5-CUR-CURRENT-LAUNCH",
         "C5-CUR-WORKER-SESSION",
         "C5-CUR-DOMAIN-CANARY",
@@ -690,16 +696,16 @@ def test_c50_freezes_dependency_and_native_shape_decisions() -> None:
     for mismatch in (
         "static launcher digest",
         "containment-profile digest",
-            "snapshots locked volume/file identities",
-            "canonical `SystemRoot` through `GetWindowsDirectoryW`",
-            "ambient poisoning is closed",
+        "snapshots locked volume/file identities",
+        "canonical `SystemRoot` through `GetWindowsDirectoryW`",
+        "ambient poisoning is closed",
         "discarded stderr",
         "restricted-token/Job/direct-import mechanics",
         "selector currently accepts WSL",
         "current profile is explicitly rejected for Product required containment",
-        "no production recovery route exists",
-        "no production activation gate is composed",
-        "ordered production rollback remains absent",
+        "full V1--V6 vector",
+        "production canary latches first",
+        "R1--R7 is executable",
     ):
         assert mismatch in inventory
 
@@ -713,16 +719,19 @@ def test_c50_freezes_dependency_and_native_shape_decisions() -> None:
     assert _drill_ledger_rows(future_evidence) == EXPECTED_DRILL_LEDGER
 
 
-def test_c50_guard_transitions_are_exact_through_c52() -> None:
+def test_c50_guard_transitions_are_exact_through_c54() -> None:
     production_sources = tuple(SOURCE_ROOT.rglob("*.py"))
     source = "\n".join(_read(path) for path in production_sources)
-    retained_absences = {"bind_coding_product_worker_canary"}
-    for token in retained_absences:
-        assert token not in source
+    assert source.count("def bind_coding_product_worker_canary(") == 1
     c51_source = _read(WORKER_ROOT / "product_activation.py")
-    for token in RESERVED_TRANSITION_TOKENS - retained_absences - C52_WORKER_PUBLIC_EXPORTS:
+    for token in (
+        RESERVED_TRANSITION_TOKENS
+        - {"bind_coding_product_worker_canary"}
+        - C52_WORKER_PUBLIC_EXPORTS
+    ):
         assert token in c51_source
     assert "ProductWorkerNativeProfilePort" in _read(NATIVE_PROFILE_BRIDGE)
+    assert "def bind_coding_product_worker_canary(" in _read(CODING_CANARY)
 
     composition_names = {
         "HostingManagedWorkerSessionAdapter",
@@ -736,7 +745,7 @@ def test_c50_guard_transitions_are_exact_through_c52() -> None:
         if not path.is_relative_to(WORKER_ROOT)
         and any(name in _read(path) for name in composition_names)
     }
-    assert outside_worker == set()
+    assert outside_worker == {CODING_CANARY}
 
     worker_consumers = {
         path
@@ -782,19 +791,18 @@ def test_c50_keeps_private_profiles_confined_and_product_layers_clean() -> None:
     assert "wsl" not in posix
     assert "microsoft" not in posix
 
-    forbidden_product_imports = (
-        "loushang.harness.worker",
-        "loushang.hosting",
-    )
-    for root in (CODING_ROOT, APPHOST_ROOT):
-        if not root.is_dir():
-            continue
-        imports = {
-            imported for path in root.rglob("*.py") for imported in _imports(path)
-        }
-        assert not any(
-            imported.startswith(forbidden_product_imports) for imported in imports
+    coding_worker_consumers = {
+        path
+        for path in CODING_ROOT.rglob("*.py")
+        if any(
+            imported.startswith("loushang.harness.worker")
+            for imported in _imports(path)
         )
+    }
+    assert coding_worker_consumers == {CODING_CANARY}
+    for path in (*CODING_ROOT.rglob("*.py"), *APPHOST_ROOT.rglob("*.py")):
+        imports = _imports(path)
+        assert not any(imported.startswith("loushang.hosting") for imported in imports)
 
 
 def test_c50_import_guard_resolves_relative_and_parent_alias_forms() -> None:

--- a/tests/architecture/test_plugin_lifecycle_plc9c5_c51_contract.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9c5_c51_contract.py
@@ -26,6 +26,7 @@ WORKER_ROOT = Path("src/loushang/harness/worker")
 WORKER_FACADE = WORKER_ROOT / "__init__.py"
 IMPLEMENTATION = WORKER_ROOT / "product_activation.py"
 NATIVE_BRIDGE = WORKER_ROOT / "_native_profile_bridge.py"
+CODING_CANARY = Path("src/loushang/coding/_product_worker_canary.py")
 CONTRACT_TEST = Path("tests/harness/worker/test_product_activation.py")
 VERIFIER = Path("scripts/dev/verify_plc9c5_manifest.py")
 VERIFIER_TEST = Path("tests/dev/test_verify_plc9c5_manifest.py")
@@ -244,16 +245,18 @@ def test_c51_contract_and_inventory_are_honest_and_indexed() -> None:
     ):
         assert token in contract
     assert index.count("(plugin-lifecycle-plc9c5-c51-contract.md)") == 1
-    assert "C5.2 Linux native profile binding, and C5.3 Windows" in (
+    assert "C5.2 Linux native profile binding, C5.3 Windows" in (
         " ".join(baseline.split())
     )
-    assert "mechanics/rejection; C5.4 not-started" in " ".join(baseline.split())
+    assert "mechanics/rejection, and the C5.4 Linux Coding Product canary" in (
+        " ".join(baseline.split())
+    )
     for token in (
         "C5-C51-RECEIPT-LIFECYCLE",
         "C5-C52-LINUX-NATIVE",
-        "retained Linux native report is implemented",
-        "no production activation gate is composed",
-        "no production recovery route exists",
+        "C5.2 Linux native",
+        "production canary latches first",
+        "full V1--V6 vector",
     ):
         assert token in inventory
 
@@ -526,7 +529,7 @@ def test_c51_required_manifest_and_test_ids_are_exact() -> None:
     assert (
         reports["PLC9C5-C5.3-WINDOWS-MECHANICS"]["status"] == "implemented"
     )
-    assert reports["PLC9C5-C5.4-LINUX-PRODUCT"]["status"] == "planned"
+    assert reports["PLC9C5-C5.4-LINUX-PRODUCT"]["status"] == "implemented"
     assert _literal_collection(CONTRACT_TEST, "PLC9C5_C51_CASES") == set(C51_CASES)
     assert _literal_collection(
         CONTRACT_TEST,
@@ -603,7 +606,7 @@ def test_c51_ci_makefile_and_manifest_verifier_are_required() -> None:
         assert behavior_test in verifier_tests
 
 
-def test_c51_has_no_production_consumer_or_native_side_effect() -> None:
+def test_c51_has_only_the_accepted_c54_consumer_and_no_native_side_effect() -> None:
     consumers: set[Path] = set()
     for path in SOURCE_ROOT.rglob("*.py"):
         if path in {IMPLEMENTATION, WORKER_FACADE}:
@@ -615,7 +618,7 @@ def test_c51_has_no_production_consumer_or_native_side_effect() -> None:
             or any(name in text for name in C51_IMPLEMENTATION_NAMES)
         ):
             consumers.add(path)
-    assert consumers == {NATIVE_BRIDGE}
+    assert consumers == {NATIVE_BRIDGE, CODING_CANARY}
     for path in WORKER_ROOT.rglob("*.py"):
         if path in {IMPLEMENTATION, WORKER_FACADE, NATIVE_BRIDGE}:
             continue

--- a/tests/architecture/test_plugin_lifecycle_plc9c5_c52_linux_native.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9c5_c52_linux_native.py
@@ -112,7 +112,7 @@ def test_c52_status_inventory_and_index_are_honest() -> None:
         "Same-boot uncertainty remains durable cleanup debt",
     ):
         assert token in document
-    assert "implemented through C5.3" in baseline
+    assert "implemented through C5.4" in baseline
     assert "C5.2 Linux native profile binding" in baseline
     assert "C5-C52-LINUX-NATIVE" in inventory
     assert "no Product, Coding, AppHost, CLI, presenter, or Session composition" in document
@@ -190,14 +190,14 @@ def test_c52_private_imports_are_exact_lazy_and_one_way() -> None:
         assert forbidden not in bridge
 
 
-def test_c52_bridge_is_default_dark_and_adapter_remains_profile_blind() -> None:
+def test_c52_bridge_has_one_explicit_product_consumer_and_adapter_stays_blind() -> None:
     factory = "_bind_posix_static_contained_product_worker_profile"
     consumers = {
         path
         for path in SOURCE_ROOT.rglob("*.py")
         if path != BRIDGE and factory in _read(path)
     }
-    assert consumers == set()
+    assert consumers == {Path("src/loushang/coding/_product_worker_canary.py")}
     adapter = _read(HOSTING_ADAPTER)
     assert "ProductWorkerNativeProfilePort" in adapter
     for forbidden in (

--- a/tests/architecture/test_plugin_lifecycle_plc9c5_c53_windows_mechanics.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9c5_c53_windows_mechanics.py
@@ -96,7 +96,7 @@ def test_c53_status_manifest_and_index_are_honest() -> None:
     assert "Implementation status: implemented" in document
     assert "Activation status: closed" in document
     assert "Production default: Current" in document
-    assert "implemented through C5.3" in baseline
+    assert "implemented through C5.4" in baseline
     assert "C5-C53-WINDOWS-MECHANICS" in inventory
     assert _read(INDEX).count(
         "(plugin-lifecycle-plc9c5-c53-windows-mechanics.md)"

--- a/tests/architecture/test_plugin_lifecycle_plc9c5_c54_linux_product.py
+++ b/tests/architecture/test_plugin_lifecycle_plc9c5_c54_linux_product.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+CANARY = Path("src/loushang/coding/_product_worker_canary.py")
+CODING_ROOT = Path("src/loushang/coding")
+WORKER_ROOT = Path("src/loushang/harness/worker")
+HOSTING_ROOT = Path("src/loushang/hosting")
+BEHAVIOR = Path("tests/harness/worker/test_coding_product_worker_canary.py")
+DOCUMENT = Path(
+    "docs/internals/architecture/harness/plugin/"
+    "plugin-lifecycle-plc9c5-c54-linux-product.md"
+)
+BASELINE = Path(
+    "docs/internals/architecture/harness/plugin/plugin-lifecycle-plc9c5-c50-baseline.md"
+)
+INVENTORY = Path(
+    "docs/internals/architecture/harness/plugin/"
+    "plugin-lifecycle-plc9c5-c50-inventory.md"
+)
+INDEX = Path("docs/internals/architecture/harness/plugin/README.md")
+MANIFEST = Path(
+    "docs/internals/architecture/harness/plugin/"
+    "plugin-lifecycle-plc9c5-evidence-manifest.json"
+)
+MAKEFILE = Path("Makefile")
+WORKFLOW = Path(".github/workflows/harness-quality.yml")
+
+C54_CASES = {
+    "C54-PRODUCT-SELECTED",
+    "C54-PRODUCT-MISSING",
+    "C54-PRODUCT-WRONG",
+    "C54-PRODUCT-DISABLED",
+    "C54-SESSION-CANONICAL",
+    "C54-SESSION-CWD",
+    "C54-SESSION-HOME",
+    "C54-SESSION-TAMPERED",
+    "C54-SESSION-ALIAS",
+    "C54-SESSION-CONFLICT",
+    "C54-SESSION-CHANGED",
+    "C54-REQUIRED-SUCCESS",
+    "C54-REQUIRED-FAILURE",
+    "C54-OPTIONAL-SUCCESS",
+    "C54-OPTIONAL-DEGRADED",
+    "C54-CLOSURE-FRESHNESS",
+    "C54-HANDSHAKE-HEALTH-PUBLICATION",
+    "C54-UNSUPPORTED-WINDOWS",
+    "C54-UNSUPPORTED-WSL",
+    "C54-UNSUPPORTED-NON-X86",
+    "C54-UNSUPPORTED-MACOS",
+    "C54-ORDERED-ROLLBACK",
+    "C54-RECOVERY-MATRIX",
+    "C54-SHARED-ENTRYPOINT-RECEIPT",
+    "C54-SENTINEL-REDACTION",
+}
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _imports(path: Path) -> set[str]:
+    imports: set[str] = set()
+    for node in ast.walk(ast.parse(_read(path), filename=str(path))):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+    return imports
+
+
+def _literal_collection(path: Path, name: str) -> tuple[str, ...]:
+    tree = ast.parse(_read(path), filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
+        if any(
+            isinstance(target, ast.Name) and target.id == name for target in targets
+        ):
+            assert node.value is not None
+            value = ast.literal_eval(node.value)
+            assert isinstance(value, (tuple, list))
+            return tuple(value)
+    raise AssertionError(f"{name} is absent from {path}")
+
+
+def _function_source(path: Path, name: str) -> str:
+    source = _read(path)
+    for node in ast.parse(source, filename=str(path)).body:
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ):
+            result = ast.get_source_segment(source, node)
+            assert result is not None
+            return result
+    raise AssertionError(f"{name} is absent from {path}")
+
+
+def _class_method_source(path: Path, class_name: str, method_name: str) -> str:
+    source = _read(path)
+    tree = ast.parse(source, filename=str(path))
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != class_name:
+            continue
+        for child in node.body:
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+                child.name == method_name
+            ):
+                result = ast.get_source_segment(source, child)
+                assert result is not None
+                return result
+    raise AssertionError(f"{class_name}.{method_name} is absent from {path}")
+
+
+def test_c54_status_inventory_manifest_and_index_are_honest() -> None:
+    document = " ".join(_read(DOCUMENT).split())
+    baseline = " ".join(_read(BASELINE).split())
+    inventory = " ".join(_read(INVENTORY).split())
+    report = json.loads(_read(MANIFEST))["reports"]["PLC9C5-C5.4-LINUX-PRODUCT"]
+    for token in (
+        "ID: `PLC9C5-C5.4-LINUX-PRODUCT`",
+        "Design status: accepted",
+        "Implementation status: implemented",
+        "Production default: Current",
+        "G7 remains open",
+        "zero skips, failures, and errors",
+    ):
+        assert token in document
+    assert "implemented through C5.4" in baseline
+    assert "C5-C54-LINUX-PRODUCT" in inventory
+    assert _read(INDEX).count("(plugin-lifecycle-plc9c5-c54-linux-product.md)") == 1
+    assert report["status"] == "implemented"
+    assert report["minimumTests"] == 25
+    assert set(report["requiredCaseIds"]) == C54_CASES
+    assert set(_literal_collection(BEHAVIOR, "PLC9C5_C54_CASES")) == C54_CASES
+
+
+def test_c54_has_one_product_root_and_one_way_dependencies() -> None:
+    source = _read(CANARY)
+    assert source.count("def bind_coding_product_worker_canary(") == 1
+    worker_consumers = {
+        path
+        for path in CODING_ROOT.rglob("*.py")
+        if any(
+            imported.startswith("loushang.harness.worker")
+            for imported in _imports(path)
+        )
+    }
+    assert worker_consumers == {CANARY}
+    assert not any(
+        imported.startswith("loushang.hosting") for imported in _imports(CANARY)
+    )
+    assert {
+        "loushang.harness.worker._native_profile_bridge",
+        "loushang.harness.worker.product_activation",
+    }.issubset(_imports(CANARY))
+    private_profiles = {
+        "loushang.hosting._posix_launch_preparation",
+        "loushang.hosting._windows_launch_preparation",
+    }
+    private_consumers = {
+        path
+        for path in Path("src/loushang").rglob("*.py")
+        if not path.is_relative_to(HOSTING_ROOT) and _imports(path) & private_profiles
+    }
+    assert private_consumers == {WORKER_ROOT / "_native_profile_bridge.py"}
+    for forbidden in (
+        "os.environ",
+        "subprocess",
+        "ctypes",
+        "_PosixStaticContainedLaunchCaptureSpec",
+        "_WindowsRestrictedLaunchCaptureSpec",
+    ):
+        assert forbidden not in source
+
+
+def test_c54_default_is_current_and_selection_is_exact() -> None:
+    binding = _function_source(CANARY, "bind_coding_product_worker_canary")
+    selected = _function_source(CANARY, "_validate_selected_components")
+    assert "policy: ProductWorkerActivationPolicyV1 | None = None" in binding
+    assert 'code="coding_worker_product_missing"' in binding
+    assert "policy.product_id != CODING_PRODUCT_ID" in binding
+    assert "policy.enabled" in binding
+    assert "receipt.policy != policy" in binding
+    assert "CODING_PRODUCT_WORKER_NATIVE_PROFILE_ID" in selected
+    assert "ProductWorkerActivationCoordinator(" in binding
+    assert "_bind_posix_static_contained_product_worker_profile(" in binding
+    assert binding.index(
+        "_bind_posix_static_contained_product_worker_profile("
+    ) < binding.index("ProductWorkerActivationCoordinator(")
+    assert 'WorkerHostingActivationV1(owner="hosting")' in binding
+    assert "HostingManagedWorkerSessionAdapter(" in binding
+    assert "os.environ" not in binding
+
+
+def test_c54_session_and_entrypoint_evidence_are_pathless_and_shared() -> None:
+    session = _function_source(CANARY, "_validate_session")
+    fingerprint = _function_source(
+        CANARY,
+        "coding_product_worker_session_fingerprint",
+    )
+    entrypoint = _class_method_source(
+        CANARY,
+        "CodingProductWorkerCanary",
+        "receipt_for_entrypoint",
+    )
+    for token in (
+        "validate_product_session",
+        "session_discovery.resumable",
+        "session_discovery.conflicts",
+        "locator.conversation_id",
+        "locator.revision",
+        "coding_product_worker_session_fingerprint",
+    ):
+        assert token in session
+    assert "discovery.to_dict()" in fingerprint
+    assert "return self._receipt" in entrypoint
+    assert "CODING_PRODUCT_WORKER_CANARY_ENTRYPOINTS" in entrypoint
+    status = _class_method_source(
+        CANARY,
+        "CodingProductWorkerCanaryStatusV1",
+        "to_dict",
+    )
+    for forbidden in ("path", "cwd", "sessionFile", "environment", "handle"):
+        assert forbidden not in status
+
+
+def test_c54_health_precedes_domain_publication_and_ambiguity_is_reclaimed() -> None:
+    start = _class_method_source(CANARY, "CodingProductWorkerCanary", "start")
+    assert start.index("supervisor.start_session(") < start.index("adapter.admit()")
+    assert start.index("adapter.admit()") < start.index("coordinator.publish(")
+    assert start.index("coordinator.publish(") < start.index("domain.publish(")
+    assert start.index("domain_publish_started = True") < start.index(
+        "await domain.publish("
+    )
+    reclaim = _class_method_source(
+        CANARY,
+        "CodingProductWorkerCanary",
+        "_reclaim_failed_attempt",
+    )
+    for token in (
+        "domain.fence_attempt",
+        "domain.revoke_and_drain",
+        "coordinator.retire_exact",
+        "supervisor.fence",
+        "coordinator.record_protocol_terminal",
+        "cleanup.settle",
+    ):
+        assert token in reclaim
+
+
+def test_c54_rollback_recovery_and_no_fallback_are_fixed() -> None:
+    assert _literal_collection(CANARY, "_ROLLBACK_STEPS") == (
+        "R1-LATCH-FUTURE",
+        "R2-FENCE-ATTEMPTS",
+        "R3-REVOKE-DRAIN",
+        "R4-TERMINATE-TREE",
+        "R5-SETTLE-OR-DEBT",
+        "R6-SETTLE-READINESS",
+        "R7-ISSUE-CURRENT",
+    )
+    assert _literal_collection(CANARY, "_RECOVERY_STEPS") == (
+        "V1-PRIOR-ABSENT",
+        "V2-EXACT-REAPED",
+        "V3-SAMEBOOT-UNKNOWN",
+        "V4-CHANGEDBOOT-ABSENT",
+        "V5-BUDGET-EXHAUSTED",
+        "V6-HOST-RESTART",
+    )
+    rollback = _class_method_source(CANARY, "CodingProductWorkerCanary", "rollback")
+    calls = (
+        "coordinator.latch_kill_switch(",
+        "domain.fence_attempt(",
+        "domain.revoke_and_drain(",
+        "coordinator.retire_exact(",
+        "supervisor.fence(",
+        "cleanup.settle(",
+        "domain.settle_readiness(",
+        "domain.issue_current(",
+    )
+    assert tuple(rollback.index(call) for call in calls) == tuple(
+        sorted(rollback.index(call) for call in calls)
+    )
+    assert "current_owner.start" not in rollback
+    recover = _class_method_source(CANARY, "CodingProductWorkerCanary", "recover")
+    assert "steps != _RECOVERY_STEPS" in recover
+    assert "coding_worker_recovery_incomplete" in recover
+
+
+def test_c54_required_report_is_mandatory_in_linux_gate() -> None:
+    makefile = _read(MAKEFILE)
+    workflow = _read(WORKFLOW)
+    for token in (
+        "test-plc9c5-c54-linux-product",
+        "check-plc9c5-c54-linux-product",
+        "plc9c5-c54-linux-product.xml",
+        "PLC9C5-C5.4-LINUX-PRODUCT",
+    ):
+        assert token in makefile
+    for token in (
+        "PLC9C5 C5.4 Linux Coding Product canary",
+        "tests/harness/worker/test_coding_product_worker_canary.py",
+        "plc9c5-c54-linux-product.xml",
+        "PLC9C5-C5.4-LINUX-PRODUCT",
+        "if-no-files-found: error",
+    ):
+        assert token in workflow

--- a/tests/harness/worker/test_coding_product_worker_canary.py
+++ b/tests/harness/worker/test_coding_product_worker_canary.py
@@ -1,0 +1,789 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from contextlib import AbstractContextManager
+from dataclasses import replace
+from hashlib import sha256
+from pathlib import Path
+
+import pytest
+
+from loushang.coding._product_worker_canary import (
+    CodingProductWorkerCanaryError,
+    bind_coding_product_worker_canary,
+    coding_product_worker_session_fingerprint,
+)
+from loushang.harness.resources.plugins.declarations import (
+    PluginLocalWorkerConfiguration,
+)
+from loushang.harness.transcript.discovery import (
+    SessionDiscoveryMetadata,
+    SessionLocator,
+)
+from loushang.harness.worker import (
+    CapabilityWorkerAuthorityV1,
+    CapabilityWorkerBindingV1,
+    ManagedWorkerLaunchRequestV1,
+    ProductWorkerActivationPolicyV1,
+    ProductWorkerActivationReceiptV1,
+    WorkerFrameCodec,
+    WorkerLaunchIdentityV1,
+    WorkerProtocolMessage,
+    WorkerRuntimeBindingV1,
+    WorkerSupervisor,
+)
+from loushang.harness.worker.journal import WorkerSupervisorJournal
+from loushang.harness.workspace.process import ProcessStderrTail
+from loushang.hosting import ProcessExit
+
+PLC9C5_C54_CASES = (
+    "C54-PRODUCT-SELECTED",
+    "C54-PRODUCT-MISSING",
+    "C54-PRODUCT-WRONG",
+    "C54-PRODUCT-DISABLED",
+    "C54-SESSION-CANONICAL",
+    "C54-SESSION-CWD",
+    "C54-SESSION-HOME",
+    "C54-SESSION-TAMPERED",
+    "C54-SESSION-ALIAS",
+    "C54-SESSION-CONFLICT",
+    "C54-SESSION-CHANGED",
+    "C54-REQUIRED-SUCCESS",
+    "C54-REQUIRED-FAILURE",
+    "C54-OPTIONAL-SUCCESS",
+    "C54-OPTIONAL-DEGRADED",
+    "C54-CLOSURE-FRESHNESS",
+    "C54-HANDSHAKE-HEALTH-PUBLICATION",
+    "C54-UNSUPPORTED-WINDOWS",
+    "C54-UNSUPPORTED-WSL",
+    "C54-UNSUPPORTED-NON-X86",
+    "C54-UNSUPPORTED-MACOS",
+    "C54-ORDERED-ROLLBACK",
+    "C54-RECOVERY-MATRIX",
+    "C54-SHARED-ENTRYPOINT-RECEIPT",
+    "C54-SENTINEL-REDACTION",
+)
+
+_DIGEST_A = "a" * 64
+_DIGEST_B = "b" * 64
+_DIGEST_C = "c" * 64
+_ATTEMPT = "d" * 32
+_SESSION_NONCE = "e" * 64
+_WORKER_BYTES = b"#!/bin/sh\nexit 0\n"
+_LAUNCHER_BYTES = b'#!/bin/sh\nexec "$@"\n'
+_WORKER_DIGEST = sha256(_WORKER_BYTES).hexdigest()
+_LAUNCHER_DIGEST = sha256(_LAUNCHER_BYTES).hexdigest()
+_CONTAINMENT_PROFILE_DIGEST = sha256(b"coding-worker-containment-v1").hexdigest()
+_EVIDENCE_AUTHORITY_ID = "coding-cleanup-evidence-v1"
+_EVIDENCE_AUTHORITY_FINGERPRINT = "f" * 64
+
+
+class _Authority:
+    def __init__(
+        self,
+        receipt: ProductWorkerActivationReceiptV1,
+        events: list[str],
+    ) -> None:
+        self._lock = threading.RLock()
+        self._witness = receipt.authority_witness
+        self._events = events
+        self._in_gate = False
+
+    def serialized_admission(self) -> AbstractContextManager[None]:
+        authority = self
+
+        class _Gate(AbstractContextManager[None]):
+            def __enter__(self) -> None:
+                authority._lock.acquire()
+                assert not authority._in_gate
+                authority._in_gate = True
+
+            def __exit__(self, *error: object) -> None:
+                authority._in_gate = False
+                authority._lock.release()
+
+        return _Gate()
+
+    def current_witness(
+        self, receipt: ProductWorkerActivationReceiptV1
+    ) -> tuple[str, str, str, int, int]:
+        del receipt
+        assert self._in_gate
+        return self._witness
+
+    def latch_kill_switch(self, *, expected_generation: int) -> int:
+        assert self._in_gate
+        current_generation = self._witness[-1]
+        if current_generation == expected_generation:
+            self._witness = (*self._witness[:-1], expected_generation + 1)
+        elif current_generation != expected_generation + 1:
+            raise AssertionError("unexpected kill-switch generation")
+        self._events.append("R1-LATCH-FUTURE")
+        return expected_generation + 1
+
+
+class _EvidenceAuthority:
+    authority_id = _EVIDENCE_AUTHORITY_ID
+    authority_fingerprint = _EVIDENCE_AUTHORITY_FINGERPRINT
+
+    def verify_tree_settlement(self, **facts: object) -> bool:
+        del facts
+        return True
+
+    def verify_changed_boot_absence(self, **facts: object) -> bool:
+        del facts
+        return True
+
+    def verify_registered_lease_expired(self, **facts: object) -> bool:
+        del facts
+        return True
+
+
+class _ActivationStateStore:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._document: dict[str, object] | None = None
+
+    def load(self) -> object:
+        with self._lock:
+            return _json_clone(self._document)
+
+    def compare_and_swap(
+        self,
+        *,
+        expected_revision: int,
+        document: object,
+    ) -> bool:
+        assert isinstance(document, dict)
+        with self._lock:
+            current_revision = (
+                0 if self._document is None else self._document["stateRevision"]
+            )
+            if current_revision != expected_revision:
+                return False
+            self._document = _json_clone(document)
+            return True
+
+
+def _json_clone(value: object):
+    if value is None:
+        return None
+    return json.loads(json.dumps(value, sort_keys=True))
+
+
+class _Endpoint:
+    def __init__(self, ready: WorkerProtocolMessage) -> None:
+        self.incoming = bytearray(WorkerFrameCodec.encode(ready))
+        self.changed = asyncio.Event()
+        self.writes: list[bytes] = []
+        self.closed = False
+
+    async def read(self, max_bytes: int) -> bytes:
+        while not self.incoming:
+            if self.closed:
+                return b""
+            self.changed.clear()
+            await self.changed.wait()
+        chunk = bytes(self.incoming[:max_bytes])
+        del self.incoming[:max_bytes]
+        return chunk
+
+    async def write(self, data: bytes) -> None:
+        self.writes.append(data)
+
+    async def close(self) -> None:
+        self.closed = True
+        self.changed.set()
+
+
+class _Process:
+    lease_id = "worker-process-one"
+
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.exit: asyncio.Future[ProcessExit] | None = None
+
+    def _exit(self) -> asyncio.Future[ProcessExit]:
+        if self.exit is None:
+            self.exit = asyncio.get_running_loop().create_future()
+        return self.exit
+
+    async def read_stdout(self, max_bytes: int) -> bytes:
+        del max_bytes
+        return b""
+
+    async def read_stderr(self, max_bytes: int) -> bytes:
+        del max_bytes
+        return b""
+
+    async def write_stdin(self, data: bytes) -> None:
+        del data
+
+    async def close_stdin(self) -> None:
+        return None
+
+    async def wait(self) -> ProcessExit:
+        return await asyncio.shield(self._exit())
+
+    async def terminate(self) -> ProcessExit:
+        self.events.append("R4-TERMINATE-TREE")
+        future = self._exit()
+        if not future.done():
+            future.set_result(ProcessExit(-15))
+        return await future
+
+    async def close(self) -> None:
+        await self.terminate()
+
+    def stderr_tail(self) -> ProcessStderrTail:
+        return ProcessStderrTail()
+
+
+class _Lease:
+    session_id = "hosting-session-one"
+
+    def __init__(self, endpoint: _Endpoint, process: _Process) -> None:
+        self.endpoint = endpoint
+        self.process = process
+
+    async def close(self) -> None:
+        await self.endpoint.close()
+        await self.process.terminate()
+
+
+class _Hosting:
+    def __init__(self, identity: WorkerLaunchIdentityV1, events: list[str]) -> None:
+        self.events = events
+        self.fail = False
+        self.endpoint = _Endpoint(
+            WorkerProtocolMessage.create(
+                "ready",
+                attemptId=identity.attempt_id,
+                identityFingerprint=identity.fingerprint,
+                protocol="capability.query",
+                protocolVersion=1,
+                sessionNonce=identity.session_nonce,
+                supervisorEpoch=identity.supervisor_epoch,
+            )
+        )
+        self.process = _Process(events)
+
+    async def start(self, request, preparation):
+        del request, preparation
+        self.events.append("hosting-start")
+        if self.fail:
+            raise RuntimeError("/secret/hosting-sentinel")
+        return _Lease(self.endpoint, self.process)
+
+    async def close(self) -> None:
+        return None
+
+
+class _CurrentOwner:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def start(self, request, *, correlation_id, signal=None):
+        del request, correlation_id, signal
+        self.calls += 1
+        raise AssertionError("same-attempt fallback is forbidden")
+
+
+class _Domain:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.fail_publish = False
+        self.ready_states: list[tuple[bool, bool, str]] = []
+
+    async def publish(self, *, adapter, admission, **identity) -> None:
+        del admission, identity
+        assert adapter._supervisor.status.state == "healthy"
+        self.events.append("domain-publish")
+        if self.fail_publish:
+            raise RuntimeError("/secret/domain-sentinel")
+
+    async def fence_attempt(self, **identity) -> None:
+        del identity
+        self.events.append("R2-FENCE-ATTEMPTS")
+
+    async def revoke_and_drain(self, **identity) -> None:
+        del identity
+        self.events.append("R3-REVOKE-DRAIN")
+
+    async def settle_readiness(self, *, required, ready, code) -> None:
+        self.ready_states.append((required, ready, code))
+        if code == "coding_worker_rollback_latched":
+            self.events.append("R6-SETTLE-READINESS")
+
+    async def issue_current(self, *, prior_receipt_fingerprint) -> object:
+        assert len(prior_receipt_fingerprint) == 64
+        self.events.append("R7-ISSUE-CURRENT")
+        return object()
+
+
+class _Cleanup:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def settle(self, **facts) -> None:
+        assert facts["protocol_terminal"] is True
+        assert facts["domain_retired"] is True
+        self.events.append("R5-SETTLE-OR-DEBT")
+
+
+class _Recovery:
+    def __init__(self) -> None:
+        self.steps = (
+            "V1-PRIOR-ABSENT",
+            "V2-EXACT-REAPED",
+            "V3-SAMEBOOT-UNKNOWN",
+            "V4-CHANGEDBOOT-ABSENT",
+            "V5-BUDGET-EXHAUSTED",
+            "V6-HOST-RESTART",
+        )
+
+    async def recover(self, **identity) -> tuple[str, ...]:
+        del identity
+        return self.steps
+
+
+class _Context:
+    def __init__(self, tmp_path: Path, *, required: bool = True) -> None:
+        self.events: list[str] = []
+        self.discovery = _discovery(tmp_path)
+        self.policy = _policy(self.discovery, required=required)
+        self.receipt = ProductWorkerActivationReceiptV1(
+            policy=self.policy,
+            issue_sequence=1,
+            issue_nonce="coding-worker-receipt-one",
+        )
+        configuration = PluginLocalWorkerConfiguration(
+            entrypoint="worker",
+            protocol="capability.query",
+            protocol_version=1,
+        )
+        executable = tmp_path / "worker"
+        executable.write_bytes(_WORKER_BYTES)
+        executable.chmod(0o500)
+        self.launcher = tmp_path / "containment-launcher"
+        self.launcher.write_bytes(_LAUNCHER_BYTES)
+        self.launcher.chmod(0o500)
+        runtime = WorkerRuntimeBindingV1.capture(
+            package_root=tmp_path,
+            configuration=configuration,
+        )
+        assert runtime.executable_digest == _WORKER_DIGEST
+        assert runtime.worker_configuration_fingerprint == (
+            self.policy.worker_configuration_fingerprint
+        )
+        identity = WorkerLaunchIdentityV1(
+            plugin_id=self.policy.plugin_id,
+            plugin_revision_digest=self.policy.plugin_revision_digest,
+            contribution_id=self.policy.contribution_id,
+            owner_id="coding.capability",
+            product_id="coding",
+            scope_id=self.policy.product_scope_id,
+            owner_generation=self.policy.owner_selection_generation,
+            declaration_fingerprint=self.policy.declaration_fingerprint,
+            worker_configuration_fingerprint=(
+                self.policy.worker_configuration_fingerprint
+            ),
+            attempt_id=_ATTEMPT,
+            supervisor_epoch=1,
+            session_nonce=_SESSION_NONCE,
+        )
+        self.request = ManagedWorkerLaunchRequestV1(
+            identity=identity,
+            runtime=runtime,
+            validate_current=lambda: None,
+        )
+        self.supervisor = WorkerSupervisor(
+            identity=identity,
+            journal=WorkerSupervisorJournal(tmp_path / "worker-journal.jsonl"),
+            protocol="capability.query",
+            protocol_version=1,
+        )
+        self.current = _CurrentOwner()
+        self.hosting = _Hosting(identity, self.events)
+        self.authority = CapabilityWorkerAuthorityV1(
+            plugin_revision_digest=self.policy.plugin_revision_digest,
+            declaration_fingerprint=self.policy.declaration_fingerprint,
+            owner_generation=self.policy.owner_selection_generation,
+            product_policy_revision=self.policy.product_policy_revision,
+            owner_policy_revision="owner-policy-1",
+            revocation_epoch=0,
+        )
+        self.binding = CapabilityWorkerBindingV1(
+            plugin_id=self.policy.plugin_id,
+            contribution_id=self.policy.contribution_id,
+            product_id="coding",
+            scope_id=self.policy.product_scope_id,
+            owner_id=identity.owner_id,
+            allowed_capability_ids=("coding.hover",),
+            authority=self.authority,
+        )
+        self.domain = _Domain(self.events)
+        self.cleanup = _Cleanup(self.events)
+        self.recovery = _Recovery()
+        self.evidence = _EvidenceAuthority()
+
+    def bind(self, **overrides):
+        selected_receipt = overrides.get("receipt", self.receipt)
+        selected_authority = (
+            _Authority(selected_receipt, self.events)
+            if isinstance(selected_receipt, ProductWorkerActivationReceiptV1)
+            else _Authority(self.receipt, self.events)
+        )
+        values = {
+            "policy": self.policy,
+            "receipt": self.receipt,
+            "session_discovery": self.discovery,
+            "validate_product_session": lambda: None,
+            "authority": selected_authority,
+            "evidence_authority": self.evidence,
+            "trusted_evidence_authority_id": self.evidence.authority_id,
+            "trusted_evidence_authority_fingerprint": (
+                self.evidence.authority_fingerprint
+            ),
+            "activation_state_store": _ActivationStateStore(),
+            "restart_budget": 3,
+            "supervisor": self.supervisor,
+            "worker_request": self.request,
+            "current_owner": self.current,
+            "hosting": self.hosting,
+            "containment_launcher_path": str(self.launcher),
+            "containment_launcher_sha256": _LAUNCHER_DIGEST,
+            "containment_profile_sha256": _CONTAINMENT_PROFILE_DIGEST,
+            "capability_binding": self.binding,
+            "capability_authority_reader": lambda: self.authority,
+            "domain": self.domain,
+            "cleanup": self.cleanup,
+            "recovery": self.recovery,
+            "host_identity": "host-one",
+            "boot_identity": "boot-one",
+        }
+        values.update(overrides)
+        return bind_coding_product_worker_canary(**values)
+
+
+def _discovery(
+    root: Path,
+    *,
+    mode: str = "canonical",
+    origin: str = "global",
+    health: str = "available",
+    aliases: tuple[SessionLocator, ...] = (),
+    conflicts: tuple[SessionLocator, ...] = (),
+) -> SessionDiscoveryMetadata:
+    return SessionDiscoveryMetadata(
+        locator=SessionLocator(
+            source_id=f"sessions.{origin}",
+            conversation_id="session-one",
+            session_file=root / "session-one.jsonl",
+            revision="locator-1",
+        ),
+        mode=mode,  # type: ignore[arg-type]
+        origin=origin,  # type: ignore[arg-type]
+        health=health,  # type: ignore[arg-type]
+        aliases=aliases,
+        conflicts=conflicts,
+    )
+
+
+def _policy(
+    discovery: SessionDiscoveryMetadata,
+    *,
+    required: bool = True,
+    product_id: str = "coding",
+    enabled: bool = True,
+    owner: str = "hosting",
+    profile_id: str = "posix-static-contained-elf-v1",
+) -> ProductWorkerActivationPolicyV1:
+    configuration = PluginLocalWorkerConfiguration(
+        entrypoint="worker",
+        protocol="capability.query",
+        protocol_version=1,
+    )
+    expected_native_policy_closure_fingerprint = (
+        ProductWorkerActivationPolicyV1.native_policy_closure_fingerprint(
+            native_profile_catalog_revision="native-catalog-1",
+            native_profile_id=profile_id,
+            payload_sha256=_WORKER_DIGEST,
+            containment_launcher_sha256=_LAUNCHER_DIGEST,
+            containment_profile_sha256=_CONTAINMENT_PROFILE_DIGEST,
+        )
+    )
+    return ProductWorkerActivationPolicyV1(
+        product_id=product_id,
+        product_runtime_id="coding-runtime-1",
+        product_scope_id="session.session-one",
+        session_id="session-one",
+        session_route="selected",
+        selected_locator_fingerprint=(
+            coding_product_worker_session_fingerprint(discovery)
+        ),
+        selected_locator_revision="locator-1",
+        plugin_id="review-pack",
+        plugin_revision_digest=_DIGEST_A,
+        contribution_id="review-provider",
+        reservation_fingerprint=_DIGEST_B,
+        declaration_fingerprint=_DIGEST_C,
+        worker_configuration_fingerprint=configuration.fingerprint,
+        declared_required=required,
+        effective_required=required,
+        enabled=enabled,
+        allowed_product_ids=(product_id,),
+        allowed_contribution_ids=("review-provider",),
+        requested_owner=owner,  # type: ignore[arg-type]
+        owner_selection_generation=3,
+        no_fallback=True,
+        native_profile_id=profile_id,
+        native_profile_catalog_revision="native-catalog-1",
+        allowed_native_profile_ids=(profile_id,),
+        expected_native_policy_closure_fingerprint=(
+            expected_native_policy_closure_fingerprint
+        ),
+        product_policy_revision="product-policy-1",
+        kill_switch_generation=2,
+    )
+
+
+@pytest.mark.parametrize("case_id", PLC9C5_C54_CASES, ids=PLC9C5_C54_CASES)
+def test_plc9c5_c54_linux_product_case(case_id: str, tmp_path: Path) -> None:
+    context = _Context(tmp_path, required="OPTIONAL" not in case_id)
+
+    if case_id == "C54-PRODUCT-SELECTED":
+        canary = context.bind()
+        assert canary.status.code == "coding_worker_selected"
+        assert canary.status.effective_owner == "hosting"
+
+    elif case_id == "C54-PRODUCT-MISSING":
+        canary = bind_coding_product_worker_canary()
+        assert canary.status.to_dict()["effectiveOwner"] == "current"
+        assert context.events == []
+
+    elif case_id == "C54-PRODUCT-WRONG":
+        wrong = replace(
+            context.policy,
+            product_id="work",
+            allowed_product_ids=("work",),
+        )
+        with pytest.raises(CodingProductWorkerCanaryError) as caught:
+            context.bind(policy=wrong, receipt=None)
+        assert caught.value.code == "coding_worker_product_mismatch"
+
+    elif case_id == "C54-PRODUCT-DISABLED":
+        disabled = _policy(
+            context.discovery,
+            enabled=False,
+            owner="current",
+        )
+        canary = context.bind(policy=disabled, receipt=None)
+        assert canary.status.code == "coding_worker_disabled_by_policy"
+        assert context.events == []
+
+    elif case_id in {"C54-SESSION-CANONICAL", "C54-SESSION-CWD", "C54-SESSION-HOME"}:
+        origin = {
+            "C54-SESSION-CANONICAL": "global",
+            "C54-SESSION-CWD": "cwd",
+            "C54-SESSION-HOME": "home",
+        }[case_id]
+        mode = "canonical" if origin == "global" else "compatibility"
+        discovery = _discovery(tmp_path, mode=mode, origin=origin)
+        policy = _policy(discovery)
+        receipt = ProductWorkerActivationReceiptV1(
+            policy=policy,
+            issue_sequence=1,
+            issue_nonce="session-route-receipt",
+        )
+        canary = context.bind(
+            policy=policy,
+            receipt=receipt,
+            session_discovery=discovery,
+        )
+        # The request is deliberately still bound to the same Product/Plugin;
+        # only locator provenance varies here.
+        assert canary.status.receipt_fingerprint == receipt.fingerprint
+
+    elif case_id == "C54-SESSION-TAMPERED":
+
+        def reject() -> None:
+            raise ValueError("/secret/tampered-session")
+
+        with pytest.raises(CodingProductWorkerCanaryError) as caught:
+            context.bind(validate_product_session=reject)
+        assert caught.value.code == "coding_worker_session_product_mismatch"
+        assert "/secret" not in str(caught.value)
+
+    elif case_id == "C54-SESSION-ALIAS":
+        alias = SessionLocator(
+            source_id="sessions.cwd",
+            conversation_id="session-one",
+            session_file=tmp_path / "alias.jsonl",
+            revision="alias-1",
+        )
+        discovery = _discovery(tmp_path, aliases=(alias,))
+        policy = _policy(discovery)
+        receipt = ProductWorkerActivationReceiptV1(
+            policy=policy,
+            issue_sequence=1,
+            issue_nonce="alias-receipt",
+        )
+        assert (
+            context.bind(
+                policy=policy,
+                receipt=receipt,
+                session_discovery=discovery,
+            ).status.code
+            == "coding_worker_selected"
+        )
+
+    elif case_id == "C54-SESSION-CONFLICT":
+        conflict = SessionLocator(
+            source_id="sessions.cwd",
+            conversation_id="session-one",
+            session_file=tmp_path / "conflict.jsonl",
+            revision="conflict-1",
+        )
+        discovery = _discovery(
+            tmp_path,
+            health="conflict",
+            conflicts=(conflict,),
+        )
+        policy = _policy(discovery)
+        receipt = ProductWorkerActivationReceiptV1(
+            policy=policy,
+            issue_sequence=1,
+            issue_nonce="conflict-receipt",
+        )
+        with pytest.raises(CodingProductWorkerCanaryError) as caught:
+            context.bind(
+                policy=policy,
+                receipt=receipt,
+                session_discovery=discovery,
+            )
+        assert caught.value.code == "coding_worker_session_locator_conflict"
+
+    elif case_id == "C54-SESSION-CHANGED":
+        changed = replace(
+            context.discovery,
+            locator=replace(context.discovery.locator, revision="locator-2"),
+        )
+        with pytest.raises(CodingProductWorkerCanaryError) as caught:
+            context.bind(session_discovery=changed)
+        assert caught.value.code == "coding_worker_session_locator_changed"
+
+    elif case_id in {"C54-REQUIRED-SUCCESS", "C54-OPTIONAL-SUCCESS"}:
+        canary = context.bind()
+        status = asyncio.run(canary.start(correlation_id="launch-one"))
+        assert status.readiness == "ready"
+        assert context.events.index("hosting-start") < context.events.index(
+            "domain-publish"
+        )
+        asyncio.run(context.supervisor.fence(code="test-complete"))
+
+    elif case_id in {"C54-REQUIRED-FAILURE", "C54-OPTIONAL-DEGRADED"}:
+        context.hosting.fail = True
+        canary = context.bind()
+        if context.policy.effective_required:
+            with pytest.raises(CodingProductWorkerCanaryError) as caught:
+                asyncio.run(canary.start(correlation_id="launch-one"))
+            assert caught.value.code == "coding_worker_required_unavailable"
+        else:
+            status = asyncio.run(canary.start(correlation_id="launch-one"))
+            assert status.readiness == "degraded"
+        assert context.current.calls == 0
+
+    elif case_id == "C54-CLOSURE-FRESHNESS":
+        stale_policy = replace(
+            context.policy,
+            expected_native_policy_closure_fingerprint=_DIGEST_A,
+        )
+        stale_receipt = ProductWorkerActivationReceiptV1(
+            policy=stale_policy,
+            issue_sequence=1,
+            issue_nonce="stale-closure-receipt",
+        )
+        state_store = _ActivationStateStore()
+        with pytest.raises(CodingProductWorkerCanaryError) as caught:
+            context.bind(
+                policy=stale_policy,
+                receipt=stale_receipt,
+                activation_state_store=state_store,
+            )
+        assert caught.value.code == "worker_native_policy_closure_mismatch"
+        assert state_store.load() is None
+
+    elif case_id == "C54-HANDSHAKE-HEALTH-PUBLICATION":
+        canary = context.bind()
+        asyncio.run(canary.start(correlation_id="launch-one"))
+        assert context.events.index("hosting-start") < context.events.index(
+            "domain-publish"
+        )
+        asyncio.run(context.supervisor.fence(code="test-complete"))
+
+    elif case_id in {
+        "C54-UNSUPPORTED-WINDOWS",
+        "C54-UNSUPPORTED-WSL",
+        "C54-UNSUPPORTED-NON-X86",
+        "C54-UNSUPPORTED-MACOS",
+    }:
+        profile_id = {
+            "C54-UNSUPPORTED-WINDOWS": "windows-restricted-direct-import-pe-v1",
+            "C54-UNSUPPORTED-WSL": "wsl-static-contained-elf-v1",
+            "C54-UNSUPPORTED-NON-X86": "posix-arm64-contained-elf-v1",
+            "C54-UNSUPPORTED-MACOS": "macos-static-contained-mach-o-v1",
+        }[case_id]
+        policy = _policy(context.discovery, profile_id=profile_id)
+        receipt = ProductWorkerActivationReceiptV1(
+            policy=policy,
+            issue_sequence=1,
+            issue_nonce="unsupported-receipt",
+        )
+        with pytest.raises(CodingProductWorkerCanaryError) as caught:
+            context.bind(policy=policy, receipt=receipt)
+        assert caught.value.code == "coding_worker_native_profile_unsupported"
+        assert context.events == []
+
+    elif case_id == "C54-ORDERED-ROLLBACK":
+        canary = context.bind()
+        asyncio.run(canary.start(correlation_id="launch-one"))
+        context.events.clear()
+        status = asyncio.run(canary.rollback())
+        observed = tuple(item for item in context.events if item.startswith("R"))
+        assert observed == canary.rollback_steps
+        assert status.effective_owner == "current"
+        assert context.current.calls == 0
+
+    elif case_id == "C54-RECOVERY-MATRIX":
+        canary = context.bind()
+        assert asyncio.run(canary.recover()) == canary.recovery_steps
+        context.recovery.steps = context.recovery.steps[:-1]
+        with pytest.raises(CodingProductWorkerCanaryError) as caught:
+            asyncio.run(canary.recover())
+        assert caught.value.code == "coding_worker_recovery_incomplete"
+
+    elif case_id == "C54-SHARED-ENTRYPOINT-RECEIPT":
+        canary = context.bind()
+        receipts = tuple(
+            canary.receipt_for_entrypoint(entrypoint)
+            for entrypoint in ("cli", "tui", "product")
+        )
+        assert all(item is context.receipt for item in receipts)
+        with pytest.raises(CodingProductWorkerCanaryError):
+            canary.receipt_for_entrypoint("lsp")
+
+    elif case_id == "C54-SENTINEL-REDACTION":
+        context.hosting.fail = True
+        canary = context.bind()
+        with pytest.raises(CodingProductWorkerCanaryError) as caught:
+            asyncio.run(canary.start(correlation_id="launch-one"))
+        serialized = json.dumps(canary.status.to_dict(), sort_keys=True)
+        assert caught.value.code == "coding_worker_required_unavailable"
+        assert "/secret" not in serialized
+        assert "sentinel" not in serialized
+
+    else:
+        raise AssertionError(f"Unhandled PLC9C5 C5.4 case {case_id}")


### PR DESCRIPTION
## Summary
- add the sole explicit Linux Coding Product Worker composition root over the real C5.1 coordinator and C5.2 native-profile friend seam
- keep omission/default Current and reject Windows, WSL, macOS, non-x86, foreign, changed, and ambiguous routes
- add the required 25-case C5.4 report, Linux CI verification, rollback/recovery coverage, and current-inventory transitions

## Validation
- make check-plc9c5-c54-linux-product (25 passed; manifest/XML verification passed)
- PLC9C5 C5.0-C5.4 architecture tests (37 passed across focused runs)
- C5.4 behavior + direct architecture baselines (41 passed)
- make check-hosting (342 passed, 20 skipped)
- make check-harness reached 4407 passed, 38 skipped; two host-load-sensitive failures were each rerun independently and passed; the remaining tail was terminated after the run exceeded one hour
- ruff and mypy passed for all changed production/test surfaces

## Contract notes
- native closure validation occurs before durable activation-state initialization
- no same-attempt fallback, ambient activation flag, raw native authority, or Windows Product activation is introduced
- parent G7 remains open pending a separately reviewed Windows required-containment profile