### PR TITLE
Promote G17.0 stable delivery baseline

### DIFF
--- a/docs/internals/architecture/README.md
+++ b/docs/internals/architecture/README.md
@@ -152,13 +152,17 @@ native evidence and integration PR.
 
 The [accepted G15 foreground Hosted TUI design](apphost/foreground-hosted-tui-g15.md)
 defines the optional A0.5 launcher and explicit client presentation boundary.
-It is design-only, not a new installed route. Its G16 handoff separates
-foreground process ownership from a future detachable connection profile.
+Its launcher and global Session-discovery picker remain design-only. G16
+delivers the shared terminal shell under a separate detachable connection
+lifetime, without activating G15 foreground process ownership.
 
-The [accepted G16 local workspace design](appserver/detachable-local-workspace-g16.md)
-defines authenticated local connections and application-owned work that can
-outlive a client. It is design-only, not an implemented listener or default-route
-change; G14's foreground EOF behavior remains independently authoritative.
+The implemented G16 local workspace supplies authenticated local connections,
+application-owned work that can outlive a client, and the installed
+`loushang-mux` Product route. Its
+[final delivery record](appserver/detachable-local-workspace-g16.md#final-delivery-acceptance)
+records native and isolated-wheel acceptance on Linux/macOS/Windows and main
+promotion, separately from the post-merge Hosting regression tracked by G17.0.
+Embedded defaults and G14's foreground EOF behavior remain unchanged.
 
 A nested scope is not automatically a top-level subsystem. The parent owns its
 placement, composition policy, and sibling relationships; the child owns its

--- a/docs/internals/architecture/apphost/README.md
+++ b/docs/internals/architecture/apphost/README.md
@@ -24,11 +24,12 @@
 - Implementation status: partial — Hosted Product Runtime G0--G10, G12
   foreground application, G13 durable continuity and G14 foreground connection
   settlement are implemented; G16 has an optional local deployment owner and
-  installed Product client/server route, with final platform acceptance pending;
+  installed Product client/server route delivered on Linux/macOS/Windows;
   A0.5 remains not-started
 - Activation status: default-dark; the exact installed G10 canary selects
   Hosting. G12/G13 have explicit library construction and the separate G14
-  `loushang-hosted` command; ordinary CLI/TUI/SDK defaults are unchanged
+  `loushang-hosted` command; G16 has the separate installed `loushang-mux`
+  local route. Ordinary CLI/TUI/SDK defaults are unchanged
 - Owner: Loushang AppHost architecture
 
 ## Scope
@@ -103,9 +104,9 @@ launch/exit. The separate Coding `loushang-hosted` command composes this edge;
 records real Product validation on Linux, macOS and Windows.
 
 The [accepted G15 design](foreground-hosted-tui-g15.md) specifies A0.5 launch
-ownership and a Harnesstui hosted shell. It is a design-only slice: neither the launcher
-nor a terminal client is made Current by design acceptance. G16's detachable
-connection lifetime requires separate acceptance; G14 EOF remains terminal.
+ownership and a Harnesstui hosted shell. Its launcher and global Session picker
+remain design-only. G16 separately delivers the shared terminal shell under
+detachable connection ownership; G14 EOF remains terminal.
 
 The [accepted G16 design](../appserver/detachable-local-workspace-g16.md)
 supplies that separate local deployment boundary. The optional
@@ -118,7 +119,7 @@ settles connections/directory before G13 releases its lease. All stop phases
 share one monotonic budget; timed-out tasks remain owned, and a new budget
 requires an explicit completed-attempt retry. Client EOF does not stop the
 application. The installed `loushang-mux` Product route and interactive shell
-now compose this edge; full native platform proof remains pending. It does not
+now compose this edge with native three-platform delivery evidence. It does not
 activate Hosting service control or change the foreground owner above.
 
 Existing Product-specific bootstrap/CLI/TUI paths remain authoritative and do
@@ -176,8 +177,10 @@ G16's optional local deployment is now composed with real Coding through the
 shared Product bootstrap and installed `coding.cli.mux` command. AppHost
 owns application settlement after Product startup handoff; its public read-only
 `accepting` fact prevents a startup delivery from announcing ready after stop.
-The [G16.9 checkpoint](../appserver/detachable-local-workspace-g16.md#g169-installed-interactive-terminal-checkpoint)
-separates that implementation and native terminal work from final platform acceptance.
+The [G16 final delivery record](../appserver/detachable-local-workspace-g16.md#final-delivery-acceptance)
+records three-platform native/isolated-wheel acceptance and main promotion.
+G17.0 tracks the subsequent Hosting handle-isolation test regression separately;
+it neither activates A0.5 nor changes application ownership.
 
 ## Target
 

--- a/docs/internals/architecture/appserver/README.md
+++ b/docs/internals/architecture/appserver/README.md
@@ -14,7 +14,7 @@
 - Parent: `loushang`
 - Authority: normative — A0.4 ports, G11 client contract and explicit G14/G16 connection edges
 - Design status: accepted
-- Implementation status: partial — G14 is delivered on Linux/macOS/Windows; G16 native connections, AppHost, real Coding composition and installed interactive attach are implemented; isolated-wheel and final platform fault evidence remain pending
+- Implementation status: implemented — G14 and G16 are delivered on Linux/macOS/Windows, including G16 native connections, real Coding composition and isolated-wheel interactive attach; see the delivery record and subsequent G17.0 baseline regression below
 - Activation status: explicit library, `loushang-hosted` foreground command or `loushang-mux` local route; no default-route change
 - Owner: Loushang AppServer architecture
 
@@ -34,9 +34,10 @@ G16 adds an explicit local connection library with native private records,
 mutual authentication and injected scope ownership. Its sole native-IO adapter
 can bind literal loopback or read an explicitly selected endpoint; no automatic
 startup, discovery, Product construction or process signaling is granted.
-The [G16 checkpoints](detachable-local-workspace-g16.md#g169-installed-interactive-terminal-checkpoint)
-distinguish the implemented library/AppHost/real Coding composition and installed
-interactive TUI from isolated-wheel and final platform acceptance still required.
+The [G16 final delivery record](detachable-local-workspace-g16.md#final-delivery-acceptance)
+records native fault and isolated-wheel terminal acceptance on all three platforms
+and promotion to main. G17.0 separately tracks the subsequent Hosting test
+regression; historical G16 checkpoints are not rewritten as current status.
 
 G12's optional AppHost application edge consumes the client contract for its
 in-process view. AppServer neither constructs nor imports that composition.
@@ -80,8 +81,8 @@ concrete semantic coordination and its in-process client implementation. The
 G14 connection edge now accepts foreground stdio lifecycle and framing.
 G16's optional local edge now composes authentication and connection-scoped
 authority. Product constructs the real Coding deployment without reverse imports;
-the installed interactive terminal borrows only AppClient. Final platform
-evidence remains separate work. The G14 foreground contract is unchanged.
+the installed interactive terminal borrows only AppClient. The delivery record
+links the accepted platform evidence. The G14 foreground contract is unchanged.
 
 ## Invariants
 
@@ -126,4 +127,4 @@ evidence remains separate work. The G14 foreground contract is unchanged.
   Linux, macOS and Windows. Platform, installation and terminal backend are
   verified properties, not conclusions inferred from report names. Gate
   implementation is distinct from the observed platform results recorded in
-  the [G16.10 checkpoint](detachable-local-workspace-g16.md#g1610-read-only-details-and-exact-evidence-gates).
+  the [final delivery record](detachable-local-workspace-g16.md#final-delivery-acceptance).

--- a/docs/internals/architecture/appserver/detachable-local-workspace-g16-inventory.json
+++ b/docs/internals/architecture/appserver/detachable-local-workspace-g16-inventory.json
@@ -3,7 +3,7 @@
   "designId": "DETACHABLE-LOCAL-WORKSPACE-G16",
   "profile": "local-detachable/v1",
   "designStatus": "accepted",
-  "implementationStatus": "partial",
+  "implementationStatus": "implemented",
   "entries": [
     {"id": "appservice.operation-owner", "source": "src/loushang/appservice/_operations.py", "status": "implemented", "owner": "application-operation-lifetime"},
     {"id": "appservice.scoped-interactions", "source": "src/loushang/appservice/_scope_interactions.py", "status": "implemented", "owner": "generation-bound-interaction-settlement"},

--- a/docs/internals/architecture/appserver/detachable-local-workspace-g16.md
+++ b/docs/internals/architecture/appserver/detachable-local-workspace-g16.md
@@ -57,8 +57,10 @@ assertion (`000PING` expected, `010PING` observed; 350 passed, one failed,
 kernel-object identity. The exited child's objects cannot be reconstructed
 from that output, so this record does not declare the failure harmless or the
 post-merge gate green. [G17.0 #569](https://github.com/zhnt/loushang/issues/569)
-tracks the identity-aware regression and native rerun, documented in the
-[Hosting baseline note](../hosting/validation/stable-delivery-baseline-g17.md).
+records the identity-aware regression, corrected DLL binding and successful
+three-platform native acceptance on [PR #570](https://github.com/zhnt/loushang/pull/570),
+documented in the
+[Hosting baseline note](../hosting/validation/stable-delivery-baseline-g17.md#native-acceptance).
 The checkpoints below retain their original pre-delivery evidence and pending
 items; they are not the current G16 acceptance status.
 

--- a/docs/internals/architecture/appserver/detachable-local-workspace-g16.md
+++ b/docs/internals/architecture/appserver/detachable-local-workspace-g16.md
@@ -15,17 +15,52 @@
 - Design status: accepted following the three-perspective review below
 - Implementation status: implemented — semantic scopes, native connections,
   AppHost/G13, real Coding composition and installed interactive attach are
-  implemented; Linux native/clean-wheel evidence and the local whole-delta
-  review passed. Three-platform native fault evidence passed at `bda21085`.
-  Release acceptance is gated by corrected-head checks and the final review
-  recorded on [PR #567](https://github.com/zhnt/loushang/pull/567), followed by
-  promotion and synchronization; implementation alone is not release acceptance
+  delivered on Linux/macOS/Windows and promoted to main. The
+  [final delivery record](#final-delivery-acceptance) separates accepted G16
+  evidence from the subsequent Hosting baseline regression tracked by G17.0;
+  implementation, delivery and current gate health are distinct facts
 - Activation status: explicit new deployment only; G14 and Embedded unchanged
 - Tracking: [Hosted Workspace V1 #566](https://github.com/zhnt/loushang/issues/566)
 - Prerequisite: G15 design accepted in `18d429bc`; G14 delivered in `815c03d2`
 - Inherits: [principles](../loushang-architecture-principles.md),
   [governance](../governance-profile.md),
   [ARD-003](../decisions/ARD-003-apphost-top-level-placement.md)
+
+## Final Delivery Acceptance
+
+The accepted feature head is `2455767acd23de1dc3422e76225b25a78a03720b`.
+[PR #567](https://github.com/zhnt/loushang/pull/567) passed all 37 checks and
+merged into `lane/harness`; the promotion
+[PR #568](https://github.com/zhnt/loushang/pull/568) also passed all 37 checks
+and merged as main `f05f8cc254642045f58af622a0c8537a2a1725cb`. That main tree
+matches the accepted feature tree. Main and the harness lane were synchronized
+at delivery; this is a historical delivery fact, not a permanent claim about
+moving branches.
+
+The corrected-head G16 evidence reports were downloaded and independently
+verified against the [exact manifest](detachable-local-workspace-g16-evidence-manifest.json):
+
+| Native platform | Native fault cases | Isolated-wheel terminal cases | Failures / errors / skips |
+| --- | ---: | ---: | --- |
+| Linux | 29 | 4 | 0 / 0 / 0 |
+| macOS | 29 | 4 | 0 / 0 / 0 |
+| Windows | 29 | 4 | 0 / 0 / 0 |
+
+G15 remains design-only for its foreground launcher and global Session picker.
+G16 delivers the shared shell and explicit detachable `loushang-mux` route;
+it does not change Embedded defaults or G14 terminal EOF semantics.
+
+After promotion, [Hosting run 34177069952](https://github.com/zhnt/loushang/actions/runs/34177069952)
+passed Ubuntu/macOS but failed the Windows endpoint round-trip isolation
+assertion (`000PING` expected, `010PING` observed; 350 passed, one failed,
+75 skipped). The old check establishes numeric handle validity, not shared
+kernel-object identity. The exited child's objects cannot be reconstructed
+from that output, so this record does not declare the failure harmless or the
+post-merge gate green. [G17.0 #569](https://github.com/zhnt/loushang/issues/569)
+tracks the identity-aware regression and native rerun, documented in the
+[Hosting baseline note](../hosting/validation/stable-delivery-baseline-g17.md).
+The checkpoints below retain their original pre-delivery evidence and pending
+items; they are not the current G16 acceptance status.
 
 ## Outcome, Requirements And Non-Goals
 
@@ -84,8 +119,8 @@ connection layer now composes record admission, authentication and an injected
 scope factory. The optional AppHost deployment owner now binds that factory to
 the recovered G13 application. Real Coding composition and the installed
 interactive terminal client activate this explicit route; the
-[inventory](detachable-local-workspace-g16-inventory.json) distinguishes
-implemented responsibilities from final delivery/evidence still outstanding.
+[inventory](detachable-local-workspace-g16-inventory.json) records implemented
+responsibilities; final delivery and later gate health are recorded above.
 
 The first G16.1 primitive, `appservice._operations._OwnedAppOperations`, now
 reserves application capacity before effects, retains tasks across delivery

--- a/docs/internals/architecture/appservice/README.md
+++ b/docs/internals/architecture/appservice/README.md
@@ -9,11 +9,12 @@
 
 - Scope: `appservice`
 - Parent: `loushang`
-- Authority: normative — G11 in-process application semantics
+- Authority: normative — G11 application semantics, G13 continuity and optional G16 client scopes
 - Design status: accepted
 - Implementation status: implemented — G11.2 Product-neutral core and the
-  AppService-owned G13.1--G13.2 continuity slices are complete
-- Activation status: explicit in-process construction only
+  AppService-owned G13.1--G13.2 continuity and G16 client-scope slices are complete
+- Activation status: explicit construction; the installed Product `loushang-mux`
+  route opts into G16 client scopes, without changing default or G14 behavior
 - Owner: Loushang AppService architecture
 
 ## Purpose
@@ -25,7 +26,7 @@ bounded logical delivery.  It does not own an AppServer listener, byte/frame
 buffers, authentication, AppHost composition, Hosting process mechanics,
 Product policy, or UI state.
 
-The [accepted G16 design](../appserver/detachable-local-workspace-g16.md)
+The [implemented G16 profile](../appserver/detachable-local-workspace-g16.md)
 adds an optional semantic client scope: connection-bound controller
 authority, application-owned admitted execution and control-loss interaction
 settlement. `client_scope.ScopedAppServiceV1` explicitly installs this policy on
@@ -35,10 +36,13 @@ its private interaction policy denies questions on control loss. AppHost's
 optional local deployment now binds its public ready-scope factory into the
 local transport. A synchronous scope fence stops new client actions before
 asynchronous stop settlement, without itself cancelling accepted work. The
-edge is absent from the default facade and installed entrypoints; ordinary
-G11/G14 behavior is unchanged.
-The explicit development-only Coding mux command composes this policy with real
-Product Sessions; it does not add transport or Product dependencies here.
+edge is absent from the default facade; ordinary G11/G14 behavior is unchanged.
+The separate installed Coding `loushang-mux` command explicitly composes this
+policy with real Product Sessions; it does not add transport or Product
+dependencies here. The
+[G16 final delivery record](../appserver/detachable-local-workspace-g16.md#final-delivery-acceptance)
+records native/isolated-wheel acceptance and main promotion, separately from
+the post-merge Hosting regression tracked by G17.0.
 The application must install it before exposing clients or starting execution,
 and must never expose a legacy unscoped client to the same untrusted peers.
 

--- a/docs/internals/architecture/harnesstui/README.md
+++ b/docs/internals/architecture/harnesstui/README.md
@@ -26,15 +26,17 @@ Harnesstui or on the other peer.
 
 The [G15 design](../apphost/foreground-hosted-tui-g15.md) specifies an explicit
 Hosted Mux terminal shell over the existing controller and shared presentation.
-The [G16 implementation](../appserver/detachable-local-workspace-g16.md#g169-installed-interactive-terminal-checkpoint)
+The [G16 delivery](../appserver/detachable-local-workspace-g16.md#final-delivery-acceptance)
 now consumes that shared shell through a separately connected local client.
 Its installed attach route reuses the conversation screen and editor, with
 per-window drafts and bounded asynchronous controls. Harnesstui binds read-only
 help/approval details to the current attachment/question; the generic TUI
 `TextPager` owns only text layout and navigation. Process launch, native local
 connections and application lifetime stay outside Harnesstui. The G15 launcher
-and global Session-discovery picker remain design-only, and G16's final
-cross-platform acceptance is still pending.
+and global Session-discovery picker remain design-only. G16's native and
+isolated-wheel terminal evidence passed on Linux/macOS/Windows before main
+promotion. G17.0 separately tracks the subsequent Hosting baseline regression;
+it does not change terminal or process ownership.
 
 This layer owns reusable Harness-oriented terminal interaction, including:
 

--- a/docs/internals/architecture/hosting/validation/stable-delivery-baseline-g17.md
+++ b/docs/internals/architecture/hosting/validation/stable-delivery-baseline-g17.md
@@ -4,6 +4,10 @@
 [G16 delivery](../../appserver/detachable-local-workspace-g16.md#final-delivery-acceptance) ·
 [Tracking #569](https://github.com/zhnt/loushang/issues/569)
 
+Native acceptance has passed; see the [accepted evidence](#native-acceptance).
+The local checkpoint and first failed publication below are historical records,
+not the current native acceptance status.
+
 ## Scope And Diagnosis
 
 This slice changes test evidence and current architecture indexes only. It does
@@ -102,3 +106,31 @@ hard failures; there is no numeric fallback, skip or production change.
 
 The local `loushang --help` and `loushang-mux --help` startup smoke checks also
 passed. Native acceptance still requires the corrected PR head's green matrix.
+
+## Native Acceptance
+
+On 2026-09-08, corrected feature head
+`fe20c1bea5451ad457f16049f8e78e94632df909` passed all 33 checks on
+[PR #570](https://github.com/zhnt/loushang/pull/570) and merged into
+`lane/harness` as `0ffe6d5249cf95753069faa007485294646ff3f9`.
+The [Hosting run](https://github.com/zhnt/loushang/actions/runs/34180343960)
+completed successfully on all three native platforms:
+
+| Platform | Full Hosting contract suite | Native job |
+| --- | --- | --- |
+| Ubuntu 24.04 | 392 passed, 47 platform/profile skips | [Linux evidence](https://github.com/zhnt/loushang/actions/runs/34180343960/job/101917980290) |
+| macOS 15 | 369 passed, 70 platform/profile skips | [macOS evidence](https://github.com/zhnt/loushang/actions/runs/34180343960/job/101917980481) |
+| Windows Server 2022 | 364 passed, 75 platform/profile skips | [Windows evidence](https://github.com/zhnt/loushang/actions/runs/34180343960/job/101917980456) |
+
+All four native Windows endpoint parameters ran successfully: `isolated`,
+`leaked-parent-read`, `leaked-parent-write` and `leaked-sentinel`. None is among
+the platform skips. The helper's ten deterministic regressions, including its
+default DLL loading path, also passed. The corrected local focused selection
+passed 30 tests with eight Windows-only skips, plus Ruff and Win32-targeted mypy.
+CI's contract selection and platform expectations differ from the local Make
+selection, so their aggregate pass/skip counts are not interchangeable.
+
+This closes the native evidence gap without changing production inheritance,
+retrospectively clearing the original failed run, or activating G15. Main
+promotion uses its own final-head PR checks; this record does not substitute
+feature-head evidence for the promotion gate.

--- a/docs/internals/architecture/hosting/validation/stable-delivery-baseline-g17.md
+++ b/docs/internals/architecture/hosting/validation/stable-delivery-baseline-g17.md
@@ -1,0 +1,84 @@
+# G17.0 Stable Delivery Baseline
+
+[Hosting](../README.md) ·
+[G16 delivery](../../appserver/detachable-local-workspace-g16.md#final-delivery-acceptance) ·
+[Tracking #569](https://github.com/zhnt/loushang/issues/569)
+
+## Scope And Diagnosis
+
+This slice changes test evidence and current architecture indexes only. It does
+not change Hosting's production inheritance list, introduce an API, activate
+G15's launcher/picker, or extend the G16 deployment profile.
+
+The Windows job in [post-merge Hosting run 34177069952](https://github.com/zhnt/loushang/actions/runs/34177069952)
+failed `test_native_windows_endpoint_process_round_trip`: `010PING` instead of
+`000PING`. The child successfully exchanged application bytes, but reported a
+valid handle at the parent's write-handle number. The old untyped ctypes call
+to `GetHandleInformation` cannot establish cross-process object identity.
+
+Windows [handle values are process-private](https://learn.microsoft.com/en-us/windows/win32/fileio/file-handles).
+A child may independently allocate the same number for a different object.
+The production spawn already supplies `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`
+through `STARTUPINFOEXW`, retaining only child stdin/stdout/stderr; parent pipe
+ends are non-inheritable. This is not evidence of a production inheritance
+defect. Conversely, the historical child's object table is gone, so numeric
+reuse is a plausible explanation, not a retrospectively proven diagnosis.
+
+## Corrected Evidence Boundary
+
+`tests/hosting/_windows_handle_probe.py` is test-only. It binds pointer-width
+Win32 signatures, validates the source process and parent reference, then
+[duplicates](https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-duplicatehandle)
+the child's candidate into the parent with `DUPLICATE_SAME_ACCESS`. It compares
+that owned duplicate against the retained parent reference using
+[CompareObjectHandles](https://learn.microsoft.com/en-us/windows/win32/api/handleapi/nf-handleapi-compareobjecthandles).
+It never closes the child source or injects a handle into the child. Every
+successful duplication has a local close attempt, including on comparison failure.
+Only an absent candidate handle is negative evidence; invalid process/reference,
+access denial and cleanup errors fail the test rather than reporting isolation.
+
+The native child sends readiness, then waits for parent input so its process
+and inherited handles stay live during comparison. The test handles partial
+reads and bounds the exchange; process cleanup is registered at spawn handoff,
+and an exit stack attempts all remaining resource cleanup on failure.
+
+Evidence has two distinct layers:
+
+- Deterministic fake handle tables reproduce a same-number/different-object
+  collision, detect genuinely shared objects, cover wide handle values and
+  fail-closed probe errors. These are not native Windows evidence.
+- The native Windows endpoint test retains the production allowlist case and
+  adds three deliberate test-only leaks: parent read, parent write and ambient
+  sentinel. Each control must report the exact shared object while the other
+  references remain isolated. An always-negative probe cannot pass the controls.
+
+The native cases run in the existing Hosting Quality matrix. No skip is removed,
+failure is retried into a pass, or production isolation rule is weakened.
+
+## Validation And Acceptance
+
+The pre-change Linux endpoint/process selection passed 17 tests with five
+native-Windows skips. The new deterministic probe selection passed nine tests.
+The new G16 inventory/index regressions failed twice against the stale status
+before the documentation correction. Current indexes now link one final G16
+delivery record, while preserving G15's unimplemented launcher and all historical
+G16 checkpoints.
+
+Final local verification on 2026-09-08:
+
+- Focused endpoint/process/probe and corrected G16 design selection: 29 passed,
+  eight native-Windows skips.
+- `make check-hosting` (offline dependencies, `not live`): Ruff passed, mypy
+  passed for 26 source files, 382 tests passed and 48 platform-only cases skipped
+  in 262.19 seconds. The three additional Windows positive controls account for
+  three additional skips on Linux; no existing selector was loosened.
+- `make check-architecture-docs`: static checks and all five tests passed.
+- Adjacent G15/G16 boundary/design/evidence selection: 15 passed.
+- The test-only probe passed Win32-targeted mypy; changed Python files passed
+  Ruff and the delta passed `git diff --check`.
+
+Local non-Windows checks do not settle the original native failure. Publication
+and a corrected-head native Windows Hosting run remain required before closing
+#569 or declaring G17.0's cross-platform baseline accepted. Publication is
+deferred at this local checkpoint under weekday push quiet hours; native
+acceptance remains open, without weakening the isolation assertion.

--- a/docs/internals/architecture/hosting/validation/stable-delivery-baseline-g17.md
+++ b/docs/internals/architecture/hosting/validation/stable-delivery-baseline-g17.md
@@ -82,3 +82,23 @@ and a corrected-head native Windows Hosting run remain required before closing
 #569 or declaring G17.0's cross-platform baseline accepted. Publication is
 deferred at this local checkpoint under weekday push quiet hours; native
 acceptance remains open, without weakening the isolation assertion.
+
+## Native Loader Correction
+
+The first published [PR #570](https://github.com/zhnt/loushang/pull/570) head
+`3114d767` passed Linux/macOS Hosting, but its
+[Windows job](https://github.com/zhnt/loushang/actions/runs/34179928549/job/101916772852)
+failed all four endpoint cases during probe construction: `CompareObjectHandles`
+is exported by the documented `Kernelbase.dll`, not `Kernel32.dll`. That run
+reported four failures, 359 passes and 75 platform skips; it never established
+native object-isolation results.
+
+The helper now binds comparison from Kernelbase and keeps the other functions
+in Kernel32. A default-construction regression models distinct DLL exports,
+reproduced the missing-symbol failure before the correction, and checks both
+collision rejection and real-sharing detection after loading. Injected fakes
+no longer constitute the only loader coverage. Missing DLLs or symbols remain
+hard failures; there is no numeric fallback, skip or production change.
+
+The local `loushang --help` and `loushang-mux --help` startup smoke checks also
+passed. Native acceptance still requires the corrected PR head's green matrix.

--- a/tests/architecture/test_detachable_local_workspace_g16_design.py
+++ b/tests/architecture/test_detachable_local_workspace_g16_design.py
@@ -14,7 +14,7 @@ def test_G16_DESIGN_inventory_preserves_current_routes_and_platform_scope() -> N
     assert inventory["inventoryVersion"] == 1
     assert inventory["profile"] == "local-detachable/v1"
     assert inventory["designStatus"] == "accepted"
-    assert inventory["implementationStatus"] == "partial"
+    assert inventory["implementationStatus"] == "implemented"
     assert set(inventory["requiredPlatforms"]) == {"linux", "darwin", "win32"}
     entries = inventory["entries"]
     assert len({entry["id"] for entry in entries}) == len(entries)
@@ -62,3 +62,27 @@ def test_G16_DESIGN_traces_detach_authority_and_real_evidence_requirements() -> 
     for finding in inventory["reviewFindings"]:
         assert finding["status"] == "resolved"
         assert f"`{finding['id']}`" in design
+
+
+def test_G17_BASELINE_indexes_link_delivery_without_activating_g15() -> None:
+    design = (ROOT / "detachable-local-workspace-g16.md").read_text()
+    assert "## Final Delivery Acceptance" in design
+    delivery = design.split("## Final Delivery Acceptance", 1)[1].split("\n## ", 1)[0]
+    for evidence in (
+        "2455767a", "f05f8cc2", "/pull/567", "/pull/568",
+        "34177069952", "G17.0", "G15", "design-only",
+    ):
+        assert evidence in delivery
+    for scope in ("", "apphost", "appserver", "appservice", "harnesstui"):
+        index = " ".join((ROOT.parent / scope / "README.md").read_text().split())
+        assert "detachable-local-workspace-g16.md#final-delivery-acceptance" in index
+        assert "G17.0" in index
+        for obsolete in (
+            "final platform acceptance pending", "full native platform proof remains pending",
+            "isolated-wheel and final platform fault evidence remain pending",
+            "final platform acceptance still required", "final cross-platform acceptance pending",
+            "cross-platform acceptance is still pending",
+            "design-only, not an implemented listener",
+        ):
+            assert obsolete not in index
+    assert "A0.5 remains not-started" in (ROOT.parent / "apphost/README.md").read_text()

--- a/tests/hosting/_windows_handle_probe.py
+++ b/tests/hosting/_windows_handle_probe.py
@@ -1,0 +1,68 @@
+"""Test-only kernel-object identity probe; never infer identity from HANDLE values."""
+
+from __future__ import annotations
+
+import ctypes
+from collections.abc import Callable
+from ctypes import wintypes
+from typing import Any
+
+
+class WindowsHandleIdentityProbe:
+    def __init__(
+        self,
+        kernel32: Any = None,
+        *,
+        last_error: Callable[[], int] | None = None,
+    ) -> None:
+        if kernel32 is None:
+            kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+        self._last_error = last_error or getattr(ctypes, "get_last_error")
+
+        def bind(name: str, result: Any, arguments: tuple[Any, ...]) -> Any:
+            function = getattr(kernel32, name)
+            function.restype = result
+            function.argtypes = arguments
+            return function
+
+        handle = wintypes.HANDLE
+        self._current = bind("GetCurrentProcess", handle, ())
+        self._process_id = bind("GetProcessId", wintypes.DWORD, (handle,))
+        self._information = bind(
+            "GetHandleInformation", wintypes.BOOL,
+            (handle, ctypes.POINTER(wintypes.DWORD)),
+        )
+        self._duplicate = bind(
+            "DuplicateHandle", wintypes.BOOL,
+            (handle, handle, handle, ctypes.POINTER(handle),
+             wintypes.DWORD, wintypes.BOOL, wintypes.DWORD),
+        )
+        self._compare = bind("CompareObjectHandles", wintypes.BOOL, (handle, handle))
+        self._close = bind("CloseHandle", wintypes.BOOL, (handle,))
+
+    def matches(self, process: int, remote: int, expected: int) -> bool:
+        """Compare a live child's handle with an already-owned parent object.
+
+        Only an absent child handle is negative evidence. Invalid reference or
+        process handles, access denial and cleanup failure must fail the test.
+        Duplicate into the parent; never close or inject a handle in the child.
+        """
+        if not self._process_id(wintypes.HANDLE(process)):
+            raise OSError(self._last_error(), "GetProcessId")
+        flags = wintypes.DWORD()
+        if not self._information(wintypes.HANDLE(expected), ctypes.byref(flags)):
+            raise OSError(self._last_error(), "GetHandleInformation(reference)")
+        duplicate = wintypes.HANDLE()
+        if not self._duplicate(
+            wintypes.HANDLE(process), wintypes.HANDLE(remote), self._current(),
+            ctypes.byref(duplicate), 0, False, 0x2,  # DUPLICATE_SAME_ACCESS only
+        ):
+            error = self._last_error()
+            if error == 6:  # ERROR_INVALID_HANDLE, with process/reference validated
+                return False
+            raise OSError(error, "DuplicateHandle")
+        try:
+            return bool(self._compare(duplicate, wintypes.HANDLE(expected)))
+        finally:
+            if not self._close(duplicate):
+                raise OSError(self._last_error(), "CloseHandle(probe duplicate)")

--- a/tests/hosting/_windows_handle_probe.py
+++ b/tests/hosting/_windows_handle_probe.py
@@ -13,14 +13,20 @@ class WindowsHandleIdentityProbe:
         self,
         kernel32: Any = None,
         *,
+        kernelbase: Any = None,
         last_error: Callable[[], int] | None = None,
     ) -> None:
         if kernel32 is None:
             kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+        if kernelbase is None:
+            kernelbase = getattr(ctypes, "WinDLL")("kernelbase", use_last_error=True)
         self._last_error = last_error or getattr(ctypes, "get_last_error")
 
-        def bind(name: str, result: Any, arguments: tuple[Any, ...]) -> Any:
-            function = getattr(kernel32, name)
+        def bind(
+            name: str, result: Any, arguments: tuple[Any, ...],
+            *, library: Any = kernel32,
+        ) -> Any:
+            function = getattr(library, name)
             function.restype = result
             function.argtypes = arguments
             return function
@@ -37,7 +43,11 @@ class WindowsHandleIdentityProbe:
             (handle, handle, handle, ctypes.POINTER(handle),
              wintypes.DWORD, wintypes.BOOL, wintypes.DWORD),
         )
-        self._compare = bind("CompareObjectHandles", wintypes.BOOL, (handle, handle))
+        # This API is documented in Kernelbase.dll, not Kernel32.dll.
+        self._compare = bind(
+            "CompareObjectHandles", wintypes.BOOL, (handle, handle),
+            library=kernelbase,
+        )
         self._close = bind("CloseHandle", wintypes.BOOL, (handle,))
 
     def matches(self, process: int, remote: int, expected: int) -> bool:

--- a/tests/hosting/test_windows_endpoint.py
+++ b/tests/hosting/test_windows_endpoint.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import threading
 from collections.abc import Awaitable, Callable
+from contextlib import AsyncExitStack
 from functools import wraps
 from pathlib import Path
 from typing import ParamSpec
@@ -20,9 +21,15 @@ from loushang.hosting import (
     ProcessStreamSpec,
 )
 from loushang.hosting._endpoint_host import _InheritedEndpointHost
-from loushang.hosting._win32_process import _Win32SpawnHandles
+from loushang.hosting._win32_process import (
+    _CtypesWin32Api,
+    _Win32AttributeList,
+    _Win32SpawnHandles,
+)
 from loushang.hosting._windows_endpoint import _WindowsEndpointBackend
 from loushang.hosting._windows_process import _WindowsProcessBackend
+
+from ._windows_handle_probe import WindowsHandleIdentityProbe
 
 _P = ParamSpec("_P")
 
@@ -310,38 +317,28 @@ async def test_windows_attachment_primary_survives_cleanup_failure() -> None:
 
 
 @pytest.mark.skipif(os.name != "nt", reason="native Windows endpoint")
+@pytest.mark.parametrize(
+    "leaked_index", [None, 0, 1, 2],
+    ids=["isolated", "leaked-parent-read", "leaked-parent-write", "leaked-sentinel"],
+)
 @_async_test
-async def test_native_windows_endpoint_process_round_trip(tmp_path: Path) -> None:
+async def test_native_windows_endpoint_process_round_trip(
+    tmp_path: Path, leaked_index: int | None,
+) -> None:
     import msvcrt
     import sys
 
-    endpoint_host = _InheritedEndpointHost(_WindowsEndpointBackend())
-    endpoint_lease = await endpoint_host.create()
-    sentinel_descriptor = os.open(
-        tmp_path / "h3-ambient-sentinel", os.O_CREAT | os.O_RDWR
-    )
-    sentinel_handle = msvcrt.get_osfhandle(sentinel_descriptor)
-    os.set_handle_inheritable(sentinel_handle, True)
-    transport = endpoint_lease._pair.transport
-    hidden_handles = (
-        transport._read_handle,  # type: ignore[attr-defined]
-        transport._write_handle,  # type: ignore[attr-defined]
-        sentinel_handle,
-    )
     request = ProcessLaunchRequest(
         argv=(
             sys.executable,
             "-c",
             (
-                "import ctypes,sys; flags=ctypes.c_ulong(); "
-                "get=ctypes.windll.kernel32.GetHandleInformation; "
-                "visibility=b''.join(b'1' if get(int(value),ctypes.byref(flags)) "
-                "else b'0' for value in sys.argv[1:]); "
+                "import sys; sys.stdout.buffer.write(b'READY'); "
+                "sys.stdout.buffer.flush(); "
                 "data=sys.stdin.buffer.read(4); "
-                "sys.stdout.buffer.write(visibility+data.upper()); "
+                "sys.stdout.buffer.write(data.upper()); "
                 "sys.stdout.buffer.flush()"
             ),
-            *(str(handle) for handle in hidden_handles),
         ),
         cwd=str(tmp_path.resolve()),
         effective_environment=tuple(os.environ.items()),
@@ -351,24 +348,72 @@ async def test_native_windows_endpoint_process_round_trip(tmp_path: Path) -> Non
             stderr=ProcessStderrMode.DISCARD,
         ),
     )
-    process_backend = _WindowsProcessBackend()
-    try:
-        process = await process_backend.spawn(
-            request,
-            inheritance=endpoint_lease.inheritance,
-            on_spawn=lambda attached: None,
+    async with AsyncExitStack() as cleanup:
+        endpoint_host = _InheritedEndpointHost(_WindowsEndpointBackend())
+        cleanup.push_async_callback(endpoint_host.close)
+        endpoint_lease = await endpoint_host.create()
+        cleanup.push_async_callback(endpoint_lease.close)
+        sentinel_descriptor = os.open(
+            tmp_path / "h3-ambient-sentinel", os.O_CREAT | os.O_RDWR
+        )
+        cleanup.callback(os.close, sentinel_descriptor)
+        sentinel_handle = msvcrt.get_osfhandle(sentinel_descriptor)
+        os.set_handle_inheritable(sentinel_handle, True)
+        transport = endpoint_lease._pair.transport
+        hidden_handles = (
+            transport._read_handle,  # type: ignore[attr-defined]
+            transport._write_handle,  # type: ignore[attr-defined]
+            sentinel_handle,
         )
 
-        await endpoint_lease.endpoint.write(b"ping")
-        assert await endpoint_lease.endpoint.read(7) == b"000PING"
-        assert await process.wait() == 0
-        await process_backend.wait_tree(process)
-        await process_backend.close_process_handles(process)
-    finally:
-        await endpoint_lease.close()
-        await process_backend.close_backend()
-        await endpoint_host.close()
-        os.close(sentinel_descriptor)
+        class _LeakingApi(_CtypesWin32Api):
+            """Native positive control: deliberately violate the exact allowlist."""
+
+            def _attribute_list(
+                self, job: int, inherited_handles: tuple[int, int, int],
+            ) -> _Win32AttributeList:
+                assert leaked_index is not None
+                leaked = hidden_handles[leaked_index]
+                os.set_handle_inheritable(leaked, True)
+                return super()._attribute_list(
+                    job, (*inherited_handles, leaked),  # type: ignore[arg-type]
+                )
+
+        process_backend = _WindowsProcessBackend(
+            api=None if leaked_index is None else _LeakingApi()
+        )
+        cleanup.push_async_callback(process_backend.close_backend)
+
+        async def read_exactly(size: int) -> bytes:
+            data = b""
+            while len(data) < size:
+                chunk = await endpoint_lease.endpoint.read(size - len(data))
+                assert chunk, "child exited before the endpoint handshake completed"
+                data += chunk
+            return data
+
+        async with asyncio.timeout(20):
+            process = await process_backend.spawn(
+                request,
+                inheritance=endpoint_lease.inheritance,
+                on_spawn=lambda attached: cleanup.push_async_callback(
+                    process_backend.close_process_handles, attached
+                ),
+            )
+            assert await read_exactly(5) == b"READY"
+            # The child remains blocked on stdin throughout object comparison.
+            # HANDLE numbers are process-local; validity alone is not leakage.
+            assert process._process_handle is not None
+            probe = WindowsHandleIdentityProbe()
+            matches = tuple(
+                probe.matches(process._process_handle, handle, handle)
+                for handle in hidden_handles
+            )
+            assert matches == tuple(index == leaked_index for index in range(3))
+            await endpoint_lease.endpoint.write(b"ping")
+            assert await read_exactly(4) == b"PING"
+            assert await process.wait() == 0
+            await process_backend.wait_tree(process)
 
 
 @pytest.mark.skipif(os.name != "nt", reason="native Windows endpoint")

--- a/tests/hosting/test_windows_handle_probe.py
+++ b/tests/hosting/test_windows_handle_probe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ctypes
 from ctypes import wintypes
 from functools import partial
+from types import SimpleNamespace
 
 import pytest
 
@@ -56,7 +57,9 @@ class _Kernel:
         return True
 
     def probe(self):
-        return WindowsHandleIdentityProbe(self, last_error=lambda: self.error)
+        return WindowsHandleIdentityProbe(
+            self, kernelbase=self, last_error=lambda: self.error
+        )
 
 
 def test_same_numeric_handle_in_another_process_is_not_inheritance() -> None:
@@ -71,6 +74,29 @@ def test_same_numeric_handle_in_another_process_is_not_inheritance() -> None:
     ]
     assert api.DuplicateHandle.argtypes[:3] == (wintypes.HANDLE,) * 3
     assert api.GetCurrentProcess.restype is wintypes.HANDLE
+
+
+def test_default_probe_loads_comparison_from_kernelbase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _Kernel()
+    kernelbase = SimpleNamespace(CompareObjectHandles=api.CompareObjectHandles)
+    del api.CompareObjectHandles  # Not exported by kernel32 on Windows Server 2022.
+    loaded: list[tuple[str, bool]] = []
+
+    def load(name: str, *, use_last_error: bool):
+        loaded.append((name, use_last_error))
+        return {"kernel32": api, "kernelbase": kernelbase}[name]
+
+    monkeypatch.setattr(ctypes, "WinDLL", load, raising=False)
+    monkeypatch.setattr(ctypes, "get_last_error", lambda: api.error, raising=False)
+    probe = WindowsHandleIdentityProbe()
+    assert loaded == [("kernel32", True), ("kernelbase", True)]
+    assert not probe.matches(api.child_process, api.expected, api.expected)
+    api.child[api.expected] = api.parent[api.expected]
+    assert probe.matches(api.child_process, api.expected, api.expected)
+    assert kernelbase.CompareObjectHandles.argtypes == (wintypes.HANDLE,) * 2
+    assert kernelbase.CompareObjectHandles.restype is wintypes.BOOL
 
 
 @pytest.mark.parametrize("same_number", [False, True])

--- a/tests/hosting/test_windows_handle_probe.py
+++ b/tests/hosting/test_windows_handle_probe.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import ctypes
+from ctypes import wintypes
+from functools import partial
+
+import pytest
+
+from ._windows_handle_probe import WindowsHandleIdentityProbe
+
+
+class _Kernel:
+    """Distinct process handle tables, including a deterministic value collision."""
+
+    def __init__(self) -> None:
+        self.expected = 2**40 + 32
+        self.child_process = 2**40 + 64
+        self.duplicate = 2**40 + 96
+        self.parent = {self.expected: "parent-pipe"}
+        self.child = {self.expected: "child-unrelated-object"}
+        self.error = 0
+        self.duplicate_error = 0
+        self.fail_compare = False
+        self.fail_close = False
+        self.closed: list[int] = []
+        self.duplicate_calls: list[tuple[object, ...]] = []
+        self.GetCurrentProcess = lambda: 777
+        self.GetProcessId = lambda handle: 123 if handle.value == self.child_process else 0
+        self.GetHandleInformation = lambda handle, flags: handle.value in self.parent
+        self.DuplicateHandle = partial(self._duplicate)
+        self.CompareObjectHandles = partial(self._compare)
+        self.CloseHandle = partial(self._close)
+
+    def _duplicate(self, process, source, target, output, access, inherit, options):
+        self.duplicate_calls.append(
+            (process.value, source.value, target, access, inherit, options)
+        )
+        if self.duplicate_error or source.value not in self.child:
+            self.error = self.duplicate_error or 6
+            return False
+        self.parent[self.duplicate] = self.child[source.value]
+        ctypes.cast(output, ctypes.POINTER(wintypes.HANDLE))[0] = self.duplicate
+        return True
+
+    def _compare(self, left, right):
+        if self.fail_compare:
+            raise RuntimeError("probe comparison failed")
+        return self.parent[left.value] == self.parent[right.value]
+
+    def _close(self, handle):
+        self.closed.append(handle.value)
+        if self.fail_close:
+            self.error = 5
+            return False
+        del self.parent[handle.value]
+        return True
+
+    def probe(self):
+        return WindowsHandleIdentityProbe(self, last_error=lambda: self.error)
+
+
+def test_same_numeric_handle_in_another_process_is_not_inheritance() -> None:
+    api = _Kernel()
+    # The old child-side GetHandleInformation(numeric_value) reports leakage.
+    assert api.expected in api.child
+    assert not api.probe().matches(api.child_process, api.expected, api.expected)
+    assert api.closed == [api.duplicate]
+    assert api.parent == {api.expected: "parent-pipe"}
+    assert api.duplicate_calls == [
+        (api.child_process, api.expected, 777, 0, False, 0x2)
+    ]
+    assert api.DuplicateHandle.argtypes[:3] == (wintypes.HANDLE,) * 3
+    assert api.GetCurrentProcess.restype is wintypes.HANDLE
+
+
+@pytest.mark.parametrize("same_number", [False, True])
+def test_actual_shared_object_is_detected_even_with_a_different_handle_value(
+    same_number: bool,
+) -> None:
+    api = _Kernel()
+    remote = api.expected if same_number else api.expected + 4
+    api.child[remote] = api.parent[api.expected]
+    assert api.probe().matches(api.child_process, remote, api.expected)
+    assert api.closed == [api.duplicate]
+    assert api.child[remote] == "parent-pipe"  # Never close the child source.
+
+
+def test_absent_child_handle_is_negative_evidence_without_cleanup() -> None:
+    api = _Kernel()
+    api.child.clear()
+    assert not api.probe().matches(api.child_process, api.expected, api.expected)
+    assert not api.closed
+
+
+@pytest.mark.parametrize("fault", ["process", "reference", "duplicate", "compare", "close"])
+def test_probe_failure_cannot_be_reported_as_successful_isolation(fault: str) -> None:
+    api = _Kernel()
+    if fault == "process":
+        api.GetProcessId = lambda handle: 0
+    elif fault == "reference":
+        api.parent.clear()
+    elif fault == "duplicate":
+        api.duplicate_error = 5
+    elif fault == "compare":
+        api.fail_compare = True
+    else:
+        api.fail_close = True
+    with pytest.raises((OSError, RuntimeError)):
+        api.probe().matches(api.child_process, api.expected, api.expected)
+    assert api.closed == ([api.duplicate] if fault in {"compare", "close"} else [])


### PR DESCRIPTION
## Summary

Promote the accepted G17.0 baseline from `lane/harness` to `main`. Refs #569.

- PR #570 passed all 33 checks at `fe20c1be` and merged as `0ffe6d52`.
- Correct the Windows handle-isolation evidence without changing production inheritance: object identity, deterministic numeric collisions, fail-closed errors and native deliberate-leak positive controls.
- Native CI exposed a missing DLL export in the initial probe; a default-loader regression reproduced it before binding comparison to the documented Kernelbase DLL. The failed run remains recorded.
- Reconcile current G16 indexes and inventory, and record the accepted native results. G15 launcher/picker and default entrypoints remain unchanged.

## Native acceptance

Hosting run: https://github.com/zhnt/loushang/actions/runs/34180343960

- Linux: 392 passed, 47 platform/profile skips.
- macOS: 369 passed, 70 platform/profile skips.
- Windows: 364 passed, 75 platform/profile skips. The normal isolation case and all three deliberate-leak controls ran successfully, not skipped.

## Local validation

- Initial `make check-hosting`: Ruff, mypy (26 files), 382 passed / 48 platform-only skips.
- Corrected focused loader/probe/endpoint/process/design selection: 30 passed / 8 Windows-only skips; Ruff and Win32-targeted mypy passed.
- G15/G16 architecture selection: 15 passed.
- `loushang --help` and `loushang-mux --help`: successful startup and exit.
- Acceptance documentation: architecture generation/link checks and G16 design/evidence regressions; `git diff --check`.

No `src/` changes are included. The only post-feature-merge delta is the native acceptance documentation. Concurrent startup-performance and staged journal work are excluded.

Merge only after this promotion head's checks are green. Keep #569 open until local synchronization and the main post-merge Hosting verification are complete.
